### PR TITLE
Add catalog kernel schema and service

### DIFF
--- a/apps/backend/src/catalog/index.test.ts
+++ b/apps/backend/src/catalog/index.test.ts
@@ -1,0 +1,542 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  attachCatalogPackageDraftMediaAssetInExecutor,
+  createCatalogPackageDraftInExecutor,
+  createCatalogPackageVersionFromWorkspaceSelectionInExecutor,
+  isCatalogPackageVersionStatusTransitionAllowed,
+  publishCatalogPackageVersionInExecutor,
+  updateCatalogPackageDraftInExecutor,
+} from ".";
+import type {
+  CatalogPackageMediaAssetRow,
+  CatalogPackageRow,
+  CatalogPackageStatus,
+  CatalogPackageVersionRow,
+  CreateCatalogPackageDraftInput,
+  UpdateCatalogPackageDraftInput,
+} from "./types";
+
+const testPackageId = "11111111-1111-4111-8111-111111111111";
+const testAuthorId = "22222222-2222-4222-8222-222222222222";
+const testPackageVersionId = "33333333-3333-4333-8333-333333333333";
+const testMediaBlobId = "44444444-4444-4444-8444-444444444444";
+const testPackageMediaAssetId = "55555555-5555-4555-8555-555555555555";
+const testWorkspaceId = "66666666-6666-4666-8666-666666666666";
+const testWorkspaceCardId = "77777777-7777-4777-8777-777777777777";
+const testTimestamp = "2026-04-18T10:00:00.000Z";
+
+const managedMediaReferenceExamples: ReadonlyArray<Readonly<{
+  name: string;
+  frontText: string;
+  backText: string;
+  expectedField: "frontText" | "backText";
+}>> = [
+  {
+    name: "UUID refs",
+    frontText: "Question",
+    backText: `![audio](fcasset:${testMediaBlobId})`,
+    expectedField: "backText",
+  },
+  {
+    name: "non-UUID refs",
+    frontText: "![image](fcasset:image-asset)",
+    backText: "Answer",
+    expectedField: "frontText",
+  },
+  {
+    name: "URL-like refs",
+    frontText: "Question",
+    backText: `![audio](FCASSET://${testMediaBlobId}?download=1)`,
+    expectedField: "backText",
+  },
+];
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createPackageRow(): CatalogPackageRow {
+  return {
+    package_id: testPackageId,
+    author_id: testAuthorId,
+    slug: "spanish-basics",
+    title: "Spanish Basics",
+    summary: "Core Spanish prompts.",
+    description: "Core Spanish flashcards for beginners.",
+    language_tags: ["en", "es"],
+    topic_tags: ["language"],
+    license: "CC-BY-4.0",
+    content_warning: null,
+    cover_package_media_key: null,
+    status: "draft",
+    created_at: testTimestamp,
+    updated_at: testTimestamp,
+    published_at: null,
+    delisted_at: null,
+  };
+}
+
+function createPackageVersionRow(status: CatalogPackageStatus): CatalogPackageVersionRow {
+  return {
+    package_version_id: testPackageVersionId,
+    package_id: testPackageId,
+    version_number: 1,
+    status,
+    slug: "spanish-basics",
+    title: "Spanish Basics",
+    summary: "Core Spanish prompts.",
+    description: "Core Spanish flashcards for beginners.",
+    language_tags: ["en", "es"],
+    topic_tags: ["language"],
+    license: "CC-BY-4.0",
+    content_warning: null,
+    cover_package_media_key: null,
+    source_workspace_id: null,
+    card_count: 1,
+    created_by_admin_email: "admin@example.com",
+    reviewed_by_admin_email: null,
+    created_at: testTimestamp,
+    updated_at: testTimestamp,
+    submitted_at: null,
+    reviewed_at: null,
+    published_at: null,
+    delisted_at: null,
+  };
+}
+
+function createPackageDraftInput(): CreateCatalogPackageDraftInput {
+  return {
+    packageId: testPackageId,
+    authorId: testAuthorId,
+    slug: "spanish-basics",
+    title: "Spanish Basics",
+    summary: "Core Spanish prompts.",
+    description: "Core Spanish flashcards for beginners.",
+    languageTags: ["en", "es"],
+    topicTags: ["language"],
+    license: "CC-BY-4.0",
+    contentWarning: null,
+  };
+}
+
+function createPackageDraftUpdateInput(coverPackageMediaKey: string | null): UpdateCatalogPackageDraftInput {
+  return {
+    ...createPackageDraftInput(),
+    coverPackageMediaKey,
+  };
+}
+
+test("catalog migration defines blob-backed media and published-version immutability", () => {
+  const migrationPath = resolve(process.cwd(), "../../db/migrations/0083_catalog_kernel.sql");
+  const migrationSql = readFileSync(migrationPath, "utf8");
+  const mediaAssetTableSql = migrationSql.slice(
+    migrationSql.indexOf("CREATE TABLE IF NOT EXISTS catalog.package_media_assets"),
+    migrationSql.indexOf("CREATE UNIQUE INDEX IF NOT EXISTS idx_package_media_assets_draft_key_unique"),
+  );
+
+  assert.match(migrationSql, /CREATE SCHEMA IF NOT EXISTS catalog;/);
+  assert.match(migrationSql, /'draft'/);
+  assert.match(migrationSql, /'needs_changes'/);
+  assert.match(migrationSql, /'published'/);
+  assert.match(migrationSql, /REFERENCES content\.media_blobs\(media_blob_id\)/);
+  assert.doesNotMatch(mediaAssetTableSql, /\bstorage_key\b/);
+  assert.doesNotMatch(mediaAssetTableSql, /\bsha256\b/);
+  assert.match(migrationSql, /prevent_published_package_version_update/);
+  assert.match(migrationSql, /package_cards_published_immutable/);
+  assert.match(migrationSql, /package_media_assets_published_immutable/);
+  assert.match(migrationSql, /IF TG_OP = 'INSERT' THEN/);
+  assert.match(migrationSql, /IF TG_OP = 'UPDATE' THEN/);
+  assert.match(migrationSql, /IF TG_OP = 'DELETE' THEN/);
+  assert.doesNotMatch(migrationSql, /TG_OP IN \('UPDATE', 'DELETE'\) AND OLD/);
+  assert.doesNotMatch(migrationSql, /TG_OP IN \('INSERT', 'UPDATE'\) AND NEW/);
+  assert.match(
+    migrationSql,
+    /OLD\.status IN \('published', 'delisted'\)\s+OR NEW\.status IN \('published', 'delisted'\)/,
+  );
+  assert.match(
+    migrationSql,
+    /OLD\.status IN \('published', 'delisted'\)\s+AND NEW\.published_at IS DISTINCT FROM OLD\.published_at/,
+  );
+});
+
+test("catalog package version status transitions are explicit", () => {
+  assert.equal(isCatalogPackageVersionStatusTransitionAllowed("draft", "submitted"), true);
+  assert.equal(isCatalogPackageVersionStatusTransitionAllowed("submitted", "approved"), true);
+  assert.equal(isCatalogPackageVersionStatusTransitionAllowed("approved", "published"), true);
+  assert.equal(isCatalogPackageVersionStatusTransitionAllowed("published", "delisted"), true);
+  assert.equal(isCatalogPackageVersionStatusTransitionAllowed("draft", "published"), false);
+  assert.equal(isCatalogPackageVersionStatusTransitionAllowed("delisted", "published"), false);
+});
+
+test("catalog package draft creation maps slug uniqueness to a conflict", async () => {
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      _params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      assert.match(text, /INSERT INTO catalog\.packages/);
+      const error = new Error("duplicate key value violates unique constraint") as Error & Readonly<{
+        code: string;
+        constraint: string;
+      }>;
+      Object.assign(error, {
+        code: "23505",
+        constraint: "packages_slug_unique",
+      });
+      throw error;
+    },
+  };
+
+  await assert.rejects(
+    createCatalogPackageDraftInExecutor(executor, createPackageDraftInput()),
+    (error: unknown) => {
+      assert.equal(error instanceof HttpError, true);
+      assert.equal((error as HttpError).statusCode, 409);
+      assert.equal((error as HttpError).code, "CATALOG_PACKAGE_SLUG_ALREADY_EXISTS");
+      return true;
+    },
+  );
+});
+
+test("catalog package draft creation starts coverless", async () => {
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      assert.match(text, /INSERT INTO catalog\.packages/);
+      assert.doesNotMatch(text.slice(0, text.indexOf("RETURNING")), /cover_package_media_key/);
+      assert.deepEqual(params, [
+        testPackageId,
+        testAuthorId,
+        "spanish-basics",
+        "Spanish Basics",
+        "Core Spanish prompts.",
+        "Core Spanish flashcards for beginners.",
+        ["en", "es"],
+        ["language"],
+        "CC-BY-4.0",
+        null,
+      ]);
+      return createQueryResult([createPackageRow() as unknown as Row]);
+    },
+  };
+
+  const catalogPackage = await createCatalogPackageDraftInExecutor(executor, createPackageDraftInput());
+
+  assert.equal(catalogPackage.coverPackageMediaKey, null);
+});
+
+test("catalog package draft update validates cover media after attach", async () => {
+  const queries: Array<string> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      queries.push(text);
+
+      if (text.includes("FROM catalog.package_media_assets")) {
+        assert.deepEqual(params, [testPackageId, ["cover"]]);
+        return createQueryResult([{ package_media_key: "cover" } as unknown as Row]);
+      }
+
+      if (text.includes("UPDATE catalog.packages")) {
+        assert.deepEqual(params, [
+          testPackageId,
+          testAuthorId,
+          "spanish-basics",
+          "Spanish Basics",
+          "Core Spanish prompts.",
+          "Core Spanish flashcards for beginners.",
+          ["en", "es"],
+          ["language"],
+          "CC-BY-4.0",
+          null,
+          "cover",
+        ]);
+        return createQueryResult([{
+          ...createPackageRow(),
+          cover_package_media_key: "cover",
+        } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const catalogPackage = await updateCatalogPackageDraftInExecutor(
+    executor,
+    createPackageDraftUpdateInput("cover"),
+  );
+
+  assert.equal(catalogPackage.coverPackageMediaKey, "cover");
+  assert.equal(queries.length, 2);
+});
+
+test("catalog package media assets attach through content.media_blobs", async () => {
+  const queries: Array<Readonly<{ text: string; params: ReadonlyArray<SqlValue> }>> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      queries.push({ text, params });
+
+      if (text.includes("FROM catalog.packages") && text.includes("FOR UPDATE")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([createPackageRow() as unknown as Row]);
+      }
+
+      if (text.includes("INSERT INTO catalog.package_media_assets")) {
+        assert.match(text, /FROM content\.media_blobs AS media_blobs/);
+        assert.doesNotMatch(text, /\bstorage_key\b/);
+        assert.deepEqual(params, [
+          testPackageMediaAssetId,
+          testPackageId,
+          "cover",
+          testMediaBlobId,
+          "Cover image",
+          null,
+          "CC-BY-4.0",
+        ]);
+        return createQueryResult([{
+          package_media_asset_id: testPackageMediaAssetId,
+          package_id: testPackageId,
+          package_version_id: null,
+          package_media_key: "cover",
+          media_blob_id: testMediaBlobId,
+          alt_text: "Cover image",
+          credit: null,
+          license: "CC-BY-4.0",
+          created_at: testTimestamp,
+          updated_at: testTimestamp,
+        } as CatalogPackageMediaAssetRow as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const mediaAsset = await attachCatalogPackageDraftMediaAssetInExecutor(
+    executor,
+    testPackageId,
+    {
+      packageMediaAssetId: testPackageMediaAssetId,
+      packageMediaKey: "cover",
+      mediaBlobId: testMediaBlobId,
+      altText: "Cover image",
+      credit: null,
+      license: "CC-BY-4.0",
+    },
+  );
+
+  assert.equal(mediaAsset.mediaBlobId, testMediaBlobId);
+  assert.equal(mediaAsset.packageMediaKey, "cover");
+  assert.equal(queries.length, 2);
+});
+
+test("publish helper rejects unapproved package versions before mutating", async () => {
+  const queries: Array<string> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      queries.push(text);
+      assert.deepEqual(params, [testPackageVersionId]);
+      if (text.includes("FROM catalog.package_versions") && text.includes("FOR UPDATE")) {
+        return createQueryResult([createPackageVersionRow("draft") as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected mutation query: ${text}`);
+    },
+  };
+
+  await assert.rejects(
+    publishCatalogPackageVersionInExecutor(
+      executor,
+      testPackageVersionId,
+      "admin@example.com",
+      null,
+    ),
+    (error: unknown) => {
+      assert.equal(error instanceof HttpError, true);
+      assert.equal((error as HttpError).statusCode, 409);
+      assert.equal((error as HttpError).code, "CATALOG_PACKAGE_VERSION_NOT_APPROVED");
+      return true;
+    },
+  );
+  assert.equal(queries.length, 1);
+});
+
+test("workspace-selected catalog versions generate fresh package card ids", async () => {
+  let insertedPackageCardId: string | null = null;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("set_config('app.user_id'")) {
+        assert.deepEqual(params, ["admin-user-id", testWorkspaceId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("FROM content.cards")) {
+        assert.deepEqual(params, [testWorkspaceId, [testWorkspaceCardId]]);
+        return createQueryResult([{
+          card_id: testWorkspaceCardId,
+          front_text: "Hola",
+          back_text: "Hello",
+          card_type: "basic",
+          metadata: { version: 1, source: null },
+          tags: ["language"],
+        } as unknown as Row]);
+      }
+
+      if (text.includes("FROM catalog.packages") && text.includes("FOR UPDATE")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([createPackageRow() as unknown as Row]);
+      }
+
+      if (text.includes("FROM catalog.package_versions") && text.includes("status IN")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("FROM catalog.package_versions") && text.includes("ORDER BY version_number DESC")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("INSERT INTO catalog.package_versions")) {
+        assert.equal(params[0], testPackageVersionId);
+        assert.equal(params[12], testWorkspaceId);
+        return createQueryResult([{
+          ...createPackageVersionRow("draft"),
+          source_workspace_id: testWorkspaceId,
+        } as unknown as Row]);
+      }
+
+      if (text.includes("INSERT INTO catalog.package_media_assets")) {
+        assert.deepEqual(params, [testPackageId, testPackageVersionId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("INSERT INTO catalog.package_cards")) {
+        insertedPackageCardId = String(params[0]);
+        assert.notEqual(insertedPackageCardId, testWorkspaceCardId);
+        assert.match(insertedPackageCardId, /^[0-9a-f-]{36}$/);
+        assert.deepEqual(params.slice(1), [
+          testPackageVersionId,
+          testWorkspaceCardId,
+          1,
+          "Hola",
+          "Hello",
+          "basic",
+          JSON.stringify({ version: 1, source: null }),
+          ["language"],
+          [],
+        ]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("INSERT INTO catalog.package_review_events")) {
+        assert.deepEqual(params, [
+          testPackageId,
+          testPackageVersionId,
+          null,
+          "draft",
+          "admin@example.com",
+          null,
+        ]);
+        return createQueryResult([]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const packageVersion = await createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+    executor,
+    testPackageId,
+    {
+      packageVersionId: testPackageVersionId,
+      workspaceId: testWorkspaceId,
+      cardIds: [testWorkspaceCardId],
+    },
+    "admin-user-id",
+    "admin@example.com",
+  );
+
+  assert.equal(packageVersion.packageVersionId, testPackageVersionId);
+  assert.equal(packageVersion.sourceWorkspaceId, testWorkspaceId);
+  assert.notEqual(insertedPackageCardId, null);
+});
+
+for (const example of managedMediaReferenceExamples) {
+  test(`workspace-selected catalog versions reject managed media references in ${example.name}`, async () => {
+    const queries: Array<string> = [];
+    const executor: DatabaseExecutor = {
+      async query<Row extends pg.QueryResultRow>(
+        text: string,
+        params: ReadonlyArray<SqlValue>,
+      ): Promise<pg.QueryResult<Row>> {
+        queries.push(text);
+        if (text.includes("set_config('app.user_id'")) {
+          assert.deepEqual(params, ["admin-user-id", testWorkspaceId]);
+          return createQueryResult([]);
+        }
+
+        if (text.includes("FROM content.cards")) {
+          assert.deepEqual(params, [testWorkspaceId, [testWorkspaceCardId]]);
+          return createQueryResult([{
+            card_id: testWorkspaceCardId,
+            front_text: example.frontText,
+            back_text: example.backText,
+            card_type: "basic",
+            metadata: { version: 1, source: null },
+            tags: [],
+          } as unknown as Row]);
+        }
+
+        throw new Error(`Unexpected query: ${text}`);
+      },
+    };
+
+    await assert.rejects(
+      createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+        executor,
+        testPackageId,
+        {
+          packageVersionId: testPackageVersionId,
+          workspaceId: testWorkspaceId,
+          cardIds: [testWorkspaceCardId],
+        },
+        "admin-user-id",
+        "admin@example.com",
+      ),
+      (error: unknown) => {
+        assert.equal(error instanceof HttpError, true);
+        assert.equal((error as HttpError).statusCode, 400);
+        assert.equal((error as HttpError).code, "CATALOG_WORKSPACE_CARD_MEDIA_REFERENCE_UNSUPPORTED");
+        assert.match((error as HttpError).message, new RegExp(`cardId=${testWorkspaceCardId}`));
+        assert.match((error as HttpError).message, new RegExp(`field=${example.expectedField}`));
+        return true;
+      },
+    );
+    assert.equal(queries.length, 2);
+  });
+}

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -1,0 +1,1445 @@
+import { randomUUID } from "node:crypto";
+import {
+  applyWorkspaceDatabaseScopeInExecutor,
+  type DatabaseExecutor,
+} from "../database";
+import { unsafeTransaction } from "../database/core";
+import { getDatabaseErrorFields } from "../database/transient";
+import { HttpError } from "../shared/errors";
+import type {
+  AttachCatalogPackageMediaAssetInput,
+  CatalogAuthor,
+  CatalogAuthorRow,
+  CatalogPackage,
+  CatalogPackageCardSnapshotInput,
+  CatalogPackageDraft,
+  CatalogPackageMediaAsset,
+  CatalogPackageMediaAssetRow,
+  CatalogPackageRow,
+  CatalogPackageStatus,
+  CatalogPackageVersion,
+  CatalogPackageVersionRow,
+  CatalogWorkspaceCardRow,
+  CreateCatalogPackageDraftInput,
+  CreateCatalogPackageVersionFromWorkspaceInput,
+  CreateCatalogPackageVersionInput,
+  TimestampValue,
+  UpdateCatalogPackageDraftInput,
+  UpdateCatalogPackageVersionStatusInput,
+  UpsertCatalogAuthorInput,
+} from "./types";
+
+const catalogAuthorColumns = [
+  "author_id",
+  "slug",
+  "display_name",
+  "bio",
+  "website_url",
+  "created_at",
+  "updated_at",
+].join(", ");
+
+const catalogPackageColumns = [
+  "package_id",
+  "author_id",
+  "slug",
+  "title",
+  "summary",
+  "description",
+  "language_tags",
+  "topic_tags",
+  "license",
+  "content_warning",
+  "cover_package_media_key",
+  "status",
+  "created_at",
+  "updated_at",
+  "published_at",
+  "delisted_at",
+].join(", ");
+
+const catalogPackageMediaAssetColumns = [
+  "package_media_asset_id",
+  "package_id",
+  "package_version_id",
+  "package_media_key",
+  "media_blob_id",
+  "alt_text",
+  "credit",
+  "license",
+  "created_at",
+  "updated_at",
+].join(", ");
+
+const catalogPackageVersionColumns = [
+  "package_version_id",
+  "package_id",
+  "version_number",
+  "status",
+  "slug",
+  "title",
+  "summary",
+  "description",
+  "language_tags",
+  "topic_tags",
+  "license",
+  "content_warning",
+  "cover_package_media_key",
+  "source_workspace_id",
+  "card_count",
+  "created_by_admin_email",
+  "reviewed_by_admin_email",
+  "created_at",
+  "updated_at",
+  "submitted_at",
+  "reviewed_at",
+  "published_at",
+  "delisted_at",
+].join(", ");
+
+const slugPattern = /^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$/u;
+const packageMediaKeyPattern = /^[a-z0-9][a-z0-9._-]{0,127}$/u;
+const mutablePackageVersionStatuses: ReadonlySet<CatalogPackageStatus> = new Set([
+  "draft",
+  "submitted",
+  "needs_changes",
+  "approved",
+]);
+const reviewStatusRouteTargets: ReadonlySet<CatalogPackageStatus> = new Set([
+  "draft",
+  "submitted",
+  "needs_changes",
+  "approved",
+  "rejected",
+]);
+const managedMediaReferencePattern = /fcasset:/iu;
+
+function toIsoString(value: TimestampValue): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return new Date(value).toISOString();
+}
+
+function toOptionalIsoString(value: TimestampValue | null): string | null {
+  return value === null ? null : toIsoString(value);
+}
+
+function toSafeNumber(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (Number.isSafeInteger(parsedValue) === false) {
+    throw new Error(`${fieldName} must be a safe integer`);
+  }
+
+  return parsedValue;
+}
+
+function normalizeNonEmptyString(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (normalizedValue === "") {
+    throw new HttpError(400, `${fieldName} must not be empty`, "CATALOG_INVALID_INPUT");
+  }
+
+  return normalizedValue;
+}
+
+function normalizeNullableString(value: string | null, fieldName: string): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return normalizeNonEmptyString(value, fieldName);
+}
+
+function normalizeSlug(value: string, fieldName: string): string {
+  const slug = normalizeNonEmptyString(value, fieldName).toLowerCase();
+  if (slugPattern.test(slug) === false) {
+    throw new HttpError(
+      400,
+      `${fieldName} must use lowercase letters, numbers, and hyphens without leading or trailing hyphens.`,
+      "CATALOG_SLUG_INVALID",
+    );
+  }
+
+  return slug;
+}
+
+function normalizePackageMediaKey(value: string, fieldName: string): string {
+  const packageMediaKey = normalizeNonEmptyString(value, fieldName).toLowerCase();
+  if (packageMediaKeyPattern.test(packageMediaKey) === false) {
+    throw new HttpError(
+      400,
+      `${fieldName} must use lowercase letters, numbers, dots, underscores, or hyphens.`,
+      "CATALOG_PACKAGE_MEDIA_KEY_INVALID",
+    );
+  }
+
+  return packageMediaKey;
+}
+
+function normalizeTextArray(
+  values: ReadonlyArray<string>,
+  fieldName: string,
+  requireNonEmpty: boolean,
+): ReadonlyArray<string> {
+  const normalizedValues = values.map((value) => normalizeNonEmptyString(value, fieldName).toLowerCase());
+  const uniqueValues = [...new Set(normalizedValues)];
+  if (requireNonEmpty && uniqueValues.length === 0) {
+    throw new HttpError(400, `${fieldName} must include at least one item`, "CATALOG_INVALID_INPUT");
+  }
+
+  return uniqueValues;
+}
+
+function normalizeAdminEmail(adminEmail: string): string {
+  return normalizeNonEmptyString(adminEmail, "adminEmail").toLowerCase();
+}
+
+function readStringField(value: unknown, fieldName: string): string | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const fieldValue = (value as Readonly<Record<string, unknown>>)[fieldName];
+  return typeof fieldValue === "string" && fieldValue !== "" ? fieldValue : null;
+}
+
+function toCatalogPersistenceError(error: unknown): HttpError | null {
+  if (error instanceof HttpError) {
+    return error;
+  }
+
+  const fields = getDatabaseErrorFields(error);
+  const constraint = readStringField(error, "constraint");
+  if (fields.sqlState === "23505") {
+    switch (constraint) {
+      case "authors_slug_unique":
+        return new HttpError(409, "Catalog author slug already exists.", "CATALOG_AUTHOR_SLUG_ALREADY_EXISTS");
+      case "packages_slug_unique":
+        return new HttpError(409, "Catalog package slug already exists.", "CATALOG_PACKAGE_SLUG_ALREADY_EXISTS");
+      case "idx_package_versions_one_review_candidate":
+        return new HttpError(
+          409,
+          "Package already has a mutable draft or review candidate version.",
+          "CATALOG_PACKAGE_VERSION_DRAFT_ALREADY_EXISTS",
+        );
+      case "package_versions_package_number_unique":
+        return new HttpError(
+          409,
+          "Package version number already exists for this package.",
+          "CATALOG_PACKAGE_VERSION_ALREADY_EXISTS",
+        );
+      case "idx_package_media_assets_draft_key_unique":
+      case "idx_package_media_assets_version_key_unique":
+        return new HttpError(
+          409,
+          "Catalog package media key already exists for this package draft or version.",
+          "CATALOG_PACKAGE_MEDIA_KEY_ALREADY_EXISTS",
+        );
+    }
+  }
+
+  if (fields.sqlState === "23503") {
+    return new HttpError(
+      400,
+      `Catalog write references a missing row. constraint=${constraint ?? "unknown"}`,
+      "CATALOG_REFERENCE_NOT_FOUND",
+    );
+  }
+
+  if (fields.sqlState === "23514") {
+    return new HttpError(
+      409,
+      `Catalog write violates a catalog database constraint. message=${fields.errorMessage}`,
+      "CATALOG_CONSTRAINT_VIOLATION",
+    );
+  }
+
+  return null;
+}
+
+function rethrowCatalogPersistenceError(error: unknown): never {
+  const mappedError = toCatalogPersistenceError(error);
+  if (mappedError !== null) {
+    throw mappedError;
+  }
+
+  throw error;
+}
+
+export function isCatalogPackageVersionStatusTransitionAllowed(
+  fromStatus: CatalogPackageStatus,
+  toStatus: CatalogPackageStatus,
+): boolean {
+  if (fromStatus === toStatus) {
+    return true;
+  }
+
+  switch (fromStatus) {
+    case "draft":
+      return toStatus === "submitted" || toStatus === "rejected";
+    case "submitted":
+      return toStatus === "needs_changes" || toStatus === "approved" || toStatus === "rejected";
+    case "needs_changes":
+      return toStatus === "submitted" || toStatus === "rejected";
+    case "approved":
+      return toStatus === "published" || toStatus === "rejected";
+    case "published":
+      return toStatus === "delisted";
+    case "rejected":
+    case "delisted":
+      return false;
+  }
+}
+
+export function assertCatalogPackageVersionStatusTransitionAllowed(
+  fromStatus: CatalogPackageStatus,
+  toStatus: CatalogPackageStatus,
+): void {
+  if (isCatalogPackageVersionStatusTransitionAllowed(fromStatus, toStatus)) {
+    return;
+  }
+
+  throw new HttpError(
+    409,
+    `Invalid catalog package version status transition. fromStatus=${fromStatus} toStatus=${toStatus}`,
+    "CATALOG_PACKAGE_VERSION_STATUS_TRANSITION_INVALID",
+  );
+}
+
+function mapCatalogAuthorRow(row: CatalogAuthorRow): CatalogAuthor {
+  return {
+    authorId: row.author_id,
+    slug: row.slug,
+    displayName: row.display_name,
+    bio: row.bio,
+    websiteUrl: row.website_url,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+  };
+}
+
+function mapCatalogPackageRow(row: CatalogPackageRow): CatalogPackage {
+  return {
+    packageId: row.package_id,
+    authorId: row.author_id,
+    slug: row.slug,
+    title: row.title,
+    summary: row.summary,
+    description: row.description,
+    languageTags: [...row.language_tags],
+    topicTags: [...row.topic_tags],
+    license: row.license,
+    contentWarning: row.content_warning,
+    coverPackageMediaKey: row.cover_package_media_key,
+    status: row.status,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+    publishedAt: toOptionalIsoString(row.published_at),
+    delistedAt: toOptionalIsoString(row.delisted_at),
+  };
+}
+
+function mapCatalogPackageMediaAssetRow(row: CatalogPackageMediaAssetRow): CatalogPackageMediaAsset {
+  return {
+    packageMediaAssetId: row.package_media_asset_id,
+    packageId: row.package_id,
+    packageVersionId: row.package_version_id,
+    packageMediaKey: row.package_media_key,
+    mediaBlobId: row.media_blob_id,
+    altText: row.alt_text,
+    credit: row.credit,
+    license: row.license,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+  };
+}
+
+function mapCatalogPackageVersionRow(row: CatalogPackageVersionRow): CatalogPackageVersion {
+  return {
+    packageVersionId: row.package_version_id,
+    packageId: row.package_id,
+    versionNumber: toSafeNumber(row.version_number, "version_number"),
+    status: row.status,
+    slug: row.slug,
+    title: row.title,
+    summary: row.summary,
+    description: row.description,
+    languageTags: [...row.language_tags],
+    topicTags: [...row.topic_tags],
+    license: row.license,
+    contentWarning: row.content_warning,
+    coverPackageMediaKey: row.cover_package_media_key,
+    sourceWorkspaceId: row.source_workspace_id,
+    cardCount: toSafeNumber(row.card_count, "card_count"),
+    createdByAdminEmail: row.created_by_admin_email,
+    reviewedByAdminEmail: row.reviewed_by_admin_email,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+    submittedAt: toOptionalIsoString(row.submitted_at),
+    reviewedAt: toOptionalIsoString(row.reviewed_at),
+    publishedAt: toOptionalIsoString(row.published_at),
+    delistedAt: toOptionalIsoString(row.delisted_at),
+  };
+}
+
+function normalizeCatalogAuthorInput(input: UpsertCatalogAuthorInput): UpsertCatalogAuthorInput {
+  return {
+    authorId: input.authorId,
+    slug: normalizeSlug(input.slug, "slug"),
+    displayName: normalizeNonEmptyString(input.displayName, "displayName"),
+    bio: normalizeNullableString(input.bio, "bio"),
+    websiteUrl: normalizeNullableString(input.websiteUrl, "websiteUrl"),
+  };
+}
+
+function normalizeCreateCatalogPackageDraftInput(
+  input: CreateCatalogPackageDraftInput,
+): CreateCatalogPackageDraftInput {
+  return {
+    packageId: input.packageId,
+    authorId: input.authorId,
+    slug: normalizeSlug(input.slug, "slug"),
+    title: normalizeNonEmptyString(input.title, "title"),
+    summary: normalizeNonEmptyString(input.summary, "summary"),
+    description: normalizeNonEmptyString(input.description, "description"),
+    languageTags: normalizeTextArray(input.languageTags, "languageTags", true),
+    topicTags: normalizeTextArray(input.topicTags, "topicTags", false),
+    license: normalizeNonEmptyString(input.license, "license"),
+    contentWarning: normalizeNullableString(input.contentWarning, "contentWarning"),
+  };
+}
+
+function normalizeUpdateCatalogPackageDraftInput(
+  input: UpdateCatalogPackageDraftInput,
+): UpdateCatalogPackageDraftInput {
+  return {
+    ...normalizeCreateCatalogPackageDraftInput(input),
+    coverPackageMediaKey: input.coverPackageMediaKey === null
+      ? null
+      : normalizePackageMediaKey(input.coverPackageMediaKey, "coverPackageMediaKey"),
+  };
+}
+
+function normalizePackageMediaAssetInput(
+  input: AttachCatalogPackageMediaAssetInput,
+): AttachCatalogPackageMediaAssetInput {
+  return {
+    packageMediaAssetId: input.packageMediaAssetId,
+    packageMediaKey: normalizePackageMediaKey(input.packageMediaKey, "packageMediaKey"),
+    mediaBlobId: input.mediaBlobId,
+    altText: normalizeNullableString(input.altText, "altText"),
+    credit: normalizeNullableString(input.credit, "credit"),
+    license: normalizeNullableString(input.license, "license"),
+  };
+}
+
+function normalizeCatalogPackageCardSnapshotInput(
+  card: CatalogPackageCardSnapshotInput,
+): CatalogPackageCardSnapshotInput {
+  if (Number.isSafeInteger(card.ordinal) === false || card.ordinal < 1) {
+    throw new HttpError(400, "card.ordinal must be a positive safe integer", "CATALOG_INVALID_INPUT");
+  }
+
+  return {
+    packageCardId: card.packageCardId,
+    stableCardKey: normalizeNonEmptyString(card.stableCardKey, "card.stableCardKey"),
+    ordinal: card.ordinal,
+    frontText: normalizeNonEmptyString(card.frontText, "card.frontText"),
+    backText: normalizeNonEmptyString(card.backText, "card.backText"),
+    cardType: normalizeNonEmptyString(card.cardType, "card.cardType"),
+    metadata: card.metadata,
+    tags: normalizeTextArray(card.tags, "card.tags", false),
+    mediaAssetKeys: card.mediaAssetKeys.map((mediaAssetKey) => (
+      normalizePackageMediaKey(mediaAssetKey, "card.mediaAssetKeys")
+    )),
+  };
+}
+
+function normalizeCreatePackageVersionInput(
+  input: CreateCatalogPackageVersionInput,
+): CreateCatalogPackageVersionInput {
+  const cards = input.cards.map((card) => normalizeCatalogPackageCardSnapshotInput(card));
+  if (cards.length === 0) {
+    throw new HttpError(400, "cards must include at least one card snapshot", "CATALOG_PACKAGE_VERSION_EMPTY");
+  }
+
+  assertUniqueCardSnapshots(cards);
+  return {
+    packageVersionId: input.packageVersionId,
+    cards,
+  };
+}
+
+function assertUniqueCardSnapshots(cards: ReadonlyArray<CatalogPackageCardSnapshotInput>): void {
+  const stableCardKeys = new Set<string>();
+  const ordinals = new Set<number>();
+  const packageCardIds = new Set<string>();
+
+  for (const card of cards) {
+    if (stableCardKeys.has(card.stableCardKey)) {
+      throw new HttpError(
+        400,
+        `cards must not repeat stableCardKey. stableCardKey=${card.stableCardKey}`,
+        "CATALOG_PACKAGE_CARD_DUPLICATE",
+      );
+    }
+    stableCardKeys.add(card.stableCardKey);
+
+    if (ordinals.has(card.ordinal)) {
+      throw new HttpError(
+        400,
+        `cards must not repeat ordinal. ordinal=${card.ordinal}`,
+        "CATALOG_PACKAGE_CARD_DUPLICATE",
+      );
+    }
+    ordinals.add(card.ordinal);
+
+    if (packageCardIds.has(card.packageCardId)) {
+      throw new HttpError(
+        400,
+        `cards must not repeat packageCardId. packageCardId=${card.packageCardId}`,
+        "CATALOG_PACKAGE_CARD_DUPLICATE",
+      );
+    }
+    packageCardIds.add(card.packageCardId);
+  }
+}
+
+function getAllCardMediaAssetKeys(cards: ReadonlyArray<CatalogPackageCardSnapshotInput>): ReadonlyArray<string> {
+  return [...new Set(cards.flatMap((card) => card.mediaAssetKeys))];
+}
+
+async function assertDraftMediaKeysExistInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  mediaAssetKeys: ReadonlyArray<string>,
+): Promise<void> {
+  if (mediaAssetKeys.length === 0) {
+    return;
+  }
+
+  const result = await executor.query<Readonly<{ package_media_key: string }>>(
+    [
+      "SELECT package_media_key",
+      "FROM catalog.package_media_assets",
+      "WHERE package_id = $1",
+      "AND package_version_id IS NULL",
+      "AND package_media_key = ANY($2)",
+    ].join(" "),
+    [packageId, mediaAssetKeys],
+  );
+  const existingKeys = new Set(result.rows.map((row) => row.package_media_key));
+  const missingKeys = mediaAssetKeys.filter((mediaAssetKey) => existingKeys.has(mediaAssetKey) === false);
+  if (missingKeys.length !== 0) {
+    throw new HttpError(
+      400,
+      `Package draft media assets are missing referenced package-local media keys. packageId=${packageId} missingKeys=${missingKeys.join(",")}`,
+      "CATALOG_PACKAGE_MEDIA_REFERENCE_NOT_FOUND",
+    );
+  }
+}
+
+async function lockCatalogPackageInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<CatalogPackageRow> {
+  const result = await executor.query<CatalogPackageRow>(
+    [
+      "SELECT",
+      catalogPackageColumns,
+      "FROM catalog.packages",
+      "WHERE package_id = $1",
+      "FOR UPDATE",
+    ].join(" "),
+    [packageId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(404, `Catalog package not found. packageId=${packageId}`, "CATALOG_PACKAGE_NOT_FOUND");
+  }
+
+  return row;
+}
+
+async function loadPackageVersionForUpdateInExecutor(
+  executor: DatabaseExecutor,
+  packageVersionId: string,
+): Promise<CatalogPackageVersionRow> {
+  const result = await executor.query<CatalogPackageVersionRow>(
+    [
+      "SELECT",
+      catalogPackageVersionColumns,
+      "FROM catalog.package_versions",
+      "WHERE package_version_id = $1",
+      "FOR UPDATE",
+    ].join(" "),
+    [packageVersionId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(
+      404,
+      `Catalog package version not found. packageVersionId=${packageVersionId}`,
+      "CATALOG_PACKAGE_VERSION_NOT_FOUND",
+    );
+  }
+
+  return row;
+}
+
+async function assertNoMutablePackageVersionInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<void> {
+  const result = await executor.query<Readonly<{
+    package_version_id: string;
+    status: CatalogPackageStatus;
+  }>>(
+    [
+      "SELECT package_version_id, status",
+      "FROM catalog.package_versions",
+      "WHERE package_id = $1",
+      "AND status IN ('draft', 'submitted', 'needs_changes', 'approved')",
+      "LIMIT 1",
+    ].join(" "),
+    [packageId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    return;
+  }
+
+  throw new HttpError(
+    409,
+    `Package already has a mutable catalog version. packageId=${packageId} packageVersionId=${row.package_version_id} status=${row.status}`,
+    "CATALOG_PACKAGE_VERSION_DRAFT_ALREADY_EXISTS",
+  );
+}
+
+async function getNextPackageVersionNumberInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<number> {
+  const result = await executor.query<Readonly<{ version_number: string | number }>>(
+    [
+      "SELECT version_number",
+      "FROM catalog.package_versions",
+      "WHERE package_id = $1",
+      "ORDER BY version_number DESC",
+      "LIMIT 1",
+      "FOR UPDATE",
+    ].join(" "),
+    [packageId],
+  );
+  const latestVersionNumber = result.rows[0]?.version_number;
+  if (latestVersionNumber === undefined) {
+    return 1;
+  }
+
+  return toSafeNumber(latestVersionNumber, "version_number") + 1;
+}
+
+async function insertPackageVersionStatusEventInExecutor(
+  executor: DatabaseExecutor,
+  params: Readonly<{
+    packageId: string;
+    packageVersionId: string | null;
+    fromStatus: CatalogPackageStatus | null;
+    toStatus: CatalogPackageStatus;
+    adminEmail: string;
+    note: string | null;
+  }>,
+): Promise<void> {
+  await executor.query(
+    [
+      "INSERT INTO catalog.package_review_events",
+      "(package_id, package_version_id, from_status, to_status, actor_admin_email, note)",
+      "VALUES ($1, $2, $3, $4, $5, $6)",
+    ].join(" "),
+    [
+      params.packageId,
+      params.packageVersionId,
+      params.fromStatus,
+      params.toStatus,
+      params.adminEmail,
+      params.note,
+    ],
+  );
+}
+
+async function copyDraftMediaAssetsToPackageVersionInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  packageVersionId: string,
+): Promise<void> {
+  await executor.query(
+    [
+      "INSERT INTO catalog.package_media_assets",
+      "(package_media_asset_id, package_id, package_version_id, package_media_key, media_blob_id, alt_text, credit, license)",
+      "SELECT gen_random_uuid(), package_id, $2, package_media_key, media_blob_id, alt_text, credit, license",
+      "FROM catalog.package_media_assets",
+      "WHERE package_id = $1",
+      "AND package_version_id IS NULL",
+    ].join(" "),
+    [packageId, packageVersionId],
+  );
+}
+
+async function insertPackageCardsInExecutor(
+  executor: DatabaseExecutor,
+  packageVersionId: string,
+  cards: ReadonlyArray<CatalogPackageCardSnapshotInput>,
+): Promise<void> {
+  for (const card of cards) {
+    await executor.query(
+      [
+        "INSERT INTO catalog.package_cards",
+        "(package_card_id, package_version_id, stable_card_key, ordinal, front_text, back_text, card_type, metadata, tags, media_asset_keys)",
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)",
+      ].join(" "),
+      [
+        card.packageCardId,
+        packageVersionId,
+        card.stableCardKey,
+        card.ordinal,
+        card.frontText,
+        card.backText,
+        card.cardType,
+        JSON.stringify(card.metadata),
+        card.tags,
+        card.mediaAssetKeys,
+      ],
+    );
+  }
+}
+
+async function createPackageVersionFromNormalizedCardsInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  input: CreateCatalogPackageVersionInput,
+  sourceWorkspaceId: string | null,
+  adminEmail: string,
+): Promise<CatalogPackageVersion> {
+  const catalogPackage = await lockCatalogPackageInExecutor(executor, packageId);
+  await assertNoMutablePackageVersionInExecutor(executor, packageId);
+  await assertDraftMediaKeysExistInExecutor(
+    executor,
+    packageId,
+    [
+      ...(catalogPackage.cover_package_media_key === null ? [] : [catalogPackage.cover_package_media_key]),
+      ...getAllCardMediaAssetKeys(input.cards),
+    ],
+  );
+  const versionNumber = await getNextPackageVersionNumberInExecutor(executor, packageId);
+  const result = await executor.query<CatalogPackageVersionRow>(
+    [
+      "INSERT INTO catalog.package_versions",
+      "(",
+      "package_version_id, package_id, version_number, status, slug, title, summary, description,",
+      "language_tags, topic_tags, license, content_warning, cover_package_media_key, source_workspace_id,",
+      "card_count, created_by_admin_email",
+      ")",
+      "VALUES ($1, $2, $3, 'draft', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+      "RETURNING",
+      catalogPackageVersionColumns,
+    ].join(" "),
+    [
+      input.packageVersionId,
+      packageId,
+      versionNumber,
+      catalogPackage.slug,
+      catalogPackage.title,
+      catalogPackage.summary,
+      catalogPackage.description,
+      catalogPackage.language_tags,
+      catalogPackage.topic_tags,
+      catalogPackage.license,
+      catalogPackage.content_warning,
+      catalogPackage.cover_package_media_key,
+      sourceWorkspaceId,
+      input.cards.length,
+      adminEmail,
+    ],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error("Expected catalog package version insert to return a row");
+  }
+
+  await copyDraftMediaAssetsToPackageVersionInExecutor(executor, packageId, input.packageVersionId);
+  await insertPackageCardsInExecutor(executor, input.packageVersionId, input.cards);
+  await insertPackageVersionStatusEventInExecutor(executor, {
+    packageId,
+    packageVersionId: input.packageVersionId,
+    fromStatus: null,
+    toStatus: "draft",
+    adminEmail,
+    note: null,
+  });
+
+  return mapCatalogPackageVersionRow(row);
+}
+
+function normalizeWorkspaceVersionInput(
+  input: CreateCatalogPackageVersionFromWorkspaceInput,
+): CreateCatalogPackageVersionFromWorkspaceInput {
+  if (input.cardIds.length === 0) {
+    throw new HttpError(400, "cardIds must include at least one card id", "CATALOG_PACKAGE_VERSION_EMPTY");
+  }
+
+  const uniqueCardIds = [...new Set(input.cardIds)];
+  if (uniqueCardIds.length !== input.cardIds.length) {
+    throw new HttpError(400, "cardIds must not include duplicates", "CATALOG_PACKAGE_CARD_DUPLICATE");
+  }
+
+  return {
+    packageVersionId: input.packageVersionId,
+    workspaceId: input.workspaceId,
+    cardIds: uniqueCardIds,
+  };
+}
+
+function mapWorkspaceCardsToSnapshots(
+  rows: ReadonlyArray<CatalogWorkspaceCardRow>,
+): ReadonlyArray<CatalogPackageCardSnapshotInput> {
+  return rows.map((row, index) => ({
+    packageCardId: randomUUID(),
+    stableCardKey: row.card_id,
+    ordinal: index + 1,
+    frontText: row.front_text,
+    backText: row.back_text,
+    cardType: row.card_type,
+    metadata: row.metadata,
+    tags: [...row.tags],
+    mediaAssetKeys: [],
+  }));
+}
+
+function assertWorkspaceCardHasNoManagedMediaReferences(row: CatalogWorkspaceCardRow): void {
+  if (managedMediaReferencePattern.test(row.front_text)) {
+    throw new HttpError(
+      400,
+      `Workspace card contains a managed media reference that cannot be copied into a catalog package yet. cardId=${row.card_id} field=frontText`,
+      "CATALOG_WORKSPACE_CARD_MEDIA_REFERENCE_UNSUPPORTED",
+    );
+  }
+
+  if (managedMediaReferencePattern.test(row.back_text)) {
+    throw new HttpError(
+      400,
+      `Workspace card contains a managed media reference that cannot be copied into a catalog package yet. cardId=${row.card_id} field=backText`,
+      "CATALOG_WORKSPACE_CARD_MEDIA_REFERENCE_UNSUPPORTED",
+    );
+  }
+}
+
+async function loadWorkspaceCardsForCatalogVersionInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  cardIds: ReadonlyArray<string>,
+): Promise<ReadonlyArray<CatalogWorkspaceCardRow>> {
+  const result = await executor.query<CatalogWorkspaceCardRow>(
+    [
+      "SELECT card_id, front_text, back_text, card_type, metadata, tags",
+      "FROM content.cards",
+      "WHERE workspace_id = $1",
+      "AND card_id = ANY($2::uuid[])",
+      "AND deleted_at IS NULL",
+      "ORDER BY array_position($2::uuid[], card_id)",
+    ].join(" "),
+    [workspaceId, cardIds],
+  );
+  if (result.rows.length !== cardIds.length) {
+    const returnedCardIds = new Set(result.rows.map((row) => row.card_id));
+    const missingCardIds = cardIds.filter((cardId) => returnedCardIds.has(cardId) === false);
+    throw new HttpError(
+      400,
+      `Workspace catalog version source is missing cards. workspaceId=${workspaceId} missingCardIds=${missingCardIds.join(",")}`,
+      "CATALOG_WORKSPACE_CARD_NOT_FOUND",
+    );
+  }
+
+  for (const row of result.rows) {
+    assertWorkspaceCardHasNoManagedMediaReferences(row);
+  }
+
+  return result.rows;
+}
+
+export async function createCatalogAuthorInExecutor(
+  executor: DatabaseExecutor,
+  input: UpsertCatalogAuthorInput,
+): Promise<CatalogAuthor> {
+  const normalizedInput = normalizeCatalogAuthorInput(input);
+  try {
+    const result = await executor.query<CatalogAuthorRow>(
+      [
+        "INSERT INTO catalog.authors",
+        "(author_id, slug, display_name, bio, website_url)",
+        "VALUES ($1, $2, $3, $4, $5)",
+        "RETURNING",
+        catalogAuthorColumns,
+      ].join(" "),
+      [
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.displayName,
+        normalizedInput.bio,
+        normalizedInput.websiteUrl,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Expected catalog author insert to return a row");
+    }
+
+    return mapCatalogAuthorRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function updateCatalogAuthorInExecutor(
+  executor: DatabaseExecutor,
+  input: UpsertCatalogAuthorInput,
+): Promise<CatalogAuthor> {
+  const normalizedInput = normalizeCatalogAuthorInput(input);
+  try {
+    const result = await executor.query<CatalogAuthorRow>(
+      [
+        "UPDATE catalog.authors",
+        "SET slug = $2, display_name = $3, bio = $4, website_url = $5",
+        "WHERE author_id = $1",
+        "RETURNING",
+        catalogAuthorColumns,
+      ].join(" "),
+      [
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.displayName,
+        normalizedInput.bio,
+        normalizedInput.websiteUrl,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new HttpError(
+        404,
+        `Catalog author not found. authorId=${normalizedInput.authorId}`,
+        "CATALOG_AUTHOR_NOT_FOUND",
+      );
+    }
+
+    return mapCatalogAuthorRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function createCatalogPackageDraftInExecutor(
+  executor: DatabaseExecutor,
+  input: CreateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  const normalizedInput = normalizeCreateCatalogPackageDraftInput(input);
+  try {
+    const result = await executor.query<CatalogPackageRow>(
+      [
+        "INSERT INTO catalog.packages",
+        "(",
+        "package_id, author_id, slug, title, summary, description, language_tags, topic_tags,",
+        "license, content_warning",
+        ")",
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+        "RETURNING",
+        catalogPackageColumns,
+      ].join(" "),
+      [
+        normalizedInput.packageId,
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.title,
+        normalizedInput.summary,
+        normalizedInput.description,
+        normalizedInput.languageTags,
+        normalizedInput.topicTags,
+        normalizedInput.license,
+        normalizedInput.contentWarning,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Expected catalog package insert to return a row");
+    }
+
+    return mapCatalogPackageRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function updateCatalogPackageDraftInExecutor(
+  executor: DatabaseExecutor,
+  input: UpdateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  const normalizedInput = normalizeUpdateCatalogPackageDraftInput(input);
+  try {
+    await assertDraftMediaKeysExistInExecutor(
+      executor,
+      normalizedInput.packageId,
+      normalizedInput.coverPackageMediaKey === null ? [] : [normalizedInput.coverPackageMediaKey],
+    );
+    const result = await executor.query<CatalogPackageRow>(
+      [
+        "UPDATE catalog.packages",
+        "SET author_id = $2, slug = $3, title = $4, summary = $5, description = $6,",
+        "language_tags = $7, topic_tags = $8, license = $9, content_warning = $10,",
+        "cover_package_media_key = $11",
+        "WHERE package_id = $1",
+        "RETURNING",
+        catalogPackageColumns,
+      ].join(" "),
+      [
+        normalizedInput.packageId,
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.title,
+        normalizedInput.summary,
+        normalizedInput.description,
+        normalizedInput.languageTags,
+        normalizedInput.topicTags,
+        normalizedInput.license,
+        normalizedInput.contentWarning,
+        normalizedInput.coverPackageMediaKey,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new HttpError(
+        404,
+        `Catalog package not found. packageId=${normalizedInput.packageId}`,
+        "CATALOG_PACKAGE_NOT_FOUND",
+      );
+    }
+
+    return mapCatalogPackageRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function loadCatalogPackageDraftInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<CatalogPackageDraft> {
+  const packageResult = await executor.query<CatalogPackageRow>(
+    [
+      "SELECT",
+      catalogPackageColumns,
+      "FROM catalog.packages",
+      "WHERE package_id = $1",
+    ].join(" "),
+    [packageId],
+  );
+  const packageRow = packageResult.rows[0];
+  if (packageRow === undefined) {
+    throw new HttpError(404, `Catalog package not found. packageId=${packageId}`, "CATALOG_PACKAGE_NOT_FOUND");
+  }
+
+  const mediaResult = await executor.query<CatalogPackageMediaAssetRow>(
+    [
+      "SELECT",
+      catalogPackageMediaAssetColumns,
+      "FROM catalog.package_media_assets",
+      "WHERE package_id = $1",
+      "AND package_version_id IS NULL",
+      "ORDER BY package_media_key ASC",
+    ].join(" "),
+    [packageId],
+  );
+
+  return {
+    catalogPackage: mapCatalogPackageRow(packageRow),
+    mediaAssets: mediaResult.rows.map((row) => mapCatalogPackageMediaAssetRow(row)),
+  };
+}
+
+export async function attachCatalogPackageDraftMediaAssetInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  input: AttachCatalogPackageMediaAssetInput,
+): Promise<CatalogPackageMediaAsset> {
+  const normalizedInput = normalizePackageMediaAssetInput(input);
+  try {
+    await lockCatalogPackageInExecutor(executor, packageId);
+    const result = await executor.query<CatalogPackageMediaAssetRow>(
+      [
+        "INSERT INTO catalog.package_media_assets",
+        "(",
+        "package_media_asset_id, package_id, package_version_id, package_media_key,",
+        "media_blob_id, alt_text, credit, license",
+        ")",
+        "SELECT $1, $2, NULL, $3, media_blobs.media_blob_id, $5, $6, $7",
+        "FROM content.media_blobs AS media_blobs",
+        "WHERE media_blobs.media_blob_id = $4",
+        "RETURNING",
+        catalogPackageMediaAssetColumns,
+      ].join(" "),
+      [
+        normalizedInput.packageMediaAssetId,
+        packageId,
+        normalizedInput.packageMediaKey,
+        normalizedInput.mediaBlobId,
+        normalizedInput.altText,
+        normalizedInput.credit,
+        normalizedInput.license,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new HttpError(
+        400,
+        `Media blob not found for catalog package media asset. mediaBlobId=${normalizedInput.mediaBlobId}`,
+        "CATALOG_MEDIA_BLOB_NOT_FOUND",
+      );
+    }
+
+    return mapCatalogPackageMediaAssetRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function createCatalogPackageVersionFromCardsInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  input: CreateCatalogPackageVersionInput,
+  adminEmail: string,
+): Promise<CatalogPackageVersion> {
+  const normalizedInput = normalizeCreatePackageVersionInput(input);
+  const normalizedAdminEmail = normalizeAdminEmail(adminEmail);
+  try {
+    return await createPackageVersionFromNormalizedCardsInExecutor(
+      executor,
+      packageId,
+      normalizedInput,
+      null,
+      normalizedAdminEmail,
+    );
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  input: CreateCatalogPackageVersionFromWorkspaceInput,
+  adminUserId: string,
+  adminEmail: string,
+): Promise<CatalogPackageVersion> {
+  const normalizedInput = normalizeWorkspaceVersionInput(input);
+  const normalizedAdminEmail = normalizeAdminEmail(adminEmail);
+  try {
+    await applyWorkspaceDatabaseScopeInExecutor(executor, {
+      userId: adminUserId,
+      workspaceId: normalizedInput.workspaceId,
+    });
+    const workspaceCards = await loadWorkspaceCardsForCatalogVersionInExecutor(
+      executor,
+      normalizedInput.workspaceId,
+      normalizedInput.cardIds,
+    );
+    const packageVersionInput = normalizeCreatePackageVersionInput({
+      packageVersionId: normalizedInput.packageVersionId,
+      cards: mapWorkspaceCardsToSnapshots(workspaceCards),
+    });
+
+    return await createPackageVersionFromNormalizedCardsInExecutor(
+      executor,
+      packageId,
+      packageVersionInput,
+      normalizedInput.workspaceId,
+      normalizedAdminEmail,
+    );
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function updateCatalogPackageVersionReviewStatusInExecutor(
+  executor: DatabaseExecutor,
+  packageVersionId: string,
+  input: UpdateCatalogPackageVersionStatusInput,
+  adminEmail: string,
+): Promise<CatalogPackageVersion> {
+  if (reviewStatusRouteTargets.has(input.status) === false) {
+    throw new HttpError(
+      400,
+      `Use the publish or delist catalog endpoint for terminal public statuses. status=${input.status}`,
+      "CATALOG_PACKAGE_VERSION_STATUS_INVALID",
+    );
+  }
+
+  const normalizedAdminEmail = normalizeAdminEmail(adminEmail);
+  const versionRow = await loadPackageVersionForUpdateInExecutor(executor, packageVersionId);
+  if (versionRow.status === input.status) {
+    throw new HttpError(
+      409,
+      `Catalog package version already has the requested status. packageVersionId=${packageVersionId} status=${input.status}`,
+      "CATALOG_PACKAGE_VERSION_STATUS_UNCHANGED",
+    );
+  }
+  assertCatalogPackageVersionStatusTransitionAllowed(versionRow.status, input.status);
+
+  try {
+    const result = await executor.query<CatalogPackageVersionRow>(
+      [
+        "UPDATE catalog.package_versions",
+        "SET status = $2,",
+        "submitted_at = CASE WHEN $2 = 'submitted' THEN now() ELSE submitted_at END,",
+        "reviewed_at = CASE WHEN $2 IN ('needs_changes', 'approved', 'rejected') THEN now() ELSE reviewed_at END,",
+        "reviewed_by_admin_email = CASE WHEN $2 IN ('needs_changes', 'approved', 'rejected') THEN $3 ELSE reviewed_by_admin_email END",
+        "WHERE package_version_id = $1",
+        "RETURNING",
+        catalogPackageVersionColumns,
+      ].join(" "),
+      [packageVersionId, input.status, normalizedAdminEmail],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Expected catalog package version status update to return a row");
+    }
+
+    await insertPackageVersionStatusEventInExecutor(executor, {
+      packageId: row.package_id,
+      packageVersionId,
+      fromStatus: versionRow.status,
+      toStatus: row.status,
+      adminEmail: normalizedAdminEmail,
+      note: normalizeNullableString(input.note, "note"),
+    });
+
+    return mapCatalogPackageVersionRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function publishCatalogPackageVersionInExecutor(
+  executor: DatabaseExecutor,
+  packageVersionId: string,
+  adminEmail: string,
+  note: string | null,
+): Promise<CatalogPackageVersion> {
+  const normalizedAdminEmail = normalizeAdminEmail(adminEmail);
+  const normalizedNote = normalizeNullableString(note, "note");
+  const versionRow = await loadPackageVersionForUpdateInExecutor(executor, packageVersionId);
+  if (versionRow.status !== "approved") {
+    throw new HttpError(
+      409,
+      `Catalog package version must be approved before publishing. packageVersionId=${packageVersionId} status=${versionRow.status}`,
+      "CATALOG_PACKAGE_VERSION_NOT_APPROVED",
+    );
+  }
+
+  try {
+    const result = await executor.query<CatalogPackageVersionRow>(
+      [
+        "UPDATE catalog.package_versions",
+        "SET status = 'published', published_at = now()",
+        "WHERE package_version_id = $1",
+        "RETURNING",
+        catalogPackageVersionColumns,
+      ].join(" "),
+      [packageVersionId],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Expected catalog package version publish to return a row");
+    }
+
+    await executor.query(
+      [
+        "UPDATE catalog.packages",
+        "SET status = 'published', published_at = COALESCE(published_at, now()), delisted_at = NULL",
+        "WHERE package_id = $1",
+      ].join(" "),
+      [row.package_id],
+    );
+    await insertPackageVersionStatusEventInExecutor(executor, {
+      packageId: row.package_id,
+      packageVersionId,
+      fromStatus: versionRow.status,
+      toStatus: "published",
+      adminEmail: normalizedAdminEmail,
+      note: normalizedNote,
+    });
+
+    return mapCatalogPackageVersionRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function delistCatalogPackageVersionInExecutor(
+  executor: DatabaseExecutor,
+  packageVersionId: string,
+  adminEmail: string,
+  note: string | null,
+): Promise<CatalogPackageVersion> {
+  const normalizedAdminEmail = normalizeAdminEmail(adminEmail);
+  const normalizedNote = normalizeNullableString(note, "note");
+  const versionRow = await loadPackageVersionForUpdateInExecutor(executor, packageVersionId);
+  if (versionRow.status !== "published") {
+    throw new HttpError(
+      409,
+      `Only published catalog package versions can be delisted. packageVersionId=${packageVersionId} status=${versionRow.status}`,
+      "CATALOG_PACKAGE_VERSION_NOT_PUBLISHED",
+    );
+  }
+
+  try {
+    const result = await executor.query<CatalogPackageVersionRow>(
+      [
+        "UPDATE catalog.package_versions",
+        "SET status = 'delisted', delisted_at = now()",
+        "WHERE package_version_id = $1",
+        "RETURNING",
+        catalogPackageVersionColumns,
+      ].join(" "),
+      [packageVersionId],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Expected catalog package version delist to return a row");
+    }
+
+    await executor.query(
+      [
+        "UPDATE catalog.packages",
+        "SET status = CASE",
+        "WHEN EXISTS (",
+        "SELECT 1 FROM catalog.package_versions",
+        "WHERE package_id = $1",
+        "AND status = 'published'",
+        ") THEN 'published'::catalog.package_status",
+        "ELSE 'delisted'::catalog.package_status",
+        "END,",
+        "delisted_at = CASE",
+        "WHEN EXISTS (",
+        "SELECT 1 FROM catalog.package_versions",
+        "WHERE package_id = $1",
+        "AND status = 'published'",
+        ") THEN delisted_at",
+        "ELSE now()",
+        "END",
+        "WHERE package_id = $1",
+      ].join(" "),
+      [row.package_id],
+    );
+    await insertPackageVersionStatusEventInExecutor(executor, {
+      packageId: row.package_id,
+      packageVersionId,
+      fromStatus: versionRow.status,
+      toStatus: "delisted",
+      adminEmail: normalizedAdminEmail,
+      note: normalizedNote,
+    });
+
+    return mapCatalogPackageVersionRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function createCatalogAuthor(input: UpsertCatalogAuthorInput): Promise<CatalogAuthor> {
+  return unsafeTransaction(async (executor) => createCatalogAuthorInExecutor(executor, input));
+}
+
+export async function updateCatalogAuthor(input: UpsertCatalogAuthorInput): Promise<CatalogAuthor> {
+  return unsafeTransaction(async (executor) => updateCatalogAuthorInExecutor(executor, input));
+}
+
+export async function createCatalogPackageDraft(
+  input: CreateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  return unsafeTransaction(async (executor) => createCatalogPackageDraftInExecutor(executor, input));
+}
+
+export async function updateCatalogPackageDraft(
+  input: UpdateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  return unsafeTransaction(async (executor) => updateCatalogPackageDraftInExecutor(executor, input));
+}
+
+export async function loadCatalogPackageDraft(packageId: string): Promise<CatalogPackageDraft> {
+  return unsafeTransaction(async (executor) => loadCatalogPackageDraftInExecutor(executor, packageId));
+}
+
+export async function attachCatalogPackageDraftMediaAsset(
+  packageId: string,
+  input: AttachCatalogPackageMediaAssetInput,
+): Promise<CatalogPackageMediaAsset> {
+  return unsafeTransaction(async (executor) => (
+    attachCatalogPackageDraftMediaAssetInExecutor(executor, packageId, input)
+  ));
+}
+
+export async function createCatalogPackageVersionFromCards(
+  packageId: string,
+  input: CreateCatalogPackageVersionInput,
+  adminEmail: string,
+): Promise<CatalogPackageVersion> {
+  return unsafeTransaction(async (executor) => (
+    createCatalogPackageVersionFromCardsInExecutor(executor, packageId, input, adminEmail)
+  ));
+}
+
+export async function createCatalogPackageVersionFromWorkspaceSelection(
+  packageId: string,
+  input: CreateCatalogPackageVersionFromWorkspaceInput,
+  adminUserId: string,
+  adminEmail: string,
+): Promise<CatalogPackageVersion> {
+  return unsafeTransaction(async (executor) => (
+    createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+      executor,
+      packageId,
+      input,
+      adminUserId,
+      adminEmail,
+    )
+  ));
+}
+
+export async function updateCatalogPackageVersionReviewStatus(
+  packageVersionId: string,
+  input: UpdateCatalogPackageVersionStatusInput,
+  adminEmail: string,
+): Promise<CatalogPackageVersion> {
+  return unsafeTransaction(async (executor) => (
+    updateCatalogPackageVersionReviewStatusInExecutor(executor, packageVersionId, input, adminEmail)
+  ));
+}
+
+export async function publishCatalogPackageVersion(
+  packageVersionId: string,
+  adminEmail: string,
+  note: string | null,
+): Promise<CatalogPackageVersion> {
+  return unsafeTransaction(async (executor) => (
+    publishCatalogPackageVersionInExecutor(executor, packageVersionId, adminEmail, note)
+  ));
+}
+
+export async function delistCatalogPackageVersion(
+  packageVersionId: string,
+  adminEmail: string,
+  note: string | null,
+): Promise<CatalogPackageVersion> {
+  return unsafeTransaction(async (executor) => (
+    delistCatalogPackageVersionInExecutor(executor, packageVersionId, adminEmail, note)
+  ));
+}

--- a/apps/backend/src/catalog/types.ts
+++ b/apps/backend/src/catalog/types.ts
@@ -1,0 +1,237 @@
+import type { CardMetadata } from "../cards/types";
+
+export const catalogPackageStatuses = [
+  "draft",
+  "submitted",
+  "needs_changes",
+  "approved",
+  "rejected",
+  "published",
+  "delisted",
+] as const;
+
+export type CatalogPackageStatus = (typeof catalogPackageStatuses)[number];
+
+export type TimestampValue = Date | string;
+
+export type CatalogAuthorRow = Readonly<{
+  author_id: string;
+  slug: string;
+  display_name: string;
+  bio: string | null;
+  website_url: string | null;
+  created_at: TimestampValue;
+  updated_at: TimestampValue;
+}>;
+
+export type CatalogAuthor = Readonly<{
+  authorId: string;
+  slug: string;
+  displayName: string;
+  bio: string | null;
+  websiteUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export type UpsertCatalogAuthorInput = Readonly<{
+  authorId: string;
+  slug: string;
+  displayName: string;
+  bio: string | null;
+  websiteUrl: string | null;
+}>;
+
+export type CatalogPackageRow = Readonly<{
+  package_id: string;
+  author_id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  language_tags: ReadonlyArray<string>;
+  topic_tags: ReadonlyArray<string>;
+  license: string;
+  content_warning: string | null;
+  cover_package_media_key: string | null;
+  status: CatalogPackageStatus;
+  created_at: TimestampValue;
+  updated_at: TimestampValue;
+  published_at: TimestampValue | null;
+  delisted_at: TimestampValue | null;
+}>;
+
+export type CatalogPackage = Readonly<{
+  packageId: string;
+  authorId: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  languageTags: ReadonlyArray<string>;
+  topicTags: ReadonlyArray<string>;
+  license: string;
+  contentWarning: string | null;
+  coverPackageMediaKey: string | null;
+  status: CatalogPackageStatus;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string | null;
+  delistedAt: string | null;
+}>;
+
+export type CreateCatalogPackageDraftInput = Readonly<{
+  packageId: string;
+  authorId: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  languageTags: ReadonlyArray<string>;
+  topicTags: ReadonlyArray<string>;
+  license: string;
+  contentWarning: string | null;
+}>;
+
+export type UpdateCatalogPackageDraftInput = Readonly<{
+  packageId: string;
+  authorId: string;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  languageTags: ReadonlyArray<string>;
+  topicTags: ReadonlyArray<string>;
+  license: string;
+  contentWarning: string | null;
+  coverPackageMediaKey: string | null;
+}>;
+
+export type CatalogPackageMediaAssetRow = Readonly<{
+  package_media_asset_id: string;
+  package_id: string;
+  package_version_id: string | null;
+  package_media_key: string;
+  media_blob_id: string;
+  alt_text: string | null;
+  credit: string | null;
+  license: string | null;
+  created_at: TimestampValue;
+  updated_at: TimestampValue;
+}>;
+
+export type CatalogPackageMediaAsset = Readonly<{
+  packageMediaAssetId: string;
+  packageId: string;
+  packageVersionId: string | null;
+  packageMediaKey: string;
+  mediaBlobId: string;
+  altText: string | null;
+  credit: string | null;
+  license: string | null;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export type AttachCatalogPackageMediaAssetInput = Readonly<{
+  packageMediaAssetId: string;
+  packageMediaKey: string;
+  mediaBlobId: string;
+  altText: string | null;
+  credit: string | null;
+  license: string | null;
+}>;
+
+export type CatalogPackageVersionRow = Readonly<{
+  package_version_id: string;
+  package_id: string;
+  version_number: string | number;
+  status: CatalogPackageStatus;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  language_tags: ReadonlyArray<string>;
+  topic_tags: ReadonlyArray<string>;
+  license: string;
+  content_warning: string | null;
+  cover_package_media_key: string | null;
+  source_workspace_id: string | null;
+  card_count: string | number;
+  created_by_admin_email: string;
+  reviewed_by_admin_email: string | null;
+  created_at: TimestampValue;
+  updated_at: TimestampValue;
+  submitted_at: TimestampValue | null;
+  reviewed_at: TimestampValue | null;
+  published_at: TimestampValue | null;
+  delisted_at: TimestampValue | null;
+}>;
+
+export type CatalogPackageVersion = Readonly<{
+  packageVersionId: string;
+  packageId: string;
+  versionNumber: number;
+  status: CatalogPackageStatus;
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  languageTags: ReadonlyArray<string>;
+  topicTags: ReadonlyArray<string>;
+  license: string;
+  contentWarning: string | null;
+  coverPackageMediaKey: string | null;
+  sourceWorkspaceId: string | null;
+  cardCount: number;
+  createdByAdminEmail: string;
+  reviewedByAdminEmail: string | null;
+  createdAt: string;
+  updatedAt: string;
+  submittedAt: string | null;
+  reviewedAt: string | null;
+  publishedAt: string | null;
+  delistedAt: string | null;
+}>;
+
+export type CatalogPackageDraft = Readonly<{
+  catalogPackage: CatalogPackage;
+  mediaAssets: ReadonlyArray<CatalogPackageMediaAsset>;
+}>;
+
+export type CatalogPackageCardSnapshotInput = Readonly<{
+  packageCardId: string;
+  stableCardKey: string;
+  ordinal: number;
+  frontText: string;
+  backText: string;
+  cardType: string;
+  metadata: CardMetadata;
+  tags: ReadonlyArray<string>;
+  mediaAssetKeys: ReadonlyArray<string>;
+}>;
+
+export type CreateCatalogPackageVersionInput = Readonly<{
+  packageVersionId: string;
+  cards: ReadonlyArray<CatalogPackageCardSnapshotInput>;
+}>;
+
+export type CreateCatalogPackageVersionFromWorkspaceInput = Readonly<{
+  packageVersionId: string;
+  workspaceId: string;
+  cardIds: ReadonlyArray<string>;
+}>;
+
+export type UpdateCatalogPackageVersionStatusInput = Readonly<{
+  status: CatalogPackageStatus;
+  note: string | null;
+}>;
+
+export type CatalogWorkspaceCardRow = Readonly<{
+  card_id: string;
+  front_text: string;
+  back_text: string;
+  card_type: string;
+  metadata: CardMetadata;
+  tags: ReadonlyArray<string>;
+}>;

--- a/db/migrations/0083_catalog_kernel.sql
+++ b/db/migrations/0083_catalog_kernel.sql
@@ -1,0 +1,437 @@
+-- Migration status: Current / additive.
+-- Introduces: admin-authored public catalog kernel with immutable package versions.
+-- Schemas touched/read explicitly: catalog, content.
+
+CREATE SCHEMA IF NOT EXISTS catalog;
+
+DO $$
+BEGIN
+  CREATE TYPE catalog.package_status AS ENUM (
+    'draft',
+    'submitted',
+    'needs_changes',
+    'approved',
+    'rejected',
+    'published',
+    'delisted'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS catalog.authors (
+  author_id    UUID        PRIMARY KEY,
+  slug         TEXT        NOT NULL,
+  display_name TEXT        NOT NULL,
+  bio          TEXT,
+  website_url  TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT authors_slug_unique UNIQUE (slug),
+  CONSTRAINT authors_slug_format CHECK (slug ~ '^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$'),
+  CONSTRAINT authors_display_name_nonempty CHECK (btrim(display_name) <> '')
+);
+
+CREATE TABLE IF NOT EXISTS catalog.packages (
+  package_id               UUID                   PRIMARY KEY,
+  author_id                UUID                   NOT NULL REFERENCES catalog.authors(author_id) ON DELETE RESTRICT,
+  slug                     TEXT                   NOT NULL,
+  title                    TEXT                   NOT NULL,
+  summary                  TEXT                   NOT NULL,
+  description              TEXT                   NOT NULL,
+  language_tags            TEXT[]                 NOT NULL,
+  topic_tags               TEXT[]                 NOT NULL,
+  license                  TEXT                   NOT NULL,
+  content_warning          TEXT,
+  cover_package_media_key  TEXT,
+  status                   catalog.package_status NOT NULL DEFAULT 'draft',
+  created_at               TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  published_at             TIMESTAMPTZ,
+  delisted_at              TIMESTAMPTZ,
+  CONSTRAINT packages_slug_unique UNIQUE (slug),
+  CONSTRAINT packages_slug_format CHECK (slug ~ '^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$'),
+  CONSTRAINT packages_title_nonempty CHECK (btrim(title) <> ''),
+  CONSTRAINT packages_summary_nonempty CHECK (btrim(summary) <> ''),
+  CONSTRAINT packages_description_nonempty CHECK (btrim(description) <> ''),
+  CONSTRAINT packages_license_nonempty CHECK (btrim(license) <> ''),
+  CONSTRAINT packages_language_tags_nonempty CHECK (cardinality(language_tags) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS catalog.package_versions (
+  package_version_id       UUID                   PRIMARY KEY,
+  package_id               UUID                   NOT NULL REFERENCES catalog.packages(package_id) ON DELETE CASCADE,
+  version_number           INTEGER                NOT NULL CHECK (version_number > 0),
+  status                   catalog.package_status NOT NULL DEFAULT 'draft',
+  slug                     TEXT                   NOT NULL,
+  title                    TEXT                   NOT NULL,
+  summary                  TEXT                   NOT NULL,
+  description              TEXT                   NOT NULL,
+  language_tags            TEXT[]                 NOT NULL,
+  topic_tags               TEXT[]                 NOT NULL,
+  license                  TEXT                   NOT NULL,
+  content_warning          TEXT,
+  cover_package_media_key  TEXT,
+  source_workspace_id      UUID,
+  card_count               INTEGER                NOT NULL DEFAULT 0 CHECK (card_count >= 0),
+  created_by_admin_email   TEXT                   NOT NULL,
+  reviewed_by_admin_email  TEXT,
+  created_at               TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  submitted_at             TIMESTAMPTZ,
+  reviewed_at              TIMESTAMPTZ,
+  published_at             TIMESTAMPTZ,
+  delisted_at              TIMESTAMPTZ,
+  CONSTRAINT package_versions_package_number_unique UNIQUE (package_id, version_number),
+  CONSTRAINT package_versions_package_version_unique UNIQUE (package_id, package_version_id),
+  CONSTRAINT package_versions_slug_format CHECK (slug ~ '^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$'),
+  CONSTRAINT package_versions_title_nonempty CHECK (btrim(title) <> ''),
+  CONSTRAINT package_versions_summary_nonempty CHECK (btrim(summary) <> ''),
+  CONSTRAINT package_versions_description_nonempty CHECK (btrim(description) <> ''),
+  CONSTRAINT package_versions_license_nonempty CHECK (btrim(license) <> ''),
+  CONSTRAINT package_versions_language_tags_nonempty CHECK (cardinality(language_tags) > 0),
+  CONSTRAINT package_versions_created_by_admin_email_nonempty CHECK (btrim(created_by_admin_email) <> '')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_package_versions_one_review_candidate
+  ON catalog.package_versions(package_id)
+  WHERE status IN ('draft', 'submitted', 'needs_changes', 'approved');
+
+CREATE TABLE IF NOT EXISTS catalog.package_cards (
+  package_card_id    UUID        PRIMARY KEY,
+  package_version_id UUID        NOT NULL REFERENCES catalog.package_versions(package_version_id) ON DELETE CASCADE,
+  stable_card_key    TEXT        NOT NULL,
+  ordinal            INTEGER     NOT NULL CHECK (ordinal > 0),
+  front_text         TEXT        NOT NULL,
+  back_text          TEXT        NOT NULL,
+  card_type          TEXT        NOT NULL,
+  metadata           JSONB       NOT NULL,
+  tags               TEXT[]      NOT NULL,
+  media_asset_keys   TEXT[]      NOT NULL DEFAULT '{}',
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT package_cards_version_stable_key_unique UNIQUE (package_version_id, stable_card_key),
+  CONSTRAINT package_cards_version_ordinal_unique UNIQUE (package_version_id, ordinal),
+  CONSTRAINT package_cards_stable_key_nonempty CHECK (btrim(stable_card_key) <> ''),
+  CONSTRAINT package_cards_front_text_nonempty CHECK (btrim(front_text) <> ''),
+  CONSTRAINT package_cards_back_text_nonempty CHECK (btrim(back_text) <> ''),
+  CONSTRAINT package_cards_card_type_nonempty CHECK (btrim(card_type) <> '')
+);
+
+CREATE TABLE IF NOT EXISTS catalog.package_media_assets (
+  package_media_asset_id UUID        PRIMARY KEY,
+  package_id             UUID        NOT NULL REFERENCES catalog.packages(package_id) ON DELETE CASCADE,
+  package_version_id     UUID,
+  package_media_key      TEXT        NOT NULL,
+  media_blob_id          UUID        NOT NULL REFERENCES content.media_blobs(media_blob_id) ON DELETE RESTRICT,
+  alt_text               TEXT,
+  credit                 TEXT,
+  license                TEXT,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT package_media_assets_version_package_fk
+    FOREIGN KEY (package_id, package_version_id)
+    REFERENCES catalog.package_versions(package_id, package_version_id)
+    ON DELETE CASCADE,
+  CONSTRAINT package_media_assets_key_format CHECK (package_media_key ~ '^[a-z0-9][a-z0-9._-]{0,127}$')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_package_media_assets_draft_key_unique
+  ON catalog.package_media_assets(package_id, package_media_key)
+  WHERE package_version_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_package_media_assets_version_key_unique
+  ON catalog.package_media_assets(package_version_id, package_media_key)
+  WHERE package_version_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_package_media_assets_media_blob
+  ON catalog.package_media_assets(media_blob_id);
+
+CREATE TABLE IF NOT EXISTS catalog.collections (
+  collection_id            UUID                   PRIMARY KEY,
+  slug                     TEXT                   NOT NULL,
+  title                    TEXT                   NOT NULL,
+  summary                  TEXT                   NOT NULL,
+  description              TEXT                   NOT NULL,
+  language_tags            TEXT[]                 NOT NULL,
+  topic_tags               TEXT[]                 NOT NULL,
+  cover_package_id         UUID REFERENCES catalog.packages(package_id) ON DELETE SET NULL,
+  status                   catalog.package_status NOT NULL DEFAULT 'draft',
+  created_at               TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  published_at             TIMESTAMPTZ,
+  delisted_at              TIMESTAMPTZ,
+  CONSTRAINT collections_slug_unique UNIQUE (slug),
+  CONSTRAINT collections_slug_format CHECK (slug ~ '^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$'),
+  CONSTRAINT collections_title_nonempty CHECK (btrim(title) <> ''),
+  CONSTRAINT collections_summary_nonempty CHECK (btrim(summary) <> ''),
+  CONSTRAINT collections_description_nonempty CHECK (btrim(description) <> ''),
+  CONSTRAINT collections_language_tags_nonempty CHECK (cardinality(language_tags) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS catalog.collection_packages (
+  collection_id UUID        NOT NULL REFERENCES catalog.collections(collection_id) ON DELETE CASCADE,
+  package_id    UUID        NOT NULL REFERENCES catalog.packages(package_id) ON DELETE CASCADE,
+  ordinal       INTEGER     NOT NULL CHECK (ordinal > 0),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (collection_id, package_id),
+  CONSTRAINT collection_packages_collection_ordinal_unique UNIQUE (collection_id, ordinal)
+);
+
+CREATE TABLE IF NOT EXISTS catalog.package_review_events (
+  package_review_event_id UUID                   PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id              UUID                   NOT NULL REFERENCES catalog.packages(package_id) ON DELETE CASCADE,
+  package_version_id      UUID REFERENCES catalog.package_versions(package_version_id) ON DELETE SET NULL,
+  from_status             catalog.package_status,
+  to_status               catalog.package_status NOT NULL,
+  actor_admin_email       TEXT                   NOT NULL,
+  note                    TEXT,
+  created_at              TIMESTAMPTZ            NOT NULL DEFAULT now(),
+  CONSTRAINT package_review_events_actor_admin_email_nonempty CHECK (btrim(actor_admin_email) <> '')
+);
+
+CREATE INDEX IF NOT EXISTS idx_package_review_events_package_created
+  ON catalog.package_review_events(package_id, created_at DESC);
+
+COMMENT ON SCHEMA catalog IS 'Admin-authored public package catalog data. Writes are exposed only through backend admin routes.';
+COMMENT ON TABLE catalog.authors IS 'Catalog authors and publisher identities controlled by backend admin operators.';
+COMMENT ON TABLE catalog.packages IS 'Mutable package draft metadata and current package lifecycle state.';
+COMMENT ON TABLE catalog.package_versions IS 'Immutable package metadata snapshots after publication.';
+COMMENT ON TABLE catalog.package_cards IS 'Package-version card snapshots. Public card text may reference package-local media keys, never storage keys.';
+COMMENT ON TABLE catalog.package_media_assets IS 'Package-local media references backed by content.media_blobs.';
+COMMENT ON TABLE catalog.collections IS 'Admin-authored package collections for future marketplace grouping.';
+COMMENT ON TABLE catalog.collection_packages IS 'Ordered package membership for catalog collections.';
+COMMENT ON TABLE catalog.package_review_events IS 'Append-only package and package-version review/status history.';
+COMMENT ON COLUMN catalog.package_media_assets.package_media_key IS 'Stable package-local media key referenced from package cards and cover metadata.';
+COMMENT ON COLUMN catalog.package_media_assets.media_blob_id IS 'Deduplicated blob metadata row. Physical bytes remain in private object storage.';
+COMMENT ON COLUMN catalog.package_versions.source_workspace_id IS 'Optional source workspace used to build this immutable catalog version snapshot.';
+
+CREATE OR REPLACE FUNCTION catalog.set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION catalog.package_status_transition_allowed(
+  from_status catalog.package_status,
+  to_status catalog.package_status
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  SELECT from_status = to_status
+    OR (from_status = 'draft' AND to_status IN ('submitted', 'rejected'))
+    OR (from_status = 'submitted' AND to_status IN ('needs_changes', 'approved', 'rejected'))
+    OR (from_status = 'needs_changes' AND to_status IN ('submitted', 'rejected'))
+    OR (from_status = 'approved' AND to_status IN ('published', 'rejected'))
+    OR (from_status = 'published' AND to_status = 'delisted');
+$$;
+
+CREATE OR REPLACE FUNCTION catalog.assert_package_version_status_transition()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status
+    AND catalog.package_status_transition_allowed(OLD.status, NEW.status) = false THEN
+    RAISE EXCEPTION 'Invalid catalog package version status transition from % to %', OLD.status, NEW.status
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION catalog.prevent_published_package_version_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF (
+      OLD.status IN ('published', 'delisted')
+      OR NEW.status IN ('published', 'delisted')
+    )
+    AND (
+      NEW.package_id IS DISTINCT FROM OLD.package_id
+      OR NEW.version_number IS DISTINCT FROM OLD.version_number
+      OR NEW.slug IS DISTINCT FROM OLD.slug
+      OR NEW.title IS DISTINCT FROM OLD.title
+      OR NEW.summary IS DISTINCT FROM OLD.summary
+      OR NEW.description IS DISTINCT FROM OLD.description
+      OR NEW.language_tags IS DISTINCT FROM OLD.language_tags
+      OR NEW.topic_tags IS DISTINCT FROM OLD.topic_tags
+      OR NEW.license IS DISTINCT FROM OLD.license
+      OR NEW.content_warning IS DISTINCT FROM OLD.content_warning
+      OR NEW.cover_package_media_key IS DISTINCT FROM OLD.cover_package_media_key
+      OR NEW.source_workspace_id IS DISTINCT FROM OLD.source_workspace_id
+      OR NEW.card_count IS DISTINCT FROM OLD.card_count
+      OR NEW.created_by_admin_email IS DISTINCT FROM OLD.created_by_admin_email
+      OR NEW.created_at IS DISTINCT FROM OLD.created_at
+      OR NEW.submitted_at IS DISTINCT FROM OLD.submitted_at
+      OR (
+        OLD.status IN ('published', 'delisted')
+        AND NEW.published_at IS DISTINCT FROM OLD.published_at
+      )
+    ) THEN
+    RAISE EXCEPTION 'Published catalog package versions are immutable'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION catalog.prevent_published_package_version_child_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  old_status catalog.package_status;
+  new_status catalog.package_status;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.package_version_id IS NOT NULL THEN
+      SELECT package_versions.status
+      INTO new_status
+      FROM catalog.package_versions AS package_versions
+      WHERE package_versions.package_version_id = NEW.package_version_id;
+
+      IF new_status IN ('published', 'delisted') THEN
+        RAISE EXCEPTION 'Published catalog package version child rows are immutable'
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.package_version_id IS NOT NULL THEN
+      SELECT package_versions.status
+      INTO old_status
+      FROM catalog.package_versions AS package_versions
+      WHERE package_versions.package_version_id = OLD.package_version_id;
+
+      IF old_status IN ('published', 'delisted') THEN
+        RAISE EXCEPTION 'Published catalog package version child rows are immutable'
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    IF NEW.package_version_id IS NOT NULL THEN
+      SELECT package_versions.status
+      INTO new_status
+      FROM catalog.package_versions AS package_versions
+      WHERE package_versions.package_version_id = NEW.package_version_id;
+
+      IF new_status IN ('published', 'delisted') THEN
+        RAISE EXCEPTION 'Published catalog package version child rows are immutable'
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.package_version_id IS NOT NULL THEN
+      SELECT package_versions.status
+      INTO old_status
+      FROM catalog.package_versions AS package_versions
+      WHERE package_versions.package_version_id = OLD.package_version_id;
+
+      IF old_status IN ('published', 'delisted') THEN
+        RAISE EXCEPTION 'Published catalog package version child rows are immutable'
+          USING ERRCODE = '23514';
+      END IF;
+    END IF;
+
+    RETURN OLD;
+  END IF;
+
+  RAISE EXCEPTION 'Unsupported catalog package version child trigger operation: %', TG_OP
+    USING ERRCODE = 'P0001';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS authors_set_updated_at ON catalog.authors;
+CREATE TRIGGER authors_set_updated_at
+  BEFORE UPDATE ON catalog.authors
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.set_updated_at();
+
+DROP TRIGGER IF EXISTS packages_set_updated_at ON catalog.packages;
+CREATE TRIGGER packages_set_updated_at
+  BEFORE UPDATE ON catalog.packages
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.set_updated_at();
+
+DROP TRIGGER IF EXISTS package_versions_set_updated_at ON catalog.package_versions;
+CREATE TRIGGER package_versions_set_updated_at
+  BEFORE UPDATE ON catalog.package_versions
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.set_updated_at();
+
+DROP TRIGGER IF EXISTS package_versions_status_transition ON catalog.package_versions;
+CREATE TRIGGER package_versions_status_transition
+  BEFORE UPDATE OF status ON catalog.package_versions
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.assert_package_version_status_transition();
+
+DROP TRIGGER IF EXISTS package_versions_published_immutable ON catalog.package_versions;
+CREATE TRIGGER package_versions_published_immutable
+  BEFORE UPDATE ON catalog.package_versions
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.prevent_published_package_version_update();
+
+DROP TRIGGER IF EXISTS package_cards_set_updated_at ON catalog.package_cards;
+CREATE TRIGGER package_cards_set_updated_at
+  BEFORE UPDATE ON catalog.package_cards
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.set_updated_at();
+
+DROP TRIGGER IF EXISTS package_cards_published_immutable ON catalog.package_cards;
+CREATE TRIGGER package_cards_published_immutable
+  BEFORE INSERT OR UPDATE OR DELETE ON catalog.package_cards
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.prevent_published_package_version_child_mutation();
+
+DROP TRIGGER IF EXISTS package_media_assets_set_updated_at ON catalog.package_media_assets;
+CREATE TRIGGER package_media_assets_set_updated_at
+  BEFORE UPDATE ON catalog.package_media_assets
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.set_updated_at();
+
+DROP TRIGGER IF EXISTS package_media_assets_published_immutable ON catalog.package_media_assets;
+CREATE TRIGGER package_media_assets_published_immutable
+  BEFORE INSERT OR UPDATE OR DELETE ON catalog.package_media_assets
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.prevent_published_package_version_child_mutation();
+
+DROP TRIGGER IF EXISTS collections_set_updated_at ON catalog.collections;
+CREATE TRIGGER collections_set_updated_at
+  BEFORE UPDATE ON catalog.collections
+  FOR EACH ROW
+  EXECUTE FUNCTION catalog.set_updated_at();
+
+GRANT USAGE ON SCHEMA catalog TO backend_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
+  catalog.authors,
+  catalog.packages,
+  catalog.package_versions,
+  catalog.package_cards,
+  catalog.package_media_assets,
+  catalog.collections,
+  catalog.collection_packages,
+  catalog.package_review_events
+TO backend_app;


### PR DESCRIPTION
## Summary
- add catalog schema for authors, packages, immutable versions, cards, media assets, collections, and review events
- add typed backend catalog service helpers for draft metadata, media, version creation, status transitions, publish/delist
- add focused catalog service and migration-source tests

## Validation
- git --no-pager diff --check
- supplemental whitespace check for untracked PR A files
- git apply --check /tmp/catalog-admin-routes-docs.patch
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend -- catalog

Review gate passed: no P0-P4 findings and no split recommendation.