### PR TITLE
Add a response-size budget to agent SQL tool results

### DIFF
--- a/apps/backend/src/aiTools/agentSql.ts
+++ b/apps/backend/src/aiTools/agentSql.ts
@@ -14,9 +14,10 @@ import {
   isSqlMutationStatement,
   isSqlReadStatement,
   type AgentSqlContext,
+  type AgentSqlExecutionResult,
 } from "./agentSql/shared";
 import { executeSqlMutationStatement } from "./agentSql/singleMutation";
-import { MAX_SQL_BATCH_STATEMENT_COUNT } from "./toolContract/sqlToolLimits";
+import { MAX_SQL_BATCH_STATEMENT_COUNT, MAX_SQL_RESULT_CHARS } from "./toolContract/sqlToolLimits";
 
 export type {
   AgentSqlExecutionResult,
@@ -88,6 +89,30 @@ function toStatementSqls(sql: string, statements: ReadonlyArray<ParsedSqlStateme
   return splitStatementSqls(sql);
 }
 
+/**
+ * Single source of truth for the agent SQL result-size budget shared by both
+ * the MCP surface (`sql_query` / `sql_execute`) and the REST surface
+ * (`POST /agent/sql/query` / `POST /agent/sql/execute`).
+ *
+ * The agent envelope serializes `result.data`, so the budget is measured
+ * against the serialized `data` payload. On overflow we fail with an actionable
+ * error (matching the repo's "clear, actionable errors / no silent fallbacks"
+ * principle) instead of returning a payload that exceeds the directory's
+ * tool-result token limit. The remedies are concrete: narrow the result set.
+ */
+function assertSqlResultWithinSizeBudget<T extends AgentSqlExecutionResult>(result: T): T {
+  const serializedLength = JSON.stringify(result.data).length;
+  if (serializedLength > MAX_SQL_RESULT_CHARS) {
+    throw new HttpError(
+      400,
+      `The result payload is too large (${serializedLength} characters, limit ${MAX_SQL_RESULT_CHARS}). Narrow the query and retry: add or lower LIMIT, SELECT fewer columns, or add WHERE filters to return fewer or smaller rows.`,
+      "QUERY_RESULT_TOO_LARGE",
+    );
+  }
+
+  return result;
+}
+
 export async function executeAgentSql(
   context: AgentSqlContext,
   sql: string,
@@ -153,10 +178,14 @@ export async function runSqlQuery(
 
   if (statements.every(isSqlReadStatement)) {
     if (statements.length === 1) {
-      return executeSqlReadStatement(dependencies, context, sql, statements[0]);
+      return assertSqlResultWithinSizeBudget(
+        await executeSqlReadStatement(dependencies, context, sql, statements[0]),
+      );
     }
 
-    return executeSqlReadBatch(dependencies, context, sql, statements, statementSqls);
+    return assertSqlResultWithinSizeBudget(
+      await executeSqlReadBatch(dependencies, context, sql, statements, statementSqls),
+    );
   }
 
   throw buildInvalidSqlError(
@@ -180,10 +209,14 @@ export async function runSqlExecute(
 
   if (statements.every(isSqlMutationStatement)) {
     if (statements.length === 1) {
-      return executeSqlMutationStatement(dependencies, context, sql, statements[0]);
+      return assertSqlResultWithinSizeBudget(
+        await executeSqlMutationStatement(dependencies, context, sql, statements[0]),
+      );
     }
 
-    return executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls);
+    return assertSqlResultWithinSizeBudget(
+      await executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls),
+    );
   }
 
   throw buildInvalidSqlError(

--- a/apps/backend/src/aiTools/toolContract/sqlToolLimits.ts
+++ b/apps/backend/src/aiTools/toolContract/sqlToolLimits.ts
@@ -7,3 +7,20 @@
  */
 export const MAX_SQL_RECORD_LIMIT = 100;
 export const MAX_SQL_BATCH_STATEMENT_COUNT = 50;
+
+/**
+ * Maximum serialized size (in UTF-16 code units, i.e. JS string length) of a
+ * single agent SQL tool/endpoint result payload.
+ *
+ * The MCP directory caps a tool result at roughly 25k tokens. The row-count
+ * limits above (100 rows, 50 statements) do not bound serialized size: 100
+ * cards with long markdown `back_text` can still overflow that token budget.
+ *
+ * Sizing: using a conservative ~4 chars/token heuristic, 25k tokens is ~100k
+ * chars. We target well under that to leave headroom for the surrounding
+ * envelope (`instructions`, `docs`, error metadata) and for tokenization that
+ * runs hotter than 4 chars/token on dense JSON/markdown. 48,000 chars (~12k
+ * tokens at 4 chars/token) is a safe round number that stays comfortably below
+ * the directory limit.
+ */
+export const MAX_SQL_RESULT_CHARS = 48_000;


### PR DESCRIPTION
## What

Adds a shared `MAX_SQL_RESULT_CHARS` (48,000 chars) response-size budget for agent SQL tool results, enforced against the serialized `result.data` for both the MCP surface (`sql_query` / `sql_execute`) and the REST surface (`POST /agent/sql/query` / `POST /agent/sql/execute`).

## Why

The existing agent SQL limits bound row and statement counts (100 rows, 50 statements) but not serialized payload size. A query returning 100 cards with long markdown `back_text` can still overflow the MCP directory's ~25k-token tool-result limit. On overflow we now fail with an actionable `QUERY_RESULT_TOO_LARGE` error that tells the agent how to narrow the result (lower LIMIT, fewer columns, add WHERE filters) instead of returning an oversized payload via a silent fallback.

## Validation

- `api` lint (redocly) passes
- `apps/backend` lint (tsc --noEmit) passes
- `apps/backend` test: 504/504 pass

Generated with Claude Code (https://claude.com/claude-code)