### PR TITLE
Add backend media asset registry foundation

### DIFF
--- a/api/src/components/schemas/AgentErrorDetails.yaml
+++ b/api/src/components/schemas/AgentErrorDetails.yaml
@@ -7,3 +7,5 @@ properties:
       $ref: ./ValidationIssueSummary.yaml
   syncConflict:
     $ref: ./PublicSyncConflictDetails.yaml
+  mediaAssetStorage:
+    $ref: ./MediaAssetStorageErrorDetails.yaml

--- a/api/src/components/schemas/CompleteMediaAssetUploadInput.yaml
+++ b/api/src/components/schemas/CompleteMediaAssetUploadInput.yaml
@@ -1,0 +1,39 @@
+type: object
+additionalProperties: false
+required:
+  - mimeType
+  - sizeBytes
+  - sha256
+  - createdAt
+  - clientUpdatedAt
+  - lastModifiedByReplicaId
+  - lastOperationId
+properties:
+  mimeType:
+    type: string
+    example: image/png
+  sizeBytes:
+    type: integer
+    format: int64
+    minimum: 0
+    maximum: 5368709120
+    example: 42817
+  sha256:
+    type: string
+    pattern: ^[0-9a-fA-F]{64}$
+    example: 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+  sourceUrl:
+    type:
+      - string
+      - 'null'
+    format: uri
+  createdAt:
+    type: string
+    format: date-time
+  clientUpdatedAt:
+    type: string
+    format: date-time
+  lastModifiedByReplicaId:
+    $ref: ./UuidString.yaml
+  lastOperationId:
+    type: string

--- a/api/src/components/schemas/MediaAsset.yaml
+++ b/api/src/components/schemas/MediaAsset.yaml
@@ -1,0 +1,59 @@
+type: object
+additionalProperties: false
+required:
+  - mediaAssetId
+  - workspaceId
+  - mimeType
+  - sizeBytes
+  - sha256
+  - storageKey
+  - sourceUrl
+  - createdAt
+  - clientUpdatedAt
+  - lastModifiedByReplicaId
+  - lastOperationId
+  - updatedAt
+  - deletedAt
+properties:
+  mediaAssetId:
+    $ref: ./UuidString.yaml
+  workspaceId:
+    $ref: ./UuidString.yaml
+  mimeType:
+    type: string
+    example: image/png
+  sizeBytes:
+    type: integer
+    format: int64
+    minimum: 0
+    example: 42817
+  sha256:
+    type: string
+    pattern: ^[0-9a-f]{64}$
+    example: 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+  storageKey:
+    type: string
+    example: media-assets/workspaces/50b5b928-7f04-4cc8-878d-6cd0e8b98474/assets/43b7ec15-0a29-46f3-9cbb-c21fa4f4903f/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+  sourceUrl:
+    type:
+      - string
+      - 'null'
+    format: uri
+  createdAt:
+    type: string
+    format: date-time
+  clientUpdatedAt:
+    type: string
+    format: date-time
+  lastModifiedByReplicaId:
+    $ref: ./UuidString.yaml
+  lastOperationId:
+    type: string
+  updatedAt:
+    type: string
+    format: date-time
+  deletedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time

--- a/api/src/components/schemas/MediaAssetDownloadUrlResponse.yaml
+++ b/api/src/components/schemas/MediaAssetDownloadUrlResponse.yaml
@@ -1,0 +1,26 @@
+type: object
+additionalProperties: false
+required:
+  - mediaAsset
+  - download
+properties:
+  mediaAsset:
+    $ref: ./MediaAsset.yaml
+  download:
+    type: object
+    additionalProperties: false
+    required:
+      - method
+      - url
+      - expiresAt
+    properties:
+      method:
+        type: string
+        enum:
+          - GET
+      url:
+        type: string
+        format: uri
+      expiresAt:
+        type: string
+        format: date-time

--- a/api/src/components/schemas/MediaAssetMutationResponse.yaml
+++ b/api/src/components/schemas/MediaAssetMutationResponse.yaml
@@ -1,0 +1,10 @@
+type: object
+additionalProperties: false
+required:
+  - mediaAsset
+  - applied
+properties:
+  mediaAsset:
+    $ref: ./MediaAsset.yaml
+  applied:
+    type: boolean

--- a/api/src/components/schemas/MediaAssetResponse.yaml
+++ b/api/src/components/schemas/MediaAssetResponse.yaml
@@ -1,0 +1,7 @@
+type: object
+additionalProperties: false
+required:
+  - mediaAsset
+properties:
+  mediaAsset:
+    $ref: ./MediaAsset.yaml

--- a/api/src/components/schemas/MediaAssetStorageErrorDetails.yaml
+++ b/api/src/components/schemas/MediaAssetStorageErrorDetails.yaml
@@ -1,0 +1,34 @@
+type: object
+additionalProperties: false
+required:
+  - operation
+  - workspaceId
+  - mediaAssetId
+  - storageKey
+  - bucketName
+  - s3StatusCode
+  - s3ErrorClass
+  - s3ErrorMessage
+properties:
+  operation:
+    type: string
+    example: head_object
+  workspaceId:
+    $ref: ./UuidString.yaml
+  mediaAssetId:
+    $ref: ./UuidString.yaml
+  storageKey:
+    type: string
+  bucketName:
+    type: string
+  s3StatusCode:
+    type:
+      - integer
+      - 'null'
+    example: 404
+  s3ErrorClass:
+    type: string
+    example: NoSuchKey
+  s3ErrorMessage:
+    type: string
+    example: Not Found

--- a/api/src/components/schemas/MediaAssetUploadIntentInput.yaml
+++ b/api/src/components/schemas/MediaAssetUploadIntentInput.yaml
@@ -1,0 +1,23 @@
+type: object
+additionalProperties: false
+required:
+  - mediaAssetId
+  - mimeType
+  - sizeBytes
+  - sha256
+properties:
+  mediaAssetId:
+    $ref: ./UuidString.yaml
+  mimeType:
+    type: string
+    example: image/png
+  sizeBytes:
+    type: integer
+    format: int64
+    minimum: 0
+    maximum: 5368709120
+    example: 42817
+  sha256:
+    type: string
+    pattern: ^[0-9a-fA-F]{64}$
+    example: 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8

--- a/api/src/components/schemas/MediaAssetUploadIntentResponse.yaml
+++ b/api/src/components/schemas/MediaAssetUploadIntentResponse.yaml
@@ -1,0 +1,41 @@
+type: object
+additionalProperties: false
+required:
+  - mediaAssetId
+  - workspaceId
+  - storageKey
+  - upload
+properties:
+  mediaAssetId:
+    $ref: ./UuidString.yaml
+  workspaceId:
+    $ref: ./UuidString.yaml
+  storageKey:
+    type: string
+  upload:
+    type: object
+    additionalProperties: false
+    required:
+      - method
+      - url
+      - expiresAt
+      - headers
+    properties:
+      method:
+        type: string
+        enum:
+          - PUT
+      url:
+        type: string
+        format: uri
+      expiresAt:
+        type: string
+        format: date-time
+      headers:
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          content-type: image/png
+          if-none-match: '*'
+          x-amz-checksum-sha256: XohImNooBHFR0OVvjccpJ3NgPQ1qq73WKhHvch0VQtg=

--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -44,6 +44,10 @@ tags:
       Split SQL surface for the selected workspace: a read-only query
       entrypoint and a separate write entrypoint. Internal sync mechanics stay
       server-side and are not part of this public contract.
+  - name: media-assets
+    description: >-
+      Workspace-scoped media asset registry metadata and direct private object
+      transfer URLs.
 paths:
   /:
     $ref: paths/_.yaml
@@ -63,6 +67,14 @@ paths:
     $ref: paths/agent_sql_query.yaml
   /agent/sql/execute:
     $ref: paths/agent_sql_execute.yaml
+  /workspaces/{workspaceId}/media-assets/upload-intents:
+    $ref: paths/workspaces_{workspaceId}_media-assets_upload-intents.yaml
+  /workspaces/{workspaceId}/media-assets/{mediaAssetId}:
+    $ref: paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}.yaml
+  /workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete:
+    $ref: paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_complete.yaml
+  /workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url:
+    $ref: paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
 components:
   securitySchemes:
     ApiKeyHeader:

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-intents.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-intents.yaml
@@ -1,0 +1,35 @@
+post:
+  tags:
+    - media-assets
+  summary: Create a direct media asset upload intent
+  description: >-
+    Returns a presigned private S3 PUT URL for a workspace media object. This
+    does not create the registry row; call the complete endpoint after the
+    bytes are uploaded.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/MediaAssetUploadIntentInput.yaml
+  responses:
+    '201':
+      description: Upload intent created
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/MediaAssetUploadIntentResponse.yaml
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}.yaml
@@ -1,0 +1,33 @@
+get:
+  tags:
+    - media-assets
+  summary: Get media asset registry metadata
+  description: >-
+    Loads one completed, non-deleted media asset registry row for the selected
+    workspace. File bytes remain outside the normal JSON payload.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+    - name: mediaAssetId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  responses:
+    '200':
+      description: Media asset metadata loaded
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/MediaAssetResponse.yaml
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_complete.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_complete.yaml
@@ -1,0 +1,40 @@
+post:
+  tags:
+    - media-assets
+  summary: Complete a direct media asset upload
+  description: >-
+    Verifies the uploaded S3 object size, content type, and SHA-256 checksum,
+    then creates or idempotently updates the workspace media asset registry
+    metadata row for the same bytes.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+    - name: mediaAssetId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/CompleteMediaAssetUploadInput.yaml
+  responses:
+    '200':
+      description: Media asset upload completed
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/MediaAssetMutationResponse.yaml
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
@@ -1,0 +1,33 @@
+get:
+  tags:
+    - media-assets
+  summary: Create a direct media asset download URL
+  description: >-
+    Returns a presigned private S3 GET URL for the stored object. Clients may
+    use normal HTTP Range requests against the returned URL for partial reads.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+    - name: mediaAssetId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  responses:
+    '200':
+      description: Download URL created
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/MediaAssetDownloadUrlResponse.yaml
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-lambda": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1075.0",
         "@aws-sdk/client-secrets-manager": "^3.1075.0",
+        "@aws-sdk/s3-request-presigner": "^3.1075.0",
         "@hono/node-server": "^2.0.6",
         "@langfuse/openai": "^5.6.0",
         "@langfuse/otel": "^5.6.0",
@@ -601,6 +602,23 @@
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
         "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1075.0.tgz",
+      "integrity": "sha512-++ftTvAGZSTuzFVHEPk8lLi7mybBD8PzJ9USWBvwnE4kSrXOyqYVJ5Ixd06xUEWS/xsrhpkI07mzCLGIxrRymA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -15,6 +15,7 @@
     "@aws-sdk/client-lambda": "^3.1075.0",
     "@aws-sdk/client-s3": "^3.1075.0",
     "@aws-sdk/client-secrets-manager": "^3.1075.0",
+    "@aws-sdk/s3-request-presigner": "^3.1075.0",
     "@hono/node-server": "^2.0.6",
     "@langfuse/openai": "^5.6.0",
     "@langfuse/otel": "^5.6.0",

--- a/apps/backend/src/mediaAssets/index.ts
+++ b/apps/backend/src/mediaAssets/index.ts
@@ -1,0 +1,342 @@
+import {
+  queryWithWorkspaceScopeReadOnly,
+  transactionWithWorkspaceScope,
+  type DatabaseExecutor,
+} from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  incomingLwwMetadataWins,
+  type LwwMetadata,
+} from "../sync/conflicts/lww";
+import { buildMediaAssetStorageKey } from "./storageKeys";
+import type {
+  CompleteMediaAssetUploadInput,
+  MediaAsset,
+  MediaAssetMutationResult,
+  MediaAssetRow,
+  TimestampValue,
+} from "./types";
+
+const MEDIA_ASSET_COLUMNS = [
+  "media_asset_id",
+  "workspace_id",
+  "mime_type",
+  "size_bytes",
+  "sha256",
+  "storage_key",
+  "source_url",
+  "created_at",
+  "client_updated_at",
+  "last_modified_by_replica_id",
+  "last_operation_id",
+  "updated_at",
+  "deleted_at",
+].join(", ");
+
+type ExistingMediaAssetIntentRow = Readonly<{
+  storage_key: string;
+}>;
+
+function toIsoString(value: TimestampValue): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return new Date(value).toISOString();
+}
+
+function toOptionalIsoString(value: TimestampValue | null): string | null {
+  return value === null ? null : toIsoString(value);
+}
+
+function toSafeNumber(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (Number.isSafeInteger(parsedValue) === false) {
+    throw new Error(`${fieldName} must be a safe integer`);
+  }
+
+  return parsedValue;
+}
+
+export function mapMediaAssetRow(row: MediaAssetRow): MediaAsset {
+  return {
+    mediaAssetId: row.media_asset_id,
+    workspaceId: row.workspace_id,
+    mimeType: row.mime_type,
+    sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
+    sha256: row.sha256,
+    storageKey: row.storage_key,
+    sourceUrl: row.source_url,
+    createdAt: toIsoString(row.created_at),
+    clientUpdatedAt: toIsoString(row.client_updated_at),
+    lastModifiedByReplicaId: row.last_modified_by_replica_id,
+    lastOperationId: row.last_operation_id,
+    updatedAt: toIsoString(row.updated_at),
+    deletedAt: toOptionalIsoString(row.deleted_at),
+  };
+}
+
+export async function assertMediaAssetUploadIntentAvailableForWorkspace(
+  userId: string,
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<void> {
+  const result = await queryWithWorkspaceScopeReadOnly<ExistingMediaAssetIntentRow>(
+    { userId, workspaceId },
+    [
+      "SELECT storage_key",
+      "FROM content.media_assets",
+      "WHERE workspace_id = $1",
+      "AND media_asset_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [workspaceId, mediaAssetId],
+  );
+
+  const existingRow = result.rows[0];
+  if (existingRow === undefined) {
+    return;
+  }
+
+  throw new HttpError(
+    409,
+    [
+      "Media asset is already registered; create a new mediaAssetId before requesting another upload intent.",
+      `workspaceId=${workspaceId}`,
+      `mediaAssetId=${mediaAssetId}`,
+      `storageKey=${existingRow.storage_key}`,
+    ].join(" "),
+    "MEDIA_ASSET_ALREADY_REGISTERED",
+  );
+}
+
+function toMediaAssetLwwMetadata(row: MediaAssetRow): LwwMetadata {
+  return {
+    clientUpdatedAt: toIsoString(row.client_updated_at),
+    lastModifiedByReplicaId: row.last_modified_by_replica_id,
+    lastOperationId: row.last_operation_id,
+  };
+}
+
+function toInputLwwMetadata(input: CompleteMediaAssetUploadInput): LwwMetadata {
+  return {
+    clientUpdatedAt: input.clientUpdatedAt,
+    lastModifiedByReplicaId: input.lastModifiedByReplicaId,
+    lastOperationId: input.lastOperationId,
+  };
+}
+
+async function assertReplicaBelongsToWorkspaceInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  replicaId: string,
+): Promise<void> {
+  const result = await executor.query<Readonly<{ ok: number }>>(
+    [
+      "SELECT 1 AS ok",
+      "FROM sync.workspace_replicas",
+      "WHERE workspace_id = $1",
+      "AND replica_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [workspaceId, replicaId],
+  );
+
+  if (result.rows.length === 0) {
+    throw new HttpError(
+      400,
+      "lastModifiedByReplicaId must reference a workspace replica accessible to the authenticated user.",
+      "MEDIA_ASSET_REPLICA_INVALID",
+    );
+  }
+}
+
+async function findMediaAssetRowForUpdateInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<MediaAssetRow | null> {
+  const result = await executor.query<MediaAssetRow>(
+    [
+      "SELECT",
+      MEDIA_ASSET_COLUMNS,
+      "FROM content.media_assets",
+      "WHERE workspace_id = $1",
+      "AND media_asset_id = $2",
+      "FOR UPDATE",
+    ].join(" "),
+    [workspaceId, mediaAssetId],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+function assertExistingMediaAssetMatchesInput(
+  existingRow: MediaAssetRow,
+  input: CompleteMediaAssetUploadInput,
+  storageKey: string,
+): void {
+  if (
+    existingRow.mime_type !== input.mimeType
+    || toSafeNumber(existingRow.size_bytes, "size_bytes") !== input.sizeBytes
+    || existingRow.sha256 !== input.sha256
+    || existingRow.storage_key !== storageKey
+  ) {
+    throw new HttpError(
+      409,
+      [
+        "mediaAssetId is already registered with different file metadata",
+        `workspaceId=${existingRow.workspace_id}`,
+        `mediaAssetId=${existingRow.media_asset_id}`,
+        `existingStorageKey=${existingRow.storage_key}`,
+        `requestedStorageKey=${storageKey}`,
+      ].join(" "),
+      "MEDIA_ASSET_ID_CONFLICT",
+    );
+  }
+}
+
+async function insertMediaAssetRowInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: CompleteMediaAssetUploadInput,
+  storageKey: string,
+): Promise<MediaAssetRow | null> {
+  const result = await executor.query<MediaAssetRow>(
+    [
+      "INSERT INTO content.media_assets",
+      "(",
+      "media_asset_id, workspace_id, mime_type, size_bytes, sha256, storage_key, source_url, created_at,",
+      "client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at",
+      ")",
+      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL)",
+      "ON CONFLICT DO NOTHING",
+      "RETURNING",
+      MEDIA_ASSET_COLUMNS,
+    ].join(" "),
+    [
+      input.mediaAssetId,
+      workspaceId,
+      input.mimeType,
+      input.sizeBytes,
+      input.sha256,
+      storageKey,
+      input.sourceUrl,
+      input.createdAt,
+      input.clientUpdatedAt,
+      input.lastModifiedByReplicaId,
+      input.lastOperationId,
+    ],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+async function updateExistingMediaAssetRowInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: CompleteMediaAssetUploadInput,
+): Promise<MediaAssetRow> {
+  const result = await executor.query<MediaAssetRow>(
+    [
+      "UPDATE content.media_assets",
+      "SET source_url = $3,",
+      "client_updated_at = $4,",
+      "last_modified_by_replica_id = $5,",
+      "last_operation_id = $6,",
+      "updated_at = now(),",
+      "deleted_at = NULL",
+      "WHERE workspace_id = $1",
+      "AND media_asset_id = $2",
+      "RETURNING",
+      MEDIA_ASSET_COLUMNS,
+    ].join(" "),
+    [
+      workspaceId,
+      input.mediaAssetId,
+      input.sourceUrl,
+      input.clientUpdatedAt,
+      input.lastModifiedByReplicaId,
+      input.lastOperationId,
+    ],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(
+      404,
+      "Media asset was not found while completing upload.",
+      "MEDIA_ASSET_NOT_FOUND",
+    );
+  }
+
+  return row;
+}
+
+export async function completeMediaAssetUploadForWorkspace(
+  userId: string,
+  workspaceId: string,
+  input: CompleteMediaAssetUploadInput,
+): Promise<MediaAssetMutationResult> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    await assertReplicaBelongsToWorkspaceInExecutor(executor, workspaceId, input.lastModifiedByReplicaId);
+    const storageKey = buildMediaAssetStorageKey(workspaceId, input.mediaAssetId, input.sha256);
+    const insertedRow = await insertMediaAssetRowInExecutor(executor, workspaceId, input, storageKey);
+    if (insertedRow !== null) {
+      return {
+        mediaAsset: mapMediaAssetRow(insertedRow),
+        applied: true,
+      };
+    }
+
+    const existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, input.mediaAssetId);
+    if (existingRow === null) {
+      throw new HttpError(
+        409,
+        `mediaAssetId is already used by another workspace: mediaAssetId=${input.mediaAssetId}`,
+        "MEDIA_ASSET_ID_CONFLICT",
+      );
+    }
+
+    assertExistingMediaAssetMatchesInput(existingRow, input, storageKey);
+    if (incomingLwwMetadataWins(toInputLwwMetadata(input), toMediaAssetLwwMetadata(existingRow)) === false) {
+      return {
+        mediaAsset: mapMediaAssetRow(existingRow),
+        applied: false,
+      };
+    }
+
+    const updatedRow = await updateExistingMediaAssetRowInExecutor(executor, workspaceId, input);
+    return {
+      mediaAsset: mapMediaAssetRow(updatedRow),
+      applied: true,
+    };
+  });
+}
+
+export async function loadMediaAssetForWorkspace(
+  userId: string,
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<MediaAsset> {
+  const result = await queryWithWorkspaceScopeReadOnly<MediaAssetRow>(
+    { userId, workspaceId },
+    [
+      "SELECT",
+      MEDIA_ASSET_COLUMNS,
+      "FROM content.media_assets",
+      "WHERE workspace_id = $1",
+      "AND media_asset_id = $2",
+      "AND deleted_at IS NULL",
+      "LIMIT 1",
+    ].join(" "),
+    [workspaceId, mediaAssetId],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(404, "Media asset not found.", "MEDIA_ASSET_NOT_FOUND");
+  }
+
+  return mapMediaAssetRow(row);
+}

--- a/apps/backend/src/mediaAssets/storage.test.ts
+++ b/apps/backend/src/mediaAssets/storage.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { S3Client } from "@aws-sdk/client-s3";
+import { createBackendObservationScope } from "../observability/sentry";
+import { HttpError } from "../shared/errors";
+import {
+  createPresignedMediaAssetUploadWithDependencies,
+  loadMediaAssetObjectMetadataWithDependencies,
+} from "./storage";
+
+type S3Error = Error & {
+  $metadata: Readonly<{
+    httpStatusCode: number;
+  }>;
+};
+
+const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
+const testMediaAssetId = "22222222-2222-4222-8222-222222222222";
+const testStorageKey = `media-assets/workspaces/${testWorkspaceId}/media/${testMediaAssetId}/original`;
+const testObservationScope = createBackendObservationScope(
+  "backend-api",
+  "request-1",
+  "/workspaces/:workspaceId/media-assets/:mediaAssetId/complete",
+  "POST",
+  "user-1",
+  testWorkspaceId,
+  null,
+  null,
+  null,
+  null,
+  null,
+);
+
+function createS3Error(statusCode: number): S3Error {
+  const error = new Error("Forbidden") as S3Error;
+  error.name = "Forbidden";
+  error.$metadata = {
+    httpStatusCode: statusCode,
+  };
+  return error;
+}
+
+function createFailingS3Client(error: S3Error): S3Client {
+  const client = new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  client.send = (async () => {
+    throw error;
+  }) as S3Client["send"];
+  return client;
+}
+
+function createTestS3Client(): S3Client {
+  return new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+}
+
+test("createPresignedMediaAssetUploadWithDependencies signs all returned required upload headers", async () => {
+  const upload = await createPresignedMediaAssetUploadWithDependencies(
+    {
+      workspaceId: testWorkspaceId,
+      mediaAssetId: testMediaAssetId,
+      storageKey: testStorageKey,
+      mimeType: "image/png",
+      sha256: "a".repeat(64),
+      observationScope: testObservationScope,
+    },
+    {
+      s3Client: createTestS3Client(),
+      getMediaAssetsStorageConfigFn: () => ({
+        bucketName: "test-media-assets-bucket",
+      }),
+    },
+  );
+
+  const signedHeaders = new URL(upload.url).searchParams.get("X-Amz-SignedHeaders");
+  assert.notEqual(signedHeaders, null);
+  const signedHeaderSet = new Set(signedHeaders?.split(";") ?? []);
+  for (const headerName of Object.keys(upload.headers)) {
+    assert.ok(signedHeaderSet.has(headerName), `Expected ${headerName} to be signed`);
+  }
+});
+
+test("loadMediaAssetObjectMetadataWithDependencies treats HeadObject 403 as upload not found", async () => {
+  await assert.rejects(
+    async () => loadMediaAssetObjectMetadataWithDependencies(
+      {
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        storageKey: testStorageKey,
+        mimeType: "image/png",
+        sizeBytes: 123,
+        sha256: "a".repeat(64),
+        observationScope: testObservationScope,
+      },
+      {
+        s3Client: createFailingS3Client(createS3Error(403)),
+        getMediaAssetsStorageConfigFn: () => ({
+          bucketName: "test-media-assets-bucket",
+        }),
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "MEDIA_ASSET_UPLOAD_NOT_FOUND");
+      assert.deepEqual(error.details?.mediaAssetStorage, {
+        operation: "head_object",
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        storageKey: testStorageKey,
+        bucketName: "test-media-assets-bucket",
+        s3StatusCode: 403,
+        s3ErrorClass: "Forbidden",
+        s3ErrorMessage: "Forbidden",
+      });
+      return true;
+    },
+  );
+});

--- a/apps/backend/src/mediaAssets/storage.ts
+++ b/apps/backend/src/mediaAssets/storage.ts
@@ -1,0 +1,415 @@
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { HttpError, type MediaAssetStorageErrorDetails } from "../shared/errors";
+import {
+  addBackendBreadcrumb,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import type {
+  MediaAssetObjectMetadata,
+  PresignedMediaAssetDownload,
+  PresignedMediaAssetUpload,
+} from "./types";
+
+export type MediaAssetsStorageConfig = Readonly<{
+  bucketName: string;
+}>;
+
+type MediaAssetStorageContext = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  storageKey: string;
+  observationScope: BackendObservationScope;
+}>;
+
+type PresignMediaAssetUploadInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  storageKey: string;
+  mimeType: string;
+  sha256: string;
+  observationScope: BackendObservationScope;
+}>;
+
+type PresignMediaAssetDownloadInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  storageKey: string;
+  observationScope: BackendObservationScope;
+}>;
+
+type AssertMediaAssetObjectInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  storageKey: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  observationScope: BackendObservationScope;
+}>;
+
+type MediaAssetStorageOperation =
+  | "create_presigned_upload"
+  | "create_presigned_download"
+  | "head_object";
+
+type MediaAssetStorageDependencies = Readonly<{
+  s3Client: S3Client;
+  getMediaAssetsStorageConfigFn: typeof getMediaAssetsStorageConfig;
+}>;
+
+const maxS3AttemptCount = 3;
+const uploadUrlExpiresSeconds = 15 * 60;
+const downloadUrlExpiresSeconds = 60 * 60;
+
+let mediaAssetsS3Client: S3Client | undefined;
+
+function getMediaAssetsS3Client(): S3Client {
+  if (mediaAssetsS3Client !== undefined) {
+    return mediaAssetsS3Client;
+  }
+
+  mediaAssetsS3Client = new S3Client({});
+  return mediaAssetsS3Client;
+}
+
+function getRequiredMediaAssetsEnv(envName: string): string {
+  const value = process.env[envName];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${envName} is required for media asset storage.`);
+  }
+
+  return value.trim();
+}
+
+export function getMediaAssetsStorageConfig(): MediaAssetsStorageConfig {
+  return {
+    bucketName: getRequiredMediaAssetsEnv("MEDIA_ASSETS_S3_BUCKET_NAME"),
+  };
+}
+
+function getS3ErrorStatusCode(error: unknown): number | null {
+  if (typeof error !== "object" || error === null || !("$metadata" in error)) {
+    return null;
+  }
+
+  const metadata = (error as Readonly<{
+    $metadata?: Readonly<{
+      httpStatusCode?: unknown;
+    }>;
+  }>).$metadata;
+
+  return typeof metadata?.httpStatusCode === "number" ? metadata.httpStatusCode : null;
+}
+
+function getS3ErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : "UnknownError";
+}
+
+function getS3ErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatS3ErrorSummary(error: unknown): string {
+  const errorName = getS3ErrorName(error);
+  const errorMessage = getS3ErrorMessage(error);
+  const statusCode = getS3ErrorStatusCode(error);
+  const statusSuffix = statusCode === null ? "" : ` status=${statusCode}`;
+  return `${errorName}${statusSuffix}: ${errorMessage}`;
+}
+
+function isHeadObjectUploadNotAvailableStatusCode(statusCode: number | null): boolean {
+  return statusCode === 403 || statusCode === 404;
+}
+
+function createExpiresAt(expiresSeconds: number): string {
+  return new Date(Date.now() + expiresSeconds * 1_000).toISOString();
+}
+
+function toBase64Sha256Digest(sha256: string): string {
+  return Buffer.from(sha256, "hex").toString("base64");
+}
+
+function toHexSha256Digest(checksumSha256: string | undefined): string | null {
+  if (checksumSha256 === undefined || checksumSha256.trim() === "") {
+    return null;
+  }
+
+  return Buffer.from(checksumSha256, "base64").toString("hex");
+}
+
+async function runMediaAssetStorageOperationWithRetries<Result>(
+  context: MediaAssetStorageContext,
+  operation: MediaAssetStorageOperation,
+  bucketName: string,
+  run: () => Promise<Result>,
+): Promise<Result> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= maxS3AttemptCount; attempt += 1) {
+    try {
+      return await run();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxS3AttemptCount) {
+        break;
+      }
+
+      addBackendBreadcrumb({
+        action: "media_asset_storage_retry",
+        scope: context.observationScope,
+        details: {
+          operation,
+          attempt,
+          maxAttempts: maxS3AttemptCount,
+          bucketName,
+          workspaceId: context.workspaceId,
+          mediaAssetId: context.mediaAssetId,
+          storageKey: context.storageKey,
+          statusCode: getS3ErrorStatusCode(error),
+          errorClass: getS3ErrorName(error),
+          errorMessage: getS3ErrorMessage(error),
+        },
+      });
+    }
+  }
+
+  if (lastError === null) {
+    throw new Error(
+      `S3 ${operation} failed without an error for workspaceId=${context.workspaceId} mediaAssetId=${context.mediaAssetId} s3://${bucketName}/${context.storageKey}.`,
+    );
+  }
+
+  throw lastError;
+}
+
+function createMediaAssetStorageError(
+  context: MediaAssetStorageContext,
+  bucketName: string,
+  operation: MediaAssetStorageOperation,
+  error: unknown,
+): HttpError {
+  const errorSummary = formatS3ErrorSummary(error);
+  const location = `workspaceId=${context.workspaceId} mediaAssetId=${context.mediaAssetId} s3://${bucketName}/${context.storageKey}`;
+  const details: MediaAssetStorageErrorDetails = {
+    operation,
+    workspaceId: context.workspaceId,
+    mediaAssetId: context.mediaAssetId,
+    storageKey: context.storageKey,
+    bucketName,
+    s3StatusCode: getS3ErrorStatusCode(error),
+    s3ErrorClass: getS3ErrorName(error),
+    s3ErrorMessage: getS3ErrorMessage(error),
+  };
+  if (operation === "head_object" && isHeadObjectUploadNotAvailableStatusCode(details.s3StatusCode)) {
+    return new HttpError(
+      409,
+      `Uploaded media asset is not available in S3 for ${location}: ${errorSummary}`,
+      "MEDIA_ASSET_UPLOAD_NOT_FOUND",
+      { mediaAssetStorage: details },
+    );
+  }
+
+  return new HttpError(
+    503,
+    `Media asset storage ${operation} failed for ${location}: ${errorSummary}`,
+    "MEDIA_ASSET_STORAGE_UNAVAILABLE",
+    { mediaAssetStorage: details },
+  );
+}
+
+function createMediaAssetUploadMismatchError(
+  input: AssertMediaAssetObjectInput,
+  objectMetadata: MediaAssetObjectMetadata,
+): HttpError {
+  return new HttpError(
+    409,
+    [
+      "Uploaded media asset does not match declared metadata",
+      `workspaceId=${input.workspaceId}`,
+      `mediaAssetId=${input.mediaAssetId}`,
+      `storageKey=${input.storageKey}`,
+      `expectedSizeBytes=${input.sizeBytes}`,
+      `actualSizeBytes=${objectMetadata.sizeBytes ?? "unknown"}`,
+      `expectedMimeType=${input.mimeType}`,
+      `actualMimeType=${objectMetadata.mimeType ?? "unknown"}`,
+      `expectedSha256=${input.sha256}`,
+      `actualSha256=${objectMetadata.checksumSha256 ?? "unknown"}`,
+    ].join(" "),
+    "MEDIA_ASSET_UPLOAD_MISMATCH",
+  );
+}
+
+function assertMediaAssetObjectMetadataMatches(
+  input: AssertMediaAssetObjectInput,
+  objectMetadata: MediaAssetObjectMetadata,
+): void {
+  if (
+    objectMetadata.sizeBytes !== input.sizeBytes
+    || objectMetadata.mimeType !== input.mimeType
+    || objectMetadata.checksumSha256 !== input.sha256
+  ) {
+    throw createMediaAssetUploadMismatchError(input, objectMetadata);
+  }
+}
+
+export async function createPresignedMediaAssetUploadWithDependencies(
+  input: PresignMediaAssetUploadInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<PresignedMediaAssetUpload> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.storageKey,
+    observationScope: input.observationScope,
+  };
+  const checksumSha256 = toBase64Sha256Digest(input.sha256);
+
+  try {
+    const url = await runMediaAssetStorageOperationWithRetries(
+      context,
+      "create_presigned_upload",
+      config.bucketName,
+      async () => getSignedUrl(
+        dependencies.s3Client,
+        new PutObjectCommand({
+          Bucket: config.bucketName,
+          Key: input.storageKey,
+          ContentType: input.mimeType,
+          ChecksumSHA256: checksumSha256,
+          IfNoneMatch: "*",
+        }),
+        {
+          expiresIn: uploadUrlExpiresSeconds,
+          signableHeaders: new Set(["content-type"]),
+          unhoistableHeaders: new Set(["x-amz-checksum-sha256"]),
+        },
+      ),
+    );
+
+    return {
+      method: "PUT",
+      url,
+      expiresAt: createExpiresAt(uploadUrlExpiresSeconds),
+      headers: {
+        "content-type": input.mimeType,
+        "if-none-match": "*",
+        "x-amz-checksum-sha256": checksumSha256,
+      },
+    };
+  } catch (error) {
+    throw createMediaAssetStorageError(context, config.bucketName, "create_presigned_upload", error);
+  }
+}
+
+export async function createPresignedMediaAssetDownloadWithDependencies(
+  input: PresignMediaAssetDownloadInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<PresignedMediaAssetDownload> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.storageKey,
+    observationScope: input.observationScope,
+  };
+
+  try {
+    const url = await runMediaAssetStorageOperationWithRetries(
+      context,
+      "create_presigned_download",
+      config.bucketName,
+      async () => getSignedUrl(
+        dependencies.s3Client,
+        new GetObjectCommand({
+          Bucket: config.bucketName,
+          Key: input.storageKey,
+        }),
+        { expiresIn: downloadUrlExpiresSeconds },
+      ),
+    );
+
+    return {
+      method: "GET",
+      url,
+      expiresAt: createExpiresAt(downloadUrlExpiresSeconds),
+    };
+  } catch (error) {
+    throw createMediaAssetStorageError(context, config.bucketName, "create_presigned_download", error);
+  }
+}
+
+export async function loadMediaAssetObjectMetadataWithDependencies(
+  input: AssertMediaAssetObjectInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<MediaAssetObjectMetadata> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.storageKey,
+    observationScope: input.observationScope,
+  };
+
+  try {
+    const response = await runMediaAssetStorageOperationWithRetries(
+      context,
+      "head_object",
+      config.bucketName,
+      async () => dependencies.s3Client.send(new HeadObjectCommand({
+        Bucket: config.bucketName,
+        Key: input.storageKey,
+        ChecksumMode: "ENABLED",
+      })),
+    );
+
+    return {
+      sizeBytes: typeof response.ContentLength === "number" ? response.ContentLength : null,
+      mimeType: typeof response.ContentType === "string" ? response.ContentType : null,
+      checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
+    };
+  } catch (error) {
+    throw createMediaAssetStorageError(context, config.bucketName, "head_object", error);
+  }
+}
+
+export async function assertMediaAssetObjectMatchesWithDependencies(
+  input: AssertMediaAssetObjectInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  const objectMetadata = await loadMediaAssetObjectMetadataWithDependencies(input, dependencies);
+  assertMediaAssetObjectMetadataMatches(input, objectMetadata);
+}
+
+export async function createPresignedMediaAssetUpload(
+  input: PresignMediaAssetUploadInput,
+): Promise<PresignedMediaAssetUpload> {
+  return createPresignedMediaAssetUploadWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function createPresignedMediaAssetDownload(
+  input: PresignMediaAssetDownloadInput,
+): Promise<PresignedMediaAssetDownload> {
+  return createPresignedMediaAssetDownloadWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function assertMediaAssetObjectMatches(
+  input: AssertMediaAssetObjectInput,
+): Promise<void> {
+  return assertMediaAssetObjectMatchesWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}

--- a/apps/backend/src/mediaAssets/storageKeys.ts
+++ b/apps/backend/src/mediaAssets/storageKeys.ts
@@ -1,0 +1,15 @@
+export function buildMediaAssetStorageKey(
+  workspaceId: string,
+  mediaAssetId: string,
+  sha256: string,
+): string {
+  const canonicalWorkspaceId = workspaceId.toLowerCase();
+  return [
+    "media-assets",
+    "workspaces",
+    canonicalWorkspaceId,
+    "assets",
+    mediaAssetId,
+    sha256,
+  ].join("/");
+}

--- a/apps/backend/src/mediaAssets/types.ts
+++ b/apps/backend/src/mediaAssets/types.ts
@@ -1,0 +1,76 @@
+export type TimestampValue = Date | string;
+
+export type MediaAssetRow = Readonly<{
+  media_asset_id: string;
+  workspace_id: string;
+  mime_type: string;
+  size_bytes: string | number;
+  sha256: string;
+  storage_key: string;
+  source_url: string | null;
+  created_at: TimestampValue;
+  client_updated_at: TimestampValue;
+  last_modified_by_replica_id: string;
+  last_operation_id: string;
+  updated_at: TimestampValue;
+  deleted_at: TimestampValue | null;
+}>;
+
+export type MediaAsset = Readonly<{
+  mediaAssetId: string;
+  workspaceId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageKey: string;
+  sourceUrl: string | null;
+  createdAt: string;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}>;
+
+export type MediaAssetUploadIntentInput = Readonly<{
+  mediaAssetId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+}>;
+
+export type CompleteMediaAssetUploadInput = Readonly<{
+  mediaAssetId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  sourceUrl: string | null;
+  createdAt: string;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+}>;
+
+export type MediaAssetMutationResult = Readonly<{
+  mediaAsset: MediaAsset;
+  applied: boolean;
+}>;
+
+export type PresignedMediaAssetUpload = Readonly<{
+  method: "PUT";
+  url: string;
+  expiresAt: string;
+  headers: Readonly<Record<string, string>>;
+}>;
+
+export type PresignedMediaAssetDownload = Readonly<{
+  method: "GET";
+  url: string;
+  expiresAt: string;
+}>;
+
+export type MediaAssetObjectMetadata = Readonly<{
+  sizeBytes: number | null;
+  mimeType: string | null;
+  checksumSha256: string | null;
+}>;

--- a/apps/backend/src/mediaAssets/validators.ts
+++ b/apps/backend/src/mediaAssets/validators.ts
@@ -1,0 +1,137 @@
+import { HttpError } from "../shared/errors";
+import {
+  expectNonEmptyString,
+  expectRecord,
+  expectUuidString,
+} from "../server/requestParsing";
+import type {
+  CompleteMediaAssetUploadInput,
+  MediaAssetUploadIntentInput,
+} from "./types";
+
+const mimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i;
+const sha256Pattern = /^[0-9a-f]{64}$/i;
+const maximumSourceUrlLength = 2_048;
+const maximumLastOperationIdLength = 1_024;
+export const maximumSinglePutUploadBytes = 5_368_709_120;
+
+export function parseMediaAssetIdParam(value: string | undefined): string {
+  if (value === undefined) {
+    throw new HttpError(400, "mediaAssetId is required", "MEDIA_ASSET_ID_REQUIRED");
+  }
+
+  try {
+    return expectUuidString(value, "mediaAssetId");
+  } catch {
+    throw new HttpError(400, "mediaAssetId must be a UUID", "MEDIA_ASSET_ID_INVALID");
+  }
+}
+
+function expectMimeType(value: unknown, fieldName: string): string {
+  const mimeType = expectNonEmptyString(value, fieldName).toLowerCase();
+  if (mimeTypePattern.test(mimeType) === false) {
+    throw new HttpError(400, `${fieldName} must be a valid MIME type`);
+  }
+
+  return mimeType;
+}
+
+function expectSha256(value: unknown, fieldName: string): string {
+  const sha256 = expectNonEmptyString(value, fieldName).toLowerCase();
+  if (sha256Pattern.test(sha256) === false) {
+    throw new HttpError(400, `${fieldName} must be a lowercase or uppercase hex SHA-256 digest`);
+  }
+
+  return sha256;
+}
+
+function expectSizeBytes(value: unknown, fieldName: string): number {
+  if (
+    typeof value !== "number"
+    || Number.isSafeInteger(value) === false
+    || value < 0
+  ) {
+    throw new HttpError(400, `${fieldName} must be a non-negative safe integer`);
+  }
+
+  if (value > maximumSinglePutUploadBytes) {
+    throw new HttpError(
+      400,
+      `${fieldName} must be at most ${maximumSinglePutUploadBytes} bytes for direct media uploads`,
+      "MEDIA_ASSET_SIZE_TOO_LARGE",
+    );
+  }
+
+  return value;
+}
+
+function expectIsoTimestamp(value: unknown, fieldName: string): string {
+  const rawTimestamp = expectNonEmptyString(value, fieldName);
+  const parsedTimestamp = new Date(rawTimestamp);
+  if (Number.isNaN(parsedTimestamp.getTime())) {
+    throw new HttpError(400, `${fieldName} must be a valid ISO timestamp`);
+  }
+
+  return parsedTimestamp.toISOString();
+}
+
+function expectSourceUrl(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const sourceUrl = expectNonEmptyString(value, fieldName);
+  if (sourceUrl.length > maximumSourceUrlLength) {
+    throw new HttpError(400, `${fieldName} must be at most ${maximumSourceUrlLength} characters`);
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(sourceUrl);
+  } catch {
+    throw new HttpError(400, `${fieldName} must be an absolute HTTP or HTTPS URL`);
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new HttpError(400, `${fieldName} must be an absolute HTTP or HTTPS URL`);
+  }
+
+  return parsedUrl.toString();
+}
+
+function expectLastOperationId(value: unknown, fieldName: string): string {
+  const lastOperationId = expectNonEmptyString(value, fieldName);
+  if (lastOperationId.length > maximumLastOperationIdLength) {
+    throw new HttpError(400, `${fieldName} must be at most ${maximumLastOperationIdLength} characters`);
+  }
+
+  return lastOperationId;
+}
+
+export function parseMediaAssetUploadIntentInput(value: unknown): MediaAssetUploadIntentInput {
+  const record = expectRecord(value);
+  return {
+    mediaAssetId: expectUuidString(record.mediaAssetId, "mediaAssetId"),
+    mimeType: expectMimeType(record.mimeType, "mimeType"),
+    sizeBytes: expectSizeBytes(record.sizeBytes, "sizeBytes"),
+    sha256: expectSha256(record.sha256, "sha256"),
+  };
+}
+
+export function parseCompleteMediaAssetUploadInput(
+  mediaAssetId: string,
+  value: unknown,
+): CompleteMediaAssetUploadInput {
+  const record = expectRecord(value);
+  return {
+    mediaAssetId,
+    mimeType: expectMimeType(record.mimeType, "mimeType"),
+    sizeBytes: expectSizeBytes(record.sizeBytes, "sizeBytes"),
+    sha256: expectSha256(record.sha256, "sha256"),
+    sourceUrl: expectSourceUrl(record.sourceUrl, "sourceUrl"),
+    createdAt: expectIsoTimestamp(record.createdAt, "createdAt"),
+    clientUpdatedAt: expectIsoTimestamp(record.clientUpdatedAt, "clientUpdatedAt"),
+    lastModifiedByReplicaId: expectUuidString(record.lastModifiedByReplicaId, "lastModifiedByReplicaId"),
+    lastOperationId: expectLastOperationId(record.lastOperationId, "lastOperationId"),
+  };
+}

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -1,3 +1,5 @@
+import type { MediaAssetStorageErrorDetails } from "../../shared/errors";
+
 export type BackendService =
   | "backend-api"
   | "chat-worker"
@@ -46,6 +48,7 @@ export type BackendFailureDetails = Readonly<{
   code: string | null;
   message: string | null;
   validationIssues: ReadonlyArray<BackendValidationIssueDetail>;
+  mediaAssetStorage?: MediaAssetStorageErrorDetails;
 }>;
 
 export type RequestErrorDetails = BackendFailureDetails & BackendErrorLogDetails & Readonly<{
@@ -245,6 +248,16 @@ export type CardsQueryDetails = Readonly<{
   resultsCount: number | null;
   totalCount: number | null;
   hasMore: boolean | null;
+}>;
+
+export type MediaAssetRouteDetails = Readonly<{
+  statusCode: number;
+  mediaAssetId: string | null;
+  storageKey: string | null;
+  mimeType?: string;
+  sizeBytes?: number;
+  sha256?: string;
+  applied?: boolean;
 }>;
 
 export type GuestUpgradeCompleteDetails = Readonly<{
@@ -651,6 +664,19 @@ export type GlobalMetricsS3RetryDetails = Readonly<{
   errorMessage: string;
 }>;
 
+export type MediaAssetStorageRetryDetails = Readonly<{
+  operation: "create_presigned_upload" | "create_presigned_download" | "head_object";
+  attempt: number;
+  maxAttempts: number;
+  bucketName: string;
+  workspaceId: string;
+  mediaAssetId: string;
+  storageKey: string;
+  statusCode: number | null;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
 export type FeedbackEmailRetryDetails = Readonly<{
   feedbackSubmissionId: string;
   attempt: number;
@@ -692,6 +718,7 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>
   | EventByAction<"database_transient_retry", DatabaseTransientRetryDetails>
   | EventByAction<"global_metrics_s3_retry", GlobalMetricsS3RetryDetails>
+  | EventByAction<"media_asset_storage_retry", MediaAssetStorageRetryDetails>
   | EventByAction<"sync_push", SyncPushDetails>
   | EventByAction<"sync_push_error", SyncConflictFailureDetailsFor<SyncPushDetails>>
   | EventByAction<"sync_pull", SyncPullDetails>
@@ -726,6 +753,14 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>>
   | EventByAction<"cards_query", CardsQueryDetails>
   | EventByAction<"cards_query_error", FailureDetailsFor<CardsQueryDetails>>
+  | EventByAction<"media_asset_upload_intent_create", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_intent_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
+  | EventByAction<"media_asset_upload_complete", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_complete_error", FailureDetailsFor<MediaAssetRouteDetails>>
+  | EventByAction<"media_asset_get", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_get_error", FailureDetailsFor<MediaAssetRouteDetails>>
+  | EventByAction<"media_asset_download_url_create", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_download_url_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
   | EventByAction<"guest_upgrade_complete", GuestUpgradeCompleteDetails>
   | EventByAction<"guest_upgrade_complete_error", FailureDetailsFor<GuestUpgradeCompleteDetails>>
   | EventByAction<"workspaces_list", WorkspacesListDetails>
@@ -849,6 +884,22 @@ export type BackendExceptionEvent =
   | (EventByAction<"feedback_submission_error", FailureDetailsFor<FeedbackSubmissionDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"cards_query_error", FailureDetailsFor<CardsQueryDetails>> & Readonly<{ error: Error }>)
+  | (
+    EventByAction<"media_asset_upload_intent_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"media_asset_upload_complete_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"media_asset_get_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"media_asset_download_url_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
   | (EventByAction<"guest_upgrade_complete_error", FailureDetailsFor<GuestUpgradeCompleteDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"workspaces_list_error", FailureDetailsFor<WorkspacesListDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"workspace_create_error", FailureDetailsFor<WorkspaceIdDetails>> & Readonly<{ error: Error }>)

--- a/apps/backend/src/routes/mediaAssets.ts
+++ b/apps/backend/src/routes/mediaAssets.ts
@@ -1,0 +1,297 @@
+import { Hono } from "hono";
+import {
+  assertMediaAssetUploadIntentAvailableForWorkspace,
+  completeMediaAssetUploadForWorkspace,
+  loadMediaAssetForWorkspace,
+} from "../mediaAssets";
+import { buildMediaAssetStorageKey } from "../mediaAssets/storageKeys";
+import {
+  assertMediaAssetObjectMatches,
+  createPresignedMediaAssetDownload,
+  createPresignedMediaAssetUpload,
+} from "../mediaAssets/storage";
+import {
+  parseCompleteMediaAssetUploadInput,
+  parseMediaAssetIdParam,
+  parseMediaAssetUploadIntentInput,
+} from "../mediaAssets/validators";
+import { assertUserHasWorkspaceAccess } from "../workspaces";
+import {
+  loadRequestContextFromRequest,
+  parseWorkspaceIdParam,
+  type RequestContext,
+} from "../server/requestContext";
+import { parseJsonBody } from "../server/requestParsing";
+import { createBackendFailureDetails } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
+import type { AppEnv } from "../server/app";
+
+type MediaAssetsRoutesOptions = Readonly<{
+  allowedOrigins: ReadonlyArray<string>;
+}>;
+
+function getRequestContextUserId(requestContext: RequestContext | null): string | null {
+  return requestContext === null ? null : requestContext.userId;
+}
+
+function createMediaAssetsScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string | null,
+  workspaceId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+    clientAppVersion,
+    clientPlatform,
+  );
+}
+
+export function createMediaAssetsRoutes(options: MediaAssetsRoutesOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+
+  app.post("/workspaces/:workspaceId/media-assets/upload-intents", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+    let mediaAssetId: string | null = null;
+    let storageKey: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccess(loadedContext.requestContext.userId, workspaceId);
+      const input = parseMediaAssetUploadIntentInput(await parseJsonBody(context.req.raw));
+      mediaAssetId = input.mediaAssetId;
+      storageKey = buildMediaAssetStorageKey(workspaceId, input.mediaAssetId, input.sha256);
+      await assertMediaAssetUploadIntentAvailableForWorkspace(
+        loadedContext.requestContext.userId,
+        workspaceId,
+        input.mediaAssetId,
+      );
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, loadedContext.requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const upload = await createPresignedMediaAssetUpload({
+        workspaceId,
+        mediaAssetId: input.mediaAssetId,
+        storageKey,
+        mimeType: input.mimeType,
+        sha256: input.sha256,
+        observationScope: scope,
+      });
+
+      addBackendBreadcrumb({
+        action: "media_asset_upload_intent_create",
+        scope,
+        details: {
+          statusCode: 201,
+          mediaAssetId: input.mediaAssetId,
+          storageKey,
+          mimeType: input.mimeType,
+          sizeBytes: input.sizeBytes,
+          sha256: input.sha256,
+        },
+      });
+      return context.json({
+        mediaAssetId: input.mediaAssetId,
+        workspaceId,
+        storageKey,
+        upload,
+      }, 201);
+    } catch (error) {
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        mediaAssetId,
+        storageKey,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "media_asset_upload_intent_create_error", error: normalizeCaughtError(error), scope, details },
+        { action: "media_asset_upload_intent_create_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.post("/workspaces/:workspaceId/media-assets/:mediaAssetId/complete", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+    let mediaAssetId: string | null = null;
+    let storageKey: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccess(loadedContext.requestContext.userId, workspaceId);
+      mediaAssetId = parseMediaAssetIdParam(context.req.param("mediaAssetId"));
+      const input = parseCompleteMediaAssetUploadInput(mediaAssetId, await parseJsonBody(context.req.raw));
+      storageKey = buildMediaAssetStorageKey(workspaceId, input.mediaAssetId, input.sha256);
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, loadedContext.requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+
+      await assertMediaAssetObjectMatches({
+        workspaceId,
+        mediaAssetId: input.mediaAssetId,
+        storageKey,
+        mimeType: input.mimeType,
+        sizeBytes: input.sizeBytes,
+        sha256: input.sha256,
+        observationScope: scope,
+      });
+      const result = await completeMediaAssetUploadForWorkspace(
+        loadedContext.requestContext.userId,
+        workspaceId,
+        input,
+      );
+
+      addBackendBreadcrumb({
+        action: "media_asset_upload_complete",
+        scope,
+        details: {
+          statusCode: 200,
+          mediaAssetId: input.mediaAssetId,
+          storageKey,
+          mimeType: input.mimeType,
+          sizeBytes: input.sizeBytes,
+          sha256: input.sha256,
+          applied: result.applied,
+        },
+      });
+      return context.json(result);
+    } catch (error) {
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        mediaAssetId,
+        storageKey,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "media_asset_upload_complete_error", error: normalizeCaughtError(error), scope, details },
+        { action: "media_asset_upload_complete_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.get("/workspaces/:workspaceId/media-assets/:mediaAssetId", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+    let mediaAssetId: string | null = null;
+    let storageKey: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccess(loadedContext.requestContext.userId, workspaceId);
+      mediaAssetId = parseMediaAssetIdParam(context.req.param("mediaAssetId"));
+      const mediaAsset = await loadMediaAssetForWorkspace(
+        loadedContext.requestContext.userId,
+        workspaceId,
+        mediaAssetId,
+      );
+      storageKey = mediaAsset.storageKey;
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, loadedContext.requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+
+      addBackendBreadcrumb({
+        action: "media_asset_get",
+        scope,
+        details: {
+          statusCode: 200,
+          mediaAssetId,
+          storageKey,
+        },
+      });
+      return context.json({ mediaAsset });
+    } catch (error) {
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        mediaAssetId,
+        storageKey,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "media_asset_get_error", error: normalizeCaughtError(error), scope, details },
+        { action: "media_asset_get_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.get("/workspaces/:workspaceId/media-assets/:mediaAssetId/download-url", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+    let mediaAssetId: string | null = null;
+    let storageKey: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccess(loadedContext.requestContext.userId, workspaceId);
+      mediaAssetId = parseMediaAssetIdParam(context.req.param("mediaAssetId"));
+      const mediaAsset = await loadMediaAssetForWorkspace(
+        loadedContext.requestContext.userId,
+        workspaceId,
+        mediaAssetId,
+      );
+      storageKey = mediaAsset.storageKey;
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, loadedContext.requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const download = await createPresignedMediaAssetDownload({
+        workspaceId,
+        mediaAssetId,
+        storageKey: mediaAsset.storageKey,
+        observationScope: scope,
+      });
+
+      addBackendBreadcrumb({
+        action: "media_asset_download_url_create",
+        scope,
+        details: {
+          statusCode: 200,
+          mediaAssetId,
+          storageKey: mediaAsset.storageKey,
+        },
+      });
+      return context.json({ mediaAsset, download });
+    } catch (error) {
+      const scope = createMediaAssetsScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        mediaAssetId,
+        storageKey,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "media_asset_download_url_create_error", error: normalizeCaughtError(error), scope, details },
+        { action: "media_asset_download_url_create_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  return app;
+}

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -30,6 +30,10 @@ const expectedPublishedExternalAgentMethods = {
   "/agent/workspaces/{workspaceId}/select": ["post"],
   "/agent/sql/query": ["post"],
   "/agent/sql/execute": ["post"],
+  "/workspaces/{workspaceId}/media-assets/upload-intents": ["post"],
+  "/workspaces/{workspaceId}/media-assets/{mediaAssetId}": ["get"],
+  "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete": ["post"],
+  "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url": ["get"],
 } as const satisfies Readonly<Record<string, ReadonlyArray<OperationMethodName>>>;
 
 function loadPublishedOpenApiDocument(): OpenApiDocumentForTest {
@@ -47,7 +51,7 @@ test("API Gateway predeclares PATCH /me/preferences", () => {
   assert.match(apiGatewaySource, /me\.addResource\("preferences"\)\.addMethod\("PATCH", integration\);/);
 });
 
-test("published OpenAPI exposes only the curated external agent contract", () => {
+test("published OpenAPI exposes only the curated external agent and media transfer contract", () => {
   const openApiDocument = loadPublishedOpenApiDocument();
   const paths = openApiDocument.paths ?? {};
   const securitySchemes = openApiDocument.components?.securitySchemes ?? {};

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -15,6 +15,7 @@ import { createAgentRoutes } from "../routes/agent";
 import { createCardsRoutes } from "../routes/cards";
 import { createFeedbackRoutes } from "../routes/feedback";
 import { createGlobalSnapshotRoutes, globalSnapshotPath } from "../routes/globalSnapshot";
+import { createMediaAssetsRoutes } from "../routes/mediaAssets";
 import { createSyncRoutes } from "../routes/sync/index";
 import { createSystemRoutes } from "../routes/system";
 import { createAdminRoutes } from "../routes/admin";
@@ -372,6 +373,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
   app.route("/", createAdminRoutes({ allowedOrigins }));
   app.route("/", createCardsRoutes({ allowedOrigins }));
   app.route("/", createFeedbackRoutes({ allowedOrigins }));
+  app.route("/", createMediaAssetsRoutes({ allowedOrigins }));
   app.route("/", createGlobalSnapshotRoutes({}));
   app.route("/", createGuestAuthRoutes());
   app.route("/", createChatTranscriptionsRoutes({ allowedOrigins }));

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -1,5 +1,5 @@
 import { AuthError, authVerificationTemporarilyUnavailableCode } from "../auth";
-import { HttpError } from "../shared/errors";
+import { HttpError, type MediaAssetStorageErrorDetails } from "../shared/errors";
 import { sanitizeBackendTelemetryValue } from "../observability/sanitizer";
 import {
   addBackendBreadcrumb,
@@ -85,12 +85,22 @@ function getRequestErrorCode(error: AuthError | HttpError | unknown): string | n
   return "INTERNAL_ERROR";
 }
 
+function getMediaAssetStorageErrorDetails(error: AuthError | HttpError | unknown): MediaAssetStorageErrorDetails | undefined {
+  if (error instanceof HttpError) {
+    return error.details?.mediaAssetStorage;
+  }
+
+  return undefined;
+}
+
 export function createBackendFailureDetails(error: AuthError | HttpError | unknown): BackendFailureDetails {
+  const mediaAssetStorage = getMediaAssetStorageErrorDetails(error);
   return {
     statusCode: getRequestErrorStatusCode(error),
     code: getRequestErrorCode(error),
     message: getInternalErrorMessage(error),
     validationIssues: summarizeValidationIssues(error),
+    ...(mediaAssetStorage === undefined ? {} : { mediaAssetStorage }),
   };
 }
 
@@ -109,6 +119,7 @@ function createErrorLevelRequestErrorDetails(
     statusCode: details.statusCode,
     code: details.code,
     validationIssues: details.validationIssues,
+    ...(details.mediaAssetStorage === undefined ? {} : { mediaAssetStorage: details.mediaAssetStorage }),
     sqlState: details.sqlState,
     errorClass: details.errorClass,
     errorMessage: details.errorMessage,

--- a/apps/backend/src/shared/errors.ts
+++ b/apps/backend/src/shared/errors.ts
@@ -19,9 +19,21 @@ export type SyncConflictDetails = Readonly<{
   recoverable: true;
 }>;
 
+export type MediaAssetStorageErrorDetails = Readonly<{
+  operation: string;
+  workspaceId: string;
+  mediaAssetId: string;
+  storageKey: string;
+  bucketName: string;
+  s3StatusCode: number | null;
+  s3ErrorClass: string;
+  s3ErrorMessage: string;
+}>;
+
 export type HttpErrorDetails = Readonly<{
   validationIssues?: ReadonlyArray<ValidationIssueSummary>;
   syncConflict?: SyncConflictDetails;
+  mediaAssetStorage?: MediaAssetStorageErrorDetails;
 }>;
 
 export type PublicSyncConflictDetails = Readonly<{
@@ -36,6 +48,7 @@ export type PublicSyncConflictDetails = Readonly<{
 export type PublicHttpErrorDetails = Readonly<{
   validationIssues?: ReadonlyArray<ValidationIssueSummary>;
   syncConflict?: PublicSyncConflictDetails;
+  mediaAssetStorage?: MediaAssetStorageErrorDetails;
 }>;
 
 function createPublicSyncConflictDetails(details: SyncConflictDetails): PublicSyncConflictDetails {
@@ -56,13 +69,15 @@ export function createPublicHttpErrorDetails(details: HttpErrorDetails | null): 
 
   const validationIssues = details.validationIssues;
   const syncConflict = details.syncConflict;
-  if (validationIssues === undefined && syncConflict === undefined) {
+  const mediaAssetStorage = details.mediaAssetStorage;
+  if (validationIssues === undefined && syncConflict === undefined && mediaAssetStorage === undefined) {
     return null;
   }
 
   return {
     ...(validationIssues === undefined ? {} : { validationIssues }),
     ...(syncConflict === undefined ? {} : { syncConflict: createPublicSyncConflictDetails(syncConflict) }),
+    ...(mediaAssetStorage === undefined ? {} : { mediaAssetStorage }),
   };
 }
 

--- a/db/migrations/0080_media_assets_registry.sql
+++ b/db/migrations/0080_media_assets_registry.sql
@@ -1,0 +1,97 @@
+-- Migration status: Current / additive.
+-- Introduces: workspace-scoped media asset metadata registry for private S3-backed transfers.
+-- Schemas touched/read explicitly: content, org, sync, security.
+
+CREATE TABLE IF NOT EXISTS content.media_assets (
+  media_asset_id              UUID        PRIMARY KEY,
+  workspace_id                UUID        NOT NULL REFERENCES org.workspaces(workspace_id) ON DELETE CASCADE,
+  mime_type                   TEXT        NOT NULL,
+  size_bytes                  BIGINT      NOT NULL CHECK (size_bytes >= 0),
+  sha256                      TEXT        NOT NULL,
+  storage_key                 TEXT        NOT NULL UNIQUE,
+  source_url                  TEXT,
+  created_at                  TIMESTAMPTZ NOT NULL,
+  client_updated_at           TIMESTAMPTZ NOT NULL,
+  last_modified_by_replica_id UUID        NOT NULL,
+  last_operation_id           TEXT        NOT NULL,
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at                  TIMESTAMPTZ,
+  CONSTRAINT media_assets_mime_type_nonempty CHECK (btrim(mime_type) <> ''),
+  CONSTRAINT media_assets_sha256_hex CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT media_assets_storage_key_nonempty CHECK (btrim(storage_key) <> ''),
+  CONSTRAINT media_assets_last_operation_id_nonempty CHECK (btrim(last_operation_id) <> ''),
+  CONSTRAINT media_assets_last_modified_replica_fk
+    FOREIGN KEY (last_modified_by_replica_id)
+    REFERENCES sync.workspace_replicas(replica_id)
+    ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE INDEX IF NOT EXISTS idx_media_assets_workspace_updated_active
+  ON content.media_assets(workspace_id, updated_at DESC, media_asset_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_media_assets_workspace_sha256_active
+  ON content.media_assets(workspace_id, sha256, media_asset_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_media_assets_workspace_client_updated
+  ON content.media_assets(workspace_id, client_updated_at DESC, media_asset_id);
+
+COMMENT ON TABLE content.media_assets IS 'Workspace-scoped media file metadata registry. File bytes live outside Postgres in private object storage.';
+COMMENT ON COLUMN content.media_assets.media_asset_id IS 'Client/server generated immutable media asset identity.';
+COMMENT ON COLUMN content.media_assets.workspace_id IS 'Owning workspace for authorization, lifecycle, and future sync scoping.';
+COMMENT ON COLUMN content.media_assets.mime_type IS 'Declared media MIME type validated by the backend API boundary.';
+COMMENT ON COLUMN content.media_assets.size_bytes IS 'Declared media object size in bytes. File bytes are stored in private object storage, not Postgres.';
+COMMENT ON COLUMN content.media_assets.sha256 IS 'Lowercase hex SHA-256 digest of the media object bytes.';
+COMMENT ON COLUMN content.media_assets.storage_key IS 'Private object storage key for the media bytes.';
+COMMENT ON COLUMN content.media_assets.source_url IS 'Optional provenance URL for imported media; the backend does not ingest external URLs in this table.';
+COMMENT ON COLUMN content.media_assets.created_at IS 'Client-visible creation timestamp for the media asset metadata row.';
+COMMENT ON COLUMN content.media_assets.client_updated_at IS 'Client LWW timestamp for the media asset metadata row.';
+COMMENT ON COLUMN content.media_assets.last_modified_by_replica_id IS 'Immutable workspace replica that last produced the winning media asset metadata row.';
+COMMENT ON COLUMN content.media_assets.last_operation_id IS 'Client operation id that produced the winning media asset metadata row.';
+COMMENT ON COLUMN content.media_assets.updated_at IS 'Server timestamp for the latest accepted metadata mutation.';
+COMMENT ON COLUMN content.media_assets.deleted_at IS 'Tombstone timestamp for future media asset sync support.';
+
+ALTER TABLE content.media_assets ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS media_assets_scoped_select_runtime ON content.media_assets;
+DROP POLICY IF EXISTS media_assets_scoped_insert_runtime ON content.media_assets;
+DROP POLICY IF EXISTS media_assets_scoped_update_runtime ON content.media_assets;
+DROP POLICY IF EXISTS media_assets_scoped_delete_runtime ON content.media_assets;
+
+CREATE POLICY media_assets_scoped_select_runtime
+  ON content.media_assets
+  FOR SELECT
+  TO backend_app
+  USING (security.current_workspace_access_allowed(workspace_id));
+
+CREATE POLICY media_assets_scoped_insert_runtime
+  ON content.media_assets
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (security.current_workspace_access_allowed(workspace_id));
+
+CREATE POLICY media_assets_scoped_update_runtime
+  ON content.media_assets
+  FOR UPDATE
+  TO backend_app
+  USING (security.current_workspace_access_allowed(workspace_id))
+  WITH CHECK (security.current_workspace_access_allowed(workspace_id));
+
+CREATE POLICY media_assets_scoped_delete_runtime
+  ON content.media_assets
+  FOR DELETE
+  TO backend_app
+  USING (security.current_workspace_access_allowed(workspace_id));
+
+DROP POLICY IF EXISTS media_assets_reporting_readonly_select ON content.media_assets;
+
+CREATE POLICY media_assets_reporting_readonly_select
+  ON content.media_assets
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON content.media_assets TO backend_app;
+GRANT SELECT ON TABLE content.media_assets TO reporting_readonly;

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -35,6 +35,7 @@ export interface ApiGatewayProps {
   globalMetricsVisible: boolean;
   globalMetricsSnapshotBucket: s3.IBucket;
   globalMetricsSnapshotObjectKey: string;
+  mediaAssetsBucket: s3.IBucket;
   userPoolId: string;
   userPoolArn: string;
   userPoolClientId: string;
@@ -74,6 +75,7 @@ interface BackendFunctionProps {
   demoEmailDostip: string | undefined;
   guestAiWeightedMonthlyTokenCap: string | undefined;
   globalMetricsConfig: GlobalMetricsConfig | undefined;
+  mediaAssetsBucket: s3.IBucket | undefined;
   memorySize: number;
 }
 
@@ -242,6 +244,20 @@ function addGlobalMetricsEnvironment(
   }));
 }
 
+function addMediaAssetsEnvironment(
+  fn: lambdaNodejs.NodejsFunction,
+  bucket: s3.IBucket,
+): void {
+  fn.addEnvironment("MEDIA_ASSETS_S3_BUCKET_NAME", bucket.bucketName);
+  fn.addToRolePolicy(new cdk.aws_iam.PolicyStatement({
+    actions: [
+      "s3:GetObject",
+      "s3:PutObject",
+    ],
+    resources: [bucket.arnForObjects("media-assets/*")],
+  }));
+}
+
 function hasConfiguredValue(value: string | undefined): value is string {
   return value !== undefined && value !== "";
 }
@@ -382,6 +398,9 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
   if (props.globalMetricsConfig !== undefined) {
     addGlobalMetricsEnvironment(fn, props.globalMetricsConfig);
   }
+  if (props.mediaAssetsBucket !== undefined) {
+    addMediaAssetsEnvironment(fn, props.mediaAssetsBucket);
+  }
 
   return fn;
 }
@@ -455,6 +474,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       snapshotBucket: props.globalMetricsSnapshotBucket,
       snapshotObjectKey: props.globalMetricsSnapshotObjectKey,
     },
+    mediaAssetsBucket: props.mediaAssetsBucket,
     memorySize: 256,
   });
   const chatWorkerFn = createBackendFunction(scope, {
@@ -488,6 +508,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
+    mediaAssetsBucket: undefined,
     memorySize: 512,
   });
   const chatLiveFn = createBackendFunction(scope, {
@@ -521,6 +542,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
+    mediaAssetsBucket: undefined,
     memorySize: 256,
   });
   const chatLiveFunctionUrl = chatLiveFn.addFunctionUrl({
@@ -705,6 +727,14 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     .addResource("cards")
     .addResource("query")
     .addMethod("POST", integration);
+  const workspaceMediaAssets = workspaceById.addResource("media-assets");
+  workspaceMediaAssets
+    .addResource("upload-intents")
+    .addMethod("POST", integration);
+  const workspaceMediaAssetById = workspaceMediaAssets.addResource("{mediaAssetId}");
+  workspaceMediaAssetById.addMethod("GET", integration);
+  workspaceMediaAssetById.addResource("complete").addMethod("POST", integration);
+  workspaceMediaAssetById.addResource("download-url").addMethod("GET", integration);
 
   const workspaceSync = workspaceById.addResource("sync");
   workspaceSync.addResource("push").addMethod("POST", integration);

--- a/infra/aws/lib/media-assets.ts
+++ b/infra/aws/lib/media-assets.ts
@@ -1,0 +1,46 @@
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+
+export interface MediaAssetsProps {
+  baseDomain: string;
+}
+
+export interface MediaAssetsResult {
+  bucket: s3.Bucket;
+}
+
+export function mediaAssets(scope: Construct, props: MediaAssetsProps): MediaAssetsResult {
+  const bucket = new s3.Bucket(scope, "MediaAssetsBucket", {
+    encryption: s3.BucketEncryption.S3_MANAGED,
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    enforceSSL: true,
+    removalPolicy: cdk.RemovalPolicy.RETAIN,
+    autoDeleteObjects: false,
+    cors: [
+      {
+        allowedOrigins: [
+          `https://app.${props.baseDomain}`,
+          "http://localhost:3000",
+          "http://localhost:3001",
+        ],
+        allowedMethods: [
+          s3.HttpMethods.GET,
+          s3.HttpMethods.HEAD,
+          s3.HttpMethods.PUT,
+        ],
+        allowedHeaders: ["*"],
+        exposedHeaders: [
+          "Accept-Ranges",
+          "Content-Length",
+          "Content-Range",
+          "ETag",
+          "x-amz-checksum-sha256",
+        ],
+        maxAge: 3_600,
+      },
+    ],
+  });
+
+  return { bucket };
+}

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -43,6 +43,7 @@ export interface OutputsProps {
   adminCustomDomain: string | undefined;
   apexRedirectDistribution: cloudfront.Distribution | undefined;
   apexRedirectCustomDomain: string | undefined;
+  mediaAssetsBucket: s3.IBucket;
   dbAccessInstance?: ec2.Instance;
   analyticsSshUsername?: string;
 }
@@ -244,6 +245,11 @@ export function outputs(scope: Construct, props: OutputsProps): void {
   new cdk.CfnOutput(scope, "AdminBucketName", {
     value: props.adminBucket.bucketName,
     description: "S3 bucket for deployed admin assets",
+  });
+
+  new cdk.CfnOutput(scope, "MediaAssetsBucketName", {
+    value: props.mediaAssetsBucket.bucketName,
+    description: "Private S3 bucket for media asset object bytes",
   });
 
   new cdk.CfnOutput(scope, "AdminDistributionId", {

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -19,6 +19,7 @@ import { globalMetrics } from "./global-metrics";
 import { communityLeaderboard } from "./community-leaderboard";
 import { streakLeaderboard } from "./streak-leaderboard";
 import { progressActiveDaysBackfill } from "./progress-active-days-backfill";
+import { mediaAssets } from "./media-assets";
 
 function getOptionalContextValue(stack: cdk.Stack, key: string): string | undefined {
   const value = stack.node.tryGetContext(key);
@@ -191,6 +192,9 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       reportingDbSecret: dbResult.reportingDbSecret,
       ...sentryContext,
     });
+    const mediaAssetsResult = mediaAssets(this, {
+      baseDomain,
+    });
     let analyticsAccessResult: AnalyticsAccessResult | undefined;
     if (analyticsAccessRequested) {
       if (analyticsSshPublicKeysValue === undefined) {
@@ -283,6 +287,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       globalMetricsVisible,
       globalMetricsSnapshotBucket: globalMetricsResult.snapshotBucket,
       globalMetricsSnapshotObjectKey: globalMetricsResult.snapshotObjectKey,
+      mediaAssetsBucket: mediaAssetsResult.bucket,
       userPoolId: authResult.userPool.userPoolId,
       userPoolArn: authResult.userPool.userPoolArn,
       userPoolClientId: authResult.userPoolClient.userPoolClientId,
@@ -370,6 +375,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       adminCustomDomain: admin.customDomain,
       apexRedirectDistribution: web.apexRedirectDistribution,
       apexRedirectCustomDomain: web.apexRedirectCustomDomain,
+      mediaAssetsBucket: mediaAssetsResult.bucket,
       dbAccessInstance: analyticsAccessResult?.dbAccessInstance,
       reportingDbSecret: dbResult.reportingDbSecret,
       analyticsSshUsername: analyticsAccessResult?.sshUsername,


### PR DESCRIPTION
## Summary
- Add content.media_assets registry migration with workspace ownership, LWW metadata, tombstones, indexes, grants, and RLS.
- Add backend media asset storage key, validation, S3 presigned upload/download, registry persistence, and authenticated workspace routes.
- Add private media S3 bucket wiring, API Gateway routes, backend env/permissions, and OpenAPI media endpoint docs.

## Validation
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend (517 tests, 0 failures)
- npm run build --prefix infra/aws
- npm run lint --prefix api
- npm run bundle --prefix api
- node --test --import tsx src/mediaAssets/storage.test.ts (2 tests)

Core-only worker-owned review found no P0-P4 issues and gave green light for commit.