### PR TITLE
Fix sharp Lambda bundling architecture

### DIFF
--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -98,13 +98,13 @@ test("API Gateway predeclares media asset image ingestion and binary image bodie
   );
 });
 
-test("Backend API Lambda packages sharp with ARM64 Docker bundling only on the API handler", () => {
+test("Backend API Lambda packages sharp with Docker bundling only on the API handler", () => {
   const apiGatewayPath = resolve(process.cwd(), "lib/gateways/api-gateway.ts");
   const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
 
   assert.match(
     apiGatewaySource,
-    /constructId: "BackendHandler"[\s\S]*architecture: lambda\.Architecture\.ARM_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
+    /constructId: "BackendHandler"[\s\S]*architecture: lambda\.Architecture\.X86_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
   );
   assert.doesNotMatch(
     apiGatewaySource,

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -503,7 +503,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     },
     mediaAssetsBucket: props.mediaAssetsBucket,
     memorySize: 256,
-    architecture: lambda.Architecture.ARM_64,
+    architecture: lambda.Architecture.X86_64,
     bundling: createLambdaBundling({
       nodeModules: ["sharp"],
       forceDockerBundling: true,


### PR DESCRIPTION
## Summary
- keep sharp Docker bundling on the backend API Lambda
- use x86_64 for the API Lambda so GitHub release synth does not need ARM64 Docker emulation
- update the infra guard test to assert the release-safe architecture

## Validation
- npm run test --prefix infra/aws

Fixes the failed AWS/Web Release synth on main run 28364784975.