### PR TITLE
Add Android managed media download rendering

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -123,6 +123,11 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onCreateCard = {},
                     onCreateCardWithAi = {},
                     onSwitchToAllCards = {},
+                    onLoadManagedMediaDownloadUrl = { mediaAssetId ->
+                        throw UnsupportedOperationException(
+                            "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"
+                        )
+                    },
                     onScreenVisible = {
                         screenVisibleCalls += 1
                     },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -72,6 +72,7 @@ import com.flashcardsopensourceapp.data.local.repository.decks.LocalDecksReposit
 import com.flashcardsopensourceapp.data.local.repository.feedback.LocalFeedbackRepository
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.progress.LocalProgressRepository
+import com.flashcardsopensourceapp.data.local.repository.review.CloudReviewMediaAssetDownloadUrlLoader
 import com.flashcardsopensourceapp.data.local.repository.review.LocalReviewRepository
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.LocalSyncRepository
 import com.flashcardsopensourceapp.data.local.repository.workspace.LocalWorkspaceRepository
@@ -313,7 +314,14 @@ class AppGraph(
         preferencesStore = cloudPreferencesStore,
         syncLocalStore = syncLocalStore,
         localProgressCacheStore = localProgressCacheStore,
-        timeProvider = SystemTimeProvider
+        timeProvider = SystemTimeProvider,
+        mediaAssetDownloadUrlLoader = CloudReviewMediaAssetDownloadUrlLoader(
+            preferencesStore = cloudPreferencesStore,
+            remoteService = cloudRemoteService,
+            operationCoordinator = cloudOperationCoordinator,
+            guestSessionStore = guestAiSessionStore,
+            resetCoordinator = cloudIdentityResetCoordinator
+        )
     )
     val feedbackRepository: FeedbackRepository = LocalFeedbackRepository(
         database = database,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -178,6 +178,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 onSwitchToAllCards = {
                     reviewViewModel.selectFilter(reviewFilter = ReviewFilter.AllCards)
                 },
+                onLoadManagedMediaDownloadUrl = reviewViewModel::loadManagedMediaDownloadUrl,
                 onRevealAnswer = reviewViewModel::revealAnswer,
                 onRateAgain = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.AGAIN) },
                 onRateHard = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.HARD) },

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
@@ -15,6 +15,7 @@ import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackSubmissionRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeReconciliation
@@ -612,6 +613,15 @@ internal class FakeCloudRemoteGateway private constructor(
         authorizationHeader: String,
         leaderboardParticipationEnabled: Boolean
     ): CloudCommunityProfile {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun loadMediaAssetDownloadUrl(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl {
         throw UnsupportedOperationException()
     }
 

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
@@ -11,6 +11,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
 import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
@@ -20,6 +21,7 @@ import com.flashcardsopensourceapp.data.local.repository.cards.LocalCardsReposit
 import com.flashcardsopensourceapp.data.local.repository.decks.LocalDecksRepository
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.review.LocalReviewRepository
+import com.flashcardsopensourceapp.data.local.repository.review.ReviewMediaAssetDownloadUrlLoader
 import com.flashcardsopensourceapp.data.local.repository.workspace.LocalWorkspaceRepository
 import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
@@ -127,8 +129,21 @@ internal fun createTestReviewRepository(runtime: LocalDatabaseTestRuntime): Revi
             database = runtime.database,
             timeProvider = SystemTimeProvider
         ),
-        timeProvider = SystemTimeProvider
+        timeProvider = SystemTimeProvider,
+        mediaAssetDownloadUrlLoader = UnsupportedTestReviewMediaAssetDownloadUrlLoader
     )
+}
+
+private object UnsupportedTestReviewMediaAssetDownloadUrlLoader : ReviewMediaAssetDownloadUrlLoader {
+    override suspend fun loadMediaAssetDownloadUrl(
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl {
+        throw UnsupportedOperationException(
+            "Test review repository does not support managed media download URLs. " +
+                "workspaceId=$workspaceId mediaAssetId=$mediaAssetId"
+        )
+    }
 }
 
 internal fun makeDueReviewOrderingCardEntity(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
@@ -13,6 +13,7 @@ import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackSubmissionRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
@@ -161,6 +162,12 @@ interface CloudRemoteGateway {
         authorizationHeader: String,
         request: CloudFeedbackSubmissionRequest
     ): CloudFeedbackState
+    suspend fun loadMediaAssetDownloadUrl(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl
 
     suspend fun deleteAccount(apiBaseUrl: String, bearerToken: String, confirmationText: String)
     suspend fun listAgentConnections(apiBaseUrl: String, bearerToken: String): AgentApiKeyConnectionsResult

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
@@ -6,6 +6,7 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.auth.CloudAuthRemoteA
 import com.flashcardsopensourceapp.data.local.cloud.remote.community.CloudCommunityProfileRemoteApi
 import com.flashcardsopensourceapp.data.local.cloud.remote.feedback.CloudFeedbackRemoteApi
 import com.flashcardsopensourceapp.data.local.cloud.remote.guest.CloudGuestUpgradeRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.CloudMediaAssetRemoteApi
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.CloudProgressRemoteApi
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.CloudSyncRemoteApi
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
@@ -25,6 +26,7 @@ import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackSubmissionRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
@@ -90,6 +92,7 @@ class CloudRemoteService private constructor(
     private val progressApi = CloudProgressRemoteApi(httpClient = httpClient)
     private val communityProfileApi = CloudCommunityProfileRemoteApi(httpClient = httpClient)
     private val feedbackApi = CloudFeedbackRemoteApi(httpClient = httpClient)
+    private val mediaAssetApi = CloudMediaAssetRemoteApi(httpClient = httpClient)
     private val agentConnectionApi = CloudAgentConnectionRemoteApi(httpClient = httpClient)
     private val syncApi = CloudSyncRemoteApi(httpClient = httpClient)
 
@@ -405,6 +408,20 @@ class CloudRemoteService private constructor(
             apiBaseUrl = apiBaseUrl,
             authorizationHeader = authorizationHeader,
             request = request
+        )
+    }
+
+    override suspend fun loadMediaAssetDownloadUrl(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl {
+        return mediaAssetApi.loadMediaAssetDownloadUrl(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            mediaAssetId = mediaAssetId
         )
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/media/CloudMediaAssetRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/media/CloudMediaAssetRemoteApi.kt
@@ -1,0 +1,90 @@
+package com.flashcardsopensourceapp.data.local.cloud.remote.media
+
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildMediaAssetDownloadUrlCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudIsoTimestampMillis
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudLong
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableIsoTimestampMillis
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableString
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudObject
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
+import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import org.json.JSONObject
+
+private const val mediaAssetDownloadHttpMethod: String = "GET"
+
+internal class CloudMediaAssetRemoteApi(
+    private val httpClient: CloudJsonHttpClient
+) {
+    suspend fun loadMediaAssetDownloadUrl(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl {
+        val response = httpClient.getJson(
+            baseUrl = apiBaseUrl,
+            path = buildMediaAssetDownloadUrlCloudPath(
+                workspaceId = workspaceId,
+                mediaAssetId = mediaAssetId
+            ),
+            authorizationHeader = authorizationHeader
+        )
+        return parseMediaAssetDownloadUrlResponse(
+            response = response,
+            fieldPath = "mediaAssetDownloadUrl"
+        )
+    }
+}
+
+internal fun parseMediaAssetDownloadUrlResponse(
+    response: JSONObject,
+    fieldPath: String
+): MediaAssetDownloadUrl {
+    val mediaAsset = parseCloudMediaAsset(
+        mediaAsset = response.requireCloudObject("mediaAsset", "$fieldPath.mediaAsset"),
+        fieldPath = "$fieldPath.mediaAsset"
+    )
+    val download = response.requireCloudObject("download", "$fieldPath.download")
+    val method = download.requireCloudString("method", "$fieldPath.download.method")
+    if (method != mediaAssetDownloadHttpMethod) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath.download.method: " +
+                "expected \"$mediaAssetDownloadHttpMethod\", got invalid string \"$method\""
+        )
+    }
+
+    return MediaAssetDownloadUrl(
+        mediaAsset = mediaAsset,
+        url = download.requireCloudString("url", "$fieldPath.download.url"),
+        expiresAtMillis = download.requireCloudIsoTimestampMillis("expiresAt", "$fieldPath.download.expiresAt")
+    )
+}
+
+private fun parseCloudMediaAsset(
+    mediaAsset: JSONObject,
+    fieldPath: String
+): MediaAsset {
+    return MediaAsset(
+        mediaAssetId = mediaAsset.requireCloudString("mediaAssetId", "$fieldPath.mediaAssetId"),
+        workspaceId = mediaAsset.requireCloudString("workspaceId", "$fieldPath.workspaceId"),
+        mimeType = mediaAsset.requireCloudString("mimeType", "$fieldPath.mimeType"),
+        sizeBytes = mediaAsset.requireCloudLong("sizeBytes", "$fieldPath.sizeBytes"),
+        sha256 = mediaAsset.requireCloudString("sha256", "$fieldPath.sha256"),
+        sourceUrl = mediaAsset.requireCloudNullableString("sourceUrl", "$fieldPath.sourceUrl"),
+        createdAtMillis = mediaAsset.requireCloudIsoTimestampMillis("createdAt", "$fieldPath.createdAt"),
+        clientUpdatedAtMillis = mediaAsset.requireCloudIsoTimestampMillis(
+            "clientUpdatedAt",
+            "$fieldPath.clientUpdatedAt"
+        ),
+        lastModifiedByReplicaId = mediaAsset.requireCloudString(
+            "lastModifiedByReplicaId",
+            "$fieldPath.lastModifiedByReplicaId"
+        ),
+        lastOperationId = mediaAsset.requireCloudString("lastOperationId", "$fieldPath.lastOperationId"),
+        updatedAtMillis = mediaAsset.requireCloudIsoTimestampMillis("updatedAt", "$fieldPath.updatedAt"),
+        deletedAtMillis = mediaAsset.requireCloudNullableIsoTimestampMillis("deletedAt", "$fieldPath.deletedAt")
+    )
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
@@ -91,6 +91,34 @@ private val expectedCloudHttpFailureCodes: Set<String> = setOf(
     "GUEST_WEB_SYNC_UNSUPPORTED",
     "INVALID_EMAIL",
     "INVALID_REQUEST",
+    "MEDIA_ASSET_ALREADY_REGISTERED",
+    "MEDIA_ASSET_DUPLICATE_PART_NUMBER",
+    "MEDIA_ASSET_ID_CONFLICT",
+    "MEDIA_ASSET_ID_INVALID",
+    "MEDIA_ASSET_ID_REQUIRED",
+    "MEDIA_ASSET_NOT_FOUND",
+    "MEDIA_ASSET_PART_COUNT_INVALID",
+    "MEDIA_ASSET_PART_COUNT_MISMATCH",
+    "MEDIA_ASSET_PART_NUMBER_INVALID",
+    "MEDIA_ASSET_PART_NUMBER_OUT_OF_RANGE",
+    "MEDIA_ASSET_PART_SEQUENCE_INVALID",
+    "MEDIA_ASSET_PART_SIZE_TOO_LARGE",
+    "MEDIA_ASSET_PARTS_REQUIRED",
+    "MEDIA_ASSET_PART_URL_BATCH_TOO_LARGE",
+    "MEDIA_ASSET_REPLICA_INVALID",
+    "MEDIA_ASSET_SIZE_INVALID",
+    "MEDIA_ASSET_SIZE_TOO_LARGE",
+    "MEDIA_ASSET_UPLOAD_MISMATCH",
+    "MEDIA_ASSET_UPLOAD_NOT_FOUND",
+    "MEDIA_ASSET_UPLOAD_PROOF_MISMATCH",
+    "MEDIA_ASSET_UPLOAD_SESSION_ABORTED",
+    "MEDIA_ASSET_UPLOAD_SESSION_COMPLETED",
+    "MEDIA_ASSET_UPLOAD_SESSION_EXPIRED",
+    "MEDIA_ASSET_UPLOAD_SESSION_ID_INVALID",
+    "MEDIA_ASSET_UPLOAD_SESSION_ID_REQUIRED",
+    "MEDIA_ASSET_UPLOAD_SESSION_NOT_FOUND",
+    "MEDIA_ASSET_UPLOAD_SESSION_RECOVERY_FAILED",
+    "MEDIA_ASSET_UPLOAD_SESSION_STATE_CONFLICT",
     "OTP_CHALLENGE_CONSUMED",
     "OTP_CODE_INVALID",
     "OTP_SESSION_EXPIRED",
@@ -677,6 +705,7 @@ private fun cloudObservationEndpointName(path: String): String {
     val normalizedSegments = segments.mapIndexed { index, segment ->
         when {
             index > 0 && segments[index - 1] == "workspaces" -> "{workspaceId}"
+            index > 0 && segments[index - 1] == "media-assets" -> "{mediaAssetId}"
             index > 0 && segments[index - 1] == "agent-api-keys" -> "{connectionId}"
             else -> segment
         }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
@@ -64,6 +64,20 @@ internal fun buildCommunityFriendInvitationsCloudPath(): String {
     return "/me/community/friend-invitations"
 }
 
+internal fun buildMediaAssetDownloadUrlCloudPath(
+    workspaceId: String,
+    mediaAssetId: String
+): String {
+    require(workspaceId.isNotBlank()) {
+        "Media asset download URL path requires a workspace id."
+    }
+    require(mediaAssetId.isNotBlank()) {
+        "Media asset download URL path requires a media asset id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}" +
+        "/media-assets/${encodeCloudPathSegment(value = mediaAssetId)}/download-url"
+}
+
 private fun encodeCloudQueryValue(value: String): String {
     return URLEncoder.encode(value, StandardCharsets.UTF_8)
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
@@ -14,3 +14,9 @@ data class MediaAsset(
     val updatedAtMillis: Long,
     val deletedAtMillis: Long?
 )
+
+data class MediaAssetDownloadUrl(
+    val mediaAsset: MediaAsset,
+    val url: String,
+    val expiresAtMillis: Long
+)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -39,6 +39,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackTrigger
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnection
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnectionsResult
@@ -109,6 +110,8 @@ interface ReviewRepository {
     ): Flow<ReviewSessionSnapshot>
 
     fun observeReviewMediaAssets(): Flow<List<MediaAsset>>
+
+    suspend fun loadReviewMediaAssetDownloadUrl(mediaAssetId: String): MediaAssetDownloadUrl
 
     suspend fun loadReviewTimelinePage(
         selectedFilter: ReviewFilter,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
@@ -14,6 +14,7 @@ import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.data.local.model.cards.DeckSummary
 import com.flashcardsopensourceapp.data.local.model.feedback.FeedbackPromptReviewActivity
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCardQueueStatus
@@ -60,7 +61,8 @@ class LocalReviewRepository(
     private val preferencesStore: CloudPreferencesStore,
     private val syncLocalStore: SyncLocalStore,
     private val localProgressCacheStore: LocalProgressCacheStore,
-    private val timeProvider: TimeProvider
+    private val timeProvider: TimeProvider,
+    private val mediaAssetDownloadUrlLoader: ReviewMediaAssetDownloadUrlLoader
 ) : ReviewRepository {
     override fun observeReviewSession(
         selectedFilter: ReviewFilter,
@@ -245,6 +247,44 @@ class LocalReviewRepository(
                 mediaAssets.map(::toMediaAsset)
             }
         }
+    }
+
+    override suspend fun loadReviewMediaAssetDownloadUrl(mediaAssetId: String): MediaAssetDownloadUrl {
+        val normalizedMediaAssetId = mediaAssetId.trim()
+        require(normalizedMediaAssetId.isNotEmpty()) {
+            "Managed media download requires a media asset id."
+        }
+
+        val workspace: WorkspaceEntity = requireNotNull(
+            loadCurrentWorkspaceOrNull(
+                database = database,
+                preferencesStore = preferencesStore
+            )
+        ) {
+            "Managed media download requires an active workspace."
+        }
+        val mediaAsset: MediaAssetEntity = requireNotNull(
+            database.mediaAssetDao().loadMediaAsset(mediaAssetId = normalizedMediaAssetId)
+        ) {
+            "Cannot load download URL for missing media asset: $normalizedMediaAssetId"
+        }
+        require(mediaAsset.workspaceId == workspace.workspaceId) {
+            "Cannot load media asset '${mediaAsset.mediaAssetId}' from workspace '${mediaAsset.workspaceId}' " +
+                "while current workspace is '${workspace.workspaceId}'."
+        }
+        require(mediaAsset.deletedAtMillis == null) {
+            "Cannot load download URL for deleted media asset: ${mediaAsset.mediaAssetId}"
+        }
+
+        val downloadUrl: MediaAssetDownloadUrl = mediaAssetDownloadUrlLoader.loadMediaAssetDownloadUrl(
+            workspaceId = workspace.workspaceId,
+            mediaAssetId = mediaAsset.mediaAssetId
+        )
+        return validateReviewMediaAssetDownloadUrl(
+            downloadUrl = downloadUrl,
+            mediaAsset = mediaAsset,
+            workspaceId = workspace.workspaceId
+        )
     }
 
     override suspend fun loadReviewTimelinePage(
@@ -476,4 +516,25 @@ private fun toMediaAsset(mediaAsset: MediaAssetEntity): MediaAsset {
         updatedAtMillis = mediaAsset.updatedAtMillis,
         deletedAtMillis = mediaAsset.deletedAtMillis
     )
+}
+
+private fun validateReviewMediaAssetDownloadUrl(
+    downloadUrl: MediaAssetDownloadUrl,
+    mediaAsset: MediaAssetEntity,
+    workspaceId: String
+): MediaAssetDownloadUrl {
+    val responseMediaAsset: MediaAsset = downloadUrl.mediaAsset
+    check(responseMediaAsset.mediaAssetId == mediaAsset.mediaAssetId) {
+        "Media asset download URL response asset mismatch: expected '${mediaAsset.mediaAssetId}' " +
+            "but received '${responseMediaAsset.mediaAssetId}'."
+    }
+    check(responseMediaAsset.workspaceId == workspaceId) {
+        "Media asset download URL response workspace mismatch for asset '${mediaAsset.mediaAssetId}': " +
+            "expected '$workspaceId' but received '${responseMediaAsset.workspaceId}'."
+    }
+    check(responseMediaAsset.deletedAtMillis == null) {
+        "Media asset download URL response returned deleted media asset '${responseMediaAsset.mediaAssetId}' " +
+            "with deletedAtMillis=${responseMediaAsset.deletedAtMillis}."
+    }
+    return downloadUrl.copy(mediaAsset = toMediaAsset(mediaAsset = mediaAsset))
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloadUrlLoader.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloadUrlLoader.kt
@@ -1,0 +1,99 @@
+package com.flashcardsopensourceapp.data.local.repository.review
+
+import com.flashcardsopensourceapp.data.local.ai.store.GuestAiSessionStore
+import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.account.CloudIdentityResetCoordinator
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.guest.loadActiveGuestSessionOrNull
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.AuthenticatedCloudSession
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudOperationCoordinator
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudSessionProvider
+
+interface ReviewMediaAssetDownloadUrlLoader {
+    suspend fun loadMediaAssetDownloadUrl(workspaceId: String, mediaAssetId: String): MediaAssetDownloadUrl
+}
+
+class CloudReviewMediaAssetDownloadUrlLoader(
+    private val preferencesStore: CloudPreferencesStore,
+    private val remoteService: CloudRemoteGateway,
+    private val operationCoordinator: CloudOperationCoordinator,
+    private val guestSessionStore: GuestAiSessionStore,
+    resetCoordinator: CloudIdentityResetCoordinator
+) : ReviewMediaAssetDownloadUrlLoader {
+    private val sessionProvider = CloudSessionProvider(
+        preferencesStore = preferencesStore,
+        remoteService = remoteService,
+        operationCoordinator = operationCoordinator,
+        resetCoordinator = resetCoordinator
+    )
+
+    override suspend fun loadMediaAssetDownloadUrl(
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl {
+        return operationCoordinator.runExclusive {
+            val session = reviewMediaCloudSession(workspaceId = workspaceId)
+            remoteService.loadMediaAssetDownloadUrl(
+                apiBaseUrl = session.apiBaseUrl,
+                authorizationHeader = session.authorizationHeader,
+                workspaceId = workspaceId,
+                mediaAssetId = mediaAssetId
+            )
+        }
+    }
+
+    private suspend fun reviewMediaCloudSession(workspaceId: String): ReviewMediaCloudSession {
+        val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+        val activeWorkspaceId = cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId
+        require(activeWorkspaceId == workspaceId) {
+            "Managed media download requires active workspace '$workspaceId', " +
+                "but cloud settings point to '$activeWorkspaceId'."
+        }
+
+        return when (cloudSettings.cloudState) {
+            CloudAccountState.LINKED -> {
+                val authenticatedSession: AuthenticatedCloudSession = sessionProvider.authenticatedSession()
+                ReviewMediaCloudSession(
+                    apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
+                    authorizationHeader = "Bearer ${authenticatedSession.credentials.idToken}"
+                )
+            }
+
+            CloudAccountState.GUEST -> {
+                val configuration: CloudServiceConfiguration = preferencesStore.currentServerConfiguration()
+                val guestSession: StoredGuestAiSession = requireNotNull(
+                    loadActiveGuestSessionOrNull(
+                        preferencesStore = preferencesStore,
+                        guestSessionStore = guestSessionStore,
+                        configuration = configuration
+                    )
+                ) {
+                    "Managed media download requires an active guest session."
+                }
+                require(guestSession.workspaceId == workspaceId) {
+                    "Managed media download requires guest workspace '$workspaceId', " +
+                        "but the stored guest session points to '${guestSession.workspaceId}'."
+                }
+                ReviewMediaCloudSession(
+                    apiBaseUrl = guestSession.apiBaseUrl,
+                    authorizationHeader = "Guest ${guestSession.guestToken}"
+                )
+            }
+
+            CloudAccountState.DISCONNECTED,
+            CloudAccountState.LINKING_READY -> throw IllegalStateException(
+                "Managed media download requires a linked or guest cloud account."
+            )
+        }
+    }
+}
+
+private data class ReviewMediaCloudSession(
+    val apiBaseUrl: String,
+    val authorizationHeader: String
+)

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -4,6 +4,7 @@ import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRe
 import com.flashcardsopensourceapp.data.local.cloud.remote.community.buildCloudFriendInvitationCreateRequest
 import com.flashcardsopensourceapp.data.local.cloud.remote.community.parseCloudFriendInvitationCreateResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.guest.buildGuestUpgradeCompleteRequest
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.parseMediaAssetDownloadUrlResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressReviewScheduleResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSeriesResponse
@@ -26,6 +27,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.Instant
 
 class CloudRemoteServiceTest {
     @Test
@@ -96,6 +98,47 @@ class CloudRemoteServiceTest {
         assertEquals(1, parsedResponse.operations.size)
         assertEquals("operation-ignored", parsedResponse.operations.single().operationId)
         assertEquals(null, parsedResponse.operations.single().resultingHotChangeId)
+    }
+
+    @Test
+    fun parseMediaAssetDownloadUrlResponseReadsSignedGetUrl() {
+        val response = JSONObject(
+            """
+            {
+              "mediaAsset": {
+                "mediaAssetId": "media-asset-1",
+                "workspaceId": "workspace-1",
+                "mimeType": "image/png",
+                "sizeBytes": 128,
+                "sha256": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+                "sourceUrl": null,
+                "createdAt": "2026-03-10T09:00:00.000Z",
+                "clientUpdatedAt": "2026-03-10T09:01:00.000Z",
+                "lastModifiedByReplicaId": "device-1",
+                "lastOperationId": "operation-1",
+                "updatedAt": "2026-03-10T09:02:00.000Z",
+                "deletedAt": null
+              },
+              "download": {
+                "method": "GET",
+                "url": "https://media.example.test/media-asset-1",
+                "expiresAt": "2026-03-10T10:00:00.000Z",
+                "rangeRequests": true
+              }
+            }
+            """.trimIndent()
+        )
+
+        val parsedResponse = parseMediaAssetDownloadUrlResponse(
+            response = response,
+            fieldPath = "mediaAssetDownloadUrl"
+        )
+
+        assertEquals("media-asset-1", parsedResponse.mediaAsset.mediaAssetId)
+        assertEquals("workspace-1", parsedResponse.mediaAsset.workspaceId)
+        assertEquals("image/png", parsedResponse.mediaAsset.mimeType)
+        assertEquals("https://media.example.test/media-asset-1", parsedResponse.url)
+        assertEquals(Instant.parse("2026-03-10T10:00:00.000Z").toEpochMilli(), parsedResponse.expiresAtMillis)
     }
 
     @Test

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
@@ -139,6 +139,50 @@ class CloudRemoteHttpClientTest {
             server.stop(0)
         }
     }
+
+    @Test
+    fun mediaAssetDownloadUrlFailureRedactsEndpointIds() = runBlocking {
+        val observability = RecordingCloudHttpObservability()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/workspaces/workspace-1/media-assets/media-asset-1/download-url") { exchange ->
+            writeCloudTestResponse(
+                exchange = exchange,
+                statusCode = 400,
+                body = """{"code":"MEDIA_TEST_UNEXPECTED","message":"Invalid media test request."}""",
+                headers = mapOf("X-Request-Id" to "request-1")
+            )
+        }
+        server.start()
+
+        try {
+            val client = CloudJsonHttpClient(
+                okHttpClient = OkHttpClient(),
+                observability = observability,
+                appVersion = testAppVersion,
+                versionCode = 123
+            )
+            var thrownError: CloudRemoteException? = null
+            try {
+                client.getJson(
+                    baseUrl = "http://127.0.0.1:${server.address.port}",
+                    path = "/workspaces/workspace-1/media-assets/media-asset-1/download-url",
+                    authorizationHeader = null
+                )
+            } catch (error: CloudRemoteException) {
+                thrownError = error
+            }
+
+            val error = thrownError ?: throw AssertionError("Expected CloudRemoteException")
+            assertEquals(400, error.statusCode)
+            val warning = observability.warnings.single()
+            assertTrue(warning is AndroidWarningIssueEvent.HttpUnexpectedClientError)
+            warning as AndroidWarningIssueEvent.HttpUnexpectedClientError
+            assertEquals("/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url", warning.endpointName)
+            assertEquals("request-1", warning.requestId)
+        } finally {
+            server.stop(0)
+        }
+    }
 }
 
 private class RecordingCloudHttpObservability : AppObservability {

--- a/apps/android/feature/review/build.gradle.kts
+++ b/apps/android/feature/review/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.lottie.compose)
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
 
     testImplementation(libs.junit4)
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewPresentation.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewPresentation.kt
@@ -1,11 +1,16 @@
 package com.flashcardsopensourceapp.feature.review
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -13,28 +18,53 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material.icons.outlined.Audiotrack
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.Movie
+import androidx.compose.material.icons.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.review.ReviewAnswerOption
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCardQueueStatus
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 
 /*
  Keep review content presentation heuristics aligned with:
@@ -59,6 +89,9 @@ private val reviewManagedMediaReferenceRegex = Regex(
 )
 private const val reviewManagedMediaSchemePrefix: String = "fcasset:"
 private val reviewManagedMediaIconSize = 22.dp
+private val reviewManagedMediaActionIconSize = 18.dp
+private val reviewManagedMediaImageMinimumHeight = 120.dp
+private val reviewManagedMediaImageMaximumHeight = 360.dp
 
 enum class ReviewContentPresentationMode {
     SHORT_PLAIN,
@@ -126,6 +159,23 @@ private enum class ReviewManagedMediaCategory {
     AUDIO,
     VIDEO,
     ATTACHMENT
+}
+
+private sealed interface ReviewManagedMediaDownloadState {
+    data object Loading : ReviewManagedMediaDownloadState
+
+    data class Ready(
+        val downloadUrl: MediaAssetDownloadUrl
+    ) : ReviewManagedMediaDownloadState
+
+    data object Unavailable : ReviewManagedMediaDownloadState
+}
+
+private enum class ReviewManagedMediaAttachmentActionState {
+    IDLE,
+    OPENING,
+    COPYING,
+    UNAVAILABLE
 }
 
 data class PreparedReviewAnswerOption(
@@ -365,6 +415,7 @@ fun buildReviewPreviewItems(
 @Composable
 fun ReviewRenderedContentView(
     content: ReviewRenderedContent,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     modifier: Modifier = Modifier
 ) {
     when (content) {
@@ -482,7 +533,8 @@ fun ReviewRenderedContentView(
                         }
 
                         is ReviewRichBlock.ManagedMedia -> ReviewManagedMediaPlaceholder(
-                            reference = block.reference
+                            reference = block.reference,
+                            onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
                         )
                     }
                 }
@@ -492,7 +544,10 @@ fun ReviewRenderedContentView(
 }
 
 @Composable
-private fun ReviewManagedMediaPlaceholder(reference: ReviewManagedMediaReference) {
+private fun ReviewManagedMediaPlaceholder(
+    reference: ReviewManagedMediaReference,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl
+) {
     val mediaAsset = reference.mediaAsset
     val category = classifyReviewManagedMediaCategory(
         mimeType = mediaAsset?.mimeType,
@@ -505,6 +560,282 @@ private fun ReviewManagedMediaPlaceholder(reference: ReviewManagedMediaReference
         mediaAsset = mediaAsset,
         categoryLabel = categoryLabel
     )
+    if (isUnavailable) {
+        ReviewManagedMediaPlaceholderRow(
+            label = label,
+            supportingText = stringResource(id = R.string.review_media_unavailable),
+            icon = Icons.Outlined.WarningAmber
+        )
+        return
+    }
+
+    when (category) {
+        ReviewManagedMediaCategory.IMAGE -> ReviewDownloadableManagedMedia(
+            mediaAsset = checkNotNull(mediaAsset),
+            category = category,
+            categoryLabel = categoryLabel,
+            label = label,
+            onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
+        )
+
+        ReviewManagedMediaCategory.ATTACHMENT -> ReviewManagedMediaAttachment(
+            mediaAssetId = checkNotNull(mediaAsset).mediaAssetId,
+            label = label,
+            categoryLabel = categoryLabel,
+            onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
+        )
+
+        ReviewManagedMediaCategory.AUDIO,
+        ReviewManagedMediaCategory.VIDEO -> ReviewManagedMediaPlaceholderRow(
+            label = label,
+            supportingText = categoryLabel,
+            icon = reviewManagedMediaCategoryIcon(category = category)
+        )
+    }
+}
+
+@Composable
+private fun ReviewDownloadableManagedMedia(
+    mediaAsset: MediaAsset,
+    category: ReviewManagedMediaCategory,
+    categoryLabel: String,
+    label: String,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl
+) {
+    val currentLoadManagedMediaDownloadUrl = rememberUpdatedState(newValue = onLoadManagedMediaDownloadUrl)
+    val downloadState by produceState<ReviewManagedMediaDownloadState>(
+        initialValue = ReviewManagedMediaDownloadState.Loading,
+        key1 = mediaAsset.mediaAssetId,
+        key2 = mediaAsset.updatedAtMillis,
+        key3 = mediaAsset.deletedAtMillis
+    ) {
+        value = try {
+            ReviewManagedMediaDownloadState.Ready(
+                downloadUrl = currentLoadManagedMediaDownloadUrl.value(mediaAsset.mediaAssetId)
+            )
+        } catch (error: Throwable) {
+            if (error is CancellationException) {
+                throw error
+            }
+            ReviewManagedMediaDownloadState.Unavailable
+        }
+    }
+
+    when (val state = downloadState) {
+        ReviewManagedMediaDownloadState.Loading -> ReviewManagedMediaPlaceholderRow(
+            label = label,
+            supportingText = stringResource(id = R.string.review_media_loading),
+            icon = reviewManagedMediaCategoryIcon(category = category)
+        )
+
+        ReviewManagedMediaDownloadState.Unavailable -> ReviewManagedMediaPlaceholderRow(
+            label = label,
+            supportingText = stringResource(id = R.string.review_media_unavailable),
+            icon = Icons.Outlined.WarningAmber
+        )
+
+        is ReviewManagedMediaDownloadState.Ready -> when (category) {
+            ReviewManagedMediaCategory.IMAGE -> ReviewManagedMediaImage(
+                label = label,
+                url = state.downloadUrl.url
+            )
+
+            ReviewManagedMediaCategory.ATTACHMENT -> ReviewManagedMediaAttachment(
+                mediaAssetId = mediaAsset.mediaAssetId,
+                label = label,
+                categoryLabel = categoryLabel,
+                onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
+            )
+
+            ReviewManagedMediaCategory.AUDIO,
+            ReviewManagedMediaCategory.VIDEO -> ReviewManagedMediaPlaceholderRow(
+                label = label,
+                supportingText = categoryLabel,
+                icon = reviewManagedMediaCategoryIcon(category = category)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReviewManagedMediaImage(
+    label: String,
+    url: String
+) {
+    val context = LocalContext.current
+    val imageRequest = remember(context, url) {
+        ImageRequest.Builder(context)
+            .data(url)
+            .diskCachePolicy(CachePolicy.DISABLED)
+            .build()
+    }
+    SubcomposeAsyncImage(
+        model = imageRequest,
+        contentDescription = label,
+        contentScale = ContentScale.Fit,
+        loading = {
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = stringResource(id = R.string.review_media_loading),
+                icon = Icons.Outlined.Image,
+                showProgress = true
+            )
+        },
+        error = {
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = stringResource(id = R.string.review_media_unavailable),
+                icon = Icons.Outlined.WarningAmber,
+                showProgress = false
+            )
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(
+                min = reviewManagedMediaImageMinimumHeight,
+                max = reviewManagedMediaImageMaximumHeight
+            )
+            .clip(shape = MaterialTheme.shapes.medium)
+            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
+    )
+}
+
+@Composable
+private fun ReviewManagedMediaImageState(
+    label: String,
+    supportingText: String,
+    icon: ImageVector,
+    showProgress: Boolean
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        if (showProgress) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(reviewManagedMediaIconSize)
+            )
+        } else {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(reviewManagedMediaIconSize)
+            )
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = supportingText,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun ReviewManagedMediaAttachment(
+    mediaAssetId: String,
+    label: String,
+    categoryLabel: String,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl
+) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    val coroutineScope = rememberCoroutineScope()
+    val currentLoadManagedMediaDownloadUrl = rememberUpdatedState(newValue = onLoadManagedMediaDownloadUrl)
+    val currentMediaAssetId = rememberUpdatedState(newValue = mediaAssetId)
+    var actionState by remember(mediaAssetId) {
+        mutableStateOf(value = ReviewManagedMediaAttachmentActionState.IDLE)
+    }
+    var activeActionJob by remember {
+        mutableStateOf<Job?>(value = null)
+    }
+    val clipboardManager = remember(context) {
+        checkNotNull(context.getSystemService(ClipboardManager::class.java)) {
+            "ClipboardManager is not available."
+        }
+    }
+    DisposableEffect(mediaAssetId) {
+        onDispose {
+            activeActionJob?.cancel()
+        }
+    }
+    val isActionRunning = actionState == ReviewManagedMediaAttachmentActionState.OPENING ||
+        actionState == ReviewManagedMediaAttachmentActionState.COPYING
+    val openAttachment = {
+        if (actionState != ReviewManagedMediaAttachmentActionState.OPENING &&
+            actionState != ReviewManagedMediaAttachmentActionState.COPYING
+        ) {
+            val actionMediaAssetId = mediaAssetId
+            activeActionJob?.cancel()
+            actionState = ReviewManagedMediaAttachmentActionState.OPENING
+            activeActionJob = coroutineScope.launch {
+                try {
+                    val downloadUrl: MediaAssetDownloadUrl = currentLoadManagedMediaDownloadUrl.value(
+                        actionMediaAssetId
+                    )
+                    currentCoroutineContext().ensureActive()
+                    if (actionMediaAssetId != currentMediaAssetId.value) {
+                        return@launch
+                    }
+                    uriHandler.openUri(uri = downloadUrl.url)
+                    actionState = ReviewManagedMediaAttachmentActionState.IDLE
+                } catch (error: Throwable) {
+                    if (error is CancellationException) {
+                        if (actionMediaAssetId == currentMediaAssetId.value) {
+                            actionState = ReviewManagedMediaAttachmentActionState.IDLE
+                        }
+                        throw error
+                    }
+                    if (actionMediaAssetId == currentMediaAssetId.value) {
+                        actionState = ReviewManagedMediaAttachmentActionState.UNAVAILABLE
+                    }
+                }
+            }
+        }
+    }
+    val copyAttachmentLink = {
+        if (actionState != ReviewManagedMediaAttachmentActionState.OPENING &&
+            actionState != ReviewManagedMediaAttachmentActionState.COPYING
+        ) {
+            val actionMediaAssetId = mediaAssetId
+            val actionLabel = label
+            activeActionJob?.cancel()
+            actionState = ReviewManagedMediaAttachmentActionState.COPYING
+            activeActionJob = coroutineScope.launch {
+                try {
+                    val downloadUrl: MediaAssetDownloadUrl = currentLoadManagedMediaDownloadUrl.value(
+                        actionMediaAssetId
+                    )
+                    currentCoroutineContext().ensureActive()
+                    if (actionMediaAssetId != currentMediaAssetId.value) {
+                        return@launch
+                    }
+                    clipboardManager.setPrimaryClip(
+                        ClipData.newPlainText(actionLabel, downloadUrl.url)
+                    )
+                    actionState = ReviewManagedMediaAttachmentActionState.IDLE
+                } catch (error: Throwable) {
+                    if (error is CancellationException) {
+                        if (actionMediaAssetId == currentMediaAssetId.value) {
+                            actionState = ReviewManagedMediaAttachmentActionState.IDLE
+                        }
+                        throw error
+                    }
+                    if (actionMediaAssetId == currentMediaAssetId.value) {
+                        actionState = ReviewManagedMediaAttachmentActionState.UNAVAILABLE
+                    }
+                }
+            }
+        }
+    }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -518,11 +849,104 @@ private fun ReviewManagedMediaPlaceholder(reference: ReviewManagedMediaReference
             .padding(12.dp)
     ) {
         Icon(
-            imageVector = if (isUnavailable) {
+            imageVector = if (actionState == ReviewManagedMediaAttachmentActionState.UNAVAILABLE) {
                 Icons.Outlined.WarningAmber
             } else {
-                reviewManagedMediaCategoryIcon(category = category)
+                Icons.Outlined.AttachFile
             },
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(reviewManagedMediaIconSize)
+        )
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.weight(weight = 1f)
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = if (actionState == ReviewManagedMediaAttachmentActionState.UNAVAILABLE) {
+                        stringResource(id = R.string.review_media_unavailable)
+                    } else {
+                        categoryLabel
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                TextButton(
+                    enabled = isActionRunning.not(),
+                    onClick = openAttachment
+                ) {
+                    if (actionState == ReviewManagedMediaAttachmentActionState.OPENING) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(reviewManagedMediaActionIconSize),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Outlined.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.size(reviewManagedMediaActionIconSize)
+                        )
+                    }
+                    Spacer(modifier = Modifier.size(4.dp))
+                    Text(text = stringResource(id = R.string.review_media_open_attachment))
+                }
+                TextButton(
+                    enabled = isActionRunning.not(),
+                    onClick = copyAttachmentLink
+                ) {
+                    if (actionState == ReviewManagedMediaAttachmentActionState.COPYING) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(reviewManagedMediaActionIconSize),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Outlined.ContentCopy,
+                            contentDescription = null,
+                            modifier = Modifier.size(reviewManagedMediaActionIconSize)
+                        )
+                    }
+                    Spacer(modifier = Modifier.size(4.dp))
+                    Text(text = stringResource(id = R.string.review_media_copy_link))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewManagedMediaPlaceholderRow(
+    label: String,
+    supportingText: String,
+    icon: ImageVector
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = MaterialTheme.shapes.medium
+            )
+            .padding(12.dp)
+    ) {
+        Icon(
+            imageVector = icon,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(reviewManagedMediaIconSize)
@@ -538,11 +962,7 @@ private fun ReviewManagedMediaPlaceholder(reference: ReviewManagedMediaReference
                 color = MaterialTheme.colorScheme.onSurface
             )
             Text(
-                text = if (isUnavailable) {
-                    stringResource(id = R.string.review_media_unavailable)
-                } else {
-                    categoryLabel
-                },
+                text = supportingText,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionEvent
@@ -58,6 +59,7 @@ fun ReviewRoute(
     onCreateCard: () -> Unit,
     onCreateCardWithAi: () -> Unit,
     onSwitchToAllCards: () -> Unit,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onRevealAnswer: () -> Unit,
     onRateAgain: () -> Unit,
     onRateHard: () -> Unit,
@@ -229,6 +231,7 @@ fun ReviewRoute(
                 onCreateCard = onCreateCard,
                 onCreateCardWithAi = onCreateCardWithAi,
                 onSwitchToAllCards = onSwitchToAllCards,
+                onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                 onToggleFrontSpeech = {
                     uiState.preparedCurrentCard?.let { currentCard ->
                         reviewSpeechController.toggleSpeech(

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -11,6 +11,7 @@ import com.flashcardsopensourceapp.core.ui.TransientMessageController
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreenRepository
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
@@ -258,6 +259,10 @@ class ReviewViewModel(
         viewModelScope.launch {
             progressRepository.refreshLeaderboardForReviewShortcut()
         }
+    }
+
+    suspend fun loadManagedMediaDownloadUrl(mediaAssetId: String): MediaAssetDownloadUrl {
+        return reviewRepository.loadReviewMediaAssetDownloadUrl(mediaAssetId = mediaAssetId)
     }
 
     fun handleNotificationPermissionGranted() {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.core.ui.bidiWrap
 import com.flashcardsopensourceapp.core.ui.currentResourceLocale
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 
 private val reviewShowAnswerContentBottomPadding = 120.dp
 private val reviewAnswerGridContentBottomPadding = 184.dp
@@ -78,6 +79,7 @@ internal fun ReviewContent(
     onCreateCard: () -> Unit,
     onCreateCardWithAi: () -> Unit,
     onSwitchToAllCards: () -> Unit,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit,
     contentPadding: PaddingValues
@@ -129,6 +131,7 @@ internal fun ReviewContent(
                                 card.tags
                             )
                         },
+                        onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                         onToggleFrontSpeech = onToggleFrontSpeech,
                         onToggleBackSpeech = onToggleBackSpeech
                     )
@@ -222,6 +225,7 @@ private fun ReviewCardContent(
     activeSpeechSide: ReviewSpeechSide?,
     onOpenCurrentCard: () -> Unit,
     onOpenCurrentCardWithAi: () -> Unit,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit
 ) {
@@ -284,6 +288,7 @@ private fun ReviewCardContent(
                     label = stringResource(id = R.string.review_front_label),
                     content = currentCard.frontContent,
                     contentModifier = Modifier.testTag(reviewCurrentCardFrontContentTag),
+                    onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                     isSpeechPlaying = activeSpeechSide == ReviewSpeechSide.FRONT,
                     onToggleSpeech = onToggleFrontSpeech,
                     showSpeechButton = currentCard.frontSpeakableText.isNotEmpty(),
@@ -296,6 +301,7 @@ private fun ReviewCardContent(
                         label = stringResource(id = R.string.review_back_label),
                         content = currentCard.backContent,
                         contentModifier = Modifier,
+                        onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                         isSpeechPlaying = activeSpeechSide == ReviewSpeechSide.BACK,
                         onToggleSpeech = onToggleBackSpeech,
                         showSpeechButton = currentCard.backSpeakableText.isNotEmpty(),
@@ -338,6 +344,7 @@ private fun ReviewCardSideSection(
     label: String,
     content: ReviewRenderedContent,
     contentModifier: Modifier,
+    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     isSpeechPlaying: Boolean,
     onToggleSpeech: () -> Unit,
     showSpeechButton: Boolean,
@@ -358,6 +365,7 @@ private fun ReviewCardSideSection(
         )
         ReviewRenderedContentView(
             content = content,
+            onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
             modifier = contentModifier
         )
         if (showSpeechButton || showAiButton) {

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -60,7 +60,10 @@
     <string name="review_speech_unavailable">Speech is unavailable on this device.</string>
     <string name="review_media_attachment_label">Attachment</string>
     <string name="review_media_audio_label">Audio attachment</string>
+    <string name="review_media_copy_link">Copy link</string>
     <string name="review_media_image_label">Managed image</string>
+    <string name="review_media_loading">Loading media...</string>
+    <string name="review_media_open_attachment">Open</string>
     <string name="review_media_unavailable">Media unavailable</string>
     <string name="review_media_video_label">Video attachment</string>
     <string name="review_no_back_text">No back text</string>

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ lifecycle = "2.10.0"
 navigationCompose = "2.9.8"
 composeBom = "2026.06.00"
 lottieCompose = "6.7.1"
+coil = "3.5.0"
 room = "2.8.4"
 work = "2.11.2"
 adaptive = "1.2.0"
@@ -52,6 +53,8 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-compose-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive", version.ref = "adaptive" }
 androidx-compose-adaptive-navigation-suite = { group = "androidx.compose.material3", name = "material3-adaptive-navigation-suite", version.ref = "adaptiveNavigationSuite" }
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottieCompose" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary
- Add Android media asset signed download-url client path for review rendering.
- Render managed images from signed URLs with Coil disk caching disabled.
- Add attachment open/copy actions that fetch fresh validated URLs at action time.
- Keep deleted/unavailable media on warning placeholders and audio/video as typed placeholders.

## Validation
- `git --no-pager diff --check`
- `xmllint --noout apps/android/feature/review/src/main/res/values/strings.xml`
- TOML parse check for `apps/android/gradle/libs.versions.toml`
- Source-level whitespace/long-line checks on touched/new Kotlin files
- Worker-owned fresh review: no P0-P4 issues, no split recommendation

Gradle was not run because repository and plan instructions forbid Android Gradle runs unless explicitly approved. Standalone `kotlinc`, `ktlint`, and `detekt` were not available in the worker worktree.
