### PR TITLE
feat(mcp): advertise branded SVG icon in MCP server metadata

### DIFF
--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -69,6 +69,21 @@ function getWebsiteUrl(baseDomain: string): string {
   return `https://${baseDomain}`;
 }
 
+/**
+ * Resolves the absolute https URL of the served branded SVG icon advertised in
+ * the MCP implementation `icons`. Derived from the same public site origin as
+ * `getWebsiteUrl` (env `PUBLIC_SITE_BASE_URL`, fallback to the apex origin from
+ * `MCP_BASE_DOMAIN`) and pointed at the served `/icon.svg`, so self-hosters
+ * advertise their own icon without extra configuration.
+ */
+function getIconUrl(baseDomain: string): string {
+  // Strip a trailing slash before appending the icon path so an operator who
+  // sets PUBLIC_SITE_BASE_URL with a trailing slash does not advertise a
+  // double-slash `//icon.svg` URL (mirrors stripTrailingSlash in
+  // src/shared/publicUrls.ts, the only other place this env value is consumed).
+  return `${getWebsiteUrl(baseDomain).replace(/\/+$/, "")}/icon.svg`;
+}
+
 function getAuthorizationServerUrl(baseDomain: string): string {
   return `https://auth.${baseDomain}`;
 }
@@ -139,7 +154,12 @@ async function handleMcpTransportRequest(
   connection: Awaited<ReturnType<typeof authenticateMcpBearerToken>>,
   baseDomain: string,
 ): Promise<Response> {
-  const server = createMcpServer(connection, getResourceUrl(baseDomain), getWebsiteUrl(baseDomain));
+  const server = createMcpServer(
+    connection,
+    getResourceUrl(baseDomain),
+    getWebsiteUrl(baseDomain),
+    getIconUrl(baseDomain),
+  );
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -296,11 +296,15 @@ const LIST_WORKSPACES_RESULT_INSTRUCTIONS =
  * envelope so the tool results share one contract with `/agent/sql/query` and
  * `/agent/sql/execute`. `websiteUrl` is the public marketing-site origin
  * (env-driven, see lambda-mcp.ts) surfaced in the MCP implementation metadata.
+ * `iconUrl` is the absolute https URL of the served branded SVG icon
+ * (`/icon.svg`), advertised as the server `icons` entry so spec-current MCP
+ * clients and auto-ingesting catalogs can render the brand.
  */
 export function createMcpServer(
   connection: AuthenticatedMcpAccessToken,
   resourceUrl: string,
   websiteUrl: string,
+  iconUrl: string,
 ): McpServer {
   const server = new McpServer(
     {
@@ -308,6 +312,7 @@ export function createMcpServer(
       version: SERVER_VERSION,
       title: "Flashcards Open Source App",
       websiteUrl,
+      icons: [{ src: iconUrl, mimeType: "image/svg+xml", sizes: ["any"] }],
     },
     {
       instructions: SERVER_INSTRUCTIONS,


### PR DESCRIPTION
## Summary

Surface the served `/icon.svg` as the MCP implementation `icons` entry so spec-current MCP clients and auto-ingesting catalogs can render the brand.

- Add `getIconUrl` in `lambda-mcp.ts`, derived from the same public site origin as `getWebsiteUrl` (env `PUBLIC_SITE_BASE_URL`, fallback to the apex origin from `MCP_BASE_DOMAIN`), pointed at `/icon.svg`, with trailing-slash normalization to avoid `//icon.svg`.
- Thread the icon URL into `createMcpServer` and emit `icons: [{ src, mimeType: "image/svg+xml", sizes: ["any"] }]` in the server implementation metadata.

Self-hosters advertise their own icon without extra configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)