### PR TITLE
Expose media asset flow to agent clients

### DIFF
--- a/api/src/components/schemas/AgentAccountData.yaml
+++ b/api/src/components/schemas/AgentAccountData.yaml
@@ -3,12 +3,21 @@ additionalProperties: false
 required:
   - userId
   - selectedWorkspaceId
+  - agentWorkspaceReplicaId
   - authTransport
   - profile
 properties:
   userId:
     type: string
   selectedWorkspaceId:
+    anyOf:
+      - $ref: ./UuidString.yaml
+      - type: 'null'
+  agentWorkspaceReplicaId:
+    description: >-
+      Workspace replica id reserved for this API-key connection after workspace
+      selection. Use this as lastModifiedByReplicaId when completing media
+      asset uploads.
     anyOf:
       - $ref: ./UuidString.yaml
       - type: 'null'

--- a/api/src/components/schemas/AgentAction.yaml
+++ b/api/src/components/schemas/AgentAction.yaml
@@ -9,6 +9,7 @@ properties:
     enum:
       - send_code
       - verify_code
+      - load_discovery
       - load_account
       - list_workspaces
       - create_workspace

--- a/api/src/components/schemas/AgentDiscoveryData.yaml
+++ b/api/src/components/schemas/AgentDiscoveryData.yaml
@@ -57,6 +57,10 @@ properties:
       - workspacesUrl
       - sqlQueryUrl
       - sqlExecuteUrl
+      - mediaAssetUploadIntentsUrlTemplate
+      - mediaAssetMetadataUrlTemplate
+      - mediaAssetCompleteUrlTemplate
+      - mediaAssetDownloadUrlTemplate
     properties:
       accountUrl:
         type: string
@@ -65,6 +69,14 @@ properties:
       sqlQueryUrl:
         type: string
       sqlExecuteUrl:
+        type: string
+      mediaAssetUploadIntentsUrlTemplate:
+        type: string
+      mediaAssetMetadataUrlTemplate:
+        type: string
+      mediaAssetCompleteUrlTemplate:
+        type: string
+      mediaAssetDownloadUrlTemplate:
         type: string
   mcp:
     type: object

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -20,7 +20,8 @@ get:
                 version: v1
                 description: >-
                   Offline-first flashcards service with user-owned workspaces
-                  and a compact SQL agent surface.
+                  and a compact SQL agent surface, and direct media transfer
+                  URLs.
               authentication:
                 type: email_otp_then_api_key
                 sendCodeUrl: https://auth.flashcards-open-source-app.com/api/agent/send-code
@@ -31,6 +32,8 @@ get:
                 - Run SQL reads through POST /agent/sql/query
                 - Run SQL writes through POST /agent/sql/execute
                 - Inspect the published SQL surface
+                - Upload and complete media assets through workspace-scoped direct transfer endpoints
+                - Read media asset metadata and create download URLs through workspace-scoped media endpoints
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -38,6 +41,10 @@ get:
                 workspacesUrl: https://api.flashcards-open-source-app.com/v1/agent/workspaces
                 sqlQueryUrl: https://api.flashcards-open-source-app.com/v1/agent/sql/query
                 sqlExecuteUrl: https://api.flashcards-open-source-app.com/v1/agent/sql/execute
+                mediaAssetUploadIntentsUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-intents
+                mediaAssetMetadataUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
+                mediaAssetCompleteUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete
+                mediaAssetDownloadUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -74,9 +81,20 @@ get:
               API key. After login, call GET /v1/agent/me, then GET
               /v1/agent/workspaces?limit=100. If no workspace is selected,
               select one before using POST /v1/agent/sql/query for reads or
-              POST /v1/agent/sql/execute for writes. For routine low-risk
+              POST /v1/agent/sql/execute for writes. After workspace selection,
+              call GET /v1/agent/me and use data.agentWorkspaceReplicaId as
+              lastModifiedByReplicaId when completing media uploads. For routine low-risk
               writes, a clear user request already counts as permission. Ask
-              again only for risky or unclear actions. Use docs.openapiUrl for
+              again only for risky or unclear actions. For media assets, create
+              an upload intent with POST
+              /v1/workspaces/{workspaceId}/media-assets/upload-intents, upload
+              bytes directly to the returned URL using the returned method and
+              headers, then register the completed object with POST
+              /v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete.
+              Use GET /v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
+              for registry metadata and GET
+              /v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
+              for a direct download URL. Use docs.openapiUrl for
               the published external agent contract.
             links:
               websiteUrl: https://flashcards-open-source-app.com/

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -19,7 +19,7 @@ get:
               service:
                 name: flashcards-open-source-app
                 version: v1
-                description: Offline-first flashcards service with user-owned workspaces and a compact SQL agent surface.
+                description: Offline-first flashcards service with user-owned workspaces, a compact SQL agent surface, and direct media transfer URLs.
               authentication:
                 type: email_otp_then_api_key
                 sendCodeUrl: https://auth.flashcards-open-source-app.com/api/agent/send-code
@@ -30,6 +30,8 @@ get:
                 - Inspect the published SQL surface through OpenAPI and SQL introspection
                 - Read cards and decks through POST /agent/sql/query (read-only)
                 - Write cards and decks through POST /agent/sql/execute (INSERT, UPDATE, DELETE)
+                - Upload and complete media assets through workspace-scoped direct transfer endpoints
+                - Read media asset metadata and create download URLs through workspace-scoped media endpoints
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -37,6 +39,10 @@ get:
                 workspacesUrl: https://api.flashcards-open-source-app.com/v1/agent/workspaces
                 sqlQueryUrl: https://api.flashcards-open-source-app.com/v1/agent/sql/query
                 sqlExecuteUrl: https://api.flashcards-open-source-app.com/v1/agent/sql/execute
+                mediaAssetUploadIntentsUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-intents
+                mediaAssetMetadataUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
+                mediaAssetCompleteUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete
+                mediaAssetDownloadUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -77,13 +83,26 @@ get:
               https://api.flashcards-open-source-app.com/v1/agent/workspaces/{workspaceId}/select
               or create one with POST
               https://api.flashcards-open-source-app.com/v1/agent/workspaces
-              using {"name":"Personal"}. After workspace bootstrap, use POST
+              using {"name":"Personal"}. After workspace bootstrap, call GET
+              https://api.flashcards-open-source-app.com/v1/agent/me and use
+              data.agentWorkspaceReplicaId as lastModifiedByReplicaId when
+              completing media uploads. Use POST
               https://api.flashcards-open-source-app.com/v1/agent/sql/query for
               shared card and deck reads and POST
               https://api.flashcards-open-source-app.com/v1/agent/sql/execute
               for writes. For routine low-risk
               writes, a clear user request already counts as permission. Ask
-              again only for risky or unclear actions. SELECT returns at most
+              again only for risky or unclear actions. For media assets, create
+              an upload intent with POST
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-intents,
+              upload bytes directly to the returned URL using the returned
+              method and headers, then register the completed object with POST
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete.
+              Use GET
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
+              for registry metadata and GET
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
+              for a direct download URL. SELECT returns at most
               100 rows per statement, and INSERT, UPDATE, and DELETE may affect
               at most 100 rows per statement. If you need more than 100
               writes, split the work into multiple batches of at most 100

--- a/api/src/paths/agent_me.yaml
+++ b/api/src/paths/agent_me.yaml
@@ -19,6 +19,7 @@ get:
             data:
               userId: user-1
               selectedWorkspaceId: 50b5b928-7f04-4cc8-878d-6cd0e8b98474
+              agentWorkspaceReplicaId: b4a0ec15-f875-5f9c-a8f8-9d6a9f42af39
               authTransport: api_key
               profile:
                 email: kirill@example.com
@@ -32,6 +33,11 @@ get:
               /v1/agent/workspaces/{workspaceId}/select. After a workspace is
               selected, use POST /v1/agent/sql/query for reads and SQL
               introspection and POST /v1/agent/sql/execute for writes. For
+              media assets, use GET /v1/agent for the full media-capable
+              discovery surface, including workspace-scoped upload-intent,
+              complete, metadata, and download URL templates. Before completing
+              a media upload, call GET /v1/agent/me after workspace selection
+              and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId. For
               routine low-risk writes, a clear user request
               already counts as permission. Ask again only for risky or unclear
               actions. Read payload from data.* and use docs.openapiUrl for the

--- a/api/src/paths/agent_workspaces.yaml
+++ b/api/src/paths/agent_workspaces.yaml
@@ -5,7 +5,7 @@ get:
   description: >-
     Lists the user's workspaces in an agent-oriented envelope and points the
     caller to either create a workspace, select one for the current API key
-    connection, or continue to SQL.
+    connection, or continue to SQL and the media-capable discovery surface.
   parameters:
     - name: limit
       in: query
@@ -46,6 +46,11 @@ get:
               reads and SQL introspection and POST /v1/agent/sql/execute for
               writes. For example, query cards with SELECT * FROM cards ORDER BY
               updated_at DESC LIMIT 20 OFFSET 0 through POST /v1/agent/sql/query.
+              For media assets, use GET /v1/agent for the full media-capable
+              discovery surface, including workspace-scoped upload-intent,
+              complete, metadata, and download URL templates. Before completing
+              a media upload, call GET /v1/agent/me after workspace selection
+              and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId.
               For routine low-risk writes, a clear user request already
               counts as permission. Ask again only for risky or unclear
               actions. Read payload from data.* and use docs.openapiUrl for the
@@ -115,7 +120,12 @@ post:
               Workspace bootstrap is complete. Use POST /v1/agent/sql/query for
               reads and SQL introspection and POST /v1/agent/sql/execute for
               writes. Start discovery with SHOW TABLES or DESCRIBE cards through
-              POST /v1/agent/sql/query when helpful. For routine low-risk
+              POST /v1/agent/sql/query when helpful. For
+              media assets, use GET /v1/agent for the full media-capable
+              discovery surface, including workspace-scoped upload-intent,
+              complete, metadata, and download URL templates. Before completing
+              a media upload, call GET /v1/agent/me after workspace selection
+              and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId. For routine low-risk
               writes, a clear user request already counts as permission. Ask
               again only for risky or unclear actions. This endpoint accepts
               the published SQL dialect, not full PostgreSQL. Read payload from

--- a/api/src/paths/agent_workspaces_{workspaceId}_select.yaml
+++ b/api/src/paths/agent_workspaces_{workspaceId}_select.yaml
@@ -32,7 +32,12 @@ post:
               Workspace bootstrap is complete. Use POST /v1/agent/sql/query for
               reads and SQL introspection and POST /v1/agent/sql/execute for
               writes. Start discovery with SHOW TABLES or DESCRIBE cards through
-              POST /v1/agent/sql/query when helpful. For routine low-risk
+              POST /v1/agent/sql/query when helpful. For
+              media assets, use GET /v1/agent for the full media-capable
+              discovery surface, including workspace-scoped upload-intent,
+              complete, metadata, and download URL templates. Before completing
+              a media upload, call GET /v1/agent/me after workspace selection
+              and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId. For routine low-risk
               writes, a clear user request already counts as permission. Ask
               again only for risky or unclear actions. This endpoint accepts
               the published SQL dialect, not full PostgreSQL. Read payload from

--- a/api/src/paths/api_agent_verify-code.yaml
+++ b/api/src/paths/api_agent_verify-code.yaml
@@ -37,6 +37,11 @@ post:
                 lastUsedAt: null
                 revokedAt: null
             actions:
+              - name: load_discovery
+                method: GET
+                url: https://api.flashcards-open-source-app.com/v1/agent
+                auth:
+                  scheme: ApiKey
               - name: load_account
                 method: GET
                 url: https://api.flashcards-open-source-app.com/v1/agent/me
@@ -77,6 +82,12 @@ post:
               /v1/agent/workspaces using {"name":"Personal"}. After a workspace
               is selected, use POST /v1/agent/sql/query for reads and POST
               /v1/agent/sql/execute for writes. For
+              media assets, use GET /v1/agent for the full media-capable
+              discovery surface, including workspace-scoped upload-intent,
+              complete, metadata, and download URL templates. After workspace
+              selection, call GET /v1/agent/me and use
+              data.agentWorkspaceReplicaId as lastModifiedByReplicaId when
+              completing media uploads. For
               routine low-risk writes, a clear user request already counts as
               permission. Ask again only for risky or unclear actions. Use
               docs.openapiUrl for the published external agent contract.

--- a/apps/auth/src/agentAuthRoutes.test.ts
+++ b/apps/auth/src/agentAuthRoutes.test.ts
@@ -48,6 +48,7 @@ type AgentVerifyCodeResponse = Readonly<{
     url?: string;
     urlTemplate?: string;
   }>>;
+  instructions: string;
 }>;
 
 type AgentErrorResponse = Readonly<{
@@ -315,8 +316,15 @@ test("agent verify-code uses the OTP challenge for non-demo emails", async () =>
   assert.equal(payload.ok, true);
   assert.equal(payload.data.authorizationScheme, "ApiKey");
   assert.equal(payload.data.connection.label, "ci-agent");
-  assert.equal(payload.actions.map((action) => action.name).join(","), "load_account,list_workspaces,create_workspace,select_workspace");
+  assert.equal(payload.actions.map((action) => action.name).join(","), "load_discovery,load_account,list_workspaces,create_workspace,select_workspace");
+  assert.equal(payload.actions.find((action) => action.name === "load_discovery")?.url, "https://api.flashcards-open-source-app.com/v1/agent");
   assert.equal(payload.actions.find((action) => action.name === "list_workspaces")?.url, "https://api.flashcards-open-source-app.com/v1/agent/workspaces?limit=100");
+  assert.match(payload.instructions, /GET https:\/\/api\.flashcards-open-source-app\.com\/v1\/agent/);
+  assert.match(payload.instructions, /media-capable discovery surface/);
+  assert.match(payload.instructions, /upload-intent/);
+  assert.match(payload.instructions, /download URL templates/);
+  assert.match(payload.instructions, /data\.agentWorkspaceReplicaId/);
+  assert.match(payload.instructions, /lastModifiedByReplicaId/);
   assert.equal(verifyEmailOtpCalled, true);
   assert.equal(signInWithPasswordCalled, false);
   assert.equal(createdKeyIdToken, "otp-id-token");

--- a/apps/auth/src/routes/agent/agentVerifyCode.ts
+++ b/apps/auth/src/routes/agent/agentVerifyCode.ts
@@ -345,6 +345,14 @@ export function createAgentVerifyCodeApp(dependencies: AgentVerifyCodeDependenci
       },
       [
         {
+          name: "load_discovery",
+          method: "GET",
+          url: `${apiBaseUrl}/agent`,
+          auth: {
+            scheme: "ApiKey",
+          },
+        },
+        {
           name: "load_account",
           method: "GET",
           url: `${apiBaseUrl}/agent/me`,
@@ -383,7 +391,7 @@ export function createAgentVerifyCodeApp(dependencies: AgentVerifyCodeDependenci
           },
         },
       ],
-      `Store this long-lived API key now and do not rely on chat history alone. A new dialog or session on the same machine will not have this key unless it was saved outside this conversation. Prefer exporting it first as FLASHCARDS_OPEN_SOURCE_API_KEY; if needed, save it in a local .env file or another local file. If the user already allowed saving or writing in this conversation, do not ask again. Otherwise, ask only when the write is risky, more persistent than the user requested, or the destination is unclear. At minimum, save it somewhere persistent outside chat memory. Then bootstrap workspace selection with explicit endpoints: GET ${apiBaseUrl}/agent/me, GET ${apiBaseUrl}/agent/workspaces?limit=100, and if selection is required call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select (or POST ${apiBaseUrl}/agent/workspaces with {\"name\":\"Personal\"} when no workspaces exist). For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. Read payload from data.* and do not expect resource fields at the top level. Select the next endpoint from instructions and confirm it with actions. Example: export FLASHCARDS_OPEN_SOURCE_API_KEY='<PASTE_KEY_HERE>' && curl -H 'Authorization: ApiKey $FLASHCARDS_OPEN_SOURCE_API_KEY' '${apiBaseUrl}/agent/me'.`,
+      `Store this long-lived API key now and do not rely on chat history alone. A new dialog or session on the same machine will not have this key unless it was saved outside this conversation. Prefer exporting it first as FLASHCARDS_OPEN_SOURCE_API_KEY; if needed, save it in a local .env file or another local file. If the user already allowed saving or writing in this conversation, do not ask again. Otherwise, ask only when the write is risky, more persistent than the user requested, or the destination is unclear. At minimum, save it somewhere persistent outside chat memory. Then bootstrap workspace selection with explicit endpoints: GET ${apiBaseUrl}/agent/me, GET ${apiBaseUrl}/agent/workspaces?limit=100, and if selection is required call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select (or POST ${apiBaseUrl}/agent/workspaces with {\"name\":\"Personal\"} when no workspaces exist). For media assets, call GET ${apiBaseUrl}/agent for the full media-capable discovery surface, including workspace-scoped upload-intent, complete, metadata, and download URL templates. After workspace selection, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when completing media uploads. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. Read payload from data.* and do not expect resource fields at the top level. Select the next endpoint from instructions and confirm it with actions. Example: export FLASHCARDS_OPEN_SOURCE_API_KEY='<PASTE_KEY_HERE>' && curl -H 'Authorization: ApiKey $FLASHCARDS_OPEN_SOURCE_API_KEY' '${apiBaseUrl}/agent/me'.`,
     ));
   });
 

--- a/apps/auth/src/server/agent/agentEnvelope.ts
+++ b/apps/auth/src/server/agent/agentEnvelope.ts
@@ -1,7 +1,7 @@
 import { getPublicAgentDocs } from "../publicUrls.js";
 
 export type AgentAction = Readonly<{
-  name: "send_code" | "verify_code" | "load_account" | "list_workspaces" | "create_workspace" | "select_workspace";
+  name: "send_code" | "verify_code" | "load_discovery" | "load_account" | "list_workspaces" | "create_workspace" | "select_workspace";
   method: "GET" | "POST";
   url?: string;
   urlTemplate?: string;

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -21,6 +21,10 @@ type AgentDiscoveryEnvelope = Readonly<{
       workspacesUrl: string;
       sqlQueryUrl: string;
       sqlExecuteUrl: string;
+      mediaAssetUploadIntentsUrlTemplate: string;
+      mediaAssetMetadataUrlTemplate: string;
+      mediaAssetCompleteUrlTemplate: string;
+      mediaAssetDownloadUrlTemplate: string;
     }>;
     mcp: Readonly<{
       url: string;
@@ -98,6 +102,10 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
   const apiBaseUrl = getPublicApiBaseUrl(requestUrl);
   const links = getPublicLegalLinks(requestUrl);
   const docs = { ...getPublicAgentDocs(requestUrl), docsUrl: links.docsUrl };
+  const mediaAssetUploadIntentsUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/upload-intents`;
+  const mediaAssetMetadataUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/{mediaAssetId}`;
+  const mediaAssetCompleteUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete`;
+  const mediaAssetDownloadUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url`;
 
   return {
     ok: true,
@@ -105,7 +113,8 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
       service: {
         name: "flashcards-open-source-app",
         version: "v1",
-        description: "Offline-first flashcards service with user-owned workspaces and a compact SQL agent surface.",
+        description:
+          "Offline-first flashcards service with user-owned workspaces, a compact SQL agent surface, and direct media transfer URLs.",
       },
       authentication: {
         type: "email_otp_then_api_key",
@@ -118,6 +127,8 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         "Inspect the published SQL surface through OpenAPI and SQL introspection",
         "Read cards and decks through POST /agent/sql/query (read-only)",
         "Write cards and decks through POST /agent/sql/execute (INSERT, UPDATE, DELETE)",
+        "Upload and complete media assets through workspace-scoped direct transfer endpoints",
+        "Read media asset metadata and create download URLs through workspace-scoped media endpoints",
       ],
       authBaseUrl,
       apiBaseUrl,
@@ -126,6 +137,10 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         workspacesUrl: `${apiBaseUrl}/agent/workspaces`,
         sqlQueryUrl: `${apiBaseUrl}/agent/sql/query`,
         sqlExecuteUrl: `${apiBaseUrl}/agent/sql/execute`,
+        mediaAssetUploadIntentsUrlTemplate,
+        mediaAssetMetadataUrlTemplate,
+        mediaAssetCompleteUrlTemplate,
+        mediaAssetDownloadUrlTemplate,
       },
       mcp: {
         url: `${mcpBaseUrl}/mcp`,
@@ -148,7 +163,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
     },
     links,
     instructions:
-      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
+      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when completing media uploads. Use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For media assets, create an upload intent with POST ${mediaAssetUploadIntentsUrlTemplate}, upload bytes directly to the returned URL using the returned method and headers, then register the completed object with POST ${mediaAssetCompleteUrlTemplate}. Use GET ${mediaAssetMetadataUrlTemplate} for registry metadata and GET ${mediaAssetDownloadUrlTemplate} for a direct download URL. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
     docs,
   };
 }

--- a/apps/backend/src/agent/setup.ts
+++ b/apps/backend/src/agent/setup.ts
@@ -5,6 +5,7 @@ import {
   type AgentEnvelope,
   type AgentErrorEnvelope,
 } from "./envelope";
+import { ensureAgentSyncReplica } from "./syncIdentity";
 import type { AuthTransport } from "../auth";
 import type { PublicHttpErrorDetails } from "../shared/errors";
 import { getPublicApiBaseUrl } from "../shared/publicUrls";
@@ -14,6 +15,7 @@ import type { WorkspaceSummary } from "../workspaces";
 type AccountData = Readonly<{
   userId: string;
   selectedWorkspaceId: string | null;
+  agentWorkspaceReplicaId: string | null;
   authTransport: AuthTransport;
   profile: Readonly<{
     email: string | null;
@@ -35,6 +37,11 @@ function buildPermissionGuidanceLine(): string {
   return "For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions.";
 }
 
+function buildMediaDiscoveryGuidanceLine(requestUrl: string): string {
+  const apiBaseUrl = getPublicApiBaseUrl(requestUrl);
+  return `Use GET ${apiBaseUrl}/agent for the full media-capable discovery surface, including workspace-scoped upload-intent, complete, metadata, and download URL templates. Before completing a media upload, call GET ${apiBaseUrl}/agent/me after workspace selection and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId.`;
+}
+
 function buildAccountBootstrapInstructions(requestUrl: string): string {
   const apiBaseUrl = getPublicApiBaseUrl(requestUrl);
   return [
@@ -43,6 +50,7 @@ function buildAccountBootstrapInstructions(requestUrl: string): string {
     `If no workspace is selected, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select.`,
     `If no workspace exists, create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}.`,
     `After a workspace is selected, use POST ${apiBaseUrl}/agent/sql/query for reads and SQL introspection and POST ${apiBaseUrl}/agent/sql/execute for writes.`,
+    buildMediaDiscoveryGuidanceLine(requestUrl),
     buildPermissionGuidanceLine(),
     "If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls.",
     "Read payload from data.* and use docs.openapiUrl for the published external agent contract.",
@@ -55,6 +63,7 @@ function buildNoWorkspaceInstructions(requestUrl: string): string {
     `No workspace is currently available for this API key.`,
     `Create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}.`,
     `After the workspace is created, use POST ${apiBaseUrl}/agent/sql/query for reads and SQL introspection and POST ${apiBaseUrl}/agent/sql/execute for writes.`,
+    buildMediaDiscoveryGuidanceLine(requestUrl),
     buildPermissionGuidanceLine(),
     "If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls.",
     "Read payload from data.* and use docs.openapiUrl for the published external agent contract.",
@@ -67,6 +76,7 @@ function buildSelectWorkspaceInstructions(requestUrl: string): string {
     `Select a workspace with POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select.`,
     `If data.nextCursor is not null, continue listing with GET ${apiBaseUrl}/agent/workspaces?limit=100 and cursor=data.nextCursor until it becomes null.`,
     `After a workspace is selected, use POST ${apiBaseUrl}/agent/sql/query for reads and SQL introspection and POST ${apiBaseUrl}/agent/sql/execute for writes.`,
+    buildMediaDiscoveryGuidanceLine(requestUrl),
     buildPermissionGuidanceLine(),
     "If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls.",
     "Read payload from data.* and use docs.openapiUrl for the published external agent contract.",
@@ -79,6 +89,7 @@ function buildWorkspaceReadyInstructions(requestUrl: string): string {
     `Workspace bootstrap is complete.`,
     `Use POST ${apiBaseUrl}/agent/sql/query for reads and SQL introspection and POST ${apiBaseUrl}/agent/sql/execute for writes.`,
     `Start discovery with SHOW TABLES or DESCRIBE cards through POST ${apiBaseUrl}/agent/sql/query when helpful.`,
+    buildMediaDiscoveryGuidanceLine(requestUrl),
     buildPermissionGuidanceLine(),
     "This endpoint accepts the published SQL dialect, not full PostgreSQL.",
     "SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement.",
@@ -91,15 +102,33 @@ export function shouldUseAgentSetupEnvelope(transport: AuthTransport): boolean {
   return transport === "api_key";
 }
 
+export async function loadAgentWorkspaceReplicaIdForSetup(requestContext: RequestContext): Promise<string | null> {
+  if (requestContext.transport !== "api_key" || requestContext.selectedWorkspaceId === null) {
+    return null;
+  }
+
+  if (requestContext.connectionId === null) {
+    throw new Error("API key request context is missing connectionId");
+  }
+
+  return ensureAgentSyncReplica(
+    requestContext.selectedWorkspaceId,
+    requestContext.userId,
+    requestContext.connectionId,
+  );
+}
+
 export function createAgentAccountEnvelope(
   requestUrl: string,
   requestContext: RequestContext,
+  agentWorkspaceReplicaId: string | null,
 ): AgentEnvelope<AccountData> {
   return createAgentEnvelope(
     requestUrl,
     {
       userId: requestContext.userId,
       selectedWorkspaceId: requestContext.selectedWorkspaceId,
+      agentWorkspaceReplicaId,
       authTransport: requestContext.transport,
       profile: {
         email: requestContext.email,

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -4,6 +4,7 @@ import {
   createAgentAccountEnvelope,
   createAgentWorkspaceReadyEnvelope,
   createAgentWorkspacesEnvelope,
+  loadAgentWorkspaceReplicaIdForSetup,
 } from "../agent/setup";
 import { runSqlExecute, runSqlQuery } from "../aiTools/agentSql";
 import { loadOpenApiDocument } from "../shared/openapi";
@@ -80,7 +81,8 @@ export function createAgentRoutes(options: AgentRoutesOptions): Hono<AppEnv> {
 
   app.get("/agent/me", async (context) => {
     const { requestContext } = await loadAgentRequest(context.req.raw, options.allowedOrigins);
-    return context.json(createAgentAccountEnvelope(context.req.url, requestContext));
+    const agentWorkspaceReplicaId = await loadAgentWorkspaceReplicaIdForSetup(requestContext);
+    return context.json(createAgentAccountEnvelope(context.req.url, requestContext, agentWorkspaceReplicaId));
   });
 
   app.get("/agent/workspaces", async (context) => {

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -2,7 +2,15 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
+import { createAgentDiscoveryEnvelope } from "../../agent/discovery";
+import {
+  createAgentAccountEnvelope,
+  createAgentWorkspaceReadyEnvelope,
+  createAgentWorkspacesEnvelope,
+} from "../../agent/setup";
 import { loadOpenApiDocument } from "../../shared/openapi";
+import type { RequestContext } from "../../server/requestContext";
+import type { WorkspaceSummary } from "../../workspaces";
 
 const operationMethodNames = ["get", "post", "put", "patch", "delete", "options", "head", "trace"] as const;
 
@@ -17,6 +25,15 @@ type OpenApiDocumentForTest = Readonly<{
   components?: Readonly<{
     schemas?: Readonly<Record<string, object>>;
     securitySchemes?: Readonly<Record<string, object>>;
+  }>;
+}>;
+
+type AgentDiscoveryDataSchemaForTest = Readonly<{
+  properties?: Readonly<{
+    surface?: Readonly<{
+      required?: ReadonlyArray<string>;
+      properties?: Readonly<Record<string, object>>;
+    }>;
   }>;
 }>;
 
@@ -35,6 +52,41 @@ const expectedPublishedExternalAgentMethods = {
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete": ["post"],
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url": ["get"],
 } as const satisfies Readonly<Record<string, ReadonlyArray<OperationMethodName>>>;
+
+const expectedMediaDiscoverySurfaceTemplates = {
+  mediaAssetUploadIntentsUrlTemplate: "/workspaces/{workspaceId}/media-assets/upload-intents",
+  mediaAssetMetadataUrlTemplate: "/workspaces/{workspaceId}/media-assets/{mediaAssetId}",
+  mediaAssetCompleteUrlTemplate: "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete",
+  mediaAssetDownloadUrlTemplate: "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url",
+} as const;
+
+const testAgentRequestUrl = "https://api.flashcards-open-source-app.com/v1/agent";
+const testAgentWorkspaceReplicaId = "b4a0ec15-f875-5f9c-a8f8-9d6a9f42af39";
+const testWorkspaceSummary: WorkspaceSummary = {
+  workspaceId: "50b5b928-7f04-4cc8-878d-6cd0e8b98474",
+  name: "Personal",
+  createdAt: "2026-03-11T08:50:55.898Z",
+  isSelected: true,
+};
+const testUnselectedWorkspaceSummary: WorkspaceSummary = {
+  ...testWorkspaceSummary,
+  isSelected: false,
+};
+const testApiKeyRequestContext: RequestContext = {
+  userId: "user-1",
+  subjectUserId: "subject-user-1",
+  selectedWorkspaceId: testWorkspaceSummary.workspaceId,
+  email: "user@example.com",
+  locale: "en",
+  userSettingsCreatedAt: "2026-03-11T08:50:55.898Z",
+  preferences: {
+    reviewReactionAnimationsEnabled: true,
+  },
+  transport: "api_key",
+  connectionId: "connection-1",
+  guestSessionId: null,
+  guestPlatform: null,
+};
 
 function loadPublishedOpenApiDocument(): OpenApiDocumentForTest {
   return loadOpenApiDocument() as OpenApiDocumentForTest;
@@ -79,6 +131,67 @@ test("published OpenAPI exposes only the curated external agent and media transf
   ]) {
     assert.equal(schemas[hiddenSchemaName], undefined, `OpenAPI must not publish ${hiddenSchemaName}`);
   }
+});
+
+test("agent discovery advertises the published media transfer surface", () => {
+  const apiBaseUrl = "https://api.flashcards-open-source-app.com/v1";
+  const discoveryEnvelope = createAgentDiscoveryEnvelope(`${apiBaseUrl}/agent`);
+  const openApiDocument = loadPublishedOpenApiDocument();
+  const schemas = openApiDocument.components?.schemas ?? {};
+  const discoveryDataSchema = schemas.AgentDiscoveryData as AgentDiscoveryDataSchemaForTest | undefined;
+  const discoverySurfaceSchema = discoveryDataSchema?.properties?.surface;
+
+  assert.ok(discoverySurfaceSchema !== undefined);
+  for (const [surfaceKey, pathTemplate] of Object.entries(expectedMediaDiscoverySurfaceTemplates)) {
+    assert.equal(
+      discoveryEnvelope.data.surface[surfaceKey as keyof typeof expectedMediaDiscoverySurfaceTemplates],
+      `${apiBaseUrl}${pathTemplate}`,
+    );
+    assert.ok(
+      expectedPublishedExternalAgentMethods[pathTemplate] !== undefined,
+      `Discovery media template ${surfaceKey} must be published in OpenAPI paths`,
+    );
+    assert.ok(
+      discoverySurfaceSchema.required?.includes(surfaceKey),
+      `AgentDiscoveryData.surface must require ${surfaceKey}`,
+    );
+    assert.ok(
+      discoverySurfaceSchema.properties?.[surfaceKey] !== undefined,
+      `AgentDiscoveryData.surface must document ${surfaceKey}`,
+    );
+  }
+
+  assert.match(discoveryEnvelope.instructions, /media-assets\/upload-intents/);
+  assert.match(discoveryEnvelope.instructions, /media-assets\/\{mediaAssetId\}\/complete/);
+  assert.match(discoveryEnvelope.instructions, /media-assets\/\{mediaAssetId\}\/download-url/);
+  assert.match(discoveryEnvelope.instructions, /data\.agentWorkspaceReplicaId/);
+  assert.match(discoveryEnvelope.instructions, /lastModifiedByReplicaId/);
+});
+
+test("agent setup envelopes point API-key clients to the media-capable discovery surface", () => {
+  const accountEnvelope = createAgentAccountEnvelope(
+    testAgentRequestUrl,
+    testApiKeyRequestContext,
+    testAgentWorkspaceReplicaId,
+  );
+  const envelopes = [
+    accountEnvelope,
+    createAgentWorkspacesEnvelope(testAgentRequestUrl, [], null),
+    createAgentWorkspacesEnvelope(testAgentRequestUrl, [testUnselectedWorkspaceSummary], null),
+    createAgentWorkspacesEnvelope(testAgentRequestUrl, [testWorkspaceSummary], null),
+    createAgentWorkspaceReadyEnvelope(testAgentRequestUrl, testWorkspaceSummary),
+  ];
+
+  for (const envelope of envelopes) {
+    assert.match(envelope.instructions, /GET https:\/\/api\.flashcards-open-source-app\.com\/v1\/agent/);
+    assert.match(envelope.instructions, /media-capable discovery surface/);
+    assert.match(envelope.instructions, /upload-intent/);
+    assert.match(envelope.instructions, /download URL templates/);
+    assert.match(envelope.instructions, /data\.agentWorkspaceReplicaId/);
+    assert.match(envelope.instructions, /lastModifiedByReplicaId/);
+  }
+
+  assert.equal(accountEnvelope.data.agentWorkspaceReplicaId, testAgentWorkspaceReplicaId);
 });
 
 test("API Gateway predeclares /me/community/profile", () => {

--- a/apps/backend/src/routes/system/index.ts
+++ b/apps/backend/src/routes/system/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { createAgentDiscoveryEnvelope } from "../../agent/discovery";
 import {
   createAgentAccountEnvelope,
+  loadAgentWorkspaceReplicaIdForSetup,
   shouldUseAgentSetupEnvelope,
 } from "../../agent/setup";
 import { unsafeQuery } from "../../database/unsafe";
@@ -72,7 +73,8 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
       options.allowedOrigins,
     );
     if (shouldUseAgentSetupEnvelope(requestContext.transport)) {
-      return context.json(createAgentAccountEnvelope(context.req.url, requestContext));
+      const agentWorkspaceReplicaId = await loadAgentWorkspaceReplicaIdForSetup(requestContext);
+      return context.json(createAgentAccountEnvelope(context.req.url, requestContext, agentWorkspaceReplicaId));
     }
 
     return context.json({


### PR DESCRIPTION
## Summary
- Expose media asset upload, completion, metadata, and download URL templates in agent discovery and OpenAPI machine docs.
- Add agent setup/auth guidance for media upload completion using data.agentWorkspaceReplicaId.
- Ensure /agent/me and API-key /me can return an agent workspace replica id for selected workspaces, and add a verify-code load_discovery action.

## Validation
- node --test --import tsx src/routes/system/contracts.test.ts (9 tests)
- node --test --import tsx src/agentAuthRoutes.test.ts (10 tests)
- npm run lint --prefix apps/backend
- npm run build --prefix apps/auth
- npm run test --prefix apps/backend (519 tests)
- npm run test --prefix apps/auth (33 tests)
- npm run lint --prefix api
- npm run bundle --prefix api
- git diff --check

Fresh worker-owned review after the P2 fix found no P0-P4 issues and gave green light for commit.