### PR TITLE
Make MCP sql tool annotations explicit and mark both tools closed-world

### DIFF
--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -311,6 +311,11 @@ export function createMcpServer(
         sql: z.string().trim().min(1),
         workspaceId: z.string().uuid().optional(),
       },
+      // sql does full read+write on our own database. Spell out the
+      // (MCP-default) non-read-only + destructive hints explicitly so the
+      // contract is clear next to list_workspaces; openWorldHint is false
+      // because both tools act only within our own closed database domain.
+      annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
     },
     async ({ sql, workspaceId: requestedWorkspaceId }): Promise<CallToolResult> => {
       try {
@@ -346,7 +351,7 @@ export function createMcpServer(
       title: "List flashcards workspaces",
       description: LIST_WORKSPACES_TOOL_DESCRIPTION,
       inputSchema: {},
-      annotations: { readOnlyHint: true },
+      annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async (): Promise<CallToolResult> => {
       try {


### PR DESCRIPTION
## What

Makes the MCP tool annotations in `apps/backend/src/mcp/server.ts` explicit:

- **`sql`**: adds `annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false }` (it previously had none).
- **`list_workspaces`**: adds `openWorldHint: false` alongside its existing `readOnlyHint: true`.

## Why

Follow-up to #747 (which marked `list_workspaces` read-only). This completes the contract on the sibling `sql` tool:

- `sql` runs arbitrary read+write SQL, so it is correctly **non-read-only and destructive**. These are also MCP's defaults for an unannotated tool, but writing them out makes the read-vs-write distinction between the two tools explicit at the registration site rather than implicit.
- `openWorldHint: false` on **both** tools is accurate because each operates only on our own backend database — a closed, bounded domain — never an open world of external entities (the canonical `openWorldHint: true` case is something like a web-search tool).

Annotations are client-facing hints only; they do not change server-side behavior, which stays enforced by the OAuth-scoped connection.

## Testing

`npm run lint` (`tsc --noEmit`) passes in `apps/backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
