### PR TITLE
Extract media asset persistence snapshots

### DIFF
--- a/apps/backend/src/mediaAssets/index.test.ts
+++ b/apps/backend/src/mediaAssets/index.test.ts
@@ -5,17 +5,13 @@ import type { DatabaseExecutor, SqlValue } from "../database";
 import { HttpError } from "../shared/errors";
 import {
   beginMediaAssetUploadSessionCompletionInExecutor,
-  mapMediaAssetRow,
-  mapMediaBlobRow,
   recoverMediaAssetUploadSessionCompletionInExecutor,
-  upsertMediaAssetSnapshotInExecutor,
 } from ".";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
   buildMediaUploadStagingStorageKey,
 } from "./storageKeys";
-import { passthroughMediaBlobNormalizationVersion } from "./types";
 import {
   maximumImageIngestionOriginalBytes,
   maximumMultipartUploadBytes,
@@ -26,30 +22,14 @@ import {
   parseMediaAssetUploadSessionCreateInput,
   readMediaAssetImageIngestionBytes,
 } from "./validators";
-import type {
-  MediaAssetRow,
-  MediaAssetSnapshotInput,
-  MediaAssetUploadSessionRow,
-  MediaBlobRow,
-} from "./types";
+import type { MediaAssetUploadSessionRow } from "./types";
 
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
 const testMediaAssetId = "22222222-2222-4222-8222-222222222222";
-const secondMediaAssetId = "33333333-3333-4333-8333-333333333333";
-const testMediaBlobId = "44444444-4444-4444-8444-444444444444";
 const testUploadSessionId = "55555555-5555-4555-8555-555555555555";
 const testSha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
 const testStorageKey = buildMediaBlobStorageKey(testSha256);
 const maximumTransportSafeImageIngestionOriginalBytes = 4_000_000;
-
-type MediaAssetMutationFixture = Readonly<{
-  sourceUrl: string | null;
-  clientUpdatedAt: string;
-  lastModifiedByReplicaId: string;
-  lastOperationId: string;
-  updatedAt: string;
-  deletedAt: string | null;
-}>;
 
 function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
   return {
@@ -58,50 +38,6 @@ function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Ro
     oid: 0,
     fields: [],
     rows: [...rows],
-  };
-}
-
-function createMediaBlobRow(fixture: Readonly<{
-  mediaBlobId: string;
-  mimeType: string;
-  sizeBytes: number;
-  sha256: string;
-  storageKey: string;
-}>): MediaBlobRow {
-  return {
-    media_blob_id: fixture.mediaBlobId,
-    mime_type: fixture.mimeType,
-    size_bytes: fixture.sizeBytes,
-    sha256: fixture.sha256,
-    storage_key: fixture.storageKey,
-    normalization_version: passthroughMediaBlobNormalizationVersion,
-    created_at: "2026-02-28T09:00:00.000Z",
-    updated_at: "2026-02-28T09:00:00.000Z",
-  };
-}
-
-function createMediaAssetRow(fixture: MediaAssetMutationFixture & Readonly<{
-  mediaAssetId: string;
-  mediaBlob: MediaBlobRow;
-}>): MediaAssetRow {
-  return {
-    media_asset_id: fixture.mediaAssetId,
-    workspace_id: testWorkspaceId,
-    media_blob_id: fixture.mediaBlob.media_blob_id,
-    mime_type: fixture.mediaBlob.mime_type,
-    size_bytes: fixture.mediaBlob.size_bytes,
-    sha256: fixture.mediaBlob.sha256,
-    storage_key: fixture.mediaBlob.storage_key,
-    blob_normalization_version: fixture.mediaBlob.normalization_version,
-    blob_created_at: fixture.mediaBlob.created_at,
-    blob_updated_at: fixture.mediaBlob.updated_at,
-    source_url: fixture.sourceUrl,
-    created_at: "2026-02-28T09:00:00.000Z",
-    client_updated_at: fixture.clientUpdatedAt,
-    last_modified_by_replica_id: fixture.lastModifiedByReplicaId,
-    last_operation_id: fixture.lastOperationId,
-    updated_at: fixture.updatedAt,
-    deleted_at: fixture.deletedAt,
   };
 }
 
@@ -130,18 +66,6 @@ function createMediaAssetUploadSessionRow(
     created_at: "2026-02-28T10:00:00.000Z",
     completed_at: null,
     aborted_at: null,
-  };
-}
-
-function createSnapshotInput(mediaAssetId: string): MediaAssetSnapshotInput {
-  return {
-    mediaAssetId,
-    mimeType: "image/png",
-    sizeBytes: 42,
-    sha256: testSha256,
-    sourceUrl: " https://example.com/source image.png ",
-    createdAt: "2026-02-28T09:00:00.000Z",
-    deletedAt: null,
   };
 }
 
@@ -200,292 +124,6 @@ function createUploadSessionCompletionExecutor(): Readonly<{
     getSessionState: () => sessionRow.state,
     getCompletionUpdateCount: () => completionUpdateCount,
     getRecoveryUpdateCount: () => recoveryUpdateCount,
-  };
-}
-
-function createWorkspaceSyncQueryResult<Row extends pg.QueryResultRow>(
-  text: string,
-  params: ReadonlyArray<SqlValue>,
-): pg.QueryResult<Row> | null {
-  if (text.includes("INSERT INTO sync.workspace_sync_metadata")) {
-    return createQueryResult<Row>([]);
-  }
-
-  if (text === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE") {
-    assert.deepEqual(params, [testWorkspaceId]);
-    return createQueryResult<Row>([{ workspace_id: testWorkspaceId } as unknown as Row]);
-  }
-
-  return null;
-}
-
-function createHotChangeResult<Row extends pg.QueryResultRow>(
-  text: string,
-  params: ReadonlyArray<SqlValue>,
-  changeId: number,
-  operationId: string,
-): pg.QueryResult<Row> | null {
-  if (text.includes("INSERT INTO sync.hot_changes")) {
-    assert.deepEqual(params, [
-      testWorkspaceId,
-      "media_asset",
-      params[2],
-      "upsert",
-      "replica-new",
-      operationId,
-      "2026-02-28T10:00:00.000Z",
-    ]);
-    return createQueryResult<Row>([{
-      change_id: changeId,
-    } as unknown as Row]);
-  }
-
-  return null;
-}
-
-function createExistingMediaAssetUpdateExecutor(): DatabaseExecutor {
-  const queries: string[] = [];
-  const mediaBlob = createMediaBlobRow({
-    mediaBlobId: testMediaBlobId,
-    mimeType: "image/png",
-    sizeBytes: 42,
-    sha256: testSha256,
-    storageKey: testStorageKey,
-  });
-  const existingRow = createMediaAssetRow({
-    mediaAssetId: testMediaAssetId,
-    mediaBlob,
-    sourceUrl: null,
-    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
-    lastModifiedByReplicaId: "replica-old",
-    lastOperationId: "operation-old",
-    updatedAt: "2026-02-28T09:00:00.000Z",
-    deletedAt: null,
-  });
-
-  return {
-    query: async <Row extends pg.QueryResultRow>(
-      text: string,
-      params: ReadonlyArray<SqlValue>,
-    ): Promise<pg.QueryResult<Row>> => {
-      queries.push(text);
-
-      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
-      if (workspaceSyncResult !== null) {
-        return workspaceSyncResult;
-      }
-
-      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
-        assert.deepEqual(queries.slice(0, 3), [
-          "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING",
-          "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE",
-          text,
-        ]);
-        assert.deepEqual(params, [testWorkspaceId, testMediaAssetId]);
-        return createQueryResult([existingRow as unknown as Row]);
-      }
-
-      if (text.startsWith("WITH updated_media_asset AS (")) {
-        assert.doesNotMatch(text, /updated_at = now\(\),\s+WHERE/);
-        assert.match(text, /INNER JOIN content\.media_blobs AS media_blobs/);
-        assert.deepEqual(params, [
-          testWorkspaceId,
-          testMediaAssetId,
-          "https://example.com/updated%20image.png",
-          "2026-02-28T09:00:00.000Z",
-          "2026-02-28T10:00:00.000Z",
-          "2026-02-28T10:00:00.000Z",
-          "replica-new",
-          "operation-new",
-        ]);
-        return createQueryResult([{
-          ...existingRow,
-          source_url: params[2],
-          client_updated_at: params[5],
-          last_modified_by_replica_id: params[6],
-          last_operation_id: params[7],
-          updated_at: "2026-02-28T10:00:01.000Z",
-          deleted_at: params[4],
-        } as MediaAssetRow as unknown as Row]);
-      }
-
-      const hotChangeResult = createHotChangeResult<Row>(text, params, 17, "operation-new");
-      if (hotChangeResult !== null) {
-        return hotChangeResult;
-      }
-
-      throw new Error(`Unexpected query: ${text}`);
-    },
-  };
-}
-
-function createExistingMediaAssetConflictExecutor(): DatabaseExecutor {
-  const conflictingSha256 = "a".repeat(64);
-  const mediaBlob = createMediaBlobRow({
-    mediaBlobId: testMediaBlobId,
-    mimeType: "image/jpeg",
-    sizeBytes: 24,
-    sha256: conflictingSha256,
-    storageKey: buildMediaBlobStorageKey(conflictingSha256),
-  });
-  const existingRow = createMediaAssetRow({
-    mediaAssetId: testMediaAssetId,
-    mediaBlob,
-    sourceUrl: null,
-    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
-    lastModifiedByReplicaId: "replica-old",
-    lastOperationId: "operation-old",
-    updatedAt: "2026-02-28T09:00:00.000Z",
-    deletedAt: null,
-  });
-
-  return {
-    query: async <Row extends pg.QueryResultRow>(
-      text: string,
-      params: ReadonlyArray<SqlValue>,
-    ): Promise<pg.QueryResult<Row>> => {
-      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
-      if (workspaceSyncResult !== null) {
-        return workspaceSyncResult;
-      }
-
-      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
-        assert.deepEqual(params, [testWorkspaceId, testMediaAssetId]);
-        return createQueryResult([existingRow as unknown as Row]);
-      }
-
-      throw new Error(`Unexpected query: ${text}`);
-    },
-  };
-}
-
-function createDuplicateBlobExecutor(): Readonly<{
-  executor: DatabaseExecutor;
-  assetRowsById: Map<string, MediaAssetRow>;
-  blobRowsBySha256: Map<string, MediaBlobRow>;
-}> {
-  const assetRowsById = new Map<string, MediaAssetRow>();
-  const blobRowsBySha256 = new Map<string, MediaBlobRow>();
-  let nextChangeId = 20;
-
-  const executor: DatabaseExecutor = {
-    query: async <Row extends pg.QueryResultRow>(
-      text: string,
-      params: ReadonlyArray<SqlValue>,
-    ): Promise<pg.QueryResult<Row>> => {
-      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
-      if (workspaceSyncResult !== null) {
-        return workspaceSyncResult;
-      }
-
-      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
-        const mediaAssetId = String(params[1]);
-        const row = assetRowsById.get(mediaAssetId);
-        return createQueryResult(row === undefined ? [] : [row as unknown as Row]);
-      }
-
-      if (text.startsWith("INSERT INTO content.media_blobs")) {
-        assert.match(text, /normalization_version/);
-        const sha256 = String(params[0]);
-        const existingBlob = blobRowsBySha256.get(sha256);
-        if (existingBlob !== undefined) {
-          return createQueryResult<Row>([]);
-        }
-
-        assert.equal(params[4], passthroughMediaBlobNormalizationVersion);
-        const mediaBlob = createMediaBlobRow({
-          mediaBlobId: testMediaBlobId,
-          mimeType: String(params[1]),
-          sizeBytes: Number(params[2]),
-          sha256,
-          storageKey: String(params[3]),
-        });
-        blobRowsBySha256.set(sha256, mediaBlob);
-        return createQueryResult([mediaBlob as unknown as Row]);
-      }
-
-      if (text.includes("FROM content.media_blobs") && text.includes("WHERE sha256 = $1")) {
-        const row = blobRowsBySha256.get(String(params[0]));
-        return createQueryResult(row === undefined ? [] : [row as unknown as Row]);
-      }
-
-      if (text.startsWith("WITH inserted_media_asset AS (")) {
-        const mediaAssetId = String(params[0]);
-        if (assetRowsById.has(mediaAssetId)) {
-          return createQueryResult<Row>([]);
-        }
-
-        const mediaBlob = [...blobRowsBySha256.values()].find((row) => row.media_blob_id === params[2]);
-        if (mediaBlob === undefined) {
-          throw new Error(`Missing media blob for ${String(params[2])}`);
-        }
-
-        const row = createMediaAssetRow({
-          mediaAssetId,
-          mediaBlob,
-          sourceUrl: params[3] === null ? null : String(params[3]),
-          clientUpdatedAt: String(params[5]),
-          lastModifiedByReplicaId: String(params[6]),
-          lastOperationId: String(params[7]),
-          updatedAt: "2026-02-28T10:00:01.000Z",
-          deletedAt: params[8] === null ? null : String(params[8]),
-        });
-        assetRowsById.set(mediaAssetId, row);
-        return createQueryResult([row as unknown as Row]);
-      }
-
-      if (text.includes("INSERT INTO sync.hot_changes")) {
-        nextChangeId += 1;
-        return createQueryResult<Row>([{
-          change_id: nextChangeId,
-        } as unknown as Row]);
-      }
-
-      throw new Error(`Unexpected query: ${text}`);
-    },
-  };
-
-  return {
-    executor,
-    assetRowsById,
-    blobRowsBySha256,
-  };
-}
-
-function createBlobMetadataConflictExecutor(): DatabaseExecutor {
-  const conflictingBlob = createMediaBlobRow({
-    mediaBlobId: testMediaBlobId,
-    mimeType: "image/jpeg",
-    sizeBytes: 42,
-    sha256: testSha256,
-    storageKey: testStorageKey,
-  });
-
-  return {
-    query: async <Row extends pg.QueryResultRow>(
-      text: string,
-      params: ReadonlyArray<SqlValue>,
-    ): Promise<pg.QueryResult<Row>> => {
-      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
-      if (workspaceSyncResult !== null) {
-        return workspaceSyncResult;
-      }
-
-      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.startsWith("INSERT INTO content.media_blobs")) {
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.includes("FROM content.media_blobs") && text.includes("WHERE sha256 = $1")) {
-        assert.deepEqual(params, [testSha256]);
-        return createQueryResult([conflictingBlob as unknown as Row]);
-      }
-
-      throw new Error(`Unexpected query: ${text}`);
-    },
   };
 }
 
@@ -627,152 +265,6 @@ test("media asset image ingestion validators parse metadata headers and reject o
       return true;
     },
   );
-});
-
-test("mapMediaAssetRow omits backend-only blob storage fields from public media assets", () => {
-  const mediaBlob = createMediaBlobRow({
-    mediaBlobId: testMediaBlobId,
-    mimeType: "image/png",
-    sizeBytes: 42,
-    sha256: testSha256,
-    storageKey: testStorageKey,
-  });
-  const mediaAsset = mapMediaAssetRow(createMediaAssetRow({
-    mediaAssetId: testMediaAssetId,
-    mediaBlob,
-    sourceUrl: null,
-    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
-    lastModifiedByReplicaId: "replica-old",
-    lastOperationId: "operation-old",
-    updatedAt: "2026-02-28T09:00:00.000Z",
-    deletedAt: null,
-  }));
-
-  assert.equal(mediaAsset.mimeType, "image/png");
-  assert.equal(mediaAsset.sha256, testSha256);
-  assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "storageKey"), false);
-  assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "mediaBlobId"), false);
-  assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "normalizationVersion"), false);
-});
-
-test("mapMediaBlobRow exposes backend-only blob normalization version", () => {
-  const mediaBlob = mapMediaBlobRow(createMediaBlobRow({
-    mediaBlobId: testMediaBlobId,
-    mimeType: "image/png",
-    sizeBytes: 42,
-    sha256: testSha256,
-    storageKey: testStorageKey,
-  }));
-
-  assert.equal(mediaBlob.normalizationVersion, passthroughMediaBlobNormalizationVersion);
-});
-
-test("upsertMediaAssetSnapshotInExecutor reuses one blob row for duplicate logical assets", async () => {
-  const { executor, assetRowsById, blobRowsBySha256 } = createDuplicateBlobExecutor();
-
-  const firstResult = await upsertMediaAssetSnapshotInExecutor(
-    executor,
-    testWorkspaceId,
-    createSnapshotInput(testMediaAssetId),
-    {
-      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
-      lastModifiedByReplicaId: "replica-new",
-      lastOperationId: "operation-one",
-    },
-  );
-  const secondResult = await upsertMediaAssetSnapshotInExecutor(
-    executor,
-    testWorkspaceId,
-    createSnapshotInput(secondMediaAssetId),
-    {
-      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
-      lastModifiedByReplicaId: "replica-new",
-      lastOperationId: "operation-two",
-    },
-  );
-
-  assert.equal(firstResult.applied, true);
-  assert.equal(secondResult.applied, true);
-  assert.equal(blobRowsBySha256.size, 1);
-  assert.equal(assetRowsById.get(testMediaAssetId)?.media_blob_id, testMediaBlobId);
-  assert.equal(assetRowsById.get(secondMediaAssetId)?.media_blob_id, testMediaBlobId);
-});
-
-test("upsertMediaAssetSnapshotInExecutor rejects sha256 blob metadata collisions", async () => {
-  await assert.rejects(
-    upsertMediaAssetSnapshotInExecutor(
-      createBlobMetadataConflictExecutor(),
-      testWorkspaceId,
-      createSnapshotInput(testMediaAssetId),
-      {
-        clientUpdatedAt: "2026-02-28T10:00:00.000Z",
-        lastModifiedByReplicaId: "replica-new",
-        lastOperationId: "operation-new",
-      },
-    ),
-    (error: unknown): boolean => {
-      if (!(error instanceof HttpError)) {
-        return false;
-      }
-
-      assert.equal(error.statusCode, 409);
-      assert.equal(error.code, "MEDIA_BLOB_METADATA_CONFLICT");
-      assert.match(error.message, /conflictingFields=mimeType,sizeBytes,sha256/);
-      assert.doesNotMatch(error.message, /storageKey|media\/blobs|s3:\/\/|sha256=/);
-      assert.doesNotMatch(error.message, new RegExp(testSha256));
-      return true;
-    },
-  );
-});
-
-test("upsertMediaAssetSnapshotInExecutor rejects media asset metadata conflicts without echoing hashes", async () => {
-  await assert.rejects(
-    upsertMediaAssetSnapshotInExecutor(
-      createExistingMediaAssetConflictExecutor(),
-      testWorkspaceId,
-      createSnapshotInput(testMediaAssetId),
-      {
-        clientUpdatedAt: "2026-02-28T10:00:00.000Z",
-        lastModifiedByReplicaId: "replica-new",
-        lastOperationId: "operation-new",
-      },
-    ),
-    (error: unknown): boolean => {
-      if (!(error instanceof HttpError)) {
-        return false;
-      }
-
-      assert.equal(error.statusCode, 409);
-      assert.equal(error.code, "MEDIA_ASSET_ID_CONFLICT");
-      assert.match(error.message, /conflictingFields=mimeType,sizeBytes,sha256/);
-      assert.doesNotMatch(error.message, /existingSha256|requestedSha256|sha256=/);
-      assert.doesNotMatch(error.message, new RegExp(testSha256));
-      return true;
-    },
-  );
-});
-
-test("upsertMediaAssetSnapshotInExecutor updates existing media asset metadata through valid SQL", async () => {
-  const result = await upsertMediaAssetSnapshotInExecutor(
-    createExistingMediaAssetUpdateExecutor(),
-    testWorkspaceId,
-    {
-      ...createSnapshotInput(testMediaAssetId),
-      sourceUrl: " https://example.com/updated image.png ",
-      deletedAt: "2026-02-28T10:00:00.000Z",
-    },
-    {
-      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
-      lastModifiedByReplicaId: "replica-new",
-      lastOperationId: "operation-new",
-    },
-  );
-
-  assert.equal(result.applied, true);
-  assert.equal(result.changeId, 17);
-  assert.equal(result.mediaAsset.sourceUrl, "https://example.com/updated%20image.png");
-  assert.equal(result.mediaAsset.deletedAt, "2026-02-28T10:00:00.000Z");
-  assert.equal(Object.prototype.hasOwnProperty.call(result.mediaAsset, "storageKey"), false);
 });
 
 test("beginMediaAssetUploadSessionCompletionInExecutor validates parts before marking the session completing", async () => {

--- a/apps/backend/src/mediaAssets/index.ts
+++ b/apps/backend/src/mediaAssets/index.ts
@@ -6,39 +6,37 @@ import {
 } from "../database";
 import { HttpError } from "../shared/errors";
 import {
-  incomingLwwMetadataWins,
-  normalizeIsoTimestamp,
-  type LwwMetadata,
-} from "../sync/conflicts/lww";
-import {
-  findLatestSyncChangeId,
-  insertSyncChange,
-  lockWorkspaceSyncMetadataForHotChangesInExecutor,
-  type HotChangeWriteLock,
-} from "../sync/replication/changes";
-import {
-  createSyncConflictHttpError,
-  findSyncConflictWorkspaceIdInExecutor,
-} from "../sync/conflicts/fork";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+  assertMediaBlobMatchesInput,
+  assertMediaBlobMatchesMetadata,
+  findMediaAssetRowForUpdateInExecutor,
+  findMediaBlobRowBySha256InExecutor,
+  MEDIA_ASSET_COLUMNS,
+  MEDIA_ASSET_JOIN_CLAUSE,
+  mapMediaAssetRow,
+  mapMediaAssetWithBlobRow,
+  mapMediaBlobRow,
+  normalizeMediaAssetMutationMetadata,
+  normalizeMediaAssetSnapshotInput,
+  toIsoString,
+  toOptionalIsoString,
+  toSafeNumber,
+  upsertMediaAssetSnapshotInExecutor,
+  upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
+} from "./persistence";
 import {
   imageJpegCardMediaBlobMimeType,
   imageJpegCardMediaBlobNormalizationVersion,
-  mediaBlobNormalizationVersions,
-  passthroughMediaBlobNormalizationVersion,
 } from "./types";
 import type {
   CompleteMediaAssetUploadInput,
   MediaAsset,
   MediaAssetWithBlob,
   MediaBlob,
-  MediaBlobNormalizationVersion,
   MediaBlobRow,
   MediaAssetMutationMetadata,
   MediaAssetMutationResult,
   MediaAssetRow,
   MediaAssetSnapshotInput,
-  MediaAssetSyncMutationResult,
   MediaAssetUploadSession,
   MediaAssetUploadSessionAbortStartResult,
   MediaAssetUploadSessionCompletionStartResult,
@@ -46,48 +44,17 @@ import type {
   MediaAssetUploadSessionCreateResult,
   MediaAssetUploadSessionRow,
   MediaAssetUploadSessionState,
-  TimestampValue,
   MediaAssetImageIngestionMetadataInput,
   NormalizedImageMediaAssetInput,
 } from "./types";
-import { expectMediaAssetSourceUrl } from "./validators";
 
-export const MEDIA_ASSET_COLUMNS = [
-  "media_assets.media_asset_id AS media_asset_id",
-  "media_assets.workspace_id AS workspace_id",
-  "media_assets.media_blob_id AS media_blob_id",
-  "media_blobs.mime_type AS mime_type",
-  "media_blobs.size_bytes AS size_bytes",
-  "media_blobs.sha256 AS sha256",
-  "media_blobs.storage_key AS storage_key",
-  "media_blobs.normalization_version AS blob_normalization_version",
-  "media_blobs.created_at AS blob_created_at",
-  "media_blobs.updated_at AS blob_updated_at",
-  "media_assets.source_url AS source_url",
-  "media_assets.created_at AS created_at",
-  "media_assets.client_updated_at AS client_updated_at",
-  "media_assets.last_modified_by_replica_id AS last_modified_by_replica_id",
-  "media_assets.last_operation_id AS last_operation_id",
-  "media_assets.updated_at AS updated_at",
-  "media_assets.deleted_at AS deleted_at",
-].join(", ");
-
-export const MEDIA_ASSET_JOIN_CLAUSE = [
-  "content.media_assets AS media_assets",
-  "INNER JOIN content.media_blobs AS media_blobs",
-  "ON media_blobs.media_blob_id = media_assets.media_blob_id",
-].join(" ");
-
-const MEDIA_BLOB_COLUMNS = [
-  "media_blob_id",
-  "mime_type",
-  "size_bytes",
-  "sha256",
-  "storage_key",
-  "normalization_version",
-  "created_at",
-  "updated_at",
-].join(", ");
+export {
+  MEDIA_ASSET_COLUMNS,
+  MEDIA_ASSET_JOIN_CLAUSE,
+  mapMediaAssetRow,
+  mapMediaBlobRow,
+  upsertMediaAssetSnapshotInExecutor,
+};
 
 const MEDIA_UPLOAD_SESSION_COLUMNS = [
   "media_upload_session_id",
@@ -117,66 +84,6 @@ type ExistingMediaAssetIntentRow = Readonly<{
   ok: number;
 }>;
 
-function toIsoString(value: TimestampValue): string {
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-
-  return new Date(value).toISOString();
-}
-
-function toOptionalIsoString(value: TimestampValue | null): string | null {
-  return value === null ? null : toIsoString(value);
-}
-
-function toSafeNumber(value: string | number, fieldName: string): number {
-  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
-  if (Number.isSafeInteger(parsedValue) === false) {
-    throw new Error(`${fieldName} must be a safe integer`);
-  }
-
-  return parsedValue;
-}
-
-function expectMediaBlobNormalizationVersion(value: string): MediaBlobNormalizationVersion {
-  const version = mediaBlobNormalizationVersions.find((knownVersion) => knownVersion === value);
-  if (version === undefined) {
-    throw new Error(`normalization_version is unsupported: ${value}`);
-  }
-
-  return version;
-}
-
-export function mapMediaAssetRow(row: MediaAssetRow): MediaAsset {
-  return {
-    mediaAssetId: row.media_asset_id,
-    workspaceId: row.workspace_id,
-    mimeType: row.mime_type,
-    sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
-    sha256: row.sha256,
-    sourceUrl: row.source_url,
-    createdAt: toIsoString(row.created_at),
-    clientUpdatedAt: toIsoString(row.client_updated_at),
-    lastModifiedByReplicaId: row.last_modified_by_replica_id,
-    lastOperationId: row.last_operation_id,
-    updatedAt: toIsoString(row.updated_at),
-    deletedAt: toOptionalIsoString(row.deleted_at),
-  };
-}
-
-export function mapMediaBlobRow(row: MediaBlobRow): MediaBlob {
-  return {
-    mediaBlobId: row.media_blob_id,
-    mimeType: row.mime_type,
-    sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
-    sha256: row.sha256,
-    storageKey: row.storage_key,
-    normalizationVersion: expectMediaBlobNormalizationVersion(row.normalization_version),
-    createdAt: toIsoString(row.created_at),
-    updatedAt: toIsoString(row.updated_at),
-  };
-}
-
 export function mapMediaAssetUploadSessionRow(row: MediaAssetUploadSessionRow): MediaAssetUploadSession {
   return {
     sessionId: row.media_upload_session_id,
@@ -200,22 +107,6 @@ export function mapMediaAssetUploadSessionRow(row: MediaAssetUploadSessionRow): 
     createdAt: toIsoString(row.created_at),
     completedAt: toOptionalIsoString(row.completed_at),
     abortedAt: toOptionalIsoString(row.aborted_at),
-  };
-}
-
-function mapMediaAssetWithBlobRow(row: MediaAssetRow): MediaAssetWithBlob {
-  return {
-    mediaAsset: mapMediaAssetRow(row),
-    mediaBlob: {
-      mediaBlobId: row.media_blob_id,
-      mimeType: row.mime_type,
-      sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
-      sha256: row.sha256,
-      storageKey: row.storage_key,
-      normalizationVersion: expectMediaBlobNormalizationVersion(row.blob_normalization_version),
-      createdAt: toIsoString(row.blob_created_at),
-      updatedAt: toIsoString(row.blob_updated_at),
-    },
   };
 }
 
@@ -252,32 +143,6 @@ export async function assertMediaAssetUploadIntentAvailableForWorkspace(
   );
 }
 
-function toMediaAssetLwwMetadata(row: MediaAssetRow): LwwMetadata {
-  return {
-    clientUpdatedAt: toIsoString(row.client_updated_at),
-    lastModifiedByReplicaId: row.last_modified_by_replica_id,
-    lastOperationId: row.last_operation_id,
-  };
-}
-
-function toInputLwwMetadata(metadata: MediaAssetMutationMetadata): LwwMetadata {
-  return {
-    clientUpdatedAt: metadata.clientUpdatedAt,
-    lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
-    lastOperationId: metadata.lastOperationId,
-  };
-}
-
-function normalizeMediaAssetMutationMetadata(
-  metadata: MediaAssetMutationMetadata,
-): MediaAssetMutationMetadata {
-  return {
-    clientUpdatedAt: normalizeIsoTimestamp(metadata.clientUpdatedAt, "clientUpdatedAt"),
-    lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
-    lastOperationId: metadata.lastOperationId,
-  };
-}
-
 async function assertReplicaBelongsToWorkspaceInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
@@ -301,126 +166,6 @@ async function assertReplicaBelongsToWorkspaceInExecutor(
       "MEDIA_ASSET_REPLICA_INVALID",
     );
   }
-}
-
-async function findMediaAssetRowForUpdateInExecutor(
-  executor: DatabaseExecutor,
-  workspaceId: string,
-  mediaAssetId: string,
-): Promise<MediaAssetRow | null> {
-  const result = await executor.query<MediaAssetRow>(
-    [
-      "SELECT",
-      MEDIA_ASSET_COLUMNS,
-      "FROM",
-      MEDIA_ASSET_JOIN_CLAUSE,
-      "WHERE media_assets.workspace_id = $1",
-      "AND media_assets.media_asset_id = $2",
-      "FOR UPDATE",
-    ].join(" "),
-    [workspaceId, mediaAssetId],
-  );
-
-  return result.rows[0] ?? null;
-}
-
-function normalizeMediaAssetSnapshotInput(input: MediaAssetSnapshotInput): MediaAssetSnapshotInput {
-  if (Number.isSafeInteger(input.sizeBytes) === false || input.sizeBytes < 0) {
-    throw new HttpError(400, "sizeBytes must be a non-negative safe integer", "MEDIA_ASSET_SIZE_INVALID");
-  }
-
-  return {
-    mediaAssetId: input.mediaAssetId,
-    mimeType: input.mimeType.trim().toLowerCase(),
-    sizeBytes: input.sizeBytes,
-    sha256: input.sha256.toLowerCase(),
-    sourceUrl: expectMediaAssetSourceUrl(input.sourceUrl, "sourceUrl"),
-    createdAt: normalizeIsoTimestamp(input.createdAt, "createdAt"),
-    deletedAt: input.deletedAt === null ? null : normalizeIsoTimestamp(input.deletedAt, "deletedAt"),
-  };
-}
-
-function assertExistingMediaAssetMatchesSnapshot(
-  existingRow: MediaAssetRow,
-  input: MediaAssetSnapshotInput,
-): void {
-  const existingSizeBytes = toSafeNumber(existingRow.size_bytes, "size_bytes");
-  const conflictingFields = [
-    ...(existingRow.mime_type === input.mimeType ? [] : ["mimeType"]),
-    ...(existingSizeBytes === input.sizeBytes ? [] : ["sizeBytes"]),
-    ...(existingRow.sha256 === input.sha256 ? [] : ["sha256"]),
-  ];
-  if (
-    existingRow.mime_type !== input.mimeType
-    || existingSizeBytes !== input.sizeBytes
-    || existingRow.sha256 !== input.sha256
-  ) {
-    throw new HttpError(
-      409,
-      [
-        "mediaAssetId is already registered with different file metadata",
-        `workspaceId=${existingRow.workspace_id}`,
-        `mediaAssetId=${existingRow.media_asset_id}`,
-        `conflictingFields=${conflictingFields.join(",")}`,
-      ].join(" "),
-      "MEDIA_ASSET_ID_CONFLICT",
-    );
-  }
-}
-
-function assertMediaBlobMatchesMetadata(
-  row: MediaBlobRow,
-  input: Readonly<{
-    mimeType: string;
-    sizeBytes: number;
-    sha256: string;
-  }>,
-): void {
-  const existingSizeBytes = toSafeNumber(row.size_bytes, "size_bytes");
-  const expectedStorageKey = buildMediaBlobStorageKey(input.sha256);
-  if (
-    row.mime_type === input.mimeType
-    && existingSizeBytes === input.sizeBytes
-    && row.sha256 === input.sha256
-    && row.storage_key === expectedStorageKey
-  ) {
-    return;
-  }
-
-  throw new HttpError(
-    409,
-    [
-      "Media bytes are already registered with different metadata.",
-      "conflictingFields=mimeType,sizeBytes,sha256",
-    ].join(" "),
-    "MEDIA_BLOB_METADATA_CONFLICT",
-  );
-}
-
-function assertMediaBlobMatchesInput(row: MediaBlobRow, input: MediaAssetSnapshotInput): void {
-  assertMediaBlobMatchesMetadata(row, {
-    mimeType: input.mimeType,
-    sizeBytes: input.sizeBytes,
-    sha256: input.sha256,
-  });
-}
-
-async function findMediaBlobRowBySha256InExecutor(
-  executor: DatabaseExecutor,
-  sha256: string,
-): Promise<MediaBlobRow | null> {
-  const result = await executor.query<MediaBlobRow>(
-    [
-      "SELECT",
-      MEDIA_BLOB_COLUMNS,
-      "FROM content.media_blobs",
-      "WHERE sha256 = $1",
-      "LIMIT 1",
-    ].join(" "),
-    [sha256],
-  );
-
-  return result.rows[0] ?? null;
 }
 
 function toMediaAssetSnapshotInputFromUploadSessionCreate(
@@ -506,259 +251,6 @@ async function findReachableMediaBlobForUploadSessionCreateInExecutor(
 
   assertMediaBlobMatchesInput(row, normalizedInput);
   return row;
-}
-
-async function upsertMediaBlobRowInExecutor(
-  executor: DatabaseExecutor,
-  input: MediaAssetSnapshotInput,
-  normalizationVersion: MediaBlobNormalizationVersion,
-): Promise<MediaBlobRow> {
-  const storageKey = buildMediaBlobStorageKey(input.sha256);
-  const insertResult = await executor.query<MediaBlobRow>(
-    [
-      "INSERT INTO content.media_blobs",
-      "(media_blob_id, sha256, mime_type, size_bytes, storage_key, normalization_version)",
-      "VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)",
-      "ON CONFLICT (sha256) DO NOTHING",
-      "RETURNING",
-      MEDIA_BLOB_COLUMNS,
-    ].join(" "),
-    [input.sha256, input.mimeType, input.sizeBytes, storageKey, normalizationVersion],
-  );
-
-  const insertedRow = insertResult.rows[0];
-  const row = insertedRow ?? await findMediaBlobRowBySha256InExecutor(executor, input.sha256);
-  if (row === null) {
-    throw new Error("Media bytes insert conflicted but no row was found");
-  }
-
-  assertMediaBlobMatchesInput(row, input);
-  return row;
-}
-
-async function insertMediaAssetSnapshotRowInExecutor(
-  executor: DatabaseExecutor,
-  workspaceId: string,
-  input: MediaAssetSnapshotInput,
-  metadata: MediaAssetMutationMetadata,
-  mediaBlobId: string,
-): Promise<MediaAssetRow | null> {
-  const result = await executor.query<MediaAssetRow>(
-    [
-      "WITH inserted_media_asset AS (",
-      "INSERT INTO content.media_assets",
-      "(",
-      "media_asset_id, workspace_id, media_blob_id, source_url, created_at,",
-      "client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at",
-      ")",
-      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
-      "ON CONFLICT DO NOTHING",
-      "RETURNING media_asset_id",
-      ")",
-      "SELECT",
-      MEDIA_ASSET_COLUMNS,
-      "FROM",
-      MEDIA_ASSET_JOIN_CLAUSE,
-      "INNER JOIN inserted_media_asset",
-      "ON inserted_media_asset.media_asset_id = media_assets.media_asset_id",
-    ].join(" "),
-    [
-      input.mediaAssetId,
-      workspaceId,
-      mediaBlobId,
-      input.sourceUrl,
-      input.createdAt,
-      metadata.clientUpdatedAt,
-      metadata.lastModifiedByReplicaId,
-      metadata.lastOperationId,
-      input.deletedAt,
-    ],
-  );
-
-  return result.rows[0] ?? null;
-}
-
-async function resolveMediaAssetSnapshotInsertConflictInExecutor(
-  executor: DatabaseExecutor,
-  workspaceId: string,
-  mediaAssetId: string,
-): Promise<MediaAssetRow> {
-  const conflictingWorkspaceId = await findSyncConflictWorkspaceIdInExecutor(executor, {
-    entityType: "media_asset",
-    entityId: mediaAssetId,
-  });
-
-  if (conflictingWorkspaceId === null) {
-    throw new Error(`Media asset insert was skipped but no conflicting workspace was found for ${mediaAssetId}`);
-  }
-
-  if (conflictingWorkspaceId !== workspaceId) {
-    throw createSyncConflictHttpError({
-      phase: "sync_write",
-      entityType: "media_asset",
-      entityId: mediaAssetId,
-      conflictingWorkspaceId,
-      constraint: "media_assets_pkey",
-      sqlState: "23505",
-      table: "media_assets",
-    });
-  }
-
-  const existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, mediaAssetId);
-  if (existingRow === null) {
-    throw new Error(`Media asset insert was skipped but the current workspace row was not found for ${mediaAssetId}`);
-  }
-
-  return existingRow;
-}
-
-async function updateExistingMediaAssetSnapshotRowInExecutor(
-  executor: DatabaseExecutor,
-  workspaceId: string,
-  input: MediaAssetSnapshotInput,
-  metadata: MediaAssetMutationMetadata,
-): Promise<MediaAssetRow> {
-  const result = await executor.query<MediaAssetRow>(
-    [
-      "WITH updated_media_asset AS (",
-      "UPDATE content.media_assets",
-      "SET source_url = $3,",
-      "created_at = $4,",
-      "deleted_at = $5,",
-      "client_updated_at = $6,",
-      "last_modified_by_replica_id = $7,",
-      "last_operation_id = $8,",
-      "updated_at = now()",
-      "WHERE workspace_id = $1",
-      "AND media_asset_id = $2",
-      "RETURNING media_asset_id",
-      ")",
-      "SELECT",
-      MEDIA_ASSET_COLUMNS,
-      "FROM",
-      MEDIA_ASSET_JOIN_CLAUSE,
-      "INNER JOIN updated_media_asset",
-      "ON updated_media_asset.media_asset_id = media_assets.media_asset_id",
-    ].join(" "),
-    [
-      workspaceId,
-      input.mediaAssetId,
-      input.sourceUrl,
-      input.createdAt,
-      input.deletedAt,
-      metadata.clientUpdatedAt,
-      metadata.lastModifiedByReplicaId,
-      metadata.lastOperationId,
-    ],
-  );
-
-  const row = result.rows[0];
-  if (row === undefined) {
-    throw new HttpError(
-      404,
-      "Media asset was not found while completing upload.",
-      "MEDIA_ASSET_NOT_FOUND",
-    );
-  }
-
-  return row;
-}
-
-async function recordMediaAssetSyncChange(
-  executor: DatabaseExecutor,
-  workspaceId: string,
-  hotChangeWriteLock: HotChangeWriteLock,
-  mediaAsset: MediaAsset,
-): Promise<number> {
-  return insertSyncChange(
-    executor,
-    workspaceId,
-    hotChangeWriteLock,
-    "media_asset",
-    mediaAsset.mediaAssetId,
-    "upsert",
-    mediaAsset.lastModifiedByReplicaId,
-    mediaAsset.lastOperationId,
-    mediaAsset.clientUpdatedAt,
-  );
-}
-
-async function upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
-  executor: DatabaseExecutor,
-  workspaceId: string,
-  input: MediaAssetSnapshotInput,
-  metadata: MediaAssetMutationMetadata,
-  normalizationVersion: MediaBlobNormalizationVersion,
-): Promise<MediaAssetSyncMutationResult> {
-  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
-  const normalizedInput = normalizeMediaAssetSnapshotInput(input);
-  const normalizedMetadata = normalizeMediaAssetMutationMetadata(metadata);
-
-  let existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, normalizedInput.mediaAssetId);
-  if (existingRow === null) {
-    const mediaBlobRow = await upsertMediaBlobRowInExecutor(executor, normalizedInput, normalizationVersion);
-    const insertedRow = await insertMediaAssetSnapshotRowInExecutor(
-      executor,
-      workspaceId,
-      normalizedInput,
-      normalizedMetadata,
-      mediaBlobRow.media_blob_id,
-    );
-
-    if (insertedRow === null) {
-      existingRow = await resolveMediaAssetSnapshotInsertConflictInExecutor(
-        executor,
-        workspaceId,
-        normalizedInput.mediaAssetId,
-      );
-    } else {
-      const insertedMediaAsset = mapMediaAssetRow(insertedRow);
-      return {
-        mediaAsset: insertedMediaAsset,
-        applied: true,
-        changeId: await recordMediaAssetSyncChange(executor, workspaceId, hotChangeWriteLock, insertedMediaAsset),
-      };
-    }
-  }
-
-  assertExistingMediaAssetMatchesSnapshot(existingRow, normalizedInput);
-  const existingMediaAsset = mapMediaAssetRow(existingRow);
-  if (incomingLwwMetadataWins(toInputLwwMetadata(normalizedMetadata), toMediaAssetLwwMetadata(existingRow)) === false) {
-    return {
-      mediaAsset: existingMediaAsset,
-      applied: false,
-      changeId: await findLatestSyncChangeId(executor, workspaceId, "media_asset", existingMediaAsset.mediaAssetId),
-    };
-  }
-
-  const updatedRow = await updateExistingMediaAssetSnapshotRowInExecutor(
-    executor,
-    workspaceId,
-    normalizedInput,
-    normalizedMetadata,
-  );
-  const updatedMediaAsset = mapMediaAssetRow(updatedRow);
-
-  return {
-    mediaAsset: updatedMediaAsset,
-    applied: true,
-    changeId: await recordMediaAssetSyncChange(executor, workspaceId, hotChangeWriteLock, updatedMediaAsset),
-  };
-}
-
-export async function upsertMediaAssetSnapshotInExecutor(
-  executor: DatabaseExecutor,
-  workspaceId: string,
-  input: MediaAssetSnapshotInput,
-  metadata: MediaAssetMutationMetadata,
-): Promise<MediaAssetSyncMutationResult> {
-  return upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
-    executor,
-    workspaceId,
-    input,
-    metadata,
-    passthroughMediaBlobNormalizationVersion,
-  );
 }
 
 export async function completeMediaAssetUploadForWorkspace(

--- a/apps/backend/src/mediaAssets/persistence/blobs.ts
+++ b/apps/backend/src/mediaAssets/persistence/blobs.ts
@@ -1,0 +1,95 @@
+import type { DatabaseExecutor } from "../../database";
+import { HttpError } from "../../shared/errors";
+import { buildMediaBlobStorageKey } from "../storageKeys";
+import type {
+  MediaAssetSnapshotInput,
+  MediaBlobNormalizationVersion,
+  MediaBlobRow,
+} from "../types";
+import {
+  MEDIA_BLOB_COLUMNS,
+  toSafeNumber,
+} from "./rows";
+
+export function assertMediaBlobMatchesMetadata(
+  row: MediaBlobRow,
+  input: Readonly<{
+    mimeType: string;
+    sizeBytes: number;
+    sha256: string;
+  }>,
+): void {
+  const existingSizeBytes = toSafeNumber(row.size_bytes, "size_bytes");
+  const expectedStorageKey = buildMediaBlobStorageKey(input.sha256);
+  if (
+    row.mime_type === input.mimeType
+    && existingSizeBytes === input.sizeBytes
+    && row.sha256 === input.sha256
+    && row.storage_key === expectedStorageKey
+  ) {
+    return;
+  }
+
+  throw new HttpError(
+    409,
+    [
+      "Media bytes are already registered with different metadata.",
+      "conflictingFields=mimeType,sizeBytes,sha256",
+    ].join(" "),
+    "MEDIA_BLOB_METADATA_CONFLICT",
+  );
+}
+
+export function assertMediaBlobMatchesInput(row: MediaBlobRow, input: MediaAssetSnapshotInput): void {
+  assertMediaBlobMatchesMetadata(row, {
+    mimeType: input.mimeType,
+    sizeBytes: input.sizeBytes,
+    sha256: input.sha256,
+  });
+}
+
+export async function findMediaBlobRowBySha256InExecutor(
+  executor: DatabaseExecutor,
+  sha256: string,
+): Promise<MediaBlobRow | null> {
+  const result = await executor.query<MediaBlobRow>(
+    [
+      "SELECT",
+      MEDIA_BLOB_COLUMNS,
+      "FROM content.media_blobs",
+      "WHERE sha256 = $1",
+      "LIMIT 1",
+    ].join(" "),
+    [sha256],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+export async function upsertMediaBlobRowInExecutor(
+  executor: DatabaseExecutor,
+  input: MediaAssetSnapshotInput,
+  normalizationVersion: MediaBlobNormalizationVersion,
+): Promise<MediaBlobRow> {
+  const storageKey = buildMediaBlobStorageKey(input.sha256);
+  const insertResult = await executor.query<MediaBlobRow>(
+    [
+      "INSERT INTO content.media_blobs",
+      "(media_blob_id, sha256, mime_type, size_bytes, storage_key, normalization_version)",
+      "VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)",
+      "ON CONFLICT (sha256) DO NOTHING",
+      "RETURNING",
+      MEDIA_BLOB_COLUMNS,
+    ].join(" "),
+    [input.sha256, input.mimeType, input.sizeBytes, storageKey, normalizationVersion],
+  );
+
+  const insertedRow = insertResult.rows[0];
+  const row = insertedRow ?? await findMediaBlobRowBySha256InExecutor(executor, input.sha256);
+  if (row === null) {
+    throw new Error("Media bytes insert conflicted but no row was found");
+  }
+
+  assertMediaBlobMatchesInput(row, input);
+  return row;
+}

--- a/apps/backend/src/mediaAssets/persistence/index.ts
+++ b/apps/backend/src/mediaAssets/persistence/index.ts
@@ -1,0 +1,27 @@
+export {
+  assertMediaBlobMatchesInput,
+  assertMediaBlobMatchesMetadata,
+  findMediaBlobRowBySha256InExecutor,
+  upsertMediaBlobRowInExecutor,
+} from "./blobs";
+export {
+  MEDIA_ASSET_COLUMNS,
+  MEDIA_ASSET_JOIN_CLAUSE,
+  MEDIA_BLOB_COLUMNS,
+  mapMediaAssetRow,
+  mapMediaAssetWithBlobRow,
+  mapMediaBlobRow,
+  toIsoString,
+  toOptionalIsoString,
+  toSafeNumber,
+} from "./rows";
+export {
+  findMediaAssetRowForUpdateInExecutor,
+  normalizeMediaAssetMutationMetadata,
+  normalizeMediaAssetSnapshotInput,
+  upsertMediaAssetSnapshotInExecutor,
+  upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
+} from "./snapshots";
+export {
+  recordMediaAssetSyncChange,
+} from "./syncChanges";

--- a/apps/backend/src/mediaAssets/persistence/rows.ts
+++ b/apps/backend/src/mediaAssets/persistence/rows.ts
@@ -1,0 +1,123 @@
+import {
+  mediaBlobNormalizationVersions,
+  type MediaAsset,
+  type MediaAssetRow,
+  type MediaAssetWithBlob,
+  type MediaBlob,
+  type MediaBlobNormalizationVersion,
+  type MediaBlobRow,
+  type TimestampValue,
+} from "../types";
+
+export const MEDIA_ASSET_COLUMNS = [
+  "media_assets.media_asset_id AS media_asset_id",
+  "media_assets.workspace_id AS workspace_id",
+  "media_assets.media_blob_id AS media_blob_id",
+  "media_blobs.mime_type AS mime_type",
+  "media_blobs.size_bytes AS size_bytes",
+  "media_blobs.sha256 AS sha256",
+  "media_blobs.storage_key AS storage_key",
+  "media_blobs.normalization_version AS blob_normalization_version",
+  "media_blobs.created_at AS blob_created_at",
+  "media_blobs.updated_at AS blob_updated_at",
+  "media_assets.source_url AS source_url",
+  "media_assets.created_at AS created_at",
+  "media_assets.client_updated_at AS client_updated_at",
+  "media_assets.last_modified_by_replica_id AS last_modified_by_replica_id",
+  "media_assets.last_operation_id AS last_operation_id",
+  "media_assets.updated_at AS updated_at",
+  "media_assets.deleted_at AS deleted_at",
+].join(", ");
+
+export const MEDIA_ASSET_JOIN_CLAUSE = [
+  "content.media_assets AS media_assets",
+  "INNER JOIN content.media_blobs AS media_blobs",
+  "ON media_blobs.media_blob_id = media_assets.media_blob_id",
+].join(" ");
+
+export const MEDIA_BLOB_COLUMNS = [
+  "media_blob_id",
+  "mime_type",
+  "size_bytes",
+  "sha256",
+  "storage_key",
+  "normalization_version",
+  "created_at",
+  "updated_at",
+].join(", ");
+
+export function toIsoString(value: TimestampValue): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return new Date(value).toISOString();
+}
+
+export function toOptionalIsoString(value: TimestampValue | null): string | null {
+  return value === null ? null : toIsoString(value);
+}
+
+export function toSafeNumber(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (Number.isSafeInteger(parsedValue) === false) {
+    throw new Error(`${fieldName} must be a safe integer`);
+  }
+
+  return parsedValue;
+}
+
+function expectMediaBlobNormalizationVersion(value: string): MediaBlobNormalizationVersion {
+  const version = mediaBlobNormalizationVersions.find((knownVersion) => knownVersion === value);
+  if (version === undefined) {
+    throw new Error(`normalization_version is unsupported: ${value}`);
+  }
+
+  return version;
+}
+
+export function mapMediaAssetRow(row: MediaAssetRow): MediaAsset {
+  return {
+    mediaAssetId: row.media_asset_id,
+    workspaceId: row.workspace_id,
+    mimeType: row.mime_type,
+    sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
+    sha256: row.sha256,
+    sourceUrl: row.source_url,
+    createdAt: toIsoString(row.created_at),
+    clientUpdatedAt: toIsoString(row.client_updated_at),
+    lastModifiedByReplicaId: row.last_modified_by_replica_id,
+    lastOperationId: row.last_operation_id,
+    updatedAt: toIsoString(row.updated_at),
+    deletedAt: toOptionalIsoString(row.deleted_at),
+  };
+}
+
+export function mapMediaBlobRow(row: MediaBlobRow): MediaBlob {
+  return {
+    mediaBlobId: row.media_blob_id,
+    mimeType: row.mime_type,
+    sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
+    sha256: row.sha256,
+    storageKey: row.storage_key,
+    normalizationVersion: expectMediaBlobNormalizationVersion(row.normalization_version),
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+  };
+}
+
+export function mapMediaAssetWithBlobRow(row: MediaAssetRow): MediaAssetWithBlob {
+  return {
+    mediaAsset: mapMediaAssetRow(row),
+    mediaBlob: {
+      mediaBlobId: row.media_blob_id,
+      mimeType: row.mime_type,
+      sizeBytes: toSafeNumber(row.size_bytes, "size_bytes"),
+      sha256: row.sha256,
+      storageKey: row.storage_key,
+      normalizationVersion: expectMediaBlobNormalizationVersion(row.blob_normalization_version),
+      createdAt: toIsoString(row.blob_created_at),
+      updatedAt: toIsoString(row.blob_updated_at),
+    },
+  };
+}

--- a/apps/backend/src/mediaAssets/persistence/snapshots.test.ts
+++ b/apps/backend/src/mediaAssets/persistence/snapshots.test.ts
@@ -1,0 +1,531 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { HttpError } from "../../shared/errors";
+import {
+  mapMediaAssetRow,
+  mapMediaBlobRow,
+  upsertMediaAssetSnapshotInExecutor,
+} from "..";
+import { buildMediaBlobStorageKey } from "../storageKeys";
+import { passthroughMediaBlobNormalizationVersion } from "../types";
+import type {
+  MediaAssetRow,
+  MediaAssetSnapshotInput,
+  MediaBlobRow,
+} from "../types";
+
+const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
+const testMediaAssetId = "22222222-2222-4222-8222-222222222222";
+const secondMediaAssetId = "33333333-3333-4333-8333-333333333333";
+const testMediaBlobId = "44444444-4444-4444-8444-444444444444";
+const testSha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
+const testStorageKey = buildMediaBlobStorageKey(testSha256);
+
+type MediaAssetMutationFixture = Readonly<{
+  sourceUrl: string | null;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  lastOperationId: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}>;
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createMediaBlobRow(fixture: Readonly<{
+  mediaBlobId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  storageKey: string;
+}>): MediaBlobRow {
+  return {
+    media_blob_id: fixture.mediaBlobId,
+    mime_type: fixture.mimeType,
+    size_bytes: fixture.sizeBytes,
+    sha256: fixture.sha256,
+    storage_key: fixture.storageKey,
+    normalization_version: passthroughMediaBlobNormalizationVersion,
+    created_at: "2026-02-28T09:00:00.000Z",
+    updated_at: "2026-02-28T09:00:00.000Z",
+  };
+}
+
+function createMediaAssetRow(fixture: MediaAssetMutationFixture & Readonly<{
+  mediaAssetId: string;
+  mediaBlob: MediaBlobRow;
+}>): MediaAssetRow {
+  return {
+    media_asset_id: fixture.mediaAssetId,
+    workspace_id: testWorkspaceId,
+    media_blob_id: fixture.mediaBlob.media_blob_id,
+    mime_type: fixture.mediaBlob.mime_type,
+    size_bytes: fixture.mediaBlob.size_bytes,
+    sha256: fixture.mediaBlob.sha256,
+    storage_key: fixture.mediaBlob.storage_key,
+    blob_normalization_version: fixture.mediaBlob.normalization_version,
+    blob_created_at: fixture.mediaBlob.created_at,
+    blob_updated_at: fixture.mediaBlob.updated_at,
+    source_url: fixture.sourceUrl,
+    created_at: "2026-02-28T09:00:00.000Z",
+    client_updated_at: fixture.clientUpdatedAt,
+    last_modified_by_replica_id: fixture.lastModifiedByReplicaId,
+    last_operation_id: fixture.lastOperationId,
+    updated_at: fixture.updatedAt,
+    deleted_at: fixture.deletedAt,
+  };
+}
+
+function createSnapshotInput(mediaAssetId: string): MediaAssetSnapshotInput {
+  return {
+    mediaAssetId,
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: testSha256,
+    sourceUrl: " https://example.com/source image.png ",
+    createdAt: "2026-02-28T09:00:00.000Z",
+    deletedAt: null,
+  };
+}
+
+function createWorkspaceSyncQueryResult<Row extends pg.QueryResultRow>(
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+): pg.QueryResult<Row> | null {
+  if (text.includes("INSERT INTO sync.workspace_sync_metadata")) {
+    return createQueryResult<Row>([]);
+  }
+
+  if (text === "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE") {
+    assert.deepEqual(params, [testWorkspaceId]);
+    return createQueryResult<Row>([{ workspace_id: testWorkspaceId } as unknown as Row]);
+  }
+
+  return null;
+}
+
+function createHotChangeResult<Row extends pg.QueryResultRow>(
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+  changeId: number,
+  operationId: string,
+): pg.QueryResult<Row> | null {
+  if (text.includes("INSERT INTO sync.hot_changes")) {
+    assert.deepEqual(params, [
+      testWorkspaceId,
+      "media_asset",
+      params[2],
+      "upsert",
+      "replica-new",
+      operationId,
+      "2026-02-28T10:00:00.000Z",
+    ]);
+    return createQueryResult<Row>([{
+      change_id: changeId,
+    } as unknown as Row]);
+  }
+
+  return null;
+}
+
+function createExistingMediaAssetUpdateExecutor(): DatabaseExecutor {
+  const queries: string[] = [];
+  const mediaBlob = createMediaBlobRow({
+    mediaBlobId: testMediaBlobId,
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: testSha256,
+    storageKey: testStorageKey,
+  });
+  const existingRow = createMediaAssetRow({
+    mediaAssetId: testMediaAssetId,
+    mediaBlob,
+    sourceUrl: null,
+    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
+    lastModifiedByReplicaId: "replica-old",
+    lastOperationId: "operation-old",
+    updatedAt: "2026-02-28T09:00:00.000Z",
+    deletedAt: null,
+  });
+
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      queries.push(text);
+
+      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
+      if (workspaceSyncResult !== null) {
+        return workspaceSyncResult;
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
+        assert.deepEqual(queries.slice(0, 3), [
+          "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING",
+          "SELECT workspace_id FROM sync.workspace_sync_metadata WHERE workspace_id = $1 FOR UPDATE",
+          text,
+        ]);
+        assert.deepEqual(params, [testWorkspaceId, testMediaAssetId]);
+        return createQueryResult([existingRow as unknown as Row]);
+      }
+
+      if (text.startsWith("WITH updated_media_asset AS (")) {
+        assert.doesNotMatch(text, /updated_at = now\(\),\s+WHERE/);
+        assert.match(text, /INNER JOIN content\.media_blobs AS media_blobs/);
+        assert.deepEqual(params, [
+          testWorkspaceId,
+          testMediaAssetId,
+          "https://example.com/updated%20image.png",
+          "2026-02-28T09:00:00.000Z",
+          "2026-02-28T10:00:00.000Z",
+          "2026-02-28T10:00:00.000Z",
+          "replica-new",
+          "operation-new",
+        ]);
+        return createQueryResult([{
+          ...existingRow,
+          source_url: params[2],
+          client_updated_at: params[5],
+          last_modified_by_replica_id: params[6],
+          last_operation_id: params[7],
+          updated_at: "2026-02-28T10:00:01.000Z",
+          deleted_at: params[4],
+        } as MediaAssetRow as unknown as Row]);
+      }
+
+      const hotChangeResult = createHotChangeResult<Row>(text, params, 17, "operation-new");
+      if (hotChangeResult !== null) {
+        return hotChangeResult;
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+}
+
+function createExistingMediaAssetConflictExecutor(): DatabaseExecutor {
+  const conflictingSha256 = "a".repeat(64);
+  const mediaBlob = createMediaBlobRow({
+    mediaBlobId: testMediaBlobId,
+    mimeType: "image/jpeg",
+    sizeBytes: 24,
+    sha256: conflictingSha256,
+    storageKey: buildMediaBlobStorageKey(conflictingSha256),
+  });
+  const existingRow = createMediaAssetRow({
+    mediaAssetId: testMediaAssetId,
+    mediaBlob,
+    sourceUrl: null,
+    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
+    lastModifiedByReplicaId: "replica-old",
+    lastOperationId: "operation-old",
+    updatedAt: "2026-02-28T09:00:00.000Z",
+    deletedAt: null,
+  });
+
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
+      if (workspaceSyncResult !== null) {
+        return workspaceSyncResult;
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
+        assert.deepEqual(params, [testWorkspaceId, testMediaAssetId]);
+        return createQueryResult([existingRow as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+}
+
+function createDuplicateBlobExecutor(): Readonly<{
+  executor: DatabaseExecutor;
+  assetRowsById: Map<string, MediaAssetRow>;
+  blobRowsBySha256: Map<string, MediaBlobRow>;
+}> {
+  const assetRowsById = new Map<string, MediaAssetRow>();
+  const blobRowsBySha256 = new Map<string, MediaBlobRow>();
+  let nextChangeId = 20;
+
+  const executor: DatabaseExecutor = {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
+      if (workspaceSyncResult !== null) {
+        return workspaceSyncResult;
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
+        const mediaAssetId = String(params[1]);
+        const row = assetRowsById.get(mediaAssetId);
+        return createQueryResult(row === undefined ? [] : [row as unknown as Row]);
+      }
+
+      if (text.startsWith("INSERT INTO content.media_blobs")) {
+        assert.match(text, /normalization_version/);
+        const sha256 = String(params[0]);
+        const existingBlob = blobRowsBySha256.get(sha256);
+        if (existingBlob !== undefined) {
+          return createQueryResult<Row>([]);
+        }
+
+        assert.equal(params[4], passthroughMediaBlobNormalizationVersion);
+        const mediaBlob = createMediaBlobRow({
+          mediaBlobId: testMediaBlobId,
+          mimeType: String(params[1]),
+          sizeBytes: Number(params[2]),
+          sha256,
+          storageKey: String(params[3]),
+        });
+        blobRowsBySha256.set(sha256, mediaBlob);
+        return createQueryResult([mediaBlob as unknown as Row]);
+      }
+
+      if (text.includes("FROM content.media_blobs") && text.includes("WHERE sha256 = $1")) {
+        const row = blobRowsBySha256.get(String(params[0]));
+        return createQueryResult(row === undefined ? [] : [row as unknown as Row]);
+      }
+
+      if (text.startsWith("WITH inserted_media_asset AS (")) {
+        const mediaAssetId = String(params[0]);
+        if (assetRowsById.has(mediaAssetId)) {
+          return createQueryResult<Row>([]);
+        }
+
+        const mediaBlob = [...blobRowsBySha256.values()].find((row) => row.media_blob_id === params[2]);
+        if (mediaBlob === undefined) {
+          throw new Error(`Missing media blob for ${String(params[2])}`);
+        }
+
+        const row = createMediaAssetRow({
+          mediaAssetId,
+          mediaBlob,
+          sourceUrl: params[3] === null ? null : String(params[3]),
+          clientUpdatedAt: String(params[5]),
+          lastModifiedByReplicaId: String(params[6]),
+          lastOperationId: String(params[7]),
+          updatedAt: "2026-02-28T10:00:01.000Z",
+          deletedAt: params[8] === null ? null : String(params[8]),
+        });
+        assetRowsById.set(mediaAssetId, row);
+        return createQueryResult([row as unknown as Row]);
+      }
+
+      if (text.includes("INSERT INTO sync.hot_changes")) {
+        nextChangeId += 1;
+        return createQueryResult<Row>([{
+          change_id: nextChangeId,
+        } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  return {
+    executor,
+    assetRowsById,
+    blobRowsBySha256,
+  };
+}
+
+function createBlobMetadataConflictExecutor(): DatabaseExecutor {
+  const conflictingBlob = createMediaBlobRow({
+    mediaBlobId: testMediaBlobId,
+    mimeType: "image/jpeg",
+    sizeBytes: 42,
+    sha256: testSha256,
+    storageKey: testStorageKey,
+  });
+
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      const workspaceSyncResult = createWorkspaceSyncQueryResult<Row>(text, params);
+      if (workspaceSyncResult !== null) {
+        return workspaceSyncResult;
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets") && text.includes("FOR UPDATE")) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (text.startsWith("INSERT INTO content.media_blobs")) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (text.includes("FROM content.media_blobs") && text.includes("WHERE sha256 = $1")) {
+        assert.deepEqual(params, [testSha256]);
+        return createQueryResult([conflictingBlob as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+}
+
+test("mapMediaAssetRow omits backend-only blob storage fields from public media assets", () => {
+  const mediaBlob = createMediaBlobRow({
+    mediaBlobId: testMediaBlobId,
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: testSha256,
+    storageKey: testStorageKey,
+  });
+  const mediaAsset = mapMediaAssetRow(createMediaAssetRow({
+    mediaAssetId: testMediaAssetId,
+    mediaBlob,
+    sourceUrl: null,
+    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
+    lastModifiedByReplicaId: "replica-old",
+    lastOperationId: "operation-old",
+    updatedAt: "2026-02-28T09:00:00.000Z",
+    deletedAt: null,
+  }));
+
+  assert.equal(mediaAsset.mimeType, "image/png");
+  assert.equal(mediaAsset.sha256, testSha256);
+  assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "storageKey"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "mediaBlobId"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "normalizationVersion"), false);
+});
+
+test("mapMediaBlobRow exposes backend-only blob normalization version", () => {
+  const mediaBlob = mapMediaBlobRow(createMediaBlobRow({
+    mediaBlobId: testMediaBlobId,
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: testSha256,
+    storageKey: testStorageKey,
+  }));
+
+  assert.equal(mediaBlob.normalizationVersion, passthroughMediaBlobNormalizationVersion);
+});
+
+test("upsertMediaAssetSnapshotInExecutor reuses one blob row for duplicate logical assets", async () => {
+  const { executor, assetRowsById, blobRowsBySha256 } = createDuplicateBlobExecutor();
+
+  const firstResult = await upsertMediaAssetSnapshotInExecutor(
+    executor,
+    testWorkspaceId,
+    createSnapshotInput(testMediaAssetId),
+    {
+      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+      lastModifiedByReplicaId: "replica-new",
+      lastOperationId: "operation-one",
+    },
+  );
+  const secondResult = await upsertMediaAssetSnapshotInExecutor(
+    executor,
+    testWorkspaceId,
+    createSnapshotInput(secondMediaAssetId),
+    {
+      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+      lastModifiedByReplicaId: "replica-new",
+      lastOperationId: "operation-two",
+    },
+  );
+
+  assert.equal(firstResult.applied, true);
+  assert.equal(secondResult.applied, true);
+  assert.equal(blobRowsBySha256.size, 1);
+  assert.equal(assetRowsById.get(testMediaAssetId)?.media_blob_id, testMediaBlobId);
+  assert.equal(assetRowsById.get(secondMediaAssetId)?.media_blob_id, testMediaBlobId);
+});
+
+test("upsertMediaAssetSnapshotInExecutor rejects sha256 blob metadata collisions", async () => {
+  await assert.rejects(
+    upsertMediaAssetSnapshotInExecutor(
+      createBlobMetadataConflictExecutor(),
+      testWorkspaceId,
+      createSnapshotInput(testMediaAssetId),
+      {
+        clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+        lastModifiedByReplicaId: "replica-new",
+        lastOperationId: "operation-new",
+      },
+    ),
+    (error: unknown): boolean => {
+      if (!(error instanceof HttpError)) {
+        return false;
+      }
+
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "MEDIA_BLOB_METADATA_CONFLICT");
+      assert.match(error.message, /conflictingFields=mimeType,sizeBytes,sha256/);
+      assert.doesNotMatch(error.message, /storageKey|media\/blobs|s3:\/\/|sha256=/);
+      assert.doesNotMatch(error.message, new RegExp(testSha256));
+      return true;
+    },
+  );
+});
+
+test("upsertMediaAssetSnapshotInExecutor rejects media asset metadata conflicts without echoing hashes", async () => {
+  await assert.rejects(
+    upsertMediaAssetSnapshotInExecutor(
+      createExistingMediaAssetConflictExecutor(),
+      testWorkspaceId,
+      createSnapshotInput(testMediaAssetId),
+      {
+        clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+        lastModifiedByReplicaId: "replica-new",
+        lastOperationId: "operation-new",
+      },
+    ),
+    (error: unknown): boolean => {
+      if (!(error instanceof HttpError)) {
+        return false;
+      }
+
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "MEDIA_ASSET_ID_CONFLICT");
+      assert.match(error.message, /conflictingFields=mimeType,sizeBytes,sha256/);
+      assert.doesNotMatch(error.message, /existingSha256|requestedSha256|sha256=/);
+      assert.doesNotMatch(error.message, new RegExp(testSha256));
+      return true;
+    },
+  );
+});
+
+test("upsertMediaAssetSnapshotInExecutor updates existing media asset metadata through valid SQL", async () => {
+  const result = await upsertMediaAssetSnapshotInExecutor(
+    createExistingMediaAssetUpdateExecutor(),
+    testWorkspaceId,
+    {
+      ...createSnapshotInput(testMediaAssetId),
+      sourceUrl: " https://example.com/updated image.png ",
+      deletedAt: "2026-02-28T10:00:00.000Z",
+    },
+    {
+      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+      lastModifiedByReplicaId: "replica-new",
+      lastOperationId: "operation-new",
+    },
+  );
+
+  assert.equal(result.applied, true);
+  assert.equal(result.changeId, 17);
+  assert.equal(result.mediaAsset.sourceUrl, "https://example.com/updated%20image.png");
+  assert.equal(result.mediaAsset.deletedAt, "2026-02-28T10:00:00.000Z");
+  assert.equal(Object.prototype.hasOwnProperty.call(result.mediaAsset, "storageKey"), false);
+});

--- a/apps/backend/src/mediaAssets/persistence/snapshots.ts
+++ b/apps/backend/src/mediaAssets/persistence/snapshots.ts
@@ -1,0 +1,332 @@
+import type { DatabaseExecutor } from "../../database";
+import { HttpError } from "../../shared/errors";
+import {
+  createSyncConflictHttpError,
+  findSyncConflictWorkspaceIdInExecutor,
+} from "../../sync/conflicts/fork";
+import {
+  incomingLwwMetadataWins,
+  normalizeIsoTimestamp,
+  type LwwMetadata,
+} from "../../sync/conflicts/lww";
+import {
+  findLatestSyncChangeId,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+} from "../../sync/replication/changes";
+import type {
+  MediaAssetMutationMetadata,
+  MediaAssetRow,
+  MediaAssetSnapshotInput,
+  MediaAssetSyncMutationResult,
+  MediaBlobNormalizationVersion,
+} from "../types";
+import { passthroughMediaBlobNormalizationVersion } from "../types";
+import { expectMediaAssetSourceUrl } from "../validators";
+import {
+  upsertMediaBlobRowInExecutor,
+} from "./blobs";
+import {
+  MEDIA_ASSET_COLUMNS,
+  MEDIA_ASSET_JOIN_CLAUSE,
+  mapMediaAssetRow,
+  toIsoString,
+  toSafeNumber,
+} from "./rows";
+import { recordMediaAssetSyncChange } from "./syncChanges";
+
+function toMediaAssetLwwMetadata(row: MediaAssetRow): LwwMetadata {
+  return {
+    clientUpdatedAt: toIsoString(row.client_updated_at),
+    lastModifiedByReplicaId: row.last_modified_by_replica_id,
+    lastOperationId: row.last_operation_id,
+  };
+}
+
+function toInputLwwMetadata(metadata: MediaAssetMutationMetadata): LwwMetadata {
+  return {
+    clientUpdatedAt: metadata.clientUpdatedAt,
+    lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
+    lastOperationId: metadata.lastOperationId,
+  };
+}
+
+export function normalizeMediaAssetMutationMetadata(
+  metadata: MediaAssetMutationMetadata,
+): MediaAssetMutationMetadata {
+  return {
+    clientUpdatedAt: normalizeIsoTimestamp(metadata.clientUpdatedAt, "clientUpdatedAt"),
+    lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
+    lastOperationId: metadata.lastOperationId,
+  };
+}
+
+export async function findMediaAssetRowForUpdateInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<MediaAssetRow | null> {
+  const result = await executor.query<MediaAssetRow>(
+    [
+      "SELECT",
+      MEDIA_ASSET_COLUMNS,
+      "FROM",
+      MEDIA_ASSET_JOIN_CLAUSE,
+      "WHERE media_assets.workspace_id = $1",
+      "AND media_assets.media_asset_id = $2",
+      "FOR UPDATE",
+    ].join(" "),
+    [workspaceId, mediaAssetId],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+export function normalizeMediaAssetSnapshotInput(input: MediaAssetSnapshotInput): MediaAssetSnapshotInput {
+  if (Number.isSafeInteger(input.sizeBytes) === false || input.sizeBytes < 0) {
+    throw new HttpError(400, "sizeBytes must be a non-negative safe integer", "MEDIA_ASSET_SIZE_INVALID");
+  }
+
+  return {
+    mediaAssetId: input.mediaAssetId,
+    mimeType: input.mimeType.trim().toLowerCase(),
+    sizeBytes: input.sizeBytes,
+    sha256: input.sha256.toLowerCase(),
+    sourceUrl: expectMediaAssetSourceUrl(input.sourceUrl, "sourceUrl"),
+    createdAt: normalizeIsoTimestamp(input.createdAt, "createdAt"),
+    deletedAt: input.deletedAt === null ? null : normalizeIsoTimestamp(input.deletedAt, "deletedAt"),
+  };
+}
+
+function assertExistingMediaAssetMatchesSnapshot(
+  existingRow: MediaAssetRow,
+  input: MediaAssetSnapshotInput,
+): void {
+  const existingSizeBytes = toSafeNumber(existingRow.size_bytes, "size_bytes");
+  const conflictingFields = [
+    ...(existingRow.mime_type === input.mimeType ? [] : ["mimeType"]),
+    ...(existingSizeBytes === input.sizeBytes ? [] : ["sizeBytes"]),
+    ...(existingRow.sha256 === input.sha256 ? [] : ["sha256"]),
+  ];
+  if (
+    existingRow.mime_type !== input.mimeType
+    || existingSizeBytes !== input.sizeBytes
+    || existingRow.sha256 !== input.sha256
+  ) {
+    throw new HttpError(
+      409,
+      [
+        "mediaAssetId is already registered with different file metadata",
+        `workspaceId=${existingRow.workspace_id}`,
+        `mediaAssetId=${existingRow.media_asset_id}`,
+        `conflictingFields=${conflictingFields.join(",")}`,
+      ].join(" "),
+      "MEDIA_ASSET_ID_CONFLICT",
+    );
+  }
+}
+
+async function insertMediaAssetSnapshotRowInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: MediaAssetSnapshotInput,
+  metadata: MediaAssetMutationMetadata,
+  mediaBlobId: string,
+): Promise<MediaAssetRow | null> {
+  const result = await executor.query<MediaAssetRow>(
+    [
+      "WITH inserted_media_asset AS (",
+      "INSERT INTO content.media_assets",
+      "(",
+      "media_asset_id, workspace_id, media_blob_id, source_url, created_at,",
+      "client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at",
+      ")",
+      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+      "ON CONFLICT DO NOTHING",
+      "RETURNING media_asset_id",
+      ")",
+      "SELECT",
+      MEDIA_ASSET_COLUMNS,
+      "FROM",
+      MEDIA_ASSET_JOIN_CLAUSE,
+      "INNER JOIN inserted_media_asset",
+      "ON inserted_media_asset.media_asset_id = media_assets.media_asset_id",
+    ].join(" "),
+    [
+      input.mediaAssetId,
+      workspaceId,
+      mediaBlobId,
+      input.sourceUrl,
+      input.createdAt,
+      metadata.clientUpdatedAt,
+      metadata.lastModifiedByReplicaId,
+      metadata.lastOperationId,
+      input.deletedAt,
+    ],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+async function resolveMediaAssetSnapshotInsertConflictInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<MediaAssetRow> {
+  const conflictingWorkspaceId = await findSyncConflictWorkspaceIdInExecutor(executor, {
+    entityType: "media_asset",
+    entityId: mediaAssetId,
+  });
+
+  if (conflictingWorkspaceId === null) {
+    throw new Error(`Media asset insert was skipped but no conflicting workspace was found for ${mediaAssetId}`);
+  }
+
+  if (conflictingWorkspaceId !== workspaceId) {
+    throw createSyncConflictHttpError({
+      phase: "sync_write",
+      entityType: "media_asset",
+      entityId: mediaAssetId,
+      conflictingWorkspaceId,
+      constraint: "media_assets_pkey",
+      sqlState: "23505",
+      table: "media_assets",
+    });
+  }
+
+  const existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, mediaAssetId);
+  if (existingRow === null) {
+    throw new Error(`Media asset insert was skipped but the current workspace row was not found for ${mediaAssetId}`);
+  }
+
+  return existingRow;
+}
+
+async function updateExistingMediaAssetSnapshotRowInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: MediaAssetSnapshotInput,
+  metadata: MediaAssetMutationMetadata,
+): Promise<MediaAssetRow> {
+  const result = await executor.query<MediaAssetRow>(
+    [
+      "WITH updated_media_asset AS (",
+      "UPDATE content.media_assets",
+      "SET source_url = $3,",
+      "created_at = $4,",
+      "deleted_at = $5,",
+      "client_updated_at = $6,",
+      "last_modified_by_replica_id = $7,",
+      "last_operation_id = $8,",
+      "updated_at = now()",
+      "WHERE workspace_id = $1",
+      "AND media_asset_id = $2",
+      "RETURNING media_asset_id",
+      ")",
+      "SELECT",
+      MEDIA_ASSET_COLUMNS,
+      "FROM",
+      MEDIA_ASSET_JOIN_CLAUSE,
+      "INNER JOIN updated_media_asset",
+      "ON updated_media_asset.media_asset_id = media_assets.media_asset_id",
+    ].join(" "),
+    [
+      workspaceId,
+      input.mediaAssetId,
+      input.sourceUrl,
+      input.createdAt,
+      input.deletedAt,
+      metadata.clientUpdatedAt,
+      metadata.lastModifiedByReplicaId,
+      metadata.lastOperationId,
+    ],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(
+      404,
+      "Media asset was not found while completing upload.",
+      "MEDIA_ASSET_NOT_FOUND",
+    );
+  }
+
+  return row;
+}
+
+export async function upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: MediaAssetSnapshotInput,
+  metadata: MediaAssetMutationMetadata,
+  normalizationVersion: MediaBlobNormalizationVersion,
+): Promise<MediaAssetSyncMutationResult> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
+  const normalizedInput = normalizeMediaAssetSnapshotInput(input);
+  const normalizedMetadata = normalizeMediaAssetMutationMetadata(metadata);
+
+  let existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, normalizedInput.mediaAssetId);
+  if (existingRow === null) {
+    const mediaBlobRow = await upsertMediaBlobRowInExecutor(executor, normalizedInput, normalizationVersion);
+    const insertedRow = await insertMediaAssetSnapshotRowInExecutor(
+      executor,
+      workspaceId,
+      normalizedInput,
+      normalizedMetadata,
+      mediaBlobRow.media_blob_id,
+    );
+
+    if (insertedRow === null) {
+      existingRow = await resolveMediaAssetSnapshotInsertConflictInExecutor(
+        executor,
+        workspaceId,
+        normalizedInput.mediaAssetId,
+      );
+    } else {
+      const insertedMediaAsset = mapMediaAssetRow(insertedRow);
+      return {
+        mediaAsset: insertedMediaAsset,
+        applied: true,
+        changeId: await recordMediaAssetSyncChange(executor, workspaceId, hotChangeWriteLock, insertedMediaAsset),
+      };
+    }
+  }
+
+  assertExistingMediaAssetMatchesSnapshot(existingRow, normalizedInput);
+  const existingMediaAsset = mapMediaAssetRow(existingRow);
+  if (incomingLwwMetadataWins(toInputLwwMetadata(normalizedMetadata), toMediaAssetLwwMetadata(existingRow)) === false) {
+    return {
+      mediaAsset: existingMediaAsset,
+      applied: false,
+      changeId: await findLatestSyncChangeId(executor, workspaceId, "media_asset", existingMediaAsset.mediaAssetId),
+    };
+  }
+
+  const updatedRow = await updateExistingMediaAssetSnapshotRowInExecutor(
+    executor,
+    workspaceId,
+    normalizedInput,
+    normalizedMetadata,
+  );
+  const updatedMediaAsset = mapMediaAssetRow(updatedRow);
+
+  return {
+    mediaAsset: updatedMediaAsset,
+    applied: true,
+    changeId: await recordMediaAssetSyncChange(executor, workspaceId, hotChangeWriteLock, updatedMediaAsset),
+  };
+}
+
+export async function upsertMediaAssetSnapshotInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: MediaAssetSnapshotInput,
+  metadata: MediaAssetMutationMetadata,
+): Promise<MediaAssetSyncMutationResult> {
+  return upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
+    executor,
+    workspaceId,
+    input,
+    metadata,
+    passthroughMediaBlobNormalizationVersion,
+  );
+}

--- a/apps/backend/src/mediaAssets/persistence/syncChanges.ts
+++ b/apps/backend/src/mediaAssets/persistence/syncChanges.ts
@@ -1,0 +1,25 @@
+import type { DatabaseExecutor } from "../../database";
+import {
+  insertSyncChange,
+  type HotChangeWriteLock,
+} from "../../sync/replication/changes";
+import type { MediaAsset } from "../types";
+
+export async function recordMediaAssetSyncChange(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  hotChangeWriteLock: HotChangeWriteLock,
+  mediaAsset: MediaAsset,
+): Promise<number> {
+  return insertSyncChange(
+    executor,
+    workspaceId,
+    hotChangeWriteLock,
+    "media_asset",
+    mediaAsset.mediaAssetId,
+    "upsert",
+    mediaAsset.lastModifiedByReplicaId,
+    mediaAsset.lastOperationId,
+    mediaAsset.clientUpdatedAt,
+  );
+}


### PR DESCRIPTION
## Summary
- Extract media asset row mapping, blob row reuse, snapshot LWW persistence, and sync-change recording into mediaAssets/persistence modules.
- Keep mediaAssets/index.ts as the stable public entrypoint plus upload-session/image-ingestion coordination.
- Move persistence snapshot tests into mediaAssets/persistence/snapshots.test.ts while keeping upload-session tests in index.test.ts.

## Validation
- npm --prefix apps/backend run lint: passed
- npm --prefix apps/backend test: passed, 585 tests, 0 failures
- git --no-pager diff --check: passed
- Review round: no P0-P4 findings, no split recommendation, green light for commit
