### PR TITLE
test(android): de-flake AI composer focus-tap instrumentation test

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -203,8 +203,7 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
             aiComposerFocusStateOrNull() == true
         )
 
-        composeRule.onNodeWithTag(aiConversationSurfaceTag).performClick()
-        waitUntilComposerIsNotFocused()
+        dismissComposerFocusBySurfaceTapAndWaitUntilNotFocused()
         assertTrue(
             "Expected tapping the AI conversation surface to clear the composer focus.",
             aiComposerFocusStateOrNull() == false
@@ -574,11 +573,27 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         }
     }
 
-    private fun waitUntilComposerIsNotFocused() {
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            countNodesWithTagInAnySemanticsTree(tag = aiComposerMessageFieldTag) > 0 &&
+    private fun dismissComposerFocusBySurfaceTapAndWaitUntilNotFocused() {
+        val deadlineMillis: Long = SystemClock.elapsedRealtime() + uiTimeoutMillis
+        while (SystemClock.elapsedRealtime() < deadlineMillis) {
+            try {
+                composeRule.onNodeWithTag(aiConversationSurfaceTag).performClick()
+            } catch (_: AssertionError) {
+                // performClick can fail to inject the tap while the soft-keyboard
+                // show/hide animation is still settling on slow managed devices
+                // ("Failed to inject touch input."); retry until the surface is stable.
+            }
+            composeRule.waitForIdle()
+            if (
+                countNodesWithTagInAnySemanticsTree(tag = aiComposerMessageFieldTag) > 0 &&
                 aiComposerFocusStateOrNull() == false
+            ) {
+                return
+            }
         }
+        throw AssertionError(
+            "Tapping the AI conversation surface did not clear the composer focus."
+        )
     }
 
     private fun waitForAiConversationReady() {


### PR DESCRIPTION
## Problem

Firebase Test Lab flagged 1 failed test case (matrix `matrix-2nbx1a8tsukys`): `aiConversationSurfaceTapClearsComposerFocus` in `MainActivityTest` failed with `java.lang.AssertionError: Failed to inject touch input.` on the `frankel` / API 36 managed device. The prior 3 FTL runs passed this test 74/74, and the failing run's commit (#802) is unrelated backend work — so this is a device-timing flake, not a regression.

## Root cause

The test focuses the AI composer (soft keyboard animates in), then taps the conversation surface to dismiss focus via a single `performClick()`. On the slow managed device the IME animation was still settling when the tap was injected (logcat: `ImeTracker … PHASE_CLIENT_ANIMATION_CANCEL STATUS_TIMEOUT` ×3, plus `Davey! duration=1572–1997ms` jank), so the platform rejected the `MotionEvent`.

The screen uses `windowSoftInputMode="adjustResize"` + `enableEdgeToEdge()`, the composer uses `imePadding()`, and the surface is `weight(1f)`, so the surface center stays visible above the keyboard. This is a transient injection race, not an off-screen target.

## Fix

Bound the existing `performClick()` in a short retry that re-checks composer focus after each attempt and throws a clear error if focus never clears. Uses only symbols already in the file (**no new imports**). Removes the now-unused `waitUntilComposerIsNotFocused()` helper it replaces.

## Validation

This `androidTest` code is not compiled locally (no local Gradle, per repo policy) and there is no pre-merge Android CI build, so the change is intentionally zero-new-import. It compiles in the post-merge `Android Release` (`:app:assembleDebugAndroidTest`) and is exercised by the Firebase Test Lab app instrumentation suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
