### PR TITLE
MCP sql tool: optional per-call workspaceId

### DIFF
--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -3,7 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { executeAgentSql } from "../aiTools/agentSql";
 import { OPENAI_SQL_TOOL, SQL_TOOL_NAME } from "../aiTools/toolContract/sqlToolContract";
-import { requireAccessibleSelectedWorkspaceId } from "../server/requestContext";
+import { resolveAccessibleMcpWorkspaceId } from "../server/requestContext";
 import { createAgentEnvelope, createAgentErrorEnvelope } from "../agent/envelope";
 import { createPublicHttpErrorDetails, HttpError } from "../shared/errors";
 import {
@@ -34,7 +34,9 @@ const baseDescription = OPENAI_SQL_TOOL.description ?? "";
 if (baseDescription === "") {
   throw new Error("OPENAI_SQL_TOOL.description must be set for the MCP sql tool");
 }
-const SQL_TOOL_DESCRIPTION = `${baseDescription} ${FRONT_BACK_CONTRACT}`;
+const WORKSPACE_ID_ARGUMENT_HINT =
+  "Optional workspaceId targets a specific workspace you belong to; omit it to use your currently selected workspace.";
+const SQL_TOOL_DESCRIPTION = `${baseDescription} ${FRONT_BACK_CONTRACT} ${WORKSPACE_ID_ARGUMENT_HINT}`;
 
 function buildToolResultText(payload: unknown): string {
   return JSON.stringify(payload, null, 2);
@@ -216,14 +218,18 @@ export function createMcpServer(
       description: SQL_TOOL_DESCRIPTION,
       inputSchema: {
         sql: z.string().trim().min(1),
+        workspaceId: z.string().uuid().optional(),
       },
     },
-    async ({ sql }): Promise<CallToolResult> => {
+    async ({ sql, workspaceId: requestedWorkspaceId }): Promise<CallToolResult> => {
       try {
-        const workspaceId = await requireAccessibleSelectedWorkspaceId({
-          userId: connection.userId,
-          selectedWorkspaceId: connection.selectedWorkspaceId,
-        });
+        const workspaceId = await resolveAccessibleMcpWorkspaceId(
+          {
+            userId: connection.userId,
+            selectedWorkspaceId: connection.selectedWorkspaceId,
+          },
+          requestedWorkspaceId,
+        );
         const result = await executeAgentSql(
           {
             userId: connection.userId,

--- a/apps/backend/src/server/requestContext.ts
+++ b/apps/backend/src/server/requestContext.ts
@@ -58,6 +58,12 @@ const aiDictationWorkspaceRequiredError: WorkspaceSelectionErrorConfig = {
   code: "AI_WORKSPACE_REQUIRED",
 };
 
+const mcpWorkspaceSelectionRequiredError: WorkspaceSelectionErrorConfig = {
+  statusCode: 409,
+  message: "Select a workspace before using the sql tool, or pass the workspaceId argument.",
+  code: "WORKSPACE_SELECTION_REQUIRED",
+};
+
 export function getAllowedOrigins(): Array<string> {
   const raw = process.env.BACKEND_ALLOWED_ORIGINS ?? "http://localhost:3000,http://localhost:3001";
   return raw
@@ -213,6 +219,17 @@ export async function resolveAccessibleAiDictationWorkspaceId(
     requestContext,
     explicitWorkspaceId,
     aiDictationWorkspaceRequiredError,
+  );
+}
+
+export async function resolveAccessibleMcpWorkspaceId(
+  requestContext: WorkspaceRequestContext,
+  explicitWorkspaceId: string | undefined,
+): Promise<string> {
+  return resolveAccessibleWorkspaceIdWithLegacySelectedWorkspaceFallback(
+    requestContext,
+    explicitWorkspaceId,
+    mcpWorkspaceSelectionRequiredError,
   );
 }
 


### PR DESCRIPTION
Adds an optional per-call `workspaceId` parameter to the MCP `sql` tool, letting a caller target a specific workspace on a single invocation without changing the resolved default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)