### PR TITLE
Add media asset object byte loader

### DIFF
--- a/apps/backend/src/mediaAssets/storage/contracts.ts
+++ b/apps/backend/src/mediaAssets/storage/contracts.ts
@@ -71,6 +71,24 @@ export type AssertMediaAssetObjectInput = Readonly<{
   observationScope: BackendObservationScope;
 }>;
 
+export type LoadMediaAssetObjectBytesInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  storageKey: string;
+  mimeType: string | null;
+  sizeBytes: number | null;
+  sha256: string | null;
+  maxByteSize: number;
+  observationScope: BackendObservationScope;
+}>;
+
+export type LoadedMediaAssetObjectBytes = Readonly<{
+  bytes: Buffer;
+  mimeType: string | null;
+  sizeBytes: number;
+  sha256: string;
+}>;
+
 export type CompleteMultipartMediaAssetUploadInput = Readonly<{
   workspaceId: string;
   mediaAssetId: string;

--- a/apps/backend/src/mediaAssets/storage/index.ts
+++ b/apps/backend/src/mediaAssets/storage/index.ts
@@ -13,6 +13,8 @@ import type {
   AssertMediaAssetObjectInput,
   CompleteMultipartMediaAssetUploadInput,
   CreateMultipartMediaAssetUploadInput,
+  LoadedMediaAssetObjectBytes,
+  LoadMediaAssetObjectBytesInput,
   PresignMediaAssetDownloadInput,
   PresignMediaAssetUploadInput,
   PresignMultipartMediaAssetUploadPartsInput,
@@ -26,6 +28,7 @@ import {
 } from "./multipart";
 import {
   assertMediaAssetObjectMatchesWithDependencies,
+  loadMediaAssetObjectBytesWithDependencies,
   loadMediaAssetObjectMetadataWithDependencies,
 } from "./objects";
 import {
@@ -45,6 +48,8 @@ export type {
   AssertMediaAssetObjectInput,
   CompleteMultipartMediaAssetUploadInput,
   CreateMultipartMediaAssetUploadInput,
+  LoadedMediaAssetObjectBytes,
+  LoadMediaAssetObjectBytesInput,
   MediaAssetStorageDependencies,
   PresignMediaAssetDownloadInput,
   PresignMediaAssetUploadInput,
@@ -59,6 +64,7 @@ export {
 } from "./multipart";
 export {
   assertMediaAssetObjectMatchesWithDependencies,
+  loadMediaAssetObjectBytesWithDependencies,
   loadMediaAssetObjectMetadataWithDependencies,
 } from "./objects";
 export {
@@ -120,6 +126,15 @@ export async function assertMediaAssetObjectMatches(
   input: AssertMediaAssetObjectInput,
 ): Promise<void> {
   return assertMediaAssetObjectMatchesWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function loadMediaAssetObjectBytes(
+  input: LoadMediaAssetObjectBytesInput,
+): Promise<LoadedMediaAssetObjectBytes> {
+  return loadMediaAssetObjectBytesWithDependencies(input, {
     s3Client: getMediaAssetsS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });

--- a/apps/backend/src/mediaAssets/storage/objects.test.ts
+++ b/apps/backend/src/mediaAssets/storage/objects.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Readable } from "node:stream";
+import {
+  GetObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { createPublicHttpErrorDetails, HttpError } from "../../shared/errors";
+import {
+  loadMediaAssetObjectBytesWithDependencies,
+  type LoadMediaAssetObjectBytesInput,
+} from ".";
+import {
+  createFailingS3Client,
+  createS3Error,
+  createTestS3Client,
+  getTestMediaAssetsStorageConfig,
+  getUnexpectedS3CommandName,
+  testBlobStorageKey,
+  testMediaAssetId,
+  testObjectBytes,
+  testObservationScope,
+  testSha256,
+  testWorkspaceId,
+} from "./testHelpers";
+
+function createLoadBytesInput(
+  fixture: Readonly<{
+    mimeType: string | null;
+    sizeBytes: number | null;
+    sha256: string | null;
+    maxByteSize: number;
+  }>,
+): LoadMediaAssetObjectBytesInput {
+  return {
+    workspaceId: testWorkspaceId,
+    mediaAssetId: testMediaAssetId,
+    storageKey: testBlobStorageKey,
+    mimeType: fixture.mimeType,
+    sizeBytes: fixture.sizeBytes,
+    sha256: fixture.sha256,
+    maxByteSize: fixture.maxByteSize,
+    observationScope: testObservationScope,
+  };
+}
+
+test("loadMediaAssetObjectBytesWithDependencies downloads verified object bytes", async () => {
+  const sentCommands: Array<string> = [];
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    if (command instanceof GetObjectCommand) {
+      sentCommands.push([
+        "get",
+        String(command.input.Bucket),
+        String(command.input.Key),
+      ].join(":"));
+      return {
+        ContentLength: testObjectBytes.byteLength,
+        Body: Readable.from([testObjectBytes]),
+      };
+    }
+
+    throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  const objectBytes = await loadMediaAssetObjectBytesWithDependencies(
+    createLoadBytesInput({
+      mimeType: "image/png",
+      sizeBytes: testObjectBytes.byteLength,
+      sha256: testSha256,
+      maxByteSize: testObjectBytes.byteLength,
+    }),
+    {
+      s3Client: client,
+      getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+    },
+  );
+
+  assert.equal(objectBytes.bytes.equals(testObjectBytes), true);
+  assert.equal(objectBytes.mimeType, "image/png");
+  assert.equal(objectBytes.sizeBytes, testObjectBytes.byteLength);
+  assert.equal(objectBytes.sha256, testSha256);
+  assert.deepEqual(sentCommands, [
+    `get:test-media-assets-bucket:${testBlobStorageKey}`,
+  ]);
+});
+
+test("loadMediaAssetObjectBytesWithDependencies treats missing objects as unavailable uploads", async () => {
+  await assert.rejects(
+    async () => loadMediaAssetObjectBytesWithDependencies(
+      createLoadBytesInput({
+        mimeType: "image/png",
+        sizeBytes: testObjectBytes.byteLength,
+        sha256: testSha256,
+        maxByteSize: testObjectBytes.byteLength,
+      }),
+      {
+        s3Client: createFailingS3Client(createS3Error(404, "NoSuchKey", `Missing s3://test-media-assets-bucket/${testBlobStorageKey}`)),
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "MEDIA_ASSET_UPLOAD_NOT_FOUND");
+      assert.doesNotMatch(error.message, /NoSuchKey|media\/blobs|s3:\/\//);
+      assert.deepEqual(error.details?.mediaAssetStorage, {
+        operation: "get_object",
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        s3StatusCode: 404,
+        s3ErrorClass: "NoSuchKey",
+        reason: "upload_not_available",
+        retryable: false,
+      });
+      assert.deepEqual(createPublicHttpErrorDetails(error.details), {
+        mediaAssetStorage: {
+          workspaceId: testWorkspaceId,
+          mediaAssetId: testMediaAssetId,
+          reason: "upload_not_available",
+          retryable: false,
+        },
+      });
+      return true;
+    },
+  );
+});
+
+test("loadMediaAssetObjectBytesWithDependencies rejects objects above the caller size cap", async () => {
+  const sentCommands: Array<string> = [];
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    if (command instanceof GetObjectCommand) {
+      sentCommands.push(`get:${String(command.input.Key)}`);
+      return {
+        Body: Readable.from([
+          Buffer.from("pass"),
+          Buffer.from("word"),
+        ]),
+      };
+    }
+
+    throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await assert.rejects(
+    async () => loadMediaAssetObjectBytesWithDependencies(
+      createLoadBytesInput({
+        mimeType: "image/png",
+        sizeBytes: null,
+        sha256: null,
+        maxByteSize: testObjectBytes.byteLength - 1,
+      }),
+      {
+        s3Client: client,
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 413);
+      assert.equal(error.code, "MEDIA_ASSET_OBJECT_BYTES_TOO_LARGE");
+      assert.match(error.message, /maxByteSize=7/);
+      assert.match(error.message, /actualSizeBytes=8/);
+      assert.doesNotMatch(error.message, /storageKey|media\/blobs|s3:\/\//);
+      return true;
+    },
+  );
+  assert.deepEqual(sentCommands, [
+    `get:${testBlobStorageKey}`,
+  ]);
+});
+
+test("loadMediaAssetObjectBytesWithDependencies rejects byte-size mismatches", async () => {
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    if (command instanceof GetObjectCommand) {
+      return {
+        Body: Readable.from([testObjectBytes]),
+      };
+    }
+
+    throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await assert.rejects(
+    async () => loadMediaAssetObjectBytesWithDependencies(
+      createLoadBytesInput({
+        mimeType: "image/png",
+        sizeBytes: testObjectBytes.byteLength + 1,
+        sha256: testSha256,
+        maxByteSize: testObjectBytes.byteLength + 1,
+      }),
+      {
+        s3Client: client,
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "MEDIA_ASSET_OBJECT_BYTES_MISMATCH");
+      assert.match(error.message, /mismatchedFields=sizeBytes/);
+      assert.doesNotMatch(error.message, /storageKey|media\/blobs|s3:\/\/|sha256=/);
+      assert.doesNotMatch(error.message, new RegExp(testSha256));
+      return true;
+    },
+  );
+});
+
+test("loadMediaAssetObjectBytesWithDependencies rejects sha256 mismatches", async () => {
+  const bytes = Buffer.from("not-password");
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    if (command instanceof GetObjectCommand) {
+      return {
+        Body: Readable.from([bytes]),
+      };
+    }
+
+    throw new Error(`Unexpected S3 command ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await assert.rejects(
+    async () => loadMediaAssetObjectBytesWithDependencies(
+      createLoadBytesInput({
+        mimeType: "image/png",
+        sizeBytes: bytes.byteLength,
+        sha256: testSha256,
+        maxByteSize: bytes.byteLength,
+      }),
+      {
+        s3Client: client,
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "MEDIA_ASSET_OBJECT_BYTES_MISMATCH");
+      assert.match(error.message, /mismatchedFields=sha256/);
+      assert.doesNotMatch(error.message, /storageKey|media\/blobs|s3:\/\/|sha256=/);
+      assert.doesNotMatch(error.message, new RegExp(testSha256));
+      return true;
+    },
+  );
+});

--- a/apps/backend/src/mediaAssets/storage/objects.ts
+++ b/apps/backend/src/mediaAssets/storage/objects.ts
@@ -3,9 +3,12 @@ import {
   HeadObjectCommand,
 } from "@aws-sdk/client-s3";
 import { createHash } from "node:crypto";
+import { HttpError } from "../../shared/errors";
 import type { MediaAssetObjectMetadata } from "../types";
 import type {
   AssertMediaAssetObjectInput,
+  LoadedMediaAssetObjectBytes,
+  LoadMediaAssetObjectBytesInput,
   MediaAssetObjectContentHash,
   MediaAssetStorageContext,
   MediaAssetStorageDependencies,
@@ -33,6 +36,82 @@ function isMediaAssetObjectBody(value: unknown): value is MediaAssetObjectBody {
 
 function toMediaAssetObjectBodyChunkBytes(chunk: MediaAssetObjectBodyChunk): Uint8Array {
   return typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+}
+
+function assertMediaAssetObjectBytesLoadInput(input: LoadMediaAssetObjectBytesInput): void {
+  if (Number.isSafeInteger(input.maxByteSize) === false || input.maxByteSize < 0) {
+    throw new Error(
+      `maxByteSize must be a non-negative safe integer for media asset object byte load workspaceId=${input.workspaceId} mediaAssetId=${input.mediaAssetId}.`,
+    );
+  }
+
+  if (
+    input.sizeBytes !== null
+    && (Number.isSafeInteger(input.sizeBytes) === false || input.sizeBytes < 0)
+  ) {
+    throw new Error(
+      `sizeBytes must be a non-negative safe integer for media asset object byte load workspaceId=${input.workspaceId} mediaAssetId=${input.mediaAssetId}.`,
+    );
+  }
+}
+
+function createMediaAssetObjectBytesTooLargeError(
+  input: LoadMediaAssetObjectBytesInput,
+  actualSizeBytes: number,
+): HttpError {
+  return new HttpError(
+    413,
+    [
+      "Media asset object is too large to load",
+      `workspaceId=${input.workspaceId}`,
+      `mediaAssetId=${input.mediaAssetId}`,
+      `maxByteSize=${input.maxByteSize}`,
+      `actualSizeBytes=${actualSizeBytes}`,
+    ].join(" "),
+    "MEDIA_ASSET_OBJECT_BYTES_TOO_LARGE",
+  );
+}
+
+function assertMediaAssetObjectBytesWithinLimit(
+  input: LoadMediaAssetObjectBytesInput,
+  actualSizeBytes: number,
+): void {
+  if (actualSizeBytes > input.maxByteSize) {
+    throw createMediaAssetObjectBytesTooLargeError(input, actualSizeBytes);
+  }
+}
+
+function createMediaAssetObjectBytesMismatchError(
+  input: LoadMediaAssetObjectBytesInput,
+  objectBytes: LoadedMediaAssetObjectBytes,
+): HttpError {
+  const mismatchedFields = [
+    ...(input.sizeBytes === null || objectBytes.sizeBytes === input.sizeBytes ? [] : ["sizeBytes"]),
+    ...(input.sha256 === null || objectBytes.sha256 === input.sha256 ? [] : ["sha256"]),
+  ];
+
+  return new HttpError(
+    409,
+    [
+      "Media asset object bytes do not match expected metadata",
+      `workspaceId=${input.workspaceId}`,
+      `mediaAssetId=${input.mediaAssetId}`,
+      `mismatchedFields=${mismatchedFields.join(",")}`,
+    ].join(" "),
+    "MEDIA_ASSET_OBJECT_BYTES_MISMATCH",
+  );
+}
+
+function assertLoadedMediaAssetObjectBytesMatch(
+  input: LoadMediaAssetObjectBytesInput,
+  objectBytes: LoadedMediaAssetObjectBytes,
+): void {
+  if (
+    (input.sizeBytes !== null && objectBytes.sizeBytes !== input.sizeBytes)
+    || (input.sha256 !== null && objectBytes.sha256 !== input.sha256)
+  ) {
+    throw createMediaAssetObjectBytesMismatchError(input, objectBytes);
+  }
 }
 
 export async function loadMediaAssetObjectMetadataWithDependencies(
@@ -72,6 +151,73 @@ export async function loadMediaAssetObjectMetadataWithDependencies(
     };
   } catch (error) {
     throw createMediaAssetStorageError(context, "head_object", error);
+  }
+}
+
+export async function loadMediaAssetObjectBytesWithDependencies(
+  input: LoadMediaAssetObjectBytesInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<LoadedMediaAssetObjectBytes> {
+  assertMediaAssetObjectBytesLoadInput(input);
+  if (input.sizeBytes !== null) {
+    assertMediaAssetObjectBytesWithinLimit(input, input.sizeBytes);
+  }
+
+  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const context: MediaAssetStorageContext = {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey: input.storageKey,
+    observationScope: input.observationScope,
+  };
+
+  try {
+    const response = await runMediaAssetStorageOperationWithRetries(
+      context,
+      "get_object",
+      async () => dependencies.s3Client.send(new GetObjectCommand({
+        Bucket: config.bucketName,
+        Key: input.storageKey,
+      })),
+    );
+
+    if (typeof response.ContentLength === "number") {
+      assertMediaAssetObjectBytesWithinLimit(input, response.ContentLength);
+    }
+
+    const body = response.Body;
+    if (isMediaAssetObjectBody(body) === false) {
+      throw new Error(
+        `S3 get_object did not return a readable body for workspaceId=${input.workspaceId} mediaAssetId=${input.mediaAssetId}.`,
+      );
+    }
+
+    const hash = createHash("sha256");
+    const chunks: Array<Uint8Array> = [];
+    let sizeBytes = 0;
+    for await (const chunk of body) {
+      const bytes = toMediaAssetObjectBodyChunkBytes(chunk);
+      sizeBytes += bytes.byteLength;
+      assertMediaAssetObjectBytesWithinLimit(input, sizeBytes);
+      chunks.push(bytes);
+      hash.update(bytes);
+    }
+
+    const objectBytes: LoadedMediaAssetObjectBytes = {
+      bytes: Buffer.concat(chunks, sizeBytes),
+      mimeType: input.mimeType,
+      sizeBytes,
+      sha256: hash.digest("hex"),
+    };
+    assertLoadedMediaAssetObjectBytesMatch(input, objectBytes);
+
+    return objectBytes;
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    throw createMediaAssetStorageError(context, "get_object", error);
   }
 }
 


### PR DESCRIPTION
## Summary
- add an internal media asset storage helper to load object bytes through existing S3 dependencies
- enforce caller-provided byte caps and verify size/hash metadata when provided
- add focused storage tests for success, missing object, size cap, byte-size mismatch, and hash mismatch

## Validation
- npm run test --prefix apps/backend -- mediaAssets: passed, 606 tests, 0 failures
- npm run lint --prefix apps/backend: passed
- worker-owned review: no split recommendation, no P0-P4 findings