### PR TITLE
Keep iOS AI composer suggestions during bootstrap

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Models/AIChatContentModels.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Models/AIChatContentModels.swift
@@ -739,6 +739,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
     let messages: [AIChatMessage]
     let chatSessionId: String
     let lastKnownChatFeatures: AIChatFeatureFlags?
+    let composerSuggestions: [AIChatComposerSuggestion]
     let pendingToolRunPostSync: Bool
     let requiresRemoteSessionProvisioning: Bool
     let suppressDraftRestore: Bool
@@ -748,6 +749,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         case chatSessionId
         case lastKnownChatFeatures
         case lastKnownChatConfig
+        case composerSuggestions
         case pendingToolRunPostSync
         case requiresRemoteSessionProvisioning
         case suppressDraftRestore
@@ -757,12 +759,14 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         messages: [AIChatMessage],
         chatSessionId: String,
         lastKnownChatFeatures: AIChatFeatureFlags?,
+        composerSuggestions: [AIChatComposerSuggestion],
         pendingToolRunPostSync: Bool
     ) {
         self.init(
             messages: messages,
             chatSessionId: chatSessionId,
             lastKnownChatFeatures: lastKnownChatFeatures,
+            composerSuggestions: composerSuggestions,
             pendingToolRunPostSync: pendingToolRunPostSync,
             requiresRemoteSessionProvisioning: false,
             suppressDraftRestore: false
@@ -773,6 +777,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         messages: [AIChatMessage],
         chatSessionId: String,
         lastKnownChatFeatures: AIChatFeatureFlags?,
+        composerSuggestions: [AIChatComposerSuggestion],
         pendingToolRunPostSync: Bool,
         requiresRemoteSessionProvisioning: Bool,
         suppressDraftRestore: Bool
@@ -780,6 +785,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         self.messages = messages
         self.chatSessionId = chatSessionId
         self.lastKnownChatFeatures = lastKnownChatFeatures
+        self.composerSuggestions = composerSuggestions
         self.pendingToolRunPostSync = pendingToolRunPostSync
         self.requiresRemoteSessionProvisioning = requiresRemoteSessionProvisioning
         self.suppressDraftRestore = suppressDraftRestore
@@ -789,6 +795,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         messages: [AIChatMessage],
         chatSessionId: String,
         lastKnownChatFeatures: AIChatFeatureFlags?,
+        composerSuggestions: [AIChatComposerSuggestion],
         pendingToolRunPostSync: Bool,
         suppressDraftRestore: Bool
     ) {
@@ -796,6 +803,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
             messages: messages,
             chatSessionId: chatSessionId,
             lastKnownChatFeatures: lastKnownChatFeatures,
+            composerSuggestions: composerSuggestions,
             pendingToolRunPostSync: pendingToolRunPostSync,
             requiresRemoteSessionProvisioning: false,
             suppressDraftRestore: suppressDraftRestore
@@ -807,6 +815,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
             messages: messages,
             chatSessionId: "",
             lastKnownChatFeatures: nil,
+            composerSuggestions: [],
             pendingToolRunPostSync: false
         )
     }
@@ -826,6 +835,10 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
                 forKey: .lastKnownChatConfig
             )?.features
         }
+        self.composerSuggestions = try container.decodeIfPresent(
+            [AIChatComposerSuggestion].self,
+            forKey: .composerSuggestions
+        ) ?? []
         self.pendingToolRunPostSync = try container.decodeIfPresent(
             Bool.self,
             forKey: .pendingToolRunPostSync
@@ -845,6 +858,7 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         try container.encode(self.messages, forKey: .messages)
         try container.encode(self.chatSessionId, forKey: .chatSessionId)
         try container.encodeIfPresent(self.lastKnownChatFeatures, forKey: .lastKnownChatFeatures)
+        try container.encode(self.composerSuggestions, forKey: .composerSuggestions)
         try container.encode(self.pendingToolRunPostSync, forKey: .pendingToolRunPostSync)
         try container.encode(
             self.requiresRemoteSessionProvisioning,

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Bootstrap/AIChatStore+AcceptedEnvelopeReconciliation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Bootstrap/AIChatStore+AcceptedEnvelopeReconciliation.swift
@@ -129,6 +129,7 @@ extension AIChatStore {
         let preSendState = preSendSnapshot.persistedState
         self.messages = preSendState.messages
         self.serverChatConfig = aiChatServerConfig(lastKnownFeatures: preSendState.lastKnownChatFeatures)
+        self.applyComposerSuggestions(preSendState.composerSuggestions)
         self.requiresRemoteSessionProvisioning = preSendSnapshot.requiresRemoteSessionProvisioning
         self.runHadToolCalls = preSendState.pendingToolRunPostSync
         self.pendingToolRunPostSync = preSendState.pendingToolRunPostSync

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatHistoryStore.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatHistoryStore.swift
@@ -62,6 +62,7 @@ func storeAIChatHistoryStateSynchronously(
         messages: Array(state.messages.suffix(aiChatMaxMessages)),
         chatSessionId: state.chatSessionId,
         lastKnownChatFeatures: state.lastKnownChatFeatures,
+        composerSuggestions: state.composerSuggestions,
         pendingToolRunPostSync: state.pendingToolRunPostSync,
         requiresRemoteSessionProvisioning: state.requiresRemoteSessionProvisioning,
         suppressDraftRestore: state.suppressDraftRestore
@@ -154,6 +155,7 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
                 messages: [],
                 chatSessionId: "",
                 lastKnownChatFeatures: nil,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         }
@@ -173,6 +175,7 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
                 messages: trimmedMessages,
                 chatSessionId: state.chatSessionId,
                 lastKnownChatFeatures: state.lastKnownChatFeatures,
+                composerSuggestions: state.composerSuggestions,
                 pendingToolRunPostSync: state.pendingToolRunPostSync,
                 requiresRemoteSessionProvisioning: state.requiresRemoteSessionProvisioning,
                 suppressDraftRestore: state.suppressDraftRestore
@@ -190,6 +193,7 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
                 messages: [],
                 chatSessionId: "",
                 lastKnownChatFeatures: nil,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         }

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatStore.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatStore.swift
@@ -509,6 +509,7 @@ final class AIChatStore {
             messages: self.messages,
             chatSessionId: self.chatSessionId,
             lastKnownChatFeatures: self.serverChatConfig.features,
+            composerSuggestions: self.composerSuggestions,
             pendingToolRunPostSync: self.pendingToolRunPostSync,
             requiresRemoteSessionProvisioning: self.requiresRemoteSessionProvisioning,
             suppressDraftRestore: self.suppressDraftRestore
@@ -582,7 +583,7 @@ final class AIChatStore {
         self.composerState = AIChatComposerState(
             inputText: "",
             pendingAttachments: [],
-            serverSuggestions: [],
+            serverSuggestions: persistedState.composerSuggestions,
             dictationState: .idle,
             completedDictationTranscript: nil
         )
@@ -635,7 +636,7 @@ final class AIChatStore {
         self.composerState = AIChatComposerState(
             inputText: initialDraft.inputText,
             pendingAttachments: initialDraft.pendingAttachments,
-            serverSuggestions: [],
+            serverSuggestions: persistedState.composerSuggestions,
             dictationState: .idle,
             completedDictationTranscript: nil
         )

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Live/AIChatStore+LiveEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Live/AIChatStore+LiveEvents.swift
@@ -355,6 +355,7 @@ extension AIChatStore {
 
         case .composerSuggestionsUpdated(metadata: _, suggestions: let suggestions):
             self.applyComposerSuggestions(suggestions)
+            self.schedulePersistCurrentState()
             logAIChatStoreEvent(
                 action: "ai_live_composer_suggestions_applied",
                 metadata: [

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Run/AIChatStore+ToolRunPostSync.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Run/AIChatStore+ToolRunPostSync.swift
@@ -90,6 +90,7 @@ extension AIChatStore {
             messages: persistedState.messages,
             chatSessionId: persistedState.chatSessionId,
             lastKnownChatFeatures: persistedState.lastKnownChatFeatures,
+            composerSuggestions: persistedState.composerSuggestions,
             pendingToolRunPostSync: false,
             requiresRemoteSessionProvisioning: persistedState.requiresRemoteSessionProvisioning,
             suppressDraftRestore: persistedState.suppressDraftRestore

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+ComposerUIState.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+ComposerUIState.swift
@@ -87,25 +87,29 @@ extension AIChatStore {
     }
 
     var visibleComposerSuggestions: [AIChatComposerSuggestion] {
-        guard self.areComposerSuggestionsEnabled else {
-            return []
-        }
-        guard self.isChatInteractive else {
-            return []
-        }
-        guard self.composerPhase == .idle else {
-            return []
-        }
-        guard self.dictationState == .idle else {
-            return []
-        }
-        guard self.pendingAttachments.isEmpty else {
-            return []
-        }
-        guard self.trimmedInputText().isEmpty else {
+        guard self.canShowComposerSuggestions else {
             return []
         }
         return self.composerSuggestions
+    }
+
+    var canShowComposerSuggestions: Bool {
+        guard self.areComposerSuggestionsEnabled else {
+            return false
+        }
+        guard self.bootstrapPhase == .ready || self.bootstrapPhase == .loading else {
+            return false
+        }
+        guard self.composerPhase == .idle else {
+            return false
+        }
+        guard self.dictationState == .idle else {
+            return false
+        }
+        guard self.pendingAttachments.isEmpty else {
+            return false
+        }
+        return self.trimmedInputText().isEmpty
     }
 
     var isStreaming: Bool {
@@ -148,7 +152,7 @@ extension AIChatStore {
         guard self.areComposerSuggestionsEnabled else {
             return
         }
-        guard self.canEditDraft else {
+        guard self.canApplyComposerSuggestion else {
             return
         }
 
@@ -160,6 +164,14 @@ extension AIChatStore {
 
         let separator = self.inputText.hasSuffix(" ") ? "" : " "
         self.inputText += separator + suggestion.text
+    }
+
+    private var canApplyComposerSuggestion: Bool {
+        if self.canEditDraft {
+            return true
+        }
+
+        return self.canShowComposerSuggestions
     }
 
     func removeAttachment(id: String) {

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
@@ -127,6 +127,7 @@ extension AIChatStore {
             messages: [],
             chatSessionId: self.chatSessionId,
             lastKnownChatFeatures: self.serverChatConfig.features,
+            composerSuggestions: [],
             pendingToolRunPostSync: false
         )
         self.conversationScopeId = self.chatSessionId
@@ -320,6 +321,7 @@ extension AIChatStore {
             inputText: restoredDraft.inputText,
             pendingAttachments: restoredDraft.pendingAttachments
         )
+        self.applyComposerSuggestions(persistedState.composerSuggestions)
         self.suppressDraftRestore = false
         if shouldSuppressDraftRestore {
             self.persistStateSynchronously(
@@ -327,6 +329,7 @@ extension AIChatStore {
                     messages: persistedState.messages,
                     chatSessionId: resolvedSessionId,
                     lastKnownChatFeatures: persistedState.lastKnownChatFeatures,
+                    composerSuggestions: persistedState.composerSuggestions,
                     pendingToolRunPostSync: persistedState.pendingToolRunPostSync,
                     requiresRemoteSessionProvisioning: persistedState.requiresRemoteSessionProvisioning,
                     suppressDraftRestore: false

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatUnknownContentTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatUnknownContentTests.swift
@@ -150,6 +150,7 @@ final class AIChatUnknownContentTests: XCTestCase {
             ],
             chatSessionId: "session-1",
             lastKnownChatFeatures: nil,
+            composerSuggestions: [],
             pendingToolRunPostSync: false
         )
 

--- a/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunAcceptedReconciliationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunAcceptedReconciliationTests.swift
@@ -67,6 +67,7 @@ final class AIChatStoreRunAcceptedReconciliationTests: XCTestCase {
                     messages: baselineMessages,
                     chatSessionId: "session-1",
                     lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                    composerSuggestions: [],
                     pendingToolRunPostSync: false
                 ),
                 requiresRemoteSessionProvisioning: false,
@@ -176,6 +177,7 @@ final class AIChatStoreRunAcceptedReconciliationTests: XCTestCase {
                     messages: baselineMessages,
                     chatSessionId: "session-1",
                     lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                    composerSuggestions: [],
                     pendingToolRunPostSync: false
                 ),
                 requiresRemoteSessionProvisioning: false,
@@ -294,6 +296,7 @@ final class AIChatStoreRunAcceptedReconciliationTests: XCTestCase {
                     messages: baselineMessages,
                     chatSessionId: "session-1",
                     lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                    composerSuggestions: [],
                     pendingToolRunPostSync: false
                 ),
                 requiresRemoteSessionProvisioning: false,
@@ -424,6 +427,7 @@ final class AIChatStoreRunAcceptedReconciliationTests: XCTestCase {
                     messages: baselineMessages,
                     chatSessionId: "session-1",
                     lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                    composerSuggestions: [],
                     pendingToolRunPostSync: false
                 ),
                 requiresRemoteSessionProvisioning: false,
@@ -541,6 +545,7 @@ final class AIChatStoreRunAcceptedReconciliationTests: XCTestCase {
                     messages: baselineMessages,
                     chatSessionId: "session-1",
                     lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                    composerSuggestions: [],
                     pendingToolRunPostSync: false
                 ),
                 requiresRemoteSessionProvisioning: false,

--- a/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunRestorationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunRestorationTests.swift
@@ -39,6 +39,7 @@ final class AIChatStoreRunRestorationTests: XCTestCase {
                 ],
                 chatSessionId: "session-restore",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         )
@@ -86,6 +87,7 @@ final class AIChatStoreRunRestorationTests: XCTestCase {
                 ],
                 chatSessionId: "session-restore",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         )
@@ -166,6 +168,7 @@ final class AIChatStoreRunRestorationTests: XCTestCase {
                 ],
                 chatSessionId: "session-restore",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         )
@@ -273,6 +276,7 @@ final class AIChatStoreRunRestorationTests: XCTestCase {
                 ],
                 chatSessionId: "session-restore",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         )

--- a/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunToolCallTrackingBootstrapTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunToolCallTrackingBootstrapTests.swift
@@ -129,6 +129,7 @@ final class AIChatStoreRunToolCallTrackingBootstrapTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-1")],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         )

--- a/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunToolCallTrackingPostSyncTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/Store/Runs/AIChatStoreRunToolCallTrackingPostSyncTests.swift
@@ -15,6 +15,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-1")],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: true
             )
         )
@@ -158,6 +159,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-1")],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: true
             )
         )
@@ -195,6 +197,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-1")],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: true
             )
         )
@@ -606,6 +609,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 ],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: false
             )
         )
@@ -679,6 +683,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-1")],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: true
             )
         )
@@ -730,6 +735,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-1")],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: true
             )
         )
@@ -740,6 +746,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-2")],
                 chatSessionId: "session-2",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: true
             )
         )
@@ -795,6 +802,7 @@ final class AIChatStoreRunToolCallTrackingPostSyncTests: XCTestCase {
                 messages: [AIChatStoreTestSupport.makeAssistantTextMessage(itemId: "item-1")],
                 chatSessionId: "session-1",
                 lastKnownChatFeatures: aiChatDefaultServerConfig.features,
+                composerSuggestions: [],
                 pendingToolRunPostSync: true
             )
         )


### PR DESCRIPTION
## Summary
- Persist iOS AI composer suggestions in the existing chat persisted state.
- Restore cached suggestions during linked bootstrap and replace them from bootstrap/new-session/live server data.
- Allow suggestion chips to remain visible and insert into an empty idle composer while bootstrap is loading.

## Validation
- git --no-pager diff --check
- Scanned iOS AIChatPersistedState initializer blocks for composerSuggestions coverage.
- Generic iOS build attempted but blocked before source compilation by local disk space while extracting Sentry binary artifacts.
- Simulator-backed tests were not run per task instruction.

## Review
- Worker-owned review: no P0-P4 issues found.