### PR TITLE
OAuth /authorize: login (email+OTP) + consent + connection minting

### DIFF
--- a/apps/auth/src/app.ts
+++ b/apps/auth/src/app.ts
@@ -7,6 +7,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { type Context, Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
 import health from "./routes/health.js";
 import agentSendCode from "./routes/agent/agentSendCode.js";
 import agentVerifyCode from "./routes/agent/agentVerifyCode.js";
@@ -154,8 +155,9 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
     await next();
   });
 
-  // Deny cross-origin requests to API endpoints (defense-in-depth).
-  app.use("/api/*", async (c, next) => {
+  // Deny cross-origin requests to cookie-authenticated, state-changing
+  // endpoints (defense-in-depth). Shared by /api/* and the OAuth consent POST.
+  const denyCrossOrigin: MiddlewareHandler<AuthAppEnv> = async (c, next) => {
     const origin = c.req.header("origin");
     if (origin !== undefined) {
       const requestOrigin = new URL(c.req.url).origin;
@@ -182,7 +184,12 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
       return c.json({ error: "Cross-origin requests not allowed" }, 403);
     }
     await next();
-  });
+  };
+
+  app.use("/api/*", denyCrossOrigin);
+  // The OAuth consent POST is cookie-authenticated and state-changing but lives
+  // outside /api/*, so it gets the same cross-origin guard explicitly.
+  app.use("/authorize/consent", denyCrossOrigin);
 
   app.onError((error, c) => {
     const requestId = getRequestId(c);

--- a/apps/auth/src/app.ts
+++ b/apps/auth/src/app.ts
@@ -21,6 +21,7 @@ import logoutLocalPage from "./routes/browser/logoutLocalPage.js";
 import oauthMetadata from "./routes/oauth/metadata.js";
 import oauthRegister from "./routes/oauth/register.js";
 import oauthToken from "./routes/oauth/token.js";
+import oauthAuthorize from "./routes/oauth/authorize.js";
 import robots from "./routes/robots.js";
 import { type AuthAppEnv, getRequestId, jsonAuthError } from "./server/apiErrors.js";
 import { getDemoEmailAccessConfig } from "./server/demoEmailAccess.js";
@@ -268,6 +269,7 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
   app.route("/", oauthMetadata);
   app.route("/", oauthRegister);
   app.route("/", oauthToken);
+  app.route("/", oauthAuthorize);
 
   return app;
 }

--- a/apps/auth/src/routes/oauth/authorize.ts
+++ b/apps/auth/src/routes/oauth/authorize.ts
@@ -1,0 +1,256 @@
+/**
+ * Browser-facing OAuth 2.1 authorization endpoint for the MCP authorization
+ * server. This is the screen the user sees after clicking "Connect" in an MCP
+ * client (Claude.ai, ChatGPT, ...).
+ *
+ * GET /authorize validates the public-client + PKCE authorization request
+ * (client_id against auth.oauth_clients, redirect_uri, response_type=code,
+ * code_challenge/S256, scope, resource) and renders a localized sign-in +
+ * consent page. Sign-in reuses the existing email + OTP flow (/api/send-code +
+ * /api/verify-code set the session cookie). On approval the page posts to
+ * POST /authorize/consent, which resolves the user from the session cookie the
+ * same way createAgentApiKeyFromIdToken does, upserts the (user, client)
+ * connection, writes a single-use authorization code (server/oauth model), and
+ * returns the redirect URL carrying code, state, and iss.
+ *
+ * Validation-error rules (RFC 6749 §4.1.2.1): if client_id or redirect_uri is
+ * invalid we MUST NOT redirect (the redirect target is untrusted) and render an
+ * inline error instead. For other invalid parameters we redirect back to the
+ * validated redirect_uri with an `error` code.
+ */
+import { Hono } from "hono";
+import { getCookie } from "hono/cookie";
+import type { Context } from "hono";
+import type { AuthAppEnv } from "../../server/apiErrors.js";
+import { getClient, approveAuthorizationRequest } from "../../server/oauth/oauthStore.js";
+import { getMcpResource, getPublicAuthBaseUrl } from "../../server/publicUrls.js";
+import { validateSessionToken } from "../../server/browserSession.js";
+import { resolveLoginPageLocale } from "../browser/loginPageLocale.js";
+import { renderAuthorizePage, type AuthorizeRequestView } from "../../templates/authorize.js";
+
+const SUPPORTED_SCOPE = "flashcards";
+const MAX_CONNECTION_LABEL_LENGTH = 120;
+const CODE_CHALLENGE_RE = /^[A-Za-z0-9\-._~]{43,128}$/;
+
+type AuthorizeErrorCode =
+  | "invalid_request"
+  | "unsupported_response_type"
+  | "invalid_scope"
+  | "access_denied"
+  | "server_error";
+
+/**
+ * Builds the redirect back to the client carrying an OAuth error
+ * (RFC 6749 §4.1.2.1). Only called once redirect_uri is validated.
+ */
+function redirectWithError(
+  c: Context<AuthAppEnv>,
+  redirectUri: string,
+  state: string | null,
+  error: AuthorizeErrorCode,
+  description: string,
+): Response {
+  const url = new URL(redirectUri);
+  url.searchParams.set("error", error);
+  url.searchParams.set("error_description", description);
+  if (state !== null) {
+    url.searchParams.set("state", state);
+  }
+  return c.redirect(url.toString(), 302);
+}
+
+/**
+ * Validates the connection label the page will show in settings, derived from
+ * the registered client name. Falls back to a generic label.
+ */
+function buildConnectionLabel(clientName: string | null): string {
+  const trimmed = (clientName ?? "").trim();
+  if (trimmed === "") {
+    return "MCP client";
+  }
+  return trimmed.slice(0, MAX_CONNECTION_LABEL_LENGTH);
+}
+
+export function createAuthorizeApp(now: () => number): Hono<AuthAppEnv> {
+  const app = new Hono<AuthAppEnv>();
+
+  app.get("/authorize", async (c) => {
+    const clientId = c.req.query("client_id") ?? "";
+    const redirectUri = c.req.query("redirect_uri") ?? "";
+    const responseType = c.req.query("response_type") ?? "";
+    const codeChallenge = c.req.query("code_challenge") ?? "";
+    const codeChallengeMethod = c.req.query("code_challenge_method") ?? "";
+    const rawScope = c.req.query("scope") ?? "";
+    const resource = c.req.query("resource") ?? "";
+    const state = c.req.query("state") ?? null;
+
+    // 1. client_id + redirect_uri: invalid here MUST NOT redirect (untrusted
+    //    target). Render inline plaintext errors instead.
+    if (clientId === "") {
+      return c.text("Missing client_id parameter", 400);
+    }
+
+    const client = await getClient(clientId);
+    if (client === null) {
+      return c.text("Unknown client_id", 400);
+    }
+
+    if (redirectUri === "") {
+      return c.text("Missing redirect_uri parameter", 400);
+    }
+
+    if (!client.redirectUris.includes(redirectUri)) {
+      return c.text("redirect_uri does not match a registered redirect URI", 400);
+    }
+
+    // 2. Remaining parameters: redirect_uri is trusted, so report errors to it.
+    if (responseType !== "code") {
+      return redirectWithError(
+        c,
+        redirectUri,
+        state,
+        "unsupported_response_type",
+        "Only response_type=code is supported.",
+      );
+    }
+
+    if (codeChallengeMethod !== "S256" || !CODE_CHALLENGE_RE.test(codeChallenge)) {
+      return redirectWithError(
+        c,
+        redirectUri,
+        state,
+        "invalid_request",
+        "A PKCE code_challenge with code_challenge_method=S256 is required.",
+      );
+    }
+
+    const scope = rawScope.trim() === "" ? null : rawScope.trim();
+    if (scope !== null && !scope.split(/\s+/).every((entry) => entry === SUPPORTED_SCOPE)) {
+      return redirectWithError(
+        c,
+        redirectUri,
+        state,
+        "invalid_scope",
+        `The only supported scope is '${SUPPORTED_SCOPE}'.`,
+      );
+    }
+
+    const expectedResource = getMcpResource(c.req.url);
+    if (resource === "") {
+      return redirectWithError(
+        c,
+        redirectUri,
+        state,
+        "invalid_request",
+        "The resource parameter (RFC 8707) is required.",
+      );
+    }
+
+    if (resource !== expectedResource) {
+      return redirectWithError(
+        c,
+        redirectUri,
+        state,
+        "invalid_request",
+        "The resource parameter does not match this server's protected resource.",
+      );
+    }
+
+    const requestView: AuthorizeRequestView = {
+      clientId,
+      redirectUri,
+      state,
+      codeChallenge,
+      scope,
+      resource,
+      clientName: buildConnectionLabel(client.clientName),
+    };
+
+    const locale = resolveLoginPageLocale(c.req.query("locale"), c.req.header("accept-language"));
+    return c.html(renderAuthorizePage(requestView, locale));
+  });
+
+  app.post("/authorize/consent", async (c) => {
+    let body: {
+      client_id?: unknown;
+      redirect_uri?: unknown;
+      state?: unknown;
+      code_challenge?: unknown;
+      scope?: unknown;
+      resource?: unknown;
+    };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid_request", error_description: "Request body must be valid JSON." }, 400);
+    }
+
+    const clientId = typeof body.client_id === "string" ? body.client_id : "";
+    const redirectUri = typeof body.redirect_uri === "string" ? body.redirect_uri : "";
+    const state = typeof body.state === "string" ? body.state : null;
+    const codeChallenge = typeof body.code_challenge === "string" ? body.code_challenge : "";
+    const scope = typeof body.scope === "string" && body.scope !== "" ? body.scope : null;
+    const resource = typeof body.resource === "string" ? body.resource : "";
+
+    // Re-validate the request server-side: the page-embedded values are
+    // attacker-influencable, so the consent grant must not trust them blindly.
+    if (clientId === "" || redirectUri === "" || resource === "" || !CODE_CHALLENGE_RE.test(codeChallenge)) {
+      return c.json({ error: "invalid_request", error_description: "The authorization request is incomplete." }, 400);
+    }
+
+    const client = await getClient(clientId);
+    if (client === null || !client.redirectUris.includes(redirectUri)) {
+      return c.json({ error: "invalid_request", error_description: "Unknown client or redirect_uri." }, 400);
+    }
+
+    if (resource !== getMcpResource(c.req.url)) {
+      return c.json({ error: "invalid_request", error_description: "Unexpected resource." }, 400);
+    }
+
+    if (scope !== null && !scope.split(/\s+/).every((entry) => entry === SUPPORTED_SCOPE)) {
+      return c.json({ error: "invalid_scope", error_description: "Unsupported scope." }, 400);
+    }
+
+    // The session cookie holds the Cognito ID token set by /api/verify-code.
+    const sessionToken = getCookie(c, "session") ?? "";
+    if (sessionToken === "") {
+      return c.json({ error: "login_required", error_description: "Sign in before approving access." }, 401);
+    }
+
+    const validation = await validateSessionToken(sessionToken);
+    if (validation.status === "error") {
+      throw new Error(validation.reason);
+    }
+    if (validation.status !== "valid") {
+      return c.json({ error: "login_required", error_description: "Sign in before approving access." }, 401);
+    }
+
+    const code = await approveAuthorizationRequest(
+      sessionToken,
+      {
+        clientId,
+        redirectUri,
+        codeChallenge,
+        scope,
+        resource,
+        connectionLabel: buildConnectionLabel(client.clientName),
+      },
+      now(),
+    );
+
+    const redirectTo = new URL(redirectUri);
+    redirectTo.searchParams.set("code", code);
+    if (state !== null) {
+      redirectTo.searchParams.set("state", state);
+    }
+    // RFC 9207: identify the issuer so clients can defend against mix-up attacks.
+    redirectTo.searchParams.set("iss", getPublicAuthBaseUrl(c.req.url));
+
+    c.header("Cache-Control", "no-store");
+    return c.json({ redirect_to: redirectTo.toString() });
+  });
+
+  return app;
+}
+
+export default createAuthorizeApp(() => Date.now());

--- a/apps/auth/src/routes/oauth/authorize.ts
+++ b/apps/auth/src/routes/oauth/authorize.ts
@@ -170,6 +170,10 @@ export function createAuthorizeApp(now: () => number): Hono<AuthAppEnv> {
     // Authenticated consent page reflecting per-request parameters: never serve
     // it from a shared cache.
     c.header("Cache-Control", "no-store");
+    // Anti-clickjacking: the consent screen is a one-click persistent OAuth-grant
+    // target, so deny framing entirely.
+    c.header("X-Frame-Options", "DENY");
+    c.header("Content-Security-Policy", "frame-ancestors 'none'");
     return c.html(renderAuthorizePage(requestView, locale));
   });
 

--- a/apps/auth/src/routes/oauth/authorize.ts
+++ b/apps/auth/src/routes/oauth/authorize.ts
@@ -167,6 +167,9 @@ export function createAuthorizeApp(now: () => number): Hono<AuthAppEnv> {
     };
 
     const locale = resolveLoginPageLocale(c.req.query("locale"), c.req.header("accept-language"));
+    // Authenticated consent page reflecting per-request parameters: never serve
+    // it from a shared cache.
+    c.header("Cache-Control", "no-store");
     return c.html(renderAuthorizePage(requestView, locale));
   });
 

--- a/apps/auth/src/routes/oauth/authorizePageLocale.ts
+++ b/apps/auth/src/routes/oauth/authorizePageLocale.ts
@@ -1,0 +1,223 @@
+/**
+ * Localized copy for the OAuth /authorize screen. The login half mirrors the
+ * browser login page copy (loginPageLocale.ts); this module adds the
+ * consent-specific strings shown after sign-in. Same locale set and resolution
+ * as the login page so the two auth surfaces stay aligned.
+ */
+import type { LoginPageLocale } from "../browser/loginPageLocale.js";
+
+export type AuthorizeConsentCopy = Readonly<{
+  pageTitle: string;
+  checkingSession: string;
+  signInTitle: string;
+  emailLabel: string;
+  sendCode: string;
+  sendingCode: string;
+  checkEmailForCode: string;
+  verificationCodeLabel: string;
+  verify: string;
+  verifying: string;
+  genericErrorPrefix: string;
+  // Consent step.
+  consentTitle: string;
+  // {client} is replaced client-side with the requesting application's name.
+  consentLead: string;
+  consentScopeAccess: string;
+  consentSignedInAs: string;
+  approve: string;
+  approving: string;
+  deny: string;
+  redirecting: string;
+}>;
+
+export const AUTHORIZE_CONSENT_COPY: Readonly<Record<LoginPageLocale, AuthorizeConsentCopy>> = {
+  en: {
+    pageTitle: "Authorize access",
+    checkingSession: "Checking session...",
+    signInTitle: "Sign in to continue",
+    emailLabel: "Email",
+    sendCode: "Send code",
+    sendingCode: "Sending...",
+    checkEmailForCode: "Check your email for an 8-digit code. If you don't see it, check your spam folder.",
+    verificationCodeLabel: "Verification code",
+    verify: "Verify",
+    verifying: "Verifying...",
+    genericErrorPrefix: "Error",
+    consentTitle: "Authorize access",
+    consentLead: "{client} wants to connect to your Flashcards account.",
+    consentScopeAccess: "It will be able to read and write your flashcards and review data through the API.",
+    consentSignedInAs: "Signed in as",
+    approve: "Allow access",
+    approving: "Authorizing...",
+    deny: "Cancel",
+    redirecting: "Redirecting...",
+  },
+  ar: {
+    pageTitle: "تفويض الوصول",
+    checkingSession: "جارٍ التحقق من الجلسة...",
+    signInTitle: "سجّل الدخول للمتابعة",
+    emailLabel: "البريد الإلكتروني",
+    sendCode: "إرسال الرمز",
+    sendingCode: "جارٍ الإرسال...",
+    checkEmailForCode: "تحقق من بريدك الإلكتروني للحصول على رمز مكوّن من 8 أرقام. إذا لم تجده، فتحقق من مجلد الرسائل غير المرغوب فيها.",
+    verificationCodeLabel: "رمز التحقق",
+    verify: "تحقق",
+    verifying: "جارٍ التحقق...",
+    genericErrorPrefix: "خطأ",
+    consentTitle: "تفويض الوصول",
+    consentLead: "يريد {client} الاتصال بحساب Flashcards الخاص بك.",
+    consentScopeAccess: "سيتمكن من قراءة بطاقاتك التعليمية وبيانات المراجعة والكتابة فيها عبر واجهة برمجة التطبيقات.",
+    consentSignedInAs: "تم تسجيل الدخول باسم",
+    approve: "السماح بالوصول",
+    approving: "جارٍ التفويض...",
+    deny: "إلغاء",
+    redirecting: "جارٍ إعادة التوجيه...",
+  },
+  "zh-Hans": {
+    pageTitle: "授权访问",
+    checkingSession: "正在检查会话...",
+    signInTitle: "登录以继续",
+    emailLabel: "电子邮件",
+    sendCode: "发送验证码",
+    sendingCode: "发送中...",
+    checkEmailForCode: "请查看电子邮件中的 8 位验证码。如果没有看到，请检查垃圾邮件文件夹。",
+    verificationCodeLabel: "验证码",
+    verify: "验证",
+    verifying: "验证中...",
+    genericErrorPrefix: "错误",
+    consentTitle: "授权访问",
+    consentLead: "{client} 想要连接到你的 Flashcards 账户。",
+    consentScopeAccess: "它将能够通过 API 读取和写入你的卡片及复习数据。",
+    consentSignedInAs: "登录身份",
+    approve: "允许访问",
+    approving: "授权中...",
+    deny: "取消",
+    redirecting: "正在跳转...",
+  },
+  de: {
+    pageTitle: "Zugriff autorisieren",
+    checkingSession: "Sitzung wird geprüft...",
+    signInTitle: "Zum Fortfahren anmelden",
+    emailLabel: "E-Mail",
+    sendCode: "Code senden",
+    sendingCode: "Wird gesendet...",
+    checkEmailForCode: "Prüfe deine E-Mail auf einen 8-stelligen Code. Wenn du ihn nicht siehst, prüfe den Spam-Ordner.",
+    verificationCodeLabel: "Bestätigungscode",
+    verify: "Bestätigen",
+    verifying: "Wird bestätigt...",
+    genericErrorPrefix: "Fehler",
+    consentTitle: "Zugriff autorisieren",
+    consentLead: "{client} möchte sich mit deinem Flashcards-Konto verbinden.",
+    consentScopeAccess: "Es kann deine Karten und Lerndaten über die API lesen und schreiben.",
+    consentSignedInAs: "Angemeldet als",
+    approve: "Zugriff erlauben",
+    approving: "Wird autorisiert...",
+    deny: "Abbrechen",
+    redirecting: "Weiterleitung...",
+  },
+  hi: {
+    pageTitle: "एक्सेस अधिकृत करें",
+    checkingSession: "सेशन जांचा जा रहा है...",
+    signInTitle: "जारी रखने के लिए साइन इन करें",
+    emailLabel: "ईमेल",
+    sendCode: "कोड भेजें",
+    sendingCode: "भेजा जा रहा है...",
+    checkEmailForCode: "8 अंकों का कोड पाने के लिए अपना ईमेल देखें। अगर यह न दिखे, तो स्पैम फ़ोल्डर देखें।",
+    verificationCodeLabel: "सत्यापन कोड",
+    verify: "सत्यापित करें",
+    verifying: "सत्यापित किया जा रहा है...",
+    genericErrorPrefix: "त्रुटि",
+    consentTitle: "एक्सेस अधिकृत करें",
+    consentLead: "{client} आपके Flashcards खाते से कनेक्ट करना चाहता है।",
+    consentScopeAccess: "यह API के ज़रिए आपके फ़्लैशकार्ड और समीक्षा डेटा को पढ़ और लिख सकेगा।",
+    consentSignedInAs: "इस रूप में साइन इन",
+    approve: "एक्सेस की अनुमति दें",
+    approving: "अधिकृत किया जा रहा है...",
+    deny: "रद्द करें",
+    redirecting: "रीडायरेक्ट किया जा रहा है...",
+  },
+  ja: {
+    pageTitle: "アクセスを許可",
+    checkingSession: "セッションを確認しています...",
+    signInTitle: "続行するにはサインイン",
+    emailLabel: "メールアドレス",
+    sendCode: "コードを送信",
+    sendingCode: "送信中...",
+    checkEmailForCode: "メールで 8 桁のコードを確認してください。見つからない場合は、迷惑メールフォルダを確認してください。",
+    verificationCodeLabel: "確認コード",
+    verify: "確認",
+    verifying: "確認中...",
+    genericErrorPrefix: "エラー",
+    consentTitle: "アクセスを許可",
+    consentLead: "{client} があなたの Flashcards アカウントへの接続を求めています。",
+    consentScopeAccess: "API を通じて、あなたのフラッシュカードと復習データの読み取りと書き込みができます。",
+    consentSignedInAs: "サインイン中のアカウント",
+    approve: "アクセスを許可",
+    approving: "許可しています...",
+    deny: "キャンセル",
+    redirecting: "リダイレクト中...",
+  },
+  ru: {
+    pageTitle: "Авторизация доступа",
+    checkingSession: "Проверяем сеанс...",
+    signInTitle: "Войдите, чтобы продолжить",
+    emailLabel: "Электронная почта",
+    sendCode: "Отправить код",
+    sendingCode: "Отправка...",
+    checkEmailForCode: "Проверьте почту: там есть 8-значный код. Если его нет, проверьте папку «Спам».",
+    verificationCodeLabel: "Код подтверждения",
+    verify: "Подтвердить",
+    verifying: "Проверка...",
+    genericErrorPrefix: "Ошибка",
+    consentTitle: "Авторизация доступа",
+    consentLead: "{client} хочет подключиться к вашему аккаунту Flashcards.",
+    consentScopeAccess: "Приложение сможет читать и изменять ваши карточки и данные повторений через API.",
+    consentSignedInAs: "Вы вошли как",
+    approve: "Разрешить доступ",
+    approving: "Авторизация...",
+    deny: "Отмена",
+    redirecting: "Перенаправление...",
+  },
+  "es-MX": {
+    pageTitle: "Autorizar acceso",
+    checkingSession: "Comprobando sesión...",
+    signInTitle: "Inicia sesión para continuar",
+    emailLabel: "Correo electrónico",
+    sendCode: "Enviar código",
+    sendingCode: "Enviando...",
+    checkEmailForCode: "Revisa tu correo para encontrar un código de 8 dígitos. Si no lo ves, revisa la carpeta de spam.",
+    verificationCodeLabel: "Código de verificación",
+    verify: "Verificar",
+    verifying: "Verificando...",
+    genericErrorPrefix: "Error",
+    consentTitle: "Autorizar acceso",
+    consentLead: "{client} quiere conectarse a tu cuenta de Flashcards.",
+    consentScopeAccess: "Podrá leer y escribir tus tarjetas y datos de repaso a través de la API.",
+    consentSignedInAs: "Sesión iniciada como",
+    approve: "Permitir acceso",
+    approving: "Autorizando...",
+    deny: "Cancelar",
+    redirecting: "Redirigiendo...",
+  },
+  "es-ES": {
+    pageTitle: "Autorizar acceso",
+    checkingSession: "Comprobando la sesión...",
+    signInTitle: "Inicia sesión para continuar",
+    emailLabel: "Correo electrónico",
+    sendCode: "Enviar código",
+    sendingCode: "Enviando...",
+    checkEmailForCode: "Revisa tu correo para encontrar un código de 8 dígitos. Si no lo ves, revisa la carpeta de spam.",
+    verificationCodeLabel: "Código de verificación",
+    verify: "Verificar",
+    verifying: "Verificando...",
+    genericErrorPrefix: "Error",
+    consentTitle: "Autorizar acceso",
+    consentLead: "{client} quiere conectarse a tu cuenta de Flashcards.",
+    consentScopeAccess: "Podrá leer y escribir tus tarjetas y datos de repaso a través de la API.",
+    consentSignedInAs: "Sesión iniciada como",
+    approve: "Permitir acceso",
+    approving: "Autorizando...",
+    deny: "Cancelar",
+    redirecting: "Redirigiendo...",
+  },
+};

--- a/apps/auth/src/server/agent/agentApiKeys.ts
+++ b/apps/auth/src/server/agent/agentApiKeys.ts
@@ -1,18 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
-  applyWorkspaceDatabaseScopeInExecutor,
-  query,
   queryWithUserScope,
   transactionWithUserScope,
-  type DatabaseExecutor,
 } from "../../db.js";
 import { verifySessionTokenIdentity } from "../browserSession.js";
 import { createCrockfordToken } from "../otp/crockford.js";
+import {
+  ensureUserSettingsAndSelectWorkspace,
+  resolveCanonicalUserId,
+} from "./userWorkspace.js";
 
 const AGENT_API_KEY_PREFIX = "fca";
 const AGENT_API_KEY_ID_LENGTH = 8;
 const AGENT_API_KEY_SECRET_LENGTH = 26;
-const AUTO_CREATED_WORKSPACE_NAME = "Personal";
 
 type AgentApiKeyRow = Readonly<{
   connection_id: string;
@@ -23,14 +23,6 @@ type AgentApiKeyRow = Readonly<{
   created_at: Date | string;
   last_used_at: Date | string | null;
   revoked_at: Date | string | null;
-}>;
-
-type WorkspaceMembershipRow = Readonly<{
-  workspace_id: string;
-}>;
-
-type IdentityMappingRow = Readonly<{
-  user_id: string;
 }>;
 
 export type AgentApiKeyConnection = Readonly<{
@@ -87,58 +79,6 @@ function formatAgentApiKey(keyId: string, secret: string): string {
   return `${AGENT_API_KEY_PREFIX}_${keyId}_${secret}`;
 }
 
-const upsertUserSettingsSql = [
-  "INSERT INTO org.user_settings (user_id, email)",
-  "VALUES ($1, $2)",
-  "ON CONFLICT (user_id) DO UPDATE",
-  "SET email = EXCLUDED.email",
-  "WHERE org.user_settings.email IS NULL",
-  "AND EXCLUDED.email IS NOT NULL",
-].join(" ");
-
-async function createWorkspaceInExecutor(
-  executor: DatabaseExecutor,
-  userId: string,
-): Promise<string> {
-  const workspaceId = randomUUID();
-  const bootstrapDeviceId = randomUUID();
-  const bootstrapTimestamp = new Date().toISOString();
-  const bootstrapOperationId = `bootstrap-workspace-${workspaceId}`;
-
-  await applyWorkspaceDatabaseScopeInExecutor(executor, { userId, workspaceId });
-
-  await executor.query(
-    [
-      "INSERT INTO org.workspaces",
-      "(",
-      "workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_device_id, fsrs_last_operation_id",
-      ")",
-      "VALUES ($1, $2, $3, $4, $5)",
-    ].join(" "),
-    [workspaceId, AUTO_CREATED_WORKSPACE_NAME, bootstrapTimestamp, bootstrapDeviceId, bootstrapOperationId],
-  );
-
-  await executor.query(
-    [
-      "INSERT INTO org.workspace_memberships",
-      "(workspace_id, user_id, role)",
-      "VALUES ($1, $2, 'owner')",
-    ].join(" "),
-    [workspaceId, userId],
-  );
-
-  await executor.query(
-    [
-      "INSERT INTO sync.devices",
-      "(device_id, workspace_id, user_id, platform, app_version, last_seen_at)",
-      "VALUES ($1, $2, $3, 'ios', $4, now())",
-    ].join(" "),
-    [bootstrapDeviceId, workspaceId, userId, "server-bootstrap"],
-  );
-
-  return workspaceId;
-}
-
 function mapConnection(row: AgentApiKeyRow): AgentApiKeyConnection {
   return {
     connectionId: row.connection_id,
@@ -147,20 +87,6 @@ function mapConnection(row: AgentApiKeyRow): AgentApiKeyConnection {
     lastUsedAt: toIsoString(row.last_used_at),
     revokedAt: toIsoString(row.revoked_at),
   };
-}
-
-async function resolveCanonicalUserId(providerSubject: string): Promise<string> {
-  const result = await query<IdentityMappingRow>(
-    [
-      "SELECT user_id",
-      "FROM auth.user_identities",
-      "WHERE provider_type = 'cognito' AND provider_subject = $1",
-      "LIMIT 1",
-    ].join(" "),
-    [providerSubject],
-  );
-
-  return result.rows[0]?.user_id ?? providerSubject;
 }
 
 /**
@@ -177,31 +103,11 @@ export async function createAgentApiKeyFromIdToken(idToken: string, label: strin
   const keyHash = hashKeySecret(keySecret);
 
   const result = await transactionWithUserScope({ userId }, async (executor) => {
-    await executor.query(
-      upsertUserSettingsSql,
-      [userId, identity.email],
+    const selectedWorkspaceId = await ensureUserSettingsAndSelectWorkspace(
+      executor,
+      userId,
+      identity.email,
     );
-    const membershipResult = await executor.query<WorkspaceMembershipRow>(
-      [
-        "SELECT workspace_id",
-        "FROM org.workspace_memberships",
-        "WHERE user_id = $1",
-        "ORDER BY created_at ASC, workspace_id ASC",
-      ].join(" "),
-      [userId],
-    );
-    let selectedWorkspaceId: string | null;
-    if (membershipResult.rows.length === 0) {
-      selectedWorkspaceId = await createWorkspaceInExecutor(executor, userId);
-    } else if (membershipResult.rows.length === 1) {
-      const onlyWorkspace = membershipResult.rows[0];
-      if (onlyWorkspace === undefined) {
-        throw new Error("Expected one workspace membership row");
-      }
-      selectedWorkspaceId = onlyWorkspace.workspace_id;
-    } else {
-      selectedWorkspaceId = null;
-    }
 
     const inserted = await executor.query<AgentApiKeyRow>(
       [

--- a/apps/auth/src/server/agent/userWorkspace.ts
+++ b/apps/auth/src/server/agent/userWorkspace.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared identity -> workspace resolution used when minting a first-party
+ * connection from a freshly verified Cognito ID token. Both the long-lived
+ * agent API key flow (agentApiKeys.ts) and the OAuth authorization-code flow
+ * (server/oauth/oauthStore.ts) resolve the same canonical user, ensure
+ * org.user_settings, and select-or-bootstrap the connection's workspace, so the
+ * logic lives here to stay identical across both paths.
+ */
+import { randomUUID } from "node:crypto";
+import {
+  applyWorkspaceDatabaseScopeInExecutor,
+  query,
+  type DatabaseExecutor,
+} from "../../db.js";
+
+const AUTO_CREATED_WORKSPACE_NAME = "Personal";
+
+type IdentityMappingRow = Readonly<{
+  user_id: string;
+}>;
+
+type WorkspaceMembershipRow = Readonly<{
+  workspace_id: string;
+}>;
+
+const upsertUserSettingsSql = [
+  "INSERT INTO org.user_settings (user_id, email)",
+  "VALUES ($1, $2)",
+  "ON CONFLICT (user_id) DO UPDATE",
+  "SET email = EXCLUDED.email",
+  "WHERE org.user_settings.email IS NULL",
+  "AND EXCLUDED.email IS NOT NULL",
+].join(" ");
+
+/**
+ * Maps a Cognito subject to the canonical org user id via auth.user_identities,
+ * falling back to the subject itself when no mapping row exists.
+ */
+export async function resolveCanonicalUserId(providerSubject: string): Promise<string> {
+  const result = await query<IdentityMappingRow>(
+    [
+      "SELECT user_id",
+      "FROM auth.user_identities",
+      "WHERE provider_type = 'cognito' AND provider_subject = $1",
+      "LIMIT 1",
+    ].join(" "),
+    [providerSubject],
+  );
+
+  return result.rows[0]?.user_id ?? providerSubject;
+}
+
+async function createWorkspaceInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+): Promise<string> {
+  const workspaceId = randomUUID();
+  const bootstrapDeviceId = randomUUID();
+  const bootstrapTimestamp = new Date().toISOString();
+  const bootstrapOperationId = `bootstrap-workspace-${workspaceId}`;
+
+  await applyWorkspaceDatabaseScopeInExecutor(executor, { userId, workspaceId });
+
+  await executor.query(
+    [
+      "INSERT INTO org.workspaces",
+      "(",
+      "workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_device_id, fsrs_last_operation_id",
+      ")",
+      "VALUES ($1, $2, $3, $4, $5)",
+    ].join(" "),
+    [workspaceId, AUTO_CREATED_WORKSPACE_NAME, bootstrapTimestamp, bootstrapDeviceId, bootstrapOperationId],
+  );
+
+  await executor.query(
+    [
+      "INSERT INTO org.workspace_memberships",
+      "(workspace_id, user_id, role)",
+      "VALUES ($1, $2, 'owner')",
+    ].join(" "),
+    [workspaceId, userId],
+  );
+
+  await executor.query(
+    [
+      "INSERT INTO sync.devices",
+      "(device_id, workspace_id, user_id, platform, app_version, last_seen_at)",
+      "VALUES ($1, $2, $3, 'ios', $4, now())",
+    ].join(" "),
+    [bootstrapDeviceId, workspaceId, userId, "server-bootstrap"],
+  );
+
+  return workspaceId;
+}
+
+/**
+ * Ensures org.user_settings for the user and resolves the workspace a new
+ * connection should be scoped to: the only existing workspace when there is
+ * exactly one, an auto-created Personal workspace when there are none, or null
+ * (unscoped, caller must select later) when the user belongs to several.
+ *
+ * Must run inside a user-scoped transaction so the workspace bootstrap and the
+ * caller's connection insert share one atomic unit.
+ */
+export async function ensureUserSettingsAndSelectWorkspace(
+  executor: DatabaseExecutor,
+  userId: string,
+  email: string,
+): Promise<string | null> {
+  await executor.query(upsertUserSettingsSql, [userId, email]);
+
+  const membershipResult = await executor.query<WorkspaceMembershipRow>(
+    [
+      "SELECT workspace_id",
+      "FROM org.workspace_memberships",
+      "WHERE user_id = $1",
+      "ORDER BY created_at ASC, workspace_id ASC",
+    ].join(" "),
+    [userId],
+  );
+
+  if (membershipResult.rows.length === 0) {
+    return createWorkspaceInExecutor(executor, userId);
+  }
+
+  if (membershipResult.rows.length === 1) {
+    const onlyWorkspace = membershipResult.rows[0];
+    if (onlyWorkspace === undefined) {
+      throw new Error("Expected one workspace membership row");
+    }
+    return onlyWorkspace.workspace_id;
+  }
+
+  return null;
+}

--- a/apps/auth/src/server/oauth/oauthStore.ts
+++ b/apps/auth/src/server/oauth/oauthStore.ts
@@ -11,13 +11,24 @@
  * db/migrations/0074), so reads/writes use the unscoped `query`/`transaction`
  * helpers rather than the RLS-scoped variants.
  */
-import { query, transaction, type DatabaseExecutor } from "../../db.js";
+import { randomUUID } from "node:crypto";
+import { query, transaction, transactionWithUserScope, type DatabaseExecutor } from "../../db.js";
+import { verifySessionTokenIdentity } from "../browserSession.js";
+import {
+  ensureUserSettingsAndSelectWorkspace,
+  resolveCanonicalUserId,
+} from "../agent/userWorkspace.js";
 import { createCrockfordToken, hashOpaqueToken, normalizeCrockfordToken } from "../otp/crockford.js";
 
 const ACCESS_TOKEN_PREFIX = "fco";
 const REFRESH_TOKEN_PREFIX = "fcr";
 const OAUTH_TOKEN_SECRET_LENGTH = 40;
 const CLIENT_ID_LENGTH = 24;
+const AUTHORIZATION_CODE_SECRET_LENGTH = 40;
+// Authorization codes are short-lived: the client redeems them at the token
+// endpoint within seconds of the redirect (OAuth 2.1 recommends <= 10 minutes).
+export const AUTHORIZATION_CODE_TTL_SECONDS = 600;
+const AUTHORIZATION_CODE_TTL_MS = AUTHORIZATION_CODE_TTL_SECONDS * 1000;
 
 export const ACCESS_TOKEN_TTL_SECONDS = 3600;
 const ACCESS_TOKEN_TTL_MS = ACCESS_TOKEN_TTL_SECONDS * 1000;
@@ -213,6 +224,123 @@ export async function getActiveAuthorizationCode(
     scope: row.scope,
     resource: row.resource,
   };
+}
+
+/**
+ * The PKCE-bound authorization request fields the browser /authorize flow
+ * verified before the user approved consent. They are persisted on the
+ * single-use code so the token endpoint can re-check redirect_uri + PKCE and
+ * carry resource/scope through to the minted access token.
+ */
+export type AuthorizationGrantRequest = Readonly<{
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scope: string | null;
+  resource: string;
+  connectionLabel: string;
+}>;
+
+async function upsertConnectionInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  clientId: string,
+  label: string,
+  selectedWorkspaceId: string | null,
+): Promise<string> {
+  // One active connection per (user, client): reuse the existing row on
+  // reconnect so revoking it stays a single, predictable action for the user.
+  // A connection revoked earlier is un-revoked here because the user is
+  // explicitly re-approving the same client.
+  const existing = await executor.query<{ connection_id: string }>(
+    [
+      "SELECT connection_id",
+      "FROM auth.oauth_connections",
+      "WHERE user_id = $1 AND client_id = $2",
+      "ORDER BY created_at DESC, connection_id DESC",
+      "LIMIT 1",
+    ].join(" "),
+    [userId, clientId],
+  );
+
+  const existingConnectionId = existing.rows[0]?.connection_id;
+  if (existingConnectionId !== undefined) {
+    await executor.query(
+      [
+        "UPDATE auth.oauth_connections",
+        "SET label = $2, selected_workspace_id = $3, revoked_at = NULL",
+        "WHERE connection_id = $1",
+      ].join(" "),
+      [existingConnectionId, label, selectedWorkspaceId],
+    );
+    return existingConnectionId;
+  }
+
+  const connectionId = randomUUID();
+  await executor.query(
+    [
+      "INSERT INTO auth.oauth_connections",
+      "(connection_id, user_id, client_id, label, selected_workspace_id)",
+      "VALUES ($1, $2, $3, $4, $5)",
+    ].join(" "),
+    [connectionId, userId, clientId, label, selectedWorkspaceId],
+  );
+  return connectionId;
+}
+
+/**
+ * Approves an OAuth authorization request: resolves the user from a freshly
+ * verified Cognito ID token (mapping the subject to the canonical user and
+ * ensuring a workspace, exactly like createAgentApiKeyFromIdToken), upserts the
+ * (user, client) connection, and writes a single-use authorization code bound to
+ * that connection. Returns the opaque code; only its hash is persisted.
+ */
+export async function approveAuthorizationRequest(
+  idToken: string,
+  request: AuthorizationGrantRequest,
+  nowMs: number,
+): Promise<string> {
+  const identity = await verifySessionTokenIdentity(idToken);
+  const userId = await resolveCanonicalUserId(identity.userId);
+  const code = createCrockfordToken(AUTHORIZATION_CODE_SECRET_LENGTH);
+  const codeHash = hashOpaqueToken(code);
+  const expiresAt = new Date(nowMs + AUTHORIZATION_CODE_TTL_MS).toISOString();
+
+  await transactionWithUserScope({ userId }, async (executor) => {
+    const selectedWorkspaceId = await ensureUserSettingsAndSelectWorkspace(
+      executor,
+      userId,
+      identity.email,
+    );
+    const connectionId = await upsertConnectionInExecutor(
+      executor,
+      userId,
+      request.clientId,
+      request.connectionLabel,
+      selectedWorkspaceId,
+    );
+
+    await executor.query(
+      [
+        "INSERT INTO auth.oauth_authorization_codes",
+        "(code_hash, client_id, connection_id, redirect_uri, code_challenge,",
+        "code_challenge_method, scope, resource, expires_at)",
+        "VALUES ($1, $2, $3, $4, $5, 'S256', $6, $7, $8)",
+      ].join(" "),
+      [
+        codeHash,
+        request.clientId,
+        connectionId,
+        request.redirectUri,
+        request.codeChallenge,
+        request.scope,
+        request.resource,
+        expiresAt,
+      ],
+    );
+  });
+
+  return code;
 }
 
 async function issueTokensInExecutor(

--- a/apps/auth/src/server/oauth/oauthStore.ts
+++ b/apps/auth/src/server/oauth/oauthStore.ts
@@ -268,7 +268,10 @@ async function upsertConnectionInExecutor(
     await executor.query(
       [
         "UPDATE auth.oauth_connections",
-        "SET label = $2, selected_workspace_id = $3, revoked_at = NULL",
+        // COALESCE preserves an existing workspace binding when the resolver
+        // returns null (multi-workspace users), so reconnect does not clobber a
+        // previously selected workspace back to NULL.
+        "SET label = $2, selected_workspace_id = COALESCE($3, auth.oauth_connections.selected_workspace_id), revoked_at = NULL",
         "WHERE connection_id = $1",
       ].join(" "),
       [existingConnectionId, label, selectedWorkspaceId],

--- a/apps/auth/src/server/publicUrls.ts
+++ b/apps/auth/src/server/publicUrls.ts
@@ -40,6 +40,28 @@ export function getPublicApiBaseUrl(requestUrl: string): string {
 }
 
 /**
+ * Resolves the canonical MCP protected-resource identifier
+ * (`https://mcp.<domain>/mcp`) that authorization codes and access tokens must
+ * be bound to. The backend validates `oauth_access_tokens.resource` against this
+ * exact value (apps/backend lambda-mcp.ts), so the /authorize endpoint binds the
+ * code to it. `MCP_RESOURCE` overrides; otherwise it is derived from the public
+ * auth origin by swapping the `auth.` subdomain for `mcp.` and appending `/mcp`.
+ */
+export function getMcpResource(requestUrl: string): string {
+  const configuredValue = process.env.MCP_RESOURCE;
+  if (configuredValue !== undefined && configuredValue !== "") {
+    return stripTrailingSlash(configuredValue);
+  }
+
+  const authBaseUrl = getPublicAuthBaseUrl(requestUrl);
+  const url = new URL(authBaseUrl);
+  url.hostname = url.hostname.startsWith("auth.")
+    ? `mcp.${url.hostname.slice("auth.".length)}`
+    : url.hostname;
+  return `${stripTrailingSlash(`${url.protocol}//${url.host}`)}/mcp`;
+}
+
+/**
  * Builds the public AI-agent documentation URLs served by the API host.
  */
 export function getPublicAgentDocs(requestUrl: string): Readonly<{

--- a/apps/auth/src/templates/authorize.ts
+++ b/apps/auth/src/templates/authorize.ts
@@ -20,8 +20,9 @@ const AUTH_FAVICON_URL =
 
 /**
  * The validated authorization request echoed into the page and posted back on
- * consent. All values are already validated by the GET handler; the JSON is
- * embedded with JSON.stringify so it is HTML-attribute and script safe.
+ * consent. Some fields (state, clientName) are attacker-influenced, so the JSON
+ * is serialized with toScriptJson, which escapes the characters that could
+ * terminate the inline <script> element or break the JS string literal.
  */
 export type AuthorizeRequestView = Readonly<{
   clientId: string;
@@ -32,6 +33,21 @@ export type AuthorizeRequestView = Readonly<{
   resource: string;
   clientName: string;
 }>;
+
+/**
+ * Serializes a value to JSON safe for embedding in an inline <script> body.
+ * JSON.stringify does not escape `<`, `>`, `&`, U+2028, or U+2029, so a string
+ * containing `</script>` (or a JS line separator) could break out of the script
+ * element or the surrounding statement. Escaping them as \uXXXX keeps the JSON
+ * valid while making breakout impossible.
+ */
+const toScriptJson = (value: unknown): string =>
+  JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 
 export const renderAuthorizePage = (
   request: AuthorizeRequestView,
@@ -246,8 +262,8 @@ export const renderAuthorizePage = (
 
   <script>
     (function() {
-      var request = ${JSON.stringify(request)};
-      var copy = ${JSON.stringify(copy)};
+      var request = ${toScriptJson(request)};
+      var copy = ${toScriptJson(copy)};
 
       var csrfToken = "";
 

--- a/apps/auth/src/templates/authorize.ts
+++ b/apps/auth/src/templates/authorize.ts
@@ -1,0 +1,464 @@
+/**
+ * OAuth /authorize screen: email + OTP sign-in followed by a consent step that
+ * mints an authorization code and redirects back to the OAuth client. Vanilla
+ * HTML + CSS + JS, sharing the visual language of the browser login page
+ * (templates/login.ts). Sign-in reuses the existing /api/send-code and
+ * /api/verify-code endpoints (which set the session cookie); consent posts to
+ * /authorize/consent, which reads that cookie and returns the redirect URL.
+ */
+import {
+  getLoginPageLocaleDirection,
+  type LoginPageLocale,
+} from "../routes/browser/loginPageLocale.js";
+import {
+  AUTHORIZE_CONSENT_COPY,
+  type AuthorizeConsentCopy,
+} from "../routes/oauth/authorizePageLocale.js";
+
+const AUTH_FAVICON_URL =
+  "data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%22512%22%20height=%22512%22%20viewBox=%220%200%20512%20512%22%3E%3Crect%20width=%22512%22%20height=%22512%22%20rx=%2296%22%20fill=%22%23232323%22/%3E%3Crect%20x=%22104%22%20y=%2292%22%20width=%22184%22%20height=%22264%22%20rx=%2232%22%20fill=%22%23f8f3ec%22/%3E%3Crect%20x=%22212%22%20y=%22156%22%20width=%22196%22%20height=%22272%22%20rx=%2232%22%20fill=%22%23c44b2d%22/%3E%3C/svg%3E";
+
+/**
+ * The validated authorization request echoed into the page and posted back on
+ * consent. All values are already validated by the GET handler; the JSON is
+ * embedded with JSON.stringify so it is HTML-attribute and script safe.
+ */
+export type AuthorizeRequestView = Readonly<{
+  clientId: string;
+  redirectUri: string;
+  state: string | null;
+  codeChallenge: string;
+  scope: string | null;
+  resource: string;
+  clientName: string;
+}>;
+
+export const renderAuthorizePage = (
+  request: AuthorizeRequestView,
+  locale: LoginPageLocale,
+): string => {
+  const copy: AuthorizeConsentCopy = AUTHORIZE_CONSENT_COPY[locale];
+  const direction = getLoginPageLocaleDirection(locale);
+
+  return `<!DOCTYPE html>
+<html lang="${locale}" dir="${direction}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="${AUTH_FAVICON_URL}">
+  <title>${copy.pageTitle}</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #050505;
+      --surface: linear-gradient(180deg, rgba(24, 24, 30, 0.94), rgba(17, 17, 22, 0.98));
+      --surface-muted: rgba(255, 255, 255, 0.04);
+      --text: #f6f6f8;
+      --text-secondary: rgba(235, 235, 245, 0.66);
+      --accent: #c44b2d;
+      --accent-strong: #d65a38;
+      --border: rgba(255, 255, 255, 0.1);
+      --border-strong: rgba(255, 255, 255, 0.16);
+      --danger: #ff4d57;
+      --shadow-soft: 0 12px 30px rgba(0, 0, 0, 0.26);
+      --radius-sm: 10px;
+      --radius-md: 14px;
+      --radius-xl: 24px;
+      --radius-pill: 999px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; }
+
+    html {
+      background:
+        radial-gradient(circle at top, rgba(196, 75, 45, 0.12), transparent 34%),
+        radial-gradient(circle at bottom left, rgba(255, 255, 255, 0.05), transparent 26%),
+        var(--bg);
+    }
+
+    body {
+      background: transparent;
+      color: var(--text);
+      font-family:
+        -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui, sans-serif;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    ::selection { background: rgba(196, 75, 45, 0.34); color: var(--text); }
+
+    .login-page {
+      position: relative;
+      display: grid;
+      place-items: center;
+      min-height: 100vh;
+      padding: 24px 16px;
+      width: 100%;
+    }
+
+    .login-card {
+      width: 100%;
+      max-width: 420px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 30px;
+      background: var(--surface);
+      box-shadow: var(--shadow-soft);
+    }
+
+    .login-title {
+      margin: 0 0 16px;
+      font-size: clamp(1.6rem, 3.4vw, 2rem);
+      font-weight: 760;
+      line-height: 1.04;
+      letter-spacing: -0.04em;
+    }
+
+    .login-label {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .login-input {
+      display: block;
+      width: 100%;
+      min-height: 44px;
+      padding: 10px 12px;
+      margin-bottom: 16px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: var(--surface-muted);
+      color: var(--text);
+      font-family: inherit;
+      font-size: 14px;
+      transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease;
+    }
+
+    .login-input::placeholder { color: rgba(235, 235, 245, 0.45); }
+
+    .login-input:focus-visible {
+      outline: none;
+      border-color: var(--border-strong);
+      background: rgba(255, 255, 255, 0.06);
+      box-shadow: 0 0 0 3px rgba(196, 75, 45, 0.18);
+    }
+
+    .login-btn {
+      display: block;
+      width: 100%;
+      min-height: 44px;
+      padding: 10px 14px;
+      border: 1px solid transparent;
+      border-radius: var(--radius-pill);
+      background: var(--accent);
+      color: #fff5f2;
+      font-family: inherit;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
+      transition: transform 140ms ease, background 140ms ease, opacity 140ms ease;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      .login-btn:hover { background: var(--accent-strong); transform: translateY(-1px); }
+    }
+
+    .login-btn:disabled { opacity: 0.5; cursor: default; }
+
+    .login-btn-secondary {
+      margin-top: 10px;
+      background: rgba(255, 255, 255, 0.05);
+      color: var(--text-secondary);
+      border-color: var(--border);
+      box-shadow: none;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      .login-btn-secondary:hover { background: rgba(255, 255, 255, 0.08); color: var(--text); }
+    }
+
+    .login-error { color: var(--danger); font-size: 13px; margin-bottom: 12px; }
+    .login-hint { color: var(--text-secondary); font-size: 14px; margin: 0 0 16px; }
+    .login-status { color: var(--text-secondary); font-size: 13px; margin: 0; }
+
+    .consent-scope {
+      margin: 0 0 18px;
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: var(--surface-muted);
+      color: var(--text-secondary);
+      font-size: 13px;
+    }
+
+    .consent-account { color: var(--text-secondary); font-size: 13px; margin: 0 0 16px; }
+    .consent-account strong { color: var(--text); font-weight: 600; }
+
+    .hidden { display: none; }
+
+    @media (max-width: 768px) {
+      .login-page { padding: 18px 14px; }
+      .login-card { max-width: 100%; border-radius: var(--radius-md); padding: 24px 18px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="login-page">
+    <div class="login-card">
+      <div id="step-checking">
+        <p class="login-status">${copy.checkingSession}</p>
+      </div>
+
+      <div id="step-email" class="hidden">
+        <h1 class="login-title">${copy.signInTitle}</h1>
+        <label class="login-label" for="login-email">${copy.emailLabel}</label>
+        <input id="login-email" class="login-input" type="email" autocomplete="email" autofocus>
+        <div id="email-error" class="login-error hidden"></div>
+        <button id="send-btn" class="login-btn" type="button">${copy.sendCode}</button>
+      </div>
+
+      <div id="step-otp" class="hidden">
+        <h1 class="login-title">${copy.signInTitle}</h1>
+        <p class="login-hint">${copy.checkEmailForCode}</p>
+        <label class="login-label" for="login-otp">${copy.verificationCodeLabel}</label>
+        <input id="login-otp" class="login-input" type="text" inputmode="numeric" autocomplete="one-time-code" maxlength="8">
+        <div id="otp-error" class="login-error hidden"></div>
+        <button id="verify-btn" class="login-btn" type="button">${copy.verify}</button>
+      </div>
+
+      <div id="step-consent" class="hidden">
+        <h1 class="login-title">${copy.consentTitle}</h1>
+        <p class="login-hint" id="consent-lead"></p>
+        <p class="consent-scope">${copy.consentScopeAccess}</p>
+        <p class="consent-account hidden" id="consent-account"></p>
+        <div id="consent-error" class="login-error hidden"></div>
+        <button id="approve-btn" class="login-btn" type="button">${copy.approve}</button>
+        <button id="deny-btn" class="login-btn login-btn-secondary" type="button">${copy.deny}</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var request = ${JSON.stringify(request)};
+      var copy = ${JSON.stringify(copy)};
+
+      var csrfToken = "";
+
+      var emailInput = document.getElementById("login-email");
+      var otpInput = document.getElementById("login-otp");
+      var sendBtn = document.getElementById("send-btn");
+      var verifyBtn = document.getElementById("verify-btn");
+      var approveBtn = document.getElementById("approve-btn");
+      var denyBtn = document.getElementById("deny-btn");
+      var stepChecking = document.getElementById("step-checking");
+      var stepEmail = document.getElementById("step-email");
+      var stepOtp = document.getElementById("step-otp");
+      var stepConsent = document.getElementById("step-consent");
+      var emailError = document.getElementById("email-error");
+      var otpError = document.getElementById("otp-error");
+      var consentError = document.getElementById("consent-error");
+      var consentLead = document.getElementById("consent-lead");
+      var consentAccount = document.getElementById("consent-account");
+
+      function showError(el, msg) {
+        el.textContent = msg;
+        el.classList.remove("hidden");
+      }
+
+      function hideError(el) {
+        el.classList.add("hidden");
+        el.textContent = "";
+      }
+
+      function hideAllSteps() {
+        stepChecking.classList.add("hidden");
+        stepEmail.classList.add("hidden");
+        stepOtp.classList.add("hidden");
+        stepConsent.classList.add("hidden");
+      }
+
+      function showEmailStep() {
+        hideAllSteps();
+        stepEmail.classList.remove("hidden");
+        emailInput.focus();
+      }
+
+      function showConsentStep(email) {
+        hideAllSteps();
+        consentLead.textContent = copy.consentLead.replace("{client}", request.clientName);
+        if (email) {
+          consentAccount.textContent = copy.consentSignedInAs + " " + email;
+          consentAccount.classList.remove("hidden");
+        }
+        stepConsent.classList.remove("hidden");
+        approveBtn.focus();
+      }
+
+      function tryRefreshSession() {
+        return fetch("api/refresh-session", {
+          method: "POST",
+          credentials: "same-origin",
+        }).then(function(res) {
+          if (res.ok) {
+            showConsentStep("");
+            return;
+          }
+          showEmailStep();
+        }).catch(function() {
+          showEmailStep();
+        });
+      }
+
+      otpInput.addEventListener("input", function() {
+        otpInput.value = otpInput.value.replace(/\\D/g, "").slice(0, 8);
+      });
+
+      emailInput.addEventListener("keydown", function(e) {
+        if (e.key === "Enter") sendBtn.click();
+      });
+
+      otpInput.addEventListener("keydown", function(e) {
+        if (e.key === "Enter") verifyBtn.click();
+      });
+
+      sendBtn.addEventListener("click", function() {
+        var email = emailInput.value.trim();
+        if (!email) return;
+
+        hideError(emailError);
+        sendBtn.disabled = true;
+        sendBtn.textContent = copy.sendingCode;
+
+        fetch("api/send-code", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({ email: email }),
+        })
+          .then(function(res) {
+            return res.json().then(function(data) {
+              if (!res.ok) {
+                showError(emailError, data.error || copy.genericErrorPrefix + ": " + res.status);
+                return;
+              }
+              if (
+                typeof data.idToken === "string" && data.idToken !== ""
+                && typeof data.refreshToken === "string" && data.refreshToken !== ""
+              ) {
+                // Configured review account emails complete sign-in immediately.
+                showConsentStep(email);
+                return;
+              }
+              csrfToken = data.csrfToken || "";
+              hideAllSteps();
+              stepOtp.classList.remove("hidden");
+              otpInput.focus();
+            });
+          })
+          .catch(function() {
+            showError(emailError, copy.genericErrorPrefix);
+          })
+          .finally(function() {
+            sendBtn.disabled = false;
+            sendBtn.textContent = copy.sendCode;
+          });
+      });
+
+      verifyBtn.addEventListener("click", function() {
+        var code = otpInput.value.trim();
+        if (code.length !== 8) return;
+
+        hideError(otpError);
+        verifyBtn.disabled = true;
+        verifyBtn.textContent = copy.verifying;
+
+        fetch("api/verify-code", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({ code: code, csrfToken: csrfToken }),
+        })
+          .then(function(res) {
+            return res.json().then(function(data) {
+              if (!res.ok) {
+                showError(otpError, data.error || copy.genericErrorPrefix + ": " + res.status);
+                return;
+              }
+              showConsentStep("");
+            });
+          })
+          .catch(function() {
+            showError(otpError, copy.genericErrorPrefix);
+          })
+          .finally(function() {
+            verifyBtn.disabled = false;
+            verifyBtn.textContent = copy.verify;
+          });
+      });
+
+      denyBtn.addEventListener("click", function() {
+        // RFC 6749 4.1.2.1: report access_denied to the client's redirect_uri.
+        var url = new URL(request.redirectUri);
+        url.searchParams.set("error", "access_denied");
+        if (request.state) url.searchParams.set("state", request.state);
+        window.location.href = url.toString();
+      });
+
+      approveBtn.addEventListener("click", function() {
+        hideError(consentError);
+        approveBtn.disabled = true;
+        denyBtn.disabled = true;
+        approveBtn.textContent = copy.approving;
+
+        fetch("authorize/consent", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            client_id: request.clientId,
+            redirect_uri: request.redirectUri,
+            state: request.state,
+            code_challenge: request.codeChallenge,
+            scope: request.scope,
+            resource: request.resource,
+          }),
+        })
+          .then(function(res) {
+            return res.json().then(function(data) {
+              if (!res.ok) {
+                if (res.status === 401) {
+                  // Session expired between sign-in and approval; re-authenticate.
+                  showEmailStep();
+                  return;
+                }
+                showError(consentError, data.error_description || data.error || copy.genericErrorPrefix + ": " + res.status);
+                approveBtn.disabled = false;
+                denyBtn.disabled = false;
+                approveBtn.textContent = copy.approve;
+                return;
+              }
+              approveBtn.textContent = copy.redirecting;
+              window.location.href = data.redirect_to;
+            });
+          })
+          .catch(function() {
+            showError(consentError, copy.genericErrorPrefix);
+            approveBtn.disabled = false;
+            denyBtn.disabled = false;
+            approveBtn.textContent = copy.approve;
+          });
+      });
+
+      void tryRefreshSession();
+    })();
+  </script>
+</body>
+</html>`;
+};

--- a/db/migrations/0076_oauth_authorize_endpoint_auth_app.sql
+++ b/db/migrations/0076_oauth_authorize_endpoint_auth_app.sql
@@ -1,0 +1,23 @@
+-- OAuth /authorize endpoint (item 06) runtime support.
+--
+-- The browser-facing /authorize endpoint runs inside the auth service
+-- (auth_app). After login + consent it upserts the (user, client)
+-- auth.oauth_connections row and writes a single-use
+-- auth.oauth_authorization_codes row. db/migrations/0074 granted these tables
+-- only to backend_app; db/migrations/0075 added the auth_app grants the /token
+-- and /register endpoints need (SELECT on connections; SELECT + UPDATE on
+-- codes). This migration adds the remaining auth_app grants the consent path
+-- needs:
+--   - oauth_connections: INSERT (mint a new connection) + UPDATE (reuse/un-revoke
+--     an existing (user, client) connection on reconnect). SELECT already granted
+--     in 0075.
+--   - oauth_authorization_codes: INSERT (write the single-use code). SELECT +
+--     UPDATE already granted in 0075.
+--
+-- The user/workspace bootstrap the consent path performs (org.user_settings,
+-- org.workspaces, org.workspace_memberships, sync.devices) reuses the same
+-- helper as the agent-API-key flow, whose auth_app grants already exist
+-- (db/migrations/0024).
+
+GRANT INSERT, UPDATE ON auth.oauth_connections TO auth_app;
+GRANT INSERT ON auth.oauth_authorization_codes TO auth_app;

--- a/infra/aws/lib/gateways/auth-gateway.ts
+++ b/infra/aws/lib/gateways/auth-gateway.ts
@@ -130,6 +130,10 @@ export function authGateway(scope: Construct, props: AuthGatewayProps): AuthGate
       COOKIE_DOMAIN: props.baseDomain,
       PUBLIC_AUTH_BASE_URL: `https://auth.${props.baseDomain}`,
       PUBLIC_API_BASE_URL: `https://api.${props.baseDomain}/v1`,
+      // Canonical MCP protected-resource identifier the /authorize endpoint binds
+      // authorization codes to; must match the backend MCP handler's resource
+      // (apps/backend lambda-mcp.ts: https://mcp.<domain>/mcp).
+      MCP_RESOURCE: `https://mcp.${props.baseDomain}/mcp`,
     },
   });
 


### PR DESCRIPTION
Implements plan item 06-auth-oauth-authorize-ui: OAuth /authorize login (email+OTP), consent, and connection minting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)