### PR TITLE
Add session-auth POST /agent-api-keys to mint agent API keys

### DIFF
--- a/apps/backend/src/agent/apiKeys.ts
+++ b/apps/backend/src/agent/apiKeys.ts
@@ -1,5 +1,5 @@
-import { createHash, timingSafeEqual } from "node:crypto";
-import { queryWithUserScope } from "../database";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { queryWithUserScope, transactionWithUserScope } from "../database";
 import { unsafeQuery } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import {
@@ -7,12 +7,13 @@ import {
   encodeOpaqueCursor,
   type CursorPageInput,
 } from "../shared/pagination";
-import { normalizeCrockfordToken } from "./crockford";
+import { createCrockfordToken, normalizeCrockfordToken } from "./crockford";
 import { ensureApiKeyWorkspaceSelection } from "../workspaces";
 
 const AGENT_API_KEY_PREFIX = "fca";
 const AGENT_API_KEY_ID_LENGTH = 8;
 const AGENT_API_KEY_SECRET_LENGTH = 26;
+const AGENT_API_KEY_LABEL_MAX_LENGTH = 120;
 const LAST_USED_UPDATE_INTERVAL_MS = 5 * 60_000;
 
 type AgentApiKeyRow = Readonly<{
@@ -236,6 +237,66 @@ export async function listAgentApiKeyConnectionsPageForUser(
       toIsoString(nextRow.created_at) ?? "",
       nextRow.connection_id,
     ]),
+  };
+}
+
+/**
+ * Validates the human-readable label shown in settings for a long-lived agent
+ * connection before it is minted.
+ */
+export function normalizeAgentApiKeyLabel(label: string): string {
+  const trimmedLabel = label.trim();
+  if (trimmedLabel === "") {
+    throw new HttpError(400, "Connection label is required", "AGENT_API_KEY_LABEL_INVALID");
+  }
+
+  if (trimmedLabel.length > AGENT_API_KEY_LABEL_MAX_LENGTH) {
+    throw new HttpError(
+      400,
+      `Connection label must be at most ${AGENT_API_KEY_LABEL_MAX_LENGTH} characters`,
+      "AGENT_API_KEY_LABEL_INVALID",
+    );
+  }
+
+  return trimmedLabel;
+}
+
+/**
+ * Mints a new human-managed long-lived agent API key for the signed-in user.
+ * The key is returned once and only its hash is persisted. The selected
+ * workspace is left NULL so ensureApiKeyWorkspaceSelection self-heals it on
+ * first use.
+ */
+export async function createAgentApiKeyForUser(
+  userId: string,
+  label: string,
+): Promise<{ apiKey: string; connection: AgentApiKeyConnection }> {
+  const connectionId = randomUUID();
+  const keyId = createCrockfordToken(AGENT_API_KEY_ID_LENGTH);
+  const secret = createCrockfordToken(AGENT_API_KEY_SECRET_LENGTH);
+  const keyHash = hashSecret(secret);
+
+  const connection = await transactionWithUserScope({ userId }, async (executor) => {
+    const inserted = await executor.query<AgentApiKeyRow>(
+      [
+        "INSERT INTO auth.agent_api_keys",
+        "(connection_id, user_id, label, key_id, key_hash)",
+        "VALUES ($1, $2, $3, $4, $5)",
+        "RETURNING connection_id, user_id, label, key_id, key_hash, selected_workspace_id, created_at, last_used_at, revoked_at",
+      ].join(" "),
+      [connectionId, userId, label, keyId, keyHash],
+    );
+    const row = inserted.rows[0];
+    if (row === undefined) {
+      throw new HttpError(500, "Failed to create agent API key", "AGENT_API_KEY_CREATE_FAILED");
+    }
+
+    return mapConnection(row);
+  });
+
+  return {
+    apiKey: `${AGENT_API_KEY_PREFIX}_${keyId}_${secret}`,
+    connection,
   };
 }
 

--- a/apps/backend/src/agent/crockford.ts
+++ b/apps/backend/src/agent/crockford.ts
@@ -1,4 +1,23 @@
+import { randomBytes } from "node:crypto";
+
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const CROCKFORD_RE = /^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]+$/;
+
+/**
+ * Creates a fixed-length Crockford Base32 token. The emitted alphabet avoids
+ * the most ambiguous uppercase letters to make retyping more reliable.
+ */
+export function createCrockfordToken(length: number): string {
+  const chars: Array<string> = [];
+  while (chars.length < length) {
+    const bytes = randomBytes(length - chars.length);
+    for (const byte of bytes) {
+      chars.push(CROCKFORD_ALPHABET[byte % CROCKFORD_ALPHABET.length] ?? "");
+    }
+  }
+
+  return chars.join("");
+}
 
 /**
  * Normalizes a human-entered Crockford Base32 token by removing spaces and

--- a/apps/backend/src/agent/setup.ts
+++ b/apps/backend/src/agent/setup.ts
@@ -215,3 +215,22 @@ export function createAgentConnectionRevokeEnvelope(connection: AgentApiKeyConne
     instructions: "This bot connection has been revoked. Its API key is no longer valid for future requests.",
   };
 }
+
+export type AgentConnectionCreateEnvelope = Readonly<{
+  ok: true;
+  apiKey: string;
+  connection: AgentApiKeyConnection;
+  instructions: string;
+}>;
+
+export function createAgentConnectionCreateEnvelope(
+  apiKey: string,
+  connection: AgentApiKeyConnection,
+): AgentConnectionCreateEnvelope {
+  return {
+    ok: true,
+    apiKey,
+    connection,
+    instructions: "Store this API key now. It is shown only once and cannot be retrieved again; if you lose it, revoke this connection and create a new one.",
+  };
+}

--- a/apps/backend/src/routes/workspaces/index.ts
+++ b/apps/backend/src/routes/workspaces/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import {
+  createAgentConnectionCreateEnvelope,
   createAgentConnectionListEnvelope,
   createAgentConnectionRevokeEnvelope,
   createAgentWorkspaceReadyEnvelope,
@@ -8,7 +9,9 @@ import {
 } from "../../agent/setup";
 import {
   type AgentApiKeyConnection,
+  createAgentApiKeyForUser,
   listAgentApiKeyConnectionsPageForUser,
+  normalizeAgentApiKeyLabel,
   revokeAgentApiKeyConnectionForUser,
 } from "../../agent/apiKeys";
 import {
@@ -78,6 +81,13 @@ type WorkspaceResetProgressResponse = ResetWorkspaceProgressResult;
 type AgentApiKeyConnectionsPageResponse = Readonly<{
   connections: ReadonlyArray<AgentApiKeyConnection>;
   nextCursor: string | null;
+  instructions: string;
+}>;
+
+type AgentApiKeyCreateResponse = Readonly<{
+  ok: true;
+  apiKey: string;
+  connection: AgentApiKeyConnection;
   instructions: string;
 }>;
 
@@ -493,6 +503,24 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       ...createAgentConnectionListEnvelope(connectionsPage.connections),
       nextCursor: connectionsPage.nextCursor,
     } satisfies AgentApiKeyConnectionsPageResponse);
+  });
+
+  app.post("/agent-api-keys", async (context) => {
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+    requireHumanManagedConnectionAccess(requestContext.transport);
+    const body = expectRecord(await parseJsonBody(context.req.raw));
+    if (typeof body.label !== "string") {
+      throw new HttpError(400, "label must be a string", "AGENT_API_KEY_LABEL_INVALID");
+    }
+
+    const { apiKey, connection } = await createAgentApiKeyForUser(
+      requestContext.userId,
+      normalizeAgentApiKeyLabel(body.label),
+    );
+    return context.json(
+      createAgentConnectionCreateEnvelope(apiKey, connection) satisfies AgentApiKeyCreateResponse,
+      201,
+    );
   });
 
   app.post("/agent-api-keys/:connectionId/revoke", async (context) => {

--- a/db/migrations/0077_agent_api_keys_backend_insert.sql
+++ b/db/migrations/0077_agent_api_keys_backend_insert.sql
@@ -1,0 +1,21 @@
+-- Migration status: Current / canonical.
+-- Introduces: backend_app INSERT access for auth.agent_api_keys so a signed-in
+--   human session can mint a long-lived agent API key from the backend.
+-- Current guidance: this is the current backend minting authorization layer; the
+--   auth_app email-OTP minting path stays intact alongside it.
+-- See also: db/migrations/0024_auth_runtime_roles.sql, db/migrations/0030_agent_api_key_selected_workspace_rls.sql, docs/auth-service.md.
+-- Allow backend_app to INSERT agent API keys for the authenticated user.
+
+GRANT INSERT ON auth.agent_api_keys TO backend_app;
+
+CREATE POLICY agent_api_keys_insert_backend
+  ON auth.agent_api_keys
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (
+    user_id = security.current_user_id()
+    AND (
+      selected_workspace_id IS NULL
+      OR security.user_has_workspace_access(selected_workspace_id)
+    )
+  );

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -674,6 +674,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
 
   const agentApiKeys = restApi.root.addResource("agent-api-keys");
   agentApiKeys.addMethod("GET", integration);
+  agentApiKeys.addMethod("POST", integration);
   agentApiKeys
     .addResource("{connectionId}")
     .addResource("revoke")


### PR DESCRIPTION
Adds a session-authenticated `POST /agent-api-keys` so a signed-in human can mint a long-lived agent API key (`fca_…`) from their session, on the same surface that already lists/revokes connections. The key is returned once; only its hash is stored.

- Migration `0077`: additive `GRANT INSERT` + a `backend_app` RLS insert policy (`WITH CHECK user_id = security.current_user_id()`); the `auth_app` OTP path is untouched.
- `createAgentApiKeyForUser` mints under `transactionWithUserScope` (CSPRNG Crockford key, sha256 of the bare secret), reusing the existing parse/hash contract.
- Human-session guard (`requireHumanManagedConnectionAccess`) like GET/revoke; registered in API Gateway.

Backend half of "Generate key in Settings"; the web button/modal follows in a separate PR.

Manual smoke (after deploy): from a signed-in web session, `POST /v1/agent-api-keys {"label":"test"}` returns a one-time `apiKey` starting `fca_`, and `GET /v1/agent-api-keys` then lists the new connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)