### PR TITLE
Make Android technical-error Sentry reports diagnosable and grouped

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
@@ -157,6 +157,7 @@ internal fun CloudCredentialRecoveryGateContainer(
         },
         onShowTechnicalDetails = { technicalDetails, reportId ->
             appGraph.showTechnicalErrorDialog(
+                source = "cloud_credential_recovery",
                 reportId = reportId,
                 title = technicalErrorDialogTitle,
                 message = technicalErrorDialogMessage,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -591,6 +591,7 @@ fun FlashcardsApp(
                     accountDeletionState = accountDeletionState,
                     onShowTechnicalDetails = { technicalDetails, reportId ->
                         appGraph.showTechnicalErrorDialog(
+                            source = "account_deletion",
                             reportId = reportId,
                             title = technicalErrorDialogTitle,
                             message = technicalErrorDialogMessage,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -105,6 +105,7 @@ sealed interface AppStartupState {
 }
 
 private class AppTechnicalErrorDetailsException(
+    val source: String,
     technicalDetails: String
 ) : IllegalStateException(technicalDetails)
 
@@ -494,6 +495,7 @@ class AppGraph(
     }
 
     fun showTechnicalErrorDialog(
+        source: String,
         reportId: String,
         title: String,
         message: String,
@@ -506,7 +508,10 @@ class AppGraph(
                 message = message,
                 technicalDetails = technicalDetails
             ),
-            throwable = AppTechnicalErrorDetailsException(technicalDetails = technicalDetails)
+            throwable = AppTechnicalErrorDetailsException(
+                source = source,
+                technicalDetails = technicalDetails
+            )
         )
     }
 
@@ -526,9 +531,12 @@ class AppGraph(
     }
 
     private fun captureTechnicalErrorDialogException(throwable: Throwable) {
+        val source = (throwable as? AppTechnicalErrorDetailsException)?.source ?: "unknown"
         observability.captureException(
             event = AndroidExceptionIssueEvent.AppTechnicalErrorDialogException(
                 throwable = throwable,
+                source = source,
+                detail = throwable.message,
                 appVersion = appPackageInfo.versionName,
                 clientVersion = appPackageInfo.versionName,
                 versionCode = appPackageInfo.longVersionCode.toInt()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -79,6 +79,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                 },
                 onShowTechnicalDetails = { technicalDetails, reportId ->
                     appGraph.showTechnicalErrorDialog(
+                        source = "sign_in_email",
                         reportId = reportId,
                         title = technicalErrorDialogTitle,
                         message = technicalErrorDialogMessage,
@@ -125,6 +126,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                 },
                 onShowTechnicalDetails = { technicalDetails, reportId ->
                     appGraph.showTechnicalErrorDialog(
+                        source = "sign_in_code",
                         reportId = reportId,
                         title = technicalErrorDialogTitle,
                         message = technicalErrorDialogMessage,
@@ -192,6 +194,7 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                 },
                 onShowTechnicalDetails = { technicalDetails, reportId ->
                     appGraph.showTechnicalErrorDialog(
+                        source = "sign_in_post_auth",
                         reportId = reportId,
                         title = technicalErrorDialogTitle,
                         message = technicalErrorDialogMessage,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
@@ -178,6 +178,7 @@ internal fun NavGraphBuilder.registerSettingsAccountNavGraph(
             },
             onShowTechnicalDetails = { technicalDetails, reportId ->
                 appGraph.showTechnicalErrorDialog(
+                    source = "account_danger_zone",
                     reportId = reportId,
                     title = technicalErrorDialogTitle,
                     message = technicalErrorDialogMessage,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
@@ -250,7 +250,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ai = null,
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.HttpUnexpectedClientError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -266,7 +267,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ai = null,
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.AiRemoteError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -300,7 +302,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.AiLifecycleWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -333,7 +336,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.AiSendWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -366,7 +370,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.AiBootstrapWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -399,7 +404,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.ProgressRefreshWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -413,7 +419,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.ProgressRepositoryWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -427,7 +434,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.AiRuntimeWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -460,7 +468,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidWarningIssueEvent.NotificationSchedulingWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -472,7 +481,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 diagnostic = event.diagnostic,
                 warningReason = event.warningReason
             ),
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
     }
 }
@@ -486,7 +496,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ai = null,
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.AppStartupException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -495,7 +506,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ai = null,
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.AppTechnicalErrorDialogException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -504,7 +516,11 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ai = null,
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = SentryTechnicalErrorContext(
+                source = sanitizeSentryContextValue(fieldName = "source", value = event.source),
+                detail = sanitizeSentryContextValue(fieldName = "detail", value = event.detail)
+            )
         )
         is AndroidExceptionIssueEvent.AiStreamCrash -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -537,7 +553,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.AiLifecycleError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -570,7 +587,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.AiSendError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -603,7 +621,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.AiBootstrapError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -636,7 +655,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.ProgressRefreshException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -650,7 +670,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.ProgressRepositoryException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -664,7 +685,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.AiRuntimeException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -697,7 +719,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ),
             progress = null,
             notifications = null,
-            feedback = null
+            feedback = null,
+            technicalError = null
         )
         is AndroidExceptionIssueEvent.FeedbackPromptException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -706,7 +729,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             ai = null,
             progress = null,
             notifications = null,
-            feedback = feedbackPromptContext(event = event)
+            feedback = feedbackPromptContext(event = event),
+            technicalError = null
         )
     }
 }
@@ -893,6 +917,12 @@ internal fun exceptionIssueFingerprint(event: AndroidExceptionIssueEvent): List<
             sanitizeSentryTagValue(fieldName = "promptAction", value = event.promptAction.tagValue)
                 ?: "no_prompt_action"
         )
+        is AndroidExceptionIssueEvent.AppTechnicalErrorDialogException -> listOf(
+            "android",
+            event.feature.tagValue,
+            event.action.tagValue,
+            sanitizeSentryTagValue(fieldName = "source", value = event.source) ?: "no_source"
+        )
         else -> null
     }
 }
@@ -944,7 +974,8 @@ private data class SentryAndroidObservationContext(
     val ai: SentryAiContext?,
     val progress: SentryProgressContext?,
     val notifications: SentryNotificationSchedulingContext?,
-    val feedback: SentryFeedbackContext?
+    val feedback: SentryFeedbackContext?,
+    val technicalError: SentryTechnicalErrorContext?
 )
 
 private data class SentryHttpContext(
@@ -992,6 +1023,11 @@ private data class SentryProgressContext(
 internal data class SentryFeedbackContext(
     val promptAction: String?,
     val trigger: String?
+)
+
+internal data class SentryTechnicalErrorContext(
+    val source: String?,
+    val detail: String?
 )
 
 private data class SentryNotificationSchedulingContext(

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
@@ -595,6 +595,8 @@ sealed interface AndroidExceptionIssueEvent : AndroidObservationEvent {
 
     data class AppTechnicalErrorDialogException(
         override val throwable: Throwable,
+        val source: String,
+        val detail: String?,
         val appVersion: String?,
         val clientVersion: String?,
         val versionCode: Int?
@@ -606,7 +608,7 @@ sealed interface AndroidExceptionIssueEvent : AndroidObservationEvent {
             workspaceId = null,
             requestId = null,
             statusCode = null,
-            code = null,
+            code = source,
             appVersion = appVersion,
             clientVersion = clientVersion,
             versionCode = versionCode


### PR DESCRIPTION
## What

Technical-error reports from the Android app (`AppTechnicalErrorDialogException`) previously landed in Sentry as an undifferentiated black hole: no diagnostic context and no per-error grouping, so distinct technical failures collapsed into one unactionable issue.

This change:

- Carries the non-PII `source` plus a sanitized error type/detail into a dedicated `technicalError` Sentry context.
- Fingerprints the `AppTechnicalErrorDialogException` channel so distinct technical errors group separately in Sentry instead of merging.

## Why

Without diagnostic fields and stable fingerprinting, technical errors were effectively invisible/unactionable in Sentry. This restores diagnosability and correct grouping.

## Safety

The user-facing error message stays redacted; only the sanitized source and error type/detail are attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)