### PR TITLE
Suppress transient Android AI post-run sync warnings

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
@@ -1,11 +1,14 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
 import com.flashcardsopensourceapp.core.observability.AppObservability
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatResumeDiagnostics
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
+import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIoException
+import com.flashcardsopensourceapp.data.local.network.isRetryableHttpStatusCode
 import com.flashcardsopensourceapp.data.local.repository.AiChatRepository
 import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncEventRepository
 import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncRequest
@@ -18,6 +21,7 @@ import com.flashcardsopensourceapp.feature.ai.runtime.observability.AiChatWarnin
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.createAiChatRuntimeObservability
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.recordAiChatWarning
 import com.flashcardsopensourceapp.feature.ai.strings.AiTextProvider
+import java.io.IOException
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
@@ -223,6 +227,9 @@ internal class AiChatRuntimeContext(
             throw error
         } catch (error: Exception) {
             releaseToolRunPostSyncInFlight()
+            if (isExpectedTransientToolRunPostSyncFailure(error = error)) {
+                return
+            }
             observability.recordAiChatWarning(
                 warning = AiChatWarning.PostRunSyncFailed(
                     workspaceId = origin.workspaceId,
@@ -305,6 +312,26 @@ internal class AiChatRuntimeContext(
             isToolRunPostSyncInFlight = false
         }
     }
+}
+
+private fun isExpectedTransientToolRunPostSyncFailure(error: Throwable): Boolean {
+    var currentError: Throwable? = error
+    while (currentError != null) {
+        if (
+            currentError is CloudRemoteException &&
+            isRetryableHttpStatusCode(statusCode = currentError.statusCode)
+        ) {
+            return true
+        }
+        if (
+            currentError is IOException &&
+            isLikelyTransientNetworkIoException(error = currentError)
+        ) {
+            return true
+        }
+        currentError = currentError.cause
+    }
+    return false
 }
 
 private fun AiChatRuntimeState.toDraftState(): AiChatDraftState {

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeContextTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeContextTest.kt
@@ -1,10 +1,14 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
-import com.flashcardsopensourceapp.feature.ai.runtime.conversation.makeAiDraftState
+import com.flashcardsopensourceapp.core.observability.AndroidAiObservationName
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
 import com.flashcardsopensourceapp.data.local.model.ai.makeDefaultAiChatPersistedState
+import com.flashcardsopensourceapp.feature.ai.runtime.conversation.makeAiDraftState
+import java.net.UnknownHostException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -103,4 +107,181 @@ class AiChatRuntimeContextTest {
         assertEquals(secondaryTestWorkspaceId, context.runtimeStateMutable.value.workspaceId)
         assertTrue(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
     }
+
+    @Test
+    fun transientNetworkAutoSyncFailureDoesNotWarnAndKeepsPendingFlagForRetry() = runTest {
+        val repository = FakeAiChatRepository()
+        val autoSyncEventRepository = FakeAutoSyncEventRepository()
+        val observability = RecordingAppObservability()
+        autoSyncEventRepository.runAutoSyncErrors += UnknownHostException("Unable to resolve host")
+        val context = makePendingPostRunSyncContext(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = autoSyncEventRepository,
+            observability = observability
+        )
+
+        context.triggerToolRunPostSyncIfNeeded(reason = "test")
+
+        assertEquals(1, autoSyncEventRepository.requests.size)
+        assertTrue(observability.warningEvents.isEmpty())
+        assertTrue(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
+        assertTrue(
+            repository.persistedStates[defaultTestWorkspaceId]?.pendingToolRunPostSync ?: false
+        )
+
+        context.triggerToolRunPostSyncIfNeeded(reason = "retry")
+
+        assertEquals(2, autoSyncEventRepository.requests.size)
+        assertTrue(observability.warningEvents.isEmpty())
+        assertFalse(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
+        assertFalse(
+            repository.persistedStates[defaultTestWorkspaceId]?.pendingToolRunPostSync ?: true
+        )
+    }
+
+    @Test
+    fun retryableCloudAutoSyncFailureDoesNotWarnAndKeepsPendingFlagForRetry() = runTest {
+        val repository = FakeAiChatRepository()
+        val autoSyncEventRepository = FakeAutoSyncEventRepository()
+        val observability = RecordingAppObservability()
+        autoSyncEventRepository.runAutoSyncErrors += makeCloudRemoteException(statusCode = 504)
+        val context = makePendingPostRunSyncContext(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = autoSyncEventRepository,
+            observability = observability
+        )
+
+        context.triggerToolRunPostSyncIfNeeded(reason = "test")
+
+        assertEquals(1, autoSyncEventRepository.requests.size)
+        assertTrue(observability.warningEvents.isEmpty())
+        assertTrue(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
+        assertTrue(
+            repository.persistedStates[defaultTestWorkspaceId]?.pendingToolRunPostSync ?: false
+        )
+
+        context.triggerToolRunPostSyncIfNeeded(reason = "retry")
+
+        assertEquals(2, autoSyncEventRepository.requests.size)
+        assertTrue(observability.warningEvents.isEmpty())
+        assertFalse(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
+        assertFalse(
+            repository.persistedStates[defaultTestWorkspaceId]?.pendingToolRunPostSync ?: true
+        )
+    }
+
+    @Test
+    fun wrappedTransientNetworkAutoSyncFailureDoesNotWarn() = runTest {
+        val repository = FakeAiChatRepository()
+        val autoSyncEventRepository = FakeAutoSyncEventRepository()
+        val observability = RecordingAppObservability()
+        autoSyncEventRepository.runAutoSyncErrors += IllegalStateException(
+            "Wrapped network error",
+            UnknownHostException("Unable to resolve host")
+        )
+        val context = makePendingPostRunSyncContext(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = autoSyncEventRepository,
+            observability = observability
+        )
+
+        context.triggerToolRunPostSyncIfNeeded(reason = "test")
+
+        assertEquals(1, autoSyncEventRepository.requests.size)
+        assertTrue(observability.warningEvents.isEmpty())
+        assertTrue(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
+        assertTrue(
+            repository.persistedStates[defaultTestWorkspaceId]?.pendingToolRunPostSync ?: false
+        )
+    }
+
+    @Test
+    fun nonTransientAutoSyncFailureKeepsPostRunSyncWarning() = runTest {
+        val repository = FakeAiChatRepository()
+        val autoSyncEventRepository = FakeAutoSyncEventRepository()
+        val observability = RecordingAppObservability()
+        autoSyncEventRepository.runAutoSyncErrors += IllegalStateException("Cloud sync failed")
+        val context = makePendingPostRunSyncContext(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = autoSyncEventRepository,
+            observability = observability
+        )
+
+        context.triggerToolRunPostSyncIfNeeded(reason = "test")
+
+        assertEquals(1, autoSyncEventRepository.requests.size)
+        assertEquals(1, observability.warningEvents.size)
+        val warning = observability.warningEvents.single()
+        assertTrue(warning is AndroidWarningIssueEvent.AiLifecycleWarning)
+        val lifecycleWarning = warning as AndroidWarningIssueEvent.AiLifecycleWarning
+        assertEquals(
+            AndroidAiObservationName.POST_RUN_SYNC_FAILED.tagValue,
+            lifecycleWarning.lifecycleAction
+        )
+        assertTrue(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
+        assertTrue(
+            repository.persistedStates[defaultTestWorkspaceId]?.pendingToolRunPostSync ?: false
+        )
+    }
+
+    @Test
+    fun nonRetryableCloudAutoSyncFailureKeepsPostRunSyncWarning() = runTest {
+        val repository = FakeAiChatRepository()
+        val autoSyncEventRepository = FakeAutoSyncEventRepository()
+        val observability = RecordingAppObservability()
+        autoSyncEventRepository.runAutoSyncErrors += makeCloudRemoteException(statusCode = 400)
+        val context = makePendingPostRunSyncContext(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = autoSyncEventRepository,
+            observability = observability
+        )
+
+        context.triggerToolRunPostSyncIfNeeded(reason = "test")
+
+        assertEquals(1, autoSyncEventRepository.requests.size)
+        assertEquals(1, observability.warningEvents.size)
+        val warning = observability.warningEvents.single()
+        assertTrue(warning is AndroidWarningIssueEvent.AiLifecycleWarning)
+        val lifecycleWarning = warning as AndroidWarningIssueEvent.AiLifecycleWarning
+        assertEquals(
+            AndroidAiObservationName.POST_RUN_SYNC_FAILED.tagValue,
+            lifecycleWarning.lifecycleAction
+        )
+        assertTrue(context.runtimeStateMutable.value.persistedState.pendingToolRunPostSync)
+        assertTrue(
+            repository.persistedStates[defaultTestWorkspaceId]?.pendingToolRunPostSync ?: false
+        )
+    }
+}
+
+private fun makePendingPostRunSyncContext(
+    scope: TestScope,
+    repository: FakeAiChatRepository,
+    autoSyncEventRepository: FakeAutoSyncEventRepository,
+    observability: RecordingAppObservability
+): AiChatRuntimeContext {
+    val originState = makeDefaultAiChatPersistedState().copy(
+        chatSessionId = "session-1",
+        pendingToolRunPostSync = true
+    )
+    repository.setPersistedState(
+        workspaceId = defaultTestWorkspaceId,
+        state = originState
+    )
+    val context = makeRuntimeContextWithObservability(
+        scope = scope,
+        repository = repository,
+        autoSyncEventRepository = autoSyncEventRepository,
+        observability = observability
+    )
+    context.runtimeStateMutable.value = makeAiDraftState(
+        workspaceId = defaultTestWorkspaceId,
+        persistedState = originState
+    )
+    return context
 }

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/support/AiChatRuntimeTestSupport.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/support/AiChatRuntimeTestSupport.kt
@@ -67,6 +67,20 @@ internal fun makeRuntimeContext(
     repository: FakeAiChatRepository,
     autoSyncEventRepository: FakeAutoSyncEventRepository
 ): AiChatRuntimeContext {
+    return makeRuntimeContextWithObservability(
+        scope = scope,
+        repository = repository,
+        autoSyncEventRepository = autoSyncEventRepository,
+        observability = TestAppObservability
+    )
+}
+
+internal fun makeRuntimeContextWithObservability(
+    scope: TestScope,
+    repository: FakeAiChatRepository,
+    autoSyncEventRepository: FakeAutoSyncEventRepository,
+    observability: AppObservability
+): AiChatRuntimeContext {
     return AiChatRuntimeContext(
         scope = scope,
         aiChatRepository = repository,
@@ -79,7 +93,7 @@ internal fun makeRuntimeContext(
         currentServerConfiguration = { makeOfficialCloudServiceConfiguration() },
         currentSyncStatus = { SyncStatus.Idle },
         currentUiLocaleTag = { testUiLocaleTag },
-        observability = TestAppObservability
+        observability = observability
     )
 }
 
@@ -158,6 +172,7 @@ private object TestAppObservability : AppObservability {
 
 internal class RecordingAppObservability : AppObservability {
     val exceptionEvents: MutableList<AndroidExceptionIssueEvent> = mutableListOf()
+    val warningEvents: MutableList<AndroidWarningIssueEvent> = mutableListOf()
 
     override fun setCloudIdentity(identity: CloudObservationIdentity) {
     }
@@ -169,6 +184,7 @@ internal class RecordingAppObservability : AppObservability {
     }
 
     override fun captureWarning(event: AndroidWarningIssueEvent) {
+        warningEvents += event
     }
 
     override fun captureException(event: AndroidExceptionIssueEvent) {


### PR DESCRIPTION
## Summary
- suppress Android AI post-run sync Sentry warnings for expected transient network failures
- include retryable cloud HTTP errors and wrapped transient IO causes
- preserve pending post-run sync retry behavior and keep warnings for non-transient failures

## Validation
- git diff --check
- Gradle not run locally per repository policy