### PR TITLE
chore: enrich server.json with MCP registry listing metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,9 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "com.flashcards-open-source-app/flashcards",
   "description": "Read and write your open-source flashcards and decks over a remote MCP server, with split read-only and write SQL tools.",
+  "status": "active",
   "version": "1.14.0",
+  "website_url": "https://flashcards-open-source-app.com",
   "repository": {
     "url": "https://github.com/kirill-markin/flashcards-open-source-app",
     "source": "github"
@@ -12,5 +14,15 @@
       "type": "streamable-http",
       "url": "https://mcp.flashcards-open-source-app.com/mcp"
     }
-  ]
+  ],
+  "_meta": {
+    "com.flashcards-open-source-app/listing": {
+      "iconUrl": "https://flashcards-open-source-app.com/icon.svg",
+      "categories": ["Productivity", "Education"],
+      "privacyPolicyUrl": "https://flashcards-open-source-app.com/privacy",
+      "termsOfServiceUrl": "https://flashcards-open-source-app.com/terms",
+      "supportUrl": "https://flashcards-open-source-app.com/support",
+      "documentationUrl": "https://flashcards-open-source-app.com/docs"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Enriches the MCP server manifest (`server.json`) with additional registry/directory listing metadata.

### Changes
- Add `status: "active"` and `website_url`.
- Add a `_meta` listing block under `com.flashcards-open-source-app/listing` with `iconUrl`, `categories`, and `privacyPolicyUrl`, `termsOfServiceUrl`, `supportUrl`, `documentationUrl`.

These fields support cleaner presentation when the connector is submitted to the MCP registry/directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)