### PR TITLE
Add backend import confirm planning core

### DIFF
--- a/apps/backend/src/workspacePackages/importPlan.test.ts
+++ b/apps/backend/src/workspacePackages/importPlan.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  planWorkspacePackageImport,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardSourceMetadataV1,
+  type WorkspacePackageCardsJsonV1,
+  type WorkspacePackageImportPlanOptions,
+} from "./index";
+
+const importedAt = "2026-06-30T12:00:00.000Z";
+const importId = "import-session-1";
+
+function createImportOptions(
+  addImportTag: boolean,
+  importTag: string,
+  removeTags: ReadonlyArray<string>,
+): WorkspacePackageImportPlanOptions {
+  return {
+    addImportTag,
+    importTag,
+    removeTags,
+    importedAt,
+    importId,
+  };
+}
+
+function createTestCard(
+  frontText: string,
+  backText: string,
+  tags: ReadonlyArray<string>,
+  cardType: string,
+  source: WorkspacePackageCardSourceMetadataV1 | null,
+): PortableWorkspacePackageCardV1 {
+  return {
+    frontText,
+    backText,
+    tags,
+    cardType,
+    metadata: {
+      version: 1,
+      source,
+    },
+  };
+}
+
+function createCardsJson(
+  cards: ReadonlyArray<PortableWorkspacePackageCardV1>,
+): WorkspacePackageCardsJsonV1 {
+  return {
+    formatVersion: 1,
+    cards,
+  };
+}
+
+test("workspace package import plan applies the import tag when enabled", () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: createCardsJson([
+      createTestCard("Prompt", "Answer", ["biology"], "basic", null),
+    ]),
+    options: createImportOptions(true, "import:2026-06-30-0", []),
+    mediaAssetIdsByPortablePath: new Map(),
+  });
+
+  assert.deepEqual(plan.cards[0]?.tags, ["biology", "import:2026-06-30-0"]);
+  assert.deepEqual(plan.summary, {
+    cardCount: 1,
+    keptTagCount: 1,
+    removedTagCount: 0,
+    importTag: "import:2026-06-30-0",
+    referencedMediaCount: 0,
+  });
+});
+
+test("workspace package import plan removes exact tags without partial matches", () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: createCardsJson([
+      createTestCard("Prompt", "Answer", ["math", "mathematics", "history"], "basic", null),
+    ]),
+    options: createImportOptions(false, "import:unused", ["math"]),
+    mediaAssetIdsByPortablePath: new Map(),
+  });
+
+  assert.deepEqual(plan.cards[0]?.tags, ["mathematics", "history"]);
+  assert.deepEqual(plan.summary, {
+    cardCount: 1,
+    keptTagCount: 2,
+    removedTagCount: 1,
+    importTag: null,
+    referencedMediaCount: 0,
+  });
+});
+
+test("workspace package import plan uses package source when card source is null", () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: {
+      formatVersion: 1,
+      label: "Package label",
+      author: "Package author",
+      comment: "Package comment",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      sourceUrl: "https://example.com/package",
+      cards: [
+        createTestCard("Prompt", "Answer", ["tag"], "basic", null),
+      ],
+    },
+    options: createImportOptions(false, "import:unused", []),
+    mediaAssetIdsByPortablePath: new Map(),
+  });
+
+  assert.deepEqual(plan.cards[0]?.metadata, {
+    version: 1,
+    source: {
+      label: "Package label",
+      author: "Package author",
+      comment: "Package comment",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      importedAt,
+      importId,
+    },
+  });
+});
+
+test("workspace package import plan lets card source override package source", () => {
+  const cardSource: WorkspacePackageCardSourceMetadataV1 = {
+    label: "Card label",
+    author: "Card author",
+    comment: null,
+    createdAt: "2026-06-15T00:00:00.000Z",
+    importedAt: "2026-01-01T00:00:00.000Z",
+    importId: "old-import",
+  };
+
+  const plan = planWorkspacePackageImport({
+    cardsJson: {
+      formatVersion: 1,
+      label: "Package label",
+      author: "Package author",
+      comment: "Package comment",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      cards: [
+        createTestCard("Prompt", "Answer", ["tag"], "custom", cardSource),
+      ],
+    },
+    options: createImportOptions(false, "import:unused", []),
+    mediaAssetIdsByPortablePath: new Map(),
+  });
+
+  assert.deepEqual(plan.cards[0]?.metadata.source, {
+    label: "Card label",
+    author: "Card author",
+    comment: "Package comment",
+    createdAt: "2026-06-15T00:00:00.000Z",
+    importedAt,
+    importId,
+  });
+});
+
+test("workspace package import plan rewrites portable Markdown media links", () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: createCardsJson([
+      createTestCard(
+        "Diagram: ![cell](media/images/cell.png)",
+        "Notes: [pdf](media/docs/notes.pdf) [remote](https://example.com/media/remote.png)",
+        ["biology"],
+        "basic",
+        null,
+      ),
+    ]),
+    options: createImportOptions(false, "import:unused", []),
+    mediaAssetIdsByPortablePath: new Map([
+      ["media/images/cell.png", "image-asset"],
+      ["media/docs/notes.pdf", "notes-asset"],
+    ]),
+  });
+
+  assert.equal(plan.cards[0]?.frontText, "Diagram: ![cell](fcasset:image-asset)");
+  assert.equal(
+    plan.cards[0]?.backText,
+    "Notes: [pdf](fcasset:notes-asset) [remote](https://example.com/media/remote.png)",
+  );
+  assert.equal(plan.summary.referencedMediaCount, 2);
+});
+
+test("workspace package import plan rejects missing media asset mappings", () => {
+  assert.throws(
+    () => planWorkspacePackageImport({
+      cardsJson: createCardsJson([
+        createTestCard("Image: ![cell](media/images/cell.png)", "Answer", ["biology"], "basic", null),
+      ]),
+      options: createImportOptions(false, "import:unused", []),
+      mediaAssetIdsByPortablePath: new Map(),
+    }),
+    /cards\[0\]\.frontText.*Missing mediaAssetId mapping.*media\/images\/cell\.png/,
+  );
+});
+
+test("workspace package import plan preserves unknown cardType values", () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: createCardsJson([
+      createTestCard("Prompt", "Answer", ["tag"], "custom-cloze", null),
+    ]),
+    options: createImportOptions(false, "import:unused", []),
+    mediaAssetIdsByPortablePath: new Map(),
+  });
+
+  assert.equal(plan.cards[0]?.cardType, "custom-cloze");
+});
+
+test("workspace package import plan normalizes duplicate final tags", () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: createCardsJson([
+      createTestCard("Prompt", "Answer", ["shared", "shared", "science"], "basic", null),
+    ]),
+    options: createImportOptions(true, "shared", []),
+    mediaAssetIdsByPortablePath: new Map(),
+  });
+
+  assert.deepEqual(plan.cards[0]?.tags, ["shared", "science"]);
+  assert.deepEqual(plan.summary, {
+    cardCount: 1,
+    keptTagCount: 2,
+    removedTagCount: 0,
+    importTag: "shared",
+    referencedMediaCount: 0,
+  });
+});

--- a/apps/backend/src/workspacePackages/importPlan.ts
+++ b/apps/backend/src/workspacePackages/importPlan.ts
@@ -1,0 +1,316 @@
+import { normalizeIsoTimestamp } from "../sync/conflicts/lww";
+import {
+  rewriteMarkdownPortableMediaUrlsToFcAssets,
+} from "./markdownMedia";
+import {
+  parseWorkspacePackageCardsJsonV1,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardMetadataV1,
+  type WorkspacePackageCardSourceMetadataV1,
+  type WorkspacePackageCardsJsonV1,
+} from "./types";
+
+export type WorkspacePackageImportPlanOptions = Readonly<{
+  addImportTag: boolean;
+  importTag: string;
+  removeTags: ReadonlyArray<string>;
+  importedAt: string;
+  importId: string;
+}>;
+
+export type WorkspacePackageImportPlanInput = Readonly<{
+  cardsJson: WorkspacePackageCardsJsonV1;
+  options: WorkspacePackageImportPlanOptions;
+  mediaAssetIdsByPortablePath: ReadonlyMap<string, string>;
+}>;
+
+export type WorkspacePackageImportPlannedCard = Readonly<{
+  frontText: string;
+  backText: string;
+  tags: ReadonlyArray<string>;
+  cardType: string;
+  metadata: WorkspacePackageCardMetadataV1;
+}>;
+
+export type WorkspacePackageImportPlanSummary = Readonly<{
+  cardCount: number;
+  keptTagCount: number;
+  removedTagCount: number;
+  importTag: string | null;
+  referencedMediaCount: number;
+}>;
+
+export type WorkspacePackageImportPlan = Readonly<{
+  cards: ReadonlyArray<WorkspacePackageImportPlannedCard>;
+  summary: WorkspacePackageImportPlanSummary;
+}>;
+
+type WorkspacePackageImportPlanNormalizedOptions = WorkspacePackageImportPlanOptions;
+
+type WorkspacePackageImportPlanTagPolicy = Readonly<{
+  keptTags: ReadonlyArray<string>;
+  removedTags: ReadonlyArray<string>;
+  removedTagSet: ReadonlySet<string>;
+}>;
+
+function createImportPlanInputError(message: string): TypeError {
+  return new TypeError(`Invalid workspace package import plan input: ${message}`);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeRequiredText(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (normalizedValue === "") {
+    throw createImportPlanInputError(`${fieldName} must not be empty`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeRequiredIsoTimestamp(value: string, fieldName: string): string {
+  return normalizeIsoTimestamp(normalizeRequiredText(value, fieldName), fieldName);
+}
+
+function normalizeRequiredUniqueTextValues(
+  values: ReadonlyArray<string>,
+  fieldName: string,
+): ReadonlyArray<string> {
+  const normalizedValues: Array<string> = [];
+  const seenValues = new Set<string>();
+
+  values.forEach((value, index) => {
+    const normalizedValue = normalizeRequiredText(value, `${fieldName}[${index}]`);
+    if (seenValues.has(normalizedValue)) {
+      throw createImportPlanInputError(`${fieldName} must not contain duplicates`);
+    }
+
+    seenValues.add(normalizedValue);
+    normalizedValues.push(normalizedValue);
+  });
+
+  return normalizedValues;
+}
+
+function normalizeImportPlanOptions(
+  options: WorkspacePackageImportPlanOptions,
+): WorkspacePackageImportPlanNormalizedOptions {
+  return {
+    addImportTag: options.addImportTag,
+    importTag: normalizeRequiredText(options.importTag, "options.importTag"),
+    removeTags: normalizeRequiredUniqueTextValues(options.removeTags, "options.removeTags"),
+    importedAt: normalizeRequiredIsoTimestamp(options.importedAt, "options.importedAt"),
+    importId: normalizeRequiredText(options.importId, "options.importId"),
+  };
+}
+
+function normalizeImportPlanCardsJson(cardsJson: WorkspacePackageCardsJsonV1): WorkspacePackageCardsJsonV1 {
+  try {
+    return parseWorkspacePackageCardsJsonV1(cardsJson);
+  } catch (error) {
+    throw createImportPlanInputError(`cardsJson must be a valid workspace package. reason=${getErrorMessage(error)}`);
+  }
+}
+
+function collectPackageTags(
+  cards: ReadonlyArray<PortableWorkspacePackageCardV1>,
+): ReadonlyArray<string> {
+  const packageTags: Array<string> = [];
+  const seenTags = new Set<string>();
+
+  for (const card of cards) {
+    for (const tag of card.tags) {
+      if (seenTags.has(tag)) {
+        continue;
+      }
+
+      seenTags.add(tag);
+      packageTags.push(tag);
+    }
+  }
+
+  return packageTags;
+}
+
+function buildImportPlanTagPolicy(
+  cards: ReadonlyArray<PortableWorkspacePackageCardV1>,
+  options: WorkspacePackageImportPlanNormalizedOptions,
+): WorkspacePackageImportPlanTagPolicy {
+  const packageTags = collectPackageTags(cards);
+  const packageTagSet = new Set(packageTags);
+  const unknownRemovedTags = options.removeTags.filter((tag) => packageTagSet.has(tag) === false);
+  if (unknownRemovedTags.length !== 0) {
+    throw createImportPlanInputError(
+      `options.removeTags must contain only exact package tag values. unknownTags=${unknownRemovedTags.join(",")}`,
+    );
+  }
+
+  const removedTagSet = new Set(options.removeTags);
+  return {
+    keptTags: packageTags.filter((tag) => removedTagSet.has(tag) === false),
+    removedTags: options.removeTags,
+    removedTagSet,
+  };
+}
+
+function dedupeTags(tags: ReadonlyArray<string>): ReadonlyArray<string> {
+  const dedupedTags: Array<string> = [];
+  const seenTags = new Set<string>();
+
+  for (const tag of tags) {
+    if (seenTags.has(tag)) {
+      continue;
+    }
+
+    seenTags.add(tag);
+    dedupedTags.push(tag);
+  }
+
+  return dedupedTags;
+}
+
+function planCardTags(
+  cardTags: ReadonlyArray<string>,
+  options: WorkspacePackageImportPlanNormalizedOptions,
+  tagPolicy: WorkspacePackageImportPlanTagPolicy,
+): ReadonlyArray<string> {
+  const keptCardTags = cardTags.filter((tag) => tagPolicy.removedTagSet.has(tag) === false);
+  const finalTags = options.addImportTag ? [...keptCardTags, options.importTag] : keptCardTags;
+  return dedupeTags(finalTags);
+}
+
+function toPackageSourceMetadata(
+  cardsJson: WorkspacePackageCardsJsonV1,
+): WorkspacePackageCardSourceMetadataV1 {
+  return {
+    label: cardsJson.label ?? null,
+    author: cardsJson.author ?? null,
+    comment: cardsJson.comment ?? null,
+    createdAt: cardsJson.createdAt ?? null,
+    importedAt: null,
+    importId: null,
+  };
+}
+
+function planCardSourceMetadata(
+  cardSource: WorkspacePackageCardSourceMetadataV1 | null,
+  packageSource: WorkspacePackageCardSourceMetadataV1,
+  options: WorkspacePackageImportPlanNormalizedOptions,
+): WorkspacePackageCardSourceMetadataV1 {
+  return {
+    label: cardSource?.label ?? packageSource.label,
+    author: cardSource?.author ?? packageSource.author,
+    comment: cardSource?.comment ?? packageSource.comment,
+    createdAt: cardSource?.createdAt ?? packageSource.createdAt,
+    importedAt: options.importedAt,
+    importId: options.importId,
+  };
+}
+
+function planCardMetadata(
+  card: PortableWorkspacePackageCardV1,
+  packageSource: WorkspacePackageCardSourceMetadataV1,
+  options: WorkspacePackageImportPlanNormalizedOptions,
+): WorkspacePackageCardMetadataV1 {
+  return {
+    version: 1,
+    source: planCardSourceMetadata(card.metadata.source, packageSource, options),
+  };
+}
+
+function resolvePortableMediaPath(
+  portableMediaPath: string,
+  mediaAssetIdsByPortablePath: ReadonlyMap<string, string>,
+  referencedMediaPaths: Set<string>,
+): string {
+  referencedMediaPaths.add(portableMediaPath);
+  const mediaAssetId = mediaAssetIdsByPortablePath.get(portableMediaPath);
+  if (mediaAssetId === undefined) {
+    throw new Error(`Missing mediaAssetId mapping for portable media path: ${portableMediaPath}`);
+  }
+
+  return mediaAssetId;
+}
+
+function rewriteCardMarkdown(
+  markdown: string,
+  mediaAssetIdsByPortablePath: ReadonlyMap<string, string>,
+  referencedMediaPaths: Set<string>,
+  cardIndex: number,
+  fieldName: "frontText" | "backText",
+): string {
+  try {
+    return rewriteMarkdownPortableMediaUrlsToFcAssets(
+      markdown,
+      (portableMediaPath) => resolvePortableMediaPath(
+        portableMediaPath,
+        mediaAssetIdsByPortablePath,
+        referencedMediaPaths,
+      ),
+    );
+  } catch (error) {
+    throw createImportPlanInputError(
+      `cards[${cardIndex}].${fieldName} media references cannot be planned. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+function planCard(
+  card: PortableWorkspacePackageCardV1,
+  cardIndex: number,
+  packageSource: WorkspacePackageCardSourceMetadataV1,
+  options: WorkspacePackageImportPlanNormalizedOptions,
+  tagPolicy: WorkspacePackageImportPlanTagPolicy,
+  mediaAssetIdsByPortablePath: ReadonlyMap<string, string>,
+  referencedMediaPaths: Set<string>,
+): WorkspacePackageImportPlannedCard {
+  return {
+    frontText: rewriteCardMarkdown(
+      card.frontText,
+      mediaAssetIdsByPortablePath,
+      referencedMediaPaths,
+      cardIndex,
+      "frontText",
+    ),
+    backText: rewriteCardMarkdown(
+      card.backText,
+      mediaAssetIdsByPortablePath,
+      referencedMediaPaths,
+      cardIndex,
+      "backText",
+    ),
+    tags: planCardTags(card.tags, options, tagPolicy),
+    cardType: card.cardType,
+    metadata: planCardMetadata(card, packageSource, options),
+  };
+}
+
+export function planWorkspacePackageImport(input: WorkspacePackageImportPlanInput): WorkspacePackageImportPlan {
+  const cardsJson = normalizeImportPlanCardsJson(input.cardsJson);
+  const options = normalizeImportPlanOptions(input.options);
+  const packageSource = toPackageSourceMetadata(cardsJson);
+  const tagPolicy = buildImportPlanTagPolicy(cardsJson.cards, options);
+  const referencedMediaPaths = new Set<string>();
+  const plannedCards = cardsJson.cards.map((card, cardIndex) => planCard(
+    card,
+    cardIndex,
+    packageSource,
+    options,
+    tagPolicy,
+    input.mediaAssetIdsByPortablePath,
+    referencedMediaPaths,
+  ));
+
+  return {
+    cards: plannedCards,
+    summary: {
+      cardCount: plannedCards.length,
+      keptTagCount: tagPolicy.keptTags.length,
+      removedTagCount: tagPolicy.removedTags.length,
+      importTag: options.addImportTag ? options.importTag : null,
+      referencedMediaCount: referencedMediaPaths.size,
+    },
+  };
+}

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -42,6 +42,10 @@ export {
   workspacePackageImportPreviewDefaultMaxZipBytes,
 } from "./importPreview";
 
+export {
+  planWorkspacePackageImport,
+} from "./importPlan";
+
 export type {
   WorkspacePackageExportCardSelection,
   WorkspacePackageExportMetadataInput,
@@ -69,6 +73,14 @@ export type {
   WorkspacePackageImportTagPolicy,
   WorkspacePackageImportTagPolicyInput,
 } from "./importPreview";
+
+export type {
+  WorkspacePackageImportPlan,
+  WorkspacePackageImportPlanInput,
+  WorkspacePackageImportPlanOptions,
+  WorkspacePackageImportPlanSummary,
+  WorkspacePackageImportPlannedCard,
+} from "./importPlan";
 
 export {
   normalizeWorkspacePackageCardMetadataV1,


### PR DESCRIPTION
## Summary
- add pure workspace package import confirm planning for parsed package cards
- compute final tags, source metadata, import markers, media rewrites, and summary inputs
- export the planner contract for later import persistence/routes

## Validation
- npm run test --prefix apps/backend -- workspacePackages (641 tests, 0 failures)
- npm run lint --prefix apps/backend
- git --no-pager diff --check
- worker-owned review: no split recommendation, no P0-P4 findings
