### PR TITLE
fix(chat): cap tool-call output size to bound chat context growth

### DIFF
--- a/apps/backend/src/chat/openai/tools/tools.ts
+++ b/apps/backend/src/chat/openai/tools/tools.ts
@@ -44,6 +44,14 @@ type ToolErrorPayload = Readonly<{
   details?: unknown;
 }>;
 
+/**
+ * Upper bound for a single serialized tool-call output.
+ * Each tool result is appended to the loop continuation and re-sent on every later model
+ * call in the turn, so one large SQL result set inflates every subsequent request and can
+ * trigger context_length_exceeded. ~24K chars leaves roughly 6K tokens of headroom per result.
+ */
+const MAX_TOOL_OUTPUT_CHARS = 24_000 as const;
+
 function createToolDependencies(): AgentToolOperationDependencies {
   return {
     ...DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
@@ -52,22 +60,66 @@ function createToolDependencies(): AgentToolOperationDependencies {
   };
 }
 
+/**
+ * Caps a single oversized envelope field by replacing it with a truncated preview string.
+ * Returns the serialized envelope when it already fits, otherwise rebuilds it with the heavy
+ * field swapped for a `<fieldKey>Preview` slice plus `truncated`/`omittedChars` markers so the
+ * model still receives valid JSON and can tell the result was capped and re-query more narrowly.
+ */
+function capSerializedEnvelope(
+  envelope: Readonly<Record<string, unknown>>,
+  fieldKey: string,
+): string {
+  const serialized = JSON.stringify(envelope);
+  if (serialized.length <= MAX_TOOL_OUTPUT_CHARS) {
+    return serialized;
+  }
+
+  const serializedField = JSON.stringify(envelope[fieldKey] ?? null);
+  const { [fieldKey]: _omitted, ...rest } = envelope;
+  const previewKey = `${fieldKey}Preview`;
+  const buildCapped = (previewLength: number): string =>
+    JSON.stringify({
+      ...rest,
+      [previewKey]: serializedField.slice(0, previewLength),
+      truncated: true,
+      omittedChars: serializedField.length - Math.min(previewLength, serializedField.length),
+    });
+
+  // Reserve headroom for the marker fields, then trim once more for JSON escaping of the
+  // preview slice so the final string is a hard bound at or below MAX_TOOL_OUTPUT_CHARS.
+  const reservedLength = buildCapped(0).length;
+  const firstPass = buildCapped(Math.max(0, MAX_TOOL_OUTPUT_CHARS - reservedLength));
+  if (firstPass.length <= MAX_TOOL_OUTPUT_CHARS) {
+    return firstPass;
+  }
+
+  const overflow = firstPass.length - MAX_TOOL_OUTPUT_CHARS;
+  return buildCapped(Math.max(0, MAX_TOOL_OUTPUT_CHARS - reservedLength - overflow));
+}
+
 function createToolSuccessResult(
   payload: Readonly<Record<string, unknown>>,
 ): string {
-  return JSON.stringify({
-    ok: true,
-    tool: SQL_TOOL_NAME,
-    ...payload,
-  });
+  return capSerializedEnvelope(
+    {
+      ok: true,
+      tool: SQL_TOOL_NAME,
+      ...payload,
+    },
+    "data",
+  );
 }
 
 function createToolErrorResult(payload: ToolErrorPayload): string {
-  return JSON.stringify({
-    ok: false,
-    tool: SQL_TOOL_NAME,
-    ...payload,
-  });
+  return capSerializedEnvelope(
+    {
+      ok: false,
+      tool: SQL_TOOL_NAME,
+      ...payload,
+    },
+    "details",
+  );
 }
 
 function serializeToolError(error: unknown): Readonly<{


### PR DESCRIPTION
Bounds the biggest within-turn context-growth source: the chat sql_query tool output is appended to the replayed items and re-sent on every model call (up to 30 per turn). Caps it at the createToolSuccessResult/createToolErrorResult chokepoint with valid-JSON truncation markers so one large result set cannot push the turn over the 272K window. Chat tool surface only; does not touch agentSql row limits or the MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)