### PR TITLE
Treat unknown progress timezone as breadcrumb

### DIFF
--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -102,6 +102,14 @@ export type ProgressCacheMissBreadcrumbDetails = Readonly<{
   workspaceIds: ReadonlyArray<string>;
 }>;
 
+export type ProgressTimezoneFallbackBreadcrumbDetails = Readonly<{
+  eventName: "progress_timezone_fallback";
+  observedTimeZone: string | null;
+  observedOffsetMinutes: number | null;
+  fallbackTimeZone: string;
+  errorName: string;
+}>;
+
 export type LocalBrowserDataCleanupReason =
   | "logout_marker"
   | "account_deleted_marker"
@@ -203,6 +211,11 @@ export type WebBreadcrumbEvent =
     action: "progress_cache_miss";
     scope: WebObservationScope;
     details: ProgressCacheMissBreadcrumbDetails;
+  }>
+  | Readonly<{
+    action: "progress_timezone_fallback";
+    scope: WebObservationScope;
+    details: ProgressTimezoneFallbackBreadcrumbDetails;
   }>
   | Readonly<{
     action: "local_browser_data_cleanup";

--- a/apps/web/src/progress/progressDates.test.ts
+++ b/apps/web/src/progress/progressDates.test.ts
@@ -1,15 +1,17 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { INSTALLATION_ID_STORAGE_KEY } from "../clientIdentity";
-import type { WebWarningEvent } from "../observability/webObservability";
+import type { WebBreadcrumbEvent, WebWarningEvent } from "../observability/webObservability";
 
 const progressTimezoneWarningHistoryStorageKey = "flashcards-progress-timezone-warning-history-v1";
 
 const observabilityMocks = vi.hoisted(() => ({
+  addWebBreadcrumbMock: vi.fn(),
   captureWebWarningMock: vi.fn(),
 }));
 
 vi.mock("../observability/webObservability", () => ({
+  addWebBreadcrumb: observabilityMocks.addWebBreadcrumbMock,
   captureWebWarning: observabilityMocks.captureWebWarningMock,
 }));
 
@@ -65,6 +67,15 @@ function readCapturedWarning(callIndex: number): WebWarningEvent {
   return event;
 }
 
+function readCapturedBreadcrumb(callIndex: number): WebBreadcrumbEvent {
+  const event = observabilityMocks.addWebBreadcrumbMock.mock.calls[callIndex]?.[0] as WebBreadcrumbEvent | undefined;
+  if (event === undefined) {
+    throw new Error(`Expected captured breadcrumb at index ${callIndex}`);
+  }
+
+  return event;
+}
+
 describe("progress date context", () => {
   beforeEach(() => {
     Object.defineProperty(window, "localStorage", {
@@ -73,12 +84,14 @@ describe("progress date context", () => {
     });
     vi.resetModules();
     window.localStorage.clear();
+    observabilityMocks.addWebBreadcrumbMock.mockReset();
     observabilityMocks.captureWebWarningMock.mockReset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     window.localStorage.clear();
+    observabilityMocks.addWebBreadcrumbMock.mockReset();
     observabilityMocks.captureWebWarningMock.mockReset();
   });
 
@@ -104,18 +117,19 @@ describe("progress date context", () => {
     });
   });
 
-  it("emits progress_timezone_invalid for the first invalid timezone", async () => {
+  it("emits progress_timezone_fallback breadcrumb for the known browser unknown timezone", async () => {
     mockBrowserTimeZone("Etc/Unknown");
     mockBrowserUtcOffset(180);
     const { buildProgressDateContext } = await loadProgressDatesModule();
 
     buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
 
-    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledTimes(1);
-    expect(readCapturedWarning(0)).toEqual(expect.objectContaining({
-      action: "progress_timezone_invalid",
+    expect(observabilityMocks.captureWebWarningMock).not.toHaveBeenCalled();
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledTimes(1);
+    expect(readCapturedBreadcrumb(0)).toEqual(expect.objectContaining({
+      action: "progress_timezone_fallback",
       details: {
-        eventName: "progress_timezone_invalid",
+        eventName: "progress_timezone_fallback",
         observedTimeZone: "Etc/Unknown",
         observedOffsetMinutes: 180,
         fallbackTimeZone: "Etc/GMT+3",
@@ -124,8 +138,29 @@ describe("progress date context", () => {
     }));
   });
 
+  it("emits progress_timezone_invalid for an unexpected invalid timezone", async () => {
+    mockBrowserTimeZone("Invalid/Timezone");
+    mockBrowserUtcOffset(180);
+    const { buildProgressDateContext } = await loadProgressDatesModule();
+
+    buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
+
+    expect(observabilityMocks.addWebBreadcrumbMock).not.toHaveBeenCalled();
+    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledTimes(1);
+    expect(readCapturedWarning(0)).toEqual(expect.objectContaining({
+      action: "progress_timezone_invalid",
+      details: {
+        eventName: "progress_timezone_invalid",
+        observedTimeZone: "Invalid/Timezone",
+        observedOffsetMinutes: 180,
+        fallbackTimeZone: "Etc/GMT+3",
+        errorName: "RangeError",
+      },
+    }));
+  });
+
   it("does not emit a second invalid timezone warning within the throttle window after reload", async () => {
-    mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserTimeZone("Invalid/Timezone");
     mockBrowserUtcOffset(180);
     const firstModule = await loadProgressDatesModule();
     firstModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
@@ -142,7 +177,7 @@ describe("progress date context", () => {
   });
 
   it("emits a new first warning after localStorage is cleared across reloads", async () => {
-    mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserTimeZone("Invalid/Timezone");
     mockBrowserUtcOffset(180);
     const firstModule = await loadProgressDatesModule();
     firstModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
@@ -160,7 +195,7 @@ describe("progress date context", () => {
 
   it("includes installationId in the warning scope when localStorage is available", async () => {
     window.localStorage.setItem(INSTALLATION_ID_STORAGE_KEY, "installation-1");
-    mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserTimeZone("Invalid/Timezone");
     mockBrowserUtcOffset(180);
     const { buildProgressDateContext } = await loadProgressDatesModule();
 

--- a/apps/web/src/progress/progressDates.ts
+++ b/apps/web/src/progress/progressDates.ts
@@ -4,6 +4,7 @@ import type {
   ProgressSummaryInput,
 } from "../types";
 import {
+  addWebBreadcrumb,
   captureWebWarning,
   type WebObservationScope,
 } from "../observability/webObservability";
@@ -254,6 +255,10 @@ function observeInvalidProgressTimeZone(
   }
 }
 
+function isKnownNonActionableProgressTimeZone(timeZone: string | null): boolean {
+  return timeZone === "Etc/Unknown";
+}
+
 function assertUsableTimeZone(timeZone: string): void {
   const formatter = new Intl.DateTimeFormat("en-CA", {
     timeZone,
@@ -310,6 +315,21 @@ function fallBackFromInvalidProgressTimeZone(
 ): string {
   const observedOffsetMinutes = readBrowserUtcOffsetMinutes();
   const fallbackTimeZone = resolveFallbackProgressTimeZone(observedOffsetMinutes);
+  if (isKnownNonActionableProgressTimeZone(observedTimeZone)) {
+    addWebBreadcrumb({
+      action: "progress_timezone_fallback",
+      scope: buildProgressObservationScope(),
+      details: {
+        eventName: "progress_timezone_fallback",
+        observedTimeZone,
+        observedOffsetMinutes,
+        fallbackTimeZone,
+        errorName,
+      },
+    });
+    return fallbackTimeZone;
+  }
+
   observeInvalidProgressTimeZone(
     observedTimeZone,
     errorName,


### PR DESCRIPTION
## Summary
- classify exact Etc/Unknown progress timezone fallback as a silent breadcrumb
- keep progress_timezone_invalid warnings and throttle/history for unexpected invalid zones
- update focused progress date coverage for breadcrumb and warning behavior

## Validation
- npm --prefix apps/web exec vitest run src/progress/progressDates.test.ts passed: 1 file, 7 tests
- review gate: no P0-P4 findings; green light for commit
- review subagent TypeScript check passed