### PR TITLE
Add ZIP import preview core

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -26,6 +26,7 @@
         "openai": "^6.44.0",
         "pg": "^8.22.0",
         "sharp": "^0.35.2",
+        "yauzl": "^3.4.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -33,6 +34,7 @@
         "@types/aws-lambda": "^8.10.162",
         "@types/node": "^24.13.2",
         "@types/pg": "^8.20.0",
+        "@types/yauzl": "^3.4.0",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
       },
@@ -2446,6 +2448,16 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3406,6 +3418,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
@@ -4031,6 +4049,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,6 +29,7 @@
     "openai": "^6.44.0",
     "pg": "^8.22.0",
     "sharp": "^0.35.2",
+    "yauzl": "^3.4.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@types/aws-lambda": "^8.10.162",
     "@types/node": "^24.13.2",
     "@types/pg": "^8.20.0",
+    "@types/yauzl": "^3.4.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
   },

--- a/apps/backend/src/workspacePackages/importPreview.test.ts
+++ b/apps/backend/src/workspacePackages/importPreview.test.ts
@@ -1,0 +1,472 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import test from "node:test";
+import { deflateRawSync } from "node:zlib";
+import { HttpError } from "../shared/errors";
+import {
+  buildSuggestedWorkspacePackageImportTag,
+  createDefaultWorkspacePackageImportTagPolicy,
+  normalizeWorkspacePackageImportTagPolicy,
+  parseWorkspacePackageCardsJsonV1,
+  previewWorkspacePackageZipImport,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardMetadataV1,
+  type WorkspacePackageCardsJsonV1,
+  type WorkspacePackageImportPreviewInput,
+} from "./index";
+
+type TestZipEntry = Readonly<{
+  path: string;
+  bytes: Buffer;
+  compressionMethod?: number;
+  uncompressedSize?: number;
+}>;
+
+type TestCentralDirectoryEntry = Readonly<{
+  pathBytes: Buffer;
+  entry: TestZipEntry;
+  localHeaderOffset: number;
+}>;
+
+const generatedAt = "2026-06-30T12:00:00.000Z";
+const zipLocalFileHeaderSignature = 0x04034b50;
+const zipCentralDirectoryHeaderSignature = 0x02014b50;
+const zipEndOfCentralDirectorySignature = 0x06054b50;
+const zipVersionNeededToExtract = 20;
+const zipStoredCompressionMethod = 0;
+const zipDeflatedCompressionMethod = 8;
+const zipDosTimeMidnight = 0;
+const zipDosDateJanuaryFirst1980 = 33;
+
+const testMetadata: WorkspacePackageCardMetadataV1 = {
+  version: 1,
+  source: null,
+};
+
+function createTestCard(
+  frontText: string,
+  backText: string,
+  tags: ReadonlyArray<string>,
+  cardType: string,
+): PortableWorkspacePackageCardV1 {
+  return {
+    frontText,
+    backText,
+    tags,
+    cardType,
+    metadata: testMetadata,
+  };
+}
+
+function createCardsJsonBuffer(cardsJson: WorkspacePackageCardsJsonV1): Buffer {
+  return Buffer.from(JSON.stringify(cardsJson), "utf8");
+}
+
+function getTestZipEntryCompressionMethod(entry: TestZipEntry): number {
+  return entry.compressionMethod ?? zipStoredCompressionMethod;
+}
+
+function getTestZipEntryUncompressedSize(entry: TestZipEntry): number {
+  return entry.uncompressedSize ?? entry.bytes.byteLength;
+}
+
+function createDeflatedZipEntry(
+  path: string,
+  uncompressedBytes: Buffer,
+  declaredUncompressedSize: number,
+): TestZipEntry {
+  return {
+    path,
+    bytes: deflateRawSync(uncompressedBytes),
+    compressionMethod: zipDeflatedCompressionMethod,
+    uncompressedSize: declaredUncompressedSize,
+  };
+}
+
+function createLocalFileHeader(pathBytes: Buffer, entry: TestZipEntry): Buffer {
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(zipLocalFileHeaderSignature, 0);
+  header.writeUInt16LE(zipVersionNeededToExtract, 4);
+  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(getTestZipEntryCompressionMethod(entry), 8);
+  header.writeUInt16LE(zipDosTimeMidnight, 10);
+  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 12);
+  header.writeUInt32LE(0, 14);
+  header.writeUInt32LE(entry.bytes.byteLength, 18);
+  header.writeUInt32LE(getTestZipEntryUncompressedSize(entry), 22);
+  header.writeUInt16LE(pathBytes.byteLength, 26);
+  header.writeUInt16LE(0, 28);
+
+  return Buffer.concat([header, pathBytes]);
+}
+
+function createCentralDirectoryHeader(entry: TestCentralDirectoryEntry): Buffer {
+  const header = Buffer.alloc(46);
+  header.writeUInt32LE(zipCentralDirectoryHeaderSignature, 0);
+  header.writeUInt16LE(zipVersionNeededToExtract, 4);
+  header.writeUInt16LE(zipVersionNeededToExtract, 6);
+  header.writeUInt16LE(0, 8);
+  header.writeUInt16LE(getTestZipEntryCompressionMethod(entry.entry), 10);
+  header.writeUInt16LE(zipDosTimeMidnight, 12);
+  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 14);
+  header.writeUInt32LE(0, 16);
+  header.writeUInt32LE(entry.entry.bytes.byteLength, 20);
+  header.writeUInt32LE(getTestZipEntryUncompressedSize(entry.entry), 24);
+  header.writeUInt16LE(entry.pathBytes.byteLength, 28);
+  header.writeUInt16LE(0, 30);
+  header.writeUInt16LE(0, 32);
+  header.writeUInt16LE(0, 34);
+  header.writeUInt16LE(0, 36);
+  header.writeUInt32LE(0, 38);
+  header.writeUInt32LE(entry.localHeaderOffset, 42);
+
+  return Buffer.concat([header, entry.pathBytes]);
+}
+
+function createEndOfCentralDirectory(
+  entryCount: number,
+  centralDirectorySize: number,
+  centralDirectoryOffset: number,
+): Buffer {
+  const header = Buffer.alloc(22);
+  header.writeUInt32LE(zipEndOfCentralDirectorySignature, 0);
+  header.writeUInt16LE(0, 4);
+  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(entryCount, 8);
+  header.writeUInt16LE(entryCount, 10);
+  header.writeUInt32LE(centralDirectorySize, 12);
+  header.writeUInt32LE(centralDirectoryOffset, 16);
+  header.writeUInt16LE(0, 20);
+
+  return header;
+}
+
+function createStoredZip(entries: ReadonlyArray<TestZipEntry>): Buffer {
+  const localFileParts: Array<Buffer> = [];
+  const centralDirectoryEntries: Array<TestCentralDirectoryEntry> = [];
+  let localHeaderOffset = 0;
+
+  for (const entry of entries) {
+    const pathBytes = Buffer.from(entry.path, "utf8");
+    const localFileHeader = createLocalFileHeader(pathBytes, entry);
+    localFileParts.push(localFileHeader, entry.bytes);
+    centralDirectoryEntries.push({
+      pathBytes,
+      entry,
+      localHeaderOffset,
+    });
+    localHeaderOffset += localFileHeader.byteLength + entry.bytes.byteLength;
+  }
+
+  const centralDirectoryOffset = localHeaderOffset;
+  const centralDirectoryParts = centralDirectoryEntries.map(createCentralDirectoryHeader);
+  const centralDirectorySize = centralDirectoryParts.reduce((totalSize, part) => totalSize + part.byteLength, 0);
+
+  return Buffer.concat([
+    ...localFileParts,
+    ...centralDirectoryParts,
+    createEndOfCentralDirectory(entries.length, centralDirectorySize, centralDirectoryOffset),
+  ]);
+}
+
+function createPackageZip(
+  cardsJson: WorkspacePackageCardsJsonV1,
+  mediaEntries: ReadonlyArray<TestZipEntry>,
+): Buffer {
+  return createStoredZip([
+    {
+      path: "cards.json",
+      bytes: createCardsJsonBuffer(cardsJson),
+    },
+    ...mediaEntries,
+  ]);
+}
+
+function createPreviewInput(
+  packageBytes: Buffer,
+  existingWorkspaceTags: ReadonlyArray<string>,
+): WorkspacePackageImportPreviewInput {
+  return {
+    packageBytes,
+    generatedAt,
+    existingWorkspaceTags,
+  };
+}
+
+async function assertImportPreviewRejects(
+  packageBytes: Buffer,
+  messagePattern: RegExp,
+): Promise<void> {
+  await assert.rejects(
+    () => previewWorkspacePackageZipImport(createPreviewInput(packageBytes, [])),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.match(error.message, messagePattern);
+      return true;
+    },
+  );
+}
+
+test("ZIP import preview accepts a valid cards.json-only package", async () => {
+  const packageBytes = createPackageZip({
+    formatVersion: 1,
+    label: "Starter deck",
+    author: "Kirill",
+    comment: "Intro cards",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    sourceUrl: "https://example.com/deck",
+    cards: [
+      createTestCard("Capital of France?", "Paris", ["geography"], "basic"),
+    ],
+  }, []);
+
+  const preview = await previewWorkspacePackageZipImport(createPreviewInput(packageBytes, [
+    "import:2026-06-30-0",
+  ]));
+
+  assert.deepEqual(preview, {
+    sourceKind: "zip",
+    packageMetadata: {
+      label: "Starter deck",
+      author: "Kirill",
+      comment: "Intro cards",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      sourceUrl: "https://example.com/deck",
+    },
+    cardCount: 1,
+    tagCounts: [
+      { tag: "geography", cardsCount: 1 },
+    ],
+    referencedMediaCount: 0,
+    packageMediaFileCount: 0,
+    warnings: [],
+    defaultOptions: {
+      addImportTag: true,
+      suggestedImportTag: "import:2026-06-30-1",
+      keptTags: ["geography"],
+      removedTags: [],
+    },
+  });
+});
+
+test("ZIP import preview validates package media references and media entries", async () => {
+  const compressedImageBytes = Buffer.from("png bytes", "utf8");
+  const packageBytes = createPackageZip({
+    formatVersion: 1,
+    cards: [
+      createTestCard(
+        "Diagram: ![cell](media/images/cell.png)",
+        "Reference: [notes](media/docs/notes.pdf)",
+        ["biology"],
+        "basic",
+      ),
+    ],
+  }, [
+    createDeflatedZipEntry("media/images/cell.png", compressedImageBytes, compressedImageBytes.byteLength),
+    { path: "media/docs/notes.pdf", bytes: Buffer.from("pdf bytes", "utf8") },
+    { path: "media/unused/extra.png", bytes: Buffer.from("unused bytes", "utf8") },
+  ]);
+
+  const preview = await previewWorkspacePackageZipImport(createPreviewInput(packageBytes, []));
+
+  assert.equal(preview.referencedMediaCount, 2);
+  assert.equal(preview.packageMediaFileCount, 3);
+  assert.deepEqual(preview.warnings, [
+    {
+      code: "WORKSPACE_PACKAGE_IMPORT_MEDIA_TYPE_UNSUPPORTED",
+      message: "Referenced package media may not be supported by the import confirmation flow.",
+      mediaPath: "media/docs/notes.pdf",
+    },
+  ]);
+});
+
+test("ZIP import preview drains compressed media entries before accepting size metadata", async () => {
+  await assertImportPreviewRejects(
+    createPackageZip({
+      formatVersion: 1,
+      cards: [
+        createTestCard("Prompt", "![media](media/bomb.bin)", ["tag"], "basic"),
+      ],
+    }, [
+      createDeflatedZipEntry("media/bomb.bin", Buffer.alloc(128, 1), 1),
+    ]),
+    /media entry cannot be read/,
+  );
+});
+
+test("ZIP import preview keeps external media URLs external", async () => {
+  const packageBytes = createPackageZip({
+    formatVersion: 1,
+    cards: [
+      createTestCard(
+        "Remote image: ![remote](https://example.com/image.png)",
+        "Remote link: [file](https://example.com/media/file.png)",
+        ["external"],
+        "basic",
+      ),
+    ],
+  }, []);
+
+  const preview = await previewWorkspacePackageZipImport(createPreviewInput(packageBytes, []));
+
+  assert.equal(preview.referencedMediaCount, 0);
+  assert.equal(preview.packageMediaFileCount, 0);
+  assert.deepEqual(preview.warnings, []);
+});
+
+test("ZIP import preview rejects missing cards.json", async () => {
+  await assertImportPreviewRejects(
+    createStoredZip([
+      { path: "media/image.png", bytes: Buffer.from("image", "utf8") },
+    ]),
+    /exactly one cards\.json/,
+  );
+});
+
+test("ZIP import preview rejects malformed cards.json", async () => {
+  await assertImportPreviewRejects(
+    createStoredZip([
+      { path: "cards.json", bytes: Buffer.from("{", "utf8") },
+    ]),
+    /malformed JSON/,
+  );
+});
+
+test("ZIP import preview rejects unsafe media paths", async () => {
+  for (const unsafeMediaPath of [
+    "media/../image.png",
+    "/media/image.png",
+    "media\\image.png",
+    "media//image.png",
+  ]) {
+    await assertImportPreviewRejects(
+      createPackageZip({
+        formatVersion: 1,
+        cards: [
+          createTestCard("Prompt", "Answer", ["tag"], "basic"),
+        ],
+      }, [
+        { path: unsafeMediaPath, bytes: Buffer.from("image", "utf8") },
+      ]),
+      /unsafe|invalid|absolute|unsupported/,
+    );
+  }
+});
+
+test("ZIP import preview rejects unsafe markdown media references as package input errors", async () => {
+  for (const unsafeMarkdownMediaReference of [
+    "media/../image.png",
+    "/media/image.png",
+    "media\\image.png",
+    "./media/image.png",
+    "../media/image.png",
+    "../../media/image.png",
+  ]) {
+    await assertImportPreviewRejects(
+      createPackageZip({
+        formatVersion: 1,
+        cards: [
+          createTestCard("Prompt", `![image](${unsafeMarkdownMediaReference})`, ["tag"], "basic"),
+        ],
+      }, [
+        { path: "media/image.png", bytes: Buffer.from("image", "utf8") },
+      ]),
+      /unsafe media references/,
+    );
+  }
+});
+
+test("ZIP import preview rejects duplicate media paths case-insensitively", async () => {
+  await assertImportPreviewRejects(
+    createPackageZip({
+      formatVersion: 1,
+      cards: [
+        createTestCard("Prompt", "![image](media/Image.png)", ["tag"], "basic"),
+      ],
+    }, [
+      { path: "media/Image.png", bytes: Buffer.from("image a", "utf8") },
+      { path: "media/image.png", bytes: Buffer.from("image b", "utf8") },
+    ]),
+    /duplicated/,
+  );
+});
+
+test("ZIP import preview rejects missing referenced media files", async () => {
+  await assertImportPreviewRejects(
+    createPackageZip({
+      formatVersion: 1,
+      cards: [
+        createTestCard("Prompt", "![image](media/image.png)", ["tag"], "basic"),
+      ],
+    }, []),
+    /missing from ZIP/,
+  );
+});
+
+test("ZIP import preview suggests the first available import tag suffix", () => {
+  assert.equal(
+    buildSuggestedWorkspacePackageImportTag(generatedAt, [
+      "import:2026-06-30-0",
+      "import:2026-06-30-1",
+      "import:2026-06-30-3",
+    ]),
+    "import:2026-06-30-2",
+  );
+});
+
+test("ZIP import preview returns tag counts and default keep-all options", async () => {
+  const packageBytes = createPackageZip({
+    formatVersion: 1,
+    cards: [
+      createTestCard("A", "A answer", ["shared", "science"], "basic"),
+      createTestCard("B", "B answer", ["shared", "draft"], "basic"),
+    ],
+  }, []);
+
+  const preview = await previewWorkspacePackageZipImport(createPreviewInput(packageBytes, []));
+
+  assert.deepEqual(preview.tagCounts, [
+    { tag: "shared", cardsCount: 2 },
+    { tag: "draft", cardsCount: 1 },
+    { tag: "science", cardsCount: 1 },
+  ]);
+  assert.deepEqual(preview.defaultOptions, {
+    addImportTag: true,
+    suggestedImportTag: "import:2026-06-30-0",
+    keptTags: ["shared", "draft", "science"],
+    removedTags: [],
+  });
+  assert.deepEqual(createDefaultWorkspacePackageImportTagPolicy(["shared", "draft"]), {
+    keptTags: ["shared", "draft"],
+    removedTags: [],
+  });
+  assert.deepEqual(
+    normalizeWorkspacePackageImportTagPolicy({ removedTags: ["draft"] }, ["shared", "draft"]),
+    {
+      keptTags: ["shared"],
+      removedTags: ["draft"],
+    },
+  );
+  assert.throws(
+    () => normalizeWorkspacePackageImportTagPolicy({ removedTags: ["missing"] }, ["shared"]),
+    /exact package tag values/,
+  );
+});
+
+test("ZIP import preview accepts unknown cardType through the existing parser", async () => {
+  const cardsJson: WorkspacePackageCardsJsonV1 = {
+    formatVersion: 1,
+    cards: [
+      createTestCard("Prompt", "Answer", ["tag"], "custom-cloze"),
+    ],
+  };
+  const parsedCardsJson = parseWorkspacePackageCardsJsonV1(JSON.parse(createCardsJsonBuffer(cardsJson).toString("utf8")));
+  assert.equal(parsedCardsJson.cards[0]?.cardType, "custom-cloze");
+
+  const preview = await previewWorkspacePackageZipImport(createPreviewInput(
+    createPackageZip(cardsJson, []),
+    [],
+  ));
+
+  assert.equal(preview.cardCount, 1);
+});

--- a/apps/backend/src/workspacePackages/importPreview.ts
+++ b/apps/backend/src/workspacePackages/importPreview.ts
@@ -1,0 +1,736 @@
+import { Buffer } from "node:buffer";
+import type { Readable } from "node:stream";
+import {
+  fromBufferPromise,
+  type Entry as ZipEntry,
+  type ZipFile,
+} from "yauzl";
+import { HttpError } from "../shared/errors";
+import {
+  extractMarkdownPortableMediaPaths,
+  validatePortableMediaPath,
+  validateUniquePortableMediaPaths,
+} from "./markdownMedia";
+import {
+  parseWorkspacePackageCardsJsonV1,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardsJsonV1,
+} from "./types";
+
+export const workspacePackageImportPreviewDefaultMaxZipBytes = 80 * 1024 * 1024;
+export const workspacePackageImportPreviewDefaultMaxEntries = 10_001;
+export const workspacePackageImportPreviewDefaultMaxCards = 5_000;
+export const workspacePackageImportPreviewDefaultMaxMediaFiles = 10_000;
+export const workspacePackageImportPreviewDefaultMaxSingleMediaBytes = 16 * 1024 * 1024;
+export const workspacePackageImportPreviewDefaultMaxTotalMediaBytes = 64 * 1024 * 1024;
+
+export type WorkspacePackageImportPreviewInput = Readonly<{
+  packageBytes: Buffer | Uint8Array;
+  generatedAt: string;
+  existingWorkspaceTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageImportPreviewLimits = Readonly<{
+  maxZipBytes: number;
+  maxEntries: number;
+  maxCards: number;
+  maxMediaFiles: number;
+  maxSingleMediaBytes: number;
+  maxTotalMediaBytes: number;
+}>;
+
+export type WorkspacePackageImportPreviewMetadata = Readonly<{
+  label: string | null;
+  author: string | null;
+  comment: string | null;
+  createdAt: string | null;
+  sourceUrl: string | null;
+}>;
+
+export type WorkspacePackageImportPreviewTagCount = Readonly<{
+  tag: string;
+  cardsCount: number;
+}>;
+
+export type WorkspacePackageImportPreviewWarning = Readonly<{
+  code: string;
+  message: string;
+  mediaPath: string;
+}>;
+
+export type WorkspacePackageImportTagPolicyInput = Readonly<{
+  removedTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageImportTagPolicy = Readonly<{
+  keptTags: ReadonlyArray<string>;
+  removedTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageImportDefaultOptions = WorkspacePackageImportTagPolicy & Readonly<{
+  addImportTag: boolean;
+  suggestedImportTag: string;
+}>;
+
+export type WorkspacePackageImportPreview = Readonly<{
+  sourceKind: "zip";
+  packageMetadata: WorkspacePackageImportPreviewMetadata;
+  cardCount: number;
+  tagCounts: ReadonlyArray<WorkspacePackageImportPreviewTagCount>;
+  referencedMediaCount: number;
+  packageMediaFileCount: number;
+  warnings: ReadonlyArray<WorkspacePackageImportPreviewWarning>;
+  defaultOptions: WorkspacePackageImportDefaultOptions;
+}>;
+
+type CollectedWorkspacePackageZip = Readonly<{
+  cardsJsonBytes: Buffer | null;
+  cardsJsonEntryCount: number;
+  mediaEntriesByPath: ReadonlyMap<string, ZipEntry>;
+  mediaPaths: ReadonlyArray<string>;
+}>;
+
+const supportedPreviewImageExtensions = new Set([
+  "avif",
+  "gif",
+  "jpeg",
+  "jpg",
+  "png",
+  "svg",
+  "webp",
+]);
+
+const defaultImportPreviewLimits: WorkspacePackageImportPreviewLimits = {
+  maxZipBytes: workspacePackageImportPreviewDefaultMaxZipBytes,
+  maxEntries: workspacePackageImportPreviewDefaultMaxEntries,
+  maxCards: workspacePackageImportPreviewDefaultMaxCards,
+  maxMediaFiles: workspacePackageImportPreviewDefaultMaxMediaFiles,
+  maxSingleMediaBytes: workspacePackageImportPreviewDefaultMaxSingleMediaBytes,
+  maxTotalMediaBytes: workspacePackageImportPreviewDefaultMaxTotalMediaBytes,
+};
+
+function createImportPreviewInputError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_INPUT_INVALID");
+}
+
+function createImportPreviewZipInvalidError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID");
+}
+
+function createImportPreviewCardsJsonMalformedError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_MALFORMED");
+}
+
+function createImportPreviewCardsJsonInvalidError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_INVALID");
+}
+
+function createImportPreviewTooLargeError(message: string): HttpError {
+  return new HttpError(413, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_TOO_LARGE");
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeNonEmptyText(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (normalizedValue === "") {
+    throw createImportPreviewInputError(`${fieldName} must not be empty`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeIsoTimestamp(value: string, fieldName: string): string {
+  const normalizedValue = normalizeNonEmptyText(value, fieldName);
+  const parsedValue = new Date(normalizedValue);
+  if (Number.isNaN(parsedValue.getTime())) {
+    throw createImportPreviewInputError(`${fieldName} must be a valid ISO timestamp`);
+  }
+
+  return parsedValue.toISOString();
+}
+
+function normalizeUniqueTextValues(
+  values: ReadonlyArray<string>,
+  fieldName: string,
+): ReadonlyArray<string> {
+  const normalizedValues: Array<string> = [];
+  const existingValues = new Set<string>();
+
+  values.forEach((value, index) => {
+    const normalizedValue = normalizeNonEmptyText(value, `${fieldName}[${index}]`);
+    if (existingValues.has(normalizedValue)) {
+      throw createImportPreviewInputError(`${fieldName} must not contain duplicates`);
+    }
+
+    existingValues.add(normalizedValue);
+    normalizedValues.push(normalizedValue);
+  });
+
+  return normalizedValues;
+}
+
+function assertPositiveSafeInteger(value: number, fieldName: string): void {
+  if (
+    Number.isSafeInteger(value) === false
+    || value < 1
+    || value >= Number.MAX_SAFE_INTEGER
+  ) {
+    throw createImportPreviewInputError(`${fieldName} must be a positive safe integer`);
+  }
+}
+
+function normalizePreviewLimits(
+  limits: WorkspacePackageImportPreviewLimits,
+): WorkspacePackageImportPreviewLimits {
+  assertPositiveSafeInteger(limits.maxZipBytes, "limits.maxZipBytes");
+  assertPositiveSafeInteger(limits.maxEntries, "limits.maxEntries");
+  assertPositiveSafeInteger(limits.maxCards, "limits.maxCards");
+  assertPositiveSafeInteger(limits.maxMediaFiles, "limits.maxMediaFiles");
+  assertPositiveSafeInteger(limits.maxSingleMediaBytes, "limits.maxSingleMediaBytes");
+  assertPositiveSafeInteger(limits.maxTotalMediaBytes, "limits.maxTotalMediaBytes");
+
+  return limits;
+}
+
+function normalizePackageBytes(packageBytes: Buffer | Uint8Array, maxZipBytes: number): Buffer {
+  const bytes = Buffer.from(packageBytes);
+  if (bytes.byteLength > maxZipBytes) {
+    throw createImportPreviewTooLargeError(
+      `Workspace package ZIP is too large. zipBytes=${bytes.byteLength} maxZipBytes=${maxZipBytes}`,
+    );
+  }
+
+  return bytes;
+}
+
+function assertZipEntryDataCanBeDecoded(entry: ZipEntry, entryPath: string): void {
+  if (entry.canDecodeFileData()) {
+    return;
+  }
+
+  throw createImportPreviewZipInvalidError(
+    [
+      "Workspace package ZIP entry uses unsupported compression or encryption.",
+      `entryPath=${entryPath}`,
+      `compressionMethod=${entry.compressionMethod}`,
+      `encrypted=${entry.isEncrypted()}`,
+    ].join(" "),
+  );
+}
+
+function normalizeZipEntryPath(entryPath: string): string {
+  if (entryPath === "") {
+    throw createImportPreviewZipInvalidError("Workspace package ZIP entry path must not be empty");
+  }
+
+  if (entryPath.includes("\\") || entryPath.includes("\0")) {
+    throw createImportPreviewZipInvalidError(`Workspace package ZIP entry path is unsafe. entryPath=${entryPath}`);
+  }
+
+  if (entryPath === "cards.json") {
+    return entryPath;
+  }
+
+  if (entryPath.startsWith("media/")) {
+    try {
+      return validatePortableMediaPath(entryPath);
+    } catch (error) {
+      throw createImportPreviewZipInvalidError(
+        `Workspace package ZIP contains unsafe media path. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  throw createImportPreviewZipInvalidError(
+    `Workspace package ZIP contains unsupported entry. entryPath=${entryPath}. Only cards.json and media/** are supported.`,
+  );
+}
+
+async function openZipFile(bytes: Buffer): Promise<ZipFile> {
+  try {
+    return await fromBufferPromise(bytes, {
+      lazyEntries: true,
+      decodeStrings: true,
+      validateEntrySizes: true,
+      strictFileNames: true,
+    });
+  } catch (error) {
+    throw createImportPreviewZipInvalidError(`Workspace package ZIP is invalid. reason=${getErrorMessage(error)}`);
+  }
+}
+
+async function readZipEntryBytes(
+  zipFile: ZipFile,
+  entry: ZipEntry,
+  maxBytes: number,
+): Promise<Buffer> {
+  let stream: Readable;
+  try {
+    stream = await zipFile.openReadStreamPromise(entry);
+  } catch (error) {
+    throw createImportPreviewZipInvalidError(
+      `Workspace package ZIP entry cannot be read. entryPath=${entry.fileName} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  const chunks: Array<Buffer> = [];
+  let totalBytes = 0;
+
+  try {
+    for await (const chunk of stream) {
+      const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += chunkBuffer.byteLength;
+      if (totalBytes > maxBytes) {
+        throw createImportPreviewTooLargeError(
+          `Workspace package ZIP entry is too large. entryPath=${entry.fileName} bytes=${totalBytes} maxBytes=${maxBytes}`,
+        );
+      }
+
+      chunks.push(chunkBuffer);
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    throw createImportPreviewZipInvalidError(
+      `Workspace package ZIP entry cannot be read. entryPath=${entry.fileName} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  return Buffer.concat(chunks, totalBytes);
+}
+
+function assertEntryCountWithinLimit(entryCount: number, maxEntries: number): void {
+  if (entryCount <= maxEntries) {
+    return;
+  }
+
+  throw createImportPreviewTooLargeError(
+    `Workspace package ZIP contains too many entries. entryCount=${entryCount} maxEntries=${maxEntries}`,
+  );
+}
+
+function getReadableChunkByteLength(chunk: unknown): number {
+  if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+    return chunk.byteLength;
+  }
+
+  if (typeof chunk === "string") {
+    return Buffer.byteLength(chunk);
+  }
+
+  throw new Error("ZIP entry stream emitted an unsupported chunk type");
+}
+
+function assertMediaEntryWithinLimit(
+  mediaBytes: number,
+  entryPath: string,
+  maxSingleMediaBytes: number,
+): void {
+  if (mediaBytes > maxSingleMediaBytes) {
+    throw createImportPreviewTooLargeError(
+      [
+        "Workspace package ZIP media entry is too large.",
+        `entryPath=${entryPath}`,
+        `mediaBytes=${mediaBytes}`,
+        `maxSingleMediaBytes=${maxSingleMediaBytes}`,
+      ].join(" "),
+    );
+  }
+}
+
+function assertMediaFileCountWithinLimit(mediaFileCount: number, maxMediaFiles: number): void {
+  if (mediaFileCount > maxMediaFiles) {
+    throw createImportPreviewTooLargeError(
+      `Workspace package ZIP contains too many media files. mediaFileCount=${mediaFileCount} maxMediaFiles=${maxMediaFiles}`,
+    );
+  }
+}
+
+function assertTotalMediaBytesWithinLimit(totalMediaBytes: number, maxTotalMediaBytes: number): void {
+  if (Number.isSafeInteger(totalMediaBytes) === false) {
+    throw new Error("Workspace package ZIP media byte total must be a safe integer");
+  }
+
+  if (totalMediaBytes > maxTotalMediaBytes) {
+    throw createImportPreviewTooLargeError(
+      [
+        "Workspace package ZIP media total is too large.",
+        `totalMediaBytes=${totalMediaBytes}`,
+        `maxTotalMediaBytes=${maxTotalMediaBytes}`,
+      ].join(" "),
+    );
+  }
+}
+
+async function drainMediaZipEntryBytes(
+  zipFile: ZipFile,
+  entry: ZipEntry,
+  entryPath: string,
+  currentTotalMediaBytes: number,
+  limits: WorkspacePackageImportPreviewLimits,
+): Promise<number> {
+  let stream: Readable;
+  try {
+    stream = await zipFile.openReadStreamPromise(entry);
+  } catch (error) {
+    throw createImportPreviewZipInvalidError(
+      `Workspace package ZIP media entry cannot be read. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  let mediaBytes = 0;
+  let totalMediaBytes = currentTotalMediaBytes;
+
+  try {
+    for await (const chunk of stream) {
+      const chunkByteLength = getReadableChunkByteLength(chunk);
+      mediaBytes += chunkByteLength;
+      if (Number.isSafeInteger(mediaBytes) === false) {
+        throw new Error(`Workspace package ZIP media entry byte count must be a safe integer. entryPath=${entryPath}`);
+      }
+
+      assertMediaEntryWithinLimit(mediaBytes, entryPath, limits.maxSingleMediaBytes);
+      totalMediaBytes += chunkByteLength;
+      assertTotalMediaBytesWithinLimit(totalMediaBytes, limits.maxTotalMediaBytes);
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    throw createImportPreviewZipInvalidError(
+      `Workspace package ZIP media entry cannot be read. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  return totalMediaBytes;
+}
+
+async function collectWorkspacePackageZipEntries(
+  zipFile: ZipFile,
+  limits: WorkspacePackageImportPreviewLimits,
+): Promise<CollectedWorkspacePackageZip> {
+  assertEntryCountWithinLimit(zipFile.entryCount, limits.maxEntries);
+
+  let cardsJsonBytes: Buffer | null = null;
+  let cardsJsonEntryCount = 0;
+  const mediaEntriesByPath = new Map<string, ZipEntry>();
+  const mediaPaths: Array<string> = [];
+  let totalMediaBytes = 0;
+
+  try {
+    for await (const entry of zipFile.eachEntry()) {
+      const entryPath = normalizeZipEntryPath(entry.fileName);
+      assertZipEntryDataCanBeDecoded(entry, entryPath);
+
+      if (entryPath === "cards.json") {
+        cardsJsonEntryCount += 1;
+        cardsJsonBytes = await readZipEntryBytes(zipFile, entry, limits.maxZipBytes);
+        continue;
+      }
+
+      assertMediaFileCountWithinLimit(mediaPaths.length + 1, limits.maxMediaFiles);
+      totalMediaBytes = await drainMediaZipEntryBytes(zipFile, entry, entryPath, totalMediaBytes, limits);
+      mediaEntriesByPath.set(entryPath, entry);
+      mediaPaths.push(entryPath);
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    throw createImportPreviewZipInvalidError(`Workspace package ZIP is invalid. reason=${getErrorMessage(error)}`);
+  }
+
+  if (cardsJsonEntryCount !== 1) {
+    throw createImportPreviewZipInvalidError(
+      `Workspace package ZIP must contain exactly one cards.json entry. cardsJsonEntryCount=${cardsJsonEntryCount}`,
+    );
+  }
+
+  try {
+    validateUniquePortableMediaPaths(mediaPaths);
+  } catch (error) {
+    throw createImportPreviewZipInvalidError(
+      `Workspace package ZIP contains duplicate or unsafe media paths. reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  return {
+    cardsJsonBytes,
+    cardsJsonEntryCount,
+    mediaEntriesByPath,
+    mediaPaths,
+  };
+}
+
+function parseCardsJsonBytes(cardsJsonBytes: Buffer): WorkspacePackageCardsJsonV1 {
+  let cardsJsonValue: unknown;
+  try {
+    cardsJsonValue = JSON.parse(cardsJsonBytes.toString("utf8"));
+  } catch (error) {
+    throw createImportPreviewCardsJsonMalformedError(
+      `Workspace package cards.json is malformed JSON. reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  try {
+    return parseWorkspacePackageCardsJsonV1(cardsJsonValue);
+  } catch (error) {
+    throw createImportPreviewCardsJsonInvalidError(
+      `Workspace package cards.json is invalid. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+function assertCardCountWithinLimit(cardCount: number, maxCards: number): void {
+  if (cardCount <= maxCards) {
+    return;
+  }
+
+  throw createImportPreviewTooLargeError(
+    `Workspace package cards.json contains too many cards. cardCount=${cardCount} maxCards=${maxCards}`,
+  );
+}
+
+function toPackageMetadataPreview(cardsJson: WorkspacePackageCardsJsonV1): WorkspacePackageImportPreviewMetadata {
+  return {
+    label: cardsJson.label ?? null,
+    author: cardsJson.author ?? null,
+    comment: cardsJson.comment ?? null,
+    createdAt: cardsJson.createdAt ?? null,
+    sourceUrl: cardsJson.sourceUrl ?? null,
+  };
+}
+
+function compareTagCounts(
+  left: WorkspacePackageImportPreviewTagCount,
+  right: WorkspacePackageImportPreviewTagCount,
+): number {
+  const countDifference = right.cardsCount - left.cardsCount;
+  if (countDifference !== 0) {
+    return countDifference;
+  }
+
+  const normalizedTagDifference = left.tag.toLowerCase().localeCompare(right.tag.toLowerCase());
+  if (normalizedTagDifference !== 0) {
+    return normalizedTagDifference;
+  }
+
+  return left.tag.localeCompare(right.tag);
+}
+
+function buildImportPreviewTagCounts(
+  cards: ReadonlyArray<PortableWorkspacePackageCardV1>,
+): ReadonlyArray<WorkspacePackageImportPreviewTagCount> {
+  const tagCounts = new Map<string, number>();
+
+  for (const card of cards) {
+    for (const tag of card.tags) {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return [...tagCounts.entries()]
+    .map(([tag, cardsCount]) => ({ tag, cardsCount }))
+    .sort(compareTagCounts);
+}
+
+function getPackageTagValues(
+  tagCounts: ReadonlyArray<WorkspacePackageImportPreviewTagCount>,
+): ReadonlyArray<string> {
+  return tagCounts.map((tagCount) => tagCount.tag);
+}
+
+function extractCardMarkdownPortableMediaPaths(markdown: string): ReadonlyArray<string> {
+  try {
+    return extractMarkdownPortableMediaPaths(markdown);
+  } catch (error) {
+    throw createImportPreviewCardsJsonInvalidError(
+      `Workspace package cards.json contains unsafe media references. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+function extractReferencedPortableMediaPaths(
+  cards: ReadonlyArray<PortableWorkspacePackageCardV1>,
+): ReadonlyArray<string> {
+  const referencedMediaPaths = new Set<string>();
+
+  for (const card of cards) {
+    for (const mediaPath of extractCardMarkdownPortableMediaPaths(card.frontText)) {
+      referencedMediaPaths.add(mediaPath);
+    }
+
+    for (const mediaPath of extractCardMarkdownPortableMediaPaths(card.backText)) {
+      referencedMediaPaths.add(mediaPath);
+    }
+  }
+
+  try {
+    return validateUniquePortableMediaPaths([...referencedMediaPaths]);
+  } catch (error) {
+    throw createImportPreviewCardsJsonInvalidError(
+      `Workspace package cards.json contains duplicate or unsafe media references. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+function assertReferencedMediaFilesExist(
+  referencedMediaPaths: ReadonlyArray<string>,
+  mediaEntriesByPath: ReadonlyMap<string, ZipEntry>,
+): void {
+  const missingMediaPaths = referencedMediaPaths.filter((mediaPath) => mediaEntriesByPath.has(mediaPath) === false);
+  if (missingMediaPaths.length === 0) {
+    return;
+  }
+
+  throw createImportPreviewZipInvalidError(
+    `Workspace package cards.json references media files missing from ZIP. missingMediaPaths=${missingMediaPaths.join(",")}`,
+  );
+}
+
+function getLowercaseFileExtension(mediaPath: string): string | null {
+  const fileName = mediaPath.slice(mediaPath.lastIndexOf("/") + 1);
+  const extensionSeparatorIndex = fileName.lastIndexOf(".");
+  if (extensionSeparatorIndex === -1 || extensionSeparatorIndex === fileName.length - 1) {
+    return null;
+  }
+
+  return fileName.slice(extensionSeparatorIndex + 1).toLowerCase();
+}
+
+function buildUnsupportedMediaWarnings(
+  referencedMediaPaths: ReadonlyArray<string>,
+): ReadonlyArray<WorkspacePackageImportPreviewWarning> {
+  return referencedMediaPaths
+    .filter((mediaPath) => {
+      const extension = getLowercaseFileExtension(mediaPath);
+      return extension === null || supportedPreviewImageExtensions.has(extension) === false;
+    })
+    .map((mediaPath) => ({
+      code: "WORKSPACE_PACKAGE_IMPORT_MEDIA_TYPE_UNSUPPORTED",
+      message: "Referenced package media may not be supported by the import confirmation flow.",
+      mediaPath,
+    }));
+}
+
+export function buildSuggestedWorkspacePackageImportTag(
+  generatedAt: string,
+  existingWorkspaceTags: ReadonlyArray<string>,
+): string {
+  const normalizedGeneratedAt = normalizeIsoTimestamp(generatedAt, "generatedAt");
+  const normalizedExistingTags = normalizeUniqueTextValues(existingWorkspaceTags, "existingWorkspaceTags");
+  const existingTags = new Set(normalizedExistingTags);
+  const importDate = normalizedGeneratedAt.slice(0, 10);
+  let suffix = 0;
+  let suggestedImportTag = `import:${importDate}-${suffix}`;
+
+  while (existingTags.has(suggestedImportTag)) {
+    suffix += 1;
+    suggestedImportTag = `import:${importDate}-${suffix}`;
+  }
+
+  return suggestedImportTag;
+}
+
+export function normalizeWorkspacePackageImportTagPolicy(
+  tagPolicy: WorkspacePackageImportTagPolicyInput,
+  packageTags: ReadonlyArray<string>,
+): WorkspacePackageImportTagPolicy {
+  const normalizedPackageTags = normalizeUniqueTextValues(packageTags, "packageTags");
+  const packageTagSet = new Set(normalizedPackageTags);
+  const removedTags = normalizeUniqueTextValues(tagPolicy.removedTags, "tagPolicy.removedTags");
+  const unknownRemovedTags = removedTags.filter((tag) => packageTagSet.has(tag) === false);
+  if (unknownRemovedTags.length !== 0) {
+    throw createImportPreviewInputError(
+      `tagPolicy.removedTags must contain only exact package tag values. unknownTags=${unknownRemovedTags.join(",")}`,
+    );
+  }
+
+  const removedTagSet = new Set(removedTags);
+  return {
+    keptTags: normalizedPackageTags.filter((tag) => removedTagSet.has(tag) === false),
+    removedTags,
+  };
+}
+
+export function createDefaultWorkspacePackageImportTagPolicy(
+  packageTags: ReadonlyArray<string>,
+): WorkspacePackageImportTagPolicy {
+  return normalizeWorkspacePackageImportTagPolicy({ removedTags: [] }, packageTags);
+}
+
+function buildDefaultImportOptions(
+  tagCounts: ReadonlyArray<WorkspacePackageImportPreviewTagCount>,
+  suggestedImportTag: string,
+): WorkspacePackageImportDefaultOptions {
+  const packageTags = getPackageTagValues(tagCounts);
+  const tagPolicy = createDefaultWorkspacePackageImportTagPolicy(packageTags);
+
+  return {
+    addImportTag: true,
+    suggestedImportTag,
+    keptTags: tagPolicy.keptTags,
+    removedTags: tagPolicy.removedTags,
+  };
+}
+
+export async function previewWorkspacePackageZipImportWithLimits(
+  input: WorkspacePackageImportPreviewInput,
+  limits: WorkspacePackageImportPreviewLimits,
+): Promise<WorkspacePackageImportPreview> {
+  const normalizedLimits = normalizePreviewLimits(limits);
+  const suggestedImportTag = buildSuggestedWorkspacePackageImportTag(
+    input.generatedAt,
+    input.existingWorkspaceTags,
+  );
+  const packageBytes = normalizePackageBytes(input.packageBytes, normalizedLimits.maxZipBytes);
+  const zipFile = await openZipFile(packageBytes);
+
+  let collectedZip: CollectedWorkspacePackageZip;
+  try {
+    collectedZip = await collectWorkspacePackageZipEntries(zipFile, normalizedLimits);
+  } finally {
+    if (zipFile.isOpen) {
+      zipFile.close();
+    }
+  }
+
+  if (collectedZip.cardsJsonBytes === null) {
+    throw createImportPreviewZipInvalidError(
+      `Workspace package ZIP must contain exactly one cards.json entry. cardsJsonEntryCount=${collectedZip.cardsJsonEntryCount}`,
+    );
+  }
+
+  const cardsJson = parseCardsJsonBytes(collectedZip.cardsJsonBytes);
+  assertCardCountWithinLimit(cardsJson.cards.length, normalizedLimits.maxCards);
+  const tagCounts = buildImportPreviewTagCounts(cardsJson.cards);
+  const referencedMediaPaths = extractReferencedPortableMediaPaths(cardsJson.cards);
+  assertReferencedMediaFilesExist(referencedMediaPaths, collectedZip.mediaEntriesByPath);
+
+  return {
+    sourceKind: "zip",
+    packageMetadata: toPackageMetadataPreview(cardsJson),
+    cardCount: cardsJson.cards.length,
+    tagCounts,
+    referencedMediaCount: referencedMediaPaths.length,
+    packageMediaFileCount: collectedZip.mediaPaths.length,
+    warnings: buildUnsupportedMediaWarnings(referencedMediaPaths),
+    defaultOptions: buildDefaultImportOptions(
+      tagCounts,
+      suggestedImportTag,
+    ),
+  };
+}
+
+export async function previewWorkspacePackageZipImport(
+  input: WorkspacePackageImportPreviewInput,
+): Promise<WorkspacePackageImportPreview> {
+  return previewWorkspacePackageZipImportWithLimits(input, defaultImportPreviewLimits);
+}

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -1,5 +1,6 @@
 export {
   extractMarkdownFcAssetIds,
+  extractMarkdownPortableMediaPaths,
   rewriteMarkdownFcAssetUrlsToPortablePaths,
   rewriteMarkdownFcAssetUrlsToPortablePathsFromMap,
   rewriteMarkdownFcAssetUrlsToSharedPortablePaths,
@@ -27,6 +28,20 @@ export {
   workspacePackageExportPackageDefaultMaxTotalMediaBytes,
 } from "./exportPackage";
 
+export {
+  buildSuggestedWorkspacePackageImportTag,
+  createDefaultWorkspacePackageImportTagPolicy,
+  normalizeWorkspacePackageImportTagPolicy,
+  previewWorkspacePackageZipImport,
+  previewWorkspacePackageZipImportWithLimits,
+  workspacePackageImportPreviewDefaultMaxCards,
+  workspacePackageImportPreviewDefaultMaxEntries,
+  workspacePackageImportPreviewDefaultMaxMediaFiles,
+  workspacePackageImportPreviewDefaultMaxSingleMediaBytes,
+  workspacePackageImportPreviewDefaultMaxTotalMediaBytes,
+  workspacePackageImportPreviewDefaultMaxZipBytes,
+} from "./importPreview";
+
 export type {
   WorkspacePackageExportCardSelection,
   WorkspacePackageExportMetadataInput,
@@ -42,6 +57,18 @@ export type {
   WorkspacePackageExportPackageInput,
   WorkspacePackageExportPackageLimits,
 } from "./exportPackage";
+
+export type {
+  WorkspacePackageImportDefaultOptions,
+  WorkspacePackageImportPreview,
+  WorkspacePackageImportPreviewInput,
+  WorkspacePackageImportPreviewLimits,
+  WorkspacePackageImportPreviewMetadata,
+  WorkspacePackageImportPreviewTagCount,
+  WorkspacePackageImportPreviewWarning,
+  WorkspacePackageImportTagPolicy,
+  WorkspacePackageImportTagPolicyInput,
+} from "./importPreview";
 
 export {
   normalizeWorkspacePackageCardMetadataV1,

--- a/apps/backend/src/workspacePackages/markdownMedia.ts
+++ b/apps/backend/src/workspacePackages/markdownMedia.ts
@@ -22,6 +22,7 @@ export type PortableMediaAssetIdResolver = (portableMediaPath: string) => string
 
 const fcAssetUrlPattern = /^fcasset:([A-Za-z0-9][A-Za-z0-9._-]*)$/;
 const absoluteUrlPattern = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const localMediaPathWithLeadingDotSegmentsPattern = /^(?:\.\.?[\\/])+media(?:[\\/]|$)/;
 const portableMediaPathSegmentPattern = /^[A-Za-z0-9._-]+$/;
 
 function matchFcAssetId(url: string): string | null {
@@ -384,7 +385,19 @@ function getPortableMediaPathDuplicateKey(portableMediaPath: string): string {
 }
 
 function isPortableMediaPathCandidate(url: string): boolean {
-  return url === "media" || url.startsWith("media/");
+  if (absoluteUrlPattern.test(url)) {
+    return false;
+  }
+
+  return (
+    url === "media"
+    || url.startsWith("media/")
+    || url === "/media"
+    || url.startsWith("/media/")
+    || url.startsWith("/media\\")
+    || url.startsWith("media\\")
+    || localMediaPathWithLeadingDotSegmentsPattern.test(url)
+  );
 }
 
 export function validatePortableMediaPath(portableMediaPath: string): string {
@@ -455,6 +468,27 @@ export function extractMarkdownFcAssetIds(markdown: string): ReadonlyArray<strin
   }
 
   return assetIds;
+}
+
+export function extractMarkdownPortableMediaPaths(markdown: string): ReadonlyArray<string> {
+  const portableMediaPaths: Array<string> = [];
+  const seenPortableMediaPaths = new Set<string>();
+
+  for (const linkDestination of listMarkdownLinkDestinations(markdown)) {
+    if (!isPortableMediaPathCandidate(linkDestination.destination)) {
+      continue;
+    }
+
+    const portableMediaPath = validatePortableMediaPath(linkDestination.destination);
+    if (seenPortableMediaPaths.has(portableMediaPath)) {
+      continue;
+    }
+
+    seenPortableMediaPaths.add(portableMediaPath);
+    portableMediaPaths.push(portableMediaPath);
+  }
+
+  return portableMediaPaths;
 }
 
 export function rewriteMarkdownFcAssetUrlsToPortablePaths(


### PR DESCRIPTION
## Summary
- Adds backend ZIP import preview core for `flashcards.zip` v1.
- Adds `yauzl` ZIP reader dependency for safe entry-level parsing.
- Validates `cards.json`, media references, unsafe paths, duplicate paths, missing media, and preview limits.
- Streams/drains media entries during preview without storing media bytes, enforcing decompressed per-file and total limits.
- Adds source-agnostic import preview/default options and import tag helpers.
- Adds focused workspace package tests for valid previews and malformed ZIP/package/media cases.

## Validation
- `npm run test --prefix apps/backend -- workspacePackages` passed, 633 tests.
- `npm run lint --prefix apps/backend` passed.
- `git --no-pager diff --check` passed.

## Review
- Review gate passed for Stage 3D1.
- No split blocker; current patch is cohesive and below the final 1,500-line review threshold.