### PR TITLE
Add backend package ZIP assembly

### DIFF
--- a/apps/backend/src/workspacePackages/exportPackage.test.ts
+++ b/apps/backend/src/workspacePackages/exportPackage.test.ts
@@ -1,0 +1,822 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import type {
+  LoadedMediaAssetObjectBytes,
+  LoadMediaAssetObjectBytesInput,
+} from "../mediaAssets/storage";
+import type { BackendObservationScope } from "../observability/sentry";
+import { HttpError } from "../shared/errors";
+import {
+  exportWorkspacePackageInExecutor,
+  parseWorkspacePackageCardsJsonV1,
+  type WorkspacePackageCardsJsonV1,
+  type WorkspacePackageCardMetadataV1,
+  type WorkspacePackageExportPackageInput,
+  type WorkspacePackageExportPackageLimits,
+} from "./index";
+
+type TestCardRow = Readonly<{
+  card_id: string;
+  workspace_id: string;
+  front_text: string;
+  back_text: string;
+  card_type: string;
+  metadata: WorkspacePackageCardMetadataV1;
+  tags: ReadonlyArray<string>;
+  created_at: string;
+  deleted_at: string | null;
+}>;
+
+type TestMediaAssetRow = Readonly<{
+  media_asset_id: string;
+  workspace_id: string;
+  media_blob_id: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string;
+  storage_key: string;
+  deleted_at: string | null;
+}>;
+
+type TestByteLoaderHarness = Readonly<{
+  loadMediaAssetObjectBytesFn: (
+    input: LoadMediaAssetObjectBytesInput,
+  ) => Promise<LoadedMediaAssetObjectBytes>;
+  calls: ReadonlyArray<LoadMediaAssetObjectBytesInput>;
+}>;
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+const otherWorkspaceId = "22222222-2222-4222-8222-222222222222";
+const cardIdA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+const cardIdB = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2";
+const mediaAssetIdA = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1";
+const mediaAssetIdB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2";
+const mediaAssetIdC = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3";
+const mediaAssetIdD = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4";
+const mediaAssetIdE = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5";
+const mediaBlobIdA = "cccccccc-cccc-4ccc-8ccc-ccccccccccc1";
+const mediaBlobIdB = "cccccccc-cccc-4ccc-8ccc-ccccccccccc2";
+const generatedAt = "2026-06-30T12:00:00.000Z";
+
+const testMetadata: WorkspacePackageCardMetadataV1 = {
+  version: 1,
+  source: {
+    label: "Source deck",
+    author: null,
+    comment: null,
+    createdAt: "2026-06-01T12:00:00.000Z",
+    importedAt: null,
+    importId: null,
+  },
+};
+
+const observationScope: BackendObservationScope = {
+  service: "backend-api",
+  requestId: "request-1",
+  route: null,
+  method: null,
+  userId: "user-1",
+  workspaceId,
+  chatRequestId: null,
+  runId: null,
+  sessionId: null,
+  clientAppVersion: null,
+  clientPlatform: null,
+};
+
+function createPackageLimits(
+  maxSelectedCards: number,
+  maxMediaFiles: number,
+  maxSingleMediaBytes: number,
+  maxTotalMediaBytes: number,
+): WorkspacePackageExportPackageLimits {
+  return { maxSelectedCards, maxMediaFiles, maxSingleMediaBytes, maxTotalMediaBytes };
+}
+
+function createBasePackageInput(
+  selection: WorkspacePackageExportPackageInput["selection"],
+): WorkspacePackageExportPackageInput {
+  return {
+    selection,
+    tagPolicy: {
+      additionalRemovedTags: [],
+    },
+    packageMetadata: {
+      label: null,
+      author: null,
+      comment: null,
+      createdAt: null,
+      sourceUrl: null,
+    },
+    generatedAt,
+    observationScope,
+  };
+}
+
+function createCardRow(
+  cardId: string,
+  cardWorkspaceId: string,
+  frontText: string,
+  backText: string,
+  tags: ReadonlyArray<string>,
+  createdAt: string,
+  deletedAt: string | null,
+): TestCardRow {
+  return {
+    card_id: cardId,
+    workspace_id: cardWorkspaceId,
+    front_text: frontText,
+    back_text: backText,
+    card_type: "basic",
+    metadata: testMetadata,
+    tags,
+    created_at: createdAt,
+    deleted_at: deletedAt,
+  };
+}
+
+function createMediaAssetRow(
+  mediaAssetId: string,
+  mediaWorkspaceId: string,
+  mediaBlobId: string,
+  mimeType: string,
+  bytes: Buffer,
+  storageKey: string,
+  deletedAt: string | null,
+): TestMediaAssetRow {
+  return {
+    media_asset_id: mediaAssetId,
+    workspace_id: mediaWorkspaceId,
+    media_blob_id: mediaBlobId,
+    mime_type: mimeType,
+    size_bytes: bytes.byteLength,
+    sha256: sha256Hex(bytes),
+    storage_key: storageKey,
+    deleted_at: deletedAt,
+  };
+}
+
+function createQueryResult<Row extends pg.QueryResultRow>(
+  rows: ReadonlyArray<Row>,
+): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function requireStringParam(params: ReadonlyArray<SqlValue>, index: number): string {
+  const value = params[index];
+  if (typeof value !== "string") {
+    throw new Error(`Expected string query parameter at index ${index}`);
+  }
+
+  return value;
+}
+
+function requireNumberParam(params: ReadonlyArray<SqlValue>, index: number): number {
+  const value = params[index];
+  if (typeof value !== "number") {
+    throw new Error(`Expected number query parameter at index ${index}`);
+  }
+
+  return value;
+}
+
+function requireStringArrayParam(params: ReadonlyArray<SqlValue>, index: number): ReadonlyArray<string> {
+  const value = params[index];
+  if (Array.isArray(value) === false || value.some((item) => typeof item !== "string")) {
+    throw new Error(`Expected string array query parameter at index ${index}`);
+  }
+
+  return value;
+}
+
+function compareCardsForPackage(left: TestCardRow, right: TestCardRow): number {
+  const createdAtDifference = new Date(right.created_at).getTime() - new Date(left.created_at).getTime();
+  if (createdAtDifference !== 0) {
+    return createdAtDifference;
+  }
+
+  return left.card_id.localeCompare(right.card_id);
+}
+
+function cardHasAnyTag(card: TestCardRow, tags: ReadonlyArray<string>): boolean {
+  return card.tags.some((tag) => tags.includes(tag));
+}
+
+function filterCardRows(
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+  cards: ReadonlyArray<TestCardRow>,
+): ReadonlyArray<TestCardRow> {
+  const requestedWorkspaceId = requireStringParam(params, 0);
+  const limit = requireNumberParam(params, params.length - 1);
+  const activeCards = cards.filter((card) => (
+    card.workspace_id === requestedWorkspaceId
+    && card.deleted_at === null
+  ));
+
+  if (text.includes("card_id = ANY($2::uuid[])")) {
+    const cardIds = requireStringArrayParam(params, 1);
+    return cardIds
+      .flatMap((cardId) => activeCards.filter((card) => card.card_id === cardId))
+      .slice(0, limit);
+  }
+
+  let nextFilterParamIndex = 1;
+  const includeTags = text.includes("AND tags &&")
+    ? requireStringArrayParam(params, nextFilterParamIndex)
+    : [];
+  nextFilterParamIndex += includeTags.length === 0 ? 0 : 1;
+  const excludeTags = text.includes("AND NOT (tags &&")
+    ? requireStringArrayParam(params, nextFilterParamIndex)
+    : [];
+
+  return activeCards
+    .filter((card) => includeTags.length === 0 || cardHasAnyTag(card, includeTags))
+    .filter((card) => excludeTags.length === 0 || cardHasAnyTag(card, excludeTags) === false)
+    .sort(compareCardsForPackage)
+    .slice(0, limit);
+}
+
+function filterMediaRows(
+  params: ReadonlyArray<SqlValue>,
+  mediaAssets: ReadonlyArray<TestMediaAssetRow>,
+): ReadonlyArray<Omit<TestMediaAssetRow, "workspace_id" | "deleted_at">> {
+  const requestedWorkspaceId = requireStringParam(params, 0);
+  const mediaAssetIds = requireStringArrayParam(params, 1);
+  const activeAssets = mediaAssets.filter((mediaAsset) => (
+    mediaAsset.workspace_id === requestedWorkspaceId
+    && mediaAsset.deleted_at === null
+  ));
+
+  return mediaAssetIds.flatMap((mediaAssetId) => (
+    activeAssets
+      .filter((mediaAsset) => mediaAsset.media_asset_id === mediaAssetId)
+      .map((mediaAsset) => ({
+        media_asset_id: mediaAsset.media_asset_id,
+        media_blob_id: mediaAsset.media_blob_id,
+        mime_type: mediaAsset.mime_type,
+        size_bytes: mediaAsset.size_bytes,
+        sha256: mediaAsset.sha256,
+        storage_key: mediaAsset.storage_key,
+      }))
+  ));
+}
+
+function createTestExecutor(
+  cards: ReadonlyArray<TestCardRow>,
+  mediaAssets: ReadonlyArray<TestMediaAssetRow>,
+): DatabaseExecutor {
+  return {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("FROM content.cards")) {
+        return createQueryResult(filterCardRows(text, params, cards) as unknown as ReadonlyArray<Row>);
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets")) {
+        return createQueryResult(filterMediaRows(params, mediaAssets) as unknown as ReadonlyArray<Row>);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+}
+
+function sha256Hex(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function createByteLoader(bytesByStorageKey: ReadonlyMap<string, Buffer>): TestByteLoaderHarness {
+  const calls: Array<LoadMediaAssetObjectBytesInput> = [];
+
+  return {
+    calls,
+    async loadMediaAssetObjectBytesFn(
+      input: LoadMediaAssetObjectBytesInput,
+    ): Promise<LoadedMediaAssetObjectBytes> {
+      calls.push(input);
+      const bytes = bytesByStorageKey.get(input.storageKey);
+      if (bytes === undefined) {
+        throw new Error(`Missing test bytes for storageKey=${input.storageKey}`);
+      }
+
+      if (bytes.byteLength > input.maxByteSize) {
+        throw new HttpError(413, "Test media bytes exceed max byte size.", "TEST_MEDIA_TOO_LARGE");
+      }
+
+      const sha256 = sha256Hex(bytes);
+      assert.equal(input.sizeBytes, bytes.byteLength);
+      assert.equal(input.sha256, sha256);
+
+      return {
+        bytes,
+        mimeType: input.mimeType,
+        sizeBytes: bytes.byteLength,
+        sha256,
+      };
+    },
+  };
+}
+
+function findEndOfCentralDirectoryOffset(zipBytes: Buffer): number {
+  const signature = Buffer.from([0x50, 0x4b, 0x05, 0x06]);
+  const offset = zipBytes.lastIndexOf(signature);
+  if (offset === -1) {
+    throw new Error("ZIP end of central directory record not found");
+  }
+
+  return offset;
+}
+
+function parseStoredZipEntries(zipBytes: Buffer): ReadonlyMap<string, Buffer> {
+  const endOfCentralDirectoryOffset = findEndOfCentralDirectoryOffset(zipBytes);
+  const entryCount = zipBytes.readUInt16LE(endOfCentralDirectoryOffset + 10);
+  const centralDirectoryOffset = zipBytes.readUInt32LE(endOfCentralDirectoryOffset + 16);
+  const entries = new Map<string, Buffer>();
+  let cursor = centralDirectoryOffset;
+
+  for (let entryIndex = 0; entryIndex < entryCount; entryIndex += 1) {
+    assert.equal(zipBytes.readUInt32LE(cursor), 0x02014b50);
+    assert.equal(zipBytes.readUInt16LE(cursor + 10), 0);
+    const compressedSize = zipBytes.readUInt32LE(cursor + 20);
+    const uncompressedSize = zipBytes.readUInt32LE(cursor + 24);
+    const fileNameLength = zipBytes.readUInt16LE(cursor + 28);
+    const extraFieldLength = zipBytes.readUInt16LE(cursor + 30);
+    const fileCommentLength = zipBytes.readUInt16LE(cursor + 32);
+    const localHeaderOffset = zipBytes.readUInt32LE(cursor + 42);
+    const path = zipBytes.toString("utf8", cursor + 46, cursor + 46 + fileNameLength);
+    assert.equal(compressedSize, uncompressedSize);
+    assert.equal(zipBytes.readUInt32LE(localHeaderOffset), 0x04034b50);
+    assert.equal(zipBytes.readUInt16LE(localHeaderOffset + 8), 0);
+    const localFileNameLength = zipBytes.readUInt16LE(localHeaderOffset + 26);
+    const localExtraFieldLength = zipBytes.readUInt16LE(localHeaderOffset + 28);
+    const contentStart = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength;
+    entries.set(path, zipBytes.subarray(contentStart, contentStart + compressedSize));
+    cursor += 46 + fileNameLength + extraFieldLength + fileCommentLength;
+  }
+
+  return entries;
+}
+
+function requireZipEntry(entries: ReadonlyMap<string, Buffer>, path: string): Buffer {
+  const entry = entries.get(path);
+  if (entry === undefined) {
+    throw new Error(`ZIP entry not found: ${path}`);
+  }
+
+  return entry;
+}
+
+function parseCardsJson(entries: ReadonlyMap<string, Buffer>): WorkspacePackageCardsJsonV1 {
+  return parseWorkspacePackageCardsJsonV1(JSON.parse(requireZipEntry(entries, "cards.json").toString("utf8")));
+}
+
+function listMediaEntryPaths(entries: ReadonlyMap<string, Buffer>): ReadonlyArray<string> {
+  return [...entries.keys()].filter((entryPath) => entryPath.startsWith("media/"));
+}
+
+test("package ZIP for text-only cards contains valid cards.json", async () => {
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      "What is the prompt?",
+      "The answer.",
+      ["core"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], []);
+  const byteLoader = createByteLoader(new Map());
+  const packageExport = await exportWorkspacePackageInExecutor(
+    executor,
+    workspaceId,
+    {
+      ...createBasePackageInput({ kind: "allActiveCards" }),
+      packageMetadata: {
+        label: "Starter export",
+        author: "Flashcards",
+        comment: null,
+        createdAt: null,
+        sourceUrl: "https://example.com/starter",
+      },
+    },
+    createPackageLimits(10, 10, 1024, 1024),
+    byteLoader,
+  );
+
+  assert.equal(packageExport.fileName, "flashcards.zip");
+  assert.equal(packageExport.contentType, "application/zip");
+  const entries = parseStoredZipEntries(packageExport.bytes);
+  assert.deepEqual([...entries.keys()], ["cards.json"]);
+  assert.deepEqual(parseCardsJson(entries), {
+    formatVersion: 1,
+    label: "Starter export",
+    author: "Flashcards",
+    createdAt: generatedAt,
+    sourceUrl: "https://example.com/starter",
+    cards: [
+      {
+        frontText: "What is the prompt?",
+        backText: "The answer.",
+        tags: ["core"],
+        cardType: "basic",
+        metadata: testMetadata,
+      },
+    ],
+  });
+  assert.equal(byteLoader.calls.length, 0);
+});
+
+test("package ZIP rewrites media references to portable media paths", async () => {
+  const imageBytes = Buffer.from("image-a");
+  const mediaRow = createMediaAssetRow(
+    mediaAssetIdA,
+    workspaceId,
+    mediaBlobIdA,
+    "image/png",
+    imageBytes,
+    "blob/image-a",
+    null,
+  );
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      `![front](fcasset:${mediaAssetIdA})`,
+      `See [image](fcasset:${mediaAssetIdA})`,
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [mediaRow]);
+  const byteLoader = createByteLoader(new Map([[mediaRow.storage_key, imageBytes]]));
+  const packageExport = await exportWorkspacePackageInExecutor(
+    executor,
+    workspaceId,
+    createBasePackageInput({ kind: "allActiveCards" }),
+    createPackageLimits(10, 10, 1024, 1024),
+    byteLoader,
+  );
+
+  const entries = parseStoredZipEntries(packageExport.bytes);
+  const mediaPaths = listMediaEntryPaths(entries);
+  assert.equal(mediaPaths.length, 1);
+  const portablePath = mediaPaths[0];
+  assert.match(portablePath, /^media\/sha256\/[0-9a-f]{2}\/[0-9a-f]{2}\/[0-9a-f]{64}\.png$/u);
+  assert.deepEqual(requireZipEntry(entries, portablePath), imageBytes);
+  const cardsJson = parseCardsJson(entries);
+  assert.equal(cardsJson.cards[0]?.frontText, `![front](${portablePath})`);
+  assert.equal(cardsJson.cards[0]?.backText, `See [image](${portablePath})`);
+});
+
+test("package ZIP includes duplicate referenced blobs once", async () => {
+  const imageBytes = Buffer.from("shared-image");
+  const mediaRowA = createMediaAssetRow(
+    mediaAssetIdA,
+    workspaceId,
+    mediaBlobIdA,
+    "image/jpeg",
+    imageBytes,
+    "blob/shared-image",
+    null,
+  );
+  const mediaRowB = createMediaAssetRow(
+    mediaAssetIdB,
+    workspaceId,
+    mediaBlobIdA,
+    "image/jpeg",
+    imageBytes,
+    "blob/shared-image",
+    null,
+  );
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      [
+        `![front](fcasset:${mediaAssetIdA})`,
+        `![same blob same side](fcasset:${mediaAssetIdB})`,
+      ].join("\n"),
+      `![same blob](fcasset:${mediaAssetIdB})`,
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [mediaRowA, mediaRowB]);
+  const byteLoader = createByteLoader(new Map([[mediaRowA.storage_key, imageBytes]]));
+  const packageExport = await exportWorkspacePackageInExecutor(
+    executor,
+    workspaceId,
+    createBasePackageInput({ kind: "allActiveCards" }),
+    createPackageLimits(10, 10, 1024, 1024),
+    byteLoader,
+  );
+
+  const entries = parseStoredZipEntries(packageExport.bytes);
+  const mediaPaths = listMediaEntryPaths(entries);
+  assert.equal(mediaPaths.length, 1);
+  assert.equal(byteLoader.calls.length, 1);
+  const portablePath = mediaPaths[0];
+  const cardsJson = parseCardsJson(entries);
+  assert.equal(cardsJson.cards[0]?.frontText, [
+    `![front](${portablePath})`,
+    `![same blob same side](${portablePath})`,
+  ].join("\n"));
+  assert.equal(cardsJson.cards[0]?.backText, `![same blob](${portablePath})`);
+});
+
+test("package export canonicalizes uppercase UUID card and media references", async () => {
+  const imageBytes = Buffer.from("uppercase-image");
+  const mediaRow = createMediaAssetRow(
+    mediaAssetIdA,
+    workspaceId,
+    mediaBlobIdA,
+    "image/png",
+    imageBytes,
+    "blob/uppercase-image",
+    null,
+  );
+  const uppercaseMediaAssetId = mediaAssetIdA.toUpperCase();
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      `![front](fcasset:${uppercaseMediaAssetId})`,
+      "Answer",
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [mediaRow]);
+  const byteLoader = createByteLoader(new Map([[mediaRow.storage_key, imageBytes]]));
+  const packageExport = await exportWorkspacePackageInExecutor(
+    executor,
+    workspaceId,
+    createBasePackageInput({
+      kind: "explicitCardIds",
+      cardIds: [cardIdA.toUpperCase()],
+    }),
+    createPackageLimits(10, 10, 1024, 1024),
+    byteLoader,
+  );
+
+  const entries = parseStoredZipEntries(packageExport.bytes);
+  const mediaPaths = listMediaEntryPaths(entries);
+  assert.equal(mediaPaths.length, 1);
+  assert.equal(parseCardsJson(entries).cards[0]?.frontText, `![front](${mediaPaths[0]})`);
+});
+
+test("package export rejects missing, deleted, or wrong-workspace media assets", async () => {
+  const bytes = Buffer.from("available");
+  const deletedRow = createMediaAssetRow(
+    mediaAssetIdB,
+    workspaceId,
+    mediaBlobIdA,
+    "image/png",
+    bytes,
+    "blob/deleted",
+    "2026-06-02T00:00:00.000Z",
+  );
+  const wrongWorkspaceRow = createMediaAssetRow(
+    mediaAssetIdE,
+    otherWorkspaceId,
+    mediaBlobIdB,
+    "image/png",
+    bytes,
+    "blob/wrong-workspace",
+    null,
+  );
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      [
+        `![missing](fcasset:${mediaAssetIdD})`,
+        `![deleted](fcasset:${mediaAssetIdB})`,
+        `![wrong workspace](fcasset:${mediaAssetIdE})`,
+      ].join("\n"),
+      "A answer",
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [deletedRow, wrongWorkspaceRow]);
+  const byteLoader = createByteLoader(new Map());
+
+  await assert.rejects(
+    async () => exportWorkspacePackageInExecutor(
+      executor,
+      workspaceId,
+      createBasePackageInput({ kind: "allActiveCards" }),
+      createPackageLimits(10, 10, 1024, 1024),
+      byteLoader,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_ASSET_UNAVAILABLE");
+      assert.match(error.message, new RegExp(mediaAssetIdD));
+      assert.match(error.message, new RegExp(mediaAssetIdB));
+      assert.match(error.message, new RegExp(mediaAssetIdE));
+      return true;
+    },
+  );
+  assert.equal(byteLoader.calls.length, 0);
+});
+
+test("package export rejects media file count before loading objects", async () => {
+  const imageBytesA = Buffer.from("count-a");
+  const imageBytesB = Buffer.from("count-b");
+  const mediaRowA = createMediaAssetRow(
+    mediaAssetIdA,
+    workspaceId,
+    mediaBlobIdA,
+    "image/png",
+    imageBytesA,
+    "blob/count-a",
+    null,
+  );
+  const mediaRowB = createMediaAssetRow(
+    mediaAssetIdB,
+    workspaceId,
+    mediaBlobIdB,
+    "image/png",
+    imageBytesB,
+    "blob/count-b",
+    null,
+  );
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      `![front](fcasset:${mediaAssetIdA})`,
+      `![back](fcasset:${mediaAssetIdB})`,
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [mediaRowA, mediaRowB]);
+  const byteLoader = createByteLoader(new Map([
+    [mediaRowA.storage_key, imageBytesA],
+    [mediaRowB.storage_key, imageBytesB],
+  ]));
+
+  await assert.rejects(
+    async () => exportWorkspacePackageInExecutor(
+      executor,
+      workspaceId,
+      createBasePackageInput({ kind: "allActiveCards" }),
+      createPackageLimits(10, 1, 1024, 1024),
+      byteLoader,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 413);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_FILE_COUNT_TOO_LARGE");
+      assert.match(error.message, /maxMediaFiles=1/u);
+      return true;
+    },
+  );
+  assert.equal(byteLoader.calls.length, 0);
+});
+
+test("package export rejects media size limits before loading objects", async () => {
+  const oversizedBytes = Buffer.from("oversized");
+  const oversizedRow: TestMediaAssetRow = {
+    media_asset_id: mediaAssetIdA,
+    workspace_id: workspaceId,
+    media_blob_id: mediaBlobIdA,
+    mime_type: "image/png",
+    size_bytes: 8,
+    sha256: sha256Hex(oversizedBytes),
+    storage_key: "blob/oversized",
+    deleted_at: null,
+  };
+  const oversizedExecutor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      `![front](fcasset:${mediaAssetIdA})`,
+      "A answer",
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [oversizedRow]);
+  const oversizedByteLoader = createByteLoader(new Map([[oversizedRow.storage_key, oversizedBytes]]));
+
+  await assert.rejects(
+    async () => exportWorkspacePackageInExecutor(
+      oversizedExecutor,
+      workspaceId,
+      createBasePackageInput({ kind: "allActiveCards" }),
+      createPackageLimits(10, 10, 4, 1024),
+      oversizedByteLoader,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 413);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_EXPORT_PACKAGE_SINGLE_MEDIA_TOO_LARGE");
+      assert.match(error.message, /maxSingleMediaBytes=4/u);
+      return true;
+    },
+  );
+  assert.equal(oversizedByteLoader.calls.length, 0);
+
+  const imageBytesA = Buffer.from("1234");
+  const imageBytesB = Buffer.from("5678");
+  const mediaRowA = createMediaAssetRow(
+    mediaAssetIdA,
+    workspaceId,
+    mediaBlobIdA,
+    "image/png",
+    imageBytesA,
+    "blob/image-a",
+    null,
+  );
+  const mediaRowB = createMediaAssetRow(
+    mediaAssetIdB,
+    workspaceId,
+    mediaBlobIdB,
+    "image/png",
+    imageBytesB,
+    "blob/image-b",
+    null,
+  );
+  const totalLimitExecutor = createTestExecutor([
+    createCardRow(
+      cardIdB,
+      workspaceId,
+      `![front](fcasset:${mediaAssetIdA})`,
+      `![back](fcasset:${mediaAssetIdB})`,
+      ["media"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], [mediaRowA, mediaRowB]);
+  const totalLimitByteLoader = createByteLoader(new Map([
+    [mediaRowA.storage_key, imageBytesA],
+    [mediaRowB.storage_key, imageBytesB],
+  ]));
+
+  await assert.rejects(
+    async () => exportWorkspacePackageInExecutor(
+      totalLimitExecutor,
+      workspaceId,
+      createBasePackageInput({ kind: "allActiveCards" }),
+      createPackageLimits(10, 10, 1024, 7),
+      totalLimitByteLoader,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 413);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_EXPORT_PACKAGE_TOTAL_MEDIA_TOO_LARGE");
+      assert.match(error.message, /maxTotalMediaBytes=7/u);
+      return true;
+    },
+  );
+  assert.equal(totalLimitByteLoader.calls.length, 0);
+});
+
+test("package export preserves default import-tag removal and additional tag removals", async () => {
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      "Prompt",
+      "Answer",
+      ["keep", "custom-remove", "import:2026-06-01-0"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+  ], []);
+  const byteLoader = createByteLoader(new Map());
+  const input = createBasePackageInput({ kind: "allActiveCards" });
+  const packageExport = await exportWorkspacePackageInExecutor(
+    executor,
+    workspaceId,
+    {
+      ...input,
+      tagPolicy: {
+        additionalRemovedTags: ["custom-remove"],
+      },
+    },
+    createPackageLimits(10, 10, 1024, 1024),
+    byteLoader,
+  );
+
+  const entries = parseStoredZipEntries(packageExport.bytes);
+  assert.deepEqual(parseCardsJson(entries).cards[0]?.tags, ["keep"]);
+});

--- a/apps/backend/src/workspacePackages/exportPackage.ts
+++ b/apps/backend/src/workspacePackages/exportPackage.ts
@@ -1,0 +1,871 @@
+import { Buffer } from "node:buffer";
+import {
+  transactionWithWorkspaceScopeReadOnly,
+  type DatabaseExecutor,
+} from "../database";
+import { MEDIA_ASSET_JOIN_CLAUSE } from "../mediaAssets";
+import {
+  loadMediaAssetObjectBytes,
+  type LoadedMediaAssetObjectBytes,
+  type LoadMediaAssetObjectBytesInput,
+} from "../mediaAssets/storage";
+import type { BackendObservationScope } from "../observability/sentry";
+import { normalizeCardMetadata } from "../cards/shared";
+import { HttpError } from "../shared/errors";
+import {
+  rewriteMarkdownFcAssetUrlsToSharedPortablePaths,
+  validatePortableMediaPath,
+} from "./markdownMedia";
+import {
+  buildAvailableWorkspacePackageExportTagCounts,
+  buildWorkspacePackageExportSelectedCardsQuery,
+  buildWorkspacePackageExportTagsSelectedForRemoval,
+  extractReferencedWorkspacePackageExportMediaAssetIds,
+  normalizeWorkspacePackageExportCardSelection,
+  normalizeWorkspacePackageExportMetadata,
+  normalizeWorkspacePackageExportTagPolicy,
+  type WorkspacePackageExportMetadataInput,
+  type WorkspacePackageExportSelectedCardRow,
+  type WorkspacePackageExportSelectedCardsQuery,
+  type WorkspacePackageExportTagPolicyInput,
+  type WorkspacePackageExportCardSelection,
+} from "./exportPreview";
+import {
+  toPortableWorkspacePackageCard,
+  workspacePackageFormatVersion,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardsJsonV1,
+} from "./types";
+
+export const workspacePackageExportPackageDefaultMaxSelectedCards = 5_000;
+export const workspacePackageExportPackageDefaultMaxMediaFiles = 10_000;
+export const workspacePackageExportPackageDefaultMaxSingleMediaBytes = 16 * 1024 * 1024;
+export const workspacePackageExportPackageDefaultMaxTotalMediaBytes = 64 * 1024 * 1024;
+
+export type WorkspacePackageExportPackageInput = Readonly<{
+  selection: WorkspacePackageExportCardSelection;
+  tagPolicy: WorkspacePackageExportTagPolicyInput;
+  packageMetadata: WorkspacePackageExportMetadataInput;
+  generatedAt: string;
+  observationScope: BackendObservationScope;
+}>;
+
+export type WorkspacePackageExportPackageLimits = Readonly<{
+  maxSelectedCards: number;
+  maxMediaFiles: number;
+  maxSingleMediaBytes: number;
+  maxTotalMediaBytes: number;
+}>;
+
+export type WorkspacePackageExportPackage = Readonly<{
+  fileName: "flashcards.zip";
+  contentType: "application/zip";
+  bytes: Buffer;
+}>;
+
+export type WorkspacePackageExportPackageDependencies = Readonly<{
+  loadMediaAssetObjectBytesFn: (input: LoadMediaAssetObjectBytesInput) => Promise<LoadedMediaAssetObjectBytes>;
+}>;
+
+type WorkspacePackageExportPackageMediaRow = Readonly<{
+  media_asset_id: string;
+  media_blob_id: string;
+  mime_type: string;
+  size_bytes: string | number;
+  sha256: string;
+  storage_key: string;
+}>;
+
+type WorkspacePackageMediaFile = Readonly<{
+  path: string;
+  mediaAssetIds: ReadonlyArray<string>;
+  row: WorkspacePackageExportPackageMediaRow;
+}>;
+
+type LoadedWorkspacePackageMediaFile = Readonly<{
+  path: string;
+  bytes: Buffer;
+}>;
+
+type PreparedWorkspacePackageExport = Readonly<{
+  cardsJson: WorkspacePackageCardsJsonV1;
+  mediaFiles: ReadonlyArray<WorkspacePackageMediaFile>;
+  limits: WorkspacePackageExportPackageLimits;
+}>;
+
+type ZipEntry = Readonly<{
+  path: string;
+  bytes: Buffer;
+}>;
+
+type StoredZipCentralDirectoryEntry = Readonly<{
+  pathBytes: Buffer;
+  crc32: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+}>;
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const sha256Pattern = /^[0-9a-f]{64}$/iu;
+const zipLocalFileHeaderSignature = 0x04034b50;
+const zipCentralDirectoryHeaderSignature = 0x02014b50;
+const zipEndOfCentralDirectorySignature = 0x06054b50;
+const zipVersionNeededToExtract = 20;
+const zipStoredCompressionMethod = 0;
+const zipDosTimeMidnight = 0;
+const zipDosDateJanuaryFirst1980 = 33;
+const zipUint16Max = 0xffff;
+const zipUint32Max = 0xffffffff;
+
+const packageMediaExtensionByMimeType: ReadonlyMap<string, string> = new Map([
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/gif", "gif"],
+  ["image/webp", "webp"],
+  ["image/avif", "avif"],
+  ["image/svg+xml", "svg"],
+  ["audio/mpeg", "mp3"],
+  ["audio/ogg", "ogg"],
+  ["audio/wav", "wav"],
+  ["audio/wave", "wav"],
+  ["audio/x-wav", "wav"],
+  ["video/mp4", "mp4"],
+  ["application/pdf", "pdf"],
+  ["text/plain", "txt"],
+]);
+
+const crc32Table = createCrc32Table();
+
+function createPackageInputError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_EXPORT_PACKAGE_INPUT_INVALID");
+}
+
+function createPackageSelectionTooLargeError(maxSelectedCards: number): HttpError {
+  return new HttpError(
+    413,
+    `Workspace package export package selection is too large. selectedCardLimit=${maxSelectedCards}`,
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_SELECTION_TOO_LARGE",
+  );
+}
+
+function createPackageCardNotFoundError(missingCardIds: ReadonlyArray<string>): HttpError {
+  return new HttpError(
+    404,
+    `Workspace package export package selection contains unavailable cards. missingCardIds=${missingCardIds.join(",")}`,
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_CARD_NOT_FOUND",
+  );
+}
+
+function createPackageMediaAssetUnavailableError(mediaAssetIds: ReadonlyArray<string>): HttpError {
+  return new HttpError(
+    400,
+    `Workspace package export package references unavailable media assets. mediaAssetIds=${mediaAssetIds.join(",")}`,
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_ASSET_UNAVAILABLE",
+  );
+}
+
+function createPackageMediaAssetIdInvalidError(mediaAssetIds: ReadonlyArray<string>): HttpError {
+  return new HttpError(
+    400,
+    `Workspace package export package references invalid media asset ids. invalidMediaAssetIds=${mediaAssetIds.join(",")}`,
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_ASSET_ID_INVALID",
+  );
+}
+
+function createPackageSingleMediaTooLargeError(
+  mediaAssetId: string,
+  sizeBytes: number,
+  maxSingleMediaBytes: number,
+): HttpError {
+  return new HttpError(
+    413,
+    [
+      "Workspace package export package media asset is too large.",
+      `mediaAssetId=${mediaAssetId}`,
+      `sizeBytes=${sizeBytes}`,
+      `maxSingleMediaBytes=${maxSingleMediaBytes}`,
+    ].join(" "),
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_SINGLE_MEDIA_TOO_LARGE",
+  );
+}
+
+function createPackageTotalMediaTooLargeError(
+  totalMediaBytes: number,
+  maxTotalMediaBytes: number,
+): HttpError {
+  return new HttpError(
+    413,
+    [
+      "Workspace package export package media total is too large.",
+      `totalMediaBytes=${totalMediaBytes}`,
+      `maxTotalMediaBytes=${maxTotalMediaBytes}`,
+    ].join(" "),
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_TOTAL_MEDIA_TOO_LARGE",
+  );
+}
+
+function createPackageMediaFileCountTooLargeError(
+  mediaFileCount: number,
+  maxMediaFiles: number,
+): HttpError {
+  return new HttpError(
+    413,
+    [
+      "Workspace package export package media file count is too large.",
+      `mediaFileCount=${mediaFileCount}`,
+      `maxMediaFiles=${maxMediaFiles}`,
+    ].join(" "),
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_FILE_COUNT_TOO_LARGE",
+  );
+}
+
+function assertPositiveSafeInteger(value: number, fieldName: string): void {
+  if (
+    Number.isSafeInteger(value) === false
+    || value < 1
+    || value >= Number.MAX_SAFE_INTEGER
+  ) {
+    throw createPackageInputError(`${fieldName} must be a positive safe integer`);
+  }
+}
+
+function normalizePackageLimits(
+  limits: WorkspacePackageExportPackageLimits,
+): WorkspacePackageExportPackageLimits {
+  assertPositiveSafeInteger(limits.maxSelectedCards, "limits.maxSelectedCards");
+  assertPositiveSafeInteger(limits.maxMediaFiles, "limits.maxMediaFiles");
+  assertPositiveSafeInteger(limits.maxSingleMediaBytes, "limits.maxSingleMediaBytes");
+  assertPositiveSafeInteger(limits.maxTotalMediaBytes, "limits.maxTotalMediaBytes");
+  if (limits.maxMediaFiles > zipUint16Max - 1) {
+    throw createPackageInputError(`limits.maxMediaFiles must be less than ${zipUint16Max}`);
+  }
+
+  return limits;
+}
+
+function toSafeNumber(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (Number.isSafeInteger(parsedValue) === false || parsedValue < 0) {
+    throw new Error(`${fieldName} must be a non-negative safe integer`);
+  }
+
+  return parsedValue;
+}
+
+function canonicalizePackageUuidValue(value: string, fieldName: string): string {
+  if (uuidPattern.test(value) === false) {
+    throw createPackageInputError(`${fieldName} must be a UUID value`);
+  }
+
+  return value.toLowerCase();
+}
+
+function canonicalizeUniquePackageUuidValues(
+  values: ReadonlyArray<string>,
+  fieldName: string,
+): ReadonlyArray<string> {
+  const canonicalValues: Array<string> = [];
+  const seenValues = new Set<string>();
+
+  values.forEach((value, index) => {
+    const canonicalValue = canonicalizePackageUuidValue(value, `${fieldName}[${index}]`);
+    if (seenValues.has(canonicalValue)) {
+      throw createPackageInputError(`${fieldName} must not contain duplicates`);
+    }
+
+    seenValues.add(canonicalValue);
+    canonicalValues.push(canonicalValue);
+  });
+
+  return canonicalValues;
+}
+
+function canonicalizePackageCardSelection(
+  selection: WorkspacePackageExportCardSelection,
+): WorkspacePackageExportCardSelection {
+  if (selection.kind !== "explicitCardIds") {
+    return selection;
+  }
+
+  return {
+    kind: "explicitCardIds",
+    cardIds: canonicalizeUniquePackageUuidValues(selection.cardIds, "selection.cardIds"),
+  };
+}
+
+function canonicalizeReferencedMediaAssetIds(
+  mediaAssetIds: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const invalidMediaAssetIds = mediaAssetIds.filter((mediaAssetId) => uuidPattern.test(mediaAssetId) === false);
+  if (invalidMediaAssetIds.length !== 0) {
+    throw createPackageMediaAssetIdInvalidError(invalidMediaAssetIds);
+  }
+
+  const canonicalMediaAssetIds: Array<string> = [];
+  const seenMediaAssetIds = new Set<string>();
+
+  for (const mediaAssetId of mediaAssetIds) {
+    const canonicalMediaAssetId = mediaAssetId.toLowerCase();
+    if (seenMediaAssetIds.has(canonicalMediaAssetId)) {
+      continue;
+    }
+
+    seenMediaAssetIds.add(canonicalMediaAssetId);
+    canonicalMediaAssetIds.push(canonicalMediaAssetId);
+  }
+
+  return canonicalMediaAssetIds;
+}
+
+function assertSelectionWithinPackageLimit(
+  selectedCardCount: number,
+  maxSelectedCards: number,
+): void {
+  if (selectedCardCount <= maxSelectedCards) {
+    return;
+  }
+
+  throw createPackageSelectionTooLargeError(maxSelectedCards);
+}
+
+function assertExplicitPackageCardsFound(
+  rows: ReadonlyArray<WorkspacePackageExportSelectedCardRow>,
+  explicitCardIds: ReadonlyArray<string> | null,
+): void {
+  if (explicitCardIds === null) {
+    return;
+  }
+
+  const returnedCardIds = new Set(rows.map((row) => row.card_id.toLowerCase()));
+  const missingCardIds = explicitCardIds.filter((cardId) => returnedCardIds.has(cardId) === false);
+  if (missingCardIds.length === 0) {
+    return;
+  }
+
+  throw createPackageCardNotFoundError(missingCardIds);
+}
+
+async function loadSelectedPackageCardsInExecutor(
+  executor: DatabaseExecutor,
+  query: WorkspacePackageExportSelectedCardsQuery,
+  maxSelectedCards: number,
+): Promise<ReadonlyArray<WorkspacePackageExportSelectedCardRow>> {
+  assertSelectionWithinPackageLimit(query.explicitCardIds?.length ?? 0, maxSelectedCards);
+  const result = await executor.query<WorkspacePackageExportSelectedCardRow>(query.text, query.params);
+  assertSelectionWithinPackageLimit(result.rows.length, maxSelectedCards);
+  assertExplicitPackageCardsFound(result.rows, query.explicitCardIds);
+
+  return result.rows;
+}
+
+function assertValidPackageMediaAssetIds(mediaAssetIds: ReadonlyArray<string>): void {
+  const invalidMediaAssetIds = mediaAssetIds.filter((mediaAssetId) => uuidPattern.test(mediaAssetId) === false);
+  if (invalidMediaAssetIds.length === 0) {
+    return;
+  }
+
+  throw createPackageMediaAssetIdInvalidError(invalidMediaAssetIds);
+}
+
+function assertReferencedPackageMediaAssetsFound(
+  mediaAssetIds: ReadonlyArray<string>,
+  rows: ReadonlyArray<WorkspacePackageExportPackageMediaRow>,
+): void {
+  const returnedMediaAssetIds = new Set(rows.map((row) => row.media_asset_id.toLowerCase()));
+  const missingMediaAssetIds = mediaAssetIds.filter((mediaAssetId) => returnedMediaAssetIds.has(mediaAssetId) === false);
+  if (missingMediaAssetIds.length === 0) {
+    return;
+  }
+
+  throw createPackageMediaAssetUnavailableError(missingMediaAssetIds);
+}
+
+async function loadReferencedPackageMediaRowsInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  mediaAssetIds: ReadonlyArray<string>,
+): Promise<ReadonlyArray<WorkspacePackageExportPackageMediaRow>> {
+  if (mediaAssetIds.length === 0) {
+    return [];
+  }
+
+  assertValidPackageMediaAssetIds(mediaAssetIds);
+  const result = await executor.query<WorkspacePackageExportPackageMediaRow>(
+    [
+      "SELECT",
+      "media_assets.media_asset_id AS media_asset_id,",
+      "media_assets.media_blob_id AS media_blob_id,",
+      "media_blobs.mime_type AS mime_type,",
+      "media_blobs.size_bytes AS size_bytes,",
+      "media_blobs.sha256 AS sha256,",
+      "media_blobs.storage_key AS storage_key",
+      "FROM",
+      MEDIA_ASSET_JOIN_CLAUSE,
+      "WHERE media_assets.workspace_id = $1",
+      "AND media_assets.media_asset_id = ANY($2::uuid[])",
+      "AND media_assets.deleted_at IS NULL",
+      "ORDER BY array_position($2::uuid[], media_assets.media_asset_id)",
+    ].join(" "),
+    [workspaceId, mediaAssetIds],
+  );
+  assertReferencedPackageMediaAssetsFound(mediaAssetIds, result.rows);
+
+  return result.rows;
+}
+
+function assertValidSha256(sha256: string, mediaAssetId: string): string {
+  if (sha256Pattern.test(sha256) === false) {
+    throw new Error(`media blob sha256 must be a lowercase or uppercase hex sha256. mediaAssetId=${mediaAssetId}`);
+  }
+
+  return sha256.toLowerCase();
+}
+
+function getPackageMediaExtension(mimeType: string): string {
+  return packageMediaExtensionByMimeType.get(mimeType.toLowerCase()) ?? "bin";
+}
+
+function buildPackageMediaPath(row: WorkspacePackageExportPackageMediaRow): string {
+  const normalizedSha256 = assertValidSha256(row.sha256, row.media_asset_id);
+  const extension = getPackageMediaExtension(row.mime_type);
+  return validatePortableMediaPath([
+    "media",
+    "sha256",
+    normalizedSha256.slice(0, 2),
+    normalizedSha256.slice(2, 4),
+    `${normalizedSha256}.${extension}`,
+  ].join("/"));
+}
+
+function assertMediaRowsWithinPackageLimits(
+  mediaRows: ReadonlyArray<WorkspacePackageExportPackageMediaRow>,
+  limits: WorkspacePackageExportPackageLimits,
+): void {
+  const countedSha256Values = new Set<string>();
+  let totalMediaBytes = 0;
+
+  for (const mediaRow of mediaRows) {
+    const normalizedSha256 = assertValidSha256(mediaRow.sha256, mediaRow.media_asset_id);
+    if (countedSha256Values.has(normalizedSha256)) {
+      continue;
+    }
+
+    countedSha256Values.add(normalizedSha256);
+    const sizeBytes = toSafeNumber(mediaRow.size_bytes, "size_bytes");
+    if (sizeBytes > limits.maxSingleMediaBytes) {
+      throw createPackageSingleMediaTooLargeError(
+        mediaRow.media_asset_id,
+        sizeBytes,
+        limits.maxSingleMediaBytes,
+      );
+    }
+
+    totalMediaBytes += sizeBytes;
+    if (Number.isSafeInteger(totalMediaBytes) === false) {
+      throw new Error("Workspace package export media byte total must be a safe integer");
+    }
+
+    if (totalMediaBytes > limits.maxTotalMediaBytes) {
+      throw createPackageTotalMediaTooLargeError(totalMediaBytes, limits.maxTotalMediaBytes);
+    }
+  }
+}
+
+function buildPackageMediaFiles(
+  mediaRows: ReadonlyArray<WorkspacePackageExportPackageMediaRow>,
+): ReadonlyArray<WorkspacePackageMediaFile> {
+  const mediaFileBySha256 = new Map<string, WorkspacePackageMediaFile>();
+
+  for (const mediaRow of mediaRows) {
+    const normalizedSha256 = assertValidSha256(mediaRow.sha256, mediaRow.media_asset_id);
+    const existingMediaFile = mediaFileBySha256.get(normalizedSha256);
+    if (existingMediaFile !== undefined) {
+      mediaFileBySha256.set(normalizedSha256, {
+        ...existingMediaFile,
+        mediaAssetIds: [...existingMediaFile.mediaAssetIds, mediaRow.media_asset_id.toLowerCase()],
+      });
+      continue;
+    }
+
+    mediaFileBySha256.set(normalizedSha256, {
+      path: buildPackageMediaPath(mediaRow),
+      mediaAssetIds: [mediaRow.media_asset_id.toLowerCase()],
+      row: mediaRow,
+    });
+  }
+
+  return [...mediaFileBySha256.values()];
+}
+
+function assertMediaFilesWithinPackageLimit(
+  mediaFiles: ReadonlyArray<WorkspacePackageMediaFile>,
+  maxMediaFiles: number,
+): void {
+  if (mediaFiles.length <= maxMediaFiles) {
+    return;
+  }
+
+  throw createPackageMediaFileCountTooLargeError(mediaFiles.length, maxMediaFiles);
+}
+
+function buildPortablePathsByAssetId(
+  mediaFiles: ReadonlyArray<WorkspacePackageMediaFile>,
+): ReadonlyMap<string, string> {
+  const portablePathsByAssetId = new Map<string, string>();
+
+  for (const mediaFile of mediaFiles) {
+    for (const mediaAssetId of mediaFile.mediaAssetIds) {
+      portablePathsByAssetId.set(mediaAssetId, mediaFile.path);
+    }
+  }
+
+  return portablePathsByAssetId;
+}
+
+function applyPackageTagRemoval(
+  tags: ReadonlyArray<string>,
+  removedTags: ReadonlySet<string>,
+): ReadonlyArray<string> {
+  return tags.filter((tag) => removedTags.has(tag) === false);
+}
+
+function buildPortablePackageCards(
+  cards: ReadonlyArray<WorkspacePackageExportSelectedCardRow>,
+  removedTags: ReadonlySet<string>,
+  portablePathsByAssetId: ReadonlyMap<string, string>,
+): ReadonlyArray<PortableWorkspacePackageCardV1> {
+  const resolvePortablePath = (assetId: string): string => {
+    const portablePath = portablePathsByAssetId.get(assetId.toLowerCase());
+    if (portablePath === undefined) {
+      throw new Error(`Missing portable media path for fcasset id: ${assetId}`);
+    }
+
+    return portablePath;
+  };
+
+  return cards.map((card) => toPortableWorkspacePackageCard({
+    frontText: rewriteMarkdownFcAssetUrlsToSharedPortablePaths(card.front_text, resolvePortablePath),
+    backText: rewriteMarkdownFcAssetUrlsToSharedPortablePaths(card.back_text, resolvePortablePath),
+    tags: applyPackageTagRemoval(card.tags, removedTags),
+    cardType: card.card_type,
+    metadata: normalizeCardMetadata(card.metadata),
+  }));
+}
+
+async function loadWorkspacePackageMediaFile(
+  workspaceId: string,
+  input: WorkspacePackageExportPackageInput,
+  limits: WorkspacePackageExportPackageLimits,
+  dependencies: WorkspacePackageExportPackageDependencies,
+  mediaFile: WorkspacePackageMediaFile,
+): Promise<LoadedWorkspacePackageMediaFile> {
+  const mediaRow = mediaFile.row;
+  const loadedBytes = await dependencies.loadMediaAssetObjectBytesFn({
+    workspaceId,
+    mediaAssetId: mediaRow.media_asset_id,
+    storageKey: mediaRow.storage_key,
+    mimeType: mediaRow.mime_type,
+    sizeBytes: toSafeNumber(mediaRow.size_bytes, "size_bytes"),
+    sha256: assertValidSha256(mediaRow.sha256, mediaRow.media_asset_id),
+    maxByteSize: limits.maxSingleMediaBytes,
+    observationScope: input.observationScope,
+  });
+
+  return {
+    path: mediaFile.path,
+    bytes: loadedBytes.bytes,
+  };
+}
+
+async function loadWorkspacePackageMediaFiles(
+  workspaceId: string,
+  input: WorkspacePackageExportPackageInput,
+  limits: WorkspacePackageExportPackageLimits,
+  dependencies: WorkspacePackageExportPackageDependencies,
+  mediaFiles: ReadonlyArray<WorkspacePackageMediaFile>,
+): Promise<ReadonlyArray<LoadedWorkspacePackageMediaFile>> {
+  const loadedMediaFiles: Array<LoadedWorkspacePackageMediaFile> = [];
+
+  for (const mediaFile of mediaFiles) {
+    loadedMediaFiles.push(await loadWorkspacePackageMediaFile(
+      workspaceId,
+      input,
+      limits,
+      dependencies,
+      mediaFile,
+    ));
+  }
+
+  return loadedMediaFiles;
+}
+
+function createPackageCardsJsonBuffer(cardsJson: WorkspacePackageCardsJsonV1): Buffer {
+  return Buffer.from(`${JSON.stringify(cardsJson, null, 2)}\n`, "utf8");
+}
+
+function assertZipEntryPath(path: string): void {
+  validatePortableMediaPath(path === "cards.json" ? "media/cards.json" : path);
+  if (path.includes("\\") || path.startsWith("/") || path.includes("\0")) {
+    throw new Error(`ZIP entry path is unsafe: ${path}`);
+  }
+}
+
+function assertZipEntrySize(value: number, fieldName: string): void {
+  if (Number.isSafeInteger(value) === false || value < 0 || value > zipUint32Max) {
+    throw new Error(`${fieldName} must fit in ZIP uint32`);
+  }
+}
+
+function assertZipEntryCount(entryCount: number): void {
+  if (entryCount > zipUint16Max) {
+    throw new Error(`Workspace package ZIP has too many entries: ${entryCount}`);
+  }
+}
+
+function createCrc32Table(): ReadonlyArray<number> {
+  const table: Array<number> = [];
+
+  for (let tableIndex = 0; tableIndex < 256; tableIndex += 1) {
+    let crc = tableIndex;
+    for (let bitIndex = 0; bitIndex < 8; bitIndex += 1) {
+      crc = (crc & 1) === 1 ? (0xedb88320 ^ (crc >>> 1)) : (crc >>> 1);
+    }
+
+    table.push(crc >>> 0);
+  }
+
+  return table;
+}
+
+function calculateCrc32(bytes: Buffer): number {
+  let crc = 0xffffffff;
+
+  for (const byte of bytes) {
+    crc = (crc >>> 8) ^ (crc32Table[(crc ^ byte) & 0xff] ?? 0);
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createLocalFileHeader(pathBytes: Buffer, bytes: Buffer, crc32: number): Buffer {
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(zipLocalFileHeaderSignature, 0);
+  header.writeUInt16LE(zipVersionNeededToExtract, 4);
+  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(zipStoredCompressionMethod, 8);
+  header.writeUInt16LE(zipDosTimeMidnight, 10);
+  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 12);
+  header.writeUInt32LE(crc32, 14);
+  header.writeUInt32LE(bytes.byteLength, 18);
+  header.writeUInt32LE(bytes.byteLength, 22);
+  header.writeUInt16LE(pathBytes.byteLength, 26);
+  header.writeUInt16LE(0, 28);
+
+  return Buffer.concat([header, pathBytes]);
+}
+
+function createCentralDirectoryHeader(entry: StoredZipCentralDirectoryEntry): Buffer {
+  const header = Buffer.alloc(46);
+  header.writeUInt32LE(zipCentralDirectoryHeaderSignature, 0);
+  header.writeUInt16LE(zipVersionNeededToExtract, 4);
+  header.writeUInt16LE(zipVersionNeededToExtract, 6);
+  header.writeUInt16LE(0, 8);
+  header.writeUInt16LE(zipStoredCompressionMethod, 10);
+  header.writeUInt16LE(zipDosTimeMidnight, 12);
+  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 14);
+  header.writeUInt32LE(entry.crc32, 16);
+  header.writeUInt32LE(entry.compressedSize, 20);
+  header.writeUInt32LE(entry.uncompressedSize, 24);
+  header.writeUInt16LE(entry.pathBytes.byteLength, 28);
+  header.writeUInt16LE(0, 30);
+  header.writeUInt16LE(0, 32);
+  header.writeUInt16LE(0, 34);
+  header.writeUInt16LE(0, 36);
+  header.writeUInt32LE(0, 38);
+  header.writeUInt32LE(entry.localHeaderOffset, 42);
+
+  return Buffer.concat([header, entry.pathBytes]);
+}
+
+function createEndOfCentralDirectory(
+  entryCount: number,
+  centralDirectorySize: number,
+  centralDirectoryOffset: number,
+): Buffer {
+  const header = Buffer.alloc(22);
+  header.writeUInt32LE(zipEndOfCentralDirectorySignature, 0);
+  header.writeUInt16LE(0, 4);
+  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(entryCount, 8);
+  header.writeUInt16LE(entryCount, 10);
+  header.writeUInt32LE(centralDirectorySize, 12);
+  header.writeUInt32LE(centralDirectoryOffset, 16);
+  header.writeUInt16LE(0, 20);
+
+  return header;
+}
+
+function createStoredZip(entries: ReadonlyArray<ZipEntry>): Buffer {
+  assertZipEntryCount(entries.length);
+  const localFileParts: Array<Buffer> = [];
+  const centralDirectoryEntries: Array<StoredZipCentralDirectoryEntry> = [];
+  let localHeaderOffset = 0;
+
+  for (const entry of entries) {
+    assertZipEntryPath(entry.path);
+    const pathBytes = Buffer.from(entry.path, "utf8");
+    assertZipEntrySize(pathBytes.byteLength, "ZIP entry path byte length");
+    assertZipEntrySize(entry.bytes.byteLength, "ZIP entry byte length");
+
+    const crc32 = calculateCrc32(entry.bytes);
+    const localFileHeader = createLocalFileHeader(pathBytes, entry.bytes, crc32);
+    localFileParts.push(localFileHeader, entry.bytes);
+    centralDirectoryEntries.push({
+      pathBytes,
+      crc32,
+      compressedSize: entry.bytes.byteLength,
+      uncompressedSize: entry.bytes.byteLength,
+      localHeaderOffset,
+    });
+    localHeaderOffset += localFileHeader.byteLength + entry.bytes.byteLength;
+    assertZipEntrySize(localHeaderOffset, "ZIP local file section length");
+  }
+
+  const centralDirectoryOffset = localHeaderOffset;
+  const centralDirectoryParts = centralDirectoryEntries.map(createCentralDirectoryHeader);
+  const centralDirectorySize = centralDirectoryParts.reduce((totalSize, part) => totalSize + part.byteLength, 0);
+  assertZipEntrySize(centralDirectorySize, "ZIP central directory size");
+  assertZipEntrySize(centralDirectoryOffset, "ZIP central directory offset");
+
+  return Buffer.concat([
+    ...localFileParts,
+    ...centralDirectoryParts,
+    createEndOfCentralDirectory(entries.length, centralDirectorySize, centralDirectoryOffset),
+  ]);
+}
+
+export async function exportWorkspacePackageInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: WorkspacePackageExportPackageInput,
+  limits: WorkspacePackageExportPackageLimits,
+  dependencies: WorkspacePackageExportPackageDependencies,
+): Promise<WorkspacePackageExportPackage> {
+  const preparedExport = await prepareWorkspacePackageExportInExecutor(
+    executor,
+    workspaceId,
+    input,
+    limits,
+  );
+
+  return assembleWorkspacePackageExport(workspaceId, input, dependencies, preparedExport);
+}
+
+async function prepareWorkspacePackageExportInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: WorkspacePackageExportPackageInput,
+  limits: WorkspacePackageExportPackageLimits,
+): Promise<PreparedWorkspacePackageExport> {
+  const normalizedLimits = normalizePackageLimits(limits);
+  const normalizedSelection = canonicalizePackageCardSelection(
+    normalizeWorkspacePackageExportCardSelection(input.selection),
+  );
+  const normalizedTagPolicy = normalizeWorkspacePackageExportTagPolicy(input.tagPolicy);
+  const packageMetadata = normalizeWorkspacePackageExportMetadata(input.packageMetadata, input.generatedAt);
+  const selectedCardsQuery = buildWorkspacePackageExportSelectedCardsQuery(
+    workspaceId,
+    normalizedSelection,
+    normalizedLimits.maxSelectedCards,
+  );
+  const selectedCards = await loadSelectedPackageCardsInExecutor(
+    executor,
+    selectedCardsQuery,
+    normalizedLimits.maxSelectedCards,
+  );
+  const availableTagCounts = buildAvailableWorkspacePackageExportTagCounts(selectedCards);
+  const tagsSelectedForRemoval = buildWorkspacePackageExportTagsSelectedForRemoval(
+    availableTagCounts,
+    normalizedTagPolicy,
+  );
+  const referencedMediaAssetIds = canonicalizeReferencedMediaAssetIds(
+    extractReferencedWorkspacePackageExportMediaAssetIds(selectedCards),
+  );
+  const mediaRows = await loadReferencedPackageMediaRowsInExecutor(executor, workspaceId, referencedMediaAssetIds);
+  assertMediaRowsWithinPackageLimits(mediaRows, normalizedLimits);
+  const mediaFiles = buildPackageMediaFiles(mediaRows);
+  assertMediaFilesWithinPackageLimit(mediaFiles, normalizedLimits.maxMediaFiles);
+  const portablePathsByAssetId = buildPortablePathsByAssetId(mediaFiles);
+  const packageCards = buildPortablePackageCards(selectedCards, new Set(
+    tagsSelectedForRemoval.map((tagCount) => tagCount.tag),
+  ), portablePathsByAssetId);
+  const cardsJson: WorkspacePackageCardsJsonV1 = {
+    formatVersion: workspacePackageFormatVersion,
+    ...packageMetadata,
+    cards: packageCards,
+  };
+
+  return {
+    cardsJson,
+    mediaFiles,
+    limits: normalizedLimits,
+  };
+}
+
+async function assembleWorkspacePackageExport(
+  workspaceId: string,
+  input: WorkspacePackageExportPackageInput,
+  dependencies: WorkspacePackageExportPackageDependencies,
+  preparedExport: PreparedWorkspacePackageExport,
+): Promise<WorkspacePackageExportPackage> {
+  const loadedMediaFiles = await loadWorkspacePackageMediaFiles(
+    workspaceId,
+    input,
+    preparedExport.limits,
+    dependencies,
+    preparedExport.mediaFiles,
+  );
+  const zipEntries: ReadonlyArray<ZipEntry> = [
+    {
+      path: "cards.json",
+      bytes: createPackageCardsJsonBuffer(preparedExport.cardsJson),
+    },
+    ...loadedMediaFiles.map((mediaFile) => ({
+      path: mediaFile.path,
+      bytes: mediaFile.bytes,
+    })),
+  ];
+
+  return {
+    fileName: "flashcards.zip",
+    contentType: "application/zip",
+    bytes: createStoredZip(zipEntries),
+  };
+}
+
+export async function exportWorkspacePackage(
+  userId: string,
+  workspaceId: string,
+  input: WorkspacePackageExportPackageInput,
+): Promise<WorkspacePackageExportPackage> {
+  const limits: WorkspacePackageExportPackageLimits = {
+    maxSelectedCards: workspacePackageExportPackageDefaultMaxSelectedCards,
+    maxMediaFiles: workspacePackageExportPackageDefaultMaxMediaFiles,
+    maxSingleMediaBytes: workspacePackageExportPackageDefaultMaxSingleMediaBytes,
+    maxTotalMediaBytes: workspacePackageExportPackageDefaultMaxTotalMediaBytes,
+  };
+  const dependencies: WorkspacePackageExportPackageDependencies = {
+    loadMediaAssetObjectBytesFn: loadMediaAssetObjectBytes,
+  };
+  const preparedExport = await transactionWithWorkspaceScopeReadOnly({ userId, workspaceId }, async (executor) => (
+    prepareWorkspacePackageExportInExecutor(
+      executor,
+      workspaceId,
+      input,
+      limits,
+    )
+  ));
+
+  return assembleWorkspacePackageExport(workspaceId, input, dependencies, preparedExport);
+}

--- a/apps/backend/src/workspacePackages/exportPreview.ts
+++ b/apps/backend/src/workspacePackages/exportPreview.ts
@@ -61,10 +61,12 @@ export type WorkspacePackageExportPreviewLimits = Readonly<{
   maxSelectedCards: number;
 }>;
 
-type WorkspacePackageExportPreviewCardRow = Readonly<{
+export type WorkspacePackageExportSelectedCardRow = Readonly<{
   card_id: string;
   front_text: string;
   back_text: string;
+  card_type: string;
+  metadata: unknown;
   tags: ReadonlyArray<string>;
 }>;
 
@@ -74,7 +76,7 @@ type WorkspacePackageExportPreviewMediaRow = Readonly<{
   size_bytes: string | number;
 }>;
 
-type SelectedCardsQuery = Readonly<{
+export type WorkspacePackageExportSelectedCardsQuery = Readonly<{
   text: string;
   params: ReadonlyArray<SqlValue>;
   explicitCardIds: ReadonlyArray<string> | null;
@@ -152,7 +154,7 @@ function normalizeUniqueUuidValues(
   return normalizedValues;
 }
 
-function normalizeCardSelection(
+export function normalizeWorkspacePackageExportCardSelection(
   selection: WorkspacePackageExportCardSelection,
 ): WorkspacePackageExportCardSelection {
   switch (selection.kind) {
@@ -184,15 +186,16 @@ function normalizePreviewLimits(limits: WorkspacePackageExportPreviewLimits): Wo
   return limits;
 }
 
-function normalizePackageMetadata(
+export function normalizeWorkspacePackageExportMetadata(
   input: WorkspacePackageExportMetadataInput,
   generatedAt: string,
 ): WorkspacePackageMetadataV1 {
   const label = normalizeNullableText(input.label, "packageMetadata.label") ?? workspacePackageExportMetadataDefaultLabel;
   const author = normalizeNullableText(input.author, "packageMetadata.author");
   const comment = normalizeNullableText(input.comment, "packageMetadata.comment");
+  const defaultCreatedAt = normalizeIsoTimestamp(generatedAt, "generatedAt");
   const createdAt = input.createdAt === null
-    ? generatedAt
+    ? defaultCreatedAt
     : normalizeIsoTimestamp(input.createdAt, "packageMetadata.createdAt");
   const sourceUrl = normalizeNullableText(input.sourceUrl, "packageMetadata.sourceUrl");
 
@@ -205,18 +208,18 @@ function normalizePackageMetadata(
   };
 }
 
-function buildSelectedCardsQuery(
+export function buildWorkspacePackageExportSelectedCardsQuery(
   workspaceId: string,
   selection: WorkspacePackageExportCardSelection,
   maxSelectedCards: number,
-): SelectedCardsQuery {
+): WorkspacePackageExportSelectedCardsQuery {
   const rowLimit = maxSelectedCards + 1;
 
   switch (selection.kind) {
   case "allActiveCards":
     return {
       text: [
-        "SELECT card_id, front_text, back_text, tags",
+        "SELECT card_id, front_text, back_text, card_type, metadata, tags",
         "FROM content.cards",
         "WHERE workspace_id = $1",
         "AND deleted_at IS NULL",
@@ -246,7 +249,7 @@ function buildSelectedCardsQuery(
     params.push(rowLimit);
     return {
       text: [
-        "SELECT card_id, front_text, back_text, tags",
+        "SELECT card_id, front_text, back_text, card_type, metadata, tags",
         "FROM content.cards",
         clauses.join(" "),
         "ORDER BY created_at DESC, card_id ASC",
@@ -259,7 +262,7 @@ function buildSelectedCardsQuery(
   case "explicitCardIds":
     return {
       text: [
-        "SELECT card_id, front_text, back_text, tags",
+        "SELECT card_id, front_text, back_text, card_type, metadata, tags",
         "FROM content.cards",
         "WHERE workspace_id = $1",
         "AND card_id = ANY($2::uuid[])",
@@ -289,7 +292,7 @@ function assertSelectionWithinLimit(
 }
 
 function assertExplicitCardsFound(
-  rows: ReadonlyArray<WorkspacePackageExportPreviewCardRow>,
+  rows: ReadonlyArray<WorkspacePackageExportSelectedCardRow>,
   explicitCardIds: ReadonlyArray<string> | null,
 ): void {
   if (explicitCardIds === null) {
@@ -309,18 +312,18 @@ function assertExplicitCardsFound(
   );
 }
 
-async function loadSelectedCardsInExecutor(
+export async function loadSelectedWorkspacePackageExportCardsInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
   selection: WorkspacePackageExportCardSelection,
   limits: WorkspacePackageExportPreviewLimits,
-): Promise<ReadonlyArray<WorkspacePackageExportPreviewCardRow>> {
+): Promise<ReadonlyArray<WorkspacePackageExportSelectedCardRow>> {
   if (selection.kind === "explicitCardIds") {
     assertSelectionWithinLimit(selection.cardIds.length, limits.maxSelectedCards);
   }
 
-  const query = buildSelectedCardsQuery(workspaceId, selection, limits.maxSelectedCards);
-  const result = await executor.query<WorkspacePackageExportPreviewCardRow>(query.text, query.params);
+  const query = buildWorkspacePackageExportSelectedCardsQuery(workspaceId, selection, limits.maxSelectedCards);
+  const result = await executor.query<WorkspacePackageExportSelectedCardRow>(query.text, query.params);
   assertSelectionWithinLimit(result.rows.length, limits.maxSelectedCards);
   assertExplicitCardsFound(result.rows, query.explicitCardIds);
 
@@ -353,8 +356,8 @@ function compareTagCounts(
   return left.tag.localeCompare(right.tag);
 }
 
-function buildAvailableTagCounts(
-  cards: ReadonlyArray<WorkspacePackageExportPreviewCardRow>,
+export function buildAvailableWorkspacePackageExportTagCounts(
+  cards: ReadonlyArray<WorkspacePackageExportSelectedCardRow>,
 ): ReadonlyArray<WorkspacePackageExportPreviewTagCount> {
   const tagCounts = new Map<string, number>();
 
@@ -369,7 +372,7 @@ function buildAvailableTagCounts(
     .sort(compareTagCounts);
 }
 
-function buildTagsSelectedForRemoval(
+export function buildWorkspacePackageExportTagsSelectedForRemoval(
   availableTagCounts: ReadonlyArray<WorkspacePackageExportPreviewTagCount>,
   tagPolicy: WorkspacePackageExportTagPolicyInput,
 ): ReadonlyArray<WorkspacePackageExportPreviewTagCount> {
@@ -381,7 +384,9 @@ function buildTagsSelectedForRemoval(
   ));
 }
 
-function normalizeTagPolicy(tagPolicy: WorkspacePackageExportTagPolicyInput): WorkspacePackageExportTagPolicyInput {
+export function normalizeWorkspacePackageExportTagPolicy(
+  tagPolicy: WorkspacePackageExportTagPolicyInput,
+): WorkspacePackageExportTagPolicyInput {
   return {
     additionalRemovedTags: normalizeUniqueTextValues(
       tagPolicy.additionalRemovedTags,
@@ -390,8 +395,8 @@ function normalizeTagPolicy(tagPolicy: WorkspacePackageExportTagPolicyInput): Wo
   };
 }
 
-function extractReferencedMediaAssetIds(
-  cards: ReadonlyArray<WorkspacePackageExportPreviewCardRow>,
+export function extractReferencedWorkspacePackageExportMediaAssetIds(
+  cards: ReadonlyArray<WorkspacePackageExportSelectedCardRow>,
 ): ReadonlyArray<string> {
   const mediaAssetIds = new Set<string>();
 
@@ -496,24 +501,24 @@ export async function previewWorkspacePackageExportInExecutor(
   limits: WorkspacePackageExportPreviewLimits,
 ): Promise<WorkspacePackageExportPreview> {
   const normalizedGeneratedAt = normalizeIsoTimestamp(input.generatedAt, "generatedAt");
-  const normalizedSelection = normalizeCardSelection(input.selection);
-  const normalizedTagPolicy = normalizeTagPolicy(input.tagPolicy);
-  const defaultPackageMetadata = normalizePackageMetadata(input.packageMetadata, normalizedGeneratedAt);
+  const normalizedSelection = normalizeWorkspacePackageExportCardSelection(input.selection);
+  const normalizedTagPolicy = normalizeWorkspacePackageExportTagPolicy(input.tagPolicy);
+  const defaultPackageMetadata = normalizeWorkspacePackageExportMetadata(input.packageMetadata, normalizedGeneratedAt);
   const normalizedLimits = normalizePreviewLimits(limits);
-  const cards = await loadSelectedCardsInExecutor(
+  const cards = await loadSelectedWorkspacePackageExportCardsInExecutor(
     executor,
     workspaceId,
     normalizedSelection,
     normalizedLimits,
   );
-  const availableTagCounts = buildAvailableTagCounts(cards);
-  const referencedMediaAssetIds = extractReferencedMediaAssetIds(cards);
+  const availableTagCounts = buildAvailableWorkspacePackageExportTagCounts(cards);
+  const referencedMediaAssetIds = extractReferencedWorkspacePackageExportMediaAssetIds(cards);
   const mediaRows = await loadReferencedMediaRowsInExecutor(executor, workspaceId, referencedMediaAssetIds);
 
   return {
     selectedCardCount: cards.length,
     availableTagCounts,
-    tagsSelectedForRemoval: buildTagsSelectedForRemoval(availableTagCounts, normalizedTagPolicy),
+    tagsSelectedForRemoval: buildWorkspacePackageExportTagsSelectedForRemoval(availableTagCounts, normalizedTagPolicy),
     referencedMediaCount: mediaRows.length,
     approximateReferencedMediaBytes: sumReferencedMediaBytes(mediaRows),
     defaultPackageMetadata,

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -2,6 +2,7 @@ export {
   extractMarkdownFcAssetIds,
   rewriteMarkdownFcAssetUrlsToPortablePaths,
   rewriteMarkdownFcAssetUrlsToPortablePathsFromMap,
+  rewriteMarkdownFcAssetUrlsToSharedPortablePaths,
   rewriteMarkdownPortableMediaUrlsToFcAssets,
   rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap,
   validatePortableMediaPath,
@@ -17,6 +18,15 @@ export {
   previewWorkspacePackageExport,
 } from "./exportPreview";
 
+export {
+  exportWorkspacePackage,
+  exportWorkspacePackageInExecutor,
+  workspacePackageExportPackageDefaultMaxMediaFiles,
+  workspacePackageExportPackageDefaultMaxSelectedCards,
+  workspacePackageExportPackageDefaultMaxSingleMediaBytes,
+  workspacePackageExportPackageDefaultMaxTotalMediaBytes,
+} from "./exportPackage";
+
 export type {
   WorkspacePackageExportCardSelection,
   WorkspacePackageExportMetadataInput,
@@ -25,6 +35,13 @@ export type {
   WorkspacePackageExportPreviewTagCount,
   WorkspacePackageExportTagPolicyInput,
 } from "./exportPreview";
+
+export type {
+  WorkspacePackageExportPackage,
+  WorkspacePackageExportPackageDependencies,
+  WorkspacePackageExportPackageInput,
+  WorkspacePackageExportPackageLimits,
+} from "./exportPackage";
 
 export {
   normalizeWorkspacePackageCardMetadataV1,

--- a/apps/backend/src/workspacePackages/markdownMedia.ts
+++ b/apps/backend/src/workspacePackages/markdownMedia.ts
@@ -502,6 +502,34 @@ export function rewriteMarkdownFcAssetUrlsToPortablePathsFromMap(
   });
 }
 
+export function rewriteMarkdownFcAssetUrlsToSharedPortablePathsFromMap(
+  markdown: string,
+  portablePathsByAssetId: ReadonlyMap<string, string>,
+): string {
+  return rewriteMarkdownFcAssetUrlsToSharedPortablePaths(markdown, (assetId) => {
+    const portablePath = portablePathsByAssetId.get(assetId);
+    if (portablePath === undefined) {
+      throw new Error(`Missing portable media path for fcasset id: ${assetId}`);
+    }
+
+    return portablePath;
+  });
+}
+
+export function rewriteMarkdownFcAssetUrlsToSharedPortablePaths(
+  markdown: string,
+  resolvePortablePath: FcAssetPortablePathResolver,
+): string {
+  return rewriteMarkdownUrls(markdown, (url) => {
+    const assetId = matchFcAssetId(url);
+    if (assetId === null) {
+      return null;
+    }
+
+    return validatePortableMediaPath(resolvePortablePath(assetId));
+  });
+}
+
 export function rewriteMarkdownPortableMediaUrlsToFcAssets(
   markdown: string,
   resolveAssetId: PortableMediaAssetIdResolver,


### PR DESCRIPTION
Summary:
- Adds internal backend `flashcards.zip` v1 assembly with root `cards.json` and optional `media/...` entries.
- Reuses export selection/tag/metadata helpers and rewrites `fcasset:` Markdown refs to portable media paths.
- Resolves workspace-scoped media assets, dedupes by physical blob/hash, loads bytes via Stage 3C1 byte-loader, and enforces card/media byte/media-file limits.
- Canonicalizes UUID-bearing package inputs and closes DB transaction before S3 byte loading / ZIP assembly.

Validation:
- `npm run lint --prefix apps/backend`: passed.
- `npm run test --prefix apps/backend -- workspacePackages mediaAssets`: passed, 614 tests, 0 failures.
- `git --no-pager diff --check`: passed.

Review status:
- Final review: no P0-P4 findings.
- Split decision: no split recommendation; reviewer explicitly accepted this as a cohesive internal backend ZIP export PR despite size.