### PR TITLE
Remove web media asset storage keys

### DIFF
--- a/apps/web/src/apiContracts/mediaAssets.test.ts
+++ b/apps/web/src/apiContracts/mediaAssets.test.ts
@@ -8,7 +8,6 @@ const mediaAssetFixture: MediaAsset = {
   mimeType: "image/png",
   sizeBytes: 42817,
   sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
-  storageKey: "media-assets/workspaces/11111111-1111-4111-8111-111111111111/assets/22222222-2222-4222-8222-222222222222/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
   sourceUrl: null,
   createdAt: "2026-03-10T09:00:00.000Z",
   clientUpdatedAt: "2026-03-10T09:00:01.000Z",

--- a/apps/web/src/apiContracts/mediaAssets.ts
+++ b/apps/web/src/apiContracts/mediaAssets.ts
@@ -21,7 +21,6 @@ export function parseMediaAsset(value: unknown, endpoint: string, path: string):
     mimeType: parseRequiredField(objectValue, "mimeType", endpoint, path, parseString),
     sizeBytes: parseRequiredField(objectValue, "sizeBytes", endpoint, path, parseNumber),
     sha256: parseRequiredField(objectValue, "sha256", endpoint, path, parseString),
-    storageKey: parseRequiredField(objectValue, "storageKey", endpoint, path, parseString),
     sourceUrl: parseRequiredField(objectValue, "sourceUrl", endpoint, path, parseNullableString),
     createdAt: parseRequiredField(objectValue, "createdAt", endpoint, path, parseString),
     clientUpdatedAt: parseRequiredField(objectValue, "clientUpdatedAt", endpoint, path, parseString),

--- a/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
@@ -28,7 +28,6 @@ function makeMediaAsset(mediaAssetId: string, mimeType: string): MediaAsset {
     mimeType,
     sizeBytes: 128,
     sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
-    storageKey: `media-assets/workspaces/workspace-1/assets/${mediaAssetId}/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8`,
     sourceUrl: null,
     createdAt: "2026-03-10T09:00:00.000Z",
     clientUpdatedAt: "2026-03-10T09:00:00.000Z",

--- a/apps/web/src/types/mediaAssets.ts
+++ b/apps/web/src/types/mediaAssets.ts
@@ -4,7 +4,6 @@ export type MediaAsset = Readonly<{
   mimeType: string;
   sizeBytes: number;
   sha256: string;
-  storageKey: string;
   sourceUrl: string | null;
   createdAt: string;
   clientUpdatedAt: string;
@@ -20,7 +19,6 @@ export type MediaAssetSnapshotPayload = Readonly<{
   mimeType: string;
   sizeBytes: number;
   sha256: string;
-  storageKey: string;
   sourceUrl: string | null;
   createdAt: string;
   deletedAt: string | null;


### PR DESCRIPTION
## Summary
- Removes stale `storageKey` from the web MediaAsset client contract and parser.
- Keeps web rendering based on logical `mediaAssetId -> backend download-url`.
- Updates focused web media asset fixtures.

## Validation
- `npm ci --prefix apps/web` passed with Node engine warning (`v25.6.1` vs declared `24.x`)
- `npm run test --prefix apps/web -- mediaAssets ReviewCardSide.media` passed: 65 files, 520 tests
- `npm run build --prefix apps/web` passed
- `git --no-pager diff --check` passed
- `npm run lint --prefix apps/web` could not run because `apps/web/package.json` has no `lint` script

## Review
- No split recommendation.
- No P0-P4 findings.
- Green commit gate.