### PR TITLE
Add export preview service

### DIFF
--- a/apps/backend/src/workspacePackages/exportPreview.test.ts
+++ b/apps/backend/src/workspacePackages/exportPreview.test.ts
@@ -1,0 +1,447 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  previewWorkspacePackageExportInExecutor,
+  type WorkspacePackageExportPreviewInput,
+} from "./exportPreview";
+
+type TestCardRow = Readonly<{
+  card_id: string;
+  workspace_id: string;
+  front_text: string;
+  back_text: string;
+  tags: ReadonlyArray<string>;
+  created_at: string;
+  deleted_at: string | null;
+}>;
+
+type TestMediaAssetRow = Readonly<{
+  media_asset_id: string;
+  workspace_id: string;
+  media_blob_id: string;
+  size_bytes: number;
+  deleted_at: string | null;
+}>;
+
+type QueryRecord = Readonly<{
+  text: string;
+  params: ReadonlyArray<SqlValue>;
+}>;
+
+type TestExecutorHarness = Readonly<{
+  executor: DatabaseExecutor;
+  queries: ReadonlyArray<QueryRecord>;
+}>;
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+const otherWorkspaceId = "22222222-2222-4222-8222-222222222222";
+const cardIdA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+const cardIdB = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2";
+const cardIdC = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3";
+const cardIdD = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4";
+const mediaAssetIdA = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1";
+const mediaAssetIdB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2";
+const mediaAssetIdC = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3";
+const mediaAssetIdD = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4";
+const mediaAssetIdE = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5";
+const mediaBlobIdA = "cccccccc-cccc-4ccc-8ccc-ccccccccccc1";
+const mediaBlobIdB = "cccccccc-cccc-4ccc-8ccc-ccccccccccc2";
+const generatedAt = "2026-06-30T12:00:00.000Z";
+
+function createBasePreviewInput(
+  selection: WorkspacePackageExportPreviewInput["selection"],
+): WorkspacePackageExportPreviewInput {
+  return {
+    selection,
+    tagPolicy: {
+      additionalRemovedTags: [],
+    },
+    packageMetadata: {
+      label: null,
+      author: null,
+      comment: null,
+      createdAt: null,
+      sourceUrl: null,
+    },
+    generatedAt,
+  };
+}
+
+function createCardRow(
+  cardId: string,
+  cardWorkspaceId: string,
+  frontText: string,
+  backText: string,
+  tags: ReadonlyArray<string>,
+  createdAt: string,
+  deletedAt: string | null,
+): TestCardRow {
+  return {
+    card_id: cardId,
+    workspace_id: cardWorkspaceId,
+    front_text: frontText,
+    back_text: backText,
+    tags,
+    created_at: createdAt,
+    deleted_at: deletedAt,
+  };
+}
+
+function createMediaAssetRow(
+  mediaAssetId: string,
+  mediaWorkspaceId: string,
+  mediaBlobId: string,
+  sizeBytes: number,
+  deletedAt: string | null,
+): TestMediaAssetRow {
+  return {
+    media_asset_id: mediaAssetId,
+    workspace_id: mediaWorkspaceId,
+    media_blob_id: mediaBlobId,
+    size_bytes: sizeBytes,
+    deleted_at: deletedAt,
+  };
+}
+
+function createQueryResult<Row extends pg.QueryResultRow>(
+  rows: ReadonlyArray<Row>,
+): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function requireStringParam(params: ReadonlyArray<SqlValue>, index: number): string {
+  const value = params[index];
+  if (typeof value !== "string") {
+    throw new Error(`Expected string query parameter at index ${index}`);
+  }
+
+  return value;
+}
+
+function requireNumberParam(params: ReadonlyArray<SqlValue>, index: number): number {
+  const value = params[index];
+  if (typeof value !== "number") {
+    throw new Error(`Expected number query parameter at index ${index}`);
+  }
+
+  return value;
+}
+
+function requireStringArrayParam(params: ReadonlyArray<SqlValue>, index: number): ReadonlyArray<string> {
+  const value = params[index];
+  if (Array.isArray(value) === false || value.some((item) => typeof item !== "string")) {
+    throw new Error(`Expected string array query parameter at index ${index}`);
+  }
+
+  return value;
+}
+
+function compareCardsForPreview(left: TestCardRow, right: TestCardRow): number {
+  const createdAtDifference = new Date(right.created_at).getTime() - new Date(left.created_at).getTime();
+  if (createdAtDifference !== 0) {
+    return createdAtDifference;
+  }
+
+  return left.card_id.localeCompare(right.card_id);
+}
+
+function cardHasAnyTag(card: TestCardRow, tags: ReadonlyArray<string>): boolean {
+  return card.tags.some((tag) => tags.includes(tag));
+}
+
+function filterCardRows(
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+  cards: ReadonlyArray<TestCardRow>,
+): ReadonlyArray<TestCardRow> {
+  const requestedWorkspaceId = requireStringParam(params, 0);
+  const limit = requireNumberParam(params, params.length - 1);
+  const activeCards = cards.filter((card) => (
+    card.workspace_id === requestedWorkspaceId
+    && card.deleted_at === null
+  ));
+
+  if (text.includes("card_id = ANY($2::uuid[])")) {
+    const cardIds = requireStringArrayParam(params, 1);
+    return cardIds
+      .flatMap((cardId) => activeCards.filter((card) => card.card_id === cardId))
+      .slice(0, limit);
+  }
+
+  let nextFilterParamIndex = 1;
+  const includeTags = text.includes("AND tags &&")
+    ? requireStringArrayParam(params, nextFilterParamIndex)
+    : [];
+  nextFilterParamIndex += includeTags.length === 0 ? 0 : 1;
+  const excludeTags = text.includes("AND NOT (tags &&")
+    ? requireStringArrayParam(params, nextFilterParamIndex)
+    : [];
+
+  return activeCards
+    .filter((card) => includeTags.length === 0 || cardHasAnyTag(card, includeTags))
+    .filter((card) => excludeTags.length === 0 || cardHasAnyTag(card, excludeTags) === false)
+    .sort(compareCardsForPreview)
+    .slice(0, limit);
+}
+
+function filterMediaRows(
+  params: ReadonlyArray<SqlValue>,
+  mediaAssets: ReadonlyArray<TestMediaAssetRow>,
+): ReadonlyArray<Pick<TestMediaAssetRow, "media_asset_id" | "media_blob_id" | "size_bytes">> {
+  const requestedWorkspaceId = requireStringParam(params, 0);
+  const mediaAssetIds = requireStringArrayParam(params, 1);
+  const activeAssets = mediaAssets.filter((mediaAsset) => (
+    mediaAsset.workspace_id === requestedWorkspaceId
+    && mediaAsset.deleted_at === null
+  ));
+
+  return mediaAssetIds.flatMap((mediaAssetId) => (
+    activeAssets
+      .filter((mediaAsset) => mediaAsset.media_asset_id === mediaAssetId)
+      .map((mediaAsset) => ({
+        media_asset_id: mediaAsset.media_asset_id,
+        media_blob_id: mediaAsset.media_blob_id,
+        size_bytes: mediaAsset.size_bytes,
+      }))
+  ));
+}
+
+function createTestExecutor(
+  cards: ReadonlyArray<TestCardRow>,
+  mediaAssets: ReadonlyArray<TestMediaAssetRow>,
+): TestExecutorHarness {
+  const queries: Array<QueryRecord> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      queries.push({ text, params });
+
+      if (text.includes("FROM content.cards")) {
+        return createQueryResult(filterCardRows(text, params, cards) as unknown as ReadonlyArray<Row>);
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets")) {
+        return createQueryResult(filterMediaRows(params, mediaAssets) as unknown as ReadonlyArray<Row>);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  return {
+    executor,
+    queries,
+  };
+}
+
+test("preview selects all active workspace cards and defaults package metadata", async () => {
+  const { executor } = createTestExecutor([
+    createCardRow(cardIdA, workspaceId, "A", "A answer", ["geography", "shared"], "2026-06-01T00:00:00.000Z", null),
+    createCardRow(cardIdB, workspaceId, "B", "B answer", ["shared", "import:2026-06-01-0"], "2026-06-02T00:00:00.000Z", null),
+    createCardRow(cardIdC, workspaceId, "C", "C answer", ["deleted"], "2026-06-03T00:00:00.000Z", "2026-06-04T00:00:00.000Z"),
+    createCardRow(cardIdD, otherWorkspaceId, "D", "D answer", ["other"], "2026-06-04T00:00:00.000Z", null),
+  ], []);
+
+  const preview = await previewWorkspacePackageExportInExecutor(
+    executor,
+    workspaceId,
+    createBasePreviewInput({ kind: "allActiveCards" }),
+    { maxSelectedCards: 10 },
+  );
+
+  assert.equal(preview.selectedCardCount, 2);
+  assert.deepEqual(preview.availableTagCounts, [
+    { tag: "shared", cardsCount: 2 },
+    { tag: "geography", cardsCount: 1 },
+    { tag: "import:2026-06-01-0", cardsCount: 1 },
+  ]);
+  assert.deepEqual(preview.tagsSelectedForRemoval, [
+    { tag: "import:2026-06-01-0", cardsCount: 1 },
+  ]);
+  assert.equal(preview.referencedMediaCount, 0);
+  assert.equal(preview.approximateReferencedMediaBytes, 0);
+  assert.deepEqual(preview.defaultPackageMetadata, {
+    label: "Workspace export",
+    createdAt: generatedAt,
+  });
+});
+
+test("preview selects explicit active card ids", async () => {
+  const { executor } = createTestExecutor([
+    createCardRow(cardIdA, workspaceId, "A", "A answer", ["first"], "2026-06-01T00:00:00.000Z", null),
+    createCardRow(cardIdB, workspaceId, "B", "B answer", ["second"], "2026-06-02T00:00:00.000Z", null),
+    createCardRow(cardIdC, workspaceId, "C", "C answer", ["third"], "2026-06-03T00:00:00.000Z", null),
+  ], []);
+
+  const preview = await previewWorkspacePackageExportInExecutor(
+    executor,
+    workspaceId,
+    createBasePreviewInput({
+      kind: "explicitCardIds",
+      cardIds: [cardIdB, cardIdA],
+    }),
+    { maxSelectedCards: 10 },
+  );
+
+  assert.equal(preview.selectedCardCount, 2);
+  assert.deepEqual(preview.availableTagCounts, [
+    { tag: "first", cardsCount: 1 },
+    { tag: "second", cardsCount: 1 },
+  ]);
+});
+
+test("preview applies include and exclude tag filters", async () => {
+  const { executor } = createTestExecutor([
+    createCardRow(cardIdA, workspaceId, "A", "A answer", ["science"], "2026-06-01T00:00:00.000Z", null),
+    createCardRow(cardIdB, workspaceId, "B", "B answer", ["science", "draft"], "2026-06-02T00:00:00.000Z", null),
+    createCardRow(cardIdC, workspaceId, "C", "C answer", ["history"], "2026-06-03T00:00:00.000Z", null),
+  ], []);
+
+  const preview = await previewWorkspacePackageExportInExecutor(
+    executor,
+    workspaceId,
+    createBasePreviewInput({
+      kind: "tagFilters",
+      includeTags: ["science"],
+      excludeTags: ["draft"],
+    }),
+    { maxSelectedCards: 10 },
+  );
+
+  assert.equal(preview.selectedCardCount, 1);
+  assert.deepEqual(preview.availableTagCounts, [
+    { tag: "science", cardsCount: 1 },
+  ]);
+});
+
+test("preview adds explicit tag removals to default import tag removals", async () => {
+  const { executor } = createTestExecutor([
+    createCardRow(cardIdA, workspaceId, "A", "A answer", ["keep", "custom-remove", "import:2026-06-01-0"], "2026-06-01T00:00:00.000Z", null),
+  ], []);
+  const input = createBasePreviewInput({ kind: "allActiveCards" });
+
+  const preview = await previewWorkspacePackageExportInExecutor(
+    executor,
+    workspaceId,
+    {
+      ...input,
+      tagPolicy: {
+        additionalRemovedTags: ["custom-remove"],
+      },
+    },
+    { maxSelectedCards: 10 },
+  );
+
+  assert.deepEqual(preview.tagsSelectedForRemoval, [
+    { tag: "custom-remove", cardsCount: 1 },
+    { tag: "import:2026-06-01-0", cardsCount: 1 },
+  ]);
+});
+
+test("preview counts referenced media assets and dedupes approximate bytes by blob metadata", async () => {
+  const { executor, queries } = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      `![front](fcasset:${mediaAssetIdA})`,
+      [
+        `![same asset](fcasset:${mediaAssetIdA})`,
+        `![same blob](fcasset:${mediaAssetIdB})`,
+        `![other blob](fcasset:${mediaAssetIdC})`,
+      ].join("\n"),
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [
+    createMediaAssetRow(mediaAssetIdA, workspaceId, mediaBlobIdA, 100, null),
+    createMediaAssetRow(mediaAssetIdB, workspaceId, mediaBlobIdA, 100, null),
+    createMediaAssetRow(mediaAssetIdC, workspaceId, mediaBlobIdB, 250, null),
+  ]);
+
+  const preview = await previewWorkspacePackageExportInExecutor(
+    executor,
+    workspaceId,
+    createBasePreviewInput({ kind: "allActiveCards" }),
+    { maxSelectedCards: 10 },
+  );
+
+  assert.equal(preview.referencedMediaCount, 3);
+  assert.equal(preview.approximateReferencedMediaBytes, 350);
+  const mediaQuery = queries.find((query) => query.text.includes("FROM content.media_assets AS media_assets"));
+  assert.notEqual(mediaQuery, undefined);
+  assert.doesNotMatch(mediaQuery?.text ?? "", /storage_key/);
+});
+
+test("preview rejects missing, deleted, or wrong-workspace media assets", async () => {
+  const { executor } = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      [
+        `![missing](fcasset:${mediaAssetIdD})`,
+        `![deleted](fcasset:${mediaAssetIdB})`,
+        `![wrong workspace](fcasset:${mediaAssetIdE})`,
+      ].join("\n"),
+      "A answer",
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [
+    createMediaAssetRow(mediaAssetIdB, workspaceId, mediaBlobIdA, 100, "2026-06-02T00:00:00.000Z"),
+    createMediaAssetRow(mediaAssetIdE, otherWorkspaceId, mediaBlobIdB, 250, null),
+  ]);
+
+  await assert.rejects(
+    async () => previewWorkspacePackageExportInExecutor(
+      executor,
+      workspaceId,
+      createBasePreviewInput({ kind: "allActiveCards" }),
+      { maxSelectedCards: 10 },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_EXPORT_PREVIEW_MEDIA_ASSET_UNAVAILABLE");
+      assert.match(error.message, new RegExp(mediaAssetIdD));
+      assert.match(error.message, new RegExp(mediaAssetIdB));
+      assert.match(error.message, new RegExp(mediaAssetIdE));
+      return true;
+    },
+  );
+});
+
+test("preview rejects selections above the workload cap before unbounded materialization", async () => {
+  const { executor } = createTestExecutor([
+    createCardRow(cardIdA, workspaceId, "A", "A answer", [], "2026-06-01T00:00:00.000Z", null),
+    createCardRow(cardIdB, workspaceId, "B", "B answer", [], "2026-06-02T00:00:00.000Z", null),
+    createCardRow(cardIdC, workspaceId, "C", "C answer", [], "2026-06-03T00:00:00.000Z", null),
+  ], []);
+
+  await assert.rejects(
+    async () => previewWorkspacePackageExportInExecutor(
+      executor,
+      workspaceId,
+      createBasePreviewInput({ kind: "allActiveCards" }),
+      { maxSelectedCards: 2 },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 413);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_EXPORT_PREVIEW_SELECTION_TOO_LARGE");
+      return true;
+    },
+  );
+});

--- a/apps/backend/src/workspacePackages/exportPreview.ts
+++ b/apps/backend/src/workspacePackages/exportPreview.ts
@@ -1,0 +1,536 @@
+import {
+  transactionWithWorkspaceScopeReadOnly,
+  type DatabaseExecutor,
+  type SqlValue,
+} from "../database";
+import { MEDIA_ASSET_JOIN_CLAUSE } from "../mediaAssets";
+import { HttpError } from "../shared/errors";
+import { extractMarkdownFcAssetIds } from "./markdownMedia";
+import type { WorkspacePackageMetadataV1 } from "./types";
+
+export const workspacePackageExportPreviewDefaultMaxSelectedCards = 5_000;
+
+export type WorkspacePackageExportCardSelection =
+  | Readonly<{
+    kind: "allActiveCards";
+  }>
+  | Readonly<{
+    kind: "tagFilters";
+    includeTags: ReadonlyArray<string>;
+    excludeTags: ReadonlyArray<string>;
+  }>
+  | Readonly<{
+    kind: "explicitCardIds";
+    cardIds: ReadonlyArray<string>;
+  }>;
+
+export type WorkspacePackageExportTagPolicyInput = Readonly<{
+  additionalRemovedTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageExportMetadataInput = Readonly<{
+  label: string | null;
+  author: string | null;
+  comment: string | null;
+  createdAt: string | null;
+  sourceUrl: string | null;
+}>;
+
+export type WorkspacePackageExportPreviewInput = Readonly<{
+  selection: WorkspacePackageExportCardSelection;
+  tagPolicy: WorkspacePackageExportTagPolicyInput;
+  packageMetadata: WorkspacePackageExportMetadataInput;
+  generatedAt: string;
+}>;
+
+export type WorkspacePackageExportPreviewTagCount = Readonly<{
+  tag: string;
+  cardsCount: number;
+}>;
+
+export type WorkspacePackageExportPreview = Readonly<{
+  selectedCardCount: number;
+  availableTagCounts: ReadonlyArray<WorkspacePackageExportPreviewTagCount>;
+  tagsSelectedForRemoval: ReadonlyArray<WorkspacePackageExportPreviewTagCount>;
+  referencedMediaCount: number;
+  approximateReferencedMediaBytes: number;
+  defaultPackageMetadata: WorkspacePackageMetadataV1;
+}>;
+
+export type WorkspacePackageExportPreviewLimits = Readonly<{
+  maxSelectedCards: number;
+}>;
+
+type WorkspacePackageExportPreviewCardRow = Readonly<{
+  card_id: string;
+  front_text: string;
+  back_text: string;
+  tags: ReadonlyArray<string>;
+}>;
+
+type WorkspacePackageExportPreviewMediaRow = Readonly<{
+  media_asset_id: string;
+  media_blob_id: string;
+  size_bytes: string | number;
+}>;
+
+type SelectedCardsQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<SqlValue>;
+  explicitCardIds: ReadonlyArray<string> | null;
+}>;
+
+const workspacePackageExportMetadataDefaultLabel = "Workspace export";
+const workspacePackageExportImportTagPrefix = "import:";
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+function createPreviewInputError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_EXPORT_PREVIEW_INPUT_INVALID");
+}
+
+function normalizeNonEmptyText(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (normalizedValue === "") {
+    throw createPreviewInputError(`${fieldName} must not be empty`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeNullableText(value: string | null, fieldName: string): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return normalizeNonEmptyText(value, fieldName);
+}
+
+function normalizeIsoTimestamp(value: string, fieldName: string): string {
+  const normalizedValue = normalizeNonEmptyText(value, fieldName);
+  const parsedValue = new Date(normalizedValue);
+  if (Number.isNaN(parsedValue.getTime())) {
+    throw createPreviewInputError(`${fieldName} must be a valid ISO timestamp`);
+  }
+
+  return parsedValue.toISOString();
+}
+
+function normalizeUniqueTextValues(
+  values: ReadonlyArray<string>,
+  fieldName: string,
+): ReadonlyArray<string> {
+  const normalizedValues: Array<string> = [];
+  const existingValues = new Set<string>();
+
+  values.forEach((value, index) => {
+    const normalizedValue = normalizeNonEmptyText(value, `${fieldName}[${index}]`);
+    if (existingValues.has(normalizedValue)) {
+      return;
+    }
+
+    existingValues.add(normalizedValue);
+    normalizedValues.push(normalizedValue);
+  });
+
+  return normalizedValues;
+}
+
+function normalizeUniqueUuidValues(
+  values: ReadonlyArray<string>,
+  fieldName: string,
+): ReadonlyArray<string> {
+  const normalizedValues = normalizeUniqueTextValues(values, fieldName);
+  const invalidValues = normalizedValues.filter((value) => uuidPattern.test(value) === false);
+  if (invalidValues.length !== 0) {
+    throw createPreviewInputError(`${fieldName} must contain only UUID values. invalidValues=${invalidValues.join(",")}`);
+  }
+
+  if (normalizedValues.length !== values.length) {
+    throw createPreviewInputError(`${fieldName} must not contain duplicates`);
+  }
+
+  return normalizedValues;
+}
+
+function normalizeCardSelection(
+  selection: WorkspacePackageExportCardSelection,
+): WorkspacePackageExportCardSelection {
+  switch (selection.kind) {
+  case "allActiveCards":
+    return selection;
+  case "tagFilters":
+    return {
+      kind: "tagFilters",
+      includeTags: normalizeUniqueTextValues(selection.includeTags, "selection.includeTags"),
+      excludeTags: normalizeUniqueTextValues(selection.excludeTags, "selection.excludeTags"),
+    };
+  case "explicitCardIds":
+    return {
+      kind: "explicitCardIds",
+      cardIds: normalizeUniqueUuidValues(selection.cardIds, "selection.cardIds"),
+    };
+  }
+}
+
+function normalizePreviewLimits(limits: WorkspacePackageExportPreviewLimits): WorkspacePackageExportPreviewLimits {
+  if (
+    Number.isSafeInteger(limits.maxSelectedCards) === false
+    || limits.maxSelectedCards < 1
+    || limits.maxSelectedCards >= Number.MAX_SAFE_INTEGER
+  ) {
+    throw createPreviewInputError("limits.maxSelectedCards must be a positive safe integer");
+  }
+
+  return limits;
+}
+
+function normalizePackageMetadata(
+  input: WorkspacePackageExportMetadataInput,
+  generatedAt: string,
+): WorkspacePackageMetadataV1 {
+  const label = normalizeNullableText(input.label, "packageMetadata.label") ?? workspacePackageExportMetadataDefaultLabel;
+  const author = normalizeNullableText(input.author, "packageMetadata.author");
+  const comment = normalizeNullableText(input.comment, "packageMetadata.comment");
+  const createdAt = input.createdAt === null
+    ? generatedAt
+    : normalizeIsoTimestamp(input.createdAt, "packageMetadata.createdAt");
+  const sourceUrl = normalizeNullableText(input.sourceUrl, "packageMetadata.sourceUrl");
+
+  return {
+    label,
+    ...(author === null ? {} : { author }),
+    ...(comment === null ? {} : { comment }),
+    createdAt,
+    ...(sourceUrl === null ? {} : { sourceUrl }),
+  };
+}
+
+function buildSelectedCardsQuery(
+  workspaceId: string,
+  selection: WorkspacePackageExportCardSelection,
+  maxSelectedCards: number,
+): SelectedCardsQuery {
+  const rowLimit = maxSelectedCards + 1;
+
+  switch (selection.kind) {
+  case "allActiveCards":
+    return {
+      text: [
+        "SELECT card_id, front_text, back_text, tags",
+        "FROM content.cards",
+        "WHERE workspace_id = $1",
+        "AND deleted_at IS NULL",
+        "ORDER BY created_at DESC, card_id ASC",
+        "LIMIT $2",
+      ].join(" "),
+      params: [workspaceId, rowLimit],
+      explicitCardIds: null,
+    };
+  case "tagFilters": {
+    const params: Array<SqlValue> = [workspaceId];
+    const clauses: Array<string> = [
+      "WHERE workspace_id = $1",
+      "AND deleted_at IS NULL",
+    ];
+
+    if (selection.includeTags.length > 0) {
+      params.push(selection.includeTags);
+      clauses.push(`AND tags && $${params.length}::text[]`);
+    }
+
+    if (selection.excludeTags.length > 0) {
+      params.push(selection.excludeTags);
+      clauses.push(`AND NOT (tags && $${params.length}::text[])`);
+    }
+
+    params.push(rowLimit);
+    return {
+      text: [
+        "SELECT card_id, front_text, back_text, tags",
+        "FROM content.cards",
+        clauses.join(" "),
+        "ORDER BY created_at DESC, card_id ASC",
+        `LIMIT $${params.length}`,
+      ].join(" "),
+      params,
+      explicitCardIds: null,
+    };
+  }
+  case "explicitCardIds":
+    return {
+      text: [
+        "SELECT card_id, front_text, back_text, tags",
+        "FROM content.cards",
+        "WHERE workspace_id = $1",
+        "AND card_id = ANY($2::uuid[])",
+        "AND deleted_at IS NULL",
+        "ORDER BY array_position($2::uuid[], card_id)",
+        "LIMIT $3",
+      ].join(" "),
+      params: [workspaceId, selection.cardIds, rowLimit],
+      explicitCardIds: selection.cardIds,
+    };
+  }
+}
+
+function assertSelectionWithinLimit(
+  selectedCardCount: number,
+  maxSelectedCards: number,
+): void {
+  if (selectedCardCount <= maxSelectedCards) {
+    return;
+  }
+
+  throw new HttpError(
+    413,
+    `Workspace package export preview selection is too large. selectedCardLimit=${maxSelectedCards}`,
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_SELECTION_TOO_LARGE",
+  );
+}
+
+function assertExplicitCardsFound(
+  rows: ReadonlyArray<WorkspacePackageExportPreviewCardRow>,
+  explicitCardIds: ReadonlyArray<string> | null,
+): void {
+  if (explicitCardIds === null) {
+    return;
+  }
+
+  const returnedCardIds = new Set(rows.map((row) => row.card_id));
+  const missingCardIds = explicitCardIds.filter((cardId) => returnedCardIds.has(cardId) === false);
+  if (missingCardIds.length === 0) {
+    return;
+  }
+
+  throw new HttpError(
+    404,
+    `Workspace package export preview selection contains unavailable cards. missingCardIds=${missingCardIds.join(",")}`,
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_CARD_NOT_FOUND",
+  );
+}
+
+async function loadSelectedCardsInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  selection: WorkspacePackageExportCardSelection,
+  limits: WorkspacePackageExportPreviewLimits,
+): Promise<ReadonlyArray<WorkspacePackageExportPreviewCardRow>> {
+  if (selection.kind === "explicitCardIds") {
+    assertSelectionWithinLimit(selection.cardIds.length, limits.maxSelectedCards);
+  }
+
+  const query = buildSelectedCardsQuery(workspaceId, selection, limits.maxSelectedCards);
+  const result = await executor.query<WorkspacePackageExportPreviewCardRow>(query.text, query.params);
+  assertSelectionWithinLimit(result.rows.length, limits.maxSelectedCards);
+  assertExplicitCardsFound(result.rows, query.explicitCardIds);
+
+  return result.rows;
+}
+
+function toSafeNumber(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (Number.isSafeInteger(parsedValue) === false) {
+    throw new Error(`${fieldName} must be a safe integer`);
+  }
+
+  return parsedValue;
+}
+
+function compareTagCounts(
+  left: WorkspacePackageExportPreviewTagCount,
+  right: WorkspacePackageExportPreviewTagCount,
+): number {
+  const countDifference = right.cardsCount - left.cardsCount;
+  if (countDifference !== 0) {
+    return countDifference;
+  }
+
+  const normalizedTagDifference = left.tag.toLowerCase().localeCompare(right.tag.toLowerCase());
+  if (normalizedTagDifference !== 0) {
+    return normalizedTagDifference;
+  }
+
+  return left.tag.localeCompare(right.tag);
+}
+
+function buildAvailableTagCounts(
+  cards: ReadonlyArray<WorkspacePackageExportPreviewCardRow>,
+): ReadonlyArray<WorkspacePackageExportPreviewTagCount> {
+  const tagCounts = new Map<string, number>();
+
+  for (const card of cards) {
+    for (const tag of card.tags) {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return [...tagCounts.entries()]
+    .map(([tag, cardsCount]) => ({ tag, cardsCount }))
+    .sort(compareTagCounts);
+}
+
+function buildTagsSelectedForRemoval(
+  availableTagCounts: ReadonlyArray<WorkspacePackageExportPreviewTagCount>,
+  tagPolicy: WorkspacePackageExportTagPolicyInput,
+): ReadonlyArray<WorkspacePackageExportPreviewTagCount> {
+  const additionalRemovedTags = new Set(tagPolicy.additionalRemovedTags);
+
+  return availableTagCounts.filter((tagCount) => (
+    tagCount.tag.startsWith(workspacePackageExportImportTagPrefix)
+    || additionalRemovedTags.has(tagCount.tag)
+  ));
+}
+
+function normalizeTagPolicy(tagPolicy: WorkspacePackageExportTagPolicyInput): WorkspacePackageExportTagPolicyInput {
+  return {
+    additionalRemovedTags: normalizeUniqueTextValues(
+      tagPolicy.additionalRemovedTags,
+      "tagPolicy.additionalRemovedTags",
+    ),
+  };
+}
+
+function extractReferencedMediaAssetIds(
+  cards: ReadonlyArray<WorkspacePackageExportPreviewCardRow>,
+): ReadonlyArray<string> {
+  const mediaAssetIds = new Set<string>();
+
+  for (const card of cards) {
+    for (const mediaAssetId of extractMarkdownFcAssetIds(card.front_text)) {
+      mediaAssetIds.add(mediaAssetId);
+    }
+
+    for (const mediaAssetId of extractMarkdownFcAssetIds(card.back_text)) {
+      mediaAssetIds.add(mediaAssetId);
+    }
+  }
+
+  return [...mediaAssetIds];
+}
+
+function assertValidMediaAssetIds(mediaAssetIds: ReadonlyArray<string>): void {
+  const invalidMediaAssetIds = mediaAssetIds.filter((mediaAssetId) => uuidPattern.test(mediaAssetId) === false);
+  if (invalidMediaAssetIds.length === 0) {
+    return;
+  }
+
+  throw new HttpError(
+    400,
+    `Workspace package export preview references invalid media asset ids. invalidMediaAssetIds=${invalidMediaAssetIds.join(",")}`,
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_MEDIA_ASSET_ID_INVALID",
+  );
+}
+
+function assertReferencedMediaAssetsFound(
+  mediaAssetIds: ReadonlyArray<string>,
+  rows: ReadonlyArray<WorkspacePackageExportPreviewMediaRow>,
+): void {
+  const returnedMediaAssetIds = new Set(rows.map((row) => row.media_asset_id));
+  const missingMediaAssetIds = mediaAssetIds.filter((mediaAssetId) => returnedMediaAssetIds.has(mediaAssetId) === false);
+  if (missingMediaAssetIds.length === 0) {
+    return;
+  }
+
+  throw new HttpError(
+    400,
+    `Workspace package export preview references unavailable media assets. mediaAssetIds=${missingMediaAssetIds.join(",")}`,
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_MEDIA_ASSET_UNAVAILABLE",
+  );
+}
+
+async function loadReferencedMediaRowsInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  mediaAssetIds: ReadonlyArray<string>,
+): Promise<ReadonlyArray<WorkspacePackageExportPreviewMediaRow>> {
+  if (mediaAssetIds.length === 0) {
+    return [];
+  }
+
+  assertValidMediaAssetIds(mediaAssetIds);
+  const result = await executor.query<WorkspacePackageExportPreviewMediaRow>(
+    [
+      "SELECT",
+      "media_assets.media_asset_id AS media_asset_id,",
+      "media_assets.media_blob_id AS media_blob_id,",
+      "media_blobs.size_bytes AS size_bytes",
+      "FROM",
+      MEDIA_ASSET_JOIN_CLAUSE,
+      "WHERE media_assets.workspace_id = $1",
+      "AND media_assets.media_asset_id = ANY($2::uuid[])",
+      "AND media_assets.deleted_at IS NULL",
+      "ORDER BY array_position($2::uuid[], media_assets.media_asset_id)",
+    ].join(" "),
+    [workspaceId, mediaAssetIds],
+  );
+  assertReferencedMediaAssetsFound(mediaAssetIds, result.rows);
+
+  return result.rows;
+}
+
+function sumReferencedMediaBytes(
+  mediaRows: ReadonlyArray<WorkspacePackageExportPreviewMediaRow>,
+): number {
+  const countedBlobIds = new Set<string>();
+  let totalSizeBytes = 0;
+
+  for (const mediaRow of mediaRows) {
+    if (countedBlobIds.has(mediaRow.media_blob_id)) {
+      continue;
+    }
+
+    countedBlobIds.add(mediaRow.media_blob_id);
+    totalSizeBytes += toSafeNumber(mediaRow.size_bytes, "size_bytes");
+    if (Number.isSafeInteger(totalSizeBytes) === false) {
+      throw new Error("referenced media byte total must be a safe integer");
+    }
+  }
+
+  return totalSizeBytes;
+}
+
+export async function previewWorkspacePackageExportInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: WorkspacePackageExportPreviewInput,
+  limits: WorkspacePackageExportPreviewLimits,
+): Promise<WorkspacePackageExportPreview> {
+  const normalizedGeneratedAt = normalizeIsoTimestamp(input.generatedAt, "generatedAt");
+  const normalizedSelection = normalizeCardSelection(input.selection);
+  const normalizedTagPolicy = normalizeTagPolicy(input.tagPolicy);
+  const defaultPackageMetadata = normalizePackageMetadata(input.packageMetadata, normalizedGeneratedAt);
+  const normalizedLimits = normalizePreviewLimits(limits);
+  const cards = await loadSelectedCardsInExecutor(
+    executor,
+    workspaceId,
+    normalizedSelection,
+    normalizedLimits,
+  );
+  const availableTagCounts = buildAvailableTagCounts(cards);
+  const referencedMediaAssetIds = extractReferencedMediaAssetIds(cards);
+  const mediaRows = await loadReferencedMediaRowsInExecutor(executor, workspaceId, referencedMediaAssetIds);
+
+  return {
+    selectedCardCount: cards.length,
+    availableTagCounts,
+    tagsSelectedForRemoval: buildTagsSelectedForRemoval(availableTagCounts, normalizedTagPolicy),
+    referencedMediaCount: mediaRows.length,
+    approximateReferencedMediaBytes: sumReferencedMediaBytes(mediaRows),
+    defaultPackageMetadata,
+  };
+}
+
+export async function previewWorkspacePackageExport(
+  userId: string,
+  workspaceId: string,
+  input: WorkspacePackageExportPreviewInput,
+): Promise<WorkspacePackageExportPreview> {
+  return transactionWithWorkspaceScopeReadOnly({ userId, workspaceId }, async (executor) => (
+    previewWorkspacePackageExportInExecutor(
+      executor,
+      workspaceId,
+      input,
+      { maxSelectedCards: workspacePackageExportPreviewDefaultMaxSelectedCards },
+    )
+  ));
+}

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -14,6 +14,19 @@ export type {
 } from "./markdownMedia";
 
 export {
+  previewWorkspacePackageExport,
+} from "./exportPreview";
+
+export type {
+  WorkspacePackageExportCardSelection,
+  WorkspacePackageExportMetadataInput,
+  WorkspacePackageExportPreview,
+  WorkspacePackageExportPreviewInput,
+  WorkspacePackageExportPreviewTagCount,
+  WorkspacePackageExportTagPolicyInput,
+} from "./exportPreview";
+
+export {
   normalizeWorkspacePackageCardMetadataV1,
   parseWorkspacePackageCardsJsonV1,
   toPortableWorkspacePackageCard,


### PR DESCRIPTION
Adds internal backend export preview service only.

- Supports all-active, explicit-card, and tag include/exclude selection.
- Uses Stage 3A Markdown helpers to scan `fcasset:<assetId>` references.
- Validates referenced media assets by workspace/deleted state and returns deduped approximate media bytes without downloading objects.
- Adds workload cap and default import-tag removal preview.
- No routes/OpenAPI/API Gateway/S3 byte download/ZIP generation/client changes in this PR.

Validation run:
- `npm run lint --prefix apps/backend`: passed.
- `npm run test --prefix apps/backend -- workspacePackages mediaAssets`: passed, 601 tests.

Review status: fresh review found no P0-P4 issues and no split recommendation.