### PR TITLE
Add admin catalog API routes and docs

### DIFF
--- a/api/src/components/schemas/AdminErrorEnvelope.yaml
+++ b/api/src/components/schemas/AdminErrorEnvelope.yaml
@@ -1,0 +1,18 @@
+type: object
+additionalProperties: false
+required:
+  - error
+  - requestId
+  - code
+properties:
+  error:
+    type: string
+  requestId:
+    type: string
+  code:
+    type:
+      - string
+      - 'null'
+  details:
+    type: object
+    additionalProperties: true

--- a/api/src/components/schemas/AttachCatalogPackageMediaAssetInput.yaml
+++ b/api/src/components/schemas/AttachCatalogPackageMediaAssetInput.yaml
@@ -1,0 +1,28 @@
+type: object
+additionalProperties: false
+required:
+  - packageMediaAssetId
+  - packageMediaKey
+  - mediaBlobId
+  - altText
+  - credit
+  - license
+properties:
+  packageMediaAssetId:
+    $ref: ./UuidString.yaml
+  packageMediaKey:
+    type: string
+  mediaBlobId:
+    $ref: ./UuidString.yaml
+  altText:
+    type:
+      - string
+      - 'null'
+  credit:
+    type:
+      - string
+      - 'null'
+  license:
+    type:
+      - string
+      - 'null'

--- a/api/src/components/schemas/CatalogAuthor.yaml
+++ b/api/src/components/schemas/CatalogAuthor.yaml
@@ -1,0 +1,33 @@
+type: object
+additionalProperties: false
+required:
+  - authorId
+  - slug
+  - displayName
+  - bio
+  - websiteUrl
+  - createdAt
+  - updatedAt
+properties:
+  authorId:
+    $ref: ./UuidString.yaml
+  slug:
+    type: string
+    pattern: ^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$
+  displayName:
+    type: string
+  bio:
+    type:
+      - string
+      - 'null'
+  websiteUrl:
+    type:
+      - string
+      - 'null'
+    format: uri
+  createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time

--- a/api/src/components/schemas/CatalogCardMetadata.yaml
+++ b/api/src/components/schemas/CatalogCardMetadata.yaml
@@ -1,0 +1,47 @@
+type: object
+additionalProperties: false
+required:
+  - version
+  - source
+properties:
+  version:
+    type: integer
+    enum:
+      - 1
+  source:
+    oneOf:
+      - type: 'null'
+      - type: object
+        additionalProperties: false
+        required:
+          - label
+          - author
+          - comment
+          - createdAt
+          - importedAt
+          - importId
+        properties:
+          label:
+            type:
+              - string
+              - 'null'
+          author:
+            type:
+              - string
+              - 'null'
+          comment:
+            type:
+              - string
+              - 'null'
+          createdAt:
+            type:
+              - string
+              - 'null'
+          importedAt:
+            type:
+              - string
+              - 'null'
+          importId:
+            type:
+              - string
+              - 'null'

--- a/api/src/components/schemas/CatalogNoteInput.yaml
+++ b/api/src/components/schemas/CatalogNoteInput.yaml
@@ -1,0 +1,9 @@
+type: object
+additionalProperties: false
+required:
+  - note
+properties:
+  note:
+    type:
+      - string
+      - 'null'

--- a/api/src/components/schemas/CatalogPackage.yaml
+++ b/api/src/components/schemas/CatalogPackage.yaml
@@ -1,0 +1,68 @@
+type: object
+additionalProperties: false
+required:
+  - packageId
+  - authorId
+  - slug
+  - title
+  - summary
+  - description
+  - languageTags
+  - topicTags
+  - license
+  - contentWarning
+  - coverPackageMediaKey
+  - status
+  - createdAt
+  - updatedAt
+  - publishedAt
+  - delistedAt
+properties:
+  packageId:
+    $ref: ./UuidString.yaml
+  authorId:
+    $ref: ./UuidString.yaml
+  slug:
+    type: string
+  title:
+    type: string
+  summary:
+    type: string
+  description:
+    type: string
+  languageTags:
+    type: array
+    items:
+      type: string
+  topicTags:
+    type: array
+    items:
+      type: string
+  license:
+    type: string
+  contentWarning:
+    type:
+      - string
+      - 'null'
+  coverPackageMediaKey:
+    type:
+      - string
+      - 'null'
+  status:
+    $ref: ./CatalogPackageStatus.yaml
+  createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time
+  publishedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  delistedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time

--- a/api/src/components/schemas/CatalogPackageCardSnapshotInput.yaml
+++ b/api/src/components/schemas/CatalogPackageCardSnapshotInput.yaml
@@ -1,0 +1,37 @@
+type: object
+additionalProperties: false
+required:
+  - packageCardId
+  - stableCardKey
+  - ordinal
+  - frontText
+  - backText
+  - cardType
+  - metadata
+  - tags
+  - mediaAssetKeys
+properties:
+  packageCardId:
+    $ref: ./UuidString.yaml
+  stableCardKey:
+    type: string
+  ordinal:
+    type: integer
+    minimum: 1
+  frontText:
+    type: string
+  backText:
+    type: string
+  cardType:
+    type: string
+    example: basic
+  metadata:
+    $ref: ./CatalogCardMetadata.yaml
+  tags:
+    type: array
+    items:
+      type: string
+  mediaAssetKeys:
+    type: array
+    items:
+      type: string

--- a/api/src/components/schemas/CatalogPackageDraft.yaml
+++ b/api/src/components/schemas/CatalogPackageDraft.yaml
@@ -1,0 +1,12 @@
+type: object
+additionalProperties: false
+required:
+  - catalogPackage
+  - mediaAssets
+properties:
+  catalogPackage:
+    $ref: ./CatalogPackage.yaml
+  mediaAssets:
+    type: array
+    items:
+      $ref: ./CatalogPackageMediaAsset.yaml

--- a/api/src/components/schemas/CatalogPackageMediaAsset.yaml
+++ b/api/src/components/schemas/CatalogPackageMediaAsset.yaml
@@ -1,0 +1,44 @@
+type: object
+additionalProperties: false
+required:
+  - packageMediaAssetId
+  - packageId
+  - packageVersionId
+  - packageMediaKey
+  - mediaBlobId
+  - altText
+  - credit
+  - license
+  - createdAt
+  - updatedAt
+properties:
+  packageMediaAssetId:
+    $ref: ./UuidString.yaml
+  packageId:
+    $ref: ./UuidString.yaml
+  packageVersionId:
+    oneOf:
+      - $ref: ./UuidString.yaml
+      - type: 'null'
+  packageMediaKey:
+    type: string
+  mediaBlobId:
+    $ref: ./UuidString.yaml
+  altText:
+    type:
+      - string
+      - 'null'
+  credit:
+    type:
+      - string
+      - 'null'
+  license:
+    type:
+      - string
+      - 'null'
+  createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time

--- a/api/src/components/schemas/CatalogPackageReviewStatus.yaml
+++ b/api/src/components/schemas/CatalogPackageReviewStatus.yaml
@@ -1,0 +1,7 @@
+type: string
+enum:
+  - draft
+  - submitted
+  - needs_changes
+  - approved
+  - rejected

--- a/api/src/components/schemas/CatalogPackageStatus.yaml
+++ b/api/src/components/schemas/CatalogPackageStatus.yaml
@@ -1,0 +1,9 @@
+type: string
+enum:
+  - draft
+  - submitted
+  - needs_changes
+  - approved
+  - rejected
+  - published
+  - delisted

--- a/api/src/components/schemas/CatalogPackageVersion.yaml
+++ b/api/src/components/schemas/CatalogPackageVersion.yaml
@@ -1,0 +1,101 @@
+type: object
+additionalProperties: false
+required:
+  - packageVersionId
+  - packageId
+  - versionNumber
+  - status
+  - slug
+  - title
+  - summary
+  - description
+  - languageTags
+  - topicTags
+  - license
+  - contentWarning
+  - coverPackageMediaKey
+  - sourceWorkspaceId
+  - cardCount
+  - createdByAdminEmail
+  - reviewedByAdminEmail
+  - createdAt
+  - updatedAt
+  - submittedAt
+  - reviewedAt
+  - publishedAt
+  - delistedAt
+properties:
+  packageVersionId:
+    $ref: ./UuidString.yaml
+  packageId:
+    $ref: ./UuidString.yaml
+  versionNumber:
+    type: integer
+    minimum: 1
+  status:
+    $ref: ./CatalogPackageStatus.yaml
+  slug:
+    type: string
+  title:
+    type: string
+  summary:
+    type: string
+  description:
+    type: string
+  languageTags:
+    type: array
+    items:
+      type: string
+  topicTags:
+    type: array
+    items:
+      type: string
+  license:
+    type: string
+  contentWarning:
+    type:
+      - string
+      - 'null'
+  coverPackageMediaKey:
+    type:
+      - string
+      - 'null'
+  sourceWorkspaceId:
+    oneOf:
+      - $ref: ./UuidString.yaml
+      - type: 'null'
+  cardCount:
+    type: integer
+    minimum: 0
+  createdByAdminEmail:
+    type: string
+  reviewedByAdminEmail:
+    type:
+      - string
+      - 'null'
+  createdAt:
+    type: string
+    format: date-time
+  updatedAt:
+    type: string
+    format: date-time
+  submittedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  reviewedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  publishedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  delistedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time

--- a/api/src/components/schemas/CreateCatalogPackageDraftInput.yaml
+++ b/api/src/components/schemas/CreateCatalogPackageDraftInput.yaml
@@ -1,0 +1,41 @@
+type: object
+additionalProperties: false
+required:
+  - packageId
+  - authorId
+  - slug
+  - title
+  - summary
+  - description
+  - languageTags
+  - topicTags
+  - license
+  - contentWarning
+properties:
+  packageId:
+    $ref: ./UuidString.yaml
+  authorId:
+    $ref: ./UuidString.yaml
+  slug:
+    type: string
+  title:
+    type: string
+  summary:
+    type: string
+  description:
+    type: string
+  languageTags:
+    type: array
+    minItems: 1
+    items:
+      type: string
+  topicTags:
+    type: array
+    items:
+      type: string
+  license:
+    type: string
+  contentWarning:
+    type:
+      - string
+      - 'null'

--- a/api/src/components/schemas/CreateCatalogPackageVersionFromWorkspaceInput.yaml
+++ b/api/src/components/schemas/CreateCatalogPackageVersionFromWorkspaceInput.yaml
@@ -1,0 +1,16 @@
+type: object
+additionalProperties: false
+required:
+  - packageVersionId
+  - workspaceId
+  - cardIds
+properties:
+  packageVersionId:
+    $ref: ./UuidString.yaml
+  workspaceId:
+    $ref: ./UuidString.yaml
+  cardIds:
+    type: array
+    minItems: 1
+    items:
+      $ref: ./UuidString.yaml

--- a/api/src/components/schemas/CreateCatalogPackageVersionInput.yaml
+++ b/api/src/components/schemas/CreateCatalogPackageVersionInput.yaml
@@ -1,0 +1,13 @@
+type: object
+additionalProperties: false
+required:
+  - packageVersionId
+  - cards
+properties:
+  packageVersionId:
+    $ref: ./UuidString.yaml
+  cards:
+    type: array
+    minItems: 1
+    items:
+      $ref: ./CatalogPackageCardSnapshotInput.yaml

--- a/api/src/components/schemas/UpdateCatalogAuthorInput.yaml
+++ b/api/src/components/schemas/UpdateCatalogAuthorInput.yaml
@@ -1,0 +1,21 @@
+type: object
+additionalProperties: false
+required:
+  - slug
+  - displayName
+  - bio
+  - websiteUrl
+properties:
+  slug:
+    type: string
+  displayName:
+    type: string
+  bio:
+    type:
+      - string
+      - 'null'
+  websiteUrl:
+    type:
+      - string
+      - 'null'
+    format: uri

--- a/api/src/components/schemas/UpdateCatalogPackageDraftInput.yaml
+++ b/api/src/components/schemas/UpdateCatalogPackageDraftInput.yaml
@@ -1,0 +1,43 @@
+type: object
+additionalProperties: false
+required:
+  - authorId
+  - slug
+  - title
+  - summary
+  - description
+  - languageTags
+  - topicTags
+  - license
+  - contentWarning
+  - coverPackageMediaKey
+properties:
+  authorId:
+    $ref: ./UuidString.yaml
+  slug:
+    type: string
+  title:
+    type: string
+  summary:
+    type: string
+  description:
+    type: string
+  languageTags:
+    type: array
+    minItems: 1
+    items:
+      type: string
+  topicTags:
+    type: array
+    items:
+      type: string
+  license:
+    type: string
+  contentWarning:
+    type:
+      - string
+      - 'null'
+  coverPackageMediaKey:
+    type:
+      - string
+      - 'null'

--- a/api/src/components/schemas/UpdateCatalogPackageVersionStatusInput.yaml
+++ b/api/src/components/schemas/UpdateCatalogPackageVersionStatusInput.yaml
@@ -1,0 +1,12 @@
+type: object
+additionalProperties: false
+required:
+  - status
+  - note
+properties:
+  status:
+    $ref: ./CatalogPackageReviewStatus.yaml
+  note:
+    type:
+      - string
+      - 'null'

--- a/api/src/components/schemas/UpsertCatalogAuthorInput.yaml
+++ b/api/src/components/schemas/UpsertCatalogAuthorInput.yaml
@@ -1,0 +1,24 @@
+type: object
+additionalProperties: false
+required:
+  - authorId
+  - slug
+  - displayName
+  - bio
+  - websiteUrl
+properties:
+  authorId:
+    $ref: ./UuidString.yaml
+  slug:
+    type: string
+  displayName:
+    type: string
+  bio:
+    type:
+      - string
+      - 'null'
+  websiteUrl:
+    type:
+      - string
+      - 'null'
+    format: uri

--- a/api/src/components/security-schemes/AdminSessionCookie.yaml
+++ b/api/src/components/security-schemes/AdminSessionCookie.yaml
@@ -1,0 +1,4 @@
+type: apiKey
+in: cookie
+name: session
+description: Signed-in browser session cookie. Admin catalog writes also require X-CSRF-Token.

--- a/api/src/components/security-schemes/CsrfTokenHeader.yaml
+++ b/api/src/components/security-schemes/CsrfTokenHeader.yaml
@@ -1,0 +1,4 @@
+type: apiKey
+in: header
+name: X-CSRF-Token
+description: CSRF token returned by GET /admin/session for session-authenticated unsafe admin requests.

--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -48,6 +48,10 @@ tags:
     description: >-
       Workspace-scoped media asset registry metadata and direct private object
       transfer URLs.
+  - name: admin-catalog
+    description: >-
+      Admin-only catalog authoring surface for marketplace authors, packages,
+      media references, review states, and immutable package versions.
 paths:
   /:
     $ref: paths/_.yaml
@@ -75,10 +79,36 @@ paths:
     $ref: paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_complete.yaml
   /workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url:
     $ref: paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
+  /admin/catalog/authors:
+    $ref: paths/admin_catalog_authors.yaml
+  /admin/catalog/authors/{authorId}:
+    $ref: paths/admin_catalog_authors_{authorId}.yaml
+  /admin/catalog/packages:
+    $ref: paths/admin_catalog_packages.yaml
+  /admin/catalog/packages/{packageId}:
+    $ref: paths/admin_catalog_packages_{packageId}.yaml
+  /admin/catalog/packages/{packageId}/draft:
+    $ref: paths/admin_catalog_packages_{packageId}_draft.yaml
+  /admin/catalog/packages/{packageId}/media-assets:
+    $ref: paths/admin_catalog_packages_{packageId}_media-assets.yaml
+  /admin/catalog/packages/{packageId}/versions:
+    $ref: paths/admin_catalog_packages_{packageId}_versions.yaml
+  /admin/catalog/packages/{packageId}/versions/from-workspace:
+    $ref: paths/admin_catalog_packages_{packageId}_versions_from-workspace.yaml
+  /admin/catalog/package-versions/{packageVersionId}/review-status:
+    $ref: paths/admin_catalog_package-versions_{packageVersionId}_review-status.yaml
+  /admin/catalog/package-versions/{packageVersionId}/publish:
+    $ref: paths/admin_catalog_package-versions_{packageVersionId}_publish.yaml
+  /admin/catalog/package-versions/{packageVersionId}/delist:
+    $ref: paths/admin_catalog_package-versions_{packageVersionId}_delist.yaml
 components:
   securitySchemes:
     ApiKeyHeader:
       $ref: ./components/security-schemes/ApiKeyHeader.yaml
+    AdminSessionCookie:
+      $ref: ./components/security-schemes/AdminSessionCookie.yaml
+    CsrfTokenHeader:
+      $ref: ./components/security-schemes/CsrfTokenHeader.yaml
     # OAuth2 documents the implemented remote-MCP authorization flow
     # (mcp.<domain>/mcp). The REST endpoints below keep ApiKeyHeader; this scheme
     # is published so the spec reflects how MCP custom-connector clients connect.

--- a/api/src/paths/admin_catalog_authors.yaml
+++ b/api/src/paths/admin_catalog_authors.yaml
@@ -1,0 +1,33 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Create a catalog author
+  description: Creates an admin-managed catalog author identity.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/UpsertCatalogAuthorInput.yaml
+  responses:
+    '201':
+      description: Catalog author created
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - author
+            properties:
+              author:
+                $ref: ../components/schemas/CatalogAuthor.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_authors_{authorId}.yaml
+++ b/api/src/paths/admin_catalog_authors_{authorId}.yaml
@@ -1,0 +1,39 @@
+put:
+  tags:
+    - admin-catalog
+  summary: Update a catalog author
+  description: Replaces catalog author metadata for an existing author.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: authorId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/UpdateCatalogAuthorInput.yaml
+  responses:
+    '200':
+      description: Catalog author updated
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - author
+            properties:
+              author:
+                $ref: ../components/schemas/CatalogAuthor.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_package-versions_{packageVersionId}_delist.yaml
+++ b/api/src/paths/admin_catalog_package-versions_{packageVersionId}_delist.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Delist a package version
+  description: Delists a published package version without mutating its card or media snapshot.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: packageVersionId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/CatalogNoteInput.yaml
+  responses:
+    '200':
+      description: Catalog package version delisted
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - packageVersion
+            properties:
+              packageVersion:
+                $ref: ../components/schemas/CatalogPackageVersion.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_package-versions_{packageVersionId}_publish.yaml
+++ b/api/src/paths/admin_catalog_package-versions_{packageVersionId}_publish.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Publish a package version
+  description: Publishes an approved package version and makes its snapshot immutable.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: packageVersionId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/CatalogNoteInput.yaml
+  responses:
+    '200':
+      description: Catalog package version published
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - packageVersion
+            properties:
+              packageVersion:
+                $ref: ../components/schemas/CatalogPackageVersion.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_package-versions_{packageVersionId}_review-status.yaml
+++ b/api/src/paths/admin_catalog_package-versions_{packageVersionId}_review-status.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Update package version review status
+  description: Moves a package version through draft review states before publication.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: packageVersionId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/UpdateCatalogPackageVersionStatusInput.yaml
+  responses:
+    '200':
+      description: Catalog package version status updated
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - packageVersion
+            properties:
+              packageVersion:
+                $ref: ../components/schemas/CatalogPackageVersion.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_packages.yaml
+++ b/api/src/paths/admin_catalog_packages.yaml
@@ -1,0 +1,33 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Create package draft metadata
+  description: Creates mutable admin-managed draft metadata for a catalog package.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/CreateCatalogPackageDraftInput.yaml
+  responses:
+    '201':
+      description: Catalog package draft created
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - catalogPackage
+            properties:
+              catalogPackage:
+                $ref: ../components/schemas/CatalogPackage.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_packages_{packageId}.yaml
+++ b/api/src/paths/admin_catalog_packages_{packageId}.yaml
@@ -1,0 +1,32 @@
+get:
+  tags:
+    - admin-catalog
+  summary: Read package draft metadata
+  description: Returns current mutable package draft metadata and draft media references.
+  security:
+    - AdminSessionCookie: []
+  parameters:
+    - name: packageId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  responses:
+    '200':
+      description: Catalog package draft
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - draft
+            properties:
+              draft:
+                $ref: ../components/schemas/CatalogPackageDraft.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_packages_{packageId}_draft.yaml
+++ b/api/src/paths/admin_catalog_packages_{packageId}_draft.yaml
@@ -1,0 +1,39 @@
+put:
+  tags:
+    - admin-catalog
+  summary: Update package draft metadata
+  description: Replaces mutable package draft metadata without changing immutable published versions.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: packageId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/UpdateCatalogPackageDraftInput.yaml
+  responses:
+    '200':
+      description: Catalog package draft updated
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - catalogPackage
+            properties:
+              catalogPackage:
+                $ref: ../components/schemas/CatalogPackage.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_packages_{packageId}_media-assets.yaml
+++ b/api/src/paths/admin_catalog_packages_{packageId}_media-assets.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Attach package draft media
+  description: Adds a package-local media key that resolves to an existing content.media_blobs row.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: packageId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/AttachCatalogPackageMediaAssetInput.yaml
+  responses:
+    '201':
+      description: Catalog package media asset attached
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - mediaAsset
+            properties:
+              mediaAsset:
+                $ref: ../components/schemas/CatalogPackageMediaAsset.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_packages_{packageId}_versions.yaml
+++ b/api/src/paths/admin_catalog_packages_{packageId}_versions.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Create a package version from card snapshots
+  description: Creates a mutable package-version review candidate from explicit card snapshot payloads.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: packageId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/CreateCatalogPackageVersionInput.yaml
+  responses:
+    '201':
+      description: Catalog package version created
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - packageVersion
+            properties:
+              packageVersion:
+                $ref: ../components/schemas/CatalogPackageVersion.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/api/src/paths/admin_catalog_packages_{packageId}_versions_from-workspace.yaml
+++ b/api/src/paths/admin_catalog_packages_{packageId}_versions_from-workspace.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - admin-catalog
+  summary: Create a package version from workspace cards
+  description: Creates a mutable package-version review candidate from an explicit workspace card selection.
+  security:
+    - AdminSessionCookie: []
+      CsrfTokenHeader: []
+  parameters:
+    - name: packageId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/CreateCatalogPackageVersionFromWorkspaceInput.yaml
+  responses:
+    '201':
+      description: Catalog package version created
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required:
+              - packageVersion
+            properties:
+              packageVersion:
+                $ref: ../components/schemas/CatalogPackageVersion.yaml
+    default:
+      description: Admin request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AdminErrorEnvelope.yaml

--- a/apps/backend/src/routes/catalogAdmin.ts
+++ b/apps/backend/src/routes/catalogAdmin.ts
@@ -1,0 +1,405 @@
+import { Hono } from "hono";
+import { requireAdminRequest, type AdminRequestContext } from "../admin/authz";
+import { normalizeCardMetadata } from "../cards/shared";
+import {
+  attachCatalogPackageDraftMediaAsset,
+  createCatalogAuthor,
+  createCatalogPackageDraft,
+  createCatalogPackageVersionFromCards,
+  createCatalogPackageVersionFromWorkspaceSelection,
+  delistCatalogPackageVersion,
+  loadCatalogPackageDraft,
+  publishCatalogPackageVersion,
+  updateCatalogAuthor,
+  updateCatalogPackageDraft,
+  updateCatalogPackageVersionReviewStatus,
+} from "../catalog";
+import {
+  catalogPackageStatuses,
+  type AttachCatalogPackageMediaAssetInput,
+  type CatalogAuthor,
+  type CatalogPackage,
+  type CatalogPackageCardSnapshotInput,
+  type CatalogPackageDraft,
+  type CatalogPackageMediaAsset,
+  type CatalogPackageStatus,
+  type CatalogPackageVersion,
+  type CreateCatalogPackageDraftInput,
+  type CreateCatalogPackageVersionFromWorkspaceInput,
+  type CreateCatalogPackageVersionInput,
+  type UpdateCatalogPackageDraftInput,
+  type UpdateCatalogPackageVersionStatusInput,
+  type UpsertCatalogAuthorInput,
+} from "../catalog/types";
+import {
+  expectNonEmptyString,
+  expectRecord,
+  expectUuidString,
+  parseJsonBodyWithByteLimit,
+} from "../server/requestParsing";
+import { HttpError } from "../shared/errors";
+import type { AppEnv } from "../server/app";
+
+type CatalogAdminRoutesOptions = Readonly<{
+  allowedOrigins: ReadonlyArray<string>;
+  requireAdminRequestFn?: (
+    request: Request,
+    allowedOrigins: ReadonlyArray<string>,
+  ) => Promise<AdminRequestContext>;
+  createCatalogAuthorFn?: (input: UpsertCatalogAuthorInput) => Promise<CatalogAuthor>;
+  updateCatalogAuthorFn?: (input: UpsertCatalogAuthorInput) => Promise<CatalogAuthor>;
+  createCatalogPackageDraftFn?: (input: CreateCatalogPackageDraftInput) => Promise<CatalogPackage>;
+  updateCatalogPackageDraftFn?: (input: UpdateCatalogPackageDraftInput) => Promise<CatalogPackage>;
+  loadCatalogPackageDraftFn?: (packageId: string) => Promise<CatalogPackageDraft>;
+  attachCatalogPackageDraftMediaAssetFn?: (
+    packageId: string,
+    input: AttachCatalogPackageMediaAssetInput,
+  ) => Promise<CatalogPackageMediaAsset>;
+  createCatalogPackageVersionFromCardsFn?: (
+    packageId: string,
+    input: CreateCatalogPackageVersionInput,
+    adminEmail: string,
+  ) => Promise<CatalogPackageVersion>;
+  createCatalogPackageVersionFromWorkspaceSelectionFn?: (
+    packageId: string,
+    input: CreateCatalogPackageVersionFromWorkspaceInput,
+    adminUserId: string,
+    adminEmail: string,
+  ) => Promise<CatalogPackageVersion>;
+  updateCatalogPackageVersionReviewStatusFn?: (
+    packageVersionId: string,
+    input: UpdateCatalogPackageVersionStatusInput,
+    adminEmail: string,
+  ) => Promise<CatalogPackageVersion>;
+  publishCatalogPackageVersionFn?: (
+    packageVersionId: string,
+    adminEmail: string,
+    note: string | null,
+  ) => Promise<CatalogPackageVersion>;
+  delistCatalogPackageVersionFn?: (
+    packageVersionId: string,
+    adminEmail: string,
+    note: string | null,
+  ) => Promise<CatalogPackageVersion>;
+}>;
+
+const catalogAdminMaximumBodyBytes = 2_000_000;
+const catalogStatusSet: ReadonlySet<string> = new Set(catalogPackageStatuses);
+
+async function parseCatalogAdminJsonBody(request: Request): Promise<Readonly<Record<string, unknown>>> {
+  return expectRecord(await parseJsonBodyWithByteLimit(
+    request,
+    catalogAdminMaximumBodyBytes,
+    "Catalog admin request body is too large.",
+    "CATALOG_ADMIN_BODY_TOO_LARGE",
+  ));
+}
+
+function parseUuidParam(value: string | undefined, fieldName: string): string {
+  if (value === undefined) {
+    throw new HttpError(400, `${fieldName} is required`, "CATALOG_ADMIN_PARAM_REQUIRED");
+  }
+
+  try {
+    return expectUuidString(value, fieldName);
+  } catch {
+    throw new HttpError(400, `${fieldName} must be a UUID`, "CATALOG_ADMIN_PARAM_INVALID");
+  }
+}
+
+function expectNullableNonEmptyString(value: unknown, fieldName: string): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return expectNonEmptyString(value, fieldName);
+}
+
+function expectStringArray(value: unknown, fieldName: string): ReadonlyArray<string> {
+  if (!Array.isArray(value)) {
+    throw new HttpError(400, `${fieldName} must be an array`);
+  }
+
+  return value.map((item, index) => expectNonEmptyString(item, `${fieldName}[${index}]`));
+}
+
+function expectPositiveSafeInteger(value: unknown, fieldName: string): number {
+  if (typeof value !== "number" || Number.isSafeInteger(value) === false || value < 1) {
+    throw new HttpError(400, `${fieldName} must be a positive safe integer`);
+  }
+
+  return value;
+}
+
+function expectCatalogPackageStatus(value: unknown, fieldName: string): CatalogPackageStatus {
+  const status = expectNonEmptyString(value, fieldName);
+  if (catalogStatusSet.has(status) === false) {
+    throw new HttpError(400, `${fieldName} must be a valid catalog package status`);
+  }
+
+  return status as CatalogPackageStatus;
+}
+
+function expectCardMetadata(value: unknown): CatalogPackageCardSnapshotInput["metadata"] {
+  try {
+    return normalizeCardMetadata(value);
+  } catch (error) {
+    throw new HttpError(
+      400,
+      `card.metadata must be valid card metadata. reason=${error instanceof Error ? error.message : String(error)}`,
+      "CATALOG_CARD_METADATA_INVALID",
+    );
+  }
+}
+
+function parseAuthorCreateInput(record: Readonly<Record<string, unknown>>): UpsertCatalogAuthorInput {
+  return {
+    authorId: expectUuidString(record.authorId, "authorId"),
+    slug: expectNonEmptyString(record.slug, "slug"),
+    displayName: expectNonEmptyString(record.displayName, "displayName"),
+    bio: expectNullableNonEmptyString(record.bio, "bio"),
+    websiteUrl: expectNullableNonEmptyString(record.websiteUrl, "websiteUrl"),
+  };
+}
+
+function parseAuthorUpdateInput(
+  authorId: string,
+  record: Readonly<Record<string, unknown>>,
+): UpsertCatalogAuthorInput {
+  return {
+    authorId,
+    slug: expectNonEmptyString(record.slug, "slug"),
+    displayName: expectNonEmptyString(record.displayName, "displayName"),
+    bio: expectNullableNonEmptyString(record.bio, "bio"),
+    websiteUrl: expectNullableNonEmptyString(record.websiteUrl, "websiteUrl"),
+  };
+}
+
+function parsePackageCreateInput(record: Readonly<Record<string, unknown>>): CreateCatalogPackageDraftInput {
+  return {
+    packageId: expectUuidString(record.packageId, "packageId"),
+    authorId: expectUuidString(record.authorId, "authorId"),
+    slug: expectNonEmptyString(record.slug, "slug"),
+    title: expectNonEmptyString(record.title, "title"),
+    summary: expectNonEmptyString(record.summary, "summary"),
+    description: expectNonEmptyString(record.description, "description"),
+    languageTags: expectStringArray(record.languageTags, "languageTags"),
+    topicTags: expectStringArray(record.topicTags, "topicTags"),
+    license: expectNonEmptyString(record.license, "license"),
+    contentWarning: expectNullableNonEmptyString(record.contentWarning, "contentWarning"),
+  };
+}
+
+function parsePackageUpdateInput(
+  packageId: string,
+  record: Readonly<Record<string, unknown>>,
+): UpdateCatalogPackageDraftInput {
+  return {
+    packageId,
+    authorId: expectUuidString(record.authorId, "authorId"),
+    slug: expectNonEmptyString(record.slug, "slug"),
+    title: expectNonEmptyString(record.title, "title"),
+    summary: expectNonEmptyString(record.summary, "summary"),
+    description: expectNonEmptyString(record.description, "description"),
+    languageTags: expectStringArray(record.languageTags, "languageTags"),
+    topicTags: expectStringArray(record.topicTags, "topicTags"),
+    license: expectNonEmptyString(record.license, "license"),
+    contentWarning: expectNullableNonEmptyString(record.contentWarning, "contentWarning"),
+    coverPackageMediaKey: expectNullableNonEmptyString(record.coverPackageMediaKey, "coverPackageMediaKey"),
+  };
+}
+
+function parsePackageMediaAssetInput(
+  record: Readonly<Record<string, unknown>>,
+): AttachCatalogPackageMediaAssetInput {
+  return {
+    packageMediaAssetId: expectUuidString(record.packageMediaAssetId, "packageMediaAssetId"),
+    packageMediaKey: expectNonEmptyString(record.packageMediaKey, "packageMediaKey"),
+    mediaBlobId: expectUuidString(record.mediaBlobId, "mediaBlobId"),
+    altText: expectNullableNonEmptyString(record.altText, "altText"),
+    credit: expectNullableNonEmptyString(record.credit, "credit"),
+    license: expectNullableNonEmptyString(record.license, "license"),
+  };
+}
+
+function parseCardSnapshotInput(value: unknown, index: number): CatalogPackageCardSnapshotInput {
+  const record = expectRecord(value);
+  return {
+    packageCardId: expectUuidString(record.packageCardId, `cards[${index}].packageCardId`),
+    stableCardKey: expectNonEmptyString(record.stableCardKey, `cards[${index}].stableCardKey`),
+    ordinal: expectPositiveSafeInteger(record.ordinal, `cards[${index}].ordinal`),
+    frontText: expectNonEmptyString(record.frontText, `cards[${index}].frontText`),
+    backText: expectNonEmptyString(record.backText, `cards[${index}].backText`),
+    cardType: expectNonEmptyString(record.cardType, `cards[${index}].cardType`),
+    metadata: expectCardMetadata(record.metadata),
+    tags: expectStringArray(record.tags, `cards[${index}].tags`),
+    mediaAssetKeys: expectStringArray(record.mediaAssetKeys, `cards[${index}].mediaAssetKeys`),
+  };
+}
+
+function parseCreatePackageVersionInput(
+  record: Readonly<Record<string, unknown>>,
+): CreateCatalogPackageVersionInput {
+  if (!Array.isArray(record.cards)) {
+    throw new HttpError(400, "cards must be an array");
+  }
+
+  return {
+    packageVersionId: expectUuidString(record.packageVersionId, "packageVersionId"),
+    cards: record.cards.map((card, index) => parseCardSnapshotInput(card, index)),
+  };
+}
+
+function parseCreatePackageVersionFromWorkspaceInput(
+  record: Readonly<Record<string, unknown>>,
+): CreateCatalogPackageVersionFromWorkspaceInput {
+  return {
+    packageVersionId: expectUuidString(record.packageVersionId, "packageVersionId"),
+    workspaceId: expectUuidString(record.workspaceId, "workspaceId"),
+    cardIds: expectStringArray(record.cardIds, "cardIds").map((cardId, index) => (
+      expectUuidString(cardId, `cardIds[${index}]`)
+    )),
+  };
+}
+
+function parseReviewStatusInput(
+  record: Readonly<Record<string, unknown>>,
+): UpdateCatalogPackageVersionStatusInput {
+  return {
+    status: expectCatalogPackageStatus(record.status, "status"),
+    note: expectNullableNonEmptyString(record.note, "note"),
+  };
+}
+
+function parseNoteInput(record: Readonly<Record<string, unknown>>): string | null {
+  return expectNullableNonEmptyString(record.note, "note");
+}
+
+export function createCatalogAdminRoutes(options: CatalogAdminRoutesOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  const requireAdminRequestFn = options.requireAdminRequestFn ?? requireAdminRequest;
+  const createCatalogAuthorFn = options.createCatalogAuthorFn ?? createCatalogAuthor;
+  const updateCatalogAuthorFn = options.updateCatalogAuthorFn ?? updateCatalogAuthor;
+  const createCatalogPackageDraftFn = options.createCatalogPackageDraftFn ?? createCatalogPackageDraft;
+  const updateCatalogPackageDraftFn = options.updateCatalogPackageDraftFn ?? updateCatalogPackageDraft;
+  const loadCatalogPackageDraftFn = options.loadCatalogPackageDraftFn ?? loadCatalogPackageDraft;
+  const attachCatalogPackageDraftMediaAssetFn = options.attachCatalogPackageDraftMediaAssetFn
+    ?? attachCatalogPackageDraftMediaAsset;
+  const createCatalogPackageVersionFromCardsFn = options.createCatalogPackageVersionFromCardsFn
+    ?? createCatalogPackageVersionFromCards;
+  const createCatalogPackageVersionFromWorkspaceSelectionFn = options.createCatalogPackageVersionFromWorkspaceSelectionFn
+    ?? createCatalogPackageVersionFromWorkspaceSelection;
+  const updateCatalogPackageVersionReviewStatusFn = options.updateCatalogPackageVersionReviewStatusFn
+    ?? updateCatalogPackageVersionReviewStatus;
+  const publishCatalogPackageVersionFn = options.publishCatalogPackageVersionFn ?? publishCatalogPackageVersion;
+  const delistCatalogPackageVersionFn = options.delistCatalogPackageVersionFn ?? delistCatalogPackageVersion;
+
+  app.post("/admin/catalog/authors", async (context) => {
+    await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const author = await createCatalogAuthorFn(parseAuthorCreateInput(await parseCatalogAdminJsonBody(context.req.raw)));
+    return context.json({ author }, 201);
+  });
+
+  app.put("/admin/catalog/authors/:authorId", async (context) => {
+    await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const authorId = parseUuidParam(context.req.param("authorId"), "authorId");
+    const author = await updateCatalogAuthorFn(parseAuthorUpdateInput(
+      authorId,
+      await parseCatalogAdminJsonBody(context.req.raw),
+    ));
+    return context.json({ author });
+  });
+
+  app.post("/admin/catalog/packages", async (context) => {
+    await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const catalogPackage = await createCatalogPackageDraftFn(parsePackageCreateInput(
+      await parseCatalogAdminJsonBody(context.req.raw),
+    ));
+    return context.json({ catalogPackage }, 201);
+  });
+
+  app.get("/admin/catalog/packages/:packageId", async (context) => {
+    await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageId = parseUuidParam(context.req.param("packageId"), "packageId");
+    const draft = await loadCatalogPackageDraftFn(packageId);
+    return context.json({ draft });
+  });
+
+  app.put("/admin/catalog/packages/:packageId/draft", async (context) => {
+    await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageId = parseUuidParam(context.req.param("packageId"), "packageId");
+    const catalogPackage = await updateCatalogPackageDraftFn(parsePackageUpdateInput(
+      packageId,
+      await parseCatalogAdminJsonBody(context.req.raw),
+    ));
+    return context.json({ catalogPackage });
+  });
+
+  app.post("/admin/catalog/packages/:packageId/media-assets", async (context) => {
+    await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageId = parseUuidParam(context.req.param("packageId"), "packageId");
+    const mediaAsset = await attachCatalogPackageDraftMediaAssetFn(
+      packageId,
+      parsePackageMediaAssetInput(await parseCatalogAdminJsonBody(context.req.raw)),
+    );
+    return context.json({ mediaAsset }, 201);
+  });
+
+  app.post("/admin/catalog/packages/:packageId/versions", async (context) => {
+    const adminContext = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageId = parseUuidParam(context.req.param("packageId"), "packageId");
+    const packageVersion = await createCatalogPackageVersionFromCardsFn(
+      packageId,
+      parseCreatePackageVersionInput(await parseCatalogAdminJsonBody(context.req.raw)),
+      adminContext.email,
+    );
+    return context.json({ packageVersion }, 201);
+  });
+
+  app.post("/admin/catalog/packages/:packageId/versions/from-workspace", async (context) => {
+    const adminContext = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageId = parseUuidParam(context.req.param("packageId"), "packageId");
+    const packageVersion = await createCatalogPackageVersionFromWorkspaceSelectionFn(
+      packageId,
+      parseCreatePackageVersionFromWorkspaceInput(await parseCatalogAdminJsonBody(context.req.raw)),
+      adminContext.userId,
+      adminContext.email,
+    );
+    return context.json({ packageVersion }, 201);
+  });
+
+  app.post("/admin/catalog/package-versions/:packageVersionId/review-status", async (context) => {
+    const adminContext = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageVersionId = parseUuidParam(context.req.param("packageVersionId"), "packageVersionId");
+    const packageVersion = await updateCatalogPackageVersionReviewStatusFn(
+      packageVersionId,
+      parseReviewStatusInput(await parseCatalogAdminJsonBody(context.req.raw)),
+      adminContext.email,
+    );
+    return context.json({ packageVersion });
+  });
+
+  app.post("/admin/catalog/package-versions/:packageVersionId/publish", async (context) => {
+    const adminContext = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageVersionId = parseUuidParam(context.req.param("packageVersionId"), "packageVersionId");
+    const packageVersion = await publishCatalogPackageVersionFn(
+      packageVersionId,
+      adminContext.email,
+      parseNoteInput(await parseCatalogAdminJsonBody(context.req.raw)),
+    );
+    return context.json({ packageVersion });
+  });
+
+  app.post("/admin/catalog/package-versions/:packageVersionId/delist", async (context) => {
+    const adminContext = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+    const packageVersionId = parseUuidParam(context.req.param("packageVersionId"), "packageVersionId");
+    const packageVersion = await delistCatalogPackageVersionFn(
+      packageVersionId,
+      adminContext.email,
+      parseNoteInput(await parseCatalogAdminJsonBody(context.req.raw)),
+    );
+    return context.json({ packageVersion });
+  });
+
+  return app;
+}

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -37,7 +37,7 @@ type AgentDiscoveryDataSchemaForTest = Readonly<{
   }>;
 }>;
 
-const expectedPublishedExternalAgentMethods = {
+const expectedPublishedApiMethods = {
   "/": ["get"],
   "/agent": ["get"],
   "/api/agent/send-code": ["post"],
@@ -51,6 +51,17 @@ const expectedPublishedExternalAgentMethods = {
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}": ["get"],
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/complete": ["post"],
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url": ["get"],
+  "/admin/catalog/authors": ["post"],
+  "/admin/catalog/authors/{authorId}": ["put"],
+  "/admin/catalog/packages": ["post"],
+  "/admin/catalog/packages/{packageId}": ["get"],
+  "/admin/catalog/packages/{packageId}/draft": ["put"],
+  "/admin/catalog/packages/{packageId}/media-assets": ["post"],
+  "/admin/catalog/packages/{packageId}/versions": ["post"],
+  "/admin/catalog/packages/{packageId}/versions/from-workspace": ["post"],
+  "/admin/catalog/package-versions/{packageVersionId}/review-status": ["post"],
+  "/admin/catalog/package-versions/{packageVersionId}/publish": ["post"],
+  "/admin/catalog/package-versions/{packageVersionId}/delist": ["post"],
 } as const satisfies Readonly<Record<string, ReadonlyArray<OperationMethodName>>>;
 
 const expectedMediaDiscoverySurfaceTemplates = {
@@ -103,7 +114,7 @@ test("API Gateway predeclares PATCH /me/preferences", () => {
   assert.match(apiGatewaySource, /me\.addResource\("preferences"\)\.addMethod\("PATCH", integration\);/);
 });
 
-test("published OpenAPI exposes only the curated external agent and media transfer contract", () => {
+test("published OpenAPI exposes the curated agent, media transfer, and admin catalog contract", () => {
   const openApiDocument = loadPublishedOpenApiDocument();
   const paths = openApiDocument.paths ?? {};
   const securitySchemes = openApiDocument.components?.securitySchemes ?? {};
@@ -111,15 +122,21 @@ test("published OpenAPI exposes only the curated external agent and media transf
 
   assert.equal(openApiDocument.info?.title, "Flashcards Open Source App External AI-Agent API");
   assert.match(openApiDocument.info?.description ?? "", /curated public api contract/i);
-  assert.deepEqual(Object.keys(paths), Object.keys(expectedPublishedExternalAgentMethods));
-  for (const [path, methods] of Object.entries(expectedPublishedExternalAgentMethods)) {
+  assert.deepEqual(Object.keys(paths), Object.keys(expectedPublishedApiMethods));
+  for (const [path, methods] of Object.entries(expectedPublishedApiMethods)) {
     assert.deepEqual(listDocumentedMethods(paths[path] ?? {}), methods, `Unexpected OpenAPI methods for ${path}`);
   }
 
   // ApiKeyHeader secures the REST agent surface; OAuth2 documents the
   // implemented remote-MCP authorization-code flow (mcp.<domain>/mcp) in the
-  // published spec.
-  assert.deepEqual(Object.keys(securitySchemes), ["ApiKeyHeader", "OAuth2"]);
+  // published spec. AdminSessionCookie and CsrfTokenHeader secure the
+  // browser-only admin catalog routes.
+  assert.deepEqual(Object.keys(securitySchemes), [
+    "ApiKeyHeader",
+    "AdminSessionCookie",
+    "CsrfTokenHeader",
+    "OAuth2",
+  ]);
   for (const hiddenSchemaName of [
     "MeResponse",
     "AccountPreferences",
@@ -148,7 +165,7 @@ test("agent discovery advertises the published media transfer surface", () => {
       `${apiBaseUrl}${pathTemplate}`,
     );
     assert.ok(
-      expectedPublishedExternalAgentMethods[pathTemplate] !== undefined,
+      expectedPublishedApiMethods[pathTemplate] !== undefined,
       `Discovery media template ${surfaceKey} must be published in OpenAPI paths`,
     );
     assert.ok(

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -19,6 +19,7 @@ import { createMediaAssetsRoutes } from "../routes/mediaAssets";
 import { createSyncRoutes } from "../routes/sync/index";
 import { createSystemRoutes } from "../routes/system";
 import { createAdminRoutes } from "../routes/admin";
+import { createCatalogAdminRoutes } from "../routes/catalogAdmin";
 import { createGuestAuthRoutes } from "../routes/guestAuth";
 import { createWorkspaceRoutes } from "../routes/workspaces/index";
 import {
@@ -371,6 +372,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
   app.route("/", createAgentRoutes({ allowedOrigins }));
   app.route("/", createWorkspaceRoutes({ allowedOrigins }));
   app.route("/", createAdminRoutes({ allowedOrigins }));
+  app.route("/", createCatalogAdminRoutes({ allowedOrigins }));
   app.route("/", createCardsRoutes({ allowedOrigins }));
   app.route("/", createFeedbackRoutes({ allowedOrigins }));
   app.route("/", createMediaAssetsRoutes({ allowedOrigins }));

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -87,6 +87,13 @@ test("API Gateway predeclares /me/progress/leaderboards/profiles/{publicProfileI
   );
 });
 
+test("API Gateway browser CORS allows PUT for admin updates", () => {
+  const apiGatewayPath = resolve(process.cwd(), "lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(apiGatewaySource, /allowMethods: \["GET", "POST", "PUT", "PATCH", "OPTIONS"\]/);
+});
+
 test("global snapshot API Gateway mock preflight allows content type and Sentry trace headers", () => {
   const stack = new cdk.Stack();
   const restApi = new apigw.RestApi(stack, "Api");
@@ -214,7 +221,7 @@ test("default API Gateway generated errors expose supported request id headers",
   const responseParameters = {
     "gatewayresponse.header.Access-Control-Allow-Credentials": "'true'",
     "gatewayresponse.header.Access-Control-Allow-Headers": `'${allowHeaders}'`,
-    "gatewayresponse.header.Access-Control-Allow-Methods": "'GET,POST,PATCH,OPTIONS'",
+    "gatewayresponse.header.Access-Control-Allow-Methods": "'GET,POST,PUT,PATCH,OPTIONS'",
     "gatewayresponse.header.Access-Control-Allow-Origin": "method.request.header.Origin",
     "gatewayresponse.header.Access-Control-Expose-Headers": "'x-request-id,x-amzn-requestid,x-amz-apigw-id'",
     "gatewayresponse.header.Vary": "'Origin'",

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -141,7 +141,7 @@ export const globalMetricsCorsPreflightOptions: apigw.CorsOptions = {
 function createBrowserCorsPreflightOptions(allowedOrigins: string[]): apigw.CorsOptions {
   return {
     allowOrigins: allowedOrigins,
-    allowMethods: ["GET", "POST", "PATCH", "OPTIONS"],
+    allowMethods: ["GET", "POST", "PUT", "PATCH", "OPTIONS"],
     allowHeaders: [...browserCorsAllowHeaders],
     allowCredentials: true,
   };
@@ -164,7 +164,7 @@ export function createGatewayErrorResponseHeaders(): GatewayErrorResponseHeaders
     "Access-Control-Allow-Origin": "method.request.header.Origin",
     "Vary": "'Origin'",
     "Access-Control-Allow-Headers": `'${browserCorsAllowHeaders.join(",")}'`,
-    "Access-Control-Allow-Methods": "'GET,POST,PATCH,OPTIONS'",
+    "Access-Control-Allow-Methods": "'GET,POST,PUT,PATCH,OPTIONS'",
     "Access-Control-Allow-Credentials": "'true'",
     "Access-Control-Expose-Headers": `'${gatewayErrorCorsExposeHeaders.join(",")}'`,
     "X-Request-Id": "context.requestId",
@@ -686,6 +686,23 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   admin.addResource("session").addMethod("GET", integration);
   const adminReports = admin.addResource("reports");
   adminReports.addResource("query").addMethod("POST", integration);
+  const adminCatalog = admin.addResource("catalog");
+  const adminCatalogAuthors = adminCatalog.addResource("authors");
+  adminCatalogAuthors.addMethod("POST", integration);
+  adminCatalogAuthors.addResource("{authorId}").addMethod("PUT", integration);
+  const adminCatalogPackages = adminCatalog.addResource("packages");
+  adminCatalogPackages.addMethod("POST", integration);
+  const adminCatalogPackageById = adminCatalogPackages.addResource("{packageId}");
+  adminCatalogPackageById.addMethod("GET", integration);
+  adminCatalogPackageById.addResource("draft").addMethod("PUT", integration);
+  adminCatalogPackageById.addResource("media-assets").addMethod("POST", integration);
+  const adminCatalogPackageVersions = adminCatalogPackageById.addResource("versions");
+  adminCatalogPackageVersions.addMethod("POST", integration);
+  adminCatalogPackageVersions.addResource("from-workspace").addMethod("POST", integration);
+  const adminCatalogPackageVersionById = adminCatalog.addResource("package-versions").addResource("{packageVersionId}");
+  adminCatalogPackageVersionById.addResource("review-status").addMethod("POST", integration);
+  adminCatalogPackageVersionById.addResource("publish").addMethod("POST", integration);
+  adminCatalogPackageVersionById.addResource("delist").addMethod("POST", integration);
 
   const chat = restApi.root.addResource("chat");
   chat.addMethod("GET", integration);


### PR DESCRIPTION
## Summary
- add admin-only catalog routes and mount them in the backend app
- add API Gateway route wiring and CORS coverage for admin catalog methods
- document admin catalog routes in OpenAPI and update system contract coverage

## Validation
- git --no-pager diff --check
- supplemental whitespace check for untracked PR B files
- npm run bundle --prefix api
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend -- catalog routes/system
- npm run build --prefix infra/aws
- node --test dist/lib/gateways/api-gateway.test.js from infra/aws

Review gate passed: no P0-P4 findings and no split recommendation.