### PR TITLE
Fix Android review route AI callback test

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -112,7 +112,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         openPreviewCalls += 1
                     },
                     onOpenCurrentCard = {},
-                    onOpenCurrentCardWithAi = { _, _, _, _, _ -> },
+                    onOpenCurrentCardWithAi = { _, _, _, _ -> },
                     onOpenDeckManagement = {},
                     onOpenLeaderboard = {
                         openLeaderboardCalls += 1


### PR DESCRIPTION
## Summary
- align ReviewRoute androidTest callback lambda with the current four-argument AI handoff contract

## Verification
- git diff --check
- GitHub Actions Android Release will validate androidTest compilation on main