### PR TITLE
Keep Android AI suggestions visible while loading

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStoreTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStoreTest.kt
@@ -201,6 +201,7 @@ class AiChatHistoryStoreTest {
                     itemId = "item-1"
                 )
             ),
+            composerSuggestions = emptyList(),
             chatSessionId = "session-1",
             lastKnownChatConfig = null,
             pendingToolRunPostSync = true,
@@ -217,6 +218,7 @@ class AiChatHistoryStoreTest {
     fun saveStatePersistsOnlyChatFeatureConfig() = runBlocking {
         val state = AiChatPersistedState(
             messages = emptyList(),
+            composerSuggestions = emptyList(),
             chatSessionId = "session-1",
             lastKnownChatConfig = defaultAiChatServerConfig,
             pendingToolRunPostSync = false,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
@@ -57,6 +57,7 @@ class CloudIdentityResetCoordinatorTest {
             workspaceId = initialLocalWorkspaceId,
             state = AiChatPersistedState(
                 messages = emptyList(),
+                composerSuggestions = emptyList(),
                 chatSessionId = "session-1",
                 lastKnownChatConfig = null,
                 pendingToolRunPostSync = false,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStore.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.flashcardsopensourceapp.data.local.ai.diagnostics.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatAttachment
+import com.flashcardsopensourceapp.data.local.model.ai.AiChatComposerSuggestion
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatContentPart
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatFeatures
@@ -205,6 +206,10 @@ class AiChatHistoryStore(
     private fun encodeState(state: AiChatPersistedState): JSONObject {
         return JSONObject()
             .put("messages", JSONArray(state.messages.map(::encodeMessage)))
+            .put(
+                "composerSuggestions",
+                JSONArray(state.composerSuggestions.map(::encodeComposerSuggestion))
+            )
             .put("chatSessionId", state.chatSessionId)
             .put("lastKnownChatConfig", state.lastKnownChatConfig?.let(::encodeChatConfig))
             .put("pendingToolRunPostSync", state.pendingToolRunPostSync)
@@ -223,11 +228,15 @@ class AiChatHistoryStore(
             }
             ?.takeLast(aiChatMaxMessages)
             ?: emptyList()
+        val composerSuggestions = jsonObject.optJSONArray("composerSuggestions")
+            ?.let(::decodeComposerSuggestions)
+            ?: emptyList()
         val lastKnownChatConfig = jsonObject.optJSONObject("lastKnownChatConfig")
             ?.let(::decodeChatConfig)
 
         return AiChatPersistedState(
             messages = messages,
+            composerSuggestions = composerSuggestions,
             chatSessionId = chatSessionId,
             lastKnownChatConfig = lastKnownChatConfig,
             pendingToolRunPostSync = jsonObject.optBoolean("pendingToolRunPostSync", false),
@@ -256,6 +265,31 @@ class AiChatHistoryStore(
                 dictationEnabled = features.optBoolean("dictationEnabled", true),
                 attachmentsEnabled = features.optBoolean("attachmentsEnabled", true)
             )
+        )
+    }
+
+    private fun encodeComposerSuggestion(suggestion: AiChatComposerSuggestion): JSONObject {
+        return JSONObject()
+            .put("id", suggestion.id)
+            .put("text", suggestion.text)
+            .put("source", suggestion.source)
+            .put("assistantItemId", suggestion.assistantItemId ?: JSONObject.NULL)
+    }
+
+    private fun decodeComposerSuggestions(jsonArray: JSONArray): List<AiChatComposerSuggestion> {
+        return buildList {
+            for (index in 0 until jsonArray.length()) {
+                add(decodeComposerSuggestion(jsonObject = jsonArray.getJSONObject(index)))
+            }
+        }
+    }
+
+    private fun decodeComposerSuggestion(jsonObject: JSONObject): AiChatComposerSuggestion {
+        return AiChatComposerSuggestion(
+            id = jsonObject.getString("id"),
+            text = jsonObject.getString("text"),
+            source = jsonObject.getString("source"),
+            assistantItemId = jsonObject.optString("assistantItemId", "").ifBlank { null }
         )
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ai/AiChatModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ai/AiChatModels.kt
@@ -226,6 +226,7 @@ data class AiChatMessage(
 
 data class AiChatPersistedState(
     val messages: List<AiChatMessage>,
+    val composerSuggestions: List<AiChatComposerSuggestion>,
     val chatSessionId: String,
     val lastKnownChatConfig: AiChatServerConfig?,
     val pendingToolRunPostSync: Boolean,
@@ -339,6 +340,7 @@ data class StoredGuestAiSession(
 fun makeDefaultAiChatPersistedState(): AiChatPersistedState {
     return AiChatPersistedState(
         messages = emptyList(),
+        composerSuggestions = emptyList(),
         chatSessionId = "",
         lastKnownChatConfig = null,
         pendingToolRunPostSync = false,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
@@ -18,6 +18,7 @@ import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiAccessConte
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiChatRuntimeState
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiComposerPhase
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiConversationBootstrapState
+import com.flashcardsopensourceapp.feature.ai.runtime.conversation.canApplyAiComposerSuggestion
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.canEditAiDraft
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.canEditAiDraftText
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.canManageAiDraftAttachments
@@ -167,7 +168,7 @@ internal class AiChatRuntime(
     }
 
     fun applyComposerSuggestion(suggestion: AiChatComposerSuggestion) {
-        if (canEditAiDraft(state = runtimeStateMutable.value).not()) {
+        if (canApplyAiComposerSuggestion(state = runtimeStateMutable.value).not()) {
             return
         }
         runtimeStateMutable.update { state ->

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
@@ -174,7 +174,9 @@ internal class AiChatRuntimeContext(
     ) {
         aiChatRepository.savePersistedState(
             workspaceId = snapshot.workspaceId,
-            state = snapshot.persistedState
+            state = snapshot.persistedState.copy(
+                composerSuggestions = snapshot.serverComposerSuggestions
+            )
         )
         val chatSessionId = snapshot.persistedState.chatSessionId.ifBlank { null }
         if (chatSessionId != null) {

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapper.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapper.kt
@@ -87,9 +87,10 @@ internal fun mapToAiUiState(
     val canEditDraftText = canEditAiDraftText(state = runtimeState)
     val canEditDraft = canEditAiDraft(state = runtimeState)
     val canManageDraftAttachments = canManageAiDraftAttachments(state = runtimeState)
+    val canShowComposerSuggestions: Boolean = isConversationReady || isConversationLoading
     val composerSuggestions = if (
         areComposerSuggestionsEnabled
-        && isConversationReady
+        && canShowComposerSuggestions
         && runtimeState.composerPhase == AiComposerPhase.IDLE
         && hasActiveRun.not()
         && runtimeState.dictationState == AiChatDictationState.IDLE

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/conversation/AiDraftState.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/conversation/AiDraftState.kt
@@ -124,6 +124,31 @@ internal fun canManageAiDraftAttachments(state: AiChatRuntimeState): Boolean {
     return canEditAiDraft(state = state)
 }
 
+internal fun canApplyAiComposerSuggestion(state: AiChatRuntimeState): Boolean {
+    val isConversationReady: Boolean =
+        state.conversationBootstrapState == AiConversationBootstrapState.READY
+    val isWarmConversationLoading: Boolean = (
+        state.conversationBootstrapState == AiConversationBootstrapState.LOADING ||
+            state.conversationBootstrapState == AiConversationBootstrapState.RESETTING
+        ) && state.serverComposerSuggestions.isNotEmpty()
+    if (isConversationReady.not() && isWarmConversationLoading.not()) {
+        return false
+    }
+    if (state.composerPhase != AiComposerPhase.IDLE) {
+        return false
+    }
+    if (state.activeRun != null) {
+        return false
+    }
+    if (state.dictationState != AiChatDictationState.IDLE) {
+        return false
+    }
+    if (state.pendingAttachments.isNotEmpty()) {
+        return false
+    }
+    return state.draftMessage.trim().isEmpty()
+}
+
 internal fun canPrepareAiDraftInComposerPhase(composerPhase: AiComposerPhase): Boolean {
     return composerPhase == AiComposerPhase.IDLE || composerPhase == AiComposerPhase.RUNNING
 }
@@ -172,7 +197,7 @@ internal fun makeAiDraftState(
         draftMessage = "",
         pendingAttachments = emptyList(),
         focusComposerRequestVersion = 0L,
-        serverComposerSuggestions = emptyList(),
+        serverComposerSuggestions = normalizedPersistedState.composerSuggestions,
         composerPhase = AiComposerPhase.IDLE,
         dictationState = AiChatDictationState.IDLE,
         conversationBootstrapState = AiConversationBootstrapState.READY,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapCoordinator.kt
@@ -146,7 +146,7 @@ internal class AiChatBootstrapCoordinator(
                             isLiveAttached = false,
                             draftMessage = "",
                             pendingAttachments = emptyList(),
-                            serverComposerSuggestions = emptyList(),
+                            serverComposerSuggestions = persistedState.composerSuggestions,
                             composerPhase = AiComposerPhase.IDLE,
                             dictationState = com.flashcardsopensourceapp.data.local.model.ai.AiChatDictationState.IDLE,
                             conversationBootstrapState = AiConversationBootstrapState.LOADING,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/session/AiChatSessionCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/session/AiChatSessionCoordinator.kt
@@ -69,7 +69,7 @@ internal class AiChatSessionCoordinator(
                 } else {
                     state.focusComposerRequestVersion
                 },
-                serverComposerSuggestions = emptyList(),
+                serverComposerSuggestions = state.serverComposerSuggestions,
                 composerPhase = AiComposerPhase.IDLE,
                 dictationState = AiChatDictationState.IDLE,
                 conversationBootstrapState = AiConversationBootstrapState.READY,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
@@ -133,7 +133,8 @@ internal fun AiRouteContent(
     }
     val hasLocalConversationContent = uiState.messages.isNotEmpty() ||
         uiState.draftMessage.isNotEmpty() ||
-        uiState.pendingAttachments.isNotEmpty()
+        uiState.pendingAttachments.isNotEmpty() ||
+        uiState.composerSuggestions.isNotEmpty()
     val isColdConversationLoading = uiState.isConversationLoading &&
         hasLocalConversationContent.not()
     val showConversation = uiState.isConversationReady ||

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeConversationResetRaceTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeConversationResetRaceTest.kt
@@ -138,7 +138,7 @@ class AiChatRuntimeConversationResetRaceTest {
     }
 
     @Test
-    fun clearConversationKeepsDraftAttachmentsAndSuggestionsClearedDuringBootstrapReload() = runTest {
+    fun clearConversationKeepsCachedSuggestionsDuringProvisioningAndClearsAfterServerResponse() = runTest {
         val repository = FakeAiChatRepository()
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
             chatSessionId = "session-1"
@@ -222,7 +222,10 @@ class AiChatRuntimeConversationResetRaceTest {
         assertEquals(freshSessionId, runtime.state.value.conversationScopeId)
         assertEquals("", runtime.state.value.draftMessage)
         assertTrue(runtime.state.value.pendingAttachments.isEmpty())
-        assertTrue(runtime.state.value.serverComposerSuggestions.isEmpty())
+        assertEquals(
+            listOf("suggestion-1"),
+            runtime.state.value.serverComposerSuggestions.map { suggestion -> suggestion.id }
+        )
         assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
 
         bootstrapGate.complete(Unit)


### PR DESCRIPTION
## Summary
- persist Android AI composer suggestions in local AI chat history
- keep cached suggestions visible during bootstrap and fresh-session loading gaps
- replace cached suggestions from bootstrap, new-session, and live updates

## Validation
- git --no-pager diff --check
- targeted searches for persisted state constructors and serverComposerSuggestions paths
- Gradle not run per task instruction