### PR TITLE
Change web review created-at ordering

### DIFF
--- a/apps/web/src/appData/domain/index.test.ts
+++ b/apps/web/src/appData/domain/index.test.ts
@@ -124,24 +124,24 @@ describe("review order domain", () => {
     ]);
   });
 
-  it("keeps due bucket tie-breakers by dueAt, newer createdAt, then cardId", () => {
+  it("keeps due bucket tie-breakers by dueAt, older createdAt, then cardId", () => {
     const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
     const cards = [
       makeReviewOrderCard("recent-b", "2026-03-10T11:30:00.000Z", "2026-03-10T09:30:00.000Z", "2026-03-10T11:30:00.000Z"),
       makeReviewOrderCard("recent-a", "2026-03-10T11:30:00.000Z", "2026-03-10T09:30:00.000Z", "2026-03-10T11:30:00.000Z"),
-      makeReviewOrderCard("recent-newer", "2026-03-10T11:30:00.000Z", "2026-03-10T09:45:00.000Z", "2026-03-10T11:30:00.000Z"),
+      makeReviewOrderCard("recent-later", "2026-03-10T11:30:00.000Z", "2026-03-10T09:45:00.000Z", "2026-03-10T11:30:00.000Z"),
       makeReviewOrderCard("old-b", "2026-03-09T11:30:00.000Z", "2026-03-10T09:30:00.000Z", null),
       makeReviewOrderCard("old-a", "2026-03-09T11:30:00.000Z", "2026-03-10T09:30:00.000Z", null),
-      makeReviewOrderCard("old-newer", "2026-03-09T11:30:00.000Z", "2026-03-10T09:45:00.000Z", null),
+      makeReviewOrderCard("old-later", "2026-03-09T11:30:00.000Z", "2026-03-10T09:45:00.000Z", null),
     ];
 
     expect(sortCardsForReviewOrder(cards, nowTimestamp).map((card) => card.cardId)).toEqual([
-      "recent-newer",
       "recent-a",
       "recent-b",
-      "old-newer",
+      "recent-later",
       "old-a",
       "old-b",
+      "old-later",
     ]);
   });
 

--- a/apps/web/src/appData/domain/index.ts
+++ b/apps/web/src/appData/domain/index.ts
@@ -322,7 +322,7 @@ function getReviewOrderCreatedTimestamp(card: Card): number {
  * window first, then other due cards, then null-due/new cards, then future cards,
  * then malformed dueAt cards.
  * Active queues include only recently reviewed due, other due, and null-due/new cards.
- * Within each bucket, earlier dueAt comes first, then newer createdAt, then cardId ascending.
+ * Within each bucket, earlier dueAt comes first, then older createdAt, then cardId ascending.
  * If this changes, mirror the same change across all three clients in the same change.
  */
 export function compareCardsForReviewOrder(leftCard: Card, rightCard: Card, nowTimestamp: number): number {
@@ -342,7 +342,7 @@ export function compareCardsForReviewOrder(leftCard: Card, rightCard: Card, nowT
   const leftCreatedAtTimestamp = getReviewOrderCreatedTimestamp(leftCard);
   const rightCreatedAtTimestamp = getReviewOrderCreatedTimestamp(rightCard);
   if (leftCreatedAtTimestamp !== rightCreatedAtTimestamp) {
-    return rightCreatedAtTimestamp - leftCreatedAtTimestamp;
+    return leftCreatedAtTimestamp - rightCreatedAtTimestamp;
   }
 
   return leftCard.cardId.localeCompare(rightCard.cardId);

--- a/apps/web/src/localDb/cards/cards/index.ts
+++ b/apps/web/src/localDb/cards/cards/index.ts
@@ -284,6 +284,69 @@ export async function iterateLocalStoredCardsByCreatedAtDesc(
   await iterateCardsByCreatedAtDescMapped(database, workspaceId, toLocalStoredCard, onCard);
 }
 
+export async function iterateLocalStoredCardsByCreatedAtAsc(
+  database: IDBDatabase,
+  workspaceId: string,
+  onCard: (card: LocalStoredCard) => boolean | void,
+): Promise<void> {
+  let currentCreatedAt: string | null | undefined;
+  let currentGroup: Array<LocalStoredCard> = [];
+  let shouldStop = false;
+
+  function flushCurrentGroup(): boolean {
+    const sortedGroup = [...currentGroup].sort((leftCard, rightCard) => leftCard.cardId.localeCompare(rightCard.cardId));
+    currentGroup = [];
+
+    for (const card of sortedGroup) {
+      if (onCard(card) === false) {
+        shouldStop = true;
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  await iterateCardsByIndex(
+    database,
+    workspaceId,
+    {
+      indexName: "workspaceId_createdAt_cardId",
+      direction: "next",
+      keyRange: makeWorkspaceKeyRange(workspaceId),
+    },
+    toLocalStoredCard,
+    (card) => {
+      if (shouldStop) {
+        return false;
+      }
+
+      if (currentCreatedAt === undefined) {
+        currentCreatedAt = card.createdAt;
+        currentGroup = [card];
+        return true;
+      }
+
+      if (currentCreatedAt === card.createdAt) {
+        currentGroup.push(card);
+        return true;
+      }
+
+      if (flushCurrentGroup() === false) {
+        return false;
+      }
+
+      currentCreatedAt = card.createdAt;
+      currentGroup = [card];
+      return true;
+    },
+  );
+
+  if (shouldStop === false && currentGroup.length > 0) {
+    flushCurrentGroup();
+  }
+}
+
 export async function iterateCardsByUpdatedAtDesc(
   database: IDBDatabase,
   workspaceId: string,

--- a/apps/web/src/localDb/core/testSupport.ts
+++ b/apps/web/src/localDb/core/testSupport.ts
@@ -254,8 +254,8 @@ export const deckLongCode = makeDeck({
 
 export const sampleCards: ReadonlyArray<Card> = [
   makeCard({
-    cardId: "null-newer",
-    frontText: "Null newer",
+    cardId: "null-later",
+    frontText: "Null later",
     backText: "back",
     tags: ["grammar"],
     dueAt: null,
@@ -270,8 +270,8 @@ export const sampleCards: ReadonlyArray<Card> = [
     createdAt: "2025-01-03T09:00:00.000Z",
   }),
   makeCard({
-    cardId: "due-same-newer",
-    frontText: "Due same newer",
+    cardId: "due-same-later",
+    frontText: "Due same later",
     backText: "search target",
     tags: ["code", "shared"],
     dueAt: "2025-01-04T10:00:00.000Z",

--- a/apps/web/src/localDb/reviews/reviews.test.ts
+++ b/apps/web/src/localDb/reviews/reviews.test.ts
@@ -74,14 +74,14 @@ describe("localDb reviews", () => {
           { kind: "allCards" },
           initialSnapshot.nextCursor,
           2,
-          new Set(["null-newer"]),
+          new Set(["null-older"]),
         );
         const legacyDueCards = legacyReviewCards(
           { kind: "allCards" },
           sampleCards,
           [deckFastGrammar, deckLongCode],
           nowTimestamp,
-        ).filter((card) => isCardDueForTest(card, nowTimestamp) && card.cardId !== "null-newer");
+        ).filter((card) => isCardDueForTest(card, nowTimestamp) && card.cardId !== "null-older");
         const cursorCardId = initialSnapshot.cards[initialSnapshot.cards.length - 1]?.cardId;
         const startIndex = cursorCardId === undefined
           ? 0
@@ -166,10 +166,10 @@ describe("localDb reviews", () => {
         expect(result.cards.map((card) => card.cardId)).toEqual(legacyCards.slice(0, 4).map((card) => card.cardId));
         expect(result.hasMoreCards).toBe(true);
         expect(result.cards.slice(0, 4).map((card) => card.cardId)).toEqual([
-          "due-same-newer",
           "due-same-older",
+          "due-same-later",
           "due-other",
-          "null-newer",
+          "null-older",
         ]);
       } finally {
         Date.now = originalNow;
@@ -185,7 +185,7 @@ describe("localDb reviews", () => {
         await replaceCards(workspaceId, [
           makeCard({
             cardId: "card-b",
-            frontText: "Null newer B",
+            frontText: "Null later B",
             backText: "back",
             tags: ["grammar"],
             dueAt: null,
@@ -193,7 +193,7 @@ describe("localDb reviews", () => {
           }),
           makeCard({
             cardId: "card-a",
-            frontText: "Null newer A",
+            frontText: "Null later A",
             backText: "back",
             tags: ["grammar"],
             dueAt: null,
@@ -236,12 +236,12 @@ describe("localDb reviews", () => {
         const result = await loadReviewTimelinePage(workspaceId, { kind: "allCards" }, 6, 0);
 
         expect(result.cards.map((card) => card.cardId)).toEqual([
+          "due-same-older",
           "due-same-a",
           "due-same-b",
-          "due-same-older",
+          "null-older",
           "card-a",
           "card-b",
-          "null-older",
         ]);
       } finally {
         Date.now = originalNow;
@@ -686,18 +686,18 @@ describe("localDb reviews", () => {
 
         expect(queueCardIds).toEqual([
           "recent-cutoff-short-fraction",
-          "due-now-short-fraction",
-          "due-now-two-digit-fraction",
           "due-now-canonical",
+          "due-now-two-digit-fraction",
+          "due-now-short-fraction",
           "old-cutoff-second",
           "new-null",
         ]);
         expect(new Set(queueCardIds).size).toBe(queueCardIds.length);
         expect(timelinePage.cards.map((card) => card.cardId)).toEqual([
           "recent-cutoff-short-fraction",
-          "due-now-short-fraction",
-          "due-now-two-digit-fraction",
           "due-now-canonical",
+          "due-now-two-digit-fraction",
+          "due-now-short-fraction",
           "old-cutoff-second",
           "new-null",
           "future-one-ms",

--- a/apps/web/src/localDb/reviews/reviews.ts
+++ b/apps/web/src/localDb/reviews/reviews.ts
@@ -14,6 +14,7 @@ import {
 } from "../../appData/domain";
 import { loadAllowedCardIdsForTag } from "../cards/tags";
 import {
+  iterateLocalStoredCardsByCreatedAtAsc,
   iterateLocalStoredCardsByCreatedAtDesc,
   iterateLocalStoredCardsByDueAtMillisAscAfter,
   iterateLocalStoredCardsByDueAtMillisAscBefore,
@@ -217,7 +218,7 @@ function compareLocalStoredCardsForReviewOrder(
   const leftCreatedAtTimestamp = getLocalReviewOrderCreatedTimestamp(leftCard);
   const rightCreatedAtTimestamp = getLocalReviewOrderCreatedTimestamp(rightCard);
   if (leftCreatedAtTimestamp !== rightCreatedAtTimestamp) {
-    return rightCreatedAtTimestamp - leftCreatedAtTimestamp;
+    return leftCreatedAtTimestamp - rightCreatedAtTimestamp;
   }
 
   return leftCard.cardId.localeCompare(rightCard.cardId);
@@ -376,7 +377,7 @@ async function iterateNullDueReviewCards(
     return true;
   }
 
-  await iterateLocalStoredCardsByCreatedAtDesc(database, workspaceId, (card) => {
+  await iterateLocalStoredCardsByCreatedAtAsc(database, workspaceId, (card) => {
     if (shouldStop) {
       return false;
     }


### PR DESCRIPTION
## Summary
- change web review ordering to prefer older createdAt values after bucket and due-time ties
- add an ascending local stored-card createdAt iterator for null-due review cards
- update review ordering fixtures and expectations

## Validation
- npm ci completed with only the Node engine warning
- npx tsc --noEmit --pretty false
- npx vitest run src/localDb/reviews/reviews.test.ts
- npx vitest run src/appData/domain/index.test.ts src/localDb/reviews/reviews.test.ts src/screens/review/data/useReviewScreenData.chunk-loading.test.tsx src/screens/review/data/useReviewScreenData.submit.test.tsx src/screens/review/tests/ReviewScreen.presented-card.test.tsx
- git --no-pager diff --check