### PR TITLE
Add web settings share section

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -364,10 +364,20 @@ const arCatalog: TranslationCatalog = {
       ariaLabel: "إنشاء دعوة صديق",
     },
     groups: {
+      share: "مشاركة",
       account: "الحساب",
       general: "عام",
       support: "الدعم",
       advanced: "متقدم",
+    },
+    shareApp: {
+      title: "مشاركة التطبيق",
+      description: "أرسل رابط تثبيت أو فتح لنظام iOS وAndroid والويب.",
+      value: "مشاركة",
+      shareTitle: "ادرس باستخدام Flashcards",
+      shareText: "افتح Flashcards على iOS أو Android أو الويب.",
+      shared: "تم فتح نافذة المشاركة.",
+      shareUnavailable: "المشاركة غير متاحة في هذا المتصفح.",
     },
     currentWorkspace: {
       title: "مساحة العمل",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -364,10 +364,20 @@ const deCatalog: TranslationCatalog = {
       ariaLabel: "Freundes-Einladung erstellen",
     },
     groups: {
+      share: "Teilen",
       account: "Konto",
       general: "Allgemein",
       support: "Support",
       advanced: "Erweitert",
+    },
+    shareApp: {
+      title: "App teilen",
+      description: "Sende einen Link zum Installieren oder Öffnen für iOS, Android und Web.",
+      value: "Teilen",
+      shareTitle: "Mit Flashcards lernen",
+      shareText: "Öffne Flashcards auf iOS, Android oder im Web.",
+      shared: "Teilen-Dialog geöffnet.",
+      shareUnavailable: "Teilen ist in diesem Browser nicht verfügbar.",
     },
     currentWorkspace: {
       title: "Arbeitsbereich",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -362,10 +362,20 @@ const enCatalog = {
       ariaLabel: "Create friend invite",
     },
     groups: {
+      share: "Share",
       account: "Account",
       general: "General",
       support: "Support",
       advanced: "Advanced",
+    },
+    shareApp: {
+      title: "Share app",
+      description: "Send an install or open link for iOS, Android, and the web.",
+      value: "Share",
+      shareTitle: "Study with Flashcards",
+      shareText: "Open Flashcards on iOS, Android, or the web.",
+      shared: "Share sheet opened.",
+      shareUnavailable: "Sharing is not available in this browser.",
     },
     currentWorkspace: {
       title: "Workspace",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -364,10 +364,20 @@ const esEsCatalog: TranslationCatalog = {
       ariaLabel: "Crear invitación de amigo",
     },
     groups: {
+      share: "Compartir",
       account: "Cuenta",
       general: "General",
       support: "Soporte",
       advanced: "Avanzado",
+    },
+    shareApp: {
+      title: "Compartir app",
+      description: "Envía un enlace para instalar o abrir la app en iOS, Android y la web.",
+      value: "Compartir",
+      shareTitle: "Estudia con Flashcards",
+      shareText: "Abre Flashcards en iOS, Android o la web.",
+      shared: "Hoja para compartir abierta.",
+      shareUnavailable: "La opción de compartir no está disponible en este navegador.",
     },
     currentWorkspace: {
       title: "Espacio de trabajo",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -364,10 +364,20 @@ const esMxCatalog: TranslationCatalog = {
       ariaLabel: "Crear invitación de amigo",
     },
     groups: {
+      share: "Compartir",
       account: "Cuenta",
       general: "General",
       support: "Soporte",
       advanced: "Avanzado",
+    },
+    shareApp: {
+      title: "Compartir app",
+      description: "Envía un enlace para instalar o abrir la app en iOS, Android y la web.",
+      value: "Compartir",
+      shareTitle: "Estudia con Flashcards",
+      shareText: "Abre Flashcards en iOS, Android o la web.",
+      shared: "Se abrió la hoja para compartir.",
+      shareUnavailable: "Compartir no está disponible en este navegador.",
     },
     currentWorkspace: {
       title: "Espacio de trabajo",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -364,10 +364,20 @@ const hiCatalog: TranslationCatalog = {
       ariaLabel: "दोस्त का आमंत्रण बनाएं",
     },
     groups: {
+      share: "शेयर करें",
       account: "खाता",
       general: "सामान्य",
       support: "सहायता",
       advanced: "उन्नत",
+    },
+    shareApp: {
+      title: "ऐप शेयर करें",
+      description: "iOS, Android और वेब के लिए इंस्टॉल या ओपन लिंक भेजें।",
+      value: "शेयर करें",
+      shareTitle: "Flashcards के साथ पढ़ें",
+      shareText: "Flashcards को iOS, Android या वेब पर खोलें।",
+      shared: "शेयर शीट खुल गई।",
+      shareUnavailable: "इस ब्राउज़र में शेयरिंग उपलब्ध नहीं है।",
     },
     currentWorkspace: {
       title: "वर्कस्पेस",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -364,10 +364,20 @@ export const jaCatalog = {
       ariaLabel: "友だち招待を作成",
     },
     groups: {
+      share: "共有",
       account: "アカウント",
       general: "一般",
       support: "サポート",
       advanced: "詳細",
+    },
+    shareApp: {
+      title: "アプリを共有",
+      description: "iOS、Android、Web でインストールまたは開くためのリンクを送信します。",
+      value: "共有",
+      shareTitle: "Flashcards で学習",
+      shareText: "Flashcards を iOS、Android、または Web で開きます。",
+      shared: "共有シートを開きました。",
+      shareUnavailable: "このブラウザでは共有を利用できません。",
     },
     currentWorkspace: {
       title: "ワークスペース",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -364,10 +364,20 @@ export const ruCatalog = {
       ariaLabel: "Создать приглашение для друга",
     },
     groups: {
+      share: "Поделиться",
       account: "Аккаунт",
       general: "Общие",
       support: "Поддержка",
       advanced: "Расширенные",
+    },
+    shareApp: {
+      title: "Поделиться приложением",
+      description: "Отправьте ссылку для установки или открытия на iOS, Android и в вебе.",
+      value: "Поделиться",
+      shareTitle: "Учитесь с Flashcards",
+      shareText: "Откройте Flashcards на iOS, Android или в вебе.",
+      shared: "Окно отправки открыто.",
+      shareUnavailable: "Отправка недоступна в этом браузере.",
     },
     currentWorkspace: {
       title: "Рабочее пространство",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -364,10 +364,20 @@ export const zhHansCatalog = {
       ariaLabel: "创建好友邀请",
     },
     groups: {
+      share: "分享",
       account: "账户",
       general: "通用",
       support: "支持",
       advanced: "高级",
+    },
+    shareApp: {
+      title: "分享应用",
+      description: "发送可在 iOS、Android 和网页版安装或打开的链接。",
+      value: "分享",
+      shareTitle: "使用 Flashcards 学习",
+      shareText: "在 iOS、Android 或网页版打开 Flashcards。",
+      shared: "分享面板已打开。",
+      shareUnavailable: "此浏览器不支持分享。",
     },
     currentWorkspace: {
       title: "工作区",

--- a/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
@@ -18,6 +18,7 @@ import {
   settingsReviewAnimationsRoute,
   settingsSchedulerRoute,
   settingsServerRoute,
+  shareRoute,
 } from "../../routes";
 import type {
   Card,
@@ -59,6 +60,10 @@ type SettingsScreenTestHarness = Readonly<{
   getContainer: () => HTMLDivElement;
   renderSettingsScreen: () => Promise<void>;
 }>;
+
+type NavigatorWithOptionalShare = Navigator & {
+  share?: (data: ShareData) => Promise<void>;
+};
 
 function throwNotUsed(functionName: string): never {
   throw new Error(`${functionName} was not expected in this test`);
@@ -196,6 +201,10 @@ function setupSettingsScreenTest(): SettingsScreenTestHarness {
       configurable: true,
       value: createStorageMock(),
     });
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: undefined,
+    });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = ReactDOM.createRoot(container);
@@ -315,10 +324,12 @@ describe("SettingsScreen navigation", () => {
     await renderSettingsScreen();
 
     expect(textContent()).toContain("Account");
+    expect(textContent()).toContain("Share");
     expect(textContent()).toContain("General");
     expect(textContent()).toContain("Support");
     expect(textContent()).toContain("Advanced");
     expectGroupLabelNotClickable("Account");
+    expectGroupLabelNotClickable("Share");
     expectGroupLabelNotClickable("General");
     expectGroupLabelNotClickable("Support");
     expectGroupLabelNotClickable("Advanced");
@@ -348,8 +359,11 @@ describe("SettingsScreen navigation", () => {
       "settings-row-delete-account",
     ].forEach(expectRowVisible);
     expectRowVisible("settings-invite-open");
+    expectRowVisible("settings-share-app-open");
     expect(getContainer().querySelector("[data-testid='settings-invite-open']")?.textContent).toBe("Invite friend");
     expect(rowIndex("settings-invite-open")).toBeLessThan(rowIndex("settings-row-account-status"));
+    expect(rowIndex("settings-invite-open")).toBeLessThan(rowIndex("settings-share-app-open"));
+    expect(rowIndex("settings-share-app-open")).toBeLessThan(rowIndex("settings-row-account-status"));
     expect(rowIndex("settings-row-review-reminders")).toBeLessThan(rowIndex("settings-row-review-animations"));
     expect(rowIndex("settings-row-review-animations")).toBeLessThan(rowIndex("settings-row-ai-chat-suggestions"));
     expect(rowIndex("settings-row-ai-chat-suggestions")).toBeLessThan(rowIndex("settings-row-leaderboard-participation"));
@@ -385,6 +399,34 @@ describe("SettingsScreen navigation", () => {
     await clickButton("settings-invite-open");
 
     expect(document.body.querySelector("[data-testid='progress-leaderboard-invite-sign-in']")).not.toBeNull();
+  });
+
+  it("opens the native app share sheet from Settings", async () => {
+    const shareMock = vi.fn(async (_data: ShareData): Promise<void> => undefined);
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: shareMock,
+    });
+
+    await renderSettingsScreen();
+
+    await clickButton("settings-share-app-open");
+
+    expect(shareMock).toHaveBeenCalledWith({
+      title: "Study with Flashcards",
+      text: "Open Flashcards on iOS, Android, or the web.",
+      url: `${window.location.origin}${shareRoute}`,
+    });
+    expect(getContainer().querySelector("[data-testid='settings-share-app-status']")?.textContent).toBe("Share sheet opened.");
+  });
+
+  it("shows an explicit app share error when native sharing is unavailable", async () => {
+    await renderSettingsScreen();
+
+    await clickButton("settings-share-app-open");
+
+    expect((navigator as NavigatorWithOptionalShare).share).toBeUndefined();
+    expect(getContainer().querySelector("[data-testid='settings-share-app-error']")?.textContent).toBe("Sharing is not available in this browser.");
   });
 
   it("navigates representative root rows to their detail routes", async () => {

--- a/apps/web/src/screens/settings/SettingsScreen.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactElement } from "react";
 import { isAuthRedirectError } from "../../api";
 import { useAppData } from "../../appData";
 import { canLoadProgressServerBase } from "../../appData/progress/progressSource";
+import { getAppConfig } from "../../config";
 import {
   autoLocalePreference,
   type Locale,
@@ -33,11 +34,13 @@ import {
   settingsServerRoute,
   settingsTagsRoute,
   settingsTestRoute,
+  shareRoute,
 } from "../../routes";
 import { useAIChatPreferences } from "../../chat/preferences/AIChatPreferencesContext";
 import { useTestMode } from "../../testMode";
 import { FriendInviteCreateDialog } from "../friends/FriendInviteCreateDialog";
 import {
+  SettingsActionCard,
   SettingsGroup,
   SettingsNavigationCard,
   SettingsShell,
@@ -68,6 +71,14 @@ function formatLocalePreferenceLabel(
   return t(localeNameKey(localePreference));
 }
 
+function formatShareErrorMessage(error: unknown, unavailableMessage: string): string {
+  if (error instanceof Error && error.message !== "") {
+    return error.message;
+  }
+
+  return unavailableMessage;
+}
+
 export function SettingsScreen(): ReactElement {
   const {
     activeWorkspace,
@@ -83,11 +94,14 @@ export function SettingsScreen(): ReactElement {
   const { aiChatComposerSuggestionsEnabled } = useAIChatPreferences();
   const { isTestModeEnabled } = useTestMode();
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState<boolean>(false);
+  const [shareStatusMessage, setShareStatusMessage] = useState<string>("");
+  const [shareErrorMessage, setShareErrorMessage] = useState<string>("");
   const currentWorkspaceName = activeWorkspace?.name ?? t("common.unavailable");
   const accountStatus = accountStatusValue(cloudSettings?.linkedEmail ?? session?.profile.email ?? null, t("common.unavailable"));
   const languagePreferenceLabel = formatLocalePreferenceLabel(localePreference, t);
   const schedulerValue = workspaceSettings === null ? t("common.unavailable") : workspaceSettings.algorithm.toUpperCase();
   const canCreateInvite = canLoadProgressServerBase(sessionVerificationState, cloudSettings);
+  const appShareUrl = `${getAppConfig().appBaseUrl}${shareRoute}`;
 
   useEffect(() => {
     if (session === null || isSessionVerified === false) {
@@ -103,23 +117,71 @@ export function SettingsScreen(): ReactElement {
     });
   }, [isSessionVerified, refreshAccountPreferences, session?.userId, setErrorMessage]);
 
+  async function shareApp(): Promise<void> {
+    setShareStatusMessage("");
+    setShareErrorMessage("");
+
+    if (typeof navigator.share !== "function") {
+      setShareErrorMessage(t("settingsHome.shareApp.shareUnavailable"));
+      return;
+    }
+
+    try {
+      await navigator.share({
+        title: t("settingsHome.shareApp.shareTitle"),
+        text: t("settingsHome.shareApp.shareText"),
+        url: appShareUrl,
+      });
+      setShareStatusMessage(t("settingsHome.shareApp.shared"));
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+
+      setShareErrorMessage(formatShareErrorMessage(error, t("settingsHome.shareApp.shareUnavailable")));
+    }
+  }
+
   return (
     <SettingsShell
       title={t("settingsHome.title")}
       subtitle={t("settingsHome.subtitle")}
       activeTab="general"
     >
-      <div className="settings-invite-row">
-        <button
-          className="primary-btn settings-invite-btn"
-          type="button"
-          aria-label={t("settingsHome.inviteFriend.ariaLabel")}
-          onClick={() => setIsInviteDialogOpen(true)}
-          data-testid="settings-invite-open"
-        >
-          {t("settingsHome.inviteFriend.actionText")}
-        </button>
-      </div>
+      <SettingsGroup title={t("settingsHome.groups.share")}>
+        <div className="settings-nav-list">
+          <div className="settings-invite-row">
+            <button
+              className="primary-btn settings-invite-btn"
+              type="button"
+              aria-label={t("settingsHome.inviteFriend.ariaLabel")}
+              onClick={() => setIsInviteDialogOpen(true)}
+              data-testid="settings-invite-open"
+            >
+              {t("settingsHome.inviteFriend.actionText")}
+            </button>
+          </div>
+          <SettingsActionCard
+            title={t("settingsHome.shareApp.title")}
+            description={t("settingsHome.shareApp.description")}
+            value={t("settingsHome.shareApp.value")}
+            onClick={() => {
+              void shareApp();
+            }}
+            testId="settings-share-app-open"
+          />
+        </div>
+        {shareStatusMessage === "" ? null : (
+          <p className="settings-temporary-banner" role="status" data-testid="settings-share-app-status">
+            {shareStatusMessage}
+          </p>
+        )}
+        {shareErrorMessage === "" ? null : (
+          <p className="error-banner" role="alert" data-testid="settings-share-app-error">
+            {shareErrorMessage}
+          </p>
+        )}
+      </SettingsGroup>
 
       <SettingsGroup title={t("settingsHome.groups.account")}>
         <div className="settings-nav-list">


### PR DESCRIPTION
## Summary
- Add a Share group at the top of web Settings with the existing friend invite action first
- Add an app-share settings action using the native share sheet and localized status/error copy
- Cover ordering, share payload, and unavailable native sharing in settings navigation tests

## Validation
- npm --prefix apps/web exec -- vitest run src/screens/settings/SettingsScreen.navigation.test.tsx
- npm --prefix apps/web run build