### PR TITLE
chore: automate MCP registry credential setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,10 @@ COOKIE_DOMAIN=localhost
 # manually for deployed-environment admin-list updates.
 # CLOUDFLARE_API_TOKEN=
 # CLOUDFLARE_ZONE_ID=
+# scripts/setup/setup-mcp-registry-credential.sh also uses DOMAIN_NAME,
+# GITHUB_REPO, and the Cloudflare values above to create the MCP Registry DNS
+# TXT record and GitHub Actions MCP_PRIVATE_KEY secret. Do not store the
+# MCP_PRIVATE_KEY value in .env.
 # Optional SSH bastion for analytical DB access. Set all three values together.
 # ANALYTICS_SSH_USERNAME=analytics
 # ANALYTICS_SSH_ALLOWED_CIDRS=203.0.113.10/32,198.51.100.0/24

--- a/docs/connector-submission-operations.md
+++ b/docs/connector-submission-operations.md
@@ -27,7 +27,10 @@ Do not submit to any directory until all checks pass.
 
   A JSON response for `com.flashcards-open-source-app/flashcards` is pass. A
   `404 Server not found` response means the entry is not published yet, the
-  server name is wrong, or the publish failed.
+  server name is wrong, or the publish failed. Use the credential setup and
+  publish flow in
+  [mcp-registry-publishing.md](mcp-registry-publishing.md#one-time-credential-setup)
+  before submitting to downstream directories.
 - Unauthenticated access to the MCP endpoint returns a standards-compatible
   OAuth challenge:
 

--- a/docs/mcp-registry-publishing.md
+++ b/docs/mcp-registry-publishing.md
@@ -22,6 +22,9 @@ which we can verify because we control `flashcards-open-source-app.com`.
   verification).
 - For GitHub Actions publishing, the Ed25519 namespace private key stored as
   the `MCP_PRIVATE_KEY` repository secret.
+- For one-time credential bootstrap, the local root `.env` must include
+  `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`, and `GITHUB_REPO`, or pass the
+  repository explicitly to the setup script.
 
 ## Validate the manifest
 
@@ -33,25 +36,45 @@ curl -fsS 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.sche
 npx --yes ajv-cli@5 validate -s /tmp/mcp-server-schema-2025-12-11.json -d server.json --strict=false
 ```
 
+## One-time credential setup
+
+Use the repo setup script to create the DNS namespace credential. It generates a
+fresh Ed25519 keypair, creates the root Cloudflare TXT record for the public key,
+stores the private key as the `MCP_PRIVATE_KEY` GitHub Actions secret, and then
+deletes the temporary local key file.
+
+```sh
+bash scripts/setup/setup-mcp-registry-credential.sh \
+  --domain flashcards-open-source-app.com \
+  --repo kirill-markin/flashcards-open-source-app
+```
+
+The script is idempotent when both the MCP Registry TXT record and
+`MCP_PRIVATE_KEY` already exist. If only one side exists, it fails with an
+explicit recovery message instead of silently rotating the namespace key.
+
 ## Publish flow
 
 1. From the repo root, validate `server.json`.
 
-2. Authenticate against the DNS namespace. `mcp-publisher`
-   prints a TXT record to add to `flashcards-open-source-app.com`; add it, then
-   complete login:
+2. Confirm the one-time credential setup is complete:
 
    ```sh
-   mcp-publisher login dns --domain flashcards-open-source-app.com
+   bash scripts/setup/setup-mcp-registry-credential.sh \
+     --domain flashcards-open-source-app.com \
+     --repo kirill-markin/flashcards-open-source-app
    ```
 
-3. Publish (or refresh) the entry from the root manifest:
+3. Run the GitHub Actions publisher:
 
    ```sh
-   mcp-publisher publish
+   gh workflow run mcp-registry-publish.yml \
+     --repo kirill-markin/flashcards-open-source-app \
+     --ref main
    ```
 
-   The CLI reads `server.json` from the current directory and submits it.
+   The workflow validates `server.json`, authenticates with
+   `mcp-publisher login dns --private-key`, and publishes the root manifest.
 
 4. Check the published entry through the official registry API:
 
@@ -61,6 +84,19 @@ npx --yes ajv-cli@5 validate -s /tmp/mcp-server-schema-2025-12-11.json -d server
 
    A `404 Server not found` response means the entry is not published or the
    publish failed.
+
+## Local manual publish fallback
+
+Use this only when debugging the publisher outside GitHub Actions. From the repo
+root, validate `server.json`, then authenticate with the private key already
+stored in `MCP_PRIVATE_KEY` and publish:
+
+```sh
+mcp-publisher login dns --domain flashcards-open-source-app.com --private-key "$MCP_PRIVATE_KEY"
+mcp-publisher publish
+```
+
+The CLI reads `server.json` from the current directory and submits it.
 
 ## Refreshing the entry
 
@@ -84,7 +120,9 @@ The workflow authenticates with `mcp-publisher login dns --private-key`, which
 needs the Ed25519 private key for the `flashcards-open-source-app.com`
 namespace, stored as the `MCP_PRIVATE_KEY` repository secret.
 
-Generate the Ed25519 keypair with `openssl`:
+Prefer
+[`scripts/setup/setup-mcp-registry-credential.sh`](../scripts/setup/setup-mcp-registry-credential.sh)
+for normal setup. The manual equivalent is:
 
 ```sh
 openssl genpkey -algorithm Ed25519 -out key.pem

--- a/scripts/setup/setup-mcp-registry-credential.sh
+++ b/scripts/setup/setup-mcp-registry-credential.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Provision the MCP Registry DNS namespace credential and GitHub Actions secret.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../cloudflare/dns-utils.sh"
+
+DOMAIN=""
+REPO=""
+SECRET_NAME="MCP_PRIVATE_KEY"
+
+usage() {
+  echo "Usage: bash scripts/setup/setup-mcp-registry-credential.sh --domain <domain> --repo <owner/name>" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --domain) DOMAIN="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$DOMAIN" ]]; then
+  DOMAIN="${DOMAIN_NAME:-}"
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="${GITHUB_REPO:-}"
+fi
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "ERROR: ${command_name} is required." >&2
+    exit 1
+  fi
+}
+
+require_command curl
+require_command gh
+require_command openssl
+require_command python3
+require_command base64
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+
+if [[ -z "$DOMAIN" || -z "$REPO" ]]; then
+  usage
+  exit 1
+fi
+
+ensure_cloudflare_env
+
+fetch_github_secrets() {
+  gh secret list --repo "$REPO" --json name
+}
+
+github_secret_exists() {
+  local secrets_json="$1"
+
+  python3 - "$secrets_json" "$SECRET_NAME" <<'PY'
+import json
+import sys
+
+secrets = json.loads(sys.argv[1])
+secret_name = sys.argv[2]
+for secret in secrets:
+    if secret.get("name") == secret_name:
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+fetch_domain_txt_records() {
+  curl -fsS -G \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data-urlencode "type=TXT" \
+    --data-urlencode "name=${DOMAIN}" \
+    "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records"
+}
+
+count_mcp_registry_txt_records() {
+  local records_json="$1"
+
+  python3 - "$records_json" <<'PY'
+import json
+import sys
+
+records = json.loads(sys.argv[1]).get("result", [])
+count = sum(
+    1
+    for record in records
+    if str(record.get("content", "")).startswith("v=MCPv1; k=ed25519; p=")
+)
+print(count)
+PY
+}
+
+assert_cloudflare_success() {
+  local response_json="$1"
+  local action_name="$2"
+
+  python3 - "$response_json" "$action_name" <<'PY'
+import json
+import sys
+
+response = json.loads(sys.argv[1])
+action_name = sys.argv[2]
+if response.get("success") is True:
+    sys.exit(0)
+
+errors = response.get("errors", [])
+print(f"ERROR: Cloudflare {action_name} failed: {json.dumps(errors)}", file=sys.stderr)
+sys.exit(1)
+PY
+}
+
+create_mcp_registry_txt_record() {
+  local public_key="$1"
+  local content="v=MCPv1; k=ed25519; p=${public_key}"
+  local payload
+  local response
+
+  payload=$(python3 - "$DOMAIN" "$content" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "type": "TXT",
+    "name": sys.argv[1],
+    "content": sys.argv[2],
+    "ttl": 120,
+}))
+PY
+)
+
+  response=$(curl -fsS -X POST \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data "$payload" \
+    "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records")
+  assert_cloudflare_success "$response" "TXT record creation"
+}
+
+GITHUB_SECRETS_JSON="$(fetch_github_secrets)"
+TXT_RECORDS_JSON="$(fetch_domain_txt_records)"
+MCP_TXT_COUNT="$(count_mcp_registry_txt_records "$TXT_RECORDS_JSON")"
+
+if [[ "$MCP_TXT_COUNT" -gt 1 ]]; then
+  echo "ERROR: Found ${MCP_TXT_COUNT} MCP Registry TXT records for ${DOMAIN}." >&2
+  echo "Keep exactly one matching TXT record before rerunning this script." >&2
+  exit 1
+fi
+
+if github_secret_exists "$GITHUB_SECRETS_JSON"; then
+  GITHUB_SECRET_EXISTS="true"
+else
+  GITHUB_SECRET_EXISTS="false"
+fi
+
+if [[ "$MCP_TXT_COUNT" != "0" && "$GITHUB_SECRET_EXISTS" == "true" ]]; then
+  echo "MCP Registry credential is already configured for ${DOMAIN} and ${REPO}."
+  echo "To publish now, run:"
+  echo "  gh workflow run mcp-registry-publish.yml --repo ${REPO} --ref main"
+  exit 0
+fi
+
+if [[ "$MCP_TXT_COUNT" != "0" && "$GITHUB_SECRET_EXISTS" == "false" ]]; then
+  echo "ERROR: Found MCP Registry TXT record for ${DOMAIN}, but ${SECRET_NAME} is missing in ${REPO}." >&2
+  echo "Recover the original private key and set ${SECRET_NAME}, or remove the stale TXT record before rerunning this script." >&2
+  exit 1
+fi
+
+if [[ "$MCP_TXT_COUNT" == "0" && "$GITHUB_SECRET_EXISTS" == "true" ]]; then
+  echo "ERROR: Found ${SECRET_NAME} in ${REPO}, but no MCP Registry TXT record for ${DOMAIN}." >&2
+  echo "Recover the matching public key and create the TXT record, or remove the stale GitHub secret before rerunning this script." >&2
+  exit 1
+fi
+
+KEY_DIR="$(mktemp -d)"
+KEY_FILE="${KEY_DIR}/mcp-registry-ed25519.pem"
+
+cleanup() {
+  rm -rf "$KEY_DIR"
+}
+trap cleanup EXIT
+
+umask 077
+openssl genpkey -algorithm Ed25519 -out "$KEY_FILE" >/dev/null 2>&1
+
+PUBLIC_KEY="$(openssl pkey -in "$KEY_FILE" -pubout -outform DER 2>/dev/null | tail -c 32 | base64)"
+PRIVATE_KEY="$(openssl pkey -in "$KEY_FILE" -noout -text 2>/dev/null | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')"
+
+if [[ "${#PRIVATE_KEY}" -ne 64 ]]; then
+  echo "ERROR: Failed to derive a 64-character Ed25519 private key for ${SECRET_NAME}." >&2
+  exit 1
+fi
+
+create_mcp_registry_txt_record "$PUBLIC_KEY"
+printf '%s' "$PRIVATE_KEY" | gh secret set "$SECRET_NAME" --repo "$REPO" >/dev/null
+
+echo "Created MCP Registry TXT record for ${DOMAIN}."
+echo "Stored ${SECRET_NAME} GitHub Actions secret in ${REPO}."
+echo "The private key was not printed and was removed from local temporary storage."
+echo "To publish now, run:"
+echo "  gh workflow run mcp-registry-publish.yml --repo ${REPO} --ref main"


### PR DESCRIPTION
## Summary
- add an MCP Registry credential bootstrap script that provisions the Cloudflare TXT record and GitHub Actions secret
- update the registry publishing runbook to use the script-first flow
- document required env inputs and link the connector pre-submit gate to the setup flow

## Checks
- bash -n scripts/setup/setup-mcp-registry-credential.sh
- shellcheck scripts/setup/setup-mcp-registry-credential.sh
- git diff --check
- no-op setup script run against the configured production DNS/GitHub state