### PR TITLE
03-auth-oauth-core: OAuth Authorization Server core (metadata + DCR + token)

### DIFF
--- a/apps/auth/src/app.ts
+++ b/apps/auth/src/app.ts
@@ -18,6 +18,9 @@ import refreshToken from "./routes/browser/refreshToken.js";
 import revokeToken from "./routes/browser/revokeToken.js";
 import logoutPage from "./routes/browser/logoutPage.js";
 import logoutLocalPage from "./routes/browser/logoutLocalPage.js";
+import oauthMetadata from "./routes/oauth/metadata.js";
+import oauthRegister from "./routes/oauth/register.js";
+import oauthToken from "./routes/oauth/token.js";
 import robots from "./routes/robots.js";
 import { type AuthAppEnv, getRequestId, jsonAuthError } from "./server/apiErrors.js";
 import { getDemoEmailAccessConfig } from "./server/demoEmailAccess.js";
@@ -232,6 +235,9 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
   app.route("/", revokeToken);
   app.route("/", logoutPage);
   app.route("/", logoutLocalPage);
+  app.route("/", oauthMetadata);
+  app.route("/", oauthRegister);
+  app.route("/", oauthToken);
 
   return app;
 }

--- a/apps/auth/src/app.ts
+++ b/apps/auth/src/app.ts
@@ -110,6 +110,20 @@ function getApiRouteKind(path: string): ApiRouteKind {
   return "non-api";
 }
 
+// Public OAuth Authorization Server endpoints (RFC 8414 metadata, RFC 7591 DCR,
+// token). These are unauthenticated and credential-free, so browser-hosted MCP
+// clients reach them with a wildcard-origin CORS policy (NO credentials),
+// distinct from the cookie-bearing /api/* policy above.
+const oauthPublicPaths: ReadonlyArray<string> = [
+  "/.well-known/oauth-authorization-server",
+  "/register",
+  "/token",
+];
+
+function isOAuthPublicPath(path: string): boolean {
+  return oauthPublicPaths.includes(stripApiStagePrefix(path));
+}
+
 function createMountedApp(basePath: string): Hono<AuthAppEnv> {
   getDemoEmailAccessConfig();
   const app = new Hono<AuthAppEnv>().basePath(basePath);
@@ -121,6 +135,22 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
     c.header("X-Request-Id", requestId);
     await next();
     c.header("X-Robots-Tag", "noindex, nofollow, noarchive");
+  });
+
+  // Public, credential-free CORS for the OAuth Authorization Server endpoints so
+  // browser-hosted MCP clients can run discovery -> DCR -> token exchange.
+  app.use("*", async (c, next) => {
+    if (!isOAuthPublicPath(c.req.path)) {
+      return next();
+    }
+
+    c.header("Access-Control-Allow-Origin", "*");
+    c.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    c.header("Access-Control-Allow-Headers", "content-type");
+    if (c.req.method === "OPTIONS") {
+      return c.body(null, 204);
+    }
+    await next();
   });
 
   // Deny cross-origin requests to API endpoints (defense-in-depth).

--- a/apps/auth/src/routes/oauth/metadata.ts
+++ b/apps/auth/src/routes/oauth/metadata.ts
@@ -1,0 +1,36 @@
+/**
+ * RFC 8414 OAuth 2.0 Authorization Server Metadata. MCP clients discover the
+ * authorization, token, and registration endpoints from this document after
+ * following the protected-resource metadata served on the mcp.<domain> host.
+ *
+ * The issuer is the public auth origin (https://auth.<domain>) with no stage
+ * prefix; the endpoints are derived from it so the discovery document is
+ * correct on both the custom domain and the raw execute-api stage URL.
+ */
+import { Hono } from "hono";
+import type { AuthAppEnv } from "../../server/apiErrors.js";
+import { getPublicAuthBaseUrl } from "../../server/publicUrls.js";
+
+function buildAuthorizationServerMetadata(issuer: string): Record<string, unknown> {
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/authorize`,
+    token_endpoint: `${issuer}/token`,
+    registration_endpoint: `${issuer}/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: ["flashcards"],
+    authorization_response_iss_parameter_supported: true,
+  };
+}
+
+const app = new Hono<AuthAppEnv>();
+
+app.get("/.well-known/oauth-authorization-server", (c) => {
+  const issuer = getPublicAuthBaseUrl(c.req.url);
+  return c.json(buildAuthorizationServerMetadata(issuer));
+});
+
+export default app;

--- a/apps/auth/src/routes/oauth/metadata.ts
+++ b/apps/auth/src/routes/oauth/metadata.ts
@@ -4,8 +4,11 @@
  * following the protected-resource metadata served on the mcp.<domain> host.
  *
  * The issuer is the public auth origin (https://auth.<domain>) with no stage
- * prefix; the endpoints are derived from it so the discovery document is
- * correct on both the custom domain and the raw execute-api stage URL.
+ * prefix; the endpoints are derived from it. Correctness depends on
+ * PUBLIC_AUTH_BASE_URL being set to the custom domain (as auth-gateway.ts does
+ * in production). Without it, getPublicAuthBaseUrl falls back to the request
+ * origin, which on the raw execute-api stage URL omits the /v1 stage prefix and
+ * yields wrong endpoints; the custom-domain path is the supported config.
  */
 import { Hono } from "hono";
 import type { AuthAppEnv } from "../../server/apiErrors.js";

--- a/apps/auth/src/routes/oauth/register.ts
+++ b/apps/auth/src/routes/oauth/register.ts
@@ -1,0 +1,120 @@
+/**
+ * RFC 7591 Dynamic Client Registration. MCP clients self-register a redirect
+ * URI set and receive a public client_id. All clients are public + PKCE:
+ * token_endpoint_auth_method is always `none`, so no client secret is issued.
+ */
+import { Hono } from "hono";
+import type { AuthAppEnv } from "../../server/apiErrors.js";
+import { saveClient } from "../../server/oauth/oauthStore.js";
+
+const MAX_REDIRECT_URIS = 10;
+const MAX_CLIENT_NAME_LENGTH = 255;
+
+type RegisterRequestBody = Readonly<{
+  redirect_uris?: unknown;
+  client_name?: unknown;
+}>;
+
+/**
+ * Validates a single redirect URI: absolute, https, or a loopback http URL for
+ * native clients (RFC 8252). No fragment is allowed (RFC 6749 §3.1.2).
+ */
+function isAllowedRedirectUri(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (url.hash !== "") {
+    return false;
+  }
+
+  if (url.protocol === "https:") {
+    return true;
+  }
+
+  if (url.protocol === "http:") {
+    return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  }
+
+  // Allow custom/private-use URI schemes (e.g. com.example.app:/callback) used
+  // by native clients per RFC 8252 §7.1.
+  return url.protocol.endsWith(":") && url.protocol !== "javascript:" && url.protocol !== "data:";
+}
+
+function parseRedirectUris(value: unknown): ReadonlyArray<string> | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_REDIRECT_URIS) {
+    return null;
+  }
+
+  const uris: Array<string> = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || !isAllowedRedirectUri(entry)) {
+      return null;
+    }
+    uris.push(entry);
+  }
+
+  return uris;
+}
+
+function parseClientName(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === "" || trimmed.length > MAX_CLIENT_NAME_LENGTH) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+const app = new Hono<AuthAppEnv>();
+
+app.post("/register", async (c) => {
+  let body: RegisterRequestBody;
+  try {
+    body = await c.req.json<RegisterRequestBody>();
+  } catch {
+    return c.json(
+      {
+        error: "invalid_client_metadata",
+        error_description: "Request body must be valid JSON.",
+      },
+      400,
+    );
+  }
+
+  const redirectUris = parseRedirectUris(body.redirect_uris);
+  if (redirectUris === null) {
+    return c.json(
+      {
+        error: "invalid_redirect_uri",
+        error_description:
+          "redirect_uris must be a non-empty array of absolute https (or loopback http / private-use scheme) URIs without a fragment.",
+      },
+      400,
+    );
+  }
+
+  const clientName = parseClientName(body.client_name);
+  const client = await saveClient(redirectUris, clientName);
+
+  return c.json(
+    {
+      client_id: client.clientId,
+      redirect_uris: client.redirectUris,
+      token_endpoint_auth_method: client.tokenEndpointAuthMethod,
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      ...(client.clientName !== null ? { client_name: client.clientName } : {}),
+    },
+    201,
+  );
+});
+
+export default app;

--- a/apps/auth/src/routes/oauth/register.ts
+++ b/apps/auth/src/routes/oauth/register.ts
@@ -40,8 +40,10 @@ function isAllowedRedirectUri(value: string): boolean {
   }
 
   // Allow custom/private-use URI schemes (e.g. com.example.app:/callback) used
-  // by native clients per RFC 8252 §7.1.
-  return url.protocol.endsWith(":") && url.protocol !== "javascript:" && url.protocol !== "data:";
+  // by native clients per RFC 8252 §7.1. Require a reverse-DNS style scheme
+  // (must contain a dot) so file:, ftp:, vbscript:, javascript:, data:, and
+  // bare single-label schemes are rejected.
+  return /^[a-z][a-z0-9+.-]*:$/i.test(url.protocol) && url.protocol.includes(".");
 }
 
 function parseRedirectUris(value: unknown): ReadonlyArray<string> | null {

--- a/apps/auth/src/routes/oauth/token.ts
+++ b/apps/auth/src/routes/oauth/token.ts
@@ -1,0 +1,177 @@
+/**
+ * OAuth 2.1 token endpoint for the MCP authorization server. Supports the
+ * authorization_code grant (public client + PKCE S256) and the refresh_token
+ * grant. Tokens are opaque secrets minted here and bound to an
+ * auth.oauth_connections row; only their hashes are persisted.
+ *
+ * Library-spike note: this endpoint is hand-written rather than delegated to
+ * @node-oauth/oauth2-server. That library owns token generation, expiry, and
+ * scope semantics through a full Model implementation plus a Request/Response
+ * adapter to bridge Hono, which is more glue than the few grant-specific
+ * checks below (S256 verify, single-use code, opaque mint). The token logic
+ * here reuses the existing opaque-token + SHA-256 hashing + Crockford patterns
+ * (server/oauth/oauthStore.ts, server/otp/crockford.ts), so no OAuth runtime
+ * dependency is added.
+ */
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { Context } from "hono";
+import type { AuthAppEnv } from "../../server/apiErrors.js";
+import {
+  consumeAuthorizationCodeAndIssueTokens,
+  getActiveAuthorizationCode,
+  getClient,
+  rotateRefreshToken,
+  type IssuedTokens,
+} from "../../server/oauth/oauthStore.js";
+import { verifyPkceS256 } from "../../server/oauth/pkce.js";
+
+type OAuthErrorCode =
+  | "invalid_request"
+  | "invalid_grant"
+  | "invalid_client"
+  | "unsupported_grant_type";
+
+function tokenError(
+  c: Context<AuthAppEnv>,
+  statusCode: ContentfulStatusCode,
+  error: OAuthErrorCode,
+  description: string,
+): Response {
+  // RFC 6749 §5.2: token error responses are JSON and must not be cached.
+  c.header("Cache-Control", "no-store");
+  c.header("Pragma", "no-cache");
+  return c.json({ error, error_description: description }, statusCode);
+}
+
+function tokenSuccess(c: Context<AuthAppEnv>, tokens: IssuedTokens): Response {
+  c.header("Cache-Control", "no-store");
+  c.header("Pragma", "no-cache");
+  return c.json({
+    access_token: tokens.accessToken,
+    token_type: "Bearer",
+    expires_in: tokens.expiresInSeconds,
+    refresh_token: tokens.refreshToken,
+    ...(tokens.scope !== null ? { scope: tokens.scope } : {}),
+  });
+}
+
+function getField(form: Record<string, string | File>, name: string): string {
+  const value = form[name];
+  return typeof value === "string" ? value : "";
+}
+
+async function handleAuthorizationCodeGrant(
+  c: Context<AuthAppEnv>,
+  form: Record<string, string | File>,
+  nowMs: number,
+): Promise<Response> {
+  const code = getField(form, "code");
+  const codeVerifier = getField(form, "code_verifier");
+  const redirectUri = getField(form, "redirect_uri");
+  const clientId = getField(form, "client_id");
+
+  if (code === "" || codeVerifier === "" || redirectUri === "" || clientId === "") {
+    return tokenError(
+      c,
+      400,
+      "invalid_request",
+      "code, code_verifier, redirect_uri, and client_id are required for the authorization_code grant.",
+    );
+  }
+
+  const authorizationCode = await getActiveAuthorizationCode(code, nowMs);
+  if (authorizationCode === null) {
+    return tokenError(c, 400, "invalid_grant", "The authorization code is invalid, expired, or already used.");
+  }
+
+  if (authorizationCode.clientId !== clientId) {
+    return tokenError(c, 400, "invalid_grant", "The authorization code was not issued to this client.");
+  }
+
+  if (authorizationCode.redirectUri !== redirectUri) {
+    return tokenError(c, 400, "invalid_grant", "redirect_uri does not match the authorization request.");
+  }
+
+  // Only S256 codes are persisted (DB CHECK constraint), but verify defensively.
+  if (
+    authorizationCode.codeChallengeMethod !== "S256"
+    || !verifyPkceS256(codeVerifier, authorizationCode.codeChallenge)
+  ) {
+    return tokenError(c, 400, "invalid_grant", "PKCE verification failed.");
+  }
+
+  const tokens = await consumeAuthorizationCodeAndIssueTokens(code, nowMs);
+  if (tokens === null) {
+    // Lost the single-use race: the code was consumed between verification and
+    // the atomic consume. Treat as already used.
+    return tokenError(c, 400, "invalid_grant", "The authorization code is invalid, expired, or already used.");
+  }
+
+  return tokenSuccess(c, tokens);
+}
+
+async function handleRefreshTokenGrant(
+  c: Context<AuthAppEnv>,
+  form: Record<string, string | File>,
+  nowMs: number,
+): Promise<Response> {
+  const refreshToken = getField(form, "refresh_token");
+  const clientId = getField(form, "client_id");
+
+  if (refreshToken === "" || clientId === "") {
+    return tokenError(
+      c,
+      400,
+      "invalid_request",
+      "refresh_token and client_id are required for the refresh_token grant.",
+    );
+  }
+
+  const client = await getClient(clientId);
+  if (client === null) {
+    return tokenError(c, 400, "invalid_client", "Unknown client_id.");
+  }
+
+  const tokens = await rotateRefreshToken(refreshToken, nowMs);
+  if (tokens === null) {
+    return tokenError(c, 400, "invalid_grant", "The refresh token is invalid, expired, or revoked.");
+  }
+
+  return tokenSuccess(c, tokens);
+}
+
+export function createTokenApp(now: () => number): Hono<AuthAppEnv> {
+  const app = new Hono<AuthAppEnv>();
+
+  app.post("/token", async (c) => {
+    let form: Record<string, string | File>;
+    try {
+      form = await c.req.parseBody();
+    } catch {
+      return tokenError(c, 400, "invalid_request", "Request body must be application/x-www-form-urlencoded.");
+    }
+
+    const grantType = getField(form, "grant_type");
+    const nowMs = now();
+
+    if (grantType === "authorization_code") {
+      return handleAuthorizationCodeGrant(c, form, nowMs);
+    }
+
+    if (grantType === "refresh_token") {
+      return handleRefreshTokenGrant(c, form, nowMs);
+    }
+
+    return tokenError(
+      c,
+      400,
+      "unsupported_grant_type",
+      "Only authorization_code and refresh_token grants are supported.",
+    );
+  });
+
+  return app;
+}
+
+export default createTokenApp(() => Date.now());

--- a/apps/auth/src/routes/oauth/token.ts
+++ b/apps/auth/src/routes/oauth/token.ts
@@ -133,7 +133,7 @@ async function handleRefreshTokenGrant(
     return tokenError(c, 400, "invalid_client", "Unknown client_id.");
   }
 
-  const tokens = await rotateRefreshToken(refreshToken, nowMs);
+  const tokens = await rotateRefreshToken(refreshToken, clientId, nowMs);
   if (tokens === null) {
     return tokenError(c, 400, "invalid_grant", "The refresh token is invalid, expired, or revoked.");
   }

--- a/apps/auth/src/routes/oauth/token.ts
+++ b/apps/auth/src/routes/oauth/token.ts
@@ -20,7 +20,6 @@ import type { AuthAppEnv } from "../../server/apiErrors.js";
 import {
   consumeAuthorizationCodeAndIssueTokens,
   getActiveAuthorizationCode,
-  getClient,
   rotateRefreshToken,
   type IssuedTokens,
 } from "../../server/oauth/oauthStore.js";
@@ -29,7 +28,6 @@ import { verifyPkceS256 } from "../../server/oauth/pkce.js";
 type OAuthErrorCode =
   | "invalid_request"
   | "invalid_grant"
-  | "invalid_client"
   | "unsupported_grant_type";
 
 function tokenError(
@@ -128,11 +126,10 @@ async function handleRefreshTokenGrant(
     );
   }
 
-  const client = await getClient(clientId);
-  if (client === null) {
-    return tokenError(c, 400, "invalid_client", "Unknown client_id.");
-  }
-
+  // No separate client lookup: rotateRefreshToken binds the token to the
+  // requesting client via conn.client_id, so an unknown or mismatched
+  // client_id yields no active row and returns invalid_grant. This is also the
+  // correct anti-enumeration behavior (no distinct unknown-client signal).
   const tokens = await rotateRefreshToken(refreshToken, clientId, nowMs);
   if (tokens === null) {
     return tokenError(c, 400, "invalid_grant", "The refresh token is invalid, expired, or revoked.");

--- a/apps/auth/src/server/oauth/oauthStore.ts
+++ b/apps/auth/src/server/oauth/oauthStore.ts
@@ -1,0 +1,305 @@
+/**
+ * Store/model over the auth.oauth_* tables backing the machine-facing OAuth 2.1
+ * Authorization Server (RFC 8414 metadata, RFC 7591 DCR, and the token
+ * endpoint). Tokens and authorization codes are opaque secrets shown to the
+ * client once; only their SHA-256 hashes are persisted, mirroring the
+ * hash-on-store / compare-on-read pattern from agentApiKeys.ts and
+ * server/otp/crockford.ts.
+ *
+ * Per-user isolation for these tables is enforced at the application layer via
+ * explicit WHERE clauses and hashed-secret point lookups (see
+ * db/migrations/0074), so reads/writes use the unscoped `query`/`transaction`
+ * helpers rather than the RLS-scoped variants.
+ */
+import { createHash } from "node:crypto";
+import { query, transaction, type DatabaseExecutor } from "../../db.js";
+import { createCrockfordToken, hashOpaqueToken } from "../otp/crockford.js";
+
+const ACCESS_TOKEN_PREFIX = "fco";
+const REFRESH_TOKEN_PREFIX = "fcr";
+const OAUTH_TOKEN_SECRET_LENGTH = 40;
+const CLIENT_ID_LENGTH = 24;
+
+export const ACCESS_TOKEN_TTL_SECONDS = 3600;
+const ACCESS_TOKEN_TTL_MS = ACCESS_TOKEN_TTL_SECONDS * 1000;
+// Refresh tokens are long-lived; the connection's revoked_at gate is the real
+// lifecycle control, so no fixed expiry is set on issuance.
+
+export type OAuthClient = Readonly<{
+  clientId: string;
+  redirectUris: ReadonlyArray<string>;
+  tokenEndpointAuthMethod: string;
+  clientName: string | null;
+}>;
+
+export type OAuthAuthorizationCode = Readonly<{
+  clientId: string;
+  connectionId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope: string | null;
+  resource: string;
+}>;
+
+export type IssuedTokens = Readonly<{
+  accessToken: string;
+  refreshToken: string;
+  expiresInSeconds: number;
+  scope: string | null;
+  resource: string;
+}>;
+
+/**
+ * Connection-bound grant context resolved when a code or refresh token is
+ * consumed. It carries everything needed to mint the next access/refresh pair.
+ */
+type GrantContext = Readonly<{
+  connectionId: string;
+  scope: string | null;
+  resource: string;
+}>;
+
+type OAuthClientRow = Readonly<{
+  client_id: string;
+  redirect_uris: ReadonlyArray<string>;
+  token_endpoint_auth_method: string;
+  client_name: string | null;
+}>;
+
+type OAuthAuthorizationCodeRow = Readonly<{
+  client_id: string;
+  connection_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  scope: string | null;
+  resource: string;
+  expires_at: Date | string;
+  consumed_at: Date | string | null;
+}>;
+
+type GrantContextRow = Readonly<{
+  connection_id: string;
+  resource: string;
+  scope: string | null;
+}>;
+
+function asMillis(value: Date | string): number {
+  return (value instanceof Date ? value : new Date(value)).getTime();
+}
+
+function hashTokenSecret(secret: string): string {
+  return createHash("sha256").update(secret).digest("hex");
+}
+
+function formatToken(prefix: string, secret: string): string {
+  return `${prefix}_${secret}`;
+}
+
+/**
+ * Generates a new opaque client identifier. Public clients have no secret
+ * (token_endpoint_auth_method = none + PKCE), so the id need not be secret.
+ */
+export function createClientId(): string {
+  return `fcc_${createCrockfordToken(CLIENT_ID_LENGTH)}`;
+}
+
+export async function getClient(clientId: string): Promise<OAuthClient | null> {
+  const result = await query<OAuthClientRow>(
+    [
+      "SELECT client_id, redirect_uris, token_endpoint_auth_method, client_name",
+      "FROM auth.oauth_clients",
+      "WHERE client_id = $1",
+    ].join(" "),
+    [clientId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    return null;
+  }
+
+  return mapClient(row);
+}
+
+/**
+ * Registers a new public + PKCE client (RFC 7591 Dynamic Client Registration).
+ */
+export async function saveClient(
+  redirectUris: ReadonlyArray<string>,
+  clientName: string | null,
+): Promise<OAuthClient> {
+  const clientId = createClientId();
+  const result = await query<OAuthClientRow>(
+    [
+      "INSERT INTO auth.oauth_clients",
+      "(client_id, redirect_uris, token_endpoint_auth_method, client_name)",
+      "VALUES ($1, $2, 'none', $3)",
+      "RETURNING client_id, redirect_uris, token_endpoint_auth_method, client_name",
+    ].join(" "),
+    [clientId, redirectUris, clientName],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error("Failed to register OAuth client");
+  }
+
+  return mapClient(row);
+}
+
+function mapClient(row: OAuthClientRow): OAuthClient {
+  return {
+    clientId: row.client_id,
+    redirectUris: row.redirect_uris,
+    tokenEndpointAuthMethod: row.token_endpoint_auth_method,
+    clientName: row.client_name,
+  };
+}
+
+/**
+ * Looks up an unconsumed, unexpired authorization code by its plaintext value
+ * so the token route can verify PKCE, client_id, and redirect_uri before
+ * consuming it. The plaintext is hashed for the point lookup.
+ */
+export async function getActiveAuthorizationCode(
+  code: string,
+  nowMs: number,
+): Promise<OAuthAuthorizationCode | null> {
+  const codeHash = hashOpaqueToken(code);
+  const result = await query<OAuthAuthorizationCodeRow>(
+    [
+      "SELECT client_id, connection_id, redirect_uri, code_challenge, code_challenge_method,",
+      "scope, resource, expires_at, consumed_at",
+      "FROM auth.oauth_authorization_codes",
+      "WHERE code_hash = $1",
+    ].join(" "),
+    [codeHash],
+  );
+  const row = result.rows[0];
+  if (row === undefined || row.consumed_at !== null || asMillis(row.expires_at) <= nowMs) {
+    return null;
+  }
+
+  return {
+    clientId: row.client_id,
+    connectionId: row.connection_id,
+    redirectUri: row.redirect_uri,
+    codeChallenge: row.code_challenge,
+    codeChallengeMethod: row.code_challenge_method,
+    scope: row.scope,
+    resource: row.resource,
+  };
+}
+
+async function issueTokensInExecutor(
+  executor: DatabaseExecutor,
+  grant: GrantContext,
+  nowMs: number,
+): Promise<IssuedTokens> {
+  const accessSecret = createCrockfordToken(OAUTH_TOKEN_SECRET_LENGTH);
+  const refreshSecret = createCrockfordToken(OAUTH_TOKEN_SECRET_LENGTH);
+  const accessHash = hashTokenSecret(accessSecret);
+  const refreshHash = hashTokenSecret(refreshSecret);
+  const accessExpiresAt = new Date(nowMs + ACCESS_TOKEN_TTL_MS).toISOString();
+
+  await executor.query(
+    [
+      "INSERT INTO auth.oauth_access_tokens",
+      "(token_hash, connection_id, scope, resource, expires_at)",
+      "VALUES ($1, $2, $3, $4, $5)",
+    ].join(" "),
+    [accessHash, grant.connectionId, grant.scope, grant.resource, accessExpiresAt],
+  );
+  await executor.query(
+    [
+      "INSERT INTO auth.oauth_refresh_tokens",
+      "(token_hash, connection_id, scope, resource)",
+      "VALUES ($1, $2, $3, $4)",
+    ].join(" "),
+    [refreshHash, grant.connectionId, grant.scope, grant.resource],
+  );
+
+  return {
+    accessToken: formatToken(ACCESS_TOKEN_PREFIX, accessSecret),
+    refreshToken: formatToken(REFRESH_TOKEN_PREFIX, refreshSecret),
+    expiresInSeconds: ACCESS_TOKEN_TTL_SECONDS,
+    scope: grant.scope,
+    resource: grant.resource,
+  };
+}
+
+/**
+ * Atomically consumes an authorization code and mints a fresh access/refresh
+ * token pair bound to the code's connection. The single-use guard
+ * (`consumed_at IS NULL` in the UPDATE) makes a concurrent double-redeem of the
+ * same code fail rather than issue two token pairs. Returns null when the code
+ * was already consumed between verification and this call.
+ */
+export async function consumeAuthorizationCodeAndIssueTokens(
+  code: string,
+  nowMs: number,
+): Promise<IssuedTokens | null> {
+  const codeHash = hashOpaqueToken(code);
+
+  return transaction(async (executor) => {
+    const consumed = await executor.query<OAuthAuthorizationCodeRow>(
+      [
+        "UPDATE auth.oauth_authorization_codes",
+        "SET consumed_at = now()",
+        "WHERE code_hash = $1 AND consumed_at IS NULL AND expires_at > now()",
+        "RETURNING client_id, connection_id, redirect_uri, code_challenge, code_challenge_method,",
+        "scope, resource, expires_at, consumed_at",
+      ].join(" "),
+      [codeHash],
+    );
+    const row = consumed.rows[0];
+    if (row === undefined) {
+      return null;
+    }
+
+    return issueTokensInExecutor(
+      executor,
+      { connectionId: row.connection_id, scope: row.scope, resource: row.resource },
+      nowMs,
+    );
+  });
+}
+
+/**
+ * Rotates a refresh token: consumes the presented refresh token and issues a
+ * fresh access/refresh pair on the same connection. Rotation makes a
+ * stolen-and-replayed refresh token detectable and bounds its useful lifetime.
+ * Returns null when the token is unknown, expired, or its connection is
+ * revoked.
+ */
+export async function rotateRefreshToken(
+  refreshToken: string,
+  nowMs: number,
+): Promise<IssuedTokens | null> {
+  const presentedHash = hashTokenSecret(refreshToken);
+
+  return transaction(async (executor) => {
+    const deleted = await executor.query<GrantContextRow>(
+      [
+        "DELETE FROM auth.oauth_refresh_tokens t",
+        "USING auth.oauth_connections conn",
+        "WHERE t.token_hash = $1",
+        "AND t.connection_id = conn.connection_id",
+        "AND conn.revoked_at IS NULL",
+        "AND (t.expires_at IS NULL OR t.expires_at > now())",
+        "RETURNING t.connection_id, t.resource, t.scope",
+      ].join(" "),
+      [presentedHash],
+    );
+    const row = deleted.rows[0];
+    if (row === undefined) {
+      return null;
+    }
+
+    return issueTokensInExecutor(
+      executor,
+      { connectionId: row.connection_id, scope: row.scope, resource: row.resource },
+      nowMs,
+    );
+  });
+}

--- a/apps/auth/src/server/oauth/oauthStore.ts
+++ b/apps/auth/src/server/oauth/oauthStore.ts
@@ -298,8 +298,14 @@ export async function consumeAuthorizationCodeAndIssueTokens(
 
 /**
  * Rotates a refresh token: consumes the presented refresh token and issues a
- * fresh access/refresh pair on the same connection. Rotation makes a
- * stolen-and-replayed refresh token detectable and bounds its useful lifetime.
+ * fresh access/refresh pair on the same connection. This is plain single-use
+ * rotation: each refresh token can be redeemed once, which bounds a leaked
+ * token's useful lifetime. It does NOT implement automatic reuse detection or
+ * token-family / connection-wide revocation (OAuth 2.1 / RFC 9700 §4.14.2):
+ * replaying an already-rotated token simply matches no active row and returns
+ * null (invalid_grant) without revoking the connection or its live tokens.
+ * Reuse-detection is deferred to a dedicated hardening item, so future code
+ * must not assume reuse-revocation exists here.
  * Returns null when the token is malformed, unknown, expired, its connection is
  * revoked, or it was not issued to the presenting client.
  */

--- a/apps/auth/src/server/oauth/oauthStore.ts
+++ b/apps/auth/src/server/oauth/oauthStore.ts
@@ -11,9 +11,8 @@
  * db/migrations/0074), so reads/writes use the unscoped `query`/`transaction`
  * helpers rather than the RLS-scoped variants.
  */
-import { createHash } from "node:crypto";
 import { query, transaction, type DatabaseExecutor } from "../../db.js";
-import { createCrockfordToken, hashOpaqueToken } from "../otp/crockford.js";
+import { createCrockfordToken, hashOpaqueToken, normalizeCrockfordToken } from "../otp/crockford.js";
 
 const ACCESS_TOKEN_PREFIX = "fco";
 const REFRESH_TOKEN_PREFIX = "fcr";
@@ -89,12 +88,37 @@ function asMillis(value: Date | string): number {
   return (value instanceof Date ? value : new Date(value)).getTime();
 }
 
-function hashTokenSecret(secret: string): string {
-  return createHash("sha256").update(secret).digest("hex");
-}
-
 function formatToken(prefix: string, secret: string): string {
   return `${prefix}_${secret}`;
+}
+
+/**
+ * Parses an issued opaque token of the form `<prefix>_<secret>` back into its
+ * bare Crockford secret, mirroring parseAgentApiKey in
+ * apps/backend/src/agent/apiKeys.ts. Returns null on a malformed or
+ * prefix-mismatched token so callers can map it to invalid_grant.
+ *
+ * Hashing asymmetry (do not "fix" by hashing the full value):
+ *   - Authorization codes hash the full opaque value via hashOpaqueToken (no
+ *     prefix is ever added to a code), so store and read hash identical bytes.
+ *   - Access/refresh tokens are issued with a `fco_`/`fcr_` prefix but stored as
+ *     the hash of the bare secret only. The read path MUST parse off the prefix
+ *     and hash just the parsed secret, or storage and lookup hash different
+ *     strings and every grant fails.
+ */
+function parseToken(prefix: string, token: string): string | null {
+  const expectedPrefix = `${prefix.toUpperCase()}_`;
+  const normalized = token.replace(/[\s-]/g, "").toUpperCase();
+  if (!normalized.startsWith(expectedPrefix)) {
+    return null;
+  }
+
+  const secret = normalized.slice(expectedPrefix.length);
+  try {
+    return normalizeCrockfordToken(secret, "oauth token secret");
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -198,8 +222,10 @@ async function issueTokensInExecutor(
 ): Promise<IssuedTokens> {
   const accessSecret = createCrockfordToken(OAUTH_TOKEN_SECRET_LENGTH);
   const refreshSecret = createCrockfordToken(OAUTH_TOKEN_SECRET_LENGTH);
-  const accessHash = hashTokenSecret(accessSecret);
-  const refreshHash = hashTokenSecret(refreshSecret);
+  // Store the hash of the bare secret only; the read path parses the prefix off
+  // the presented token before hashing (see parseToken).
+  const accessHash = hashOpaqueToken(accessSecret);
+  const refreshHash = hashOpaqueToken(refreshSecret);
   const accessExpiresAt = new Date(nowMs + ACCESS_TOKEN_TTL_MS).toISOString();
 
   await executor.query(
@@ -247,6 +273,11 @@ export async function consumeAuthorizationCodeAndIssueTokens(
         "UPDATE auth.oauth_authorization_codes",
         "SET consumed_at = now()",
         "WHERE code_hash = $1 AND consumed_at IS NULL AND expires_at > now()",
+        // Gate minting on an active connection, matching the refresh path: a
+        // connection revoked between code issuance and redemption must not mint.
+        "AND connection_id IN (",
+        "SELECT connection_id FROM auth.oauth_connections WHERE revoked_at IS NULL",
+        ")",
         "RETURNING client_id, connection_id, redirect_uri, code_challenge, code_challenge_method,",
         "scope, resource, expires_at, consumed_at",
       ].join(" "),
@@ -269,14 +300,21 @@ export async function consumeAuthorizationCodeAndIssueTokens(
  * Rotates a refresh token: consumes the presented refresh token and issues a
  * fresh access/refresh pair on the same connection. Rotation makes a
  * stolen-and-replayed refresh token detectable and bounds its useful lifetime.
- * Returns null when the token is unknown, expired, or its connection is
- * revoked.
+ * Returns null when the token is malformed, unknown, expired, its connection is
+ * revoked, or it was not issued to the presenting client.
  */
 export async function rotateRefreshToken(
   refreshToken: string,
+  clientId: string,
   nowMs: number,
 ): Promise<IssuedTokens | null> {
-  const presentedHash = hashTokenSecret(refreshToken);
+  // Parse the prefix off the presented token and hash only the bare secret so
+  // the lookup hashes the same bytes that issuance stored (see parseToken).
+  const parsedSecret = parseToken(REFRESH_TOKEN_PREFIX, refreshToken);
+  if (parsedSecret === null) {
+    return null;
+  }
+  const presentedHash = hashOpaqueToken(parsedSecret);
 
   return transaction(async (executor) => {
     const deleted = await executor.query<GrantContextRow>(
@@ -285,11 +323,14 @@ export async function rotateRefreshToken(
         "USING auth.oauth_connections conn",
         "WHERE t.token_hash = $1",
         "AND t.connection_id = conn.connection_id",
+        // Bind the refresh token to the requesting client (RFC 6749 §6); a
+        // client_id mismatch is indistinguishable from an unknown token.
+        "AND conn.client_id = $2",
         "AND conn.revoked_at IS NULL",
         "AND (t.expires_at IS NULL OR t.expires_at > now())",
         "RETURNING t.connection_id, t.resource, t.scope",
       ].join(" "),
-      [presentedHash],
+      [presentedHash, clientId],
     );
     const row = deleted.rows[0];
     if (row === undefined) {

--- a/apps/auth/src/server/oauth/pkce.ts
+++ b/apps/auth/src/server/oauth/pkce.ts
@@ -1,0 +1,24 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+const CODE_VERIFIER_RE = /^[A-Za-z0-9\-._~]{43,128}$/;
+
+/**
+ * Verifies a PKCE `code_verifier` against a stored S256 `code_challenge`
+ * (RFC 7636). The challenge is the base64url-encoded SHA-256 of the verifier.
+ * Only S256 is supported; `plain` is intentionally rejected. The comparison is
+ * constant-time to avoid leaking how much of the challenge matched.
+ */
+export function verifyPkceS256(codeVerifier: string, codeChallenge: string): boolean {
+  if (!CODE_VERIFIER_RE.test(codeVerifier)) {
+    return false;
+  }
+
+  const computedChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+  const computedBuffer = Buffer.from(computedChallenge);
+  const storedBuffer = Buffer.from(codeChallenge);
+  if (computedBuffer.length !== storedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(computedBuffer, storedBuffer);
+}

--- a/db/migrations/0075_oauth_token_endpoint_auth_app.sql
+++ b/db/migrations/0075_oauth_token_endpoint_auth_app.sql
@@ -1,0 +1,30 @@
+-- OAuth token endpoint (item 03) runtime support.
+--
+-- The machine-facing OAuth Authorization Server endpoints (RFC 8414 metadata,
+-- RFC 7591 DCR, and the token endpoint) run inside the auth service, which
+-- connects as auth_app. db/migrations/0074 deliberately granted the auth.oauth_*
+-- tables only to backend_app (mirroring the guest_sessions precedent) and left
+-- the auth_app grants to "the resolver and endpoints" items. This migration
+-- adds the auth_app grants that the token/register endpoints need.
+--
+-- It also adds scope/resource to auth.oauth_refresh_tokens so the refresh_token
+-- grant can re-mint an access token that carries the same audience (resource)
+-- and scope as the original authorization_code grant without a second lookup.
+-- The authorization-code and access-token tables already store resource/scope;
+-- only the refresh-token table was missing them.
+
+ALTER TABLE auth.oauth_refresh_tokens
+  ADD COLUMN IF NOT EXISTS scope    TEXT,
+  ADD COLUMN IF NOT EXISTS resource TEXT;
+
+-- auth_app grants for the OAuth Authorization Server endpoints:
+--   - oauth_clients: SELECT (token grant client check) + INSERT (DCR /register)
+--   - oauth_connections: SELECT (joined when rotating refresh tokens)
+--   - oauth_authorization_codes: SELECT + UPDATE (single-use consume)
+--   - oauth_access_tokens: INSERT (mint on token grant)
+--   - oauth_refresh_tokens: INSERT + DELETE (mint + rotation)
+GRANT SELECT, INSERT ON auth.oauth_clients TO auth_app;
+GRANT SELECT ON auth.oauth_connections TO auth_app;
+GRANT SELECT, UPDATE ON auth.oauth_authorization_codes TO auth_app;
+GRANT INSERT ON auth.oauth_access_tokens TO auth_app;
+GRANT INSERT, DELETE ON auth.oauth_refresh_tokens TO auth_app;

--- a/db/migrations/0075_oauth_token_endpoint_auth_app.sql
+++ b/db/migrations/0075_oauth_token_endpoint_auth_app.sql
@@ -22,9 +22,11 @@ ALTER TABLE auth.oauth_refresh_tokens
 --   - oauth_connections: SELECT (joined when rotating refresh tokens)
 --   - oauth_authorization_codes: SELECT + UPDATE (single-use consume)
 --   - oauth_access_tokens: INSERT (mint on token grant)
---   - oauth_refresh_tokens: INSERT + DELETE (mint + rotation)
+--   - oauth_refresh_tokens: SELECT + INSERT + DELETE (mint + rotation; SELECT is
+--     required because rotation runs DELETE ... RETURNING, and Postgres needs
+--     SELECT on every RETURNING column)
 GRANT SELECT, INSERT ON auth.oauth_clients TO auth_app;
 GRANT SELECT ON auth.oauth_connections TO auth_app;
 GRANT SELECT, UPDATE ON auth.oauth_authorization_codes TO auth_app;
 GRANT INSERT ON auth.oauth_access_tokens TO auth_app;
-GRANT INSERT, DELETE ON auth.oauth_refresh_tokens TO auth_app;
+GRANT SELECT, INSERT, DELETE ON auth.oauth_refresh_tokens TO auth_app;


### PR DESCRIPTION
Implements plan item 03-auth-oauth-core: OAuth Authorization Server core (metadata + DCR + token) in apps/auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)