### PR TITLE
Fix Android review created order

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/CardDaoReviewQueueContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/CardDaoReviewQueueContractTest.kt
@@ -174,11 +174,11 @@ class CardDaoReviewQueueContractTest {
             tagNames = listOf("Future Only")
         ).first()
 
-        assertEquals("recent-cutoff-a", allCardsTop?.cardId)
-        assertEquals("recent-cutoff-a", tagTop?.cardId)
+        assertEquals("recent-cutoff-older-created", allCardsTop?.cardId)
+        assertEquals("recent-cutoff-older-created", tagTop?.cardId)
         assertNull(futureOnlyTagTop)
         assertEquals(
-            listOf("recent-cutoff-a", "recent-cutoff-b", "recent-cutoff-older-created", "old-boundary-card"),
+            listOf("recent-cutoff-older-created", "recent-cutoff-a", "recent-cutoff-b", "old-boundary-card"),
             boundedQueue
         )
         assertEquals(boundedQueue, priorityQueue)
@@ -186,5 +186,78 @@ class CardDaoReviewQueueContractTest {
         assertEquals(6, priorityTotalCount)
         assertEquals(0, futureOnlyDueCount)
         assertEquals(1, futureOnlyTotalCount)
+    }
+
+    @Test
+    fun newReviewCardQueriesUseOlderCreatedBeforeNewerAndCardIdAscending(): Unit = runBlocking {
+        val nowMillis = 12 * 60 * 60 * 1_000L
+        val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = nowMillis)
+        val reviewTag = TagEntity(
+            tagId = "tag-review",
+            workspaceId = workspaceId,
+            name = "Review"
+        )
+
+        database.cardDao().insertCards(
+            listOf(
+                makeNewReviewOrderingCardEntity(
+                    cardId = "new-equal-a",
+                    workspaceId = workspaceId,
+                    createdAtMillis = 100L,
+                    updatedAtMillis = 100L
+                ),
+                makeNewReviewOrderingCardEntity(
+                    cardId = "new-equal-b",
+                    workspaceId = workspaceId,
+                    createdAtMillis = 100L,
+                    updatedAtMillis = 100L
+                ),
+                makeNewReviewOrderingCardEntity(
+                    cardId = "new-newer-card",
+                    workspaceId = workspaceId,
+                    createdAtMillis = 200L,
+                    updatedAtMillis = 200L
+                )
+            )
+        )
+        database.tagDao().insertTags(tags = listOf(reviewTag))
+        database.tagDao().insertCardTags(
+            cardTags = listOf(
+                CardTagEntity(cardId = "new-equal-a", tagId = reviewTag.tagId),
+                CardTagEntity(cardId = "new-equal-b", tagId = reviewTag.tagId),
+                CardTagEntity(cardId = "new-newer-card", tagId = reviewTag.tagId)
+            )
+        )
+
+        val allCardsQueue = database.reviewQueueDao().observeNewReviewQueue(
+            workspaceId = workspaceId,
+            limit = 3
+        ).first().map { card ->
+            card.card.cardId
+        }
+        val tagQueue = database.reviewQueueDao().observeNewReviewQueueByAnyTags(
+            workspaceId = workspaceId,
+            tagNames = listOf("Review"),
+            limit = 3
+        ).first().map { card ->
+            card.card.cardId
+        }
+        val allCardsTop = loadTopActiveReviewCard(
+            reviewCardSelectionDao = database.reviewCardSelectionDao(),
+            workspaceId = workspaceId,
+            nowMillis = nowMillis,
+            tagNames = emptyList()
+        )
+        val tagTop = loadTopActiveReviewCard(
+            reviewCardSelectionDao = database.reviewCardSelectionDao(),
+            workspaceId = workspaceId,
+            nowMillis = nowMillis,
+            tagNames = listOf("Review")
+        )
+
+        assertEquals(listOf("new-equal-a", "new-equal-b", "new-newer-card"), allCardsQueue)
+        assertEquals(allCardsQueue, tagQueue)
+        assertEquals("new-equal-a", allCardsTop?.cardId)
+        assertEquals("new-equal-a", tagTop?.cardId)
     }
 }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewQueueContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewQueueContractTest.kt
@@ -285,17 +285,17 @@ class LocalReviewQueueContractTest {
         ).first()
 
         assertEquals(8, sessionSnapshot.cards.size)
-        assertEquals("new-card-09", sessionSnapshot.presentedCard?.cardId)
+        assertEquals("new-card-00", sessionSnapshot.presentedCard?.cardId)
         assertEquals(
             listOf(
-                "new-card-09",
-                "new-card-08",
-                "new-card-07",
-                "new-card-06",
-                "new-card-05",
-                "new-card-04",
+                "new-card-00",
+                "new-card-01",
+                "new-card-02",
                 "new-card-03",
-                "new-card-02"
+                "new-card-04",
+                "new-card-05",
+                "new-card-06",
+                "new-card-07"
             ),
             sessionSnapshot.cards.map { card -> card.cardId }
         )
@@ -356,14 +356,14 @@ class LocalReviewQueueContractTest {
 
         assertEquals(
             listOf(
-                "recent-card-07",
-                "recent-card-06",
-                "recent-card-05",
-                "recent-card-04",
-                "recent-card-03",
-                "recent-card-02",
+                "recent-card-00",
                 "recent-card-01",
-                "recent-card-00"
+                "recent-card-02",
+                "recent-card-03",
+                "recent-card-04",
+                "recent-card-05",
+                "recent-card-06",
+                "recent-card-07"
             ),
             preservedSnapshot.cards.map { card -> card.cardId }
         )
@@ -371,7 +371,7 @@ class LocalReviewQueueContractTest {
         assertTrue(preservedSnapshot.answerOptionsByCardId.containsKey("old-presented-card"))
         assertEquals(9, preservedSnapshot.dueCount)
         assertEquals(10, preservedSnapshot.totalCount)
-        assertEquals("recent-card-07", futurePresentedSnapshot.presentedCard?.cardId)
+        assertEquals("recent-card-00", futurePresentedSnapshot.presentedCard?.cardId)
         assertFalse(futurePresentedSnapshot.answerOptionsByCardId.containsKey("future-presented-card"))
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewCardSelectionDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewCardSelectionDao.kt
@@ -18,7 +18,7 @@ interface ReviewCardSelectionDao {
             AND fsrsLastReviewedAtMillis IS NOT NULL
             AND fsrsLastReviewedAtMillis >= :cutoffMillis
             AND fsrsLastReviewedAtMillis <= :nowMillis
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT 1
         """
     )
@@ -46,7 +46,7 @@ interface ReviewCardSelectionDao {
                     AND tags.workspaceId = cards.workspaceId
                     AND tags.name IN (:tagNames)
             )
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT 1
         """
     )
@@ -69,7 +69,7 @@ interface ReviewCardSelectionDao {
                 OR fsrsLastReviewedAtMillis < :cutoffMillis
                 OR fsrsLastReviewedAtMillis > :nowMillis
             )
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT 1
         """
     )
@@ -99,7 +99,7 @@ interface ReviewCardSelectionDao {
                     AND tags.workspaceId = cards.workspaceId
                     AND tags.name IN (:tagNames)
             )
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT 1
         """
     )
@@ -116,7 +116,7 @@ interface ReviewCardSelectionDao {
         WHERE workspaceId = :workspaceId
             AND deletedAtMillis IS NULL
             AND dueAtMillis IS NULL
-        ORDER BY createdAtMillis DESC, cardId ASC
+        ORDER BY createdAtMillis ASC, cardId ASC
         LIMIT 1
         """
     )
@@ -136,7 +136,7 @@ interface ReviewCardSelectionDao {
                     AND tags.workspaceId = cards.workspaceId
                     AND tags.name IN (:tagNames)
             )
-        ORDER BY createdAtMillis DESC, cardId ASC
+        ORDER BY createdAtMillis ASC, cardId ASC
         LIMIT 1
         """
     )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewQueueDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewQueueDao.kt
@@ -19,7 +19,7 @@ interface ReviewQueueDao {
             AND fsrsLastReviewedAtMillis IS NOT NULL
             AND fsrsLastReviewedAtMillis >= :cutoffMillis
             AND fsrsLastReviewedAtMillis <= :nowMillis
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )
@@ -49,7 +49,7 @@ interface ReviewQueueDao {
                     AND tags.workspaceId = cards.workspaceId
                     AND tags.name IN (:tagNames)
             )
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )
@@ -74,7 +74,7 @@ interface ReviewQueueDao {
                 OR fsrsLastReviewedAtMillis < :cutoffMillis
                 OR fsrsLastReviewedAtMillis > :nowMillis
             )
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )
@@ -106,7 +106,7 @@ interface ReviewQueueDao {
                     AND tags.workspaceId = cards.workspaceId
                     AND tags.name IN (:tagNames)
             )
-        ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )
@@ -125,7 +125,7 @@ interface ReviewQueueDao {
         WHERE workspaceId = :workspaceId
             AND deletedAtMillis IS NULL
             AND dueAtMillis IS NULL
-        ORDER BY createdAtMillis DESC, cardId ASC
+        ORDER BY createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )
@@ -149,7 +149,7 @@ interface ReviewQueueDao {
                     AND tags.workspaceId = cards.workspaceId
                     AND tags.name IN (:tagNames)
             )
-        ORDER BY createdAtMillis DESC, cardId ASC
+        ORDER BY createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )
@@ -174,7 +174,7 @@ interface ReviewQueueDao {
                     AND fsrsLastReviewedAtMillis IS NOT NULL
                     AND fsrsLastReviewedAtMillis >= :cutoffMillis
                     AND fsrsLastReviewedAtMillis <= :nowMillis
-                ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+                ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
                 LIMIT :limit
             )
             UNION ALL
@@ -190,7 +190,7 @@ interface ReviewQueueDao {
                         OR fsrsLastReviewedAtMillis < :cutoffMillis
                         OR fsrsLastReviewedAtMillis > :nowMillis
                     )
-                ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+                ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
                 LIMIT :limit
             )
             UNION ALL
@@ -200,11 +200,11 @@ interface ReviewQueueDao {
                 WHERE workspaceId = :workspaceId
                     AND deletedAtMillis IS NULL
                     AND dueAtMillis IS NULL
-                ORDER BY createdAtMillis DESC, cardId ASC
+                ORDER BY createdAtMillis ASC, cardId ASC
                 LIMIT :limit
             )
         )
-        ORDER BY activeQueueBucket ASC, dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY activeQueueBucket ASC, dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )
@@ -238,7 +238,7 @@ interface ReviewQueueDao {
                             AND tags.workspaceId = cards.workspaceId
                             AND tags.name IN (:tagNames)
                     )
-                ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+                ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
                 LIMIT :limit
             )
             UNION ALL
@@ -262,7 +262,7 @@ interface ReviewQueueDao {
                             AND tags.workspaceId = cards.workspaceId
                             AND tags.name IN (:tagNames)
                     )
-                ORDER BY dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+                ORDER BY dueAtMillis ASC, createdAtMillis ASC, cardId ASC
                 LIMIT :limit
             )
             UNION ALL
@@ -280,11 +280,11 @@ interface ReviewQueueDao {
                             AND tags.workspaceId = cards.workspaceId
                             AND tags.name IN (:tagNames)
                     )
-                ORDER BY createdAtMillis DESC, cardId ASC
+                ORDER BY createdAtMillis ASC, cardId ASC
                 LIMIT :limit
             )
         )
-        ORDER BY activeQueueBucket ASC, dueAtMillis ASC, createdAtMillis DESC, cardId ASC
+        ORDER BY activeQueueBucket ASC, dueAtMillis ASC, createdAtMillis ASC, cardId ASC
         LIMIT :limit
         """
     )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt
@@ -8,16 +8,16 @@ import com.flashcardsopensourceapp.data.local.model.cards.normalizeTagKey
 import com.flashcardsopensourceapp.data.local.model.scheduling.WorkspaceSchedulerSettings
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagsSummary
 
-// Keep review queue ordering aligned with:
+// Android review queue ordering.
+// Cross-client maintenance: when this product contract changes, review related client implementations too:
 // - apps/ios/Flashcards/Flashcards/Review/Queue/Query/ReviewQuerySupport.swift::compareCardsForReviewOrder
 // - apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+ReadSQL.swift review queue ORDER BY
 // - apps/web/src/appData/domain/index.ts::compareCardsForReviewOrder
-// Active queue contract: recently reviewed due cards within the inclusive one-hour
+// Android active queue contract: recently reviewed due cards within the inclusive one-hour
 // fsrsLastReviewedAtMillis window first, then other due cards, then null due/new cards.
 // Future cards are excluded from the active queue and can appear later in timeline ordering;
 // malformed dueAt values are excluded in string-date clients and are not representable by Android dueAtMillis.
-// Within each bucket, earlier dueAt comes first, then newer createdAt, then cardId ascending.
-// If this changes, mirror the same change across all three clients in the same change.
+// Within each bucket, earlier dueAt comes first, then older createdAt, then cardId ascending.
 private const val recentReviewPriorityWindowMillis: Long = 60L * 60L * 1_000L
 
 private fun reviewOrderRank(card: CardSummary, nowMillis: Long): Int {
@@ -42,7 +42,7 @@ private fun sortCardsForReviewQueue(cards: List<CardSummary>, nowMillis: Long): 
             reviewOrderRank(card = card, nowMillis = nowMillis)
         }.thenBy { card ->
             card.dueAtMillis ?: Long.MIN_VALUE
-        }.thenByDescending { card ->
+        }.thenBy { card ->
             card.createdAtMillis
         }.thenBy { card ->
             card.cardId


### PR DESCRIPTION
## Summary
- order Android review queue and top-card selection ties by older createdAtMillis first
- update in-memory review/timeline comparator and Android-local contract comment
- update Android review queue contract expectations for same-due and null-due ordering

## Validation
- git --no-pager diff --check
- targeted rg searches for stale review-order assumptions in Android review paths
- Gradle not run because this task did not grant ./gradlew permission