### PR TITLE
Show viewer anonymous leaderboard subtitle

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardProfileSheet.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardProfileSheet.kt
@@ -106,7 +106,8 @@ private fun ProgressLeaderboardProfileHeader(
             val selectedProfileLooksFriend = readyState == null &&
                 uiState.selectedProfile.friendDisplayName != null &&
                 uiState.selectedProfile.isViewer.not()
-            val isFriend = readyState?.profile?.isFriend == true || selectedProfileLooksFriend
+            val isFriend = uiState.selectedProfile.isViewer.not() &&
+                (readyState?.profile?.isFriend == true || selectedProfileLooksFriend)
             if (isFriend) {
                 Surface(
                     color = MaterialTheme.colorScheme.secondaryContainer,
@@ -120,6 +121,16 @@ private fun ProgressLeaderboardProfileHeader(
                     )
                 }
             }
+        }
+        leaderboardProfileAnonymousSubtitle(uiState = uiState)?.let { anonymousDisplayName ->
+            Text(
+                text = anonymousDisplayName,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }
@@ -384,6 +395,17 @@ private fun leaderboardProfileDisplayName(
     return readyProfile?.friendDisplayName
         ?: readyProfile?.anonymousDisplayName
         ?: uiState.selectedProfile.displayName
+}
+
+private fun leaderboardProfileAnonymousSubtitle(
+    uiState: ProgressLeaderboardProfileSheetUiState
+): String? {
+    if (uiState.selectedProfile.isViewer.not()) {
+        return null
+    }
+
+    val readyProfile = (uiState as? ProgressLeaderboardProfileSheetUiState.Ready)?.profile
+    return readyProfile?.anonymousDisplayName ?: uiState.selectedProfile.anonymousDisplayName
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- Show the viewer anonymous display name under the localized leaderboard profile sheet title
- Keep the friend badge hidden for viewer profiles

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff --check
- Worker-owned read-only review: no P0-P4 issues found; green light for commit

Gradle was not run because this task did not explicitly approve local Gradle runs.