### PR TITLE
Add media blob normalization version migration

### DIFF
--- a/db/migrations/0085_media_blob_normalization_version.sql
+++ b/db/migrations/0085_media_blob_normalization_version.sql
@@ -1,0 +1,14 @@
+-- Migration status: Current / additive.
+-- Introduces: media blob normalization pipeline version metadata.
+-- Schemas touched/read explicitly: content.
+
+ALTER TABLE content.media_blobs
+  ADD COLUMN IF NOT EXISTS normalization_version TEXT NOT NULL DEFAULT 'passthrough-v1';
+
+ALTER TABLE content.media_blobs
+  DROP CONSTRAINT IF EXISTS media_blobs_normalization_version_supported,
+  ADD CONSTRAINT media_blobs_normalization_version_supported
+    CHECK (normalization_version IN ('passthrough-v1', 'image-jpeg-card-v1'));
+
+COMMENT ON COLUMN content.media_blobs.normalization_version IS
+  'Normalization pipeline version applied before blob storage. Existing unnormalized blobs default to passthrough-v1.';


### PR DESCRIPTION
## Summary
- add migration 0085 for content.media_blobs.normalization_version
- keep passthrough-v1 as the DB default for old backend insert paths
- constrain supported first-version values to passthrough-v1 and image-jpeg-card-v1

## Validation
- git --no-pager diff --check
- worker-owned review found no P0-P4 issues