### PR TITLE
fix(chat): stop paging Sentry on expected context-length terminal runs

### DIFF
--- a/apps/backend/src/chat/runtime/lifecycleLogs.ts
+++ b/apps/backend/src/chat/runtime/lifecycleLogs.ts
@@ -8,6 +8,7 @@ import {
 } from "../worker/logging";
 import {
   createSafeProviderErrorDetails,
+  isContextLengthExceededError,
   isHandledProviderFailure,
 } from "./providerErrors";
 import type {
@@ -133,10 +134,15 @@ export function logTerminalStatePersisted(
     return;
   }
 
+  // Demote context_length_exceeded to a breadcrumb instead of a Sentry warning:
+  // it is an expected, user-actionable terminal already surfaced to the user with a
+  // clean "start a new chat" message, and the root cause is mitigated in the OpenAI loop,
+  // so it should not page as a warning. The payload (including providerErrorCode) is
+  // unchanged, so the event stays fully searchable in CloudWatch.
   logChatWorkerLifecycleEvent(
     "chat_worker_terminal_state_persisted",
     context,
     payload,
-    runStatus === "failed",
+    runStatus === "failed" && !isContextLengthExceededError(error),
   );
 }


### PR DESCRIPTION
## Problem

`context_length_exceeded` chat terminals were logged with the Sentry-warning flag set, paging on an expected, user-actionable condition. These runs are already surfaced to the user with a clean "start a new chat" message, and the root cause is mitigated in the OpenAI loop, so they should not raise a Sentry warning.

## What this changes

`logTerminalStatePersisted` in `apps/backend/src/chat/runtime/lifecycleLogs.ts` now demotes `context_length_exceeded` terminal runs to a breadcrumb (`runStatus === "failed" && !isContextLengthExceededError(error)`) instead of a warning. The structured payload (including `providerErrorCode`) is unchanged, so the events remain fully searchable in CloudWatch.

## Validation

Reviewed clean; `isContextLengthExceededError` is exported from `providerErrors.ts` and `error` is in scope in the function. CI runs the backend checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)