### PR TITLE
Auth service: Sentry init, handler wrap, and 5xx capture

### DIFF
--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1070.0",
         "@hono/node-server": "^2.0.5",
+        "@sentry/aws-serverless": "^10.58.0",
         "aws-jwt-verify": "^5.2.1",
         "hono": "^4.12.25",
         "pg": "^8.21.0"
@@ -22,6 +23,49 @@
       },
       "engines": {
         "node": "24.x"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
+      "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz",
+      "integrity": "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.15.0",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.0.tgz",
+      "integrity": "sha512-2/Z3NTewJTruUkmsSnBC5bJlLNUd9keuD1OLlTEpim4FyLhm6m2Rnfv+wrFdUvFfhmH8CRdiDZBqBrn+wyaGuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.15.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -830,6 +874,12 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
     "node_modules/@nodable/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
@@ -841,6 +891,241 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/aws-serverless": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.59.0.tgz",
+      "integrity": "sha512-iwzwejYn05TPApCQu6tSnFxiSidF275RX725WUZJT0oiKEQNyqiXWlo3dcxt46D7MKervVQ1GDPaOhK1ryxxyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.59.0",
+        "@sentry/node": "10.59.0",
+        "@sentry/node-core": "10.59.0",
+        "@types/aws-lambda": "^8.10.161"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.12.0.tgz",
+      "integrity": "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.59.0.tgz",
+      "integrity": "sha512-QeG7XZL5j6CkToYCE7OwCerb/r742Tjj9p1BBohBKcypYTPRuqfD+A3FeUj7pk5CGO6Vj1/gOAmdbuuNbR51dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.59.0.tgz",
+      "integrity": "sha512-qzqbP6OVoMijlDBUxWtbvVF5j73+vyzGFi+yFIslhVvzBj97TFkIeP3TpBLsmu/0L5ZvxpQCCEmzJ677tFkq/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry/core": "10.59.0",
+        "@sentry/node-core": "10.59.0",
+        "@sentry/opentelemetry": "10.59.0",
+        "@sentry/server-utils": "10.59.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.59.0.tgz",
+      "integrity": "sha512-qFbepzntYhDleNG9ZCZWCSoAJK0Nsx+UJxsuiygaaAf1rJMj95RVckLyslhY86pyDLVATNMmWm2elm6etgKaJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.59.0",
+        "@sentry/opentelemetry": "10.59.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.59.0.tgz",
+      "integrity": "sha512-wV9/HR9btrNhSkJC2S0urqsD9pE4K0f6AmdfTK3qhH505mLoyV4ekTG66hdDR9xD2zOYCm58CNzaK+336zu3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.59.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.59.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.59.0.tgz",
+      "integrity": "sha512-mR3fWaU7uGxIstRba6YO+/6V3qIa7432F7/U8EWHry+dY4C9DWAVG90E2GCzeD2MwLSP0tB25i8p1TWTGiQgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
+        "@apm-js-collab/tracing-hooks": "^0.10.0",
+        "@sentry/conventions": "^0.12.0",
+        "@sentry/core": "10.59.0",
+        "magic-string": "~0.30.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@smithy/core": {
       "version": "3.25.0",
@@ -962,6 +1247,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.162",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+      "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
@@ -984,6 +1281,27 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/anynum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
@@ -995,6 +1313,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
     },
     "node_modules/aws-jwt-verify": {
       "version": "5.2.1",
@@ -1009,6 +1336,35 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -1051,6 +1407,27 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/fast-xml-builder": {
@@ -1113,6 +1490,51 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+      "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
@@ -1253,6 +1675,34 @@
       "dependencies": {
         "xtend": "^4.0.0"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1070.0",
     "@hono/node-server": "^2.0.5",
+    "@sentry/aws-serverless": "^10.58.0",
     "aws-jwt-verify": "^5.2.1",
     "hono": "^4.12.25",
     "pg": "^8.21.0"

--- a/apps/auth/src/app.ts
+++ b/apps/auth/src/app.ts
@@ -6,6 +6,7 @@
  * Custom-domain auth traffic arrives without a stage prefix.
  */
 import { randomUUID } from "node:crypto";
+import * as Sentry from "@sentry/aws-serverless";
 import { type Context, Hono } from "hono";
 import type { MiddlewareHandler } from "hono";
 import health from "./routes/health.js";
@@ -241,6 +242,13 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
       statusCode: 500,
       code: "INTERNAL_ERROR",
       error: error instanceof Error ? error.message : String(error),
+    });
+
+    // Hono's onError swallows the error (returns a 500 response), so
+    // Sentry.wrapHandler never sees it. Capture explicitly here.
+    Sentry.captureException(error, {
+      tags: { service: "auth", route: c.req.path, code: "INTERNAL_ERROR" },
+      extra: { requestId },
     });
 
     if (routeKind === "agent" || routeKind === "api") {

--- a/apps/auth/src/lambda.ts
+++ b/apps/auth/src/lambda.ts
@@ -1,9 +1,13 @@
 /**
  * Auth service Lambda entry point for the dedicated auth API Gateway.
  */
+import * as Sentry from "@sentry/aws-serverless";
 import { handle } from "hono/aws-lambda";
+import { initializeAuthSentry } from "./server/sentry.js";
 import { createApp } from "./app.js";
+
+initializeAuthSentry();
 
 const app = createApp("/v1");
 
-export const handler = handle(app);
+export const handler = Sentry.wrapHandler(handle(app));

--- a/apps/auth/src/server/sentry.ts
+++ b/apps/auth/src/server/sentry.ts
@@ -1,0 +1,128 @@
+/**
+ * Sentry initialization for the auth service Lambda.
+ *
+ * Self-contained module (the auth package does not import from apps/backend):
+ * hard-requires SENTRY_DSN on Lambda, stays disabled off-Lambda so local
+ * `tsx`/tests run without Sentry, and scrubs PII (emails, OTPs, tokens,
+ * cookies, authorization headers) before events leave the process.
+ */
+import * as Sentry from "@sentry/aws-serverless";
+
+type AuthSentryInitOptions = NonNullable<Parameters<typeof Sentry.init>[0]>;
+type AuthSentryEvent = Parameters<NonNullable<AuthSentryInitOptions["beforeSend"]>>[0];
+
+type AuthSentryConfig = Readonly<{
+  dsn: string;
+  environment: string;
+  release: string;
+  tracesSampleRate: number;
+}>;
+
+const emailPattern = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const secretKeyPattern = /otp|token|secret|password|code|authorization|cookie/i;
+const redactedSecretValue = "<redacted>";
+const maskedEmailValue = "<masked-email>";
+
+let authSentryInitialized = false;
+
+function isAwsLambdaRuntime(env: NodeJS.ProcessEnv): boolean {
+  return (env.AWS_EXECUTION_ENV ?? "").startsWith("AWS_Lambda_")
+    || (env.AWS_LAMBDA_FUNCTION_NAME ?? "") !== "";
+}
+
+function readRequiredSentryValue(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${name} is required when auth Sentry is enabled`);
+  }
+
+  return value.trim();
+}
+
+function parseTraceSampleRate(rawValue: string): number {
+  const tracesSampleRate = Number.parseFloat(rawValue);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("SENTRY_TRACES_SAMPLE_RATE must be a number between 0 and 1");
+  }
+
+  return tracesSampleRate;
+}
+
+export function getAuthSentryConfig(env: NodeJS.ProcessEnv): AuthSentryConfig | null {
+  const dsn = env.SENTRY_DSN;
+  if (dsn === undefined || dsn.trim() === "") {
+    if (isAwsLambdaRuntime(env)) {
+      throw new Error("SENTRY_DSN is required in AWS Lambda auth runtimes");
+    }
+
+    return null;
+  }
+
+  return {
+    dsn: dsn.trim(),
+    environment: readRequiredSentryValue(env, "SENTRY_ENVIRONMENT"),
+    release: readRequiredSentryValue(env, "SENTRY_RELEASE"),
+    tracesSampleRate: parseTraceSampleRate(readRequiredSentryValue(env, "SENTRY_TRACES_SAMPLE_RATE")),
+  };
+}
+
+function maskSensitiveText(value: string): string {
+  return value.replace(emailPattern, maskedEmailValue);
+}
+
+function redactHeaderValues(headers: Record<string, unknown>): void {
+  for (const headerName of Object.keys(headers)) {
+    if (secretKeyPattern.test(headerName)) {
+      headers[headerName] = redactedSecretValue;
+    }
+  }
+}
+
+function scrubAuthSentryEvent(event: AuthSentryEvent): AuthSentryEvent {
+  const request = event.request;
+  if (request !== undefined) {
+    delete request.data;
+    delete request.cookies;
+    const headers = request.headers;
+    if (headers !== undefined && headers !== null) {
+      redactHeaderValues(headers as Record<string, unknown>);
+    }
+  }
+
+  if (typeof event.message === "string") {
+    event.message = maskSensitiveText(event.message);
+  }
+
+  const exceptionValues = event.exception?.values;
+  if (exceptionValues !== undefined) {
+    for (const exceptionValue of exceptionValues) {
+      if (typeof exceptionValue.value === "string") {
+        exceptionValue.value = maskSensitiveText(exceptionValue.value);
+      }
+    }
+  }
+
+  return event;
+}
+
+export function initializeAuthSentry(): void {
+  if (authSentryInitialized) {
+    return;
+  }
+  authSentryInitialized = true;
+
+  const config = getAuthSentryConfig(process.env);
+  if (config === null) {
+    return;
+  }
+
+  Sentry.init({
+    dsn: config.dsn,
+    environment: config.environment,
+    release: config.release,
+    tracesSampleRate: config.tracesSampleRate,
+    sendDefaultPii: false,
+    beforeSend: (event) => scrubAuthSentryEvent(event),
+  });
+  Sentry.setTag("service", "auth");
+}


### PR DESCRIPTION
## What

Instrument the auth service Lambda with Sentry error reporting.

- New self-contained `apps/auth/src/server/sentry.ts` initializes the `@sentry/aws-serverless` SDK. It hard-requires `SENTRY_DSN` on Lambda, stays disabled off-Lambda (so local `tsx`/tests run without Sentry), and scrubs PII (emails, OTPs, tokens, cookies, authorization headers) via `beforeSend` before events leave the process.
- `apps/auth/src/lambda.ts` initializes Sentry and wraps the Lambda handler with `Sentry.wrapHandler`.
- `apps/auth/src/app.ts` captures exceptions explicitly in the Hono `onError` path, tagged with `service`/`route`/`code` plus the `requestId`.
- Adds the `@sentry/aws-serverless` dependency (`package.json` + `package-lock.json`).

## Why

Bring the auth service into the same error-reporting setup as the rest of the backend so 5xx failures are visible and correlatable in Sentry.

Hono's `onError` returns a 500 response and otherwise swallows the error before `wrapHandler` can observe it, so the handler-level wrap alone would miss internal errors. The explicit `captureException` in `onError` ensures 5xx failures are reported with full tagging and request correlation.

## Builds on

Builds on the Sentry infra foundation (#732). `SENTRY_DSN` and the related Sentry environment variables are already provisioned and live in production for the auth runtime, so this change activates reporting without further infra work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)