### PR TITLE
Surface SQL examples in the agent-facing tool contract

### DIFF
--- a/api/src/paths/agent_sql.yaml
+++ b/api/src/paths/agent_sql.yaml
@@ -12,7 +12,8 @@ post:
     atomically. SELECT supports projected column lists, LIKE, case-insensitive
     exact string matches via LOWER(column) = 'value', LOWER(column) IN (...),
     and LOWER(column) NOT IN (...), aggregates, GROUP BY, NOW(), standalone
-    ORDER BY RANDOM(), and cards UNNEST tags AS tag.
+    ORDER BY RANDOM(), and cards UNNEST tags AS tag. Array columns (e.g. tags)
+    take a parenthesized list such as ('tag1', 'tag2'), or () for empty.
   security:
     - ApiKeyHeader: []
   requestBody:
@@ -21,8 +22,15 @@ post:
       application/json:
         schema:
           $ref: ../components/schemas/AgentSqlRequest.yaml
-        example:
-          sql: SELECT * FROM workspace LIMIT 1 OFFSET 0
+        examples:
+          selectWorkspace:
+            value:
+              sql: SELECT * FROM workspace LIMIT 1 OFFSET 0
+          insertCard:
+            value:
+              sql: >-
+                INSERT INTO cards (front_text, back_text, tags) VALUES
+                ('Question?', 'Answer', ('tag'))
   responses:
     '200':
       description: SQL executed successfully

--- a/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
+++ b/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
@@ -22,6 +22,8 @@ export const SQL_TOOL_PROMPT_EXAMPLE_LINES = Object.freeze([
   "- sql => {\"sql\": \"SELECT tag, COUNT(*) AS cards_count FROM cards UNNEST tags AS tag GROUP BY tag ORDER BY cards_count DESC LIMIT 100 OFFSET 0\"}",
   "- sql => {\"sql\": \"SELECT * FROM cards WHERE due_at IS NULL OR due_at <= NOW() ORDER BY due_at ASC, created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
   "- sql => {\"sql\": \"INSERT INTO cards (front_text, back_text, tags) VALUES ('Question?', 'Answer', ('tag'))\"}",
+  "- sql => {\"sql\": \"INSERT INTO cards (front_text, back_text, tags) VALUES ('Q?', 'A', ('grammar', 'a1'))\"}",
+  "- sql => {\"sql\": \"INSERT INTO cards (front_text, back_text, tags) VALUES ('Q?', 'A', ())\"}",
   "- sql => {\"sql\": \"UPDATE cards SET back_text = 'Updated answer' WHERE card_id = '00000000-0000-4000-8000-000000000000'\"}",
   "- sql => {\"sql\": \"UPDATE cards SET back_text = 'First update' WHERE card_id = '00000000-0000-4000-8000-000000000000'; UPDATE cards SET back_text = 'Second update' WHERE card_id = '00000000-0000-4000-8000-000000000001'\"}",
   "- sql => {\"sql\": \"DELETE FROM decks WHERE deck_id IN ('00000000-0000-4000-8000-000000000000')\"}",
@@ -45,6 +47,9 @@ export const OPENAI_SQL_TOOL: FunctionTool = {
     `INSERT, UPDATE, and DELETE may affect at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
     `If you need to create, update, or delete more than ${MAX_SQL_RECORD_LIMIT} records, split the work into multiple batches of at most ${MAX_SQL_RECORD_LIMIT} records across separate SQL statements or separate tool calls.`,
     "SELECT supports projected column lists, LIKE, LOWER(column) = 'value', LOWER(column) IN (...), and LOWER(column) NOT IN (...) for case-insensitive exact string matches, COUNT(*), SUM, AVG, MIN, MAX, GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag.",
+    "Array columns (e.g. tags) take a parenthesized list: ('tag1', 'tag2'), or () for empty.",
+    "Examples (tool-call JSON):",
+    ...SQL_TOOL_PROMPT_EXAMPLE_LINES,
   ].join(" "),
   strict: false,
   parameters: {

--- a/apps/backend/src/chat/shared.ts
+++ b/apps/backend/src/chat/shared.ts
@@ -2,7 +2,6 @@
  * Shared system-prompt builders for the backend-owned chat stack.
  * These helpers keep the new server-owned chat contract aligned across routes, runtime, and replay.
  */
-import { SQL_TOOL_PROMPT_EXAMPLE_LINES } from "../aiTools/toolContract/sqlToolContract";
 
 function joinLines(lines: ReadonlyArray<string>): string {
   return lines.join("\n");
@@ -86,13 +85,6 @@ function buildToolCallRulesSection(): string {
   ]);
 }
 
-function buildToolCallExamplesSection(): string {
-  return joinLines([
-    "Tool-call JSON examples:",
-    ...SQL_TOOL_PROMPT_EXAMPLE_LINES,
-  ]);
-}
-
 function buildRepairSection(): string {
   return joinLines([
     "If a previous tool call was rejected for invalid arguments, correct the tool call shape and continue without repeating earlier assistant text.",
@@ -130,7 +122,6 @@ export function buildSystemInstructions(timezone: string): string {
     buildPlainTextChatFormattingSection(),
     buildWritePolicySection(),
     buildToolCallRulesSection(),
-    buildToolCallExamplesSection(),
     buildRepairSection(),
     "Be concise, direct, and operational.",
     buildDatetimeSection(timezone),


### PR DESCRIPTION
## Summary

Make the published SQL examples — especially the INSERT statement and the parenthesized array syntax for `tags` — visible in the tool description that external MCP/REST agents actually read, and keep the published OpenAPI spec in sync. Previously these examples were wired only into the in-app chat system prompt, so external agents had to brute-force INSERT/array syntax.

## Changes

- `apps/backend/src/aiTools/toolContract/sqlToolContract.ts`: add 2-tag and empty-tags INSERT example lines, append the examples plus an explicit array-column rule sentence to `OPENAI_SQL_TOOL.description`. The MCP `sql` tool inherits these automatically via `SQL_TOOL_DESCRIPTION`.
- `apps/backend/src/chat/shared.ts`: remove the now-redundant in-app `buildToolCallExamplesSection()` from the system-prompt assembly, since the examples now live in the tool description the chat already passes.
- `api/src/paths/agent_sql.yaml`: add an INSERT request example using the `('tag')` parenthesized-array form plus a one-line array-column note, keeping machine-API docs in sync across the tool surface and published spec.

## Validation

- `npm run lint --prefix api` (redocly lint)
- `npm run bundle --prefix api` (regenerated `api/dist/openapi.json`, gitignored)
- `npm run lint --prefix apps/backend` (tsc --noEmit)
- `npm test --prefix apps/backend` (offline backend suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
