### PR TITLE
feat(backend): tag Sentry events with client app version and platform

### DIFF
--- a/apps/backend/src/admin/query.ts
+++ b/apps/backend/src/admin/query.ts
@@ -521,6 +521,8 @@ export async function executeAdminQuery(
     null,
     null,
     null,
+    null,
+    null,
   );
   const sqlFingerprint = getAdminQueryFingerprint(params.sql);
   const startedAt = Date.now();

--- a/apps/backend/src/admin/reportingDb.test.ts
+++ b/apps/backend/src/admin/reportingDb.test.ts
@@ -99,6 +99,8 @@ test("withReportingReadOnlyTransaction preserves original error when rollback cl
       chatRequestId: null,
       runId: null,
       sessionId: null,
+      clientAppVersion: null,
+      clientPlatform: null,
       originalSqlState: "42601",
       originalErrorCode: "42601",
       originalErrorClass: "Error",

--- a/apps/backend/src/chat/http/diagnostics.ts
+++ b/apps/backend/src/chat/http/diagnostics.ts
@@ -67,6 +67,8 @@ export function logChatResumeContractViolation(
       null,
       null,
       details.sessionId,
+      diagnostics.clientVersion,
+      diagnostics.clientPlatform,
     ),
     details: {
       path,
@@ -97,6 +99,7 @@ export function captureUnexpectedChatLiveEnvelopeError(
   error: unknown,
 ): void {
   const path = new URL(request.url).pathname;
+  const diagnostics = readChatResumeDiagnosticsHeaders(request);
   captureBackendException({
     action: "request_failed",
     error: normalizeCaughtError(error),
@@ -110,6 +113,8 @@ export function captureUnexpectedChatLiveEnvelopeError(
       null,
       runId,
       sessionId,
+      diagnostics.clientVersion,
+      diagnostics.clientPlatform,
     ),
     details: {
       statusCode: 500,

--- a/apps/backend/src/chat/live/index.ts
+++ b/apps/backend/src/chat/live/index.ts
@@ -177,6 +177,8 @@ function createChatLiveObservationScope(
     params.clientRequestId ?? null,
     params.runId,
     params.sessionId,
+    params.clientVersion ?? null,
+    params.clientPlatform ?? null,
   );
 }
 

--- a/apps/backend/src/chat/tests/transcriptions/transcriptions.test.ts
+++ b/apps/backend/src/chat/tests/transcriptions/transcriptions.test.ts
@@ -155,6 +155,8 @@ test("invalid chat transcription audio failures create a breadcrumb without a Se
       chatRequestId: null,
       runId: null,
       sessionId: "session-1",
+      clientAppVersion: null,
+      clientPlatform: null,
       source: "web",
       provider: "openai",
       fileSize: 5,

--- a/apps/backend/src/chat/transcriptions.ts
+++ b/apps/backend/src/chat/transcriptions.ts
@@ -197,6 +197,8 @@ function logChatTranscriptionFailure(details: ChatTranscriptionFailureDetails): 
       null,
       null,
       details.sessionId,
+      null,
+      null,
     ),
     details,
   });
@@ -218,6 +220,8 @@ function logChatTranscriptionInvalidAudio(details: ChatTranscriptionFailureDetai
       null,
       null,
       details.sessionId,
+      null,
+      null,
     ),
     details,
   });

--- a/apps/backend/src/chat/worker/invoke.ts
+++ b/apps/backend/src/chat/worker/invoke.ts
@@ -147,6 +147,8 @@ function createChatWorkerDispatchFailedEvent(
       payload.chatRequestId ?? null,
       payload.runId,
       payload.sessionId ?? null,
+      null,
+      null,
     ),
     details: {
       message,

--- a/apps/backend/src/chat/worker/logging.ts
+++ b/apps/backend/src/chat/worker/logging.ts
@@ -39,6 +39,8 @@ function createChatWorkerScope(context: ChatWorkerLogContext): BackendObservatio
     context.chatRequestId,
     context.runId,
     context.sessionId,
+    null,
+    null,
   );
 }
 

--- a/apps/backend/src/database/core.test.ts
+++ b/apps/backend/src/database/core.test.ts
@@ -195,6 +195,8 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
         chatRequestId: null,
         runId: null,
         sessionId: null,
+        clientAppVersion: null,
+        clientPlatform: null,
         originalSqlState: "23514",
         originalErrorCode: "23514",
         originalErrorClass: "Error",

--- a/apps/backend/src/database/transient.test.ts
+++ b/apps/backend/src/database/transient.test.ts
@@ -104,6 +104,8 @@ test("retryTransientDatabaseOperationWithDependencies retries transient DB error
     null,
     null,
     null,
+    null,
+    null,
   );
 
   console.log = (message?: unknown): void => {
@@ -153,6 +155,8 @@ test("retryTransientDatabaseOperationWithDependencies retries transient DB error
       chatRequestId: null,
       runId: null,
       sessionId: null,
+      clientAppVersion: null,
+      clientPlatform: null,
       attempt: 1,
       maxAttempts: 3,
       delayMs: 50,
@@ -173,6 +177,8 @@ test("retryTransientDatabaseOperationWithDependencies retries transient DB error
       chatRequestId: null,
       runId: null,
       sessionId: null,
+      clientAppVersion: null,
+      clientPlatform: null,
       attempt: 2,
       maxAttempts: 3,
       delayMs: 100,
@@ -195,6 +201,8 @@ test("retryTransientDatabaseOperationWithDependencies does not retry non-transie
       },
       () => createBackendObservationScope(
         "backend-api",
+        null,
+        null,
         null,
         null,
         null,

--- a/apps/backend/src/entrypoints/lambda-chat-live.ts
+++ b/apps/backend/src/entrypoints/lambda-chat-live.ts
@@ -286,6 +286,8 @@ async function liveStreamHandler(
     clientRequestId,
     url.searchParams.get("runId"),
     url.searchParams.get("sessionId"),
+    clientVersion,
+    clientPlatform,
   );
 
   let params: LiveStreamParams;
@@ -342,6 +344,8 @@ async function liveStreamHandler(
     params.clientRequestId ?? null,
     params.runId,
     params.sessionId,
+    clientVersion,
+    clientPlatform,
   );
 
   const metadata = {
@@ -427,6 +431,8 @@ const chatLiveStreamHandler: StreamifyHandler<APIGatewayProxyEventV2, void> = as
     const normalizedError = normalizeCaughtError(error);
     const requestId = getLiveRequestId(event);
     const clientRequestId = readOptionalChatRequestIdHeader(event.headers ?? {}) ?? null;
+    const clientPlatform = readApiGatewayHeader(event.headers, "x-client-platform");
+    const clientVersion = readApiGatewayHeader(event.headers, "x-client-version");
     const observationScope = createBackendObservationScope(
       "chat-live",
       requestId,
@@ -437,6 +443,8 @@ const chatLiveStreamHandler: StreamifyHandler<APIGatewayProxyEventV2, void> = as
       clientRequestId,
       null,
       null,
+      clientVersion,
+      clientPlatform,
     );
     captureBackendException({
       action: "chat_live_bootstrap_failed",

--- a/apps/backend/src/entrypoints/lambda-chat-worker.ts
+++ b/apps/backend/src/entrypoints/lambda-chat-worker.ts
@@ -81,6 +81,8 @@ const chatWorkerHandler: Handler<ChatWorkerEvent, void> = async (event, context)
     event.chatRequestId ?? null,
     event.runId,
     event.sessionId ?? null,
+    null,
+    null,
   );
   let runtimeHttpError: HttpErrorClass | null = null;
   let runtime: ChatWorkerRuntime | null = null;

--- a/apps/backend/src/entrypoints/lambda-community-leaderboard-snapshot.ts
+++ b/apps/backend/src/entrypoints/lambda-community-leaderboard-snapshot.ts
@@ -55,6 +55,8 @@ const communityLeaderboardSnapshotHandler: Handler<
     null,
     null,
     null,
+    null,
+    null,
   );
   try {
     const runtime = await getCommunityLeaderboardSnapshotRuntime();

--- a/apps/backend/src/entrypoints/lambda-global-metrics-snapshot.ts
+++ b/apps/backend/src/entrypoints/lambda-global-metrics-snapshot.ts
@@ -80,6 +80,8 @@ const globalMetricsSnapshotHandler: Handler<
     null,
     null,
     null,
+    null,
+    null,
   );
   try {
     const runtime = await getGlobalMetricsSnapshotRuntime();

--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -267,6 +267,8 @@ app.onError((error, context) => {
         null,
         null,
         null,
+        null,
+        null,
       ),
       details: {
         statusCode: error instanceof HttpError ? error.statusCode : 500,

--- a/apps/backend/src/entrypoints/lambda-progress-active-days-backfill.ts
+++ b/apps/backend/src/entrypoints/lambda-progress-active-days-backfill.ts
@@ -133,6 +133,8 @@ const progressActiveDaysBackfillHandler: Handler<
     null,
     null,
     null,
+    null,
+    null,
   );
   let request: Readonly<{ batchSize: number; maxPages: number }> | null = null;
   try {

--- a/apps/backend/src/entrypoints/lambda-streak-leaderboard-snapshot.ts
+++ b/apps/backend/src/entrypoints/lambda-streak-leaderboard-snapshot.ts
@@ -58,6 +58,8 @@ const streakLeaderboardSnapshotHandler: Handler<
     null,
     null,
     null,
+    null,
+    null,
   );
   try {
     const runtime = await getStreakLeaderboardSnapshotRuntime();

--- a/apps/backend/src/entrypoints/lambda.ts
+++ b/apps/backend/src/entrypoints/lambda.ts
@@ -94,6 +94,8 @@ const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => 
     null,
     null,
     null,
+    null,
+    null,
   );
   let runtime: BackendApiRuntime | null = null;
   try {

--- a/apps/backend/src/entrypoints/migrate-lambda.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.ts
@@ -70,6 +70,8 @@ const migrationHandler: Handler<unknown, MigrationLambdaResult> = async (_event,
         null,
         null,
         null,
+        null,
+        null,
       ),
       details: createMigrationFailureDetails(normalizedError),
     });

--- a/apps/backend/src/guestAuth/merge/index.ts
+++ b/apps/backend/src/guestAuth/merge/index.ts
@@ -144,6 +144,8 @@ function logGuestMergeFsrsStateReset(
       null,
       null,
       null,
+      null,
+      null,
     ),
     details: {
       workspaceId,
@@ -382,6 +384,8 @@ function logGuestMergeDroppedEntity(
       null,
       null,
       null,
+      null,
+      null,
     ),
     details: {
       entityType,
@@ -410,6 +414,8 @@ function logGuestMergeDroppedReviewEventForMissingCard(
       null,
       null,
       targetWorkspaceId,
+      null,
+      null,
       null,
       null,
       null,

--- a/apps/backend/src/guestAuth/upgrade/index.ts
+++ b/apps/backend/src/guestAuth/upgrade/index.ts
@@ -154,6 +154,8 @@ function logSuspiciousGuestUpgradeReplay(
       null,
       null,
       guestSessionId,
+      null,
+      null,
     ),
     details: {
       reason,

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -153,6 +153,8 @@ async function buildToolErrorResult(
             null,
             null,
             null,
+            null,
+            null,
           ),
           details: {
             statusCode: error.statusCode,
@@ -218,6 +220,8 @@ async function buildToolErrorResult(
             null,
             null,
             null,
+            null,
+            null,
           ),
           message: "MCP WORKSPACE_SELECTION_REQUIRED workspace enrichment failed; returning base envelope without details.workspaces.",
           details: {
@@ -252,6 +256,8 @@ async function buildToolErrorResult(
         `mcp/${toolName}`,
         "POST",
         userId,
+        null,
+        null,
         null,
         null,
         null,

--- a/apps/backend/src/observability/reporting.test.ts
+++ b/apps/backend/src/observability/reporting.test.ts
@@ -50,6 +50,8 @@ test("backend reporting records auth errors as breadcrumbs", () => {
       null,
       null,
       null,
+      null,
+      null,
     );
     const details = {
       installationId: null,
@@ -95,6 +97,8 @@ test("backend reporting keeps non-server http errors as breadcrumbs", () => {
       null,
       null,
       null,
+      null,
+      null,
     );
     const details = createBackendFailureDetails(error);
     const breadcrumbMessages = withCapturedConsole("log", () => {
@@ -131,6 +135,8 @@ test("backend reporting does not recapture already captured exceptions", () => {
       "workspace-1",
       null,
       "run-1",
+      null,
+      null,
       null,
     );
     const event = {
@@ -189,6 +195,8 @@ test("backend reporting recognizes repeated normalized non-Error throws", () => 
       "POST",
       "user-2",
       "workspace-2",
+      null,
+      null,
       null,
       null,
       null,
@@ -267,6 +275,8 @@ test("backend reporting treats temporary auth verification failures as expected"
       "POST",
       "user-3",
       "workspace-1",
+      null,
+      null,
       null,
       null,
       null,

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -18,6 +18,8 @@ export type BackendObservationScope = Readonly<{
   chatRequestId: string | null;
   runId: string | null;
   sessionId: string | null;
+  clientAppVersion: string | null;
+  clientPlatform: string | null;
 }>;
 
 export type BackendTraceCarrier = Readonly<{

--- a/apps/backend/src/observability/sentry/hooks.test.ts
+++ b/apps/backend/src/observability/sentry/hooks.test.ts
@@ -103,6 +103,8 @@ test("backend Sentry beforeSend drops automatic recaptures of manually captured 
         null,
         "run-1",
         null,
+        null,
+        null,
       ),
       details: {
         lambdaRequestId: "lambda-request-1",
@@ -488,6 +490,8 @@ test("backend Sentry scope preserves raw backend identifiers before capture", ()
       safeChatRequestId,
       "run-1",
       "session-1",
+      null,
+      null,
     ),
   );
 
@@ -528,6 +532,8 @@ test("backend Sentry scope preserves raw backend identifiers before capture", ()
       safeRequestId,
       "/v1/cards",
       "POST",
+      null,
+      null,
       null,
       null,
       null,

--- a/apps/backend/src/observability/sentry/index.test.ts
+++ b/apps/backend/src/observability/sentry/index.test.ts
@@ -131,6 +131,8 @@ test("backend Sentry facade exports the public observability API", () => {
     null,
     null,
     null,
+    null,
+    null,
   );
   const normalizedError = normalizeCaughtError("failed");
   const typeSample = createFacadeTypeSample(scope, normalizedError);

--- a/apps/backend/src/observability/sentry/logging.test.ts
+++ b/apps/backend/src/observability/sentry/logging.test.ts
@@ -58,6 +58,8 @@ test("backend breadcrumb serialization keeps CloudWatch JSON shape", () => {
         "chat-request-1",
         "run-1",
         null,
+        null,
+        null,
       ),
       details,
     });
@@ -76,6 +78,8 @@ test("backend breadcrumb serialization keeps CloudWatch JSON shape", () => {
     chatRequestId: "chat-request-1",
     runId: "run-1",
     sessionId: null,
+    clientAppVersion: null,
+    clientPlatform: null,
     lambdaRequestId: "lambda-request-1",
     abortReason: null,
     signalAborted: false,
@@ -116,6 +120,8 @@ test("backend warning and exception serialization include typed details", () => 
         null,
         null,
         null,
+        null,
+        null,
       ),
       details: {
         statusCode: 503,
@@ -140,6 +146,8 @@ test("backend warning and exception serialization include typed details", () => 
         "workspace-1",
         null,
         "run-1",
+        null,
+        null,
         null,
       ),
       details: {
@@ -192,6 +200,8 @@ test("backend warnings create Sentry warning issues", () => {
           null,
           null,
           null,
+          null,
+          null,
         ),
         details: {
           statusCode: 503,
@@ -223,6 +233,8 @@ test("backend runtime exception serialization includes chat worker failure conte
         "chat-request-1",
         "run-1",
         "session-1",
+        null,
+        null,
       ),
       details: {
         lambdaRequestId: "lambda-request-1",
@@ -273,6 +285,8 @@ test("backend runtime exception serialization includes global metrics failure co
         null,
         null,
         null,
+        null,
+        null,
       ),
       details: {
         bucketName: "metrics-bucket",
@@ -302,6 +316,8 @@ test("backend runtime exception serialization includes migration failure context
       scope: createBackendObservationScope(
         "migration",
         "lambda-request-3",
+        null,
+        null,
         null,
         null,
         null,

--- a/apps/backend/src/observability/sentry/scope.ts
+++ b/apps/backend/src/observability/sentry/scope.ts
@@ -25,6 +25,8 @@ export function setSentryScope(scope: Sentry.Scope, observationScope: BackendObs
   const chatRequestId = getScopeTagValue(observationScope.chatRequestId);
   const runId = getScopeTagValue(observationScope.runId);
   const sessionId = getScopeTagValue(observationScope.sessionId);
+  const clientAppVersion = getScopeTagValue(observationScope.clientAppVersion);
+  const clientPlatform = getScopeTagValue(observationScope.clientPlatform);
 
   if (requestId !== undefined) scope.setTag("requestId", requestId);
   if (route !== undefined) scope.setTag("route", route);
@@ -34,6 +36,8 @@ export function setSentryScope(scope: Sentry.Scope, observationScope: BackendObs
   if (chatRequestId !== undefined) scope.setTag("chatRequestId", chatRequestId);
   if (runId !== undefined) scope.setTag("runId", runId);
   if (sessionId !== undefined) scope.setTag("sessionId", sessionId);
+  if (clientAppVersion !== undefined) scope.setTag("clientAppVersion", clientAppVersion);
+  if (clientPlatform !== undefined) scope.setTag("clientPlatform", clientPlatform);
   if (userId !== undefined) scope.setUser({ id: userId });
 
   scope.setContext(
@@ -62,6 +66,8 @@ export function createBackendObservationScope(
   chatRequestId: string | null,
   runId: string | null,
   sessionId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
 ): BackendObservationScope {
   return {
     service,
@@ -73,6 +79,8 @@ export function createBackendObservationScope(
     chatRequestId,
     runId,
     sessionId,
+    clientAppVersion,
+    clientPlatform,
   };
 }
 
@@ -84,6 +92,8 @@ export function createBackendRuntimeObservationScope(): BackendObservationScope 
 
   return createBackendObservationScope(
     currentBackendService,
+    null,
+    null,
     null,
     null,
     null,

--- a/apps/backend/src/progress/activeReviewDays/activeReviewDaysBackfill.test.ts
+++ b/apps/backend/src/progress/activeReviewDays/activeReviewDaysBackfill.test.ts
@@ -121,6 +121,8 @@ function createTestObservationScope() {
     null,
     null,
     null,
+    null,
+    null,
   );
 }
 

--- a/apps/backend/src/routes/cards.ts
+++ b/apps/backend/src/routes/cards.ts
@@ -60,6 +60,8 @@ function createCardsScope(
   method: string,
   userId: string,
   workspaceId: string,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
 ): BackendObservationScope {
   return createBackendObservationScope(
     "backend-api",
@@ -71,6 +73,8 @@ function createCardsScope(
     null,
     null,
     null,
+    clientAppVersion,
+    clientPlatform,
   );
 }
 
@@ -137,7 +141,7 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
       const result = await listWorkspaceTagsSummary(requestContext.userId, workspaceId);
       addBackendBreadcrumb({
         action: "workspace_tags_list",
-        scope: createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        scope: createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           tagsCount: result.tags.length,
@@ -146,7 +150,7 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
       });
       return context.json(result satisfies WorkspaceTagsSummaryResponse);
     } catch (error) {
-      const scope = createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         tagsCount: null,
         totalCards: null,
@@ -172,7 +176,7 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
       const result = await queryCardsPage(requestContext.userId, workspaceId, body);
       addBackendBreadcrumb({
         action: "cards_query",
-        scope: createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        scope: createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           limit: body.limit,
@@ -186,7 +190,7 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
       });
       return context.json(result);
     } catch (error) {
-      const scope = createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         limit: body.limit,
         sortsCount: body.sorts.length,

--- a/apps/backend/src/routes/feedback.ts
+++ b/apps/backend/src/routes/feedback.ts
@@ -43,6 +43,8 @@ function createFeedbackRouteScope(
   method: string,
   userId: string | null,
   workspaceId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
 ): BackendObservationScope {
   return createBackendObservationScope(
     "backend-api",
@@ -54,6 +56,8 @@ function createFeedbackRouteScope(
     null,
     null,
     null,
+    clientAppVersion,
+    clientPlatform,
   );
 }
 
@@ -101,7 +105,7 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           assertFeedbackTransport(loadedContext.requestContext);
           return loadFeedbackStateForRequest(
             toFeedbackRequestUser(loadedContext.requestContext),
-            createFeedbackRouteScope(requestId, context.req.path, context.req.method, loadedContext.requestContext.userId, null),
+            createFeedbackRouteScope(requestId, context.req.path, context.req.method, loadedContext.requestContext.userId, null, context.get("clientAppVersion"), context.get("clientPlatform")),
             withTransientDatabaseRetryFn,
             dependencies,
           );
@@ -112,6 +116,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           getRequestContextUserId(requestContext),
           null,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
       );
 
@@ -123,6 +129,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           getRequestContextUserId(requestContext),
           null,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         details: {
           statusCode: 200,
@@ -136,6 +144,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
         context.req.method,
         getRequestContextUserId(requestContext),
         null,
+        context.get("clientAppVersion"),
+        context.get("clientPlatform"),
       );
       const details = {
         ...createBackendFailureDetails(error),
@@ -168,6 +178,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           getRequestContextUserId(requestContext),
           null,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
       );
       input = parseFeedbackPromptEventInput(await parseFeedbackJsonBody(context.req.raw));
@@ -181,6 +193,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           loadedContext.requestContext.userId,
           input.workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         withTransientDatabaseRetryFn,
         dependencies,
@@ -194,6 +208,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           getRequestContextUserId(requestContext),
           input?.workspaceId ?? null,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         details: {
           statusCode: 200,
@@ -209,6 +225,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
         context.req.method,
         getRequestContextUserId(requestContext),
         input?.workspaceId ?? null,
+        context.get("clientAppVersion"),
+        context.get("clientPlatform"),
       );
       const details = {
         platform: input?.platform ?? null,
@@ -243,6 +261,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           getRequestContextUserId(requestContext),
           null,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
       );
       input = parseFeedbackSubmissionInput(await parseFeedbackJsonBody(context.req.raw));
@@ -257,6 +277,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           loadedContext.requestContext.userId,
           input.workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         withTransientDatabaseRetryFn,
         dependencies,
@@ -270,6 +292,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
           context.req.method,
           loadedContext.requestContext.userId,
           input.workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         details: {
           statusCode: 200,
@@ -285,6 +309,8 @@ export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEn
         context.req.method,
         getRequestContextUserId(requestContext),
         input?.workspaceId ?? null,
+        context.get("clientAppVersion"),
+        context.get("clientPlatform"),
       );
       const details = {
         platform: input?.platform ?? null,

--- a/apps/backend/src/routes/globalSnapshot.test.ts
+++ b/apps/backend/src/routes/globalSnapshot.test.ts
@@ -192,6 +192,8 @@ test("GET /v1/global/snapshot returns the snapshot when visible", async () => {
     chatRequestId: null,
     runId: null,
     sessionId: null,
+    clientAppVersion: null,
+    clientPlatform: null,
   });
 });
 

--- a/apps/backend/src/routes/globalSnapshot.ts
+++ b/apps/backend/src/routes/globalSnapshot.ts
@@ -67,6 +67,8 @@ export function createGlobalSnapshotRoutes(options: GlobalSnapshotRoutesOptions)
       null,
       null,
       null,
+      context.get("clientAppVersion") ?? null,
+      context.get("clientPlatform") ?? null,
     );
     try {
       const response = context.json(await loadGlobalMetricsSnapshotFn(observationScope));

--- a/apps/backend/src/routes/guestAuth.ts
+++ b/apps/backend/src/routes/guestAuth.ts
@@ -166,6 +166,8 @@ function createGuestUpgradeScope(
   route: string,
   method: string,
   userId: string,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
 ): BackendObservationScope {
   return createBackendObservationScope(
     "backend-api",
@@ -177,6 +179,8 @@ function createGuestUpgradeScope(
     null,
     null,
     null,
+    clientAppVersion,
+    clientPlatform,
   );
 }
 
@@ -245,7 +249,7 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
       const result = await completeGuestUpgradeFn(guestToken, auth.subjectUserId, selection, capabilities);
       addBackendBreadcrumb({
         action: "guest_upgrade_complete",
-        scope: createGuestUpgradeScope(requestId, context.req.path, context.req.method, result.targetUserId),
+        scope: createGuestUpgradeScope(requestId, context.req.path, context.req.method, result.targetUserId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           selectionType: selection.type,
@@ -270,7 +274,7 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
         };
       return context.json(response);
     } catch (error) {
-      const scope = createGuestUpgradeScope(requestId, context.req.path, context.req.method, auth.userId);
+      const scope = createGuestUpgradeScope(requestId, context.req.path, context.req.method, auth.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         selectionType: selection.type,
         guestWorkspaceSyncedAndOutboxDrained: capabilities.guestWorkspaceSyncedAndOutboxDrained,

--- a/apps/backend/src/routes/sync/index.ts
+++ b/apps/backend/src/routes/sync/index.ts
@@ -98,7 +98,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
       const result = await processSyncPushFn(workspaceId, requestContext.userId, input);
       addBackendBreadcrumb({
         action: "sync_push",
-        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           installationId: input.installationId,
@@ -110,7 +110,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
       });
       return context.json(result);
     } catch (error) {
-      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         installationId: input.installationId,
         platform: input.platform,
@@ -169,6 +169,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
           context.req.method,
           getRequestContextUserId(requestContext),
           workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
       );
       addBackendBreadcrumb({
@@ -179,6 +181,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
           context.req.method,
           routeState.requestContext.userId,
           routeState.workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         details: {
           statusCode: 200,
@@ -198,6 +202,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         context.req.method,
         getRequestContextUserId(requestContext),
         workspaceId,
+        context.get("clientAppVersion"),
+        context.get("clientPlatform"),
       );
       const details = {
         ...getSyncPullInputDetails(input),
@@ -228,13 +234,13 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
       const durationMs = Date.now() - startedAtMs;
       addBackendBreadcrumb({
         action: "sync_bootstrap",
-        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: buildSyncBootstrapDetails(input, result, durationMs),
       });
       return context.json(result);
     } catch (error) {
       const durationMs = Date.now() - startedAtMs;
-      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         ...getSyncBootstrapFailureInputDetails(input, durationMs),
         ...createBackendFailureDetails(error),
@@ -289,6 +295,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
           context.req.method,
           getRequestContextUserId(requestContext),
           workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
       );
       addBackendBreadcrumb({
@@ -299,6 +307,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
           context.req.method,
           routeState.requestContext.userId,
           routeState.workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         details: {
           statusCode: 200,
@@ -318,6 +328,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         context.req.method,
         getRequestContextUserId(requestContext),
         workspaceId,
+        context.get("clientAppVersion"),
+        context.get("clientPlatform"),
       );
       const details = {
         ...getSyncReviewHistoryPullInputDetails(input),
@@ -346,7 +358,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
       const result = await processSyncReviewHistoryImport(workspaceId, requestContext.userId, input);
       addBackendBreadcrumb({
         action: "sync_review_history_import",
-        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           installationId: input.installationId,
@@ -359,7 +371,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
       });
       return context.json(result);
     } catch (error) {
-      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         installationId: input.installationId,
         platform: input.platform,

--- a/apps/backend/src/routes/sync/observation.ts
+++ b/apps/backend/src/routes/sync/observation.ts
@@ -60,6 +60,8 @@ export function createSyncScope(
   method: string,
   userId: string | null,
   workspaceId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
 ): BackendObservationScope {
   return createBackendObservationScope(
     "backend-api",
@@ -71,5 +73,7 @@ export function createSyncScope(
     null,
     null,
     null,
+    clientAppVersion,
+    clientPlatform,
   );
 }

--- a/apps/backend/src/routes/system/accountDeletion.ts
+++ b/apps/backend/src/routes/system/accountDeletion.ts
@@ -61,7 +61,7 @@ export function registerAccountDeletionRoute(
       });
       addBackendBreadcrumb({
         action: "account_delete",
-        scope: createSystemScope(requestId, context.req.path, context.req.method, auth.userId),
+        scope: createSystemScope(requestId, context.req.path, context.req.method, auth.userId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           transport: auth.transport,
@@ -69,7 +69,7 @@ export function registerAccountDeletionRoute(
       });
       return context.json({ ok: true } as const);
     } catch (error) {
-      const scope = createSystemScope(requestId, context.req.path, context.req.method, auth.userId);
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, auth.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         transport: auth.transport,
         ...createBackendFailureDetails(error),

--- a/apps/backend/src/routes/system/progress.ts
+++ b/apps/backend/src/routes/system/progress.ts
@@ -74,7 +74,7 @@ export function registerProgressRoutes(
 
       addBackendBreadcrumb({
         action: "me_progress_summary",
-        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           authTransport: requestContext.transport,
@@ -97,7 +97,7 @@ export function registerProgressRoutes(
 
       return context.json(progress satisfies ProgressSummaryResponse);
     } catch (error) {
-      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         authTransport: requestContext.transport,
         timeZone: requestedParameters.timeZone,
@@ -145,7 +145,7 @@ export function registerProgressRoutes(
 
       addBackendBreadcrumb({
         action: "me_progress_review_schedule",
-        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           authTransport: requestContext.transport,
@@ -158,7 +158,7 @@ export function registerProgressRoutes(
 
       return context.json(progress satisfies ProgressReviewSchedule);
     } catch (error) {
-      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         authTransport: requestContext.transport,
         timeZone: requestedParameters.timeZone,
@@ -199,7 +199,7 @@ export function registerProgressRoutes(
 
       addBackendBreadcrumb({
         action: "me_progress_series",
-        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           authTransport: requestContext.transport,
@@ -214,7 +214,7 @@ export function registerProgressRoutes(
 
       return context.json(progress satisfies ProgressSeries);
     } catch (error) {
-      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         authTransport: requestContext.transport,
         timeZone: requestedParameters.timeZone,
@@ -254,7 +254,7 @@ export function registerProgressRoutes(
 
       addBackendBreadcrumb({
         action: "me_progress_leaderboard",
-        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           authTransport: requestContext.transport,
@@ -267,7 +267,7 @@ export function registerProgressRoutes(
 
       return context.json(leaderboard satisfies ProgressLeaderboard);
     } catch (error) {
-      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         authTransport: requestContext.transport,
         status: null,
@@ -306,7 +306,7 @@ export function registerProgressRoutes(
 
       addBackendBreadcrumb({
         action: "me_progress_leaderboard_profile",
-        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           authTransport: requestContext.transport,
@@ -323,7 +323,7 @@ export function registerProgressRoutes(
 
       return context.json(profile satisfies LeaderboardProfile);
     } catch (error) {
-      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         authTransport: requestContext.transport,
         status: null,
@@ -363,7 +363,7 @@ export function registerProgressRoutes(
 
       addBackendBreadcrumb({
         action: "me_progress_streak_leaderboard",
-        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           authTransport: requestContext.transport,
@@ -375,7 +375,7 @@ export function registerProgressRoutes(
 
       return context.json(leaderboard satisfies StreakLeaderboard);
     } catch (error) {
-      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         authTransport: requestContext.transport,
         status: null,

--- a/apps/backend/src/routes/system/support.ts
+++ b/apps/backend/src/routes/system/support.ts
@@ -157,6 +157,8 @@ export function createSystemScope(
   route: string,
   method: string,
   userId: string,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
 ): BackendObservationScope {
   return createBackendObservationScope(
     "backend-api",
@@ -168,5 +170,7 @@ export function createSystemScope(
     null,
     null,
     null,
+    clientAppVersion,
+    clientPlatform,
   );
 }

--- a/apps/backend/src/routes/workspaces/index.ts
+++ b/apps/backend/src/routes/workspaces/index.ts
@@ -124,7 +124,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
         );
       addBackendBreadcrumb({
         action: "workspaces_list",
-        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null),
+        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
           selectedWorkspaceId: requestContext.selectedWorkspaceId,
@@ -145,7 +145,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
         nextCursor: workspacesPage.nextCursor,
       } satisfies WorkspacesPageResponse);
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         selectedWorkspaceId: requestContext.selectedWorkspaceId,
         workspacesCount: null,
@@ -189,6 +189,8 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
             context.req.method,
             currentRequestContext.userId,
             null,
+            context.get("clientAppVersion"),
+            context.get("clientPlatform"),
           );
           const workspace = shouldUseAgentSetupEnvelope(currentRequestContext.transport)
             ? await createWorkspaceForApiKeyConnectionWithObservationScopeFn(
@@ -210,6 +212,8 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
           context.req.method,
           getRequestContextUserId(requestContext),
           null,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
       );
       addBackendBreadcrumb({
@@ -220,6 +224,8 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
           context.req.method,
           routeState.requestContext.userId,
           routeState.workspace.workspaceId,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         details: {
           statusCode: 201,
@@ -236,6 +242,8 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
         context.req.method,
         getRequestContextUserId(requestContext),
         null,
+        context.get("clientAppVersion"),
+        context.get("clientPlatform"),
       );
       const details = {
         ...createBackendFailureDetails(error),
@@ -264,7 +272,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
         : await selectWorkspaceForUser(requestContext.userId, workspaceId);
       addBackendBreadcrumb({
         action: "workspace_select",
-        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
         },
@@ -274,7 +282,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       }
       return context.json({ workspace });
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         ...createBackendFailureDetails(error),
       };
@@ -304,14 +312,14 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       );
       addBackendBreadcrumb({
         action: "workspace_rename",
-        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform")),
         details: {
           statusCode: 200,
         },
       });
       return context.json({ workspace });
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         ...createBackendFailureDetails(error),
       };
@@ -331,7 +339,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     const requestId = context.get("requestId");
 
     try {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const preview = await loadWorkspaceDeletePreviewForUserWithObservationScope(
         requestContext.userId,
         workspaceId,
@@ -347,7 +355,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       });
       return context.json(preview satisfies WorkspaceDeletePreview);
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         cardsCount: null,
         ...createBackendFailureDetails(error),
@@ -377,7 +385,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     }
 
     try {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const response = await deleteWorkspaceForUserWithObservationScope(
         requestContext.userId,
         workspaceId,
@@ -395,7 +403,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       });
       return context.json(response satisfies WorkspaceDeleteResponse);
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         deletedCardsCount: null,
         nextWorkspaceId: null,
@@ -417,7 +425,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     const requestId = context.get("requestId");
 
     try {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const preview = await loadWorkspaceResetProgressPreviewForUserWithObservationScope(
         requestContext.userId,
         workspaceId,
@@ -433,7 +441,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       });
       return context.json(preview satisfies WorkspaceResetProgressPreviewResponse);
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         cardsCount: null,
         ...createBackendFailureDetails(error),
@@ -463,7 +471,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     }
 
     try {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const response = await resetWorkspaceProgressForUserWithObservationScope(
         requestContext.userId,
         workspaceId,
@@ -480,7 +488,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       });
       return context.json(response satisfies WorkspaceResetProgressResponse);
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
       const details = {
         cardsResetCount: null,
         ...createBackendFailureDetails(error),

--- a/apps/backend/src/routes/workspaces/observation.ts
+++ b/apps/backend/src/routes/workspaces/observation.ts
@@ -14,6 +14,8 @@ export function createWorkspaceRouteScope(
   method: string,
   userId: string | null,
   workspaceId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
 ): BackendObservationScope {
   return createBackendObservationScope(
     "backend-api",
@@ -25,5 +27,7 @@ export function createWorkspaceRouteScope(
     null,
     null,
     null,
+    clientAppVersion,
+    clientPlatform,
   );
 }

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -38,6 +38,8 @@ import { hasReportedBackendException } from "../observability/reporting";
 export type AppEnv = {
   Variables: {
     requestId: string;
+    clientAppVersion: string | null;
+    clientPlatform: string | null;
   };
 };
 
@@ -198,6 +200,8 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
   app.use("*", async (context, next) => {
     const requestId = crypto.randomUUID();
     context.set("requestId", requestId);
+    context.set("clientAppVersion", context.req.header("x-client-version") ?? null);
+    context.set("clientPlatform", context.req.header("x-client-platform") ?? null);
     context.header("X-Request-Id", requestId);
     await next();
   });
@@ -256,6 +260,8 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
           null,
           null,
           null,
+          context.get("clientAppVersion"),
+          context.get("clientPlatform"),
         ),
         details: {
           statusCode: error instanceof HttpError ? error.statusCode : 500,

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -158,6 +158,8 @@ export function logRequestError(
         null,
         null,
         null,
+        null,
+        null,
       ),
       details,
     });
@@ -186,6 +188,8 @@ export function logAdminQueryEvent(
     payload.requestId,
     "/admin/reports/query",
     "POST",
+    null,
+    null,
     null,
     null,
     null,

--- a/apps/backend/src/telemetry/langfuse.test.ts
+++ b/apps/backend/src/telemetry/langfuse.test.ts
@@ -249,6 +249,8 @@ test("Langfuse flush no-ops before telemetry starts", async () => {
       null,
       null,
       null,
+      null,
+      null,
     ));
   } finally {
     resetLangfuseTelemetryForTests();
@@ -276,6 +278,8 @@ test("Langfuse flush force-flushes the isolated provider", async () => {
 
     await flushLangfuseTelemetry(createBackendObservationScope(
       "backend-api",
+      null,
+      null,
       null,
       null,
       null,
@@ -330,6 +334,8 @@ test("Langfuse flush logs and swallows force-flush failures", async () => {
       "chat-request-1",
       "run-1",
       "session-1",
+      null,
+      null,
     ));
 
     assert.deepEqual(warningRecords, [
@@ -345,6 +351,8 @@ test("Langfuse flush logs and swallows force-flush failures", async () => {
         chatRequestId: "chat-request-1",
         runId: "run-1",
         sessionId: "session-1",
+        clientAppVersion: null,
+        clientPlatform: null,
         errorClass: "Error",
         errorMessage: "Langfuse export failed",
         telemetryStarted: true,

--- a/apps/backend/src/telemetry/langfuse.ts
+++ b/apps/backend/src/telemetry/langfuse.ts
@@ -244,6 +244,8 @@ function logChatTurnExportFailure(
       null,
       null,
       params.sessionId,
+      null,
+      null,
     ),
     details,
   });
@@ -275,6 +277,8 @@ function logChatTurnStartFailure(
       null,
       null,
       params.sessionId,
+      null,
+      null,
     ),
     details,
   });
@@ -306,6 +310,8 @@ function logChatTranscriptionExportFailure(
       null,
       null,
       params.sessionId,
+      null,
+      null,
     ),
     details,
   });
@@ -337,6 +343,8 @@ function logChatTranscriptionStartFailure(
       null,
       null,
       params.sessionId,
+      null,
+      null,
     ),
     details,
   });

--- a/apps/backend/src/workspaces/shared.ts
+++ b/apps/backend/src/workspaces/shared.ts
@@ -157,6 +157,8 @@ export function createWorkspaceTransactionScope(
     observationScope?.chatRequestId ?? null,
     observationScope?.runId ?? null,
     observationScope?.sessionId ?? null,
+    observationScope?.clientAppVersion ?? null,
+    observationScope?.clientPlatform ?? null,
   );
 }
 


### PR DESCRIPTION
## What
Adds `clientAppVersion` and `clientPlatform` to `BackendObservationScope`, so every backend Sentry event carries the client's app version and platform as first-class, **groupable tags** (sourced from `X-Client-Version` / `X-Client-Platform`). Combined with the existing `release` (git SHA = the deployed backend), this makes "client X × backend Y" compatibility issues filterable in one Sentry query instead of correlating by `requestId` into CloudWatch logs.

## How
- `events.ts`: two new `string | null` fields on `BackendObservationScope`.
- `scope.ts`: two new params on `createBackendObservationScope`; two `getScopeTagValue`-guarded `setTag` calls in `setSentryScope` (same pattern as the sibling tags); runtime builder passes `null`.
- `server/app.ts`: the request middleware reads the two headers (`?? null`) into the Hono context; the `onError` scope passes them through.
- Threaded through **all ~64 `createBackendObservationScope` call sites**: request paths read from context; `chat-live` and `chat-resume` paths reuse the client values already on their `params` / `diagnostics`; background/worker/scheduled paths pass `null`.
- Version-coupled test expectations aligned.

## Validation
- `npm run lint --prefix apps/backend` (tsc --noEmit): **pass**
- `npm test --prefix apps/backend`: **513 / 513 pass**

## Reviewed-to-clean (loop-claude)
Implemented, then looped fresh empty-history reviews → fix until a clean pass. Beyond the bulk, the loop caught and fixed: chat-live lifecycle scope and two `chat/http/diagnostics.ts` scopes that were dropping already-available client values to `null`.

### Flagged during review, intentionally left out of scope (follow-ups)
- **Cold-start bootstrap scopes** (`entrypoints/lambda.ts`, `entrypoints/lambda-mcp.ts`): pass `null` though `event.headers` are reachable. Edge path — normal requests already get the tags via middleware; MCP is a machine surface where these app-client headers are typically absent.
- **Transcription failure loggers** (`chat/transcriptions.ts`): would require extending `ChatTranscriptionRequestContext` and `ChatTranscriptionFailureDetails` to plumb the values — deferred as scope creep.
- **Tag cardinality / `clientVersion` vs `clientAppVersion` local naming**: accepted as matching existing repo convention (sibling tags like `requestId`/`sessionId` are already set raw; chat code already uses the `clientVersion` local name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)