### PR TITLE
fix(ios): stop reporting credential-recovery state as a technical error in progress refresh

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -49,6 +49,10 @@ extension FlashcardsStore {
                 return
             }
 
+            guard self.isCloudSyncBlocked == false else {
+                return
+            }
+
             guard let activeSession = try await self.progressCloudSession(scopeKey: scopeKey) else {
                 return
             }
@@ -79,6 +83,10 @@ extension FlashcardsStore {
                 return
             }
 
+            if self.isCloudSyncBlocked {
+                return
+            }
+
             self.presentTechnicalError(error)
             self.replaceProgressErrorMessage(message: localizedProgressUnavailableErrorMessage())
         }
@@ -101,6 +109,10 @@ extension FlashcardsStore {
                 return
             }
 
+            guard self.isCloudSyncBlocked == false else {
+                return
+            }
+
             guard let activeSession = try await self.progressCloudSession(scopeKey: scopeKey) else {
                 return
             }
@@ -111,6 +123,10 @@ extension FlashcardsStore {
             )
         } catch {
             if isRequestCancellationError(error: error) {
+                return
+            }
+
+            if self.isCloudSyncBlocked {
                 return
             }
 
@@ -136,6 +152,10 @@ extension FlashcardsStore {
                 return
             }
 
+            guard self.isCloudSyncBlocked == false else {
+                return
+            }
+
             guard let activeSession = try await self.progressCloudSession(scopeKey: scopeKey) else {
                 return
             }
@@ -146,6 +166,10 @@ extension FlashcardsStore {
             )
         } catch {
             if isRequestCancellationError(error: error) {
+                return
+            }
+
+            if self.isCloudSyncBlocked {
                 return
             }
 
@@ -179,6 +203,10 @@ extension FlashcardsStore {
                 || shouldRefreshReviewSchedule
                 || shouldRefreshLeaderboard
                 || shouldRefreshStreakLeaderboard else {
+                return
+            }
+
+            guard self.isCloudSyncBlocked == false else {
                 return
             }
 
@@ -240,6 +268,10 @@ extension FlashcardsStore {
                 return
             }
 
+            if self.isCloudSyncBlocked {
+                return
+            }
+
             self.presentTechnicalError(error)
             self.replaceProgressErrorMessage(message: localizedProgressUnavailableErrorMessage())
         }
@@ -253,6 +285,10 @@ extension FlashcardsStore {
             let leaderboardScopeKey = self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
 
             self.invalidateProgress(scopeKey: scopeKey, summaryScopeKey: summaryScopeKey)
+            guard self.isCloudSyncBlocked == false else {
+                return
+            }
+
             guard let activeSession = try await self.progressCloudSession(scopeKey: scopeKey) else {
                 return
             }
@@ -289,6 +325,10 @@ extension FlashcardsStore {
             }
         } catch {
             if isRequestCancellationError(error: error) {
+                return
+            }
+
+            if self.isCloudSyncBlocked {
                 return
             }
 


### PR DESCRIPTION
Treat the linked-credential recovery / blocked-sync state as expected in the progress refresh path. Guard the cloud-refresh catch blocks on isCloudSyncBlocked so the recovery-blocked LocalStoreError is no longer surfaced via presentTechnicalError or captured in Sentry, and short-circuit before progressCloudSession while blocked so no keychain probe / network call happens. Eliminates the false technical_error_presented (feature prompts, LocalStoreError Code 1) Sentry events seen when linked Cloud credentials are missing on device.\n\n## Validation\nManual smoke / simulator build was NOT run (requires explicit user permission per repo policy). Pure logic guards on the existing isCloudSyncBlocked predicate; no UI, navigation, localization, or dependency changes.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)