### PR TITLE
Fix web sync unhandled rejections

### DIFF
--- a/apps/web/src/appData/session/actions/useWorkspaceActions.ts
+++ b/apps/web/src/appData/session/actions/useWorkspaceActions.ts
@@ -80,6 +80,10 @@ function isExpectedWorkspaceActionApiError(error: Error): boolean {
     );
 }
 
+function runWorkspaceActionTaskInBackground(task: Promise<void>): void {
+  void task.catch((): void => undefined);
+}
+
 export function useWorkspaceActions(params: UseWorkspaceActionsParams): WorkspaceSessionCommands {
   const {
     t,
@@ -386,7 +390,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     try {
       const response = await resetWorkspaceProgressRequest(workspaceId, confirmationText);
       if (activeWorkspace?.workspaceId === workspaceId) {
-        void runSync();
+        runWorkspaceActionTaskInBackground(runSync());
       }
       setErrorMessage("");
       return response;

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -68,6 +68,10 @@ function isExpectedWorkspaceSessionApiError(error: Error): boolean {
   return false;
 }
 
+function runLifecycleTaskInBackground(task: Promise<void>): void {
+  void task.catch((): void => undefined);
+}
+
 export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): WorkspaceLifecycle {
   const {
     t,
@@ -358,12 +362,12 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
 
     const intervalId = window.setInterval(() => {
       if (document.visibilityState === "visible") {
-        void runSync();
+        runLifecycleTaskInBackground(runSync());
       }
     }, 60_000);
 
     const handleResume = (): void => {
-      void resumeInBackground();
+      runLifecycleTaskInBackground(resumeInBackground());
     };
 
     const handleFocus = (): void => {

--- a/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
@@ -68,6 +68,7 @@ describe("useWorkspaceSession bootstrap", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (root !== null) {
       await act(async () => {
         root?.unmount();
@@ -249,6 +250,79 @@ describe("useWorkspaceSession bootstrap", () => {
     expect(observabilityMocks.captureWebExceptionMock).not.toHaveBeenCalled();
     expect(latestState?.sessionTechnicalError).toBeNull();
     expect(latestState?.technicalError).toBeNull();
+  });
+
+  it("catches rejecting visible interval sync tasks", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+
+    let intervalHandler: (() => void) | null = null;
+    vi.spyOn(window, "setInterval").mockImplementation((handler: TimerHandler): number => {
+      if (typeof handler === "string") {
+        throw new Error("String interval handlers are not supported in this test");
+      }
+
+      intervalHandler = handler;
+      return 1;
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: (): DocumentVisibilityState => "visible",
+    });
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const intervalSyncError = new Error("Interval sync failed");
+    const runSyncMock = vi.fn(async (): Promise<void> => {
+      throw intervalSyncError;
+    });
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={runSyncMock}
+          runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
+          runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
+          onActionsChange={null}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionLoadState).toBe("ready");
+      expect(latestState?.sessionVerificationState).toBe("verified");
+      expect(intervalHandler).not.toBeNull();
+    });
+
+    const visibleIntervalHandler = intervalHandler;
+    if (visibleIntervalHandler === null) {
+      throw new Error("Visible sync interval handler was not registered");
+    }
+
+    await act(async () => {
+      visibleIntervalHandler();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runSyncMock).toHaveBeenCalledTimes(1);
+    expect(latestState?.sessionLoadState).toBe("ready");
+    expect(latestState?.sessionVerificationState).toBe("verified");
   });
 
   it("redirects after unrecoverable bootstrap auth failure, preserves local data, and skips the generic error state", async () => {

--- a/apps/web/src/appData/session/useWorkspaceSession.reauthResume.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.reauthResume.test.tsx
@@ -45,6 +45,7 @@ describe("useWorkspaceSession reauth resume", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (root !== null) {
       await act(async () => {
         root?.unmount();
@@ -115,6 +116,68 @@ describe("useWorkspaceSession reauth resume", () => {
     expect(latestState?.session?.userId).toBe("user-1");
     expect(latestState?.session?.csrfToken).toBe("csrf-resume");
     expect(isBrowserReauthRequired()).toBe(false);
+  });
+
+  it("catches rejecting focus resume tasks after surfacing the sync error", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]))
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-resume-1"))
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-resume-2"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resumeSyncError = Object.assign(new Error("Resume sync failed"), {
+      syncFailureWasCaptured: false,
+    });
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {
+      throw resumeSyncError;
+    });
+    const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {});
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={vi.fn(async (): Promise<void> => {})}
+          runSyncSilentlyMock={runSyncSilentlyMock}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
+          onActionsChange={null}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionVerificationState).toBe("verified");
+      expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    });
+    await flushEffects();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await vi.waitFor(() => {
+      expect(runSyncSilentlyMock).toHaveBeenCalledTimes(2);
+      expect(latestState?.errorMessage).toBe("Resume sync failed");
+    }, {
+      timeout: 2_000,
+    });
+
+    expect(latestState?.technicalError).toBeNull();
   });
 
   it("clears local data when resume confirms a different user", async () => {

--- a/apps/web/src/appData/session/useWorkspaceSession.workspaceDeletion.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.workspaceDeletion.test.tsx
@@ -38,6 +38,19 @@ function buildWorkspaceDeleteErrorResponse(message: string, code: string): Respo
   });
 }
 
+function buildResetWorkspaceProgressResponse(): Response {
+  return new Response(JSON.stringify({
+    ok: true,
+    workspaceId: "workspace-1",
+    cardsResetCount: 2,
+  }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
 describe("useWorkspaceSession workspace deletion", () => {
   let container: HTMLDivElement | null = null;
   let root: ReactDOM.Root | null = null;
@@ -212,5 +225,82 @@ describe("useWorkspaceSession workspace deletion", () => {
     expect(latestState?.errorMessage).toBe(deleteErrorMessage);
     expect(latestState?.technicalError).toBeNull();
     expect(getObservabilityMocks().captureWebExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps reset progress post-sync failures in the background", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]))
+      .mockResolvedValueOnce(buildResetWorkspaceProgressResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const refreshWorkspaceViewMock = vi.fn(async (_workspaceId: string): Promise<void> => {});
+    const postResetSyncError = new Error("Post reset sync failed");
+    const runSyncMock = vi.fn(async (): Promise<void> => {
+      throw postResetSyncError;
+    });
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {});
+    const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {});
+    const discardWorkspaceSyncMock = vi.fn((_workspaceId: string): void => {});
+    let latestActions: HarnessActions | null = null;
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={refreshWorkspaceViewMock}
+          runSyncMock={runSyncMock}
+          runSyncSilentlyMock={runSyncSilentlyMock}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={discardWorkspaceSyncMock}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
+          onActionsChange={(actions: HarnessActions): void => {
+            latestActions = actions;
+          }}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionLoadState).toBe("ready");
+      expect(latestState?.sessionVerificationState).toBe("verified");
+      expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    });
+    await flushEffects();
+
+    if (latestActions === null) {
+      throw new Error("Workspace session actions were not published");
+    }
+
+    let caughtError: unknown = null;
+    let resetResponseWorkspaceId: string | null = null;
+    await act(async () => {
+      try {
+        const resetResponse = await latestActions.resetWorkspaceProgress(
+          "workspace-1",
+          "reset all progress for all cards in this workspace",
+        );
+        resetResponseWorkspaceId = resetResponse.workspaceId;
+      } catch (error) {
+        caughtError = error;
+      }
+      await Promise.resolve();
+    });
+
+    expect(caughtError).toBeNull();
+    expect(resetResponseWorkspaceId).toBe("workspace-1");
+    expect(runSyncMock).toHaveBeenCalledTimes(1);
+    expect(latestState?.errorMessage).toBe("");
   });
  });

--- a/apps/web/src/appData/session/useWorkspaceSessionTestSupport.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSessionTestSupport.tsx
@@ -6,7 +6,12 @@ import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../i18n/runtime";
 import { WARM_START_SNAPSHOT_STORAGE_KEY } from "./activation/warmStart";
 import { useWorkspaceSession } from "./useWorkspaceSession";
 import { putCloudSettings } from "../../localDb/sync/cloudSettings";
-import type { CloudSettings, SessionInfo, WorkspaceSummary } from "../../types";
+import type {
+  CloudSettings,
+  ResetWorkspaceProgressResponse,
+  SessionInfo,
+  WorkspaceSummary,
+} from "../../types";
 import type { TranslationKey } from "../../i18n";
 import type { SessionLoadState } from "../context/types";
 import type { SessionVerificationState } from "./workspaceSessionTypes";
@@ -46,6 +51,10 @@ export type HarnessSnapshot = Readonly<{
 
 export type HarnessActions = Readonly<{
   deleteWorkspace: (workspaceId: string, confirmationText: string) => Promise<void>;
+  resetWorkspaceProgress: (
+    workspaceId: string,
+    confirmationText: string,
+  ) => Promise<ResetWorkspaceProgressResponse>;
 }>;
 
 export type CapturedWebBreadcrumb = Readonly<{
@@ -287,8 +296,9 @@ export function TestHarness(props: TestHarnessProps): ReactElement {
 
     onActionsChange({
       deleteWorkspace: actions.deleteWorkspace,
+      resetWorkspaceProgress: actions.resetWorkspaceProgress,
     });
-  }, [actions.deleteWorkspace, onActionsChange]);
+  }, [actions.deleteWorkspace, actions.resetWorkspaceProgress, onActionsChange]);
 
   useEffect(() => {
     onStateChange({

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../../api";
 import type { Card } from "../../../types";
 import {
   clickElement,
@@ -147,6 +148,22 @@ describe("ReviewScreen controls", () => {
     expect(reviewPane.dataset.reviewPaneEmptyReason).toBe("no-cards");
     expect(getContainer().textContent).not.toContain("Cloud sync failed");
     expect(getContainer().querySelector(".error-banner")?.textContent).toContain("A technical error occurred.");
+
+    const expectedSyncError = new ApiError({
+      statusCode: 404,
+      message: "Workspace not found",
+      code: "WORKSPACE_NOT_FOUND",
+      requestId: "request-1",
+      endpoint: "POST /workspaces/workspace-1/sync/pull",
+      responseBodyKind: "json",
+    });
+    state.appData.refreshLocalData.mockRejectedValueOnce(expectedSyncError);
+
+    await clickElementAsync(retryButton);
+    await flushReviewScreenPromises();
+
+    expect(state.appData.refreshLocalData).toHaveBeenCalledTimes(1);
+    expect(state.appData.setErrorMessage).toHaveBeenCalledWith("Workspace not found");
   });
 
   it("renders compact review header controls with scope before streak", async () => {

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -36,6 +36,7 @@ import { normalizeCaughtError } from "../../observability/webObservability";
 import { useAiCardHandoff } from "../../chat/handoff/useAiCardHandoff";
 import { useTransientMessage } from "../../useTransientMessage";
 import type { Card, FeedbackPromptEventType, FeedbackSubmissionRequest } from "../../types";
+import { handleRefreshLocalDataError } from "../shared/refreshLocalDataError";
 import { isCardFormStateDirty } from "../cards/form/CardForm";
 import type { ReviewEditorModalProps } from "./components/ReviewEditorModal";
 import type { ReviewPaneProps } from "./components/ReviewPane";
@@ -497,8 +498,25 @@ export function useReviewScreenController(
     setIsAnswerVisible(true);
   }
 
-  function handleRetryReviewLoad(): void {
-    void refreshLocalData();
+  async function handleRetryReviewLoad(): Promise<void> {
+    try {
+      await refreshLocalData();
+    } catch (error) {
+      handleRefreshLocalDataError({
+        error,
+        context: {
+          feature: "sync",
+          operation: "refresh_local_metadata",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace?.workspaceId ?? null,
+        },
+        setErrorMessage,
+        showCapturedTechnicalError,
+        technicalErrorMessage: t("appError.technicalError.message"),
+      });
+    }
   }
 
   function handleSwitchToAllCards(): void {

--- a/apps/web/src/screens/settings/workspace/TagsScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/TagsScreen.tsx
@@ -6,6 +6,7 @@ import { useI18n } from "../../../i18n";
 import { loadWorkspaceTagsSummary } from "../../../localDb/cards/workspace";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import { reviewRoute } from "../../../routes";
+import { handleRefreshLocalDataError } from "../../shared/refreshLocalDataError";
 import type { ReviewFilter, WorkspaceTagsSummary } from "../../../types";
 
 const emptyTagsSummary: WorkspaceTagsSummary = {
@@ -98,6 +99,27 @@ export function TagsScreen(): ReactElement {
     navigate(reviewRoute);
   }
 
+  async function handleRefreshLocalData(): Promise<void> {
+    try {
+      await refreshLocalData();
+    } catch (error) {
+      handleRefreshLocalDataError({
+        error,
+        context: {
+          feature: "sync",
+          operation: "refresh_local_metadata",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace?.workspaceId ?? null,
+        },
+        setErrorMessage,
+        showCapturedTechnicalError,
+        technicalErrorMessage,
+      });
+    }
+  }
+
   if (isLoading) {
     return (
       <main className="container">
@@ -115,7 +137,7 @@ export function TagsScreen(): ReactElement {
         <section className="panel tags-screen-panel">
           <h1 className="title">{t("tagsScreen.title")}</h1>
           <p className="error-banner">{errorMessage}</p>
-          <button className="primary-btn" type="button" onClick={() => void refreshLocalData()}>
+          <button className="primary-btn" type="button" onClick={() => void handleRefreshLocalData()}>
             {t("common.retry")}
           </button>
         </section>

--- a/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
@@ -9,6 +9,7 @@ import { buildSettingsDeckEditRoute, reviewRoute, settingsDecksRoute } from "../
 import { loadCardsMatchingDeck } from "../../../../localDb/cards/cards";
 import { loadDeckById, loadDecksListSnapshot } from "../../../../localDb/cards/decks";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
+import { handleRefreshLocalDataError } from "../../../shared/refreshLocalDataError";
 import type { Card, DeckFilterDefinition, ReviewFilter } from "../../../../types";
 import { formatDeckFilterSummary, formatNullableDateTime, formatTagSummary } from "../../../shared/featureFormatting";
 
@@ -198,6 +199,27 @@ export function DeckDetailScreen(): ReactElement {
     navigate(reviewRoute);
   }
 
+  async function handleRefreshLocalData(): Promise<void> {
+    try {
+      await refreshLocalData();
+    } catch (error) {
+      handleRefreshLocalDataError({
+        error,
+        context: {
+          feature: "sync",
+          operation: "refresh_local_metadata",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace?.workspaceId ?? null,
+        },
+        setErrorMessage: setScreenErrorMessage,
+        showCapturedTechnicalError,
+        technicalErrorMessage,
+      });
+    }
+  }
+
   if (isLoading) {
     return (
       <main className="container">
@@ -215,7 +237,7 @@ export function DeckDetailScreen(): ReactElement {
         <section className="panel">
           <h1 className="title">{t("deckDetail.title")}</h1>
           <p className="error-banner">{screenErrorMessage}</p>
-          <button className="primary-btn" type="button" onClick={() => void refreshLocalData()}>
+          <button className="primary-btn" type="button" onClick={() => void handleRefreshLocalData()}>
             {t("common.retry")}
           </button>
         </section>

--- a/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
@@ -7,6 +7,7 @@ import { useI18n } from "../../../../i18n";
 import { buildSettingsDeckDetailRoute, settingsDeckNewRoute } from "../../../../routes";
 import { loadDecksListSnapshot } from "../../../../localDb/cards/decks";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
+import { handleRefreshLocalDataError } from "../../../shared/refreshLocalDataError";
 import type { DeckCardStats, DecksListSnapshot } from "../../../../types";
 import { formatDeckFilterSummary } from "../../../shared/featureFormatting";
 
@@ -129,6 +130,27 @@ export function DecksScreen(): ReactElement {
 
   const deckListEntries = makeDeckListEntries(decksSnapshot);
 
+  async function handleRefreshLocalData(): Promise<void> {
+    try {
+      await refreshLocalData();
+    } catch (error) {
+      handleRefreshLocalDataError({
+        error,
+        context: {
+          feature: "sync",
+          operation: "refresh_local_metadata",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace?.workspaceId ?? null,
+        },
+        setErrorMessage,
+        showCapturedTechnicalError,
+        technicalErrorMessage,
+      });
+    }
+  }
+
   if (isLoading) {
     return (
       <main className="container">
@@ -146,7 +168,7 @@ export function DecksScreen(): ReactElement {
         <section className="panel">
           <h1 className="title">{t("decksScreen.title")}</h1>
           <p className="error-banner">{errorMessage}</p>
-          <button className="primary-btn" type="button" onClick={() => void refreshLocalData()}>
+          <button className="primary-btn" type="button" onClick={() => void handleRefreshLocalData()}>
             {t("common.retry")}
           </button>
         </section>

--- a/apps/web/src/screens/shared/refreshLocalDataError.ts
+++ b/apps/web/src/screens/shared/refreshLocalDataError.ts
@@ -1,0 +1,49 @@
+import { getErrorMessage } from "../../appData/domain";
+import {
+  isCapturedSyncFailure,
+  isExpectedUnobservedSyncFailure,
+} from "../../appData/sync/observation/syncErrorObservation";
+import { captureAppOperationError } from "../../observability/appOperationObservation";
+import type {
+  WebAppOperation,
+  WebObservationFeature,
+} from "../../observability/webObservability";
+
+type RefreshLocalDataErrorContext = Readonly<{
+  feature: WebObservationFeature;
+  operation: WebAppOperation;
+  userId: string | null;
+  workspaceId: string | null;
+  installationId: string | null;
+  entityId: string | null;
+}>;
+
+type HandleRefreshLocalDataErrorInput = Readonly<{
+  error: unknown;
+  context: RefreshLocalDataErrorContext;
+  setErrorMessage: (message: string) => void;
+  showCapturedTechnicalError: (error: unknown) => void;
+  technicalErrorMessage: string;
+}>;
+
+export function handleRefreshLocalDataError(input: HandleRefreshLocalDataErrorInput): void {
+  if (isCapturedSyncFailure(input.error)) {
+    input.showCapturedTechnicalError(input.error);
+    input.setErrorMessage(input.technicalErrorMessage);
+    return;
+  }
+
+  if (isExpectedUnobservedSyncFailure(input.error)) {
+    input.setErrorMessage(getErrorMessage(input.error));
+    return;
+  }
+
+  const wasCaptured = captureAppOperationError(input.error, input.context);
+  if (wasCaptured) {
+    input.showCapturedTechnicalError(input.error);
+    input.setErrorMessage(input.technicalErrorMessage);
+    return;
+  }
+
+  input.setErrorMessage(getErrorMessage(input.error));
+}


### PR DESCRIPTION
## Summary
- catch web lifecycle and reset fire-and-forget sync promises
- route review/deck/tag retry refresh failures into existing app error handling
- add focused Vitest coverage for background sync and retry rejection paths

## Validation
- npm --prefix apps/web run test -- 'src/appData/session/useWorkspaceSession*.test.tsx' 'src/screens/review/**/*.test.tsx' 'src/screens/settings/**/*.test.tsx'
- npm --prefix apps/web run build
- git --no-pager diff --check