### PR TITLE
Remove iOS media asset storage keys

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
@@ -8,7 +8,6 @@ struct MediaAsset: Codable, Identifiable, Hashable, Sendable {
     let mimeType: String
     let sizeBytes: Int64
     let sha256: String
-    let storageKey: String
     let sourceUrl: String?
     let createdAt: String
     let clientUpdatedAt: String
@@ -27,7 +26,6 @@ struct MediaAsset: Codable, Identifiable, Hashable, Sendable {
         mimeType: String,
         sizeBytes: Int64,
         sha256: String,
-        storageKey: String,
         sourceUrl: String?,
         createdAt: String,
         clientUpdatedAt: String,
@@ -41,7 +39,6 @@ struct MediaAsset: Codable, Identifiable, Hashable, Sendable {
         self.mimeType = mimeType
         self.sizeBytes = sizeBytes
         self.sha256 = sha256
-        self.storageKey = storageKey
         self.sourceUrl = sourceUrl
         self.createdAt = createdAt
         self.clientUpdatedAt = clientUpdatedAt

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncContracts.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncContracts.swift
@@ -405,7 +405,6 @@ private struct BootstrapMediaAssetPayload: Encodable {
         case mimeType
         case sizeBytes
         case sha256
-        case storageKey
         case sourceUrl
         case createdAt
         case clientUpdatedAt
@@ -428,7 +427,6 @@ private struct BootstrapMediaAssetPayload: Encodable {
         try container.encode(self.snapshot.mimeType, forKey: .mimeType)
         try container.encode(self.snapshot.sizeBytes, forKey: .sizeBytes)
         try container.encode(self.snapshot.sha256, forKey: .sha256)
-        try container.encode(self.snapshot.storageKey, forKey: .storageKey)
         try encodeNullableBootstrapValue(self.snapshot.sourceUrl, forKey: .sourceUrl, in: &container)
         try container.encode(self.snapshot.createdAt, forKey: .createdAt)
         try container.encode(self.clientUpdatedAt, forKey: .clientUpdatedAt)
@@ -572,7 +570,6 @@ struct RemoteMediaAssetChangePayload: Decodable {
     let mimeType: String
     let sizeBytes: Int64
     let sha256: String
-    let storageKey: String
     let sourceUrl: String?
     let createdAt: String
     let clientUpdatedAt: String

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncMapper.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncMapper.swift
@@ -65,7 +65,6 @@ enum CloudSyncMapper {
             mimeType: payload.mimeType,
             sizeBytes: payload.sizeBytes,
             sha256: payload.sha256,
-            storageKey: payload.storageKey,
             sourceUrl: payload.sourceUrl,
             createdAt: payload.createdAt,
             clientUpdatedAt: payload.clientUpdatedAt,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
@@ -570,7 +570,6 @@ struct MediaAssetSyncPayload: Codable, Hashable {
     let mimeType: String
     let sizeBytes: Int64
     let sha256: String
-    let storageKey: String
     let sourceUrl: String?
     let createdAt: String
     let deletedAt: String?
@@ -581,7 +580,6 @@ struct MediaAssetSyncPayload: Codable, Hashable {
         case mimeType
         case sizeBytes
         case sha256
-        case storageKey
         case sourceUrl
         case createdAt
         case deletedAt
@@ -594,7 +592,6 @@ struct MediaAssetSyncPayload: Codable, Hashable {
         try container.encode(self.mimeType, forKey: .mimeType)
         try container.encode(self.sizeBytes, forKey: .sizeBytes)
         try container.encode(self.sha256, forKey: .sha256)
-        try container.encode(self.storageKey, forKey: .storageKey)
         if let sourceUrl = self.sourceUrl {
             try container.encode(sourceUrl, forKey: .sourceUrl)
         } else {
@@ -616,7 +613,6 @@ extension MediaAssetSyncPayload {
         self.mimeType = mediaAsset.mimeType
         self.sizeBytes = mediaAsset.sizeBytes
         self.sha256 = mediaAsset.sha256
-        self.storageKey = mediaAsset.storageKey
         self.sourceUrl = mediaAsset.sourceUrl
         self.createdAt = mediaAsset.createdAt
         self.deletedAt = mediaAsset.deletedAt

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
@@ -101,6 +101,9 @@ struct LocalDatabaseMigrator {
             case 21:
                 try self.migrateSchemaVersion21To22()
                 schemaVersion = 22
+            case 22:
+                try self.migrateSchemaVersion22To23()
+                schemaVersion = 23
             default:
                 throw LocalStoreError.database("Unsupported local schema version: \(schemaVersion)")
             }
@@ -701,7 +704,6 @@ struct LocalDatabaseMigrator {
                 mime_type TEXT NOT NULL CHECK (length(trim(mime_type)) > 0),
                 size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0),
                 sha256 TEXT NOT NULL CHECK (length(trim(sha256)) > 0),
-                storage_key TEXT NOT NULL CHECK (length(trim(storage_key)) > 0),
                 source_url TEXT,
                 created_at TEXT NOT NULL,
                 client_updated_at TEXT NOT NULL,
@@ -730,6 +732,20 @@ struct LocalDatabaseMigrator {
                 updated_at = ?
             """,
             values: [.text(nowIsoTimestamp())]
+        )
+    }
+
+    private func migrateSchemaVersion22To23() throws {
+        guard try self.core.columnExists(tableName: "media_assets", columnName: "storage_key") else {
+            return
+        }
+
+        try self.core.execute(
+            sql: """
+            ALTER TABLE media_assets
+            DROP COLUMN storage_key
+            """,
+            values: []
         )
     }
 

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum LocalDatabaseSchema {
-    static let currentVersion: Int = 22
+    static let currentVersion: Int = 23
 
     static var baseMigrationSQL: String {
         let defaultEnableFuzzValue: Int = defaultSchedulerSettingsConfig.enableFuzz ? 1 : 0
@@ -77,7 +77,6 @@ enum LocalDatabaseSchema {
             mime_type TEXT NOT NULL CHECK (length(trim(mime_type)) > 0), -- backend-provided MIME type used for read-only rendering
             size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0), -- byte size metadata only; media bytes are never stored in this table
             sha256 TEXT NOT NULL CHECK (length(trim(sha256)) > 0), -- content digest from the backend registry
-            storage_key TEXT NOT NULL CHECK (length(trim(storage_key)) > 0), -- opaque backend storage key used only by the server
             source_url TEXT, -- original external source URL when available
             created_at TEXT NOT NULL, -- original asset creation timestamp
             client_updated_at TEXT NOT NULL, -- client-side LWW timestamp for the most recent media registry winner

--- a/apps/ios/Flashcards/Flashcards/Database/MediaAssetStore/MediaAssetStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/MediaAssetStore/MediaAssetStore.swift
@@ -6,7 +6,6 @@ let mediaAssetStoreSelectColumnsSQL: String = """
     mime_type,
     size_bytes,
     sha256,
-    storage_key,
     source_url,
     created_at,
     client_updated_at,
@@ -64,14 +63,13 @@ struct MediaAssetStore {
             mimeType: DatabaseCore.columnText(statement: statement, index: 2),
             sizeBytes: DatabaseCore.columnInt64(statement: statement, index: 3),
             sha256: DatabaseCore.columnText(statement: statement, index: 4),
-            storageKey: DatabaseCore.columnText(statement: statement, index: 5),
-            sourceUrl: DatabaseCore.columnOptionalText(statement: statement, index: 6),
-            createdAt: DatabaseCore.columnText(statement: statement, index: 7),
-            clientUpdatedAt: DatabaseCore.columnText(statement: statement, index: 8),
-            lastModifiedByReplicaId: DatabaseCore.columnText(statement: statement, index: 9),
-            lastOperationId: DatabaseCore.columnText(statement: statement, index: 10),
-            updatedAt: DatabaseCore.columnText(statement: statement, index: 11),
-            deletedAt: DatabaseCore.columnOptionalText(statement: statement, index: 12)
+            sourceUrl: DatabaseCore.columnOptionalText(statement: statement, index: 5),
+            createdAt: DatabaseCore.columnText(statement: statement, index: 6),
+            clientUpdatedAt: DatabaseCore.columnText(statement: statement, index: 7),
+            lastModifiedByReplicaId: DatabaseCore.columnText(statement: statement, index: 8),
+            lastOperationId: DatabaseCore.columnText(statement: statement, index: 9),
+            updatedAt: DatabaseCore.columnText(statement: statement, index: 10),
+            deletedAt: DatabaseCore.columnOptionalText(statement: statement, index: 11)
         )
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
@@ -326,7 +326,6 @@ struct SyncApplier {
                 mime_type,
                 size_bytes,
                 sha256,
-                storage_key,
                 source_url,
                 created_at,
                 client_updated_at,
@@ -335,12 +334,11 @@ struct SyncApplier {
                 updated_at,
                 deleted_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(workspace_id, media_asset_id) DO UPDATE SET
                 mime_type = excluded.mime_type,
                 size_bytes = excluded.size_bytes,
                 sha256 = excluded.sha256,
-                storage_key = excluded.storage_key,
                 source_url = excluded.source_url,
                 created_at = excluded.created_at,
                 client_updated_at = excluded.client_updated_at,
@@ -355,7 +353,6 @@ struct SyncApplier {
                 .text(mediaAsset.mimeType),
                 .integer(mediaAsset.sizeBytes),
                 .text(mediaAsset.sha256),
-                .text(mediaAsset.storageKey),
                 mediaAsset.sourceUrl.map(SQLiteValue.text) ?? .null,
                 .text(mediaAsset.createdAt),
                 .text(mediaAsset.clientUpdatedAt),

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/CloudSyncContractsEncodingTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/CloudSyncContractsEncodingTests.swift
@@ -261,7 +261,7 @@ final class CloudSyncContractsEncodingTests: XCTestCase {
         XCTAssertEqual(payload["mimeType"] as? String, mediaAsset.mimeType)
         XCTAssertEqual(payload["sizeBytes"] as? Int, Int(mediaAsset.sizeBytes))
         XCTAssertEqual(payload["sha256"] as? String, mediaAsset.sha256)
-        XCTAssertEqual(payload["storageKey"] as? String, mediaAsset.storageKey)
+        XCTAssertNil(payload["storageKey"])
         XCTAssertEqual(payload["clientUpdatedAt"] as? String, mediaAsset.clientUpdatedAt)
         XCTAssertEqual(payload["lastOperationId"] as? String, mediaAsset.lastOperationId)
         XCTAssertEqual(payload["updatedAt"] as? String, mediaAsset.updatedAt)
@@ -282,7 +282,6 @@ final class CloudSyncContractsEncodingTests: XCTestCase {
                 "mimeType": "image/png",
                 "sizeBytes": 1234,
                 "sha256": "sha",
-                "storageKey": "workspaces/workspace-1/media/asset.png",
                 "sourceUrl": null,
                 "createdAt": "2026-04-24T10:00:00.000Z",
                 "clientUpdatedAt": "2026-04-24T10:00:01.000Z",
@@ -424,7 +423,6 @@ final class CloudSyncContractsEncodingTests: XCTestCase {
             mimeType: "image/png",
             sizeBytes: 1234,
             sha256: "sha",
-            storageKey: "workspaces/workspace-1/media/asset.png",
             sourceUrl: nil,
             createdAt: "2026-04-24T10:00:00.000Z",
             clientUpdatedAt: "2026-04-24T10:00:01.000Z",

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
@@ -173,6 +173,7 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
         let mediaAsset = self.makeMediaAsset(workspaceId: workspace.workspaceId, deletedAt: nil)
+        XCTAssertFalse(try self.hasColumn(database: database, tableName: "media_assets", columnName: "storage_key"))
 
         let applyResult = try database.applySyncBootstrapEntry(
             workspaceId: workspace.workspaceId,
@@ -235,7 +236,6 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
             mimeType: "image/png",
             sizeBytes: 1234,
             sha256: "sha",
-            storageKey: "workspaces/\(workspaceId)/media/asset.png",
             sourceUrl: nil,
             createdAt: "2026-04-24T10:00:00.000Z",
             clientUpdatedAt: deletedAt == nil ? "2026-04-24T10:00:01.000Z" : "2026-04-25T10:00:00.000Z",

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion21To22MigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion21To22MigrationTests.swift
@@ -32,6 +32,7 @@ final class LocalDatabaseSchemaVersion21To22MigrationTests: LocalDatabaseTestCas
 
         XCTAssertEqual(LocalDatabaseSchema.currentVersion, try self.loadSchemaVersion(database: migratedDatabase))
         XCTAssertTrue(try self.hasColumn(database: migratedDatabase, tableName: "media_assets", columnName: "media_asset_id"))
+        XCTAssertFalse(try self.hasColumn(database: migratedDatabase, tableName: "media_assets", columnName: "storage_key"))
         XCTAssertEqual(syncState.lastAppliedHotChangeId, 0)
         XCTAssertFalse(syncState.hasHydratedHotState)
         XCTAssertEqual(syncState.lastAppliedReviewSequenceId, 456)

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion22To23MigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion22To23MigrationTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import XCTest
+@testable import Flashcards
+
+final class LocalDatabaseSchemaVersion22To23MigrationTests: LocalDatabaseTestCase {
+    func testSchemaVersion22MigrationDropsMediaAssetStorageKey() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let mediaAsset = MediaAsset(
+            mediaAssetId: "00000000-0000-4000-8000-000000000001",
+            workspaceId: workspace.workspaceId,
+            mimeType: "image/png",
+            sizeBytes: 1234,
+            sha256: "sha",
+            sourceUrl: nil,
+            createdAt: "2026-04-24T10:00:00.000Z",
+            clientUpdatedAt: "2026-04-24T10:00:01.000Z",
+            lastModifiedByReplicaId: "replica-1",
+            lastOperationId: "operation-media-1",
+            updatedAt: "2026-04-24T10:00:02.000Z",
+            deletedAt: nil
+        )
+
+        _ = try database.applySyncBootstrapEntry(
+            workspaceId: workspace.workspaceId,
+            entry: SyncBootstrapEntry(
+                entityType: .mediaAsset,
+                entityId: mediaAsset.mediaAssetId,
+                action: .upsert,
+                payload: .mediaAsset(mediaAsset)
+            )
+        )
+        try database.core.execute(
+            sql: """
+            ALTER TABLE media_assets
+            ADD COLUMN storage_key TEXT NOT NULL DEFAULT 'legacy-storage-key' CHECK (length(trim(storage_key)) > 0)
+            """,
+            values: []
+        )
+        try database.core.executeScript(
+            sql: "PRAGMA user_version = 22;",
+            errorContext: "Failed to prepare schema v22 fixture"
+        )
+        try database.close()
+        self.database = nil
+
+        let migratedDatabase = try LocalDatabase(databaseURL: try XCTUnwrap(self.databaseURL))
+        self.database = migratedDatabase
+
+        XCTAssertEqual(LocalDatabaseSchema.currentVersion, try self.loadSchemaVersion(database: migratedDatabase))
+        XCTAssertFalse(try self.hasColumn(database: migratedDatabase, tableName: "media_assets", columnName: "storage_key"))
+        let migratedMediaAsset = try XCTUnwrap(
+            try migratedDatabase.loadOptionalMediaAssetIncludingDeleted(
+                workspaceId: workspace.workspaceId,
+                mediaAssetId: mediaAsset.mediaAssetId
+            )
+        )
+        XCTAssertEqual(migratedMediaAsset, mediaAsset)
+    }
+}


### PR DESCRIPTION
## Summary
- Removes `storageKey` from iOS MediaAsset model, sync payloads, local SQLite schema, and media asset store writes/reads.
- Adds local schema version 23 with a 22 -> 23 migration dropping legacy `media_assets.storage_key`.
- Preserves managed media rendering based on logical `mediaAssetId` and backend download-url.
- Updates focused sync/database tests.

## Validation
- `git --no-pager diff --check` passed.
- `xcrun swiftc -parse ...touched Swift files...` passed.
- No simulator-backed tests or smoke flows were run by instruction.
- `xcodebuild build-for-testing`/non-simulator app build could not complete due local Xcode destination/resource setup, not known edited Swift compile errors.

## Review
- No split recommendation.
- No P0-P4 findings.
- Green commit gate.