### PR TITLE
Add iOS settings app share row

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -47,6 +47,7 @@ enum UITestIdentifier {
     static let cardsScreen: String = "cards.screen"
     static let settingsScreen: String = "settings.screen"
     static let settingsInviteFriendButton: String = "settings.inviteFriendButton"
+    static let settingsShareAppRow: String = "settings.shareAppRow"
     static let settingsAccountStatusRow: String = "settings.accountStatusRow"
     static let settingsCurrentWorkspaceRow: String = "settings.currentWorkspaceRow"
     static let settingsReviewRemindersRow: String = "settings.reviewRemindersRow"

--- a/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
@@ -41,6 +41,13 @@ let cloudCredentialRecoveryStateUserDefaultsKey: String = "cloud-credential-reco
 let cloudCredentialRecoveryStateSilentFailureDigestUserDefaultsKey: String = "cloud-credential-recovery-state-silent-failure-digest"
 let guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey: String = "guest-local-recovery-workspace-checkpoint"
 let flashcardsRepositoryUrl: String = "https://github.com/kirill-markin/flashcards-open-source-app"
+let flashcardsAppShareUrl: URL = {
+    let urlString: String = "https://app.flashcards-open-source-app.com/share"
+    guard let url = URL(string: urlString) else {
+        preconditionFailure("Flashcards app share URL is invalid: \(urlString)")
+    }
+    return url
+}()
 
 var flashcardsPrivacyPolicyUrl: String {
     flashcardsLegalSupportConfiguration.privacyPolicyUrl

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -50,8 +50,18 @@ struct SettingsView: View {
 
     var body: some View {
         List {
-            Section {
+            Section(aiSettingsLocalized("settings.section.share", "Share")) {
                 self.friendInviteButton
+
+                ShareLink(item: flashcardsAppShareUrl) {
+                    SettingsNavigationRow(
+                        title: aiSettingsLocalized("settings.row.shareApp", "Share Flashcards"),
+                        value: nil,
+                        systemImage: "square.and.arrow.up",
+                        attentionCount: nil
+                    )
+                }
+                .accessibilityIdentifier(UITestIdentifier.settingsShareAppRow)
             }
 
             Section(aiSettingsLocalized("settings.section.account", "Account")) {

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "الإعدادات";
 "settings.inviteFriend.button" = "دعوة صديق";
+"settings.section.share" = "مشاركة";
+"settings.row.shareApp" = "مشاركة Flashcards";
 "settings.section.account" = "الحساب";
 "settings.section.general" = "عام";
 "settings.section.support" = "الدعم";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "Einstellungen";
 "settings.inviteFriend.button" = "Freund einladen";
+"settings.section.share" = "Teilen";
+"settings.row.shareApp" = "Flashcards teilen";
 "settings.section.account" = "Konto";
 "settings.section.general" = "Allgemein";
 "settings.section.support" = "Support";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "Ajustes";
 "settings.inviteFriend.button" = "Invitar amigo";
+"settings.section.share" = "Compartir";
+"settings.row.shareApp" = "Compartir Flashcards";
 "settings.section.account" = "Cuenta";
 "settings.section.general" = "General";
 "settings.section.support" = "Soporte";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "Ajustes";
 "settings.inviteFriend.button" = "Invitar amigo";
+"settings.section.share" = "Compartir";
+"settings.row.shareApp" = "Compartir Flashcards";
 "settings.section.account" = "Cuenta";
 "settings.section.general" = "General";
 "settings.section.support" = "Soporte";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "सेटिंग्स";
 "settings.inviteFriend.button" = "दोस्त को आमंत्रित करें";
+"settings.section.share" = "साझा करें";
+"settings.row.shareApp" = "Flashcards साझा करें";
 "settings.section.account" = "खाता";
 "settings.section.general" = "सामान्य";
 "settings.section.support" = "सहायता";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "設定";
 "settings.inviteFriend.button" = "友達を招待";
+"settings.section.share" = "共有";
+"settings.row.shareApp" = "Flashcardsを共有";
 "settings.section.account" = "アカウント";
 "settings.section.general" = "一般";
 "settings.section.support" = "サポート";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "Настройки";
 "settings.inviteFriend.button" = "Пригласить друга";
+"settings.section.share" = "Поделиться";
+"settings.row.shareApp" = "Поделиться Flashcards";
 "settings.section.account" = "Аккаунт";
 "settings.section.general" = "Общие";
 "settings.section.support" = "Поддержка";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -127,6 +127,8 @@
 
 "settings.title" = "设置";
 "settings.inviteFriend.button" = "邀请朋友";
+"settings.section.share" = "分享";
+"settings.row.shareApp" = "分享 Flashcards";
 "settings.section.account" = "账户";
 "settings.section.general" = "通用";
 "settings.section.support" = "支持";


### PR DESCRIPTION
## Summary
- Add a native Share section to iOS Settings with Invite Friend first
- Add a ShareLink row for the public app share URL
- Localize the new settings labels across supported iOS locales

## Validation
- plutil -lint passed for all modified AISettings.strings files
- git --no-pager diff --check passed
- Read-only review found no P0-P4 issues
- Generic iOS build was blocked before compilation because the local iOS 26.5 platform is not installed