### PR TITLE
fix(sync): accept null reviewedTimeZone in sync push

### DIFF
--- a/apps/backend/src/sync/contracts/input.test.ts
+++ b/apps/backend/src/sync/contracts/input.test.ts
@@ -24,7 +24,7 @@ import type { BootstrapProjectionRow } from "./types";
 type ReviewEventTimestampFixture = Readonly<{
   clientUpdatedAt: string;
   reviewedAtClient: string;
-  reviewedTimeZone?: string;
+  reviewedTimeZone?: string | null;
 }>;
 
 type CardDueAtFixture = Readonly<{
@@ -100,7 +100,7 @@ function createSyncPushInput(
       clientEventId: string;
       rating: 2;
       reviewedAtClient: string;
-      reviewedTimeZone?: string;
+      reviewedTimeZone?: string | null;
     }>;
   }>>;
 }> {
@@ -342,6 +342,22 @@ test("parseSyncPushInput accepts optional reviewedTimeZone on review_event opera
     assert.fail("Expected the parsed sync operation to remain a review_event");
   }
   assert.equal(parsedInput.operations[0].payload.reviewedTimeZone, "Europe/Madrid");
+});
+
+test("parseSyncPushInput accepts null reviewedTimeZone on review_event operations", () => {
+  const input = createSyncPushInput({
+    clientUpdatedAt: "2018-02-03T04:05:06.000Z",
+    reviewedAtClient: "2018-02-03T04:05:06.000Z",
+    reviewedTimeZone: null,
+  });
+
+  const parsedInput = parseSyncPushInput(input);
+
+  assert.equal(parsedInput.operations[0]?.entityType, "review_event");
+  if (parsedInput.operations[0]?.entityType !== "review_event") {
+    assert.fail("Expected the parsed sync operation to remain a review_event");
+  }
+  assert.equal(parsedInput.operations[0].payload.reviewedTimeZone, undefined);
 });
 
 test("parseSyncPushInput rejects malformed reviewedTimeZone on review_event operations", () => {

--- a/apps/backend/src/sync/contracts/input.ts
+++ b/apps/backend/src/sync/contracts/input.ts
@@ -217,7 +217,7 @@ const reviewEventPushPayloadSchema = z.object({
   clientEventId: z.string().min(1),
   rating: reviewRatingSchema,
   reviewedAtClient: z.string().datetime(),
-  reviewedTimeZone: z.string().superRefine(validateReviewedTimeZone).optional(),
+  reviewedTimeZone: z.preprocess((value) => value ?? undefined, z.string().superRefine(validateReviewedTimeZone).optional()),
 });
 
 const reviewEventImportPayloadSchema = reviewEventPushPayloadSchema.extend({


### PR DESCRIPTION
## Problem

Production Sentry warning `progress_summary_sync_before_remote_load_failed` (Android 1.13.0) traced to a **persistent `400 SYNC_INVALID_INPUT`** on `POST /v1/workspaces/{id}/sync/push`. CloudWatch (`requestId 4a5e0b75…`) pinned the exact field:

```
validationIssues: [{ path: "operations.N.payload.reviewedTimeZone", code: "invalid_type" }]
```

Shipped Android clients serialize legacy review events (rows predating the `reviewedTimeZone` column, backfilled `null`) as `"reviewedTimeZone": null` on the wire via `CloudSyncRunner.putNullableString` → `JSONObject.NULL`. The contract used `.optional()`, which accepts a string or an **absent** key but rejects `null`. The result is a **poison operation in the outbox**: the whole push 400s forever on retry, blocking all sync for the workspace, and surfacing as the progress warning.

Backend must stay backward-compatible with already-released clients, so the backend must accept `null` (semantically "no recorded timezone", same as absent). iOS is unaffected (it omits the field).

## Change

- `reviewedTimeZone` now uses `z.preprocess((value) => value ?? undefined, z.string().superRefine(validateReviewedTimeZone).optional())`:
  - accepts `null`, `undefined`, and valid IANA strings; still **rejects malformed** IANA strings;
  - normalizes `null`/`undefined` → `undefined`, preserving the **optional output key** so downstream consumers (`push.ts`, `cards/types.ts`) and import fixtures are unaffected.
- Added a regression test asserting `null` is accepted and normalized.

The fix covers both the sync-push and review-history-import paths (the import schema `.extend()`s the same base).

## Validation

- `tsc --noEmit` clean.
- `npm test` (backend): **505/505 pass**, including the new `accepts null reviewedTimeZone` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
