### PR TITLE
Accept the agent API key (fca_) as Bearer on the MCP endpoint

### DIFF
--- a/apps/backend/src/auth/mcpTokens.ts
+++ b/apps/backend/src/auth/mcpTokens.ts
@@ -2,7 +2,10 @@ import { createHash } from "node:crypto";
 import { unsafeQuery } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import { normalizeCrockfordToken } from "../agent/crockford";
+import { authenticateAgentApiKey } from "../agent/apiKeys";
 import { ensureMcpConnectionWorkspaceSelection } from "../workspaces";
+
+const AGENT_API_KEY_PREFIX = "FCA_";
 
 const ACCESS_TOKEN_PREFIX = "FCO_";
 
@@ -138,4 +141,39 @@ export async function authenticateMcpAccessToken(
     connectionId: row.connection_id,
     selectedWorkspaceId,
   };
+}
+
+/**
+ * Authenticates a `/mcp` Bearer token, dispatching by normalized prefix to the
+ * matching resolver. Both resolvers return the same `{ userId, connectionId,
+ * selectedWorkspaceId }` shape, so the request handler is agnostic to which
+ * credential the caller presented.
+ *
+ * - `fca_` (agent API key) → `authenticateAgentApiKey`. This is a long-lived
+ *   full-access PAT and is intentionally NOT audience-bound: the same key
+ *   already grants identical `executeAgentSql` access on the REST `/agent`
+ *   surface, so accepting it on MCP is no new privilege. `expectedResource` is
+ *   therefore not consulted for this branch.
+ * - everything else (the OAuth `fco_` access token) → `authenticateMcpAccessToken`,
+ *   which is audience-bound and validates the token's `resource` against
+ *   `expectedResource`, and itself 401s on a non-`fco_`/invalid token.
+ *
+ * An empty token is rejected with the same opaque 401 as any other invalid
+ * token so callers cannot probe token state.
+ */
+export async function authenticateMcpBearerToken(
+  token: string,
+  expectedResource: string,
+): Promise<AuthenticatedMcpAccessToken> {
+  const trimmedToken = token.trim();
+  if (trimmedToken === "") {
+    throw new HttpError(401, "Invalid MCP access token", MCP_TOKEN_INVALID_CODE);
+  }
+
+  const normalizedPrefix = trimmedToken.replace(/[\s-]/g, "").toUpperCase();
+  if (normalizedPrefix.startsWith(AGENT_API_KEY_PREFIX)) {
+    return authenticateAgentApiKey(trimmedToken);
+  }
+
+  return authenticateMcpAccessToken(trimmedToken, expectedResource);
 }

--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -19,7 +19,7 @@ import { handle } from "hono/aws-lambda";
 import { type Context, Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { authenticateMcpAccessToken } from "../auth/mcpTokens";
+import { authenticateMcpBearerToken } from "../auth/mcpTokens";
 import { createMcpServer } from "../mcp/server";
 import { HttpError } from "../shared/errors";
 import { getHttpErrorResponseHeaders } from "../server/app";
@@ -121,7 +121,7 @@ function extractBearerToken(authorization: string | undefined): string | null {
  */
 async function handleMcpTransportRequest(
   request: Request,
-  connection: Awaited<ReturnType<typeof authenticateMcpAccessToken>>,
+  connection: Awaited<ReturnType<typeof authenticateMcpBearerToken>>,
   baseDomain: string,
 ): Promise<Response> {
   const server = createMcpServer(connection, getResourceUrl(baseDomain));
@@ -160,9 +160,9 @@ function buildMcpRoutes(app: Hono): Hono {
       return buildBearerChallenge(c, baseDomain);
     }
 
-    let connection: Awaited<ReturnType<typeof authenticateMcpAccessToken>>;
+    let connection: Awaited<ReturnType<typeof authenticateMcpBearerToken>>;
     try {
-      connection = await authenticateMcpAccessToken(token, getResourceUrl(baseDomain));
+      connection = await authenticateMcpBearerToken(token, getResourceUrl(baseDomain));
     } catch (error) {
       if (error instanceof HttpError && error.statusCode === 401) {
         return buildBearerChallenge(c, baseDomain);


### PR DESCRIPTION
## Summary

The `/mcp` endpoint previously accepted only OAuth `fco_` access tokens as Bearer credentials. This adds a prefix-dispatching wrapper so the long-lived agent API key (`fca_`) is also accepted, matching the access it already grants on the REST `/agent` surface.

- New `authenticateMcpBearerToken(token, expectedResource)` in `apps/backend/src/auth/mcpTokens.ts` normalizes the token prefix and dispatches:
  - `fca_` agent API keys → `authenticateAgentApiKey` (long-lived full-access PAT, not audience-bound; no new privilege since the same key already grants identical `executeAgentSql` on `/agent`).
  - everything else (`fco_` OAuth access token) → `authenticateMcpAccessToken`, which stays audience-bound and validates `resource` against `expectedResource`.
- Empty tokens rejected with the same opaque 401 to avoid token-state probing.
- `apps/backend/src/entrypoints/lambda-mcp.ts` now calls the new wrapper.

Both resolvers return the same `{ userId, connectionId, selectedWorkspaceId }` shape, so the request handler is agnostic to which credential was presented.

## Manual post-deploy smoke test

After deploy, call the live MCP endpoint with an `fca_` agent API key as the Bearer token and confirm the `sql` tool works:

```
curl -sS -X POST https://mcp.flashcards-open-source-app.com/mcp \
  -H "Authorization: Bearer fca_<your-agent-api-key>" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

Expect a 200 with the `sql` tool listed. Confirm an `fco_` OAuth token still works and an invalid/empty token still returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)