### PR TITLE
Pre-SignUp: capture trigger failures to Sentry

### DIFF
--- a/infra/aws/lambda/pre-signup/index.ts
+++ b/infra/aws/lambda/pre-signup/index.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/aws-serverless";
+
 /** Cognito PreSignUp trigger: auto-confirms user and verifies email. */
 type PreSignUpEvent = {
   request: {
@@ -9,10 +11,59 @@ type PreSignUpEvent = {
   };
 };
 
-export const handler = async (event: PreSignUpEvent) => {
+type SentryInitOptions = NonNullable<Parameters<typeof Sentry.init>[0]>;
+type SentryEvent = Parameters<NonNullable<SentryInitOptions["beforeSend"]>>[0];
+
+const emailPattern = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
+function isAwsLambdaRuntime(): boolean {
+  return (process.env.AWS_EXECUTION_ENV ?? "").startsWith("AWS_Lambda_")
+    || (process.env.AWS_LAMBDA_FUNCTION_NAME ?? "") !== "";
+}
+
+function maskEmails(value: string): string {
+  return value.replace(emailPattern, "<masked-email>");
+}
+
+function beforeSend(event: SentryEvent): SentryEvent | null {
+  if (event.request !== undefined) {
+    delete event.request.data;
+  }
+  if (event.message !== undefined) {
+    event.message = maskEmails(event.message);
+  }
+  for (const exceptionValue of event.exception?.values ?? []) {
+    if (exceptionValue.value !== undefined) {
+      exceptionValue.value = maskEmails(exceptionValue.value);
+    }
+  }
+  return event;
+}
+
+const dsn = process.env.SENTRY_DSN;
+if (dsn === undefined || dsn.trim() === "") {
+  if (isAwsLambdaRuntime()) {
+    throw new Error("SENTRY_DSN is required in AWS Lambda pre-signup runtime");
+  }
+} else {
+  const tracesSampleRateRaw = process.env.SENTRY_TRACES_SAMPLE_RATE;
+  Sentry.init({
+    dsn: dsn.trim(),
+    environment: process.env.SENTRY_ENVIRONMENT,
+    release: process.env.SENTRY_RELEASE,
+    tracesSampleRate: tracesSampleRateRaw === undefined
+      ? undefined
+      : Number.parseFloat(tracesSampleRateRaw),
+    sendDefaultPii: false,
+    beforeSend,
+  });
+  Sentry.setTag("service", "pre-signup");
+}
+
+export const handler = Sentry.wrapHandler(async (event: PreSignUpEvent) => {
   event.response.autoConfirmUser = true;
   if (event.request.userAttributes.email) {
     event.response.autoVerifyEmail = true;
   }
   return event;
-};
+});


### PR DESCRIPTION
## What

Instrument the Cognito **PreSignUp** Lambda trigger with Sentry so failures in the auto-confirm / email auto-verify path are reported instead of failing silently.

- Initialize `@sentry/aws-serverless` from `SENTRY_DSN` and the existing `SENTRY_*` env (`environment`, `release`, traces sample rate).
- Require `SENTRY_DSN` when running in the AWS Lambda runtime; stay inert locally when no DSN is set, so non-Lambda execution is unaffected.
- Add a `beforeSend` scrubber that drops request data and masks email addresses in messages and exception values; `sendDefaultPii=false`.
- Tag events with `service=pre-signup` and wrap the handler via `Sentry.wrapHandler`.

## Why

The PreSignUp trigger gates account creation. If it throws, sign-up breaks for users with no visibility on our side. Routing its failures to Sentry gives us alerting and stack traces while keeping PII out of the captured events.

## Builds on

Builds on the Sentry infra foundation (#732): `SENTRY_DSN` and the Sentry env wiring are already deployed and live in production, so this change only needs the handler-level instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)