### PR TITLE
fix(android): pin coreKtx/lifecycle to compileSdk 36 and add drift guardrail

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -23,6 +23,10 @@ We do not want an Android app that imitates iPhone UI. We want a modern Android 
 
 The development focus is Android 14, 15, and 16. We do not spend effort validating or polishing older Android versions.
 
+## Dependency Version Pin
+
+AndroidX and other dependency versions in `gradle/libs.versions.toml` must stay at the highest versions still compatible with `compileSdk = 36`, our stable baseline. Some newer releases — currently `androidx.core:core-ktx >= 1.19.0` and `androidx.lifecycle >= 2.11.0` — require `compileSdk = 37` (Android 17), which is not yet a stable SDK, so they fail the Android build at `:app:checkDebugAarMetadata`. Do not bump these past their `compileSdk 36`-compatible versions (`coreKtx = 1.18.0`, `lifecycle = 2.10.0`) until the whole app intentionally moves to `compileSdk 37`. Automated dependency-drift updates must respect this pin, because Gradle is not run during their validation and cannot catch the break locally.
+
 ## Design Rule
 
 Use Google-provided Android components and Android interaction patterns whenever they fit the problem.

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -2,10 +2,13 @@
 agp = "9.2.1"
 kotlin = "2.3.21"
 ksp = "2.3.9"
-coreKtx = "1.19.0"
+# Pinned for compileSdk 36 (our stable baseline — see apps/android/README.md):
+# coreKtx >= 1.19.0 requires compileSdk 37 (Android 17, not yet stable) and breaks the Android build.
+coreKtx = "1.18.0"
 splashscreen = "1.2.0"
 activityCompose = "1.13.0"
-lifecycle = "2.11.0"
+# Pinned for compileSdk 36: lifecycle >= 2.11.0 requires compileSdk 37 (see coreKtx note above).
+lifecycle = "2.10.0"
 navigationCompose = "2.9.8"
 composeBom = "2026.06.00"
 lottieCompose = "6.7.1"


### PR DESCRIPTION
## Summary
`main` is red on **Android Release** ([run #482](https://github.com/kirill-markin/flashcards-open-source-app/actions/runs/28078667268)). The dependency-drift PR #762 bumped `androidx.core` coreKtx to `1.19.0` and `androidx.lifecycle` to `2.11.0`; both require **compileSdk 37**, but every Android module pins **compileSdk 36**, so the build fails at `:app:checkDebugAarMetadata`.

## Fix (durable pin, not a compileSdk bump)
- Revert `coreKtx → 1.18.0` and `lifecycle → 2.10.0` (the last values green on the previous Android release).
- **Why not compileSdk 37:** API 37 (Android 17) is not a stable SDK yet, and GitHub's Ubuntu runner installs it only as `android-37.0` (AGP looks for `android-37`), so moving the production build to 37 now is intentionally deferred.

## Guardrail (stops the recurrence)
This exact break has recurred several times because the automated drift job does not run Gradle during validation and can't catch it locally. Added:
- Comments at the pinned lines in `apps/android/gradle/libs.versions.toml`.
- A **Dependency Version Pin** note in `apps/android/README.md` next to the `compileSdk 36` baseline.

## Validation
- Reverts to the exact versions that last passed Android Release; all 9 Android modules remain on `compileSdk 36`.
- A fresh review confirmed `coreKtx`/`lifecycle` are the only refs requiring 37; the un-reverted `composeBom 2026.06.00` pins Compose `1.11.3`, which is safe on compileSdk 36.
- Android Gradle not run locally per repo policy; **Android Release** on `main` is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)