### PR TITLE
Add Android settings share block

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
@@ -43,6 +43,8 @@ import com.flashcardsopensourceapp.feature.settings.settingsReviewRemindersRowTa
 import com.flashcardsopensourceapp.feature.settings.settingsRootScreenTag
 import com.flashcardsopensourceapp.feature.settings.settingsSchedulingRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsServerRowTag
+import com.flashcardsopensourceapp.feature.settings.settingsShareAppRowTag
+import com.flashcardsopensourceapp.feature.settings.settingsShareSectionTag
 import com.flashcardsopensourceapp.feature.settings.settingsSupportSectionTag
 import com.flashcardsopensourceapp.feature.settings.settingsSupportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsTagsRowTag
@@ -74,6 +76,7 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         )
 
         listOf(
+            settingsShareSectionTag,
             settingsAccountSectionTag,
             settingsGeneralSectionTag,
             settingsSupportSectionTag,
@@ -84,6 +87,7 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
 
         listOf(
             settingsInviteFriendButtonTag,
+            settingsShareAppRowTag,
             settingsAccountStatusRowTag,
             settingsCurrentWorkspaceRowTag,
             settingsReviewRemindersRowTag,
@@ -110,7 +114,15 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
             assertRootRowVisible(rowTag = rowTag)
         }
         assertRootRowOrder(
+            firstRowTag = settingsShareSectionTag,
+            secondRowTag = settingsInviteFriendButtonTag
+        )
+        assertRootRowOrder(
             firstRowTag = settingsInviteFriendButtonTag,
+            secondRowTag = settingsShareAppRowTag
+        )
+        assertRootRowOrder(
+            firstRowTag = settingsShareAppRowTag,
             secondRowTag = settingsAccountSectionTag
         )
         assertRootRowOrder(
@@ -138,6 +150,11 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         assertRowClick(
             rowTag = settingsInviteFriendButtonTag,
             expectedClick = "friend_invite",
+            clickedRows = clickedRows
+        )
+        assertRowClick(
+            rowTag = settingsShareAppRowTag,
+            expectedClick = "share_app",
             clickedRows = clickedRows
         )
         assertRowClick(
@@ -267,6 +284,7 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         )
 
         assertRootRowVisible(rowTag = settingsInviteFriendButtonTag)
+        assertRootRowVisible(rowTag = settingsShareAppRowTag)
         composeRule.onNodeWithTag(settingsInviteFriendButtonTag).assertIsNotEnabled()
     }
 
@@ -296,6 +314,9 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     ),
                     onOpenFriendInvite = {
                         clickedRows += "friend_invite"
+                    },
+                    onShareApp = {
+                        clickedRows += "share_app"
                     },
                     onOpenAccountStatus = {
                         clickedRows += "account_status"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
@@ -49,6 +49,7 @@ import com.flashcardsopensourceapp.feature.settings.notifications.NotificationDi
 import com.flashcardsopensourceapp.feature.settings.notifications.NotificationDiagnosticsUiState
 import com.flashcardsopensourceapp.feature.settings.review.ReviewAnimationsRoute
 import com.flashcardsopensourceapp.feature.settings.settingsInviteFriendDisplayNameFieldTag
+import com.flashcardsopensourceapp.feature.settings.shareFlashcardsApp
 import com.flashcardsopensourceapp.feature.settings.workspace.current.CurrentWorkspaceRoute
 import com.flashcardsopensourceapp.feature.settings.workspace.current.createCurrentWorkspaceViewModelFactory
 import java.util.Locale
@@ -91,6 +92,15 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
         val uiState by settingsViewModel.uiState.collectAsStateWithLifecycle()
         val friendInvitationUiState by friendInvitationViewModel.uiState.collectAsStateWithLifecycle()
         var isFriendInvitationDialogVisible by rememberSaveable { mutableStateOf(false) }
+        val shareUrl: String = stringResource(
+            id = com.flashcardsopensourceapp.feature.settings.R.string.flashcards_share_url
+        )
+        val shareChooserTitle: String = stringResource(
+            id = com.flashcardsopensourceapp.feature.settings.R.string.settings_share_app_chooser_title
+        )
+        val shareText: String = stringResource(
+            id = com.flashcardsopensourceapp.feature.settings.R.string.settings_share_app_text
+        )
 
         LaunchedEffect(settingsViewModel) {
             settingsViewModel.refreshAccountContextAsync()
@@ -116,6 +126,14 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
 
                     SettingsFriendInviteAvailability.LOADING -> Unit
                 }
+            },
+            onShareApp = {
+                shareFlashcardsApp(
+                    context = context,
+                    shareUrl = shareUrl,
+                    title = shareChooserTitle,
+                    text = shareText
+                )
             },
             onOpenAccountStatus = {
                 navController.navigate(route = SettingsAccountStatusDestination.route)

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -88,6 +88,7 @@ internal fun SettingsScreenScaffold(
 fun SettingsRoute(
     uiState: SettingsUiState,
     onOpenFriendInvite: () -> Unit,
+    onShareApp: () -> Unit,
     onOpenAccountStatus: () -> Unit,
     onOpenCurrentWorkspace: () -> Unit,
     onOpenReviewReminders: () -> Unit,
@@ -125,9 +126,26 @@ fun SettingsRoute(
                 .testTag(tag = settingsRootScreenTag)
         ) {
             item {
+                SettingsRootSectionTitle(
+                    title = stringResource(R.string.settings_section_share),
+                    testTag = settingsShareSectionTag
+                )
+            }
+
+            item {
                 SettingsInviteFriendButton(
                     isEnabled = uiState.friendInviteAvailability != SettingsFriendInviteAvailability.LOADING,
                     onClick = onOpenFriendInvite
+                )
+            }
+
+            item {
+                SettingsRootRow(
+                    title = stringResource(R.string.settings_share_app_title),
+                    summary = stringResource(R.string.settings_share_app_summary),
+                    attentionCount = null,
+                    testTag = settingsShareAppRowTag,
+                    onClick = onShareApp
                 )
             }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
@@ -2,6 +2,7 @@ package com.flashcardsopensourceapp.feature.settings
 
 const val settingsAccountStatusRowTag: String = "settings_row_account_status"
 const val settingsInviteFriendButtonTag: String = "settings_invite_friend_button"
+const val settingsShareAppRowTag: String = "settings_row_share_app"
 const val settingsInviteFriendDisplayNameFieldTag: String = "settings_invite_friend_display_name_field"
 const val settingsCurrentWorkspaceRowTag: String = "settings_row_current_workspace"
 const val settingsReviewRemindersRowTag: String = "settings_row_review_reminders"
@@ -25,6 +26,7 @@ const val settingsResetStudyProgressRowTag: String = "settings_row_reset_study_p
 const val settingsDeleteCurrentWorkspaceRowTag: String = "settings_row_delete_current_workspace"
 const val settingsDeleteAccountRowTag: String = "settings_row_delete_account"
 const val settingsRootScreenTag: String = "settings_root_screen"
+const val settingsShareSectionTag: String = "settings_section_share"
 const val settingsAccountSectionTag: String = "settings_section_account"
 const val settingsGeneralSectionTag: String = "settings_section_general"
 const val settingsSupportSectionTag: String = "settings_section_support"

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsSupport.kt
@@ -30,6 +30,15 @@ fun sendSupportEmail(context: Context, emailAddress: String) {
     context.startActivity(intent)
 }
 
+fun shareFlashcardsApp(context: Context, shareUrl: String, title: String, text: String) {
+    val intent: Intent = Intent(Intent.ACTION_SEND)
+        .setType("text/plain")
+        .putExtra(Intent.EXTRA_TEXT, "$text\n$shareUrl")
+    val chooserIntent: Intent = Intent.createChooser(intent, title)
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(chooserIntent)
+}
+
 fun formatTimestampLabel(timestampMillis: Long?, strings: SettingsStringResolver): String {
     if (timestampMillis == null) {
         return strings.get(R.string.settings_never)

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="flashcards_privacy_policy_url" translatable="false">https://flashcards-open-source-app.com/privacy/</string>
     <string name="flashcards_terms_of_service_url" translatable="false">https://flashcards-open-source-app.com/terms/</string>
     <string name="flashcards_support_url" translatable="false">https://flashcards-open-source-app.com/support/</string>
+    <string name="flashcards_share_url" translatable="false">https://app.flashcards-open-source-app.com/share</string>
     <string name="flashcards_repository_url" translatable="false">https://github.com/kirill-markin/flashcards-open-source-app</string>
     <string name="third_party_notices_url" translatable="false">https://github.com/kirill-markin/flashcards-open-source-app/blob/main/THIRD_PARTY_NOTICES.md</string>
     <string name="review_owl_animation_url" translatable="false">https://iconscout.com/free-lottie-animation/free-owl-animation_12152606</string>
@@ -71,6 +72,7 @@
     <string name="settings_delete">Delete</string>
 
     <string name="settings_root_title">Settings</string>
+    <string name="settings_section_share">Share</string>
     <string name="settings_section_account">Account</string>
     <string name="settings_section_general">General</string>
     <string name="settings_section_support">Support</string>
@@ -82,6 +84,10 @@
     <string name="settings_root_access_summary">Camera, microphone, photos, and files</string>
     <string name="settings_root_feedback_title">Send feedback</string>
     <string name="settings_root_feedback_summary">Share an idea to improve the app</string>
+    <string name="settings_share_app_title">Share app</string>
+    <string name="settings_share_app_summary">Send the iOS, Android, and web app link</string>
+    <string name="settings_share_app_chooser_title">Share Flashcards</string>
+    <string name="settings_share_app_text">Study with Flashcards. Your cards stay available across iOS, Android, and the web.</string>
     <string name="settings_root_test_title">Test</string>
     <string name="settings_root_test_summary">3 items</string>
     <string name="settings_review_reminders_title">Reminders</string>


### PR DESCRIPTION
## Summary
- add a Share section to Android Settings with invite first and app sharing below it
- wire app sharing through an Android ACTION_SEND chooser for the app-hosted /share URL
- update settings route instrumentation coverage for visibility, ordering, clicks, and loading disabled state

## Validation
- git --no-pager diff --check
- rg confirmed flashcards_share_url is https://app.flashcards-open-source-app.com/share
- Android Gradle/instrumentation not run because no explicit Gradle permission was granted