### PR TITLE
auth: fix agent first-login workspace bootstrap + add real-Postgres schema-contract gate

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -168,6 +168,20 @@ jobs:
     if: ${{ needs.changes.outputs.aws_changed == 'true' }}
     runs-on: ubuntu-24.04
 
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: flashcards
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v6
 
@@ -198,6 +212,19 @@ jobs:
 
       - name: Bundle OpenAPI spec
         run: npm run bundle --prefix api
+
+      # Guards against workspace-bootstrap SQL drifting from the live schema
+      # (e.g. migration 0035 dropping sync.devices). Applies the full
+      # db/migrations chain to a throwaway Postgres, then runs both the auth and
+      # backend first-login bootstrap routines against it as their runtime roles.
+      - name: Bootstrap schema contract (auth + backend vs live migrations)
+        env:
+          BOOTSTRAP_CONTRACT_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/flashcards
+        run: |
+          : "${BOOTSTRAP_CONTRACT_DATABASE_URL:?bootstrap schema contract requires BOOTSTRAP_CONTRACT_DATABASE_URL; the contract tests must not silently skip in CI}"
+          node apps/backend/scripts/apply-schema-contract-db.mjs
+          ( cd apps/auth && node --test --import tsx src/server/agent/agentApiKeys.contract.test.ts )
+          ( cd apps/backend && node --test --import tsx src/workspaces/create.contract.test.ts )
 
       - name: Build auth app
         if: ${{ needs.changes.outputs.auth_changed == 'true' }}

--- a/apps/auth/src/server/agent/agentApiKeys.contract.test.ts
+++ b/apps/auth/src/server/agent/agentApiKeys.contract.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+import { createWorkspaceInExecutor } from "./agentApiKeys.js";
+import { buildSystemWorkspaceReplicaId } from "../sync/workspaceReplicaId.js";
+import type { DatabaseExecutor } from "../../db.js";
+
+/**
+ * Schema contract: the auth first-login workspace bootstrap must stay valid
+ * against the live migration chain. This is the guard that would have caught
+ * migration 0035 dropping sync.devices / fsrs_last_modified_by_device_id while
+ * this hand-written copy still referenced them.
+ *
+ * Runs only when BOOTSTRAP_CONTRACT_DATABASE_URL points at a throwaway Postgres
+ * with every db/migrations file applied (see
+ * apps/backend/scripts/apply-schema-contract-db.mjs); the default offline
+ * `npm test` skips it.
+ */
+const databaseUrl = process.env.BOOTSTRAP_CONTRACT_DATABASE_URL;
+const skip = databaseUrl
+  ? false
+  : "requires BOOTSTRAP_CONTRACT_DATABASE_URL (real Postgres with all migrations applied)";
+
+test("auth workspace bootstrap matches the live replica schema", { skip }, async () => {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    // Never committed: SET LOCAL ROLE and uncommitted work are discarded when
+    // the connection ends, so the contract database stays clean for other tests.
+    await client.query("BEGIN");
+    await client.query("SET LOCAL ROLE auth_app");
+
+    const executor: DatabaseExecutor = {
+      query(text, params) {
+        return client.query(text, params as Array<unknown>);
+      },
+    };
+
+    const userId = randomUUID();
+    // Production seeds org.user_settings before bootstrapping the first workspace
+    // (org.workspace_memberships.user_id has a non-deferrable FK to
+    // org.user_settings), so reproduce that precondition under the auth_app
+    // security context, mirroring the caller in createAgentApiKeyFromIdToken.
+    await client.query("SELECT set_config('app.user_id', $1, true)", [userId]);
+    await client.query(
+      "INSERT INTO org.user_settings (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING",
+      [userId],
+    );
+    const workspaceId = await createWorkspaceInExecutor(executor, userId);
+
+    // The workspace<->replica foreign keys are DEFERRABLE INITIALLY DEFERRED, so
+    // force them to validate now instead of only at COMMIT.
+    await client.query("SET CONSTRAINTS ALL IMMEDIATE");
+
+    // auth_app may only INSERT into org.workspaces (no SELECT grant), matching
+    // production where auth never reads it. SET CONSTRAINTS ALL IMMEDIATE above
+    // already validated that the workspace's fsrs_last_modified_by_replica_id
+    // foreign key resolves to an existing replica, so assert the rest via the
+    // auth_app-readable workspace_seed replica and its deterministic id.
+    const expectedReplicaId = buildSystemWorkspaceReplicaId(workspaceId, "workspace_seed", "workspace-seed");
+    const replicaRows = await client.query<{ replica_id: string }>(
+      "SELECT replica_id FROM sync.workspace_replicas WHERE workspace_id = $1 AND actor_kind = 'workspace_seed'",
+      [workspaceId],
+    );
+    assert.equal(replicaRows.rowCount, 1, "workspace_seed replica row should exist");
+    assert.equal(
+      replicaRows.rows[0]?.replica_id,
+      expectedReplicaId,
+      "bootstrap replica should use the deterministic workspace_seed id",
+    );
+  } finally {
+    await client.end();
+  }
+});

--- a/apps/auth/src/server/agent/agentApiKeys.ts
+++ b/apps/auth/src/server/agent/agentApiKeys.ts
@@ -8,6 +8,7 @@ import {
 } from "../../db.js";
 import { verifySessionTokenIdentity } from "../browserSession.js";
 import { createCrockfordToken } from "../otp/crockford.js";
+import { buildSystemWorkspaceReplicaId } from "../sync/workspaceReplicaId.js";
 
 const AGENT_API_KEY_PREFIX = "fca";
 const AGENT_API_KEY_ID_LENGTH = 8;
@@ -96,12 +97,26 @@ const upsertUserSettingsSql = [
   "AND EXCLUDED.email IS NOT NULL",
 ].join(" ");
 
-async function createWorkspaceInExecutor(
+/**
+ * Bootstraps the first workspace for a brand-new agent user.
+ *
+ * Writes the workspace row, the owner membership, and the deterministic
+ * `workspace_seed` sync replica that the workspace's
+ * `fsrs_last_modified_by_replica_id` foreign key points at. The workspace and
+ * replica rows form an intentional foreign-key cycle that is `DEFERRABLE
+ * INITIALLY DEFERRED` (db/migrations/0036, 0037), so both are written inside
+ * the caller's transaction and validate at commit time.
+ *
+ * This mirrors the canonical backend bootstrap in
+ * apps/backend/src/workspaces/create.ts; keep the two aligned. The bootstrap
+ * schema contract test exercises this against the live migration chain.
+ */
+export async function createWorkspaceInExecutor(
   executor: DatabaseExecutor,
   userId: string,
 ): Promise<string> {
   const workspaceId = randomUUID();
-  const bootstrapDeviceId = randomUUID();
+  const bootstrapReplicaId = buildSystemWorkspaceReplicaId(workspaceId, "workspace_seed", "workspace-seed");
   const bootstrapTimestamp = new Date().toISOString();
   const bootstrapOperationId = `bootstrap-workspace-${workspaceId}`;
 
@@ -111,11 +126,11 @@ async function createWorkspaceInExecutor(
     [
       "INSERT INTO org.workspaces",
       "(",
-      "workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_device_id, fsrs_last_operation_id",
+      "workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_replica_id, fsrs_last_operation_id",
       ")",
       "VALUES ($1, $2, $3, $4, $5)",
     ].join(" "),
-    [workspaceId, AUTO_CREATED_WORKSPACE_NAME, bootstrapTimestamp, bootstrapDeviceId, bootstrapOperationId],
+    [workspaceId, AUTO_CREATED_WORKSPACE_NAME, bootstrapTimestamp, bootstrapReplicaId, bootstrapOperationId],
   );
 
   await executor.query(
@@ -129,11 +144,14 @@ async function createWorkspaceInExecutor(
 
   await executor.query(
     [
-      "INSERT INTO sync.devices",
-      "(device_id, workspace_id, user_id, platform, app_version, last_seen_at)",
-      "VALUES ($1, $2, $3, 'ios', $4, now())",
+      "INSERT INTO sync.workspace_replicas",
+      "(",
+      "replica_id, workspace_id, user_id, actor_kind, installation_id, actor_key, platform, app_version, last_seen_at",
+      ")",
+      "VALUES ($1, $2, $3, 'workspace_seed', NULL, 'workspace-seed', 'system', $4, now())",
+      "ON CONFLICT (replica_id) DO NOTHING",
     ].join(" "),
-    [bootstrapDeviceId, workspaceId, userId, "server-bootstrap"],
+    [bootstrapReplicaId, workspaceId, userId, "server-bootstrap"],
   );
 
   return workspaceId;

--- a/apps/auth/src/server/sync/workspaceReplicaId.ts
+++ b/apps/auth/src/server/sync/workspaceReplicaId.ts
@@ -1,0 +1,48 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Deterministic workspace replica identity for non-client (system) actors.
+ *
+ * This mirrors the backend derivation in
+ * apps/backend/src/sync/identity/replica.ts exactly, including the
+ * version/variant nibble layout. Both packages MUST produce the same
+ * replica id for the same `(workspaceId, actorKind, actorKey)` because the
+ * unique index `idx_workspace_replicas_workspace_actor_kind_key` keys system
+ * replicas on `(workspace_id, actor_kind, actor_key)`; a divergent id would
+ * collide with that index when the backend later re-ensures the same actor.
+ *
+ * The auth Lambda is intentionally dependency-light and cannot import the
+ * backend package, so this small helper is duplicated here. The duplication is
+ * guarded by the bootstrap schema contract test and is the target of the
+ * planned shared workspace-bootstrap module.
+ */
+
+type SystemWorkspaceReplicaActorKind =
+  | "workspace_seed"
+  | "workspace_reset"
+  | "agent_connection"
+  | "ai_chat";
+
+function toUuidFromSeed(seed: string): string {
+  const digest = createHash("sha256").update(seed).digest("hex");
+  const baseHex = digest.slice(0, 32).split("");
+
+  baseHex[12] = "5";
+  baseHex[16] = ((parseInt(baseHex[16], 16) & 0x3) | 0x8).toString(16);
+
+  return [
+    baseHex.slice(0, 8).join(""),
+    baseHex.slice(8, 12).join(""),
+    baseHex.slice(12, 16).join(""),
+    baseHex.slice(16, 20).join(""),
+    baseHex.slice(20, 32).join(""),
+  ].join("-");
+}
+
+export function buildSystemWorkspaceReplicaId(
+  workspaceId: string,
+  actorKind: SystemWorkspaceReplicaActorKind,
+  actorKey: string,
+): string {
+  return toUuidFromSeed(`${workspaceId}:${actorKind}:${actorKey}`);
+}

--- a/apps/backend/scripts/apply-schema-contract-db.mjs
+++ b/apps/backend/scripts/apply-schema-contract-db.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Apply the full db/migrations chain (then db/views) to a throwaway Postgres so
+// the workspace-bootstrap schema contract test can run against the real schema.
+//
+// Mirrors the apply semantics of apps/backend/src/database/migrationRunner.ts
+// (one transaction per migration file, recorded in schema_migrations) but stays
+// dependency-light (only `pg`) and decoupled from AWS Secrets Manager so it can
+// run against a CI service container or a local Postgres. It lives inside the
+// backend package so the bare `pg` import resolves from apps/backend/node_modules.
+//
+// Connection: BOOTSTRAP_CONTRACT_DATABASE_URL, else standard PG* env vars. The
+// target database must be named `flashcards` because the migration chain runs
+// `GRANT ... ON DATABASE flashcards` (db/migrations/0001, 0024, 0044). Must run
+// as a superuser/owner role because migrations create roles, schemas,
+// extensions, and row-level-security policies.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const migrationsDir = path.join(repoRoot, "db", "migrations");
+const viewsDir = path.join(repoRoot, "db", "views");
+
+async function listSqlFiles(directoryPath) {
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+async function ensureSchemaMigrationsTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      filename TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+async function applyMigrations(client) {
+  const fileNames = await listSqlFiles(migrationsDir);
+  let appliedCount = 0;
+  for (const fileName of fileNames) {
+    const alreadyApplied = await client.query(
+      "SELECT 1 FROM schema_migrations WHERE filename = $1",
+      [fileName],
+    );
+    if (alreadyApplied.rowCount !== 0) {
+      continue;
+    }
+
+    const sql = await fs.readFile(path.join(migrationsDir, fileName), "utf8");
+    try {
+      await client.query("BEGIN");
+      await client.query(sql);
+      await client.query("INSERT INTO schema_migrations (filename) VALUES ($1)", [fileName]);
+      await client.query("COMMIT");
+      appliedCount += 1;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to apply migration ${fileName}: ${message}`);
+    }
+  }
+  return appliedCount;
+}
+
+async function applyViews(client) {
+  const fileNames = await listSqlFiles(viewsDir);
+  for (const fileName of fileNames) {
+    const sql = await fs.readFile(path.join(viewsDir, fileName), "utf8");
+    try {
+      await client.query(sql);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to apply view ${fileName}: ${message}`);
+    }
+  }
+  return fileNames.length;
+}
+
+async function main() {
+  const connectionString = process.env.BOOTSTRAP_CONTRACT_DATABASE_URL;
+  const client = connectionString ? new pg.Client({ connectionString }) : new pg.Client();
+  await client.connect();
+  try {
+    await ensureSchemaMigrationsTable(client);
+    const appliedMigrations = await applyMigrations(client);
+    const appliedViews = await applyViews(client);
+    process.stdout.write(
+      `Applied ${appliedMigrations} migration(s) and ${appliedViews} view(s) to the contract database.\n`,
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/apps/backend/src/workspaces/create.contract.test.ts
+++ b/apps/backend/src/workspaces/create.contract.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+import { createWorkspaceInExecutor } from "./create";
+import type { DatabaseExecutor } from "../database";
+
+/**
+ * Schema contract: the canonical backend workspace bootstrap must stay valid
+ * against the live migration chain. Pairs with the auth bootstrap contract test
+ * so both independent copies are checked against the same real schema.
+ *
+ * Runs only when BOOTSTRAP_CONTRACT_DATABASE_URL points at a throwaway Postgres
+ * with every db/migrations file applied (see
+ * apps/backend/scripts/apply-schema-contract-db.mjs); the default offline
+ * `npm test` skips it.
+ */
+const databaseUrl = process.env.BOOTSTRAP_CONTRACT_DATABASE_URL;
+const skip = databaseUrl
+  ? false
+  : "requires BOOTSTRAP_CONTRACT_DATABASE_URL (real Postgres with all migrations applied)";
+
+test("backend workspace bootstrap matches the live replica schema", { skip }, async () => {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    // Never committed: SET LOCAL ROLE and uncommitted work are discarded when
+    // the connection ends, so the contract database stays clean for other tests.
+    await client.query("BEGIN");
+    await client.query("SET LOCAL ROLE backend_app");
+
+    const executor: DatabaseExecutor = {
+      query(text, params) {
+        return client.query(text, params as Array<unknown>);
+      },
+    };
+
+    const userId = randomUUID();
+    const workspaceId = await createWorkspaceInExecutor(executor, userId, "Personal");
+
+    // The workspace<->replica foreign keys are DEFERRABLE INITIALLY DEFERRED, so
+    // force them to validate now instead of only at COMMIT.
+    await client.query("SET CONSTRAINTS ALL IMMEDIATE");
+
+    const workspaceRows = await client.query<{ fsrs_last_modified_by_replica_id: string }>(
+      "SELECT fsrs_last_modified_by_replica_id FROM org.workspaces WHERE workspace_id = $1",
+      [workspaceId],
+    );
+    assert.equal(workspaceRows.rowCount, 1, "workspace row should exist");
+
+    const replicaRows = await client.query<{ replica_id: string }>(
+      "SELECT replica_id FROM sync.workspace_replicas WHERE workspace_id = $1 AND actor_kind = 'workspace_seed'",
+      [workspaceId],
+    );
+    assert.equal(replicaRows.rowCount, 1, "workspace_seed replica row should exist");
+    assert.equal(
+      workspaceRows.rows[0]?.fsrs_last_modified_by_replica_id,
+      replicaRows.rows[0]?.replica_id,
+      "workspace fsrs replica pointer should reference the bootstrap replica",
+    );
+  } finally {
+    await client.end();
+  }
+});


### PR DESCRIPTION
## Why

Brand-new agent-API users 5xx'd at first sign-in: the auth first-login workspace bootstrap (`apps/auth/.../agentApiKeys.ts`) still wrote columns/tables that migration **0035** dropped (`sync.devices`, `workspaces.fsrs_last_modified_by_device_id`). The backend's equivalent was updated during the device→replica refactor; the independent auth copy was missed, and it only fires on the zero-membership first-login path, so it slipped past existing tests and the demo-account smoke.

## What

**Fix:** align the auth bootstrap to the current schema — `fsrs_last_modified_by_replica_id` + a `sync.workspace_replicas` `workspace_seed` row, with a deterministic replica id (`workspaceReplicaId.ts`) that matches the backend derivation byte-for-byte (required by the unique index on `(workspace_id, actor_kind, actor_key)`).

**Guard (the real fix for recurrence):** a real-Postgres schema-contract gate. `apps/backend/scripts/apply-schema-contract-db.mjs` applies the full `db/migrations` chain to a throwaway Postgres, and contract tests run **both** the auth and backend `createWorkspaceInExecutor` against the live schema as their runtime roles (`auth_app` / `backend_app`), validating the deferred workspace↔replica FK cycle via `SET CONSTRAINTS ALL IMMEDIATE`. The in-memory test harness can't see schema drift; this can. Wired into `aws-web-release` `pre_deploy_checks` behind a `postgres:18` service so it gates the deploy. Tests self-skip without `BOOTSTRAP_CONTRACT_DATABASE_URL`, so offline `npm test` stays green.

## Validation

- `tsc --noEmit` clean for `apps/auth` and `apps/backend`; both offline suites green (contract tests skip).
- Multiple blind code-review passes to convergence; verified against the actual migration chain: replica-id parity, per-statement GRANT/RLS/FK permissions for each runtime role, deferred-FK handling, `pg`/path resolution, and that the migration chain is portable to stock `postgres:18` (only `pgcrypto`/`pg_trgm`, all roles self-created).
- Not run against a real Postgres locally (no local PG server / Docker); the gate's first real-DB execution is this workflow's `pre_deploy_checks` run — a failure there blocks deploy (safe), not production.

## Follow-up (separate PR)

Extract the duplicated bootstrap into one shared module so the two copies can't drift again, and resolve the auth/backend scheduler-seed divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)