### PR TITLE
Fix iOS leaderboard profile display name getter

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardProfileSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardProfileSheet.swift
@@ -293,7 +293,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
             return progressLeaderboardViewerRowTitle()
         }
 
-        progressLeaderboardProfileDisplayName(
+        return progressLeaderboardProfileDisplayName(
             anonymousDisplayName: self.profile.anonymousDisplayName,
             friendDisplayName: self.profile.friendDisplayName
         )


### PR DESCRIPTION
## Summary
- return the formatted leaderboard profile display name from the Swift getter

## Validation
- Attempted `xcodebuild` build-only checks locally, but Xcode could not find an eligible iOS destination for this scheme before compilation.