### PR TITLE
Add package export routes

### DIFF
--- a/api/src/components/schemas/AgentDiscoveryData.yaml
+++ b/api/src/components/schemas/AgentDiscoveryData.yaml
@@ -64,6 +64,8 @@ properties:
       - mediaAssetUploadSessionAbortUrlTemplate
       - mediaAssetMetadataUrlTemplate
       - mediaAssetDownloadUrlTemplate
+      - workspacePackageExportPreviewUrlTemplate
+      - workspacePackageExportUrlTemplate
     properties:
       accountUrl:
         type: string
@@ -86,6 +88,10 @@ properties:
       mediaAssetMetadataUrlTemplate:
         type: string
       mediaAssetDownloadUrlTemplate:
+        type: string
+      workspacePackageExportPreviewUrlTemplate:
+        type: string
+      workspacePackageExportUrlTemplate:
         type: string
   mcp:
     type: object

--- a/api/src/components/schemas/WorkspacePackageExportAllActiveCardsSelection.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportAllActiveCardsSelection.yaml
@@ -1,0 +1,9 @@
+type: object
+additionalProperties: false
+required:
+  - kind
+properties:
+  kind:
+    type: string
+    enum:
+      - allActiveCards

--- a/api/src/components/schemas/WorkspacePackageExportExplicitCardIdsSelection.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportExplicitCardIdsSelection.yaml
@@ -1,0 +1,16 @@
+type: object
+additionalProperties: false
+required:
+  - kind
+  - cardIds
+properties:
+  kind:
+    type: string
+    enum:
+      - explicitCardIds
+  cardIds:
+    type: array
+    minItems: 1
+    maxItems: 5000
+    items:
+      $ref: ./UuidString.yaml

--- a/api/src/components/schemas/WorkspacePackageExportMetadataInput.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportMetadataInput.yaml
@@ -1,0 +1,34 @@
+type: object
+additionalProperties: false
+required:
+  - label
+  - author
+  - comment
+  - createdAt
+  - sourceUrl
+properties:
+  label:
+    type:
+      - string
+      - 'null'
+    minLength: 1
+  author:
+    type:
+      - string
+      - 'null'
+    minLength: 1
+  comment:
+    type:
+      - string
+      - 'null'
+    minLength: 1
+  createdAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  sourceUrl:
+    type:
+      - string
+      - 'null'
+    format: uri

--- a/api/src/components/schemas/WorkspacePackageExportPreviewResponse.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportPreviewResponse.yaml
@@ -1,0 +1,30 @@
+type: object
+additionalProperties: false
+required:
+  - selectedCardCount
+  - availableTagCounts
+  - tagsSelectedForRemoval
+  - referencedMediaCount
+  - approximateReferencedMediaBytes
+  - defaultPackageMetadata
+properties:
+  selectedCardCount:
+    type: integer
+    minimum: 0
+  availableTagCounts:
+    type: array
+    items:
+      $ref: ./WorkspacePackageExportTagCount.yaml
+  tagsSelectedForRemoval:
+    type: array
+    items:
+      $ref: ./WorkspacePackageExportTagCount.yaml
+  referencedMediaCount:
+    type: integer
+    minimum: 0
+  approximateReferencedMediaBytes:
+    type: integer
+    format: int64
+    minimum: 0
+  defaultPackageMetadata:
+    $ref: ./WorkspacePackageMetadata.yaml

--- a/api/src/components/schemas/WorkspacePackageExportRequest.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportRequest.yaml
@@ -1,0 +1,13 @@
+type: object
+additionalProperties: false
+required:
+  - selection
+  - tagPolicy
+  - packageMetadata
+properties:
+  selection:
+    $ref: ./WorkspacePackageExportSelection.yaml
+  tagPolicy:
+    $ref: ./WorkspacePackageExportTagPolicyInput.yaml
+  packageMetadata:
+    $ref: ./WorkspacePackageExportMetadataInput.yaml

--- a/api/src/components/schemas/WorkspacePackageExportSelection.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportSelection.yaml
@@ -1,0 +1,10 @@
+oneOf:
+  - $ref: ./WorkspacePackageExportAllActiveCardsSelection.yaml
+  - $ref: ./WorkspacePackageExportTagFiltersSelection.yaml
+  - $ref: ./WorkspacePackageExportExplicitCardIdsSelection.yaml
+discriminator:
+  propertyName: kind
+  mapping:
+    allActiveCards: ./WorkspacePackageExportAllActiveCardsSelection.yaml
+    tagFilters: ./WorkspacePackageExportTagFiltersSelection.yaml
+    explicitCardIds: ./WorkspacePackageExportExplicitCardIdsSelection.yaml

--- a/api/src/components/schemas/WorkspacePackageExportTagCount.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportTagCount.yaml
@@ -1,0 +1,11 @@
+type: object
+additionalProperties: false
+required:
+  - tag
+  - cardsCount
+properties:
+  tag:
+    type: string
+  cardsCount:
+    type: integer
+    minimum: 0

--- a/api/src/components/schemas/WorkspacePackageExportTagFiltersSelection.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportTagFiltersSelection.yaml
@@ -1,0 +1,21 @@
+type: object
+additionalProperties: false
+required:
+  - kind
+  - includeTags
+  - excludeTags
+properties:
+  kind:
+    type: string
+    enum:
+      - tagFilters
+  includeTags:
+    type: array
+    items:
+      type: string
+      minLength: 1
+  excludeTags:
+    type: array
+    items:
+      type: string
+      minLength: 1

--- a/api/src/components/schemas/WorkspacePackageExportTagPolicyInput.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportTagPolicyInput.yaml
@@ -1,0 +1,10 @@
+type: object
+additionalProperties: false
+required:
+  - additionalRemovedTags
+properties:
+  additionalRemovedTags:
+    type: array
+    items:
+      type: string
+      minLength: 1

--- a/api/src/components/schemas/WorkspacePackageMetadata.yaml
+++ b/api/src/components/schemas/WorkspacePackageMetadata.yaml
@@ -1,0 +1,21 @@
+type: object
+additionalProperties: false
+required:
+  - label
+  - createdAt
+properties:
+  label:
+    type: string
+    minLength: 1
+  author:
+    type: string
+    minLength: 1
+  comment:
+    type: string
+    minLength: 1
+  createdAt:
+    type: string
+    format: date-time
+  sourceUrl:
+    type: string
+    format: uri

--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -48,6 +48,9 @@ tags:
     description: >-
       Workspace-scoped media asset registry metadata and direct private object
       transfer URLs.
+  - name: workspace-packages
+    description: >-
+      Workspace-scoped package export preview and portable ZIP download.
   - name: admin-catalog
     description: >-
       Admin-only catalog authoring surface for marketplace authors, packages,
@@ -85,6 +88,10 @@ paths:
     $ref: paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}.yaml
   /workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url:
     $ref: paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
+  /workspaces/{workspaceId}/packages/export/preview:
+    $ref: paths/workspaces_{workspaceId}_packages_export_preview.yaml
+  /workspaces/{workspaceId}/packages/export:
+    $ref: paths/workspaces_{workspaceId}_packages_export.yaml
   /admin/catalog/authors:
     $ref: paths/admin_catalog_authors.yaml
   /admin/catalog/authors/{authorId}:

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -35,6 +35,7 @@ get:
                 - Ingest JPEG, PNG, and WebP media images through the workspace-scoped image endpoint
                 - Upload and complete media assets through workspace-scoped direct transfer endpoints
                 - Read media asset metadata and create download URLs through workspace-scoped media endpoints
+                - Preview and download portable workspace package ZIP exports
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -49,6 +50,8 @@ get:
                 mediaAssetUploadSessionAbortUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/abort
                 mediaAssetMetadataUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
                 mediaAssetDownloadUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
+                workspacePackageExportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
+                workspacePackageExportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -106,8 +109,11 @@ get:
               Use GET /v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
               for registry metadata and GET
               /v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
-              for a range-capable direct download URL. Use docs.openapiUrl for
-              the published external agent contract.
+              for a range-capable direct download URL. Use POST
+              /v1/workspaces/{workspaceId}/packages/export/preview to preview a
+              portable workspace package export, then POST
+              /v1/workspaces/{workspaceId}/packages/export to download the ZIP.
+              Use docs.openapiUrl for the published external agent contract.
             links:
               websiteUrl: https://flashcards-open-source-app.com/
               privacyUrl: https://flashcards-open-source-app.com/privacy/

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -33,6 +33,7 @@ get:
                 - Ingest JPEG, PNG, and WebP media images through the workspace-scoped image endpoint
                 - Upload and complete media assets through workspace-scoped direct transfer endpoints
                 - Read media asset metadata and create download URLs through workspace-scoped media endpoints
+                - Preview and download portable workspace package ZIP exports
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -47,6 +48,8 @@ get:
                 mediaAssetUploadSessionAbortUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/abort
                 mediaAssetMetadataUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
                 mediaAssetDownloadUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
+                workspacePackageExportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
+                workspacePackageExportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -114,7 +117,11 @@ get:
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
               for registry metadata and GET
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
-              for a range-capable direct download URL. SELECT returns at most
+              for a range-capable direct download URL. Use POST
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
+              to preview a portable workspace package export, then POST
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
+              to download the ZIP. SELECT returns at most
               100 rows per statement, and INSERT, UPDATE, and DELETE may affect
               at most 100 rows per statement. If you need more than 100
               writes, split the work into multiple batches of at most 100

--- a/api/src/paths/workspaces_{workspaceId}_packages_export.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_export.yaml
@@ -1,0 +1,41 @@
+post:
+  tags:
+    - workspace-packages
+  summary: Export a workspace package ZIP
+  description: >-
+    Assembles the selected active cards and referenced media into a portable
+    workspace package ZIP. Backend media blob identifiers, storage keys, and
+    object URLs are not exposed in the response.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/WorkspacePackageExportRequest.yaml
+  responses:
+    '200':
+      description: Portable workspace package ZIP
+      headers:
+        Content-Disposition:
+          schema:
+            type: string
+            example: attachment; filename="flashcards.zip"
+      content:
+        application/zip:
+          schema:
+            type: string
+            format: binary
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/api/src/paths/workspaces_{workspaceId}_packages_export_preview.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_export_preview.yaml
@@ -1,0 +1,35 @@
+post:
+  tags:
+    - workspace-packages
+  summary: Preview a workspace package export
+  description: >-
+    Returns counts, removable tag choices, referenced media totals, and the
+    normalized package metadata that would be used for a portable workspace
+    package export. The path workspaceId is authoritative for selection scope.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/WorkspacePackageExportRequest.yaml
+  responses:
+    '200':
+      description: Workspace package export preview
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/WorkspacePackageExportPreviewResponse.yaml
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -29,6 +29,8 @@ type AgentDiscoveryEnvelope = Readonly<{
       mediaAssetUploadSessionAbortUrlTemplate: string;
       mediaAssetMetadataUrlTemplate: string;
       mediaAssetDownloadUrlTemplate: string;
+      workspacePackageExportPreviewUrlTemplate: string;
+      workspacePackageExportUrlTemplate: string;
     }>;
     mcp: Readonly<{
       url: string;
@@ -113,6 +115,8 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
   const mediaAssetUploadSessionAbortUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/abort`;
   const mediaAssetMetadataUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/{mediaAssetId}`;
   const mediaAssetDownloadUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url`;
+  const workspacePackageExportPreviewUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/export/preview`;
+  const workspacePackageExportUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/export`;
 
   return {
     ok: true,
@@ -137,6 +141,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         "Ingest JPEG, PNG, and WebP image bytes through the workspace-scoped image media endpoint",
         "Upload and complete media assets through workspace-scoped direct transfer endpoints",
         "Read media asset metadata and create download URLs through workspace-scoped media endpoints",
+        "Preview and download portable workspace package ZIP exports",
       ],
       authBaseUrl,
       apiBaseUrl,
@@ -152,6 +157,8 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         mediaAssetUploadSessionAbortUrlTemplate,
         mediaAssetMetadataUrlTemplate,
         mediaAssetDownloadUrlTemplate,
+        workspacePackageExportPreviewUrlTemplate,
+        workspacePackageExportUrlTemplate,
       },
       mcp: {
         url: `${mcpBaseUrl}/mcp`,
@@ -174,7 +181,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
     },
     links,
     instructions:
-      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when creating media assets. Use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For JPEG, PNG, or WebP images up to ${maximumImageIngestionOriginalBytes} bytes, prefer POST ${mediaAssetImageIngestionUrlTemplate} with the image bytes as the request body and x-media-asset-id, x-media-created-at, x-media-client-updated-at, x-media-last-modified-by-replica-id, and x-media-last-operation-id headers; the backend normalizes to canonical JPEG bytes and returns the mediaAsset. For other media assets, create a multipart upload session with POST ${mediaAssetUploadSessionCreateUrlTemplate}; if status is already_available, use the returned mediaAsset and skip byte upload. If status is upload_required, request signed part URLs with POST ${mediaAssetUploadSessionPartsUrlTemplate}, upload each part with the returned signed URL, method, and headers, then complete the upload with POST ${mediaAssetUploadSessionCompleteUrlTemplate}. Abort unused sessions with POST ${mediaAssetUploadSessionAbortUrlTemplate}. Use GET ${mediaAssetMetadataUrlTemplate} for registry metadata and GET ${mediaAssetDownloadUrlTemplate} for a range-capable direct download URL. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
+      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when creating media assets. Use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For JPEG, PNG, or WebP images up to ${maximumImageIngestionOriginalBytes} bytes, prefer POST ${mediaAssetImageIngestionUrlTemplate} with the image bytes as the request body and x-media-asset-id, x-media-created-at, x-media-client-updated-at, x-media-last-modified-by-replica-id, and x-media-last-operation-id headers; the backend normalizes to canonical JPEG bytes and returns the mediaAsset. For other media assets, create a multipart upload session with POST ${mediaAssetUploadSessionCreateUrlTemplate}; if status is already_available, use the returned mediaAsset and skip byte upload. If status is upload_required, request signed part URLs with POST ${mediaAssetUploadSessionPartsUrlTemplate}, upload each part with the returned signed URL, method, and headers, then complete the upload with POST ${mediaAssetUploadSessionCompleteUrlTemplate}. Abort unused sessions with POST ${mediaAssetUploadSessionAbortUrlTemplate}. Use GET ${mediaAssetMetadataUrlTemplate} for registry metadata and GET ${mediaAssetDownloadUrlTemplate} for a range-capable direct download URL. Use POST ${workspacePackageExportPreviewUrlTemplate} to preview a portable workspace package export, then POST ${workspacePackageExportUrlTemplate} to download the ZIP. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
     docs,
   };
 }

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -250,6 +250,17 @@ export type CardsQueryDetails = Readonly<{
   hasMore: boolean | null;
 }>;
 
+export type WorkspacePackageExportPreviewDetails = Readonly<{
+  statusCode: number;
+  selectedCardCount: number | null;
+  referencedMediaCount: number | null;
+}>;
+
+export type WorkspacePackageExportDetails = Readonly<{
+  statusCode: number;
+  bytesCount: number | null;
+}>;
+
 export type MediaAssetRouteDetails = Readonly<{
   statusCode: number;
   mediaAssetId: string | null;
@@ -761,6 +772,10 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>>
   | EventByAction<"cards_query", CardsQueryDetails>
   | EventByAction<"cards_query_error", FailureDetailsFor<CardsQueryDetails>>
+  | EventByAction<"workspace_package_export_preview", WorkspacePackageExportPreviewDetails>
+  | EventByAction<"workspace_package_export_preview_error", FailureDetailsFor<WorkspacePackageExportPreviewDetails>>
+  | EventByAction<"workspace_package_export", WorkspacePackageExportDetails>
+  | EventByAction<"workspace_package_export_error", FailureDetailsFor<WorkspacePackageExportDetails>>
   | EventByAction<"media_asset_image_ingest", MediaAssetRouteDetails>
   | EventByAction<"media_asset_image_ingest_error", FailureDetailsFor<MediaAssetRouteDetails>>
   | EventByAction<"media_asset_upload_session_media_reuse", MediaAssetRouteDetails>
@@ -900,6 +915,14 @@ export type BackendExceptionEvent =
   | (EventByAction<"feedback_submission_error", FailureDetailsFor<FeedbackSubmissionDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"cards_query_error", FailureDetailsFor<CardsQueryDetails>> & Readonly<{ error: Error }>)
+  | (
+    EventByAction<"workspace_package_export_preview_error", FailureDetailsFor<WorkspacePackageExportPreviewDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"workspace_package_export_error", FailureDetailsFor<WorkspacePackageExportDetails>>
+    & Readonly<{ error: Error }>
+  )
   | (
     EventByAction<"media_asset_image_ingest_error", FailureDetailsFor<MediaAssetRouteDetails>>
     & Readonly<{ error: Error }>

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -70,6 +70,8 @@ const expectedPublishedApiMethods = {
   "/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/abort": ["post"],
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}": ["get"],
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url": ["get"],
+  "/workspaces/{workspaceId}/packages/export/preview": ["post"],
+  "/workspaces/{workspaceId}/packages/export": ["post"],
   "/admin/catalog/authors": ["post"],
   "/admin/catalog/authors/{authorId}": ["put"],
   "/admin/catalog/packages": ["post"],
@@ -91,6 +93,8 @@ const expectedMediaDiscoverySurfaceTemplates = {
   mediaAssetUploadSessionAbortUrlTemplate: "/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/abort",
   mediaAssetMetadataUrlTemplate: "/workspaces/{workspaceId}/media-assets/{mediaAssetId}",
   mediaAssetDownloadUrlTemplate: "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url",
+  workspacePackageExportPreviewUrlTemplate: "/workspaces/{workspaceId}/packages/export/preview",
+  workspacePackageExportUrlTemplate: "/workspaces/{workspaceId}/packages/export",
 } as const;
 const supportedImageIngestionOpenApiContentTypes = [
   "application/octet-stream",
@@ -158,6 +162,15 @@ test("API Gateway predeclares POST /workspaces/{workspaceId}/media-assets/images
   const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
 
   assert.match(apiGatewaySource, /workspaceMediaAssets\.addResource\("images"\)\.addMethod\("POST", integration\);/);
+});
+
+test("API Gateway predeclares package export routes and ZIP binary media", () => {
+  const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(apiGatewaySource, /binaryMediaTypes: \[[^\]]*"application\/zip"/);
+  assert.match(apiGatewaySource, /workspacePackageExport\.addMethod\("POST", integration\);/);
+  assert.match(apiGatewaySource, /workspacePackageExport\.addResource\("preview"\)\.addMethod\("POST", integration\);/);
 });
 
 test("published OpenAPI exposes the curated agent, media transfer, and admin catalog contract", () => {
@@ -232,6 +245,8 @@ test("agent discovery advertises the published media transfer surface", () => {
   assert.match(discoveryEnvelope.instructions, /media-assets\/upload-sessions\/\{sessionId\}\/abort/);
   assertDoesNotAdvertiseUploadIntentFlow(discoveryEnvelope.instructions, "Agent discovery instructions");
   assert.match(discoveryEnvelope.instructions, /media-assets\/\{mediaAssetId\}\/download-url/);
+  assert.match(discoveryEnvelope.instructions, /packages\/export\/preview/);
+  assert.match(discoveryEnvelope.instructions, /packages\/export/);
   assert.match(discoveryEnvelope.instructions, /data\.agentWorkspaceReplicaId/);
   assert.match(discoveryEnvelope.instructions, /lastModifiedByReplicaId/);
 });

--- a/apps/backend/src/routes/workspacePackages.test.ts
+++ b/apps/backend/src/routes/workspacePackages.test.ts
@@ -1,0 +1,365 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import test from "node:test";
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { createWorkspacePackageRoutes } from "./workspacePackages";
+import { HttpError } from "../shared/errors";
+import type { AppEnv } from "../server/app";
+import type { RequestContext } from "../server/requestContext";
+import type {
+  WorkspacePackageExportPackageInput,
+  WorkspacePackageExportPreviewInput,
+} from "../workspacePackages";
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+const otherWorkspaceId = "22222222-2222-4222-8222-222222222222";
+const cardId = "33333333-3333-4333-8333-333333333333";
+
+type ErrorResponseBody = Readonly<{
+  error: string;
+  requestId: string;
+  code: string | null;
+  details?: unknown;
+}>;
+
+function createRequestContext(): RequestContext {
+  return {
+    userId: "user-1",
+    subjectUserId: "subject-1",
+    selectedWorkspaceId: otherWorkspaceId,
+    email: "user@example.com",
+    locale: "en",
+    userSettingsCreatedAt: "2026-06-30T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
+    transport: "bearer",
+    connectionId: null,
+    guestSessionId: null,
+    guestPlatform: null,
+  };
+}
+
+function createWorkspacePackageExportRequestBody(): Record<string, unknown> {
+  return {
+    workspaceId: otherWorkspaceId,
+    selection: {
+      kind: "explicitCardIds",
+      cardIds: [cardId],
+    },
+    tagPolicy: {
+      additionalRemovedTags: ["draft"],
+    },
+    packageMetadata: {
+      label: "Starter deck",
+      author: null,
+      comment: null,
+      createdAt: null,
+      sourceUrl: null,
+    },
+  };
+}
+
+function createWorkspacePackageTestApp(routes: Hono<AppEnv>): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-1");
+    context.set("clientAppVersion", null);
+    context.set("clientPlatform", null);
+    await next();
+  });
+  app.onError((error, context) => {
+    if (error instanceof HttpError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: error.message,
+        requestId: context.get("requestId"),
+        code: error.code,
+        ...(error.details === null ? {} : { details: error.details }),
+      } satisfies ErrorResponseBody);
+    }
+
+    context.status(500);
+    return context.json({
+      error: "Request failed. Try again.",
+      requestId: context.get("requestId"),
+      code: "INTERNAL_ERROR",
+    } satisfies ErrorResponseBody);
+  });
+  app.route("/", routes);
+  return app;
+}
+
+function assertExportInput(input: WorkspacePackageExportPreviewInput): void {
+  assert.deepEqual(input.selection, {
+    kind: "explicitCardIds",
+    cardIds: [cardId],
+  });
+  assert.deepEqual(input.tagPolicy, {
+    additionalRemovedTags: ["draft"],
+  });
+  assert.deepEqual(input.packageMetadata, {
+    label: "Starter deck",
+    author: null,
+    comment: null,
+    createdAt: null,
+    sourceUrl: null,
+  });
+  assert.equal(new Date(input.generatedAt).toISOString(), input.generatedAt);
+}
+
+test("POST /workspaces/:workspaceId/packages/export/preview returns preview JSON for the path workspace", async () => {
+  let accessChecks = 0;
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
+      accessChecks += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(checkedWorkspaceId, workspaceId);
+    },
+    previewWorkspacePackageExportFn: async (userId, requestedWorkspaceId, input) => {
+      previewCalls += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, workspaceId);
+      assertExportInput(input);
+
+      return {
+        selectedCardCount: 1,
+        availableTagCounts: [
+          {
+            tag: "draft",
+            cardsCount: 1,
+          },
+        ],
+        tagsSelectedForRemoval: [
+          {
+            tag: "draft",
+            cardsCount: 1,
+          },
+        ],
+        referencedMediaCount: 0,
+        approximateReferencedMediaBytes: 0,
+        defaultPackageMetadata: {
+          label: "Starter deck",
+          createdAt: input.generatedAt,
+        },
+      };
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
+  });
+
+  assert.equal(response.status, 200);
+  const responseBody = await response.json() as Readonly<{
+    selectedCardCount: number;
+    availableTagCounts: ReadonlyArray<Readonly<{
+      tag: string;
+      cardsCount: number;
+    }>>;
+    tagsSelectedForRemoval: ReadonlyArray<Readonly<{
+      tag: string;
+      cardsCount: number;
+    }>>;
+    referencedMediaCount: number;
+    approximateReferencedMediaBytes: number;
+    defaultPackageMetadata: Readonly<{
+      label: string;
+      createdAt: string;
+    }>;
+  }>;
+  assert.equal(new Date(responseBody.defaultPackageMetadata.createdAt).toISOString(), responseBody.defaultPackageMetadata.createdAt);
+  assert.deepEqual(responseBody, {
+    selectedCardCount: 1,
+    availableTagCounts: [
+      {
+        tag: "draft",
+        cardsCount: 1,
+      },
+    ],
+    tagsSelectedForRemoval: [
+      {
+        tag: "draft",
+        cardsCount: 1,
+      },
+    ],
+    referencedMediaCount: 0,
+    approximateReferencedMediaBytes: 0,
+    defaultPackageMetadata: {
+      label: "Starter deck",
+      createdAt: responseBody.defaultPackageMetadata.createdAt,
+    },
+  });
+  assert.equal(accessChecks, 1);
+  assert.equal(previewCalls, 1);
+});
+
+test("POST /workspaces/:workspaceId/packages/export returns ZIP bytes with download headers", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  let exportCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
+      assert.equal(userId, "user-1");
+      assert.equal(checkedWorkspaceId, workspaceId);
+    },
+    exportWorkspacePackageFn: async (userId, requestedWorkspaceId, input: WorkspacePackageExportPackageInput) => {
+      exportCalls += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, workspaceId);
+      assertExportInput(input);
+      assert.equal(input.observationScope.service, "backend-api");
+      assert.equal(input.observationScope.requestId, "request-1");
+      assert.equal(input.observationScope.workspaceId, workspaceId);
+
+      return {
+        fileName: "flashcards.zip",
+        contentType: "application/zip",
+        bytes: zipBytes,
+      };
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "application/zip");
+  assert.equal(response.headers.get("content-disposition"), 'attachment; filename="flashcards.zip"');
+  assert.equal(response.headers.get("content-length"), zipBytes.byteLength.toString());
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), zipBytes);
+  assert.equal(exportCalls, 1);
+});
+
+test("workspace package export routes stop before service calls when workspace access is denied", async () => {
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => {
+      throw new HttpError(403, "Workspace access denied", "WORKSPACE_ACCESS_DENIED");
+    },
+    previewWorkspacePackageExportFn: async () => {
+      previewCalls += 1;
+      throw new Error("Preview service must not be called when workspace access is denied.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 403);
+  assert.equal(body.code, "WORKSPACE_ACCESS_DENIED");
+  assert.equal(previewCalls, 0);
+});
+
+test("workspace package export routes reject malformed requests before service calls", async () => {
+  let exportCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    exportWorkspacePackageFn: async () => {
+      exportCalls += 1;
+      throw new Error("Export service must not be called for malformed requests.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      selection: {
+        kind: "explicitCardIds",
+        cardIds: [cardId],
+      },
+      tagPolicy: {
+        additionalRemovedTags: "draft",
+      },
+      packageMetadata: {
+        label: "Starter deck",
+        author: null,
+        comment: null,
+        createdAt: null,
+        sourceUrl: null,
+      },
+    }),
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.code, "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID");
+  assert.match(JSON.stringify(body.details), /tagPolicy\.additionalRemovedTags/);
+  assert.equal(exportCalls, 0);
+});
+
+test("workspace package export routes reject empty explicit card id selections before service calls", async () => {
+  let exportCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    exportWorkspacePackageFn: async () => {
+      exportCalls += 1;
+      throw new Error("Export service must not be called for empty explicit card id selections.");
+    },
+  }));
+
+  const requestBody = createWorkspacePackageExportRequestBody();
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ...requestBody,
+      selection: {
+        kind: "explicitCardIds",
+        cardIds: [],
+      },
+    }),
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.code, "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID");
+  assert.match(JSON.stringify(body.details), /selection\.cardIds/);
+  assert.equal(exportCalls, 0);
+});

--- a/apps/backend/src/routes/workspacePackages.ts
+++ b/apps/backend/src/routes/workspacePackages.ts
@@ -1,0 +1,291 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  exportWorkspacePackage,
+  previewWorkspacePackageExport,
+  type WorkspacePackageExportCardSelection,
+  type WorkspacePackageExportMetadataInput,
+  type WorkspacePackageExportPackage,
+  type WorkspacePackageExportPackageInput,
+  type WorkspacePackageExportPreview,
+  type WorkspacePackageExportPreviewInput,
+  type WorkspacePackageExportTagPolicyInput,
+} from "../workspacePackages";
+import { assertUserHasWorkspaceAccess } from "../workspaces";
+import {
+  loadRequestContextFromRequest,
+  parseWorkspaceIdParam,
+  type RequestContext,
+} from "../server/requestContext";
+import { parseJsonBody } from "../server/requestParsing";
+import { createBackendFailureDetails } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
+import { HttpError, type HttpErrorDetails, type ValidationIssueSummary } from "../shared/errors";
+import type { AppEnv } from "../server/app";
+
+type WorkspacePackageRoutesOptions = Readonly<{
+  allowedOrigins: ReadonlyArray<string>;
+  loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
+  assertUserHasWorkspaceAccessFn?: typeof assertUserHasWorkspaceAccess;
+  previewWorkspacePackageExportFn?: typeof previewWorkspacePackageExport;
+  exportWorkspacePackageFn?: typeof exportWorkspacePackage;
+}>;
+
+type WorkspacePackageExportRouteInput = Readonly<{
+  selection: WorkspacePackageExportCardSelection;
+  tagPolicy: WorkspacePackageExportTagPolicyInput;
+  packageMetadata: WorkspacePackageExportMetadataInput;
+}>;
+
+type WorkspacePackageExportPreviewResponse = WorkspacePackageExportPreview;
+
+const allActiveCardsSelectionSchema = z.object({
+  kind: z.literal("allActiveCards"),
+});
+
+const tagFiltersSelectionSchema = z.object({
+  kind: z.literal("tagFilters"),
+  includeTags: z.array(z.string()),
+  excludeTags: z.array(z.string()),
+});
+
+const explicitCardIdsSelectionSchema = z.object({
+  kind: z.literal("explicitCardIds"),
+  cardIds: z.array(z.string()).min(1),
+});
+
+const workspacePackageExportSelectionSchema = z.discriminatedUnion("kind", [
+  allActiveCardsSelectionSchema,
+  tagFiltersSelectionSchema,
+  explicitCardIdsSelectionSchema,
+]).transform((selection): WorkspacePackageExportCardSelection => {
+  switch (selection.kind) {
+  case "allActiveCards":
+    return {
+      kind: "allActiveCards",
+    };
+  case "tagFilters":
+    return {
+      kind: "tagFilters",
+      includeTags: selection.includeTags,
+      excludeTags: selection.excludeTags,
+    };
+  case "explicitCardIds":
+    return {
+      kind: "explicitCardIds",
+      cardIds: selection.cardIds,
+    };
+  }
+});
+
+const workspacePackageExportTagPolicySchema = z.object({
+  additionalRemovedTags: z.array(z.string()),
+}).transform((tagPolicy): WorkspacePackageExportTagPolicyInput => ({
+  additionalRemovedTags: tagPolicy.additionalRemovedTags,
+}));
+
+const workspacePackageExportMetadataSchema = z.object({
+  label: z.string().nullable(),
+  author: z.string().nullable(),
+  comment: z.string().nullable(),
+  createdAt: z.string().nullable(),
+  sourceUrl: z.string().nullable(),
+}).transform((packageMetadata): WorkspacePackageExportMetadataInput => ({
+  label: packageMetadata.label,
+  author: packageMetadata.author,
+  comment: packageMetadata.comment,
+  createdAt: packageMetadata.createdAt,
+  sourceUrl: packageMetadata.sourceUrl,
+}));
+
+const workspacePackageExportRouteInputSchema = z.object({
+  selection: workspacePackageExportSelectionSchema,
+  tagPolicy: workspacePackageExportTagPolicySchema,
+  packageMetadata: workspacePackageExportMetadataSchema,
+}).transform((input): WorkspacePackageExportRouteInput => ({
+  selection: input.selection,
+  tagPolicy: input.tagPolicy,
+  packageMetadata: input.packageMetadata,
+}));
+
+function summarizeValidationPath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) {
+    return "<root>";
+  }
+
+  return path.join(".");
+}
+
+function summarizeValidationIssue(issue: z.core.$ZodIssue): ValidationIssueSummary {
+  return {
+    path: summarizeValidationPath(issue.path),
+    code: issue.code,
+    message: issue.message,
+  };
+}
+
+function summarizeValidationDetails(error: z.ZodError): HttpErrorDetails {
+  return {
+    validationIssues: error.issues.map(summarizeValidationIssue),
+  };
+}
+
+export function parseWorkspacePackageExportRouteInput(value: unknown): WorkspacePackageExportRouteInput {
+  const parsedInput = workspacePackageExportRouteInputSchema.safeParse(value);
+  if (parsedInput.success) {
+    return parsedInput.data;
+  }
+
+  throw new HttpError(
+    400,
+    "Workspace package export request is invalid.",
+    "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID",
+    summarizeValidationDetails(parsedInput.error),
+  );
+}
+
+function createWorkspacePackageExportInput(
+  routeInput: WorkspacePackageExportRouteInput,
+  generatedAt: string,
+): WorkspacePackageExportPreviewInput {
+  return {
+    selection: routeInput.selection,
+    tagPolicy: routeInput.tagPolicy,
+    packageMetadata: routeInput.packageMetadata,
+    generatedAt,
+  };
+}
+
+function createWorkspacePackageScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string | null,
+  workspaceId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+    clientAppVersion,
+    clientPlatform,
+  );
+}
+
+function getRequestContextUserId(requestContext: RequestContext | null): string | null {
+  return requestContext === null ? null : requestContext.userId;
+}
+
+function createContentDispositionHeader(packageExport: WorkspacePackageExportPackage): string {
+  return `attachment; filename="${packageExport.fileName}"`;
+}
+
+export function createWorkspacePackageRoutes(options: WorkspacePackageRoutesOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
+  const assertUserHasWorkspaceAccessFn = options.assertUserHasWorkspaceAccessFn ?? assertUserHasWorkspaceAccess;
+  const previewWorkspacePackageExportFn = options.previewWorkspacePackageExportFn ?? previewWorkspacePackageExport;
+  const exportWorkspacePackageFn = options.exportWorkspacePackageFn ?? exportWorkspacePackage;
+
+  app.post("/workspaces/:workspaceId/packages/export/preview", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
+      const routeInput = parseWorkspacePackageExportRouteInput(await parseJsonBody(context.req.raw));
+      const input = createWorkspacePackageExportInput(routeInput, new Date().toISOString());
+      const preview = await previewWorkspacePackageExportFn(requestContext.userId, workspaceId, input);
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      addBackendBreadcrumb({
+        action: "workspace_package_export_preview",
+        scope,
+        details: {
+          statusCode: 200,
+          selectedCardCount: preview.selectedCardCount,
+          referencedMediaCount: preview.referencedMediaCount,
+        },
+      });
+
+      return context.json(preview satisfies WorkspacePackageExportPreviewResponse);
+    } catch (error) {
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        selectedCardCount: null,
+        referencedMediaCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_package_export_preview_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_package_export_preview_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.post("/workspaces/:workspaceId/packages/export", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const routeInput = parseWorkspacePackageExportRouteInput(await parseJsonBody(context.req.raw));
+      const input: WorkspacePackageExportPackageInput = {
+        ...createWorkspacePackageExportInput(routeInput, new Date().toISOString()),
+        observationScope: scope,
+      };
+      const packageExport = await exportWorkspacePackageFn(requestContext.userId, workspaceId, input);
+      addBackendBreadcrumb({
+        action: "workspace_package_export",
+        scope,
+        details: {
+          statusCode: 200,
+          bytesCount: packageExport.bytes.byteLength,
+        },
+      });
+
+      context.header("Content-Disposition", createContentDispositionHeader(packageExport));
+      context.header("Content-Length", packageExport.bytes.byteLength.toString());
+      context.header("Content-Type", packageExport.contentType);
+      return context.body(new Uint8Array(packageExport.bytes), 200);
+    } catch (error) {
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        bytesCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_package_export_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_package_export_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  return app;
+}

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -15,6 +15,7 @@ import { createCardsRoutes } from "../routes/cards";
 import { createFeedbackRoutes } from "../routes/feedback";
 import { createGlobalSnapshotRoutes, globalSnapshotPath } from "../routes/globalSnapshot";
 import { createMediaAssetsRoutes } from "../routes/mediaAssets";
+import { createWorkspacePackageRoutes } from "../routes/workspacePackages";
 import { createSyncRoutes } from "../routes/sync/index";
 import { createSystemRoutes } from "../routes/system";
 import { createAdminRoutes } from "../routes/admin";
@@ -63,6 +64,19 @@ const browserCorsAllowHeaders = [
   "x-media-client-updated-at",
   "x-media-last-modified-by-replica-id",
   "x-media-last-operation-id",
+] as const;
+
+const browserCorsExposeHeaders = [
+  "cache-control",
+  "content-disposition",
+  "content-encoding",
+  "content-length",
+  "content-type",
+  "x-request-id",
+  "x-amz-apigw-id",
+  "x-amzn-requestid",
+  "x-chat-request-id",
+  "retry-after",
 ] as const;
 
 const globalSnapshotCorsAllowHeaders = [
@@ -223,17 +237,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
     origin: allowedOrigins,
     allowMethods: ["GET", "POST", "PATCH", "PUT", "OPTIONS"],
     allowHeaders: [...browserCorsAllowHeaders],
-    exposeHeaders: [
-      "cache-control",
-      "content-encoding",
-      "content-length",
-      "content-type",
-      "x-request-id",
-      "x-amz-apigw-id",
-      "x-amzn-requestid",
-      "x-chat-request-id",
-      "retry-after",
-    ],
+    exposeHeaders: [...browserCorsExposeHeaders],
     credentials: true,
   }));
 
@@ -371,6 +375,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
   app.route("/", createCatalogAdminRoutes({ allowedOrigins }));
   app.route("/", createCardsRoutes({ allowedOrigins }));
   app.route("/", createFeedbackRoutes({ allowedOrigins }));
+  app.route("/", createWorkspacePackageRoutes({ allowedOrigins }));
   app.route("/", createMediaAssetsRoutes({ allowedOrigins }));
   app.route("/", createGlobalSnapshotRoutes({}));
   app.route("/", createGuestAuthRoutes());

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -94,7 +94,7 @@ test("API Gateway predeclares media asset image ingestion and binary image bodie
   assert.match(apiGatewaySource, /workspaceMediaAssets\.addResource\("images"\)\.addMethod\("POST", integration\);/);
   assert.match(
     apiGatewaySource,
-    /binaryMediaTypes: \["application\/octet-stream", "image\/jpeg", "image\/png", "image\/webp", "multipart\/form-data"\]/,
+    /binaryMediaTypes: \["application\/octet-stream", "application\/zip", "image\/jpeg", "image\/png", "image\/webp", "multipart\/form-data"\]/,
   );
 });
 
@@ -201,7 +201,7 @@ test("chat live Lambda Function URL CORS exposes request id header", () => {
       ],
       AllowMethods: ["GET"],
       AllowOrigins: ["https://app.example.test"],
-      ExposeHeaders: ["x-request-id"],
+      ExposeHeaders: ["content-disposition", "x-request-id"],
     },
   });
 });
@@ -274,7 +274,7 @@ test("default API Gateway generated errors expose supported request id headers",
     "gatewayresponse.header.Access-Control-Allow-Headers": `'${allowHeaders}'`,
     "gatewayresponse.header.Access-Control-Allow-Methods": "'GET,POST,PUT,PATCH,OPTIONS'",
     "gatewayresponse.header.Access-Control-Allow-Origin": "method.request.header.Origin",
-    "gatewayresponse.header.Access-Control-Expose-Headers": "'x-request-id,x-amzn-requestid,x-amz-apigw-id'",
+    "gatewayresponse.header.Access-Control-Expose-Headers": "'content-disposition,x-request-id,x-amzn-requestid,x-amz-apigw-id'",
     "gatewayresponse.header.Vary": "'Origin'",
     "gatewayresponse.header.X-Request-Id": "context.requestId",
   };

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -131,6 +131,7 @@ const browserCorsAllowHeaders = [
 ] as const;
 
 const browserCorsExposeHeaders = [
+  "content-disposition",
   "x-request-id",
 ] as const;
 const dockerBundlingRepoRootPath = "/asset-repo-root";
@@ -640,7 +641,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   const restApi = new apigw.RestApi(scope, "Api", {
     restApiName: "flashcards-open-source-app-api",
     description: "Public API for flashcards mobile clients",
-    binaryMediaTypes: ["application/octet-stream", "image/jpeg", "image/png", "image/webp", "multipart/form-data"],
+    binaryMediaTypes: ["application/octet-stream", "application/zip", "image/jpeg", "image/png", "image/webp", "multipart/form-data"],
     deployOptions: {
       stageName: "v1",
       throttlingRateLimit: 50,
@@ -823,6 +824,10 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     .addResource("cards")
     .addResource("query")
     .addMethod("POST", integration);
+  const workspacePackages = workspaceById.addResource("packages");
+  const workspacePackageExport = workspacePackages.addResource("export");
+  workspacePackageExport.addMethod("POST", integration);
+  workspacePackageExport.addResource("preview").addMethod("POST", integration);
   const workspaceMediaAssets = workspaceById.addResource("media-assets");
   workspaceMediaAssets.addResource("images").addMethod("POST", integration);
   const workspaceMediaAssetUploadSessions = workspaceMediaAssets.addResource("upload-sessions");


### PR DESCRIPTION
## Summary
- Adds authenticated package export preview and ZIP download routes.
- Reuses the existing workspace package preview/export services.
- Adds OpenAPI path/schema files and keeps agent discovery aligned.
- Wires API Gateway for package export paths and `application/zip` binary responses.
- Adds focused route, discovery contract, and infra gateway test coverage.

## Validation
- `npm run test --prefix apps/backend -- workspacePackages routes system`: passed, 620/620.
- `npm run lint --prefix apps/backend`: passed.
- `npm run bundle --prefix api`: passed.
- `git --no-pager diff --check`: passed.
- Earlier fix pass also ran `npm run build --prefix infra/aws` and `node --test dist/lib/gateways/api-gateway.test.js` from `infra/aws`: passed, 12/12.

## Review
- Review gate passed for Stage 3C3.
- First review findings were fixed.
- Second review gave green light; remaining P3s were fixed and validated.
