### PR TITLE
Fix iOS progress freshness copy

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
@@ -302,11 +302,19 @@ func progressStreakLeaderboardSectionTitle() -> String {
 }
 
 func progressStreakLeaderboardInfoMessage(snapshotGeneratedAt: String?, now: Date) -> String {
-    let baseMessage = String(
+    let localizedFormat = String(
         localized: "progress.screen.streak_leaderboard.info.message",
-        defaultValue: "Current streak days determine your rank.",
+        defaultValue: "Current streak days determine your rank. A streak day is any local day with at least one card review rated %1$@, %2$@, %3$@, or %4$@.",
         table: progressStringsTableName,
         comment: "Progress streak leaderboard info explanation of ranking metric"
+    )
+    let baseMessage = String(
+        format: localizedFormat,
+        locale: Locale.current,
+        ReviewRating.again.title,
+        ReviewRating.hard.title,
+        ReviewRating.good.title,
+        ReviewRating.easy.title
     )
 
     guard let snapshotGeneratedAt,
@@ -469,13 +477,79 @@ func progressLeaderboardUpdatedText(snapshotGeneratedAt: String, now: Date) -> S
         return nil
     }
 
-    let elapsedSeconds = max(0, now.timeIntervalSince(generatedAtDate))
-    let elapsedMinutes = Int64(elapsedSeconds / 60)
+    let elapsedTime = progressLeaderboardElapsedTime(generatedAtDate: generatedAtDate, now: now)
+    let elapsedText: String
+    if elapsedTime.hours == 0 {
+        elapsedText = progressLeaderboardElapsedMinuteText(minutes: elapsedTime.minutes)
+    } else if elapsedTime.minutes == 0 {
+        elapsedText = progressLeaderboardElapsedHourText(hours: elapsedTime.hours)
+    } else {
+        let localizedFormat = String(
+            localized: "progress.screen.leaderboard.updated_at.elapsed.hours_minutes",
+            defaultValue: "%1$@ %2$@",
+            table: progressStringsTableName,
+            comment: "Progress leaderboard freshness elapsed time with hours and remaining minutes"
+        )
+        elapsedText = String(
+            format: localizedFormat,
+            locale: Locale.current,
+            progressLeaderboardElapsedHourText(hours: elapsedTime.hours),
+            progressLeaderboardElapsedMinuteText(minutes: elapsedTime.minutes)
+        )
+    }
+
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at",
-        defaultValue: "Updated %lld min ago",
+        defaultValue: "Updated %@ ago",
         table: progressStringsTableName,
-        comment: "Progress leaderboard freshness text with elapsed whole minutes"
+        comment: "Progress leaderboard freshness text with localized elapsed time"
     )
-    return String(format: localizedFormat, locale: Locale.current, elapsedMinutes)
+    return String(format: localizedFormat, locale: Locale.current, elapsedText)
+}
+
+private func progressLeaderboardElapsedTime(
+    generatedAtDate: Date,
+    now: Date
+) -> (hours: Int64, minutes: Int64) {
+    let elapsedSeconds = max(0, now.timeIntervalSince(generatedAtDate))
+    let elapsedMinutes = Int64(elapsedSeconds / 60)
+    return (hours: elapsedMinutes / 60, minutes: elapsedMinutes % 60)
+}
+
+private func progressLeaderboardElapsedHourText(hours: Int64) -> String {
+    if hours == 1 {
+        return String(
+            localized: "progress.screen.leaderboard.updated_at.hour.one",
+            defaultValue: "1 hour",
+            table: progressStringsTableName,
+            comment: "Progress leaderboard freshness singular elapsed hour"
+        )
+    }
+
+    let localizedFormat = String(
+        localized: "progress.screen.leaderboard.updated_at.hour.other",
+        defaultValue: "%lld hours",
+        table: progressStringsTableName,
+        comment: "Progress leaderboard freshness plural elapsed hours"
+    )
+    return String(format: localizedFormat, locale: Locale.current, hours)
+}
+
+private func progressLeaderboardElapsedMinuteText(minutes: Int64) -> String {
+    if minutes == 1 {
+        return String(
+            localized: "progress.screen.leaderboard.updated_at.minute.one",
+            defaultValue: "1 minute",
+            table: progressStringsTableName,
+            comment: "Progress leaderboard freshness singular elapsed minute"
+        )
+    }
+
+    let localizedFormat = String(
+        localized: "progress.screen.leaderboard.updated_at.minute.other",
+        defaultValue: "%lld minutes",
+        table: progressStringsTableName,
+        comment: "Progress leaderboard freshness plural elapsed minutes"
+    )
+    return String(format: localizedFormat, locale: Locale.current, minutes)
 }

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -6256,60 +6256,355 @@
       }
     },
     "progress.screen.leaderboard.updated_at" : {
-      "comment" : "Progress leaderboard freshness text with elapsed whole minutes",
+      "comment" : "Progress leaderboard freshness text with localized elapsed time",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تم التحديث قبل %lld دقيقة"
+            "value" : "تم التحديث قبل %@"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vor %lld min aktualisiert"
+            "value" : "Vor %@ aktualisiert"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Updated %lld min ago"
+            "value" : "Updated %@ ago"
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Actualizado hace %lld min"
+            "value" : "Actualizado hace %@"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Actualizado hace %lld min"
+            "value" : "Actualizado hace %@"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld मिनट पहले अपडेट किया गया"
+            "value" : "%@ पहले अपडेट किया गया"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld分前に更新"
+            "value" : "%@前に更新"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Обновлено %lld мин назад"
+            "value" : "Обновлено %@ назад"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld分钟前更新"
+            "value" : "%@前更新"
+          }
+        }
+      }
+    },
+    "progress.screen.leaderboard.updated_at.elapsed.hours_minutes" : {
+      "comment" : "Progress leaderboard freshness elapsed time with hours and remaining minutes",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ و%2$@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@%2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@%2$@"
+          }
+        }
+      }
+    },
+    "progress.screen.leaderboard.updated_at.hour.one" : {
+      "comment" : "Progress leaderboard freshness singular elapsed hour",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ساعة واحدة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 Stunde"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 hour"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 hora"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 hora"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 घंटा"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1時間"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 час"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1小时"
+          }
+        }
+      }
+    },
+    "progress.screen.leaderboard.updated_at.hour.other" : {
+      "comment" : "Progress leaderboard freshness plural elapsed hours",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld ساعة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Stunden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld hours"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld horas"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld horas"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld घंटे"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld時間"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld ч"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld小时"
+          }
+        }
+      }
+    },
+    "progress.screen.leaderboard.updated_at.minute.one" : {
+      "comment" : "Progress leaderboard freshness singular elapsed minute",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دقيقة واحدة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 Minute"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 minute"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 minuto"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 minuto"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 मिनट"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1分"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 мин"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1分钟"
+          }
+        }
+      }
+    },
+    "progress.screen.leaderboard.updated_at.minute.other" : {
+      "comment" : "Progress leaderboard freshness plural elapsed minutes",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld دقيقة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Minuten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld minutes"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld minutos"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld minutos"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld मिनट"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld мин"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分钟"
           }
         }
       }
@@ -9152,55 +9447,55 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تحدد أيام سلسلتك الحالية ترتيبك."
+            "value" : "تحدد أيام سلسلتك الحالية ترتيبك. يوم السلسلة هو أي يوم محلي يحتوي على مراجعة بطاقة واحدة على الأقل بتقييم %1$@ أو %2$@ أو %3$@ أو %4$@."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deine aktuellen Serientage bestimmen deinen Rang."
+            "value" : "Deine aktuellen Serientage bestimmen deinen Rang. Ein Serientag ist jeder lokale Tag mit mindestens einer Kartenwiederholung, die mit %1$@, %2$@, %3$@ oder %4$@ bewertet wurde."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Current streak days determine your rank."
+            "value" : "Current streak days determine your rank. A streak day is any local day with at least one card review rated %1$@, %2$@, %3$@, or %4$@."
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tus días de racha actuales determinan tu posición."
+            "value" : "Tus días de racha actuales determinan tu posición. Un día de racha es cualquier día local con al menos una revisión de tarjeta calificada como %1$@, %2$@, %3$@ o %4$@."
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tus días de racha actuales determinan tu posición."
+            "value" : "Tus días de racha actuales determinan tu posición. Un día de racha es cualquier día local con al menos una revisión de tarjeta calificada como %1$@, %2$@, %3$@ o %4$@."
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "आपकी मौजूदा स्ट्रीक के दिन आपकी रैंक तय करते हैं।"
+            "value" : "आपकी मौजूदा स्ट्रीक के दिन आपकी रैंक तय करते हैं। स्ट्रीक दिन कोई भी स्थानीय दिन है जिसमें कम से कम एक कार्ड समीक्षा को %1$@, %2$@, %3$@ या %4$@ रेट किया गया हो।"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "現在の連続記録日数でランクが決まります。"
+            "value" : "現在の連続記録日数でランクが決まります。連続記録の1日は、カードレビューが1回以上%1$@、%2$@、%3$@、または%4$@で評価されたローカル日です。"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ваше место определяется текущим числом дней серии."
+            "value" : "Ваше место определяется текущим числом дней серии. Днем серии считается любой локальный день, когда хотя бы одно повторение карточки оценено как %1$@, %2$@, %3$@ или %4$@."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当前连续记录天数决定你的排名。"
+            "value" : "当前连续记录天数决定你的排名。连续记录日是指本地日期内至少有一次卡片复习被评为%1$@、%2$@、%3$@或%4$@。"
           }
         }
       }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
@@ -176,6 +176,72 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
         )
     }
 
+    private func expectedLeaderboardUpdatedText(elapsedText: String) -> String {
+        let localizedFormat = String(
+            localized: "progress.screen.leaderboard.updated_at",
+            defaultValue: "Updated %@ ago",
+            table: progressStringsTableName,
+            comment: "Progress leaderboard freshness text with localized elapsed time"
+        )
+        return String(format: localizedFormat, locale: Locale.current, elapsedText)
+    }
+
+    private func expectedLeaderboardElapsedHourText(hours: Int64) -> String {
+        if hours == 1 {
+            return String(
+                localized: "progress.screen.leaderboard.updated_at.hour.one",
+                defaultValue: "1 hour",
+                table: progressStringsTableName,
+                comment: "Progress leaderboard freshness singular elapsed hour"
+            )
+        }
+
+        let localizedFormat = String(
+            localized: "progress.screen.leaderboard.updated_at.hour.other",
+            defaultValue: "%lld hours",
+            table: progressStringsTableName,
+            comment: "Progress leaderboard freshness plural elapsed hours"
+        )
+        return String(format: localizedFormat, locale: Locale.current, hours)
+    }
+
+    private func expectedLeaderboardElapsedMinuteText(minutes: Int64) -> String {
+        if minutes == 1 {
+            return String(
+                localized: "progress.screen.leaderboard.updated_at.minute.one",
+                defaultValue: "1 minute",
+                table: progressStringsTableName,
+                comment: "Progress leaderboard freshness singular elapsed minute"
+            )
+        }
+
+        let localizedFormat = String(
+            localized: "progress.screen.leaderboard.updated_at.minute.other",
+            defaultValue: "%lld minutes",
+            table: progressStringsTableName,
+            comment: "Progress leaderboard freshness plural elapsed minutes"
+        )
+        return String(format: localizedFormat, locale: Locale.current, minutes)
+    }
+
+    private func expectedLeaderboardElapsedHoursMinutesText(
+        hours: Int64,
+        minutes: Int64
+    ) -> String {
+        let localizedFormat = String(
+            localized: "progress.screen.leaderboard.updated_at.elapsed.hours_minutes",
+            defaultValue: "%1$@ %2$@",
+            table: progressStringsTableName,
+            comment: "Progress leaderboard freshness elapsed time with hours and remaining minutes"
+        )
+        return String(
+            format: localizedFormat,
+            locale: Locale.current,
+            self.expectedLeaderboardElapsedHourText(hours: hours),
+            self.expectedLeaderboardElapsedMinuteText(minutes: minutes)
+        )
+    }
+
     func testStreakLeaderboardProjectionUsesPersonalStreakAndViewerWinsTies() throws {
         let leaderboard = makeReadyProgressStreakLeaderboardForTests(
             participantCount: 4,
@@ -714,6 +780,38 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
         }
     }
 
+    func testLeaderboardUpdatedTextFormatsElapsedFreshness() throws {
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
+
+        XCTAssertEqual(
+            self.expectedLeaderboardUpdatedText(
+                elapsedText: self.expectedLeaderboardElapsedMinuteText(minutes: 59)
+            ),
+            progressLeaderboardUpdatedText(snapshotGeneratedAt: "2026-06-10T14:00:30.000Z", now: now)
+        )
+        XCTAssertEqual(
+            self.expectedLeaderboardUpdatedText(
+                elapsedText: self.expectedLeaderboardElapsedHourText(hours: 1)
+            ),
+            progressLeaderboardUpdatedText(snapshotGeneratedAt: "2026-06-10T14:00:00.000Z", now: now)
+        )
+        XCTAssertEqual(
+            self.expectedLeaderboardUpdatedText(
+                elapsedText: self.expectedLeaderboardElapsedHoursMinutesText(hours: 1, minutes: 5)
+            ),
+            progressLeaderboardUpdatedText(snapshotGeneratedAt: "2026-06-10T13:55:00.000Z", now: now)
+        )
+        XCTAssertEqual(
+            self.expectedLeaderboardUpdatedText(
+                elapsedText: self.expectedLeaderboardElapsedMinuteText(minutes: 0)
+            ),
+            progressLeaderboardUpdatedText(snapshotGeneratedAt: "2026-06-10T15:01:00.000Z", now: now)
+        )
+        XCTAssertNil(
+            progressLeaderboardUpdatedText(snapshotGeneratedAt: "not-a-timestamp", now: now)
+        )
+    }
+
     // The info copy must mention the same localized rating names the review
     // buttons use, in whichever language the test bundle runs.
     func testInfoCopyIncludesAgainExclusion() {
@@ -726,6 +824,18 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
         XCTAssertTrue(infoMessage.contains(ReviewRating.good.title))
         XCTAssertTrue(infoMessage.contains(ReviewRating.easy.title))
         XCTAssertTrue(infoMessage.contains(ReviewRating.again.title))
+    }
+
+    func testStreakInfoCopyIncludesAllReviewedRatingNames() {
+        let infoMessage = progressStreakLeaderboardInfoMessage(
+            snapshotGeneratedAt: nil,
+            now: Date()
+        )
+
+        XCTAssertTrue(infoMessage.contains(ReviewRating.again.title))
+        XCTAssertTrue(infoMessage.contains(ReviewRating.hard.title))
+        XCTAssertTrue(infoMessage.contains(ReviewRating.good.title))
+        XCTAssertTrue(infoMessage.contains(ReviewRating.easy.title))
     }
 
     func testLiveOverlayReranksOnlyViewerFromRankingRows() throws {


### PR DESCRIPTION
## Summary
- format iOS progress leaderboard freshness as localized minutes, hours, or hours plus minutes
- clarify streak leaderboard copy using localized review rating names
- add focused progress formatting assertions

## Validation
- Worktree freshness check passed.
- `plutil -lint apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings` failed with `Unexpected character { at line 1`; the same failure happens on an untouched `.xcstrings` file on this host, so this appears to be a host/tool limitation rather than this edit.
- `python3 -m json.tool apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings` passed.
- `xcrun xcstringstool compile --dry-run apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings` passed.
- `git --no-pager diff --check` passed.
- Simulator-backed `xcodebuild test` was not run because repository instructions require explicit current-task permission and it was not approved.
- Worker-owned review found no P0-P4 issues and gave green light for commit.
