### PR TITLE
Fix MCP Lambda error header import

### DIFF
--- a/apps/backend/src/entrypoints/lambda-mcp.test.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("MCP Lambda entrypoint does not import the backend Hono app", () => {
+  const sourcePath = path.resolve(process.cwd(), "src/entrypoints/lambda-mcp.ts");
+  const source = readFileSync(sourcePath, "utf8");
+  const backendAppImportPattern = /from\s+["']\.\.\/server\/app["']|import\s*\(\s*["']\.\.\/server\/app["']\s*\)/;
+
+  assert.equal(backendAppImportPattern.test(source), false);
+});

--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -22,7 +22,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { authenticateMcpBearerToken } from "../auth/mcpTokens";
 import { createMcpServer } from "../mcp/server";
 import { HttpError } from "../shared/errors";
-import { getHttpErrorResponseHeaders } from "../server/app";
+import { getHttpErrorResponseHeaders } from "../server/httpErrorResponseHeaders";
 import {
   captureBackendException,
   createBackendObservationScope,

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -4,7 +4,6 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
   AuthError,
-  authVerificationRetryAfterSeconds,
   authVerificationTemporarilyUnavailableCode,
 } from "../auth";
 import { getAuthConfig } from "../auth/config";
@@ -36,6 +35,9 @@ import {
   normalizeCaughtError,
 } from "../observability/sentry";
 import { hasReportedBackendException } from "../observability/reporting";
+import { getHttpErrorResponseHeaders } from "./httpErrorResponseHeaders";
+
+export { getHttpErrorResponseHeaders } from "./httpErrorResponseHeaders";
 
 export type AppEnv = {
   Variables: {
@@ -136,18 +138,6 @@ export function createAgentInstructions(code: string | null, statusCode: number)
   }
 
   return "If the issue persists, reload account context from GET /v1/agent/me or restart from GET /v1/agent.";
-}
-
-export function getHttpErrorResponseHeaders(error: HttpError): ReadonlyArray<readonly [string, string]> {
-  if (error.statusCode === 503 && error.code === "SERVICE_UNAVAILABLE") {
-    return [["Retry-After", "1"]];
-  }
-
-  if (error.statusCode === 503 && error.code === authVerificationTemporarilyUnavailableCode) {
-    return [["Retry-After", authVerificationRetryAfterSeconds.toString()]];
-  }
-
-  return [];
 }
 
 function applyHttpErrorResponseHeaders(

--- a/apps/backend/src/server/httpErrorResponseHeaders.ts
+++ b/apps/backend/src/server/httpErrorResponseHeaders.ts
@@ -1,0 +1,17 @@
+import {
+  authVerificationRetryAfterSeconds,
+  authVerificationTemporarilyUnavailableCode,
+} from "../auth";
+import type { HttpError } from "../shared/errors";
+
+export function getHttpErrorResponseHeaders(error: HttpError): ReadonlyArray<readonly [string, string]> {
+  if (error.statusCode === 503 && error.code === "SERVICE_UNAVAILABLE") {
+    return [["Retry-After", "1"]];
+  }
+
+  if (error.statusCode === 503 && error.code === authVerificationTemporarilyUnavailableCode) {
+    return [["Retry-After", authVerificationRetryAfterSeconds.toString()]];
+  }
+
+  return [];
+}


### PR DESCRIPTION
## Summary
- extract HTTP error Retry-After header logic into a small server helper module
- keep server/app re-export compatibility while letting the MCP Lambda avoid importing the full backend app
- add a regression guard that prevents lambda-mcp.ts from importing ../server/app

## Validation
- npm run lint --prefix apps/backend
- node --test --import tsx src/server/app.test.ts src/entrypoints/lambda-mcp.test.ts (9 tests)
- npm run test --prefix apps/backend (585 tests)

## Notes
- Local validation used locked deps installed with npm ci --prefix apps/backend and npm ci --prefix api. npm warned the local shell used Node 25.6.1 while packages declare Node 24.x.