### PR TITLE
Extract catalog draft foundation modules

### DIFF
--- a/apps/backend/src/catalog/authors.ts
+++ b/apps/backend/src/catalog/authors.ts
@@ -1,0 +1,106 @@
+import type { DatabaseExecutor } from "../database";
+import { unsafeTransaction } from "../database/core";
+import { HttpError } from "../shared/errors";
+import {
+  normalizeNonEmptyString,
+  normalizeNullableString,
+  normalizeSlug,
+} from "./common";
+import { rethrowCatalogPersistenceError } from "./errors";
+import {
+  catalogAuthorColumns,
+  mapCatalogAuthorRow,
+} from "./rows";
+import type {
+  CatalogAuthor,
+  CatalogAuthorRow,
+  UpsertCatalogAuthorInput,
+} from "./types";
+
+function normalizeCatalogAuthorInput(input: UpsertCatalogAuthorInput): UpsertCatalogAuthorInput {
+  return {
+    authorId: input.authorId,
+    slug: normalizeSlug(input.slug, "slug"),
+    displayName: normalizeNonEmptyString(input.displayName, "displayName"),
+    bio: normalizeNullableString(input.bio, "bio"),
+    websiteUrl: normalizeNullableString(input.websiteUrl, "websiteUrl"),
+  };
+}
+
+export async function createCatalogAuthorInExecutor(
+  executor: DatabaseExecutor,
+  input: UpsertCatalogAuthorInput,
+): Promise<CatalogAuthor> {
+  const normalizedInput = normalizeCatalogAuthorInput(input);
+  try {
+    const result = await executor.query<CatalogAuthorRow>(
+      [
+        "INSERT INTO catalog.authors",
+        "(author_id, slug, display_name, bio, website_url)",
+        "VALUES ($1, $2, $3, $4, $5)",
+        "RETURNING",
+        catalogAuthorColumns,
+      ].join(" "),
+      [
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.displayName,
+        normalizedInput.bio,
+        normalizedInput.websiteUrl,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Expected catalog author insert to return a row");
+    }
+
+    return mapCatalogAuthorRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function updateCatalogAuthorInExecutor(
+  executor: DatabaseExecutor,
+  input: UpsertCatalogAuthorInput,
+): Promise<CatalogAuthor> {
+  const normalizedInput = normalizeCatalogAuthorInput(input);
+  try {
+    const result = await executor.query<CatalogAuthorRow>(
+      [
+        "UPDATE catalog.authors",
+        "SET slug = $2, display_name = $3, bio = $4, website_url = $5",
+        "WHERE author_id = $1",
+        "RETURNING",
+        catalogAuthorColumns,
+      ].join(" "),
+      [
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.displayName,
+        normalizedInput.bio,
+        normalizedInput.websiteUrl,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new HttpError(
+        404,
+        `Catalog author not found. authorId=${normalizedInput.authorId}`,
+        "CATALOG_AUTHOR_NOT_FOUND",
+      );
+    }
+
+    return mapCatalogAuthorRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function createCatalogAuthor(input: UpsertCatalogAuthorInput): Promise<CatalogAuthor> {
+  return unsafeTransaction(async (executor) => createCatalogAuthorInExecutor(executor, input));
+}
+
+export async function updateCatalogAuthor(input: UpsertCatalogAuthorInput): Promise<CatalogAuthor> {
+  return unsafeTransaction(async (executor) => updateCatalogAuthorInExecutor(executor, input));
+}

--- a/apps/backend/src/catalog/common.ts
+++ b/apps/backend/src/catalog/common.ts
@@ -1,0 +1,87 @@
+import { HttpError } from "../shared/errors";
+import type { TimestampValue } from "./types";
+
+const slugPattern = /^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$/u;
+const packageMediaKeyPattern = /^[a-z0-9][a-z0-9._-]{0,127}$/u;
+
+export function toIsoString(value: TimestampValue): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return new Date(value).toISOString();
+}
+
+export function toOptionalIsoString(value: TimestampValue | null): string | null {
+  return value === null ? null : toIsoString(value);
+}
+
+export function toSafeNumber(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (Number.isSafeInteger(parsedValue) === false) {
+    throw new Error(`${fieldName} must be a safe integer`);
+  }
+
+  return parsedValue;
+}
+
+export function normalizeNonEmptyString(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (normalizedValue === "") {
+    throw new HttpError(400, `${fieldName} must not be empty`, "CATALOG_INVALID_INPUT");
+  }
+
+  return normalizedValue;
+}
+
+export function normalizeNullableString(value: string | null, fieldName: string): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return normalizeNonEmptyString(value, fieldName);
+}
+
+export function normalizeSlug(value: string, fieldName: string): string {
+  const slug = normalizeNonEmptyString(value, fieldName).toLowerCase();
+  if (slugPattern.test(slug) === false) {
+    throw new HttpError(
+      400,
+      `${fieldName} must use lowercase letters, numbers, and hyphens without leading or trailing hyphens.`,
+      "CATALOG_SLUG_INVALID",
+    );
+  }
+
+  return slug;
+}
+
+export function normalizePackageMediaKey(value: string, fieldName: string): string {
+  const packageMediaKey = normalizeNonEmptyString(value, fieldName).toLowerCase();
+  if (packageMediaKeyPattern.test(packageMediaKey) === false) {
+    throw new HttpError(
+      400,
+      `${fieldName} must use lowercase letters, numbers, dots, underscores, or hyphens.`,
+      "CATALOG_PACKAGE_MEDIA_KEY_INVALID",
+    );
+  }
+
+  return packageMediaKey;
+}
+
+export function normalizeTextArray(
+  values: ReadonlyArray<string>,
+  fieldName: string,
+  requireNonEmpty: boolean,
+): ReadonlyArray<string> {
+  const normalizedValues = values.map((value) => normalizeNonEmptyString(value, fieldName).toLowerCase());
+  const uniqueValues = [...new Set(normalizedValues)];
+  if (requireNonEmpty && uniqueValues.length === 0) {
+    throw new HttpError(400, `${fieldName} must include at least one item`, "CATALOG_INVALID_INPUT");
+  }
+
+  return uniqueValues;
+}
+
+export function normalizeAdminEmail(adminEmail: string): string {
+  return normalizeNonEmptyString(adminEmail, "adminEmail").toLowerCase();
+}

--- a/apps/backend/src/catalog/draftMedia.ts
+++ b/apps/backend/src/catalog/draftMedia.ts
@@ -1,0 +1,118 @@
+import type { DatabaseExecutor } from "../database";
+import { unsafeTransaction } from "../database/core";
+import { HttpError } from "../shared/errors";
+import {
+  normalizeNullableString,
+  normalizePackageMediaKey,
+} from "./common";
+import { rethrowCatalogPersistenceError } from "./errors";
+import {
+  catalogPackageMediaAssetColumns,
+  lockCatalogPackageInExecutor,
+  mapCatalogPackageMediaAssetRow,
+} from "./rows";
+import type {
+  AttachCatalogPackageMediaAssetInput,
+  CatalogPackageMediaAsset,
+  CatalogPackageMediaAssetRow,
+} from "./types";
+
+type PackageMediaKeyRow = Readonly<{ package_media_key: string }>;
+
+function normalizePackageMediaAssetInput(
+  input: AttachCatalogPackageMediaAssetInput,
+): AttachCatalogPackageMediaAssetInput {
+  return {
+    packageMediaAssetId: input.packageMediaAssetId,
+    packageMediaKey: normalizePackageMediaKey(input.packageMediaKey, "packageMediaKey"),
+    mediaBlobId: input.mediaBlobId,
+    altText: normalizeNullableString(input.altText, "altText"),
+    credit: normalizeNullableString(input.credit, "credit"),
+    license: normalizeNullableString(input.license, "license"),
+  };
+}
+
+export async function assertDraftMediaKeysExistInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  mediaAssetKeys: ReadonlyArray<string>,
+): Promise<void> {
+  if (mediaAssetKeys.length === 0) {
+    return;
+  }
+
+  const result = await executor.query<PackageMediaKeyRow>(
+    [
+      "SELECT package_media_key",
+      "FROM catalog.package_media_assets",
+      "WHERE package_id = $1",
+      "AND package_version_id IS NULL",
+      "AND package_media_key = ANY($2)",
+    ].join(" "),
+    [packageId, mediaAssetKeys],
+  );
+  const existingKeys = new Set(result.rows.map((row: PackageMediaKeyRow) => row.package_media_key));
+  const missingKeys = mediaAssetKeys.filter((mediaAssetKey) => existingKeys.has(mediaAssetKey) === false);
+  if (missingKeys.length !== 0) {
+    throw new HttpError(
+      400,
+      `Package draft media assets are missing referenced package-local media keys. packageId=${packageId} missingKeys=${missingKeys.join(",")}`,
+      "CATALOG_PACKAGE_MEDIA_REFERENCE_NOT_FOUND",
+    );
+  }
+}
+
+export async function attachCatalogPackageDraftMediaAssetInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  input: AttachCatalogPackageMediaAssetInput,
+): Promise<CatalogPackageMediaAsset> {
+  const normalizedInput = normalizePackageMediaAssetInput(input);
+  try {
+    await lockCatalogPackageInExecutor(executor, packageId);
+    const result = await executor.query<CatalogPackageMediaAssetRow>(
+      [
+        "INSERT INTO catalog.package_media_assets",
+        "(",
+        "package_media_asset_id, package_id, package_version_id, package_media_key,",
+        "media_blob_id, alt_text, credit, license",
+        ")",
+        "SELECT $1, $2, NULL, $3, media_blobs.media_blob_id, $5, $6, $7",
+        "FROM content.media_blobs AS media_blobs",
+        "WHERE media_blobs.media_blob_id = $4",
+        "RETURNING",
+        catalogPackageMediaAssetColumns,
+      ].join(" "),
+      [
+        normalizedInput.packageMediaAssetId,
+        packageId,
+        normalizedInput.packageMediaKey,
+        normalizedInput.mediaBlobId,
+        normalizedInput.altText,
+        normalizedInput.credit,
+        normalizedInput.license,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new HttpError(
+        400,
+        `Media blob not found for catalog package media asset. mediaBlobId=${normalizedInput.mediaBlobId}`,
+        "CATALOG_MEDIA_BLOB_NOT_FOUND",
+      );
+    }
+
+    return mapCatalogPackageMediaAssetRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function attachCatalogPackageDraftMediaAsset(
+  packageId: string,
+  input: AttachCatalogPackageMediaAssetInput,
+): Promise<CatalogPackageMediaAsset> {
+  return unsafeTransaction(async (executor) => (
+    attachCatalogPackageDraftMediaAssetInExecutor(executor, packageId, input)
+  ));
+}

--- a/apps/backend/src/catalog/drafts.ts
+++ b/apps/backend/src/catalog/drafts.ts
@@ -1,0 +1,197 @@
+import type { DatabaseExecutor } from "../database";
+import { unsafeTransaction } from "../database/core";
+import { HttpError } from "../shared/errors";
+import {
+  normalizeNonEmptyString,
+  normalizeNullableString,
+  normalizePackageMediaKey,
+  normalizeSlug,
+  normalizeTextArray,
+} from "./common";
+import { assertDraftMediaKeysExistInExecutor } from "./draftMedia";
+import { rethrowCatalogPersistenceError } from "./errors";
+import {
+  catalogPackageColumns,
+  catalogPackageMediaAssetColumns,
+  mapCatalogPackageMediaAssetRow,
+  mapCatalogPackageRow,
+} from "./rows";
+import type {
+  CatalogPackage,
+  CatalogPackageDraft,
+  CatalogPackageMediaAssetRow,
+  CatalogPackageRow,
+  CreateCatalogPackageDraftInput,
+  UpdateCatalogPackageDraftInput,
+} from "./types";
+
+function normalizeCreateCatalogPackageDraftInput(
+  input: CreateCatalogPackageDraftInput,
+): CreateCatalogPackageDraftInput {
+  return {
+    packageId: input.packageId,
+    authorId: input.authorId,
+    slug: normalizeSlug(input.slug, "slug"),
+    title: normalizeNonEmptyString(input.title, "title"),
+    summary: normalizeNonEmptyString(input.summary, "summary"),
+    description: normalizeNonEmptyString(input.description, "description"),
+    languageTags: normalizeTextArray(input.languageTags, "languageTags", true),
+    topicTags: normalizeTextArray(input.topicTags, "topicTags", false),
+    license: normalizeNonEmptyString(input.license, "license"),
+    contentWarning: normalizeNullableString(input.contentWarning, "contentWarning"),
+  };
+}
+
+function normalizeUpdateCatalogPackageDraftInput(
+  input: UpdateCatalogPackageDraftInput,
+): UpdateCatalogPackageDraftInput {
+  return {
+    ...normalizeCreateCatalogPackageDraftInput(input),
+    coverPackageMediaKey: input.coverPackageMediaKey === null
+      ? null
+      : normalizePackageMediaKey(input.coverPackageMediaKey, "coverPackageMediaKey"),
+  };
+}
+
+export async function createCatalogPackageDraftInExecutor(
+  executor: DatabaseExecutor,
+  input: CreateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  const normalizedInput = normalizeCreateCatalogPackageDraftInput(input);
+  try {
+    const result = await executor.query<CatalogPackageRow>(
+      [
+        "INSERT INTO catalog.packages",
+        "(",
+        "package_id, author_id, slug, title, summary, description, language_tags, topic_tags,",
+        "license, content_warning",
+        ")",
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+        "RETURNING",
+        catalogPackageColumns,
+      ].join(" "),
+      [
+        normalizedInput.packageId,
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.title,
+        normalizedInput.summary,
+        normalizedInput.description,
+        normalizedInput.languageTags,
+        normalizedInput.topicTags,
+        normalizedInput.license,
+        normalizedInput.contentWarning,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("Expected catalog package insert to return a row");
+    }
+
+    return mapCatalogPackageRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function updateCatalogPackageDraftInExecutor(
+  executor: DatabaseExecutor,
+  input: UpdateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  const normalizedInput = normalizeUpdateCatalogPackageDraftInput(input);
+  try {
+    await assertDraftMediaKeysExistInExecutor(
+      executor,
+      normalizedInput.packageId,
+      normalizedInput.coverPackageMediaKey === null ? [] : [normalizedInput.coverPackageMediaKey],
+    );
+    const result = await executor.query<CatalogPackageRow>(
+      [
+        "UPDATE catalog.packages",
+        "SET author_id = $2, slug = $3, title = $4, summary = $5, description = $6,",
+        "language_tags = $7, topic_tags = $8, license = $9, content_warning = $10,",
+        "cover_package_media_key = $11",
+        "WHERE package_id = $1",
+        "RETURNING",
+        catalogPackageColumns,
+      ].join(" "),
+      [
+        normalizedInput.packageId,
+        normalizedInput.authorId,
+        normalizedInput.slug,
+        normalizedInput.title,
+        normalizedInput.summary,
+        normalizedInput.description,
+        normalizedInput.languageTags,
+        normalizedInput.topicTags,
+        normalizedInput.license,
+        normalizedInput.contentWarning,
+        normalizedInput.coverPackageMediaKey,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new HttpError(
+        404,
+        `Catalog package not found. packageId=${normalizedInput.packageId}`,
+        "CATALOG_PACKAGE_NOT_FOUND",
+      );
+    }
+
+    return mapCatalogPackageRow(row);
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function loadCatalogPackageDraftInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<CatalogPackageDraft> {
+  const packageResult = await executor.query<CatalogPackageRow>(
+    [
+      "SELECT",
+      catalogPackageColumns,
+      "FROM catalog.packages",
+      "WHERE package_id = $1",
+    ].join(" "),
+    [packageId],
+  );
+  const packageRow = packageResult.rows[0];
+  if (packageRow === undefined) {
+    throw new HttpError(404, `Catalog package not found. packageId=${packageId}`, "CATALOG_PACKAGE_NOT_FOUND");
+  }
+
+  const mediaResult = await executor.query<CatalogPackageMediaAssetRow>(
+    [
+      "SELECT",
+      catalogPackageMediaAssetColumns,
+      "FROM catalog.package_media_assets",
+      "WHERE package_id = $1",
+      "AND package_version_id IS NULL",
+      "ORDER BY package_media_key ASC",
+    ].join(" "),
+    [packageId],
+  );
+
+  return {
+    catalogPackage: mapCatalogPackageRow(packageRow),
+    mediaAssets: mediaResult.rows.map((row: CatalogPackageMediaAssetRow) => mapCatalogPackageMediaAssetRow(row)),
+  };
+}
+
+export async function createCatalogPackageDraft(
+  input: CreateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  return unsafeTransaction(async (executor) => createCatalogPackageDraftInExecutor(executor, input));
+}
+
+export async function updateCatalogPackageDraft(
+  input: UpdateCatalogPackageDraftInput,
+): Promise<CatalogPackage> {
+  return unsafeTransaction(async (executor) => updateCatalogPackageDraftInExecutor(executor, input));
+}
+
+export async function loadCatalogPackageDraft(packageId: string): Promise<CatalogPackageDraft> {
+  return unsafeTransaction(async (executor) => loadCatalogPackageDraftInExecutor(executor, packageId));
+}

--- a/apps/backend/src/catalog/errors.ts
+++ b/apps/backend/src/catalog/errors.ts
@@ -1,0 +1,74 @@
+import { getDatabaseErrorFields } from "../database/transient";
+import { HttpError } from "../shared/errors";
+
+function readStringField(value: unknown, fieldName: string): string | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const fieldValue = (value as Readonly<Record<string, unknown>>)[fieldName];
+  return typeof fieldValue === "string" && fieldValue !== "" ? fieldValue : null;
+}
+
+export function toCatalogPersistenceError(error: unknown): HttpError | null {
+  if (error instanceof HttpError) {
+    return error;
+  }
+
+  const fields = getDatabaseErrorFields(error);
+  const constraint = readStringField(error, "constraint");
+  if (fields.sqlState === "23505") {
+    switch (constraint) {
+      case "authors_slug_unique":
+        return new HttpError(409, "Catalog author slug already exists.", "CATALOG_AUTHOR_SLUG_ALREADY_EXISTS");
+      case "packages_slug_unique":
+        return new HttpError(409, "Catalog package slug already exists.", "CATALOG_PACKAGE_SLUG_ALREADY_EXISTS");
+      case "idx_package_versions_one_review_candidate":
+        return new HttpError(
+          409,
+          "Package already has a mutable draft or review candidate version.",
+          "CATALOG_PACKAGE_VERSION_DRAFT_ALREADY_EXISTS",
+        );
+      case "package_versions_package_number_unique":
+        return new HttpError(
+          409,
+          "Package version number already exists for this package.",
+          "CATALOG_PACKAGE_VERSION_ALREADY_EXISTS",
+        );
+      case "idx_package_media_assets_draft_key_unique":
+      case "idx_package_media_assets_version_key_unique":
+        return new HttpError(
+          409,
+          "Catalog package media key already exists for this package draft or version.",
+          "CATALOG_PACKAGE_MEDIA_KEY_ALREADY_EXISTS",
+        );
+    }
+  }
+
+  if (fields.sqlState === "23503") {
+    return new HttpError(
+      400,
+      `Catalog write references a missing row. constraint=${constraint ?? "unknown"}`,
+      "CATALOG_REFERENCE_NOT_FOUND",
+    );
+  }
+
+  if (fields.sqlState === "23514") {
+    return new HttpError(
+      409,
+      `Catalog write violates a catalog database constraint. message=${fields.errorMessage}`,
+      "CATALOG_CONSTRAINT_VIOLATION",
+    );
+  }
+
+  return null;
+}
+
+export function rethrowCatalogPersistenceError(error: unknown): never {
+  const mappedError = toCatalogPersistenceError(error);
+  if (mappedError !== null) {
+    throw mappedError;
+  }
+
+  throw error;
+}

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -4,107 +4,52 @@ import {
   type DatabaseExecutor,
 } from "../database";
 import { unsafeTransaction } from "../database/core";
-import { getDatabaseErrorFields } from "../database/transient";
 import { HttpError } from "../shared/errors";
+import {
+  normalizeAdminEmail,
+  normalizeNonEmptyString,
+  normalizeNullableString,
+  normalizePackageMediaKey,
+  normalizeTextArray,
+  toSafeNumber,
+} from "./common";
+import { assertDraftMediaKeysExistInExecutor } from "./draftMedia";
+import { rethrowCatalogPersistenceError } from "./errors";
+import {
+  catalogPackageVersionColumns,
+  lockCatalogPackageInExecutor,
+  mapCatalogPackageVersionRow,
+} from "./rows";
 import type {
-  AttachCatalogPackageMediaAssetInput,
-  CatalogAuthor,
-  CatalogAuthorRow,
-  CatalogPackage,
   CatalogPackageCardSnapshotInput,
-  CatalogPackageDraft,
-  CatalogPackageMediaAsset,
-  CatalogPackageMediaAssetRow,
-  CatalogPackageRow,
   CatalogPackageStatus,
   CatalogPackageVersion,
   CatalogPackageVersionRow,
   CatalogWorkspaceCardRow,
-  CreateCatalogPackageDraftInput,
   CreateCatalogPackageVersionFromWorkspaceInput,
   CreateCatalogPackageVersionInput,
-  TimestampValue,
-  UpdateCatalogPackageDraftInput,
   UpdateCatalogPackageVersionStatusInput,
-  UpsertCatalogAuthorInput,
 } from "./types";
 
-const catalogAuthorColumns = [
-  "author_id",
-  "slug",
-  "display_name",
-  "bio",
-  "website_url",
-  "created_at",
-  "updated_at",
-].join(", ");
+export {
+  createCatalogAuthor,
+  createCatalogAuthorInExecutor,
+  updateCatalogAuthor,
+  updateCatalogAuthorInExecutor,
+} from "./authors";
+export {
+  attachCatalogPackageDraftMediaAsset,
+  attachCatalogPackageDraftMediaAssetInExecutor,
+} from "./draftMedia";
+export {
+  createCatalogPackageDraft,
+  createCatalogPackageDraftInExecutor,
+  loadCatalogPackageDraft,
+  loadCatalogPackageDraftInExecutor,
+  updateCatalogPackageDraft,
+  updateCatalogPackageDraftInExecutor,
+} from "./drafts";
 
-const catalogPackageColumns = [
-  "package_id",
-  "author_id",
-  "slug",
-  "title",
-  "summary",
-  "description",
-  "language_tags",
-  "topic_tags",
-  "license",
-  "content_warning",
-  "cover_package_media_key",
-  "status",
-  "created_at",
-  "updated_at",
-  "published_at",
-  "delisted_at",
-].join(", ");
-
-const catalogPackageMediaAssetColumns = [
-  "package_media_asset_id",
-  "package_id",
-  "package_version_id",
-  "package_media_key",
-  "media_blob_id",
-  "alt_text",
-  "credit",
-  "license",
-  "created_at",
-  "updated_at",
-].join(", ");
-
-const catalogPackageVersionColumns = [
-  "package_version_id",
-  "package_id",
-  "version_number",
-  "status",
-  "slug",
-  "title",
-  "summary",
-  "description",
-  "language_tags",
-  "topic_tags",
-  "license",
-  "content_warning",
-  "cover_package_media_key",
-  "source_workspace_id",
-  "card_count",
-  "created_by_admin_email",
-  "reviewed_by_admin_email",
-  "created_at",
-  "updated_at",
-  "submitted_at",
-  "reviewed_at",
-  "published_at",
-  "delisted_at",
-].join(", ");
-
-const slugPattern = /^[a-z0-9](?:[a-z0-9-]{0,118}[a-z0-9])?$/u;
-const packageMediaKeyPattern = /^[a-z0-9][a-z0-9._-]{0,127}$/u;
-const mutablePackageVersionStatuses: ReadonlySet<CatalogPackageStatus> = new Set([
-  "draft",
-  "submitted",
-  "needs_changes",
-  "approved",
-]);
 const reviewStatusRouteTargets: ReadonlySet<CatalogPackageStatus> = new Set([
   "draft",
   "submitted",
@@ -113,160 +58,6 @@ const reviewStatusRouteTargets: ReadonlySet<CatalogPackageStatus> = new Set([
   "rejected",
 ]);
 const managedMediaReferencePattern = /fcasset:/iu;
-
-function toIsoString(value: TimestampValue): string {
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-
-  return new Date(value).toISOString();
-}
-
-function toOptionalIsoString(value: TimestampValue | null): string | null {
-  return value === null ? null : toIsoString(value);
-}
-
-function toSafeNumber(value: string | number, fieldName: string): number {
-  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
-  if (Number.isSafeInteger(parsedValue) === false) {
-    throw new Error(`${fieldName} must be a safe integer`);
-  }
-
-  return parsedValue;
-}
-
-function normalizeNonEmptyString(value: string, fieldName: string): string {
-  const normalizedValue = value.trim();
-  if (normalizedValue === "") {
-    throw new HttpError(400, `${fieldName} must not be empty`, "CATALOG_INVALID_INPUT");
-  }
-
-  return normalizedValue;
-}
-
-function normalizeNullableString(value: string | null, fieldName: string): string | null {
-  if (value === null) {
-    return null;
-  }
-
-  return normalizeNonEmptyString(value, fieldName);
-}
-
-function normalizeSlug(value: string, fieldName: string): string {
-  const slug = normalizeNonEmptyString(value, fieldName).toLowerCase();
-  if (slugPattern.test(slug) === false) {
-    throw new HttpError(
-      400,
-      `${fieldName} must use lowercase letters, numbers, and hyphens without leading or trailing hyphens.`,
-      "CATALOG_SLUG_INVALID",
-    );
-  }
-
-  return slug;
-}
-
-function normalizePackageMediaKey(value: string, fieldName: string): string {
-  const packageMediaKey = normalizeNonEmptyString(value, fieldName).toLowerCase();
-  if (packageMediaKeyPattern.test(packageMediaKey) === false) {
-    throw new HttpError(
-      400,
-      `${fieldName} must use lowercase letters, numbers, dots, underscores, or hyphens.`,
-      "CATALOG_PACKAGE_MEDIA_KEY_INVALID",
-    );
-  }
-
-  return packageMediaKey;
-}
-
-function normalizeTextArray(
-  values: ReadonlyArray<string>,
-  fieldName: string,
-  requireNonEmpty: boolean,
-): ReadonlyArray<string> {
-  const normalizedValues = values.map((value) => normalizeNonEmptyString(value, fieldName).toLowerCase());
-  const uniqueValues = [...new Set(normalizedValues)];
-  if (requireNonEmpty && uniqueValues.length === 0) {
-    throw new HttpError(400, `${fieldName} must include at least one item`, "CATALOG_INVALID_INPUT");
-  }
-
-  return uniqueValues;
-}
-
-function normalizeAdminEmail(adminEmail: string): string {
-  return normalizeNonEmptyString(adminEmail, "adminEmail").toLowerCase();
-}
-
-function readStringField(value: unknown, fieldName: string): string | null {
-  if (typeof value !== "object" || value === null) {
-    return null;
-  }
-
-  const fieldValue = (value as Readonly<Record<string, unknown>>)[fieldName];
-  return typeof fieldValue === "string" && fieldValue !== "" ? fieldValue : null;
-}
-
-function toCatalogPersistenceError(error: unknown): HttpError | null {
-  if (error instanceof HttpError) {
-    return error;
-  }
-
-  const fields = getDatabaseErrorFields(error);
-  const constraint = readStringField(error, "constraint");
-  if (fields.sqlState === "23505") {
-    switch (constraint) {
-      case "authors_slug_unique":
-        return new HttpError(409, "Catalog author slug already exists.", "CATALOG_AUTHOR_SLUG_ALREADY_EXISTS");
-      case "packages_slug_unique":
-        return new HttpError(409, "Catalog package slug already exists.", "CATALOG_PACKAGE_SLUG_ALREADY_EXISTS");
-      case "idx_package_versions_one_review_candidate":
-        return new HttpError(
-          409,
-          "Package already has a mutable draft or review candidate version.",
-          "CATALOG_PACKAGE_VERSION_DRAFT_ALREADY_EXISTS",
-        );
-      case "package_versions_package_number_unique":
-        return new HttpError(
-          409,
-          "Package version number already exists for this package.",
-          "CATALOG_PACKAGE_VERSION_ALREADY_EXISTS",
-        );
-      case "idx_package_media_assets_draft_key_unique":
-      case "idx_package_media_assets_version_key_unique":
-        return new HttpError(
-          409,
-          "Catalog package media key already exists for this package draft or version.",
-          "CATALOG_PACKAGE_MEDIA_KEY_ALREADY_EXISTS",
-        );
-    }
-  }
-
-  if (fields.sqlState === "23503") {
-    return new HttpError(
-      400,
-      `Catalog write references a missing row. constraint=${constraint ?? "unknown"}`,
-      "CATALOG_REFERENCE_NOT_FOUND",
-    );
-  }
-
-  if (fields.sqlState === "23514") {
-    return new HttpError(
-      409,
-      `Catalog write violates a catalog database constraint. message=${fields.errorMessage}`,
-      "CATALOG_CONSTRAINT_VIOLATION",
-    );
-  }
-
-  return null;
-}
-
-function rethrowCatalogPersistenceError(error: unknown): never {
-  const mappedError = toCatalogPersistenceError(error);
-  if (mappedError !== null) {
-    throw mappedError;
-  }
-
-  throw error;
-}
 
 export function isCatalogPackageVersionStatusTransitionAllowed(
   fromStatus: CatalogPackageStatus,
@@ -306,133 +97,6 @@ export function assertCatalogPackageVersionStatusTransitionAllowed(
     `Invalid catalog package version status transition. fromStatus=${fromStatus} toStatus=${toStatus}`,
     "CATALOG_PACKAGE_VERSION_STATUS_TRANSITION_INVALID",
   );
-}
-
-function mapCatalogAuthorRow(row: CatalogAuthorRow): CatalogAuthor {
-  return {
-    authorId: row.author_id,
-    slug: row.slug,
-    displayName: row.display_name,
-    bio: row.bio,
-    websiteUrl: row.website_url,
-    createdAt: toIsoString(row.created_at),
-    updatedAt: toIsoString(row.updated_at),
-  };
-}
-
-function mapCatalogPackageRow(row: CatalogPackageRow): CatalogPackage {
-  return {
-    packageId: row.package_id,
-    authorId: row.author_id,
-    slug: row.slug,
-    title: row.title,
-    summary: row.summary,
-    description: row.description,
-    languageTags: [...row.language_tags],
-    topicTags: [...row.topic_tags],
-    license: row.license,
-    contentWarning: row.content_warning,
-    coverPackageMediaKey: row.cover_package_media_key,
-    status: row.status,
-    createdAt: toIsoString(row.created_at),
-    updatedAt: toIsoString(row.updated_at),
-    publishedAt: toOptionalIsoString(row.published_at),
-    delistedAt: toOptionalIsoString(row.delisted_at),
-  };
-}
-
-function mapCatalogPackageMediaAssetRow(row: CatalogPackageMediaAssetRow): CatalogPackageMediaAsset {
-  return {
-    packageMediaAssetId: row.package_media_asset_id,
-    packageId: row.package_id,
-    packageVersionId: row.package_version_id,
-    packageMediaKey: row.package_media_key,
-    mediaBlobId: row.media_blob_id,
-    altText: row.alt_text,
-    credit: row.credit,
-    license: row.license,
-    createdAt: toIsoString(row.created_at),
-    updatedAt: toIsoString(row.updated_at),
-  };
-}
-
-function mapCatalogPackageVersionRow(row: CatalogPackageVersionRow): CatalogPackageVersion {
-  return {
-    packageVersionId: row.package_version_id,
-    packageId: row.package_id,
-    versionNumber: toSafeNumber(row.version_number, "version_number"),
-    status: row.status,
-    slug: row.slug,
-    title: row.title,
-    summary: row.summary,
-    description: row.description,
-    languageTags: [...row.language_tags],
-    topicTags: [...row.topic_tags],
-    license: row.license,
-    contentWarning: row.content_warning,
-    coverPackageMediaKey: row.cover_package_media_key,
-    sourceWorkspaceId: row.source_workspace_id,
-    cardCount: toSafeNumber(row.card_count, "card_count"),
-    createdByAdminEmail: row.created_by_admin_email,
-    reviewedByAdminEmail: row.reviewed_by_admin_email,
-    createdAt: toIsoString(row.created_at),
-    updatedAt: toIsoString(row.updated_at),
-    submittedAt: toOptionalIsoString(row.submitted_at),
-    reviewedAt: toOptionalIsoString(row.reviewed_at),
-    publishedAt: toOptionalIsoString(row.published_at),
-    delistedAt: toOptionalIsoString(row.delisted_at),
-  };
-}
-
-function normalizeCatalogAuthorInput(input: UpsertCatalogAuthorInput): UpsertCatalogAuthorInput {
-  return {
-    authorId: input.authorId,
-    slug: normalizeSlug(input.slug, "slug"),
-    displayName: normalizeNonEmptyString(input.displayName, "displayName"),
-    bio: normalizeNullableString(input.bio, "bio"),
-    websiteUrl: normalizeNullableString(input.websiteUrl, "websiteUrl"),
-  };
-}
-
-function normalizeCreateCatalogPackageDraftInput(
-  input: CreateCatalogPackageDraftInput,
-): CreateCatalogPackageDraftInput {
-  return {
-    packageId: input.packageId,
-    authorId: input.authorId,
-    slug: normalizeSlug(input.slug, "slug"),
-    title: normalizeNonEmptyString(input.title, "title"),
-    summary: normalizeNonEmptyString(input.summary, "summary"),
-    description: normalizeNonEmptyString(input.description, "description"),
-    languageTags: normalizeTextArray(input.languageTags, "languageTags", true),
-    topicTags: normalizeTextArray(input.topicTags, "topicTags", false),
-    license: normalizeNonEmptyString(input.license, "license"),
-    contentWarning: normalizeNullableString(input.contentWarning, "contentWarning"),
-  };
-}
-
-function normalizeUpdateCatalogPackageDraftInput(
-  input: UpdateCatalogPackageDraftInput,
-): UpdateCatalogPackageDraftInput {
-  return {
-    ...normalizeCreateCatalogPackageDraftInput(input),
-    coverPackageMediaKey: input.coverPackageMediaKey === null
-      ? null
-      : normalizePackageMediaKey(input.coverPackageMediaKey, "coverPackageMediaKey"),
-  };
-}
-
-function normalizePackageMediaAssetInput(
-  input: AttachCatalogPackageMediaAssetInput,
-): AttachCatalogPackageMediaAssetInput {
-  return {
-    packageMediaAssetId: input.packageMediaAssetId,
-    packageMediaKey: normalizePackageMediaKey(input.packageMediaKey, "packageMediaKey"),
-    mediaBlobId: input.mediaBlobId,
-    altText: normalizeNullableString(input.altText, "altText"),
-    credit: normalizeNullableString(input.credit, "credit"),
-    license: normalizeNullableString(input.license, "license"),
-  };
 }
 
 function normalizeCatalogPackageCardSnapshotInput(
@@ -509,58 +173,6 @@ function assertUniqueCardSnapshots(cards: ReadonlyArray<CatalogPackageCardSnapsh
 
 function getAllCardMediaAssetKeys(cards: ReadonlyArray<CatalogPackageCardSnapshotInput>): ReadonlyArray<string> {
   return [...new Set(cards.flatMap((card) => card.mediaAssetKeys))];
-}
-
-async function assertDraftMediaKeysExistInExecutor(
-  executor: DatabaseExecutor,
-  packageId: string,
-  mediaAssetKeys: ReadonlyArray<string>,
-): Promise<void> {
-  if (mediaAssetKeys.length === 0) {
-    return;
-  }
-
-  const result = await executor.query<Readonly<{ package_media_key: string }>>(
-    [
-      "SELECT package_media_key",
-      "FROM catalog.package_media_assets",
-      "WHERE package_id = $1",
-      "AND package_version_id IS NULL",
-      "AND package_media_key = ANY($2)",
-    ].join(" "),
-    [packageId, mediaAssetKeys],
-  );
-  const existingKeys = new Set(result.rows.map((row) => row.package_media_key));
-  const missingKeys = mediaAssetKeys.filter((mediaAssetKey) => existingKeys.has(mediaAssetKey) === false);
-  if (missingKeys.length !== 0) {
-    throw new HttpError(
-      400,
-      `Package draft media assets are missing referenced package-local media keys. packageId=${packageId} missingKeys=${missingKeys.join(",")}`,
-      "CATALOG_PACKAGE_MEDIA_REFERENCE_NOT_FOUND",
-    );
-  }
-}
-
-async function lockCatalogPackageInExecutor(
-  executor: DatabaseExecutor,
-  packageId: string,
-): Promise<CatalogPackageRow> {
-  const result = await executor.query<CatalogPackageRow>(
-    [
-      "SELECT",
-      catalogPackageColumns,
-      "FROM catalog.packages",
-      "WHERE package_id = $1",
-      "FOR UPDATE",
-    ].join(" "),
-    [packageId],
-  );
-  const row = result.rows[0];
-  if (row === undefined) {
-    throw new HttpError(404, `Catalog package not found. packageId=${packageId}`, "CATALOG_PACKAGE_NOT_FOUND");
-  }
-
-  return row;
 }
 
 async function loadPackageVersionForUpdateInExecutor(
@@ -852,7 +464,7 @@ async function loadWorkspaceCardsForCatalogVersionInExecutor(
     [workspaceId, cardIds],
   );
   if (result.rows.length !== cardIds.length) {
-    const returnedCardIds = new Set(result.rows.map((row) => row.card_id));
+    const returnedCardIds = new Set(result.rows.map((row: CatalogWorkspaceCardRow) => row.card_id));
     const missingCardIds = cardIds.filter((cardId) => returnedCardIds.has(cardId) === false);
     throw new HttpError(
       400,
@@ -866,249 +478,6 @@ async function loadWorkspaceCardsForCatalogVersionInExecutor(
   }
 
   return result.rows;
-}
-
-export async function createCatalogAuthorInExecutor(
-  executor: DatabaseExecutor,
-  input: UpsertCatalogAuthorInput,
-): Promise<CatalogAuthor> {
-  const normalizedInput = normalizeCatalogAuthorInput(input);
-  try {
-    const result = await executor.query<CatalogAuthorRow>(
-      [
-        "INSERT INTO catalog.authors",
-        "(author_id, slug, display_name, bio, website_url)",
-        "VALUES ($1, $2, $3, $4, $5)",
-        "RETURNING",
-        catalogAuthorColumns,
-      ].join(" "),
-      [
-        normalizedInput.authorId,
-        normalizedInput.slug,
-        normalizedInput.displayName,
-        normalizedInput.bio,
-        normalizedInput.websiteUrl,
-      ],
-    );
-    const row = result.rows[0];
-    if (row === undefined) {
-      throw new Error("Expected catalog author insert to return a row");
-    }
-
-    return mapCatalogAuthorRow(row);
-  } catch (error) {
-    rethrowCatalogPersistenceError(error);
-  }
-}
-
-export async function updateCatalogAuthorInExecutor(
-  executor: DatabaseExecutor,
-  input: UpsertCatalogAuthorInput,
-): Promise<CatalogAuthor> {
-  const normalizedInput = normalizeCatalogAuthorInput(input);
-  try {
-    const result = await executor.query<CatalogAuthorRow>(
-      [
-        "UPDATE catalog.authors",
-        "SET slug = $2, display_name = $3, bio = $4, website_url = $5",
-        "WHERE author_id = $1",
-        "RETURNING",
-        catalogAuthorColumns,
-      ].join(" "),
-      [
-        normalizedInput.authorId,
-        normalizedInput.slug,
-        normalizedInput.displayName,
-        normalizedInput.bio,
-        normalizedInput.websiteUrl,
-      ],
-    );
-    const row = result.rows[0];
-    if (row === undefined) {
-      throw new HttpError(
-        404,
-        `Catalog author not found. authorId=${normalizedInput.authorId}`,
-        "CATALOG_AUTHOR_NOT_FOUND",
-      );
-    }
-
-    return mapCatalogAuthorRow(row);
-  } catch (error) {
-    rethrowCatalogPersistenceError(error);
-  }
-}
-
-export async function createCatalogPackageDraftInExecutor(
-  executor: DatabaseExecutor,
-  input: CreateCatalogPackageDraftInput,
-): Promise<CatalogPackage> {
-  const normalizedInput = normalizeCreateCatalogPackageDraftInput(input);
-  try {
-    const result = await executor.query<CatalogPackageRow>(
-      [
-        "INSERT INTO catalog.packages",
-        "(",
-        "package_id, author_id, slug, title, summary, description, language_tags, topic_tags,",
-        "license, content_warning",
-        ")",
-        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
-        "RETURNING",
-        catalogPackageColumns,
-      ].join(" "),
-      [
-        normalizedInput.packageId,
-        normalizedInput.authorId,
-        normalizedInput.slug,
-        normalizedInput.title,
-        normalizedInput.summary,
-        normalizedInput.description,
-        normalizedInput.languageTags,
-        normalizedInput.topicTags,
-        normalizedInput.license,
-        normalizedInput.contentWarning,
-      ],
-    );
-    const row = result.rows[0];
-    if (row === undefined) {
-      throw new Error("Expected catalog package insert to return a row");
-    }
-
-    return mapCatalogPackageRow(row);
-  } catch (error) {
-    rethrowCatalogPersistenceError(error);
-  }
-}
-
-export async function updateCatalogPackageDraftInExecutor(
-  executor: DatabaseExecutor,
-  input: UpdateCatalogPackageDraftInput,
-): Promise<CatalogPackage> {
-  const normalizedInput = normalizeUpdateCatalogPackageDraftInput(input);
-  try {
-    await assertDraftMediaKeysExistInExecutor(
-      executor,
-      normalizedInput.packageId,
-      normalizedInput.coverPackageMediaKey === null ? [] : [normalizedInput.coverPackageMediaKey],
-    );
-    const result = await executor.query<CatalogPackageRow>(
-      [
-        "UPDATE catalog.packages",
-        "SET author_id = $2, slug = $3, title = $4, summary = $5, description = $6,",
-        "language_tags = $7, topic_tags = $8, license = $9, content_warning = $10,",
-        "cover_package_media_key = $11",
-        "WHERE package_id = $1",
-        "RETURNING",
-        catalogPackageColumns,
-      ].join(" "),
-      [
-        normalizedInput.packageId,
-        normalizedInput.authorId,
-        normalizedInput.slug,
-        normalizedInput.title,
-        normalizedInput.summary,
-        normalizedInput.description,
-        normalizedInput.languageTags,
-        normalizedInput.topicTags,
-        normalizedInput.license,
-        normalizedInput.contentWarning,
-        normalizedInput.coverPackageMediaKey,
-      ],
-    );
-    const row = result.rows[0];
-    if (row === undefined) {
-      throw new HttpError(
-        404,
-        `Catalog package not found. packageId=${normalizedInput.packageId}`,
-        "CATALOG_PACKAGE_NOT_FOUND",
-      );
-    }
-
-    return mapCatalogPackageRow(row);
-  } catch (error) {
-    rethrowCatalogPersistenceError(error);
-  }
-}
-
-export async function loadCatalogPackageDraftInExecutor(
-  executor: DatabaseExecutor,
-  packageId: string,
-): Promise<CatalogPackageDraft> {
-  const packageResult = await executor.query<CatalogPackageRow>(
-    [
-      "SELECT",
-      catalogPackageColumns,
-      "FROM catalog.packages",
-      "WHERE package_id = $1",
-    ].join(" "),
-    [packageId],
-  );
-  const packageRow = packageResult.rows[0];
-  if (packageRow === undefined) {
-    throw new HttpError(404, `Catalog package not found. packageId=${packageId}`, "CATALOG_PACKAGE_NOT_FOUND");
-  }
-
-  const mediaResult = await executor.query<CatalogPackageMediaAssetRow>(
-    [
-      "SELECT",
-      catalogPackageMediaAssetColumns,
-      "FROM catalog.package_media_assets",
-      "WHERE package_id = $1",
-      "AND package_version_id IS NULL",
-      "ORDER BY package_media_key ASC",
-    ].join(" "),
-    [packageId],
-  );
-
-  return {
-    catalogPackage: mapCatalogPackageRow(packageRow),
-    mediaAssets: mediaResult.rows.map((row) => mapCatalogPackageMediaAssetRow(row)),
-  };
-}
-
-export async function attachCatalogPackageDraftMediaAssetInExecutor(
-  executor: DatabaseExecutor,
-  packageId: string,
-  input: AttachCatalogPackageMediaAssetInput,
-): Promise<CatalogPackageMediaAsset> {
-  const normalizedInput = normalizePackageMediaAssetInput(input);
-  try {
-    await lockCatalogPackageInExecutor(executor, packageId);
-    const result = await executor.query<CatalogPackageMediaAssetRow>(
-      [
-        "INSERT INTO catalog.package_media_assets",
-        "(",
-        "package_media_asset_id, package_id, package_version_id, package_media_key,",
-        "media_blob_id, alt_text, credit, license",
-        ")",
-        "SELECT $1, $2, NULL, $3, media_blobs.media_blob_id, $5, $6, $7",
-        "FROM content.media_blobs AS media_blobs",
-        "WHERE media_blobs.media_blob_id = $4",
-        "RETURNING",
-        catalogPackageMediaAssetColumns,
-      ].join(" "),
-      [
-        normalizedInput.packageMediaAssetId,
-        packageId,
-        normalizedInput.packageMediaKey,
-        normalizedInput.mediaBlobId,
-        normalizedInput.altText,
-        normalizedInput.credit,
-        normalizedInput.license,
-      ],
-    );
-    const row = result.rows[0];
-    if (row === undefined) {
-      throw new HttpError(
-        400,
-        `Media blob not found for catalog package media asset. mediaBlobId=${normalizedInput.mediaBlobId}`,
-        "CATALOG_MEDIA_BLOB_NOT_FOUND",
-      );
-    }
-
-    return mapCatalogPackageMediaAssetRow(row);
-  } catch (error) {
-    rethrowCatalogPersistenceError(error);
-  }
 }
 
 export async function createCatalogPackageVersionFromCardsInExecutor(
@@ -1352,39 +721,6 @@ export async function delistCatalogPackageVersionInExecutor(
   } catch (error) {
     rethrowCatalogPersistenceError(error);
   }
-}
-
-export async function createCatalogAuthor(input: UpsertCatalogAuthorInput): Promise<CatalogAuthor> {
-  return unsafeTransaction(async (executor) => createCatalogAuthorInExecutor(executor, input));
-}
-
-export async function updateCatalogAuthor(input: UpsertCatalogAuthorInput): Promise<CatalogAuthor> {
-  return unsafeTransaction(async (executor) => updateCatalogAuthorInExecutor(executor, input));
-}
-
-export async function createCatalogPackageDraft(
-  input: CreateCatalogPackageDraftInput,
-): Promise<CatalogPackage> {
-  return unsafeTransaction(async (executor) => createCatalogPackageDraftInExecutor(executor, input));
-}
-
-export async function updateCatalogPackageDraft(
-  input: UpdateCatalogPackageDraftInput,
-): Promise<CatalogPackage> {
-  return unsafeTransaction(async (executor) => updateCatalogPackageDraftInExecutor(executor, input));
-}
-
-export async function loadCatalogPackageDraft(packageId: string): Promise<CatalogPackageDraft> {
-  return unsafeTransaction(async (executor) => loadCatalogPackageDraftInExecutor(executor, packageId));
-}
-
-export async function attachCatalogPackageDraftMediaAsset(
-  packageId: string,
-  input: AttachCatalogPackageMediaAssetInput,
-): Promise<CatalogPackageMediaAsset> {
-  return unsafeTransaction(async (executor) => (
-    attachCatalogPackageDraftMediaAssetInExecutor(executor, packageId, input)
-  ));
 }
 
 export async function createCatalogPackageVersionFromCards(

--- a/apps/backend/src/catalog/rows.ts
+++ b/apps/backend/src/catalog/rows.ts
@@ -1,0 +1,183 @@
+import type { DatabaseExecutor } from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  toIsoString,
+  toOptionalIsoString,
+  toSafeNumber,
+} from "./common";
+import type {
+  CatalogAuthor,
+  CatalogAuthorRow,
+  CatalogPackage,
+  CatalogPackageMediaAsset,
+  CatalogPackageMediaAssetRow,
+  CatalogPackageRow,
+  CatalogPackageVersion,
+  CatalogPackageVersionRow,
+} from "./types";
+
+export const catalogAuthorColumns = [
+  "author_id",
+  "slug",
+  "display_name",
+  "bio",
+  "website_url",
+  "created_at",
+  "updated_at",
+].join(", ");
+
+export const catalogPackageColumns = [
+  "package_id",
+  "author_id",
+  "slug",
+  "title",
+  "summary",
+  "description",
+  "language_tags",
+  "topic_tags",
+  "license",
+  "content_warning",
+  "cover_package_media_key",
+  "status",
+  "created_at",
+  "updated_at",
+  "published_at",
+  "delisted_at",
+].join(", ");
+
+export const catalogPackageMediaAssetColumns = [
+  "package_media_asset_id",
+  "package_id",
+  "package_version_id",
+  "package_media_key",
+  "media_blob_id",
+  "alt_text",
+  "credit",
+  "license",
+  "created_at",
+  "updated_at",
+].join(", ");
+
+export const catalogPackageVersionColumns = [
+  "package_version_id",
+  "package_id",
+  "version_number",
+  "status",
+  "slug",
+  "title",
+  "summary",
+  "description",
+  "language_tags",
+  "topic_tags",
+  "license",
+  "content_warning",
+  "cover_package_media_key",
+  "source_workspace_id",
+  "card_count",
+  "created_by_admin_email",
+  "reviewed_by_admin_email",
+  "created_at",
+  "updated_at",
+  "submitted_at",
+  "reviewed_at",
+  "published_at",
+  "delisted_at",
+].join(", ");
+
+export function mapCatalogAuthorRow(row: CatalogAuthorRow): CatalogAuthor {
+  return {
+    authorId: row.author_id,
+    slug: row.slug,
+    displayName: row.display_name,
+    bio: row.bio,
+    websiteUrl: row.website_url,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+  };
+}
+
+export function mapCatalogPackageRow(row: CatalogPackageRow): CatalogPackage {
+  return {
+    packageId: row.package_id,
+    authorId: row.author_id,
+    slug: row.slug,
+    title: row.title,
+    summary: row.summary,
+    description: row.description,
+    languageTags: [...row.language_tags],
+    topicTags: [...row.topic_tags],
+    license: row.license,
+    contentWarning: row.content_warning,
+    coverPackageMediaKey: row.cover_package_media_key,
+    status: row.status,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+    publishedAt: toOptionalIsoString(row.published_at),
+    delistedAt: toOptionalIsoString(row.delisted_at),
+  };
+}
+
+export function mapCatalogPackageMediaAssetRow(row: CatalogPackageMediaAssetRow): CatalogPackageMediaAsset {
+  return {
+    packageMediaAssetId: row.package_media_asset_id,
+    packageId: row.package_id,
+    packageVersionId: row.package_version_id,
+    packageMediaKey: row.package_media_key,
+    mediaBlobId: row.media_blob_id,
+    altText: row.alt_text,
+    credit: row.credit,
+    license: row.license,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+  };
+}
+
+export function mapCatalogPackageVersionRow(row: CatalogPackageVersionRow): CatalogPackageVersion {
+  return {
+    packageVersionId: row.package_version_id,
+    packageId: row.package_id,
+    versionNumber: toSafeNumber(row.version_number, "version_number"),
+    status: row.status,
+    slug: row.slug,
+    title: row.title,
+    summary: row.summary,
+    description: row.description,
+    languageTags: [...row.language_tags],
+    topicTags: [...row.topic_tags],
+    license: row.license,
+    contentWarning: row.content_warning,
+    coverPackageMediaKey: row.cover_package_media_key,
+    sourceWorkspaceId: row.source_workspace_id,
+    cardCount: toSafeNumber(row.card_count, "card_count"),
+    createdByAdminEmail: row.created_by_admin_email,
+    reviewedByAdminEmail: row.reviewed_by_admin_email,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+    submittedAt: toOptionalIsoString(row.submitted_at),
+    reviewedAt: toOptionalIsoString(row.reviewed_at),
+    publishedAt: toOptionalIsoString(row.published_at),
+    delistedAt: toOptionalIsoString(row.delisted_at),
+  };
+}
+
+export async function lockCatalogPackageInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<CatalogPackageRow> {
+  const result = await executor.query<CatalogPackageRow>(
+    [
+      "SELECT",
+      catalogPackageColumns,
+      "FROM catalog.packages",
+      "WHERE package_id = $1",
+      "FOR UPDATE",
+    ].join(" "),
+    [packageId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(404, `Catalog package not found. packageId=${packageId}`, "CATALOG_PACKAGE_NOT_FOUND");
+  }
+
+  return row;
+}


### PR DESCRIPTION
## Summary
- Extract catalog shared helpers, persistence error mapping, row mappers, and package locking into catalog support modules
- Move catalog author CRUD, package draft CRUD, and draft media attachment into dedicated catalog modules
- Keep catalog index public exports stable while leaving version lifecycle logic in index.ts

## Validation
- npm --prefix apps/backend run lint
- npm --prefix apps/backend test (585 tests)
- git --no-pager diff --check

Review round: no P0-P4 findings, no split recommendation, green light for commit.