### PR TITLE
fix(mcp): use real support email and canonicalize listing URLs

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -16,7 +16,7 @@ info:
   contact:
     name: Flashcards Open Source App support
     url: https://flashcards-open-source-app.com/support/
-    email: support@flashcards-open-source-app.com
+    email: kirill+flashcards@kirill-markin.com
   license:
     name: MIT
     url: https://github.com/kirill-markin/flashcards-open-source-app/blob/main/LICENSE

--- a/server.json
+++ b/server.json
@@ -19,10 +19,10 @@
     "com.flashcards-open-source-app/listing": {
       "iconUrl": "https://flashcards-open-source-app.com/icon.svg",
       "categories": ["Productivity", "Education"],
-      "privacyPolicyUrl": "https://flashcards-open-source-app.com/privacy",
-      "termsOfServiceUrl": "https://flashcards-open-source-app.com/terms",
-      "supportUrl": "https://flashcards-open-source-app.com/support",
-      "documentationUrl": "https://flashcards-open-source-app.com/docs"
+      "privacyPolicyUrl": "https://flashcards-open-source-app.com/privacy/",
+      "termsOfServiceUrl": "https://flashcards-open-source-app.com/terms/",
+      "supportUrl": "https://flashcards-open-source-app.com/support/",
+      "documentationUrl": "https://flashcards-open-source-app.com/docs/api/"
     }
   }
 }


### PR DESCRIPTION
Replace the placeholder `support@` address in the OpenAPI contact block with the real `kirill+flashcards@kirill-markin.com` mailbox.

Canonicalize the `server.json` listing URLs to their trailing-slash forms (privacy, terms, support) and point the docs link at the live `/docs/api/` path so MCP registry metadata matches the published site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)