### PR TITLE
auth: derive the first-login workspace_seed replica id deterministically

### DIFF
--- a/apps/auth/src/server/agent/userWorkspace.ts
+++ b/apps/auth/src/server/agent/userWorkspace.ts
@@ -12,6 +12,7 @@ import {
   query,
   type DatabaseExecutor,
 } from "../../db.js";
+import { buildSystemWorkspaceReplicaId } from "../sync/workspaceReplicaId.js";
 
 const AUTO_CREATED_WORKSPACE_NAME = "Personal";
 
@@ -55,7 +56,11 @@ async function createWorkspaceInExecutor(
   userId: string,
 ): Promise<string> {
   const workspaceId = randomUUID();
-  const bootstrapReplicaId = randomUUID();
+  const bootstrapReplicaId = buildSystemWorkspaceReplicaId(
+    workspaceId,
+    "workspace_seed",
+    "workspace-seed",
+  );
   const bootstrapTimestamp = new Date().toISOString();
   const bootstrapOperationId = `bootstrap-workspace-${workspaceId}`;
 
@@ -93,6 +98,7 @@ async function createWorkspaceInExecutor(
       "replica_id, workspace_id, user_id, actor_kind, actor_key, platform, app_version, last_seen_at",
       ")",
       "VALUES ($1, $2, $3, 'workspace_seed', 'workspace-seed', 'system', $4, now())",
+      "ON CONFLICT (replica_id) DO NOTHING",
     ].join(" "),
     [bootstrapReplicaId, workspaceId, userId, "server-bootstrap"],
   );

--- a/apps/auth/src/server/sync/workspaceReplicaId.ts
+++ b/apps/auth/src/server/sync/workspaceReplicaId.ts
@@ -1,0 +1,48 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Deterministic workspace replica identity for non-client (system) actors.
+ *
+ * Mirrors the backend derivation in apps/backend/src/sync/identity/replica.ts
+ * exactly, including the version/variant nibble layout. Both packages MUST
+ * produce the same replica id for the same `(workspaceId, actorKind, actorKey)`
+ * because sync.workspace_replicas has a unique index on
+ * `(workspace_id, actor_kind, actor_key)` for non-client actors: if auth seeds a
+ * `workspace_seed` replica with a different id than the backend would later
+ * derive, a backend re-ensure of the same system actor would violate that index
+ * (its `INSERT ... ON CONFLICT (replica_id) DO NOTHING` does not catch the
+ * actor-key conflict).
+ *
+ * The auth Lambda is intentionally dependency-light and cannot import the
+ * backend package, so this small helper is duplicated here.
+ */
+
+type SystemWorkspaceReplicaActorKind =
+  | "workspace_seed"
+  | "workspace_reset"
+  | "agent_connection"
+  | "ai_chat";
+
+function toUuidFromSeed(seed: string): string {
+  const digest = createHash("sha256").update(seed).digest("hex");
+  const baseHex = digest.slice(0, 32).split("");
+
+  baseHex[12] = "5";
+  baseHex[16] = ((parseInt(baseHex[16], 16) & 0x3) | 0x8).toString(16);
+
+  return [
+    baseHex.slice(0, 8).join(""),
+    baseHex.slice(8, 12).join(""),
+    baseHex.slice(12, 16).join(""),
+    baseHex.slice(16, 20).join(""),
+    baseHex.slice(20, 32).join(""),
+  ].join("-");
+}
+
+export function buildSystemWorkspaceReplicaId(
+  workspaceId: string,
+  actorKind: SystemWorkspaceReplicaActorKind,
+  actorKey: string,
+): string {
+  return toUuidFromSeed(`${workspaceId}:${actorKind}:${actorKey}`);
+}


### PR DESCRIPTION
## Why
The shared auth first-login bootstrap (`apps/auth/src/server/agent/userWorkspace.ts` `createWorkspaceInExecutor`, used by both the agent-API-key and OAuth flows) seeded the `workspace_seed` sync replica with `randomUUID()`, diverging from the canonical backend seed (`apps/backend/src/workspaces/create.ts`) which derives it deterministically via `buildSystemWorkspaceReplicaId`.

`sync.workspace_replicas` has a unique index on `(workspace_id, actor_kind, actor_key)` for non-client actors. With a random id, a later backend re-ensure of the same `workspace_seed` actor for an auth-created workspace would compute a *different* (deterministic) id and violate that index — `INSERT ... ON CONFLICT (replica_id) DO NOTHING` does not catch the actor-key conflict. Deterministic ids make that re-ensure a safe no-op.

## What
- New auth-local `apps/auth/src/server/sync/workspaceReplicaId.ts`: `buildSystemWorkspaceReplicaId` — a byte-for-byte copy of the backend derivation (auth is dependency-light and can't import the backend package; verified identical to `replica.ts` and the SQL `pg_temp.uuid_from_seed` in migration 0035).
- `userWorkspace.ts`: derive the bootstrap replica id deterministically; add `ON CONFLICT (replica_id) DO NOTHING` for idempotent parity with the backend seed.

## Validation
- `tsc --noEmit` clean for `apps/auth`; offline auth suite green (33/0).
- Reviewed-to-clean (blind review passes; derivation equivalence confirmed empirically across multiple seeds vs both the backend twin and the SQL migration).
- No schema change; no behavior change beyond a stable, contract-aligned replica id.

## Related (separate tracks)
- Scheduler-settings sync-change parity for auth-created workspaces (verify-then-fix; needs an `auth_app` grant migration) — separate plan.
- Real-Postgres workspace-bootstrap schema-contract CI guard — separate plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)