### PR TITLE
Fix forced Docker bundling hooks

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -231,6 +231,11 @@ jobs:
         if: ${{ needs.changes.outputs.infra_changed == 'true' }}
         run: npm run test --prefix infra/aws
 
+      - name: Set up Docker QEMU for CDK bundling
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Synthesize infra
         working-directory: infra/aws
         env:

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -98,13 +98,21 @@ test("API Gateway predeclares media asset image ingestion and binary image bodie
   );
 });
 
-test("Backend API Lambda packages sharp with Docker bundling only on the API handler", () => {
+test("Backend API Lambda packages sharp with ARM64 Docker bundling only on the API handler", () => {
   const apiGatewayPath = resolve(process.cwd(), "lib/gateways/api-gateway.ts");
   const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
 
   assert.match(
     apiGatewaySource,
-    /constructId: "BackendHandler"[\s\S]*architecture: lambda\.Architecture\.X86_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
+    /constructId: "BackendHandler"[\s\S]*architecture: lambda\.Architecture\.ARM_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /hostPath: resolveFromRepoRoot\(\)[\s\S]*containerPath: dockerBundlingRepoRootPath/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /SENTRY_BACKEND_CLI_PATH: `\$\{dockerBundlingRepoRootPath\}\/apps\/backend\/node_modules\/\.bin\/sentry-cli`/,
   );
   assert.doesNotMatch(
     apiGatewaySource,

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -133,6 +133,15 @@ const browserCorsAllowHeaders = [
 const browserCorsExposeHeaders = [
   "x-request-id",
 ] as const;
+const dockerBundlingRepoRootPath = "/asset-repo-root";
+type DockerBundlingEnvironmentVariableName =
+  | "GITHUB_ACTIONS"
+  | "SENTRY_AUTH_TOKEN"
+  | "SENTRY_BACKEND_CLI_PATH"
+  | "SENTRY_ORG"
+  | "SENTRY_PROJECT"
+  | "SENTRY_RELEASE"
+  | "SENTRY_UPLOAD_BACKEND_SOURCEMAPS";
 
 const gatewayErrorCorsExposeHeaders = [
   ...browserCorsExposeHeaders,
@@ -179,24 +188,52 @@ export function createGatewayErrorResponseHeaders(): GatewayErrorResponseHeaders
   };
 }
 
+function createDockerBundlingEnvironment(): Record<DockerBundlingEnvironmentVariableName, string> {
+  return {
+    GITHUB_ACTIONS: process.env.GITHUB_ACTIONS ?? "",
+    SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN ?? "",
+    SENTRY_BACKEND_CLI_PATH: `${dockerBundlingRepoRootPath}/apps/backend/node_modules/.bin/sentry-cli`,
+    SENTRY_ORG: process.env.SENTRY_ORG ?? "",
+    SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? "",
+    SENTRY_RELEASE: process.env.SENTRY_RELEASE ?? "",
+    SENTRY_UPLOAD_BACKEND_SOURCEMAPS: process.env.SENTRY_UPLOAD_BACKEND_SOURCEMAPS ?? "",
+  };
+}
+
 function createLambdaBundling(
   input: Readonly<{
     nodeModules: ReadonlyArray<string>;
     forceDockerBundling: boolean;
   }>,
 ): lambdaNodejs.BundlingOptions {
+  const openApiDocumentPath = input.forceDockerBundling
+    ? `${dockerBundlingRepoRootPath}/api/dist/openapi.json`
+    : resolveFromRepoRoot("api", "dist", "openapi.json");
+
   return {
     minify: true,
     sourceMap: true,
     ...(input.nodeModules.length === 0 ? {} : { nodeModules: [...input.nodeModules] }),
-    ...(input.forceDockerBundling ? { forceDockerBundling: true } : {}),
+    ...(input.forceDockerBundling
+      ? {
+          forceDockerBundling: true,
+          volumes: [
+            {
+              hostPath: resolveFromRepoRoot(),
+              containerPath: dockerBundlingRepoRootPath,
+              consistency: cdk.DockerVolumeConsistency.CONSISTENT,
+            },
+          ],
+          environment: createDockerBundlingEnvironment(),
+        }
+      : {}),
     commandHooks: {
       beforeBundling: () => [],
       beforeInstall: () => [],
       afterBundling: (_inputDir: string, outputDir: string) => [
         `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
         `mkdir -p ${outputDir}/api/dist`,
-        `cp ${resolveFromRepoRoot("api", "dist", "openapi.json")} ${outputDir}/api/dist/openapi.json`,
+        `cp ${openApiDocumentPath} ${outputDir}/api/dist/openapi.json`,
         createSentrySourceMapUploadCommand(outputDir),
       ],
     },
@@ -503,7 +540,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     },
     mediaAssetsBucket: props.mediaAssetsBucket,
     memorySize: 256,
-    architecture: lambda.Architecture.X86_64,
+    architecture: lambda.Architecture.ARM_64,
     bundling: createLambdaBundling({
       nodeModules: ["sharp"],
       forceDockerBundling: true,

--- a/infra/aws/lib/sentry-source-maps.ts
+++ b/infra/aws/lib/sentry-source-maps.ts
@@ -1,6 +1,6 @@
 import { resolveFromRepoRoot } from "./nodejs-project-paths";
 
-const backendSentryCliPath = resolveFromRepoRoot("apps", "backend", "node_modules", ".bin", "sentry-cli");
+const defaultBackendSentryCliPath = resolveFromRepoRoot("apps", "backend", "node_modules", ".bin", "sentry-cli");
 const sentrySourceMapUploadMaxAttempts = 3;
 
 export function createSentrySourceMapUploadCommand(outputDir: string): string {
@@ -16,10 +16,11 @@ export function createSentrySourceMapUploadCommand(outputDir: string): string {
     `[ -n "$SENTRY_PROJECT" ] || missing_sentry_env="$missing_sentry_env SENTRY_PROJECT";`,
     `[ -n "$SENTRY_RELEASE" ] || missing_sentry_env="$missing_sentry_env SENTRY_RELEASE";`,
     `if [ -n "$missing_sentry_env" ]; then echo "Missing required Sentry source map upload environment variables:$missing_sentry_env" >&2; exit 1; fi;`,
-    `if [ ! -x "${backendSentryCliPath}" ]; then echo "Sentry CLI not found or not executable at ${backendSentryCliPath}. Run npm ci --prefix apps/backend before CDK deploy." >&2; exit 1; fi;`,
+    `backend_sentry_cli_path="\${SENTRY_BACKEND_CLI_PATH:-${defaultBackendSentryCliPath}}";`,
+    `if [ ! -x "$backend_sentry_cli_path" ]; then echo "Sentry CLI not found or not executable at $backend_sentry_cli_path. Run npm ci --prefix apps/backend before CDK deploy." >&2; exit 1; fi;`,
     `run_sentry_command_with_retries() { sentry_command_name="$1"; shift; sentry_attempt=1; while true; do sentry_status=0; "$@" || sentry_status="$?"; if [ "$sentry_status" -eq 0 ]; then return 0; fi; if [ "$sentry_attempt" -ge "${sentrySourceMapUploadMaxAttempts}" ]; then echo "Sentry \${sentry_command_name} failed after \${sentry_attempt} attempts with exit status \${sentry_status}." >&2; return "$sentry_status"; fi; sentry_next_attempt=$((sentry_attempt + 1)); echo "WARNING: Sentry \${sentry_command_name} failed with exit status \${sentry_status}; retrying attempt \${sentry_next_attempt}/${sentrySourceMapUploadMaxAttempts}." >&2; sentry_attempt="$sentry_next_attempt"; sleep "$sentry_attempt"; done; };`,
-    `run_sentry_command_with_retries "source map inject" "${backendSentryCliPath}" sourcemaps inject "${outputDir}" || exit "$?";`,
-    `run_sentry_command_with_retries "source map upload" "${backendSentryCliPath}" sourcemaps upload "${outputDir}" --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --release "$SENTRY_RELEASE" || exit "$?";`,
+    `run_sentry_command_with_retries "source map inject" "$backend_sentry_cli_path" sourcemaps inject "${outputDir}" || exit "$?";`,
+    `run_sentry_command_with_retries "source map upload" "$backend_sentry_cli_path" sourcemaps upload "${outputDir}" --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --release "$SENTRY_RELEASE" || exit "$?";`,
     `fi`,
   ].join(" ");
 }


### PR DESCRIPTION
## Summary
- restore the sharp-enabled API Lambda to ARM64 for the ARM deploy runner
- mount the repo root into forced Docker bundling so the backend bundle can copy api/dist/openapi.json
- pass Sentry upload environment and CLI path into forced Docker bundling
- set up QEMU before pre-deploy synth so the x64 runner can build ARM64 Lambda assets

## Validation
- npm run test --prefix infra/aws

Follow-up to #850 for the AWS/Web Release synth failure.