### PR TITLE
Update iOS review created order

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
@@ -457,7 +457,7 @@ extension CardStore {
                     ELSE 3
                 END ASC,
                 due_at_millis ASC,
-                created_at DESC,
+                created_at ASC,
                 card_id ASC
             LIMIT ? OFFSET ?
             """,

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+ReadSQL.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+ReadSQL.swift
@@ -34,7 +34,7 @@ let cardStoreActiveReviewDueEligibilitySQL: String = """
 )
 """
 
-let cardStoreActiveDueBucketOrderSQL: String = "due_at_millis ASC, created_at DESC, card_id ASC"
+let cardStoreActiveDueBucketOrderSQL: String = "due_at_millis ASC, created_at ASC, card_id ASC"
 
 private enum ActiveReviewQueueSQLBucket {
     case recentDue(cutoffMillis: Int64, nowMillis: Int64)
@@ -91,7 +91,7 @@ private func makeActiveReviewQueueBucketOrderSQL(bucket: ActiveReviewQueueSQLBuc
     case .recentDue, .oldDue:
         return cardStoreActiveDueBucketOrderSQL
     case .new:
-        return "created_at DESC, card_id ASC"
+        return "created_at ASC, card_id ASC"
     }
 }
 
@@ -276,14 +276,13 @@ extension CardStore {
             excludedCardValues = excludedCardIds.sorted().map(SQLiteValue.text)
         }
 
-        // Keep review queue ordering aligned with:
+        // Keep SQLite review queue ordering aligned with:
         // - apps/ios/Flashcards/Flashcards/Review/Queue/Query/ReviewQuerySupport.swift::compareCardsForReviewOrder
-        // - apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt::sortCardsForReviewQueue
-        // - apps/web/src/appData/domain/index.ts::compareCardsForReviewOrder
         // Ordering contract: recently reviewed due cards within the inclusive one-hour fsrsLastReviewedAt
         // window first, then other due cards, then nil dueAt new cards. Future and malformed dueAt
-        // values are excluded from the active queue.
-        // If this changes, mirror the same change across all three clients in the same change.
+        // values are excluded from the active queue. Cards in the same bucket and due-time position
+        // use older created_at first.
+        // When this contract changes, coordinate matching review-order updates for supported clients.
         let targetLimit = limit + 1
         let nowMillis = epochMillis(date: now)
         let cutoffMillis = epochMillis(date: now.addingTimeInterval(-recentDuePriorityWindow))

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
@@ -87,6 +87,9 @@ struct LocalDatabaseMigrator {
             case 18:
                 try self.migrateSchemaVersion18To19()
                 schemaVersion = 19
+            case 19:
+                try self.migrateSchemaVersion19To20()
+                schemaVersion = 20
             default:
                 throw LocalStoreError.database("Unsupported local schema version: \(schemaVersion)")
             }
@@ -609,6 +612,10 @@ struct LocalDatabaseMigrator {
         try self.rebuildCardTagsReadModel()
     }
 
+    private func migrateSchemaVersion19To20() throws {
+        try self.rebuildReviewOrderIndexesWithCreatedAtAscending()
+    }
+
     private func appendLegacyEffortTagsToCards() throws {
         let rows = try self.core.query(
             sql: """
@@ -731,22 +738,7 @@ struct LocalDatabaseMigrator {
     }
 
     private func createDueAtMillisIndexes() throws {
-        try self.core.execute(
-            sql: """
-            CREATE INDEX IF NOT EXISTS idx_cards_workspace_due_millis_active
-                ON cards(workspace_id, due_at_millis, created_at DESC, card_id ASC)
-                WHERE deleted_at IS NULL AND due_at_millis IS NOT NULL
-            """,
-            values: []
-        )
-        try self.core.execute(
-            sql: """
-            CREATE INDEX IF NOT EXISTS idx_cards_workspace_new_due_active
-                ON cards(workspace_id, created_at DESC, card_id ASC)
-                WHERE deleted_at IS NULL AND due_at IS NULL
-            """,
-            values: []
-        )
+        try self.createDueAtMillisReviewOrderIndexesWithCreatedAtAscending()
     }
 
     private func populateFsrsLastReviewedAtMillisFromText() throws {
@@ -785,10 +777,50 @@ struct LocalDatabaseMigrator {
     }
 
     private func createFsrsLastReviewedAtMillisIndex() throws {
+        try self.createFsrsLastReviewedAtMillisReviewOrderIndexWithCreatedAtAscending()
+    }
+
+    private func rebuildReviewOrderIndexesWithCreatedAtAscending() throws {
+        try self.core.execute(
+            sql: "DROP INDEX IF EXISTS idx_cards_workspace_due_millis_active",
+            values: []
+        )
+        try self.core.execute(
+            sql: "DROP INDEX IF EXISTS idx_cards_workspace_new_due_active",
+            values: []
+        )
+        try self.core.execute(
+            sql: "DROP INDEX IF EXISTS idx_cards_workspace_fsrs_last_reviewed_millis_due_active",
+            values: []
+        )
+        try self.createDueAtMillisReviewOrderIndexesWithCreatedAtAscending()
+        try self.createFsrsLastReviewedAtMillisReviewOrderIndexWithCreatedAtAscending()
+    }
+
+    private func createDueAtMillisReviewOrderIndexesWithCreatedAtAscending() throws {
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_cards_workspace_due_millis_active
+                ON cards(workspace_id, due_at_millis, created_at ASC, card_id ASC)
+                WHERE deleted_at IS NULL AND due_at_millis IS NOT NULL
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_cards_workspace_new_due_active
+                ON cards(workspace_id, created_at ASC, card_id ASC)
+                WHERE deleted_at IS NULL AND due_at IS NULL
+            """,
+            values: []
+        )
+    }
+
+    private func createFsrsLastReviewedAtMillisReviewOrderIndexWithCreatedAtAscending() throws {
         try self.core.execute(
             sql: """
             CREATE INDEX IF NOT EXISTS idx_cards_workspace_fsrs_last_reviewed_millis_due_active
-                ON cards(workspace_id, fsrs_last_reviewed_at_millis, due_at_millis, created_at DESC, card_id ASC)
+                ON cards(workspace_id, fsrs_last_reviewed_at_millis, due_at_millis, created_at ASC, card_id ASC)
                 WHERE deleted_at IS NULL AND due_at_millis IS NOT NULL AND fsrs_last_reviewed_at_millis IS NOT NULL
             """,
             values: []

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum LocalDatabaseSchema {
-    static let currentVersion: Int = 19
+    static let currentVersion: Int = 20
 
     static var baseMigrationSQL: String {
         let defaultEnableFuzzValue: Int = defaultSchedulerSettingsConfig.enableFuzz ? 1 : 0
@@ -134,11 +134,11 @@ enum LocalDatabaseSchema {
             ON cards(workspace_id, updated_at DESC, card_id ASC);
 
         CREATE INDEX IF NOT EXISTS idx_cards_workspace_due_millis_active
-            ON cards(workspace_id, due_at_millis, created_at DESC, card_id ASC)
+            ON cards(workspace_id, due_at_millis, created_at ASC, card_id ASC)
             WHERE deleted_at IS NULL AND due_at_millis IS NOT NULL;
 
         CREATE INDEX IF NOT EXISTS idx_cards_workspace_new_due_active
-            ON cards(workspace_id, created_at DESC, card_id ASC)
+            ON cards(workspace_id, created_at ASC, card_id ASC)
             WHERE deleted_at IS NULL AND due_at IS NULL;
 
         CREATE INDEX IF NOT EXISTS idx_cards_workspace_fsrs_last_reviewed_at
@@ -146,7 +146,7 @@ enum LocalDatabaseSchema {
             WHERE deleted_at IS NULL;
 
         CREATE INDEX IF NOT EXISTS idx_cards_workspace_fsrs_last_reviewed_millis_due_active
-            ON cards(workspace_id, fsrs_last_reviewed_at_millis, due_at_millis, created_at DESC, card_id ASC)
+            ON cards(workspace_id, fsrs_last_reviewed_at_millis, due_at_millis, created_at ASC, card_id ASC)
             WHERE deleted_at IS NULL AND due_at_millis IS NOT NULL AND fsrs_last_reviewed_at_millis IS NOT NULL;
 
         CREATE INDEX IF NOT EXISTS idx_decks_workspace_created_at

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/Query/ReviewQuerySupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/Query/ReviewQuerySupport.swift
@@ -92,14 +92,13 @@ private func activeTagNames(cards: [Card]) -> [String] {
     deriveActiveCards(cards: cards).flatMap(\.tags)
 }
 
-// Keep review queue ordering aligned with:
+// Keep iOS in-memory review ordering aligned with:
 // - apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+ReadSQL.swift review queue ORDER BY
-// - apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt::sortCardsForReviewQueue
-// - apps/web/src/appData/domain/index.ts::compareCardsForReviewOrder
 // Ordering contract: recently reviewed due cards within the inclusive one-hour fsrsLastReviewedAt
 // window first, then other due cards, then nil dueAt new cards, then future cards,
-// then malformed dueAt values last.
-// If this changes, mirror the same change across all three clients in the same change.
+// then malformed dueAt values last. Cards in the same bucket and due-time position use
+// older createdAt first.
+// When this contract changes, coordinate matching review-order updates for supported clients.
 func compareCardsForReviewOrder(leftCard: Card, rightCard: Card, now: Date) -> Bool {
     let leftRank = makeReviewOrderRank(card: leftCard, now: now)
     let rightRank = makeReviewOrderRank(card: rightCard, now: now)
@@ -118,7 +117,7 @@ func compareCardsForReviewOrder(leftCard: Card, rightCard: Card, now: Date) -> B
     let leftCreatedAt = parseIsoTimestamp(value: leftCard.createdAt) ?? .distantFuture
     let rightCreatedAt = parseIsoTimestamp(value: rightCard.createdAt) ?? .distantFuture
     if leftCreatedAt != rightCreatedAt {
-        return leftCreatedAt > rightCreatedAt
+        return leftCreatedAt < rightCreatedAt
     }
 
     return leftCard.cardId < rightCard.cardId

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
@@ -25,6 +25,15 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
                 indexName: "idx_cards_workspace_due_millis_active"
             )
         )
+        XCTAssertEqual(
+            try self.loadIndexColumnOrder(database: database, indexName: "idx_cards_workspace_due_millis_active"),
+            [
+                SQLiteIndexColumnOrder(name: "workspace_id", isDescending: false),
+                SQLiteIndexColumnOrder(name: "due_at_millis", isDescending: false),
+                SQLiteIndexColumnOrder(name: "created_at", isDescending: false),
+                SQLiteIndexColumnOrder(name: "card_id", isDescending: false)
+            ]
+        )
         XCTAssertTrue(
             try self.hasIndex(
                 database: database,
@@ -32,12 +41,33 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
                 indexName: "idx_cards_workspace_new_due_active"
             )
         )
+        XCTAssertEqual(
+            try self.loadIndexColumnOrder(database: database, indexName: "idx_cards_workspace_new_due_active"),
+            [
+                SQLiteIndexColumnOrder(name: "workspace_id", isDescending: false),
+                SQLiteIndexColumnOrder(name: "created_at", isDescending: false),
+                SQLiteIndexColumnOrder(name: "card_id", isDescending: false)
+            ]
+        )
         XCTAssertTrue(
             try self.hasIndex(
                 database: database,
                 tableName: "cards",
                 indexName: "idx_cards_workspace_fsrs_last_reviewed_millis_due_active"
             )
+        )
+        XCTAssertEqual(
+            try self.loadIndexColumnOrder(
+                database: database,
+                indexName: "idx_cards_workspace_fsrs_last_reviewed_millis_due_active"
+            ),
+            [
+                SQLiteIndexColumnOrder(name: "workspace_id", isDescending: false),
+                SQLiteIndexColumnOrder(name: "fsrs_last_reviewed_at_millis", isDescending: false),
+                SQLiteIndexColumnOrder(name: "due_at_millis", isDescending: false),
+                SQLiteIndexColumnOrder(name: "created_at", isDescending: false),
+                SQLiteIndexColumnOrder(name: "card_id", isDescending: false)
+            ]
         )
         XCTAssertEqual(1, try self.countRows(database: database, tableName: "app_local_settings"))
         XCTAssertEqual(1, try self.countRows(database: database, tableName: "workspaces"))

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion19To20MigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion19To20MigrationTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import Flashcards
+
+final class LocalDatabaseSchemaVersion19To20MigrationTests: LocalDatabaseTestCase {
+    func testSchemaVersion19MigrationRebuildsReviewOrderIndexesWithCreatedAtAscending() throws {
+        let database = try self.makeDatabase()
+        try database.close()
+        self.database = nil
+
+        try self.prepareSchemaVersion19Database(databaseURL: try XCTUnwrap(self.databaseURL))
+
+        let migratedDatabase = try LocalDatabase(databaseURL: try XCTUnwrap(self.databaseURL))
+        self.database = migratedDatabase
+
+        XCTAssertEqual(LocalDatabaseSchema.currentVersion, try self.loadSchemaVersion(database: migratedDatabase))
+        XCTAssertEqual(
+            try self.loadIndexColumnOrder(database: migratedDatabase, indexName: "idx_cards_workspace_due_millis_active"),
+            [
+                SQLiteIndexColumnOrder(name: "workspace_id", isDescending: false),
+                SQLiteIndexColumnOrder(name: "due_at_millis", isDescending: false),
+                SQLiteIndexColumnOrder(name: "created_at", isDescending: false),
+                SQLiteIndexColumnOrder(name: "card_id", isDescending: false)
+            ]
+        )
+        XCTAssertEqual(
+            try self.loadIndexColumnOrder(database: migratedDatabase, indexName: "idx_cards_workspace_new_due_active"),
+            [
+                SQLiteIndexColumnOrder(name: "workspace_id", isDescending: false),
+                SQLiteIndexColumnOrder(name: "created_at", isDescending: false),
+                SQLiteIndexColumnOrder(name: "card_id", isDescending: false)
+            ]
+        )
+        XCTAssertEqual(
+            try self.loadIndexColumnOrder(
+                database: migratedDatabase,
+                indexName: "idx_cards_workspace_fsrs_last_reviewed_millis_due_active"
+            ),
+            [
+                SQLiteIndexColumnOrder(name: "workspace_id", isDescending: false),
+                SQLiteIndexColumnOrder(name: "fsrs_last_reviewed_at_millis", isDescending: false),
+                SQLiteIndexColumnOrder(name: "due_at_millis", isDescending: false),
+                SQLiteIndexColumnOrder(name: "created_at", isDescending: false),
+                SQLiteIndexColumnOrder(name: "card_id", isDescending: false)
+            ]
+        )
+        XCTAssertEqual(
+            try self.loadIndexColumnOrder(database: migratedDatabase, indexName: "idx_cards_workspace_created_at"),
+            [
+                SQLiteIndexColumnOrder(name: "workspace_id", isDescending: false),
+                SQLiteIndexColumnOrder(name: "created_at", isDescending: true),
+                SQLiteIndexColumnOrder(name: "card_id", isDescending: false)
+            ]
+        )
+    }
+
+    private func prepareSchemaVersion19Database(databaseURL: URL) throws {
+        var connection: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            databaseURL.path,
+            &connection,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        )
+        guard openResult == SQLITE_OK, let connection else {
+            throw LocalStoreError.database("Failed to open schema v19 test database")
+        }
+        defer {
+            sqlite3_close_v2(connection)
+        }
+
+        let downgradeSQL = """
+        DROP INDEX IF EXISTS idx_cards_workspace_due_millis_active;
+        DROP INDEX IF EXISTS idx_cards_workspace_new_due_active;
+        DROP INDEX IF EXISTS idx_cards_workspace_fsrs_last_reviewed_millis_due_active;
+        CREATE INDEX idx_cards_workspace_due_millis_active
+            ON cards(workspace_id, due_at_millis, created_at DESC, card_id ASC)
+            WHERE deleted_at IS NULL AND due_at_millis IS NOT NULL;
+        CREATE INDEX idx_cards_workspace_new_due_active
+            ON cards(workspace_id, created_at DESC, card_id ASC)
+            WHERE deleted_at IS NULL AND due_at IS NULL;
+        CREATE INDEX idx_cards_workspace_fsrs_last_reviewed_millis_due_active
+            ON cards(workspace_id, fsrs_last_reviewed_at_millis, due_at_millis, created_at DESC, card_id ASC)
+            WHERE deleted_at IS NULL AND due_at_millis IS NOT NULL AND fsrs_last_reviewed_at_millis IS NOT NULL;
+        PRAGMA user_version = 19;
+        """
+
+        let execResult = sqlite3_exec(connection, downgradeSQL, nil, nil, nil)
+        guard execResult == SQLITE_OK else {
+            let message = String(cString: sqlite3_errmsg(connection))
+            throw LocalStoreError.database("Failed to prepare schema v19 fixture: \(message)")
+        }
+    }
+}

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseTestCase.swift
@@ -2,6 +2,11 @@ import Foundation
 import XCTest
 @testable import Flashcards
 
+struct SQLiteIndexColumnOrder: Equatable {
+    let name: String
+    let isDescending: Bool
+}
+
 class LocalDatabaseTestCase: XCTestCase {
     var databaseURL: URL?
     var database: LocalDatabase?
@@ -70,8 +75,28 @@ class LocalDatabaseTestCase: XCTestCase {
         try database.core.columnExists(tableName: tableName, columnName: columnName)
     }
 
+    func loadIndexColumnOrder(database: LocalDatabase, indexName: String) throws -> [SQLiteIndexColumnOrder] {
+        let columnOrder: [SQLiteIndexColumnOrder?] = try database.core.query(
+            sql: "PRAGMA index_xinfo(\(self.singleQuotedSQLIdentifier(identifier: indexName)))",
+            values: []
+        ) { statement in
+            let isKeyColumn = DatabaseCore.columnInt64(statement: statement, index: 5) == 1
+            guard isKeyColumn, let name = DatabaseCore.columnOptionalText(statement: statement, index: 2) else {
+                return nil
+            }
+
+            return SQLiteIndexColumnOrder(
+                name: name,
+                isDescending: DatabaseCore.columnInt64(statement: statement, index: 3) == 1
+            )
+        }
+
+        return columnOrder.compactMap { column in
+            column
+        }
+    }
+
     private func singleQuotedSQLIdentifier(identifier: String) -> String {
         "'\(identifier.replacingOccurrences(of: "'", with: "''"))'"
     }
 }
-

--- a/apps/ios/Flashcards/FlashcardsTests/Review/FSRS/FsrsReviewPresentationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/FSRS/FsrsReviewPresentationTests.swift
@@ -174,7 +174,7 @@ final class FsrsReviewPresentationTests: XCTestCase {
         )
     }
 
-    func testMakeReviewTimelineAppendsFutureCardsSortedByDueAtAndCreatedAtDescending() throws {
+    func testMakeReviewTimelineAppendsFutureCardsSortedByDueAtAndCreatedAtAscending() throws {
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
         let cards = [
             FsrsSchedulerTestSupport.makeTestCard(
@@ -209,11 +209,11 @@ final class FsrsReviewPresentationTests: XCTestCase {
         XCTAssertEqual(reviewQueue.map(\.cardId), ["current"])
         XCTAssertEqual(
             reviewTimeline.map(\.cardId),
-            ["current", "future-early", "future-tie-newer", "future-tie-older"]
+            ["current", "future-early", "future-tie-older", "future-tie-newer"]
         )
     }
 
-    func testMakeReviewQueuePlacesTimedDueAtBeforeNilDueAtAndUsesCreatedAtDescendingAsFinalTiebreaker() throws {
+    func testMakeReviewQueuePlacesTimedDueAtBeforeNilDueAtAndUsesCreatedAtAscendingAsFinalTiebreaker() throws {
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
         let cards = [
             FsrsSchedulerTestSupport.makeTestCard(
@@ -244,7 +244,7 @@ final class FsrsReviewPresentationTests: XCTestCase {
 
         XCTAssertEqual(
             makeReviewQueue(reviewFilter: .allCards, decks: [], cards: cards, now: now).map(\.cardId),
-            ["timed-earlier", "timed-tie-newer", "timed-tie-older", "nil-due"]
+            ["timed-earlier", "timed-tie-older", "timed-tie-newer", "nil-due"]
         )
     }
 
@@ -332,12 +332,12 @@ final class FsrsReviewPresentationTests: XCTestCase {
             makeReviewQueue(reviewFilter: .allCards, decks: [], cards: cards, now: now).map(\.cardId),
             [
                 "recent-cutoff",
-                "recent-tie-newer",
                 "recent-tie-older",
+                "recent-tie-newer",
                 "recent-now",
                 "old-earlier",
-                "old-tie-newer",
                 "old-tie-older",
+                "old-tie-newer",
                 "due-last-hour-old-review",
                 "new-card"
             ]
@@ -346,12 +346,12 @@ final class FsrsReviewPresentationTests: XCTestCase {
             makeReviewTimeline(reviewFilter: .allCards, decks: [], cards: cards, now: now).map(\.cardId),
             [
                 "recent-cutoff",
-                "recent-tie-newer",
                 "recent-tie-older",
+                "recent-tie-newer",
                 "recent-now",
                 "old-earlier",
-                "old-tie-newer",
                 "old-tie-older",
+                "old-tie-newer",
                 "due-last-hour-old-review",
                 "new-card",
                 "future-one-millisecond",

--- a/apps/ios/Flashcards/FlashcardsTests/Review/SQLite/ReviewSQLiteOrderingTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/SQLite/ReviewSQLiteOrderingTests.swift
@@ -219,11 +219,11 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
             offset: 0
         )
 
-        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["truncated-now-newer", "canonical-now-older"])
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["canonical-now-older", "truncated-now-newer"])
         XCTAssertFalse(reviewHead.hasMoreCards)
         XCTAssertEqual(
             timelinePage.cards.map(\.cardId),
-            ["truncated-now-newer", "canonical-now-older", "future-one-millisecond"]
+            ["canonical-now-older", "truncated-now-newer", "future-one-millisecond"]
         )
         XCTAssertEqual(
             timelinePage.cards.map(\.cardId),
@@ -285,8 +285,61 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
             return
         }
         XCTAssertEqual(Set<String>(exactTagNames), Set<String>(["Éclair", "éclair"]))
-        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["uppercase-tag-card", "lowercase-tag-card"])
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["lowercase-tag-card", "uppercase-tag-card"])
         XCTAssertEqual(reviewCounts, ReviewCounts(dueCount: 2, totalCount: 2))
+    }
+
+    func testSQLiteDeckReviewQueueOrdersNewCardsByCreatedAtAscending() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "deck-matching-newer",
+            dueAt: nil,
+            createdAt: "2026-03-09T08:30:00.000Z",
+            tags: ["topic"]
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "deck-matching-older",
+            dueAt: nil,
+            createdAt: "2026-03-09T08:00:00.000Z",
+            tags: ["topic"]
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "deck-nonmatching-oldest",
+            dueAt: nil,
+            createdAt: "2026-03-09T07:00:00.000Z",
+            tags: ["other"]
+        )
+        let deck = try database.createDeck(
+            workspaceId: workspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Topic",
+                filterDefinition: buildDeckFilterDefinition(tags: ["topic"])
+            )
+        )
+
+        let resolvedReviewQuery = try database.loadResolvedReviewQuery(
+            workspaceId: workspace.workspaceId,
+            reviewFilter: .deck(deckId: deck.deckId)
+        )
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: resolvedReviewQuery.reviewFilter,
+            reviewQueryDefinition: resolvedReviewQuery.queryDefinition,
+            now: now,
+            limit: 8
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["deck-matching-older", "deck-matching-newer"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
     }
 
     func testSQLiteResolvedDeckReviewFilterMatchesUnicodeStoredTagName() throws {
@@ -402,7 +455,7 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
         XCTAssertEqual(missingSnapshot.totalCount, 0)
     }
 
-    func testSQLiteReviewTimelineOrdersMalformedDueAtByCreatedAtThenCardId() throws {
+    func testSQLiteReviewTimelineOrdersMalformedDueAtByOlderCreatedAtThenCardId() throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
@@ -448,7 +501,7 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
         XCTAssertFalse(reviewHead.hasMoreCards)
         XCTAssertEqual(
             timelinePage.cards.map(\.cardId),
-            ["malformed-newer-a", "malformed-newer-z", "malformed-older"]
+            ["malformed-older", "malformed-newer-a", "malformed-newer-z"]
         )
         XCTAssertFalse(timelinePage.hasMoreCards)
     }
@@ -522,11 +575,11 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
             timelinePage.cards.map(\.cardId),
             [
                 "recent-valid",
-                "invalid-calendar-day",
-                "invalid-non-leap-day",
-                "invalid-month",
+                "invalid-second",
                 "invalid-minute",
-                "invalid-second"
+                "invalid-month",
+                "invalid-non-leap-day",
+                "invalid-calendar-day"
             ]
         )
         XCTAssertFalse(timelinePage.hasMoreCards)
@@ -573,7 +626,7 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
         XCTAssertFalse(timelinePage.hasMoreCards)
     }
 
-    func testSQLiteReviewQueueAndTimelineOrderEquivalentDueTimesByCreatedAtDescending() throws {
+    func testSQLiteReviewQueueAndTimelineOrderEquivalentDueTimesByCreatedAtAscending() throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
@@ -608,9 +661,50 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
             offset: 0
         )
 
-        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["same-due-newer", "same-due-older"])
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["same-due-older", "same-due-newer"])
         XCTAssertFalse(reviewHead.hasMoreCards)
-        XCTAssertEqual(timelinePage.cards.map(\.cardId), ["same-due-newer", "same-due-older"])
+        XCTAssertEqual(timelinePage.cards.map(\.cardId), ["same-due-older", "same-due-newer"])
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueAndTimelineOrderNewCardsByCreatedAtAscending() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "new-card-older",
+            dueAt: nil,
+            createdAt: "2026-03-09T07:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "new-card-newer",
+            dueAt: nil,
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["new-card-older", "new-card-newer"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(timelinePage.cards.map(\.cardId), ["new-card-older", "new-card-newer"])
         XCTAssertFalse(timelinePage.hasMoreCards)
     }
 
@@ -705,7 +799,7 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
             excludedCardIds: []
         )
 
-        XCTAssertEqual(queueRows.map(\.cardId), ["fraction-a-newer", "fraction-b-newer"])
+        XCTAssertEqual(queueRows.map(\.cardId), ["fraction-d-oldest", "fraction-c-older"])
     }
 
     func testSQLiteReviewCountsUseActiveQueueDueEligibility() throws {
@@ -779,6 +873,7 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
     func testSQLiteActiveDueBucketOrderUsesDueAtIndexOrder() throws {
         XCTAssertFalse(cardStoreActiveDueBucketOrderSQL.lowercased().contains("julianday"))
         XCTAssertTrue(cardStoreActiveDueBucketOrderSQL.lowercased().contains("due_at_millis"))
+        XCTAssertTrue(cardStoreActiveDueBucketOrderSQL.lowercased().contains("created_at asc"))
 
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()


### PR DESCRIPTION
## Summary
- order iOS review queue and timeline ties by older created_at before newer created_at
- rebuild affected SQLite review-order indexes through schema version 20
- update SQLite and in-memory review ordering coverage

## Validation
- git --no-pager diff --check
- stale review-order comment/name searches
- worker-owned review rounds passed with no P0/P1 issues

Note: iOS simulator-backed XCTest was not run because simulator permission was not granted for this task.