### PR TITLE
docs: add marketing attribution link reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Build a practical Anki-like alternative focused on fast mobile UX, offline-first
 - Terminal / AI-agent API client: supported via the canonical machine API entrypoint `GET https://api.flashcards-open-source-app.com/v1/` (the same discovery payload is also available at `GET https://api.flashcards-open-source-app.com/v1/agent`)
 
 For iOS App Store screenshots and derived marketing materials, read [apps/ios/docs/marketing-screenshots.md](apps/ios/docs/marketing-screenshots.md).
+Marketing attribution links and campaign naming rules live in [docs/marketing-links.md](docs/marketing-links.md).
 
 We support the web app, the iOS app, the Android app, and the terminal-first AI-agent API flow. When making changes, we try to keep all supported clients aligned where relevant.
 The platform READMEs are part of the working agreement for client work: [apps/web/README.md](apps/web/README.md) for web changes, [apps/ios/README.md](apps/ios/README.md) for iOS changes, and [apps/android/README.md](apps/android/README.md) for Android changes.

--- a/docs/marketing-links.md
+++ b/docs/marketing-links.md
@@ -1,0 +1,40 @@
+# Marketing Links
+
+Store campaign links use coarse campaign buckets. Do not create per-user,
+per-page, per-button, or per-deck store campaign values.
+
+Current campaign buckets:
+
+| Bucket | Use |
+| ------ | --- |
+| `marketing_site` | Marketing landing pages and public content. |
+| `share_app` | Future app share pages. |
+| `share_deck` | Future deck share pages, grouped across decks. |
+| `marketplace` | Future deck marketplace surfaces. |
+
+## Google Play
+
+Use Google Play UTM parameters for Android store links:
+
+- `utm_source=flashcards_website`
+- `utm_medium=referral` for owned web-to-store links
+- `utm_campaign=<bucket>`, starting with `marketing_site`
+
+Current marketing-site Google Play URL:
+
+`https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=marketing_site`
+
+## App Store
+
+Use App Store Connect campaign links for iOS store links, not `utm_*`.
+Use `ct=<bucket>`, starting with `ct=marketing_site`.
+
+Current marketing-site App Store campaign URL:
+
+`https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=marketing_site&mt=8`
+
+Keep the App Store Connect-generated URL as-is once generated; do not rewrite
+the path manually.
+
+Track fine-grained button placement in site or product analytics, not in store
+campaign names.


### PR DESCRIPTION
## Summary
- link AGENTS.md to the shared marketing attribution reference
- document store campaign buckets and Android/iOS campaign URL patterns

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff -- AGENTS.md docs/marketing-links.md
- git --no-pager diff --no-index -- /dev/null docs/marketing-links.md
- docs-only change; no tests run
- worker-owned read-only review reported no P0-P4 issues