### PR TITLE
Remove Android media asset storage keys

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
@@ -258,7 +258,7 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             assertEquals(
                 "Cannot fork workspace identity from workspace '$syncLocalStoreContractWorkspaceId' to " +
                     "'workspace-2' because the source workspace has 1 media asset registry row(s). " +
-                    "Android cannot reassign workspace-scoped media storage keys in this sync/storage split.",
+                    "Android cannot reassign managed media assets in this sync/storage split.",
                 error.message
             )
         }
@@ -301,7 +301,7 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             assertEquals(
                 "Cannot fork workspace identity from workspace '$syncLocalStoreContractWorkspaceId' to " +
                     "'workspace-2' because the destination workspace has 1 media asset registry row(s). " +
-                    "Android cannot delete or reassign workspace-scoped media storage keys in this sync/storage split.",
+                    "Android cannot delete or reassign managed media assets in this sync/storage split.",
                 error.message
             )
         }
@@ -503,7 +503,6 @@ private fun createMediaAssetEntity(
         mimeType = "image/png",
         sizeBytes = 12L,
         sha256 = sha256,
-        storageKey = "media-assets/workspaces/$workspaceId/assets/$mediaAssetId/$sha256",
         sourceUrl = null,
         createdAtMillis = 1L,
         clientUpdatedAtMillis = 2L,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
@@ -294,7 +294,7 @@ internal class WorkspaceIdentityLocalStore(
         require(mediaAssetCount == 0) {
             "Cannot fork workspace identity from workspace '$currentLocalWorkspaceId' to " +
                 "'${destinationWorkspace.workspaceId}' because the source workspace has $mediaAssetCount media asset " +
-                "registry row(s). Android cannot reassign workspace-scoped media storage keys in this sync/storage split."
+                "registry row(s). Android cannot reassign managed media assets in this sync/storage split."
         }
         val snapshot = loadWorkspaceForkSnapshot(workspaceId = currentLocalWorkspaceId)
         val forkMappings = buildWorkspaceForkIdMappings(
@@ -312,7 +312,7 @@ internal class WorkspaceIdentityLocalStore(
                 "Cannot fork workspace identity from workspace '$currentLocalWorkspaceId' to " +
                     "'${destinationWorkspace.workspaceId}' because the destination workspace has " +
                     "$destinationMediaAssetCount media asset registry row(s). Android cannot delete or reassign " +
-                    "workspace-scoped media storage keys in this sync/storage split."
+                    "managed media assets in this sync/storage split."
             }
         }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
@@ -187,7 +187,6 @@ internal class SyncHotStateLocalStore(
                 mimeType = payload.requireCloudString("mimeType", "$fieldPath.mimeType"),
                 sizeBytes = payload.requireCloudLong("sizeBytes", "$fieldPath.sizeBytes"),
                 sha256 = payload.requireCloudString("sha256", "$fieldPath.sha256"),
-                storageKey = payload.requireCloudString("storageKey", "$fieldPath.storageKey"),
                 sourceUrl = payload.requireCloudNullableString("sourceUrl", "$fieldPath.sourceUrl"),
                 createdAtMillis = payload.requireCloudIsoTimestampMillis("createdAt", "$fieldPath.createdAt"),
                 clientUpdatedAtMillis = payload.requireCloudIsoTimestampMillis(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
@@ -115,7 +115,6 @@ internal fun buildMediaAssetOutboxPayloadJson(mediaAsset: MediaAssetEntity): JSO
         .put("mimeType", mediaAsset.mimeType)
         .put("sizeBytes", mediaAsset.sizeBytes)
         .put("sha256", mediaAsset.sha256)
-        .put("storageKey", mediaAsset.storageKey)
         .putNullableString("sourceUrl", mediaAsset.sourceUrl)
         .put("createdAt", formatIsoTimestamp(mediaAsset.createdAtMillis))
         .putNullableString("deletedAt", mediaAsset.deletedAtMillis?.let(::formatIsoTimestamp))
@@ -320,7 +319,6 @@ internal fun decodeOutboxOperation(entry: OutboxEntryEntity): SyncOperation {
                     mimeType = payloadJson.requireCloudString("mimeType", "outbox.mediaAsset.mimeType"),
                     sizeBytes = payloadJson.requireCloudLong("sizeBytes", "outbox.mediaAsset.sizeBytes"),
                     sha256 = payloadJson.requireCloudString("sha256", "outbox.mediaAsset.sha256"),
-                    storageKey = payloadJson.requireCloudString("storageKey", "outbox.mediaAsset.storageKey"),
                     sourceUrl = payloadJson.requireCloudNullableString("sourceUrl", "outbox.mediaAsset.sourceUrl"),
                     createdAt = payloadJson.requireCloudString("createdAt", "outbox.mediaAsset.createdAt"),
                     deletedAt = payloadJson.requireCloudNullableString("deletedAt", "outbox.mediaAsset.deletedAt")

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -65,7 +65,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 27,
+    version = 28,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/MediaAssetEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/MediaAssetEntities.kt
@@ -17,7 +17,6 @@ import androidx.room.PrimaryKey
     ],
     indices = [
         Index("workspaceId"),
-        Index(value = ["storageKey"], unique = true),
         Index(value = ["workspaceId", "updatedAtMillis", "mediaAssetId"]),
         Index(value = ["workspaceId", "sha256", "mediaAssetId"])
     ]
@@ -28,7 +27,6 @@ data class MediaAssetEntity(
     val mimeType: String,
     val sizeBytes: Long,
     val sha256: String,
-    val storageKey: String,
     val sourceUrl: String?,
     val createdAtMillis: Long,
     val clientUpdatedAtMillis: Long,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -41,7 +41,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration23To24,
         migration24To25,
         migration25To26,
-        migration26To27
+        migration26To27,
+        migration27To28
     )
 }
 
@@ -880,7 +881,6 @@ val migration26To27: Migration = object : Migration(26, 27) {
                 mimeType TEXT NOT NULL,
                 sizeBytes INTEGER NOT NULL,
                 sha256 TEXT NOT NULL,
-                storageKey TEXT NOT NULL,
                 sourceUrl TEXT,
                 createdAtMillis INTEGER NOT NULL,
                 clientUpdatedAtMillis INTEGER NOT NULL,
@@ -893,7 +893,6 @@ val migration26To27: Migration = object : Migration(26, 27) {
             """.trimIndent()
         )
         db.execSQL("CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId ON media_assets(workspaceId)")
-        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_media_assets_storageKey ON media_assets(storageKey)")
         db.execSQL(
             """
             CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId_updatedAtMillis_mediaAssetId
@@ -912,6 +911,77 @@ val migration26To27: Migration = object : Migration(26, 27) {
             SET lastSyncCursor = NULL,
                 hasHydratedHotState = 0
             WHERE hasHydratedHotState = 1
+            """.trimIndent()
+        )
+    }
+}
+
+val migration27To28: Migration = object : Migration(27, 28) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS media_assets_v28 (
+                mediaAssetId TEXT NOT NULL PRIMARY KEY,
+                workspaceId TEXT NOT NULL,
+                mimeType TEXT NOT NULL,
+                sizeBytes INTEGER NOT NULL,
+                sha256 TEXT NOT NULL,
+                sourceUrl TEXT,
+                createdAtMillis INTEGER NOT NULL,
+                clientUpdatedAtMillis INTEGER NOT NULL,
+                lastModifiedByReplicaId TEXT NOT NULL,
+                lastOperationId TEXT NOT NULL,
+                updatedAtMillis INTEGER NOT NULL,
+                deletedAtMillis INTEGER,
+                FOREIGN KEY(workspaceId) REFERENCES workspaces(workspaceId) ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO media_assets_v28 (
+                mediaAssetId,
+                workspaceId,
+                mimeType,
+                sizeBytes,
+                sha256,
+                sourceUrl,
+                createdAtMillis,
+                clientUpdatedAtMillis,
+                lastModifiedByReplicaId,
+                lastOperationId,
+                updatedAtMillis,
+                deletedAtMillis
+            )
+            SELECT
+                mediaAssetId,
+                workspaceId,
+                mimeType,
+                sizeBytes,
+                sha256,
+                sourceUrl,
+                createdAtMillis,
+                clientUpdatedAtMillis,
+                lastModifiedByReplicaId,
+                lastOperationId,
+                updatedAtMillis,
+                deletedAtMillis
+            FROM media_assets
+            """.trimIndent()
+        )
+        db.execSQL("DROP TABLE media_assets")
+        db.execSQL("ALTER TABLE media_assets_v28 RENAME TO media_assets")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId ON media_assets(workspaceId)")
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId_updatedAtMillis_mediaAssetId
+            ON media_assets(workspaceId, updatedAtMillis, mediaAssetId)
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_media_assets_workspaceId_sha256_mediaAssetId
+            ON media_assets(workspaceId, sha256, mediaAssetId)
             """.trimIndent()
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
@@ -6,7 +6,6 @@ data class MediaAsset(
     val mimeType: String,
     val sizeBytes: Long,
     val sha256: String,
-    val storageKey: String,
     val sourceUrl: String?,
     val createdAtMillis: Long,
     val clientUpdatedAtMillis: Long,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
@@ -107,7 +107,6 @@ data class MediaAssetSyncPayload(
     val mimeType: String,
     val sizeBytes: Long,
     val sha256: String,
-    val storageKey: String,
     val sourceUrl: String?,
     val createdAt: String,
     val deletedAt: String?

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
@@ -721,7 +721,6 @@ private fun buildOperationPayload(payload: SyncOperationPayload): JSONObject {
             .put("mimeType", payload.payload.mimeType)
             .put("sizeBytes", payload.payload.sizeBytes)
             .put("sha256", payload.payload.sha256)
-            .put("storageKey", payload.payload.storageKey)
             .putNullableString("sourceUrl", payload.payload.sourceUrl)
             .put("createdAt", payload.payload.createdAt)
             .putNullableString("deletedAt", payload.payload.deletedAt)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
@@ -468,7 +468,6 @@ private fun toMediaAsset(mediaAsset: MediaAssetEntity): MediaAsset {
         mimeType = mediaAsset.mimeType,
         sizeBytes = mediaAsset.sizeBytes,
         sha256 = mediaAsset.sha256,
-        storageKey = mediaAsset.storageKey,
         sourceUrl = mediaAsset.sourceUrl,
         createdAtMillis = mediaAsset.createdAtMillis,
         clientUpdatedAtMillis = mediaAsset.clientUpdatedAtMillis,


### PR DESCRIPTION
## Summary
- Removes `storageKey` from Android media asset model, Room entity, wire/sync payloads, and local review/sync mappings.
- Adds Room schema version 28 with a 27 -> 28 migration dropping legacy `media_assets.storage_key`.
- Keeps Android aligned to the logical media asset contract: `mediaAssetId` plus safe metadata such as `sha256`, no storage implementation keys.

## Validation
- `git --no-pager diff --check` passed.
- Kotlin PSI syntax check over 11 edited Kotlin files passed.
- Targeted `storageKey`/`blob` search was clean for the edited Android contract.
- No Gradle run was performed because project instructions require explicit permission for `./gradlew`.

## Review
- No split recommendation.
- No P0-P4 findings.
- Green commit gate.