### PR TITLE
Add share app store campaign links

### DIFF
--- a/apps/web/src/screens/invite/FriendInviteScreen.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.tsx
@@ -19,7 +19,7 @@ import type {
   FriendInvitationPreviewResponse,
   SessionInfo,
 } from "../../types";
-import { AppPlatformLinks } from "../share/AppPlatformLinks";
+import { AppPlatformLinks, defaultAppPlatformStoreLinks } from "../share/AppPlatformLinks";
 import { validateFriendInvitationDisplayName } from "./friendInvitationDisplayName";
 
 type InviteLoadState = "loading" | "inactive" | "error" | "signed_out" | "ready" | "success";
@@ -85,6 +85,7 @@ function InviteSuccessLinks(): ReactElement {
         android: t("friendInvite.links.android"),
         web: t("friendInvite.links.web"),
       }}
+      storeLinks={defaultAppPlatformStoreLinks}
       webRoute={progressLeaderboardRoute}
       webHref={webHref}
       gridTestId="friend-invite-success-links"

--- a/apps/web/src/screens/share/AppPlatformLinks.tsx
+++ b/apps/web/src/screens/share/AppPlatformLinks.tsx
@@ -1,10 +1,18 @@
 import type { ReactElement } from "react";
 import { Link } from "react-router-dom";
 
-const iosAppLink: string = "https://apps.apple.com/us/app/flashcards-open-source-app/id6760538964";
-const androidAppLink: string = "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&pcampaignid=web_share";
 const appStoreBadgeSrc: string = "/home/app-store-badge.svg";
 const googlePlayLockupSrc: string = "/home/google-play-lockup.png";
+
+export type AppPlatformStoreLinks = Readonly<{
+  ios: string;
+  android: string;
+}>;
+
+export const defaultAppPlatformStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/us/app/flashcards-open-source-app/id6760538964",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&pcampaignid=web_share",
+};
 
 export type AppPlatformLinkLabels = Readonly<{
   ios: string;
@@ -14,6 +22,7 @@ export type AppPlatformLinkLabels = Readonly<{
 
 type AppPlatformLinksProps = Readonly<{
   labels: AppPlatformLinkLabels;
+  storeLinks: AppPlatformStoreLinks;
   webRoute: string;
   webHref: string;
   gridTestId: string;
@@ -41,6 +50,7 @@ function WebAppIcon(): ReactElement {
 
 export function AppPlatformLinks({
   labels,
+  storeLinks,
   webRoute,
   webHref,
   gridTestId,
@@ -50,7 +60,7 @@ export function AppPlatformLinks({
     <div className="invite-link-grid" data-testid={gridTestId}>
       <a
         className="invite-platform-link"
-        href={iosAppLink}
+        href={storeLinks.ios}
         rel="noreferrer"
         target="_blank"
         aria-label={labels.ios}
@@ -66,7 +76,7 @@ export function AppPlatformLinks({
       </a>
       <a
         className="invite-platform-link"
-        href={androidAppLink}
+        href={storeLinks.android}
         rel="noreferrer"
         target="_blank"
         aria-label={labels.android}

--- a/apps/web/src/screens/share/ShareAppScreen.test.tsx
+++ b/apps/web/src/screens/share/ShareAppScreen.test.tsx
@@ -8,6 +8,8 @@ import { reviewRoute, shareRoute } from "../../routes";
 import { ShareAppScreen } from "./ShareAppScreen";
 
 const localePreferenceStorageKey: string = "flashcards-web-locale-preference";
+const shareAppIosHref: string = "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=share_app&mt=8";
+const shareAppAndroidHref: string = "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=share_app";
 
 function createStorageMock(): Storage {
   const state = new Map<string, string>();
@@ -105,6 +107,10 @@ describe("ShareAppScreen", () => {
       "app-platform-link-web",
     ]);
 
+    const iosLink: HTMLElement = requireElement(container, "[data-testid='app-platform-link-ios']");
+    expect(iosLink.getAttribute("href")).toBe(shareAppIosHref);
+    const androidLink: HTMLElement = requireElement(container, "[data-testid='app-platform-link-android']");
+    expect(androidLink.getAttribute("href")).toBe(shareAppAndroidHref);
     const webLink: HTMLElement = requireElement(container, "[data-testid='app-platform-link-web']");
     expect(webLink.getAttribute("href")).toBe(reviewRoute);
     expect(requireElement(container, "[data-testid='share-app-web-link-value']").textContent).toBe(

--- a/apps/web/src/screens/share/ShareAppScreen.tsx
+++ b/apps/web/src/screens/share/ShareAppScreen.tsx
@@ -2,7 +2,12 @@ import type { ReactElement } from "react";
 import { getAppConfig } from "../../config";
 import { useI18n } from "../../i18n";
 import { reviewRoute } from "../../routes";
-import { AppPlatformLinks } from "./AppPlatformLinks";
+import { AppPlatformLinks, type AppPlatformStoreLinks } from "./AppPlatformLinks";
+
+const shareAppStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=share_app&mt=8",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=share_app",
+};
 
 export function ShareAppScreen(): ReactElement {
   const { t } = useI18n();
@@ -19,6 +24,7 @@ export function ShareAppScreen(): ReactElement {
             android: t("shareApp.links.android"),
             web: t("shareApp.links.web"),
           }}
+          storeLinks={shareAppStoreLinks}
           webRoute={reviewRoute}
           webHref={webHref}
           gridTestId="share-app-platform-links"


### PR DESCRIPTION
## Summary
- pass explicit store links into the shared app platform links component
- use share_app attributed App Store and Play Store links on /share
- keep friend invite success links on the previous default store URLs

## Validation
- npm --prefix apps/web exec -- vitest run src/screens/share/ShareAppScreen.test.tsx src/screens/invite/FriendInviteScreen.test.tsx
- npm --prefix apps/web run build
- git --no-pager diff --check