### PR TITLE
Update agent smoke media paths

### DIFF
--- a/scripts/checks/check-agent-api-smoke.sh
+++ b/scripts/checks/check-agent-api-smoke.sh
@@ -195,6 +195,7 @@ required_paths = {
     "/agent/workspaces/{workspaceId}/select",
     "/agent/sql/query",
     "/agent/sql/execute",
+    "/workspaces/{workspaceId}/media-assets/images",
     "/workspaces/{workspaceId}/media-assets/upload-sessions",
     "/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/parts",
     "/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/complete",


### PR DESCRIPTION
## Summary
- include the image ingestion media route in the agent OpenAPI smoke contract

## Validation
- bash scripts/checks/check-agent-api-smoke.sh

Follow-up to #851: the deployed API was healthy, but the post-deploy agent smoke still rejected the newly published image ingestion path.