### PR TITLE
Fix agent/OAuth first-login workspace bootstrap to current sync schema

### DIFF
--- a/apps/auth/src/server/agent/userWorkspace.ts
+++ b/apps/auth/src/server/agent/userWorkspace.ts
@@ -55,21 +55,23 @@ async function createWorkspaceInExecutor(
   userId: string,
 ): Promise<string> {
   const workspaceId = randomUUID();
-  const bootstrapDeviceId = randomUUID();
+  const bootstrapReplicaId = randomUUID();
   const bootstrapTimestamp = new Date().toISOString();
   const bootstrapOperationId = `bootstrap-workspace-${workspaceId}`;
 
   await applyWorkspaceDatabaseScopeInExecutor(executor, { userId, workspaceId });
 
+  // The workspace row references the bootstrap replica via a deferred FK, so it
+  // is inserted first and validated against the replica row at commit.
   await executor.query(
     [
       "INSERT INTO org.workspaces",
       "(",
-      "workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_device_id, fsrs_last_operation_id",
+      "workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_replica_id, fsrs_last_operation_id",
       ")",
       "VALUES ($1, $2, $3, $4, $5)",
     ].join(" "),
-    [workspaceId, AUTO_CREATED_WORKSPACE_NAME, bootstrapTimestamp, bootstrapDeviceId, bootstrapOperationId],
+    [workspaceId, AUTO_CREATED_WORKSPACE_NAME, bootstrapTimestamp, bootstrapReplicaId, bootstrapOperationId],
   );
 
   await executor.query(
@@ -81,13 +83,18 @@ async function createWorkspaceInExecutor(
     [workspaceId, userId],
   );
 
+  // Seed the workspace replica that owns the bootstrap scheduler-settings row,
+  // mirroring the canonical backend workspace seed (org.workspaces ->
+  // sync.workspace_replicas as the LWW actor).
   await executor.query(
     [
-      "INSERT INTO sync.devices",
-      "(device_id, workspace_id, user_id, platform, app_version, last_seen_at)",
-      "VALUES ($1, $2, $3, 'ios', $4, now())",
+      "INSERT INTO sync.workspace_replicas",
+      "(",
+      "replica_id, workspace_id, user_id, actor_kind, actor_key, platform, app_version, last_seen_at",
+      ")",
+      "VALUES ($1, $2, $3, 'workspace_seed', 'workspace-seed', 'system', $4, now())",
     ].join(" "),
-    [bootstrapDeviceId, workspaceId, userId, "server-bootstrap"],
+    [bootstrapReplicaId, workspaceId, userId, "server-bootstrap"],
   );
 
   return workspaceId;


### PR DESCRIPTION
## Problem
The shared connection-minting helper `createWorkspaceInExecutor` in `apps/auth/src/server/agent/userWorkspace.ts` — used by **both** the agent API key flow (`agentApiKeys.ts`) and the OAuth authorization-code flow (`oauth/oauthStore.ts`) — provisions a new user's first workspace using schema removed in migration `0035`:
- column `org.workspaces.fsrs_last_modified_by_device_id` (dropped)
- table `sync.devices` (dropped)

Result: first-time sign-ins (no existing workspace) fail with HTTP 500 (`post_cognito_database_error`) right after Cognito OTP verification. Existing users are unaffected (they skip the bootstrap path).

## Fix
Align the bootstrap with the canonical backend seed in `apps/backend/src/workspaces/create.ts`:
- write `fsrs_last_modified_by_replica_id` instead of `fsrs_last_modified_by_device_id`
- insert a `workspace_seed` row into `sync.workspace_replicas` instead of `sync.devices`

Both callers run inside `transactionWithUserScope`. The workspace→replica FK is `DEFERRABLE INITIALLY DEFERRED` (migrations `0036`/`0037`), so the existing insert order (workspace → membership → replica) validates at commit. `auth_app` already holds `INSERT` grant + RLS insert policy on `sync.workspace_replicas` (migration `0035`). Fixing the shared helper repairs both flows in one place.

## Validation
- `tsc --noEmit` clean; `npm test` (auth) 33/33 pass.
- SQL verified against the migration chain: column/table/CHECK (`actor_kind='workspace_seed'` per `0042`, `platform='system'` per `0035`), deferred FK, RLS policy + grant for `auth_app`.
- No stale dependents: sole internal helper; `createAgentApiKeyFromIdToken` is fully mocked in tests (no SQL string-matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)