### PR TITLE
Add Android card metadata roundtrip

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/RepositorySeedExecutor.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/RepositorySeedExecutor.kt
@@ -10,8 +10,11 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardWithRelations
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
@@ -142,6 +145,8 @@ internal class RepositorySeedExecutor(
             workspaceId = workspaceId,
             frontText = seedCard.frontText,
             backText = seedCard.backText,
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(createdAtMillis)),
             dueAtMillis = null,
             createdAtMillis = createdAtMillis,
             updatedAtMillis = createdAtMillis,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cards/LocalCardsDecksRepositoryContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cards/LocalCardsDecksRepositoryContractTest.kt
@@ -6,6 +6,9 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
 import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
@@ -100,6 +103,8 @@ class LocalCardsDecksRepositoryContractTest {
             workspaceId = workspaceId,
             frontText = "Older",
             backText = "Back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(100L)),
             dueAtMillis = null,
             createdAtMillis = 100L,
             updatedAtMillis = 100L,
@@ -118,6 +123,8 @@ class LocalCardsDecksRepositoryContractTest {
             workspaceId = workspaceId,
             frontText = "Newer",
             backText = "Back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(200L)),
             dueAtMillis = null,
             createdAtMillis = 200L,
             updatedAtMillis = 200L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreContractTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreContractTestFixtures.kt
@@ -8,6 +8,9 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.scheduling.WorkspaceSchedulerSettings
 import com.flashcardsopensourceapp.data.local.model.scheduling.encodeSchedulerStepListJson
@@ -101,6 +104,8 @@ internal suspend fun insertSyncContractCard(
             workspaceId = workspaceId,
             frontText = "Front",
             backText = "Back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
             dueAtMillis = null,
             createdAtMillis = 1L,
             updatedAtMillis = 1L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreForkReidentificationContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreForkReidentificationContractTest.kt
@@ -7,6 +7,9 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
@@ -57,6 +60,8 @@ class SyncLocalStoreForkReidentificationContractTest {
             workspaceId = syncLocalStoreContractWorkspaceId,
             frontText = "Front",
             backText = "Back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
             dueAtMillis = null,
             createdAtMillis = 1L,
             updatedAtMillis = 2L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreHotRowPreservationContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreHotRowPreservationContractTest.kt
@@ -7,6 +7,11 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
+import com.flashcardsopensourceapp.data.local.model.cards.buildCardMetadataJsonObject
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cards.makeDefaultCardMetadata
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import kotlinx.coroutines.flow.first
@@ -50,6 +55,8 @@ class SyncLocalStoreHotRowPreservationContractTest {
             workspaceId = syncLocalStoreContractWorkspaceId,
             frontText = "Local front",
             backText = "Local back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
             dueAtMillis = null,
             createdAtMillis = 1L,
             updatedAtMillis = 2L,
@@ -161,6 +168,13 @@ private fun remoteCardBootstrapEntry(
             .put("cardId", cardId)
             .put("frontText", frontText)
             .put("backText", backText)
+            .put("cardType", defaultCardType)
+            .put(
+                "metadata",
+                buildCardMetadataJsonObject(
+                    metadata = makeDefaultCardMetadata(createdAt = "2026-03-27T19:00:00Z")
+                )
+            )
             .put("tags", JSONArray(tags))
             .put("effortLevel", "fast")
             .put("dueAt", JSONObject.NULL)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreTimestampPayloadContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreTimestampPayloadContractTest.kt
@@ -6,6 +6,8 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapE
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
+import com.flashcardsopensourceapp.data.local.model.cards.decodeCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.sync.SyncOperationPayload
 import kotlinx.coroutines.runBlocking
@@ -94,6 +96,11 @@ class SyncLocalStoreTimestampPayloadContractTest {
 
         requireNotNull(card)
         requireNotNull(deck)
+        assertEquals(defaultCardType, card.cardType)
+        assertEquals(
+            "2026-03-27T19:00:00Z",
+            decodeCardMetadataJson(metadataJson = card.metadataJson).source?.createdAt
+        )
         assertNull(card.dueAtMillis)
         assertNull(card.fsrsLastReviewedAtMillis)
         assertNull(card.deletedAtMillis)
@@ -189,6 +196,8 @@ class SyncLocalStoreTimestampPayloadContractTest {
         val outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId = syncLocalStoreContractWorkspaceId)
         val payload = (outboxEntries.single().operation.payload as SyncOperationPayload.Card).payload
 
+        assertEquals(defaultCardType, payload.cardType)
+        assertEquals("2026-03-27T19:00:00Z", payload.metadata.source?.createdAt)
         assertNull(payload.dueAt)
         assertNull(payload.fsrsLastReviewedAt)
         assertNull(payload.deletedAt)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
@@ -11,6 +11,9 @@ import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
@@ -58,6 +61,8 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             workspaceId = syncLocalStoreContractWorkspaceId,
             frontText = "Front",
             backText = "Back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
             dueAtMillis = null,
             createdAtMillis = 1L,
             updatedAtMillis = 2L,
@@ -234,6 +239,8 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             workspaceId = syncLocalStoreContractWorkspaceId,
             frontText = "Front",
             backText = "Back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
             dueAtMillis = null,
             createdAtMillis = 1L,
             updatedAtMillis = 2L,
@@ -347,6 +354,8 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             workspaceId = syncLocalStoreContractWorkspaceId,
             frontText = "Front",
             backText = "Back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
             dueAtMillis = null,
             createdAtMillis = 1L,
             updatedAtMillis = 2L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration25To26Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration25To26Test.kt
@@ -1,0 +1,141 @@
+package com.flashcardsopensourceapp.data.local.migrations
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.database.migrations.migration25To26
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val migration25To26DatabaseName: String = "migration-25-to-26-test.db"
+
+@RunWith(AndroidJUnit4::class)
+class AppDatabaseMigration25To26Test {
+    @After
+    fun tearDown(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        deleteMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration25To26DatabaseName
+        )
+    }
+
+    @Test
+    fun migration25To26AddsCardTypeAndBackfillsMetadataJson(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        createVersion25Database(context = context)
+
+        val openHelper: SupportSQLiteOpenHelper = openMigrationDatabaseAtVersion(
+            context = context,
+            databaseName = migration25To26DatabaseName,
+            version = 25
+        )
+        val database: SupportSQLiteDatabase = openHelper.writableDatabase
+
+        try {
+            migration25To26.migrate(database)
+
+            val metadataJson: String = readMigrationSingleString(
+                database = database,
+                sql = "SELECT metadataJson FROM cards WHERE cardId = 'card-1'"
+            )
+            val metadata: JSONObject = JSONObject(metadataJson)
+            val source: JSONObject = metadata.getJSONObject("source")
+
+            assertEquals(
+                "basic",
+                readMigrationSingleString(
+                    database = database,
+                    sql = "SELECT cardType FROM cards WHERE cardId = 'card-1'"
+                )
+            )
+            assertEquals(1, metadata.getInt("version"))
+            assertTrue(source.isNull("label"))
+            assertTrue(source.isNull("author"))
+            assertTrue(source.isNull("comment"))
+            assertEquals("1970-01-01T00:00:01.000Z", source.getString("createdAt"))
+            assertTrue(source.isNull("importedAt"))
+            assertTrue(source.isNull("importId"))
+        } finally {
+            database.close()
+            openHelper.close()
+        }
+    }
+
+    private fun createVersion25Database(context: Context): Unit {
+        createMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration25To26DatabaseName,
+            version = 25
+        ) { sqliteDatabase: SQLiteDatabase ->
+            sqliteDatabase.execSQL(
+                """
+                CREATE TABLE cards (
+                    cardId TEXT NOT NULL PRIMARY KEY,
+                    workspaceId TEXT NOT NULL,
+                    frontText TEXT NOT NULL,
+                    backText TEXT NOT NULL,
+                    dueAtMillis INTEGER,
+                    createdAtMillis INTEGER NOT NULL,
+                    updatedAtMillis INTEGER NOT NULL,
+                    reps INTEGER NOT NULL,
+                    lapses INTEGER NOT NULL,
+                    fsrsCardState TEXT NOT NULL,
+                    fsrsStepIndex INTEGER,
+                    fsrsStability REAL,
+                    fsrsDifficulty REAL,
+                    fsrsLastReviewedAtMillis INTEGER,
+                    fsrsScheduledDays INTEGER,
+                    deletedAtMillis INTEGER
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                INSERT INTO cards (
+                    cardId,
+                    workspaceId,
+                    frontText,
+                    backText,
+                    dueAtMillis,
+                    createdAtMillis,
+                    updatedAtMillis,
+                    reps,
+                    lapses,
+                    fsrsCardState,
+                    fsrsStepIndex,
+                    fsrsStability,
+                    fsrsDifficulty,
+                    fsrsLastReviewedAtMillis,
+                    fsrsScheduledDays,
+                    deletedAtMillis
+                ) VALUES (
+                    'card-1',
+                    'workspace-1',
+                    'Question',
+                    'Answer',
+                    NULL,
+                    1000,
+                    2000,
+                    0,
+                    0,
+                    'NEW',
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL
+                )
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryPendingGuestUpgradeRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryPendingGuestUpgradeRecoveryTest.kt
@@ -9,12 +9,15 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHist
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.CloudIdentityTestEnvironment
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.FakeCloudRemoteGateway
@@ -344,6 +347,8 @@ private fun createPendingGuestUpgradeBlockedCard(workspaceId: String): CardEntit
         workspaceId = workspaceId,
         frontText = "Blocked Question",
         backText = "Blocked Answer",
+        cardType = defaultCardType,
+        metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(500L)),
         dueAtMillis = null,
         createdAtMillis = 500L,
         updatedAtMillis = 500L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeDrainTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeDrainTest.kt
@@ -7,10 +7,13 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapP
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPushResponse
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.repository.SyncBlockedException
@@ -475,6 +478,8 @@ private fun createBlockedGuestUpgradeCard(workspaceId: String): CardEntity {
         workspaceId = workspaceId,
         frontText = "Blocked Question",
         backText = "Blocked Answer",
+        cardType = defaultCardType,
+        metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(500L)),
         dueAtMillis = null,
         createdAtMillis = 500L,
         updatedAtMillis = 500L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
@@ -9,10 +9,13 @@ import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntit
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.CloudIdentityTestEnvironment
@@ -80,6 +83,8 @@ class LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest {
                 workspaceId = localWorkspaceId,
                 frontText = "Keep Question",
                 backText = "Keep Answer",
+                cardType = defaultCardType,
+                metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(110L)),
                 dueAtMillis = null,
                 createdAtMillis = 110L,
                 updatedAtMillis = 110L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
@@ -20,6 +20,9 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.scheduling.encodeSchedulerStepListJson
@@ -299,6 +302,8 @@ internal class CloudIdentityTestEnvironment private constructor(
                 workspaceId = workspaceId,
                 frontText = "Question",
                 backText = "Answer",
+                cardType = defaultCardType,
+                metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(100L)),
                 dueAtMillis = null,
                 createdAtMillis = 100L,
                 updatedAtMillis = 100L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryDisconnectedStateTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryDisconnectedStateTest.kt
@@ -4,10 +4,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryReason
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.cloud.cloudCredentialRecoveryRequiredMessage
@@ -187,6 +190,8 @@ class LocalSyncRepositoryDisconnectedStateTest {
                 workspaceId = localWorkspaceId,
                 frontText = "Question",
                 backText = "Answer",
+                cardType = defaultCardType,
+                metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(100L)),
                 dueAtMillis = null,
                 createdAtMillis = 100L,
                 updatedAtMillis = 100L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryHotRowReplayTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryHotRowReplayTest.kt
@@ -10,6 +10,12 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushRespon
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteSyncChange
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
+import com.flashcardsopensourceapp.data.local.model.cards.buildCardMetadataJsonObject
+import com.flashcardsopensourceapp.data.local.model.cards.decodeCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cards.makeDefaultCardMetadata
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
@@ -50,6 +56,8 @@ class LocalSyncRepositoryHotRowReplayTest {
             workspaceId = workspaceId,
             frontText = "Local pending front",
             backText = "Local pending back",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(100L)),
             dueAtMillis = null,
             createdAtMillis = 100L,
             updatedAtMillis = 200L,
@@ -420,6 +428,11 @@ class LocalSyncRepositoryHotRowReplayTest {
         assertEquals(listOf(5L), hotPullCursors)
         assertEquals("Remote unseen front", remoteCard.frontText)
         assertEquals("Remote unseen back", remoteCard.backText)
+        assertEquals(defaultCardType, remoteCard.cardType)
+        assertEquals(
+            "2026-04-02T15:50:57.000Z",
+            decodeCardMetadataJson(metadataJson = remoteCard.metadataJson).source?.createdAt
+        )
         assertEquals(0, environment.database.outboxDao().countOutboxEntries())
         assertEquals("100", persistedSyncState.lastSyncCursor)
         assertTrue(baseGateway.bootstrapPullWorkspaceIds.isEmpty())
@@ -437,6 +450,13 @@ private fun createRemoteCardHotPayload(
         .put("cardId", cardId)
         .put("frontText", frontText)
         .put("backText", backText)
+        .put("cardType", defaultCardType)
+        .put(
+            "metadata",
+            buildCardMetadataJsonObject(
+                metadata = makeDefaultCardMetadata(createdAt = "2026-04-02T15:50:57.000Z")
+            )
+        )
         .put("tags", JSONArray(tags))
         .put("effortLevel", "fast")
         .put("dueAt", JSONObject.NULL)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryWorkspaceForkRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryWorkspaceForkRecoveryTest.kt
@@ -7,7 +7,10 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushRespon
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
@@ -184,6 +187,8 @@ class LocalSyncRepositoryWorkspaceForkRecoveryTest {
             workspaceId = workspaceId,
             frontText = "Question 2",
             backText = "Answer 2",
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(110L)),
             dueAtMillis = null,
             createdAtMillis = 110L,
             updatedAtMillis = 110L,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
@@ -8,6 +8,9 @@ import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
@@ -140,6 +143,8 @@ internal fun makeDueReviewOrderingCardEntity(
         workspaceId = workspaceId,
         frontText = cardId,
         backText = "Back",
+        cardType = defaultCardType,
+        metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(createdAtMillis)),
         dueAtMillis = dueAtMillis,
         createdAtMillis = createdAtMillis,
         updatedAtMillis = updatedAtMillis,
@@ -166,6 +171,8 @@ internal fun makeNewReviewOrderingCardEntity(
         workspaceId = workspaceId,
         frontText = cardId,
         backText = "Back",
+        cardType = defaultCardType,
+        metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(createdAtMillis)),
         dueAtMillis = null,
         createdAtMillis = createdAtMillis,
         updatedAtMillis = updatedAtMillis,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/sync/LocalSyncOutboxContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/sync/LocalSyncOutboxContractTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
 import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
@@ -75,6 +76,15 @@ class LocalSyncOutboxContractTest {
         assertEquals(3, entries.size)
         assertTrue(entries.all { entry -> entry.entityType == "card" })
         assertTrue(entries.all { entry -> entry.operationType == "upsert" })
+        assertTrue(entries.all { entry ->
+            JSONObject(entry.payloadJson).getString("cardType") == defaultCardType
+        })
+        assertTrue(entries.all { entry ->
+            val payload = JSONObject(entry.payloadJson)
+            payload.getJSONObject("metadata")
+                .getJSONObject("source")
+                .getString("createdAt") == payload.getString("createdAt")
+        })
         assertTrue(entries.any { entry ->
             JSONObject(entry.payloadJson).getString("frontText") == "What is a repository pattern?"
         })

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
@@ -12,6 +12,9 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.legacyEffortTag
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudDoubleOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudIntOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull
+import com.flashcardsopensourceapp.data.local.cloud.wire.parseCardPayloadCardType
+import com.flashcardsopensourceapp.data.local.cloud.wire.parseCardPayloadMetadata
+import com.flashcardsopensourceapp.data.local.cloud.wire.parseCloudIsoTimestamp
 import com.flashcardsopensourceapp.data.local.cloud.wire.parseLegacyEffortLevel
 import com.flashcardsopensourceapp.data.local.cloud.wire.parseDeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.cloud.wire.parseFsrsCardState
@@ -27,6 +30,7 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.toCloudIntList
 import com.flashcardsopensourceapp.data.local.cloud.wire.toCloudStringList
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.scheduling.encodeSchedulerStepListJson
+import com.flashcardsopensourceapp.data.local.model.cards.encodeCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cards.encodeDeckFilterDefinitionJson
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
 import org.json.JSONObject
@@ -68,13 +72,22 @@ internal class SyncHotStateLocalStore(
     }
 
     private suspend fun applyRemoteCard(workspaceId: String, payload: JSONObject, fieldPath: String) {
+        val createdAt: String = payload.requireCloudString("createdAt", "$fieldPath.createdAt")
         val card = CardEntity(
             cardId = payload.requireCloudString("cardId", "$fieldPath.cardId"),
             workspaceId = workspaceId,
             frontText = payload.requireCloudString("frontText", "$fieldPath.frontText"),
             backText = payload.requireCloudString("backText", "$fieldPath.backText"),
+            cardType = parseCardPayloadCardType(payloadJson = payload, fieldPath = fieldPath),
+            metadataJson = encodeCardMetadataJson(
+                metadata = parseCardPayloadMetadata(
+                    payloadJson = payload,
+                    createdAt = createdAt,
+                    fieldPath = fieldPath
+                )
+            ),
             dueAtMillis = payload.requireCloudNullableIsoTimestampMillis("dueAt", "$fieldPath.dueAt"),
-            createdAtMillis = payload.requireCloudIsoTimestampMillis("createdAt", "$fieldPath.createdAt"),
+            createdAtMillis = parseCloudIsoTimestamp(value = createdAt, fieldPath = "$fieldPath.createdAt"),
             updatedAtMillis = payload.requireCloudIsoTimestampMillis("clientUpdatedAt", "$fieldPath.clientUpdatedAt"),
             reps = payload.requireCloudInt("reps", "$fieldPath.reps"),
             lapses = payload.requireCloudInt("lapses", "$fieldPath.lapses"),

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
@@ -7,10 +7,13 @@ import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntit
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
+import com.flashcardsopensourceapp.data.local.model.cards.CardMetadata
+import com.flashcardsopensourceapp.data.local.model.cards.CardSourceMetadata
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.data.local.model.sync.CardSyncPayload
 import com.flashcardsopensourceapp.data.local.model.cards.DeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.sync.DeckSyncPayload
+import com.flashcardsopensourceapp.data.local.model.cards.buildCardMetadataJsonObject
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.ReviewEventSyncPayload
 import com.flashcardsopensourceapp.data.local.model.sync.SyncAction
@@ -20,6 +23,10 @@ import com.flashcardsopensourceapp.data.local.model.sync.SyncOperationPayload
 import com.flashcardsopensourceapp.data.local.model.sync.WorkspaceSchedulerSettingsSyncPayload
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinitionJsonObject
+import com.flashcardsopensourceapp.data.local.model.cards.decodeCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.makeDefaultCardMetadata
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeCardType
 import com.flashcardsopensourceapp.data.local.model.scheduling.decodeSchedulerStepListJson
 import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
@@ -43,6 +50,8 @@ internal fun buildCardOutboxPayloadJson(card: CardEntity, tags: List<String>): J
         .put("cardId", card.cardId)
         .put("frontText", card.frontText)
         .put("backText", card.backText)
+        .put("cardType", normalizeCardType(rawValue = card.cardType))
+        .put("metadata", buildCardMetadataJsonObject(metadata = decodeCardMetadataJson(metadataJson = card.metadataJson)))
         .put("tags", JSONArray(tags))
         // TODO: Remove legacy effortLevel once the backend wire contract drops it.
         .put("effortLevel", legacyFastEffortWireValue)
@@ -111,6 +120,8 @@ internal fun buildCardBootstrapEntryJson(
                 .put("cardId", card.cardId)
                 .put("frontText", card.frontText)
                 .put("backText", card.backText)
+                .put("cardType", card.cardType)
+                .put("metadata", buildCardMetadataJsonObject(metadata = card.metadata))
                 .put("tags", JSONArray(card.tags))
                 // TODO: Remove legacy effortLevel once the backend wire contract drops it.
                 .put("effortLevel", legacyFastEffortWireValue)
@@ -212,6 +223,12 @@ internal fun decodeOutboxOperation(entry: OutboxEntryEntity): SyncOperation {
                     cardId = payloadJson.requireCloudString("cardId", "outbox.card.cardId"),
                     frontText = payloadJson.requireCloudString("frontText", "outbox.card.frontText"),
                     backText = payloadJson.requireCloudString("backText", "outbox.card.backText"),
+                    cardType = parseCardPayloadCardType(payloadJson = payloadJson, fieldPath = "outbox.card"),
+                    metadata = parseCardPayloadMetadata(
+                        payloadJson = payloadJson,
+                        createdAt = payloadJson.requireCloudString("createdAt", "outbox.card.createdAt"),
+                        fieldPath = "outbox.card"
+                    ),
                     tags = parseCardOutboxTags(payloadJson = payloadJson, fieldPath = "outbox.card"),
                     effortLevel = legacyFastEffortWireValue,
                     dueAt = payloadJson.requireCloudNullableString("dueAt", "outbox.card.dueAt"),
@@ -317,6 +334,56 @@ internal fun parseSyncAction(rawValue: String): SyncAction {
     }
 }
 
+internal fun parseCardPayloadCardType(payloadJson: JSONObject, fieldPath: String): String {
+    if (payloadJson.has("cardType").not()) {
+        return defaultCardType
+    }
+    return normalizeCardType(rawValue = payloadJson.requireCloudString("cardType", "$fieldPath.cardType"))
+}
+
+internal fun parseCardPayloadMetadata(
+    payloadJson: JSONObject,
+    createdAt: String,
+    fieldPath: String
+): CardMetadata {
+    if (payloadJson.has("metadata").not()) {
+        return makeDefaultCardMetadata(createdAt = createdAt)
+    }
+    val metadataObject = payloadJson.requireCloudObject("metadata", "$fieldPath.metadata")
+    val version: Int = metadataObject.requireCloudInt("version", "$fieldPath.metadata.version")
+    if (version != 1) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath.metadata.version: expected 1, got $version"
+        )
+    }
+    if (metadataObject.has("source").not()) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath.metadata.source: expected present value, got missing"
+        )
+    }
+
+    return CardMetadata(
+        version = version,
+        source = metadataObject.optCloudObjectOrNull("source", "$fieldPath.metadata.source")?.let { sourceObject ->
+            parseCardSourceMetadata(
+                metadataObject = sourceObject,
+                fieldPath = "$fieldPath.metadata.source"
+            )
+        }
+    )
+}
+
+private fun parseCardSourceMetadata(metadataObject: JSONObject, fieldPath: String): CardSourceMetadata {
+    return CardSourceMetadata(
+        label = metadataObject.requireCloudNullableString("label", "$fieldPath.label"),
+        author = metadataObject.requireCloudNullableString("author", "$fieldPath.author"),
+        comment = metadataObject.requireCloudNullableString("comment", "$fieldPath.comment"),
+        createdAt = metadataObject.requireCloudNullableString("createdAt", "$fieldPath.createdAt"),
+        importedAt = metadataObject.requireCloudNullableString("importedAt", "$fieldPath.importedAt"),
+        importId = metadataObject.requireCloudNullableString("importId", "$fieldPath.importId")
+    )
+}
+
 internal fun SyncEntityType.toRemoteValue(): String {
     return when (this) {
         SyncEntityType.CARD -> "card"
@@ -410,6 +477,8 @@ internal fun toCardSummary(card: CardWithRelations): CardSummary {
         workspaceId = card.card.workspaceId,
         frontText = card.card.frontText,
         backText = card.card.backText,
+        cardType = normalizeCardType(rawValue = card.card.cardType),
+        metadata = decodeCardMetadataJson(metadataJson = card.card.metadataJson),
         tags = normalizeTags(card.tags.map(TagEntity::name), emptyList()),
         dueAtMillis = card.card.dueAtMillis,
         createdAtMillis = card.card.createdAtMillis,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -62,7 +62,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 25,
+    version = 26,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/CardEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/CardEntities.kt
@@ -65,6 +65,8 @@ data class CardEntity(
     val workspaceId: String,
     val frontText: String,
     val backText: String,
+    val cardType: String,
+    val metadataJson: String,
     val dueAtMillis: Long?,
     val createdAtMillis: Long,
     val updatedAtMillis: Long,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -5,6 +5,7 @@ import androidx.sqlite.db.SimpleSQLiteQuery
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.cardsRecentlyReviewedDueIndexName
 import com.flashcardsopensourceapp.data.local.database.entities.cardsReviewQueueIndexName
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import java.util.UUID
 import org.json.JSONArray
 import org.json.JSONException
@@ -38,7 +39,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration21To22,
         migration22To23,
         migration23To24,
-        migration24To25
+        migration24To25,
+        migration25To26
     )
 }
 
@@ -854,10 +856,28 @@ val migration24To25: Migration = object : Migration(24, 25) {
     }
 }
 
+val migration25To26: Migration = object : Migration(25, 26) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE cards ADD COLUMN cardType TEXT NOT NULL DEFAULT 'basic'")
+        db.execSQL(
+            """
+            ALTER TABLE cards
+            ADD COLUMN metadataJson TEXT NOT NULL DEFAULT '{"version":1,"source":null}'
+            """.trimIndent()
+        )
+        backfillCardMetadataJson(db = db)
+    }
+}
+
 private data class LegacyCardEffortRow(
     val cardId: String,
     val workspaceId: String,
     val effortTag: String
+)
+
+private data class CardMetadataBackfillRow(
+    val cardId: String,
+    val createdAtMillis: Long
 )
 
 private data class LegacyDeckFilterRow(
@@ -1225,4 +1245,48 @@ private fun rebuildCardsWithoutLegacyEffort(db: SupportSQLiteDatabase) {
     db.execSQL("CREATE INDEX IF NOT EXISTS index_review_logs_cardId ON review_logs(cardId)")
     db.execSQL("CREATE INDEX IF NOT EXISTS index_review_logs_reviewedAtMillis ON review_logs(reviewedAtMillis)")
     db.execSQL("DROP TABLE review_logs_v25_backup")
+}
+
+private fun backfillCardMetadataJson(db: SupportSQLiteDatabase) {
+    loadCardMetadataBackfillRows(db = db).forEach { row ->
+        db.execSQL(
+            "UPDATE cards SET metadataJson = ? WHERE cardId = ?",
+            arrayOf(buildDefaultCardMetadataJson(createdAt = formatIsoTimestamp(row.createdAtMillis)), row.cardId)
+        )
+    }
+}
+
+private fun loadCardMetadataBackfillRows(db: SupportSQLiteDatabase): List<CardMetadataBackfillRow> {
+    return db.query(SimpleSQLiteQuery("SELECT cardId, createdAtMillis FROM cards")).use { cursor ->
+        val cardIdIndex = cursor.getColumnIndexOrThrow("cardId")
+        val createdAtMillisIndex = cursor.getColumnIndexOrThrow("createdAtMillis")
+        val rows = mutableListOf<CardMetadataBackfillRow>()
+
+        while (cursor.moveToNext()) {
+            rows.add(
+                CardMetadataBackfillRow(
+                    cardId = cursor.getString(cardIdIndex),
+                    createdAtMillis = cursor.getLong(createdAtMillisIndex)
+                )
+            )
+        }
+
+        rows.toList()
+    }
+}
+
+private fun buildDefaultCardMetadataJson(createdAt: String): String {
+    return JSONObject()
+        .put("version", 1)
+        .put(
+            "source",
+            JSONObject()
+                .put("label", JSONObject.NULL)
+                .put("author", JSONObject.NULL)
+                .put("comment", JSONObject.NULL)
+                .put("createdAt", createdAt)
+                .put("importedAt", JSONObject.NULL)
+                .put("importId", JSONObject.NULL)
+        )
+        .toString()
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewQueueDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewQueueDao.kt
@@ -162,9 +162,9 @@ interface ReviewQueueDao {
     @Transaction
     @Query(
         """
-        SELECT cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+        SELECT cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
         FROM (
-            SELECT 0 AS activeQueueBucket, cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+            SELECT 0 AS activeQueueBucket, cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
             FROM (
                 SELECT * FROM cards INDEXED BY index_cards_workspaceId_fsrsLastReviewedAtMillis_dueAtMillis_createdAtMillis_cardId
                 WHERE workspaceId = :workspaceId
@@ -178,7 +178,7 @@ interface ReviewQueueDao {
                 LIMIT :limit
             )
             UNION ALL
-            SELECT 1 AS activeQueueBucket, cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+            SELECT 1 AS activeQueueBucket, cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
             FROM (
                 SELECT * FROM cards INDEXED BY index_cards_workspaceId_dueAtMillis_createdAtMillis_cardId
                 WHERE workspaceId = :workspaceId
@@ -194,7 +194,7 @@ interface ReviewQueueDao {
                 LIMIT :limit
             )
             UNION ALL
-            SELECT 2 AS activeQueueBucket, cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+            SELECT 2 AS activeQueueBucket, cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
             FROM (
                 SELECT * FROM cards INDEXED BY index_cards_workspaceId_dueAtMillis_createdAtMillis_cardId
                 WHERE workspaceId = :workspaceId
@@ -218,9 +218,9 @@ interface ReviewQueueDao {
     @Transaction
     @Query(
         """
-        SELECT cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+        SELECT cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
         FROM (
-            SELECT 0 AS activeQueueBucket, cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+            SELECT 0 AS activeQueueBucket, cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
             FROM (
                 SELECT * FROM cards INDEXED BY index_cards_workspaceId_fsrsLastReviewedAtMillis_dueAtMillis_createdAtMillis_cardId
                 WHERE workspaceId = :workspaceId
@@ -242,7 +242,7 @@ interface ReviewQueueDao {
                 LIMIT :limit
             )
             UNION ALL
-            SELECT 1 AS activeQueueBucket, cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+            SELECT 1 AS activeQueueBucket, cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
             FROM (
                 SELECT * FROM cards INDEXED BY index_cards_workspaceId_dueAtMillis_createdAtMillis_cardId
                 WHERE workspaceId = :workspaceId
@@ -266,7 +266,7 @@ interface ReviewQueueDao {
                 LIMIT :limit
             )
             UNION ALL
-            SELECT 2 AS activeQueueBucket, cardId, workspaceId, frontText, backText, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
+            SELECT 2 AS activeQueueBucket, cardId, workspaceId, frontText, backText, cardType, metadataJson, dueAtMillis, createdAtMillis, updatedAtMillis, reps, lapses, fsrsCardState, fsrsStepIndex, fsrsStability, fsrsDifficulty, fsrsLastReviewedAtMillis, fsrsScheduledDays, deletedAtMillis
             FROM (
                 SELECT * FROM cards INDEXED BY index_cards_workspaceId_dueAtMillis_createdAtMillis_cardId
                 WHERE workspaceId = :workspaceId

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/CardMetadataSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/CardMetadataSupport.kt
@@ -1,0 +1,114 @@
+package com.flashcardsopensourceapp.data.local.model.cards
+
+import org.json.JSONException
+import org.json.JSONObject
+
+fun normalizeCardType(rawValue: String): String {
+    val trimmedValue: String = rawValue.trim()
+    return if (trimmedValue.isEmpty()) {
+        defaultCardType
+    } else {
+        trimmedValue
+    }
+}
+
+fun makeDefaultCardSourceMetadata(createdAt: String): CardSourceMetadata {
+    return CardSourceMetadata(
+        label = null,
+        author = null,
+        comment = null,
+        createdAt = createdAt,
+        importedAt = null,
+        importId = null
+    )
+}
+
+fun makeDefaultCardMetadata(createdAt: String): CardMetadata {
+    return CardMetadata(
+        version = 1,
+        source = makeDefaultCardSourceMetadata(createdAt = createdAt)
+    )
+}
+
+fun encodeCardMetadataJson(metadata: CardMetadata): String {
+    return buildCardMetadataJsonObject(metadata = metadata).toString()
+}
+
+fun encodeDefaultCardMetadataJson(createdAt: String): String {
+    return encodeCardMetadataJson(metadata = makeDefaultCardMetadata(createdAt = createdAt))
+}
+
+fun buildCardMetadataJsonObject(metadata: CardMetadata): JSONObject {
+    return JSONObject()
+        .put("version", metadata.version)
+        .put("source", metadata.source?.let(::buildCardSourceMetadataJsonObject) ?: JSONObject.NULL)
+}
+
+fun decodeCardMetadataJson(metadataJson: String): CardMetadata {
+    val metadataObject: JSONObject = try {
+        JSONObject(metadataJson)
+    } catch (error: JSONException) {
+        throw IllegalArgumentException("Card metadataJson must be a JSON object.", error)
+    }
+
+    return decodeCardMetadataJsonObject(metadataObject = metadataObject)
+}
+
+fun decodeCardMetadataJsonObject(metadataObject: JSONObject): CardMetadata {
+    require(metadataObject.has("version")) {
+        "Card metadata version is required."
+    }
+    val version: Int = metadataObject.getInt("version")
+    require(version == 1) {
+        "Card metadata version must be 1."
+    }
+    require(metadataObject.has("source")) {
+        "Card metadata source is required."
+    }
+
+    return CardMetadata(
+        version = version,
+        source = if (metadataObject.isNull("source")) {
+            null
+        } else {
+            decodeCardSourceMetadataJsonObject(metadataObject = metadataObject.getJSONObject("source"))
+        }
+    )
+}
+
+private fun buildCardSourceMetadataJsonObject(metadata: CardSourceMetadata): JSONObject {
+    return JSONObject()
+        .putNullableString("label", metadata.label)
+        .putNullableString("author", metadata.author)
+        .putNullableString("comment", metadata.comment)
+        .putNullableString("createdAt", metadata.createdAt)
+        .putNullableString("importedAt", metadata.importedAt)
+        .putNullableString("importId", metadata.importId)
+}
+
+private fun decodeCardSourceMetadataJsonObject(metadataObject: JSONObject): CardSourceMetadata {
+    return CardSourceMetadata(
+        label = metadataObject.requireNullableString(key = "label"),
+        author = metadataObject.requireNullableString(key = "author"),
+        comment = metadataObject.requireNullableString(key = "comment"),
+        createdAt = metadataObject.requireNullableString(key = "createdAt"),
+        importedAt = metadataObject.requireNullableString(key = "importedAt"),
+        importId = metadataObject.requireNullableString(key = "importId")
+    )
+}
+
+private fun JSONObject.putNullableString(key: String, value: String?): JSONObject {
+    return put(key, value ?: JSONObject.NULL)
+}
+
+private fun JSONObject.requireNullableString(key: String): String? {
+    require(has(key)) {
+        "Card metadata source $key is required."
+    }
+    val value = get(key)
+    return when {
+        value === JSONObject.NULL -> null
+        value is String -> value
+        else -> throw IllegalArgumentException("Card metadata source $key must be a string or null.")
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/CardModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/CardModels.kt
@@ -25,12 +25,30 @@ data class DeckSummary(
     val updatedAtMillis: Long
 )
 
+const val defaultCardType: String = "basic"
+
+data class CardSourceMetadata(
+    val label: String?,
+    val author: String?,
+    val comment: String?,
+    val createdAt: String?,
+    val importedAt: String?,
+    val importId: String?
+)
+
+data class CardMetadata(
+    val version: Int,
+    val source: CardSourceMetadata?
+)
+
 // Keep in sync with apps/backend/src/cards/types.ts::Card, apps/web/src/types.ts::Card, and apps/ios/Flashcards/Flashcards/Cards/Model/CardDeckTypes.swift::Card.
 data class CardSummary(
     val cardId: String,
     val workspaceId: String,
     val frontText: String,
     val backText: String,
+    val cardType: String,
+    val metadata: CardMetadata,
     val tags: List<String>,
     val dueAtMillis: Long?,
     val createdAtMillis: Long,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.data.local.model.sync
 
 import com.flashcardsopensourceapp.data.local.model.cards.DeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.model.cards.CardMetadata
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 
 enum class SyncEntityType {
@@ -55,6 +56,8 @@ data class CardSyncPayload(
     val cardId: String,
     val frontText: String,
     val backText: String,
+    val cardType: String,
+    val metadata: CardMetadata,
     val tags: List<String>,
     // TODO: Remove legacy effortLevel once the backend wire contract drops it.
     val effortLevel: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cards/CardRepositorySupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cards/CardRepositorySupport.kt
@@ -5,6 +5,8 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardWithRelations
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import com.flashcardsopensourceapp.data.local.model.cards.decodeCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeCardType
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
 import java.util.UUID
 
@@ -14,6 +16,8 @@ internal fun toCardSummary(card: CardWithRelations): CardSummary {
         workspaceId = card.card.workspaceId,
         frontText = card.card.frontText,
         backText = card.card.backText,
+        cardType = normalizeCardType(rawValue = card.card.cardType),
+        metadata = decodeCardMetadataJson(metadataJson = card.card.metadataJson),
         tags = normalizeTags(
             values = card.tags.map { tag -> tag.name },
             referenceTags = emptyList()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cards/LocalCardsRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cards/LocalCardsRepository.kt
@@ -6,9 +6,12 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
 import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.cards.queryCards
 import com.flashcardsopensourceapp.data.local.repository.CardsRepository
@@ -53,6 +56,8 @@ class LocalCardsRepository(
             workspaceId = workspace.workspaceId,
             frontText = cardDraft.frontText,
             backText = cardDraft.backText,
+            cardType = defaultCardType,
+            metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(currentTimeMillis)),
             dueAtMillis = null,
             createdAtMillis = currentTimeMillis,
             updatedAtMillis = currentTimeMillis,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
@@ -9,6 +9,7 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableString
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRequiredErrorCode
+import com.flashcardsopensourceapp.data.local.model.cards.buildCardMetadataJsonObject
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.sync.PersistedOutboxEntry
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
@@ -678,6 +679,8 @@ private fun buildOperationPayload(payload: SyncOperationPayload): JSONObject {
             .put("cardId", payload.payload.cardId)
             .put("frontText", payload.payload.frontText)
             .put("backText", payload.payload.backText)
+            .put("cardType", payload.payload.cardType)
+            .put("metadata", buildCardMetadataJsonObject(metadata = payload.payload.metadata))
             .put("tags", JSONArray(payload.payload.tags))
             // TODO: Remove legacy effortLevel once the backend wire contract drops it.
             .put("effortLevel", payload.payload.effortLevel)

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewPinnedCurrentCardQueueOrderingTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewPinnedCurrentCardQueueOrderingTest.kt
@@ -1,6 +1,9 @@
 package com.flashcardsopensourceapp.feature.review
 
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
+import com.flashcardsopensourceapp.data.local.model.cards.makeDefaultCardMetadata
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
@@ -161,6 +164,8 @@ private fun makePinnedReviewCardSummary(
         workspaceId = pinnedReviewWorkspaceId,
         frontText = "Front $cardId",
         backText = "Back $cardId",
+        cardType = defaultCardType,
+        metadata = makeDefaultCardMetadata(createdAt = formatIsoTimestamp(createdAtMillis)),
         tags = emptyList(),
         dueAtMillis = dueAtMillis,
         createdAtMillis = createdAtMillis,


### PR DESCRIPTION
## Summary
- Add Android cardType and metadata domain models and Room persistence.
- Preserve card metadata through local mutations, outbox, sync push, sync pull, and bootstrap.
- Add Room 25 -> 26 migration and focused Android storage/sync fixtures.

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff --check
- Targeted rg checks for missed constructors/projections
- Worker-owned read-only review: no P0-P4 findings

Gradle was not run locally per task restriction.