### PR TITLE
Freeze version-coupled test fixtures to a static dummy

### DIFF
--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/ProgressContextRefreshControllerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/ProgressContextRefreshControllerTest.kt
@@ -168,7 +168,8 @@ class ProgressContextRefreshControllerTest {
     }
 }
 
-private const val testAppVersion: String = "1.15.0"
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+private const val testAppVersion: String = "1.0.0"
 private const val testVersionCode: Int = 1
 
 private class TestAppObservability : AppObservability {

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -460,5 +460,6 @@ private fun parseTimestampMillis(value: String): Long {
     return Instant.parse(value).toEpochMilli()
 }
 
-private const val testAppVersion: String = "1.15.0"
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+private const val testAppVersion: String = "1.0.0"
 private const val testVersionCode: Int = 1

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
@@ -269,5 +269,6 @@ class SentryAppObservabilityTest {
     }
 }
 
-private const val testAppVersion: String = "1.15.0"
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+private const val testAppVersion: String = "1.0.0"
 private const val testVersionCode: Int = 1

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
@@ -47,7 +47,8 @@ internal class CloudIdentityTestEnvironment private constructor(
     val resetCoordinator: CloudIdentityResetCoordinator,
     val aiChatRemoteService: AiChatRemoteService
 ) {
-    private val appVersion: String = "1.15.0"
+    // Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+    private val appVersion: String = "1.0.0"
 
     companion object {
         suspend fun create(): CloudIdentityTestEnvironment {

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteTestFixtures.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteTestFixtures.kt
@@ -5,7 +5,8 @@ import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.Dispatchers
 
-internal const val AI_CHAT_TEST_APP_VERSION: String = "1.15.0"
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+internal const val AI_CHAT_TEST_APP_VERSION: String = "1.0.0"
 internal const val AI_CHAT_TEST_UI_LOCALE: String = "es-ES"
 internal const val AI_CHAT_TEST_WORKSPACE_ID: String = "workspace-1"
 

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
@@ -19,6 +19,9 @@ import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
 
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+private const val testAppVersion: String = "1.0.0"
+
 class CloudRemoteHttpClientTest {
     @Test
     fun syncPullRetriesTransientGatewayTimeoutBeforeCapturingWarning() = runBlocking {
@@ -49,7 +52,7 @@ class CloudRemoteHttpClientTest {
             val client = CloudJsonHttpClient(
                 okHttpClient = OkHttpClient(),
                 observability = observability,
-                appVersion = "1.15.0",
+                appVersion = testAppVersion,
                 versionCode = 123
             )
             val response = client.postJson(
@@ -59,7 +62,7 @@ class CloudRemoteHttpClientTest {
                 body = JSONObject()
                     .put("installationId", "installation-1")
                     .put("platform", "android")
-                    .put("appVersion", "1.15.0")
+                    .put("appVersion", testAppVersion)
                     .put("afterHotChangeId", 0)
                     .put("limit", 200)
             )
@@ -102,7 +105,7 @@ class CloudRemoteHttpClientTest {
             val client = CloudJsonHttpClient(
                 okHttpClient = OkHttpClient(),
                 observability = observability,
-                appVersion = "1.15.0",
+                appVersion = testAppVersion,
                 versionCode = 123
             )
             var thrownError: CloudRemoteException? = null
@@ -115,7 +118,7 @@ class CloudRemoteHttpClientTest {
                         .put("mode", "push")
                         .put("installationId", "installation-1")
                         .put("platform", "android")
-                        .put("appVersion", "1.15.0")
+                        .put("appVersion", testAppVersion)
                         .put("entries", JSONArray())
                 )
             } catch (error: CloudRemoteException) {

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/support/AiChatRuntimeTestSupport.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/support/AiChatRuntimeTestSupport.kt
@@ -50,7 +50,8 @@ import kotlinx.coroutines.withContext
 internal const val defaultTestWorkspaceId: String = "workspace-1"
 internal const val secondaryTestWorkspaceId: String = "workspace-2"
 
-private const val testAppVersion: String = "1.15.0"
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+private const val testAppVersion: String = "1.0.0"
 private const val testVersionCode: Int = 10300
 internal const val testUiLocaleTag: String = "en-US"
 

--- a/apps/web/src/api/endpoints/feedback.test.ts
+++ b/apps/web/src/api/endpoints/feedback.test.ts
@@ -9,6 +9,9 @@ import {
   submitFeedback,
 } from "./feedback";
 
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+const TEST_APP_VERSION = "1.0.0";
+
 describe("feedback API endpoints", () => {
   const emptyFeedbackState = {
     automaticPromptCooldownDays: 30,
@@ -53,7 +56,7 @@ describe("feedback API endpoints", () => {
       workspaceId: "workspace-1",
       installationId: "installation-1",
       platform: "web" as const,
-      appVersion: "1.15.0",
+      appVersion: TEST_APP_VERSION,
       locale: "en" as const,
       timezone: "Europe/Madrid",
       eventType: "automatic_prompt_shown",
@@ -75,7 +78,7 @@ describe("feedback API endpoints", () => {
       workspaceId: "workspace-1",
       installationId: "installation-1",
       platform: "web" as const,
-      appVersion: "1.15.0",
+      appVersion: TEST_APP_VERSION,
       locale: "en" as const,
       timezone: "Europe/Madrid",
       trigger: "settings" as const,
@@ -111,7 +114,7 @@ describe("feedback API endpoints", () => {
       workspaceId: "workspace-1",
       installationId: "installation-1",
       platform: "web",
-      appVersion: "1.15.0",
+      appVersion: TEST_APP_VERSION,
       locale: "en",
       timezone: "Europe/Madrid",
       eventType: "automatic_prompt_dismissed",

--- a/apps/web/src/api/transport/transport.test.ts
+++ b/apps/web/src/api/transport/transport.test.ts
@@ -36,6 +36,9 @@ import {
 } from "./transport";
 import { listWorkspaces } from "../endpoints/workspaces";
 
+// Frozen test input — intentionally not the real app version; do not bump on release (see docs/version-bump.md).
+const TEST_APP_VERSION = "1.0.0";
+
 async function createTransportBackedChatSession(sessionId: string): Promise<NewChatSessionResponse> {
   return createNewChatSession(sessionId, "workspace-1", "en");
 }
@@ -604,7 +607,7 @@ describe("API transport network retry", () => {
       workspaceId,
       "installation-1",
       "web",
-      "1.15.0",
+      TEST_APP_VERSION,
       0,
       200,
     )).resolves.toEqual({
@@ -643,7 +646,7 @@ describe("API transport network retry", () => {
       workspaceId,
       "installation-1",
       "web",
-      "1.15.0",
+      TEST_APP_VERSION,
       0,
       200,
     )).resolves.toEqual({
@@ -818,7 +821,7 @@ describe("API transport network retry", () => {
       workspaceId,
       "installation-1",
       "web",
-      "1.15.0",
+      TEST_APP_VERSION,
       0,
       200,
     );

--- a/docs/version-bump.md
+++ b/docs/version-bump.md
@@ -69,14 +69,12 @@ The main Android consumers of that runtime value are:
 - `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudGuestSessionCoordinator.kt`
 - `apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiChatRuntime.kt`
 
-Tests that assert the Android client version must stay aligned too, especially:
-
-- `apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteTestFixtures.kt`
-- `apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteTransportRequestTest.kt`
-
-Search for additional Android test fixtures or AndroidTest support files that
-embed the app version as request metadata or expected wire values, and keep
-them aligned in the same change.
+Test fixtures do not track the release version. Android and web unit tests
+that need an app-version string use a frozen dummy (`"1.0.0"`) as a
+self-referential input/output value, so they are intentionally not bumped on
+release. Each such fixture carries a "do not bump" comment in code. If you add
+a new fixture that embeds an app version, reuse the same frozen dummy instead
+of the real release version.
 
 Android `versionCode` is not bumped manually in the repo. Release builds receive `ANDROID_VERSION_CODE` from CI, and the workflow computes that value at release time.
 
@@ -166,9 +164,9 @@ when the user-facing effect is unclear.
 
 1. Choose the next semantic version for the release.
 2. By default, treat that version as the shared project version for backend, web, Android, and iOS.
-3. Search the repo for the current version strings so you can see every manifest, runtime reader, test expectation, and newly added repo-owned version surface that still reports the old value for the release.
+3. Search the repo for the current version strings so you can see every manifest, runtime reader, and newly added repo-owned version surface that still reports the old value for the release.
 4. Update all repo-owned version surfaces that participate in that release, and keep each platform's runtime-reported version aligned with its checked-in version source.
-5. Update version-coupled test fixtures, Android instrumentation support values, and compatibility comments that explicitly name the released first-party client version.
+5. Update compatibility comments that explicitly name the released first-party client version. Do not bump test fixtures: tests that need an app-version string use a frozen dummy (`"1.0.0"`) and are intentionally excluded from the release bump.
 6. Update release metadata only when that metadata actually names the current app version for the touched platform.
 7. Re-run targeted searches to confirm the old app version strings are gone from the intended version surfaces and any version-coupled fixtures or comments you intended to update.
 8. Run the smallest useful verification commands for the touched platforms.
@@ -179,7 +177,7 @@ when the user-facing effect is unclear.
 After a version bump, use targeted checks instead of broad test runs:
 
 - repo search for stale old-version literals in intended version surfaces
-- repo search for stale old-version literals in version-coupled test fixtures and compatibility comments when the repo uses them
+- repo search for stale old-version literals in compatibility comments when the repo uses them (test fixtures use a frozen `"1.0.0"` dummy and are not bumped)
 - `npm run build --prefix apps/web`
 - `./gradlew :app:assembleDebug` from `apps/android/`
 


### PR DESCRIPTION
## What
Web and Android unit tests that need an app-version string previously used the **real release version**, so a version bump had to touch **9 test files** (16 literal edits). This freezes them to a static `"1.0.0"` and documents the policy.

- Each fixture now uses a named constant (`testAppVersion` / `TEST_APP_VERSION` / `AI_CHAT_TEST_APP_VERSION`) set to `"1.0.0"`, with a `// … do not bump on release` comment.
- Files where the literal was scattered inline (`CloudRemoteHttpClientTest.kt`, `feedback.test.ts`, `transport.test.ts`) now route through a single named constant.
- `docs/version-bump.md` updated: test fixtures are intentionally **not** bumped (Android section, Expected Flow step 5, Minimum Verification, and step 3).

## Why it's safe
The version in these tests is **self-referential** — the value is passed into a request and asserted back out, so the specific number is irrelevant (this matches the backend tests, which already use a frozen `"1.0.0"`). No production code path changes. Confirmed no test compares against the real `BuildConfig.VERSION_NAME` / `PackageInfo`.

## Effect
Future version bumps drop these 9 files entirely — from ~24 changed files down to the real version surfaces.

Not run: web vitest / Android Gradle (test-input-only change; fresh worktree without installed deps). The edits are mechanical and self-referential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)