### PR TITLE
iOS: drop CI-simulator app-hang events at the source

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
@@ -3,6 +3,8 @@ import Sentry
 
 let filteredDiagnosticValue: String = "[Filtered]"
 
+private let ciSimulatorEnvironment: String = "ci-simulator"
+
 func safeDiagnosticIdentifier(_ value: String) -> String {
     let trimmedValue: String = value.trimmingCharacters(in: .whitespacesAndNewlines)
     guard trimmedValue.isEmpty == false, trimmedValue.count <= 160 else {
@@ -22,6 +24,12 @@ func safeDiagnosticIdentifier(_ value: String) -> String {
 }
 
 func sanitizeSentryEvent(_ event: Event) -> Event? {
+    // Drop App Hang events from CI simulator smoke runs: these are debug-build
+    // automation hangs, not real user-facing issues, so they must not create issues.
+    if event.environment == ciSimulatorEnvironment,
+       event.exceptions?.contains(where: { $0.mechanism?.type == "AppHang" }) == true {
+        return nil
+    }
     if let request = event.request {
         request.headers = sanitizedHeaders(request.headers)
         request.cookies = nil


### PR DESCRIPTION
## Summary

CI simulator smoke runs execute a debug build under automation, which regularly trips the watchdog and emits App Hang events. These hangs are an artifact of the test harness rather than real user-facing problems, yet they create noisy Sentry issues.

This change filters them in `sanitizeSentryEvent`: when an event has the `ci-simulator` environment and contains an App Hang exception mechanism, it is dropped (`return nil`) at the source before reaching Sentry.

## Rationale

Suppressing these events at the source keeps Sentry focused on genuine user-facing issues and avoids noise from automation-induced hangs in debug CI builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)