### PR TITLE
Recover chat live transport errors

### DIFF
--- a/apps/web/src/chat/ChatPanel/tests/ChatPanel.stream-rendering.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/ChatPanel.stream-rendering.test.tsx
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import {
+  ChatLiveContractErrorMock,
+  ChatLiveHttpErrorMock,
+  ChatLiveTransportErrorMock,
   consumeChatLiveStreamMock,
   createChatActiveRun,
   createChatSnapshot,
@@ -14,6 +17,19 @@ const {
   renderChatPanel,
   sendMessage,
 } = setupChatPanelTest();
+
+function createRecoverableTransportError(): InstanceType<typeof ChatLiveTransportErrorMock> {
+  return new ChatLiveTransportErrorMock(
+    "AI live stream transport failed: browser stream interrupted",
+    {
+      requestId: "request-transport-1",
+      statusCode: 200,
+      code: null,
+    },
+    "TypeError",
+    new TypeError("browser stream interrupted"),
+  );
+}
 
 describe("ChatPanel stream rendering", () => {
   it("reconciles a clean unexpected EOF without opening an error dialog", async () => {
@@ -55,6 +71,132 @@ describe("ChatPanel stream rendering", () => {
     expect(getContainer().querySelector('[role="dialog"]')).not.toBeNull();
     expect(getContainer().textContent).toContain("AI live stream ended before the run finished.");
     expect(getContainer().querySelector(".chat-msg-error")).toBeNull();
+  });
+
+  it("recovers a live transport error with a terminal snapshot without opening an error dialog", async () => {
+    getChatSnapshotMock
+      .mockResolvedValueOnce(createChatSnapshot())
+      .mockResolvedValueOnce(createChatSnapshot({
+        sessionId: "session-1",
+        activeRun: null,
+        conversation: {
+          updatedAt: 2,
+          mainContentInvalidationVersion: 0,
+          messages: [{
+            role: "assistant",
+            content: [{ type: "text", text: "Recovered terminal response" }],
+            timestamp: 2,
+            isError: false,
+            isStopped: false,
+          }],
+        },
+      }));
+    consumeChatLiveStreamMock.mockRejectedValueOnce(createRecoverableTransportError());
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+    await flushAsync();
+    await flushAsync();
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(1);
+    expect(getContainer().textContent).toContain("Recovered terminal response");
+    expect(getContainer().querySelector('[role="dialog"]')).toBeNull();
+    expect(getContainer().querySelector(".chat-msg-error")).toBeNull();
+  });
+
+  it("recovers a live transport error with a replacement live stream when the snapshot is still running", async () => {
+    const replacementActiveRun = createChatActiveRun({
+      runId: "run-resumed",
+      live: {
+        cursor: "cursor-resume",
+        stream: {
+          url: "https://chat-live.example.com/resumed",
+          authorization: "Live resumed-token",
+          expiresAt: Date.now() + 60_000,
+        },
+      },
+    });
+    getChatSnapshotMock
+      .mockResolvedValueOnce(createChatSnapshot())
+      .mockResolvedValueOnce(createChatSnapshot({
+        sessionId: "session-1",
+        activeRun: replacementActiveRun,
+      }));
+    consumeChatLiveStreamMock
+      .mockRejectedValueOnce(createRecoverableTransportError())
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+    await flushAsync();
+    await flushAsync();
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(consumeChatLiveStreamMock).toHaveBeenCalledTimes(2);
+    const replacementStreamParams = consumeChatLiveStreamMock.mock.calls[1]?.[0] as Readonly<{
+      runId: string;
+      afterCursor: string | null;
+      resumeAttemptId: number | null;
+    }> | undefined;
+    expect(replacementStreamParams?.runId).toBe("run-resumed");
+    expect(replacementStreamParams?.afterCursor).toBe("cursor-resume");
+    expect(replacementStreamParams?.resumeAttemptId).not.toBeNull();
+    expect(getChatSnapshotMock.mock.calls[1]?.[2]).toEqual({
+      resumeAttemptId: replacementStreamParams?.resumeAttemptId,
+    });
+    expect(getContainer().querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("keeps non-transport live errors on the hard-failure path", async () => {
+    getChatSnapshotMock.mockResolvedValueOnce(createChatSnapshot());
+    consumeChatLiveStreamMock.mockRejectedValueOnce(new TypeError("network changed"));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+    await flushAsync();
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(getContainer().querySelector('[role="dialog"]')).not.toBeNull();
+    expect(getContainer().textContent).toContain("network changed");
+  });
+
+  it.each([
+    [
+      "HTTP",
+      () => new ChatLiveHttpErrorMock(
+        "AI live stream failed with status 503: upstream unavailable",
+        503,
+        "request-http-1",
+        "UPSTREAM_UNAVAILABLE",
+      ),
+    ],
+    [
+      "contract",
+      () => new ChatLiveContractErrorMock(
+        "AI live stream event is invalid: cursor must be a string.",
+        "assistant_delta",
+        "{\"type\":\"assistant_delta\"}",
+      ),
+    ],
+  ])("keeps %s live errors on the hard-failure path", async (_errorKind, createError) => {
+    getChatSnapshotMock.mockResolvedValueOnce(createChatSnapshot());
+    consumeChatLiveStreamMock.mockRejectedValueOnce(createError());
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+    await flushAsync();
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(getContainer().querySelector('[role="dialog"]')).not.toBeNull();
   });
 
   it("ignores duplicate visible visibilitychange events while the live stream is already connected", async () => {

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -18,6 +18,9 @@ const {
   ApiErrorMock,
   AuthRedirectErrorMock,
   ApiContractErrorMock,
+  ChatLiveContractErrorMock,
+  ChatLiveHttpErrorMock,
+  ChatLiveTransportErrorMock,
   addWebBreadcrumbMock,
   captureWebExceptionMock,
   captureWebWarningMock,
@@ -69,6 +72,60 @@ const {
       this.endpoint = endpoint;
       this.fieldPath = fieldPath;
       this.expected = expected;
+    }
+  },
+  ChatLiveContractErrorMock: class ChatLiveContractError extends Error {
+    readonly eventType: string | null;
+    readonly payloadSnippet: string;
+    requestId: string | null;
+    statusCode: number | null;
+    code: string | null;
+
+    constructor(message: string, eventType: string | null, payload: string) {
+      super(message);
+      this.name = "ChatLiveContractError";
+      this.eventType = eventType;
+      this.payloadSnippet = payload.trim().slice(0, 240);
+      this.requestId = null;
+      this.statusCode = null;
+      this.code = null;
+    }
+  },
+  ChatLiveHttpErrorMock: class ChatLiveHttpError extends Error {
+    readonly statusCode: number;
+    readonly requestId: string | null;
+    readonly code: string | null;
+
+    constructor(message: string, statusCode: number, requestId: string | null, code: string | null) {
+      super(message);
+      this.name = "ChatLiveHttpError";
+      this.statusCode = statusCode;
+      this.requestId = requestId;
+      this.code = code;
+    }
+  },
+  ChatLiveTransportErrorMock: class ChatLiveTransportError extends Error {
+    readonly requestId: string | null;
+    readonly statusCode: number | null;
+    readonly code: string | null;
+    readonly originalErrorName: string | null;
+
+    constructor(
+      message: string,
+      metadata: Readonly<{
+        requestId: string | null;
+        statusCode: number | null;
+        code: string | null;
+      }>,
+      originalErrorName: string | null,
+      cause: unknown,
+    ) {
+      super(message, { cause });
+      this.name = "ChatLiveTransportError";
+      this.requestId = metadata.requestId;
+      this.statusCode = metadata.statusCode;
+      this.code = metadata.code;
+      this.originalErrorName = originalErrorName;
     }
   },
   addWebBreadcrumbMock: vi.fn(),
@@ -136,6 +193,9 @@ vi.mock("../../../../localDb/sync/outbox", () => ({
 }));
 
 vi.mock("../../../streaming/liveStream", () => ({
+  ChatLiveContractError: ChatLiveContractErrorMock,
+  ChatLiveHttpError: ChatLiveHttpErrorMock,
+  ChatLiveTransportError: ChatLiveTransportErrorMock,
   consumeChatLiveStream: consumeChatLiveStreamMock,
 }));
 
@@ -224,6 +284,9 @@ export {
   ApiContractErrorMock,
   ApiErrorMock,
   AuthRedirectErrorMock,
+  ChatLiveContractErrorMock,
+  ChatLiveHttpErrorMock,
+  ChatLiveTransportErrorMock,
   addWebBreadcrumbMock,
   captureWebExceptionMock,
   captureWebWarningMock,

--- a/apps/web/src/chat/sessionController/snapshotSync/useLiveSession.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useLiveSession.ts
@@ -3,6 +3,7 @@ import type { ChatLiveStream } from "../../../types";
 import {
   ChatLiveContractError,
   ChatLiveHttpError,
+  ChatLiveTransportError,
   consumeChatLiveStream,
   type ChatLiveEvent,
 } from "../../streaming/liveStream";
@@ -24,6 +25,12 @@ type UseChatLiveSessionParams = Readonly<{
   applyLiveEvent: (event: ChatLiveEvent) => void;
   finalizeInterruptedRun: (message: string) => void;
   onVisibleResumeRequested: () => void;
+  onRecoverableStreamError: (
+    sessionId: string,
+    runId: string,
+    error: ChatLiveTransportError,
+    previousResumeAttemptId: number | null,
+  ) => void;
   onUnexpectedStreamEnd: (sessionId: string, runId: string) => void;
   onLiveAttachConnected: (sessionId: string, runId: string, resumeAttemptId: number | null) => void;
 }>;
@@ -59,15 +66,27 @@ function getCurrentRoute(): string | null {
 }
 
 function getLiveErrorRequestId(error: Error): string | null {
-  return error instanceof ChatLiveContractError || error instanceof ChatLiveHttpError ? error.requestId : null;
+  return error instanceof ChatLiveContractError
+    || error instanceof ChatLiveHttpError
+    || error instanceof ChatLiveTransportError
+    ? error.requestId
+    : null;
 }
 
 function getLiveErrorStatusCode(error: Error): number | null {
-  return error instanceof ChatLiveContractError || error instanceof ChatLiveHttpError ? error.statusCode : null;
+  return error instanceof ChatLiveContractError
+    || error instanceof ChatLiveHttpError
+    || error instanceof ChatLiveTransportError
+    ? error.statusCode
+    : null;
 }
 
 function getLiveErrorCode(error: Error): string | null {
-  return error instanceof ChatLiveContractError || error instanceof ChatLiveHttpError ? error.code : null;
+  return error instanceof ChatLiveContractError
+    || error instanceof ChatLiveHttpError
+    || error instanceof ChatLiveTransportError
+    ? error.code
+    : null;
 }
 
 function buildChatLiveScope(error: Error): WebObservationScope {
@@ -118,6 +137,10 @@ function captureLiveStreamError(
   });
 }
 
+function isRecoverableLiveTransportError(error: unknown): error is ChatLiveTransportError {
+  return error instanceof ChatLiveTransportError && error.statusCode === 200;
+}
+
 /**
  * Owns the browser-side live SSE lifecycle for one visible chat surface.
  * Snapshot loading remains outside this hook. On resume, callers must refresh
@@ -130,6 +153,7 @@ export function useChatLiveSession(
     applyLiveEvent,
     finalizeInterruptedRun,
     onVisibleResumeRequested,
+    onRecoverableStreamError,
     onUnexpectedStreamEnd,
     onLiveAttachConnected,
   } = params;
@@ -139,6 +163,12 @@ export function useChatLiveSession(
   const applyLiveEventRef = useRef<(event: ChatLiveEvent) => void>(applyLiveEvent);
   const finalizeInterruptedRunRef = useRef<(message: string) => void>(finalizeInterruptedRun);
   const onVisibleResumeRequestedRef = useRef<() => void>(onVisibleResumeRequested);
+  const onRecoverableStreamErrorRef = useRef<(
+    sessionId: string,
+    runId: string,
+    error: ChatLiveTransportError,
+    previousResumeAttemptId: number | null,
+  ) => void>(onRecoverableStreamError);
   const onUnexpectedStreamEndRef = useRef<(sessionId: string, runId: string) => void>(onUnexpectedStreamEnd);
   const onLiveAttachConnectedRef = useRef<(sessionId: string, runId: string, resumeAttemptId: number | null) => void>(
     onLiveAttachConnected,
@@ -175,6 +205,10 @@ export function useChatLiveSession(
   useEffect(() => {
     onVisibleResumeRequestedRef.current = onVisibleResumeRequested;
   }, [onVisibleResumeRequested]);
+
+  useEffect(() => {
+    onRecoverableStreamErrorRef.current = onRecoverableStreamError;
+  }, [onRecoverableStreamError]);
 
   useEffect(() => {
     onUnexpectedStreamEndRef.current = onUnexpectedStreamEnd;
@@ -267,6 +301,11 @@ export function useChatLiveSession(
 
       activeLiveConnectionRef.current = null;
       setIsLiveStreamConnected(false);
+      if (isRecoverableLiveTransportError(error)) {
+        onRecoverableStreamErrorRef.current(sessionId, runId, error, resumeAttemptId);
+        return;
+      }
+
       const normalizedError = normalizeCaughtError(error);
       captureLiveStreamError(normalizedError, sessionId, runId, resumeAttemptId);
       finalizeInterruptedRunRef.current(normalizedError.message);

--- a/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
@@ -53,6 +53,7 @@ type UseChatSessionSnapshotSyncParams = Readonly<{
 
 type SnapshotRequestTrigger =
   | "initial_hydration"
+  | "stream_transport_error"
   | "terminal_reconcile"
   | "unexpected_stream_end"
   | "visible_resume";
@@ -427,6 +428,7 @@ export function useChatSessionSnapshotSync(
   const lastSnapshotUpdatedAtRef = useRef<number | null>(initialLastSnapshotUpdatedAt);
   const snapshotRequestVersionRef = useRef<number>(0);
   const visibilityResumePromiseRef = useRef<Promise<void> | null>(null);
+  const streamTransportRecoveryPromiseRef = useRef<Promise<void> | null>(null);
   const activeToolRunPostSyncPromiseRef = useRef<Promise<void> | null>(null);
   const liveCursorRef = useRef<string | null>(null);
   const resumeAttemptCounterRef = useRef<number>(0);
@@ -717,6 +719,59 @@ export function useChatSessionSnapshotSync(
       })();
 
       visibilityResumePromiseRef.current = refreshPromise;
+    },
+    onRecoverableStreamError: (sessionId) => {
+      if (streamTransportRecoveryPromiseRef.current !== null) {
+        return;
+      }
+
+      const resumeAttemptId = nextResumeAttemptId();
+      let recoveryPromise: Promise<void> | null = null;
+      recoveryPromise = (async (): Promise<void> => {
+        try {
+          const snapshot = await loadAndApplySnapshot(
+            sessionId,
+            true,
+            "stream_transport_error",
+            resumeAttemptId,
+          );
+          if (snapshot === null) {
+            return;
+          }
+
+          const snapshotErrorMessage = extractAssistantErrorMessage(snapshot.conversation.messages);
+          if (snapshot.activeRun !== null) {
+            startLiveStream(
+              snapshot.sessionId,
+              snapshot.activeRun.runId,
+              snapshot.activeRun.live.stream,
+              snapshot.activeRun.live.cursor,
+              resumeAttemptId,
+            );
+            return;
+          }
+
+          detachLiveStream(snapshot.sessionId, null);
+          if (snapshotErrorMessage !== null) {
+            dispatch({
+              type: "run_interrupted",
+              message: snapshotErrorMessage,
+            });
+          }
+        } catch (error) {
+          detachLiveStream(null, null);
+          dispatch({
+            type: "run_interrupted",
+            message: `${uiMessages.refreshFailedPrefix} ${toErrorMessage(error, uiMessages.errorFallbacks)}`,
+          });
+        } finally {
+          if (streamTransportRecoveryPromiseRef.current === recoveryPromise) {
+            streamTransportRecoveryPromiseRef.current = null;
+          }
+        }
+      })();
+
+      streamTransportRecoveryPromiseRef.current = recoveryPromise;
     },
     onLiveAttachConnected: () => {
       dispatch({ type: "live_attach_connected" });


### PR DESCRIPTION
## Summary
- route successful-response browser SSE transport failures through snapshot recovery instead of immediate interruption
- resume live streaming from the refreshed server-owned active run and cursor when still running
- add ChatPanel coverage for terminal recovery, replacement stream recovery, and hard-failure paths

## Validation
- Initial requested Vitest run failed because apps/web/node_modules was missing and Vitest could not resolve jsdom.
- npm --prefix apps/web ci succeeded with Node engine warning: package wants Node 24.x, shell has Node 25.6.1.
- npm --prefix apps/web exec -- vitest run src/chat/ChatPanel/tests/ChatPanel.stream-rendering.test.tsx src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx passed: 2 files / 29 tests.
- npm --prefix apps/web run build passed. Vite reports the existing large-chunk warning.
- git --no-pager diff --check passed.
- Fresh review round returned no P0-P4 findings and no split recommendation.