### PR TITLE
Add portable package core

### DIFF
--- a/apps/backend/src/workspacePackages/core.test.ts
+++ b/apps/backend/src/workspacePackages/core.test.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  extractMarkdownFcAssetIds,
+  parseWorkspacePackageCardsJsonV1,
+  rewriteMarkdownFcAssetUrlsToPortablePathsFromMap,
+  rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap,
+  toPortableWorkspacePackageCard,
+  validatePortableMediaPath,
+  validateUniquePortableMediaPaths,
+} from "./index";
+import type { WorkspacePackageCardMetadataV1 } from "./index";
+
+const testMetadata: WorkspacePackageCardMetadataV1 = {
+  version: 1,
+  source: {
+    label: "Starter deck",
+    author: null,
+    comment: null,
+    createdAt: "2026-06-01T12:00:00.000Z",
+    importedAt: null,
+    importId: null,
+  },
+};
+
+test("toPortableWorkspacePackageCard projects only portable card fields", () => {
+  const card = {
+    cardId: "backend-card-id",
+    frontText: "What is the prompt?",
+    backText: "The answer.",
+    tags: ["core", "portable"],
+    cardType: "basic",
+    metadata: testMetadata,
+    dueAt: "2026-06-02T12:00:00.000Z",
+    reps: 12,
+    lapses: 1,
+    fsrsCardState: "review",
+    lastOperationId: "operation-1",
+    updatedAt: "2026-06-02T12:00:00.000Z",
+  };
+
+  assert.deepEqual(toPortableWorkspacePackageCard(card), {
+    frontText: "What is the prompt?",
+    backText: "The answer.",
+    tags: ["core", "portable"],
+    cardType: "basic",
+    metadata: testMetadata,
+  });
+});
+
+test("Markdown fcasset helpers only read and rewrite inline link and image destinations", () => {
+  const markdown = [
+    "Plain fcasset:plain-asset stays plain.",
+    "![diagram](fcasset:image-asset)",
+    "[source](fcasset:link-asset)",
+    "<img src=\"fcasset:html-asset\">",
+    "[external](https://example.com/fcasset:not-internal)",
+  ].join("\n");
+
+  assert.deepEqual(extractMarkdownFcAssetIds(markdown), [
+    "image-asset",
+    "link-asset",
+  ]);
+
+  assert.equal(
+    rewriteMarkdownFcAssetUrlsToPortablePathsFromMap(markdown, new Map([
+      ["image-asset", "media/image.png"],
+      ["link-asset", "media/docs/source.txt"],
+    ])),
+    [
+      "Plain fcasset:plain-asset stays plain.",
+      "![diagram](media/image.png)",
+      "[source](media/docs/source.txt)",
+      "<img src=\"fcasset:html-asset\">",
+      "[external](https://example.com/fcasset:not-internal)",
+    ].join("\n"),
+  );
+});
+
+test("Markdown media helpers skip fenced code blocks and inline code spans", () => {
+  const markdown = [
+    "`![inline code](fcasset:inline-code-image)`",
+    "Text with `[inline code](fcasset:inline-code-link)` example.",
+    "```markdown",
+    "![fenced](fcasset:fenced-image)",
+    "[fenced](media/fenced.txt)",
+    "```",
+    "![real](fcasset:real-image)",
+    "[real](media/real.txt)",
+  ].join("\n");
+
+  assert.deepEqual(extractMarkdownFcAssetIds(markdown), ["real-image"]);
+
+  assert.equal(
+    rewriteMarkdownFcAssetUrlsToPortablePathsFromMap(markdown, new Map([
+      ["real-image", "media/real.png"],
+    ])),
+    [
+      "`![inline code](fcasset:inline-code-image)`",
+      "Text with `[inline code](fcasset:inline-code-link)` example.",
+      "```markdown",
+      "![fenced](fcasset:fenced-image)",
+      "[fenced](media/fenced.txt)",
+      "```",
+      "![real](media/real.png)",
+      "[real](media/real.txt)",
+    ].join("\n"),
+  );
+
+  assert.equal(
+    rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap(markdown, new Map([
+      ["media/real.txt", "real-link"],
+    ])),
+    [
+      "`![inline code](fcasset:inline-code-image)`",
+      "Text with `[inline code](fcasset:inline-code-link)` example.",
+      "```markdown",
+      "![fenced](fcasset:fenced-image)",
+      "[fenced](media/fenced.txt)",
+      "```",
+      "![real](fcasset:real-image)",
+      "[real](fcasset:real-link)",
+    ].join("\n"),
+  );
+});
+
+test("Markdown portable media helpers rewrite only package media destinations", () => {
+  const markdown = [
+    "media/plain.png is plain text.",
+    "![diagram](media/image.png)",
+    "[notes](media/docs/source.txt)",
+    "[remote](https://example.com/media/image.png)",
+  ].join("\n");
+
+  assert.equal(
+    rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap(markdown, new Map([
+      ["media/image.png", "image-asset"],
+      ["media/docs/source.txt", "link-asset"],
+    ])),
+    [
+      "media/plain.png is plain text.",
+      "![diagram](fcasset:image-asset)",
+      "[notes](fcasset:link-asset)",
+      "[remote](https://example.com/media/image.png)",
+    ].join("\n"),
+  );
+});
+
+test("Markdown media helpers preserve link titles while rewriting destinations", () => {
+  const markdown = [
+    "![diagram](fcasset:image-asset \"Diagram title\")",
+    "[notes](media/docs/source.txt 'Notes title')",
+  ].join("\n");
+
+  assert.deepEqual(extractMarkdownFcAssetIds(markdown), ["image-asset"]);
+
+  assert.equal(
+    rewriteMarkdownFcAssetUrlsToPortablePathsFromMap(markdown, new Map([
+      ["image-asset", "media/image.png"],
+    ])),
+    [
+      "![diagram](media/image.png \"Diagram title\")",
+      "[notes](media/docs/source.txt 'Notes title')",
+    ].join("\n"),
+  );
+
+  assert.equal(
+    rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap(markdown, new Map([
+      ["media/docs/source.txt", "notes-asset"],
+    ])),
+    [
+      "![diagram](fcasset:image-asset \"Diagram title\")",
+      "[notes](fcasset:notes-asset 'Notes title')",
+    ].join("\n"),
+  );
+});
+
+test("portable media path validation accepts relative media paths and rejects unsafe paths", () => {
+  assert.equal(validatePortableMediaPath("media/image.png"), "media/image.png");
+  assert.deepEqual(
+    validateUniquePortableMediaPaths(["media/image.png", "media/docs/source.txt"]),
+    ["media/image.png", "media/docs/source.txt"],
+  );
+
+  for (const invalidPath of [
+    "",
+    "image.png",
+    "media",
+    "media/",
+    "media//image.png",
+    "media/my image.png",
+    "media/my(image).png",
+    "media/my%20image.png",
+    "media/image+.png",
+    "media/../image.png",
+    "media/%2e%2e/image.png",
+    "/media/image.png",
+    "https://example.com/media/image.png",
+    "media\\image.png",
+    "media/image.png?download=1",
+    "media/image.png#fragment",
+  ]) {
+    assert.throws(() => validatePortableMediaPath(invalidPath), Error);
+  }
+
+  assert.throws(
+    () => validateUniquePortableMediaPaths(["media/Image.png", "media/image.png"]),
+    /duplicated/,
+  );
+});
+
+test("portable media path validation rejects destinations the Markdown helper cannot round-trip", () => {
+  for (const invalidPath of [
+    "media/my image.png",
+    "media/my(image).png",
+    "media/my%20image.png",
+  ]) {
+    assert.throws(
+      () => rewriteMarkdownFcAssetUrlsToPortablePathsFromMap("![image](fcasset:image-asset)", new Map([
+        ["image-asset", invalidPath],
+      ])),
+      /Portable media path segments/,
+    );
+  }
+});
+
+test("workspace package cards.json parser normalizes card source metadata", () => {
+  const parsedPackage = parseWorkspacePackageCardsJsonV1({
+    formatVersion: 1,
+    label: "Starter",
+    extraPackageField: "ignored",
+    cards: [
+      {
+        frontText: " Prompt ",
+        backText: " Answer ",
+        tags: [" tag "],
+        cardType: " ",
+        metadata: {
+          version: 1,
+          source: {
+            label: "Source label",
+            importId: "import-1",
+            extraSourceField: "ignored",
+          },
+        },
+        dueAt: "must not leak",
+      },
+      {
+        frontText: "Second prompt",
+        backText: "Second answer",
+        tags: [" custom "],
+        cardType: " custom-type ",
+        metadata: {
+          version: 1,
+          source: null,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(parsedPackage, {
+    formatVersion: 1,
+    label: "Starter",
+    cards: [
+      {
+        frontText: "Prompt",
+        backText: "Answer",
+        tags: ["tag"],
+        cardType: "basic",
+        metadata: {
+          version: 1,
+          source: {
+            label: "Source label",
+            author: null,
+            comment: null,
+            createdAt: null,
+            importedAt: null,
+            importId: "import-1",
+          },
+        },
+      },
+      {
+        frontText: "Second prompt",
+        backText: "Second answer",
+        tags: ["custom"],
+        cardType: "custom-type",
+        metadata: {
+          version: 1,
+          source: null,
+        },
+      },
+    ],
+  });
+});
+
+test("workspace package cards.json parser rejects empty normalized card fields", () => {
+  const baseCard = {
+    frontText: "Prompt",
+    backText: "Answer",
+    tags: ["tag"],
+    cardType: "basic",
+    metadata: {
+      version: 1,
+      source: null,
+    },
+  };
+
+  assert.throws(
+    () => parseWorkspacePackageCardsJsonV1({
+      formatVersion: 1,
+      cards: [
+        {
+          ...baseCard,
+          frontText: " ",
+        },
+      ],
+    }),
+    /Invalid workspace package cards\.json/,
+  );
+
+  assert.throws(
+    () => parseWorkspacePackageCardsJsonV1({
+      formatVersion: 1,
+      cards: [
+        {
+          ...baseCard,
+          tags: ["tag", " "],
+        },
+      ],
+    }),
+    /Invalid workspace package cards\.json/,
+  );
+});

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -1,0 +1,34 @@
+export {
+  extractMarkdownFcAssetIds,
+  rewriteMarkdownFcAssetUrlsToPortablePaths,
+  rewriteMarkdownFcAssetUrlsToPortablePathsFromMap,
+  rewriteMarkdownPortableMediaUrlsToFcAssets,
+  rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap,
+  validatePortableMediaPath,
+  validateUniquePortableMediaPaths,
+} from "./markdownMedia";
+
+export type {
+  FcAssetPortablePathResolver,
+  PortableMediaAssetIdResolver,
+} from "./markdownMedia";
+
+export {
+  normalizeWorkspacePackageCardMetadataV1,
+  parseWorkspacePackageCardsJsonV1,
+  toPortableWorkspacePackageCard,
+  workspacePackageCardsJsonV1Schema,
+  workspacePackageFormatVersion,
+} from "./types";
+
+export type {
+  PortableWorkspacePackageCardInputV1,
+  PortableWorkspacePackageCardV1,
+  WorkspacePackageCardMetadataInputV1,
+  WorkspacePackageCardMetadataV1,
+  WorkspacePackageCardSourceMetadataInputV1,
+  WorkspacePackageCardSourceMetadataV1,
+  WorkspacePackageCardsJsonV1,
+  WorkspacePackageMetadataV1,
+  WorkspacePackageValidationIssue,
+} from "./types";

--- a/apps/backend/src/workspacePackages/markdownMedia.ts
+++ b/apps/backend/src/workspacePackages/markdownMedia.ts
@@ -1,0 +1,532 @@
+type MarkdownUrlRewrite = Readonly<{
+  startIndex: number;
+  endIndex: number;
+  replacementUrl: string;
+}>;
+
+type MarkdownLinkDestination = Readonly<{
+  startIndex: number;
+  endIndex: number;
+  linkEndIndex: number;
+  destination: string;
+}>;
+
+type MarkdownFence = Readonly<{
+  marker: "`" | "~";
+  length: number;
+  lineEndIndex: number;
+}>;
+
+export type FcAssetPortablePathResolver = (assetId: string) => string;
+export type PortableMediaAssetIdResolver = (portableMediaPath: string) => string;
+
+const fcAssetUrlPattern = /^fcasset:([A-Za-z0-9][A-Za-z0-9._-]*)$/;
+const absoluteUrlPattern = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const portableMediaPathSegmentPattern = /^[A-Za-z0-9._-]+$/;
+
+function matchFcAssetId(url: string): string | null {
+  const match = fcAssetUrlPattern.exec(url);
+  if (match === null) {
+    return null;
+  }
+
+  return match[1] ?? null;
+}
+
+function isLineStart(markdown: string, index: number): boolean {
+  return index === 0 || markdown[index - 1] === "\n";
+}
+
+function getLineEndIndex(markdown: string, index: number): number {
+  const newlineIndex = markdown.indexOf("\n", index);
+  return newlineIndex === -1 ? markdown.length : newlineIndex;
+}
+
+function getNextLineStartIndex(markdown: string, lineEndIndex: number): number {
+  return lineEndIndex >= markdown.length ? markdown.length : lineEndIndex + 1;
+}
+
+function countRepeatedCharacter(markdown: string, index: number, marker: "`" | "~"): number {
+  let cursorIndex = index;
+  while (markdown[cursorIndex] === marker) {
+    cursorIndex += 1;
+  }
+
+  return cursorIndex - index;
+}
+
+function parseFenceAtLineStart(markdown: string, index: number): MarkdownFence | null {
+  if (!isLineStart(markdown, index)) {
+    return null;
+  }
+
+  let cursorIndex = index;
+  let leadingSpaces = 0;
+  while (markdown[cursorIndex] === " " && leadingSpaces < 4) {
+    cursorIndex += 1;
+    leadingSpaces += 1;
+  }
+
+  if (leadingSpaces > 3) {
+    return null;
+  }
+
+  const marker = markdown[cursorIndex];
+  if (marker !== "`" && marker !== "~") {
+    return null;
+  }
+
+  const markerLength = countRepeatedCharacter(markdown, cursorIndex, marker);
+  if (markerLength < 3) {
+    return null;
+  }
+
+  return {
+    marker,
+    length: markerLength,
+    lineEndIndex: getLineEndIndex(markdown, index),
+  };
+}
+
+function findFencedCodeBlockEndIndex(markdown: string, openingFence: MarkdownFence): number {
+  let cursorIndex = getNextLineStartIndex(markdown, openingFence.lineEndIndex);
+
+  while (cursorIndex < markdown.length) {
+    const closingFence = parseFenceAtLineStart(markdown, cursorIndex);
+    if (
+      closingFence !== null
+      && closingFence.marker === openingFence.marker
+      && closingFence.length >= openingFence.length
+    ) {
+      return getNextLineStartIndex(markdown, closingFence.lineEndIndex);
+    }
+
+    cursorIndex = getNextLineStartIndex(markdown, getLineEndIndex(markdown, cursorIndex));
+  }
+
+  return markdown.length;
+}
+
+function findInlineCodeSpanEndIndex(markdown: string, index: number): number {
+  const markerLength = countRepeatedCharacter(markdown, index, "`");
+  const closingMarker = "`".repeat(markerLength);
+  const closingIndex = markdown.indexOf(closingMarker, index + markerLength);
+  if (closingIndex === -1) {
+    return index + markerLength;
+  }
+
+  return closingIndex + markerLength;
+}
+
+function findClosingBracketIndex(markdown: string, index: number): number | null {
+  let cursorIndex = index;
+
+  while (cursorIndex < markdown.length) {
+    const character = markdown[cursorIndex];
+    if (character === "\\") {
+      cursorIndex += 2;
+      continue;
+    }
+
+    if (character === "\n") {
+      return null;
+    }
+
+    if (character === "]") {
+      return cursorIndex;
+    }
+
+    cursorIndex += 1;
+  }
+
+  return null;
+}
+
+function skipHorizontalWhitespace(markdown: string, index: number): number {
+  let cursorIndex = index;
+  while (markdown[cursorIndex] === " " || markdown[cursorIndex] === "\t") {
+    cursorIndex += 1;
+  }
+
+  return cursorIndex;
+}
+
+function findClosingTitleQuoteIndex(markdown: string, index: number, quote: "\"" | "'"): number | null {
+  let cursorIndex = index;
+
+  while (cursorIndex < markdown.length) {
+    const character = markdown[cursorIndex];
+    if (character === "\\") {
+      cursorIndex += 2;
+      continue;
+    }
+
+    if (character === "\n") {
+      return null;
+    }
+
+    if (character === quote) {
+      return cursorIndex;
+    }
+
+    cursorIndex += 1;
+  }
+
+  return null;
+}
+
+function parseBareDestinationEndIndex(markdown: string, index: number): number {
+  let cursorIndex = index;
+
+  while (cursorIndex < markdown.length) {
+    const character = markdown[cursorIndex];
+    if (
+      character === ")"
+      || character === " "
+      || character === "\t"
+      || character === "\n"
+    ) {
+      return cursorIndex;
+    }
+
+    cursorIndex += 1;
+  }
+
+  return cursorIndex;
+}
+
+function parseAngledDestinationEndIndex(markdown: string, index: number): number | null {
+  let cursorIndex = index;
+
+  while (cursorIndex < markdown.length) {
+    const character = markdown[cursorIndex];
+    if (character === "\n") {
+      return null;
+    }
+
+    if (character === ">") {
+      return cursorIndex;
+    }
+
+    cursorIndex += 1;
+  }
+
+  return null;
+}
+
+function parseMarkdownLinkDestinationAtIndex(markdown: string, index: number): MarkdownLinkDestination | null {
+  const labelOpenIndex = markdown[index] === "!" ? index + 1 : index;
+  if (markdown[labelOpenIndex] !== "[") {
+    return null;
+  }
+
+  const labelCloseIndex = findClosingBracketIndex(markdown, labelOpenIndex + 1);
+  if (labelCloseIndex === null || markdown[labelCloseIndex + 1] !== "(") {
+    return null;
+  }
+
+  let cursorIndex = skipHorizontalWhitespace(markdown, labelCloseIndex + 2);
+  let destinationStartIndex = cursorIndex;
+  let destinationEndIndex: number | null;
+
+  if (markdown[cursorIndex] === "<") {
+    destinationStartIndex = cursorIndex + 1;
+    destinationEndIndex = parseAngledDestinationEndIndex(markdown, destinationStartIndex);
+    if (destinationEndIndex === null) {
+      return null;
+    }
+
+    cursorIndex = destinationEndIndex + 1;
+  } else {
+    destinationEndIndex = parseBareDestinationEndIndex(markdown, cursorIndex);
+    cursorIndex = destinationEndIndex;
+  }
+
+  if (destinationStartIndex === destinationEndIndex) {
+    return null;
+  }
+
+  cursorIndex = skipHorizontalWhitespace(markdown, cursorIndex);
+  const titleQuote = markdown[cursorIndex];
+  if (titleQuote === "\"" || titleQuote === "'") {
+    const closingQuoteIndex = findClosingTitleQuoteIndex(markdown, cursorIndex + 1, titleQuote);
+    if (closingQuoteIndex === null) {
+      return null;
+    }
+
+    cursorIndex = skipHorizontalWhitespace(markdown, closingQuoteIndex + 1);
+  }
+
+  if (markdown[cursorIndex] !== ")") {
+    return null;
+  }
+
+  return {
+    startIndex: destinationStartIndex,
+    endIndex: destinationEndIndex,
+    linkEndIndex: cursorIndex + 1,
+    destination: markdown.slice(destinationStartIndex, destinationEndIndex),
+  };
+}
+
+function listMarkdownLinkDestinations(markdown: string): ReadonlyArray<MarkdownLinkDestination> {
+  const destinations: Array<MarkdownLinkDestination> = [];
+  let cursorIndex = 0;
+
+  while (cursorIndex < markdown.length) {
+    const openingFence = parseFenceAtLineStart(markdown, cursorIndex);
+    if (openingFence !== null) {
+      cursorIndex = findFencedCodeBlockEndIndex(markdown, openingFence);
+      continue;
+    }
+
+    const character = markdown[cursorIndex];
+    if (character === "`") {
+      cursorIndex = findInlineCodeSpanEndIndex(markdown, cursorIndex);
+      continue;
+    }
+
+    if (character === "[" || (character === "!" && markdown[cursorIndex + 1] === "[")) {
+      const destination = parseMarkdownLinkDestinationAtIndex(markdown, cursorIndex);
+      if (destination !== null) {
+        destinations.push(destination);
+        cursorIndex = destination.linkEndIndex;
+        continue;
+      }
+    }
+
+    cursorIndex += 1;
+  }
+
+  return destinations;
+}
+
+function rewriteMarkdownUrls(
+  markdown: string,
+  buildRewrite: (url: string) => string | null,
+): string {
+  const rewrites: Array<MarkdownUrlRewrite> = [];
+
+  for (const linkDestination of listMarkdownLinkDestinations(markdown)) {
+    const replacementUrl = buildRewrite(linkDestination.destination);
+    if (replacementUrl === null) {
+      continue;
+    }
+
+    rewrites.push({
+      startIndex: linkDestination.startIndex,
+      endIndex: linkDestination.endIndex,
+      replacementUrl,
+    });
+  }
+
+  if (rewrites.length === 0) {
+    return markdown;
+  }
+
+  let rewrittenMarkdown = "";
+  let cursorIndex = 0;
+  for (const rewrite of rewrites) {
+    rewrittenMarkdown += markdown.slice(cursorIndex, rewrite.startIndex);
+    rewrittenMarkdown += rewrite.replacementUrl;
+    cursorIndex = rewrite.endIndex;
+  }
+
+  return rewrittenMarkdown + markdown.slice(cursorIndex);
+}
+
+function assertFcAssetId(value: string, fieldName: string): string {
+  if (matchFcAssetId(`fcasset:${value}`) === null) {
+    throw new Error(`${fieldName} must contain only portable fcasset id characters.`);
+  }
+
+  return value;
+}
+
+function validatePortableMediaPathSegment(segment: string, portableMediaPath: string): string {
+  if (segment === "") {
+    throw new Error(`Portable media path must not contain empty path segments: ${portableMediaPath}`);
+  }
+
+  let decodedSegment: string;
+  try {
+    decodedSegment = decodeURIComponent(segment);
+  } catch {
+    throw new Error(`Portable media path segment must use valid percent encoding: ${portableMediaPath}`);
+  }
+
+  if (decodedSegment === "." || decodedSegment === "..") {
+    throw new Error(`Portable media path must not contain traversal segments: ${portableMediaPath}`);
+  }
+
+  if (!portableMediaPathSegmentPattern.test(segment)) {
+    throw new Error(
+      `Portable media path segments must contain only letters, numbers, dots, underscores, and hyphens: ${portableMediaPath}`,
+    );
+  }
+
+  if (
+    decodedSegment.includes("/")
+    || decodedSegment.includes("\\")
+    || decodedSegment.includes("\0")
+  ) {
+    throw new Error(`Portable media path segment decodes to an unsafe name: ${portableMediaPath}`);
+  }
+
+  return decodedSegment;
+}
+
+function getPortableMediaPathDuplicateKey(portableMediaPath: string): string {
+  return portableMediaPath
+    .split("/")
+    .map((segment) => decodeURIComponent(segment).normalize("NFC").toLowerCase())
+    .join("/");
+}
+
+function isPortableMediaPathCandidate(url: string): boolean {
+  return url === "media" || url.startsWith("media/");
+}
+
+export function validatePortableMediaPath(portableMediaPath: string): string {
+  if (portableMediaPath === "") {
+    throw new Error("Portable media path must not be empty.");
+  }
+
+  if (portableMediaPath.includes("\\")) {
+    throw new Error(`Portable media path must use forward slashes: ${portableMediaPath}`);
+  }
+
+  if (portableMediaPath.includes("?") || portableMediaPath.includes("#")) {
+    throw new Error(`Portable media path must not include query strings or fragments: ${portableMediaPath}`);
+  }
+
+  if (portableMediaPath.startsWith("/") || absoluteUrlPattern.test(portableMediaPath)) {
+    throw new Error(`Portable media path must be relative: ${portableMediaPath}`);
+  }
+
+  if (!portableMediaPath.startsWith("media/")) {
+    throw new Error(`Portable media path must be under media/: ${portableMediaPath}`);
+  }
+
+  const pathSegments = portableMediaPath.split("/");
+  for (const segment of pathSegments) {
+    validatePortableMediaPathSegment(segment, portableMediaPath);
+  }
+
+  if (pathSegments.length < 2) {
+    throw new Error(`Portable media path must include a file name under media/: ${portableMediaPath}`);
+  }
+
+  return portableMediaPath;
+}
+
+export function validateUniquePortableMediaPaths(
+  portableMediaPaths: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const seenDuplicateKeys = new Set<string>();
+  const validatedPaths: Array<string> = [];
+
+  for (const portableMediaPath of portableMediaPaths) {
+    const validatedPath = validatePortableMediaPath(portableMediaPath);
+    const duplicateKey = getPortableMediaPathDuplicateKey(validatedPath);
+    if (seenDuplicateKeys.has(duplicateKey)) {
+      throw new Error(`Portable media path is duplicated: ${portableMediaPath}`);
+    }
+
+    seenDuplicateKeys.add(duplicateKey);
+    validatedPaths.push(validatedPath);
+  }
+
+  return validatedPaths;
+}
+
+export function extractMarkdownFcAssetIds(markdown: string): ReadonlyArray<string> {
+  const assetIds: Array<string> = [];
+  const seenAssetIds = new Set<string>();
+
+  for (const linkDestination of listMarkdownLinkDestinations(markdown)) {
+    const assetId = matchFcAssetId(linkDestination.destination);
+    if (assetId === null || seenAssetIds.has(assetId)) {
+      continue;
+    }
+
+    seenAssetIds.add(assetId);
+    assetIds.push(assetId);
+  }
+
+  return assetIds;
+}
+
+export function rewriteMarkdownFcAssetUrlsToPortablePaths(
+  markdown: string,
+  resolvePortablePath: FcAssetPortablePathResolver,
+): string {
+  const portablePathByAssetId = new Map<string, string>();
+  const assetIdByDuplicateKey = new Map<string, string>();
+
+  return rewriteMarkdownUrls(markdown, (url) => {
+    const assetId = matchFcAssetId(url);
+    if (assetId === null) {
+      return null;
+    }
+
+    const portablePath = validatePortableMediaPath(resolvePortablePath(assetId));
+    const previousPortablePath = portablePathByAssetId.get(assetId);
+    if (previousPortablePath !== undefined && previousPortablePath !== portablePath) {
+      throw new Error(`fcasset id resolved to multiple portable media paths: ${assetId}`);
+    }
+
+    portablePathByAssetId.set(assetId, portablePath);
+    const duplicateKey = getPortableMediaPathDuplicateKey(portablePath);
+    const existingAssetId = assetIdByDuplicateKey.get(duplicateKey);
+    if (existingAssetId !== undefined && existingAssetId !== assetId) {
+      throw new Error(`Portable media path is shared by multiple fcasset ids: ${portablePath}`);
+    }
+
+    assetIdByDuplicateKey.set(duplicateKey, assetId);
+    return portablePath;
+  });
+}
+
+export function rewriteMarkdownFcAssetUrlsToPortablePathsFromMap(
+  markdown: string,
+  portablePathsByAssetId: ReadonlyMap<string, string>,
+): string {
+  return rewriteMarkdownFcAssetUrlsToPortablePaths(markdown, (assetId) => {
+    const portablePath = portablePathsByAssetId.get(assetId);
+    if (portablePath === undefined) {
+      throw new Error(`Missing portable media path for fcasset id: ${assetId}`);
+    }
+
+    return portablePath;
+  });
+}
+
+export function rewriteMarkdownPortableMediaUrlsToFcAssets(
+  markdown: string,
+  resolveAssetId: PortableMediaAssetIdResolver,
+): string {
+  return rewriteMarkdownUrls(markdown, (url) => {
+    if (!isPortableMediaPathCandidate(url)) {
+      return null;
+    }
+
+    const portableMediaPath = validatePortableMediaPath(url);
+    const assetId = assertFcAssetId(resolveAssetId(portableMediaPath), "Resolved fcasset id");
+    return `fcasset:${assetId}`;
+  });
+}
+
+export function rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap(
+  markdown: string,
+  assetIdsByPortablePath: ReadonlyMap<string, string>,
+): string {
+  return rewriteMarkdownPortableMediaUrlsToFcAssets(markdown, (portableMediaPath) => {
+    const assetId = assetIdsByPortablePath.get(portableMediaPath);
+    if (assetId === undefined) {
+      throw new Error(`Missing fcasset id for portable media path: ${portableMediaPath}`);
+    }
+
+    return assetId;
+  });
+}

--- a/apps/backend/src/workspacePackages/types.ts
+++ b/apps/backend/src/workspacePackages/types.ts
@@ -1,0 +1,198 @@
+import { z } from "zod";
+
+export const workspacePackageFormatVersion = 1 as const;
+
+export type WorkspacePackageMetadataV1 = Readonly<{
+  label?: string;
+  author?: string;
+  comment?: string;
+  createdAt?: string;
+  sourceUrl?: string;
+}>;
+
+export type WorkspacePackageCardSourceMetadataV1 = Readonly<{
+  label: string | null;
+  author: string | null;
+  comment: string | null;
+  createdAt: string | null;
+  importedAt: string | null;
+  importId: string | null;
+}>;
+
+export type WorkspacePackageCardSourceMetadataInputV1 = Readonly<{
+  label?: string | null;
+  author?: string | null;
+  comment?: string | null;
+  createdAt?: string | null;
+  importedAt?: string | null;
+  importId?: string | null;
+}>;
+
+export type WorkspacePackageCardMetadataV1 = Readonly<{
+  version: 1;
+  source: WorkspacePackageCardSourceMetadataV1 | null;
+}>;
+
+export type WorkspacePackageCardMetadataInputV1 = Readonly<{
+  version: 1;
+  source: WorkspacePackageCardSourceMetadataInputV1 | null;
+}>;
+
+export type PortableWorkspacePackageCardV1 = Readonly<{
+  frontText: string;
+  backText: string;
+  tags: ReadonlyArray<string>;
+  cardType: string;
+  metadata: WorkspacePackageCardMetadataV1;
+}>;
+
+export type PortableWorkspacePackageCardInputV1 = Readonly<{
+  frontText: string;
+  backText: string;
+  tags: ReadonlyArray<string>;
+  cardType: string;
+  metadata: WorkspacePackageCardMetadataInputV1;
+}>;
+
+export type WorkspacePackageCardsJsonV1 = WorkspacePackageMetadataV1 & Readonly<{
+  formatVersion: 1;
+  cards: ReadonlyArray<PortableWorkspacePackageCardV1>;
+}>;
+
+export type WorkspacePackageValidationIssue = Readonly<{
+  path: string;
+  code: string;
+  message: string;
+}>;
+
+const optionalPackageMetadataSchema = {
+  label: z.string().optional(),
+  author: z.string().optional(),
+  comment: z.string().optional(),
+  createdAt: z.string().optional(),
+  sourceUrl: z.string().optional(),
+} as const;
+
+const optionalNullableStringSchema = z.string().nullable().optional();
+const requiredTrimmedStringSchema = z.string().trim().min(1);
+
+function normalizeCardSourceMetadata(
+  sourceMetadata: WorkspacePackageCardSourceMetadataInputV1,
+): WorkspacePackageCardSourceMetadataV1 {
+  return {
+    label: sourceMetadata.label ?? null,
+    author: sourceMetadata.author ?? null,
+    comment: sourceMetadata.comment ?? null,
+    createdAt: sourceMetadata.createdAt ?? null,
+    importedAt: sourceMetadata.importedAt ?? null,
+    importId: sourceMetadata.importId ?? null,
+  };
+}
+
+const cardSourceMetadataSchema = z.object({
+  label: optionalNullableStringSchema,
+  author: optionalNullableStringSchema,
+  comment: optionalNullableStringSchema,
+  createdAt: optionalNullableStringSchema,
+  importedAt: optionalNullableStringSchema,
+  importId: optionalNullableStringSchema,
+}).transform((sourceMetadata): WorkspacePackageCardSourceMetadataV1 => (
+  normalizeCardSourceMetadata(sourceMetadata)
+));
+
+const cardMetadataSchema = z.object({
+  version: z.literal(workspacePackageFormatVersion),
+  source: z.union([cardSourceMetadataSchema, z.null()]),
+}).transform((metadata): WorkspacePackageCardMetadataV1 => ({
+  version: workspacePackageFormatVersion,
+  source: metadata.source,
+}));
+
+function normalizeRequiredWorkspacePackageText(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (normalizedValue === "") {
+    throw new TypeError(`${fieldName} must not be empty`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeWorkspacePackageCardType(cardType: string): string {
+  const normalizedCardType = cardType.trim();
+  return normalizedCardType === "" ? "basic" : normalizedCardType;
+}
+
+function normalizeWorkspacePackageTags(tags: ReadonlyArray<string>): ReadonlyArray<string> {
+  return tags.map((tag) => normalizeRequiredWorkspacePackageText(tag, "tags[]"));
+}
+
+const portableCardSchema = z.object({
+  frontText: requiredTrimmedStringSchema,
+  backText: z.string().transform((backText): string => backText.trim()),
+  tags: z.array(requiredTrimmedStringSchema),
+  cardType: z.string().transform((cardType): string => normalizeWorkspacePackageCardType(cardType)),
+  metadata: cardMetadataSchema,
+}).transform((card): PortableWorkspacePackageCardV1 => (
+  toPortableWorkspacePackageCard(card)
+));
+
+export const workspacePackageCardsJsonV1Schema = z.object({
+  formatVersion: z.literal(workspacePackageFormatVersion),
+  ...optionalPackageMetadataSchema,
+  cards: z.array(portableCardSchema),
+}).transform((cardsJson): WorkspacePackageCardsJsonV1 => ({
+  ...cardsJson,
+  formatVersion: workspacePackageFormatVersion,
+  cards: cardsJson.cards,
+}));
+
+function summarizeValidationPath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) {
+    return "<root>";
+  }
+
+  return path.join(".");
+}
+
+function summarizeValidationIssue(issue: z.core.$ZodIssue): WorkspacePackageValidationIssue {
+  return {
+    path: summarizeValidationPath(issue.path),
+    code: issue.code,
+    message: issue.message,
+  };
+}
+
+function summarizeValidationIssues(error: z.ZodError): ReadonlyArray<WorkspacePackageValidationIssue> {
+  return error.issues.map(summarizeValidationIssue);
+}
+
+export function parseWorkspacePackageCardsJsonV1(value: unknown): WorkspacePackageCardsJsonV1 {
+  const parsedCardsJson = workspacePackageCardsJsonV1Schema.safeParse(value);
+  if (parsedCardsJson.success) {
+    return parsedCardsJson.data;
+  }
+
+  const issues = summarizeValidationIssues(parsedCardsJson.error);
+  throw new TypeError(`Invalid workspace package cards.json: ${JSON.stringify(issues)}`);
+}
+
+export function normalizeWorkspacePackageCardMetadataV1(
+  metadata: WorkspacePackageCardMetadataInputV1,
+): WorkspacePackageCardMetadataV1 {
+  return {
+    version: workspacePackageFormatVersion,
+    source: metadata.source === null ? null : normalizeCardSourceMetadata(metadata.source),
+  };
+}
+
+export function toPortableWorkspacePackageCard(
+  card: PortableWorkspacePackageCardInputV1,
+): PortableWorkspacePackageCardV1 {
+  return {
+    frontText: normalizeRequiredWorkspacePackageText(card.frontText, "frontText"),
+    backText: card.backText.trim(),
+    tags: normalizeWorkspacePackageTags(card.tags),
+    cardType: normalizeWorkspacePackageCardType(card.cardType),
+    metadata: normalizeWorkspacePackageCardMetadataV1(card.metadata),
+  };
+}


### PR DESCRIPTION
Adds route-independent package v1 types/parser and Markdown media helpers.

Keeps media path syntax conservative and Markdown-safe.

No routes/OpenAPI/API Gateway/S3/ZIP/client changes in this PR.

Validation run:
- `node --test --import tsx src/workspacePackages/core.test.ts` from `apps/backend`: passed, 9/9.
- `npm run test --prefix apps/backend -- workspacePackages`: passed, 594/594.
- `npm run lint --prefix apps/backend`: passed.

Review status: final fresh review found no P0-P4 issues and no split recommendation.