### PR TITLE
iOS: report only fully-blocking app hangs

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/SentryConfiguration.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryConfiguration.swift
@@ -38,6 +38,12 @@ extension SentryObservabilityAdapter {
             options.releaseName = "\(configuration.bundleIdentifier)@\(configuration.marketingVersion)"
             options.dist = configuration.buildNumber
             options.environment = configuration.environment
+            // Report only fully-blocking app hangs. Non-fully-blocking "partial" hangs are
+            // dominated by throttled / low-memory / Low Power Mode device conditions and are not
+            // individually actionable (e.g. Sentry FLASHCARDS-IOS-40). Overall app-hang tracking
+            // stays on (SDK default) so genuine fully-blocking freezes are still captured.
+            options.enableReportNonFullyBlockingAppHangs = false
+            options.appHangTimeoutInterval = 3.0
             options.sampleRate = NSNumber(value: 1.0)
             options.tracesSampleRate = NSNumber(value: configuration.tracesSampleRate)
             options.sendDefaultPii = false


### PR DESCRIPTION
## What

Configure the iOS Sentry SDK to report only fully-blocking app hangs:
- `enableReportNonFullyBlockingAppHangs = false`
- `appHangTimeoutInterval = 3.0` (explicit, raised from the 2.0s default)

## Why

App Hang "Non Fully Blocked" reports (e.g. Sentry `FLASHCARDS-IOS-40`) carry no app frames and fire on throttled / low-memory / Low Power Mode devices; they are not individually actionable. Overall app-hang tracking stays on (SDK default) so genuine fully-blocking freezes are still captured.

Verified against sentry-cocoa 9.18.0 — these options exist; there is no `enableAppHangTrackingV2` in this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)