### PR TITLE
Fix Android leaderboard freshness copy

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressLeaderboardModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressLeaderboardModels.kt
@@ -481,7 +481,7 @@ private fun createDefaultProgressStreakLeaderboardMetric(): CloudProgressStreakL
     return CloudProgressStreakLeaderboardMetric(
         metricVersion = "streak_days_v1",
         title = "Current streak days",
-        description = "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+        description = "Ranks use current streak days from the public daily snapshot. A streak day is any local day with at least one card review rated Again, Hard, Good, or Easy. Public values can trail your live personal streak."
     )
 }
 

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -466,7 +466,7 @@ class CloudRemoteServiceTest {
               "metric": {
                 "metricVersion": "streak_days_v1",
                 "title": "Current streak days",
-                "description": "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+                "description": "Ranks use current streak days from the public daily snapshot. A streak day is any local day with at least one card review rated Again, Hard, Good, or Easy. Public values can trail your live personal streak."
               },
               "snapshotId": "3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4",
               "snapshotGeneratedAt": "2026-06-10T12:00:05.000Z",
@@ -543,7 +543,7 @@ class CloudRemoteServiceTest {
               "metric": {
                 "metricVersion": "streak_days_v1",
                 "title": "Current streak days",
-                "description": "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+                "description": "Ranks use current streak days from the public daily snapshot. A streak day is any local day with at least one card review rated Again, Hard, Good, or Easy. Public values can trail your live personal streak."
               },
               "snapshotId": "3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4",
               "snapshotGeneratedAt": "2026-06-10T12:00:05.000Z",

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
@@ -248,7 +248,7 @@ internal fun createProgressStreakLeaderboardForTest(
         metric = CloudProgressStreakLeaderboardMetric(
             metricVersion = "streak_days_v1",
             title = "Current streak days",
-            description = "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+            description = "Ranks use current streak days from the public daily snapshot. A streak day is any local day with at least one card review rated Again, Hard, Good, or Easy. Public values can trail your live personal streak."
         ),
         snapshotId = "snapshot-1",
         snapshotGeneratedAt = "2026-06-10T12:00:05.000Z",

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
@@ -59,6 +59,7 @@ import java.util.Locale
 
 private const val leaderboardReservedGapRowCount: Int = 2
 private const val millisecondsPerMinute: Long = 60_000L
+private const val minutesPerHour: Int = 60
 
 @Composable
 internal fun LeaderboardSectionCard(
@@ -213,12 +214,11 @@ internal fun LeaderboardSectionCard(
         val infoBody = readyState?.metricDescription ?: fallbackInfoBody
         val selectedSnapshotGeneratedAtMillis = readyState?.selectedWindow?.snapshotGeneratedAtMillis
         val updatedText = selectedSnapshotGeneratedAtMillis?.let { snapshotGeneratedAtMillis ->
-                    stringResource(
-                        id = R.string.progress_leaderboard_updated_label,
-                        progressLeaderboardElapsedMinutes(
-                            snapshotGeneratedAtMillis = snapshotGeneratedAtMillis,
-                            nowMillis = System.currentTimeMillis()
-                        )
+            progressLeaderboardUpdatedLabel(
+                elapsedTime = progressLeaderboardElapsedTime(
+                    snapshotGeneratedAtMillis = snapshotGeneratedAtMillis,
+                    nowMillis = System.currentTimeMillis()
+                )
             )
         }
         AlertDialog(
@@ -383,8 +383,61 @@ private fun LeaderboardReadyContent(
     }
 }
 
-internal fun progressLeaderboardElapsedMinutes(snapshotGeneratedAtMillis: Long, nowMillis: Long): Long {
-    return maxOf(0L, nowMillis - snapshotGeneratedAtMillis) / millisecondsPerMinute
+internal data class ProgressLeaderboardElapsedTime(
+    val hours: Int,
+    val remainingMinutes: Int
+)
+
+internal fun progressLeaderboardElapsedTime(
+    snapshotGeneratedAtMillis: Long,
+    nowMillis: Long
+): ProgressLeaderboardElapsedTime {
+    val elapsedWholeMinutes: Long =
+        maxOf(0L, nowMillis - snapshotGeneratedAtMillis) / millisecondsPerMinute
+    require(elapsedWholeMinutes <= Int.MAX_VALUE) {
+        "Leaderboard snapshot elapsed freshness is too large to format: " +
+            "snapshotGeneratedAtMillis=$snapshotGeneratedAtMillis, nowMillis=$nowMillis, " +
+            "elapsedWholeMinutes=$elapsedWholeMinutes"
+    }
+    val elapsedWholeMinutesInt: Int = elapsedWholeMinutes.toInt()
+
+    return ProgressLeaderboardElapsedTime(
+        hours = elapsedWholeMinutesInt / minutesPerHour,
+        remainingMinutes = elapsedWholeMinutesInt % minutesPerHour
+    )
+}
+
+@Composable
+internal fun progressLeaderboardUpdatedLabel(
+    elapsedTime: ProgressLeaderboardElapsedTime
+): String {
+    if (elapsedTime.hours == 0) {
+        return pluralStringResource(
+            id = R.plurals.progress_leaderboard_updated_minute_label,
+            count = elapsedTime.remainingMinutes,
+            elapsedTime.remainingMinutes
+        )
+    }
+
+    if (elapsedTime.remainingMinutes == 0) {
+        return pluralStringResource(
+            id = R.plurals.progress_leaderboard_updated_hour_label,
+            count = elapsedTime.hours,
+            elapsedTime.hours
+        )
+    }
+
+    val remainingMinutesLabel: String = pluralStringResource(
+        id = R.plurals.progress_leaderboard_elapsed_minute_count,
+        count = elapsedTime.remainingMinutes,
+        elapsedTime.remainingMinutes
+    )
+    return pluralStringResource(
+        id = R.plurals.progress_leaderboard_updated_hour_minute_label,
+        count = elapsedTime.hours,
+        elapsedTime.hours,
+        remainingMinutesLabel
+    )
 }
 
 private data class LeaderboardReservedRows(

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakLeaderboardSection.kt
@@ -169,9 +169,8 @@ internal fun StreakLeaderboardSectionCard(
         val fallbackInfoBody = stringResource(id = R.string.progress_streak_leaderboard_info_fallback_body)
         val infoBody = readyState?.metricDescription ?: fallbackInfoBody
         val updatedText = readyState?.snapshotGeneratedAtMillis?.let { snapshotGeneratedAtMillis ->
-            stringResource(
-                id = R.string.progress_leaderboard_updated_label,
-                progressLeaderboardElapsedMinutes(
+            progressLeaderboardUpdatedLabel(
+                elapsedTime = progressLeaderboardElapsedTime(
                     snapshotGeneratedAtMillis = snapshotGeneratedAtMillis,
                     nowMillis = System.currentTimeMillis()
                 )

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -57,7 +57,6 @@
     <string name="progress_leaderboard_rank_label">#%1$s</string>
     <string name="progress_leaderboard_gap_content_description">Hidden ranks</string>
     <string name="progress_leaderboard_empty_window">No qualified reviews in this period yet.</string>
-    <string name="progress_leaderboard_updated_label">Updated %1$d min ago</string>
     <string name="progress_leaderboard_sign_in_message">Sign up or sign in to see how your reviews rank on the rating leaderboard.</string>
     <string name="progress_leaderboard_sign_in_button">Sign in</string>
     <string name="progress_leaderboard_participation_disabled_message">Rating rankings are visible only while you participate in the rating leaderboard. Turn participation on in leaderboard settings.</string>
@@ -80,7 +79,7 @@
     <string name="progress_streak_leaderboard_title">Streak leaderboard</string>
     <string name="progress_streak_leaderboard_info_button_content_description">About the streak leaderboard</string>
     <string name="progress_streak_leaderboard_info_title">How streak ranking works</string>
-    <string name="progress_streak_leaderboard_info_fallback_body">Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak.</string>
+    <string name="progress_streak_leaderboard_info_fallback_body">Ranks use current streak days from the public daily snapshot. A streak day is any local day with at least one card review rated Again, Hard, Good, or Easy. Public values can trail your live personal streak.</string>
     <string name="progress_streak_leaderboard_empty">No streak leaderboard rows yet.</string>
     <string name="progress_streak_leaderboard_sign_in_message">Sign up or sign in to compare streaks with the community.</string>
     <string name="progress_streak_leaderboard_participation_disabled_message">Streak rankings are visible only while you participate in the streak leaderboard. Turn participation on in leaderboard settings.</string>
@@ -106,6 +105,22 @@
     <plurals name="progress_streak_leaderboard_day_count">
         <item quantity="one">%1$s day</item>
         <item quantity="other">%1$s days</item>
+    </plurals>
+    <plurals name="progress_leaderboard_updated_minute_label">
+        <item quantity="one">Updated %1$d minute ago</item>
+        <item quantity="other">Updated %1$d minutes ago</item>
+    </plurals>
+    <plurals name="progress_leaderboard_updated_hour_label">
+        <item quantity="one">Updated %1$d hour ago</item>
+        <item quantity="other">Updated %1$d hours ago</item>
+    </plurals>
+    <plurals name="progress_leaderboard_elapsed_minute_count">
+        <item quantity="one">%1$d minute</item>
+        <item quantity="other">%1$d minutes</item>
+    </plurals>
+    <plurals name="progress_leaderboard_updated_hour_minute_label">
+        <item quantity="one">Updated %1$d hour %2$s ago</item>
+        <item quantity="other">Updated %1$d hours %2$s ago</item>
     </plurals>
     <plurals name="progress_leaderboard_profile_activity_total">
         <item quantity="one">%1$s review total</item>

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelStreakLeaderboardTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelStreakLeaderboardTest.kt
@@ -63,6 +63,7 @@ class ProgressViewModelStreakLeaderboardTest {
         ) as ProgressStreakLeaderboardSectionUiState.Ready
 
         assertEquals(1, sectionUiState.participantCount)
+        assertTrue(checkNotNull(sectionUiState.metricDescription).contains("Again, Hard, Good, or Easy"))
         val viewerRow = sectionUiState.rows.single() as ProgressStreakLeaderboardRowUiState.Participant
         assertEquals(1, viewerRow.rank)
         assertEquals(12, viewerRow.streakDays)

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
@@ -587,7 +587,7 @@ internal fun createCloudProgressStreakLeaderboard(): CloudProgressStreakLeaderbo
         metric = CloudProgressStreakLeaderboardMetric(
             metricVersion = "streak_days_v1",
             title = "Current streak days",
-            description = "Ranks use current streak days from the public daily snapshot."
+            description = "Ranks use current streak days from the public daily snapshot. A streak day is any local day with at least one card review rated Again, Hard, Good, or Easy. Public values can trail your live personal streak."
         ),
         snapshotId = "streak-snapshot-1",
         snapshotGeneratedAt = "2026-04-18T14:00:05.000Z",
@@ -624,7 +624,7 @@ internal fun createCloudProgressStreakLeaderboardNonReady(
         metric = CloudProgressStreakLeaderboardMetric(
             metricVersion = "streak_days_v1",
             title = "Current streak days",
-            description = "Ranks use current streak days from the public daily snapshot."
+            description = "Ranks use current streak days from the public daily snapshot. A streak day is any local day with at least one card review rated Again, Hard, Good, or Easy. Public values can trail your live personal streak."
         )
     )
 }


### PR DESCRIPTION
## Summary
- format Android leaderboard snapshot freshness as minutes below one hour and hours plus optional minutes after one hour
- reuse the freshness formatter for rating and streak leaderboard info dialogs
- clarify Android streak leaderboard fallback and synthetic viewer-only metric copy

## Validation
- Worktree freshness check passed before implementation
- git --no-pager diff --check
- xmllint --noout apps/android/feature/progress/src/main/res/values/strings.xml
- exact stale-copy rg search found no matches
- worker-owned review found no P0-P4 issues

Gradle was not run because repository instructions require explicit current-task approval and it was not approved.