### PR TITLE
Fix Android sync wire filter import

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
@@ -19,6 +19,7 @@ import com.flashcardsopensourceapp.data.local.model.sync.SyncOperation
 import com.flashcardsopensourceapp.data.local.model.sync.SyncOperationPayload
 import com.flashcardsopensourceapp.data.local.model.sync.WorkspaceSchedulerSettingsSyncPayload
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinitionJsonObject
 import com.flashcardsopensourceapp.data.local.model.scheduling.decodeSchedulerStepListJson
 import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags


### PR DESCRIPTION
## Summary
- import the existing deck filter JSON builder used by Android sync wire payloads

## Verification
- git diff --check
- GitHub Actions will validate Android build/lint on PR and main