### PR TITLE
fix(chat): reserve output budget and retry context overflow on every model call

### DIFF
--- a/apps/backend/src/chat/config.ts
+++ b/apps/backend/src/chat/config.ts
@@ -37,6 +37,28 @@ export const CHAT_HISTORY_REPLAY_TOKEN_BUDGET = 110_000 as const;
  */
 export const CHAT_MODEL_CONTEXT_WINDOW_TOKENS = 272_000 as const;
 
+/**
+ * Output headroom reserved on every model call via `max_output_tokens`.
+ *
+ * In the Responses API this cap covers reasoning tokens plus visible output
+ * combined. With `medium` reasoning effort a long multi-tool turn can spend
+ * tens of thousands of tokens on reasoning before any answer text streams, so
+ * the cap is sized to stay comfortably above that worst-case reasoning budget.
+ * If it fires, it should only ever fire after a substantial visible answer has
+ * already streamed, which the loop then finishes gracefully with the partial
+ * text instead of hard-failing the turn.
+ *
+ * `CHAT_HISTORY_REPLAY_TOKEN_BUDGET + CHAT_MAX_OUTPUT_TOKENS` (110K + 32K = 142K)
+ * stays well under `CHAT_MODEL_CONTEXT_WINDOW_TOKENS` (272K), so the input plus
+ * reserved output always fits the window with room to spare. Reserving output
+ * headroom turns oversized input into a fast, deterministic pre-flight
+ * `context_length_exceeded` rejection instead of a mid-generation failure ~30s
+ * in, and bounds within-run growth against the remaining window so the loop
+ * diverts into the summary turn before base input + continuation + reserved
+ * output can exceed the window.
+ */
+export const CHAT_MAX_OUTPUT_TOKENS = 32_000 as const;
+
 export type ChatRuntimeModelId =
   | typeof CHAT_MODEL_ID
   | typeof CHAT_LOW_COST_MODEL_ID;

--- a/apps/backend/src/chat/openai/loop/loop.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.test.ts
@@ -8,6 +8,7 @@ import {
   type StartOpenAILoopParams,
 } from "./loop";
 import { buildOpenAISafetyIdentifier } from "../safetyIdentifier";
+import { CHAT_MAX_OUTPUT_TOKENS } from "../../config";
 
 type OpenAILoopDependencies = Parameters<typeof startOpenAILoopWithDeps>[2];
 type OpenAIResponseStream = AsyncIterable<OpenAI.Responses.ResponseStreamEvent> & Readonly<{
@@ -184,6 +185,20 @@ function createResponseErrorEvent(
   };
 }
 
+function createContextLengthExceededError(): Error {
+  return Object.assign(new Error("input exceeds the context window"), {
+    code: "context_length_exceeded",
+  });
+}
+
+function createContextLengthExceededStream(): OpenAIResponseStream {
+  return {
+    async *[Symbol.asyncIterator](): AsyncGenerator<OpenAI.Responses.ResponseStreamEvent> {
+      throw createContextLengthExceededError();
+    },
+  };
+}
+
 function createTerminalEventStream(
   event: OpenAI.Responses.ResponseStreamEvent,
 ): OpenAIResponseStream {
@@ -198,6 +213,45 @@ function createStreamWithoutCompletedResponse(): OpenAIResponseStream {
   return {
     async *[Symbol.asyncIterator](): AsyncGenerator<OpenAI.Responses.ResponseStreamEvent> {
       yield createOutputTextDeltaEvent("partial");
+    },
+  };
+}
+
+function createPartialThenIncompleteStream(
+  text: string,
+  reason: "max_output_tokens" | "content_filter",
+): OpenAIResponseStream {
+  return {
+    async *[Symbol.asyncIterator](): AsyncGenerator<OpenAI.Responses.ResponseStreamEvent> {
+      yield createOutputTextDeltaEvent(text);
+      yield createResponseIncompleteEvent(reason);
+    },
+  };
+}
+
+function createMaxOutputTokensIncompleteEventWithFunctionCall(
+  outputText: string,
+  functionCallItem: OpenAI.Responses.ResponseFunctionToolCall,
+): OpenAI.Responses.ResponseIncompleteEvent {
+  return {
+    type: "response.incomplete",
+    sequence_number: 1,
+    response: {
+      ...createResponse([functionCallItem], outputText),
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+    },
+  } as OpenAI.Responses.ResponseIncompleteEvent;
+}
+
+function createPartialThenIncompleteWithFunctionCallStream(
+  text: string,
+  functionCallItem: OpenAI.Responses.ResponseFunctionToolCall,
+): OpenAIResponseStream {
+  return {
+    async *[Symbol.asyncIterator](): AsyncGenerator<OpenAI.Responses.ResponseStreamEvent> {
+      yield createOutputTextDeltaEvent(text);
+      yield createMaxOutputTokensIncompleteEventWithFunctionCall(text, functionCallItem);
     },
   };
 }
@@ -305,6 +359,7 @@ test("startOpenAILoopWithDeps sends a hashed safety identifier on the initial mo
   assert.equal(requests.length, 1);
   assert.equal(requests[0].safety_identifier, buildOpenAISafetyIdentifier("user-1"));
   assert.equal(requests[0].prompt_cache_key, "session-1");
+  assert.equal(requests[0].max_output_tokens, CHAT_MAX_OUTPUT_TOKENS);
   assert.equal(Object.hasOwn(requests[0], "user"), false);
 });
 
@@ -829,14 +884,78 @@ test("startOpenAILoopWithDeps fails with a classified terminal error on response
   );
 });
 
-test("startOpenAILoopWithDeps fails with a classified terminal error on response.incomplete", async () => {
+test("startOpenAILoopWithDeps finishes gracefully with partial text on a max_output_tokens incomplete response", async () => {
+  const { sink, events } = collectEvents();
+
+  const result = await startOpenAILoopWithDeps(
+    createParams(),
+    sink,
+    createDependencies(
+      () => createPartialThenIncompleteStream("partial answer", "max_output_tokens"),
+      async () => {
+        throw new Error("runOneToolCall should not be called");
+      },
+    ),
+  );
+
+  assert.equal(result.terminationReason, "completed");
+  assert.deepEqual(events, [
+    {
+      type: "delta",
+      text: "partial answer",
+      itemId: "message-1",
+      responseIndex: 0,
+      outputIndex: 0,
+      contentIndex: 0,
+      sequenceNumber: 1,
+    },
+    { type: "done" },
+  ]);
+});
+
+test("startOpenAILoopWithDeps finishes with partial text and skips the tool call when a max_output_tokens response also carries a function call", async () => {
+  let toolCallCount = 0;
+  const { sink, events } = collectEvents();
+
+  const result = await startOpenAILoopWithDeps(
+    createParams(),
+    sink,
+    createDependencies(
+      () => createPartialThenIncompleteWithFunctionCallStream(
+        "partial answer",
+        createFunctionCallItem("completed"),
+      ),
+      async () => {
+        toolCallCount += 1;
+        return {
+          output: "{\"ok\":true}",
+          isMutating: false,
+          succeeded: true,
+        };
+      },
+    ),
+  );
+
+  assert.equal(toolCallCount, 0);
+  assert.equal(result.terminationReason, "completed");
+  assert.deepEqual(events.at(-1), { type: "done" });
+  // The truncated function_call must not be persisted: replaying an orphan
+  // function_call without a paired function_call_output makes the OpenAI
+  // Responses API reject every later turn in the session.
+  const unpairedFunctionCalls = result.openaiItems.filter(
+    (item) => item.type === "function_call",
+  );
+  assert.equal(unpairedFunctionCalls.length, 0);
+});
+
+test("startOpenAILoopWithDeps fails with a classified terminal error on a content_filter incomplete response", async () => {
   await assert.rejects(
     startOpenAILoopWithDeps(
       createParams(),
       async (): Promise<void> => undefined,
       createDependencies(
         () => createTerminalEventStream(
-          createResponseIncompleteEvent("max_output_tokens"),
+          createResponseIncompleteEvent("content_filter"),
         ),
         async () => {
           throw new Error("runOneToolCall should not be called");
@@ -846,7 +965,7 @@ test("startOpenAILoopWithDeps fails with a classified terminal error on response
     (error: unknown): boolean => {
       assert(error instanceof Error);
       assert.equal(error.name, "ChatProviderTerminalEventError");
-      assert.equal((error as { code?: string }).code, "max_output_tokens");
+      assert.equal((error as { code?: string }).code, "content_filter");
       return true;
     },
   );
@@ -918,4 +1037,81 @@ test("startOpenAILoopWithDeps completes normally when no stop is requested", asy
   assert.equal(streamCallCount, 1);
   assert.equal(result.terminationReason, "completed");
   assert.deepEqual(events, [{ type: "done" }]);
+});
+
+test("startOpenAILoopWithDeps retries a callIndex > 1 overflow once with the reduced history budget then succeeds", async () => {
+  let streamCallCount = 0;
+  let toolCallCount = 0;
+  let reducedBudgetRebuilds = 0;
+  const startedFunctionCallItem = createFunctionCallItem("in_progress");
+  const completedFunctionCallItem = createFunctionCallItem("completed");
+  const messageItem = createAssistantMessageItem("recovered");
+  const { sink, events } = collectEvents();
+
+  const dependencies: OpenAILoopDependencies = {
+    buildChatCompletionInput: async () => [],
+    buildChatCompletionInputWithBudget: async () => {
+      reducedBudgetRebuilds += 1;
+      return [];
+    },
+    getObservedOpenAIClient: () => ({
+      responses: {
+        stream: () => {
+          streamCallCount += 1;
+          if (streamCallCount === 1) {
+            return createResponseStream(
+              [createFunctionCallAddedEvent(startedFunctionCallItem)],
+              createResponse([completedFunctionCallItem], ""),
+            );
+          }
+
+          if (streamCallCount === 2) {
+            return createContextLengthExceededStream();
+          }
+
+          return createResponseStream([], createResponse([messageItem], "recovered"));
+        },
+      },
+    } as unknown as OpenAI),
+    runOneToolCall: async () => {
+      toolCallCount += 1;
+      return {
+        output: "{\"ok\":true}",
+        isMutating: false,
+        succeeded: true,
+      };
+    },
+  };
+
+  const result = await startOpenAILoopWithDeps(createParams(), sink, dependencies);
+
+  assert.equal(streamCallCount, 3);
+  assert.equal(toolCallCount, 1);
+  assert.equal(reducedBudgetRebuilds, 1);
+  assert.equal(result.terminationReason, "completed");
+  assert.deepEqual(events.at(-1), { type: "done" });
+  assert.deepEqual(result.openaiItems, [
+    {
+      type: "function_call",
+      call_id: "call-1",
+      name: "sql",
+      arguments: "{\"sql\":\"select 1\"}",
+      status: "completed",
+    },
+    {
+      type: "function_call_output",
+      call_id: "call-1",
+      output: "{\"ok\":true}",
+    },
+    {
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      content: [{
+        type: "output_text",
+        text: "recovered",
+        annotations: [],
+      }],
+    },
+  ]);
 });

--- a/apps/backend/src/chat/openai/loop/loop.ts
+++ b/apps/backend/src/chat/openai/loop/loop.ts
@@ -37,6 +37,7 @@ import type { ChatStreamEvent, ContentPart } from "../../types";
 import { createProviderTerminalEventError } from "../../providerFailure";
 import {
   CHAT_HISTORY_REPLAY_TOKEN_BUDGET,
+  CHAT_MAX_OUTPUT_TOKENS,
   CHAT_MODEL_CONTEXT_WINDOW_TOKENS,
   CHAT_MODEL_REASONING_SUMMARY,
   type ChatRuntimeModelId,
@@ -51,11 +52,15 @@ const TOOL_LIMIT_FALLBACK_ITEM_ID = "tool-limit-summary";
  * Maximum estimated tokens of within-run continuation growth (model output plus
  * tool-call replay items accumulated across tool rounds) before the loop diverts
  * into the tool-limit summary turn instead of scheduling another tool-enabled
- * call. Reserves the history-replay budget for the base input so the full
- * `base input + continuation` stays under the model context window even when the
- * character-based estimate under-counts dense content.
+ * call. Reserves the history-replay budget for the base input and the
+ * `max_output_tokens` headroom for the response, so the loop diverts into the
+ * summary turn before `base input + continuation + reserved output` can exceed
+ * the model context window even when the character-based estimate under-counts
+ * dense content.
  */
-const MAX_WITHIN_RUN_REPLAY_TOKENS = CHAT_MODEL_CONTEXT_WINDOW_TOKENS - CHAT_HISTORY_REPLAY_TOKEN_BUDGET;
+const MAX_WITHIN_RUN_REPLAY_TOKENS = CHAT_MODEL_CONTEXT_WINDOW_TOKENS
+  - CHAT_HISTORY_REPLAY_TOKEN_BUDGET
+  - CHAT_MAX_OUTPUT_TOKENS;
 
 /**
  * Tighter history-replay budget used to rebuild the base input when the first
@@ -100,6 +105,7 @@ type OpenAIResponsesRequest = Readonly<{
   include: ["reasoning.encrypted_content"];
   tools: Array<OpenAI.Responses.Tool>;
   input: Array<OpenAI.Responses.ResponseInputItem>;
+  max_output_tokens: number;
   reasoning: Readonly<{
     effort: ChatRuntimeReasoningEffort;
     summary: typeof CHAT_MODEL_REASONING_SUMMARY;
@@ -141,6 +147,10 @@ type ModelCallResult = Readonly<{
   replayItems: ReadonlyArray<StoredOpenAIReplayItem>;
   streamedText: string;
   toolStates: ReturnType<typeof createToolCallStateMap>;
+  // True when the response was capped at `max_output_tokens` after streaming a
+  // partial answer. The loop must finish with that partial text and never run
+  // any (possibly truncated) function call carried in the same output.
+  forceComplete: boolean;
 }>;
 
 function createToolCallPosition(
@@ -313,6 +323,42 @@ function buildToolLimitFallbackText(): string {
   return `I reached the tool-call limit for this turn (${String(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)}). Send another message such as continue and I will resume from the same chat session.`;
 }
 
+/**
+ * Drops the replay items that a `max_output_tokens`-capped response cannot persist
+ * safely alongside its partial streamed answer.
+ *
+ * The loop finishes with the partial text and never executes the truncated
+ * `function_call` items, so persisting them would leave orphan `function_call`
+ * items with no paired `function_call_output`. Dropping a trailing `function_call`
+ * can in turn orphan a `reasoning` item that immediately preceded it: a reasoning
+ * item replayed with no following same-turn output item is the same orphan class
+ * and the Responses API rejects it on the next turn. So a `reasoning` item is kept
+ * only when a later item in the same response output survives this filter; trailing
+ * reasoning items left unpaired by the dropped calls are dropped too. The
+ * user-visible answer is preserved via the streamed deltas regardless.
+ */
+function dropUnpairedFunctionCalls(
+  items: ReadonlyArray<StoredOpenAIReplayItem>,
+): ReadonlyArray<StoredOpenAIReplayItem> {
+  const withoutFunctionCalls = items.filter((item) => item.type !== "function_call");
+  const kept: Array<StoredOpenAIReplayItem> = [];
+
+  // Walk from the end so a `reasoning` item is kept only when a later item that
+  // survives the function-call drop follows it in the same response output.
+  let hasFollowingKeptItem = false;
+  for (let index = withoutFunctionCalls.length - 1; index >= 0; index -= 1) {
+    const item = withoutFunctionCalls[index];
+    if (item.type === "reasoning" && !hasFollowingKeptItem) {
+      continue;
+    }
+
+    kept.push(item);
+    hasFollowingKeptItem = true;
+  }
+
+  return kept.reverse();
+}
+
 function createAssistantReplayMessage(text: string): StoredOpenAIReplayMessage {
   return {
     type: "message",
@@ -373,6 +419,7 @@ function buildOpenAIResponsesRequest(params: BuildOpenAIResponsesRequestParams):
     include: ["reasoning.encrypted_content"],
     tools: [...params.tools],
     input: buildOpenAIInput(params.baseInput, params.continuationItems, params.extraInput),
+    max_output_tokens: CHAT_MAX_OUTPUT_TOKENS,
     reasoning: {
       effort: params.reasoningEffort,
       summary: CHAT_MODEL_REASONING_SUMMARY,
@@ -422,6 +469,7 @@ async function runOneModelCall(
   let toolStates = createToolCallStateMap();
   let completedResponse: OpenAI.Responses.Response | null = null;
   let streamedText = "";
+  let forceComplete = false;
 
   for await (const event of stream) {
     if (isResponseCompletedEvent(event)) {
@@ -437,6 +485,24 @@ async function runOneModelCall(
     }
 
     if (isResponseIncompleteEvent(event)) {
+      // A `max_output_tokens` incomplete response means the model hit the
+      // reserved output cap after streaming a partial answer. Treat it as a
+      // normal completion so the loop returns the partial text and emits `done`
+      // instead of failing the run, and mark it `forceComplete` so the loop
+      // finishes with that partial text and never runs a truncated function
+      // call that may also appear in the capped output. All other incomplete
+      // reasons (e.g. `content_filter`) still throw. An empty partial answer is
+      // never returned silently: it falls through to the stream-without-response
+      // throw below.
+      if (
+        event.response.incomplete_details?.reason === "max_output_tokens"
+        && streamedText.length > 0
+      ) {
+        completedResponse = event.response;
+        forceComplete = true;
+        continue;
+      }
+
       throw createProviderTerminalEventError({
         code: event.response.incomplete_details?.reason ?? null,
         message: null,
@@ -562,6 +628,7 @@ async function runOneModelCall(
     replayItems: finalResponse.output.map(toStoredOpenAIReplayItem),
     streamedText,
     toolStates,
+    forceComplete,
   };
 }
 
@@ -587,6 +654,7 @@ async function runOneModelCallWithPhase(
 async function completeToolLimitSummaryTurn(
   params: StartOpenAILoopParams,
   onEvent: OpenAILoopEventSink,
+  dependencies: OpenAILoopDependencies,
   client: OpenAI,
   baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
   continuationItems: Array<StoredOpenAIReplayItem>,
@@ -594,12 +662,14 @@ async function completeToolLimitSummaryTurn(
   const summaryCallIndex = CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1;
   let summaryCall: ModelCallResult;
   try {
-    summaryCall = await runOneModelCallWithPhase(
+    const call = await runModelCallWithOverflowRetry(
       client,
       params,
       onEvent,
-      buildOpenAIResponsesRequest({
-        baseInput,
+      dependencies,
+      baseInput,
+      (input) => buildOpenAIResponsesRequest({
+        baseInput: input,
         continuationItems,
         userId: params.userId,
         sessionId: params.sessionId,
@@ -610,6 +680,7 @@ async function completeToolLimitSummaryTurn(
       }),
       summaryCallIndex,
     );
+    summaryCall = call.modelCall;
   } catch (error) {
     if (shouldStopForOpenAIAbort(params, error)) {
       return createStoppedBeforeNextStepCompletion(continuationItems);
@@ -623,8 +694,14 @@ async function completeToolLimitSummaryTurn(
     ? finalResponseText
     : summaryCall.streamedText.trim();
 
-  if (summaryCall.functionCalls.length === 0 && finalAssistantText.length > 0) {
-    continuationItems.push(...summaryCall.replayItems);
+  // A `max_output_tokens`-capped summary turn (`forceComplete`) keeps its
+  // partial answer even if the truncated output also carries a function call,
+  // so the user sees the real summary instead of the generic fallback text. The
+  // truncated call is dropped so it is never persisted as an orphan replay item.
+  if ((summaryCall.forceComplete || summaryCall.functionCalls.length === 0) && finalAssistantText.length > 0) {
+    continuationItems.push(...(summaryCall.forceComplete
+      ? dropUnpairedFunctionCalls(summaryCall.replayItems)
+      : summaryCall.replayItems));
     if (summaryCall.streamedText.length === 0) {
       await emitSyntheticAssistantDelta(onEvent, finalAssistantText, summaryCallIndex - 1);
     }
@@ -647,41 +724,35 @@ async function completeToolLimitSummaryTurn(
   };
 }
 
-type FirstModelCallResult = Readonly<{
+type ModelCallWithOverflowRetryResult = Readonly<{
   baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
   modelCall: ModelCallResult;
 }>;
 
+type BuildModelCallRequest = (
+  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
+) => OpenAIResponsesRequest;
+
 /**
- * Runs the very first model call of a run and, on a first-call
- * `context_length_exceeded` (nothing streamed yet), rebuilds the base input with
- * a tighter history-replay budget and retries exactly once. Any other failure,
- * or a second overflow, propagates to the existing graceful terminal handling.
+ * Runs exactly one model call and, on a `context_length_exceeded` overflow,
+ * rebuilds only the history base input with a tighter history-replay budget and
+ * retries the same call once. Any other failure, or a second overflow,
+ * propagates to the existing graceful terminal handling.
  *
- * The retry only fires before any tool output exists, so no streamed content or
- * accumulated continuation items can be lost.
+ * The retry only shrinks the replayed history: the caller's already-accumulated
+ * continuation items are carried by `buildRequest` and are never dropped. The
+ * returned `baseInput` is the input actually sent (reduced when the retry fired),
+ * so later calls reuse the smaller history.
  */
-async function runFirstModelCallWithOverflowRetry(
+async function runModelCallWithOverflowRetry(
   client: OpenAI,
   params: StartOpenAILoopParams,
   onEvent: OpenAILoopEventSink,
   dependencies: OpenAILoopDependencies,
   baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-  firstCallIndex: number,
-): Promise<FirstModelCallResult> {
-  const buildFirstCallRequest = (
-    input: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-  ): OpenAIResponsesRequest => buildOpenAIResponsesRequest({
-    baseInput: input,
-    continuationItems: [],
-    userId: params.userId,
-    sessionId: params.sessionId,
-    modelId: params.modelId,
-    reasoningEffort: params.reasoningEffort,
-    extraInput: [],
-    tools: OPENAI_CHAT_TOOLS,
-  });
-
+  buildRequest: BuildModelCallRequest,
+  callIndex: number,
+): Promise<ModelCallWithOverflowRetryResult> {
   try {
     return {
       baseInput,
@@ -689,8 +760,8 @@ async function runFirstModelCallWithOverflowRetry(
         client,
         params,
         onEvent,
-        buildFirstCallRequest(baseInput),
-        firstCallIndex,
+        buildRequest(baseInput),
+        callIndex,
       ),
     };
   } catch (error) {
@@ -710,8 +781,8 @@ async function runFirstModelCallWithOverflowRetry(
         client,
         params,
         onEvent,
-        buildFirstCallRequest(reducedBaseInput),
-        firstCallIndex,
+        buildRequest(reducedBaseInput),
+        callIndex,
       ),
     };
   }
@@ -737,41 +808,47 @@ async function runLoopWithDeps(
 
     let modelCall: ModelCallResult;
     try {
-      if (callIndex === 1) {
-        const firstCall = await runFirstModelCallWithOverflowRetry(
-          client,
-          params,
-          onEvent,
-          dependencies,
-          baseInput,
-          callIndex,
-        );
-        baseInput = firstCall.baseInput;
-        modelCall = firstCall.modelCall;
-      } else {
-        modelCall = await runOneModelCallWithPhase(
-          client,
-          params,
-          onEvent,
-          buildOpenAIResponsesRequest({
-            baseInput,
-            continuationItems,
-            userId: params.userId,
-            sessionId: params.sessionId,
-            modelId: params.modelId,
-            reasoningEffort: params.reasoningEffort,
-            extraInput: [],
-            tools: OPENAI_CHAT_TOOLS,
-          }),
-          callIndex,
-        );
-      }
+      const call = await runModelCallWithOverflowRetry(
+        client,
+        params,
+        onEvent,
+        dependencies,
+        baseInput,
+        (input) => buildOpenAIResponsesRequest({
+          baseInput: input,
+          continuationItems,
+          userId: params.userId,
+          sessionId: params.sessionId,
+          modelId: params.modelId,
+          reasoningEffort: params.reasoningEffort,
+          extraInput: [],
+          tools: OPENAI_CHAT_TOOLS,
+        }),
+        callIndex,
+      );
+      baseInput = call.baseInput;
+      modelCall = call.modelCall;
     } catch (error) {
       if (shouldStopForOpenAIAbort(params, error)) {
         return createStoppedBeforeNextStepCompletion(continuationItems);
       }
 
       throw error;
+    }
+
+    // `forceComplete` wins over any function call: a `max_output_tokens`-capped
+    // response may carry a truncated function_call alongside the partial answer,
+    // and the loop must finish with that partial text instead of executing it.
+    // That unexecuted call, plus any reasoning item it orphans, is dropped here
+    // so neither is persisted as an unpaired replay item that the Responses API
+    // would reject on a later turn.
+    if (modelCall.forceComplete) {
+      continuationItems.push(...dropUnpairedFunctionCalls(modelCall.replayItems));
+      await onEvent({ type: "done" });
+      return {
+        openaiItems: continuationItems,
+        terminationReason: "completed",
+      };
     }
 
     continuationItems.push(...modelCall.replayItems);
@@ -837,6 +914,7 @@ async function runLoopWithDeps(
       return completeToolLimitSummaryTurn(
         params,
         onEvent,
+        dependencies,
         client,
         baseInput,
         continuationItems,


### PR DESCRIPTION
## Problem

Long multi-tool chat turns could fail mid-generation with a context overflow ~30s in, or loop into context_length_exceeded states, because output headroom was never reserved on Responses API calls and the context-overflow retry only fired on the very first model call.

## What this change does

- Reserves a 32K `max_output_tokens` headroom (`CHAT_MAX_OUTPUT_TOKENS`) on every model call and subtracts it from the within-run replay budget, so `base input + continuation + reserved output` always fits the 272K context window. Oversized input now fails fast as a deterministic pre-flight `context_length_exceeded` rejection instead of a mid-generation failure.
- Generalizes the first-call `context_length_exceeded` retry (`runModelCallWithOverflowRetry`) so it fires on every model call, including the tool-limit summary turn, rebuilding only the replayed history with a tighter budget and retrying once while preserving already-accumulated continuation items.
- Finishes gracefully with partial text on a `max_output_tokens` incomplete response (`forceComplete`), dropping the unpaired truncated `function_call` and any `reasoning` item it orphans so neither is persisted as a replay item the API would reject on a later turn.

## Validation

`npm test` in `apps/backend` — 513 passed, 0 failed (includes new tests covering the max_output_tokens incomplete path, the function-call drop, and the per-call overflow retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)