### PR TITLE
Clarify streak leaderboard day definition

### DIFF
--- a/apps/backend/src/community/leaderboard/streak/streakLeaderboard.test.ts
+++ b/apps/backend/src/community/leaderboard/streak/streakLeaderboard.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
+import { supportedAnonymousDisplayNameLocales } from "../../anonymousDisplayNames";
 import type { DatabaseExecutor, SqlValue } from "../../../database";
 import {
   loadStreakLeaderboard,
@@ -218,6 +219,27 @@ test("guest viewers receive linked_account_required with localized metric copy a
   assert.equal(leaderboard.metric.metricVersion, "streak_days_v1");
   assert.notEqual(leaderboard.metric.title, "Current streak days");
   assert.equal("rows" in leaderboard, false);
+});
+
+test("streak metric copy is populated for every supported locale and English defines streak days by any rating", async () => {
+  for (const localeHint of supportedAnonymousDisplayNameLocales) {
+    const leaderboard = await loadStreakLeaderboard({
+      userId: VIEWER_USER_ID,
+      transport: "guest",
+      localeHint,
+    });
+
+    assert.equal(leaderboard.status, "linked_account_required");
+    assert.notEqual(leaderboard.metric.title.trim(), "");
+    assert.notEqual(leaderboard.metric.description.trim(), "");
+
+    if (localeHint === "en") {
+      assert.match(
+        leaderboard.metric.description,
+        /local day with at least one card review rated Again, Hard, Good, or Easy/u,
+      );
+    }
+  }
 });
 
 test("opted-out viewers receive participation_disabled without reading snapshot data", async () => {

--- a/apps/backend/src/community/leaderboard/streak/streakLeaderboard.ts
+++ b/apps/backend/src/community/leaderboard/streak/streakLeaderboard.ts
@@ -123,39 +123,39 @@ const STREAK_LEADERBOARD_METRIC_COPY_BY_LOCALE: Readonly<
 > = {
   en: {
     title: "Current streak days",
-    description: "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak.",
+    description: "A streak day is a local day with at least one card review rated Again, Hard, Good, or Easy. Ranks use current streak days from the public daily snapshot; public values can trail your live personal streak.",
   },
   ar: {
     title: "أيام السلسلة الحالية",
-    description: "يستخدم الترتيب أيام السلسلة الحالية من اللقطة العامة اليومية. قد تتأخر القيم العامة عن سلسلتك الشخصية المباشرة.",
+    description: "يوم السلسلة هو يوم محلي يحتوي على مراجعة بطاقة واحدة على الأقل بتقييم مرة أخرى أو صعب أو جيد أو سهل. يستخدم الترتيب أيام السلسلة الحالية من اللقطة العامة اليومية؛ قد تتأخر القيم العامة عن سلسلتك الشخصية المباشرة.",
   },
   "zh-Hans": {
     title: "当前连续天数",
-    description: "排名使用公共每日快照中的当前连续天数。公共数值可能落后于你的实时个人连续记录。",
+    description: "连续记录日是至少有一次卡片复习被评为重来、困难、良好或简单的本地日。排名使用公共每日快照中的当前连续天数；公共数值可能落后于你的实时个人连续记录。",
   },
   de: {
     title: "Aktuelle Serien-Tage",
-    description: "Ränge verwenden aktuelle Serien-Tage aus dem öffentlichen täglichen Snapshot. Öffentliche Werte können deiner live persönlichen Serie hinterherhinken.",
+    description: "Ein Serien-Tag ist ein lokaler Tag mit mindestens einer Kartenabfrage, die mit Nochmal, Schwer, Gut oder Leicht bewertet wurde. Ränge verwenden aktuelle Serien-Tage aus dem öffentlichen täglichen Snapshot; öffentliche Werte können deiner aktuellen persönlichen Serie hinterherhinken.",
   },
   hi: {
     title: "मौजूदा स्ट्रीक दिन",
-    description: "रैंक सार्वजनिक दैनिक स्नैपशॉट के मौजूदा स्ट्रीक दिनों का उपयोग करती है। सार्वजनिक मान आपकी लाइव निजी स्ट्रीक से पीछे रह सकते हैं।",
+    description: "स्ट्रीक दिन वह स्थानीय दिन है जिसमें कम से कम एक कार्ड समीक्षा को फिर से, कठिन, अच्छा या आसान रेट किया गया हो। रैंक सार्वजनिक दैनिक स्नैपशॉट के मौजूदा स्ट्रीक दिनों का उपयोग करती है; सार्वजनिक मान आपकी लाइव निजी स्ट्रीक से पीछे रह सकते हैं।",
   },
   ja: {
     title: "現在の連続日数",
-    description: "順位は公開の日次スナップショットの現在の連続日数を使います。公開値は個人の最新連続記録より遅れることがあります。",
+    description: "連続日とは、少なくとも1回のカード復習がもう一度、難しい、良い、簡単のいずれかで評価されたローカル日です。順位は公開の日次スナップショットの現在の連続日数を使います。公開値は個人の最新連続記録より遅れることがあります。",
   },
   ru: {
     title: "Текущая серия в днях",
-    description: "Рейтинг использует текущую серию в днях из публичного ежедневного снимка. Публичные значения могут отставать от вашей личной серии в реальном времени.",
+    description: "День серии считается локальным днем, когда хотя бы один повтор карточки был оценен как Снова, Трудно, Хорошо или Легко. Рейтинг использует текущую серию в днях из публичного ежедневного снимка; публичные значения могут отставать от вашей личной серии в реальном времени.",
   },
   "es-MX": {
     title: "Días de racha actual",
-    description: "La clasificación usa los días de racha actual de la captura pública diaria. Los valores públicos pueden ir detrás de tu racha personal en vivo.",
+    description: "Un día de racha es un día local con al menos un repaso de tarjeta calificado como Otra vez, Difícil, Bien o Fácil. La clasificación usa los días de racha actual de la captura pública diaria; los valores públicos pueden ir detrás de tu racha personal en vivo.",
   },
   "es-ES": {
     title: "Días de racha actual",
-    description: "La clasificación usa los días de racha actual de la captura pública diaria. Los valores públicos pueden ir por detrás de tu racha personal en vivo.",
+    description: "Un día de racha es un día local con al menos un repaso de tarjeta valorado como Otra vez, Difícil, Bien o Fácil. La clasificación usa los días de racha actual de la captura pública diaria; los valores públicos pueden ir por detrás de tu racha personal en vivo.",
   },
 };
 

--- a/apps/backend/src/routes/system/systemTestSupport.ts
+++ b/apps/backend/src/routes/system/systemTestSupport.ts
@@ -257,7 +257,7 @@ export function createStreakLeaderboard(): StreakLeaderboard {
     metric: {
       metricVersion: "streak_days_v1",
       title: "Current streak days",
-      description: "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak.",
+      description: "A streak day is a local day with at least one card review rated Again, Hard, Good, or Easy. Ranks use current streak days from the public daily snapshot; public values can trail your live personal streak.",
     },
     snapshotId: "3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4",
     snapshotGeneratedAt: "2026-06-10T12:00:05.000Z",


### PR DESCRIPTION
## Summary
- Clarify backend streak leaderboard metric copy so a streak day is any local day with at least one card review rated Again, Hard, Good, or Easy.
- Update the duplicated system test fixture copy.
- Add focused backend assertions for supported locale copy and the English any-rating rule.

## Validation
- `cd apps/backend && npm run bundle --prefix ../../api`
- `cd apps/backend && node --test --import tsx src/community/leaderboard/streak/streakLeaderboard.test.ts src/routes/system/progress.test.ts` (23 tests)
- `cd apps/backend && npm run lint`