### PR TITLE
MCP self-heal: auto-bind workspace for OAuth (MCP) connections

### DIFF
--- a/apps/backend/src/auth/mcpTokens.ts
+++ b/apps/backend/src/auth/mcpTokens.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { unsafeQuery } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import { normalizeCrockfordToken } from "../agent/crockford";
+import { ensureMcpConnectionWorkspaceSelection } from "../workspaces";
 
 const ACCESS_TOKEN_PREFIX = "FCO_";
 
@@ -126,9 +127,15 @@ export async function authenticateMcpAccessToken(
     throw new HttpError(401, "Invalid MCP access token", MCP_TOKEN_INVALID_CODE);
   }
 
+  const selectedWorkspaceId = await ensureMcpConnectionWorkspaceSelection(
+    row.user_id,
+    row.connection_id,
+    row.selected_workspace_id,
+  );
+
   return {
     userId: row.user_id,
     connectionId: row.connection_id,
-    selectedWorkspaceId: row.selected_workspace_id,
+    selectedWorkspaceId,
   };
 }

--- a/apps/backend/src/workspaces/create.ts
+++ b/apps/backend/src/workspaces/create.ts
@@ -29,6 +29,7 @@ import { loadWorkspaceSummaryInExecutor } from "./queries";
 import {
   lockUserSettingsForWorkspaceLifecycleInExecutor,
   persistSelectedWorkspaceForApiKeyConnectionInExecutor,
+  persistSelectedWorkspaceForOAuthConnectionInExecutor,
   persistSelectedWorkspaceForUserInExecutor,
 } from "./state";
 import type { TimestampValue } from "./shared";
@@ -260,6 +261,35 @@ export async function createWorkspaceForApiKeyConnectionWithObservationScope(
 
     try {
       await persistSelectedWorkspaceForApiKeyConnectionInExecutor(executor, userId, connectionId, workspaceId);
+
+      stage = "load_workspace_summary";
+      return loadWorkspaceSummaryInExecutor(executor, userId, workspaceId, workspaceId);
+    } catch (error) {
+      handleWorkspaceCreateFailure(error, userId, workspaceId, stage, observationScope);
+    }
+  });
+}
+
+export async function createWorkspaceForOAuthConnection(
+  userId: string,
+  connectionId: string,
+  name: string,
+): Promise<WorkspaceSummary> {
+  return createWorkspaceForOAuthConnectionWithObservationScope(userId, connectionId, name, null);
+}
+
+export async function createWorkspaceForOAuthConnectionWithObservationScope(
+  userId: string,
+  connectionId: string,
+  name: string,
+  observationScope: BackendObservationScope | null,
+): Promise<WorkspaceSummary> {
+  return transactionWithUserScope({ userId }, async (executor) => {
+    const workspaceId = await createWorkspaceInExecutorWithObservationScope(executor, userId, name, observationScope);
+    let stage: WorkspaceCreateFailureStage = "select_workspace";
+
+    try {
+      await persistSelectedWorkspaceForOAuthConnectionInExecutor(executor, userId, connectionId, workspaceId);
 
       stage = "load_workspace_summary";
       return loadWorkspaceSummaryInExecutor(executor, userId, workspaceId, workspaceId);

--- a/apps/backend/src/workspaces/index.ts
+++ b/apps/backend/src/workspaces/index.ts
@@ -24,6 +24,7 @@ export {
 export {
   assertUserHasWorkspaceAccess,
   ensureApiKeyWorkspaceSelection,
+  ensureMcpConnectionWorkspaceSelection,
   ensureUserSelectedWorkspaceInExecutor,
   selectWorkspaceForApiKeyConnection,
   selectWorkspaceForUser,

--- a/apps/backend/src/workspaces/selection.ts
+++ b/apps/backend/src/workspaces/selection.ts
@@ -6,6 +6,7 @@ import {
 import { HttpError } from "../shared/errors";
 import {
   createWorkspaceForApiKeyConnection,
+  createWorkspaceForOAuthConnection,
   createWorkspaceInExecutor,
 } from "./create";
 import {
@@ -18,6 +19,7 @@ import { createWorkspaceInvariantError } from "./shared";
 import {
   lockUserSettingsForWorkspaceLifecycleInExecutor,
   persistSelectedWorkspaceForApiKeyConnectionInExecutor,
+  persistSelectedWorkspaceForOAuthConnectionInExecutor,
   persistSelectedWorkspaceForUserInExecutor,
 } from "./state";
 import {
@@ -83,6 +85,34 @@ export async function setSelectedWorkspaceForApiKeyConnection(
 ): Promise<void> {
   await transactionWithUserScope({ userId }, async (executor) => {
     await setSelectedWorkspaceForApiKeyConnectionInExecutor(executor, userId, connectionId, selectedWorkspaceId);
+  });
+}
+
+export async function setSelectedWorkspaceForOAuthConnectionInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  connectionId: string,
+  selectedWorkspaceId: string | null,
+): Promise<void> {
+  if (selectedWorkspaceId !== null) {
+    await assertUserHasWorkspaceMembershipInExecutor(executor, userId, selectedWorkspaceId);
+  }
+
+  await persistSelectedWorkspaceForOAuthConnectionInExecutor(
+    executor,
+    userId,
+    connectionId,
+    selectedWorkspaceId,
+  );
+}
+
+export async function setSelectedWorkspaceForOAuthConnection(
+  userId: string,
+  connectionId: string,
+  selectedWorkspaceId: string | null,
+): Promise<void> {
+  await transactionWithUserScope({ userId }, async (executor) => {
+    await setSelectedWorkspaceForOAuthConnectionInExecutor(executor, userId, connectionId, selectedWorkspaceId);
   });
 }
 
@@ -156,6 +186,44 @@ export async function ensureApiKeyWorkspaceSelection(
 
   if (selectedWorkspaceId !== null) {
     await setSelectedWorkspaceForApiKeyConnection(userId, connectionId, null);
+  }
+
+  return null;
+}
+
+export async function ensureMcpConnectionWorkspaceSelection(
+  userId: string,
+  connectionId: string,
+  selectedWorkspaceId: string | null,
+): Promise<string | null> {
+  const workspaces = await listUserWorkspacesForSelectedWorkspace(userId, selectedWorkspaceId);
+  const selectedWorkspaceIsAccessible = selectedWorkspaceId !== null
+    && workspaces.some((workspace) => workspace.workspaceId === selectedWorkspaceId);
+
+  if (selectedWorkspaceIsAccessible) {
+    return selectedWorkspaceId;
+  }
+
+  if (workspaces.length === 0) {
+    const workspace = await createWorkspaceForOAuthConnection(userId, connectionId, AUTO_CREATED_WORKSPACE_NAME);
+    return workspace.workspaceId;
+  }
+
+  if (workspaces.length === 1) {
+    const onlyWorkspace = workspaces[0];
+    if (onlyWorkspace === undefined) {
+      throw createWorkspaceInvariantError(
+        "Workspace selection could not be recovered because no workspace was available.",
+        "WORKSPACE_SELECTION_RECOVERY_FAILED",
+      );
+    }
+
+    await setSelectedWorkspaceForOAuthConnection(userId, connectionId, onlyWorkspace.workspaceId);
+    return onlyWorkspace.workspaceId;
+  }
+
+  if (selectedWorkspaceId !== null) {
+    await setSelectedWorkspaceForOAuthConnection(userId, connectionId, null);
   }
 
   return null;

--- a/apps/backend/src/workspaces/state.ts
+++ b/apps/backend/src/workspaces/state.ts
@@ -5,6 +5,10 @@ type AgentApiKeySelectionRow = Readonly<{
   connection_id: string;
 }>;
 
+type OAuthConnectionSelectionRow = Readonly<{
+  connection_id: string;
+}>;
+
 type UserSettingsLockRow = Readonly<{
   user_id: string;
 }>;
@@ -64,5 +68,26 @@ export async function persistSelectedWorkspaceForApiKeyConnectionInExecutor(
 
   if (result.rows.length === 0) {
     throw new HttpError(404, "Agent connection not found", "AGENT_API_KEY_NOT_FOUND");
+  }
+}
+
+export async function persistSelectedWorkspaceForOAuthConnectionInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  connectionId: string,
+  selectedWorkspaceId: string | null,
+): Promise<void> {
+  const result = await executor.query<OAuthConnectionSelectionRow>(
+    [
+      "UPDATE auth.oauth_connections",
+      "SET selected_workspace_id = $1",
+      "WHERE user_id = $2 AND connection_id = $3 AND revoked_at IS NULL",
+      "RETURNING connection_id",
+    ].join(" "),
+    [selectedWorkspaceId, userId, connectionId],
+  );
+
+  if (result.rows.length === 0) {
+    throw new HttpError(404, "OAuth connection not found", "OAUTH_CONNECTION_NOT_FOUND");
   }
 }


### PR DESCRIPTION
Auto-bind the workspace for OAuth (MCP) connections when the connection's user has exactly one workspace, so single-workspace MCP OAuth users no longer hit unbound-workspace errors and the connection self-heals on use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)