### PR TITLE
Web: add breadcrumb for tolerated-slow hot bootstraps

### DIFF
--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
@@ -164,6 +164,35 @@ export function observeSlowHotBootstrap(input: HotBootstrapSlowObservationInput)
   });
 }
 
+// Tolerated-slow single-page bootstrap: slow enough to be worth recording (>= the
+// breadcrumb floor) but below the warning threshold. Mirrors observeSlowHotBootstrap
+// but emits a silent breadcrumb (no Sentry issue) so we keep "what was slow before this
+// failure" context without raising noise. The warning path stays mutually exclusive (see
+// bootstrapHotState).
+export function observeToleratedSlowHotBootstrap(input: HotBootstrapSlowObservationInput): void {
+  addWebBreadcrumb({
+    action: "sync_hot_bootstrap_tolerated_slow",
+    scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
+    details: {
+      eventName: "sync_hot_bootstrap_tolerated_slow",
+      syncRunId: input.syncRunId,
+      workspaceId: input.workspaceId,
+      installationId: input.installationId,
+      durationMs: input.durationMs,
+      pageSize: input.pageSize,
+      pageCount: input.pageCount,
+      entriesCount: input.entriesCount,
+      localCardCountBefore: input.localCardCountBefore,
+      localCardCountAfter: input.localCardCountAfter,
+      localBootstrapState: input.localBootstrapState,
+      lastAppliedHotChangeIdBefore: input.lastAppliedHotChangeIdBefore,
+      nextHotChangeId: input.nextHotChangeId,
+      remoteIsEmpty: input.remoteIsEmpty,
+      ...buildSyncBootstrapTimingDetails(input),
+    },
+  });
+}
+
 // Expected, self-healing condition: the browser evicted the best-effort local
 // IndexedDB cache and we are about to transparently re-hydrate from the backend
 // (the source of truth). Emitted as a silent breadcrumb, not a warning, so it never

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -19,6 +19,7 @@ import {
   observeLocalDbRecoverySucceeded,
   observePersistentStorageState,
   observeSlowHotBootstrap,
+  observeToleratedSlowHotBootstrap,
 } from "../observation/syncLifecycleObservation";
 import {
   loadSyncRestoreHistoryEntry,
@@ -26,6 +27,7 @@ import {
   type SyncRestoreHistoryEntry,
 } from "../restore/syncRestoreHistory";
 import {
+  slowHotBootstrapBreadcrumbThresholdMs,
   slowHotBootstrapWarningThresholdMs,
   syncBootstrapPageSize,
 } from "./constants";
@@ -71,6 +73,26 @@ function shouldObserveHotBootstrap(input: Readonly<{
   }
 
   return input.durationMs >= slowHotBootstrapWarningThresholdMs || input.pageCount > 1;
+}
+
+// Tolerated-slow band: a single-page, non-empty bootstrap that is slow enough to record
+// (>= the breadcrumb floor) but below the warning threshold. The warning gate
+// (shouldObserveHotBootstrap) takes precedence, so this stays mutually exclusive with it:
+// the >=8000ms or multi-page case warns, this band only breadcrumbs.
+function shouldBreadcrumbSlowHotBootstrap(input: Readonly<{
+  durationMs: number;
+  pageCount: number;
+  entriesCount: number;
+  localCardCountAfter: number;
+  remoteIsEmpty: boolean | null;
+}>): boolean {
+  if (isEmptyRemoteBootstrapNoise(input.remoteIsEmpty, input.entriesCount, input.localCardCountAfter)) {
+    return false;
+  }
+
+  return input.pageCount === 1
+    && input.durationMs >= slowHotBootstrapBreadcrumbThresholdMs
+    && input.durationMs < slowHotBootstrapWarningThresholdMs;
 }
 
 function determineLocalBootstrapState(
@@ -319,17 +341,15 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     }
 
     recoveryFailurePhase = "slow_bootstrap_observation";
-    if (
-      isLocalDbRecovery === false
-      && shouldObserveHotBootstrap({
+    if (isLocalDbRecovery === false) {
+      const slowBootstrapObservation = {
         durationMs,
         pageCount,
         entriesCount,
         localCardCountAfter,
         remoteIsEmpty,
-      })
-    ) {
-      observeSlowHotBootstrap({
+      };
+      const slowHotBootstrapDetails = {
         userId: input.userId,
         workspaceId: input.workspaceId,
         installationId: input.installationId,
@@ -345,7 +365,15 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         nextHotChangeId,
         remoteIsEmpty,
         ...readBootstrapTimingDetails(),
-      });
+      };
+      // Warning wins: the >=8000ms or multi-page case raises a Sentry issue; the
+      // tolerated-slow single-page band only adds a silent breadcrumb. The two predicates
+      // never overlap, so at most one fires.
+      if (shouldObserveHotBootstrap(slowBootstrapObservation)) {
+        observeSlowHotBootstrap(slowHotBootstrapDetails);
+      } else if (shouldBreadcrumbSlowHotBootstrap(slowBootstrapObservation)) {
+        observeToleratedSlowHotBootstrap(slowHotBootstrapDetails);
+      }
     }
 
     return {

--- a/apps/web/src/appData/sync/remote/constants.ts
+++ b/apps/web/src/appData/sync/remote/constants.ts
@@ -2,3 +2,5 @@ export const syncIncrementalPageSize = 500;
 export const syncBootstrapPageSize = 1000;
 // Normal cold-start fresh single-page bootstraps run ~6.5s (server/network latency), which is expected; multi-page bootstraps still warn via pageCount > 1.
 export const slowHotBootstrapWarningThresholdMs = 8000;
+// Floor for the tolerated-slow breadcrumb: single-page bootstraps in the 2–8s band emit a silent breadcrumb (no Sentry issue) for debugging context, staying below the 8000ms warning threshold.
+export const slowHotBootstrapBreadcrumbThresholdMs = 2000;

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -230,6 +230,11 @@ export type WebBreadcrumbEvent =
     details: SyncLocalDbRecoverySucceededBreadcrumbDetails;
   }>
   | Readonly<{
+    action: "sync_hot_bootstrap_tolerated_slow";
+    scope: WebObservationScope;
+    details: SyncRestoreToleratedSlowBreadcrumbDetails;
+  }>
+  | Readonly<{
     action: "stale_bundle_reload";
     scope: WebObservationScope;
     details: StaleBundleReloadBreadcrumbDetails;
@@ -478,6 +483,28 @@ export type SyncBootstrapTimingDetails = Readonly<{
 
 export type SyncRestoreWarningDetails = SyncBootstrapTimingDetails & Readonly<{
   eventName: "sync_hot_bootstrap_slow";
+  syncRunId: string;
+  workspaceId: string;
+  installationId: string;
+  durationMs: number;
+  pageSize: number;
+  pageCount: number;
+  entriesCount: number;
+  localCardCountBefore: number;
+  localCardCountAfter: number;
+  localBootstrapState: SyncRestoreLocalBootstrapState;
+  lastAppliedHotChangeIdBefore: number | null;
+  nextHotChangeId: number | null;
+  remoteIsEmpty: boolean | null;
+}>;
+
+// Single-page bootstraps slow enough to be interesting (>= the breadcrumb floor)
+// but below the warning threshold are a tolerated, expected condition (server/network
+// latency), so they are emitted as a silent breadcrumb for debugging context — never a
+// warning. The >= warning-threshold or multi-page case stays a warning (see
+// SyncRestoreWarningDetails); the two are mutually exclusive.
+export type SyncRestoreToleratedSlowBreadcrumbDetails = SyncBootstrapTimingDetails & Readonly<{
+  eventName: "sync_hot_bootstrap_tolerated_slow";
   syncRunId: string;
   workspaceId: string;
   installationId: string;


### PR DESCRIPTION
## What

Adds a silent breadcrumb for single-page, non-recovery hot bootstraps that fall in the tolerated-slow band (>= 2000ms and < the 8000ms warning threshold).

## Why

After the slow-hot-bootstrap warning threshold was raised to 8000ms, we lose all signal in the 2-8s band. This change emits a breadcrumb (no Sentry issue) for single-page non-recovery bootstraps in that band so we keep "what was slow right before this failure" debugging context without adding warning noise.

The new `observeToleratedSlowHotBootstrap` mirrors `observeSlowHotBootstrap` but uses `addWebBreadcrumb` instead of `captureWebWarning`, matching the existing breadcrumb-vs-warning idiom already used by the local-DB missing/recovered observers. The new `shouldBreadcrumbSlowHotBootstrap` gate is mutually exclusive with the warning gate `shouldObserveHotBootstrap`: the warning path wins (>=8000ms or multi-page raises an issue), and the breadcrumb only fires for the single-page 2-8s band, so at most one of the two ever fires. Empty-remote bootstrap noise is excluded from both.

## Changes

- `constants.ts`: add `slowHotBootstrapBreadcrumbThresholdMs = 2000` (the breadcrumb floor).
- `syncLifecycleObservation.ts`: add `observeToleratedSlowHotBootstrap` (silent breadcrumb).
- `bootstrapHotState.ts`: add `shouldBreadcrumbSlowHotBootstrap` and wire the warning-vs-breadcrumb branch.
- `webObservability.ts`: add the `sync_hot_bootstrap_tolerated_slow` breadcrumb event + `SyncRestoreToleratedSlowBreadcrumbDetails`.

## Validation

- `npx tsc -b` (apps/web): passes.
- `npx vitest run src/appData/sync/observation/syncLifecycleObservation.test.ts`: 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)