### PR TITLE
Surface env-driven public/legal URLs and complete machine-API metadata

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -263,6 +263,7 @@ jobs:
           CDK_CONTEXT_SENTRY_ENVIRONMENT: ${{ vars.CDK_SENTRY_ENVIRONMENT }}
           CDK_CONTEXT_SENTRY_RELEASE: ${{ github.sha }}
           CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.CDK_SENTRY_TRACES_SAMPLE_RATE }}
+          CDK_CONTEXT_SITE_BASE_URL: ${{ vars.CDK_SITE_BASE_URL }}
           CDK_CONTEXT_WEB_CERTIFICATE_ARN_US_EAST_1: ${{ vars.CDK_WEB_CERTIFICATE_ARN_US_EAST_1 }}
         run: |
           python3 ../../scripts/generate/write-ci-cdk-context.py \
@@ -359,6 +360,7 @@ jobs:
           CDK_CONTEXT_SENTRY_ENVIRONMENT: ${{ vars.CDK_SENTRY_ENVIRONMENT }}
           CDK_CONTEXT_SENTRY_RELEASE: ${{ github.sha }}
           CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.CDK_SENTRY_TRACES_SAMPLE_RATE }}
+          CDK_CONTEXT_SITE_BASE_URL: ${{ vars.CDK_SITE_BASE_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_BACKEND_PROJECT }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Card scheduling uses FSRS-based spaced repetition. Detailed scheduling rules liv
 - [Web app](apps/web/README.md)
 - [Architecture](docs/architecture.md)
 - [Backend and web deployment](docs/backend-web-deployment.md)
+- [Public site URLs (`PUBLIC_SITE_BASE_URL`)](docs/public-site-urls.md)
 - [Release gates and monitoring](docs/release-gates.md)
 - [iOS local setup](docs/ios-local-setup.md)
 - [iOS CI/CD](docs/ios-ci-cd.md)

--- a/api/redocly.yaml
+++ b/api/redocly.yaml
@@ -6,3 +6,8 @@ rules:
   operation-4xx-response: off
   operation-operationId: off
   security-defined: off
+  # The OAuth2 security scheme is published purely to document the implemented
+  # remote-MCP authorization flow (mcp.<domain>/mcp). This REST spec contains no
+  # MCP-transport operation to attach it to, so it is intentionally defined
+  # without being referenced; disable no-unused-components to keep that conscious.
+  no-unused-components: off

--- a/api/src/components/schemas/AgentDiscoveryEnvelope.yaml
+++ b/api/src/components/schemas/AgentDiscoveryEnvelope.yaml
@@ -3,6 +3,7 @@ additionalProperties: false
 required:
   - ok
   - data
+  - links
   - instructions
   - docs
 properties:
@@ -12,6 +13,8 @@ properties:
       - true
   data:
     $ref: ./AgentDiscoveryData.yaml
+  links:
+    $ref: ./AgentLegalLinks.yaml
   instructions:
     type: string
   docs:

--- a/api/src/components/schemas/AgentDocs.yaml
+++ b/api/src/components/schemas/AgentDocs.yaml
@@ -2,10 +2,16 @@ type: object
 additionalProperties: false
 required:
   - openapiUrl
+  - docsUrl
 properties:
   openapiUrl:
     type: string
     description: URL for the curated published external AI-agent OpenAPI contract.
+  docsUrl:
+    type: string
+    description: >-
+      Public human-readable documentation landing page on the marketing site
+      (apex domain, trailing slash). Env-driven per deployment.
   swaggerUrl:
     type: string
     description: Optional equivalent documentation alias returned by the auth bootstrap flow.

--- a/api/src/components/schemas/AgentLegalLinks.yaml
+++ b/api/src/components/schemas/AgentLegalLinks.yaml
@@ -1,0 +1,28 @@
+type: object
+additionalProperties: false
+required:
+  - websiteUrl
+  - privacyUrl
+  - termsUrl
+  - supportUrl
+  - docsUrl
+description: >-
+  Public marketing-site, legal, and docs links for this deployment. The domain
+  is env-driven (`PUBLIC_SITE_BASE_URL`, defaulting to the apex origin derived
+  from the request); the paths are conventional trailing-slash constants.
+properties:
+  websiteUrl:
+    type: string
+    description: Public marketing-site landing page (apex domain, trailing slash).
+  privacyUrl:
+    type: string
+    description: Privacy policy page.
+  termsUrl:
+    type: string
+    description: Terms of service page.
+  supportUrl:
+    type: string
+    description: Support / contact page.
+  docsUrl:
+    type: string
+    description: Human-readable documentation landing page.

--- a/api/src/components/security-schemes/OAuth2.yaml
+++ b/api/src/components/security-schemes/OAuth2.yaml
@@ -1,0 +1,14 @@
+type: oauth2
+description: >-
+  OAuth2 authorization-code flow with PKCE used by the remote MCP server
+  (mcp.<domain>/mcp). MCP clients that connect as custom connectors authorize
+  through the auth host; the REST agent surface itself uses the ApiKeyHeader
+  scheme instead. These authorization/token URLs are the canonical reference
+  deployment values, consistent with the static `servers:` block; per-deploy
+  hosts are advertised at runtime in the discovery envelope.
+flows:
+  authorizationCode:
+    authorizationUrl: https://auth.flashcards-open-source-app.com/authorize
+    tokenUrl: https://auth.flashcards-open-source-app.com/token
+    scopes:
+      flashcards: Read and write the authorized user's flashcards workspaces.

--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -8,6 +8,18 @@ info:
     intentionally omitted from this published specification. This document
     excludes internal sync transport, local chat runtime endpoints, and
     human-only agent connection management.
+  # These info URLs are static canonical reference values for the published
+  # spec, consistent with the static `servers:` block above. The env-driven,
+  # per-deploy public/legal links (self-hosters set their own domain) live in
+  # the discovery envelope `links` block, not here.
+  termsOfService: https://flashcards-open-source-app.com/terms/
+  contact:
+    name: Flashcards Open Source App support
+    url: https://flashcards-open-source-app.com/support/
+    email: support@flashcards-open-source-app.com
+  license:
+    name: MIT
+    url: https://github.com/kirill-markin/flashcards-open-source-app/blob/main/LICENSE
 servers:
   - url: https://api.flashcards-open-source-app.com/v1
     description: >-
@@ -55,3 +67,8 @@ components:
   securitySchemes:
     ApiKeyHeader:
       $ref: ./components/security-schemes/ApiKeyHeader.yaml
+    # OAuth2 documents the implemented remote-MCP authorization flow
+    # (mcp.<domain>/mcp). The REST endpoints below keep ApiKeyHeader; this scheme
+    # is published so the spec reflects how MCP custom-connector clients connect.
+    OAuth2:
+      $ref: ./components/security-schemes/OAuth2.yaml

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -78,5 +78,12 @@ get:
               writes, a clear user request already counts as permission. Ask
               again only for risky or unclear actions. Use docs.openapiUrl for
               the published external agent contract.
+            links:
+              websiteUrl: https://flashcards-open-source-app.com/
+              privacyUrl: https://flashcards-open-source-app.com/privacy/
+              termsUrl: https://flashcards-open-source-app.com/terms/
+              supportUrl: https://flashcards-open-source-app.com/support/
+              docsUrl: https://flashcards-open-source-app.com/docs/
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -92,5 +92,12 @@ get:
               https://api.flashcards-open-source-app.com/v1/agent/openapi.json
               for the published external agent contract. The SQL surface is intentionally limited
               and is not full PostgreSQL.
+            links:
+              websiteUrl: https://flashcards-open-source-app.com/
+              privacyUrl: https://flashcards-open-source-app.com/privacy/
+              termsUrl: https://flashcards-open-source-app.com/terms/
+              supportUrl: https://flashcards-open-source-app.com/support/
+              docsUrl: https://flashcards-open-source-app.com/docs/
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/

--- a/api/src/paths/agent_me.yaml
+++ b/api/src/paths/agent_me.yaml
@@ -38,6 +38,7 @@ get:
               published external agent contract.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
     '503':
       description: Service temporarily unavailable
       headers:
@@ -56,6 +57,7 @@ get:
             instructions: Wait for the Retry-After header before retrying the same request.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
             error:
               code: SERVICE_UNAVAILABLE
               message: Service is temporarily unavailable. Retry shortly.

--- a/api/src/paths/agent_sql_execute.yaml
+++ b/api/src/paths/agent_sql_execute.yaml
@@ -69,6 +69,7 @@ post:
                   docs.openapiUrl for the published external agent contract.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
             mutationBatch:
               value:
                 ok: true
@@ -116,6 +117,7 @@ post:
                   external agent contract.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
     '503':
       description: Service temporarily unavailable
       headers:
@@ -134,6 +136,7 @@ post:
             instructions: Wait for the Retry-After header before retrying the same request.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
             error:
               code: SERVICE_UNAVAILABLE
               message: Service is temporarily unavailable. Retry shortly.

--- a/api/src/paths/agent_sql_query.yaml
+++ b/api/src/paths/agent_sql_query.yaml
@@ -76,6 +76,7 @@ post:
                   PostgreSQL. Use docs.openapiUrl for the published external agent contract.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
             showTables:
               value:
                 ok: true
@@ -107,6 +108,7 @@ post:
                   docs.openapiUrl for the published external agent contract.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
             projectedCards:
               value:
                 ok: true
@@ -142,6 +144,7 @@ post:
                   PostgreSQL. Use docs.openapiUrl for the published external agent contract.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
     '503':
       description: Service temporarily unavailable
       headers:
@@ -160,6 +163,7 @@ post:
             instructions: Wait for the Retry-After header before retrying the same request.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
             error:
               code: SERVICE_UNAVAILABLE
               message: Service is temporarily unavailable. Retry shortly.

--- a/api/src/paths/agent_workspaces.yaml
+++ b/api/src/paths/agent_workspaces.yaml
@@ -52,6 +52,7 @@ get:
               published external agent contract.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
     '503':
       description: Service temporarily unavailable
       headers:
@@ -70,6 +71,7 @@ get:
             instructions: Wait for the Retry-After header before retrying the same request.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
             error:
               code: SERVICE_UNAVAILABLE
               message: Service is temporarily unavailable. Retry shortly.
@@ -120,6 +122,7 @@ post:
               data.* and use docs.openapiUrl for the published external agent contract.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
     '503':
       description: Service temporarily unavailable
       headers:
@@ -138,6 +141,7 @@ post:
             instructions: Wait for the Retry-After header before retrying the same request.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
             error:
               code: SERVICE_UNAVAILABLE
               message: Service is temporarily unavailable. Retry shortly.

--- a/api/src/paths/agent_workspaces_{workspaceId}_select.yaml
+++ b/api/src/paths/agent_workspaces_{workspaceId}_select.yaml
@@ -39,6 +39,7 @@ post:
               data.* and use docs.openapiUrl for the published external agent contract.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
     '503':
       description: Service temporarily unavailable
       headers:
@@ -57,6 +58,7 @@ post:
             instructions: Wait for the Retry-After header before retrying the same request.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
             error:
               code: SERVICE_UNAVAILABLE
               message: Service is temporarily unavailable. Retry shortly.

--- a/api/src/paths/api_agent_send-code.yaml
+++ b/api/src/paths/api_agent_send-code.yaml
@@ -53,6 +53,7 @@ post:
                   docs.openapiUrl for the published external agent contract.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
             demo:
               summary: Configured review/demo account
@@ -84,6 +85,7 @@ post:
                   from instructions and confirm it with actions.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
     '503':
       description: >-
@@ -107,6 +109,7 @@ post:
                 instructions: Retry the same action shortly.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
                 error:
                   code: SERVICE_UNAVAILABLE
@@ -128,6 +131,7 @@ post:
                   latest otpSessionToken.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
                 error:
                   code: SERVICE_UNAVAILABLE

--- a/api/src/paths/api_agent_verify-code.yaml
+++ b/api/src/paths/api_agent_verify-code.yaml
@@ -82,6 +82,7 @@ post:
               docs.openapiUrl for the published external agent contract.
             docs:
               openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+              docsUrl: https://flashcards-open-source-app.com/docs/
               swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
     '503':
       description: >-
@@ -105,6 +106,7 @@ post:
                 instructions: Retry the same action shortly.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
                 error:
                   code: SERVICE_UNAVAILABLE
@@ -121,6 +123,7 @@ post:
                   otpSessionToken because the code may already be consumed.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
                 error:
                   code: SERVICE_UNAVAILABLE
@@ -140,6 +143,7 @@ post:
                   /api/agent/send-code.
                 docs:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
                 error:
                   code: SERVICE_UNAVAILABLE

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -1,4 +1,4 @@
-import { getPublicAgentDocs, getPublicApiBaseUrl } from "../shared/publicUrls";
+import { getPublicAgentDocs, getPublicApiBaseUrl, getPublicLegalLinks } from "../shared/publicUrls";
 
 type AgentDiscoveryEnvelope = Readonly<{
   ok: true;
@@ -39,9 +39,17 @@ type AgentDiscoveryEnvelope = Readonly<{
       }>;
     }>;
   }>;
+  links: Readonly<{
+    websiteUrl: string;
+    privacyUrl: string;
+    termsUrl: string;
+    supportUrl: string;
+    docsUrl: string;
+  }>;
   instructions: string;
   docs: Readonly<{
     openapiUrl: string;
+    docsUrl: string;
   }>;
 }>;
 
@@ -88,7 +96,8 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
   const authBaseUrl = buildAuthBaseUrl(requestUrl);
   const mcpBaseUrl = buildMcpBaseUrl(requestUrl);
   const apiBaseUrl = getPublicApiBaseUrl(requestUrl);
-  const docs = getPublicAgentDocs(requestUrl);
+  const links = getPublicLegalLinks(requestUrl);
+  const docs = { ...getPublicAgentDocs(requestUrl), docsUrl: links.docsUrl };
 
   return {
     ok: true,
@@ -137,6 +146,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         },
       },
     },
+    links,
     instructions:
       `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
     docs,

--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -54,6 +54,21 @@ function getResourceUrl(baseDomain: string): string {
   return `https://mcp.${baseDomain}/mcp`;
 }
 
+/**
+ * Resolves the public marketing-site origin surfaced in the MCP implementation
+ * metadata. Env-driven via `PUBLIC_SITE_BASE_URL` (self-hosters set their own
+ * domain, mirroring the discovery envelope's legal links); when unset it
+ * defaults to the apex origin derived from `MCP_BASE_DOMAIN`.
+ */
+function getWebsiteUrl(baseDomain: string): string {
+  const configuredValue = process.env.PUBLIC_SITE_BASE_URL;
+  if (configuredValue !== undefined && configuredValue.trim() !== "") {
+    return configuredValue.trim();
+  }
+
+  return `https://${baseDomain}`;
+}
+
 function getAuthorizationServerUrl(baseDomain: string): string {
   return `https://auth.${baseDomain}`;
 }
@@ -124,7 +139,7 @@ async function handleMcpTransportRequest(
   connection: Awaited<ReturnType<typeof authenticateMcpBearerToken>>,
   baseDomain: string,
 ): Promise<Response> {
-  const server = createMcpServer(connection, getResourceUrl(baseDomain));
+  const server = createMcpServer(connection, getResourceUrl(baseDomain), getWebsiteUrl(baseDomain));
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -294,17 +294,20 @@ const LIST_WORKSPACES_RESULT_INSTRUCTIONS =
  * call) so the tools never read ambient request state. `resourceUrl` is the
  * canonical MCP resource (`https://mcp.<domain>/mcp`) used to build the agent
  * envelope so the tool results share one contract with `/agent/sql/query` and
- * `/agent/sql/execute`.
+ * `/agent/sql/execute`. `websiteUrl` is the public marketing-site origin
+ * (env-driven, see lambda-mcp.ts) surfaced in the MCP implementation metadata.
  */
 export function createMcpServer(
   connection: AuthenticatedMcpAccessToken,
   resourceUrl: string,
+  websiteUrl: string,
 ): McpServer {
   const server = new McpServer(
     {
       name: SERVER_NAME,
       version: SERVER_VERSION,
       title: "Flashcards Open Source App",
+      websiteUrl,
     },
     {
       instructions: SERVER_INSTRUCTIONS,

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -60,7 +60,10 @@ test("published OpenAPI exposes only the curated external agent contract", () =>
     assert.deepEqual(listDocumentedMethods(paths[path] ?? {}), methods, `Unexpected OpenAPI methods for ${path}`);
   }
 
-  assert.deepEqual(Object.keys(securitySchemes), ["ApiKeyHeader"]);
+  // ApiKeyHeader secures the REST agent surface; OAuth2 documents the
+  // implemented remote-MCP authorization-code flow (mcp.<domain>/mcp) in the
+  // published spec.
+  assert.deepEqual(Object.keys(securitySchemes), ["ApiKeyHeader", "OAuth2"]);
   for (const hiddenSchemaName of [
     "MeResponse",
     "AccountPreferences",

--- a/apps/backend/src/shared/publicUrls.ts
+++ b/apps/backend/src/shared/publicUrls.ts
@@ -41,3 +41,49 @@ export function getPublicAgentDocs(requestUrl: string): Readonly<{
     openapiUrl: `${apiBaseUrl}/agent/openapi.json`,
   };
 }
+
+/**
+ * Resolves the public marketing-site base URL (the apex origin, e.g.
+ * `https://flashcards-open-source-app.com`). Self-hosters set their own domain,
+ * so this is env-driven via `PUBLIC_SITE_BASE_URL` first; when unset it derives
+ * the apex origin from the request by stripping a leading `api.`/`auth.`/`mcp.`
+ * subdomain. The returned value never carries a trailing slash; the conventional
+ * trailing-slash legal paths are appended by `getPublicLegalLinks`.
+ */
+export function getPublicSiteBaseUrl(requestUrl: string): string {
+  const configuredValue = process.env.PUBLIC_SITE_BASE_URL;
+  if (configuredValue !== undefined && configuredValue.trim() !== "") {
+    return stripTrailingSlash(configuredValue.trim());
+  }
+
+  const origin = toRequestOrigin(requestUrl);
+  const host = new URL(requestUrl).host;
+  if (host === "localhost:8080" || host === "127.0.0.1:8080") {
+    return stripTrailingSlash(origin);
+  }
+
+  return stripTrailingSlash(origin.replace(/\/\/(api|auth|mcp)\./, "//"));
+}
+
+/**
+ * Builds the public site, privacy, terms, support, and docs links. The domain
+ * comes from `getPublicSiteBaseUrl` (env-driven); the paths are conventional
+ * trailing-slash constants matching the marketing site (`trailingSlash: true`).
+ */
+export function getPublicLegalLinks(requestUrl: string): Readonly<{
+  websiteUrl: string;
+  privacyUrl: string;
+  termsUrl: string;
+  supportUrl: string;
+  docsUrl: string;
+}> {
+  const siteBaseUrl = getPublicSiteBaseUrl(requestUrl);
+
+  return {
+    websiteUrl: `${siteBaseUrl}/`,
+    privacyUrl: `${siteBaseUrl}/privacy/`,
+    termsUrl: `${siteBaseUrl}/terms/`,
+    supportUrl: `${siteBaseUrl}/support/`,
+    docsUrl: `${siteBaseUrl}/docs/`,
+  };
+}

--- a/docs/public-site-urls.md
+++ b/docs/public-site-urls.md
@@ -1,0 +1,47 @@
+# Public site URLs (`PUBLIC_SITE_BASE_URL`)
+
+This is an open-source, self-hostable project, so the public marketing-site,
+legal, and docs links must not be hardcoded to the reference domain. They are
+env-driven through `PUBLIC_SITE_BASE_URL`, following the same pattern as
+`PUBLIC_API_BASE_URL` and `PUBLIC_AUTH_BASE_URL`.
+
+## Purpose
+
+`PUBLIC_SITE_BASE_URL` is the public origin of your marketing site (the apex
+domain), with no trailing slash, for example
+`https://flashcards-open-source-app.com`. It feeds:
+
+- the discovery envelope `links` block (`GET /v1/` and `GET /v1/agent`), which
+  surfaces the website, privacy, terms, support, and docs URLs to AI agents;
+- the remote MCP server implementation metadata (`websiteUrl`).
+
+## Default
+
+When `PUBLIC_SITE_BASE_URL` is unset, the value is derived automatically:
+
+- The backend discovery surface strips a leading `api.`/`auth.`/`mcp.`
+  subdomain from the incoming request origin to reach the apex origin.
+- The MCP and backend Lambdas default to `https://<baseDomain>` (the deployment
+  apex domain), so the reference deployment works without setting anything.
+
+## Derived legal links
+
+The legal/docs paths are conventional trailing-slash constants appended to the
+base URL (the marketing site uses `trailingSlash: true`):
+
+| Link        | Path        |
+| ----------- | ----------- |
+| `websiteUrl` | `/`        |
+| `privacyUrl` | `/privacy/`|
+| `termsUrl`   | `/terms/`  |
+| `supportUrl` | `/support/`|
+| `docsUrl`    | `/docs/`   |
+
+## AWS deployment
+
+In CDK, the value defaults to `https://<domainName>` for the backend and MCP
+Lambda environments. To override it (for example when the marketing site lives
+on a different host than the API apex), set the optional GitHub Actions
+repository variable `CDK_SITE_BASE_URL`; it flows through
+`CDK_CONTEXT_SITE_BASE_URL` into the `siteBaseUrl` CDK context. Production works
+without setting it because the value defaults from the domain.

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -18,6 +18,7 @@ export interface ApiGatewayProps {
   backendDbSecret: cdk.aws_secretsmanager.Secret;
   reportingDbSecret: cdk.aws_secretsmanager.ISecret;
   baseDomain: string;
+  siteBaseUrl: string | undefined;
   apiCertificateArn: string | undefined;
   openAiApiKeySecretArn: string | undefined;
   langfusePublicKeySecretArn: string | undefined;
@@ -51,6 +52,7 @@ interface BackendFunctionProps {
   constructId: string;
   entry: string;
   baseDomain: string;
+  siteBaseUrl: string | undefined;
   vpc: ec2.Vpc;
   lambdaSg: ec2.SecurityGroup;
   db: rds.DatabaseInstance;
@@ -321,6 +323,9 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
       BACKEND_CHAT_LIVE_AUTH_SECRET_ARN: props.backendChatLiveAuthSecret.secretArn,
       PUBLIC_API_BASE_URL: `https://api.${props.baseDomain}/v1`,
       PUBLIC_AUTH_BASE_URL: `https://auth.${props.baseDomain}`,
+      // Public marketing-site origin for the discovery legal links. Defaults to
+      // the apex domain; an optional CDK `siteBaseUrl` context overrides it.
+      PUBLIC_SITE_BASE_URL: props.siteBaseUrl ?? `https://${props.baseDomain}`,
       GUEST_AI_WEIGHTED_MONTHLY_TOKEN_CAP: props.guestAiWeightedMonthlyTokenCap ?? "0",
       ...(langfuseConfig === null
         ? {}
@@ -419,6 +424,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     constructId: "BackendHandler",
     entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda.ts"),
     baseDomain: props.baseDomain,
+    siteBaseUrl: props.siteBaseUrl,
     vpc: props.vpc,
     lambdaSg: props.lambdaSg,
     db: props.db,
@@ -455,6 +461,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     constructId: "ChatRunWorkerHandler",
     entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-chat-worker.ts"),
     baseDomain: props.baseDomain,
+    siteBaseUrl: props.siteBaseUrl,
     vpc: props.vpc,
     lambdaSg: props.lambdaSg,
     db: props.db,
@@ -487,6 +494,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     constructId: "ChatLiveHandler",
     entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-chat-live.ts"),
     baseDomain: props.baseDomain,
+    siteBaseUrl: props.siteBaseUrl,
     vpc: props.vpc,
     lambdaSg: props.lambdaSg,
     db: props.db,

--- a/infra/aws/lib/gateways/mcp-gateway.ts
+++ b/infra/aws/lib/gateways/mcp-gateway.ts
@@ -15,6 +15,7 @@ export interface McpGatewayProps {
   db: rds.DatabaseInstance;
   backendDbSecret: cdk.aws_secretsmanager.Secret;
   baseDomain: string;
+  siteBaseUrl: string | undefined;
   mcpCertificateArn: string | undefined;
   sentryDsnSecretArn: string | undefined;
   sentryEnvironment: string | undefined;
@@ -100,6 +101,10 @@ export function mcpGateway(scope: Construct, props: McpGatewayProps): McpGateway
       // matches `/agent/sql/query` and `/agent/sql/execute` instead of resolving
       // against the mcp.<domain> request host.
       PUBLIC_API_BASE_URL: `https://api.${props.baseDomain}/v1`,
+      // Public marketing-site origin surfaced in the MCP implementation
+      // metadata (websiteUrl). Defaults to the apex domain; an optional CDK
+      // `siteBaseUrl` context overrides it for self-host deployments.
+      PUBLIC_SITE_BASE_URL: props.siteBaseUrl ?? `https://${props.baseDomain}`,
     },
   });
 

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -131,6 +131,11 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const langfusePublicKeySecretArn = getOptionalContextValue(this, "langfusePublicKeySecretArn");
     const langfuseSecretKeySecretArn = getOptionalContextValue(this, "langfuseSecretKeySecretArn");
     const langfuseBaseUrl = getOptionalContextValue(this, "langfuseBaseUrl");
+    // Optional per-deploy override for the public marketing-site origin used by
+    // the discovery legal links and MCP implementation metadata. Defaults inside
+    // each gateway to `https://<baseDomain>` when unset, so prod works without
+    // setting the GitHub var.
+    const siteBaseUrl = getOptionalContextValue(this, "siteBaseUrl");
     const sentryContext = validateBackendSentryContext({
       sentryDsnSecretArn: getOptionalContextValue(this, "sentryDsnSecretArn"),
       sentryEnvironment: getOptionalContextValue(this, "sentryEnvironment"),
@@ -242,6 +247,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       db: dbResult.db,
       backendDbSecret: dbResult.backendDbSecret,
       baseDomain,
+      siteBaseUrl,
       mcpCertificateArn,
       ...sentryContext,
     });
@@ -263,6 +269,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       backendDbSecret: dbResult.backendDbSecret,
       reportingDbSecret: dbResult.reportingDbSecret,
       baseDomain,
+      siteBaseUrl,
       apiCertificateArn,
       openAiApiKeySecretArn,
       langfusePublicKeySecretArn,

--- a/scripts/generate/write-ci-cdk-context.py
+++ b/scripts/generate/write-ci-cdk-context.py
@@ -140,6 +140,7 @@ def build_context_values(aws_deploy_role_arn: str) -> dict[str, str]:
         "sentryEnvironment": get_trimmed_env("CDK_CONTEXT_SENTRY_ENVIRONMENT"),
         "sentryRelease": get_trimmed_env("CDK_CONTEXT_SENTRY_RELEASE"),
         "sentryTracesSampleRate": get_trimmed_env("CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE"),
+        "siteBaseUrl": get_trimmed_env("CDK_CONTEXT_SITE_BASE_URL"),
         "webCertificateArnUsEast1": get_trimmed_env("CDK_CONTEXT_WEB_CERTIFICATE_ARN_US_EAST_1"),
     }
     validate_required_backend_sentry_context(values, aws_deploy_role_arn)


### PR DESCRIPTION
## What

Wire public site and legal URLs through env-driven config (`apps/backend/src/shared/publicUrls.ts`, `infra/aws/lib/stack.ts`, gateways, and CI context generation) and surface them across the machine-API surface:

- Agent discovery envelope and `/v1` + `/v1/agent` responses now expose public/legal URLs and completed metadata.
- New `AgentLegalLinks` schema and OAuth2 security scheme; OpenAPI/Redocly definitions updated and bundle verified.
- MCP server/gateway wiring and discovery docs aligned.
- Adds `docs/public-site-urls.md`.

## Why

Keep the machine-API metadata complete and consistent across the discovery envelope, published specs, and gateway wiring, with public/legal URLs driven by environment configuration rather than hardcoded values.

## Validation

- `api` lint + bundle
- `apps/backend` lint + test (504 passing)
- `infra/aws` build

Generated with Claude Code (https://claude.com/claude-code)