### PR TITLE
Align progress streak calendar across clients

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
@@ -27,12 +27,12 @@ data class ProgressReviewPageUiState(
 )
 
 data class ProgressStreakDayUiState(
-    val date: LocalDate?,
-    val dayOfMonthLabel: String?,
+    val date: LocalDate,
+    val dayOfMonthLabel: String,
     val reviewCount: Int,
-    val state: CloudProgressStreakDayState?,
+    val state: CloudProgressStreakDayState,
     val isToday: Boolean,
-    val isPlaceholder: Boolean
+    val isFuture: Boolean
 )
 
 data class ProgressStreakWeekUiState(

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -766,12 +766,12 @@ private fun createStreakWeeks(
 
                 if (date.isAfter(today)) {
                     return@map ProgressStreakDayUiState(
-                        date = null,
-                        dayOfMonthLabel = null,
+                        date = date,
+                        dayOfMonthLabel = date.dayOfMonth.toString(),
                         reviewCount = 0,
-                        state = null,
+                        state = CloudProgressStreakDayState.PENDING,
                         isToday = false,
-                        isPlaceholder = true
+                        isFuture = true
                     )
                 }
 
@@ -788,7 +788,7 @@ private fun createStreakWeeks(
                         reviewCount = reviewCount
                     ),
                     isToday = date == today,
-                    isPlaceholder = false
+                    isFuture = false
                 )
             }
         )

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
@@ -286,15 +286,8 @@ private fun StreakDayCell(
     day: ProgressStreakDayUiState,
     modifier: Modifier
 ) {
-    if (day.isPlaceholder) {
-        Box(
-            modifier = modifier.aspectRatio(1f)
-        )
-        return
-    }
-
-    val state = day.state ?: CloudProgressStreakDayState.MISSED
-    val date = checkNotNull(day.date)
+    val state = day.state
+    val date = day.date
     val highlightColor = when {
         state == CloudProgressStreakDayState.REVIEWED -> Color.Transparent
         state == CloudProgressStreakDayState.FROZEN -> Color.Transparent
@@ -304,26 +297,34 @@ private fun StreakDayCell(
     val markerColor = MaterialTheme.colorScheme.primary
     val markerContentColor = MaterialTheme.colorScheme.onPrimary
     val dateTextColor = when {
+        day.isFuture -> MaterialTheme.colorScheme.onSurfaceVariant
         day.isToday -> MaterialTheme.colorScheme.primary
         else -> MaterialTheme.colorScheme.onSurface
     }
-    val contentDescription = when (state) {
-        CloudProgressStreakDayState.REVIEWED -> stringResource(
-            id = R.string.progress_streak_day_reviewed_content_description,
+    val contentDescription = if (day.isFuture) {
+        stringResource(
+            id = R.string.progress_streak_day_future_content_description,
             date.toString()
         )
-        CloudProgressStreakDayState.FROZEN -> stringResource(
-            id = R.string.progress_streak_day_frozen_content_description,
-            date.toString()
-        )
-        CloudProgressStreakDayState.PENDING -> stringResource(
-            id = R.string.progress_streak_day_pending_content_description,
-            date.toString()
-        )
-        CloudProgressStreakDayState.MISSED -> stringResource(
-            id = R.string.progress_streak_day_missed_content_description,
-            date.toString()
-        )
+    } else {
+        when (state) {
+            CloudProgressStreakDayState.REVIEWED -> stringResource(
+                id = R.string.progress_streak_day_reviewed_content_description,
+                date.toString()
+            )
+            CloudProgressStreakDayState.FROZEN -> stringResource(
+                id = R.string.progress_streak_day_frozen_content_description,
+                date.toString()
+            )
+            CloudProgressStreakDayState.PENDING -> stringResource(
+                id = R.string.progress_streak_day_pending_content_description,
+                date.toString()
+            )
+            CloudProgressStreakDayState.MISSED -> stringResource(
+                id = R.string.progress_streak_day_missed_content_description,
+                date.toString()
+            )
+        }
     }
 
     Box(
@@ -415,14 +416,12 @@ private fun DateStreakMarker(
             .then(todayOutlineModifier),
         contentAlignment = Alignment.Center
     ) {
-        day.dayOfMonthLabel?.let { dayOfMonthLabel ->
-            Text(
-                text = dayOfMonthLabel,
-                color = dateTextColor,
-                fontWeight = if (day.isToday) FontWeight.SemiBold else FontWeight.Normal,
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
+        Text(
+            text = day.dayOfMonthLabel,
+            color = dateTextColor,
+            fontWeight = if (day.isToday) FontWeight.SemiBold else FontWeight.Normal,
+            style = MaterialTheme.typography.bodyMedium
+        )
     }
 }
 

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="progress_streak_freeze_bank_info_dismiss">OK</string>
     <string name="progress_streak_day_reviewed_content_description">%1$s reviewed.</string>
     <string name="progress_streak_day_frozen_content_description">%1$s protected by a streak freeze.</string>
+    <string name="progress_streak_day_future_content_description">%1$s future day.</string>
     <string name="progress_streak_day_pending_content_description">%1$s pending.</string>
     <string name="progress_streak_day_missed_content_description">%1$s missed.</string>
     <string name="progress_reviews_title">Reviews</string>

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressStreakSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressStreakSection.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 
-private let progressCalendarColumnCount: Int = 7
 private let progressReviewCardsStringsTableName: String = "ReviewCards"
 private let progressStreakBadgeSize: CGFloat = 34
 private let progressStreakBadgeHorizontalPadding: CGFloat = 8
+private let progressStreakCalendarColumnSpacing: CGFloat = 10
+private let progressStreakCalendarHeaderSpacing: CGFloat = 10
+private let progressStreakCalendarWeekSpacing: CGFloat = 12
 private let progressFrozenStreakBorderColor = Color(red: 0x9D / 255, green: 0xD8 / 255, blue: 0xFF / 255)
 private let progressFrozenStreakContentColor = Color(red: 0x2A / 255, green: 0x7F / 255, blue: 0xC2 / 255)
 
@@ -15,16 +17,8 @@ struct ProgressStreakSection: View {
 
     @State private var isFreezeInfoAlertPresented: Bool = false
 
-    private var columns: [GridItem] {
-        Array(repeating: GridItem(.flexible(), spacing: 10, alignment: .center), count: progressCalendarColumnCount)
-    }
-
     private var headerDays: [ProgressCalendarDay] {
         self.weeks.first?.days ?? []
-    }
-
-    private var streakDays: [ProgressCalendarDay] {
-        self.weeks.flatMap(\.days)
     }
 
     var body: some View {
@@ -40,20 +34,11 @@ struct ProgressStreakSection: View {
                 Spacer(minLength: 0)
             }
 
-            LazyVGrid(columns: self.columns, spacing: 12) {
-                ForEach(self.headerDays) { day in
-                    Text(progressWeekdayLabel(date: day.date, calendar: self.calendar))
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .accessibilityHidden(true)
-                }
-
-                ForEach(self.streakDays) { day in
-                    ProgressStreakDayCell(day: day, calendar: self.calendar)
-                        .frame(maxWidth: .infinity)
-                }
-            }
+            ProgressStreakCalendarGrid(
+                headerDays: self.headerDays,
+                weeks: self.weeks,
+                calendar: self.calendar
+            )
         }
         .padding(.vertical, 4)
         .alert(
@@ -97,6 +82,50 @@ struct ProgressStreakSection: View {
             self.streakFreeze.nextCreditProgressUnits.formatted(),
             self.streakFreeze.nextCreditRequiredUnits.formatted()
         )
+    }
+}
+
+private struct ProgressStreakCalendarGrid: View {
+    let headerDays: [ProgressCalendarDay]
+    let weeks: [ProgressCalendarWeek]
+    let calendar: Calendar
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: progressStreakCalendarHeaderSpacing) {
+            HStack(spacing: progressStreakCalendarColumnSpacing) {
+                ForEach(self.headerDays) { day in
+                    Text(progressWeekdayLabel(date: day.date, calendar: self.calendar))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .accessibilityHidden(true)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: progressStreakCalendarWeekSpacing) {
+                ForEach(self.weeks) { week in
+                    ProgressStreakWeekRow(week: week, calendar: self.calendar)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ProgressStreakWeekRow: View {
+    let week: ProgressCalendarWeek
+    let calendar: Calendar
+
+    var body: some View {
+        HStack(spacing: progressStreakCalendarColumnSpacing) {
+            ForEach(self.week.days) { day in
+                ProgressStreakDayCell(day: day, calendar: self.calendar)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -235,11 +264,7 @@ private struct ProgressStreakDayCell: View {
             Circle()
                 .stroke(self.borderColor, lineWidth: self.borderLineWidth)
 
-            if self.day.isFuturePlaceholder {
-                Circle()
-                    .fill(Color(uiColor: .tertiarySystemGroupedBackground))
-                    .frame(width: 8, height: 8)
-            } else if self.isActiveFlameDay {
+            if self.isActiveFlameDay {
                 Image(systemName: "flame.fill")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(self.foregroundColor)
@@ -256,7 +281,6 @@ private struct ProgressStreakDayCell: View {
         }
         .frame(width: 38, height: 38)
         .accessibilityElement(children: .ignore)
-        .accessibilityHidden(self.day.isFuturePlaceholder)
         .accessibilityLabel(self.accessibilityLabel)
     }
 
@@ -330,7 +354,15 @@ private struct ProgressStreakDayCell: View {
 
     private var accessibilityLabel: String {
         if self.day.isFuturePlaceholder {
-            return ""
+            let dateTitle = progressCompleteDateLabel(date: self.day.date, calendar: self.calendar)
+            let futureTitle = String(
+                localized: "progress.screen.streak.future_day.accessibility",
+                defaultValue: "Future day",
+                table: progressStringsTableName,
+                comment: "Accessibility label component for a future streak calendar day"
+            )
+
+            return [dateTitle, futureTitle].joined(separator: ", ")
         }
 
         let dateTitle = progressCompleteDateLabel(date: self.day.date, calendar: self.calendar)

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -9264,6 +9264,65 @@
         }
       }
     },
+    "progress.screen.streak.future_day.accessibility" : {
+      "comment" : "Accessibility label component for a future streak calendar day",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يوم مستقبلي"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zukünftiger Tag"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Future day"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Día futuro"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Día futuro"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "भविष्य का दिन"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未来の日"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Будущий день"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未来日期"
+          }
+        }
+      }
+    },
     "progress.screen.streak_leaderboard.day_count.one" : {
       "comment" : "Progress streak leaderboard singular day count",
       "localizations" : {

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -139,6 +139,17 @@ const arCatalog: TranslationCatalog = {
     streakTitle: "السلسلة",
     streakInfoToggleLabel: "حول تجميد السلسلة",
     streakInfo: "رصيد التجميد {{available}}/{{capacity}}. الشحن التالي {{progress}}/{{required}}.",
+    streakDayReviewCount: {
+      one: "مراجعة",
+      other: "مراجعات",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}، تمت المراجعة، {{reviewCount}}.",
+      frozen: "{{date}}، محمي بتجميد السلسلة، {{reviewCount}}.",
+      pending: "{{date}}، قيد الانتظار، {{reviewCount}}.",
+      missed: "{{date}}، فائت، {{reviewCount}}.",
+      future: "{{date}}، يوم مستقبلي.",
+    },
     reviewsTitle: "المراجعات",
     lastThirtyDays: "آخر 30 يومًا",
     empty: "لم تُسجَّل أي مراجعات خلال نطاق الثلاثين يومًا هذا.",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -139,6 +139,17 @@ const deCatalog: TranslationCatalog = {
     streakTitle: "Serie",
     streakInfoToggleLabel: "Über Serien-Frost",
     streakInfo: "Frostbank {{available}}/{{capacity}}. Nächste Aufladung {{progress}}/{{required}}.",
+    streakDayReviewCount: {
+      one: "Wiederholung",
+      other: "Wiederholungen",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}, wiederholt, {{reviewCount}}.",
+      frozen: "{{date}}, durch Serien-Frost geschützt, {{reviewCount}}.",
+      pending: "{{date}}, ausstehend, {{reviewCount}}.",
+      missed: "{{date}}, verpasst, {{reviewCount}}.",
+      future: "{{date}}, zukünftiger Tag.",
+    },
     reviewsTitle: "Wiederholungen",
     lastThirtyDays: "Letzte 30 Tage",
     empty: "Für diesen 30-Tage-Zeitraum wurden keine Wiederholungen erfasst.",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -137,6 +137,17 @@ const enCatalog = {
     streakTitle: "Streak",
     streakInfoToggleLabel: "About streak freezes",
     streakInfo: "Freeze bank {{available}}/{{capacity}}. Next recharge {{progress}}/{{required}}.",
+    streakDayReviewCount: {
+      one: "review",
+      other: "reviews",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}, reviewed, {{reviewCount}}.",
+      frozen: "{{date}}, protected by a streak freeze, {{reviewCount}}.",
+      pending: "{{date}}, pending, {{reviewCount}}.",
+      missed: "{{date}}, missed, {{reviewCount}}.",
+      future: "{{date}}, future day.",
+    },
     reviewsTitle: "Reviews",
     lastThirtyDays: "Last 30 days",
     empty: "No reviews were recorded for this 30-day range.",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -139,6 +139,17 @@ const esEsCatalog: TranslationCatalog = {
     streakTitle: "Racha",
     streakInfoToggleLabel: "Acerca de las congelaciones de racha",
     streakInfo: "Banco de congelaciones {{available}}/{{capacity}}. Próxima recarga {{progress}}/{{required}}.",
+    streakDayReviewCount: {
+      one: "repaso",
+      other: "repasos",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}, repasado, {{reviewCount}}.",
+      frozen: "{{date}}, protegido por una congelación de racha, {{reviewCount}}.",
+      pending: "{{date}}, pendiente, {{reviewCount}}.",
+      missed: "{{date}}, perdido, {{reviewCount}}.",
+      future: "{{date}}, día futuro.",
+    },
     reviewsTitle: "Repasos",
     lastThirtyDays: "Últimos 30 días",
     empty: "No se registraron repasos en este rango de 30 días.",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -139,6 +139,17 @@ const esMxCatalog: TranslationCatalog = {
     streakTitle: "Racha",
     streakInfoToggleLabel: "Acerca de las congelaciones de racha",
     streakInfo: "Banco de congelaciones {{available}}/{{capacity}}. Próxima recarga {{progress}}/{{required}}.",
+    streakDayReviewCount: {
+      one: "repaso",
+      other: "repasos",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}, repasado, {{reviewCount}}.",
+      frozen: "{{date}}, protegido por una congelación de racha, {{reviewCount}}.",
+      pending: "{{date}}, pendiente, {{reviewCount}}.",
+      missed: "{{date}}, perdido, {{reviewCount}}.",
+      future: "{{date}}, día futuro.",
+    },
     reviewsTitle: "Repasos",
     lastThirtyDays: "Últimos 30 días",
     empty: "No se registraron repasos en este rango de 30 días.",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -139,6 +139,17 @@ const hiCatalog: TranslationCatalog = {
     streakTitle: "स्ट्रीक",
     streakInfoToggleLabel: "स्ट्रीक फ़्रीज़ के बारे में",
     streakInfo: "फ़्रीज़ बैंक {{available}}/{{capacity}}। अगला रीचार्ज {{progress}}/{{required}}।",
+    streakDayReviewCount: {
+      one: "रिव्यू",
+      other: "रिव्यू",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}, रिव्यू किया गया, {{reviewCount}}.",
+      frozen: "{{date}}, स्ट्रीक फ़्रीज़ से सुरक्षित, {{reviewCount}}.",
+      pending: "{{date}}, लंबित, {{reviewCount}}.",
+      missed: "{{date}}, छूटा हुआ, {{reviewCount}}.",
+      future: "{{date}}, भविष्य का दिन.",
+    },
     reviewsTitle: "रिव्यू",
     lastThirtyDays: "पिछले 30 दिन",
     empty: "इन 30 दिनों की अवधि में कोई रिव्यू दर्ज नहीं किया गया।",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -139,6 +139,17 @@ export const jaCatalog = {
     streakTitle: "連続日数",
     streakInfoToggleLabel: "連続フリーズについて",
     streakInfo: "フリーズ残数 {{available}}/{{capacity}}。次の回復 {{progress}}/{{required}}。",
+    streakDayReviewCount: {
+      one: "回の復習",
+      other: "回の復習",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}、復習済み、{{reviewCount}}。",
+      frozen: "{{date}}、連続フリーズで保護済み、{{reviewCount}}。",
+      pending: "{{date}}、未完了、{{reviewCount}}。",
+      missed: "{{date}}、未達成、{{reviewCount}}。",
+      future: "{{date}}、未来の日。",
+    },
     reviewsTitle: "復習回数",
     lastThirtyDays: "過去30日間",
     empty: "この30日間では復習が記録されていません。",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -139,6 +139,17 @@ export const ruCatalog = {
     streakTitle: "Серия",
     streakInfoToggleLabel: "О заморозках серии",
     streakInfo: "Запас заморозок {{available}}/{{capacity}}. Следующее пополнение {{progress}}/{{required}}.",
+    streakDayReviewCount: {
+      one: "повторение",
+      other: "повторений",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}, повторено, {{reviewCount}}.",
+      frozen: "{{date}}, защищено заморозкой серии, {{reviewCount}}.",
+      pending: "{{date}}, ожидает повторения, {{reviewCount}}.",
+      missed: "{{date}}, пропущено, {{reviewCount}}.",
+      future: "{{date}}, будущий день.",
+    },
     reviewsTitle: "Повторения",
     lastThirtyDays: "Последние 30 дней",
     empty: "За этот 30-дневный период повторения не были записаны.",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -139,6 +139,17 @@ export const zhHansCatalog = {
     streakTitle: "连续天数",
     streakInfoToggleLabel: "关于连续冻结",
     streakInfo: "冻结额度 {{available}}/{{capacity}}。下次补充 {{progress}}/{{required}}。",
+    streakDayReviewCount: {
+      one: "次复习",
+      other: "次复习",
+    },
+    streakDayAria: {
+      reviewed: "{{date}}，已复习，{{reviewCount}}。",
+      frozen: "{{date}}，已用连续冻结保护，{{reviewCount}}。",
+      pending: "{{date}}，待完成，{{reviewCount}}。",
+      missed: "{{date}}，已错过，{{reviewCount}}。",
+      future: "{{date}}，未来日期。",
+    },
     reviewsTitle: "复习次数",
     lastThirtyDays: "最近 30 天",
     empty: "在这 30 天范围内没有记录到任何复习。",

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -41,7 +41,7 @@ import {
   type ProgressReviewsChartSelection,
 } from "./reviewsChart/progressReviewsChartModel";
 import { ProgressStreakSection, type ProgressStreakSummaryView } from "./streak/ProgressStreakSection";
-import { buildStreakWeeks } from "./streak/progressStreakModel";
+import { buildStreakWeeks, type StreakDay } from "./streak/progressStreakModel";
 
 function sortDailyReviews(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyArray<DailyReviewPoint> {
   return [...dailyReviews].sort((leftDay, rightDay) => leftDay.date.localeCompare(rightDay.date));
@@ -77,7 +77,7 @@ export function ProgressScreen(): ReactElement {
       includeLeaderboard: true,
     },
   });
-  const { locale, matchedBrowserLanguageTag, direction, t, formatDate, formatNumber } = useI18n();
+  const { locale, matchedBrowserLanguageTag, direction, t, formatDate, formatNumber, formatCount } = useI18n();
   const [selectedPageStartLocalDate, setSelectedPageStartLocalDate] = useState<string | null>(null);
   const [reviewsChartSelection, setReviewsChartSelection] = useState<ProgressReviewsChartSelection>({ kind: "none" });
   const [selectedReviewScheduleBucket, setSelectedReviewScheduleBucket] = useState<ProgressReviewScheduleBucketKey | null>(null);
@@ -177,6 +177,42 @@ export function ProgressScreen(): ReactElement {
   const today = progress === null ? "" : progress.to;
   const weekContext = resolveLocaleWeekContext(matchedBrowserLanguageTag ?? locale, locale);
   const streakWeeks = progress === null ? [] : buildStreakWeeks(dailyReviews, progress.streakDays, today, formatDate, weekContext);
+  const formatStreakReviewCount = (reviewCount: number): string => formatCount(reviewCount, {
+    one: t("progressScreen.streakDayReviewCount.one"),
+    other: t("progressScreen.streakDayReviewCount.other"),
+  });
+  const formatProgressStreakDayAriaLabel = (day: StreakDay): string => {
+    if (day.isFuture) {
+      return t("progressScreen.streakDayAria.future", {
+        date: day.title,
+      });
+    }
+
+    const reviewCount = formatStreakReviewCount(day.reviewCount);
+
+    switch (day.state) {
+      case "reviewed":
+        return t("progressScreen.streakDayAria.reviewed", {
+          date: day.title,
+          reviewCount,
+        });
+      case "frozen":
+        return t("progressScreen.streakDayAria.frozen", {
+          date: day.title,
+          reviewCount,
+        });
+      case "pending":
+        return t("progressScreen.streakDayAria.pending", {
+          date: day.title,
+          reviewCount,
+        });
+      case "missed":
+        return t("progressScreen.streakDayAria.missed", {
+          date: day.title,
+          reviewCount,
+        });
+    }
+  };
   const selectedReviewsChartRatingKey = reviewsChartSelection.kind === "rating"
     ? reviewsChartSelection.ratingKey
     : null;
@@ -233,8 +269,6 @@ export function ProgressScreen(): ReactElement {
   const progressStreakSummary: ProgressStreakSummaryView | null = progressSummary === null
     ? null
     : {
-      label: t("reviewScreen.progressBadge.title"),
-      status: reviewProgressBadgeTodayStatus,
       hasReviewedToday: reviewProgressBadge.hasReviewedToday,
       ariaLabel: reviewProgressBadgeAriaLabel,
       formattedStreakValue: formatReviewProgressBadgeValue(reviewProgressBadge.streakDays),
@@ -335,6 +369,7 @@ export function ProgressScreen(): ReactElement {
               isInfoVisible={isStreakInfoVisible}
               onToggleInfo={() => setIsStreakInfoVisible((previous) => previous === false)}
               streakWeeks={streakWeeks}
+              formatDayAriaLabel={formatProgressStreakDayAriaLabel}
             />
 
             <ProgressLeaderboardSection

--- a/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
+++ b/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
@@ -1,22 +1,8 @@
-import type { CSSProperties, ReactElement, Ref } from "react";
+import type { ReactElement, Ref } from "react";
 import { ReviewProgressBadgeIcon, StreakFreezeIcon } from "../../shared/ReviewProgressBadgeIcon";
 import type { StreakDay } from "./progressStreakModel";
 
-const futureStreakDayStyle: Readonly<CSSProperties> = {
-  borderStyle: "dashed",
-  background: "transparent",
-  opacity: 0.64,
-};
-
-const futureStreakMarkerStyle: Readonly<CSSProperties> = {
-  background: "transparent",
-  boxShadow: "inset 0 0 0 1px rgba(255, 255, 255, 0.12)",
-  color: "var(--text-tertiary)",
-};
-
 export type ProgressStreakSummaryView = Readonly<{
-  label: string;
-  status: string;
   hasReviewedToday: boolean;
   ariaLabel: string;
   formattedStreakValue: string;
@@ -33,16 +19,19 @@ type ProgressStreakSectionProps = Readonly<{
   isInfoVisible: boolean;
   onToggleInfo: () => void;
   streakWeeks: ReadonlyArray<ReadonlyArray<StreakDay>>;
+  formatDayAriaLabel: (day: StreakDay) => string;
 }>;
 
 function ProgressStreakDay(props: Readonly<{
   day: StreakDay;
+  formatDayAriaLabel: (day: StreakDay) => string;
 }>): ReactElement {
-  const { day } = props;
+  const { day, formatDayAriaLabel } = props;
   const dayClassName = [
     "progress-streak-day",
     day.state === "reviewed" ? "progress-streak-day-complete" : "",
     day.state === "frozen" ? "progress-streak-day-frozen" : "",
+    day.isFuture ? "progress-streak-day-future" : "",
     day.isToday && day.state === "pending" ? "progress-streak-day-today" : "",
   ]
     .filter((className) => className !== "")
@@ -53,14 +42,9 @@ function ProgressStreakDay(props: Readonly<{
       className={dayClassName}
       title={day.title}
       data-streak-state={day.isFuture ? "future" : day.state}
-      style={day.isFuture ? futureStreakDayStyle : undefined}
+      aria-label={formatDayAriaLabel(day)}
     >
-      <span className="progress-streak-weekday">{day.weekdayLabel}</span>
-      <span
-        className="progress-streak-marker"
-        aria-hidden="true"
-        style={day.isFuture ? futureStreakMarkerStyle : undefined}
-      >
+      <span className="progress-streak-marker" aria-hidden="true">
         {day.state === "reviewed" ? (
           <span className="progress-streak-marker-flame">
             <ReviewProgressBadgeIcon />
@@ -69,7 +53,7 @@ function ProgressStreakDay(props: Readonly<{
           <span className="progress-streak-marker-freeze">
             <StreakFreezeIcon />
           </span>
-        ) : day.isFuture ? null : (
+        ) : (
           <span className="progress-streak-marker-day-value">{day.dayLabel}</span>
         )}
       </span>
@@ -79,29 +63,62 @@ function ProgressStreakDay(props: Readonly<{
 
 function ProgressStreakSummary(props: Readonly<{
   summary: ProgressStreakSummaryView;
+  infoToggleLabel: string;
+  isInfoVisible: boolean;
+  canShowInfo: boolean;
+  onToggleInfo: () => void;
 }>): ReactElement {
-  const { summary } = props;
+  const { summary, infoToggleLabel, isInfoVisible, canShowInfo, onToggleInfo } = props;
 
   return (
     <div className="progress-streak-summary">
-      <div className="progress-streak-summary-copy">
-        <span className="progress-streak-summary-label">{summary.label}</span>
-        <p className="progress-streak-summary-status">{summary.status}</p>
-      </div>
       <span
-        className={`badge review-progress-badge progress-streak-summary-badge${summary.hasReviewedToday ? " review-progress-badge-active" : ""}`}
+        className={`progress-streak-chip progress-streak-value-chip${summary.hasReviewedToday ? " is-active" : ""}`}
         aria-label={summary.ariaLabel}
         title={summary.ariaLabel}
       >
         <ReviewProgressBadgeIcon />
-        <span className="review-progress-badge-value">
+        <span className="progress-streak-chip-value">
           {summary.formattedStreakValue}
         </span>
-        <span className="review-progress-freeze-indicator" aria-hidden="true">
-          <StreakFreezeIcon />
-          <span className="review-progress-freeze-value">{summary.formattedFreezeValue}</span>
-        </span>
       </span>
+
+      {canShowInfo ? (
+        <button
+          type="button"
+          className="progress-streak-chip progress-streak-freeze-chip"
+          aria-expanded={isInfoVisible}
+          aria-label={infoToggleLabel}
+          title={infoToggleLabel}
+          onClick={onToggleInfo}
+          data-testid="progress-streak-info-toggle"
+        >
+          <StreakFreezeIcon />
+          <span className="progress-streak-chip-value">{summary.formattedFreezeValue}</span>
+          <span className="progress-streak-freeze-info-icon" aria-hidden="true">i</span>
+        </button>
+      ) : (
+        <span className="progress-streak-chip progress-streak-freeze-chip">
+          <StreakFreezeIcon />
+          <span className="progress-streak-chip-value">{summary.formattedFreezeValue}</span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ProgressStreakWeekdayLabels(props: Readonly<{
+  days: ReadonlyArray<StreakDay>;
+}>): ReactElement {
+  const { days } = props;
+
+  return (
+    <div className="progress-streak-weekdays" aria-hidden="true">
+      {days.map((day) => (
+        <span key={`weekday-${day.date}`} className="progress-streak-weekday">
+          {day.weekdayLabel}
+        </span>
+      ))}
     </div>
   );
 }
@@ -117,6 +134,7 @@ export function ProgressStreakSection(props: ProgressStreakSectionProps): ReactE
     isInfoVisible,
     onToggleInfo,
     streakWeeks,
+    formatDayAriaLabel,
   } = props;
 
   return (
@@ -128,21 +146,17 @@ export function ProgressStreakSection(props: ProgressStreakSectionProps): ReactE
     >
       <div className="progress-section-head">
         <h2 className="progress-section-title">{title}</h2>
-        {infoText === null ? null : (
-          <button
-            type="button"
-            className="ghost-btn progress-streak-info-btn"
-            aria-expanded={isInfoVisible}
-            aria-label={infoToggleLabel}
-            onClick={onToggleInfo}
-            data-testid="progress-streak-info-toggle"
-          >
-            <span className="progress-streak-info-icon" aria-hidden="true">i</span>
-          </button>
-        )}
       </div>
 
-      {summary === null ? null : <ProgressStreakSummary summary={summary} />}
+      {summary === null ? null : (
+        <ProgressStreakSummary
+          summary={summary}
+          infoToggleLabel={infoToggleLabel}
+          isInfoVisible={isInfoVisible}
+          canShowInfo={infoText !== null}
+          onToggleInfo={onToggleInfo}
+        />
+      )}
 
       {infoText !== null && isInfoVisible ? (
         <p className="progress-streak-info" data-testid="progress-streak-info">
@@ -150,14 +164,17 @@ export function ProgressStreakSection(props: ProgressStreakSectionProps): ReactE
         </p>
       ) : null}
 
-      <div className="progress-streak-weeks">
-        {streakWeeks.map((week, weekIndex) => (
-          <div key={`streak-week-${weekIndex}`} className="progress-streak-week">
-            {week.map((day) => (
-              <ProgressStreakDay key={day.date} day={day} />
-            ))}
-          </div>
-        ))}
+      <div className="progress-streak-calendar">
+        <ProgressStreakWeekdayLabels days={streakWeeks[0] ?? []} />
+        <div className="progress-streak-weeks">
+          {streakWeeks.map((week, weekIndex) => (
+            <div key={`streak-week-${weekIndex}`} className="progress-streak-week">
+              {week.map((day) => (
+                <ProgressStreakDay key={day.date} day={day} formatDayAriaLabel={formatDayAriaLabel} />
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/apps/web/src/styles/features/progress/leaderboard.css
+++ b/apps/web/src/styles/features/progress/leaderboard.css
@@ -5,7 +5,6 @@
   gap: 8px;
 }
 
-.progress-streak-info-btn,
 .progress-leaderboard-info-btn {
   min-width: 34px;
   padding: 0 10px;
@@ -19,7 +18,6 @@
   width: 100%;
 }
 
-.progress-streak-info-icon,
 .progress-leaderboard-info-icon {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/styles/features/progress/streak.css
+++ b/apps/web/src/styles/features/progress/streak.css
@@ -1,37 +1,108 @@
 .progress-streak-summary {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
-.progress-streak-summary-badge {
+.progress-streak-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   min-height: 34px;
-}
-
-.progress-streak-summary-copy {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
-
-.progress-streak-summary-label {
+  padding: 0 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-pill);
+  background: var(--surface-hover);
   color: var(--text-secondary);
+  font: inherit;
   font-size: 13px;
-  font-weight: 600;
+  line-height: 1;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-decoration: none;
 }
 
-.progress-streak-summary-status {
-  margin: 0;
+button.progress-streak-chip {
+  cursor: pointer;
+}
+
+button.progress-streak-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.progress-streak-chip .review-progress-badge-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.progress-streak-value-chip {
+  border-color: rgba(196, 75, 45, 0.55);
+  color: var(--text);
+}
+
+.progress-streak-value-chip .review-progress-badge-icon {
+  color: var(--accent);
+}
+
+.progress-streak-value-chip:not(.is-active) {
+  border-color: rgba(235, 235, 245, 0.24);
+  color: var(--text-secondary);
+}
+
+.progress-streak-value-chip:not(.is-active) .review-progress-badge-icon {
   color: var(--text-tertiary);
-  font-size: 13px;
-  line-height: 1.3;
+}
+
+.progress-streak-freeze-chip {
+  border-color: rgba(157, 216, 255, 0.78);
+  color: var(--text);
+}
+
+.progress-streak-freeze-chip .streak-freeze-icon {
+  color: #2a7fc2;
+}
+
+.progress-streak-freeze-info-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
+  font-style: italic;
+}
+
+.progress-streak-calendar {
+  display: grid;
+  gap: 10px;
+}
+
+.progress-streak-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.progress-streak-weekday {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-align: center;
 }
 
 .progress-streak-weeks {
   display: grid;
-  gap: 8px;
+  gap: 10px;
 }
 
 .progress-streak-week {
@@ -42,94 +113,53 @@
 
 .progress-streak-day {
   display: grid;
-  justify-items: center;
-  align-content: center;
-  gap: 7px;
-  min-height: 58px;
+  place-items: center;
+  min-height: 42px;
   aspect-ratio: 1;
-  padding: 7px 4px;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--content-card-inner-radius, var(--radius-sm));
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.progress-streak-day-complete {
-  background: var(--accent);
-  border-color: var(--accent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
-}
-
-.progress-streak-day-today {
-  border-color: var(--accent-muted);
-  box-shadow: inset 0 0 0 1px var(--accent-soft);
-  background: var(--accent-soft);
-}
-
-.progress-streak-day-frozen {
-  border-color: rgba(125, 211, 252, 0.45);
-  background: rgba(125, 211, 252, 0.08);
-}
-
-.progress-streak-weekday {
-  color: var(--text-tertiary);
-  font-size: 10px;
-  line-height: 1;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.progress-streak-day-complete .progress-streak-weekday {
-  color: rgba(255, 245, 242, 0.78);
-}
-
-.progress-streak-day-today .progress-streak-weekday {
-  color: var(--accent);
-}
-
-.progress-streak-day-frozen .progress-streak-weekday {
-  color: rgba(191, 234, 255, 0.86);
 }
 
 .progress-streak-marker {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid transparent;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(235, 235, 245, 0.22);
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(235, 235, 245, 0.08);
   color: var(--text);
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1;
-  font-weight: 700;
+  font-weight: 650;
   font-variant-numeric: tabular-nums;
   overflow: hidden;
 }
 
 .progress-streak-day-complete .progress-streak-marker {
-  border-color: rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--accent);
+  background: var(--accent);
   color: #fff5f2;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  box-shadow: none;
 }
 
 .progress-streak-day-today .progress-streak-marker {
-  border-color: rgba(196, 75, 45, 0.2);
-  background: rgba(196, 75, 45, 0.08);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.18),
-    0 0 0 3px var(--accent-soft);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 700;
 }
 
 .progress-streak-day-frozen .progress-streak-marker {
-  border-color: rgba(125, 211, 252, 0.9);
+  border-color: #9dd8ff;
   background: #ffffff;
-  color: #0284c7;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.8),
-    0 0 0 3px rgba(125, 211, 252, 0.14);
+  color: #2a7fc2;
+  box-shadow: none;
+}
+
+.progress-streak-day-future .progress-streak-marker {
+  border-color: rgba(235, 235, 245, 0.14);
+  background: transparent;
+  color: var(--text-tertiary);
 }
 
 .progress-streak-marker-flame,
@@ -138,18 +168,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 100%;
 }
 
 .progress-streak-marker-flame .review-progress-badge-icon {
-  width: 15px;
-  height: 15px;
+  width: 17px;
+  height: 17px;
 }
 
 .progress-streak-marker-freeze .review-progress-badge-icon {
-  width: 15px;
-  height: 15px;
+  width: 18px;
+  height: 18px;
 }
 
 .progress-streak-marker-day-value {
@@ -157,46 +185,53 @@
 }
 
 @media (max-width: 768px) {
+  .progress-streak-calendar,
+  .progress-streak-weeks {
+    gap: 10px;
+  }
+
   .progress-streak-week {
-    gap: 8px;
+    gap: 6px;
   }
 
   .progress-streak-day {
-    min-height: 54px;
-    gap: 6px;
-    padding: 10px 4px;
+    min-height: 38px;
   }
 }
 
 @container progress-section (max-width: 440px) {
-  .progress-streak-weeks,
-  .progress-streak-week {
+  .progress-streak-calendar,
+  .progress-streak-weeks {
     gap: 6px;
   }
 
+  .progress-streak-weekdays,
+  .progress-streak-week {
+    gap: 5px;
+  }
+
   .progress-streak-day {
-    min-height: 44px;
-    gap: 4px;
-    padding: 5px 3px;
+    min-height: 32px;
   }
 
   .progress-streak-weekday {
-    font-size: 9px;
+    font-size: 11px;
   }
 
   .progress-streak-marker {
-    width: 22px;
-    height: 22px;
+    width: 30px;
+    height: 30px;
     font-size: 12px;
   }
 
   .progress-streak-marker-flame .review-progress-badge-icon {
-    width: 12px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
   }
 
   .progress-streak-marker-freeze .review-progress-badge-icon {
-    width: 12px;
-    height: 12px;
+    width: 15px;
+    height: 15px;
   }
+
 }


### PR DESCRIPTION
## Summary
- align the web progress streak calendar closer to the iOS presentation
- show future day-of-month numbers instead of dot/empty placeholders across web, iOS, and Android
- add localized accessibility labels for future/streak days

## Validation
- npm exec -- vitest run src/screens/progress/ProgressScreen.test.ts src/screens/progress/ProgressScreen.shell.render.test.tsx
- npm run build
- jq empty apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
- xmllint --noout apps/android/feature/progress/src/main/res/values/strings.xml
- git diff --check

## Notes
- Android Gradle and iOS simulator-backed checks were not run locally per repository policy.