### PR TITLE
Add Android media asset rendering

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MediaAssetDao {
@@ -16,6 +17,9 @@ interface MediaAssetDao {
 
     @Query("SELECT * FROM media_assets WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, mediaAssetId ASC")
     suspend fun loadMediaAssets(workspaceId: String): List<MediaAssetEntity>
+
+    @Query("SELECT * FROM media_assets WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, mediaAssetId ASC")
+    fun observeMediaAssets(workspaceId: String): Flow<List<MediaAssetEntity>>
 
     @Query("SELECT COUNT(*) FROM media_assets WHERE workspaceId = :workspaceId")
     suspend fun countMediaAssets(workspaceId: String): Int

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -38,6 +38,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSele
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackTrigger
+import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnection
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnectionsResult
@@ -106,6 +107,8 @@ interface ReviewRepository {
         pendingReviewedCards: Set<PendingReviewedCard>,
         presentedCardId: String?
     ): Flow<ReviewSessionSnapshot>
+
+    fun observeReviewMediaAssets(): Flow<List<MediaAsset>>
 
     suspend fun loadReviewTimelinePage(
         selectedFilter: ReviewFilter,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
@@ -6,12 +6,14 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardWithRelations
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.data.local.model.cards.DeckSummary
 import com.flashcardsopensourceapp.data.local.model.feedback.FeedbackPromptReviewActivity
+import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCardQueueStatus
@@ -230,6 +232,21 @@ class LocalReviewRepository(
         }
     }
 
+    override fun observeReviewMediaAssets(): Flow<List<MediaAsset>> {
+        return observeCurrentWorkspace(
+            database = database,
+            preferencesStore = preferencesStore
+        ).flatMapLatest { workspace ->
+            if (workspace == null) {
+                return@flatMapLatest flowOf<List<MediaAsset>>(emptyList())
+            }
+
+            database.mediaAssetDao().observeMediaAssets(workspaceId = workspace.workspaceId).map { mediaAssets ->
+                mediaAssets.map(::toMediaAsset)
+            }
+        }
+    }
+
     override suspend fun loadReviewTimelinePage(
         selectedFilter: ReviewFilter,
         pendingReviewedCards: Set<PendingReviewedCard>,
@@ -442,4 +459,22 @@ class LocalReviewRepository(
             )
         }
     }
+}
+
+private fun toMediaAsset(mediaAsset: MediaAssetEntity): MediaAsset {
+    return MediaAsset(
+        mediaAssetId = mediaAsset.mediaAssetId,
+        workspaceId = mediaAsset.workspaceId,
+        mimeType = mediaAsset.mimeType,
+        sizeBytes = mediaAsset.sizeBytes,
+        sha256 = mediaAsset.sha256,
+        storageKey = mediaAsset.storageKey,
+        sourceUrl = mediaAsset.sourceUrl,
+        createdAtMillis = mediaAsset.createdAtMillis,
+        clientUpdatedAtMillis = mediaAsset.clientUpdatedAtMillis,
+        lastModifiedByReplicaId = mediaAsset.lastModifiedByReplicaId,
+        lastOperationId = mediaAsset.lastOperationId,
+        updatedAtMillis = mediaAsset.updatedAtMillis,
+        deletedAtMillis = mediaAsset.deletedAtMillis
+    )
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewPresentation.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewPresentation.kt
@@ -8,18 +8,29 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AttachFile
+import androidx.compose.material.icons.outlined.Audiotrack
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.Movie
+import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.review.ReviewAnswerOption
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCardQueueStatus
@@ -43,6 +54,11 @@ private val reviewHorizontalRuleRegex = Regex(pattern = """^\s{0,3}(?:-{3,}|\*{3
 private val reviewTableDelimiterRegex = Regex(
     pattern = """^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$"""
 )
+private val reviewManagedMediaReferenceRegex = Regex(
+    pattern = """(!)?\[([^\]]*)]\(([^)\s]+)(?:\s+"[^"]*")?\)"""
+)
+private const val reviewManagedMediaSchemePrefix: String = "fcasset:"
+private val reviewManagedMediaIconSize = 22.dp
 
 enum class ReviewContentPresentationMode {
     SHORT_PLAIN,
@@ -87,12 +103,30 @@ sealed interface ReviewRichBlock {
         val languageLabel: String?,
         val code: String
     ) : ReviewRichBlock
+
+    data class ManagedMedia(
+        val reference: ReviewManagedMediaReference
+    ) : ReviewRichBlock
 }
 
 data class ReviewInlineSegment(
     val text: String,
     val isCode: Boolean
 )
+
+data class ReviewManagedMediaReference(
+    val mediaAssetId: String,
+    val label: String?,
+    val isImageSyntax: Boolean,
+    val mediaAsset: MediaAsset?
+)
+
+private enum class ReviewManagedMediaCategory {
+    IMAGE,
+    AUDIO,
+    VIDEO,
+    ATTACHMENT
+}
 
 data class PreparedReviewAnswerOption(
     val rating: ReviewRating,
@@ -162,12 +196,18 @@ fun classifyReviewContentPresentation(text: String): ReviewContentPresentationMo
     return ReviewContentPresentationMode.SHORT_PLAIN
 }
 
-fun makeReviewRenderedContent(text: String): ReviewRenderedContent {
+fun makeReviewRenderedContent(
+    text: String,
+    mediaAssetsById: Map<String, MediaAsset>
+): ReviewRenderedContent {
     return when (classifyReviewContentPresentation(text = text)) {
         ReviewContentPresentationMode.SHORT_PLAIN -> ReviewRenderedContent.ShortPlain(text = text)
         ReviewContentPresentationMode.PARAGRAPH_PLAIN -> ReviewRenderedContent.ParagraphPlain(text = text)
         ReviewContentPresentationMode.RICH -> ReviewRenderedContent.Rich(
-            blocks = parseReviewRichBlocks(text = text)
+            blocks = parseReviewRichBlocks(
+                text = text,
+                mediaAssetsById = mediaAssetsById
+            )
         )
     }
 }
@@ -212,6 +252,7 @@ fun makeReviewSpeakableText(text: String): String {
 fun prepareReviewCardPresentation(
     card: ReviewCard,
     answerOptions: List<ReviewAnswerOption>,
+    mediaAssetsById: Map<String, MediaAsset>,
     textProvider: ReviewTextProvider
 ): PreparedReviewCardPresentation {
     val normalizedBackText = if (card.backText.trim().isEmpty()) {
@@ -226,8 +267,14 @@ fun prepareReviewCardPresentation(
         dueLabel = textProvider.dueLabel(dueAtMillis = card.dueAtMillis),
         repsLabel = textProvider.repsLabel(reps = card.reps),
         lapsesLabel = textProvider.lapsesLabel(lapses = card.lapses),
-        frontContent = makeReviewRenderedContent(text = card.frontText),
-        backContent = makeReviewRenderedContent(text = normalizedBackText),
+        frontContent = makeReviewRenderedContent(
+            text = card.frontText,
+            mediaAssetsById = mediaAssetsById
+        ),
+        backContent = makeReviewRenderedContent(
+            text = normalizedBackText,
+            mediaAssetsById = mediaAssetsById
+        ),
         frontSpeakableText = makeReviewSpeakableText(text = card.frontText),
         backSpeakableText = makeReviewSpeakableText(text = card.backText),
         answerOptions = answerOptions.map { option ->
@@ -238,6 +285,32 @@ fun prepareReviewCardPresentation(
                 )
             )
         }
+    )
+}
+
+fun refreshPreparedReviewCardPresentationMedia(
+    presentation: PreparedReviewCardPresentation,
+    mediaAssetsById: Map<String, MediaAsset>,
+    textProvider: ReviewTextProvider
+): PreparedReviewCardPresentation {
+    val card = presentation.card
+    val normalizedBackText = if (card.backText.trim().isEmpty()) {
+        textProvider.emptyBackTextPlaceholder()
+    } else {
+        card.backText
+    }
+
+    return presentation.copy(
+        frontContent = makeReviewRenderedContent(
+            text = card.frontText,
+            mediaAssetsById = mediaAssetsById
+        ),
+        backContent = makeReviewRenderedContent(
+            text = normalizedBackText,
+            mediaAssetsById = mediaAssetsById
+        ),
+        frontSpeakableText = makeReviewSpeakableText(text = card.frontText),
+        backSpeakableText = makeReviewSpeakableText(text = card.backText)
     )
 }
 
@@ -407,11 +480,142 @@ fun ReviewRenderedContentView(
                                     .horizontalScroll(state = rememberScrollState())
                             )
                         }
+
+                        is ReviewRichBlock.ManagedMedia -> ReviewManagedMediaPlaceholder(
+                            reference = block.reference
+                        )
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun ReviewManagedMediaPlaceholder(reference: ReviewManagedMediaReference) {
+    val mediaAsset = reference.mediaAsset
+    val category = classifyReviewManagedMediaCategory(
+        mimeType = mediaAsset?.mimeType,
+        isImageSyntax = reference.isImageSyntax
+    )
+    val isUnavailable = mediaAsset == null || mediaAsset.deletedAtMillis != null
+    val categoryLabel = stringResource(id = reviewManagedMediaCategoryLabelResId(category = category))
+    val label = reviewManagedMediaDisplayLabel(
+        reference = reference,
+        mediaAsset = mediaAsset,
+        categoryLabel = categoryLabel
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = MaterialTheme.shapes.medium
+            )
+            .padding(12.dp)
+    ) {
+        Icon(
+            imageVector = if (isUnavailable) {
+                Icons.Outlined.WarningAmber
+            } else {
+                reviewManagedMediaCategoryIcon(category = category)
+            },
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(reviewManagedMediaIconSize)
+        )
+        Column(
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier.weight(weight = 1f)
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = if (isUnavailable) {
+                    stringResource(id = R.string.review_media_unavailable)
+                } else {
+                    categoryLabel
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun classifyReviewManagedMediaCategory(
+    mimeType: String?,
+    isImageSyntax: Boolean
+): ReviewManagedMediaCategory {
+    val normalizedMimeType = mimeType?.lowercase()
+    return when {
+        normalizedMimeType == null -> {
+            if (isImageSyntax) {
+                ReviewManagedMediaCategory.IMAGE
+            } else {
+                ReviewManagedMediaCategory.ATTACHMENT
+            }
+        }
+        normalizedMimeType.startsWith(prefix = "image/") -> ReviewManagedMediaCategory.IMAGE
+        normalizedMimeType.startsWith(prefix = "audio/") -> ReviewManagedMediaCategory.AUDIO
+        normalizedMimeType.startsWith(prefix = "video/") -> ReviewManagedMediaCategory.VIDEO
+        else -> ReviewManagedMediaCategory.ATTACHMENT
+    }
+}
+
+private fun reviewManagedMediaCategoryIcon(category: ReviewManagedMediaCategory): ImageVector {
+    return when (category) {
+        ReviewManagedMediaCategory.IMAGE -> Icons.Outlined.Image
+        ReviewManagedMediaCategory.AUDIO -> Icons.Outlined.Audiotrack
+        ReviewManagedMediaCategory.VIDEO -> Icons.Outlined.Movie
+        ReviewManagedMediaCategory.ATTACHMENT -> Icons.Outlined.AttachFile
+    }
+}
+
+private fun reviewManagedMediaCategoryLabelResId(category: ReviewManagedMediaCategory): Int {
+    return when (category) {
+        ReviewManagedMediaCategory.IMAGE -> R.string.review_media_image_label
+        ReviewManagedMediaCategory.AUDIO -> R.string.review_media_audio_label
+        ReviewManagedMediaCategory.VIDEO -> R.string.review_media_video_label
+        ReviewManagedMediaCategory.ATTACHMENT -> R.string.review_media_attachment_label
+    }
+}
+
+private fun reviewManagedMediaDisplayLabel(
+    reference: ReviewManagedMediaReference,
+    mediaAsset: MediaAsset?,
+    categoryLabel: String
+): String {
+    val explicitLabel = reference.label?.trim()
+    if (explicitLabel != null && explicitLabel.isNotEmpty()) {
+        return explicitLabel
+    }
+
+    val sourceUrl = mediaAsset?.sourceUrl
+    if (sourceUrl != null) {
+        val fileName = reviewManagedMediaFileName(sourceUrl = sourceUrl)
+        if (fileName != null) {
+            return fileName
+        }
+    }
+
+    return categoryLabel
+}
+
+private fun reviewManagedMediaFileName(sourceUrl: String): String? {
+    val lastPathComponent = sourceUrl
+        .substringBefore(delimiter = "?")
+        .substringBefore(delimiter = "#")
+        .substringAfterLast(delimiter = "/")
+        .trim()
+    return lastPathComponent.ifEmpty { null }
 }
 
 @Composable
@@ -448,6 +652,9 @@ private fun hasStrongRichCue(text: String): Boolean {
     if (text.isBlank()) {
         return false
     }
+    if (containsReviewManagedMediaReference(text = text)) {
+        return true
+    }
 
     return text.lineSequence().any { line ->
         reviewHeadingRegex.matches(line)
@@ -460,7 +667,38 @@ private fun hasStrongRichCue(text: String): Boolean {
     }
 }
 
-private fun parseReviewRichBlocks(text: String): List<ReviewRichBlock> {
+private fun containsReviewManagedMediaReference(text: String): Boolean {
+    return reviewManagedMediaReferenceRegex.findAll(input = text).any { match ->
+        val reference = match.groups[3]?.value ?: return@any false
+        parseReviewManagedMediaAssetId(reference = reference) != null
+    }
+}
+
+private fun parseReviewManagedMediaAssetId(reference: String): String? {
+    val trimmedReference = reference.trim()
+    if (trimmedReference.lowercase().startsWith(prefix = reviewManagedMediaSchemePrefix).not()) {
+        return null
+    }
+
+    var rawAssetId = trimmedReference.drop(n = reviewManagedMediaSchemePrefix.length)
+    while (rawAssetId.startsWith(prefix = "/")) {
+        rawAssetId = rawAssetId.drop(n = 1)
+    }
+
+    val fragmentOrQueryStart = rawAssetId.indexOfAny(chars = charArrayOf('?', '#'))
+    val mediaAssetId = if (fragmentOrQueryStart >= 0) {
+        rawAssetId.substring(startIndex = 0, endIndex = fragmentOrQueryStart)
+    } else {
+        rawAssetId
+    }.trim()
+
+    return mediaAssetId.ifEmpty { null }
+}
+
+private fun parseReviewRichBlocks(
+    text: String,
+    mediaAssetsById: Map<String, MediaAsset>
+): List<ReviewRichBlock> {
     val normalizedText = text.replace("\r\n", "\n").replace('\r', '\n')
     val lines = normalizedText.lines()
     var index = 0
@@ -494,6 +732,16 @@ private fun parseReviewRichBlocks(text: String): List<ReviewRichBlock> {
                 languageLabel = languageLabel,
                 code = codeLines.joinToString(separator = "\n")
             )
+            continue
+        }
+
+        val managedMediaBlocks = splitReviewManagedMediaLine(
+            line = line,
+            mediaAssetsById = mediaAssetsById
+        )
+        if (managedMediaBlocks != null) {
+            blocks += managedMediaBlocks
+            index += 1
             continue
         }
 
@@ -574,10 +822,70 @@ private fun shouldContinueParagraph(line: String): Boolean {
     }
 
     return reviewFenceRegex.matches(line).not()
+        && containsReviewManagedMediaReference(text = line).not()
         && reviewHeadingRegex.matches(line).not()
         && reviewQuoteRegex.matches(line).not()
         && reviewBulletRegex.matches(line).not()
         && reviewOrderedListRegex.matches(line).not()
+}
+
+private fun splitReviewManagedMediaLine(
+    line: String,
+    mediaAssetsById: Map<String, MediaAsset>
+): List<ReviewRichBlock>? {
+    val matches = reviewManagedMediaReferenceRegex.findAll(input = line).toList()
+    if (matches.isEmpty()) {
+        return null
+    }
+
+    val blocks = mutableListOf<ReviewRichBlock>()
+    var currentIndex = 0
+    var didFindManagedMedia = false
+
+    matches.forEach { match ->
+        val reference = match.groups[3]?.value ?: return@forEach
+        val mediaAssetId = parseReviewManagedMediaAssetId(reference = reference) ?: return@forEach
+        val matchStart = match.range.first
+        val matchEndExclusive = match.range.last + 1
+
+        appendReviewManagedMediaTextBlock(
+            text = line.substring(startIndex = currentIndex, endIndex = matchStart),
+            blocks = blocks
+        )
+        blocks += ReviewRichBlock.ManagedMedia(
+            reference = ReviewManagedMediaReference(
+                mediaAssetId = mediaAssetId,
+                label = match.groups[2]?.value?.trim()?.ifEmpty { null },
+                isImageSyntax = match.groups[1] != null,
+                mediaAsset = mediaAssetsById[mediaAssetId]
+            )
+        )
+        currentIndex = matchEndExclusive
+        didFindManagedMedia = true
+    }
+
+    if (didFindManagedMedia.not()) {
+        return null
+    }
+
+    appendReviewManagedMediaTextBlock(
+        text = line.substring(startIndex = currentIndex),
+        blocks = blocks
+    )
+    return blocks
+}
+
+private fun appendReviewManagedMediaTextBlock(
+    text: String,
+    blocks: MutableList<ReviewRichBlock>
+) {
+    if (text.trim().isEmpty()) {
+        return
+    }
+
+    blocks += ReviewRichBlock.Paragraph(
+        segments = parseInlineSegments(text = text)
+    )
 }
 
 private fun parseInlineSegments(text: String): List<ReviewInlineSegment> {
@@ -642,6 +950,7 @@ fun reviewRenderedContentDebugText(content: ReviewRenderedContent): String {
 
                 is ReviewRichBlock.Quote -> inlineSegmentsDebugText(block.segments)
                 is ReviewRichBlock.CodeBlock -> block.code
+                is ReviewRichBlock.ManagedMedia -> block.reference.label.orEmpty()
             }
         }
     }
@@ -694,8 +1003,27 @@ private fun normalizeReviewSpeakableText(lines: List<String>): String {
 }
 
 private fun normalizeReviewSpeakableInlineText(text: String): String {
-    return text.replace(oldValue = "`", newValue = "")
+    return reviewSpeakableTextReplacingManagedMediaReferences(text = text)
+        .replace(oldValue = "`", newValue = "")
         .replace(oldValue = "|", newValue = " ")
         .replace(regex = Regex(pattern = """\s+"""), replacement = " ")
         .trim()
+}
+
+private fun reviewSpeakableTextReplacingManagedMediaReferences(text: String): String {
+    var output = text
+    reviewManagedMediaReferenceRegex.findAll(input = text).toList().asReversed().forEach { match ->
+        val reference = match.groups[3]?.value ?: return@forEach
+        if (parseReviewManagedMediaAssetId(reference = reference) == null) {
+            return@forEach
+        }
+
+        val label = match.groups[2]?.value?.trim().orEmpty()
+        output = output.replaceRange(
+            range = match.range,
+            replacement = label
+        )
+    }
+
+    return output
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiStateMapping.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiStateMapping.kt
@@ -2,6 +2,7 @@ package com.flashcardsopensourceapp.feature.review
 
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
+import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.review.ReviewAnswerOption
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
@@ -73,8 +74,12 @@ internal fun mapToReviewUiState(
     appMetadata: AppMetadataSummary,
     progressSummarySnapshot: ProgressSummarySnapshot?,
     progressLeaderboardSnapshot: ProgressLeaderboardSnapshot?,
+    mediaAssets: List<MediaAsset>,
     textProvider: ReviewTextProvider
 ): ReviewUiState {
+    val mediaAssetsById = mediaAssets.associateBy { mediaAsset ->
+        mediaAsset.mediaAssetId
+    }
     val displayedCurrentCard = state.optimisticPreparedCurrentCard?.card
         ?: resolveDisplayedCurrentCard(
             sessionCards = sessionSnapshot.cards,
@@ -84,20 +89,29 @@ internal fun mapToReviewUiState(
         sessionCards = sessionSnapshot.cards,
         displayedCurrentCard = displayedCurrentCard
     )
-    val sessionPreparedCurrentCard = if (state.optimisticPreparedCurrentCard == null) {
+    val optimisticPreparedCurrentCard = state.optimisticPreparedCurrentCard?.let { presentation ->
+        refreshPreparedReviewCardPresentationMedia(
+            presentation = presentation,
+            mediaAssetsById = mediaAssetsById,
+            textProvider = textProvider
+        )
+    }
+    val sessionPreparedCurrentCard = if (optimisticPreparedCurrentCard == null) {
         prepareDisplayedSessionCardPresentation(
             displayedCard = displayedCurrentCard,
             answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId,
+            mediaAssetsById = mediaAssetsById,
             textProvider = textProvider
         )
     } else {
         null
     }
-    val currentPreparedCard = state.optimisticPreparedCurrentCard ?: sessionPreparedCurrentCard
+    val currentPreparedCard = optimisticPreparedCurrentCard ?: sessionPreparedCurrentCard
     val displayedNextCard = displayedQueue.getOrNull(index = 1)
     val preparedNextCard = prepareDisplayedSessionCardPresentation(
         displayedCard = displayedNextCard,
         answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId,
+        mediaAssetsById = mediaAssetsById,
         textProvider = textProvider
     )
     val emptyState = resolveReviewEmptyState(
@@ -206,6 +220,7 @@ internal fun resolveDisplayedSessionAnswerOptions(
 internal fun prepareDisplayedSessionCardPresentation(
     displayedCard: ReviewCard?,
     answerOptionsByCardId: Map<String, List<ReviewAnswerOption>>,
+    mediaAssetsById: Map<String, MediaAsset>,
     textProvider: ReviewTextProvider
 ): PreparedReviewCardPresentation? {
     val card = displayedCard ?: return null
@@ -224,6 +239,7 @@ internal fun prepareDisplayedSessionCardPresentation(
     return prepareReviewCardPresentation(
         card = card,
         answerOptions = answerOptions,
+        mediaAssetsById = mediaAssetsById,
         textProvider = textProvider
     )
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -101,6 +101,21 @@ class ReviewViewModel(
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
         initialValue = initialReviewAppMetadataSummary(textProvider = textProvider)
     )
+    private val progressBadgeInputsState = combine(
+        progressRepository.observeSummarySnapshot(),
+        progressRepository.observeLeaderboardSnapshot()
+    ) { progressSummarySnapshot, progressLeaderboardSnapshot ->
+        progressSummarySnapshot to progressLeaderboardSnapshot
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = null to null
+    )
+    private val reviewMediaAssetsState = reviewRepository.observeReviewMediaAssets().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = emptyList()
+    )
 
     private var pendingAutoSyncRequestId: String? = null
     private var visibleAutoSyncChangeSignatureAtStart: VisibleAutoSyncChangeSignature? = null
@@ -120,15 +135,16 @@ class ReviewViewModel(
         reviewSessionState,
         draftState,
         appMetadataState,
-        progressRepository.observeSummarySnapshot(),
-        progressRepository.observeLeaderboardSnapshot()
-    ) { reviewSessionState, state, appMetadata, progressSummarySnapshot, progressLeaderboardSnapshot ->
+        progressBadgeInputsState,
+        reviewMediaAssetsState
+    ) { reviewSessionState, state, appMetadata, progressBadgeInputs, mediaAssets ->
         mapToReviewUiState(
             sessionSnapshot = reviewSessionState.sessionSnapshot,
             state = state,
             appMetadata = appMetadata,
-            progressSummarySnapshot = progressSummarySnapshot,
-            progressLeaderboardSnapshot = progressLeaderboardSnapshot,
+            progressSummarySnapshot = progressBadgeInputs.first,
+            progressLeaderboardSnapshot = progressBadgeInputs.second,
+            mediaAssets = mediaAssets,
             textProvider = textProvider
         )
     }.stateIn(
@@ -733,6 +749,9 @@ class ReviewViewModel(
         val preparedCurrentCardAfterSync = prepareDisplayedSessionCardPresentation(
             displayedCard = displayedCurrentCardAfterSync,
             answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId,
+            mediaAssetsById = reviewMediaAssetsState.value.associateBy { mediaAsset ->
+                mediaAsset.mediaAssetId
+            },
             textProvider = textProvider
         )
         val nextVisibleChangeSignature = makeVisibleAutoSyncChangeSignature(

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -58,6 +58,11 @@
     <string name="review_could_not_be_saved">Review could not be saved.</string>
     <string name="review_queue_could_not_be_loaded">Review queue could not be loaded.</string>
     <string name="review_speech_unavailable">Speech is unavailable on this device.</string>
+    <string name="review_media_attachment_label">Attachment</string>
+    <string name="review_media_audio_label">Audio attachment</string>
+    <string name="review_media_image_label">Managed image</string>
+    <string name="review_media_unavailable">Media unavailable</string>
+    <string name="review_media_video_label">Video attachment</string>
     <string name="review_no_back_text">No back text</string>
     <string name="review_reps_label">Reps %1$d</string>
     <string name="review_lapses_label">Lapses %1$d</string>


### PR DESCRIPTION
## Summary
- Add Android read-only placeholder rendering for managed `fcasset:` Markdown references using locally synced media asset metadata.
- Keep normal Markdown and external URL rendering unchanged.
- Render image, audio, video, and generic attachment categories as stable Compose placeholders, including missing/deleted/unavailable media.

## Scope
- This is read-only placeholder rendering for managed `fcasset:` refs.
- No upload/cache/prefetch/download playback, external URL ingestion/rewriting, compression, package import/export, or Anki/Quizlet adapters.
- Normal Markdown/external URL behavior should remain unchanged.

## Validation
- `git diff --check`
- `strings.xml` XML parse
- Basic Kotlin brace-count/static checks
- Parser/render text checks
- Optimistic media refresh text check
- Fresh read-only re-review: no P0-P4 issues, no split recommendation

`./gradlew` was not run because local Gradle permission was not granted.