### PR TITLE
Preserve chat live transport metadata

### DIFF
--- a/apps/web/src/chat/streaming/liveStream.test.ts
+++ b/apps/web/src/chat/streaming/liveStream.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ChatLiveContractError,
+  ChatLiveTransportError,
   consumeChatLiveStream,
   parseChatLiveEvent,
 } from "./liveStream";
@@ -45,6 +46,19 @@ function createLiveStreamResponseWithHeaders(body: string, headers: HeadersInit)
 function createLiveStreamResponse(body: string): Response {
   return createLiveStreamResponseWithHeaders(body, {
     "Content-Type": "text/event-stream",
+  });
+}
+
+function createFailingLiveStreamResponse(streamError: Error, headers: HeadersInit): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      controller.error(streamError);
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers,
   });
 }
 
@@ -112,6 +126,99 @@ describe("parseChatLiveEvent", () => {
 describe("consumeChatLiveStream", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("wraps pre-response fetch failures as transport errors without response metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Network offline"));
+
+    const promise = consumeChatLiveStream({
+      liveStream: {
+        url: "https://chat-live.example.com",
+        authorization: "Live token",
+        expiresAt: Date.now() + 60_000,
+      },
+      sessionId: "session-1",
+      runId: "run-1",
+      afterCursor: null,
+      resumeAttemptId: null,
+      signal: new AbortController().signal,
+      onEvent: vi.fn(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(ChatLiveTransportError);
+    await expect(promise).rejects.toMatchObject({
+      message: "AI live stream transport failed: Network offline",
+      requestId: null,
+      statusCode: null,
+      code: null,
+      originalErrorName: "TypeError",
+    } satisfies Partial<ChatLiveTransportError>);
+  });
+
+  it("wraps post-response body read failures as transport errors with response metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(createFailingLiveStreamResponse(
+      new Error("Stream read failed"),
+      {
+        "Content-Type": "text/event-stream",
+        "X-Request-Id": "live-request-id",
+      },
+    ));
+
+    const promise = consumeChatLiveStream({
+      liveStream: {
+        url: "https://chat-live.example.com",
+        authorization: "Live token",
+        expiresAt: Date.now() + 60_000,
+      },
+      sessionId: "session-1",
+      runId: "run-1",
+      afterCursor: null,
+      resumeAttemptId: null,
+      signal: new AbortController().signal,
+      onEvent: vi.fn(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(ChatLiveTransportError);
+    await expect(promise).rejects.toMatchObject({
+      message: "AI live stream transport failed: Stream read failed",
+      requestId: "live-request-id",
+      statusCode: 200,
+      code: null,
+      originalErrorName: "Error",
+    } satisfies Partial<ChatLiveTransportError>);
+  });
+
+  it("wraps missing response body failures as transport errors with response metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Request-Id": "live-request-id",
+      },
+    }));
+
+    const promise = consumeChatLiveStream({
+      liveStream: {
+        url: "https://chat-live.example.com",
+        authorization: "Live token",
+        expiresAt: Date.now() + 60_000,
+      },
+      sessionId: "session-1",
+      runId: "run-1",
+      afterCursor: null,
+      resumeAttemptId: null,
+      signal: new AbortController().signal,
+      onEvent: vi.fn(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(ChatLiveTransportError);
+    await expect(promise).rejects.toMatchObject({
+      message: "AI live stream transport failed: Successful AI live stream response body is missing.",
+      requestId: "live-request-id",
+      statusCode: 200,
+      code: null,
+      originalErrorName: "Error",
+    } satisfies Partial<ChatLiveTransportError>);
   });
 
   it("fails the stream when an SSE payload is malformed", async () => {

--- a/apps/web/src/chat/streaming/liveStream.ts
+++ b/apps/web/src/chat/streaming/liveStream.ts
@@ -130,6 +130,27 @@ export class ChatLiveHttpError extends Error {
   }
 }
 
+export class ChatLiveTransportError extends Error {
+  readonly requestId: string | null;
+  readonly statusCode: number | null;
+  readonly code: string | null;
+  readonly originalErrorName: string | null;
+
+  constructor(
+    message: string,
+    metadata: ChatLiveErrorMetadata,
+    originalErrorName: string | null,
+    cause: unknown,
+  ) {
+    super(message, { cause });
+    this.name = "ChatLiveTransportError";
+    this.requestId = metadata.requestId;
+    this.statusCode = metadata.statusCode;
+    this.code = metadata.code;
+    this.originalErrorName = originalErrorName;
+  }
+}
+
 function parseJsonObject(value: string): JsonObject | null {
   try {
     const parsed = JSON.parse(value) as unknown;
@@ -155,6 +176,36 @@ function readLivePayloadCode(payload: string): string | null {
 
 function normalizeMetadataString(value: string | null): string | null {
   return value === null || value.trim() === "" ? null : value;
+}
+
+function readThrownStringField(value: unknown, field: "message" | "name"): string | null {
+  if (typeof value !== "object" || value === null || !(field in value)) {
+    return null;
+  }
+
+  const fieldValue = (value as Readonly<Record<"message" | "name", unknown>>)[field];
+  return typeof fieldValue === "string" ? normalizeMetadataString(fieldValue) : null;
+}
+
+function readThrownMessage(value: unknown): string {
+  const message = readThrownStringField(value, "message");
+  if (message !== null) {
+    return message;
+  }
+
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : "Unknown browser transport error";
+}
+
+function normalizeChatLiveTransportError(
+  error: unknown,
+  metadata: ChatLiveErrorMetadata,
+): ChatLiveTransportError {
+  return new ChatLiveTransportError(
+    `AI live stream transport failed: ${readThrownMessage(error)}`,
+    metadata,
+    readThrownStringField(error, "name"),
+    error,
+  );
 }
 
 function enrichChatLiveContractError(
@@ -538,18 +589,28 @@ export async function consumeChatLiveStream(
     headers.set("X-Client-Platform", "web");
     headers.set("X-Client-Version", webAppVersion);
   }
+  const fetchFailureMetadata: ChatLiveErrorMetadata = {
+    requestId: null,
+    statusCode: null,
+    code: null,
+  };
 
-  const response = await fetch(buildLiveStreamUrl(
-    params.liveStream,
-    params.sessionId,
-    params.runId,
-    params.afterCursor,
-  ), {
-    method: "GET",
-    credentials: "omit",
-    headers,
-    signal: params.signal,
-  });
+  let response: Response;
+  try {
+    response = await fetch(buildLiveStreamUrl(
+      params.liveStream,
+      params.sessionId,
+      params.runId,
+      params.afterCursor,
+    ), {
+      method: "GET",
+      credentials: "omit",
+      headers,
+      signal: params.signal,
+    });
+  } catch (error) {
+    throw normalizeChatLiveTransportError(error, fetchFailureMetadata);
+  }
 
   if (response.ok === false) {
     throw buildLiveStreamHttpError(
@@ -559,15 +620,18 @@ export async function consumeChatLiveStream(
     );
   }
 
-  if (response.body === null) {
-    throw new Error("AI live stream response body is missing.");
-  }
-
   const responseMetadata: ChatLiveErrorMetadata = {
     requestId: normalizeMetadataString(response.headers.get("X-Request-Id")),
     statusCode: response.status,
     code: null,
   };
+  if (response.body === null) {
+    throw normalizeChatLiveTransportError(
+      new Error("Successful AI live stream response body is missing."),
+      responseMetadata,
+    );
+  }
+
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -575,12 +639,23 @@ export async function consumeChatLiveStream(
   let currentDataLines: string[] = [];
 
   while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
+    let readResult: ReadableStreamReadResult<Uint8Array>;
+    try {
+      readResult = await reader.read();
+    } catch (error) {
+      throw normalizeChatLiveTransportError(error, responseMetadata);
+    }
+
+    if (readResult.done) {
       break;
     }
 
-    buffer += decoder.decode(value, { stream: true });
+    try {
+      buffer += decoder.decode(readResult.value, { stream: true });
+    } catch (error) {
+      throw normalizeChatLiveTransportError(error, responseMetadata);
+    }
+
     const lines = buffer.split(/\r?\n/);
     buffer = lines.pop() ?? "";
 
@@ -607,7 +682,12 @@ export async function consumeChatLiveStream(
     }
   }
 
-  buffer += decoder.decode();
+  try {
+    buffer += decoder.decode();
+  } catch (error) {
+    throw normalizeChatLiveTransportError(error, responseMetadata);
+  }
+
   if (buffer !== "") {
     const trailingLines = buffer.split(/\r?\n/);
     for (const line of trailingLines) {


### PR DESCRIPTION
## Summary
- add typed ChatLiveTransportError for live SSE transport failures
- preserve request id/status metadata for post-response stream failures
- cover fetch, read, and missing-body transport failures in live stream tests

## Validation
- npm --prefix apps/web exec -- vitest run src/chat/streaming/liveStream.test.ts
- npm --prefix apps/web run build

Fresh review round returned no P0-P4 findings and no split recommendation.