### PR TITLE
Folder backend active review days modules

### DIFF
--- a/apps/backend/src/cards/reviews.ts
+++ b/apps/backend/src/cards/reviews.ts
@@ -6,7 +6,7 @@ import {
   type CurrentUserPublicProfileResolver,
 } from "../community/reviewActivityFacts";
 import { HttpError } from "../shared/errors";
-import { storeActiveReviewDayForReviewEventInExecutor } from "../progress/activeReviewDays";
+import { storeActiveReviewDayForReviewEventInExecutor } from "../progress/activeReviewDays/activeReviewDays";
 import {
   computeReviewSchedule,
   type ReviewableCardScheduleState,

--- a/apps/backend/src/entrypoints/lambda-progress-active-days-backfill.ts
+++ b/apps/backend/src/entrypoints/lambda-progress-active-days-backfill.ts
@@ -30,7 +30,7 @@ type ProgressActiveDaysBackfillResponse = Readonly<{
 }>;
 
 type ProgressActiveDaysBackfillRuntime = Readonly<{
-  backfillActiveReviewDays: typeof import("../progress/activeReviewDaysBackfill").backfillActiveReviewDays;
+  backfillActiveReviewDays: typeof import("../progress/activeReviewDays/activeReviewDaysBackfill").backfillActiveReviewDays;
 }>;
 
 const scheduledBatchSize = 25;
@@ -41,7 +41,7 @@ const maximumMaxPages = 100;
 let progressActiveDaysBackfillRuntimePromise: Promise<ProgressActiveDaysBackfillRuntime> | null = null;
 
 async function createProgressActiveDaysBackfillRuntime(): Promise<ProgressActiveDaysBackfillRuntime> {
-  const { backfillActiveReviewDays } = await import("../progress/activeReviewDaysBackfill");
+  const { backfillActiveReviewDays } = await import("../progress/activeReviewDays/activeReviewDaysBackfill");
   return {
     backfillActiveReviewDays,
   };

--- a/apps/backend/src/progress/activeReviewDays/activeReviewDays.ts
+++ b/apps/backend/src/progress/activeReviewDays/activeReviewDays.ts
@@ -1,8 +1,8 @@
-import type { DatabaseExecutor } from "../database";
+import type { DatabaseExecutor } from "../../database";
 import {
   formatDateAsTimeZoneLocalDate,
   requireIanaTimeZone,
-} from "./timeZone";
+} from "../timeZone";
 
 export type ReviewTimeZoneSource = "client" | "user_settings";
 

--- a/apps/backend/src/progress/activeReviewDays/activeReviewDaysBackfill.test.ts
+++ b/apps/backend/src/progress/activeReviewDays/activeReviewDaysBackfill.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../database";
-import { createBackendObservationScope } from "../observability/sentry";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { createBackendObservationScope } from "../../observability/sentry";
 import {
   backfillActiveReviewDaysWithDependencies,
   loadActiveReviewDaysBackfillCandidatePageInExecutor,

--- a/apps/backend/src/progress/activeReviewDays/activeReviewDaysBackfill.ts
+++ b/apps/backend/src/progress/activeReviewDays/activeReviewDaysBackfill.ts
@@ -3,15 +3,15 @@ import {
   applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
   type SqlValue,
-} from "../database";
-import { withTransientDatabaseRetry } from "../database/transient";
-import { unsafeRepeatableReadTransaction, unsafeTransaction } from "../database/unsafe";
-import { withReportingReadOnlyTransaction } from "../admin/reportingDb";
+} from "../../database";
+import { withTransientDatabaseRetry } from "../../database/transient";
+import { unsafeRepeatableReadTransaction, unsafeTransaction } from "../../database/unsafe";
+import { withReportingReadOnlyTransaction } from "../../admin/reportingDb";
 import {
   captureBackendWarning,
   normalizeCaughtError,
   type BackendObservationScope,
-} from "../observability/sentry";
+} from "../../observability/sentry";
 import {
   materializeMissingActiveReviewDaysForUserInExecutor,
   type ActiveReviewDayMaterializationResult,

--- a/apps/backend/src/progress/index.ts
+++ b/apps/backend/src/progress/index.ts
@@ -13,7 +13,7 @@ import {
   loadUserActiveReviewLocalDatesInExecutor,
   materializeMissingActiveReviewDaysForUserInExecutor,
   rememberProgressTimeZoneInExecutor,
-} from "./activeReviewDays";
+} from "./activeReviewDays/activeReviewDays";
 import {
   evaluateStreakFreeze,
   streakFreezePolicy,


### PR DESCRIPTION
## Summary
- Move active review day materialization and backfill modules under apps/backend/src/progress/activeReviewDays/
- Update backend direct imports and the active-days backfill Lambda dynamic import
- Keep progress read-model support and timezone/streak files flat

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend (509 tests)
- git --no-pager diff --check
- worker-owned read-only review subagent: no P0-P4 findings

Environment caveat: local installs/checks ran under Node v25.6.1 while package engines request Node 24.x; validation passed.