### PR TITLE
Add web media asset sync and rendering

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -54,6 +54,9 @@ export {
   loadProgressSummary,
 } from "./api/endpoints/progress";
 export {
+  loadMediaAssetDownloadUrl,
+} from "./api/endpoints/mediaAssets";
+export {
   bootstrapPullSyncState,
   bootstrapPushSyncState,
   importReviewHistorySync,

--- a/apps/web/src/api/endpoints/mediaAssets.ts
+++ b/apps/web/src/api/endpoints/mediaAssets.ts
@@ -1,0 +1,16 @@
+import { parseMediaAssetDownloadUrlResponse } from "../../apiContracts/mediaAssets";
+import type { MediaAssetDownloadUrlResult } from "../../types";
+import { parseContractResponse } from "../transport/response";
+import {
+  allowAuthRecoveryWithTransientNetworkRetry,
+  requestJson,
+} from "../transport/transport";
+
+export async function loadMediaAssetDownloadUrl(
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<MediaAssetDownloadUrlResult> {
+  return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/media-assets/${mediaAssetId}/download-url`, {
+    method: "GET",
+  }, allowAuthRecoveryWithTransientNetworkRetry), `GET /workspaces/${workspaceId}/media-assets/${mediaAssetId}/download-url`, parseMediaAssetDownloadUrlResponse);
+}

--- a/apps/web/src/api/endpoints/sync.test.ts
+++ b/apps/web/src/api/endpoints/sync.test.ts
@@ -2,9 +2,31 @@
 import { describe, expect, it, vi } from "vitest";
 import "./endpointsTestSupport";
 import { primeSessionCsrfToken } from "../transport/transport";
-import { pullReviewHistorySync } from "./sync";
+import { pullReviewHistorySync, pullSyncChanges } from "./sync";
 
 describe("sync API endpoints", () => {
+  it("opts incremental sync pulls into media asset registry metadata", async () => {
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        changes: [],
+        nextHotChangeId: 42,
+        hasMore: false,
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await pullSyncChanges("workspace-1", "device-1", "web", "1.0.0", 41, 100, true);
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const requestBody = JSON.parse(String(requestInit?.body)) as Readonly<{ includeMediaAssets?: unknown }>;
+    expect(requestBody.includeMediaAssets).toBe(true);
+  });
+
   it("decodes review-history events with optional reviewed timezone", async () => {
     primeSessionCsrfToken("csrf-token-1");
     const reviewEventWithTimeZone = {

--- a/apps/web/src/api/endpoints/sync.ts
+++ b/apps/web/src/api/endpoints/sync.ts
@@ -49,6 +49,7 @@ export async function pullSyncChanges(
   appVersion: string,
   afterHotChangeId: number,
   limit: number,
+  includeMediaAssets: boolean,
 ): Promise<SyncPullResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/pull`, {
     method: "POST",
@@ -58,6 +59,7 @@ export async function pullSyncChanges(
       appVersion,
       afterHotChangeId,
       limit,
+      includeMediaAssets,
     }),
   }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/pull`, parseSyncPullResultResponse);
 }
@@ -69,6 +71,7 @@ export async function bootstrapPullSyncState(
   appVersion: string,
   cursor: string | null,
   limit: number,
+  includeMediaAssets: boolean,
 ): Promise<SyncBootstrapPullResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/bootstrap`, {
     method: "POST",
@@ -79,6 +82,7 @@ export async function bootstrapPullSyncState(
       appVersion,
       cursor,
       limit,
+      includeMediaAssets,
     }),
   }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/bootstrap`, parseSyncBootstrapPullResultResponse);
 }
@@ -89,6 +93,7 @@ export async function bootstrapPushSyncState(
   platform: "web",
   appVersion: string,
   entries: ReadonlyArray<SyncBootstrapEntry>,
+  includeMediaAssets: boolean,
 ): Promise<SyncBootstrapPushResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/bootstrap`, {
     method: "POST",
@@ -98,6 +103,7 @@ export async function bootstrapPushSyncState(
       platform,
       appVersion,
       entries,
+      includeMediaAssets,
     }),
   }, allowAuthRecovery), `POST /workspaces/${workspaceId}/sync/bootstrap`, parseSyncBootstrapPushResultResponse);
 }

--- a/apps/web/src/api/transport/transport.test.ts
+++ b/apps/web/src/api/transport/transport.test.ts
@@ -610,6 +610,7 @@ describe("API transport network retry", () => {
       TEST_APP_VERSION,
       0,
       200,
+      false,
     )).resolves.toEqual({
       changes: [],
       nextHotChangeId: 42,
@@ -649,6 +650,7 @@ describe("API transport network retry", () => {
       TEST_APP_VERSION,
       0,
       200,
+      false,
     )).resolves.toEqual({
       changes: [],
       nextHotChangeId: 42,
@@ -824,6 +826,7 @@ describe("API transport network retry", () => {
       TEST_APP_VERSION,
       0,
       200,
+      false,
     );
     refreshResponse.resolve(new Response(null, { status: 200 }));
 

--- a/apps/web/src/apiContracts/mediaAssets.test.ts
+++ b/apps/web/src/apiContracts/mediaAssets.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { MediaAsset } from "../types";
+import { parseSyncPullResultResponse } from "./sync";
+
+const mediaAssetFixture: MediaAsset = {
+  mediaAssetId: "22222222-2222-4222-8222-222222222222",
+  workspaceId: "11111111-1111-4111-8111-111111111111",
+  mimeType: "image/png",
+  sizeBytes: 42817,
+  sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+  storageKey: "media-assets/workspaces/11111111-1111-4111-8111-111111111111/assets/22222222-2222-4222-8222-222222222222/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+  sourceUrl: null,
+  createdAt: "2026-03-10T09:00:00.000Z",
+  clientUpdatedAt: "2026-03-10T09:00:01.000Z",
+  lastModifiedByReplicaId: "33333333-3333-4333-8333-333333333333",
+  lastOperationId: "operation-1",
+  updatedAt: "2026-03-10T09:00:02.000Z",
+  deletedAt: "2026-03-10T09:30:00.000Z",
+};
+
+describe("media asset API contracts", () => {
+  it("parses media asset hot sync tombstones", () => {
+    const result = parseSyncPullResultResponse({
+      changes: [
+        {
+          changeId: 10,
+          entityType: "media_asset",
+          entityId: mediaAssetFixture.mediaAssetId,
+          action: "upsert",
+          payload: mediaAssetFixture,
+        },
+      ],
+      nextHotChangeId: 10,
+      hasMore: false,
+    }, "POST /sync/pull");
+
+    const change = result.changes[0];
+    expect(change?.entityType).toBe("media_asset");
+    if (change?.entityType !== "media_asset") {
+      throw new Error("Expected sync change to parse as a media asset");
+    }
+
+    expect(change.payload).toEqual(mediaAssetFixture);
+  });
+});

--- a/apps/web/src/apiContracts/mediaAssets.ts
+++ b/apps/web/src/apiContracts/mediaAssets.ts
@@ -1,0 +1,62 @@
+import type {
+  MediaAsset,
+  MediaAssetDownloadUrlResult,
+  PresignedMediaAssetDownload,
+} from "../types";
+import {
+  joinPath,
+  parseLiteral,
+  parseNullableString,
+  parseNumber,
+  parseObject,
+  parseRequiredField,
+  parseString,
+} from "./core";
+
+export function parseMediaAsset(value: unknown, endpoint: string, path: string): MediaAsset {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    mediaAssetId: parseRequiredField(objectValue, "mediaAssetId", endpoint, path, parseString),
+    workspaceId: parseRequiredField(objectValue, "workspaceId", endpoint, path, parseString),
+    mimeType: parseRequiredField(objectValue, "mimeType", endpoint, path, parseString),
+    sizeBytes: parseRequiredField(objectValue, "sizeBytes", endpoint, path, parseNumber),
+    sha256: parseRequiredField(objectValue, "sha256", endpoint, path, parseString),
+    storageKey: parseRequiredField(objectValue, "storageKey", endpoint, path, parseString),
+    sourceUrl: parseRequiredField(objectValue, "sourceUrl", endpoint, path, parseNullableString),
+    createdAt: parseRequiredField(objectValue, "createdAt", endpoint, path, parseString),
+    clientUpdatedAt: parseRequiredField(objectValue, "clientUpdatedAt", endpoint, path, parseString),
+    lastModifiedByReplicaId: parseRequiredField(objectValue, "lastModifiedByReplicaId", endpoint, path, parseString),
+    lastOperationId: parseRequiredField(objectValue, "lastOperationId", endpoint, path, parseString),
+    updatedAt: parseRequiredField(objectValue, "updatedAt", endpoint, path, parseString),
+    deletedAt: parseRequiredField(objectValue, "deletedAt", endpoint, path, parseNullableString),
+  };
+}
+
+function parsePresignedMediaAssetDownload(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): PresignedMediaAssetDownload {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    method: parseLiteral(
+      parseRequiredField(objectValue, "method", endpoint, path, parseString),
+      endpoint,
+      joinPath(path, "method"),
+      "GET",
+    ),
+    url: parseRequiredField(objectValue, "url", endpoint, path, parseString),
+    expiresAt: parseRequiredField(objectValue, "expiresAt", endpoint, path, parseString),
+  };
+}
+
+export function parseMediaAssetDownloadUrlResponse(
+  value: unknown,
+  endpoint: string,
+): MediaAssetDownloadUrlResult {
+  const objectValue = parseObject(value, endpoint, "");
+  return {
+    mediaAsset: parseRequiredField(objectValue, "mediaAsset", endpoint, "", parseMediaAsset),
+    download: parseRequiredField(objectValue, "download", endpoint, "", parsePresignedMediaAssetDownload),
+  };
+}

--- a/apps/web/src/apiContracts/sync.ts
+++ b/apps/web/src/apiContracts/sync.ts
@@ -28,13 +28,14 @@ import {
   parseReviewEvent,
   parseWorkspaceSchedulerSettings,
 } from "./studyData";
+import { parseMediaAsset } from "./mediaAssets";
 
 function parseSyncBootstrapEntityType(
   value: unknown,
   endpoint: string,
   path: string,
-): "card" | "deck" | "workspace_scheduler_settings" {
-  return parseEnum(value, endpoint, path, ["card", "deck", "workspace_scheduler_settings"]);
+): "card" | "deck" | "workspace_scheduler_settings" | "media_asset" {
+  return parseEnum(value, endpoint, path, ["card", "deck", "workspace_scheduler_settings", "media_asset"]);
 }
 
 function parseSyncBootstrapEntry(value: unknown, endpoint: string, path: string): SyncBootstrapEntry {
@@ -62,6 +63,15 @@ function parseSyncBootstrapEntry(value: unknown, endpoint: string, path: string)
       entityId: parseRequiredField(objectValue, "entityId", endpoint, path, parseString),
       action,
       payload: parseRequiredField(objectValue, "payload", endpoint, path, parseDeck),
+    };
+  }
+
+  if (entityType === "media_asset") {
+    return {
+      entityType,
+      entityId: parseRequiredField(objectValue, "entityId", endpoint, path, parseString),
+      action,
+      payload: parseRequiredField(objectValue, "payload", endpoint, path, parseMediaAsset),
     };
   }
 
@@ -105,6 +115,16 @@ function parseSyncChange(value: unknown, endpoint: string, path: string): SyncCh
     };
   }
 
+  if (entityType === "media_asset") {
+    return {
+      changeId,
+      entityType,
+      entityId,
+      action,
+      payload: parseRequiredField(objectValue, "payload", endpoint, path, parseMediaAsset),
+    };
+  }
+
   return {
     changeId,
     entityType,
@@ -120,7 +140,7 @@ function parseSyncPushOperationResults(
   path: string,
 ): ReadonlyArray<Readonly<{
   operationId: string;
-  entityType: "card" | "deck" | "workspace_scheduler_settings" | "review_event";
+  entityType: "card" | "deck" | "workspace_scheduler_settings" | "review_event" | "media_asset";
   entityId: string;
   status: "applied" | "ignored" | "duplicate" | "rejected";
   resultingHotChangeId: number | null;
@@ -135,7 +155,7 @@ function parseSyncPushOperationResult(
   path: string,
 ): Readonly<{
   operationId: string;
-  entityType: "card" | "deck" | "workspace_scheduler_settings" | "review_event";
+  entityType: "card" | "deck" | "workspace_scheduler_settings" | "review_event" | "media_asset";
   entityId: string;
   status: "applied" | "ignored" | "duplicate" | "rejected";
   resultingHotChangeId: number | null;
@@ -156,8 +176,8 @@ function parseSyncPushResultEntityType(
   value: unknown,
   endpoint: string,
   path: string,
-): "card" | "deck" | "workspace_scheduler_settings" | "review_event" {
-  return parseEnum(value, endpoint, path, ["card", "deck", "workspace_scheduler_settings", "review_event"]);
+): "card" | "deck" | "workspace_scheduler_settings" | "review_event" | "media_asset" {
+  return parseEnum(value, endpoint, path, ["card", "deck", "workspace_scheduler_settings", "review_event", "media_asset"]);
 }
 
 function parseSyncPushStatus(

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -42,7 +42,7 @@ vi.mock("../../../api", () => ({
   pushSyncOperations: apiMocks.pushSyncOperationsMock,
 }));
 
-const currentWebSyncDatabaseVersion = 16;
+const currentWebSyncDatabaseVersion = 17;
 
 function createRemoteSyncInput(): WorkspaceRemoteSyncInput {
   return {
@@ -357,6 +357,7 @@ describe("sync lifecycle observation", () => {
       webAppVersion,
       null,
       1000,
+      true,
     );
     expect(apiMocks.pullSyncChangesMock).toHaveBeenCalledWith(
       "workspace-1",
@@ -365,6 +366,7 @@ describe("sync lifecycle observation", () => {
       webAppVersion,
       12,
       500,
+      true,
     );
     expect(apiMocks.pullReviewHistorySyncMock).toHaveBeenCalledWith(
       "workspace-1",

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -252,6 +252,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         webAppVersion,
         bootstrapCursor,
         syncBootstrapPageSize,
+        true,
       );
       const bootstrapPullElapsedMs = Date.now() - bootstrapPullStartedAtMs;
       bootstrapPullDurationMs += bootstrapPullElapsedMs;

--- a/apps/web/src/appData/sync/remote/pullHotChanges.ts
+++ b/apps/web/src/appData/sync/remote/pullHotChanges.ts
@@ -28,6 +28,7 @@ export async function pullHotChanges(input: WorkspaceRemoteSyncInput): Promise<R
       webAppVersion,
       afterHotChangeId,
       syncIncrementalPageSize,
+      true,
     );
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -698,6 +698,14 @@ const arCatalog: TranslationCatalog = {
       reviewQueue: "جارٍ تحميل قائمة انتظار المراجعة...",
       snapshot: "جارٍ عرض لقطة محلية حديثة...",
     },
+    media: {
+      attachmentLabel: "مرفق",
+      audioLabel: "مرفق صوتي",
+      imageAlt: "صورة مُدارة",
+      loading: "جارٍ تحميل الوسائط...",
+      unavailable: "الوسائط غير متاحة",
+      videoLabel: "مرفق فيديو",
+    },
     meta: {
       due: "مستحق {{value}}",
       lapses: "الإخفاقات {{count}}",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -698,6 +698,14 @@ const deCatalog: TranslationCatalog = {
       reviewQueue: "Wiederholungswarteschlange wird geladen...",
       snapshot: "Ein aktueller lokaler Schnappschuss wird angezeigt...",
     },
+    media: {
+      attachmentLabel: "Anhang",
+      audioLabel: "Audioanhang",
+      imageAlt: "Verwaltetes Bild",
+      loading: "Medien werden geladen...",
+      unavailable: "Medien nicht verfügbar",
+      videoLabel: "Videoanhang",
+    },
     meta: {
       due: "Fällig {{value}}",
       lapses: "Fehlversuche {{count}}",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -696,6 +696,14 @@ const enCatalog = {
       reviewQueue: "Loading review queue...",
       snapshot: "Showing a recent local snapshot...",
     },
+    media: {
+      attachmentLabel: "Attachment",
+      audioLabel: "Audio attachment",
+      imageAlt: "Managed image",
+      loading: "Loading media...",
+      unavailable: "Media unavailable",
+      videoLabel: "Video attachment",
+    },
     meta: {
       due: "Due {{value}}",
       lapses: "Lapses {{count}}",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -698,6 +698,14 @@ const esEsCatalog: TranslationCatalog = {
       reviewQueue: "Cargando la cola de repaso...",
       snapshot: "Mostrando una instantánea local reciente...",
     },
+    media: {
+      attachmentLabel: "Adjunto",
+      audioLabel: "Adjunto de audio",
+      imageAlt: "Imagen gestionada",
+      loading: "Cargando archivo multimedia...",
+      unavailable: "Archivo multimedia no disponible",
+      videoLabel: "Adjunto de video",
+    },
     meta: {
       due: "Pendiente {{value}}",
       lapses: "Fallos {{count}}",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -698,6 +698,14 @@ const esMxCatalog: TranslationCatalog = {
       reviewQueue: "Cargando la cola de repaso...",
       snapshot: "Mostrando una instantánea local reciente...",
     },
+    media: {
+      attachmentLabel: "Adjunto",
+      audioLabel: "Adjunto de audio",
+      imageAlt: "Imagen gestionada",
+      loading: "Cargando archivo multimedia...",
+      unavailable: "Archivo multimedia no disponible",
+      videoLabel: "Adjunto de video",
+    },
     meta: {
       due: "Pendiente {{value}}",
       lapses: "Fallos {{count}}",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -698,6 +698,14 @@ const hiCatalog: TranslationCatalog = {
       reviewQueue: "रिव्यू कतार लोड हो रही है...",
       snapshot: "हाल का स्थानीय स्नैपशॉट दिखाया जा रहा है...",
     },
+    media: {
+      attachmentLabel: "अटैचमेंट",
+      audioLabel: "ऑडियो अटैचमेंट",
+      imageAlt: "प्रबंधित छवि",
+      loading: "मीडिया लोड हो रहा है...",
+      unavailable: "मीडिया उपलब्ध नहीं है",
+      videoLabel: "वीडियो अटैचमेंट",
+    },
     meta: {
       due: "बाकी {{value}}",
       lapses: "चूक {{count}}",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -698,6 +698,14 @@ export const jaCatalog = {
       reviewQueue: "復習キューを読み込んでいます...",
       snapshot: "最近のローカルスナップショットを表示しています...",
     },
+    media: {
+      attachmentLabel: "添付ファイル",
+      audioLabel: "音声添付",
+      imageAlt: "管理対象画像",
+      loading: "メディアを読み込み中...",
+      unavailable: "メディアを利用できません",
+      videoLabel: "動画添付",
+    },
     meta: {
       due: "期限 {{value}}",
       lapses: "失敗 {{count}}",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -698,6 +698,14 @@ export const ruCatalog = {
       reviewQueue: "Загрузка очереди повторения...",
       snapshot: "Показываем недавний локальный снимок...",
     },
+    media: {
+      attachmentLabel: "Вложение",
+      audioLabel: "Аудиовложение",
+      imageAlt: "Управляемое изображение",
+      loading: "Загрузка медиа...",
+      unavailable: "Медиа недоступно",
+      videoLabel: "Видеовложение",
+    },
     meta: {
       due: "Срок {{value}}",
       lapses: "Ошибки {{count}}",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -698,6 +698,14 @@ export const zhHansCatalog = {
       reviewQueue: "正在加载复习队列...",
       snapshot: "正在显示最近的本地快照...",
     },
+    media: {
+      attachmentLabel: "附件",
+      audioLabel: "音频附件",
+      imageAlt: "托管图片",
+      loading: "正在加载媒体...",
+      unavailable: "媒体不可用",
+      videoLabel: "视频附件",
+    },
     meta: {
       due: "到期 {{value}}",
       lapses: "失误 {{count}}",

--- a/apps/web/src/localDb/cards/workspace/index.ts
+++ b/apps/web/src/localDb/cards/workspace/index.ts
@@ -18,6 +18,7 @@ import {
 import { putDeckInTransaction } from "../decks";
 import { loadProgressCacheState, markProgressCacheDirtyInTransaction } from "../../progress/progress";
 import { putReviewEventInTransaction } from "../../reviews/reviews";
+import { putMediaAssetInTransaction } from "../../mediaAssets";
 
 type HotSyncStateUpdate = Readonly<{
   lastAppliedHotChangeId: number;
@@ -112,8 +113,8 @@ function putWorkspaceSyncStateInTransaction(
 
 function createHotSyncStoreNames(syncStateUpdate: HotSyncStateUpdate | null): ReadonlyArray<DatabaseStores> {
   return syncStateUpdate === null
-    ? ["cards", "cardTags", "decks", "workspaceSettings"]
-    : ["cards", "cardTags", "decks", "workspaceSettings", "workspaceSyncState"];
+    ? ["cards", "cardTags", "decks", "mediaAssets", "workspaceSettings"]
+    : ["cards", "cardTags", "decks", "mediaAssets", "workspaceSettings", "workspaceSyncState"];
 }
 
 function createReviewSyncStoreNames(): ReadonlyArray<DatabaseStores> {
@@ -189,6 +190,15 @@ export async function applyHotSyncPage(
           }
 
           putDeckInTransaction(transaction, entry.payload);
+          continue;
+        }
+
+        if (entry.entityType === "media_asset") {
+          if (entry.payload.workspaceId !== workspaceId) {
+            throw new Error(`Media asset sync payload workspace mismatch: ${entry.payload.workspaceId}`);
+          }
+
+          putMediaAssetInTransaction(transaction, entry.payload);
           continue;
         }
 

--- a/apps/web/src/localDb/core/core.migrations.test.ts
+++ b/apps/web/src/localDb/core/core.migrations.test.ts
@@ -35,7 +35,7 @@ type LegacyStoredCard = Omit<
 }>;
 
 const webSyncDatabaseName = "flashcards-web-sync";
-const currentWebSyncDatabaseVersion = 16;
+const currentWebSyncDatabaseVersion = 17;
 const legacyNullDueAtBucketMillis = -1;
 const legacyMalformedDueAtBucketMillis = -2;
 
@@ -332,6 +332,23 @@ async function loadCardsStoreIndexNamesForTest(): Promise<ReadonlyArray<string>>
   }
 }
 
+async function loadObjectStoreNamesForTest(): Promise<ReadonlyArray<string>> {
+  const database = await openDatabase();
+  try {
+    const result: Array<string> = [];
+    for (let index = 0; index < database.objectStoreNames.length; index += 1) {
+      const storeName = database.objectStoreNames.item(index);
+      if (storeName === null) {
+        throw new Error(`IndexedDB object store name is missing at position ${index}`);
+      }
+      result.push(storeName);
+    }
+    return result;
+  } finally {
+    database.close();
+  }
+}
+
 describe("localDb core migrations", () => {
   it("adds IndexedDB open metadata and breadcrumb when opening database fails", async () => {
     const sourceError = new DOMException("Open failed", "InvalidStateError");
@@ -422,6 +439,15 @@ describe("localDb core migrations", () => {
       databaseUpgraded: false,
     }));
 
+    await clearWebSyncCache();
+  });
+
+  it("creates the media asset registry metadata store", async () => {
+    await clearWebSyncCache();
+
+    const storeNames = await loadObjectStoreNamesForTest();
+
+    expect(storeNames).toContain("mediaAssets");
     await clearWebSyncCache();
   });
 

--- a/apps/web/src/localDb/core/database.ts
+++ b/apps/web/src/localDb/core/database.ts
@@ -3,6 +3,7 @@ import type {
   CloudSettings,
   Deck,
   LegacyEffortLevel,
+  MediaAsset,
   ReviewEvent,
   SyncPushOperation,
   WorkspaceSchedulerSettings,
@@ -49,6 +50,8 @@ export type WorkspaceSettingsRecord = Readonly<{
   settings: WorkspaceSchedulerSettings;
 }>;
 
+export type StoredMediaAsset = MediaAsset;
+
 export type WorkspaceSyncStateRecord = Readonly<{
   workspaceId: string;
   lastAppliedHotChangeId: number;
@@ -86,6 +89,7 @@ export type DatabaseStores =
   | "cards"
   | "cardTags"
   | "decks"
+  | "mediaAssets"
   | "progressDailyCounts"
   | "reviewEvents"
   | "workspaceSettings"
@@ -104,7 +108,7 @@ export type IndexedDbOpenLifecycleSnapshot = Readonly<{
 }>;
 
 const databaseName = "flashcards-web-sync";
-const databaseVersion = 16;
+const databaseVersion = 17;
 const progressCacheStateKey = "progress_cache_state";
 const deleteDatabaseBlockedWaitMs = 3000;
 const activeDatabaseOperationPromises = new Set<Promise<unknown>>();
@@ -337,6 +341,11 @@ function createCardTagsStore(database: IDBDatabase): void {
 function createDecksStore(database: IDBDatabase): void {
   const decksStore = database.createObjectStore("decks", { keyPath: ["workspaceId", "deckId"] });
   decksStore.createIndex("workspaceId_createdAt_deckId", ["workspaceId", "createdAt", "deckId"], { unique: false });
+}
+
+function createMediaAssetsStore(database: IDBDatabase): void {
+  const mediaAssetsStore = database.createObjectStore("mediaAssets", { keyPath: ["workspaceId", "mediaAssetId"] });
+  mediaAssetsStore.createIndex("workspaceId_updatedAt_mediaAssetId", ["workspaceId", "updatedAt", "mediaAssetId"], { unique: false });
 }
 
 function createReviewEventsStore(database: IDBDatabase): void {
@@ -726,6 +735,12 @@ function upgradeToVersion16(transaction: IDBTransaction): void {
   migrateOutboxCardMetadataOperations(transaction.objectStore("outbox"));
 }
 
+function upgradeToVersion17(database: IDBDatabase): void {
+  if (database.objectStoreNames.contains("mediaAssets") === false) {
+    createMediaAssetsStore(database);
+  }
+}
+
 export function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(databaseName, databaseVersion);
@@ -838,6 +853,9 @@ export function openDatabase(): Promise<IDBDatabase> {
         upgradeToVersion16(transaction);
       }
 
+      if (oldVersion < 17) {
+        upgradeToVersion17(request.result);
+      }
     };
 
     request.onsuccess = () => {

--- a/apps/web/src/localDb/mediaAssets/index.ts
+++ b/apps/web/src/localDb/mediaAssets/index.ts
@@ -1,0 +1,1 @@
+export * from "./mediaAssets";

--- a/apps/web/src/localDb/mediaAssets/mediaAssets.ts
+++ b/apps/web/src/localDb/mediaAssets/mediaAssets.ts
@@ -1,0 +1,62 @@
+import type { MediaAsset } from "../../types";
+import {
+  closeDatabaseAfter,
+  closeDatabaseAfterWrite,
+  describeIndexedDbError,
+  getFromStore,
+  runReadwrite,
+  type StoredMediaAsset,
+} from "../core/database";
+
+function makeWorkspaceKeyRange(workspaceId: string): IDBKeyRange {
+  return IDBKeyRange.bound([workspaceId], [workspaceId, []]);
+}
+
+export function putMediaAssetInTransaction(transaction: IDBTransaction, mediaAsset: MediaAsset): void {
+  transaction.objectStore("mediaAssets").put(mediaAsset satisfies StoredMediaAsset);
+}
+
+export async function putMediaAsset(mediaAsset: MediaAsset): Promise<void> {
+  await closeDatabaseAfterWrite(async (database) => {
+    await runReadwrite(database, ["mediaAssets"], (transaction) => {
+      putMediaAssetInTransaction(transaction, mediaAsset);
+      return null;
+    });
+  });
+}
+
+export async function loadMediaAssetRecord(
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<MediaAsset | null> {
+  const record = await closeDatabaseAfter((database) => getFromStore<StoredMediaAsset>(
+    database,
+    "mediaAssets",
+    [workspaceId, mediaAssetId],
+  ));
+  return record ?? null;
+}
+
+export async function replaceMediaAssets(
+  workspaceId: string,
+  mediaAssets: ReadonlyArray<MediaAsset>,
+): Promise<void> {
+  await closeDatabaseAfterWrite(async (database) => {
+    await runReadwrite(database, ["mediaAssets"], (transaction) => {
+      const mediaAssetsStore = transaction.objectStore("mediaAssets");
+      const deleteMediaAssetsRequest = mediaAssetsStore.delete(makeWorkspaceKeyRange(workspaceId));
+      for (const mediaAsset of mediaAssets) {
+        if (mediaAsset.workspaceId !== workspaceId) {
+          throw new Error(`Media asset workspace mismatch: expected=${workspaceId}, actual=${mediaAsset.workspaceId}`);
+        }
+
+        mediaAssetsStore.put(mediaAsset satisfies StoredMediaAsset);
+      }
+
+      deleteMediaAssetsRequest.onerror = () => {
+        throw describeIndexedDbError("IndexedDB media asset replacement failed", deleteMediaAssetsRequest.error);
+      };
+      return deleteMediaAssetsRequest;
+    });
+  });
+}

--- a/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import ReactDOM from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "../../../i18n";
+import { createStorageMock } from "../../../api/ApiTestSupport";
+import type { MediaAsset } from "../../../types";
+import { ReviewCardSide } from "./ReviewCardSide";
+
+const mediaMocks = vi.hoisted(() => ({
+  loadMediaAssetDownloadUrlMock: vi.fn(),
+  loadMediaAssetRecordMock: vi.fn(),
+}));
+
+vi.mock("../../../api", () => ({
+  loadMediaAssetDownloadUrl: mediaMocks.loadMediaAssetDownloadUrlMock,
+}));
+
+vi.mock("../../../localDb/mediaAssets", () => ({
+  loadMediaAssetRecord: mediaMocks.loadMediaAssetRecordMock,
+}));
+
+function makeMediaAsset(mediaAssetId: string, mimeType: string): MediaAsset {
+  return {
+    mediaAssetId,
+    workspaceId: "workspace-1",
+    mimeType,
+    sizeBytes: 128,
+    sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+    storageKey: `media-assets/workspaces/workspace-1/assets/${mediaAssetId}/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8`,
+    sourceUrl: null,
+    createdAt: "2026-03-10T09:00:00.000Z",
+    clientUpdatedAt: "2026-03-10T09:00:00.000Z",
+    lastModifiedByReplicaId: "device-1",
+    lastOperationId: `operation-${mediaAssetId}`,
+    updatedAt: "2026-03-10T09:00:00.000Z",
+    deletedAt: null,
+  };
+}
+
+function renderReviewCardSide(container: HTMLDivElement, text: string): ReactDOM.Root {
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider>
+        <ReviewCardSide
+          aiButtonAriaLabel={null}
+          contentClassName="review-front"
+          isSpeaking={false}
+          label="Front"
+          localReadVersion={0}
+          onOpenAi={null}
+          onToggleSpeech={() => undefined}
+          showAiButton={false}
+          showSpeechButton={false}
+          speechButtonAriaLabel={null}
+          speechButtonDisabled={false}
+          text={text}
+          workspaceId="workspace-1"
+        />
+      </I18nProvider>,
+    );
+  });
+  return root;
+}
+
+describe("ReviewCardSide managed media rendering", () => {
+  let container: HTMLDivElement;
+  let root: ReactDOM.Root | null;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = null;
+    mediaMocks.loadMediaAssetDownloadUrlMock.mockReset();
+    mediaMocks.loadMediaAssetRecordMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (root !== null) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("renders managed image, audio, video, and generic attachments from fcasset Markdown", async () => {
+    const mediaAssets = new Map<string, MediaAsset>([
+      ["image-asset", makeMediaAsset("image-asset", "image/png")],
+      ["audio-asset", makeMediaAsset("audio-asset", "audio/mpeg")],
+      ["video-asset", makeMediaAsset("video-asset", "video/mp4")],
+      ["file-asset", makeMediaAsset("file-asset", "application/pdf")],
+    ]);
+    mediaMocks.loadMediaAssetRecordMock.mockImplementation(async (_workspaceId: string, mediaAssetId: string): Promise<MediaAsset | null> => {
+      return mediaAssets.get(mediaAssetId) ?? null;
+    });
+    mediaMocks.loadMediaAssetDownloadUrlMock.mockImplementation(async (_workspaceId: string, mediaAssetId: string) => {
+      const mediaAsset = mediaAssets.get(mediaAssetId);
+      if (mediaAsset === undefined) {
+        throw new Error(`Missing test media asset: ${mediaAssetId}`);
+      }
+
+      return {
+        mediaAsset,
+        download: {
+          method: "GET" as const,
+          url: `https://media.example.test/${mediaAssetId}`,
+          expiresAt: "2026-03-10T10:00:00.000Z",
+        },
+      };
+    });
+
+    root = renderReviewCardSide(container, [
+      "![Diagram](fcasset:image-asset)",
+      "[Audio clip](fcasset:audio-asset)",
+      "[Video clip](fcasset:video-asset)",
+      "[Worksheet](fcasset:file-asset)",
+    ].join("\n\n"));
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+      expect(container.querySelector("audio.review-markdown-media-control")).not.toBeNull();
+      expect(container.querySelector("video.review-markdown-media-control")).not.toBeNull();
+      expect(container.querySelector("a.review-markdown-media-attachment")).not.toBeNull();
+    });
+
+    const image = container.querySelector(".review-markdown-media-image");
+    if (!(image instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered");
+    }
+    expect(image.alt).toBe("Diagram");
+    expect(image.src).toBe("https://media.example.test/image-asset");
+    expect(container.querySelector("audio.review-markdown-media-control")?.getAttribute("src")).toBe("https://media.example.test/audio-asset");
+    expect(container.querySelector("video.review-markdown-media-control")?.getAttribute("src")).toBe("https://media.example.test/video-asset");
+    expect(container.querySelector("a.review-markdown-media-attachment")?.getAttribute("href")).toBe("https://media.example.test/file-asset");
+  });
+
+  it("keeps external Markdown images on the normal image path", async () => {
+    root = renderReviewCardSide(container, "![External](https://example.test/image.png)");
+
+    await vi.waitFor(() => {
+      expect(container.querySelector("img.review-markdown-img")).not.toBeNull();
+    });
+
+    expect(mediaMocks.loadMediaAssetRecordMock).not.toHaveBeenCalled();
+    expect(mediaMocks.loadMediaAssetDownloadUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("renders a stable fallback for missing managed media", async () => {
+    mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(null);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => undefined);
+
+    root = renderReviewCardSide(container, "![Missing](fcasset:missing-asset)");
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
+    });
+    expect(mediaMocks.loadMediaAssetDownloadUrlMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/screens/review/components/ReviewCardSide.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.tsx
@@ -1,5 +1,10 @@
 import type { ReactElement } from "react";
 import ReactMarkdown from "react-markdown";
+import {
+  ManagedMediaReference,
+  parseManagedMediaAssetId,
+  reviewMarkdownUrlTransform,
+} from "./ReviewManagedMedia";
 import { classifyReviewContentPresentation } from "./reviewContentPresentation";
 
 const REVIEW_MARKDOWN_FENCE_PATTERN = /^\s{0,3}(`{3,}|~{3,})/;
@@ -18,11 +23,13 @@ export type ReviewCardSideProps = Readonly<{
   showSpeechButton: boolean;
   speechButtonAriaLabel: string | null;
   speechButtonDisabled: boolean;
+  localReadVersion: number;
   surfaceCardId?: string;
   surfaceClassName?: string;
   surfaceFrontText?: string;
   surfaceTestId?: string;
   text: string;
+  workspaceId: string | null;
 }>;
 
 export type ReviewCardSpeechButtonProps = Readonly<{
@@ -95,12 +102,39 @@ export function normalizeReviewMarkdownForWeb(text: string): string {
   return normalizedLines.join("\n");
 }
 
-function ReviewCardMarkdown({ text }: Readonly<{ text: string }>): ReactElement {
+function ReviewCardMarkdown(props: Readonly<{
+  localReadVersion: number;
+  text: string;
+  workspaceId: string | null;
+}>): ReactElement {
+  const {
+    localReadVersion,
+    text,
+    workspaceId,
+  } = props;
   const normalizedText = normalizeReviewMarkdownForWeb(text);
 
   return (
     <ReactMarkdown
+      urlTransform={reviewMarkdownUrlTransform}
       components={{
+        a: ({ children, href, title }) => {
+          const mediaAssetId = parseManagedMediaAssetId(href);
+          if (mediaAssetId !== null) {
+            return (
+              <ManagedMediaReference
+                altText=""
+                localReadVersion={localReadVersion}
+                mediaAssetId={mediaAssetId}
+                workspaceId={workspaceId}
+              >
+                {children}
+              </ManagedMediaReference>
+            );
+          }
+
+          return <a className={reviewMarkdownClassName("a")} href={href} title={title}>{children}</a>;
+        },
         h1: ({ children }) => <h1 className={reviewMarkdownClassName("h1")}>{children}</h1>,
         h2: ({ children }) => <h2 className={reviewMarkdownClassName("h2")}>{children}</h2>,
         h3: ({ children }) => <h3 className={reviewMarkdownClassName("h3")}>{children}</h3>,
@@ -120,6 +154,32 @@ function ReviewCardMarkdown({ text }: Readonly<{ text: string }>): ReactElement 
         th: ({ children }) => <th className={reviewMarkdownClassName("th")}>{children}</th>,
         td: ({ children }) => <td className={reviewMarkdownClassName("td")}>{children}</td>,
         pre: ({ children }) => <pre className={reviewMarkdownClassName("pre")}>{children}</pre>,
+        img: ({ alt, src, title }) => {
+          const mediaAssetId = parseManagedMediaAssetId(src);
+          if (mediaAssetId !== null) {
+            return (
+              <ManagedMediaReference
+                altText={alt ?? ""}
+                localReadVersion={localReadVersion}
+                mediaAssetId={mediaAssetId}
+                workspaceId={workspaceId}
+              >
+                {alt ?? ""}
+              </ManagedMediaReference>
+            );
+          }
+
+          return (
+            <img
+              className="review-markdown-img"
+              src={src}
+              alt={alt ?? ""}
+              title={title}
+              loading="lazy"
+              decoding="async"
+            />
+          );
+        },
         code: ({ children, className }) => (
           <code className={`${reviewMarkdownClassName("code")}${className === undefined ? "" : ` ${className}`}`}>
             {children}
@@ -199,11 +259,13 @@ export function ReviewCardSide(props: ReviewCardSideProps): ReactElement {
     showSpeechButton,
     speechButtonAriaLabel,
     speechButtonDisabled,
+    localReadVersion,
     surfaceCardId,
     surfaceClassName,
     surfaceFrontText,
     surfaceTestId,
     text,
+    workspaceId,
   } = props;
   const presentationMode = classifyReviewContentPresentation(text);
 
@@ -225,7 +287,9 @@ export function ReviewCardSide(props: ReviewCardSideProps): ReactElement {
             ].join(" ")}
             data-presentation-mode={presentationMode}
           >
-            {presentationMode === "markdown" ? <ReviewCardMarkdown text={text} /> : text}
+            {presentationMode === "markdown" ? (
+              <ReviewCardMarkdown localReadVersion={localReadVersion} text={text} workspaceId={workspaceId} />
+            ) : text}
           </div>
         </div>
 

--- a/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
+++ b/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
@@ -1,0 +1,286 @@
+import {
+  useEffect,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { defaultUrlTransform } from "react-markdown";
+import { loadMediaAssetDownloadUrl } from "../../../api";
+import { useI18n } from "../../../i18n";
+import { loadMediaAssetRecord } from "../../../localDb/mediaAssets";
+import type { MediaAsset } from "../../../types";
+
+const FCASSET_URL_PREFIX = "fcasset:";
+
+type ManagedMediaKind = "image" | "audio" | "video" | "attachment";
+type ManagedMediaLoadState =
+  | Readonly<{ status: "loading" }>
+  | Readonly<{ status: "unavailable"; mediaAsset: MediaAsset | null }>
+  | Readonly<{ status: "ready"; mediaAsset: MediaAsset; url: string }>;
+
+export function parseManagedMediaAssetId(url: string | null | undefined): string | null {
+  if (url === null || url === undefined) {
+    return null;
+  }
+
+  const trimmedUrl = url.trim();
+  if (trimmedUrl.toLowerCase().startsWith(FCASSET_URL_PREFIX) === false) {
+    return null;
+  }
+
+  const rawReference = trimmedUrl.slice(FCASSET_URL_PREFIX.length).replace(/^\/+/, "");
+  const mediaAssetId = rawReference.split(/[?#]/, 1)[0]?.trim() ?? "";
+  return mediaAssetId === "" ? null : mediaAssetId;
+}
+
+export function reviewMarkdownUrlTransform(url: string): string {
+  return parseManagedMediaAssetId(url) === null ? defaultUrlTransform(url) : url;
+}
+
+function readErrorName(error: unknown): string {
+  if (error instanceof Error && error.name.trim() !== "") {
+    return error.name;
+  }
+
+  return typeof error;
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim() !== "") {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function warnManagedMediaUnavailable(workspaceId: string, mediaAssetId: string, error: unknown): void {
+  console.warn("Managed media download unavailable", {
+    workspaceId,
+    mediaAssetId,
+    errorName: readErrorName(error),
+    errorMessage: readErrorMessage(error),
+  });
+}
+
+function classifyManagedMediaKind(mimeType: string): ManagedMediaKind {
+  const normalizedMimeType = mimeType.toLowerCase();
+  if (normalizedMimeType.startsWith("image/")) {
+    return "image";
+  }
+
+  if (normalizedMimeType.startsWith("audio/")) {
+    return "audio";
+  }
+
+  if (normalizedMimeType.startsWith("video/")) {
+    return "video";
+  }
+
+  return "attachment";
+}
+
+function resolveManagedMediaLabel(
+  mediaAsset: MediaAsset,
+  explicitLabel: string,
+  fallbackLabel: string,
+): string {
+  const trimmedExplicitLabel = explicitLabel.trim();
+  if (trimmedExplicitLabel !== "") {
+    return trimmedExplicitLabel;
+  }
+
+  if (mediaAsset.sourceUrl !== null) {
+    try {
+      const sourceUrl = new URL(mediaAsset.sourceUrl);
+      const fileName = sourceUrl.pathname.split("/").filter((part) => part !== "").at(-1) ?? "";
+      if (fileName !== "") {
+        return decodeURIComponent(fileName);
+      }
+    } catch {
+      return fallbackLabel;
+    }
+  }
+
+  return fallbackLabel;
+}
+
+function readTextFromReactNode(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(readTextFromReactNode).join("");
+  }
+
+  return "";
+}
+
+function ManagedMediaFallback(props: Readonly<{
+  mediaAssetId: string;
+  message: string;
+}>): ReactElement {
+  const { mediaAssetId, message } = props;
+
+  return (
+    <span
+      className="review-markdown-managed-media review-markdown-media-fallback"
+      data-fcasset-id={mediaAssetId}
+      role="note"
+    >
+      {message}
+    </span>
+  );
+}
+
+export function ManagedMediaReference(props: Readonly<{
+  altText: string;
+  children: ReactNode;
+  localReadVersion: number;
+  mediaAssetId: string;
+  workspaceId: string | null;
+}>): ReactElement {
+  const {
+    altText,
+    children,
+    localReadVersion,
+    mediaAssetId,
+    workspaceId,
+  } = props;
+  const { t } = useI18n();
+  const [loadState, setLoadState] = useState<ManagedMediaLoadState>({ status: "loading" });
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function loadManagedMedia(): Promise<void> {
+      if (workspaceId === null) {
+        setLoadState({ status: "unavailable", mediaAsset: null });
+        return;
+      }
+
+      setLoadState({ status: "loading" });
+      let mediaAsset: MediaAsset | null;
+      try {
+        mediaAsset = await loadMediaAssetRecord(workspaceId, mediaAssetId);
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        warnManagedMediaUnavailable(workspaceId, mediaAssetId, error);
+        setLoadState({ status: "unavailable", mediaAsset: null });
+        return;
+      }
+
+      if (isCancelled) {
+        return;
+      }
+
+      if (mediaAsset === null || mediaAsset.deletedAt !== null) {
+        setLoadState({ status: "unavailable", mediaAsset });
+        return;
+      }
+
+      try {
+        const downloadResult = await loadMediaAssetDownloadUrl(workspaceId, mediaAssetId);
+        if (isCancelled) {
+          return;
+        }
+
+        setLoadState({
+          status: "ready",
+          mediaAsset: downloadResult.mediaAsset,
+          url: downloadResult.download.url,
+        });
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        warnManagedMediaUnavailable(workspaceId, mediaAssetId, error);
+        setLoadState({ status: "unavailable", mediaAsset });
+      }
+    }
+
+    void loadManagedMedia();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [localReadVersion, mediaAssetId, workspaceId]);
+
+  if (loadState.status === "loading") {
+    return (
+      <span
+        className="review-markdown-managed-media review-markdown-media-loading"
+        data-fcasset-id={mediaAssetId}
+        aria-busy="true"
+      >
+        {t("reviewScreen.media.loading")}
+      </span>
+    );
+  }
+
+  if (loadState.status === "unavailable") {
+    return (
+      <ManagedMediaFallback
+        mediaAssetId={mediaAssetId}
+        message={t("reviewScreen.media.unavailable")}
+      />
+    );
+  }
+
+  const mediaKind = classifyManagedMediaKind(loadState.mediaAsset.mimeType);
+  const childrenText = readTextFromReactNode(children);
+  const fallbackLabel = mediaKind === "audio"
+    ? t("reviewScreen.media.audioLabel")
+    : mediaKind === "video"
+      ? t("reviewScreen.media.videoLabel")
+      : mediaKind === "image"
+        ? t("reviewScreen.media.imageAlt")
+        : t("reviewScreen.media.attachmentLabel");
+  const label = resolveManagedMediaLabel(loadState.mediaAsset, childrenText, fallbackLabel);
+
+  if (mediaKind === "image") {
+    return (
+      <img
+        className="review-markdown-media-image"
+        src={loadState.url}
+        alt={altText.trim() === "" ? t("reviewScreen.media.imageAlt") : altText}
+        loading="lazy"
+        decoding="async"
+      />
+    );
+  }
+
+  if (mediaKind === "audio") {
+    return (
+      <span className="review-markdown-managed-media review-markdown-media-audio" data-fcasset-id={mediaAssetId}>
+        <span className="review-markdown-media-label">{label}</span>
+        <audio className="review-markdown-media-control" src={loadState.url} controls preload="metadata" aria-label={label} />
+      </span>
+    );
+  }
+
+  if (mediaKind === "video") {
+    return (
+      <span className="review-markdown-managed-media review-markdown-media-video" data-fcasset-id={mediaAssetId}>
+        <span className="review-markdown-media-label">{label}</span>
+        <video className="review-markdown-media-control" src={loadState.url} controls preload="metadata" aria-label={label} />
+      </span>
+    );
+  }
+
+  return (
+    <a
+      className="review-markdown-managed-media review-markdown-media-attachment"
+      href={loadState.url}
+      target="_blank"
+      rel="noreferrer"
+      data-fcasset-id={mediaAssetId}
+    >
+      {label}
+    </a>
+  );
+}

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -26,6 +26,7 @@ export type ReviewPaneProps = Readonly<{
   isInitialReviewLoad: boolean;
   isSubmitting: boolean;
   lastSubmittedReview: LastSubmittedReview | null;
+  localReadVersion: number;
   loadingReviewCurrentCard: ReviewLoadingSnapshot["currentCard"];
   onAiHandoff: (card: Card) => Promise<boolean>;
   onEditCard: (card: Card) => void;
@@ -41,11 +42,14 @@ export type ReviewPaneProps = Readonly<{
   selectedCard: Card | null;
   selectedFrontSpeakableText: string;
   shouldShowSwitchToAllCardsAction: boolean;
+  workspaceId: string | null;
 }>;
 
 type ReviewLoadingPaneProps = Readonly<{
+  localReadVersion: number;
   loadingReviewCurrentCard: ReviewLoadingSnapshot["currentCard"];
   reviewLoadingSnapshot: ReviewLoadingSnapshot | null;
+  workspaceId: string | null;
 }>;
 
 type ReviewEmptyPaneProps = Readonly<{
@@ -58,6 +62,7 @@ type ReviewActiveCardPaneProps = Readonly<{
   activeSpeechSide: ReviewSpeechSide | null;
   isAnswerVisible: boolean;
   isSubmitting: boolean;
+  localReadVersion: number;
   onAiHandoff: (card: Card) => Promise<boolean>;
   onEditCard: (card: Card) => void;
   onRevealAnswer: () => void;
@@ -68,6 +73,7 @@ type ReviewActiveCardPaneProps = Readonly<{
   selectedBackSpeakableText: string;
   selectedCard: Card;
   selectedFrontSpeakableText: string;
+  workspaceId: string | null;
 }>;
 
 type ReviewRatingButtonColumnProps = Readonly<{
@@ -80,7 +86,12 @@ function handleDisabledSpeechToggle(): void {
 }
 
 function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
-  const { loadingReviewCurrentCard, reviewLoadingSnapshot } = props;
+  const {
+    localReadVersion,
+    loadingReviewCurrentCard,
+    reviewLoadingSnapshot,
+    workspaceId,
+  } = props;
   const { t } = useI18n();
   const frontSideLabel = t("reviewScreen.sides.front");
   const frontSpeechButtonAriaLabel = t("reviewScreen.speakAriaLabel.start", {
@@ -128,10 +139,12 @@ function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
             showSpeechButton={true}
             speechButtonAriaLabel={frontSpeechButtonAriaLabel}
             speechButtonDisabled={true}
+            localReadVersion={localReadVersion}
             surfaceCardId={loadingReviewCurrentCard.cardId}
             surfaceClassName="review-card-surface review-card-surface-front"
             surfaceFrontText={loadingReviewCurrentCard.frontText}
             surfaceTestId="review-current-front-card"
+            workspaceId={workspaceId}
           />
         ) : (
           <div className="review-card-surface review-card-surface-front review-loading-card-surface" aria-hidden="true">
@@ -235,6 +248,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
     activeSpeechSide,
     isAnswerVisible,
     isSubmitting,
+    localReadVersion,
     onAiHandoff,
     onEditCard,
     onRevealAnswer,
@@ -245,6 +259,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
     selectedBackSpeakableText,
     selectedCard,
     selectedFrontSpeakableText,
+    workspaceId,
   } = props;
   const { t, formatDateTime, formatNumber } = useI18n();
   const frontSideLabel = t("reviewScreen.sides.front");
@@ -285,10 +300,12 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
             side: frontSideLabel.toLowerCase(),
           })}
           speechButtonDisabled={false}
+          localReadVersion={localReadVersion}
           surfaceCardId={selectedCard.cardId}
           surfaceClassName="review-card-surface review-card-surface-front"
           surfaceFrontText={selectedCard.frontText}
           surfaceTestId="review-current-front-card"
+          workspaceId={workspaceId}
         />
 
         {isAnswerVisible ? (
@@ -308,7 +325,9 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
               side: backSideLabel.toLowerCase(),
             })}
             speechButtonDisabled={false}
+            localReadVersion={localReadVersion}
             surfaceClassName="review-card-surface review-card-answer"
+            workspaceId={workspaceId}
           />
         ) : null}
       </div>
@@ -364,6 +383,7 @@ export function ReviewPane(props: ReviewPaneProps): ReactElement {
     isInitialReviewLoad,
     isSubmitting,
     lastSubmittedReview,
+    localReadVersion,
     loadingReviewCurrentCard,
     onAiHandoff,
     onEditCard,
@@ -379,6 +399,7 @@ export function ReviewPane(props: ReviewPaneProps): ReactElement {
     selectedCard,
     selectedFrontSpeakableText,
     shouldShowSwitchToAllCardsAction,
+    workspaceId,
   } = props;
   const reviewPaneState = resolveReviewPaneState(isInitialReviewLoad, selectedCard);
   const reviewPaneEmptyReason = resolveReviewPaneEmptyReason(isInitialReviewLoad, selectedCard, hasCards);
@@ -396,8 +417,10 @@ export function ReviewPane(props: ReviewPaneProps): ReactElement {
     >
       {reviewPaneState === "loading" ? (
         <ReviewLoadingPane
+          localReadVersion={localReadVersion}
           loadingReviewCurrentCard={loadingReviewCurrentCard}
           reviewLoadingSnapshot={reviewLoadingSnapshot}
+          workspaceId={workspaceId}
         />
       ) : null}
       {reviewPaneState === "empty" ? (
@@ -412,6 +435,7 @@ export function ReviewPane(props: ReviewPaneProps): ReactElement {
           activeSpeechSide={activeSpeechSide}
           isAnswerVisible={isAnswerVisible}
           isSubmitting={isSubmitting}
+          localReadVersion={localReadVersion}
           onAiHandoff={onAiHandoff}
           onEditCard={onEditCard}
           onRevealAnswer={onRevealAnswer}
@@ -422,6 +446,7 @@ export function ReviewPane(props: ReviewPaneProps): ReactElement {
           selectedBackSpeakableText={selectedBackSpeakableText}
           selectedCard={selectedCard}
           selectedFrontSpeakableText={selectedFrontSpeakableText}
+          workspaceId={workspaceId}
         />
       ) : null}
     </section>

--- a/apps/web/src/screens/review/components/reviewContentPresentation.ts
+++ b/apps/web/src/screens/review/components/reviewContentPresentation.ts
@@ -10,6 +10,7 @@ const markdownBlockquotePattern = /^\s{0,3}>\s+\S/m;
 const markdownUnorderedListPattern = /^\s{0,3}[-*+]\s+\S/m;
 const markdownOrderedListPattern = /^\s{0,3}\d+\.\s+\S/m;
 const markdownFencedCodePattern = /^\s{0,3}(?:```|~~~)/m;
+const markdownLinkOrMediaPattern = /!?\[[^\]]*]\([^)]+\)/;
 const markdownThematicBreakPattern = /^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/m;
 const markdownTableSeparatorPattern = /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$/m;
 const newlinePattern = /[\r\n]/;
@@ -23,6 +24,7 @@ function hasStrongMarkdownCue(text: string): boolean {
     || markdownUnorderedListPattern.test(text)
     || markdownOrderedListPattern.test(text)
     || markdownFencedCodePattern.test(text)
+    || markdownLinkOrMediaPattern.test(text)
     || markdownThematicBreakPattern.test(text)
     || markdownTableSeparatorPattern.test(text);
 }

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -690,6 +690,7 @@ export function useReviewScreenController(
       isInitialReviewLoad,
       isSubmitting,
       lastSubmittedReview,
+      localReadVersion,
       loadingReviewCurrentCard,
       onAiHandoff: handoffCardToAi,
       onEditCard: handleOpenEditor,
@@ -705,6 +706,7 @@ export function useReviewScreenController(
       selectedCard,
       selectedFrontSpeakableText,
       shouldShowSwitchToAllCardsAction,
+      workspaceId: activeWorkspace?.workspaceId ?? null,
     },
     queuePanelProps: {
       isInitialReviewLoad,

--- a/apps/web/src/styles/features/review/review-markdown.css
+++ b/apps/web/src/styles/features/review/review-markdown.css
@@ -35,8 +35,14 @@
 .review-markdown-p,
 .review-markdown-blockquote,
 .review-markdown-pre,
-.review-markdown-table {
+.review-markdown-table,
+.review-markdown-managed-media {
   margin: 0 0 0.75em;
+}
+
+.review-markdown-a {
+  color: var(--accent);
+  overflow-wrap: anywhere;
 }
 
 .review-markdown-ul,
@@ -111,4 +117,67 @@
   padding: 0.45rem 0.6rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   text-align: start;
+}
+
+.review-markdown-img,
+.review-markdown-media-image,
+.review-markdown-media-video {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  max-height: 24rem;
+  border-radius: 8px;
+  background: rgba(7, 7, 10, 0.34);
+}
+
+.review-markdown-managed-media {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.review-markdown-media-audio,
+.review-markdown-media-video {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.review-markdown-media-control {
+  width: 100%;
+  max-width: 100%;
+}
+
+.review-markdown-media-label {
+  color: var(--muted);
+  font-size: 0.9em;
+  overflow-wrap: anywhere;
+}
+
+.review-markdown-media-attachment,
+.review-markdown-media-fallback,
+.review-markdown-media-loading {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.48rem 0.62rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.review-markdown-media-attachment {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.review-markdown-media-attachment:hover {
+  text-decoration: underline;
+}
+
+.review-markdown-media-fallback,
+.review-markdown-media-loading {
+  color: var(--muted);
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -4,5 +4,6 @@ export * from "./types/progress";
 export * from "./types/feedback";
 export * from "./types/agent";
 export * from "./types/chat";
+export * from "./types/mediaAssets";
 export * from "./types/study";
 export * from "./types/sync";

--- a/apps/web/src/types/mediaAssets.ts
+++ b/apps/web/src/types/mediaAssets.ts
@@ -1,0 +1,38 @@
+export type MediaAsset = Readonly<{
+  mediaAssetId: string;
+  workspaceId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageKey: string;
+  sourceUrl: string | null;
+  createdAt: string;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}>;
+
+export type MediaAssetSnapshotPayload = Readonly<{
+  mediaAssetId: string;
+  workspaceId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageKey: string;
+  sourceUrl: string | null;
+  createdAt: string;
+  deletedAt: string | null;
+}>;
+
+export type PresignedMediaAssetDownload = Readonly<{
+  method: "GET";
+  url: string;
+  expiresAt: string;
+}>;
+
+export type MediaAssetDownloadUrlResult = Readonly<{
+  mediaAsset: MediaAsset;
+  download: PresignedMediaAssetDownload;
+}>;

--- a/apps/web/src/types/sync.ts
+++ b/apps/web/src/types/sync.ts
@@ -1,6 +1,7 @@
+import type { MediaAsset, MediaAssetSnapshotPayload } from "./mediaAssets";
 import type { Card, CardMetadata, Deck, FsrsCardState, ReviewEvent, ReviewRating, WorkspaceSchedulerSettings } from "./study";
 
-export type SyncEntityType = "card" | "deck" | "workspace_scheduler_settings" | "review_event";
+export type SyncEntityType = "card" | "deck" | "workspace_scheduler_settings" | "review_event" | "media_asset";
 export type SyncAction = "upsert" | "append";
 export type LegacyEffortLevel = "fast" | "medium" | "long";
 
@@ -69,6 +70,14 @@ export type SyncPushOperation =
   }>
   | Readonly<{
     operationId: string;
+    entityType: "media_asset";
+    entityId: string;
+    action: "upsert";
+    clientUpdatedAt: string;
+    payload: MediaAssetSnapshotPayload;
+  }>
+  | Readonly<{
+    operationId: string;
     entityType: "review_event";
     entityId: string;
     action: "append";
@@ -112,6 +121,12 @@ export type SyncBootstrapEntry =
     entityId: string;
     action: "upsert";
     payload: WorkspaceSchedulerSettings;
+  }>
+  | Readonly<{
+    entityType: "media_asset";
+    entityId: string;
+    action: "upsert";
+    payload: MediaAsset;
   }>;
 
 export type SyncChange = SyncBootstrapEntry & Readonly<{


### PR DESCRIPTION
Adds web media asset registry metadata sync and local IndexedDB storage without storing media bytes.

Includes media-aware bootstrap and incremental sync opt-in, plus read-only `fcasset:` Markdown rendering for image, audio, video, and generic attachments with stable fallbacks.

Validation:
- `npm ci`: passed with Node engine warning only (`apps/web` asks for Node 24.x; environment Node 25.6.1)
- focused Vitest files: passed
- `npm run build`: passed with existing Vite large chunk warning
- `npm run test`: passed, 65 files / 512 tests
- `git --no-pager diff --check`: passed