### PR TITLE
Web: raise slow hot-bootstrap warning threshold to 8000ms

### DIFF
--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -642,7 +642,7 @@ describe("sync lifecycle observation", () => {
     const clock = installMutableDateNow(0);
     installPersistentStorageMockWithClock(clock, 0, 7, 0);
     apiMocks.bootstrapPullSyncStateMock.mockImplementation(async () => {
-      clock.advance(800);
+      clock.advance(8000);
       return createBootstrapPullResult({
         entries: [],
         bootstrapHotChangeId: 12,
@@ -662,13 +662,13 @@ describe("sync lifecycle observation", () => {
     expect(findCapturedWarning("sync_restore_slow")).toEqual(expect.objectContaining({
       action: "sync_restore_slow",
       details: expect.objectContaining({
-        durationMs: 2000,
+        durationMs: 9200,
         pageSize: 1000,
-        bootstrapPullDurationMs: 800,
+        bootstrapPullDurationMs: 8000,
         applyHotPagesDurationMs: 0,
         finalRefreshDurationMs: 1200,
         persistentStorageDurationMs: 7,
-        bootstrapPageDurationMs: [800],
+        bootstrapPageDurationMs: [8000],
       }),
     }));
   });

--- a/apps/web/src/appData/sync/remote/constants.ts
+++ b/apps/web/src/appData/sync/remote/constants.ts
@@ -1,3 +1,4 @@
 export const syncIncrementalPageSize = 500;
 export const syncBootstrapPageSize = 1000;
-export const slowHotBootstrapWarningThresholdMs = 2000;
+// Normal cold-start fresh single-page bootstraps run ~6.5s (server/network latency), which is expected; multi-page bootstraps still warn via pageCount > 1.
+export const slowHotBootstrapWarningThresholdMs = 8000;


### PR DESCRIPTION
Raises `slowHotBootstrapWarningThresholdMs` in the web sync layer from `2000ms` to `8000ms`.

## Why

The `web.sync_restore_slow` warning was firing on normal cold-start, fresh single-page bootstraps. In production these run around 6.5s, with almost all of that time spent in a single backend pull (server/network latency), which is expected rather than a real problem. At the old 2000ms threshold these routine runs generated noisy warnings.

Raising the threshold to 8000ms silences those normal single-page bootstraps while still warning on:
- multi-page bootstraps (which also surface via `pageCount > 1`), and
- truly pathological runs that exceed 8s.

The matching assertion in `syncLifecycleObservation.test.ts` is updated to exercise the new boundary (8000ms backend pull producing a 9200ms total restore that still warns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)