### PR TITLE
Add media upload session internals

### DIFF
--- a/apps/backend/src/mediaAssets/index.test.ts
+++ b/apps/backend/src/mediaAssets/index.test.ts
@@ -9,8 +9,15 @@ import {
 } from ".";
 import {
   buildMediaBlobStorageKey,
+  buildMediaMultipartUploadStagingStorageKey,
   buildMediaUploadStagingStorageKey,
 } from "./storageKeys";
+import {
+  maximumMultipartUploadBytes,
+  maximumSinglePutUploadBytes,
+  parseMediaAssetUploadIntentInput,
+  parseMediaAssetUploadSessionCreateInput,
+} from "./validators";
 import type {
   MediaAssetRow,
   MediaAssetSnapshotInput,
@@ -358,6 +365,69 @@ test("buildMediaUploadStagingStorageKey scopes temporary uploads by workspace as
       testMediaAssetId,
       "operations/e12febdf2c87aabeb4f0594f67409b7ec07fe532eb25e0c9e9f8f4f3febb0d6d",
     ].join("/"),
+  );
+});
+
+test("buildMediaMultipartUploadStagingStorageKey scopes temporary multipart uploads by session", () => {
+  assert.equal(
+    buildMediaMultipartUploadStagingStorageKey(
+      testWorkspaceId,
+      testMediaAssetId,
+      "33333333-3333-4333-8333-333333333333",
+    ),
+    [
+      "media/uploads/workspaces",
+      testWorkspaceId,
+      "assets",
+      testMediaAssetId,
+      "sessions/33333333-3333-4333-8333-333333333333",
+    ].join("/"),
+  );
+});
+
+test("media asset upload validators keep direct uploads compatible and cap multipart promotion size", () => {
+  assert.equal(maximumMultipartUploadBytes, maximumSinglePutUploadBytes);
+  assert.equal(parseMediaAssetUploadIntentInput({
+    mediaAssetId: testMediaAssetId,
+    mimeType: "image/png",
+    sizeBytes: 0,
+    sha256: testSha256,
+    lastOperationId: "operation-direct-zero",
+  }).sizeBytes, 0);
+  assert.equal(parseMediaAssetUploadSessionCreateInput({
+    mediaAssetId: testMediaAssetId,
+    mimeType: "image/png",
+    sizeBytes: maximumMultipartUploadBytes,
+    sha256: testSha256,
+    partSizeBytes: maximumMultipartUploadBytes,
+    partCount: 1,
+    sourceUrl: null,
+    createdAt: "2026-02-28T09:00:00.000Z",
+    clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+    lastModifiedByReplicaId: "55555555-5555-4555-8555-555555555555",
+    lastOperationId: "operation-multipart-max",
+  }).sizeBytes, maximumMultipartUploadBytes);
+
+  assert.throws(
+    () => parseMediaAssetUploadSessionCreateInput({
+      mediaAssetId: testMediaAssetId,
+      mimeType: "image/png",
+      sizeBytes: maximumMultipartUploadBytes + 1,
+      sha256: testSha256,
+      partSizeBytes: maximumMultipartUploadBytes,
+      partCount: 2,
+      sourceUrl: null,
+      createdAt: "2026-02-28T09:00:00.000Z",
+      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+      lastModifiedByReplicaId: "55555555-5555-4555-8555-555555555555",
+      lastOperationId: "operation-multipart-too-large",
+    }),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "MEDIA_ASSET_SIZE_TOO_LARGE");
+      return true;
+    },
   );
 });
 

--- a/apps/backend/src/mediaAssets/index.ts
+++ b/apps/backend/src/mediaAssets/index.ts
@@ -31,6 +31,13 @@ import type {
   MediaAssetRow,
   MediaAssetSnapshotInput,
   MediaAssetSyncMutationResult,
+  MediaAssetUploadSession,
+  MediaAssetUploadSessionAbortStartResult,
+  MediaAssetUploadSessionCompletionStartResult,
+  MediaAssetUploadSessionCreateInput,
+  MediaAssetUploadSessionCreateResult,
+  MediaAssetUploadSessionRow,
+  MediaAssetUploadSessionState,
   TimestampValue,
 } from "./types";
 import { expectMediaAssetSourceUrl } from "./validators";
@@ -68,6 +75,30 @@ const MEDIA_BLOB_COLUMNS = [
   "storage_key",
   "created_at",
   "updated_at",
+].join(", ");
+
+const MEDIA_UPLOAD_SESSION_COLUMNS = [
+  "media_upload_session_id",
+  "workspace_id",
+  "media_asset_id",
+  "media_blob_sha256",
+  "staging_storage_key",
+  "blob_storage_key",
+  "s3_upload_id",
+  "mime_type",
+  "size_bytes",
+  "part_size_bytes",
+  "part_count",
+  "state",
+  "source_url",
+  "asset_created_at",
+  "client_updated_at",
+  "last_modified_by_replica_id",
+  "last_operation_id",
+  "expires_at",
+  "created_at",
+  "completed_at",
+  "aborted_at",
 ].join(", ");
 
 type ExistingMediaAssetIntentRow = Readonly<{
@@ -121,6 +152,32 @@ export function mapMediaBlobRow(row: MediaBlobRow): MediaBlob {
     storageKey: row.storage_key,
     createdAt: toIsoString(row.created_at),
     updatedAt: toIsoString(row.updated_at),
+  };
+}
+
+export function mapMediaAssetUploadSessionRow(row: MediaAssetUploadSessionRow): MediaAssetUploadSession {
+  return {
+    sessionId: row.media_upload_session_id,
+    workspaceId: row.workspace_id,
+    mediaAssetId: row.media_asset_id,
+    mediaBlobSha256: row.media_blob_sha256,
+    stagingStorageKey: row.staging_storage_key,
+    blobStorageKey: row.blob_storage_key,
+    s3UploadId: row.s3_upload_id,
+    mimeType: row.mime_type,
+    sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
+    partSizeBytes: toSafeNumber(row.part_size_bytes, "part_size_bytes"),
+    partCount: toSafeNumber(row.part_count, "part_count"),
+    state: row.state,
+    sourceUrl: row.source_url,
+    assetCreatedAt: toIsoString(row.asset_created_at),
+    clientUpdatedAt: toIsoString(row.client_updated_at),
+    lastModifiedByReplicaId: row.last_modified_by_replica_id,
+    lastOperationId: row.last_operation_id,
+    expiresAt: toIsoString(row.expires_at),
+    createdAt: toIsoString(row.created_at),
+    completedAt: toOptionalIsoString(row.completed_at),
+    abortedAt: toOptionalIsoString(row.aborted_at),
   };
 }
 
@@ -329,6 +386,90 @@ async function findMediaBlobRowBySha256InExecutor(
   );
 
   return result.rows[0] ?? null;
+}
+
+function toMediaAssetSnapshotInputFromUploadSessionCreate(
+  input: MediaAssetUploadSessionCreateInput,
+): MediaAssetSnapshotInput {
+  return {
+    mediaAssetId: input.mediaAssetId,
+    mimeType: input.mimeType,
+    sizeBytes: input.sizeBytes,
+    sha256: input.sha256,
+    sourceUrl: input.sourceUrl,
+    createdAt: input.createdAt,
+    deletedAt: null,
+  };
+}
+
+function toMediaAssetSnapshotInputFromUploadSession(
+  session: MediaAssetUploadSession,
+): MediaAssetSnapshotInput {
+  return {
+    mediaAssetId: session.mediaAssetId,
+    mimeType: session.mimeType,
+    sizeBytes: session.sizeBytes,
+    sha256: session.mediaBlobSha256,
+    sourceUrl: session.sourceUrl,
+    createdAt: session.assetCreatedAt,
+    deletedAt: null,
+  };
+}
+
+function toMediaAssetMutationMetadataFromUploadSessionCreate(
+  input: MediaAssetUploadSessionCreateInput,
+): MediaAssetMutationMetadata {
+  return {
+    clientUpdatedAt: input.clientUpdatedAt,
+    lastModifiedByReplicaId: input.lastModifiedByReplicaId,
+    lastOperationId: input.lastOperationId,
+  };
+}
+
+function toMediaAssetMutationMetadataFromUploadSession(
+  session: MediaAssetUploadSession,
+): MediaAssetMutationMetadata {
+  return {
+    clientUpdatedAt: session.clientUpdatedAt,
+    lastModifiedByReplicaId: session.lastModifiedByReplicaId,
+    lastOperationId: session.lastOperationId,
+  };
+}
+
+async function findReachableMediaBlobForUploadSessionCreateInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: MediaAssetUploadSessionCreateInput,
+): Promise<MediaBlobRow | null> {
+  const normalizedInput = normalizeMediaAssetSnapshotInput(toMediaAssetSnapshotInputFromUploadSessionCreate(input));
+  const result = await executor.query<MediaBlobRow>(
+    [
+      "SELECT",
+      [
+        "media_blobs.media_blob_id AS media_blob_id",
+        "media_blobs.mime_type AS mime_type",
+        "media_blobs.size_bytes AS size_bytes",
+        "media_blobs.sha256 AS sha256",
+        "media_blobs.storage_key AS storage_key",
+        "media_blobs.created_at AS created_at",
+        "media_blobs.updated_at AS updated_at",
+      ].join(", "),
+      "FROM",
+      MEDIA_ASSET_JOIN_CLAUSE,
+      "WHERE media_assets.workspace_id = $1",
+      "AND media_assets.deleted_at IS NULL",
+      "AND media_blobs.sha256 = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [workspaceId, normalizedInput.sha256],
+  );
+  const row = result.rows[0] ?? null;
+  if (row === null) {
+    return null;
+  }
+
+  assertMediaBlobMatchesInput(row, normalizedInput);
+  return row;
 }
 
 async function upsertMediaBlobRowInExecutor(
@@ -597,6 +738,489 @@ export async function completeMediaAssetUploadForWorkspace(
       mediaAsset: result.mediaAsset,
       applied: result.applied,
     };
+  });
+}
+
+export async function createMediaAssetFromReachableBlobForWorkspace(
+  userId: string,
+  workspaceId: string,
+  input: MediaAssetUploadSessionCreateInput,
+): Promise<MediaAssetMutationResult | null> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    await assertReplicaBelongsToWorkspaceInExecutor(executor, workspaceId, input.lastModifiedByReplicaId);
+    const mediaBlobRow = await findReachableMediaBlobForUploadSessionCreateInExecutor(executor, workspaceId, input);
+    if (mediaBlobRow === null) {
+      return null;
+    }
+
+    const result = await upsertMediaAssetSnapshotInExecutor(
+      executor,
+      workspaceId,
+      toMediaAssetSnapshotInputFromUploadSessionCreate(input),
+      toMediaAssetMutationMetadataFromUploadSessionCreate(input),
+    );
+
+    return {
+      mediaAsset: result.mediaAsset,
+      applied: result.applied,
+    };
+  });
+}
+
+export async function createMediaAssetFromAvailableBlobForWorkspace(
+  userId: string,
+  workspaceId: string,
+  input: MediaAssetUploadSessionCreateInput,
+): Promise<MediaAssetMutationResult | null> {
+  return createMediaAssetFromReachableBlobForWorkspace(userId, workspaceId, input);
+}
+
+async function findMediaAssetUploadSessionRowForUpdateInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  sessionId: string,
+): Promise<MediaAssetUploadSessionRow | null> {
+  const result = await executor.query<MediaAssetUploadSessionRow>(
+    [
+      "SELECT",
+      MEDIA_UPLOAD_SESSION_COLUMNS,
+      "FROM content.media_upload_sessions",
+      "WHERE workspace_id = $1",
+      "AND media_upload_session_id = $2",
+      "FOR UPDATE",
+    ].join(" "),
+    [workspaceId, sessionId],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+function createMediaAssetUploadSessionNotFoundError(sessionId: string): HttpError {
+  return new HttpError(
+    404,
+    `Media asset upload session not found. sessionId=${sessionId}`,
+    "MEDIA_ASSET_UPLOAD_SESSION_NOT_FOUND",
+  );
+}
+
+function assertMediaAssetUploadSessionActive(session: MediaAssetUploadSession): void {
+  assertMediaAssetUploadSessionState(session, "active");
+
+  if (new Date(session.expiresAt).getTime() <= Date.now()) {
+    throw new HttpError(
+      409,
+      `Media asset upload session is expired. sessionId=${session.sessionId} expiresAt=${session.expiresAt}`,
+      "MEDIA_ASSET_UPLOAD_SESSION_EXPIRED",
+    );
+  }
+}
+
+function assertMediaAssetUploadSessionState(
+  session: MediaAssetUploadSession,
+  expectedState: MediaAssetUploadSessionState,
+): void {
+  if (session.state === expectedState) {
+    return;
+  }
+
+  if (session.state === "completed") {
+    throw new HttpError(
+      409,
+      `Media asset upload session is already completed. sessionId=${session.sessionId}`,
+      "MEDIA_ASSET_UPLOAD_SESSION_COMPLETED",
+    );
+  }
+
+  if (session.state === "aborted") {
+    throw new HttpError(
+      409,
+      `Media asset upload session is already aborted. sessionId=${session.sessionId}`,
+      "MEDIA_ASSET_UPLOAD_SESSION_ABORTED",
+    );
+  }
+
+  throw new HttpError(
+    409,
+    `Media asset upload session is ${session.state}; expected ${expectedState}. sessionId=${session.sessionId}`,
+    "MEDIA_ASSET_UPLOAD_SESSION_STATE_CONFLICT",
+  );
+}
+
+function assertMediaAssetUploadSessionCanComplete(session: MediaAssetUploadSession): void {
+  if (session.state === "completing") {
+    return;
+  }
+
+  if (session.state === "active") {
+    if (new Date(session.expiresAt).getTime() <= Date.now()) {
+      throw new HttpError(
+        409,
+        `Media asset upload session is expired. sessionId=${session.sessionId} expiresAt=${session.expiresAt}`,
+        "MEDIA_ASSET_UPLOAD_SESSION_EXPIRED",
+      );
+    }
+
+    return;
+  }
+
+  assertMediaAssetUploadSessionState(session, "completing");
+}
+
+function assertMediaAssetUploadSessionCanAbort(session: MediaAssetUploadSession): void {
+  if (session.state === "active" || session.state === "aborting") {
+    return;
+  }
+
+  assertMediaAssetUploadSessionState(session, "aborting");
+}
+
+export function assertMediaAssetUploadSessionPartNumbersInRange(
+  session: MediaAssetUploadSession,
+  parts: ReadonlyArray<Readonly<{ partNumber: number }>>,
+): void {
+  for (const part of parts) {
+    if (part.partNumber > session.partCount) {
+      throw new HttpError(
+        400,
+        `partNumber must be between 1 and ${session.partCount} for this upload session`,
+        "MEDIA_ASSET_PART_NUMBER_OUT_OF_RANGE",
+      );
+    }
+  }
+}
+
+export function assertMediaAssetUploadSessionCompletionPartsMatch(
+  session: MediaAssetUploadSession,
+  parts: ReadonlyArray<Readonly<{ partNumber: number }>>,
+): void {
+  if (parts.length !== session.partCount) {
+    throw new HttpError(
+      400,
+      `parts must contain exactly ${session.partCount} completed parts for this upload session`,
+      "MEDIA_ASSET_PART_COUNT_MISMATCH",
+    );
+  }
+
+  const sortedPartNumbers = parts.map((part) => part.partNumber).sort((left, right) => left - right);
+  for (let index = 0; index < sortedPartNumbers.length; index += 1) {
+    const expectedPartNumber = index + 1;
+    if (sortedPartNumbers[index] !== expectedPartNumber) {
+      throw new HttpError(
+        400,
+        "parts must contain every partNumber from 1 through the upload session partCount",
+        "MEDIA_ASSET_PART_SEQUENCE_INVALID",
+      );
+    }
+  }
+}
+
+export async function recordMediaAssetUploadSessionForWorkspace(
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  input: MediaAssetUploadSessionCreateInput,
+  stagingStorageKey: string,
+  blobStorageKey: string,
+  s3UploadId: string,
+  expiresAt: string,
+): Promise<MediaAssetUploadSessionCreateResult> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    await assertReplicaBelongsToWorkspaceInExecutor(executor, workspaceId, input.lastModifiedByReplicaId);
+    const existingMediaBlobRow = await findReachableMediaBlobForUploadSessionCreateInExecutor(
+      executor,
+      workspaceId,
+      input,
+    );
+    if (existingMediaBlobRow !== null) {
+      const result = await upsertMediaAssetSnapshotInExecutor(
+        executor,
+        workspaceId,
+        toMediaAssetSnapshotInputFromUploadSessionCreate(input),
+        toMediaAssetMutationMetadataFromUploadSessionCreate(input),
+      );
+
+      return {
+        status: "already_available",
+        mediaAsset: result.mediaAsset,
+        applied: result.applied,
+      };
+    }
+
+    const normalizedSnapshot = normalizeMediaAssetSnapshotInput(toMediaAssetSnapshotInputFromUploadSessionCreate(input));
+    const normalizedMetadata = normalizeMediaAssetMutationMetadata(
+      toMediaAssetMutationMetadataFromUploadSessionCreate(input),
+    );
+    const result = await executor.query<MediaAssetUploadSessionRow>(
+      [
+        "INSERT INTO content.media_upload_sessions",
+        "(",
+        "media_upload_session_id, workspace_id, media_asset_id, media_blob_sha256, staging_storage_key,",
+        "blob_storage_key, s3_upload_id, mime_type, size_bytes, part_size_bytes, part_count, state, source_url,",
+        "asset_created_at, client_updated_at, last_modified_by_replica_id, last_operation_id, expires_at",
+        ")",
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'active', $12, $13, $14, $15, $16, $17)",
+        "RETURNING",
+        MEDIA_UPLOAD_SESSION_COLUMNS,
+      ].join(" "),
+      [
+        sessionId,
+        workspaceId,
+        normalizedSnapshot.mediaAssetId,
+        normalizedSnapshot.sha256,
+        stagingStorageKey,
+        blobStorageKey,
+        s3UploadId,
+        normalizedSnapshot.mimeType,
+        normalizedSnapshot.sizeBytes,
+        input.partSizeBytes,
+        input.partCount,
+        normalizedSnapshot.sourceUrl,
+        normalizedSnapshot.createdAt,
+        normalizedMetadata.clientUpdatedAt,
+        normalizedMetadata.lastModifiedByReplicaId,
+        normalizedMetadata.lastOperationId,
+        expiresAt,
+      ],
+    );
+
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Media asset upload session insert did not return a row");
+    }
+
+    return {
+      status: "upload_required",
+      uploadSession: mapMediaAssetUploadSessionRow(row),
+    };
+  });
+}
+
+export async function loadMediaAssetUploadSessionForWorkspace(
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+): Promise<MediaAssetUploadSession> {
+  const result = await queryWithWorkspaceScopeReadOnly<MediaAssetUploadSessionRow>(
+    { userId, workspaceId },
+    [
+      "SELECT",
+      MEDIA_UPLOAD_SESSION_COLUMNS,
+      "FROM content.media_upload_sessions",
+      "WHERE workspace_id = $1",
+      "AND media_upload_session_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [workspaceId, sessionId],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw createMediaAssetUploadSessionNotFoundError(sessionId);
+  }
+
+  const session = mapMediaAssetUploadSessionRow(row);
+  assertMediaAssetUploadSessionActive(session);
+  return session;
+}
+
+async function findMediaAssetFromSessionInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  session: MediaAssetUploadSession,
+): Promise<MediaAsset> {
+  const row = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, session.mediaAssetId);
+  if (row === null) {
+    throw new Error(`Completed media asset upload session has no media asset row. sessionId=${session.sessionId}`);
+  }
+
+  return mapMediaAssetRow(row);
+}
+
+export async function beginMediaAssetUploadSessionCompletionForWorkspace(
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+): Promise<MediaAssetUploadSessionCompletionStartResult> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    const row = await findMediaAssetUploadSessionRowForUpdateInExecutor(executor, workspaceId, sessionId);
+    if (row === null) {
+      throw createMediaAssetUploadSessionNotFoundError(sessionId);
+    }
+
+    const session = mapMediaAssetUploadSessionRow(row);
+    if (session.state === "completed") {
+      return {
+        status: "already_completed",
+        mediaAsset: await findMediaAssetFromSessionInExecutor(executor, workspaceId, session),
+        applied: false,
+      };
+    }
+
+    assertMediaAssetUploadSessionCanComplete(session);
+    if (session.state === "completing") {
+      return {
+        status: "complete_required",
+        uploadSession: session,
+      };
+    }
+
+    const result = await executor.query<MediaAssetUploadSessionRow>(
+      [
+        "UPDATE content.media_upload_sessions",
+        "SET state = 'completing'",
+        "WHERE workspace_id = $1",
+        "AND media_upload_session_id = $2",
+        "AND state = 'active'",
+        "RETURNING",
+        MEDIA_UPLOAD_SESSION_COLUMNS,
+      ].join(" "),
+      [workspaceId, sessionId],
+    );
+    const updatedRow = result.rows[0];
+    if (updatedRow === undefined) {
+      throw new Error(`Media asset upload session completing update did not return a row. sessionId=${sessionId}`);
+    }
+
+    return {
+      status: "complete_required",
+      uploadSession: mapMediaAssetUploadSessionRow(updatedRow),
+    };
+  });
+}
+
+export async function completeMediaAssetUploadSessionForWorkspace(
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+): Promise<MediaAssetMutationResult> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    const row = await findMediaAssetUploadSessionRowForUpdateInExecutor(executor, workspaceId, sessionId);
+    if (row === null) {
+      throw createMediaAssetUploadSessionNotFoundError(sessionId);
+    }
+
+    const session = mapMediaAssetUploadSessionRow(row);
+    if (session.state === "completed") {
+      return {
+        mediaAsset: await findMediaAssetFromSessionInExecutor(executor, workspaceId, session),
+        applied: false,
+      };
+    }
+
+    assertMediaAssetUploadSessionState(session, "completing");
+    await assertReplicaBelongsToWorkspaceInExecutor(executor, workspaceId, session.lastModifiedByReplicaId);
+    const result = await upsertMediaAssetSnapshotInExecutor(
+      executor,
+      workspaceId,
+      toMediaAssetSnapshotInputFromUploadSession(session),
+      toMediaAssetMutationMetadataFromUploadSession(session),
+    );
+    await executor.query(
+      [
+        "UPDATE content.media_upload_sessions",
+        "SET state = 'completed', completed_at = now()",
+        "WHERE workspace_id = $1",
+        "AND media_upload_session_id = $2",
+        "AND state = 'completing'",
+      ].join(" "),
+      [workspaceId, sessionId],
+    );
+
+    return {
+      mediaAsset: result.mediaAsset,
+      applied: result.applied,
+    };
+  });
+}
+
+export async function beginMediaAssetUploadSessionAbortForWorkspace(
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+): Promise<MediaAssetUploadSessionAbortStartResult> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    const row = await findMediaAssetUploadSessionRowForUpdateInExecutor(executor, workspaceId, sessionId);
+    if (row === null) {
+      throw createMediaAssetUploadSessionNotFoundError(sessionId);
+    }
+
+    const session = mapMediaAssetUploadSessionRow(row);
+    if (session.state === "aborted") {
+      return {
+        status: "already_aborted",
+        uploadSession: session,
+      };
+    }
+
+    assertMediaAssetUploadSessionCanAbort(session);
+    if (session.state === "aborting") {
+      return {
+        status: "abort_required",
+        uploadSession: session,
+      };
+    }
+
+    const result = await executor.query<MediaAssetUploadSessionRow>(
+      [
+        "UPDATE content.media_upload_sessions",
+        "SET state = 'aborting'",
+        "WHERE workspace_id = $1",
+        "AND media_upload_session_id = $2",
+        "AND state = 'active'",
+        "RETURNING",
+        MEDIA_UPLOAD_SESSION_COLUMNS,
+      ].join(" "),
+      [workspaceId, sessionId],
+    );
+
+    const updatedRow = result.rows[0];
+    if (updatedRow === undefined) {
+      throw new Error(`Media asset upload session aborting update did not return a row. sessionId=${sessionId}`);
+    }
+
+    return {
+      status: "abort_required",
+      uploadSession: mapMediaAssetUploadSessionRow(updatedRow),
+    };
+  });
+}
+
+export async function markMediaAssetUploadSessionAbortedForWorkspace(
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+): Promise<MediaAssetUploadSession> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    const row = await findMediaAssetUploadSessionRowForUpdateInExecutor(executor, workspaceId, sessionId);
+    if (row === null) {
+      throw createMediaAssetUploadSessionNotFoundError(sessionId);
+    }
+
+    const session = mapMediaAssetUploadSessionRow(row);
+    if (session.state === "aborted") {
+      return session;
+    }
+
+    assertMediaAssetUploadSessionState(session, "aborting");
+    const result = await executor.query<MediaAssetUploadSessionRow>(
+      [
+        "UPDATE content.media_upload_sessions",
+        "SET state = 'aborted', aborted_at = now()",
+        "WHERE workspace_id = $1",
+        "AND media_upload_session_id = $2",
+        "AND state = 'aborting'",
+        "RETURNING",
+        MEDIA_UPLOAD_SESSION_COLUMNS,
+      ].join(" "),
+      [workspaceId, sessionId],
+    );
+
+    const updatedRow = result.rows[0];
+    if (updatedRow === undefined) {
+      throw new Error(`Media asset upload session aborted update did not return a row. sessionId=${sessionId}`);
+    }
+
+    return mapMediaAssetUploadSessionRow(updatedRow);
   });
 }
 

--- a/apps/backend/src/mediaAssets/storage.test.ts
+++ b/apps/backend/src/mediaAssets/storage.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Readable } from "node:stream";
 import {
+  CompleteMultipartUploadCommand,
   CopyObjectCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
   HeadObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
@@ -9,12 +13,16 @@ import { createBackendObservationScope } from "../observability/sentry";
 import { createPublicHttpErrorDetails, HttpError } from "../shared/errors";
 import {
   assertMediaAssetObjectMatchesWithDependencies,
+  completeMultipartMediaAssetUploadWithDependencies,
+  createMultipartMediaAssetUploadWithDependencies,
   createPresignedMediaAssetUploadWithDependencies,
+  createPresignedMediaAssetUploadPartsWithDependencies,
   loadMediaAssetObjectMetadataWithDependencies,
   promoteMediaAssetUploadToBlobWithDependencies,
 } from "./storage";
 import {
   buildMediaBlobStorageKey,
+  buildMediaMultipartUploadStagingStorageKey,
   buildMediaUploadStagingStorageKey,
 } from "./storageKeys";
 
@@ -26,18 +34,26 @@ type S3Error = Error & {
 
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
 const testMediaAssetId = "22222222-2222-4222-8222-222222222222";
-const testLastOperationId = "operation-media-1";
+const testSessionId = "33333333-3333-4333-8333-333333333333";
+const testLastOperationId = "operation-1";
+const testLastOperationIdSha256 = "187f0349dd12b6dc73d76d86f421cd454facccc36ef9a2ba6956b37abbb31102";
 const testSha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
-const testStorageKey = buildMediaBlobStorageKey(testSha256);
+const testObjectBytes = Buffer.from("password");
+const testBlobStorageKey = buildMediaBlobStorageKey(testSha256);
 const testUploadStorageKey = buildMediaUploadStagingStorageKey(
   testWorkspaceId,
   testMediaAssetId,
   testLastOperationId,
 );
+const testStagingStorageKey = buildMediaMultipartUploadStagingStorageKey(
+  testWorkspaceId,
+  testMediaAssetId,
+  testSessionId,
+);
 const testObservationScope = createBackendObservationScope(
   "backend-api",
   "request-1",
-  "/workspaces/:workspaceId/media-assets/:mediaAssetId/complete",
+  "/workspaces/:workspaceId/media-assets/upload-sessions/:sessionId/complete",
   "POST",
   "user-1",
   testWorkspaceId,
@@ -81,29 +97,6 @@ function createTestS3Client(): S3Client {
   });
 }
 
-function createHeadObjectS3Client(fixture: Readonly<{
-  sizeBytes: number;
-  mimeType: string;
-  sha256: string;
-  workspaceId: string;
-  mediaAssetId: string;
-  lastOperationIdSha256: string;
-}>): S3Client {
-  const client = createTestS3Client();
-  client.send = (async () => ({
-    ContentLength: fixture.sizeBytes,
-    ContentType: fixture.mimeType,
-    ChecksumSHA256: Buffer.from(fixture.sha256, "hex").toString("base64"),
-    Metadata: {
-      "flashcards-workspace-id": fixture.workspaceId,
-      "flashcards-media-asset-id": fixture.mediaAssetId,
-      "flashcards-last-operation-id-sha256": fixture.lastOperationIdSha256,
-      "flashcards-sha256": fixture.sha256,
-    },
-  })) as S3Client["send"];
-  return client;
-}
-
 function createHeadObjectResponse(fixture: Readonly<{
   sizeBytes: number;
   mimeType: string;
@@ -111,21 +104,25 @@ function createHeadObjectResponse(fixture: Readonly<{
   workspaceId?: string;
   mediaAssetId?: string;
   lastOperationIdSha256?: string;
+  checksumSha256?: string;
+  checksumType?: "COMPOSITE" | "FULL_OBJECT";
 }>): Readonly<{
   ContentLength: number;
   ContentType: string;
   ChecksumSHA256: string;
+  ChecksumType: "COMPOSITE" | "FULL_OBJECT";
   Metadata: Readonly<Record<string, string>>;
 }> {
   return {
     ContentLength: fixture.sizeBytes,
     ContentType: fixture.mimeType,
-    ChecksumSHA256: Buffer.from(fixture.sha256, "hex").toString("base64"),
+    ChecksumSHA256: Buffer.from(fixture.checksumSha256 ?? fixture.sha256, "hex").toString("base64"),
+    ChecksumType: fixture.checksumType ?? "FULL_OBJECT",
     Metadata: {
-      ...(fixture.workspaceId === undefined ? {} : { "flashcards-workspace-id": fixture.workspaceId }),
-      ...(fixture.mediaAssetId === undefined ? {} : { "flashcards-media-asset-id": fixture.mediaAssetId }),
-      ...(fixture.lastOperationIdSha256 === undefined ? {} : { "flashcards-last-operation-id-sha256": fixture.lastOperationIdSha256 }),
       "flashcards-sha256": fixture.sha256,
+      "flashcards-workspace-id": fixture.workspaceId ?? testWorkspaceId,
+      "flashcards-media-asset-id": fixture.mediaAssetId ?? testMediaAssetId,
+      "flashcards-last-operation-id-sha256": fixture.lastOperationIdSha256 ?? testLastOperationIdSha256,
     },
   };
 }
@@ -162,7 +159,87 @@ test("createPresignedMediaAssetUploadWithDependencies signs all returned require
   assert.equal(upload.headers["x-amz-meta-flashcards-workspace-id"], testWorkspaceId);
   assert.equal(upload.headers["x-amz-meta-flashcards-media-asset-id"], testMediaAssetId);
   assert.equal(upload.headers["x-amz-meta-flashcards-sha256"], "a".repeat(64));
-  assert.match(upload.headers["x-amz-meta-flashcards-last-operation-id-sha256"] ?? "", /^[0-9a-f]{64}$/);
+  assert.equal(upload.headers["x-amz-meta-flashcards-last-operation-id-sha256"], testLastOperationIdSha256);
+});
+
+test("createMultipartMediaAssetUploadWithDependencies starts uploads at a session-scoped staging key", async () => {
+  const sentCommands: Array<string> = [];
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    if (command instanceof CreateMultipartUploadCommand) {
+      assert.equal(command.input.ChecksumType, undefined);
+      sentCommands.push([
+        String(command.input.Key),
+        String(command.input.ContentType),
+        String(command.input.ChecksumAlgorithm),
+        String(command.input.Metadata?.["flashcards-sha256"]),
+      ].join(":"));
+      return { UploadId: "s3-upload-id-1" };
+    }
+
+    throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  const upload = await createMultipartMediaAssetUploadWithDependencies(
+    {
+      workspaceId: testWorkspaceId,
+      mediaAssetId: testMediaAssetId,
+      stagingStorageKey: testStagingStorageKey,
+      mimeType: "image/png",
+      sha256: testSha256,
+      lastOperationId: testLastOperationId,
+      observationScope: testObservationScope,
+    },
+    {
+      s3Client: client,
+      getMediaAssetsStorageConfigFn: () => ({
+        bucketName: "test-media-assets-bucket",
+      }),
+    },
+  );
+
+  assert.equal(upload.storageKey, testStagingStorageKey);
+  assert.equal(upload.s3UploadId, "s3-upload-id-1");
+  assert.match(upload.expiresAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.deepEqual(sentCommands, [
+    `${testStagingStorageKey}:image/png:SHA256:${testSha256}`,
+  ]);
+});
+
+test("createPresignedMediaAssetUploadPartsWithDependencies signs per-part checksum headers", async () => {
+  const partUrls = await createPresignedMediaAssetUploadPartsWithDependencies(
+    {
+      workspaceId: testWorkspaceId,
+      mediaAssetId: testMediaAssetId,
+      stagingStorageKey: testStagingStorageKey,
+      s3UploadId: "s3-upload-id-1",
+      parts: [
+        {
+          partNumber: 1,
+          sha256: "a".repeat(64),
+        },
+      ],
+      observationScope: testObservationScope,
+    },
+    {
+      s3Client: createTestS3Client(),
+      getMediaAssetsStorageConfigFn: () => ({
+        bucketName: "test-media-assets-bucket",
+      }),
+    },
+  );
+
+  const partUrl = partUrls[0];
+  assert.notEqual(partUrl, undefined);
+  assert.equal(partUrl?.method, "PUT");
+  assert.equal(partUrl?.partNumber, 1);
+  assert.equal(
+    partUrl?.headers["x-amz-checksum-sha256"],
+    Buffer.from("a".repeat(64), "hex").toString("base64"),
+  );
+  const signedHeaders = new URL(partUrl?.url ?? "").searchParams.get("X-Amz-SignedHeaders");
+  assert.notEqual(signedHeaders, null);
+  assert.ok(new Set(signedHeaders?.split(";") ?? []).has("x-amz-checksum-sha256"));
 });
 
 test("loadMediaAssetObjectMetadataWithDependencies treats HeadObject 403 as upload not found", async () => {
@@ -171,15 +248,15 @@ test("loadMediaAssetObjectMetadataWithDependencies treats HeadObject 403 as uplo
       {
         workspaceId: testWorkspaceId,
         mediaAssetId: testMediaAssetId,
-        storageKey: testStorageKey,
+        storageKey: testStagingStorageKey,
         mimeType: "image/png",
-        sizeBytes: 123,
-        sha256: "a".repeat(64),
+        sizeBytes: 42,
+        sha256: testSha256,
         lastOperationId: testLastOperationId,
         observationScope: testObservationScope,
       },
       {
-        s3Client: createFailingS3Client(createS3Error(403, "Forbidden", `Forbidden for s3://test-media-assets-bucket/${testStorageKey}`)),
+        s3Client: createFailingS3Client(createS3Error(403, "Forbidden", `Forbidden for s3://test-media-assets-bucket/${testStagingStorageKey}`)),
         getMediaAssetsStorageConfigFn: () => ({
           bucketName: "test-media-assets-bucket",
         }),
@@ -194,11 +271,11 @@ test("loadMediaAssetObjectMetadataWithDependencies treats HeadObject 403 as uplo
         operation: "head_object",
         workspaceId: testWorkspaceId,
         mediaAssetId: testMediaAssetId,
-        storageKey: testStorageKey,
+        storageKey: testStagingStorageKey,
         bucketName: "test-media-assets-bucket",
         s3StatusCode: 403,
         s3ErrorClass: "Forbidden",
-        s3ErrorMessage: `Forbidden for s3://test-media-assets-bucket/${testStorageKey}`,
+        s3ErrorMessage: `Forbidden for s3://test-media-assets-bucket/${testStagingStorageKey}`,
       });
       assert.deepEqual(createPublicHttpErrorDetails(error.details), {
         mediaAssetStorage: {
@@ -215,11 +292,18 @@ test("loadMediaAssetObjectMetadataWithDependencies treats HeadObject 403 as uplo
 });
 
 test("assertMediaAssetObjectMatchesWithDependencies accepts matching signed upload proof metadata", async () => {
+  const client = createTestS3Client();
+  client.send = (async () => createHeadObjectResponse({
+    sizeBytes: 42,
+    mimeType: "image/png",
+    sha256: testSha256,
+  })) as S3Client["send"];
+
   await assertMediaAssetObjectMatchesWithDependencies(
     {
       workspaceId: testWorkspaceId,
       mediaAssetId: testMediaAssetId,
-      storageKey: testStorageKey,
+      storageKey: testBlobStorageKey,
       mimeType: "image/png",
       sizeBytes: 42,
       sha256: testSha256,
@@ -227,14 +311,7 @@ test("assertMediaAssetObjectMatchesWithDependencies accepts matching signed uplo
       observationScope: testObservationScope,
     },
     {
-      s3Client: createHeadObjectS3Client({
-        sizeBytes: 42,
-        mimeType: "image/png",
-        sha256: testSha256,
-        workspaceId: testWorkspaceId,
-        mediaAssetId: testMediaAssetId,
-        lastOperationIdSha256: "e12febdf2c87aabeb4f0594f67409b7ec07fe532eb25e0c9e9f8f4f3febb0d6d",
-      }),
+      s3Client: client,
       getMediaAssetsStorageConfigFn: () => ({
         bucketName: "test-media-assets-bucket",
       }),
@@ -243,12 +320,22 @@ test("assertMediaAssetObjectMatchesWithDependencies accepts matching signed uplo
 });
 
 test("assertMediaAssetObjectMatchesWithDependencies rejects existing blobs without matching upload proof", async () => {
+  const client = createTestS3Client();
+  client.send = (async () => createHeadObjectResponse({
+    sizeBytes: 42,
+    mimeType: "image/png",
+    sha256: testSha256,
+    workspaceId: "44444444-4444-4444-8444-444444444444",
+    mediaAssetId: "55555555-5555-4555-8555-555555555555",
+    lastOperationIdSha256: "0".repeat(64),
+  })) as S3Client["send"];
+
   await assert.rejects(
     async () => assertMediaAssetObjectMatchesWithDependencies(
       {
         workspaceId: testWorkspaceId,
         mediaAssetId: testMediaAssetId,
-        storageKey: testStorageKey,
+        storageKey: testBlobStorageKey,
         mimeType: "image/png",
         sizeBytes: 42,
         sha256: testSha256,
@@ -256,14 +343,7 @@ test("assertMediaAssetObjectMatchesWithDependencies rejects existing blobs witho
         observationScope: testObservationScope,
       },
       {
-        s3Client: createHeadObjectS3Client({
-          sizeBytes: 42,
-          mimeType: "image/png",
-          sha256: testSha256,
-          workspaceId: "33333333-3333-4333-8333-333333333333",
-          mediaAssetId: "44444444-4444-4444-8444-444444444444",
-          lastOperationIdSha256: "0".repeat(64),
-        }),
+        s3Client: client,
         getMediaAssetsStorageConfigFn: () => ({
           bucketName: "test-media-assets-bucket",
         }),
@@ -286,24 +366,11 @@ test("promoteMediaAssetUploadToBlobWithDependencies reuses an existing blob afte
     if (command instanceof HeadObjectCommand) {
       const key = command.input.Key;
       sentCommands.push(`head:${String(key)}`);
-      if (key === testUploadStorageKey) {
-        return createHeadObjectResponse({
-          sizeBytes: 42,
-          mimeType: "image/png",
-          sha256: testSha256,
-          workspaceId: testWorkspaceId,
-          mediaAssetId: testMediaAssetId,
-          lastOperationIdSha256: "e12febdf2c87aabeb4f0594f67409b7ec07fe532eb25e0c9e9f8f4f3febb0d6d",
-        });
-      }
-
-      if (key === testStorageKey) {
-        return createHeadObjectResponse({
-          sizeBytes: 42,
-          mimeType: "image/png",
-          sha256: testSha256,
-        });
-      }
+      return createHeadObjectResponse({
+        sizeBytes: 42,
+        mimeType: "image/png",
+        sha256: testSha256,
+      });
     }
 
     if (command instanceof CopyObjectCommand) {
@@ -319,7 +386,7 @@ test("promoteMediaAssetUploadToBlobWithDependencies reuses an existing blob afte
       workspaceId: testWorkspaceId,
       mediaAssetId: testMediaAssetId,
       uploadStorageKey: testUploadStorageKey,
-      blobStorageKey: testStorageKey,
+      blobStorageKey: testBlobStorageKey,
       mimeType: "image/png",
       sizeBytes: 42,
       sha256: testSha256,
@@ -336,59 +403,75 @@ test("promoteMediaAssetUploadToBlobWithDependencies reuses an existing blob afte
 
   assert.deepEqual(sentCommands, [
     `head:${testUploadStorageKey}`,
-    `head:${testStorageKey}`,
+    `head:${testBlobStorageKey}`,
   ]);
 });
 
-test("promoteMediaAssetUploadToBlobWithDependencies copies staging upload when blob is missing", async () => {
+test("completeMultipartMediaAssetUploadWithDependencies completes parts and validates the stored blob", async () => {
   const sentCommands: Array<string> = [];
   const client = createTestS3Client();
   client.send = (async (command: unknown) => {
-    if (command instanceof HeadObjectCommand) {
-      const key = command.input.Key;
-      sentCommands.push(`head:${String(key)}`);
-      if (key === testUploadStorageKey) {
-        return createHeadObjectResponse({
-          sizeBytes: 42,
-          mimeType: "image/png",
-          sha256: testSha256,
-          workspaceId: testWorkspaceId,
-          mediaAssetId: testMediaAssetId,
-          lastOperationIdSha256: "e12febdf2c87aabeb4f0594f67409b7ec07fe532eb25e0c9e9f8f4f3febb0d6d",
-        });
-      }
-
-      if (key === testStorageKey && sentCommands.filter((value) => value === `head:${testStorageKey}`).length <= 3) {
-        throw createS3Error(404, "NoSuchKey", "Not Found");
-      }
-
-      if (key === testStorageKey) {
-        return createHeadObjectResponse({
-          sizeBytes: 42,
-          mimeType: "image/png",
-          sha256: testSha256,
-        });
-      }
-    }
-
-    if (command instanceof CopyObjectCommand) {
-      sentCommands.push(`copy:${String(command.input.CopySource)}:${String(command.input.Key)}:${String(command.input.IfNoneMatch)}`);
+    if (command instanceof CompleteMultipartUploadCommand) {
+      assert.equal(command.input.ChecksumType, undefined);
+      assert.equal(command.input.ChecksumSHA256, undefined);
+      assert.equal(command.input.MpuObjectSize, undefined);
+      sentCommands.push([
+        "complete",
+        String(command.input.Key),
+        String(command.input.UploadId),
+        String(command.input.MultipartUpload?.Parts?.[0]?.PartNumber),
+        String(command.input.MultipartUpload?.Parts?.[0]?.ChecksumSHA256),
+      ].join(":"));
       return {};
     }
 
+    if (command instanceof HeadObjectCommand) {
+      sentCommands.push(`head:${String(command.input.Key)}`);
+      if (command.input.Key === testStagingStorageKey) {
+        return createHeadObjectResponse({
+          sizeBytes: testObjectBytes.byteLength,
+          mimeType: "image/png",
+          sha256: testSha256,
+          checksumSha256: "c".repeat(64),
+          checksumType: "COMPOSITE",
+        });
+      }
+
+      return createHeadObjectResponse({
+        sizeBytes: testObjectBytes.byteLength,
+        mimeType: "image/png",
+        sha256: testSha256,
+      });
+    }
+
+    if (command instanceof GetObjectCommand) {
+      sentCommands.push(`get:${String(command.input.Key)}`);
+      return {
+        Body: Readable.from([testObjectBytes]),
+      };
+    }
+
     throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
   }) as S3Client["send"];
 
-  await promoteMediaAssetUploadToBlobWithDependencies(
+  await completeMultipartMediaAssetUploadWithDependencies(
     {
       workspaceId: testWorkspaceId,
       mediaAssetId: testMediaAssetId,
-      uploadStorageKey: testUploadStorageKey,
-      blobStorageKey: testStorageKey,
+      stagingStorageKey: testStagingStorageKey,
+      blobStorageKey: testBlobStorageKey,
+      s3UploadId: "s3-upload-id-1",
       mimeType: "image/png",
-      sizeBytes: 42,
+      sizeBytes: testObjectBytes.byteLength,
       sha256: testSha256,
       lastOperationId: testLastOperationId,
+      parts: [
+        {
+          partNumber: 1,
+          eTag: "\"etag-1\"",
+          sha256: "b".repeat(64),
+        },
+      ],
       observationScope: testObservationScope,
     },
     {
@@ -400,80 +483,228 @@ test("promoteMediaAssetUploadToBlobWithDependencies copies staging upload when b
   );
 
   assert.deepEqual(sentCommands, [
-    `head:${testUploadStorageKey}`,
-    `head:${testStorageKey}`,
-    `head:${testStorageKey}`,
-    `head:${testStorageKey}`,
-    `copy:test-media-assets-bucket/${testUploadStorageKey}:${testStorageKey}:*`,
-    `head:${testStorageKey}`,
+    `complete:${testStagingStorageKey}:s3-upload-id-1:1:${Buffer.from("b".repeat(64), "hex").toString("base64")}`,
+    `head:${testStagingStorageKey}`,
+    `get:${testStagingStorageKey}`,
+    `head:${testBlobStorageKey}`,
   ]);
 });
 
-test("promoteMediaAssetUploadToBlobWithDependencies rereads blob after concurrent conditional copy conflict", async () => {
+test("completeMultipartMediaAssetUploadWithDependencies rejects a streamed staging object hash mismatch", async () => {
   const sentCommands: Array<string> = [];
   const client = createTestS3Client();
   client.send = (async (command: unknown) => {
-    if (command instanceof HeadObjectCommand) {
-      const key = command.input.Key;
-      sentCommands.push(`head:${String(key)}`);
-      if (key === testUploadStorageKey) {
-        return createHeadObjectResponse({
-          sizeBytes: 42,
-          mimeType: "image/png",
-          sha256: testSha256,
-          workspaceId: testWorkspaceId,
-          mediaAssetId: testMediaAssetId,
-          lastOperationIdSha256: "e12febdf2c87aabeb4f0594f67409b7ec07fe532eb25e0c9e9f8f4f3febb0d6d",
-        });
-      }
-
-      if (key === testStorageKey && sentCommands.filter((value) => value === `head:${testStorageKey}`).length <= 3) {
-        throw createS3Error(404, "NoSuchKey", "Not Found");
-      }
-
-      if (key === testStorageKey) {
-        return createHeadObjectResponse({
-          sizeBytes: 42,
-          mimeType: "image/png",
-          sha256: testSha256,
-        });
-      }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      sentCommands.push("complete");
+      return {};
     }
 
-    if (command instanceof CopyObjectCommand) {
-      sentCommands.push(`copy:${String(command.input.IfNoneMatch)}`);
-      throw createS3Error(412, "PreconditionFailed", "Precondition Failed");
+    if (command instanceof HeadObjectCommand) {
+      sentCommands.push(`head:${String(command.input.Key)}`);
+      return createHeadObjectResponse({
+        sizeBytes: testObjectBytes.byteLength,
+        mimeType: "image/png",
+        sha256: testSha256,
+        checksumSha256: "c".repeat(64),
+        checksumType: "COMPOSITE",
+      });
+    }
+
+    if (command instanceof GetObjectCommand) {
+      sentCommands.push(`get:${String(command.input.Key)}`);
+      return {
+        Body: Readable.from([Buffer.from("not-password")]),
+      };
     }
 
     throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
   }) as S3Client["send"];
 
-  await promoteMediaAssetUploadToBlobWithDependencies(
-    {
-      workspaceId: testWorkspaceId,
-      mediaAssetId: testMediaAssetId,
-      uploadStorageKey: testUploadStorageKey,
-      blobStorageKey: testStorageKey,
-      mimeType: "image/png",
-      sizeBytes: 42,
-      sha256: testSha256,
-      lastOperationId: testLastOperationId,
-      observationScope: testObservationScope,
-    },
-    {
-      s3Client: client,
-      getMediaAssetsStorageConfigFn: () => ({
-        bucketName: "test-media-assets-bucket",
-      }),
+  await assert.rejects(
+    async () => completeMultipartMediaAssetUploadWithDependencies(
+      {
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        stagingStorageKey: testStagingStorageKey,
+        blobStorageKey: testBlobStorageKey,
+        s3UploadId: "s3-upload-id-1",
+        mimeType: "image/png",
+        sizeBytes: testObjectBytes.byteLength,
+        sha256: testSha256,
+        lastOperationId: testLastOperationId,
+        parts: [
+          {
+            partNumber: 1,
+            eTag: "\"etag-1\"",
+            sha256: "b".repeat(64),
+          },
+        ],
+        observationScope: testObservationScope,
+      },
+      {
+        s3Client: client,
+        getMediaAssetsStorageConfigFn: () => ({
+          bucketName: "test-media-assets-bucket",
+        }),
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "MEDIA_ASSET_UPLOAD_MISMATCH");
+      assert.doesNotMatch(error.message, /storageKey|media\/blobs|s3:\/\//);
+      return true;
     },
   );
-
   assert.deepEqual(sentCommands, [
-    `head:${testUploadStorageKey}`,
-    `head:${testStorageKey}`,
-    `head:${testStorageKey}`,
-    `head:${testStorageKey}`,
-    "copy:*",
-    `head:${testStorageKey}`,
+    "complete",
+    `head:${testStagingStorageKey}`,
+    `get:${testStagingStorageKey}`,
   ]);
+});
+
+test("completeMultipartMediaAssetUploadWithDependencies treats GetObject 403 as storage unavailable", async () => {
+  const sentCommands: Array<string> = [];
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    if (command instanceof CompleteMultipartUploadCommand) {
+      sentCommands.push("complete");
+      return {};
+    }
+
+    if (command instanceof HeadObjectCommand) {
+      sentCommands.push(`head:${String(command.input.Key)}`);
+      return createHeadObjectResponse({
+        sizeBytes: testObjectBytes.byteLength,
+        mimeType: "image/png",
+        sha256: testSha256,
+      });
+    }
+
+    if (command instanceof GetObjectCommand) {
+      sentCommands.push(`get:${String(command.input.Key)}`);
+      throw createS3Error(403, "Forbidden", `Forbidden for s3://test-media-assets-bucket/${testStagingStorageKey}`);
+    }
+
+    throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await assert.rejects(
+    async () => completeMultipartMediaAssetUploadWithDependencies(
+      {
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        stagingStorageKey: testStagingStorageKey,
+        blobStorageKey: testBlobStorageKey,
+        s3UploadId: "s3-upload-id-1",
+        mimeType: "image/png",
+        sizeBytes: testObjectBytes.byteLength,
+        sha256: testSha256,
+        lastOperationId: testLastOperationId,
+        parts: [
+          {
+            partNumber: 1,
+            eTag: "\"etag-1\"",
+            sha256: "b".repeat(64),
+          },
+        ],
+        observationScope: testObservationScope,
+      },
+      {
+        s3Client: client,
+        getMediaAssetsStorageConfigFn: () => ({
+          bucketName: "test-media-assets-bucket",
+        }),
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 503);
+      assert.equal(error.code, "MEDIA_ASSET_STORAGE_UNAVAILABLE");
+      assert.deepEqual(error.details?.mediaAssetStorage, {
+        operation: "get_object",
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        storageKey: testStagingStorageKey,
+        bucketName: "test-media-assets-bucket",
+        s3StatusCode: 403,
+        s3ErrorClass: "Forbidden",
+        s3ErrorMessage: `Forbidden for s3://test-media-assets-bucket/${testStagingStorageKey}`,
+      });
+      assert.deepEqual(createPublicHttpErrorDetails(error.details), {
+        mediaAssetStorage: {
+          operation: "get_object",
+          workspaceId: testWorkspaceId,
+          mediaAssetId: testMediaAssetId,
+          s3StatusCode: 403,
+          s3ErrorClass: "Forbidden",
+        },
+      });
+      return true;
+    },
+  );
+  assert.deepEqual(sentCommands, [
+    "complete",
+    `head:${testStagingStorageKey}`,
+    `get:${testStagingStorageKey}`,
+    `get:${testStagingStorageKey}`,
+    `get:${testStagingStorageKey}`,
+  ]);
+});
+
+test("completeMultipartMediaAssetUploadWithDependencies exposes multipart storage error details", async () => {
+  await assert.rejects(
+    async () => completeMultipartMediaAssetUploadWithDependencies(
+      {
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        stagingStorageKey: testStagingStorageKey,
+        blobStorageKey: testBlobStorageKey,
+        s3UploadId: "s3-upload-id-1",
+        mimeType: "image/png",
+        sizeBytes: 42,
+        sha256: testSha256,
+        lastOperationId: testLastOperationId,
+        parts: [
+          {
+            partNumber: 1,
+            eTag: "\"etag-1\"",
+            sha256: "b".repeat(64),
+          },
+        ],
+        observationScope: testObservationScope,
+      },
+      {
+        s3Client: createFailingS3Client(createS3Error(500, "InternalError", `Failed complete for s3://test-media-assets-bucket/${testStagingStorageKey}`)),
+        getMediaAssetsStorageConfigFn: () => ({
+          bucketName: "test-media-assets-bucket",
+        }),
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 503);
+      assert.equal(error.code, "MEDIA_ASSET_STORAGE_UNAVAILABLE");
+      assert.deepEqual(error.details?.mediaAssetStorage, {
+        operation: "complete_multipart_upload",
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        storageKey: testStagingStorageKey,
+        bucketName: "test-media-assets-bucket",
+        s3StatusCode: 500,
+        s3ErrorClass: "InternalError",
+        s3ErrorMessage: `Failed complete for s3://test-media-assets-bucket/${testStagingStorageKey}`,
+      });
+      assert.deepEqual(createPublicHttpErrorDetails(error.details), {
+        mediaAssetStorage: {
+          operation: "complete_multipart_upload",
+          workspaceId: testWorkspaceId,
+          mediaAssetId: testMediaAssetId,
+          s3StatusCode: 500,
+          s3ErrorClass: "InternalError",
+        },
+      });
+      return true;
+    },
+  );
 });

--- a/apps/backend/src/mediaAssets/storage.ts
+++ b/apps/backend/src/mediaAssets/storage.ts
@@ -1,9 +1,13 @@
 import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
   CopyObjectCommand,
+  CreateMultipartUploadCommand,
   GetObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
   S3Client,
+  UploadPartCommand,
 } from "@aws-sdk/client-s3";
 import { createHash } from "node:crypto";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
@@ -13,9 +17,13 @@ import {
   type BackendObservationScope,
 } from "../observability/sentry";
 import type {
+  CompleteMediaAssetUploadPartInput,
+  CreatedMultipartMediaAssetUpload,
   MediaAssetObjectMetadata,
   PresignedMediaAssetDownload,
   PresignedMediaAssetUpload,
+  PresignedMediaAssetUploadPart,
+  MediaAssetUploadSessionPartRequest,
 } from "./types";
 
 export type MediaAssetsStorageConfig = Readonly<{
@@ -46,6 +54,25 @@ type PresignMediaAssetDownloadInput = Readonly<{
   observationScope: BackendObservationScope;
 }>;
 
+type CreateMultipartMediaAssetUploadInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  stagingStorageKey: string;
+  mimeType: string;
+  sha256: string;
+  lastOperationId: string;
+  observationScope: BackendObservationScope;
+}>;
+
+type PresignMultipartMediaAssetUploadPartsInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  stagingStorageKey: string;
+  s3UploadId: string;
+  parts: ReadonlyArray<MediaAssetUploadSessionPartRequest>;
+  observationScope: BackendObservationScope;
+}>;
+
 type AssertMediaAssetObjectInput = Readonly<{
   workspaceId: string;
   mediaAssetId: string;
@@ -54,6 +81,28 @@ type AssertMediaAssetObjectInput = Readonly<{
   sizeBytes: number;
   sha256: string;
   lastOperationId: string;
+  observationScope: BackendObservationScope;
+}>;
+
+type CompleteMultipartMediaAssetUploadInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  s3UploadId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  lastOperationId: string;
+  parts: ReadonlyArray<CompleteMediaAssetUploadPartInput>;
+  observationScope: BackendObservationScope;
+}>;
+
+type AbortMultipartMediaAssetUploadInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  stagingStorageKey: string;
+  s3UploadId: string;
   observationScope: BackendObservationScope;
 }>;
 
@@ -72,7 +121,12 @@ type PromoteMediaAssetUploadInput = Readonly<{
 type MediaAssetStorageOperation =
   | "create_presigned_upload"
   | "create_presigned_download"
+  | "create_multipart_upload"
+  | "create_presigned_part_upload"
+  | "complete_multipart_upload"
+  | "abort_multipart_upload"
   | "head_object"
+  | "get_object"
   | "copy_object";
 
 type MediaAssetStorageDependencies = Readonly<{
@@ -83,6 +137,7 @@ type MediaAssetStorageDependencies = Readonly<{
 const maxS3AttemptCount = 3;
 const uploadUrlExpiresSeconds = 15 * 60;
 const downloadUrlExpiresSeconds = 60 * 60;
+const multipartUploadExpiresSeconds = 24 * 60 * 60;
 const uploadProofWorkspaceIdKey = "flashcards-workspace-id";
 const uploadProofMediaAssetIdKey = "flashcards-media-asset-id";
 const uploadProofLastOperationIdSha256Key = "flashcards-last-operation-id-sha256";
@@ -140,6 +195,14 @@ function isHeadObjectUploadNotAvailableStatusCode(statusCode: number | null): bo
   return statusCode === 403 || statusCode === 404;
 }
 
+function isUploadNotAvailableStorageError(operation: MediaAssetStorageOperation, statusCode: number | null): boolean {
+  if (operation === "head_object") {
+    return isHeadObjectUploadNotAvailableStatusCode(statusCode);
+  }
+
+  return operation === "get_object" && statusCode === 404;
+}
+
 function createExpiresAt(expiresSeconds: number): string {
   return new Date(Date.now() + expiresSeconds * 1_000).toISOString();
 }
@@ -154,6 +217,23 @@ function toHexSha256Digest(checksumSha256: string | undefined): string | null {
   }
 
   return Buffer.from(checksumSha256, "base64").toString("hex");
+}
+
+type MediaAssetObjectBodyChunk = Uint8Array | string;
+
+type MediaAssetObjectBody = AsyncIterable<MediaAssetObjectBodyChunk>;
+
+type MediaAssetObjectContentHash = Readonly<{
+  sizeBytes: number;
+  sha256: string;
+}>;
+
+function isMediaAssetObjectBody(value: unknown): value is MediaAssetObjectBody {
+  return typeof value === "object" && value !== null && Symbol.asyncIterator in value;
+}
+
+function toMediaAssetObjectBodyChunkBytes(chunk: MediaAssetObjectBodyChunk): Uint8Array {
+  return typeof chunk === "string" ? Buffer.from(chunk) : chunk;
 }
 
 function createCopySource(bucketName: string, storageKey: string): string {
@@ -246,10 +326,10 @@ function createMediaAssetStorageError(
     s3ErrorClass: getS3ErrorName(error),
     s3ErrorMessage: getS3ErrorMessage(error),
   };
-  if (operation === "head_object" && isHeadObjectUploadNotAvailableStatusCode(details.s3StatusCode)) {
+  if (isUploadNotAvailableStorageError(operation, details.s3StatusCode)) {
     return new HttpError(
       409,
-      `Uploaded media asset is not available in object storage for ${publicLocation}. Upload the file through a fresh media upload intent, then retry completion.`,
+      `Completed media blob is not available in object storage for ${publicLocation}. Upload the file through a fresh media upload session, then retry completion.`,
       "MEDIA_ASSET_UPLOAD_NOT_FOUND",
       { mediaAssetStorage: details },
     );
@@ -284,6 +364,25 @@ function createMediaAssetUploadMismatchError(
   );
 }
 
+function createMediaAssetUploadContentHashMismatchError(
+  input: AssertMediaAssetObjectInput,
+  objectContent: MediaAssetObjectContentHash,
+): HttpError {
+  return new HttpError(
+    409,
+    [
+      "Uploaded media asset bytes do not match declared metadata",
+      `workspaceId=${input.workspaceId}`,
+      `mediaAssetId=${input.mediaAssetId}`,
+      `expectedSizeBytes=${input.sizeBytes}`,
+      `actualSizeBytes=${objectContent.sizeBytes}`,
+      `expectedSha256=${input.sha256}`,
+      `actualSha256=${objectContent.sha256}`,
+    ].join(" "),
+    "MEDIA_ASSET_UPLOAD_MISMATCH",
+  );
+}
+
 function createMediaAssetUploadProofMismatchError(
   input: AssertMediaAssetObjectInput,
   objectMetadata: MediaAssetObjectMetadata,
@@ -307,12 +406,33 @@ function assertMediaAssetObjectContentMatches(
   input: AssertMediaAssetObjectInput,
   objectMetadata: MediaAssetObjectMetadata,
 ): void {
+  assertMediaAssetObjectShapeMatches(input, objectMetadata);
+  if (objectMetadata.checksumSha256 !== input.sha256) {
+    throw createMediaAssetUploadMismatchError(input, objectMetadata);
+  }
+}
+
+function assertMediaAssetObjectShapeMatches(
+  input: AssertMediaAssetObjectInput,
+  objectMetadata: MediaAssetObjectMetadata,
+): void {
   if (
     objectMetadata.sizeBytes !== input.sizeBytes
     || objectMetadata.mimeType !== input.mimeType
-    || objectMetadata.checksumSha256 !== input.sha256
   ) {
     throw createMediaAssetUploadMismatchError(input, objectMetadata);
+  }
+}
+
+function assertMediaAssetObjectContentHashMatches(
+  input: AssertMediaAssetObjectInput,
+  objectContent: MediaAssetObjectContentHash,
+): void {
+  if (
+    objectContent.sizeBytes !== input.sizeBytes
+    || objectContent.sha256 !== input.sha256
+  ) {
+    throw createMediaAssetUploadContentHashMismatchError(input, objectContent);
   }
 }
 
@@ -337,6 +457,18 @@ function assertMediaAssetObjectMetadataMatches(
 ): void {
   assertMediaAssetObjectContentMatches(input, objectMetadata);
   assertMediaAssetObjectUploadProofMatches(input, objectMetadata);
+}
+
+function assertMediaAssetObjectShapeAndProofMatches(
+  input: AssertMediaAssetObjectInput,
+  objectMetadata: MediaAssetObjectMetadata,
+): void {
+  assertMediaAssetObjectShapeMatches(input, objectMetadata);
+  assertMediaAssetObjectUploadProofMatches(input, objectMetadata);
+}
+
+function isNoSuchMultipartUploadError(error: unknown): boolean {
+  return getS3ErrorStatusCode(error) === 404 && getS3ErrorName(error) === "NoSuchUpload";
 }
 
 function isMediaAssetObjectNotFoundError(error: unknown): boolean {
@@ -407,6 +539,100 @@ export async function createPresignedMediaAssetUploadWithDependencies(
   }
 }
 
+export async function createMultipartMediaAssetUploadWithDependencies(
+  input: CreateMultipartMediaAssetUploadInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<CreatedMultipartMediaAssetUpload> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.stagingStorageKey,
+    observationScope: input.observationScope,
+  };
+  const uploadProofMetadata = createUploadProofMetadata(input);
+
+  try {
+    const response = await runMediaAssetStorageOperationWithRetries(
+      context,
+      "create_multipart_upload",
+      config.bucketName,
+      async () => dependencies.s3Client.send(new CreateMultipartUploadCommand({
+        Bucket: config.bucketName,
+        Key: input.stagingStorageKey,
+        ContentType: input.mimeType,
+        ChecksumAlgorithm: "SHA256",
+        Metadata: uploadProofMetadata,
+      })),
+    );
+    if (response.UploadId === undefined || response.UploadId.trim() === "") {
+      throw new Error(
+        `S3 create_multipart_upload did not return UploadId for workspaceId=${input.workspaceId} mediaAssetId=${input.mediaAssetId} s3://${config.bucketName}/${input.stagingStorageKey}.`,
+      );
+    }
+
+    return {
+      storageKey: input.stagingStorageKey,
+      s3UploadId: response.UploadId,
+      expiresAt: createExpiresAt(multipartUploadExpiresSeconds),
+    };
+  } catch (error) {
+    throw createMediaAssetStorageError(context, config.bucketName, "create_multipart_upload", error);
+  }
+}
+
+export async function createPresignedMediaAssetUploadPartsWithDependencies(
+  input: PresignMultipartMediaAssetUploadPartsInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<ReadonlyArray<PresignedMediaAssetUploadPart>> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.stagingStorageKey,
+    observationScope: input.observationScope,
+  };
+
+  try {
+    return await runMediaAssetStorageOperationWithRetries(
+      context,
+      "create_presigned_part_upload",
+      config.bucketName,
+      async () => Promise.all(input.parts.map(async (part) => {
+        const checksumSha256 = toBase64Sha256Digest(part.sha256);
+        const requiredUploadHeaders = {
+          "x-amz-checksum-sha256": checksumSha256,
+        };
+        const url = await getSignedUrl(
+          dependencies.s3Client,
+          new UploadPartCommand({
+            Bucket: config.bucketName,
+            Key: input.stagingStorageKey,
+            UploadId: input.s3UploadId,
+            PartNumber: part.partNumber,
+            ChecksumSHA256: checksumSha256,
+          }),
+          {
+            expiresIn: uploadUrlExpiresSeconds,
+            signableHeaders: new Set(Object.keys(requiredUploadHeaders)),
+            unhoistableHeaders: new Set(Object.keys(requiredUploadHeaders)),
+          },
+        );
+
+        return {
+          partNumber: part.partNumber,
+          method: "PUT",
+          url,
+          expiresAt: createExpiresAt(uploadUrlExpiresSeconds),
+          headers: requiredUploadHeaders,
+        };
+      })),
+    );
+  } catch (error) {
+    throw createMediaAssetStorageError(context, config.bucketName, "create_presigned_part_upload", error);
+  }
+}
+
 export async function createPresignedMediaAssetDownloadWithDependencies(
   input: PresignMediaAssetDownloadInput,
   dependencies: MediaAssetStorageDependencies,
@@ -472,6 +698,7 @@ export async function loadMediaAssetObjectMetadataWithDependencies(
       sizeBytes: typeof response.ContentLength === "number" ? response.ContentLength : null,
       mimeType: typeof response.ContentType === "string" ? response.ContentType : null,
       checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
+      checksumType: response.ChecksumType ?? null,
       uploadProof: {
         workspaceId: response.Metadata?.[uploadProofWorkspaceIdKey] ?? null,
         mediaAssetId: response.Metadata?.[uploadProofMediaAssetIdKey] ?? null,
@@ -490,6 +717,52 @@ export async function assertMediaAssetObjectMatchesWithDependencies(
 ): Promise<void> {
   const objectMetadata = await loadMediaAssetObjectMetadataWithDependencies(input, dependencies);
   assertMediaAssetObjectMetadataMatches(input, objectMetadata);
+}
+
+async function hashMediaAssetObjectContentWithDependencies(
+  input: AssertMediaAssetObjectInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<MediaAssetObjectContentHash> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.storageKey,
+    observationScope: input.observationScope,
+  };
+
+  try {
+    const response = await runMediaAssetStorageOperationWithRetries(
+      context,
+      "get_object",
+      config.bucketName,
+      async () => dependencies.s3Client.send(new GetObjectCommand({
+        Bucket: config.bucketName,
+        Key: input.storageKey,
+      })),
+    );
+    const body = response.Body;
+    if (isMediaAssetObjectBody(body) === false) {
+      throw new Error(
+        `S3 get_object did not return a readable body for workspaceId=${input.workspaceId} mediaAssetId=${input.mediaAssetId} s3://${config.bucketName}/${input.storageKey}.`,
+      );
+    }
+
+    const hash = createHash("sha256");
+    let sizeBytes = 0;
+    for await (const chunk of body) {
+      const bytes = toMediaAssetObjectBodyChunkBytes(chunk);
+      sizeBytes += bytes.byteLength;
+      hash.update(bytes);
+    }
+
+    return {
+      sizeBytes,
+      sha256: hash.digest("hex"),
+    };
+  } catch (error) {
+    throw createMediaAssetStorageError(context, config.bucketName, "get_object", error);
+  }
 }
 
 async function copyMediaAssetObjectIfAbsentWithDependencies(
@@ -545,7 +818,7 @@ async function copyMediaAssetObjectIfAbsentWithDependencies(
   }
 }
 
-export async function promoteMediaAssetUploadToBlobWithDependencies(
+async function promoteVerifiedMediaAssetUploadToBlobWithDependencies(
   input: PromoteMediaAssetUploadInput,
   dependencies: MediaAssetStorageDependencies,
 ): Promise<void> {
@@ -559,9 +832,6 @@ export async function promoteMediaAssetUploadToBlobWithDependencies(
     lastOperationId: input.lastOperationId,
     observationScope: input.observationScope,
   };
-  const uploadObjectMetadata = await loadMediaAssetObjectMetadataWithDependencies(uploadObjectInput, dependencies);
-  assertMediaAssetObjectMetadataMatches(uploadObjectInput, uploadObjectMetadata);
-
   const blobObjectInput: AssertMediaAssetObjectInput = {
     ...uploadObjectInput,
     storageKey: input.blobStorageKey,
@@ -593,10 +863,150 @@ export async function promoteMediaAssetUploadToBlobWithDependencies(
   }
 }
 
+export async function promoteMediaAssetUploadToBlobWithDependencies(
+  input: PromoteMediaAssetUploadInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  const uploadObjectInput: AssertMediaAssetObjectInput = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.uploadStorageKey,
+    mimeType: input.mimeType,
+    sizeBytes: input.sizeBytes,
+    sha256: input.sha256,
+    lastOperationId: input.lastOperationId,
+    observationScope: input.observationScope,
+  };
+  const uploadObjectMetadata = await loadMediaAssetObjectMetadataWithDependencies(uploadObjectInput, dependencies);
+  assertMediaAssetObjectMetadataMatches(uploadObjectInput, uploadObjectMetadata);
+
+  await promoteVerifiedMediaAssetUploadToBlobWithDependencies(input, dependencies);
+}
+
+export async function completeMultipartMediaAssetUploadWithDependencies(
+  input: CompleteMultipartMediaAssetUploadInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.stagingStorageKey,
+    observationScope: input.observationScope,
+  };
+  const completedParts = [...input.parts]
+    .sort((left, right) => left.partNumber - right.partNumber)
+    .map((part) => ({
+      PartNumber: part.partNumber,
+      ETag: part.eTag,
+      ChecksumSHA256: toBase64Sha256Digest(part.sha256),
+    }));
+
+  try {
+    await runMediaAssetStorageOperationWithRetries(
+      context,
+      "complete_multipart_upload",
+      config.bucketName,
+      async () => dependencies.s3Client.send(new CompleteMultipartUploadCommand({
+        Bucket: config.bucketName,
+        Key: input.stagingStorageKey,
+        UploadId: input.s3UploadId,
+        MultipartUpload: {
+          Parts: completedParts,
+        },
+      })),
+    );
+  } catch (error) {
+    if (isNoSuchMultipartUploadError(error) === false) {
+      throw createMediaAssetStorageError(context, config.bucketName, "complete_multipart_upload", error);
+    }
+  }
+
+  const stagingObjectInput: AssertMediaAssetObjectInput = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.stagingStorageKey,
+    mimeType: input.mimeType,
+    sizeBytes: input.sizeBytes,
+    sha256: input.sha256,
+    lastOperationId: input.lastOperationId,
+    observationScope: input.observationScope,
+  };
+  const stagingObjectMetadata = await loadMediaAssetObjectMetadataWithDependencies(stagingObjectInput, dependencies);
+  assertMediaAssetObjectShapeAndProofMatches(stagingObjectInput, stagingObjectMetadata);
+  const stagingObjectContent = await hashMediaAssetObjectContentWithDependencies(stagingObjectInput, dependencies);
+  assertMediaAssetObjectContentHashMatches(stagingObjectInput, stagingObjectContent);
+
+  await promoteVerifiedMediaAssetUploadToBlobWithDependencies(
+    {
+      workspaceId: input.workspaceId,
+      mediaAssetId: input.mediaAssetId,
+      uploadStorageKey: input.stagingStorageKey,
+      blobStorageKey: input.blobStorageKey,
+      mimeType: input.mimeType,
+      sizeBytes: input.sizeBytes,
+      sha256: input.sha256,
+      lastOperationId: input.lastOperationId,
+      observationScope: input.observationScope,
+    },
+    dependencies,
+  );
+}
+
+export async function abortMultipartMediaAssetUploadWithDependencies(
+  input: AbortMultipartMediaAssetUploadInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.stagingStorageKey,
+    observationScope: input.observationScope,
+  };
+
+  try {
+    await runMediaAssetStorageOperationWithRetries(
+      context,
+      "abort_multipart_upload",
+      config.bucketName,
+      async () => dependencies.s3Client.send(new AbortMultipartUploadCommand({
+        Bucket: config.bucketName,
+        Key: input.stagingStorageKey,
+        UploadId: input.s3UploadId,
+      })),
+    );
+  } catch (error) {
+    if (isNoSuchMultipartUploadError(error)) {
+      return;
+    }
+
+    throw createMediaAssetStorageError(context, config.bucketName, "abort_multipart_upload", error);
+  }
+}
+
+export async function createMultipartMediaAssetUpload(
+  input: CreateMultipartMediaAssetUploadInput,
+): Promise<CreatedMultipartMediaAssetUpload> {
+  return createMultipartMediaAssetUploadWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
 export async function createPresignedMediaAssetUpload(
   input: PresignMediaAssetUploadInput,
 ): Promise<PresignedMediaAssetUpload> {
   return createPresignedMediaAssetUploadWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function createPresignedMediaAssetUploadParts(
+  input: PresignMultipartMediaAssetUploadPartsInput,
+): Promise<ReadonlyArray<PresignedMediaAssetUploadPart>> {
+  return createPresignedMediaAssetUploadPartsWithDependencies(input, {
     s3Client: getMediaAssetsS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });
@@ -624,6 +1034,24 @@ export async function promoteMediaAssetUploadToBlob(
   input: PromoteMediaAssetUploadInput,
 ): Promise<void> {
   return promoteMediaAssetUploadToBlobWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function completeMultipartMediaAssetUpload(
+  input: CompleteMultipartMediaAssetUploadInput,
+): Promise<void> {
+  return completeMultipartMediaAssetUploadWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function abortMultipartMediaAssetUpload(
+  input: AbortMultipartMediaAssetUploadInput,
+): Promise<void> {
+  return abortMultipartMediaAssetUploadWithDependencies(input, {
     s3Client: getMediaAssetsS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });

--- a/apps/backend/src/mediaAssets/storageKeys.ts
+++ b/apps/backend/src/mediaAssets/storageKeys.ts
@@ -29,3 +29,20 @@ export function buildMediaUploadStagingStorageKey(
     lastOperationIdSha256,
   ].join("/");
 }
+
+export function buildMediaMultipartUploadStagingStorageKey(
+  workspaceId: string,
+  mediaAssetId: string,
+  sessionId: string,
+): string {
+  return [
+    "media",
+    "uploads",
+    "workspaces",
+    workspaceId.toLowerCase(),
+    "assets",
+    mediaAssetId.toLowerCase(),
+    "sessions",
+    sessionId.toLowerCase(),
+  ].join("/");
+}

--- a/apps/backend/src/mediaAssets/types.ts
+++ b/apps/backend/src/mediaAssets/types.ts
@@ -79,6 +79,39 @@ export type CompleteMediaAssetUploadInput = Readonly<{
   lastOperationId: string;
 }>;
 
+export type MediaAssetUploadSessionCreateInput = Readonly<{
+  mediaAssetId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  partSizeBytes: number;
+  partCount: number;
+  sourceUrl: string | null;
+  createdAt: string;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+}>;
+
+export type MediaAssetUploadSessionPartRequest = Readonly<{
+  partNumber: number;
+  sha256: string;
+}>;
+
+export type MediaAssetUploadSessionPartUrlsInput = Readonly<{
+  parts: ReadonlyArray<MediaAssetUploadSessionPartRequest>;
+}>;
+
+export type CompleteMediaAssetUploadPartInput = Readonly<{
+  partNumber: number;
+  eTag: string;
+  sha256: string;
+}>;
+
+export type CompleteMediaAssetUploadSessionInput = Readonly<{
+  parts: ReadonlyArray<CompleteMediaAssetUploadPartInput>;
+}>;
+
 export type MediaAssetMutationMetadata = Readonly<{
   clientUpdatedAt: string;
   lastModifiedByReplicaId: string;
@@ -100,6 +133,93 @@ export type MediaAssetMutationResult = Readonly<{
   applied: boolean;
 }>;
 
+export type MediaAssetUploadSessionRow = Readonly<{
+  media_upload_session_id: string;
+  workspace_id: string;
+  media_asset_id: string;
+  media_blob_sha256: string;
+  staging_storage_key: string;
+  blob_storage_key: string;
+  s3_upload_id: string;
+  mime_type: string;
+  size_bytes: string | number;
+  part_size_bytes: string | number;
+  part_count: string | number;
+  state: MediaAssetUploadSessionState;
+  source_url: string | null;
+  asset_created_at: TimestampValue;
+  client_updated_at: TimestampValue;
+  last_modified_by_replica_id: string;
+  last_operation_id: string;
+  expires_at: TimestampValue;
+  created_at: TimestampValue;
+  completed_at: TimestampValue | null;
+  aborted_at: TimestampValue | null;
+}>;
+
+export type MediaAssetUploadSession = Readonly<{
+  sessionId: string;
+  workspaceId: string;
+  mediaAssetId: string;
+  mediaBlobSha256: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  s3UploadId: string;
+  mimeType: string;
+  sizeBytes: number;
+  partSizeBytes: number;
+  partCount: number;
+  state: MediaAssetUploadSessionState;
+  sourceUrl: string | null;
+  assetCreatedAt: string;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+  expiresAt: string;
+  createdAt: string;
+  completedAt: string | null;
+  abortedAt: string | null;
+}>;
+
+export type MediaAssetUploadSessionCreateResult =
+  | Readonly<{
+    status: "already_available";
+    mediaAsset: MediaAsset;
+    applied: boolean;
+  }>
+  | Readonly<{
+    status: "upload_required";
+    uploadSession: MediaAssetUploadSession;
+  }>;
+
+export type MediaAssetUploadSessionCompletionStartResult =
+  | Readonly<{
+    status: "complete_required";
+    uploadSession: MediaAssetUploadSession;
+  }>
+  | Readonly<{
+    status: "already_completed";
+    mediaAsset: MediaAsset;
+    applied: false;
+  }>;
+
+export type MediaAssetUploadSessionAbortStartResult =
+  | Readonly<{
+    status: "abort_required";
+    uploadSession: MediaAssetUploadSession;
+  }>
+  | Readonly<{
+    status: "already_aborted";
+    uploadSession: MediaAssetUploadSession;
+  }>;
+
+export type MediaAssetUploadSessionState =
+  | "active"
+  | "completing"
+  | "completed"
+  | "aborting"
+  | "aborted";
+
 export type MediaAssetSyncMutationResult = Readonly<{
   mediaAsset: MediaAsset;
   applied: boolean;
@@ -119,10 +239,25 @@ export type PresignedMediaAssetDownload = Readonly<{
   expiresAt: string;
 }>;
 
+export type CreatedMultipartMediaAssetUpload = Readonly<{
+  storageKey: string;
+  s3UploadId: string;
+  expiresAt: string;
+}>;
+
+export type PresignedMediaAssetUploadPart = Readonly<{
+  partNumber: number;
+  method: "PUT";
+  url: string;
+  expiresAt: string;
+  headers: Readonly<Record<string, string>>;
+}>;
+
 export type MediaAssetObjectMetadata = Readonly<{
   sizeBytes: number | null;
   mimeType: string | null;
   checksumSha256: string | null;
+  checksumType: "COMPOSITE" | "FULL_OBJECT" | null;
   uploadProof: Readonly<{
     workspaceId: string | null;
     mediaAssetId: string | null;

--- a/apps/backend/src/mediaAssets/validators.ts
+++ b/apps/backend/src/mediaAssets/validators.ts
@@ -6,14 +6,23 @@ import {
 } from "../server/requestParsing";
 import type {
   CompleteMediaAssetUploadInput,
+  CompleteMediaAssetUploadSessionInput,
   MediaAssetUploadIntentInput,
+  MediaAssetUploadSessionCreateInput,
+  MediaAssetUploadSessionPartUrlsInput,
 } from "./types";
 
 const mimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i;
 const sha256Pattern = /^[0-9a-f]{64}$/i;
 const maximumSourceUrlLength = 2_048;
 const maximumLastOperationIdLength = 1_024;
+const maximumETagLength = 256;
 export const maximumSinglePutUploadBytes = 5_368_709_120;
+export const minimumMultipartPartSizeBytes = 5_242_880;
+export const maximumMultipartPartSizeBytes = 5_368_709_120;
+export const maximumMultipartUploadPartCount = 10_000;
+export const maximumMultipartUploadBytes = maximumSinglePutUploadBytes;
+export const maximumMultipartPartUrlBatchCount = 100;
 
 export function parseMediaAssetIdParam(value: string | undefined): string {
   if (value === undefined) {
@@ -24,6 +33,18 @@ export function parseMediaAssetIdParam(value: string | undefined): string {
     return expectUuidString(value, "mediaAssetId");
   } catch {
     throw new HttpError(400, "mediaAssetId must be a UUID", "MEDIA_ASSET_ID_INVALID");
+  }
+}
+
+export function parseMediaAssetUploadSessionIdParam(value: string | undefined): string {
+  if (value === undefined) {
+    throw new HttpError(400, "sessionId is required", "MEDIA_ASSET_UPLOAD_SESSION_ID_REQUIRED");
+  }
+
+  try {
+    return expectUuidString(value, "sessionId");
+  } catch {
+    throw new HttpError(400, "sessionId must be a UUID", "MEDIA_ASSET_UPLOAD_SESSION_ID_INVALID");
   }
 }
 
@@ -45,7 +66,7 @@ function expectSha256(value: unknown, fieldName: string): string {
   return sha256;
 }
 
-function expectSizeBytes(value: unknown, fieldName: string): number {
+function expectDirectUploadSizeBytes(value: unknown, fieldName: string): number {
   if (
     typeof value !== "number"
     || Number.isSafeInteger(value) === false
@@ -63,6 +84,86 @@ function expectSizeBytes(value: unknown, fieldName: string): number {
   }
 
   return value;
+}
+
+function expectMultipartUploadSizeBytes(value: unknown, fieldName: string): number {
+  if (
+    typeof value !== "number"
+    || Number.isSafeInteger(value) === false
+    || value < 1
+  ) {
+    throw new HttpError(400, `${fieldName} must be a positive safe integer`);
+  }
+
+  if (value > maximumMultipartUploadBytes) {
+    throw new HttpError(
+      400,
+      `${fieldName} must be at most ${maximumMultipartUploadBytes} bytes for multipart media uploads`,
+      "MEDIA_ASSET_SIZE_TOO_LARGE",
+    );
+  }
+
+  return value;
+}
+
+function expectPartSizeBytes(value: unknown, fieldName: string): number {
+  if (
+    typeof value !== "number"
+    || Number.isSafeInteger(value) === false
+    || value < 1
+  ) {
+    throw new HttpError(400, `${fieldName} must be a positive safe integer`);
+  }
+
+  if (value > maximumMultipartPartSizeBytes) {
+    throw new HttpError(
+      400,
+      `${fieldName} must be at most ${maximumMultipartPartSizeBytes} bytes`,
+      "MEDIA_ASSET_PART_SIZE_TOO_LARGE",
+    );
+  }
+
+  return value;
+}
+
+function expectPartCount(value: unknown, fieldName: string): number {
+  if (
+    typeof value !== "number"
+    || Number.isSafeInteger(value) === false
+    || value < 1
+    || value > maximumMultipartUploadPartCount
+  ) {
+    throw new HttpError(
+      400,
+      `${fieldName} must be an integer from 1 to ${maximumMultipartUploadPartCount}`,
+      "MEDIA_ASSET_PART_COUNT_INVALID",
+    );
+  }
+
+  return value;
+}
+
+function assertMultipartShape(input: Readonly<{
+  sizeBytes: number;
+  partSizeBytes: number;
+  partCount: number;
+}>): void {
+  if (input.partCount > 1 && input.partSizeBytes < minimumMultipartPartSizeBytes) {
+    throw new HttpError(
+      400,
+      `partSizeBytes must be at least ${minimumMultipartPartSizeBytes} bytes when partCount is greater than 1`,
+      "MEDIA_ASSET_PART_SIZE_TOO_SMALL",
+    );
+  }
+
+  const expectedPartCount = Math.ceil(input.sizeBytes / input.partSizeBytes);
+  if (input.partCount !== expectedPartCount) {
+    throw new HttpError(
+      400,
+      `partCount must equal ceil(sizeBytes / partSizeBytes); expected ${expectedPartCount}`,
+      "MEDIA_ASSET_PART_COUNT_MISMATCH",
+    );
+  }
 }
 
 function expectIsoTimestamp(value: unknown, fieldName: string): string {
@@ -108,12 +209,87 @@ function expectLastOperationId(value: unknown, fieldName: string): string {
   return lastOperationId;
 }
 
+function expectPartNumber(value: unknown, fieldName: string): number {
+  if (
+    typeof value !== "number"
+    || Number.isSafeInteger(value) === false
+    || value < 1
+    || value > maximumMultipartUploadPartCount
+  ) {
+    throw new HttpError(
+      400,
+      `${fieldName} must be an integer from 1 to ${maximumMultipartUploadPartCount}`,
+      "MEDIA_ASSET_PART_NUMBER_INVALID",
+    );
+  }
+
+  return value;
+}
+
+function expectETag(value: unknown, fieldName: string): string {
+  const eTag = expectNonEmptyString(value, fieldName);
+  if (eTag.length > maximumETagLength) {
+    throw new HttpError(400, `${fieldName} must be at most ${maximumETagLength} characters`);
+  }
+
+  return eTag;
+}
+
+function expectRecordArray(value: unknown, fieldName: string): ReadonlyArray<Readonly<Record<string, unknown>>> {
+  if (Array.isArray(value) === false) {
+    throw new HttpError(400, `${fieldName} must be an array`);
+  }
+
+  return value.map((entry, index) => {
+    try {
+      return expectRecord(entry);
+    } catch {
+      throw new HttpError(400, `${fieldName}[${index}] must be an object`);
+    }
+  });
+}
+
+function assertUniquePartNumbers(parts: ReadonlyArray<Readonly<{ partNumber: number }>>, fieldName: string): void {
+  const partNumbers = new Set<number>();
+  for (const part of parts) {
+    if (partNumbers.has(part.partNumber)) {
+      throw new HttpError(
+        400,
+        `${fieldName} must not contain duplicate partNumber values`,
+        "MEDIA_ASSET_DUPLICATE_PART_NUMBER",
+      );
+    }
+
+    partNumbers.add(part.partNumber);
+  }
+}
+
+export function parseMediaAssetUploadSessionCreateInput(value: unknown): MediaAssetUploadSessionCreateInput {
+  const record = expectRecord(value);
+  const input = {
+    mediaAssetId: expectUuidString(record.mediaAssetId, "mediaAssetId"),
+    mimeType: expectMimeType(record.mimeType, "mimeType"),
+    sizeBytes: expectMultipartUploadSizeBytes(record.sizeBytes, "sizeBytes"),
+    sha256: expectSha256(record.sha256, "sha256"),
+    partSizeBytes: expectPartSizeBytes(record.partSizeBytes, "partSizeBytes"),
+    partCount: expectPartCount(record.partCount, "partCount"),
+    sourceUrl: expectMediaAssetSourceUrl(record.sourceUrl, "sourceUrl"),
+    createdAt: expectIsoTimestamp(record.createdAt, "createdAt"),
+    clientUpdatedAt: expectIsoTimestamp(record.clientUpdatedAt, "clientUpdatedAt"),
+    lastModifiedByReplicaId: expectUuidString(record.lastModifiedByReplicaId, "lastModifiedByReplicaId"),
+    lastOperationId: expectLastOperationId(record.lastOperationId, "lastOperationId"),
+  };
+
+  assertMultipartShape(input);
+  return input;
+}
+
 export function parseMediaAssetUploadIntentInput(value: unknown): MediaAssetUploadIntentInput {
   const record = expectRecord(value);
   return {
     mediaAssetId: expectUuidString(record.mediaAssetId, "mediaAssetId"),
     mimeType: expectMimeType(record.mimeType, "mimeType"),
-    sizeBytes: expectSizeBytes(record.sizeBytes, "sizeBytes"),
+    sizeBytes: expectDirectUploadSizeBytes(record.sizeBytes, "sizeBytes"),
     sha256: expectSha256(record.sha256, "sha256"),
     lastOperationId: expectLastOperationId(record.lastOperationId, "lastOperationId"),
   };
@@ -127,12 +303,65 @@ export function parseCompleteMediaAssetUploadInput(
   return {
     mediaAssetId,
     mimeType: expectMimeType(record.mimeType, "mimeType"),
-    sizeBytes: expectSizeBytes(record.sizeBytes, "sizeBytes"),
+    sizeBytes: expectDirectUploadSizeBytes(record.sizeBytes, "sizeBytes"),
     sha256: expectSha256(record.sha256, "sha256"),
     sourceUrl: expectMediaAssetSourceUrl(record.sourceUrl, "sourceUrl"),
     createdAt: expectIsoTimestamp(record.createdAt, "createdAt"),
     clientUpdatedAt: expectIsoTimestamp(record.clientUpdatedAt, "clientUpdatedAt"),
     lastModifiedByReplicaId: expectUuidString(record.lastModifiedByReplicaId, "lastModifiedByReplicaId"),
     lastOperationId: expectLastOperationId(record.lastOperationId, "lastOperationId"),
+  };
+}
+
+export function parseMediaAssetUploadSessionPartUrlsInput(
+  value: unknown,
+): MediaAssetUploadSessionPartUrlsInput {
+  const record = expectRecord(value);
+  const partRecords = expectRecordArray(record.parts, "parts");
+  if (partRecords.length === 0) {
+    throw new HttpError(400, "parts must contain at least one part", "MEDIA_ASSET_PARTS_REQUIRED");
+  }
+  if (partRecords.length > maximumMultipartPartUrlBatchCount) {
+    throw new HttpError(
+      400,
+      `parts must contain at most ${maximumMultipartPartUrlBatchCount} parts per request`,
+      "MEDIA_ASSET_PART_URL_BATCH_TOO_LARGE",
+    );
+  }
+
+  const parts = partRecords.map((partRecord, index) => ({
+    partNumber: expectPartNumber(partRecord.partNumber, `parts[${index}].partNumber`),
+    sha256: expectSha256(partRecord.sha256, `parts[${index}].sha256`),
+  }));
+  assertUniquePartNumbers(parts, "parts");
+
+  return {
+    parts,
+  };
+}
+
+export function parseCompleteMediaAssetUploadSessionInput(value: unknown): CompleteMediaAssetUploadSessionInput {
+  const record = expectRecord(value);
+  const partRecords = expectRecordArray(record.parts, "parts");
+  if (partRecords.length === 0) {
+    throw new HttpError(400, "parts must contain at least one part", "MEDIA_ASSET_PARTS_REQUIRED");
+  }
+  if (partRecords.length > maximumMultipartUploadPartCount) {
+    throw new HttpError(
+      400,
+      `parts must contain at most ${maximumMultipartUploadPartCount} parts`,
+      "MEDIA_ASSET_PART_COUNT_INVALID",
+    );
+  }
+
+  const parts = partRecords.map((partRecord, index) => ({
+    partNumber: expectPartNumber(partRecord.partNumber, `parts[${index}].partNumber`),
+    eTag: expectETag(partRecord.eTag, `parts[${index}].eTag`),
+    sha256: expectSha256(partRecord.sha256, `parts[${index}].sha256`),
+  }));
+  assertUniquePartNumbers(parts, "parts");
+
+  return {
+    parts,
   };
 }

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -253,11 +253,15 @@ export type CardsQueryDetails = Readonly<{
 export type MediaAssetRouteDetails = Readonly<{
   statusCode: number;
   mediaAssetId: string | null;
+  sessionId?: string | null;
   storageKey: string | null;
-  blobStorageKey?: string;
+  blobStorageKey?: string | null;
+  s3UploadId?: string | null;
   mimeType?: string;
   sizeBytes?: number;
   sha256?: string;
+  partSizeBytes?: number;
+  partCount?: number;
   applied?: boolean;
 }>;
 
@@ -666,7 +670,16 @@ export type GlobalMetricsS3RetryDetails = Readonly<{
 }>;
 
 export type MediaAssetStorageRetryDetails = Readonly<{
-  operation: "create_presigned_upload" | "create_presigned_download" | "head_object" | "copy_object";
+  operation:
+    | "create_presigned_upload"
+    | "create_presigned_download"
+    | "create_multipart_upload"
+    | "create_presigned_part_upload"
+    | "complete_multipart_upload"
+    | "abort_multipart_upload"
+    | "head_object"
+    | "get_object"
+    | "copy_object";
   attempt: number;
   maxAttempts: number;
   bucketName: string;
@@ -758,6 +771,16 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"media_asset_upload_intent_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
   | EventByAction<"media_asset_upload_complete", MediaAssetRouteDetails>
   | EventByAction<"media_asset_upload_complete_error", FailureDetailsFor<MediaAssetRouteDetails>>
+  | EventByAction<"media_asset_upload_session_blob_reuse", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_session_concurrent_blob_reuse", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_session_create", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_session_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
+  | EventByAction<"media_asset_upload_session_part_urls_create", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_session_part_urls_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
+  | EventByAction<"media_asset_upload_session_complete", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_session_complete_error", FailureDetailsFor<MediaAssetRouteDetails>>
+  | EventByAction<"media_asset_upload_session_abort", MediaAssetRouteDetails>
+  | EventByAction<"media_asset_upload_session_abort_error", FailureDetailsFor<MediaAssetRouteDetails>>
   | EventByAction<"media_asset_get", MediaAssetRouteDetails>
   | EventByAction<"media_asset_get_error", FailureDetailsFor<MediaAssetRouteDetails>>
   | EventByAction<"media_asset_download_url_create", MediaAssetRouteDetails>
@@ -891,6 +914,22 @@ export type BackendExceptionEvent =
   )
   | (
     EventByAction<"media_asset_upload_complete_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"media_asset_upload_session_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"media_asset_upload_session_part_urls_create_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"media_asset_upload_session_complete_error", FailureDetailsFor<MediaAssetRouteDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"media_asset_upload_session_abort_error", FailureDetailsFor<MediaAssetRouteDetails>>
     & Readonly<{ error: Error }>
   )
   | (

--- a/db/migrations/0084_media_upload_sessions.sql
+++ b/db/migrations/0084_media_upload_sessions.sql
@@ -1,0 +1,108 @@
+-- Migration status: Current.
+-- Introduces: backend-owned S3 multipart media upload session state.
+-- Schemas touched/read explicitly: content, org, sync, security.
+
+CREATE TABLE IF NOT EXISTS content.media_upload_sessions (
+  media_upload_session_id UUID        PRIMARY KEY,
+  workspace_id             UUID        NOT NULL REFERENCES org.workspaces(workspace_id) ON DELETE CASCADE,
+  media_asset_id           UUID        NOT NULL,
+  media_blob_sha256        TEXT        NOT NULL CHECK (media_blob_sha256 ~ '^[0-9a-f]{64}$'),
+  staging_storage_key      TEXT        NOT NULL CHECK (btrim(staging_storage_key) <> ''),
+  blob_storage_key         TEXT        NOT NULL CHECK (btrim(blob_storage_key) <> ''),
+  s3_upload_id             TEXT        NOT NULL CHECK (btrim(s3_upload_id) <> ''),
+  mime_type                TEXT        NOT NULL CHECK (btrim(mime_type) <> ''),
+  size_bytes               BIGINT      NOT NULL CHECK (size_bytes > 0),
+  part_size_bytes          BIGINT      NOT NULL CHECK (part_size_bytes > 0),
+  part_count               INTEGER     NOT NULL CHECK (part_count > 0 AND part_count <= 10000),
+  state                    TEXT        NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'completing', 'completed', 'aborting', 'aborted')),
+  source_url               TEXT,
+  asset_created_at         TIMESTAMPTZ NOT NULL,
+  client_updated_at        TIMESTAMPTZ NOT NULL,
+  last_modified_by_replica_id UUID     NOT NULL,
+  last_operation_id        TEXT        NOT NULL CHECK (btrim(last_operation_id) <> ''),
+  expires_at               TIMESTAMPTZ NOT NULL,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at             TIMESTAMPTZ,
+  aborted_at               TIMESTAMPTZ,
+  CONSTRAINT media_upload_sessions_replica_fk
+    FOREIGN KEY (last_modified_by_replica_id)
+    REFERENCES sync.workspace_replicas(replica_id)
+    ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED,
+  CONSTRAINT media_upload_sessions_blob_storage_key_matches_blob_sha
+    CHECK (blob_storage_key = 'media/blobs/sha256/' || substring(media_blob_sha256 from 1 for 2) || '/' || substring(media_blob_sha256 from 3 for 2) || '/' || media_blob_sha256),
+  CONSTRAINT media_upload_sessions_staging_storage_key_scoped
+    CHECK (staging_storage_key = 'media/uploads/workspaces/' || lower(workspace_id::text) || '/assets/' || lower(media_asset_id::text) || '/sessions/' || lower(media_upload_session_id::text)),
+  CONSTRAINT media_upload_sessions_state_timestamps
+    CHECK (
+      (state = 'active' AND completed_at IS NULL AND aborted_at IS NULL)
+      OR (state = 'completing' AND completed_at IS NULL AND aborted_at IS NULL)
+      OR (state = 'completed' AND completed_at IS NOT NULL AND aborted_at IS NULL)
+      OR (state = 'aborting' AND completed_at IS NULL AND aborted_at IS NULL)
+      OR (state = 'aborted' AND completed_at IS NULL AND aborted_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_media_upload_sessions_workspace_active
+  ON content.media_upload_sessions(workspace_id, expires_at, media_upload_session_id)
+  WHERE state = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_media_upload_sessions_workspace_asset
+  ON content.media_upload_sessions(workspace_id, media_asset_id, created_at DESC);
+
+COMMENT ON TABLE content.media_upload_sessions IS 'Backend-owned S3 multipart upload state for media blobs before a logical media asset is registered.';
+COMMENT ON COLUMN content.media_upload_sessions.media_upload_session_id IS 'Backend-generated upload session id exposed to clients instead of S3 object keys or upload ids.';
+COMMENT ON COLUMN content.media_upload_sessions.workspace_id IS 'Owning workspace for authorization and RLS scoping.';
+COMMENT ON COLUMN content.media_upload_sessions.media_asset_id IS 'Logical media asset id that will reference the uploaded blob after completion.';
+COMMENT ON COLUMN content.media_upload_sessions.media_blob_sha256 IS 'Declared lowercase hex SHA-256 digest of the final normalized blob bytes.';
+COMMENT ON COLUMN content.media_upload_sessions.staging_storage_key IS 'Private session-scoped object storage key that receives unvalidated multipart bytes.';
+COMMENT ON COLUMN content.media_upload_sessions.blob_storage_key IS 'Private content-addressed object storage key for the validated target blob.';
+COMMENT ON COLUMN content.media_upload_sessions.s3_upload_id IS 'Private S3 multipart upload id required for part signing, completion, and abort.';
+COMMENT ON COLUMN content.media_upload_sessions.mime_type IS 'Canonical MIME type for the final normalized blob bytes.';
+COMMENT ON COLUMN content.media_upload_sessions.size_bytes IS 'Final normalized blob size in bytes.';
+COMMENT ON COLUMN content.media_upload_sessions.part_size_bytes IS 'Requested multipart part size in bytes.';
+COMMENT ON COLUMN content.media_upload_sessions.part_count IS 'Expected number of S3 upload parts.';
+COMMENT ON COLUMN content.media_upload_sessions.state IS 'Upload session lifecycle: active, completing, completed, aborting, or aborted.';
+COMMENT ON COLUMN content.media_upload_sessions.source_url IS 'Optional provenance URL for imported media.';
+COMMENT ON COLUMN content.media_upload_sessions.asset_created_at IS 'Client-visible creation timestamp for the logical media asset metadata row.';
+COMMENT ON COLUMN content.media_upload_sessions.client_updated_at IS 'Client LWW timestamp for the logical media asset metadata row.';
+COMMENT ON COLUMN content.media_upload_sessions.last_modified_by_replica_id IS 'Workspace replica that produced this upload session metadata.';
+COMMENT ON COLUMN content.media_upload_sessions.last_operation_id IS 'Client operation id for the logical media asset metadata row.';
+COMMENT ON COLUMN content.media_upload_sessions.expires_at IS 'Time after which the backend no longer signs parts or accepts completion for this session.';
+COMMENT ON COLUMN content.media_upload_sessions.created_at IS 'Server timestamp when this upload session was created.';
+COMMENT ON COLUMN content.media_upload_sessions.completed_at IS 'Server timestamp when the session successfully registered its logical media asset.';
+COMMENT ON COLUMN content.media_upload_sessions.aborted_at IS 'Server timestamp when the session was explicitly aborted.';
+
+ALTER TABLE content.media_upload_sessions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS media_upload_sessions_scoped_select_runtime ON content.media_upload_sessions;
+DROP POLICY IF EXISTS media_upload_sessions_scoped_insert_runtime ON content.media_upload_sessions;
+DROP POLICY IF EXISTS media_upload_sessions_scoped_update_runtime ON content.media_upload_sessions;
+DROP POLICY IF EXISTS media_upload_sessions_scoped_delete_runtime ON content.media_upload_sessions;
+
+CREATE POLICY media_upload_sessions_scoped_select_runtime
+  ON content.media_upload_sessions
+  FOR SELECT
+  TO backend_app
+  USING (security.current_workspace_access_allowed(workspace_id));
+
+CREATE POLICY media_upload_sessions_scoped_insert_runtime
+  ON content.media_upload_sessions
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (security.current_workspace_access_allowed(workspace_id));
+
+CREATE POLICY media_upload_sessions_scoped_update_runtime
+  ON content.media_upload_sessions
+  FOR UPDATE
+  TO backend_app
+  USING (security.current_workspace_access_allowed(workspace_id))
+  WITH CHECK (security.current_workspace_access_allowed(workspace_id));
+
+CREATE POLICY media_upload_sessions_scoped_delete_runtime
+  ON content.media_upload_sessions
+  FOR DELETE
+  TO backend_app
+  USING (security.current_workspace_access_allowed(workspace_id));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON content.media_upload_sessions TO backend_app;


### PR DESCRIPTION
## Summary
- add internal media upload session database/state primitives
- add staging/canonical storage keys and multipart S3 operations
- validate multipart staging bytes with backend-computed SHA-256 before promotion/reuse
- keep current public upload-intent compatibility for PR A

## Validation
- git --no-pager diff --check
- migration whitespace check for db/migrations/0084_media_upload_sessions.sql
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend -- mediaAssets storage
- git apply --check /tmp/multipart-routes-contract.patch
- git apply --check /tmp/multipart-auth-smoke.patch