### PR TITLE
Mark MCP list_workspaces tool as read-only

### DIFF
--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -346,6 +346,7 @@ export function createMcpServer(
       title: "List flashcards workspaces",
       description: LIST_WORKSPACES_TOOL_DESCRIPTION,
       inputSchema: {},
+      annotations: { readOnlyHint: true },
     },
     async (): Promise<CallToolResult> => {
       try {


### PR DESCRIPTION
## What

Marks the MCP `list_workspaces` tool as read-only via `annotations: { readOnlyHint: true }` in `apps/backend/src/mcp/server.ts`.

## Why

`list_workspaces` only reads — it returns the caller's accessible workspaces with stats via `listUserWorkspacesWithStatsForSelectedWorkspace` and never mutates. Advertising `readOnlyHint: true` lets MCP clients treat it as safe: many connectors gate write/destructive tools behind a per-call confirmation but auto-run read-only ones, so this keeps the documented `WORKSPACE_SELECTION_REQUIRED` recovery flow (which instructs the model to call `list_workspaces`) friction-free.

The annotation is a client-facing hint only; it does not change server-side behavior, which stays enforced by the OAuth-scoped connection. The sibling `sql` tool is intentionally left unannotated: it does full read+write, and MCP's defaults already treat an unannotated tool as non-read-only/destructive, so the conservative default is correct.

## Testing

`npm run lint` (`tsc --noEmit`) passes in `apps/backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
