### PR TITLE
Fix Android AI send readiness and custom server URLs

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cloud/CloudSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cloud/CloudSupport.kt
@@ -8,6 +8,8 @@ import java.util.Locale
 
 private const val flashcardsOfficialApiBaseUrl: String = "https://api.flashcards-open-source-app.com/v1"
 private const val flashcardsOfficialAuthBaseUrl: String = "https://auth.flashcards-open-source-app.com"
+private const val customCloudApiHostPrefix: String = "api."
+private const val customCloudAuthHostPrefix: String = "auth."
 private val canonicalIsoTimestampFormatter: DateTimeFormatter = DateTimeFormatter
     .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
     .withZone(ZoneOffset.UTC)
@@ -75,7 +77,21 @@ fun normalizeCustomCloudOrigin(customOrigin: String): String {
         ":${parsedOrigin.port}"
     }
 
-    return "https://${parsedOrigin.host.lowercase(Locale.US)}$normalizedPort"
+    val canonicalHost = canonicalCustomCloudOriginHost(host = parsedOrigin.host)
+    require(canonicalHost.isNotBlank()) {
+        "Custom server must include a root host: $customOrigin"
+    }
+
+    return "https://$canonicalHost$normalizedPort"
+}
+
+private fun canonicalCustomCloudOriginHost(host: String): String {
+    val normalizedHost = host.lowercase(Locale.US)
+    return when {
+        normalizedHost.startsWith(customCloudApiHostPrefix) -> normalizedHost.removePrefix(customCloudApiHostPrefix)
+        normalizedHost.startsWith(customCloudAuthHostPrefix) -> normalizedHost.removePrefix(customCloudAuthHostPrefix)
+        else -> normalizedHost
+    }
 }
 
 fun shouldRefreshCloudIdToken(idTokenExpiresAtMillis: Long, nowMillis: Long): Boolean {

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/model/CloudSupportTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/model/CloudSupportTest.kt
@@ -5,6 +5,39 @@ import org.junit.Test
 
 class CloudSupportTest {
     @Test
+    fun makeCustomCloudServiceConfigurationCanonicalizesApiHostToRootOrigin() {
+        val configuration = makeCustomCloudServiceConfiguration(
+            customOrigin = " https://api.Example.COM:8443 "
+        )
+
+        assertEquals("https://example.com:8443", configuration.customOrigin)
+        assertEquals("https://api.example.com:8443/v1", configuration.apiBaseUrl)
+        assertEquals("https://auth.example.com:8443", configuration.authBaseUrl)
+    }
+
+    @Test
+    fun makeCustomCloudServiceConfigurationCanonicalizesAuthHostToRootOrigin() {
+        val configuration = makeCustomCloudServiceConfiguration(
+            customOrigin = "https://auth.example.com"
+        )
+
+        assertEquals("https://example.com", configuration.customOrigin)
+        assertEquals("https://api.example.com/v1", configuration.apiBaseUrl)
+        assertEquals("https://auth.example.com", configuration.authBaseUrl)
+    }
+
+    @Test
+    fun makeCustomCloudServiceConfigurationKeepsRootOrigin() {
+        val configuration = makeCustomCloudServiceConfiguration(
+            customOrigin = "https://Example.COM"
+        )
+
+        assertEquals("https://example.com", configuration.customOrigin)
+        assertEquals("https://api.example.com/v1", configuration.apiBaseUrl)
+        assertEquals("https://auth.example.com", configuration.authBaseUrl)
+    }
+
+    @Test
     fun formatIsoTimestampEmitsCanonicalUtcMilliseconds() {
         assertEquals(
             "2026-03-10T12:00:00.000Z",

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/send/AiChatSendCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/send/AiChatSendCoordinator.kt
@@ -140,6 +140,11 @@ internal class AiChatSendCoordinator(
             var requestSessionId = currentState.persistedState.chatSessionId
             var rollbackPersistedState = initialPersistedState
             try {
+                if (currentCloudState() == CloudAccountState.DISCONNECTED) {
+                    context.aiChatRepository.prepareSessionForAi(
+                        workspaceId = context.runtimeStateMutable.value.workspaceId
+                    )
+                }
                 // AI send is blocked on a direct sync so the backend run never starts
                 // from stale local writes that are still sitting in the outbox.
                 context.aiChatRepository.ensureReadyForSend(workspaceId = context.runtimeStateMutable.value.workspaceId)

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeSendDraftRestorationTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeSendDraftRestorationTest.kt
@@ -14,6 +14,7 @@ import com.flashcardsopensourceapp.data.local.model.ai.aiChatMaximumAttachmentBy
 import com.flashcardsopensourceapp.data.local.model.ai.aiChatMaximumStartRunRequestBytes
 import com.flashcardsopensourceapp.data.local.model.ai.makeDefaultAiChatPersistedState
 import java.io.IOException
+import java.net.MalformedURLException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -87,6 +88,55 @@ class AiChatRuntimeSendDraftRestorationTest {
         assertEquals("send-session-1", repository.lastStartRunState?.chatSessionId)
         assertEquals(testUiLocaleTag, repository.lastStartRunUiLocale)
         assertEquals("send-session-1", runtime.state.value.persistedState.chatSessionId)
+    }
+
+    @Test
+    fun disconnectedSendPreparesGuestAccessBeforeSyncWhenWarmUpFailed() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.nextEnsureSessionId = "send-session-1"
+        repository.prepareSessionErrors += MalformedURLException("bad guest auth URL")
+        repository.startRunResponse = makeAcceptedStartRunResponse(
+            sessionId = "send-session-1",
+            activeRun = null,
+            messages = listOf(
+                makeUserMessage(
+                    content = listOf(AiChatContentPart.Text(text = "Hello")),
+                    timestampMillis = 1L
+                ),
+                makeAssistantStatusMessage(timestampMillis = 2L)
+            ),
+            composerSuggestions = emptyList()
+        )
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.DISCONNECTED
+        )
+
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId).copy(
+                cloudState = CloudAccountState.DISCONNECTED
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf(defaultTestWorkspaceId), repository.prepareSessionRequests)
+
+        runtime.updateDraftMessage(draftMessage = "Hello")
+        runtime.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
+            repository.prepareSessionRequests
+        )
+        assertEquals(1, repository.ensureReadyForSendCalls)
+        assertEquals(1, repository.startRunCalls)
+        assertEquals("send-session-1", runtime.state.value.persistedState.chatSessionId)
+        assertEquals("", runtime.state.value.draftMessage)
+        assertTrue(runtime.state.value.pendingAttachments.isEmpty())
+        assertEquals(AiComposerPhase.IDLE, runtime.state.value.composerPhase)
     }
 
     @Test

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/server/ServerSettingsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/server/ServerSettingsViewModel.kt
@@ -115,16 +115,73 @@ class ServerSettingsViewModel(
 
     suspend fun applyPreviewConfiguration() {
         val previewConfiguration = draftState.value.previewConfiguration
-        if (previewConfiguration == null) {
+        val customOrigin = previewConfiguration?.customOrigin
+        if (customOrigin == null) {
             draftState.update { state ->
                 state.copy(errorMessage = strings.get(R.string.settings_server_enter_valid_url))
             }
             return
         }
         draftState.update { state -> state.copy(isApplying = true, errorMessage = "") }
+        val validatedConfiguration = try {
+            cloudAccountRepository.validateCustomServer(customOrigin)
+        } catch (error: IllegalArgumentException) {
+            draftState.update { state ->
+                state.copy(
+                    isApplying = false,
+                    errorMessage = strings.get(R.string.settings_server_enter_valid_url)
+                )
+            }
+            return
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: CloudRemoteException) {
+            draftState.update { state ->
+                state.copy(
+                    isApplying = false,
+                    errorMessage = strings.get(R.string.settings_server_validate_failed)
+                )
+            }
+            return
+        } catch (error: CloudHealthValidationException) {
+            draftState.update { state ->
+                state.copy(
+                    isApplying = false,
+                    errorMessage = strings.get(R.string.settings_server_validate_failed)
+                )
+            }
+            return
+        } catch (error: IOException) {
+            draftState.update { state ->
+                state.copy(
+                    isApplying = false,
+                    errorMessage = strings.get(R.string.settings_server_validate_failed)
+                )
+            }
+            return
+        } catch (error: Exception) {
+            val errorMessage = strings.get(R.string.settings_server_validate_failed)
+            draftState.update { state ->
+                state.copy(
+                    isApplying = false,
+                    errorMessage = errorMessage
+                )
+            }
+            showTechnicalError(
+                message = errorMessage,
+                throwable = error
+            )
+            return
+        }
         try {
-            cloudAccountRepository.applyCustomServer(previewConfiguration)
-            draftState.update { state -> state.copy(isApplying = false, errorMessage = "") }
+            cloudAccountRepository.applyCustomServer(validatedConfiguration)
+            draftState.update { state ->
+                state.copy(
+                    previewConfiguration = validatedConfiguration,
+                    isApplying = false,
+                    errorMessage = ""
+                )
+            }
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -21,6 +21,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetPro
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.cloud.makeCustomCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.cloud.makeOfficialCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardProfile
@@ -111,6 +112,11 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
     private val completeCloudLinkResults = ArrayDeque<CompletableDeferred<CloudWorkspaceSummary>>()
     private val preparedLinkContexts = mutableMapOf<String, CompletableDeferred<CloudWorkspaceLinkContext>>()
     val completeCloudLinkSelections = mutableListOf<CloudWorkspaceLinkSelection>()
+    val validatedCustomOrigins = mutableListOf<String>()
+    val appliedCustomServerConfigurations = mutableListOf<CloudServiceConfiguration>()
+    var validateCustomServerError: Exception? = null
+    var applyCustomServerError: Exception? = null
+    var nextValidatedCustomServerConfiguration: CloudServiceConfiguration? = null
     var resetInvalidCloudCredentialRecoveryStateCalls: Int = 0
         private set
     var logoutCalls: Int = 0
@@ -334,19 +340,30 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
     }
 
     override suspend fun currentServerConfiguration(): CloudServiceConfiguration {
-        return makeOfficialCloudServiceConfiguration()
+        return serverConfiguration.value
     }
 
     override suspend fun validateCustomServer(customOrigin: String): CloudServiceConfiguration {
-        throw UnsupportedOperationException()
+        validatedCustomOrigins += customOrigin
+        val error = validateCustomServerError
+        if (error != null) {
+            throw error
+        }
+        return nextValidatedCustomServerConfiguration
+            ?: makeCustomCloudServiceConfiguration(customOrigin = customOrigin)
     }
 
     override suspend fun applyCustomServer(configuration: CloudServiceConfiguration) {
-        throw UnsupportedOperationException()
+        val error = applyCustomServerError
+        if (error != null) {
+            throw error
+        }
+        appliedCustomServerConfigurations += configuration
+        serverConfiguration.value = configuration
     }
 
     override suspend fun resetToOfficialServer() {
-        throw UnsupportedOperationException()
+        serverConfiguration.value = makeOfficialCloudServiceConfiguration()
     }
 }
 
@@ -371,6 +388,14 @@ internal class TestSettingsStringResolver : SettingsStringResolver {
 
             R.string.settings_sign_in_verify_failed -> "Could not verify the code."
             R.string.settings_current_workspace_new_title -> "New workspace"
+            R.string.settings_loading -> "Loading..."
+            R.string.settings_technical_error_title -> "Something went wrong"
+            R.string.settings_server_mode_official -> "Official"
+            R.string.settings_server_mode_custom -> "Custom"
+            R.string.settings_server_enter_valid_url -> "Enter a valid custom server URL."
+            R.string.settings_server_apply_failed -> "Could not apply custom server."
+            R.string.settings_server_validate_failed -> "Custom server validation failed."
+            R.string.settings_server_reset_failed -> "Could not reset the official server."
             R.string.settings_logout -> "Log out"
             R.string.settings_current_workspace_create_new_title -> "Create new workspace"
             R.string.settings_current_workspace_create_new_summary -> {

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/ServerSettingsViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/ServerSettingsViewModelTest.kt
@@ -1,0 +1,118 @@
+package com.flashcardsopensourceapp.feature.settings
+
+import com.flashcardsopensourceapp.core.ui.AppTechnicalError
+import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
+import com.flashcardsopensourceapp.data.local.model.cloud.makeCustomCloudServiceConfiguration
+import com.flashcardsopensourceapp.feature.settings.server.ServerSettingsViewModel
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerSettingsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val strings: SettingsStringResolver = TestSettingsStringResolver()
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun customOriginPreviewCanonicalizesApiHostToRootOrigin() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val viewModel = ServerSettingsViewModel(
+            cloudAccountRepository = repository,
+            technicalErrorController = RecordingTechnicalErrorController(),
+            strings = strings
+        )
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.updateCustomOrigin(customOrigin = "https://api.deepseek.com")
+        advanceUntilIdle()
+
+        assertEquals("https://api.deepseek.com/v1", viewModel.uiState.value.previewApiBaseUrl)
+        assertEquals("https://auth.deepseek.com", viewModel.uiState.value.previewAuthBaseUrl)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun applyPreviewConfigurationValidatesBeforePersistingCustomServer() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.validateCustomServerError = IOException("Unable to resolve host")
+        val viewModel = ServerSettingsViewModel(
+            cloudAccountRepository = repository,
+            technicalErrorController = RecordingTechnicalErrorController(),
+            strings = strings
+        )
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.updateCustomOrigin(customOrigin = "https://api.deepseek.com")
+        viewModel.applyPreviewConfiguration()
+        advanceUntilIdle()
+
+        assertEquals(listOf("https://deepseek.com"), repository.validatedCustomOrigins)
+        assertTrue(repository.appliedCustomServerConfigurations.isEmpty())
+        assertEquals("Custom server validation failed.", viewModel.uiState.value.errorMessage)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun applyPreviewConfigurationPersistsValidatedCustomServerConfiguration() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val validatedConfiguration = makeCustomCloudServiceConfiguration(
+            customOrigin = "https://validated.example.com"
+        )
+        repository.nextValidatedCustomServerConfiguration = validatedConfiguration
+        val viewModel = ServerSettingsViewModel(
+            cloudAccountRepository = repository,
+            technicalErrorController = RecordingTechnicalErrorController(),
+            strings = strings
+        )
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.updateCustomOrigin(customOrigin = "https://api.example.com")
+        viewModel.applyPreviewConfiguration()
+        advanceUntilIdle()
+
+        assertEquals(listOf("https://example.com"), repository.validatedCustomOrigins)
+        assertEquals(listOf(validatedConfiguration), repository.appliedCustomServerConfigurations)
+        assertEquals(validatedConfiguration.apiBaseUrl, viewModel.uiState.value.apiBaseUrl)
+        assertEquals(validatedConfiguration.authBaseUrl, viewModel.uiState.value.authBaseUrl)
+
+        stateJob.cancel()
+    }
+}
+
+private class RecordingTechnicalErrorController : AppTechnicalErrorController {
+    val errors: MutableList<AppTechnicalError> = mutableListOf()
+
+    override fun showTechnicalError(
+        error: AppTechnicalError,
+        throwable: Throwable
+    ) {
+        errors += error
+    }
+}


### PR DESCRIPTION
## Summary
- prepare guest cloud access before Android AI pre-send sync when disconnected
- canonicalize custom server api/auth host input to the root service origin
- validate custom server configuration before applying it in settings

## Validation
- git --no-pager diff --check
- pre-commit review via review-kirill

Gradle tests were not run locally because this repository requires explicit permission for ./gradlew runs.