### PR TITLE
Add media blob normalization version plumbing

### DIFF
--- a/apps/backend/src/mediaAssets/index.test.ts
+++ b/apps/backend/src/mediaAssets/index.test.ts
@@ -6,6 +6,7 @@ import { HttpError } from "../shared/errors";
 import {
   beginMediaAssetUploadSessionCompletionInExecutor,
   mapMediaAssetRow,
+  mapMediaBlobRow,
   recoverMediaAssetUploadSessionCompletionInExecutor,
   upsertMediaAssetSnapshotInExecutor,
 } from ".";
@@ -14,6 +15,7 @@ import {
   buildMediaMultipartUploadStagingStorageKey,
   buildMediaUploadStagingStorageKey,
 } from "./storageKeys";
+import { passthroughMediaBlobNormalizationVersion } from "./types";
 import {
   maximumMultipartUploadBytes,
   maximumSinglePutUploadBytes,
@@ -67,6 +69,7 @@ function createMediaBlobRow(fixture: Readonly<{
     size_bytes: fixture.sizeBytes,
     sha256: fixture.sha256,
     storage_key: fixture.storageKey,
+    normalization_version: passthroughMediaBlobNormalizationVersion,
     created_at: "2026-02-28T09:00:00.000Z",
     updated_at: "2026-02-28T09:00:00.000Z",
   };
@@ -84,6 +87,7 @@ function createMediaAssetRow(fixture: MediaAssetMutationFixture & Readonly<{
     size_bytes: fixture.mediaBlob.size_bytes,
     sha256: fixture.mediaBlob.sha256,
     storage_key: fixture.mediaBlob.storage_key,
+    blob_normalization_version: fixture.mediaBlob.normalization_version,
     blob_created_at: fixture.mediaBlob.created_at,
     blob_updated_at: fixture.mediaBlob.updated_at,
     source_url: fixture.sourceUrl,
@@ -376,12 +380,14 @@ function createDuplicateBlobExecutor(): Readonly<{
       }
 
       if (text.startsWith("INSERT INTO content.media_blobs")) {
+        assert.match(text, /normalization_version/);
         const sha256 = String(params[0]);
         const existingBlob = blobRowsBySha256.get(sha256);
         if (existingBlob !== undefined) {
           return createQueryResult<Row>([]);
         }
 
+        assert.equal(params[4], passthroughMediaBlobNormalizationVersion);
         const mediaBlob = createMediaBlobRow({
           mediaBlobId: testMediaBlobId,
           mimeType: String(params[1]),
@@ -584,6 +590,19 @@ test("mapMediaAssetRow omits backend-only blob storage fields from public media 
   assert.equal(mediaAsset.sha256, testSha256);
   assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "storageKey"), false);
   assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "mediaBlobId"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "normalizationVersion"), false);
+});
+
+test("mapMediaBlobRow exposes backend-only blob normalization version", () => {
+  const mediaBlob = mapMediaBlobRow(createMediaBlobRow({
+    mediaBlobId: testMediaBlobId,
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: testSha256,
+    storageKey: testStorageKey,
+  }));
+
+  assert.equal(mediaBlob.normalizationVersion, passthroughMediaBlobNormalizationVersion);
 });
 
 test("upsertMediaAssetSnapshotInExecutor reuses one blob row for duplicate logical assets", async () => {

--- a/apps/backend/src/mediaAssets/index.ts
+++ b/apps/backend/src/mediaAssets/index.ts
@@ -20,11 +20,16 @@ import {
   findSyncConflictWorkspaceIdInExecutor,
 } from "../sync/conflicts/fork";
 import { buildMediaBlobStorageKey } from "./storageKeys";
+import {
+  mediaBlobNormalizationVersions,
+  passthroughMediaBlobNormalizationVersion,
+} from "./types";
 import type {
   CompleteMediaAssetUploadInput,
   MediaAsset,
   MediaAssetWithBlob,
   MediaBlob,
+  MediaBlobNormalizationVersion,
   MediaBlobRow,
   MediaAssetMutationMetadata,
   MediaAssetMutationResult,
@@ -50,6 +55,7 @@ export const MEDIA_ASSET_COLUMNS = [
   "media_blobs.size_bytes AS size_bytes",
   "media_blobs.sha256 AS sha256",
   "media_blobs.storage_key AS storage_key",
+  "media_blobs.normalization_version AS blob_normalization_version",
   "media_blobs.created_at AS blob_created_at",
   "media_blobs.updated_at AS blob_updated_at",
   "media_assets.source_url AS source_url",
@@ -73,6 +79,7 @@ const MEDIA_BLOB_COLUMNS = [
   "size_bytes",
   "sha256",
   "storage_key",
+  "normalization_version",
   "created_at",
   "updated_at",
 ].join(", ");
@@ -126,6 +133,15 @@ function toSafeNumber(value: string | number, fieldName: string): number {
   return parsedValue;
 }
 
+function expectMediaBlobNormalizationVersion(value: string): MediaBlobNormalizationVersion {
+  const version = mediaBlobNormalizationVersions.find((knownVersion) => knownVersion === value);
+  if (version === undefined) {
+    throw new Error(`normalization_version is unsupported: ${value}`);
+  }
+
+  return version;
+}
+
 export function mapMediaAssetRow(row: MediaAssetRow): MediaAsset {
   return {
     mediaAssetId: row.media_asset_id,
@@ -150,6 +166,7 @@ export function mapMediaBlobRow(row: MediaBlobRow): MediaBlob {
     sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
     sha256: row.sha256,
     storageKey: row.storage_key,
+    normalizationVersion: expectMediaBlobNormalizationVersion(row.normalization_version),
     createdAt: toIsoString(row.created_at),
     updatedAt: toIsoString(row.updated_at),
   };
@@ -190,6 +207,7 @@ function mapMediaAssetWithBlobRow(row: MediaAssetRow): MediaAssetWithBlob {
       sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
       sha256: row.sha256,
       storageKey: row.storage_key,
+      normalizationVersion: expectMediaBlobNormalizationVersion(row.blob_normalization_version),
       createdAt: toIsoString(row.blob_created_at),
       updatedAt: toIsoString(row.blob_updated_at),
     },
@@ -448,6 +466,7 @@ async function findReachableMediaBlobForUploadSessionCreateInExecutor(
         "media_blobs.size_bytes AS size_bytes",
         "media_blobs.sha256 AS sha256",
         "media_blobs.storage_key AS storage_key",
+        "media_blobs.normalization_version AS normalization_version",
         "media_blobs.created_at AS created_at",
         "media_blobs.updated_at AS updated_at",
       ].join(", "),
@@ -477,13 +496,13 @@ async function upsertMediaBlobRowInExecutor(
   const insertResult = await executor.query<MediaBlobRow>(
     [
       "INSERT INTO content.media_blobs",
-      "(media_blob_id, sha256, mime_type, size_bytes, storage_key)",
-      "VALUES (gen_random_uuid(), $1, $2, $3, $4)",
+      "(media_blob_id, sha256, mime_type, size_bytes, storage_key, normalization_version)",
+      "VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)",
       "ON CONFLICT (sha256) DO NOTHING",
       "RETURNING",
       MEDIA_BLOB_COLUMNS,
     ].join(" "),
-    [input.sha256, input.mimeType, input.sizeBytes, storageKey],
+    [input.sha256, input.mimeType, input.sizeBytes, storageKey, passthroughMediaBlobNormalizationVersion],
   );
 
   const insertedRow = insertResult.rows[0];

--- a/apps/backend/src/mediaAssets/types.ts
+++ b/apps/backend/src/mediaAssets/types.ts
@@ -1,5 +1,15 @@
 export type TimestampValue = Date | string;
 
+export const passthroughMediaBlobNormalizationVersion = "passthrough-v1";
+export const imageJpegCardMediaBlobNormalizationVersion = "image-jpeg-card-v1";
+
+export const mediaBlobNormalizationVersions = [
+  passthroughMediaBlobNormalizationVersion,
+  imageJpegCardMediaBlobNormalizationVersion,
+] as const;
+
+export type MediaBlobNormalizationVersion = typeof mediaBlobNormalizationVersions[number];
+
 export type MediaAssetRow = Readonly<{
   media_asset_id: string;
   workspace_id: string;
@@ -8,6 +18,7 @@ export type MediaAssetRow = Readonly<{
   size_bytes: string | number;
   sha256: string;
   storage_key: string;
+  blob_normalization_version: string;
   blob_created_at: TimestampValue;
   blob_updated_at: TimestampValue;
   source_url: string | null;
@@ -40,6 +51,7 @@ export type MediaBlob = Readonly<{
   sizeBytes: number;
   sha256: string;
   storageKey: string;
+  normalizationVersion: MediaBlobNormalizationVersion;
   createdAt: string;
   updatedAt: string;
 }>;
@@ -50,6 +62,7 @@ export type MediaBlobRow = Readonly<{
   size_bytes: string | number;
   sha256: string;
   storage_key: string;
+  normalization_version: string;
   created_at: TimestampValue;
   updated_at: TimestampValue;
 }>;

--- a/apps/backend/src/sync/conflicts/conflict.test.ts
+++ b/apps/backend/src/sync/conflicts/conflict.test.ts
@@ -8,6 +8,7 @@ import { upsertCardSnapshotInExecutor } from "../../cards";
 import type { DatabaseExecutor } from "../../database";
 import { upsertDeckSnapshotInExecutor } from "../../decks";
 import { upsertMediaAssetSnapshotInExecutor } from "../../mediaAssets";
+import { passthroughMediaBlobNormalizationVersion } from "../../mediaAssets/types";
 import { HttpError } from "../../shared/errors";
 import {
   annotateSyncConflictHttpError,
@@ -160,6 +161,7 @@ function createConflictExecutor(
           mime_type: String(params[1]),
           size_bytes: Number(params[2]),
           storage_key: String(params[3]),
+          normalization_version: passthroughMediaBlobNormalizationVersion,
           created_at: "2026-04-24T10:00:00.000Z",
           updated_at: "2026-04-24T10:00:00.000Z",
         } as unknown as Row]);

--- a/apps/backend/src/sync/contracts/input.test.ts
+++ b/apps/backend/src/sync/contracts/input.test.ts
@@ -30,6 +30,7 @@ import {
 } from "./snapshots";
 import type { LegacyEffortLevel } from "./legacyEffort";
 import type { BootstrapProjectionRow } from "./types";
+import { passthroughMediaBlobNormalizationVersion } from "../../mediaAssets/types";
 
 type ReviewEventTimestampFixture = Readonly<{
   clientUpdatedAt: string;
@@ -363,6 +364,7 @@ function createHotPullMediaAssetRow(deletedAt: string | null): MediaAssetRow {
     size_bytes: payload.sizeBytes,
     sha256: payload.sha256,
     storage_key: buildMediaBlobStorageKey(payload.sha256),
+    blob_normalization_version: passthroughMediaBlobNormalizationVersion,
     blob_created_at: payload.createdAt,
     blob_updated_at: payload.updatedAt,
     source_url: payload.sourceUrl,


### PR DESCRIPTION
## Summary
- add backend-internal media blob normalization version constants and row mapping
- select blob normalization_version wherever internal blob rows are mapped
- explicitly create existing passthrough media blobs with normalization_version = passthrough-v1

## Validation
- npm run test --prefix apps/backend -- mediaAssets (573 tests)
- npm run lint --prefix apps/backend
- npm run build --prefix apps/backend
- git --no-pager diff --check

## Review
- worker-owned review: no split recommendation, no P0-P4 findings, green light for commit

Residual risk: local validation shell used Node v25.6.1 while packages declare Node 24.x; checks passed.