### PR TITLE
Advertise the MCP API-key (Bearer fca_) option in agent discovery

### DIFF
--- a/api/src/components/schemas/AgentDiscoveryData.yaml
+++ b/api/src/components/schemas/AgentDiscoveryData.yaml
@@ -70,6 +70,7 @@ properties:
       - url
       - description
       - authorization
+      - apiKeyBearer
     properties:
       url:
         type: string
@@ -93,4 +94,27 @@ properties:
           authorizationServerMetadataUrl:
             type: string
           protectedResourceMetadataUrl:
+            type: string
+      apiKeyBearer:
+        type: object
+        additionalProperties: false
+        required:
+          - type
+          - header
+          - scheme
+          - description
+        properties:
+          type:
+            type: string
+            enum:
+              - api_key
+          header:
+            type: string
+            enum:
+              - Authorization
+          scheme:
+            type: string
+            enum:
+              - Bearer
+          description:
             type: string

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -42,12 +42,22 @@ get:
                   Remote MCP server for AI clients that connect through custom
                   connectors (for example Claude.ai or ChatGPT). Add the url as a
                   custom connector and authorize through OAuth, then use the sql
-                  tool to read and write cards and decks.
+                  tool to read and write cards and decks. Headless or CLI clients
+                  may instead send Authorization: Bearer fca_… using the agent
+                  API key from email_otp_then_api_key login (the same key as the
+                  REST agent surface), with no OAuth or browser needed.
                 authorization:
                   type: oauth2
                   authorizationServer: https://auth.flashcards-open-source-app.com
                   authorizationServerMetadataUrl: https://auth.flashcards-open-source-app.com/.well-known/oauth-authorization-server
                   protectedResourceMetadataUrl: https://mcp.flashcards-open-source-app.com/.well-known/oauth-protected-resource
+                apiKeyBearer:
+                  type: api_key
+                  header: Authorization
+                  scheme: Bearer
+                  description: >-
+                    Send the agent API key (fca_…) as a Bearer token for
+                    headless/CLI use; same key as the REST agent surface.
             instructions: >-
               Start with agent auth bootstrap. First call POST
               https://auth.flashcards-open-source-app.com/api/agent/send-code

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -41,12 +41,22 @@ get:
                   Remote MCP server for AI clients that connect through custom
                   connectors (for example Claude.ai or ChatGPT). Add the url as a
                   custom connector and authorize through OAuth, then use the sql
-                  tool to read and write cards and decks.
+                  tool to read and write cards and decks. Headless or CLI clients
+                  may instead send Authorization: Bearer fca_… using the agent
+                  API key from email_otp_then_api_key login (the same key as the
+                  REST agent surface), with no OAuth or browser needed.
                 authorization:
                   type: oauth2
                   authorizationServer: https://auth.flashcards-open-source-app.com
                   authorizationServerMetadataUrl: https://auth.flashcards-open-source-app.com/.well-known/oauth-authorization-server
                   protectedResourceMetadataUrl: https://mcp.flashcards-open-source-app.com/.well-known/oauth-protected-resource
+                apiKeyBearer:
+                  type: api_key
+                  header: Authorization
+                  scheme: Bearer
+                  description: >-
+                    Send the agent API key (fca_…) as a Bearer token for
+                    headless/CLI use; same key as the REST agent surface.
             instructions: >-
               Start with POST
               https://auth.flashcards-open-source-app.com/api/agent/send-code

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -30,6 +30,12 @@ type AgentDiscoveryEnvelope = Readonly<{
         authorizationServerMetadataUrl: string;
         protectedResourceMetadataUrl: string;
       }>;
+      apiKeyBearer: Readonly<{
+        type: "api_key";
+        header: "Authorization";
+        scheme: "Bearer";
+        description: string;
+      }>;
     }>;
   }>;
   instructions: string;
@@ -112,12 +118,19 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
       mcp: {
         url: `${mcpBaseUrl}/mcp`,
         description:
-          "Remote MCP server for AI clients that connect through custom connectors (for example Claude.ai or ChatGPT). Add the url as a custom connector and authorize through OAuth, then use the sql tool to read and write cards and decks.",
+          "Remote MCP server for AI clients that connect through custom connectors (for example Claude.ai or ChatGPT). Add the url as a custom connector and authorize through OAuth, then use the sql tool to read and write cards and decks. Headless or CLI clients may instead send Authorization: Bearer fca_… using the agent API key from email_otp_then_api_key login (the same key as the REST agent surface), with no OAuth or browser needed.",
         authorization: {
           type: "oauth2",
           authorizationServer: authBaseUrl,
           authorizationServerMetadataUrl: `${authBaseUrl}/.well-known/oauth-authorization-server`,
           protectedResourceMetadataUrl: `${mcpBaseUrl}/.well-known/oauth-protected-resource`,
+        },
+        apiKeyBearer: {
+          type: "api_key",
+          header: "Authorization",
+          scheme: "Bearer",
+          description:
+            "Send the agent API key (fca_…) as a Bearer token for headless/CLI use; same key as the REST agent surface.",
         },
       },
     },


### PR DESCRIPTION
## Summary

Advertises the MCP API-key authentication option (Bearer `fca_` tokens) alongside the existing OAuth path in the machine API surface. Keeps the discovery envelope and published OpenAPI specs in sync:

- `apps/backend/src/agent/discovery.ts` — surface the API-key Bearer option in the agent discovery payload.
- `api/src/components/schemas/AgentDiscoveryData.yaml` — describe the new API-key auth option in the discovery schema.
- `api/src/paths/_.yaml` and `api/src/paths/agent.yaml` — keep the discovery path docs aligned.

## Manual post-deploy smoke test

After deploy, fetch the discovery payload and confirm the API-key Bearer (`fca_`) option appears:

```
curl -s https://api.flashcards-open-source-app.com/v1/ | jq '.'
curl -s https://api.flashcards-open-source-app.com/v1/agent | jq '.'
```

Verify the MCP auth options list both the OAuth and the API-key (Bearer `fca_`) paths, and that `/v1/openapi.json` reflects the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)