### PR TITLE
Fix web self leaderboard profile title

### DIFF
--- a/apps/web/src/screens/progress/ProgressScreen.leaderboard.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.leaderboard.render.test.tsx
@@ -322,6 +322,48 @@ describe("ProgressScreen leaderboard", () => {
     expect(document.body.querySelector("[data-testid='progress-leaderboard-profile-dialog']")?.textContent).toContain("Mina");
   });
 
+  it("keeps the viewer title and shows the anonymous name for the rating leaderboard profile", async () => {
+    useAppDataMock.mockReturnValue({
+      ...createAppData(),
+      cloudSettings: linkedCloudSettings,
+    });
+    mockProgressSourceStateWithLeaderboard(createLeaderboardSourceState("ready", null));
+    const deferredProfile = createDeferredProfile();
+    apiMocks.loadProgressLeaderboardProfileMock.mockReturnValueOnce(deferredProfile.promise);
+
+    await progressScreen.renderProgressScreen();
+    const container = progressScreen.getContainer();
+    const openButton = container.querySelector("[data-testid='progress-leaderboard-row-viewer-button']");
+    if (!(openButton instanceof HTMLButtonElement)) {
+      throw new Error("Rating leaderboard viewer profile button was not found");
+    }
+
+    await act(async () => {
+      openButton.click();
+    });
+
+    const loadingDialog = document.body.querySelector("[data-testid='progress-leaderboard-profile-dialog']");
+    if (!(loadingDialog instanceof HTMLElement)) {
+      throw new Error("Leaderboard viewer profile dialog was not opened");
+    }
+    expect(apiMocks.loadProgressLeaderboardProfileMock).toHaveBeenCalledWith("viewer-profile");
+    expect(loadingDialog.querySelector("[data-testid='progress-leaderboard-profile-title']")?.textContent).toBe("You");
+    expect(loadingDialog.querySelector(".progress-leaderboard-profile-anonymous-name")?.textContent).toBe("Quiet Maple Grove");
+
+    await act(async () => {
+      deferredProfile.resolve(createLeaderboardReadyProfile("viewer-profile", "Quiet Maple Grove", null));
+      await deferredProfile.promise;
+    });
+
+    const loadedDialog = document.body.querySelector("[data-testid='progress-leaderboard-profile-dialog']");
+    if (!(loadedDialog instanceof HTMLElement)) {
+      throw new Error("Loaded leaderboard viewer profile dialog was not found");
+    }
+    expect(loadedDialog.querySelector("[data-testid='progress-leaderboard-profile-title']")?.textContent).toBe("You");
+    expect(loadedDialog.querySelector(".progress-leaderboard-profile-anonymous-name")?.textContent).toBe("Quiet Maple Grove");
+    expect(loadedDialog.querySelector(".progress-leaderboard-profile-friend-label")).toBeNull();
+  });
+
   it("renders separate rating and streak leaderboard cards with streak day values", async () => {
     useAppDataMock.mockReturnValue({
       ...createAppData(),

--- a/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardPresentation.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardPresentation.tsx
@@ -30,6 +30,7 @@ export type ProgressLeaderboardProfileDialogSeed = Readonly<{
   anonymousDisplayName: string;
   friendDisplayName?: string;
   displayName: string;
+  isViewer: boolean;
 }>;
 
 export function getProgressLeaderboardElapsedMinutes(snapshotGeneratedAt: string, now: Date): number {
@@ -125,6 +126,7 @@ export function ProgressLeaderboardRows(props: Readonly<{
                 anonymousDisplayName: row.anonymousDisplayName,
                 friendDisplayName: row.friendDisplayName,
                 displayName,
+                isViewer: row.kind === "viewer",
               })}
             >
               {rowContent}

--- a/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardProfileDialog.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardProfileDialog.tsx
@@ -69,11 +69,30 @@ function getProfileTitle(
   initialProfile: ProgressLeaderboardProfileDialogSeed,
   profile: ProgressLeaderboardProfile | null,
 ): string {
+  if (initialProfile.isViewer) {
+    return initialProfile.displayName;
+  }
+
   if (profile?.status === "ready") {
     return profile.friendDisplayName ?? profile.anonymousDisplayName;
   }
 
   return initialProfile.displayName;
+}
+
+function getProfileIdentityAnonymousName(
+  initialProfile: ProgressLeaderboardProfileDialogSeed,
+  profile: ProgressLeaderboardProfile | null,
+): string | null {
+  if (initialProfile.isViewer) {
+    return profile?.status === "ready" ? profile.anonymousDisplayName : initialProfile.anonymousDisplayName;
+  }
+
+  if (profile?.status === "ready" && profile.friendDisplayName !== undefined) {
+    return profile.anonymousDisplayName;
+  }
+
+  return null;
 }
 
 function getNonReadyMessage(status: ProgressLeaderboardProfile["status"], t: ReturnType<typeof useI18n>["t"]): string {
@@ -258,6 +277,10 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
     ? loadState.message
     : "";
   const dialogTitle = getProfileTitle(initialProfile, loadedProfile);
+  const identityAnonymousName = getProfileIdentityAnonymousName(initialProfile, loadedProfile);
+  const isFriendIdentity = initialProfile.isViewer === false
+    && loadedProfile?.status === "ready"
+    && loadedProfile.friendDisplayName !== undefined;
 
   return createPortal(
     <div className="progress-leaderboard-profile-backdrop" role="dialog" aria-modal="true" aria-labelledby="progress-leaderboard-profile-title">
@@ -267,16 +290,18 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
             <h2 id="progress-leaderboard-profile-title" className="panel-subtitle" data-testid="progress-leaderboard-profile-title">
               {dialogTitle}
             </h2>
-            {loadedProfile?.status === "ready" && loadedProfile.friendDisplayName !== undefined ? (
+            {identityAnonymousName === null ? null : (
               <div className="progress-leaderboard-profile-identity">
-                <span className="progress-leaderboard-profile-friend-label">
-                  {t("progressScreen.leaderboard.profile.friendLabel")}
-                </span>
+                {isFriendIdentity ? (
+                  <span className="progress-leaderboard-profile-friend-label">
+                    {t("progressScreen.leaderboard.profile.friendLabel")}
+                  </span>
+                ) : null}
                 <span className="progress-leaderboard-profile-anonymous-name">
-                  {loadedProfile.anonymousDisplayName}
+                  {identityAnonymousName}
                 </span>
               </div>
-            ) : null}
+            )}
           </div>
           <button
             className="ghost-btn progress-leaderboard-profile-close"


### PR DESCRIPTION
## Summary
- keep the viewer leaderboard profile dialog title as the localized viewer label after profile load
- show the viewer anonymous display name in the dialog identity area
- add focused render coverage for the viewer rating leaderboard row profile dialog

## Validation
- npx vitest run src/screens/progress/ProgressScreen.leaderboard.render.test.tsx
- npm run build
- read-only review: no P0-P4 issues found