### PR TITLE
Filter non-actionable timezone Sentry warnings

### DIFF
--- a/apps/web/src/observability/instrument.test.ts
+++ b/apps/web/src/observability/instrument.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import { ApiNetworkError } from "../api";
-import { sanitizeSentryBreadcrumbForPrivacy, sanitizeSentryEventForPrivacy } from "./instrument";
+import {
+  prepareSentryEventForSend,
+  sanitizeSentryBreadcrumbForPrivacy,
+  sanitizeSentryEventForPrivacy,
+} from "./instrument";
 import {
   buildWebExceptionFingerprint,
   type WebExceptionEvent,
@@ -235,6 +239,72 @@ describe("Sentry privacy sanitizer", () => {
     expect(sanitizedEvent.extra?.messageCount).toBe(3);
     expect(serializeEvent(sanitizedEvent)).not.toContain(sensitiveCardText);
     expect(serializeEvent(sanitizedEvent)).not.toContain(sensitiveAiText);
+  });
+
+  it("drops non-actionable unknown progress timezone warnings", () => {
+    const event: SentryPrivacyEvent = {
+      message: "web.progress_timezone_invalid",
+      contexts: {
+        "web.warning": {
+          eventName: "progress_timezone_invalid",
+          observedTimeZone: "Etc/Unknown",
+          fallbackTimeZone: "UTC",
+          errorName: "RangeError",
+        },
+      },
+    };
+
+    expect(prepareSentryEventForSend(event)).toBeNull();
+  });
+
+  it("keeps unusual invalid timezone warnings and sanitizes sensitive fields", () => {
+    const event: SentryPrivacyEvent = {
+      message: "web.progress_timezone_invalid",
+      contexts: {
+        "web.warning": {
+          eventName: "progress_timezone_invalid",
+          observedTimeZone: "Invalid/Timezone",
+          fallbackTimeZone: "UTC",
+          errorName: "RangeError",
+        },
+      },
+      extra: {
+        cardFrontText: sensitiveCardText,
+      },
+    };
+
+    const preparedEvent = prepareSentryEventForSend(event);
+
+    if (preparedEvent === null) {
+      throw new Error("Expected unusual invalid timezone warning to be kept");
+    }
+
+    expect(preparedEvent.message).toBe("web.progress_timezone_invalid");
+    expect(preparedEvent.contexts?.["web.warning"]?.observedTimeZone).toBe("Invalid/Timezone");
+    expect(preparedEvent.extra?.cardFrontText).toBe("[Filtered]");
+    expect(serializeEvent(preparedEvent)).not.toContain(sensitiveCardText);
+  });
+
+  it("keeps unrelated errors and sanitizes them before send", () => {
+    const event: SentryPrivacyEvent = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: `Cannot read private card text: ${sensitiveCardText}`,
+          },
+        ],
+      },
+    };
+
+    const preparedEvent = prepareSentryEventForSend(event);
+
+    if (preparedEvent === null) {
+      throw new Error("Expected unrelated error event to be kept");
+    }
+
+    expect(preparedEvent.exception?.values?.[0]?.value).toBe("[Filtered exception value]");
+    expect(serializeEvent(preparedEvent)).not.toContain(sensitiveCardText);
   });
 
   it("groups API network errors by transport endpoint", () => {

--- a/apps/web/src/observability/instrument.ts
+++ b/apps/web/src/observability/instrument.ts
@@ -401,12 +401,50 @@ export function sanitizeSentryBreadcrumbForPrivacy(breadcrumb: SentryBreadcrumb)
   return sanitizeUnknown(breadcrumb, null, []) as SentryBreadcrumb;
 }
 
+function getEventContextObject(event: SentryEvent, name: string): UnknownObject | null {
+  if (isPlainObject(event.contexts) === false) {
+    return null;
+  }
+
+  const context = event.contexts[name];
+  return isPlainObject(context) ? context : null;
+}
+
+function getEventMessage(event: SentryEvent): string | null {
+  if (typeof event.message === "string") {
+    return event.message;
+  }
+
+  if (isPlainObject(event.logentry) && typeof event.logentry.message === "string") {
+    return event.logentry.message;
+  }
+
+  return null;
+}
+
+function shouldDropNonActionableSentryEvent(event: SentryEvent): boolean {
+  if (getEventMessage(event) !== "web.progress_timezone_invalid") {
+    return false;
+  }
+
+  const warningContext = getEventContextObject(event, "web.warning");
+  return warningContext?.observedTimeZone === "Etc/Unknown";
+}
+
+export function prepareSentryEventForSend(event: SentryEvent): SentryEvent | null {
+  if (shouldDropNonActionableSentryEvent(event)) {
+    return null;
+  }
+
+  return sanitizeSentryEventForPrivacy(event);
+}
+
 const beforeBreadcrumb: SentryBeforeBreadcrumb = (breadcrumb: SentryBreadcrumb): SentryBreadcrumb | null => {
   return sanitizeSentryBreadcrumbForPrivacy(breadcrumb);
 };
 
-const beforeSend: SentryBeforeSend = (event: SentryEvent): SentryEvent => {
-  return sanitizeSentryEventForPrivacy(event);
+const beforeSend: SentryBeforeSend = (event: SentryEvent): SentryEvent | null => {
+  return prepareSentryEventForSend(event);
 };
 
 const beforeSendSpan: SentryBeforeSendSpan = (span: SentrySpan): SentrySpan => {


### PR DESCRIPTION
## Summary
- Add a Sentry beforeSend preparation wrapper that drops only web.progress_timezone_invalid events for Etc/Unknown.
- Keep the existing privacy sanitizer for retained Sentry events.
- Cover the drop and retained sanitization paths in observability tests.

## Validation
- npm --prefix apps/web exec vitest run src/observability/instrument.test.ts
- npm exec -- tsc -b --pretty false (from apps/web)
- git --no-pager diff --check

Note: npm --prefix apps/web ci succeeded with the local Node v25.6.1 engine warning; apps/web declares Node 24.x.