### PR TITLE
Track server.json in the release version-bump flow

### DIFF
--- a/docs/version-bump.md
+++ b/docs/version-bump.md
@@ -27,6 +27,12 @@ Update these package manifests together:
 
 For each of those packages, also update the matching top-level package version fields in the adjacent `package-lock.json`.
 
+Also update the MCP registry manifest at the repo root:
+
+- `server.json`
+
+`server.json` carries the published MCP registry manifest `version`, and it must move with the shared release version so the registry entry matches releases. There is no adjacent `package-lock.json` to update for it.
+
 If backend comments or compatibility notes explicitly describe the currently
 released first-party client version, update those references in the same
 change so the documented minimum-compatible client behavior stays accurate.


### PR DESCRIPTION
`server.json` carries the published MCP registry manifest `version`. It was not listed among the version-bump surfaces in `docs/version-bump.md`, so it would silently drift from the shared release version on the next bump (it happens to match `1.14.0` today).

- Document `server.json` (repo root) as a backend-adjacent release-version surface that moves with the shared release version.

Docs-only. The `server.json` `version` is the release version, distinct from the `/v1` API contract version; `/v1` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
