### PR TITLE
Add Android media asset registry sync

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
@@ -8,6 +8,7 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
@@ -229,6 +230,88 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
     }
 
     @Test
+    fun forkWorkspaceIdentityBlocksWhenWorkspaceHasMediaAssets(): Unit = runBlocking {
+        insertSyncContractWorkspaceShell(
+            database = database,
+            workspaceId = syncLocalStoreContractWorkspaceId
+        )
+        database.mediaAssetDao().insertMediaAsset(
+            createMediaAssetEntity(
+                mediaAssetId = "media-1",
+                workspaceId = syncLocalStoreContractWorkspaceId
+            )
+        )
+
+        try {
+            syncLocalStore.forkWorkspaceIdentity(
+                currentLocalWorkspaceId = syncLocalStoreContractWorkspaceId,
+                sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+                destinationWorkspace = CloudWorkspaceSummary(
+                    workspaceId = "workspace-2",
+                    name = "Forked",
+                    createdAtMillis = 2_000L,
+                    isSelected = true
+                )
+            )
+            throw AssertionError("Expected media asset registry rows to block workspace identity fork.")
+        } catch (error: IllegalArgumentException) {
+            assertEquals(
+                "Cannot fork workspace identity from workspace '$syncLocalStoreContractWorkspaceId' to " +
+                    "'workspace-2' because the source workspace has 1 media asset registry row(s). " +
+                    "Android cannot reassign workspace-scoped media storage keys in this sync/storage split.",
+                error.message
+            )
+        }
+
+        assertEquals(syncLocalStoreContractWorkspaceId, database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertNotNull(database.mediaAssetDao().loadMediaAsset(mediaAssetId = "media-1"))
+        assertNull(database.workspaceDao().loadWorkspaceById(workspaceId = "workspace-2"))
+    }
+
+    @Test
+    fun forkWorkspaceIdentityBlocksWhenDestinationWorkspaceHasMediaAssets(): Unit = runBlocking {
+        insertSyncContractWorkspaceShell(
+            database = database,
+            workspaceId = syncLocalStoreContractWorkspaceId
+        )
+        insertSyncContractWorkspaceShell(
+            database = database,
+            workspaceId = "workspace-2"
+        )
+        database.mediaAssetDao().insertMediaAsset(
+            createMediaAssetEntity(
+                mediaAssetId = "media-destination-1",
+                workspaceId = "workspace-2"
+            )
+        )
+
+        try {
+            syncLocalStore.forkWorkspaceIdentity(
+                currentLocalWorkspaceId = syncLocalStoreContractWorkspaceId,
+                sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+                destinationWorkspace = CloudWorkspaceSummary(
+                    workspaceId = "workspace-2",
+                    name = "Forked",
+                    createdAtMillis = 2_000L,
+                    isSelected = true
+                )
+            )
+            throw AssertionError("Expected destination media asset registry rows to block workspace identity fork.")
+        } catch (error: IllegalArgumentException) {
+            assertEquals(
+                "Cannot fork workspace identity from workspace '$syncLocalStoreContractWorkspaceId' to " +
+                    "'workspace-2' because the destination workspace has 1 media asset registry row(s). " +
+                    "Android cannot delete or reassign workspace-scoped media storage keys in this sync/storage split.",
+                error.message
+            )
+        }
+
+        assertNotNull(database.workspaceDao().loadWorkspaceById(workspaceId = syncLocalStoreContractWorkspaceId))
+        assertNotNull(database.workspaceDao().loadWorkspaceById(workspaceId = "workspace-2"))
+        assertNotNull(database.mediaAssetDao().loadMediaAsset(mediaAssetId = "media-destination-1"))
+    }
+
+    @Test
     fun forkWorkspaceIdentityRewritesCurrentLocalShellUsingSourceNamespace(): Unit = runBlocking {
         insertSyncContractWorkspaceShell(
             database = database,
@@ -407,4 +490,26 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             outboxEntries.map { entry -> entry.operation.entityId }.toSet()
         )
     }
+}
+
+private fun createMediaAssetEntity(
+    mediaAssetId: String,
+    workspaceId: String
+): MediaAssetEntity {
+    val sha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+    return MediaAssetEntity(
+        mediaAssetId = mediaAssetId,
+        workspaceId = workspaceId,
+        mimeType = "image/png",
+        sizeBytes = 12L,
+        sha256 = sha256,
+        storageKey = "media-assets/workspaces/$workspaceId/assets/$mediaAssetId/$sha256",
+        sourceUrl = null,
+        createdAtMillis = 1L,
+        clientUpdatedAtMillis = 2L,
+        lastModifiedByReplicaId = "replica-1",
+        lastOperationId = "operation-1",
+        updatedAtMillis = 3L,
+        deletedAtMillis = null
+    )
 }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
@@ -549,6 +549,7 @@ class CloudGuestSessionCoordinatorTest {
 
         assertEquals(0, remoteGateway.completeGuestUpgradeCalls)
         assertEquals(listOf(linkedWorkspace.workspaceId), remoteGateway.bootstrapPullWorkspaceIds)
+        assertEquals(true, remoteGateway.bootstrapPullBodies.single().getBoolean("includeMediaAssets"))
         assertEquals(
             CloudAccountState.LINKED,
             restartedRuntime.cloudPreferencesStore.currentCloudSettings().cloudState

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
@@ -377,6 +377,7 @@ internal class FakeCloudRemoteGateway private constructor(
     val pullBodies = mutableListOf<JSONObject>()
     val pullReviewHistoryBodies = mutableListOf<JSONObject>()
     val bootstrapPullWorkspaceIds = mutableListOf<String>()
+    val bootstrapPullBodies = mutableListOf<JSONObject>()
     val bootstrapPushBodies = mutableListOf<JSONObject>()
     val importReviewHistoryBodies = mutableListOf<JSONObject>()
     val createdWorkspaceId: String = createdWorkspace.workspaceId
@@ -713,6 +714,7 @@ internal class FakeCloudRemoteGateway private constructor(
         }
         syncRequestEvents += "bootstrap_pull"
         bootstrapPullWorkspaceIds += workspaceId
+        bootstrapPullBodies += JSONObject(body.toString())
         return RemoteBootstrapPullResponse(
             entries = emptyList(),
             nextCursor = null,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/LocalSyncRepositoryCloudIdentityFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/LocalSyncRepositoryCloudIdentityFixtures.kt
@@ -18,6 +18,7 @@ internal fun createSyncWorkspaceForkRequiredError(
     val remoteEntityType = when (entityType) {
         SyncEntityType.CARD -> "card"
         SyncEntityType.DECK -> "deck"
+        SyncEntityType.MEDIA_ASSET -> "media_asset"
         SyncEntityType.REVIEW_EVENT -> "review_event"
         SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> "workspace_scheduler_settings"
     }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/LocalCloudAccountRepositoryLinkedWorkspaceTransitionTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/LocalCloudAccountRepositoryLinkedWorkspaceTransitionTest.kt
@@ -121,6 +121,7 @@ class LocalCloudAccountRepositoryLinkedWorkspaceTransitionTest {
         assertEquals(linkedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
         assertNotNull(environment.cloudPreferencesStore.loadCredentials())
         assertEquals(linkedWorkspace.workspaceId, remoteGateway.renameWorkspaceIds.single())
+        assertEquals(true, remoteGateway.bootstrapPullBodies.single().getBoolean("includeMediaAssets"))
         assertEquals("Renamed Linked Workspace", renamedWorkspace.name)
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityFork.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityFork.kt
@@ -153,6 +153,10 @@ internal fun rewriteOutboxEntryForFork(
             entityType = "review_event",
             sourceId = entry.entityId
         )
+
+        SyncEntityType.MEDIA_ASSET -> throw IllegalArgumentException(
+            "Cannot rewrite media_asset outbox entry '${entry.outboxEntryId}' during workspace identity fork."
+        )
     }
     when (entityType) {
         SyncEntityType.CARD -> {
@@ -196,6 +200,10 @@ internal fun rewriteOutboxEntryForFork(
                 )
             )
         }
+
+        SyncEntityType.MEDIA_ASSET -> throw IllegalArgumentException(
+            "Cannot rewrite media_asset outbox entry '${entry.outboxEntryId}' during workspace identity fork."
+        )
     }
     return entry.copy(
         workspaceId = destinationWorkspaceId,
@@ -267,6 +275,7 @@ internal fun rewriteOutboxEntryForWorkspaceForkEntityReId(
         }
 
         SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> Unit
+        SyncEntityType.MEDIA_ASSET -> Unit
     }
 
     return if (changed) {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
@@ -66,7 +66,8 @@ internal class WorkspaceIdentityLocalStore(
                     reviewEventId = entityId
                 )
 
-                SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> throw IllegalArgumentException(
+                SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS,
+                SyncEntityType.MEDIA_ASSET -> throw IllegalArgumentException(
                     "Cannot recover workspace fork conflict for unsupported entity type " +
                         "'${entityType.toRemoteValue()}' in workspace '$workspaceId'."
                 )
@@ -289,6 +290,12 @@ internal class WorkspaceIdentityLocalStore(
         ) {
             "Cannot fork workspace identity because current local workspace '$currentLocalWorkspaceId' does not exist."
         }
+        val mediaAssetCount = database.mediaAssetDao().countMediaAssets(workspaceId = currentLocalWorkspaceId)
+        require(mediaAssetCount == 0) {
+            "Cannot fork workspace identity from workspace '$currentLocalWorkspaceId' to " +
+                "'${destinationWorkspace.workspaceId}' because the source workspace has $mediaAssetCount media asset " +
+                "registry row(s). Android cannot reassign workspace-scoped media storage keys in this sync/storage split."
+        }
         val snapshot = loadWorkspaceForkSnapshot(workspaceId = currentLocalWorkspaceId)
         val forkMappings = buildWorkspaceForkIdMappings(
             sourceWorkspaceId = sourceWorkspaceId,
@@ -298,6 +305,16 @@ internal class WorkspaceIdentityLocalStore(
             reviewLogs = snapshot.reviewLogs
         )
         val destinationMatchesCurrentWorkspace = currentLocalWorkspaceId == destinationWorkspace.workspaceId
+        if (destinationMatchesCurrentWorkspace.not()) {
+            val destinationMediaAssetCount = database.mediaAssetDao()
+                .countMediaAssets(workspaceId = destinationWorkspace.workspaceId)
+            require(destinationMediaAssetCount == 0) {
+                "Cannot fork workspace identity from workspace '$currentLocalWorkspaceId' to " +
+                    "'${destinationWorkspace.workspaceId}' because the destination workspace has " +
+                    "$destinationMediaAssetCount media asset registry row(s). Android cannot delete or reassign " +
+                    "workspace-scoped media storage keys in this sync/storage split."
+            }
+        }
 
         if (destinationMatchesCurrentWorkspace) {
             database.workspaceDao().updateWorkspace(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/sync/CloudSyncRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/sync/CloudSyncRemoteApi.kt
@@ -329,9 +329,10 @@ private fun parseRemoteSyncEntityType(rawValue: String, fieldPath: String): Sync
         "card" -> SyncEntityType.CARD
         "deck" -> SyncEntityType.DECK
         "workspace_scheduler_settings" -> SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS
+        "media_asset" -> SyncEntityType.MEDIA_ASSET
         "review_event" -> SyncEntityType.REVIEW_EVENT
         else -> throw CloudContractMismatchException(
-            "Cloud contract mismatch for $fieldPath: expected one of [card, deck, workspace_scheduler_settings, review_event], got invalid string \"$rawValue\""
+            "Cloud contract mismatch for $fieldPath: expected one of [card, deck, workspace_scheduler_settings, media_asset, review_event], got invalid string \"$rawValue\""
         )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
@@ -876,9 +876,10 @@ private fun parseSyncConflictEntityType(rawValue: String, fieldPath: String): Sy
     return when (rawValue) {
         "card" -> SyncEntityType.CARD
         "deck" -> SyncEntityType.DECK
+        "media_asset" -> SyncEntityType.MEDIA_ASSET
         "review_event" -> SyncEntityType.REVIEW_EVENT
         else -> throw CloudContractMismatchException(
-            "Cloud contract mismatch for $fieldPath: expected one of [card, deck, review_event], got invalid string \"$rawValue\""
+            "Cloud contract mismatch for $fieldPath: expected one of [card, deck, media_asset, review_event], got invalid string \"$rawValue\""
         )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapEntry
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildCardBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildDeckBootstrapEntryJson
+import com.flashcardsopensourceapp.data.local.cloud.wire.buildMediaAssetBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildReviewHistoryImportEventJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildWorkspaceSchedulerSettingsBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.toCardSummary
@@ -49,6 +50,16 @@ internal class SyncBootstrapLocalStore(
                     buildDeckBootstrapEntryJson(
                         deck = deck,
                         lastOperationId = UUID.randomUUID().toString()
+                    )
+                )
+            }
+
+        database.mediaAssetDao().loadMediaAssets(workspaceId = workspaceId)
+            .forEach { mediaAsset ->
+                entries.put(
+                    buildMediaAssetBootstrapEntryJson(
+                        mediaAsset = mediaAsset,
+                        lastOperationId = mediaAsset.lastOperationId
                     )
                 )
             }
@@ -130,7 +141,8 @@ internal fun SyncEntityType.toPendingLocalHotEntityKey(entityId: String): Pendin
     return when (this) {
         SyncEntityType.CARD,
         SyncEntityType.DECK,
-        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> PendingLocalHotEntityKey(
+        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS,
+        SyncEntityType.MEDIA_ASSET -> PendingLocalHotEntityKey(
             entityType = this,
             entityId = entityId
         )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
@@ -5,9 +5,11 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteSyncChange
+import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.cloud.wire.legacyEffortTag
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudDoubleOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudIntOrNull
@@ -23,7 +25,9 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudDouble
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudIsoTimestampMillis
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudLong
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableIsoTimestampMillis
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableString
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudObject
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
 import com.flashcardsopensourceapp.data.local.cloud.wire.toCloudIntList
@@ -67,6 +71,11 @@ internal class SyncHotStateLocalStore(
                 fieldPath = fieldPath
             )
 
+            SyncEntityType.MEDIA_ASSET -> applyRemoteMediaAsset(
+                workspaceId = workspaceId,
+                payload = payload,
+                fieldPath = fieldPath
+            )
             SyncEntityType.REVIEW_EVENT -> error("Hot-state payload unexpectedly contained review event.")
         }
     }
@@ -159,6 +168,39 @@ internal class SyncHotStateLocalStore(
                 maximumIntervalDays = payload.requireCloudInt("maximumIntervalDays", "$fieldPath.maximumIntervalDays"),
                 enableFuzz = payload.requireCloudBoolean("enableFuzz", "$fieldPath.enableFuzz"),
                 updatedAtMillis = payload.requireCloudIsoTimestampMillis("clientUpdatedAt", "$fieldPath.clientUpdatedAt")
+            )
+        )
+    }
+
+    private suspend fun applyRemoteMediaAsset(workspaceId: String, payload: JSONObject, fieldPath: String) {
+        val payloadWorkspaceId = payload.requireCloudString("workspaceId", "$fieldPath.workspaceId")
+        if (payloadWorkspaceId != workspaceId) {
+            throw CloudContractMismatchException(
+                "Cloud contract mismatch for $fieldPath.workspaceId: expected \"$workspaceId\", got \"$payloadWorkspaceId\""
+            )
+        }
+
+        database.mediaAssetDao().insertMediaAsset(
+            mediaAsset = MediaAssetEntity(
+                mediaAssetId = payload.requireCloudString("mediaAssetId", "$fieldPath.mediaAssetId"),
+                workspaceId = payloadWorkspaceId,
+                mimeType = payload.requireCloudString("mimeType", "$fieldPath.mimeType"),
+                sizeBytes = payload.requireCloudLong("sizeBytes", "$fieldPath.sizeBytes"),
+                sha256 = payload.requireCloudString("sha256", "$fieldPath.sha256"),
+                storageKey = payload.requireCloudString("storageKey", "$fieldPath.storageKey"),
+                sourceUrl = payload.requireCloudNullableString("sourceUrl", "$fieldPath.sourceUrl"),
+                createdAtMillis = payload.requireCloudIsoTimestampMillis("createdAt", "$fieldPath.createdAt"),
+                clientUpdatedAtMillis = payload.requireCloudIsoTimestampMillis(
+                    "clientUpdatedAt",
+                    "$fieldPath.clientUpdatedAt"
+                ),
+                lastModifiedByReplicaId = payload.requireCloudString(
+                    "lastModifiedByReplicaId",
+                    "$fieldPath.lastModifiedByReplicaId"
+                ),
+                lastOperationId = payload.requireCloudString("lastOperationId", "$fieldPath.lastOperationId"),
+                updatedAtMillis = payload.requireCloudIsoTimestampMillis("updatedAt", "$fieldPath.updatedAt"),
+                deletedAtMillis = payload.requireCloudNullableIsoTimestampMillis("deletedAt", "$fieldPath.deletedAt")
             )
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
@@ -3,6 +3,7 @@ package com.flashcardsopensourceapp.data.local.cloud.wire
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardWithRelations
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
@@ -15,6 +16,7 @@ import com.flashcardsopensourceapp.data.local.model.cards.DeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.sync.DeckSyncPayload
 import com.flashcardsopensourceapp.data.local.model.cards.buildCardMetadataJsonObject
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
+import com.flashcardsopensourceapp.data.local.model.sync.MediaAssetSyncPayload
 import com.flashcardsopensourceapp.data.local.model.sync.ReviewEventSyncPayload
 import com.flashcardsopensourceapp.data.local.model.sync.SyncAction
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
@@ -104,6 +106,19 @@ internal fun buildReviewEventOutboxPayloadJson(reviewLog: ReviewLogEntity): JSON
         .put("rating", reviewLog.rating.ordinal)
         .put("reviewedAtClient", formatIsoTimestamp(reviewLog.reviewedAtMillis))
         .putNullableString("reviewedTimeZone", reviewLog.reviewedTimeZone)
+}
+
+internal fun buildMediaAssetOutboxPayloadJson(mediaAsset: MediaAssetEntity): JSONObject {
+    return JSONObject()
+        .put("mediaAssetId", mediaAsset.mediaAssetId)
+        .put("workspaceId", mediaAsset.workspaceId)
+        .put("mimeType", mediaAsset.mimeType)
+        .put("sizeBytes", mediaAsset.sizeBytes)
+        .put("sha256", mediaAsset.sha256)
+        .put("storageKey", mediaAsset.storageKey)
+        .putNullableString("sourceUrl", mediaAsset.sourceUrl)
+        .put("createdAt", formatIsoTimestamp(mediaAsset.createdAtMillis))
+        .putNullableString("deletedAt", mediaAsset.deletedAtMillis?.let(::formatIsoTimestamp))
 }
 
 internal fun buildCardBootstrapEntryJson(
@@ -196,6 +211,23 @@ internal fun buildWorkspaceSchedulerSettingsBootstrapEntryJson(
         )
 }
 
+internal fun buildMediaAssetBootstrapEntryJson(
+    mediaAsset: MediaAssetEntity,
+    lastOperationId: String
+): JSONObject {
+    return JSONObject()
+        .put("entityType", "media_asset")
+        .put("entityId", mediaAsset.mediaAssetId)
+        .put("action", "upsert")
+        .put(
+            "payload",
+            buildMediaAssetBootstrapPayloadJson(
+                mediaAsset = mediaAsset,
+                lastOperationId = lastOperationId
+            )
+        )
+}
+
 internal fun buildReviewHistoryImportEventJson(reviewLog: ReviewLogEntity): JSONObject {
     return JSONObject()
         .put("reviewEventId", reviewLog.reviewLogId)
@@ -281,6 +313,20 @@ internal fun decodeOutboxOperation(entry: OutboxEntryEntity): SyncOperation {
                 )
             )
 
+            SyncEntityType.MEDIA_ASSET -> SyncOperationPayload.MediaAsset(
+                MediaAssetSyncPayload(
+                    mediaAssetId = payloadJson.requireCloudString("mediaAssetId", "outbox.mediaAsset.mediaAssetId"),
+                    workspaceId = payloadJson.requireCloudString("workspaceId", "outbox.mediaAsset.workspaceId"),
+                    mimeType = payloadJson.requireCloudString("mimeType", "outbox.mediaAsset.mimeType"),
+                    sizeBytes = payloadJson.requireCloudLong("sizeBytes", "outbox.mediaAsset.sizeBytes"),
+                    sha256 = payloadJson.requireCloudString("sha256", "outbox.mediaAsset.sha256"),
+                    storageKey = payloadJson.requireCloudString("storageKey", "outbox.mediaAsset.storageKey"),
+                    sourceUrl = payloadJson.requireCloudNullableString("sourceUrl", "outbox.mediaAsset.sourceUrl"),
+                    createdAt = payloadJson.requireCloudString("createdAt", "outbox.mediaAsset.createdAt"),
+                    deletedAt = payloadJson.requireCloudNullableString("deletedAt", "outbox.mediaAsset.deletedAt")
+                )
+            )
+
             SyncEntityType.REVIEW_EVENT -> SyncOperationPayload.ReviewEvent(
                 ReviewEventSyncPayload(
                     reviewEventId = payloadJson.requireCloudString("reviewEventId", "outbox.reviewEvent.reviewEventId"),
@@ -321,6 +367,7 @@ internal fun parseSyncEntityType(rawValue: String): SyncEntityType {
         "card" -> SyncEntityType.CARD
         "deck" -> SyncEntityType.DECK
         "workspace_scheduler_settings" -> SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS
+        "media_asset" -> SyncEntityType.MEDIA_ASSET
         "review_event" -> SyncEntityType.REVIEW_EVENT
         else -> throw IllegalArgumentException("Unsupported sync entity type: $rawValue")
     }
@@ -389,6 +436,7 @@ internal fun SyncEntityType.toRemoteValue(): String {
         SyncEntityType.CARD -> "card"
         SyncEntityType.DECK -> "deck"
         SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> "workspace_scheduler_settings"
+        SyncEntityType.MEDIA_ASSET -> "media_asset"
         SyncEntityType.REVIEW_EVENT -> "review_event"
     }
 }
@@ -493,4 +541,15 @@ internal fun toCardSummary(card: CardWithRelations): CardSummary {
         fsrsScheduledDays = card.card.fsrsScheduledDays,
         deletedAtMillis = card.card.deletedAtMillis
     )
+}
+
+private fun buildMediaAssetBootstrapPayloadJson(
+    mediaAsset: MediaAssetEntity,
+    lastOperationId: String
+): JSONObject {
+    return buildMediaAssetOutboxPayloadJson(mediaAsset = mediaAsset)
+        .put("clientUpdatedAt", formatIsoTimestamp(mediaAsset.clientUpdatedAtMillis))
+        .put("lastModifiedByReplicaId", mediaAsset.lastModifiedByReplicaId)
+        .put("lastOperationId", lastOperationId)
+        .put("updatedAt", formatIsoTimestamp(mediaAsset.updatedAtMillis))
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -14,6 +14,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.AppLocalSettings
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressLocalCacheStateEntity
@@ -29,6 +30,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.database.migrations.createAppDatabaseMigrations
+import com.flashcardsopensourceapp.data.local.database.media.MediaAssetDao
 import com.flashcardsopensourceapp.data.local.database.progress.ProgressCardDao
 import com.flashcardsopensourceapp.data.local.database.progress.ProgressLocalCacheDao
 import com.flashcardsopensourceapp.data.local.database.progress.ProgressRemoteCacheDao
@@ -47,6 +49,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         WorkspaceEntity::class,
         WorkspaceSchedulerSettingsEntity::class,
         DeckEntity::class,
+        MediaAssetEntity::class,
         CardEntity::class,
         TagEntity::class,
         CardTagEntity::class,
@@ -62,7 +65,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 26,
+    version = 27,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)
@@ -71,6 +74,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun workspaceDao(): WorkspaceDao
     abstract fun workspaceSchedulerSettingsDao(): WorkspaceSchedulerSettingsDao
     abstract fun deckDao(): DeckDao
+    abstract fun mediaAssetDao(): MediaAssetDao
     abstract fun cardDao(): CardDao
     abstract fun reviewQueueDao(): ReviewQueueDao
     abstract fun reviewCardSelectionDao(): ReviewCardSelectionDao

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/MediaAssetEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/MediaAssetEntities.kt
@@ -1,0 +1,39 @@
+package com.flashcardsopensourceapp.data.local.database.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "media_assets",
+    foreignKeys = [
+        ForeignKey(
+            entity = WorkspaceEntity::class,
+            parentColumns = ["workspaceId"],
+            childColumns = ["workspaceId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("workspaceId"),
+        Index(value = ["storageKey"], unique = true),
+        Index(value = ["workspaceId", "updatedAtMillis", "mediaAssetId"]),
+        Index(value = ["workspaceId", "sha256", "mediaAssetId"])
+    ]
+)
+data class MediaAssetEntity(
+    @PrimaryKey val mediaAssetId: String,
+    val workspaceId: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val sha256: String,
+    val storageKey: String,
+    val sourceUrl: String?,
+    val createdAtMillis: Long,
+    val clientUpdatedAtMillis: Long,
+    val lastModifiedByReplicaId: String,
+    val lastOperationId: String,
+    val updatedAtMillis: Long,
+    val deletedAtMillis: Long?
+)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
@@ -1,0 +1,22 @@
+package com.flashcardsopensourceapp.data.local.database.media
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+
+@Dao
+interface MediaAssetDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMediaAsset(mediaAsset: MediaAssetEntity)
+
+    @Query("SELECT * FROM media_assets WHERE mediaAssetId = :mediaAssetId LIMIT 1")
+    suspend fun loadMediaAsset(mediaAssetId: String): MediaAssetEntity?
+
+    @Query("SELECT * FROM media_assets WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, mediaAssetId ASC")
+    suspend fun loadMediaAssets(workspaceId: String): List<MediaAssetEntity>
+
+    @Query("SELECT COUNT(*) FROM media_assets WHERE workspaceId = :workspaceId")
+    suspend fun countMediaAssets(workspaceId: String): Int
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -40,7 +40,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration22To23,
         migration23To24,
         migration24To25,
-        migration25To26
+        migration25To26,
+        migration26To27
     )
 }
 
@@ -866,6 +867,53 @@ val migration25To26: Migration = object : Migration(25, 26) {
             """.trimIndent()
         )
         backfillCardMetadataJson(db = db)
+    }
+}
+
+val migration26To27: Migration = object : Migration(26, 27) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS media_assets (
+                mediaAssetId TEXT NOT NULL PRIMARY KEY,
+                workspaceId TEXT NOT NULL,
+                mimeType TEXT NOT NULL,
+                sizeBytes INTEGER NOT NULL,
+                sha256 TEXT NOT NULL,
+                storageKey TEXT NOT NULL,
+                sourceUrl TEXT,
+                createdAtMillis INTEGER NOT NULL,
+                clientUpdatedAtMillis INTEGER NOT NULL,
+                lastModifiedByReplicaId TEXT NOT NULL,
+                lastOperationId TEXT NOT NULL,
+                updatedAtMillis INTEGER NOT NULL,
+                deletedAtMillis INTEGER,
+                FOREIGN KEY(workspaceId) REFERENCES workspaces(workspaceId) ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId ON media_assets(workspaceId)")
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_media_assets_storageKey ON media_assets(storageKey)")
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId_updatedAtMillis_mediaAssetId
+            ON media_assets(workspaceId, updatedAtMillis, mediaAssetId)
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId_sha256_mediaAssetId
+            ON media_assets(workspaceId, sha256, mediaAssetId)
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            UPDATE sync_state
+            SET lastSyncCursor = NULL,
+                hasHydratedHotState = 0
+            WHERE hasHydratedHotState = 1
+            """.trimIndent()
+        )
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
@@ -1,0 +1,17 @@
+package com.flashcardsopensourceapp.data.local.model.media
+
+data class MediaAsset(
+    val mediaAssetId: String,
+    val workspaceId: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val sha256: String,
+    val storageKey: String,
+    val sourceUrl: String?,
+    val createdAtMillis: Long,
+    val clientUpdatedAtMillis: Long,
+    val lastModifiedByReplicaId: String,
+    val lastOperationId: String,
+    val updatedAtMillis: Long,
+    val deletedAtMillis: Long?
+)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
@@ -8,6 +8,7 @@ enum class SyncEntityType {
     CARD,
     DECK,
     WORKSPACE_SCHEDULER_SETTINGS,
+    MEDIA_ASSET,
     REVIEW_EVENT
 }
 
@@ -100,6 +101,18 @@ data class ReviewEventSyncPayload(
     val reviewedTimeZone: String?
 )
 
+data class MediaAssetSyncPayload(
+    val mediaAssetId: String,
+    val workspaceId: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val sha256: String,
+    val storageKey: String,
+    val sourceUrl: String?,
+    val createdAt: String,
+    val deletedAt: String?
+)
+
 sealed interface SyncOperationPayload {
     data class Card(
         val payload: CardSyncPayload
@@ -111,6 +124,10 @@ sealed interface SyncOperationPayload {
 
     data class WorkspaceSchedulerSettings(
         val payload: WorkspaceSchedulerSettingsSyncPayload
+    ) : SyncOperationPayload
+
+    data class MediaAsset(
+        val payload: MediaAssetSyncPayload
     ) : SyncOperationPayload
 
     data class ReviewEvent(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -485,6 +485,7 @@ class CloudGuestSessionCoordinator(
                 .put("appVersion", appVersion)
                 .put("cursor", org.json.JSONObject.NULL)
                 .put("limit", 1)
+                .put("includeMediaAssets", true)
         )
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
@@ -123,6 +123,7 @@ internal suspend fun runCloudSyncCore(
                         .put("appVersion", appVersion)
                         .put("afterHotChangeId", lastHotCursor)
                         .put("limit", syncPullPageLimit)
+                        .put("includeMediaAssets", true)
                 )
                 syncLocalStore.applyPullChanges(workspaceId, pullResponse.changes)
                 lastHotCursor = pullResponse.nextHotChangeId
@@ -276,6 +277,7 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
                                 .put("installationId", cloudSettings.installationId)
                                 .put("platform", androidClientPlatform)
                                 .put("appVersion", appVersion)
+                                .put("includeMediaAssets", true)
                                 .put("entries", bootstrapEntries)
                         )
                         lastHotCursor = bootstrapPushResponse.bootstrapHotChangeId ?: lastHotCursor
@@ -604,6 +606,7 @@ private fun buildInitialBootstrapPullRequest(
         .put("appVersion", appVersion)
         .put("cursor", JSONObject.NULL)
         .put("limit", limit)
+        .put("includeMediaAssets", true)
 }
 
 private fun buildPagedBootstrapPullRequest(
@@ -619,6 +622,7 @@ private fun buildPagedBootstrapPullRequest(
         .put("appVersion", appVersion)
         .put("cursor", cursor)
         .put("limit", limit)
+        .put("includeMediaAssets", true)
 }
 
 private fun buildWorkspaceForkBlockedMessage(
@@ -711,6 +715,17 @@ private fun buildOperationPayload(payload: SyncOperationPayload): JSONObject {
             .put("maximumIntervalDays", payload.payload.maximumIntervalDays)
             .put("enableFuzz", payload.payload.enableFuzz)
 
+        is SyncOperationPayload.MediaAsset -> JSONObject()
+            .put("mediaAssetId", payload.payload.mediaAssetId)
+            .put("workspaceId", payload.payload.workspaceId)
+            .put("mimeType", payload.payload.mimeType)
+            .put("sizeBytes", payload.payload.sizeBytes)
+            .put("sha256", payload.payload.sha256)
+            .put("storageKey", payload.payload.storageKey)
+            .putNullableString("sourceUrl", payload.payload.sourceUrl)
+            .put("createdAt", payload.payload.createdAt)
+            .putNullableString("deletedAt", payload.payload.deletedAt)
+
         is SyncOperationPayload.ReviewEvent -> JSONObject()
             .put("reviewEventId", payload.payload.reviewEventId)
             .put("cardId", payload.payload.cardId)
@@ -730,6 +745,7 @@ private fun com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType.toR
         com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType.CARD -> "card"
         com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType.DECK -> "deck"
         com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> "workspace_scheduler_settings"
+        com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType.MEDIA_ASSET -> "media_asset"
         com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType.REVIEW_EVENT -> "review_event"
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudLinkedWorkspaceTransitionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudLinkedWorkspaceTransitionCoordinator.kt
@@ -282,6 +282,7 @@ internal class CloudLinkedWorkspaceTransitionCoordinator(
                 .put("appVersion", appVersion)
                 .put("cursor", JSONObject.NULL)
                 .put("limit", 1)
+                .put("includeMediaAssets", true)
         ).remoteIsEmpty
     }
 


### PR DESCRIPTION
## Summary
- Add Android Room metadata-only media asset registry storage and migration
- Opt Android bootstrap/pull/probe sync requests into media asset metadata
- Decode/apply/export media_asset hot sync rows and block unsupported workspace fork media reassignment

## Validation
- git --no-pager diff --check: passed
- Changed/untracked file whitespace checks: passed per worker report
- SQLite in-memory migration syntax/check: passed per worker report
- Gradle/Room compile validation: not run because permission was not granted