### PR TITLE
Stabilize web review loading preview

### DIFF
--- a/apps/web/src/screens/review/components/ReviewCardSide.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.tsx
@@ -17,11 +17,19 @@ export type ReviewCardSideProps = Readonly<{
   showAiButton: boolean;
   showSpeechButton: boolean;
   speechButtonAriaLabel: string | null;
+  speechButtonDisabled: boolean;
   surfaceCardId?: string;
   surfaceClassName?: string;
   surfaceFrontText?: string;
   surfaceTestId?: string;
   text: string;
+}>;
+
+export type ReviewCardSpeechButtonProps = Readonly<{
+  ariaLabel: string;
+  disabled: boolean;
+  isSpeaking: boolean;
+  onToggleSpeech: () => void;
 }>;
 
 function reviewMarkdownClassName(tagName: string): string {
@@ -145,6 +153,40 @@ export function ReviewEditIcon(): ReactElement {
   );
 }
 
+export function ReviewCardSpeechButton(props: ReviewCardSpeechButtonProps): ReactElement {
+  const {
+    ariaLabel,
+    disabled,
+    isSpeaking,
+    onToggleSpeech,
+  } = props;
+  const className = `review-card-speech-btn${isSpeaking && disabled === false ? " review-card-speech-btn-active" : ""}`;
+
+  function handleClick(): void {
+    if (disabled) {
+      return;
+    }
+
+    onToggleSpeech();
+  }
+
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={handleClick}
+      aria-label={ariaLabel}
+      disabled={disabled}
+    >
+      <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M5 14H2V10H5L10 6V18L5 14Z" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M14 9C15.333 10.2 15.333 13.8 14 15" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M17.5 6.5C20.5 9.4 20.5 14.6 17.5 17.5" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </button>
+  );
+}
+
 export function ReviewCardSide(props: ReviewCardSideProps): ReactElement {
   const {
     aiButtonAriaLabel,
@@ -156,6 +198,7 @@ export function ReviewCardSide(props: ReviewCardSideProps): ReactElement {
     showAiButton,
     showSpeechButton,
     speechButtonAriaLabel,
+    speechButtonDisabled,
     surfaceCardId,
     surfaceClassName,
     surfaceFrontText,
@@ -189,18 +232,12 @@ export function ReviewCardSide(props: ReviewCardSideProps): ReactElement {
         {showSpeechButton || showAiButton ? (
           <div className="review-card-actions">
             {showSpeechButton ? (
-              <button
-                type="button"
-                className={`review-card-speech-btn${isSpeaking ? " review-card-speech-btn-active" : ""}`}
-                onClick={onToggleSpeech}
-                aria-label={speechButtonAriaLabel ?? label}
-              >
-                <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path d="M5 14H2V10H5L10 6V18L5 14Z" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M14 9C15.333 10.2 15.333 13.8 14 15" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M17.5 6.5C20.5 9.4 20.5 14.6 17.5 17.5" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </button>
+              <ReviewCardSpeechButton
+                ariaLabel={speechButtonAriaLabel ?? label}
+                disabled={speechButtonDisabled}
+                isSpeaking={isSpeaking}
+                onToggleSpeech={onToggleSpeech}
+              />
             ) : null}
             {showAiButton && onOpenAi !== null ? (
               <button

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -6,7 +6,7 @@ import { cardsRoute, chatRoute } from "../../../routes";
 import type { Card } from "../../../types";
 import type { ReviewLoadingSnapshot } from "../../shared/loadingSnapshots";
 import { formatNullableDateTime, formatTagSummary } from "../../shared/featureFormatting";
-import { ReviewCardSide, ReviewEditIcon } from "./ReviewCardSide";
+import { ReviewCardSide, ReviewCardSpeechButton, ReviewEditIcon } from "./ReviewCardSide";
 import type { ReviewButtonOption } from "./reviewRatingOptions";
 import type { ReviewSpeechSide } from "../speech/reviewSpeech";
 import {
@@ -82,6 +82,10 @@ function handleDisabledSpeechToggle(): void {
 function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
   const { loadingReviewCurrentCard, reviewLoadingSnapshot } = props;
   const { t } = useI18n();
+  const frontSideLabel = t("reviewScreen.sides.front");
+  const frontSpeechButtonAriaLabel = t("reviewScreen.speakAriaLabel.start", {
+    side: frontSideLabel.toLowerCase(),
+  });
 
   return (
     <>
@@ -113,7 +117,7 @@ function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
       <div className="review-card-stack">
         {loadingReviewCurrentCard !== null ? (
           <ReviewCardSide
-            label={t("reviewScreen.sides.front")}
+            label={frontSideLabel}
             aiButtonAriaLabel={null}
             text={loadingReviewCurrentCard.frontText}
             contentClassName="review-front"
@@ -121,8 +125,9 @@ function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
             onOpenAi={null}
             onToggleSpeech={handleDisabledSpeechToggle}
             showAiButton={false}
-            showSpeechButton={false}
-            speechButtonAriaLabel={null}
+            showSpeechButton={true}
+            speechButtonAriaLabel={frontSpeechButtonAriaLabel}
+            speechButtonDisabled={true}
             surfaceCardId={loadingReviewCurrentCard.cardId}
             surfaceClassName="review-card-surface review-card-surface-front"
             surfaceFrontText={loadingReviewCurrentCard.frontText}
@@ -130,26 +135,24 @@ function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
           />
         ) : (
           <div className="review-card-surface review-card-surface-front review-loading-card-surface" aria-hidden="true">
-            <div className="review-label">{t("reviewScreen.sides.front")}</div>
+            <div className="review-label">{frontSideLabel}</div>
             <div className="review-card-body">
               <div className="review-loading-card-lines">
                 <span className="review-loading-line review-loading-line-title" />
                 <span className="review-loading-line" />
                 <span className="review-loading-line review-loading-line-short" />
               </div>
+              <div className="review-card-actions">
+                <ReviewCardSpeechButton
+                  ariaLabel={frontSpeechButtonAriaLabel}
+                  disabled={true}
+                  isSpeaking={false}
+                  onToggleSpeech={handleDisabledSpeechToggle}
+                />
+              </div>
             </div>
           </div>
         )}
-        <div className="review-card-surface review-card-answer review-loading-card-surface" aria-hidden="true">
-          <div className="review-label">{t("reviewScreen.sides.back")}</div>
-          <div className="review-card-body">
-            <div className="review-loading-card-lines">
-              <span className="review-loading-line" />
-              <span className="review-loading-line review-loading-line-short" />
-              <span className="review-loading-line review-loading-line-shorter" />
-            </div>
-          </div>
-        </div>
       </div>
       <div className="review-meta review-meta-loading">
         <span>{reviewLoadingSnapshot === null ? t("reviewScreen.loading.reviewQueue") : t("reviewScreen.loading.snapshot")}</span>
@@ -281,6 +284,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
           speechButtonAriaLabel={t(activeSpeechSide === "front" ? "reviewScreen.speakAriaLabel.stop" : "reviewScreen.speakAriaLabel.start", {
             side: frontSideLabel.toLowerCase(),
           })}
+          speechButtonDisabled={false}
           surfaceCardId={selectedCard.cardId}
           surfaceClassName="review-card-surface review-card-surface-front"
           surfaceFrontText={selectedCard.frontText}
@@ -303,6 +307,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
             speechButtonAriaLabel={t(activeSpeechSide === "back" ? "reviewScreen.speakAriaLabel.stop" : "reviewScreen.speakAriaLabel.start", {
               side: backSideLabel.toLowerCase(),
             })}
+            speechButtonDisabled={false}
             surfaceClassName="review-card-surface review-card-answer"
           />
         ) : null}

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -2,11 +2,13 @@
 import { act } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../../api";
-import type { Card } from "../../../types";
+import type { Card, ReviewQueueSnapshot } from "../../../types";
+import { buildReviewLoadingCardPreview, writeReviewLoadingSnapshot } from "../../shared/loadingSnapshots";
 import {
   clickElement,
   clickElementAsync,
   createCard,
+  createDeferredPromise,
   createDecks,
   dispatchKeydown,
   hasHydratedHotStateMock,
@@ -149,7 +151,77 @@ describe("ReviewScreen controls", () => {
 
     expect(reviewPane.dataset.reviewPaneState).toBe("loading");
     expect(reviewPane.dataset.reviewPaneEmptyReason).toBe("none");
+    expect(reviewPane.querySelector(".review-card-answer")).toBeNull();
+    const speechButton = reviewPane.querySelector(".review-card-surface-front .review-card-speech-btn");
+    if (!(speechButton instanceof HTMLButtonElement)) {
+      throw new Error("Review loading front speech button was not found");
+    }
+
+    expect(speechButton.disabled).toBe(true);
     expect(getContainer().textContent).not.toContain("No Cards Yet");
+  });
+
+  it("keeps a loading snapshot preview on the unrevealed front card surface", async () => {
+    const state = getState();
+    const snapshotCard = createCard({
+      cardId: "card-loading-preview",
+      frontText: "Snapshot front prompt",
+      backText: "Snapshot back answer",
+      tags: ["grammar"],
+      dueAt: "2026-03-10T12:30:00.000Z",
+    });
+    state.cards = [snapshotCard];
+    state.reviewQueue = [snapshotCard];
+    state.reviewTimeline = [snapshotCard];
+    writeReviewLoadingSnapshot({
+      version: 1,
+      workspaceId: "workspace-1",
+      selectedReviewFilterKey: "allCards",
+      resolvedReviewFilterTitle: "All Cards",
+      reviewCounts: {
+        dueCount: 1,
+        totalCount: 1,
+      },
+      currentCard: buildReviewLoadingCardPreview(snapshotCard),
+      queuePreview: [buildReviewLoadingCardPreview(snapshotCard)],
+      savedAt: "2026-03-10T12:00:00.000Z",
+    });
+    const pendingReviewQueueSnapshot = createDeferredPromise<ReviewQueueSnapshot>();
+    loadReviewQueueSnapshotMock.mockImplementation((): Promise<ReviewQueueSnapshot> => pendingReviewQueueSnapshot.promise);
+
+    await renderReviewScreen();
+
+    const reviewPane = getContainer().querySelector("[data-testid='review-pane']");
+    if (!(reviewPane instanceof HTMLElement)) {
+      throw new Error("Review pane was not found");
+    }
+    const frontCard = reviewPane.querySelector("[data-testid='review-current-front-card']");
+    if (!(frontCard instanceof HTMLElement)) {
+      throw new Error("Review loading front card was not found");
+    }
+    const speechButton = reviewPane.querySelector(".review-card-surface-front .review-card-speech-btn");
+    if (!(speechButton instanceof HTMLButtonElement)) {
+      throw new Error("Review loading front speech button was not found");
+    }
+
+    expect(reviewPane.dataset.reviewPaneState).toBe("loading");
+    expect(reviewPane.querySelector(".review-card-answer")).toBeNull();
+    expect(frontCard.textContent).toContain("Snapshot front prompt");
+    expect(speechButton.disabled).toBe(true);
+
+    await act(async () => {
+      pendingReviewQueueSnapshot.resolve({
+        resolvedReviewFilter: state.appData.selectedReviewFilter,
+        cards: [snapshotCard],
+        nextCursor: null,
+        reviewCounts: {
+          dueCount: 1,
+          totalCount: 1,
+        },
+      });
+      await pendingReviewQueueSnapshot.promise;
+    });
+    await flushReviewScreenPromises();
   });
 
   it("shows a retry path instead of staying in cold empty loading after sync fails", async () => {

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -237,6 +237,14 @@
   border-color: rgba(255, 255, 255, 0.14);
 }
 
+.review-card-speech-btn:disabled,
+.review-card-speech-btn:disabled:hover {
+  color: var(--text-tertiary);
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.06);
+  cursor: default;
+}
+
 .review-card-speech-btn svg {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
## Summary
- render the review loading preview as a single front-card surface
- reserve a disabled speech button in snapshot and cold skeleton loading states
- add focused review controls coverage for the loading preview contract

## Validation
- npm ci in apps/web: passed with existing Node engine warning because package declares Node 24.x and shell is Node 25.6.1
- npx vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx: passed, 25 tests
- npm run build: passed
- git --no-pager diff --check: passed
- worker-owned review subagent: no P0-P4 issues found