### PR TITLE
Add media asset sync contract

### DIFF
--- a/api/src/components/schemas/PublicSyncConflictDetails.yaml
+++ b/api/src/components/schemas/PublicSyncConflictDetails.yaml
@@ -14,6 +14,7 @@ properties:
       - card
       - deck
       - review_event
+      - media_asset
   entityId:
     type: string
   entryIndex:

--- a/apps/backend/src/aiTools/agentSql/batchMutation.test.ts
+++ b/apps/backend/src/aiTools/agentSql/batchMutation.test.ts
@@ -206,6 +206,17 @@ test("executeSqlMutationBatch appends legacy deck effort tags after final tags a
         return createQueryResult<Row>([]);
       }
 
+      if (
+        text
+          === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE"
+      ) {
+        if (params === undefined) {
+          throw new Error("Workspace sync metadata lock params are required");
+        }
+
+        return createQueryResult<Row>([{ workspace_id: String(params[0]) } as unknown as Row]);
+      }
+
       if (text.includes("INSERT INTO sync.hot_changes")) {
         const row = {
           change_id: nextChangeId,

--- a/apps/backend/src/cards/index.test.ts
+++ b/apps/backend/src/cards/index.test.ts
@@ -168,6 +168,7 @@ test("submitReview fails invalid persisted fsrs state without repairing the card
         text === "BEGIN"
         || text === "ROLLBACK"
         || text.includes("set_config")
+        || text.includes("INSERT INTO sync.workspace_sync_metadata")
       ) {
         return {
           command: "SELECT",
@@ -175,6 +176,16 @@ test("submitReview fails invalid persisted fsrs state without repairing the card
           oid: 0,
           fields: [],
           rows: [],
+        };
+      }
+
+      if (text === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE") {
+        return {
+          command: "SELECT",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+          rows: [{ workspace_id: params?.[0] }],
         };
       }
 
@@ -241,6 +252,8 @@ test("submitReview fails invalid persisted fsrs state without repairing the card
     assert.deepEqual(queries.map((query) => query.text), [
       "BEGIN",
       "SELECT set_config('app.user_id', $1, true), set_config('app.workspace_id', $2, true)",
+      "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING",
+      "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE",
       [
         "SELECT",
         "card_id, front_text, back_text, due_at, reps, lapses, fsrs_card_state, fsrs_step_index, fsrs_stability, fsrs_difficulty, fsrs_last_reviewed_at, fsrs_scheduled_days",

--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -8,7 +8,7 @@ import {
   incomingLwwMetadataWins,
   normalizeIsoTimestamp,
 } from "../sync/conflicts/lww";
-import { findLatestSyncChangeId } from "../sync/replication/changes";
+import { findLatestSyncChangeId, lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../sync/replication/changes";
 import {
   createSyncConflictHttpError,
   findSyncConflictWorkspaceIdInExecutor,
@@ -286,6 +286,7 @@ export async function upsertCardSnapshotInExecutor(
   input: CardSnapshotInput,
   metadata: CardMutationMetadata,
 ): Promise<CardMutationResult> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const normalizedInput = normalizeCardSnapshotInput(input);
   const normalizedMetadata = normalizeCardMutationMetadata(metadata);
 
@@ -307,7 +308,7 @@ export async function upsertCardSnapshotInExecutor(
       );
     } else {
       const insertedCard = mapCard(insertedRow);
-      const changeId = await recordCardSyncChange(executor, workspaceId, insertedCard);
+      const changeId = await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, insertedCard);
 
       return {
         card: insertedCard,
@@ -367,7 +368,7 @@ export async function upsertCardSnapshotInExecutor(
   }
 
   const updatedCard = mapCard(updatedRow);
-  const changeId = await recordCardSyncChange(executor, workspaceId, updatedCard);
+  const changeId = await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, updatedCard);
 
   return {
     card: updatedCard,
@@ -393,6 +394,7 @@ export async function createCardInExecutor(
   input: CreateCardInput,
   metadata: CardMutationMetadata,
 ): Promise<Card> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const normalizedInput = normalizeCreateCardInput(input);
   const normalizedMetadata = normalizeCardMutationMetadata(metadata);
   const createdAt = normalizeIsoTimestamp(normalizedMetadata.clientUpdatedAt, "clientUpdatedAt");
@@ -430,7 +432,7 @@ export async function createCardInExecutor(
   }
 
   const card = mapCard(row);
-  await recordCardSyncChange(executor, workspaceId, card);
+  await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, card);
   return card;
 }
 
@@ -470,6 +472,7 @@ export async function updateCardInExecutor(
   input: UpdateCardInput,
   metadata: CardMutationMetadata,
 ): Promise<Card> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const normalizedInput = normalizeUpdateCardInput(input);
   const normalizedMetadata = normalizeCardMutationMetadata(metadata);
 
@@ -506,7 +509,7 @@ export async function updateCardInExecutor(
   }
 
   const card = mapCard(row);
-  await recordCardSyncChange(executor, workspaceId, card);
+  await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, card);
   return card;
 }
 
@@ -549,6 +552,7 @@ export async function deleteCardInExecutor(
   cardId: string,
   metadata: CardMutationMetadata,
 ): Promise<Card> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const normalizedMetadata = normalizeCardMutationMetadata(metadata);
 
   const result = await executor.query<CardRow>(
@@ -575,7 +579,7 @@ export async function deleteCardInExecutor(
   }
 
   const card = mapCard(row);
-  await recordCardSyncChange(executor, workspaceId, card);
+  await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, card);
   return card;
 }
 

--- a/apps/backend/src/cards/reviews.ts
+++ b/apps/backend/src/cards/reviews.ts
@@ -15,6 +15,7 @@ import {
   createSyncConflictHttpError,
   findSyncConflictWorkspaceIdInExecutor,
 } from "../sync/conflicts/fork";
+import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../sync/replication/changes";
 import { getWorkspaceSchedulerConfig } from "../scheduling/workspaceSettings";
 import { assertConsistentFsrsState } from "./fsrs";
 import {
@@ -233,6 +234,7 @@ export async function submitReview(
   const normalizedMetadata = normalizeCardMutationMetadata(metadata);
 
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
     const existingCard = await loadReviewableCardForUpdate(executor, workspaceId, input.cardId);
     const schedulerConfig = await getWorkspaceSchedulerConfig(executor, workspaceId);
     const schedule = computeReviewSchedule(
@@ -294,7 +296,7 @@ export async function submitReview(
     }
 
     const mappedCard = mapCard(updatedCard);
-    await recordCardSyncChange(executor, workspaceId, mappedCard);
+    await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, mappedCard);
 
     return {
       card: mappedCard,

--- a/apps/backend/src/cards/shared.ts
+++ b/apps/backend/src/cards/shared.ts
@@ -1,6 +1,6 @@
 import type { DatabaseExecutor } from "../database";
 import { normalizeIsoTimestamp } from "../sync/conflicts/lww";
-import { insertSyncChange } from "../sync/replication/changes";
+import { insertSyncChange, type HotChangeWriteLock } from "../sync/replication/changes";
 import type {
   Card,
   CardMetadata,
@@ -218,11 +218,13 @@ export function toCardLwwMetadata(card: Card): CardMutationMetadata {
 export async function recordCardSyncChange(
   executor: DatabaseExecutor,
   workspaceId: string,
+  hotChangeWriteLock: HotChangeWriteLock,
   card: Card,
 ): Promise<number> {
   return insertSyncChange(
     executor,
     workspaceId,
+    hotChangeWriteLock,
     "card",
     card.cardId,
     "upsert",

--- a/apps/backend/src/decks/index.ts
+++ b/apps/backend/src/decks/index.ts
@@ -20,7 +20,12 @@ import {
   encodeOpaqueCursor,
   type CursorPageInput,
 } from "../shared/pagination";
-import { findLatestSyncChangeId, insertSyncChange } from "../sync/replication/changes";
+import {
+  findLatestSyncChangeId,
+  insertSyncChange,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+  type HotChangeWriteLock,
+} from "../sync/replication/changes";
 import {
   createSyncConflictHttpError,
   findSyncConflictWorkspaceIdInExecutor,
@@ -326,11 +331,13 @@ function toDeckLwwMetadata(deck: Deck): DeckMutationMetadata {
 async function recordDeckSyncChange(
   executor: DatabaseExecutor,
   workspaceId: string,
+  hotChangeWriteLock: HotChangeWriteLock,
   deck: Deck,
 ): Promise<number> {
   return insertSyncChange(
     executor,
     workspaceId,
+    hotChangeWriteLock,
     "deck",
     deck.deckId,
     "upsert",
@@ -608,6 +615,7 @@ export async function upsertDeckSnapshotInExecutor(
   input: DeckSnapshotInput,
   metadata: DeckMutationMetadata,
 ): Promise<DeckMutationResult> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const normalizedInput = normalizeDeckSnapshotInput(input);
   const normalizedMetadata = normalizeDeckMutationMetadata(metadata);
 
@@ -652,7 +660,7 @@ export async function upsertDeckSnapshotInExecutor(
     const insertedRow = insertResult.rows[0];
     if (insertedRow !== undefined) {
       const insertedDeck = mapDeck(insertedRow);
-      const changeId = await recordDeckSyncChange(executor, workspaceId, insertedDeck);
+      const changeId = await recordDeckSyncChange(executor, workspaceId, hotChangeWriteLock, insertedDeck);
 
       return {
         deck: insertedDeck,
@@ -734,7 +742,7 @@ export async function upsertDeckSnapshotInExecutor(
   }
 
   const updatedDeck = mapDeck(updatedRow);
-  const changeId = await recordDeckSyncChange(executor, workspaceId, updatedDeck);
+  const changeId = await recordDeckSyncChange(executor, workspaceId, hotChangeWriteLock, updatedDeck);
 
   return {
     deck: updatedDeck,
@@ -838,6 +846,7 @@ export async function deleteDeckInExecutor(
   deckId: string,
   metadata: DeckMutationMetadata,
 ): Promise<Deck> {
+  await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const existingResult = await executor.query<DeckRow>(
     [
       "SELECT deck_id, workspace_id, name, filter_definition, created_at, client_updated_at,",

--- a/apps/backend/src/guestAuth/merge/index.ts
+++ b/apps/backend/src/guestAuth/merge/index.ts
@@ -29,7 +29,10 @@ import {
   type DeckMutationMetadata,
   type DeckSnapshotInput,
 } from "../../decks";
-import { insertSyncChange } from "../../sync/replication/changes";
+import {
+  insertSyncChange,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+} from "../../sync/replication/changes";
 import {
   ensureSystemWorkspaceReplicaInExecutor,
   ensureWorkspaceReplicaInExecutor,
@@ -58,8 +61,10 @@ import type {
 } from "../types";
 import { toIsoString } from "../shared";
 
+type GuestMergeEntityType = Exclude<SyncConflictEntityType, "media_asset">;
+
 type GuestMergeWriteInput = Readonly<{
-  entityType: SyncConflictEntityType;
+  entityType: GuestMergeEntityType;
   entityId: string;
   sourceGuestWorkspaceId: string;
   targetWorkspaceId: string;
@@ -231,7 +236,7 @@ function createGuestMergeDroppedEntitiesAccumulator(): GuestMergeDroppedEntities
 }
 
 function createGuestMergeSourceCleanupInvariantError(
-  entityType: SyncConflictEntityType,
+  entityType: GuestMergeEntityType,
   entityId: string,
   sourceGuestWorkspaceId: string,
 ): Error {
@@ -243,7 +248,7 @@ function createGuestMergeSourceCleanupInvariantError(
 
 function recordDroppedGuestMergeEntity(
   droppedEntities: GuestMergeDroppedEntitiesAccumulator,
-  entityType: SyncConflictEntityType,
+  entityType: GuestMergeEntityType,
   entityId: string,
 ): void {
   if (entityType === "card") {
@@ -278,7 +283,7 @@ function finalizeGuestMergeDroppedEntities(
 }
 
 function createGuestMergeDroppedEntitiesUnsupportedError(
-  entityType: SyncConflictEntityType,
+  entityType: GuestMergeEntityType,
   entityId: string,
   conflictingWorkspaceId: string,
 ): HttpError {
@@ -325,7 +330,7 @@ function createGuestMergeDedupedReviewEventUnsupportedError(
 
 function resolveGuestMergeThirdWorkspaceConflict(
   error: unknown,
-  entityType: SyncConflictEntityType,
+  entityType: GuestMergeEntityType,
   entityId: string,
   sourceGuestWorkspaceId: string,
   targetWorkspaceId: string,
@@ -367,7 +372,7 @@ function resolveGuestMergeThirdWorkspaceConflict(
 }
 
 function logGuestMergeDroppedEntity(
-  entityType: SyncConflictEntityType,
+  entityType: GuestMergeEntityType,
   entityId: string,
   sourceGuestWorkspaceId: string,
   targetWorkspaceId: string,
@@ -701,6 +706,7 @@ async function maybeApplyGuestSchedulerInExecutor(
   }
 
   const targetReplicaId = requireMappedReplicaId(replicaIdMap, guestScheduler.lastModifiedByReplicaId);
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, targetWorkspaceId);
   await updateWorkspaceSchedulerFromGuestInExecutor(
     executor,
     targetUserId,
@@ -711,6 +717,7 @@ async function maybeApplyGuestSchedulerInExecutor(
   await insertSyncChange(
     executor,
     targetWorkspaceId,
+    hotChangeWriteLock,
     "workspace_scheduler_settings",
     targetWorkspaceId,
     "upsert",

--- a/apps/backend/src/guestAuthTestHarness/executor.ts
+++ b/apps/backend/src/guestAuthTestHarness/executor.ts
@@ -340,6 +340,7 @@ export function isGuestUpgradeMergeOnlyExecutorQuery(text: string): boolean {
     || text === "SELECT community.transfer_guest_public_profile($1, $2)"
     || text === "UPDATE auth.guest_sessions SET revoked_at = now() WHERE session_id = $1"
     || text === "SELECT workspace_id FROM sync.find_conflicting_workspace_id($1, $2) LIMIT 1"
+    || text === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE"
     || text.includes("FROM sync.hot_changes")
     || text.includes("INSERT INTO sync.hot_changes")
     || text === "SELECT progress_time_zone FROM org.user_settings WHERE user_id = $1 LIMIT 1"

--- a/apps/backend/src/guestAuthTestHarness/handlers/sync.ts
+++ b/apps/backend/src/guestAuthTestHarness/handlers/sync.ts
@@ -159,6 +159,15 @@ export function handleSyncExecutorQuery<Row extends pg.QueryResultRow>(
 
   if (
     text
+      === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE"
+  ) {
+    return createQueryResult<Row>([{
+      workspace_id: String(params[0]),
+    } as unknown as Row]);
+  }
+
+  if (
+    text
       === "INSERT INTO sync.hot_changes ( workspace_id, entity_type, entity_id, action, replica_id, operation_id, client_updated_at ) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING change_id"
   ) {
     const changeId = state.nextHotChangeId;

--- a/apps/backend/src/mediaAssets/index.test.ts
+++ b/apps/backend/src/mediaAssets/index.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import { buildMediaAssetStorageKey } from "./storageKeys";
+import {
+  upsertMediaAssetSnapshotInExecutor,
+} from ".";
+import type { MediaAssetRow } from "./types";
+
+const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
+const testMediaAssetId = "22222222-2222-4222-8222-222222222222";
+const testSha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
+const testStorageKey = buildMediaAssetStorageKey(testWorkspaceId, testMediaAssetId, testSha256);
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createMediaAssetRow(fixture: Readonly<{
+  sourceUrl: string | null;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}>): MediaAssetRow {
+  return {
+    media_asset_id: testMediaAssetId,
+    workspace_id: testWorkspaceId,
+    mime_type: "image/png",
+    size_bytes: 42,
+    sha256: testSha256,
+    storage_key: testStorageKey,
+    source_url: fixture.sourceUrl,
+    created_at: "2026-02-28T09:00:00.000Z",
+    client_updated_at: fixture.clientUpdatedAt,
+    last_modified_by_replica_id: fixture.lastModifiedByReplicaId,
+    last_operation_id: fixture.lastOperationId,
+    updated_at: fixture.updatedAt,
+    deleted_at: fixture.deletedAt,
+  };
+}
+
+function createExistingMediaAssetUpdateExecutor(): DatabaseExecutor {
+  const queries: string[] = [];
+  const existingRow = createMediaAssetRow({
+    sourceUrl: null,
+    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
+    lastModifiedByReplicaId: "replica-old",
+    lastOperationId: "operation-old",
+    updatedAt: "2026-02-28T09:00:00.000Z",
+    deletedAt: null,
+  });
+
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      queries.push(text);
+
+      if (text.includes("FROM content.media_assets") && text.includes("FOR UPDATE")) {
+        assert.deepEqual(queries.slice(0, 3), [
+          "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING",
+          "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE",
+          text,
+        ]);
+        assert.deepEqual(params, [testWorkspaceId, testMediaAssetId]);
+        return createQueryResult([existingRow as unknown as Row]);
+      }
+
+      if (text.startsWith("UPDATE content.media_assets")) {
+        assert.doesNotMatch(text, /updated_at = now\(\),\s+WHERE/);
+        assert.deepEqual(params, [
+          testWorkspaceId,
+          testMediaAssetId,
+          "https://example.com/updated%20image.png",
+          "2026-02-28T09:00:00.000Z",
+          "2026-02-28T10:00:00.000Z",
+          "2026-02-28T10:00:00.000Z",
+          "replica-new",
+          "operation-new",
+        ]);
+        return createQueryResult([{
+          ...existingRow,
+          source_url: params[2],
+          client_updated_at: params[5],
+          last_modified_by_replica_id: params[6],
+          last_operation_id: params[7],
+          updated_at: "2026-02-28T10:00:01.000Z",
+          deleted_at: params[4],
+        } as MediaAssetRow as unknown as Row]);
+      }
+
+      if (text.includes("INSERT INTO sync.workspace_sync_metadata")) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        text
+          === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE"
+      ) {
+        assert.deepEqual(params, [testWorkspaceId]);
+        return createQueryResult<Row>([{ workspace_id: testWorkspaceId } as unknown as Row]);
+      }
+
+      if (text.includes("INSERT INTO sync.hot_changes")) {
+        assert.deepEqual(params, [
+          testWorkspaceId,
+          "media_asset",
+          testMediaAssetId,
+          "upsert",
+          "replica-new",
+          "operation-new",
+          "2026-02-28T10:00:00.000Z",
+        ]);
+        return createQueryResult<Row>([{
+          change_id: 17,
+        } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+}
+
+test("upsertMediaAssetSnapshotInExecutor updates existing media asset metadata through valid SQL", async () => {
+  const result = await upsertMediaAssetSnapshotInExecutor(
+    createExistingMediaAssetUpdateExecutor(),
+    testWorkspaceId,
+    {
+      mediaAssetId: testMediaAssetId,
+      mimeType: "image/png",
+      sizeBytes: 42,
+      sha256: testSha256,
+      storageKey: testStorageKey,
+      sourceUrl: " https://example.com/updated image.png ",
+      createdAt: "2026-02-28T09:00:00.000Z",
+      deletedAt: "2026-02-28T10:00:00.000Z",
+    },
+    {
+      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+      lastModifiedByReplicaId: "replica-new",
+      lastOperationId: "operation-new",
+    },
+  );
+
+  assert.equal(result.applied, true);
+  assert.equal(result.changeId, 17);
+  assert.equal(result.mediaAsset.sourceUrl, "https://example.com/updated%20image.png");
+  assert.equal(result.mediaAsset.deletedAt, "2026-02-28T10:00:00.000Z");
+});

--- a/apps/backend/src/mediaAssets/index.ts
+++ b/apps/backend/src/mediaAssets/index.ts
@@ -6,18 +6,33 @@ import {
 import { HttpError } from "../shared/errors";
 import {
   incomingLwwMetadataWins,
+  normalizeIsoTimestamp,
   type LwwMetadata,
 } from "../sync/conflicts/lww";
+import {
+  findLatestSyncChangeId,
+  insertSyncChange,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+  type HotChangeWriteLock,
+} from "../sync/replication/changes";
+import {
+  createSyncConflictHttpError,
+  findSyncConflictWorkspaceIdInExecutor,
+} from "../sync/conflicts/fork";
 import { buildMediaAssetStorageKey } from "./storageKeys";
 import type {
   CompleteMediaAssetUploadInput,
   MediaAsset,
+  MediaAssetMutationMetadata,
   MediaAssetMutationResult,
   MediaAssetRow,
+  MediaAssetSnapshotInput,
+  MediaAssetSyncMutationResult,
   TimestampValue,
 } from "./types";
+import { expectMediaAssetSourceUrl } from "./validators";
 
-const MEDIA_ASSET_COLUMNS = [
+export const MEDIA_ASSET_COLUMNS = [
   "media_asset_id",
   "workspace_id",
   "mime_type",
@@ -118,11 +133,21 @@ function toMediaAssetLwwMetadata(row: MediaAssetRow): LwwMetadata {
   };
 }
 
-function toInputLwwMetadata(input: CompleteMediaAssetUploadInput): LwwMetadata {
+function toInputLwwMetadata(metadata: MediaAssetMutationMetadata): LwwMetadata {
   return {
-    clientUpdatedAt: input.clientUpdatedAt,
-    lastModifiedByReplicaId: input.lastModifiedByReplicaId,
-    lastOperationId: input.lastOperationId,
+    clientUpdatedAt: metadata.clientUpdatedAt,
+    lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
+    lastOperationId: metadata.lastOperationId,
+  };
+}
+
+function normalizeMediaAssetMutationMetadata(
+  metadata: MediaAssetMutationMetadata,
+): MediaAssetMutationMetadata {
+  return {
+    clientUpdatedAt: normalizeIsoTimestamp(metadata.clientUpdatedAt, "clientUpdatedAt"),
+    lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
+    lastOperationId: metadata.lastOperationId,
   };
 }
 
@@ -171,16 +196,54 @@ async function findMediaAssetRowForUpdateInExecutor(
   return result.rows[0] ?? null;
 }
 
-function assertExistingMediaAssetMatchesInput(
+function normalizeMediaAssetSnapshotInput(input: MediaAssetSnapshotInput): MediaAssetSnapshotInput {
+  if (Number.isSafeInteger(input.sizeBytes) === false || input.sizeBytes < 0) {
+    throw new HttpError(400, "sizeBytes must be a non-negative safe integer", "MEDIA_ASSET_SIZE_INVALID");
+  }
+
+  return {
+    mediaAssetId: input.mediaAssetId,
+    mimeType: input.mimeType.trim().toLowerCase(),
+    sizeBytes: input.sizeBytes,
+    sha256: input.sha256.toLowerCase(),
+    storageKey: input.storageKey,
+    sourceUrl: expectMediaAssetSourceUrl(input.sourceUrl, "sourceUrl"),
+    createdAt: normalizeIsoTimestamp(input.createdAt, "createdAt"),
+    deletedAt: input.deletedAt === null ? null : normalizeIsoTimestamp(input.deletedAt, "deletedAt"),
+  };
+}
+
+function assertMediaAssetStorageKeyMatchesSnapshot(
+  workspaceId: string,
+  input: MediaAssetSnapshotInput,
+): void {
+  const expectedStorageKey = buildMediaAssetStorageKey(workspaceId, input.mediaAssetId, input.sha256);
+  if (input.storageKey === expectedStorageKey) {
+    return;
+  }
+
+  throw new HttpError(
+    400,
+    [
+      "media_asset payload.storageKey must match the backend media asset storage key.",
+      `workspaceId=${workspaceId}`,
+      `mediaAssetId=${input.mediaAssetId}`,
+      `expectedStorageKey=${expectedStorageKey}`,
+      `receivedStorageKey=${input.storageKey}`,
+    ].join(" "),
+    "MEDIA_ASSET_STORAGE_KEY_INVALID",
+  );
+}
+
+function assertExistingMediaAssetMatchesSnapshot(
   existingRow: MediaAssetRow,
-  input: CompleteMediaAssetUploadInput,
-  storageKey: string,
+  input: MediaAssetSnapshotInput,
 ): void {
   if (
     existingRow.mime_type !== input.mimeType
     || toSafeNumber(existingRow.size_bytes, "size_bytes") !== input.sizeBytes
     || existingRow.sha256 !== input.sha256
-    || existingRow.storage_key !== storageKey
+    || existingRow.storage_key !== input.storageKey
   ) {
     throw new HttpError(
       409,
@@ -189,18 +252,18 @@ function assertExistingMediaAssetMatchesInput(
         `workspaceId=${existingRow.workspace_id}`,
         `mediaAssetId=${existingRow.media_asset_id}`,
         `existingStorageKey=${existingRow.storage_key}`,
-        `requestedStorageKey=${storageKey}`,
+        `requestedStorageKey=${input.storageKey}`,
       ].join(" "),
       "MEDIA_ASSET_ID_CONFLICT",
     );
   }
 }
 
-async function insertMediaAssetRowInExecutor(
+async function insertMediaAssetSnapshotRowInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
-  input: CompleteMediaAssetUploadInput,
-  storageKey: string,
+  input: MediaAssetSnapshotInput,
+  metadata: MediaAssetMutationMetadata,
 ): Promise<MediaAssetRow | null> {
   const result = await executor.query<MediaAssetRow>(
     [
@@ -209,7 +272,7 @@ async function insertMediaAssetRowInExecutor(
       "media_asset_id, workspace_id, mime_type, size_bytes, sha256, storage_key, source_url, created_at,",
       "client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at",
       ")",
-      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL)",
+      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
       "ON CONFLICT DO NOTHING",
       "RETURNING",
       MEDIA_ASSET_COLUMNS,
@@ -220,32 +283,69 @@ async function insertMediaAssetRowInExecutor(
       input.mimeType,
       input.sizeBytes,
       input.sha256,
-      storageKey,
+      input.storageKey,
       input.sourceUrl,
       input.createdAt,
-      input.clientUpdatedAt,
-      input.lastModifiedByReplicaId,
-      input.lastOperationId,
+      metadata.clientUpdatedAt,
+      metadata.lastModifiedByReplicaId,
+      metadata.lastOperationId,
+      input.deletedAt,
     ],
   );
 
   return result.rows[0] ?? null;
 }
 
-async function updateExistingMediaAssetRowInExecutor(
+async function resolveMediaAssetSnapshotInsertConflictInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
-  input: CompleteMediaAssetUploadInput,
+  mediaAssetId: string,
+): Promise<MediaAssetRow> {
+  const conflictingWorkspaceId = await findSyncConflictWorkspaceIdInExecutor(executor, {
+    entityType: "media_asset",
+    entityId: mediaAssetId,
+  });
+
+  if (conflictingWorkspaceId === null) {
+    throw new Error(`Media asset insert was skipped but no conflicting workspace was found for ${mediaAssetId}`);
+  }
+
+  if (conflictingWorkspaceId !== workspaceId) {
+    throw createSyncConflictHttpError({
+      phase: "sync_write",
+      entityType: "media_asset",
+      entityId: mediaAssetId,
+      conflictingWorkspaceId,
+      constraint: "media_assets_pkey",
+      sqlState: "23505",
+      table: "media_assets",
+    });
+  }
+
+  const existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, mediaAssetId);
+  if (existingRow === null) {
+    throw new Error(`Media asset insert was skipped but the current workspace row was not found for ${mediaAssetId}`);
+  }
+
+  return existingRow;
+}
+
+async function updateExistingMediaAssetSnapshotRowInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: MediaAssetSnapshotInput,
+  metadata: MediaAssetMutationMetadata,
 ): Promise<MediaAssetRow> {
   const result = await executor.query<MediaAssetRow>(
     [
       "UPDATE content.media_assets",
       "SET source_url = $3,",
-      "client_updated_at = $4,",
-      "last_modified_by_replica_id = $5,",
-      "last_operation_id = $6,",
-      "updated_at = now(),",
-      "deleted_at = NULL",
+      "created_at = $4,",
+      "deleted_at = $5,",
+      "client_updated_at = $6,",
+      "last_modified_by_replica_id = $7,",
+      "last_operation_id = $8,",
+      "updated_at = now()",
       "WHERE workspace_id = $1",
       "AND media_asset_id = $2",
       "RETURNING",
@@ -255,9 +355,11 @@ async function updateExistingMediaAssetRowInExecutor(
       workspaceId,
       input.mediaAssetId,
       input.sourceUrl,
-      input.clientUpdatedAt,
-      input.lastModifiedByReplicaId,
-      input.lastOperationId,
+      input.createdAt,
+      input.deletedAt,
+      metadata.clientUpdatedAt,
+      metadata.lastModifiedByReplicaId,
+      metadata.lastOperationId,
     ],
   );
 
@@ -273,6 +375,86 @@ async function updateExistingMediaAssetRowInExecutor(
   return row;
 }
 
+async function recordMediaAssetSyncChange(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  hotChangeWriteLock: HotChangeWriteLock,
+  mediaAsset: MediaAsset,
+): Promise<number> {
+  return insertSyncChange(
+    executor,
+    workspaceId,
+    hotChangeWriteLock,
+    "media_asset",
+    mediaAsset.mediaAssetId,
+    "upsert",
+    mediaAsset.lastModifiedByReplicaId,
+    mediaAsset.lastOperationId,
+    mediaAsset.clientUpdatedAt,
+  );
+}
+
+export async function upsertMediaAssetSnapshotInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: MediaAssetSnapshotInput,
+  metadata: MediaAssetMutationMetadata,
+): Promise<MediaAssetSyncMutationResult> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
+  const normalizedInput = normalizeMediaAssetSnapshotInput(input);
+  const normalizedMetadata = normalizeMediaAssetMutationMetadata(metadata);
+  assertMediaAssetStorageKeyMatchesSnapshot(workspaceId, normalizedInput);
+
+  let existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, normalizedInput.mediaAssetId);
+  if (existingRow === null) {
+    const insertedRow = await insertMediaAssetSnapshotRowInExecutor(
+      executor,
+      workspaceId,
+      normalizedInput,
+      normalizedMetadata,
+    );
+
+    if (insertedRow === null) {
+      existingRow = await resolveMediaAssetSnapshotInsertConflictInExecutor(
+        executor,
+        workspaceId,
+        normalizedInput.mediaAssetId,
+      );
+    } else {
+      const insertedMediaAsset = mapMediaAssetRow(insertedRow);
+      return {
+        mediaAsset: insertedMediaAsset,
+        applied: true,
+        changeId: await recordMediaAssetSyncChange(executor, workspaceId, hotChangeWriteLock, insertedMediaAsset),
+      };
+    }
+  }
+
+  assertExistingMediaAssetMatchesSnapshot(existingRow, normalizedInput);
+  const existingMediaAsset = mapMediaAssetRow(existingRow);
+  if (incomingLwwMetadataWins(toInputLwwMetadata(normalizedMetadata), toMediaAssetLwwMetadata(existingRow)) === false) {
+    return {
+      mediaAsset: existingMediaAsset,
+      applied: false,
+      changeId: await findLatestSyncChangeId(executor, workspaceId, "media_asset", existingMediaAsset.mediaAssetId),
+    };
+  }
+
+  const updatedRow = await updateExistingMediaAssetSnapshotRowInExecutor(
+    executor,
+    workspaceId,
+    normalizedInput,
+    normalizedMetadata,
+  );
+  const updatedMediaAsset = mapMediaAssetRow(updatedRow);
+
+  return {
+    mediaAsset: updatedMediaAsset,
+    applied: true,
+    changeId: await recordMediaAssetSyncChange(executor, workspaceId, hotChangeWriteLock, updatedMediaAsset),
+  };
+}
+
 export async function completeMediaAssetUploadForWorkspace(
   userId: string,
   workspaceId: string,
@@ -281,35 +463,29 @@ export async function completeMediaAssetUploadForWorkspace(
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
     await assertReplicaBelongsToWorkspaceInExecutor(executor, workspaceId, input.lastModifiedByReplicaId);
     const storageKey = buildMediaAssetStorageKey(workspaceId, input.mediaAssetId, input.sha256);
-    const insertedRow = await insertMediaAssetRowInExecutor(executor, workspaceId, input, storageKey);
-    if (insertedRow !== null) {
-      return {
-        mediaAsset: mapMediaAssetRow(insertedRow),
-        applied: true,
-      };
-    }
+    const result = await upsertMediaAssetSnapshotInExecutor(
+      executor,
+      workspaceId,
+      {
+        mediaAssetId: input.mediaAssetId,
+        mimeType: input.mimeType,
+        sizeBytes: input.sizeBytes,
+        sha256: input.sha256,
+        storageKey,
+        sourceUrl: input.sourceUrl,
+        createdAt: input.createdAt,
+        deletedAt: null,
+      },
+      {
+        clientUpdatedAt: input.clientUpdatedAt,
+        lastModifiedByReplicaId: input.lastModifiedByReplicaId,
+        lastOperationId: input.lastOperationId,
+      },
+    );
 
-    const existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, input.mediaAssetId);
-    if (existingRow === null) {
-      throw new HttpError(
-        409,
-        `mediaAssetId is already used by another workspace: mediaAssetId=${input.mediaAssetId}`,
-        "MEDIA_ASSET_ID_CONFLICT",
-      );
-    }
-
-    assertExistingMediaAssetMatchesInput(existingRow, input, storageKey);
-    if (incomingLwwMetadataWins(toInputLwwMetadata(input), toMediaAssetLwwMetadata(existingRow)) === false) {
-      return {
-        mediaAsset: mapMediaAssetRow(existingRow),
-        applied: false,
-      };
-    }
-
-    const updatedRow = await updateExistingMediaAssetRowInExecutor(executor, workspaceId, input);
     return {
-      mediaAsset: mapMediaAssetRow(updatedRow),
-      applied: true,
+      mediaAsset: result.mediaAsset,
+      applied: result.applied,
     };
   });
 }

--- a/apps/backend/src/mediaAssets/types.ts
+++ b/apps/backend/src/mediaAssets/types.ts
@@ -51,9 +51,32 @@ export type CompleteMediaAssetUploadInput = Readonly<{
   lastOperationId: string;
 }>;
 
+export type MediaAssetMutationMetadata = Readonly<{
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+}>;
+
+export type MediaAssetSnapshotInput = Readonly<{
+  mediaAssetId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageKey: string;
+  sourceUrl: string | null;
+  createdAt: string;
+  deletedAt: string | null;
+}>;
+
 export type MediaAssetMutationResult = Readonly<{
   mediaAsset: MediaAsset;
   applied: boolean;
+}>;
+
+export type MediaAssetSyncMutationResult = Readonly<{
+  mediaAsset: MediaAsset;
+  applied: boolean;
+  changeId: number | null;
 }>;
 
 export type PresignedMediaAssetUpload = Readonly<{

--- a/apps/backend/src/mediaAssets/validators.ts
+++ b/apps/backend/src/mediaAssets/validators.ts
@@ -75,7 +75,7 @@ function expectIsoTimestamp(value: unknown, fieldName: string): string {
   return parsedTimestamp.toISOString();
 }
 
-function expectSourceUrl(value: unknown, fieldName: string): string | null {
+export function expectMediaAssetSourceUrl(value: unknown, fieldName: string): string | null {
   if (value === undefined || value === null) {
     return null;
   }
@@ -128,7 +128,7 @@ export function parseCompleteMediaAssetUploadInput(
     mimeType: expectMimeType(record.mimeType, "mimeType"),
     sizeBytes: expectSizeBytes(record.sizeBytes, "sizeBytes"),
     sha256: expectSha256(record.sha256, "sha256"),
-    sourceUrl: expectSourceUrl(record.sourceUrl, "sourceUrl"),
+    sourceUrl: expectMediaAssetSourceUrl(record.sourceUrl, "sourceUrl"),
     createdAt: expectIsoTimestamp(record.createdAt, "createdAt"),
     clientUpdatedAt: expectIsoTimestamp(record.clientUpdatedAt, "clientUpdatedAt"),
     lastModifiedByReplicaId: expectUuidString(record.lastModifiedByReplicaId, "lastModifiedByReplicaId"),

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -64,7 +64,7 @@ export type BackendDatabaseDetails = Readonly<{
 
 export type BackendSyncConflictDetails = Readonly<{
   syncConflictPhase: string | null;
-  syncConflictEntityType: "card" | "deck" | "review_event" | null;
+  syncConflictEntityType: "card" | "deck" | "review_event" | "media_asset" | null;
   syncConflictEntityId: string | null;
   conflictingWorkspaceId: string | null;
   constraint: string | null;

--- a/apps/backend/src/scheduling/workspaceSettings.ts
+++ b/apps/backend/src/scheduling/workspaceSettings.ts
@@ -22,7 +22,12 @@ import {
   normalizeIsoTimestamp,
   type LwwMetadata,
 } from "../sync/conflicts/lww";
-import { findLatestSyncChangeId, insertSyncChange } from "../sync/replication/changes";
+import {
+  findLatestSyncChangeId,
+  insertSyncChange,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+  type HotChangeWriteLock,
+} from "../sync/replication/changes";
 import {
   defaultWorkspaceSchedulerConfig,
   type SchedulerAlgorithm,
@@ -142,11 +147,13 @@ function toWorkspaceSchedulerLwwMetadata(
 async function recordWorkspaceSchedulerSyncChange(
   executor: DatabaseExecutor,
   workspaceId: string,
+  hotChangeWriteLock: HotChangeWriteLock,
   settings: WorkspaceSchedulerSettings,
 ): Promise<number> {
   return insertSyncChange(
     executor,
     workspaceId,
+    hotChangeWriteLock,
     "workspace_scheduler_settings",
     workspaceId,
     "upsert",
@@ -286,6 +293,7 @@ export async function applyWorkspaceSchedulerSettingsSnapshotInExecutor(
   input: WorkspaceSchedulerSettingsSnapshotInput,
   metadata: WorkspaceSchedulerSettingsMutationMetadata,
 ): Promise<WorkspaceSchedulerSettingsMutationResult> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   if (input.algorithm !== "fsrs-6") {
     throw new HttpError(400, "algorithm must be fsrs-6");
   }
@@ -357,7 +365,12 @@ export async function applyWorkspaceSchedulerSettingsSnapshotInExecutor(
   }
 
   const updatedSettings = mapWorkspaceSchedulerSettings(updatedRow);
-  const changeId = await recordWorkspaceSchedulerSyncChange(executor, workspaceId, updatedSettings);
+  const changeId = await recordWorkspaceSchedulerSyncChange(
+    executor,
+    workspaceId,
+    hotChangeWriteLock,
+    updatedSettings,
+  );
 
   return {
     settings: updatedSettings,

--- a/apps/backend/src/shared/errors.ts
+++ b/apps/backend/src/shared/errors.ts
@@ -4,7 +4,7 @@ export type ValidationIssueSummary = Readonly<{
   message: string;
 }>;
 
-export type SyncConflictEntityType = "card" | "deck" | "review_event";
+export type SyncConflictEntityType = "card" | "deck" | "review_event" | "media_asset";
 
 export type SyncConflictDetails = Readonly<{
   phase: string;

--- a/apps/backend/src/sync/conflicts/conflict.test.ts
+++ b/apps/backend/src/sync/conflicts/conflict.test.ts
@@ -7,6 +7,7 @@ import { createPublicHttpErrorBody } from "../../server/app";
 import { upsertCardSnapshotInExecutor } from "../../cards";
 import type { DatabaseExecutor } from "../../database";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
+import { upsertMediaAssetSnapshotInExecutor } from "../../mediaAssets";
 import { HttpError } from "../../shared/errors";
 import {
   annotateSyncConflictHttpError,
@@ -16,7 +17,7 @@ import {
 } from "./fork";
 import { processSyncReviewHistoryImportInExecutor } from "../replication/reviewHistory";
 
-type EntityType = "card" | "deck" | "review_event";
+type EntityType = "card" | "deck" | "review_event" | "media_asset";
 
 type RecordedQuery = Readonly<{
   text: string;
@@ -89,6 +90,16 @@ function createConflictExecutor(
         } as unknown as Row]);
       }
 
+      if (text.includes("INSERT INTO sync.workspace_sync_metadata")) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (text === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE") {
+        return createQueryResult<Row>([{
+          workspace_id: String(params[0]),
+        } as unknown as Row]);
+      }
+
       if (
         options.entityType === "card"
         && text.includes("FROM content.cards")
@@ -129,6 +140,23 @@ function createConflictExecutor(
         return createQueryResult<Row>([]);
       }
 
+      if (
+        options.entityType === "media_asset"
+        && text.includes("FROM content.media_assets")
+        && text.includes("WHERE workspace_id = $1")
+        && text.includes("AND media_asset_id = $2")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        options.entityType === "media_asset"
+        && text.includes("INSERT INTO content.media_assets")
+        && text.includes("ON CONFLICT DO NOTHING")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
       throw new Error(`Unexpected query: ${text}`);
     },
   };
@@ -159,9 +187,9 @@ test("findSyncConflictWorkspaceIdInExecutor resolves conflicts without membershi
   );
 });
 
-test("0048 sync conflict lookup casts target ids once and compares UUID columns directly", () => {
+test("canonical sync conflict lookup casts target ids once and compares UUID columns directly", () => {
   const migration = readFileSync(
-    join(__dirname, "../../../../../db/migrations/0048_sync_conflict_lookup.sql"),
+    join(__dirname, "../../../../../db/migrations/0081_media_assets_sync_contract.sql"),
     "utf8",
   );
 
@@ -171,6 +199,7 @@ test("0048 sync conflict lookup casts target ids once and compares UUID columns 
   assert.match(migration, /cards\.card_id = target_entity_uuid/);
   assert.match(migration, /decks\.deck_id = target_entity_uuid/);
   assert.match(migration, /review_events\.review_event_id = target_entity_uuid/);
+  assert.match(migration, /media_assets\.media_asset_id = target_entity_uuid/);
 });
 
 test("upsertCardSnapshotInExecutor returns a typed cross-workspace fork error", async () => {
@@ -277,6 +306,56 @@ test("upsertDeckSnapshotInExecutor returns a typed cross-workspace fork error", 
         constraint: "decks_pkey",
         sqlState: "23505",
         table: "decks",
+        recoverable: true,
+      });
+      return true;
+    },
+  );
+});
+
+test("upsertMediaAssetSnapshotInExecutor returns a typed cross-workspace fork error", async () => {
+  const mediaAssetId = "media-asset-conflict-1";
+  const { executor } = createConflictExecutor({
+    currentUserId: "user-1",
+    currentWorkspaceId: "workspace-current",
+    conflictingWorkspaceId: "workspace-other",
+    entityType: "media_asset",
+  });
+
+  await assert.rejects(
+    upsertMediaAssetSnapshotInExecutor(
+      executor,
+      "workspace-current",
+      {
+        mediaAssetId,
+        mimeType: "image/png",
+        sizeBytes: 42,
+        sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+        storageKey: "media-assets/workspaces/workspace-current/assets/media-asset-conflict-1/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+        sourceUrl: null,
+        createdAt: "2026-04-24T10:00:00.000Z",
+        deletedAt: null,
+      },
+      {
+        clientUpdatedAt: "2026-04-24T10:00:00.000Z",
+        lastModifiedByReplicaId: "replica-1",
+        lastOperationId: "op-1",
+      },
+    ),
+    (error: unknown): boolean => {
+      if (!(error instanceof HttpError)) {
+        return false;
+      }
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, SYNC_WORKSPACE_FORK_REQUIRED);
+      assert.deepEqual(error.details?.syncConflict, {
+        phase: "sync_write",
+        entityType: "media_asset",
+        entityId: mediaAssetId,
+        conflictingWorkspaceId: "workspace-other",
+        constraint: "media_assets_pkey",
+        sqlState: "23505",
+        table: "media_assets",
         recoverable: true,
       });
       return true;

--- a/apps/backend/src/sync/contracts/input.test.ts
+++ b/apps/backend/src/sync/contracts/input.test.ts
@@ -14,10 +14,16 @@ import {
   type DeckSnapshotInput,
   type DeckRow,
 } from "../../decks";
+import { buildMediaAssetStorageKey } from "../../mediaAssets/storageKeys";
+import type { MediaAssetRow } from "../../mediaAssets/types";
 import { HttpError } from "../../shared/errors";
 import { parseBootstrapEntryRow } from "../replication/bootstrap";
 import { buildHotChangesFromRows } from "../replication/hotPull";
-import { parseSyncPushInput } from "./input";
+import {
+  parseSyncBootstrapInput,
+  parseSyncPullInput,
+  parseSyncPushInput,
+} from "./input";
 import {
   toCardSnapshotInput,
   toDeckSnapshotInput,
@@ -88,6 +94,25 @@ type CardBootstrapPayload = CardSnapshotInput & Readonly<{
   lastOperationId: string;
   updatedAt: string;
 }>;
+
+type MediaAssetPayload = Readonly<{
+  mediaAssetId: string;
+  workspaceId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageKey: string;
+  sourceUrl: string | null;
+  createdAt: string;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}>;
+
+const mediaAssetId = "22222222-2222-4222-8222-222222222222";
+const mediaAssetSha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
 
 function createSyncPushInput(
   fixture: ReviewEventTimestampFixture,
@@ -253,6 +278,33 @@ function createCardBootstrapProjectionRow(fixture: CardDueAtFixture): BootstrapP
   };
 }
 
+function createMediaAssetPayload(deletedAt: string | null): MediaAssetPayload {
+  return {
+    mediaAssetId,
+    workspaceId: "workspace-1",
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: mediaAssetSha256,
+    storageKey: buildMediaAssetStorageKey("workspace-1", mediaAssetId, mediaAssetSha256),
+    sourceUrl: "https://example.com/source.png",
+    createdAt: "2026-02-28T09:00:00.000Z",
+    clientUpdatedAt: "2026-02-28T09:30:00.000Z",
+    lastModifiedByReplicaId: "replica-1",
+    lastOperationId: "operation-media-1",
+    updatedAt: "2026-02-28T09:30:00.000Z",
+    deletedAt,
+  };
+}
+
+function createMediaAssetBootstrapProjectionRow(deletedAt: string | null): BootstrapProjectionRow {
+  return {
+    entity_rank: 3,
+    entity_type: "media_asset",
+    entity_id: mediaAssetId,
+    payload: createMediaAssetPayload(deletedAt),
+  };
+}
+
 function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
   return {
     command: "SELECT",
@@ -299,6 +351,38 @@ function createHotPullCardExecutor(effortLevel: LegacyEffortLevel): DatabaseExec
       assert.match(text, /FROM content\.cards/);
       assert.deepEqual(params, ["workspace-1", ["card-1"]]);
       return createQueryResult([createHotPullCardRow(effortLevel) as unknown as Row]);
+    },
+  };
+}
+
+function createHotPullMediaAssetRow(deletedAt: string | null): MediaAssetRow {
+  const payload = createMediaAssetPayload(deletedAt);
+  return {
+    media_asset_id: payload.mediaAssetId,
+    workspace_id: payload.workspaceId,
+    mime_type: payload.mimeType,
+    size_bytes: payload.sizeBytes,
+    sha256: payload.sha256,
+    storage_key: payload.storageKey,
+    source_url: payload.sourceUrl,
+    created_at: payload.createdAt,
+    client_updated_at: payload.clientUpdatedAt,
+    last_modified_by_replica_id: payload.lastModifiedByReplicaId,
+    last_operation_id: payload.lastOperationId,
+    updated_at: payload.updatedAt,
+    deleted_at: payload.deletedAt,
+  };
+}
+
+function createHotPullMediaAssetExecutor(deletedAt: string | null): DatabaseExecutor {
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      assert.match(text, /FROM content\.media_assets/);
+      assert.deepEqual(params, ["workspace-1", [mediaAssetId]]);
+      return createQueryResult([createHotPullMediaAssetRow(deletedAt) as unknown as Row]);
     },
   };
 }
@@ -364,6 +448,13 @@ function createLegacyCardUpdateExecutor(
         return createQueryResult<Row>([]);
       }
 
+      if (
+        text
+          === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE"
+      ) {
+        return createQueryResult<Row>([{ workspace_id: String(params[0]) } as unknown as Row]);
+      }
+
       if (text.includes("INSERT INTO sync.hot_changes")) {
         return createQueryResult<Row>([{
           change_id: 9,
@@ -409,6 +500,13 @@ function createDeckSnapshotExecutor(): DatabaseExecutor {
 
       if (text.includes("INSERT INTO sync.workspace_sync_metadata")) {
         return createQueryResult<Row>([]);
+      }
+
+      if (
+        text
+          === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE"
+      ) {
+        return createQueryResult<Row>([{ workspace_id: String(params[0]) } as unknown as Row]);
       }
 
       if (text.includes("INSERT INTO sync.hot_changes")) {
@@ -672,6 +770,173 @@ test("parseSyncPushInput accepts deck operations without legacy effortLevels", (
   });
 });
 
+test("parseSyncPushInput accepts media_asset metadata operations", () => {
+  const parsedInput = parseSyncPushInput({
+    installationId: "installation-1",
+    platform: "ios",
+    operations: [
+      {
+        operationId: "operation-media-1",
+        entityType: "media_asset",
+        action: "upsert",
+        entityId: mediaAssetId,
+        clientUpdatedAt: "2026-02-28T09:30:00.000Z",
+        payload: {
+          mediaAssetId,
+          workspaceId: "workspace-1",
+          mimeType: "image/png",
+          sizeBytes: 42,
+          sha256: mediaAssetSha256,
+          storageKey: buildMediaAssetStorageKey("workspace-1", mediaAssetId, mediaAssetSha256),
+          sourceUrl: " https://example.com/source image.png ",
+          createdAt: "2026-02-28T09:00:00.000Z",
+          deletedAt: "2026-02-28T09:30:00.000Z",
+        },
+      },
+    ],
+  });
+
+  const operation = parsedInput.operations[0];
+  if (operation?.entityType !== "media_asset") {
+    assert.fail("Expected the parsed sync operation to remain a media_asset");
+  }
+
+  assert.equal(operation.payload.mediaAssetId, mediaAssetId);
+  assert.equal(operation.payload.sourceUrl, "https://example.com/source%20image.png");
+  assert.equal(operation.payload.deletedAt, "2026-02-28T09:30:00.000Z");
+  assert.equal(Object.prototype.hasOwnProperty.call(operation.payload, "bytes"), false);
+});
+
+test("parseSyncPushInput rejects non-http media_asset source URLs", () => {
+  assert.throws(
+    () => parseSyncPushInput({
+      installationId: "installation-1",
+      platform: "ios",
+      operations: [
+        {
+          operationId: "operation-media-1",
+          entityType: "media_asset",
+          action: "upsert",
+          entityId: mediaAssetId,
+          clientUpdatedAt: "2026-02-28T09:30:00.000Z",
+          payload: {
+            mediaAssetId,
+            workspaceId: "workspace-1",
+            mimeType: "image/png",
+            sizeBytes: 42,
+            sha256: mediaAssetSha256,
+            storageKey: buildMediaAssetStorageKey("workspace-1", mediaAssetId, mediaAssetSha256),
+            sourceUrl: "file:///tmp/source.png",
+            createdAt: "2026-02-28T09:00:00.000Z",
+            deletedAt: null,
+          },
+        },
+      ],
+    }),
+    (error: unknown) => {
+      if (!(error instanceof HttpError)) {
+        assert.fail("Expected parseSyncPushInput to throw HttpError");
+      }
+
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "SYNC_INVALID_INPUT");
+      assert.deepEqual(error.details?.validationIssues, [
+        {
+          path: "operations.0.payload.sourceUrl",
+          code: "custom",
+          message: "sourceUrl must be an absolute HTTP or HTTPS URL",
+        },
+      ]);
+
+      return true;
+    },
+  );
+});
+
+test("parseSyncPullInput accepts media asset opt-in without requiring it", () => {
+  const legacyInput = parseSyncPullInput({
+    installationId: "installation-1",
+    platform: "ios",
+    afterHotChangeId: 0,
+    limit: 100,
+  });
+  const mediaInput = parseSyncPullInput({
+    installationId: "installation-1",
+    platform: "ios",
+    afterHotChangeId: 0,
+    limit: 100,
+    includeMediaAssets: true,
+  });
+
+  assert.equal(legacyInput.includeMediaAssets, undefined);
+  assert.equal(mediaInput.includeMediaAssets, true);
+});
+
+test("parseSyncBootstrapInput accepts media asset opt-in for pull", () => {
+  const input = parseSyncBootstrapInput({
+    mode: "pull",
+    installationId: "installation-1",
+    platform: "ios",
+    cursor: null,
+    limit: 100,
+    includeMediaAssets: true,
+  });
+
+  if (input.mode !== "pull") {
+    assert.fail("Expected parsed bootstrap input to remain pull mode");
+  }
+
+  assert.equal(input.includeMediaAssets, true);
+});
+
+test("parseSyncBootstrapInput accepts media asset opt-in for push with empty entries", () => {
+  const input = parseSyncBootstrapInput({
+    mode: "push",
+    installationId: "installation-1",
+    platform: "ios",
+    includeMediaAssets: true,
+    entries: [],
+  });
+
+  if (input.mode !== "push") {
+    assert.fail("Expected parsed bootstrap input to remain push mode");
+  }
+
+  assert.equal(input.includeMediaAssets, true);
+  assert.deepEqual(input.entries, []);
+});
+
+test("parseSyncBootstrapInput accepts media_asset metadata entries for push", () => {
+  const input = parseSyncBootstrapInput({
+    mode: "push",
+    installationId: "installation-1",
+    platform: "ios",
+    entries: [
+      {
+        entityType: "media_asset",
+        entityId: mediaAssetId,
+        action: "upsert",
+        payload: {
+          ...createMediaAssetPayload(null),
+          lastModifiedByReplicaId: undefined,
+        },
+      },
+    ],
+  });
+
+  if (input.mode !== "push") {
+    assert.fail("Expected parsed bootstrap input to remain push mode");
+  }
+
+  const entry = input.entries[0];
+  if (entry?.entityType !== "media_asset") {
+    assert.fail("Expected parsed bootstrap entry to remain a media_asset");
+  }
+
+  assert.equal(Object.prototype.hasOwnProperty.call(entry.payload, "lastModifiedByReplicaId"), false);
+  assert.equal(entry.payload.mediaAssetId, mediaAssetId);
+});
+
 test("toCardSnapshotInput converts legacy medium and long effort into tags", () => {
   const mediumSnapshot = toCardSnapshotInput({
     ...createCardSnapshotPayload({ dueAt: null }),
@@ -793,6 +1058,18 @@ test("parseBootstrapEntryRow keeps outbound card dueAt as a string or null witho
   assert.equal(Object.prototype.hasOwnProperty.call(entryWithoutDueAt.payload, "dueAtMillis"), false);
 });
 
+test("parseBootstrapEntryRow accepts media_asset metadata tombstones", () => {
+  const entry = parseBootstrapEntryRow(createMediaAssetBootstrapProjectionRow("2026-02-28T09:30:00.000Z"));
+  if (entry.entityType !== "media_asset") {
+    assert.fail("Expected the bootstrap entry to remain a media_asset");
+  }
+
+  assert.equal(entry.entityId, mediaAssetId);
+  assert.equal(entry.payload.mediaAssetId, mediaAssetId);
+  assert.equal(entry.payload.deletedAt, "2026-02-28T09:30:00.000Z");
+  assert.equal(Object.prototype.hasOwnProperty.call(entry.payload, "bytes"), false);
+});
+
 test("buildHotChangesFromRows keeps outbound card effortLevel as fast", async () => {
   const changes = await buildHotChangesFromRows(
     createHotPullCardExecutor("long"),
@@ -814,4 +1091,28 @@ test("buildHotChangesFromRows keeps outbound card effortLevel as fast", async ()
   assert.equal(change.payload.effortLevel, "fast");
   assert.equal(change.payload.cardType, "basic");
   assert.deepEqual(change.payload.metadata, createCardMetadata("2026-02-28T09:00:00.000Z"));
+});
+
+test("buildHotChangesFromRows emits media_asset metadata tombstones", async () => {
+  const changes = await buildHotChangesFromRows(
+    createHotPullMediaAssetExecutor("2026-02-28T09:30:00.000Z"),
+    "workspace-1",
+    [
+      {
+        change_id: 8,
+        entity_type: "media_asset",
+        entity_id: mediaAssetId,
+      },
+    ],
+  );
+
+  const change = changes[0];
+  if (change?.entityType !== "media_asset") {
+    assert.fail("Expected the hot pull entry to remain a media_asset");
+  }
+
+  assert.equal(change.changeId, 8);
+  assert.equal(change.payload.mediaAssetId, mediaAssetId);
+  assert.equal(change.payload.deletedAt, "2026-02-28T09:30:00.000Z");
+  assert.equal(Object.prototype.hasOwnProperty.call(change.payload, "bytes"), false);
 });

--- a/apps/backend/src/sync/contracts/input.ts
+++ b/apps/backend/src/sync/contracts/input.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../shared/errors";
 import { normalizeIsoTimestamp } from "../conflicts/lww";
 import { validateIanaTimeZone } from "../../progress/timeZone";
+import { expectMediaAssetSourceUrl } from "../../mediaAssets/validators";
 
 type Platform = "ios" | "android" | "web";
 
@@ -15,6 +16,8 @@ const reviewRatingSchema = z.union([z.literal(0), z.literal(1), z.literal(2), z.
 const platformSchema = z.enum(["ios", "android", "web"]);
 const isoTimestampStringSchema = z.string().datetime();
 const cardTypeSchema = z.string();
+const mediaAssetMimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i;
+const mediaAssetSha256Pattern = /^[0-9a-f]{64}$/;
 const isoDatePrefixPattern = /^(\d{4})-(\d{2})-(\d{2})T/i;
 const syncIncrementalPullLimit = 500;
 const syncReviewHistoryPullLimit = 500;
@@ -46,6 +49,22 @@ function validateReviewedTimeZone(value: string, refinementContext: z.core.$Refi
       ? "reviewedTimeZone is required when provided"
       : "reviewedTimeZone must be a valid IANA timezone",
   });
+}
+
+function transformMediaAssetSourceUrl(value: string | null, context: z.core.$RefinementCtx): string | null {
+  try {
+    return expectMediaAssetSourceUrl(value, "sourceUrl");
+  } catch (error) {
+    if (error instanceof HttpError) {
+      context.addIssue({
+        code: "custom",
+        message: error.message,
+      });
+      return z.NEVER;
+    }
+
+    throw error;
+  }
 }
 
 type IsoDateParts = Readonly<{
@@ -214,6 +233,25 @@ export const deckPayloadSchema = deckSnapshotSchema.extend({
   updatedAt: z.string().datetime(),
 });
 
+const mediaAssetSnapshotSchema = z.object({
+  mediaAssetId: z.string().min(1),
+  workspaceId: z.string().min(1),
+  mimeType: z.string().regex(mediaAssetMimeTypePattern),
+  sizeBytes: z.number().int().nonnegative(),
+  sha256: z.string().regex(mediaAssetSha256Pattern),
+  storageKey: z.string().min(1),
+  sourceUrl: z.union([z.string(), z.null()]).transform(transformMediaAssetSourceUrl),
+  createdAt: z.string().datetime(),
+  deletedAt: z.string().datetime().nullable(),
+});
+
+export const mediaAssetPayloadSchema = mediaAssetSnapshotSchema.extend({
+  clientUpdatedAt: z.string().datetime(),
+  lastModifiedByReplicaId: z.string().min(1),
+  lastOperationId: z.string().min(1),
+  updatedAt: z.string().datetime(),
+});
+
 const workspaceSchedulerSettingsSnapshotSchema = z.object({
   algorithm: z.literal("fsrs-6"),
   desiredRetention: z.number().gt(0).lt(1),
@@ -263,6 +301,12 @@ const workspaceSchedulerSettingsBootstrapPushPayloadSchema = workspaceSchedulerS
   updatedAt: z.string().datetime(),
 });
 
+const mediaAssetBootstrapPushPayloadSchema = mediaAssetSnapshotSchema.extend({
+  clientUpdatedAt: z.string().datetime(),
+  lastOperationId: z.string().min(1),
+  updatedAt: z.string().datetime(),
+});
+
 const baseOperationSchema = z.object({
   operationId: z.string().min(1),
   entityId: z.string().min(1),
@@ -287,6 +331,12 @@ const workspaceSchedulerSettingsOperationSchema = baseOperationSchema.extend({
   payload: workspaceSchedulerSettingsSnapshotSchema,
 });
 
+const mediaAssetOperationSchema = baseOperationSchema.extend({
+  entityType: z.literal("media_asset"),
+  action: z.literal("upsert"),
+  payload: mediaAssetSnapshotSchema,
+});
+
 const reviewEventOperationSchema = baseOperationSchema.extend({
   entityType: z.literal("review_event"),
   action: z.literal("append"),
@@ -297,6 +347,7 @@ const syncPushOperationSchema = z.discriminatedUnion("entityType", [
   cardOperationSchema,
   deckOperationSchema,
   workspaceSchedulerSettingsOperationSchema,
+  mediaAssetOperationSchema,
   reviewEventOperationSchema,
 ]);
 
@@ -340,6 +391,7 @@ const syncPullInputSchema = z.object({
   appVersion: z.string().min(1).nullable().optional(),
   afterHotChangeId: z.number().int().nonnegative(),
   limit: z.number().int().positive().max(syncIncrementalPullLimit),
+  includeMediaAssets: z.boolean().optional(),
 });
 
 const syncBootstrapPullInputSchema = z.object({
@@ -349,6 +401,7 @@ const syncBootstrapPullInputSchema = z.object({
   appVersion: z.string().min(1).nullable().optional(),
   cursor: z.string().min(1).nullable(),
   limit: z.number().int().positive().max(syncBootstrapPullLimit),
+  includeMediaAssets: z.boolean().optional(),
 });
 
 const syncBootstrapPushInputSchema = z.object({
@@ -356,6 +409,7 @@ const syncBootstrapPushInputSchema = z.object({
   installationId: z.string().min(1),
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
+  includeMediaAssets: z.boolean().optional(),
   entries: z.array(
     z.discriminatedUnion("entityType", [
       z.object({
@@ -375,6 +429,12 @@ const syncBootstrapPushInputSchema = z.object({
         entityId: z.string().min(1),
         action: z.literal("upsert"),
         payload: workspaceSchedulerSettingsBootstrapPushPayloadSchema,
+      }),
+      z.object({
+        entityType: z.literal("media_asset"),
+        entityId: z.string().min(1),
+        action: z.literal("upsert"),
+        payload: mediaAssetBootstrapPushPayloadSchema,
       }),
     ]),
   ),

--- a/apps/backend/src/sync/contracts/snapshots.ts
+++ b/apps/backend/src/sync/contracts/snapshots.ts
@@ -10,6 +10,10 @@ import type {
   DeckSnapshotInput,
 } from "../../decks";
 import type {
+  MediaAssetMutationMetadata,
+  MediaAssetSnapshotInput,
+} from "../../mediaAssets/types";
+import type {
   WorkspaceSchedulerSettingsMutationMetadata,
   WorkspaceSchedulerSettingsSnapshotInput,
 } from "../../scheduling/workspaceSettings";
@@ -33,6 +37,10 @@ type DeckFilterDefinitionPayload = DeckFilterDefinition & Readonly<{
 
 type DeckSnapshotPayload = Omit<DeckSnapshotInput, "filterDefinition"> & Readonly<{
   filterDefinition: DeckFilterDefinitionPayload;
+}>;
+
+type MediaAssetSnapshotPayload = MediaAssetSnapshotInput & Readonly<{
+  workspaceId: string;
 }>;
 
 export function toCardSnapshotInput(payload: CardSnapshotPayload): CardSnapshotInput {
@@ -89,6 +97,19 @@ export function toWorkspaceSchedulerSettingsSnapshotInput(
   };
 }
 
+export function toMediaAssetSnapshotInput(payload: MediaAssetSnapshotPayload): MediaAssetSnapshotInput {
+  return {
+    mediaAssetId: payload.mediaAssetId,
+    mimeType: payload.mimeType,
+    sizeBytes: payload.sizeBytes,
+    sha256: payload.sha256,
+    storageKey: payload.storageKey,
+    sourceUrl: payload.sourceUrl,
+    createdAt: payload.createdAt,
+    deletedAt: payload.deletedAt,
+  };
+}
+
 export function toCardMutationMetadata(input: MutationMetadataInput): CardMutationMetadata {
   return {
     clientUpdatedAt: input.clientUpdatedAt,
@@ -108,6 +129,14 @@ export function toDeckMutationMetadata(input: MutationMetadataInput): DeckMutati
 export function toWorkspaceSchedulerSettingsMutationMetadata(
   input: MutationMetadataInput,
 ): WorkspaceSchedulerSettingsMutationMetadata {
+  return {
+    clientUpdatedAt: input.clientUpdatedAt,
+    lastModifiedByReplicaId: input.lastModifiedByReplicaId,
+    lastOperationId: input.lastOperationId,
+  };
+}
+
+export function toMediaAssetMutationMetadata(input: MutationMetadataInput): MediaAssetMutationMetadata {
   return {
     clientUpdatedAt: input.clientUpdatedAt,
     lastModifiedByReplicaId: input.lastModifiedByReplicaId,

--- a/apps/backend/src/sync/contracts/types.ts
+++ b/apps/backend/src/sync/contracts/types.ts
@@ -3,13 +3,14 @@ import type {
   ReviewEvent,
 } from "../../cards";
 import type { Deck } from "../../decks";
+import type { MediaAsset } from "../../mediaAssets/types";
 import type { WorkspaceSchedulerSettings } from "../../scheduling/workspaceSettings";
 import type { LegacyEffortLevel } from "./legacyEffort";
 
 export type TimestampValue = Date | string;
 
-export type SyncEntityType = "card" | "deck" | "workspace_scheduler_settings" | "review_event";
-export type HotSyncEntityType = "card" | "deck" | "workspace_scheduler_settings";
+export type SyncEntityType = "card" | "deck" | "workspace_scheduler_settings" | "review_event" | "media_asset";
+export type HotSyncEntityType = "card" | "deck" | "workspace_scheduler_settings" | "media_asset";
 export type SyncAction = "upsert" | "append";
 
 export type WorkspaceSchedulerSettingsRow = Readonly<{
@@ -44,6 +45,7 @@ export type RemoteEmptyRow = Readonly<{
   has_cards: boolean;
   has_decks: boolean;
   has_review_events: boolean;
+  has_media_assets: boolean;
 }>;
 
 export type ReviewSequenceRow = Readonly<{
@@ -104,6 +106,12 @@ export type SyncBootstrapEntry =
     entityId: string;
     action: "upsert";
     payload: WorkspaceSchedulerSettings;
+  }>
+  | Readonly<{
+    entityType: "media_asset";
+    entityId: string;
+    action: "upsert";
+    payload: MediaAsset;
   }>;
 
 export type SyncPushOperationResult = Readonly<{

--- a/apps/backend/src/sync/replication/bootstrap.test.ts
+++ b/apps/backend/src/sync/replication/bootstrap.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import {
+  bootstrapPushIncludesMediaAssets,
+  loadRemoteEmptyState,
+} from "./bootstrap";
+import type { RemoteEmptyRow } from "../contracts/types";
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createRemoteEmptyStateExecutor(row: RemoteEmptyRow): DatabaseExecutor {
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      assert.match(text, /FROM content\.media_assets/);
+      assert.deepEqual(params, ["workspace-1"]);
+      return createQueryResult([row as unknown as Row]);
+    },
+  };
+}
+
+test("loadRemoteEmptyState ignores media-only state for clients without media asset visibility", async () => {
+  const remoteIsEmpty = await loadRemoteEmptyState(
+    createRemoteEmptyStateExecutor({
+      has_cards: false,
+      has_decks: false,
+      has_review_events: false,
+      has_media_assets: true,
+    }),
+    "workspace-1",
+    false,
+  );
+
+  assert.equal(remoteIsEmpty, true);
+});
+
+test("loadRemoteEmptyState counts media-only state for media-aware clients", async () => {
+  const remoteIsEmpty = await loadRemoteEmptyState(
+    createRemoteEmptyStateExecutor({
+      has_cards: false,
+      has_decks: false,
+      has_review_events: false,
+      has_media_assets: true,
+    }),
+    "workspace-1",
+    true,
+  );
+
+  assert.equal(remoteIsEmpty, false);
+});
+
+test("bootstrapPushIncludesMediaAssets is true for explicit media-aware bootstrap pushes", () => {
+  assert.equal(bootstrapPushIncludesMediaAssets({
+    includeMediaAssets: true,
+    entries: [],
+  }), true);
+});
+
+test("bootstrapPushIncludesMediaAssets preserves media entry compatibility", () => {
+  assert.equal(bootstrapPushIncludesMediaAssets({
+    entries: [
+      { entityType: "card" },
+      { entityType: "deck" },
+    ],
+  }), false);
+  assert.equal(bootstrapPushIncludesMediaAssets({
+    entries: [
+      { entityType: "media_asset" },
+    ],
+  }), true);
+});
+
+test("bootstrap push media opt-in checks media-only remote state as non-empty", async () => {
+  const remoteIsEmpty = await loadRemoteEmptyState(
+    createRemoteEmptyStateExecutor({
+      has_cards: false,
+      has_decks: false,
+      has_review_events: false,
+      has_media_assets: true,
+    }),
+    "workspace-1",
+    bootstrapPushIncludesMediaAssets({
+      includeMediaAssets: true,
+      entries: [],
+    }),
+  );
+
+  assert.equal(remoteIsEmpty, false);
+});

--- a/apps/backend/src/sync/replication/bootstrap.ts
+++ b/apps/backend/src/sync/replication/bootstrap.ts
@@ -4,6 +4,7 @@ import {
   type DatabaseExecutor,
 } from "../../database";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
+import { upsertMediaAssetSnapshotInExecutor } from "../../mediaAssets";
 import { HttpError } from "../../shared/errors";
 import {
   decodeOpaqueCursor,
@@ -16,7 +17,9 @@ import { applyWorkspaceSchedulerSettingsSnapshotInExecutor } from "../../schedul
 import {
   cardPayloadSchema,
   deckPayloadSchema,
+  mediaAssetPayloadSchema,
   type SyncBootstrapInput,
+  type SyncBootstrapPushEntry,
   workspaceSchedulerSettingsPayloadSchema,
 } from "../contracts/input";
 import {
@@ -24,6 +27,8 @@ import {
   toCardSnapshotInput,
   toDeckMutationMetadata,
   toDeckSnapshotInput,
+  toMediaAssetMutationMetadata,
+  toMediaAssetSnapshotInput,
   toWorkspaceSchedulerSettingsMutationMetadata,
   toWorkspaceSchedulerSettingsSnapshotInput,
 } from "../contracts/snapshots";
@@ -66,16 +71,18 @@ async function loadCurrentMaxHotChangeId(
   return toNumber(row.max_change_id) ?? 0;
 }
 
-async function loadRemoteEmptyState(
+export async function loadRemoteEmptyState(
   executor: DatabaseExecutor,
   workspaceId: string,
+  includeMediaAssets: boolean,
 ): Promise<boolean> {
   const result = await executor.query<RemoteEmptyRow>(
     [
       "SELECT",
       "EXISTS (SELECT 1 FROM content.cards WHERE workspace_id = $1) AS has_cards,",
       "EXISTS (SELECT 1 FROM content.decks WHERE workspace_id = $1) AS has_decks,",
-      "EXISTS (SELECT 1 FROM content.review_events WHERE workspace_id = $1) AS has_review_events",
+      "EXISTS (SELECT 1 FROM content.review_events WHERE workspace_id = $1) AS has_review_events,",
+      "EXISTS (SELECT 1 FROM content.media_assets WHERE workspace_id = $1) AS has_media_assets",
     ].join(" "),
     [workspaceId],
   );
@@ -85,7 +92,10 @@ async function loadRemoteEmptyState(
     throw new Error("Failed to determine remote bootstrap state");
   }
 
-  return row.has_cards === false && row.has_decks === false && row.has_review_events === false;
+  return row.has_cards === false
+    && row.has_decks === false
+    && row.has_review_events === false
+    && (includeMediaAssets === false || row.has_media_assets === false);
 }
 
 export function encodeBootstrapCursor(cursor: SyncBootstrapCursor): string {
@@ -135,12 +145,32 @@ export function parseBootstrapEntryRow(row: BootstrapProjectionRow): SyncBootstr
     };
   }
 
+  if (row.entity_type === "media_asset") {
+    return {
+      entityType: "media_asset",
+      entityId: row.entity_id,
+      action: "upsert",
+      payload: mediaAssetPayloadSchema.parse(row.payload),
+    };
+  }
+
   return {
     entityType: "workspace_scheduler_settings",
     entityId: row.entity_id,
     action: "upsert",
     payload: workspaceSchedulerSettingsPayloadSchema.parse(row.payload),
   };
+}
+
+type BootstrapPushMediaAwarenessInput = Readonly<{
+  includeMediaAssets?: boolean;
+  entries: ReadonlyArray<Pick<SyncBootstrapPushEntry, "entityType">>,
+}>;
+
+export function bootstrapPushIncludesMediaAssets(
+  input: BootstrapPushMediaAwarenessInput,
+): boolean {
+  return input.includeMediaAssets === true || input.entries.some((entry) => entry.entityType === "media_asset");
 }
 
 export async function processSyncBootstrap(
@@ -158,7 +188,11 @@ export async function processSyncBootstrap(
         appVersion: input.appVersion ?? null,
       });
       await ensureWorkspaceSyncMetadataInExecutor(executor, workspaceId);
-      const remoteIsEmpty = await loadRemoteEmptyState(executor, workspaceId);
+      const remoteIsEmpty = await loadRemoteEmptyState(
+        executor,
+        workspaceId,
+        bootstrapPushIncludesMediaAssets(input),
+      );
       if (remoteIsEmpty === false) {
         throw new HttpError(409, "Cloud bootstrap requires an empty remote workspace", "SYNC_BOOTSTRAP_NOT_EMPTY");
       }
@@ -187,6 +221,33 @@ export async function processSyncBootstrap(
               workspaceId,
               toDeckSnapshotInput(entry.payload),
               toDeckMutationMetadata({
+                clientUpdatedAt: entry.payload.clientUpdatedAt,
+                lastModifiedByReplicaId: replicaId,
+                lastOperationId: entry.payload.lastOperationId,
+              }),
+            );
+            appliedEntriesCount += 1;
+            continue;
+          }
+
+          if (entry.entityType === "media_asset") {
+            if (entry.entityId !== entry.payload.mediaAssetId) {
+              throw new HttpError(400, "media_asset entityId must match payload.mediaAssetId", "SYNC_INVALID_INPUT");
+            }
+
+            if (entry.payload.workspaceId !== workspaceId) {
+              throw new HttpError(
+                400,
+                "media_asset payload.workspaceId must match the authenticated workspaceId",
+                "SYNC_INVALID_INPUT",
+              );
+            }
+
+            await upsertMediaAssetSnapshotInExecutor(
+              executor,
+              workspaceId,
+              toMediaAssetSnapshotInput(entry.payload),
+              toMediaAssetMutationMetadata({
                 clientUpdatedAt: entry.payload.clientUpdatedAt,
                 lastModifiedByReplicaId: replicaId,
                 lastOperationId: entry.payload.lastOperationId,
@@ -240,7 +301,7 @@ export async function processSyncBootstrap(
         entityId: "",
       }
       : decodeBootstrapCursor(input.cursor);
-    const remoteIsEmpty = await loadRemoteEmptyState(executor, workspaceId);
+    const remoteIsEmpty = await loadRemoteEmptyState(executor, workspaceId, input.includeMediaAssets === true);
 
     // TODO(old-mobile-cutoff): Remove legacy effort fields during final sync wire-drop cleanup.
     const result = await executor.query<BootstrapProjectionRow>(
@@ -318,6 +379,29 @@ export async function processSyncBootstrap(
         "    ) AS payload",
         "  FROM content.decks AS decks",
         "  WHERE decks.workspace_id = $1",
+        "  UNION ALL",
+        "  SELECT",
+        "    3 AS entity_rank,",
+        "    'media_asset'::text AS entity_type,",
+        "    media_assets.media_asset_id::text AS entity_id,",
+        "    jsonb_build_object(",
+        "      'mediaAssetId', media_assets.media_asset_id::text,",
+        "      'workspaceId', media_assets.workspace_id::text,",
+        "      'mimeType', media_assets.mime_type,",
+        "      'sizeBytes', media_assets.size_bytes,",
+        "      'sha256', media_assets.sha256,",
+        "      'storageKey', media_assets.storage_key,",
+        "      'sourceUrl', media_assets.source_url,",
+        "      'createdAt', to_char(date_trunc('milliseconds', media_assets.created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),",
+        "      'clientUpdatedAt', to_char(date_trunc('milliseconds', media_assets.client_updated_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),",
+        "      'lastModifiedByReplicaId', media_assets.last_modified_by_replica_id::text,",
+        "      'lastOperationId', media_assets.last_operation_id,",
+        "      'updatedAt', to_char(date_trunc('milliseconds', media_assets.updated_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),",
+        "      'deletedAt', CASE WHEN media_assets.deleted_at IS NULL THEN NULL ELSE to_char(date_trunc('milliseconds', media_assets.deleted_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') END",
+        "    ) AS payload",
+        "  FROM content.media_assets AS media_assets",
+        "  WHERE media_assets.workspace_id = $1",
+        "  AND $5::boolean",
         ")",
         "SELECT entity_rank, entity_type, entity_id, payload",
         "FROM bootstrap_entries",
@@ -325,7 +409,7 @@ export async function processSyncBootstrap(
         "ORDER BY entity_rank ASC, entity_id ASC",
         "LIMIT $4",
       ].join(" "),
-      [workspaceId, cursor.entityRank, cursor.entityId, input.limit + 1],
+      [workspaceId, cursor.entityRank, cursor.entityId, input.limit + 1, input.includeMediaAssets === true],
     );
 
     const hasMore = result.rows.length > input.limit;

--- a/apps/backend/src/sync/replication/changes.test.ts
+++ b/apps/backend/src/sync/replication/changes.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import {
+  insertSyncChange,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+} from "./changes";
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+test("lockWorkspaceSyncMetadataForHotChangesInExecutor locks workspace metadata before hot change insert", async () => {
+  const queries: string[] = [];
+  const workspaceId = "11111111-1111-4111-8111-111111111111";
+
+  const executor: DatabaseExecutor = {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      queries.push(text);
+
+      if (text.startsWith("INSERT INTO sync.workspace_sync_metadata")) {
+        assert.deepEqual(params, [workspaceId]);
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        text
+          === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE"
+      ) {
+        assert.deepEqual(params, [workspaceId]);
+        return createQueryResult<Row>([{ workspace_id: workspaceId } as unknown as Row]);
+      }
+
+      if (text.startsWith("INSERT INTO sync.hot_changes")) {
+        assert.deepEqual(params, [
+          workspaceId,
+          "card",
+          "22222222-2222-4222-8222-222222222222",
+          "upsert",
+          "replica-1",
+          "operation-1",
+          "2026-02-28T10:00:00.000Z",
+        ]);
+        return createQueryResult<Row>([{ change_id: 42 } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(
+    executor,
+    workspaceId,
+  );
+  const changeId = await insertSyncChange(
+    executor,
+    workspaceId,
+    hotChangeWriteLock,
+    "card",
+    "22222222-2222-4222-8222-222222222222",
+    "upsert",
+    "replica-1",
+    "operation-1",
+    "2026-02-28T10:00:00.000Z",
+  );
+
+  assert.equal(changeId, 42);
+  assert.deepEqual(queries, [
+    "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING",
+    "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE",
+    "INSERT INTO sync.hot_changes ( workspace_id, entity_type, entity_id, action, replica_id, operation_id, client_updated_at ) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING change_id",
+  ]);
+});

--- a/apps/backend/src/sync/replication/changes.ts
+++ b/apps/backend/src/sync/replication/changes.ts
@@ -1,7 +1,7 @@
 import type { DatabaseExecutor } from "../../database";
 import { normalizeIsoTimestamp } from "../conflicts/lww";
 
-export type SyncEntityType = "card" | "deck" | "workspace_scheduler_settings";
+export type SyncEntityType = "card" | "deck" | "workspace_scheduler_settings" | "media_asset";
 export type SyncChangeAction = "upsert";
 
 type ChangeIdRow = Readonly<{
@@ -10,6 +10,17 @@ type ChangeIdRow = Readonly<{
 
 type WorkspaceSyncMetadataRow = Readonly<{
   min_available_hot_change_id: string | number;
+}>;
+
+type WorkspaceSyncMetadataLockRow = Readonly<{
+  workspace_id: string;
+}>;
+
+const hotChangeWriteLockBrand: unique symbol = Symbol("hotChangeWriteLock");
+
+export type HotChangeWriteLock = Readonly<{
+  workspaceId: string;
+  [hotChangeWriteLockBrand]: true;
 }>;
 
 function toNumber(value: string | number): number {
@@ -35,6 +46,32 @@ export async function ensureWorkspaceSyncMetadataInExecutor(
   );
 }
 
+export async function lockWorkspaceSyncMetadataForHotChangesInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+): Promise<HotChangeWriteLock> {
+  await ensureWorkspaceSyncMetadataInExecutor(executor, workspaceId);
+
+  const result = await executor.query<WorkspaceSyncMetadataLockRow>(
+    [
+      "SELECT workspace_id",
+      "FROM sync.workspace_sync_metadata",
+      "WHERE workspace_id = $1",
+      "FOR UPDATE",
+    ].join(" "),
+    [workspaceId],
+  );
+
+  if (result.rows[0] === undefined) {
+    throw new Error("Workspace sync metadata row is missing");
+  }
+
+  return {
+    workspaceId,
+    [hotChangeWriteLockBrand]: true,
+  };
+}
+
 /**
  * Records one mutable-root winner in the compact hot-state change log. Review
  * history is intentionally excluded from this lane and syncs through its own
@@ -43,6 +80,7 @@ export async function ensureWorkspaceSyncMetadataInExecutor(
 export async function insertSyncChange(
   executor: DatabaseExecutor,
   workspaceId: string,
+  hotChangeWriteLock: HotChangeWriteLock,
   entityType: SyncEntityType,
   entityId: string,
   action: SyncChangeAction,
@@ -50,7 +88,9 @@ export async function insertSyncChange(
   operationId: string,
   clientUpdatedAt: string,
 ): Promise<number> {
-  await ensureWorkspaceSyncMetadataInExecutor(executor, workspaceId);
+  if (hotChangeWriteLock.workspaceId !== workspaceId) {
+    throw new Error("Hot sync change lock does not match workspace");
+  }
 
   const result = await executor.query<ChangeIdRow>(
     [

--- a/apps/backend/src/sync/replication/hotPull.test.ts
+++ b/apps/backend/src/sync/replication/hotPull.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveNextHotChangeId } from "./hotPull";
+
+test("resolveNextHotChangeId advances empty opt-out pulls past invisible media-only tails", () => {
+  assert.equal(resolveNextHotChangeId(7, [], 12, false), 12);
+});
+
+test("resolveNextHotChangeId uses the last visible change without an opt-out hidden tail", () => {
+  assert.equal(resolveNextHotChangeId(7, [{ changeId: 9 }], null, false), 9);
+});
+
+test("resolveNextHotChangeId advances visible opt-out pulls past invisible media tails", () => {
+  assert.equal(resolveNextHotChangeId(7, [{ changeId: 9 }], 12, false), 12);
+});
+
+test("resolveNextHotChangeId does not skip visible pagination for opt-out pulls", () => {
+  assert.equal(resolveNextHotChangeId(7, [{ changeId: 9 }], 12, true), 9);
+});
+
+test("resolveNextHotChangeId does not advance an empty page while visible pagination remains", () => {
+  assert.equal(resolveNextHotChangeId(7, [], 12, true), 7);
+});
+
+test("resolveNextHotChangeId never moves an empty-page cursor backwards", () => {
+  assert.equal(resolveNextHotChangeId(7, [], 0, false), 7);
+});

--- a/apps/backend/src/sync/replication/hotPull.ts
+++ b/apps/backend/src/sync/replication/hotPull.ts
@@ -10,6 +10,14 @@ import type {
   DeckRow,
 } from "../../decks";
 import { mapDeck } from "../../decks";
+import {
+  MEDIA_ASSET_COLUMNS,
+  mapMediaAssetRow,
+} from "../../mediaAssets";
+import type {
+  MediaAsset,
+  MediaAssetRow,
+} from "../../mediaAssets/types";
 import { HttpError } from "../../shared/errors";
 import { ensureWorkspaceReplicaInExecutor } from "../identity/replica";
 import { ensureWorkspaceSyncMetadataInExecutor, loadMinAvailableHotChangeId } from "./changes";
@@ -24,6 +32,13 @@ import type {
   TimestampValue,
   WorkspaceSchedulerSettingsRow,
 } from "../contracts/types";
+
+type HotPullProjectionRow = Readonly<{
+  change_id: string | number | null;
+  entity_type: HotChangeRow["entity_type"] | null;
+  entity_id: string | null;
+  current_max_hot_change_id: string | number | null;
+}>;
 
 function toNumber(value: string | number | null): number | null {
   if (value === null) {
@@ -145,6 +160,77 @@ async function loadDecksByIdsInExecutor(
   return new Map(result.rows.map((row) => [row.deck_id, mapDeck(row)]));
 }
 
+async function loadMediaAssetsByIdsInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  mediaAssetIds: ReadonlyArray<string>,
+): Promise<ReadonlyMap<string, MediaAsset>> {
+  if (mediaAssetIds.length === 0) {
+    return new Map();
+  }
+
+  const result = await executor.query<MediaAssetRow>(
+    [
+      "SELECT",
+      MEDIA_ASSET_COLUMNS,
+      "FROM content.media_assets",
+      "WHERE workspace_id = $1 AND media_asset_id = ANY($2::uuid[])",
+    ].join(" "),
+    [workspaceId, [...mediaAssetIds]],
+  );
+
+  return new Map(result.rows.map((row) => [row.media_asset_id, mapMediaAssetRow(row)]));
+}
+
+export function resolveNextHotChangeId(
+  afterHotChangeId: number,
+  changes: ReadonlyArray<Readonly<{ changeId: number }>>,
+  currentMaxHotChangeId: number | null,
+  hasMore: boolean,
+): number {
+  if (changes.length > 0) {
+    const lastVisibleChangeId = changes[changes.length - 1]?.changeId ?? afterHotChangeId;
+    if (hasMore || currentMaxHotChangeId === null) {
+      return lastVisibleChangeId;
+    }
+
+    return Math.max(lastVisibleChangeId, currentMaxHotChangeId);
+  }
+
+  if (hasMore) {
+    return afterHotChangeId;
+  }
+
+  return currentMaxHotChangeId === null ? afterHotChangeId : Math.max(afterHotChangeId, currentMaxHotChangeId);
+}
+
+function readCurrentMaxHotChangeId(rows: ReadonlyArray<HotPullProjectionRow>): number {
+  const row = rows[0];
+  if (row === undefined) {
+    throw new Error("Failed to load current hot change id");
+  }
+
+  return toNumber(row.current_max_hot_change_id) ?? 0;
+}
+
+function toVisibleHotChangeRows(rows: ReadonlyArray<HotPullProjectionRow>): ReadonlyArray<HotChangeRow> {
+  return rows.flatMap((row) => {
+    if (row.change_id === null && row.entity_type === null && row.entity_id === null) {
+      return [];
+    }
+
+    if (row.change_id === null || row.entity_type === null || row.entity_id === null) {
+      throw new Error("Hot pull projection row must include a complete visible change");
+    }
+
+    return [{
+      change_id: row.change_id,
+      entity_type: row.entity_type,
+      entity_id: row.entity_id,
+    }];
+  });
+}
+
 export async function buildHotChangesFromRows(
   executor: DatabaseExecutor,
   workspaceId: string,
@@ -152,11 +238,13 @@ export async function buildHotChangesFromRows(
 ): Promise<ReadonlyArray<Readonly<SyncBootstrapEntry & { changeId: number }>>> {
   const cardIds = rows.filter((row) => row.entity_type === "card").map((row) => row.entity_id);
   const deckIds = rows.filter((row) => row.entity_type === "deck").map((row) => row.entity_id);
+  const mediaAssetIds = rows.filter((row) => row.entity_type === "media_asset").map((row) => row.entity_id);
   const workspaceSettingsNeeded = rows.some((row) => row.entity_type === "workspace_scheduler_settings");
 
-  const [cardsById, decksById, workspaceSchedulerSettings] = await Promise.all([
+  const [cardsById, decksById, mediaAssetsById, workspaceSchedulerSettings] = await Promise.all([
     loadCardsByIdsInExecutor(executor, workspaceId, cardIds),
     loadDecksByIdsInExecutor(executor, workspaceId, deckIds),
+    loadMediaAssetsByIdsInExecutor(executor, workspaceId, mediaAssetIds),
     workspaceSettingsNeeded ? loadWorkspaceSchedulerSettingsInExecutor(executor, workspaceId) : Promise.resolve(null),
   ]);
 
@@ -193,6 +281,21 @@ export async function buildHotChangesFromRows(
         entityId: row.entity_id,
         action: "upsert" as const,
         payload: toLegacySyncDeckPayload(deck),
+      };
+    }
+
+    if (row.entity_type === "media_asset") {
+      const mediaAsset = mediaAssetsById.get(row.entity_id);
+      if (mediaAsset === undefined) {
+        throw new Error(`Hot sync media asset ${row.entity_id} is missing`);
+      }
+
+      return {
+        changeId,
+        entityType: "media_asset" as const,
+        entityId: row.entity_id,
+        action: "upsert" as const,
+        payload: mediaAsset,
       };
     }
 
@@ -233,29 +336,44 @@ export async function processSyncPull(
       );
     }
 
-    const result = await executor.query<HotChangeRow>(
+    const result = await executor.query<HotPullProjectionRow>(
       [
-        "WITH latest_changes AS (",
+        "WITH current_max AS (",
+        "  SELECT COALESCE(MAX(change_id), 0) AS current_max_hot_change_id",
+        "  FROM sync.hot_changes",
+        "  WHERE workspace_id = $1",
+        "),",
+        "latest_changes AS (",
         "  SELECT DISTINCT ON (entity_type, entity_id)",
         "    change_id, entity_type, entity_id",
         "  FROM sync.hot_changes",
         "  WHERE workspace_id = $1 AND change_id > $2",
+        "  AND ($4::boolean OR entity_type <> 'media_asset')",
         "  ORDER BY entity_type ASC, entity_id ASC, change_id DESC",
+        "),",
+        "visible_page AS (",
+        "  SELECT change_id, entity_type, entity_id",
+        "  FROM latest_changes",
+        "  ORDER BY change_id ASC",
+        "  LIMIT $3",
         ")",
-        "SELECT change_id, entity_type, entity_id",
-        "FROM latest_changes",
-        "ORDER BY change_id ASC",
-        "LIMIT $3",
+        "SELECT visible_page.change_id, visible_page.entity_type, visible_page.entity_id,",
+        "current_max.current_max_hot_change_id",
+        "FROM current_max",
+        "LEFT JOIN visible_page ON TRUE",
+        "ORDER BY visible_page.change_id ASC NULLS LAST",
       ].join(" "),
-      [workspaceId, input.afterHotChangeId, input.limit + 1],
+      [workspaceId, input.afterHotChangeId, input.limit + 1, input.includeMediaAssets === true],
     );
 
-    const hasMore = result.rows.length > input.limit;
-    const visibleRows = hasMore ? result.rows.slice(0, input.limit) : result.rows;
+    const visibleProjectionRows = toVisibleHotChangeRows(result.rows);
+    const hasMore = visibleProjectionRows.length > input.limit;
+    const visibleRows = hasMore ? visibleProjectionRows.slice(0, input.limit) : visibleProjectionRows;
     const changes = await buildHotChangesFromRows(executor, workspaceId, visibleRows);
-    const nextHotChangeId = changes.length === 0
-      ? input.afterHotChangeId
-      : changes[changes.length - 1].changeId;
+    const currentMaxHotChangeId = input.includeMediaAssets !== true && hasMore === false
+      ? readCurrentMaxHotChangeId(result.rows)
+      : null;
+    const nextHotChangeId = resolveNextHotChangeId(input.afterHotChangeId, changes, currentMaxHotChangeId, hasMore);
 
     return {
       changes,

--- a/apps/backend/src/sync/replication/push.ts
+++ b/apps/backend/src/sync/replication/push.ts
@@ -11,6 +11,7 @@ import {
   type DatabaseExecutor,
 } from "../../database";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
+import { upsertMediaAssetSnapshotInExecutor } from "../../mediaAssets";
 import { normalizeIsoTimestamp } from "../conflicts/lww";
 import { ensureWorkspaceReplicaInExecutor } from "../identity/replica";
 import { ensureWorkspaceSyncMetadataInExecutor } from "./changes";
@@ -24,6 +25,8 @@ import {
   toCardSnapshotInput,
   toDeckMutationMetadata,
   toDeckSnapshotInput,
+  toMediaAssetMutationMetadata,
+  toMediaAssetSnapshotInput,
   toWorkspaceSchedulerSettingsMutationMetadata,
   toWorkspaceSchedulerSettingsSnapshotInput,
 } from "../contracts/snapshots";
@@ -167,6 +170,41 @@ export async function processOperationInExecutor(
       workspaceId,
       toWorkspaceSchedulerSettingsSnapshotInput(operation.payload),
       toWorkspaceSchedulerSettingsMutationMetadata({
+        clientUpdatedAt: operation.clientUpdatedAt,
+        lastModifiedByReplicaId: replicaId,
+        lastOperationId: operation.operationId,
+      }),
+    );
+    status = mutation.applied ? "applied" : "ignored";
+    resultingHotChangeId = mutation.changeId;
+  } else if (operation.entityType === "media_asset") {
+    if (operation.entityId !== operation.payload.mediaAssetId) {
+      return {
+        operationId: operation.operationId,
+        entityType: operation.entityType,
+        entityId: operation.entityId,
+        status: "rejected",
+        resultingHotChangeId: null,
+        error: "media_asset entityId must match payload.mediaAssetId",
+      };
+    }
+
+    if (operation.payload.workspaceId !== workspaceId) {
+      return {
+        operationId: operation.operationId,
+        entityType: operation.entityType,
+        entityId: operation.entityId,
+        status: "rejected",
+        resultingHotChangeId: null,
+        error: "media_asset payload.workspaceId must match the authenticated workspaceId",
+      };
+    }
+
+    const mutation = await upsertMediaAssetSnapshotInExecutor(
+      executor,
+      workspaceId,
+      toMediaAssetSnapshotInput(operation.payload),
+      toMediaAssetMutationMetadata({
         clientUpdatedAt: operation.clientUpdatedAt,
         lastModifiedByReplicaId: replicaId,
         lastOperationId: operation.operationId,

--- a/apps/backend/src/workspaces/create.ts
+++ b/apps/backend/src/workspaces/create.ts
@@ -18,7 +18,10 @@ import {
   buildSystemWorkspaceReplicaId,
   ensureBootstrapSystemWorkspaceReplicaInExecutor,
 } from "../sync/identity/replica";
-import { insertSyncChange } from "../sync/replication/changes";
+import {
+  insertSyncChange,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+} from "../sync/replication/changes";
 import {
   createWorkspaceCreateFailedError,
   createWorkspaceInvariantError,
@@ -198,9 +201,11 @@ export async function createWorkspaceInExecutorWithObservationScope(
     }
 
     stage = "seed_scheduler_change";
+    const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
     await insertSyncChange(
       executor,
       workspaceId,
+      hotChangeWriteLock,
       "workspace_scheduler_settings",
       workspaceId,
       "upsert",

--- a/apps/backend/src/workspaces/management.ts
+++ b/apps/backend/src/workspaces/management.ts
@@ -16,6 +16,7 @@ import {
 } from "../observability/sentry";
 import { markBackendExceptionWrapperAsReported } from "../observability/reporting";
 import { ensureSystemWorkspaceReplicaInExecutor } from "../sync/identity/replica";
+import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../sync/replication/changes";
 import { lockWorkspaceAccessLifecycleInExecutor } from "./accessLocks";
 import { createWorkspaceInExecutorWithObservationScope } from "./create";
 import {
@@ -181,6 +182,7 @@ async function resetCardProgressInExecutor(
   replicaId: string,
   cardId: string,
 ): Promise<CardRow> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const clientUpdatedAt = new Date().toISOString();
   const operationId = randomUUID();
 
@@ -203,7 +205,7 @@ async function resetCardProgressInExecutor(
   }
 
   const updatedCard = mapCard(updatedCardRow);
-  await recordCardSyncChange(executor, workspaceId, updatedCard);
+  await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, updatedCard);
   return updatedCardRow;
 }
 

--- a/db/migrations/0081_media_assets_sync_contract.sql
+++ b/db/migrations/0081_media_assets_sync_contract.sql
@@ -1,0 +1,89 @@
+-- Migration status: Current / additive.
+-- Introduces: media asset registry metadata as a hot sync root.
+-- Schemas touched/read explicitly: sync, content.
+
+ALTER TABLE sync.hot_changes
+  DROP CONSTRAINT IF EXISTS hot_changes_entity_type_check;
+
+ALTER TABLE sync.hot_changes
+  ADD CONSTRAINT hot_changes_entity_type_check
+  CHECK (entity_type IN ('card', 'deck', 'workspace_scheduler_settings', 'media_asset'));
+
+ALTER TABLE sync.applied_operations_current
+  DROP CONSTRAINT IF EXISTS applied_operations_current_entity_type_check;
+
+ALTER TABLE sync.applied_operations_current
+  ADD CONSTRAINT applied_operations_current_entity_type_check
+  CHECK (entity_type IN ('card', 'deck', 'workspace_scheduler_settings', 'review_event', 'media_asset'));
+
+CREATE OR REPLACE FUNCTION sync.find_conflicting_workspace_id(
+  target_entity_type TEXT,
+  target_entity_id TEXT
+)
+RETURNS TABLE (
+  workspace_id UUID
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  target_entity_uuid UUID;
+BEGIN
+  IF target_entity_type NOT IN ('card', 'deck', 'review_event', 'media_asset') THEN
+    RAISE EXCEPTION 'Unsupported sync conflict entity type: %', target_entity_type
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  BEGIN
+    target_entity_uuid := target_entity_id::UUID;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'Invalid sync conflict entity id for %: %', target_entity_type, target_entity_id
+        USING ERRCODE = '22P02';
+  END;
+
+  IF target_entity_type = 'card' THEN
+    RETURN QUERY
+    SELECT cards.workspace_id
+    FROM content.cards AS cards
+    WHERE cards.card_id = target_entity_uuid
+    LIMIT 1;
+    RETURN;
+  END IF;
+
+  IF target_entity_type = 'deck' THEN
+    RETURN QUERY
+    SELECT decks.workspace_id
+    FROM content.decks AS decks
+    WHERE decks.deck_id = target_entity_uuid
+    LIMIT 1;
+    RETURN;
+  END IF;
+
+  IF target_entity_type = 'review_event' THEN
+    RETURN QUERY
+    SELECT review_events.workspace_id
+    FROM content.review_events AS review_events
+    WHERE review_events.review_event_id = target_entity_uuid
+    LIMIT 1;
+    RETURN;
+  END IF;
+
+  IF target_entity_type = 'media_asset' THEN
+    RETURN QUERY
+    SELECT media_assets.workspace_id
+    FROM content.media_assets AS media_assets
+    WHERE media_assets.media_asset_id = target_entity_uuid
+    LIMIT 1;
+    RETURN;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION sync.find_conflicting_workspace_id(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION sync.find_conflicting_workspace_id(TEXT, TEXT) TO backend_app;
+
+COMMENT ON FUNCTION sync.find_conflicting_workspace_id(TEXT, TEXT) IS
+  'Returns the owning workspace for one globally keyed sync entity id without depending on caller-visible workspace memberships.';

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,6 +210,7 @@ Implemented sync behavior:
   - `clientUpdatedAt`
   - `lastModifiedByDeviceId`
   - `lastOperationId`
+- Media asset registry metadata and tombstones use the same hot-state sync lane when clients opt into `includeMediaAssets`; bootstrap push also treats `media_asset` entries as media-aware for compatibility. File bytes still move only through the media upload/download URL APIs.
 - Review events are append-only and deduplicated by `(workspace_id, device_id, client_event_id)`.
 - Review events use the normal `POST /v1/workspaces/:workspaceId/sync/push` contract for both live and historical submissions. For `review_event` operations, `clientUpdatedAt` must equal `payload.reviewedAtClient`.
 - Mutable state and review history are synchronized through separate lanes:


### PR DESCRIPTION
## Summary
- Adds sync support for media asset registry metadata and tombstones only; file bytes remain on the upload/download URL APIs.
- Keeps media assets opt-in for pull/bootstrap and adds explicit bootstrap push `includeMediaAssets` capability while preserving media-entry compatibility.
- Serializes hot-change ordering with an early workspace metadata lock token.

## Validation
- `npm run lint --prefix apps/backend`: passed
- `npm run test --prefix apps/backend`: passed, 541 tests
- `npm run lint --prefix api`: passed
- `npm run bundle --prefix api`: passed
- `git --no-pager diff --check`: passed