### PR TITLE
Add FSRS card state invariants migration

### DIFF
--- a/db/migrations/0078_fsrs_card_state_invariants.sql
+++ b/db/migrations/0078_fsrs_card_state_invariants.sql
@@ -1,0 +1,117 @@
+-- Migration status: Current / additive.
+-- Introduces: persisted FSRS card state repair and database invariants.
+-- Schemas touched/read explicitly: content, sync.
+
+CREATE TEMP TABLE migration_0078_invalid_cards ON COMMIT DROP AS
+SELECT
+  cards.workspace_id,
+  cards.card_id,
+  cards.deleted_at,
+  cards.last_modified_by_replica_id,
+  cards.client_updated_at
+FROM content.cards AS cards
+WHERE (
+    cards.fsrs_card_state = 'new'
+    AND (
+      cards.due_at IS NOT NULL
+      OR cards.fsrs_step_index IS NOT NULL
+      OR cards.fsrs_stability IS NOT NULL
+      OR cards.fsrs_difficulty IS NOT NULL
+      OR cards.fsrs_last_reviewed_at IS NOT NULL
+      OR cards.fsrs_scheduled_days IS NOT NULL
+    )
+  )
+  OR (
+    cards.fsrs_card_state <> 'new'
+    AND (
+      cards.fsrs_stability IS NULL
+      OR cards.fsrs_difficulty IS NULL
+      OR cards.fsrs_last_reviewed_at IS NULL
+      OR cards.fsrs_scheduled_days IS NULL
+    )
+  )
+  OR (
+    cards.fsrs_card_state = 'review'
+    AND cards.fsrs_step_index IS NOT NULL
+  )
+  OR (
+    cards.fsrs_card_state IN ('learning', 'relearning')
+    AND cards.fsrs_step_index IS NULL
+  );
+
+UPDATE content.cards AS cards
+SET
+  due_at = NULL,
+  reps = 0,
+  lapses = 0,
+  fsrs_card_state = 'new',
+  fsrs_step_index = NULL,
+  fsrs_stability = NULL,
+  fsrs_difficulty = NULL,
+  fsrs_last_reviewed_at = NULL,
+  fsrs_scheduled_days = NULL,
+  updated_at = now()
+FROM migration_0078_invalid_cards AS invalid_cards
+WHERE cards.workspace_id = invalid_cards.workspace_id
+  AND cards.card_id = invalid_cards.card_id;
+
+INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at)
+SELECT invalid_cards.workspace_id, 0, now()
+FROM migration_0078_invalid_cards AS invalid_cards
+WHERE invalid_cards.deleted_at IS NULL
+GROUP BY invalid_cards.workspace_id
+ON CONFLICT (workspace_id) DO NOTHING;
+
+INSERT INTO sync.hot_changes (
+  workspace_id,
+  entity_type,
+  entity_id,
+  action,
+  replica_id,
+  operation_id,
+  client_updated_at
+)
+SELECT
+  invalid_cards.workspace_id,
+  'card',
+  invalid_cards.card_id::text,
+  'upsert',
+  invalid_cards.last_modified_by_replica_id,
+  'migration-0078-fsrs-state-repair-card-' || invalid_cards.card_id::text,
+  invalid_cards.client_updated_at
+FROM migration_0078_invalid_cards AS invalid_cards
+WHERE invalid_cards.deleted_at IS NULL;
+
+ALTER TABLE content.cards
+  DROP CONSTRAINT IF EXISTS cards_fsrs_state_invariants;
+
+ALTER TABLE content.cards
+  ADD CONSTRAINT cards_fsrs_state_invariants
+  CHECK (
+    (
+      fsrs_card_state = 'new'
+      AND due_at IS NULL
+      AND fsrs_step_index IS NULL
+      AND fsrs_stability IS NULL
+      AND fsrs_difficulty IS NULL
+      AND fsrs_last_reviewed_at IS NULL
+      AND fsrs_scheduled_days IS NULL
+    )
+    OR (
+      fsrs_card_state <> 'new'
+      AND fsrs_stability IS NOT NULL
+      AND fsrs_difficulty IS NOT NULL
+      AND fsrs_last_reviewed_at IS NOT NULL
+      AND fsrs_scheduled_days IS NOT NULL
+      AND (
+        (
+          fsrs_card_state = 'review'
+          AND fsrs_step_index IS NULL
+        )
+        OR (
+          fsrs_card_state IN ('learning', 'relearning')
+          AND fsrs_step_index IS NOT NULL
+        )
+      )
+    )
+  );

--- a/docs/fsrs-scheduling-logic.md
+++ b/docs/fsrs-scheduling-logic.md
@@ -140,9 +140,10 @@ Card invariants:
 - `review` cards must have full FSRS memory state and `fsrs_step_index = NULL`
 - `learning` and `relearning` cards must have full FSRS memory state and a non-null `fsrs_step_index`
 
-Runtime code must validate persisted scheduler state during normal reads and review submission.
-If a card is invalid, runtime code must log the error and reset that card to the canonical `new` scheduler state.
-The repair path must not rewrite or delete `review_events`.
+Existing invalid persisted scheduler state is repaired by migration or explicit maintenance outside normal read paths.
+Writes must preserve the card invariants above, and normal reads must remain pure reads without hidden repair.
+Review submission must fail when persisted card state is impossible.
+Any repair path must not rewrite or delete `review_events`.
 Elapsed days are computed from UTC calendar-day boundaries only.
 If `fsrs_last_reviewed_at` is later than the current review timestamp, even within the same UTC day, the scheduler must throw.
 


### PR DESCRIPTION
## Summary
- repair persisted invalid FSRS card state once in migration 0078
- emit hot sync changes for active repaired cards
- enforce future persisted FSRS invariants with a content.cards CHECK constraint
- update FSRS scheduling docs so normal reads remain pure reads

## Validation
- npm --prefix apps/backend test (509 tests passed)
- npm --prefix apps/backend run lint
- manual predicate inspection against apps/backend/src/cards/fsrs.ts::getInvalidFsrsStateReason
- worker-owned review: no P0-P4 findings, green light

Note: npm ci emitted Node engine warnings because the local shell used Node v25.6.1 while packages declare 24.x; validation commands passed.