### PR TITLE
fix(ios): skip tab progress refresh while the credential-recovery gate is shown

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -270,6 +270,10 @@ struct RootTabView: View {
 
     @MainActor
     private func refreshSelectedTabIfNeeded(nextTab: AppTab) async {
+        guard self.store.isCloudSyncBlocked == false else {
+            return
+        }
+
         switch nextTab {
         case .review:
             await self.store.refreshReviewBadgesIfNeeded()


### PR DESCRIPTION
Skip starting tab progress/badge refresh while the credential-recovery gate is shown, matching the isCloudCredentialRecoveryGateActive guards used across FlashcardsApp. Avoids re-entering the blocked path and making wasted cloud calls when the recovery gate is up.\n\n## Validation\nManual smoke / simulator build was NOT run (requires explicit user permission per repo policy). Pure logic guards on the existing isCloudSyncBlocked predicate; no UI, navigation, localization, or dependency changes.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)