### PR TITLE
fix(backend): surface OpenAI terminal stream events as provider errors

### DIFF
--- a/apps/backend/src/chat/openai/loop/loop.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.test.ts
@@ -142,6 +142,66 @@ function createOutputTextDeltaEvent(text: string): OpenAI.Responses.ResponseText
   } as OpenAI.Responses.ResponseTextDeltaEvent;
 }
 
+function createResponseFailedEvent(
+  code: OpenAI.Responses.ResponseError["code"],
+  message: string,
+): OpenAI.Responses.ResponseFailedEvent {
+  return {
+    type: "response.failed",
+    sequence_number: 1,
+    response: {
+      ...createResponse([], ""),
+      status: "failed",
+      error: { code, message },
+    },
+  } as OpenAI.Responses.ResponseFailedEvent;
+}
+
+function createResponseIncompleteEvent(
+  reason: "max_output_tokens" | "content_filter",
+): OpenAI.Responses.ResponseIncompleteEvent {
+  return {
+    type: "response.incomplete",
+    sequence_number: 1,
+    response: {
+      ...createResponse([], ""),
+      status: "incomplete",
+      incomplete_details: { reason },
+    },
+  } as OpenAI.Responses.ResponseIncompleteEvent;
+}
+
+function createResponseErrorEvent(
+  code: string | null,
+  message: string,
+): OpenAI.Responses.ResponseErrorEvent {
+  return {
+    type: "error",
+    code,
+    message,
+    param: null,
+    sequence_number: 1,
+  };
+}
+
+function createTerminalEventStream(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): OpenAIResponseStream {
+  return {
+    async *[Symbol.asyncIterator](): AsyncGenerator<OpenAI.Responses.ResponseStreamEvent> {
+      yield event;
+    },
+  };
+}
+
+function createStreamWithoutCompletedResponse(): OpenAIResponseStream {
+  return {
+    async *[Symbol.asyncIterator](): AsyncGenerator<OpenAI.Responses.ResponseStreamEvent> {
+      yield createOutputTextDeltaEvent("partial");
+    },
+  };
+}
+
 function createResponseStream(
   events: ReadonlyArray<OpenAI.Responses.ResponseStreamEvent>,
   finalResponse: OpenAI.Responses.Response,
@@ -743,6 +803,96 @@ test("startOpenAILoopWithDeps preserves replay items when a deadline aborts the 
     call_id: `call-${String(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)}`,
     output: `{"call":${String(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)}}`,
   });
+});
+
+test("startOpenAILoopWithDeps fails with a classified terminal error on response.failed", async () => {
+  await assert.rejects(
+    startOpenAILoopWithDeps(
+      createParams(),
+      async (): Promise<void> => undefined,
+      createDependencies(
+        () => createTerminalEventStream(
+          createResponseFailedEvent("server_error", "upstream model failure"),
+        ),
+        async () => {
+          throw new Error("runOneToolCall should not be called");
+        },
+      ),
+    ),
+    (error: unknown): boolean => {
+      assert(error instanceof Error);
+      assert.equal(error.name, "ChatProviderTerminalEventError");
+      assert.equal((error as { code?: string }).code, "server_error");
+      return true;
+    },
+  );
+});
+
+test("startOpenAILoopWithDeps fails with a classified terminal error on response.incomplete", async () => {
+  await assert.rejects(
+    startOpenAILoopWithDeps(
+      createParams(),
+      async (): Promise<void> => undefined,
+      createDependencies(
+        () => createTerminalEventStream(
+          createResponseIncompleteEvent("max_output_tokens"),
+        ),
+        async () => {
+          throw new Error("runOneToolCall should not be called");
+        },
+      ),
+    ),
+    (error: unknown): boolean => {
+      assert(error instanceof Error);
+      assert.equal(error.name, "ChatProviderTerminalEventError");
+      assert.equal((error as { code?: string }).code, "max_output_tokens");
+      return true;
+    },
+  );
+});
+
+test("startOpenAILoopWithDeps fails with a classified terminal error on an error event", async () => {
+  await assert.rejects(
+    startOpenAILoopWithDeps(
+      createParams(),
+      async (): Promise<void> => undefined,
+      createDependencies(
+        () => createTerminalEventStream(
+          createResponseErrorEvent("rate_limit_exceeded", "provider error event"),
+        ),
+        async () => {
+          throw new Error("runOneToolCall should not be called");
+        },
+      ),
+    ),
+    (error: unknown): boolean => {
+      assert(error instanceof Error);
+      assert.equal(error.name, "ChatProviderTerminalEventError");
+      assert.equal((error as { code?: string }).code, "rate_limit_exceeded");
+      return true;
+    },
+  );
+});
+
+test("startOpenAILoopWithDeps fails with a classified terminal error when the stream ends without a completed response", async () => {
+  await assert.rejects(
+    startOpenAILoopWithDeps(
+      createParams(),
+      async (): Promise<void> => undefined,
+      createDependencies(
+        () => createStreamWithoutCompletedResponse(),
+        async () => {
+          throw new Error("runOneToolCall should not be called");
+        },
+      ),
+    ),
+    (error: unknown): boolean => {
+      assert(error instanceof Error);
+      assert.equal(error.name, "ChatProviderTerminalEventError");
+      assert.equal((error as { code?: string }).code, "stream_closed_without_response");
+      return true;
+    },
+  );
 });
 
 test("startOpenAILoopWithDeps completes normally when no stop is requested", async () => {

--- a/apps/backend/src/chat/openai/loop/loop.ts
+++ b/apps/backend/src/chat/openai/loop/loop.ts
@@ -29,6 +29,7 @@ import {
 } from "../tools/tools";
 import { buildOpenAISafetyIdentifier } from "../safetyIdentifier";
 import type { ChatStreamEvent, ContentPart } from "../../types";
+import { createProviderTerminalEventError } from "../../providerFailure";
 import {
   CHAT_MODEL_REASONING_SUMMARY,
   type ChatRuntimeModelId,
@@ -178,6 +179,24 @@ function isResponseCompletedEvent(
   return event.type === "response.completed";
 }
 
+function isResponseFailedEvent(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseFailedEvent {
+  return event.type === "response.failed";
+}
+
+function isResponseIncompleteEvent(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseIncompleteEvent {
+  return event.type === "response.incomplete";
+}
+
+function isResponseErrorEvent(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseErrorEvent {
+  return event.type === "error";
+}
+
 const OPENAI_STREAM_ABORT_ERROR_MESSAGE = "OpenAI response stream was aborted before a final response";
 
 class OpenAIStreamAbortError extends Error {
@@ -213,7 +232,10 @@ async function getFinalResponseFromStream(
     throw createOpenAIStreamAbortError();
   }
 
-  throw new Error("OpenAI response stream completed without a final response");
+  throw createProviderTerminalEventError({
+    code: "stream_closed_without_response",
+    message: "OpenAI response stream completed without a final response",
+  });
 }
 
 async function runOneToolCall(
@@ -378,6 +400,27 @@ async function runOneModelCall(
     if (isResponseCompletedEvent(event)) {
       completedResponse = event.response;
       continue;
+    }
+
+    if (isResponseFailedEvent(event)) {
+      throw createProviderTerminalEventError({
+        code: event.response.error?.code ?? null,
+        message: event.response.error?.message ?? null,
+      });
+    }
+
+    if (isResponseIncompleteEvent(event)) {
+      throw createProviderTerminalEventError({
+        code: event.response.incomplete_details?.reason ?? null,
+        message: null,
+      });
+    }
+
+    if (isResponseErrorEvent(event)) {
+      throw createProviderTerminalEventError({
+        code: event.code ?? null,
+        message: event.message,
+      });
     }
 
     if (isOutputTextDelta(event)) {

--- a/apps/backend/src/chat/providerFailure.ts
+++ b/apps/backend/src/chat/providerFailure.ts
@@ -1,5 +1,49 @@
 import { HttpError } from "../shared/errors";
 
+export const CHAT_PROVIDER_TERMINAL_EVENT_ERROR_NAME = "ChatProviderTerminalEventError";
+
+export type ChatProviderTerminalEventDetail = Readonly<{
+  code?: string | null;
+  message?: string | null;
+}>;
+
+type ChatProviderTerminalEventError = Error & Readonly<{
+  code?: string;
+}>;
+
+function buildTerminalErrorMessage(detail: ChatProviderTerminalEventDetail | undefined): string {
+  const trimmedMessage = typeof detail?.message === "string" ? detail.message.trim() : "";
+  if (trimmedMessage !== "") {
+    return trimmedMessage;
+  }
+
+  const trimmedCode = typeof detail?.code === "string" ? detail.code.trim() : "";
+  if (trimmedCode !== "") {
+    return `Chat provider emitted a terminal error event (${trimmedCode})`;
+  }
+
+  return "Chat provider emitted a terminal error event";
+}
+
+/**
+ * Builds the shared terminal-event error so the OpenAI adapter and the runtime
+ * executor produce the same classified `provider_error` without depending on
+ * each other. The optional detail carries the real provider code/message; when
+ * `detail.code` is set it is exposed as an own `code` property so
+ * `createSafeProviderErrorDetails` can surface `providerErrorCode`.
+ */
+export function createProviderTerminalEventError(detail?: ChatProviderTerminalEventDetail): ChatProviderTerminalEventError {
+  const error: ChatProviderTerminalEventError = new Error(buildTerminalErrorMessage(detail));
+  error.name = CHAT_PROVIDER_TERMINAL_EVENT_ERROR_NAME;
+
+  const trimmedCode = typeof detail?.code === "string" ? detail.code.trim() : "";
+  if (trimmedCode !== "") {
+    return Object.assign(error, { code: trimmedCode });
+  }
+
+  return error;
+}
+
 export type AIProviderFailureMetadata = Readonly<{
   upstreamStatus: number | null;
   upstreamRequestId: string | null;

--- a/apps/backend/src/chat/runtime/providerErrors.ts
+++ b/apps/backend/src/chat/runtime/providerErrors.ts
@@ -4,6 +4,8 @@ import {
   isChatAttachmentUnsupportedTypeError,
 } from "../attachmentPolicy";
 import {
+  CHAT_PROVIDER_TERMINAL_EVENT_ERROR_NAME,
+  createProviderTerminalEventError,
   getAIProviderFailureMetadata,
 } from "../providerFailure";
 import {
@@ -50,7 +52,7 @@ function classifyProviderErrorCategory(error: unknown, providerStatus: number | 
     return "provider_abort";
   }
 
-  if (error instanceof Error && error.name === "ChatProviderTerminalEventError") {
+  if (error instanceof Error && error.name === CHAT_PROVIDER_TERMINAL_EVENT_ERROR_NAME) {
     return "provider_error";
   }
 
@@ -144,11 +146,7 @@ export function isHandledProviderFailure(error: unknown): boolean {
   return category !== null && category !== "runtime_error";
 }
 
-export function createProviderTerminalEventError(): Error {
-  const error = new Error("Chat provider emitted a terminal error event");
-  error.name = "ChatProviderTerminalEventError";
-  return error;
-}
+export { createProviderTerminalEventError } from "../providerFailure";
 
 export function isUserAbortError(error: unknown): boolean {
   return error instanceof OpenAI.APIUserAbortError


### PR DESCRIPTION
## Root cause

The Sentry issue "OpenAI response stream completed without a final response" surfaced as a generic `runtime_error`. The OpenAI loop only reacted to the *absence* of a final response and ignored the `response.failed`, `response.incomplete`, and `error` stream events that explain *why* the stream terminated. The actual provider failure detail was discarded and the error was misclassified.

## Fix

Route these terminal stream events through the typed `ChatProviderTerminalEventError` so they classify as `provider_error` and carry the real provider detail instead of a generic `runtime_error`.

- `apps/backend/src/chat/openai/loop/loop.ts` — detect and raise terminal stream events
- `apps/backend/src/chat/providerFailure.ts` — typed terminal-event error + classification
- `apps/backend/src/chat/runtime/providerErrors.ts` — map to `provider_error`

## Testing

- `npm --prefix apps/backend run lint` — clean (`tsc --noEmit`)
- `npm --prefix apps/backend test` — 508 pass / 0 fail, including new `loop.test.ts` cases covering the terminal stream events

🤖 Generated with [Claude Code](https://claude.com/claude-code)