### PR TITLE
Advertise MCP connector in agent discovery + precursor TODOs

### DIFF
--- a/api/src/components/schemas/AgentDiscoveryData.yaml
+++ b/api/src/components/schemas/AgentDiscoveryData.yaml
@@ -7,6 +7,7 @@ required:
   - authBaseUrl
   - apiBaseUrl
   - surface
+  - mcp
 properties:
   service:
     type: object
@@ -62,3 +63,34 @@ properties:
         type: string
       sqlUrl:
         type: string
+  mcp:
+    type: object
+    additionalProperties: false
+    required:
+      - url
+      - description
+      - authorization
+    properties:
+      url:
+        type: string
+      description:
+        type: string
+      authorization:
+        type: object
+        additionalProperties: false
+        required:
+          - type
+          - authorizationServer
+          - authorizationServerMetadataUrl
+          - protectedResourceMetadataUrl
+        properties:
+          type:
+            type: string
+            enum:
+              - oauth2
+          authorizationServer:
+            type: string
+          authorizationServerMetadataUrl:
+            type: string
+          protectedResourceMetadataUrl:
+            type: string

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -36,6 +36,18 @@ get:
                 accountUrl: https://api.flashcards-open-source-app.com/v1/agent/me
                 workspacesUrl: https://api.flashcards-open-source-app.com/v1/agent/workspaces
                 sqlUrl: https://api.flashcards-open-source-app.com/v1/agent/sql
+              mcp:
+                url: https://mcp.flashcards-open-source-app.com/mcp
+                description: >-
+                  Remote MCP server for AI clients that connect through custom
+                  connectors (for example Claude.ai or ChatGPT). Add the url as a
+                  custom connector and authorize through OAuth, then use the sql
+                  tool to read and write cards and decks.
+                authorization:
+                  type: oauth2
+                  authorizationServer: https://auth.flashcards-open-source-app.com
+                  authorizationServerMetadataUrl: https://auth.flashcards-open-source-app.com/.well-known/oauth-authorization-server
+                  protectedResourceMetadataUrl: https://mcp.flashcards-open-source-app.com/.well-known/oauth-protected-resource
             instructions: >-
               Start with agent auth bootstrap. First call POST
               https://auth.flashcards-open-source-app.com/api/agent/send-code

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -35,6 +35,18 @@ get:
                 accountUrl: https://api.flashcards-open-source-app.com/v1/agent/me
                 workspacesUrl: https://api.flashcards-open-source-app.com/v1/agent/workspaces
                 sqlUrl: https://api.flashcards-open-source-app.com/v1/agent/sql
+              mcp:
+                url: https://mcp.flashcards-open-source-app.com/mcp
+                description: >-
+                  Remote MCP server for AI clients that connect through custom
+                  connectors (for example Claude.ai or ChatGPT). Add the url as a
+                  custom connector and authorize through OAuth, then use the sql
+                  tool to read and write cards and decks.
+                authorization:
+                  type: oauth2
+                  authorizationServer: https://auth.flashcards-open-source-app.com
+                  authorizationServerMetadataUrl: https://auth.flashcards-open-source-app.com/.well-known/oauth-authorization-server
+                  protectedResourceMetadataUrl: https://mcp.flashcards-open-source-app.com/.well-known/oauth-protected-resource
             instructions: >-
               Start with POST
               https://auth.flashcards-open-source-app.com/api/agent/send-code

--- a/apps/auth/src/routes/agent/agentSendCode.ts
+++ b/apps/auth/src/routes/agent/agentSendCode.ts
@@ -2,6 +2,12 @@
  * Agent-only OTP bootstrap route for terminal clients. It returns a short
  * opaque handle instead of a signed payload so agents do not need to repeat
  * the full Cognito session blob in the next request.
+ *
+ * TODO(mcp-oauth): This bespoke email_otp_then_api_key agent bootstrap is the
+ * precursor to the standardized OAuth 2.1 /authorize + /token endpoints added
+ * for the MCP connector. Long term, MCP can become the single agent surface for
+ * both naive (Claude.ai, ChatGPT) and smart clients, and this flow may fold into
+ * the standard OAuth path.
  */
 import { Hono } from "hono";
 import { initiateEmailOtp } from "../../server/cognito/cognitoAuth.js";

--- a/apps/auth/src/routes/agent/agentVerifyCode.ts
+++ b/apps/auth/src/routes/agent/agentVerifyCode.ts
@@ -1,6 +1,12 @@
 /**
  * Agent-only OTP completion route. A short opaque OTP handle is resolved to
  * the server-side Cognito session, then exchanged for a long-lived API key.
+ *
+ * TODO(mcp-oauth): This bespoke email_otp_then_api_key agent flow (issuing a
+ * long-lived fca_ API key) is the precursor to the standardized OAuth 2.1
+ * /authorize + /token endpoints added for the MCP connector. Long term, MCP can
+ * become the single agent surface for both naive and smart clients, and this
+ * flow may fold into the standard OAuth path.
  */
 import { Hono } from "hono";
 import { type AuthAppEnv, getRequestId } from "../../server/apiErrors.js";

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -21,6 +21,16 @@ type AgentDiscoveryEnvelope = Readonly<{
       workspacesUrl: string;
       sqlUrl: string;
     }>;
+    mcp: Readonly<{
+      url: string;
+      description: string;
+      authorization: Readonly<{
+        type: "oauth2";
+        authorizationServer: string;
+        authorizationServerMetadataUrl: string;
+        protectedResourceMetadataUrl: string;
+      }>;
+    }>;
   }>;
   instructions: string;
   docs: Readonly<{
@@ -52,8 +62,24 @@ function buildAuthBaseUrl(requestUrl: string): string {
   return stripTrailingSlash(origin.replace("//api.", "//auth."));
 }
 
+function buildMcpBaseUrl(requestUrl: string): string {
+  const configuredBaseUrl = process.env.PUBLIC_MCP_BASE_URL;
+  if (configuredBaseUrl !== undefined && configuredBaseUrl !== "") {
+    return stripTrailingSlash(configuredBaseUrl);
+  }
+
+  const origin = toRequestOrigin(requestUrl);
+  const host = new URL(requestUrl).host;
+  if (host === "localhost:8080" || host === "127.0.0.1:8080") {
+    return "http://localhost:8082";
+  }
+
+  return stripTrailingSlash(origin.replace("//api.", "//mcp."));
+}
+
 export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscoveryEnvelope {
   const authBaseUrl = buildAuthBaseUrl(requestUrl);
+  const mcpBaseUrl = buildMcpBaseUrl(requestUrl);
   const apiBaseUrl = getPublicApiBaseUrl(requestUrl);
   const docs = getPublicAgentDocs(requestUrl);
 
@@ -82,6 +108,17 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         accountUrl: `${apiBaseUrl}/agent/me`,
         workspacesUrl: `${apiBaseUrl}/agent/workspaces`,
         sqlUrl: `${apiBaseUrl}/agent/sql`,
+      },
+      mcp: {
+        url: `${mcpBaseUrl}/mcp`,
+        description:
+          "Remote MCP server for AI clients that connect through custom connectors (for example Claude.ai or ChatGPT). Add the url as a custom connector and authorize through OAuth, then use the sql tool to read and write cards and decks.",
+        authorization: {
+          type: "oauth2",
+          authorizationServer: authBaseUrl,
+          authorizationServerMetadataUrl: `${authBaseUrl}/.well-known/oauth-authorization-server`,
+          protectedResourceMetadataUrl: `${mcpBaseUrl}/.well-known/oauth-protected-resource`,
+        },
       },
     },
     instructions:


### PR DESCRIPTION
Finishes item "05" of the MCP/OAuth rollout — the one the loop-claude run dropped twice (its implement step never committed the work; not a code/plan problem).

## What
- Advertise the remote MCP server in the agent discovery envelope (`GET /` and `GET /agent`): a new `data.mcp` block with the MCP url (`mcp.<domain>/mcp`) and its OAuth authorization metadata (authorization server, AS-metadata URL, protected-resource-metadata URL).
- Mirror the field in the OpenAPI schema (`AgentDiscoveryData.yaml`) and both discovery examples (`paths/_.yaml`, `paths/agent.yaml`).
- Add precursor TODO comments to the bespoke `email_otp_then_api_key` agent routes (`agentSendCode.ts`, `agentVerifyCode.ts`) pointing at the standardized OAuth `/authorize` + `/token` flow.

Additive / non-functional: the connector already works without this (clients discover auth via the PRM served by the `mcp` Lambda). This just advertises the surface in the published machine API.

Deliberately did **not** add an `OAuthBearer` security scheme to the API OpenAPI — it would be an unused/orphan scheme (the MCP server is a separate host with no operations in this curated contract), tripping the unused-component lint and churning `contracts.test.ts` for no value.

## Validation
- `npm run bundle --prefix api` clean (redocly validates schema + both examples)
- `apps/backend` build + `npm test` → 504/504 pass (incl. `contracts.test.ts`, securitySchemes unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
