### PR TITLE
Extract workspace package import ZIP helpers

### DIFF
--- a/apps/backend/src/workspacePackages/importPreview.test.ts
+++ b/apps/backend/src/workspacePackages/importPreview.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import { deflateRawSync } from "node:zlib";
 import { HttpError } from "../shared/errors";
 import {
   buildSuggestedWorkspacePackageImportTag,
@@ -14,29 +13,14 @@ import {
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageImportPreviewInput,
 } from "./index";
-
-type TestZipEntry = Readonly<{
-  path: string;
-  bytes: Buffer;
-  compressionMethod?: number;
-  uncompressedSize?: number;
-}>;
-
-type TestCentralDirectoryEntry = Readonly<{
-  pathBytes: Buffer;
-  entry: TestZipEntry;
-  localHeaderOffset: number;
-}>;
+import {
+  createCardsJsonBuffer,
+  createDeflatedZipEntry,
+  createPackageZip,
+  createStoredZip,
+} from "./testZipHelpers";
 
 const generatedAt = "2026-06-30T12:00:00.000Z";
-const zipLocalFileHeaderSignature = 0x04034b50;
-const zipCentralDirectoryHeaderSignature = 0x02014b50;
-const zipEndOfCentralDirectorySignature = 0x06054b50;
-const zipVersionNeededToExtract = 20;
-const zipStoredCompressionMethod = 0;
-const zipDeflatedCompressionMethod = 8;
-const zipDosTimeMidnight = 0;
-const zipDosDateJanuaryFirst1980 = 33;
 
 const testMetadata: WorkspacePackageCardMetadataV1 = {
   version: 1,
@@ -56,130 +40,6 @@ function createTestCard(
     cardType,
     metadata: testMetadata,
   };
-}
-
-function createCardsJsonBuffer(cardsJson: WorkspacePackageCardsJsonV1): Buffer {
-  return Buffer.from(JSON.stringify(cardsJson), "utf8");
-}
-
-function getTestZipEntryCompressionMethod(entry: TestZipEntry): number {
-  return entry.compressionMethod ?? zipStoredCompressionMethod;
-}
-
-function getTestZipEntryUncompressedSize(entry: TestZipEntry): number {
-  return entry.uncompressedSize ?? entry.bytes.byteLength;
-}
-
-function createDeflatedZipEntry(
-  path: string,
-  uncompressedBytes: Buffer,
-  declaredUncompressedSize: number,
-): TestZipEntry {
-  return {
-    path,
-    bytes: deflateRawSync(uncompressedBytes),
-    compressionMethod: zipDeflatedCompressionMethod,
-    uncompressedSize: declaredUncompressedSize,
-  };
-}
-
-function createLocalFileHeader(pathBytes: Buffer, entry: TestZipEntry): Buffer {
-  const header = Buffer.alloc(30);
-  header.writeUInt32LE(zipLocalFileHeaderSignature, 0);
-  header.writeUInt16LE(zipVersionNeededToExtract, 4);
-  header.writeUInt16LE(0, 6);
-  header.writeUInt16LE(getTestZipEntryCompressionMethod(entry), 8);
-  header.writeUInt16LE(zipDosTimeMidnight, 10);
-  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 12);
-  header.writeUInt32LE(0, 14);
-  header.writeUInt32LE(entry.bytes.byteLength, 18);
-  header.writeUInt32LE(getTestZipEntryUncompressedSize(entry), 22);
-  header.writeUInt16LE(pathBytes.byteLength, 26);
-  header.writeUInt16LE(0, 28);
-
-  return Buffer.concat([header, pathBytes]);
-}
-
-function createCentralDirectoryHeader(entry: TestCentralDirectoryEntry): Buffer {
-  const header = Buffer.alloc(46);
-  header.writeUInt32LE(zipCentralDirectoryHeaderSignature, 0);
-  header.writeUInt16LE(zipVersionNeededToExtract, 4);
-  header.writeUInt16LE(zipVersionNeededToExtract, 6);
-  header.writeUInt16LE(0, 8);
-  header.writeUInt16LE(getTestZipEntryCompressionMethod(entry.entry), 10);
-  header.writeUInt16LE(zipDosTimeMidnight, 12);
-  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 14);
-  header.writeUInt32LE(0, 16);
-  header.writeUInt32LE(entry.entry.bytes.byteLength, 20);
-  header.writeUInt32LE(getTestZipEntryUncompressedSize(entry.entry), 24);
-  header.writeUInt16LE(entry.pathBytes.byteLength, 28);
-  header.writeUInt16LE(0, 30);
-  header.writeUInt16LE(0, 32);
-  header.writeUInt16LE(0, 34);
-  header.writeUInt16LE(0, 36);
-  header.writeUInt32LE(0, 38);
-  header.writeUInt32LE(entry.localHeaderOffset, 42);
-
-  return Buffer.concat([header, entry.pathBytes]);
-}
-
-function createEndOfCentralDirectory(
-  entryCount: number,
-  centralDirectorySize: number,
-  centralDirectoryOffset: number,
-): Buffer {
-  const header = Buffer.alloc(22);
-  header.writeUInt32LE(zipEndOfCentralDirectorySignature, 0);
-  header.writeUInt16LE(0, 4);
-  header.writeUInt16LE(0, 6);
-  header.writeUInt16LE(entryCount, 8);
-  header.writeUInt16LE(entryCount, 10);
-  header.writeUInt32LE(centralDirectorySize, 12);
-  header.writeUInt32LE(centralDirectoryOffset, 16);
-  header.writeUInt16LE(0, 20);
-
-  return header;
-}
-
-function createStoredZip(entries: ReadonlyArray<TestZipEntry>): Buffer {
-  const localFileParts: Array<Buffer> = [];
-  const centralDirectoryEntries: Array<TestCentralDirectoryEntry> = [];
-  let localHeaderOffset = 0;
-
-  for (const entry of entries) {
-    const pathBytes = Buffer.from(entry.path, "utf8");
-    const localFileHeader = createLocalFileHeader(pathBytes, entry);
-    localFileParts.push(localFileHeader, entry.bytes);
-    centralDirectoryEntries.push({
-      pathBytes,
-      entry,
-      localHeaderOffset,
-    });
-    localHeaderOffset += localFileHeader.byteLength + entry.bytes.byteLength;
-  }
-
-  const centralDirectoryOffset = localHeaderOffset;
-  const centralDirectoryParts = centralDirectoryEntries.map(createCentralDirectoryHeader);
-  const centralDirectorySize = centralDirectoryParts.reduce((totalSize, part) => totalSize + part.byteLength, 0);
-
-  return Buffer.concat([
-    ...localFileParts,
-    ...centralDirectoryParts,
-    createEndOfCentralDirectory(entries.length, centralDirectorySize, centralDirectoryOffset),
-  ]);
-}
-
-function createPackageZip(
-  cardsJson: WorkspacePackageCardsJsonV1,
-  mediaEntries: ReadonlyArray<TestZipEntry>,
-): Buffer {
-  return createStoredZip([
-    {
-      path: "cards.json",
-      bytes: createCardsJsonBuffer(cardsJson),
-    },
-    ...mediaEntries,
-  ]);
 }
 
 function createPreviewInput(

--- a/apps/backend/src/workspacePackages/importPreview.ts
+++ b/apps/backend/src/workspacePackages/importPreview.ts
@@ -1,28 +1,35 @@
 import { Buffer } from "node:buffer";
-import type { Readable } from "node:stream";
 import {
-  fromBufferPromise,
-  type Entry as ZipEntry,
-  type ZipFile,
-} from "yauzl";
-import { HttpError } from "../shared/errors";
-import {
-  extractMarkdownPortableMediaPaths,
-  validatePortableMediaPath,
-  validateUniquePortableMediaPaths,
-} from "./markdownMedia";
-import {
-  parseWorkspacePackageCardsJsonV1,
-  type PortableWorkspacePackageCardV1,
-  type WorkspacePackageCardsJsonV1,
+  assertReferencedWorkspacePackageMediaFilesExist,
+  assertWorkspacePackageCardCountWithinLimit,
+  collectWorkspacePackageZipEntries,
+  createWorkspacePackageImportInputError,
+  defaultWorkspacePackageImportZipLimits,
+  extractReferencedWorkspacePackageMediaPaths,
+  normalizeWorkspacePackageImportZipLimits,
+  normalizeWorkspacePackageZipBytes,
+  openWorkspacePackageZipFile,
+  parseWorkspacePackageCardsJsonBytes,
+  workspacePackageImportZipDefaultMaxCards,
+  workspacePackageImportZipDefaultMaxEntries,
+  workspacePackageImportZipDefaultMaxMediaFiles,
+  workspacePackageImportZipDefaultMaxSingleMediaBytes,
+  workspacePackageImportZipDefaultMaxTotalMediaBytes,
+  workspacePackageImportZipDefaultMaxZipBytes,
+  type CollectedWorkspacePackageZip,
+  type WorkspacePackageImportZipLimits,
+} from "./importZip";
+import type {
+  PortableWorkspacePackageCardV1,
+  WorkspacePackageCardsJsonV1,
 } from "./types";
 
-export const workspacePackageImportPreviewDefaultMaxZipBytes = 80 * 1024 * 1024;
-export const workspacePackageImportPreviewDefaultMaxEntries = 10_001;
-export const workspacePackageImportPreviewDefaultMaxCards = 5_000;
-export const workspacePackageImportPreviewDefaultMaxMediaFiles = 10_000;
-export const workspacePackageImportPreviewDefaultMaxSingleMediaBytes = 16 * 1024 * 1024;
-export const workspacePackageImportPreviewDefaultMaxTotalMediaBytes = 64 * 1024 * 1024;
+export const workspacePackageImportPreviewDefaultMaxZipBytes = workspacePackageImportZipDefaultMaxZipBytes;
+export const workspacePackageImportPreviewDefaultMaxEntries = workspacePackageImportZipDefaultMaxEntries;
+export const workspacePackageImportPreviewDefaultMaxCards = workspacePackageImportZipDefaultMaxCards;
+export const workspacePackageImportPreviewDefaultMaxMediaFiles = workspacePackageImportZipDefaultMaxMediaFiles;
+export const workspacePackageImportPreviewDefaultMaxSingleMediaBytes = workspacePackageImportZipDefaultMaxSingleMediaBytes;
+export const workspacePackageImportPreviewDefaultMaxTotalMediaBytes = workspacePackageImportZipDefaultMaxTotalMediaBytes;
 
 export type WorkspacePackageImportPreviewInput = Readonly<{
   packageBytes: Buffer | Uint8Array;
@@ -30,14 +37,7 @@ export type WorkspacePackageImportPreviewInput = Readonly<{
   existingWorkspaceTags: ReadonlyArray<string>;
 }>;
 
-export type WorkspacePackageImportPreviewLimits = Readonly<{
-  maxZipBytes: number;
-  maxEntries: number;
-  maxCards: number;
-  maxMediaFiles: number;
-  maxSingleMediaBytes: number;
-  maxTotalMediaBytes: number;
-}>;
+export type WorkspacePackageImportPreviewLimits = WorkspacePackageImportZipLimits;
 
 export type WorkspacePackageImportPreviewMetadata = Readonly<{
   label: string | null;
@@ -83,13 +83,6 @@ export type WorkspacePackageImportPreview = Readonly<{
   defaultOptions: WorkspacePackageImportDefaultOptions;
 }>;
 
-type CollectedWorkspacePackageZip = Readonly<{
-  cardsJsonBytes: Buffer | null;
-  cardsJsonEntryCount: number;
-  mediaEntriesByPath: ReadonlyMap<string, ZipEntry>;
-  mediaPaths: ReadonlyArray<string>;
-}>;
-
 const supportedPreviewImageExtensions = new Set([
   "avif",
   "gif",
@@ -100,43 +93,12 @@ const supportedPreviewImageExtensions = new Set([
   "webp",
 ]);
 
-const defaultImportPreviewLimits: WorkspacePackageImportPreviewLimits = {
-  maxZipBytes: workspacePackageImportPreviewDefaultMaxZipBytes,
-  maxEntries: workspacePackageImportPreviewDefaultMaxEntries,
-  maxCards: workspacePackageImportPreviewDefaultMaxCards,
-  maxMediaFiles: workspacePackageImportPreviewDefaultMaxMediaFiles,
-  maxSingleMediaBytes: workspacePackageImportPreviewDefaultMaxSingleMediaBytes,
-  maxTotalMediaBytes: workspacePackageImportPreviewDefaultMaxTotalMediaBytes,
-};
-
-function createImportPreviewInputError(message: string): HttpError {
-  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_INPUT_INVALID");
-}
-
-function createImportPreviewZipInvalidError(message: string): HttpError {
-  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID");
-}
-
-function createImportPreviewCardsJsonMalformedError(message: string): HttpError {
-  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_MALFORMED");
-}
-
-function createImportPreviewCardsJsonInvalidError(message: string): HttpError {
-  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_INVALID");
-}
-
-function createImportPreviewTooLargeError(message: string): HttpError {
-  return new HttpError(413, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_TOO_LARGE");
-}
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
+const defaultImportPreviewLimits: WorkspacePackageImportPreviewLimits = defaultWorkspacePackageImportZipLimits;
 
 function normalizeNonEmptyText(value: string, fieldName: string): string {
   const normalizedValue = value.trim();
   if (normalizedValue === "") {
-    throw createImportPreviewInputError(`${fieldName} must not be empty`);
+    throw createWorkspacePackageImportInputError(`${fieldName} must not be empty`);
   }
 
   return normalizedValue;
@@ -146,7 +108,7 @@ function normalizeIsoTimestamp(value: string, fieldName: string): string {
   const normalizedValue = normalizeNonEmptyText(value, fieldName);
   const parsedValue = new Date(normalizedValue);
   if (Number.isNaN(parsedValue.getTime())) {
-    throw createImportPreviewInputError(`${fieldName} must be a valid ISO timestamp`);
+    throw createWorkspacePackageImportInputError(`${fieldName} must be a valid ISO timestamp`);
   }
 
   return parsedValue.toISOString();
@@ -162,7 +124,7 @@ function normalizeUniqueTextValues(
   values.forEach((value, index) => {
     const normalizedValue = normalizeNonEmptyText(value, `${fieldName}[${index}]`);
     if (existingValues.has(normalizedValue)) {
-      throw createImportPreviewInputError(`${fieldName} must not contain duplicates`);
+      throw createWorkspacePackageImportInputError(`${fieldName} must not contain duplicates`);
     }
 
     existingValues.add(normalizedValue);
@@ -170,332 +132,6 @@ function normalizeUniqueTextValues(
   });
 
   return normalizedValues;
-}
-
-function assertPositiveSafeInteger(value: number, fieldName: string): void {
-  if (
-    Number.isSafeInteger(value) === false
-    || value < 1
-    || value >= Number.MAX_SAFE_INTEGER
-  ) {
-    throw createImportPreviewInputError(`${fieldName} must be a positive safe integer`);
-  }
-}
-
-function normalizePreviewLimits(
-  limits: WorkspacePackageImportPreviewLimits,
-): WorkspacePackageImportPreviewLimits {
-  assertPositiveSafeInteger(limits.maxZipBytes, "limits.maxZipBytes");
-  assertPositiveSafeInteger(limits.maxEntries, "limits.maxEntries");
-  assertPositiveSafeInteger(limits.maxCards, "limits.maxCards");
-  assertPositiveSafeInteger(limits.maxMediaFiles, "limits.maxMediaFiles");
-  assertPositiveSafeInteger(limits.maxSingleMediaBytes, "limits.maxSingleMediaBytes");
-  assertPositiveSafeInteger(limits.maxTotalMediaBytes, "limits.maxTotalMediaBytes");
-
-  return limits;
-}
-
-function normalizePackageBytes(packageBytes: Buffer | Uint8Array, maxZipBytes: number): Buffer {
-  const bytes = Buffer.from(packageBytes);
-  if (bytes.byteLength > maxZipBytes) {
-    throw createImportPreviewTooLargeError(
-      `Workspace package ZIP is too large. zipBytes=${bytes.byteLength} maxZipBytes=${maxZipBytes}`,
-    );
-  }
-
-  return bytes;
-}
-
-function assertZipEntryDataCanBeDecoded(entry: ZipEntry, entryPath: string): void {
-  if (entry.canDecodeFileData()) {
-    return;
-  }
-
-  throw createImportPreviewZipInvalidError(
-    [
-      "Workspace package ZIP entry uses unsupported compression or encryption.",
-      `entryPath=${entryPath}`,
-      `compressionMethod=${entry.compressionMethod}`,
-      `encrypted=${entry.isEncrypted()}`,
-    ].join(" "),
-  );
-}
-
-function normalizeZipEntryPath(entryPath: string): string {
-  if (entryPath === "") {
-    throw createImportPreviewZipInvalidError("Workspace package ZIP entry path must not be empty");
-  }
-
-  if (entryPath.includes("\\") || entryPath.includes("\0")) {
-    throw createImportPreviewZipInvalidError(`Workspace package ZIP entry path is unsafe. entryPath=${entryPath}`);
-  }
-
-  if (entryPath === "cards.json") {
-    return entryPath;
-  }
-
-  if (entryPath.startsWith("media/")) {
-    try {
-      return validatePortableMediaPath(entryPath);
-    } catch (error) {
-      throw createImportPreviewZipInvalidError(
-        `Workspace package ZIP contains unsafe media path. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
-      );
-    }
-  }
-
-  throw createImportPreviewZipInvalidError(
-    `Workspace package ZIP contains unsupported entry. entryPath=${entryPath}. Only cards.json and media/** are supported.`,
-  );
-}
-
-async function openZipFile(bytes: Buffer): Promise<ZipFile> {
-  try {
-    return await fromBufferPromise(bytes, {
-      lazyEntries: true,
-      decodeStrings: true,
-      validateEntrySizes: true,
-      strictFileNames: true,
-    });
-  } catch (error) {
-    throw createImportPreviewZipInvalidError(`Workspace package ZIP is invalid. reason=${getErrorMessage(error)}`);
-  }
-}
-
-async function readZipEntryBytes(
-  zipFile: ZipFile,
-  entry: ZipEntry,
-  maxBytes: number,
-): Promise<Buffer> {
-  let stream: Readable;
-  try {
-    stream = await zipFile.openReadStreamPromise(entry);
-  } catch (error) {
-    throw createImportPreviewZipInvalidError(
-      `Workspace package ZIP entry cannot be read. entryPath=${entry.fileName} reason=${getErrorMessage(error)}`,
-    );
-  }
-
-  const chunks: Array<Buffer> = [];
-  let totalBytes = 0;
-
-  try {
-    for await (const chunk of stream) {
-      const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      totalBytes += chunkBuffer.byteLength;
-      if (totalBytes > maxBytes) {
-        throw createImportPreviewTooLargeError(
-          `Workspace package ZIP entry is too large. entryPath=${entry.fileName} bytes=${totalBytes} maxBytes=${maxBytes}`,
-        );
-      }
-
-      chunks.push(chunkBuffer);
-    }
-  } catch (error) {
-    if (error instanceof HttpError) {
-      throw error;
-    }
-
-    throw createImportPreviewZipInvalidError(
-      `Workspace package ZIP entry cannot be read. entryPath=${entry.fileName} reason=${getErrorMessage(error)}`,
-    );
-  }
-
-  return Buffer.concat(chunks, totalBytes);
-}
-
-function assertEntryCountWithinLimit(entryCount: number, maxEntries: number): void {
-  if (entryCount <= maxEntries) {
-    return;
-  }
-
-  throw createImportPreviewTooLargeError(
-    `Workspace package ZIP contains too many entries. entryCount=${entryCount} maxEntries=${maxEntries}`,
-  );
-}
-
-function getReadableChunkByteLength(chunk: unknown): number {
-  if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
-    return chunk.byteLength;
-  }
-
-  if (typeof chunk === "string") {
-    return Buffer.byteLength(chunk);
-  }
-
-  throw new Error("ZIP entry stream emitted an unsupported chunk type");
-}
-
-function assertMediaEntryWithinLimit(
-  mediaBytes: number,
-  entryPath: string,
-  maxSingleMediaBytes: number,
-): void {
-  if (mediaBytes > maxSingleMediaBytes) {
-    throw createImportPreviewTooLargeError(
-      [
-        "Workspace package ZIP media entry is too large.",
-        `entryPath=${entryPath}`,
-        `mediaBytes=${mediaBytes}`,
-        `maxSingleMediaBytes=${maxSingleMediaBytes}`,
-      ].join(" "),
-    );
-  }
-}
-
-function assertMediaFileCountWithinLimit(mediaFileCount: number, maxMediaFiles: number): void {
-  if (mediaFileCount > maxMediaFiles) {
-    throw createImportPreviewTooLargeError(
-      `Workspace package ZIP contains too many media files. mediaFileCount=${mediaFileCount} maxMediaFiles=${maxMediaFiles}`,
-    );
-  }
-}
-
-function assertTotalMediaBytesWithinLimit(totalMediaBytes: number, maxTotalMediaBytes: number): void {
-  if (Number.isSafeInteger(totalMediaBytes) === false) {
-    throw new Error("Workspace package ZIP media byte total must be a safe integer");
-  }
-
-  if (totalMediaBytes > maxTotalMediaBytes) {
-    throw createImportPreviewTooLargeError(
-      [
-        "Workspace package ZIP media total is too large.",
-        `totalMediaBytes=${totalMediaBytes}`,
-        `maxTotalMediaBytes=${maxTotalMediaBytes}`,
-      ].join(" "),
-    );
-  }
-}
-
-async function drainMediaZipEntryBytes(
-  zipFile: ZipFile,
-  entry: ZipEntry,
-  entryPath: string,
-  currentTotalMediaBytes: number,
-  limits: WorkspacePackageImportPreviewLimits,
-): Promise<number> {
-  let stream: Readable;
-  try {
-    stream = await zipFile.openReadStreamPromise(entry);
-  } catch (error) {
-    throw createImportPreviewZipInvalidError(
-      `Workspace package ZIP media entry cannot be read. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
-    );
-  }
-
-  let mediaBytes = 0;
-  let totalMediaBytes = currentTotalMediaBytes;
-
-  try {
-    for await (const chunk of stream) {
-      const chunkByteLength = getReadableChunkByteLength(chunk);
-      mediaBytes += chunkByteLength;
-      if (Number.isSafeInteger(mediaBytes) === false) {
-        throw new Error(`Workspace package ZIP media entry byte count must be a safe integer. entryPath=${entryPath}`);
-      }
-
-      assertMediaEntryWithinLimit(mediaBytes, entryPath, limits.maxSingleMediaBytes);
-      totalMediaBytes += chunkByteLength;
-      assertTotalMediaBytesWithinLimit(totalMediaBytes, limits.maxTotalMediaBytes);
-    }
-  } catch (error) {
-    if (error instanceof HttpError) {
-      throw error;
-    }
-
-    throw createImportPreviewZipInvalidError(
-      `Workspace package ZIP media entry cannot be read. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
-    );
-  }
-
-  return totalMediaBytes;
-}
-
-async function collectWorkspacePackageZipEntries(
-  zipFile: ZipFile,
-  limits: WorkspacePackageImportPreviewLimits,
-): Promise<CollectedWorkspacePackageZip> {
-  assertEntryCountWithinLimit(zipFile.entryCount, limits.maxEntries);
-
-  let cardsJsonBytes: Buffer | null = null;
-  let cardsJsonEntryCount = 0;
-  const mediaEntriesByPath = new Map<string, ZipEntry>();
-  const mediaPaths: Array<string> = [];
-  let totalMediaBytes = 0;
-
-  try {
-    for await (const entry of zipFile.eachEntry()) {
-      const entryPath = normalizeZipEntryPath(entry.fileName);
-      assertZipEntryDataCanBeDecoded(entry, entryPath);
-
-      if (entryPath === "cards.json") {
-        cardsJsonEntryCount += 1;
-        cardsJsonBytes = await readZipEntryBytes(zipFile, entry, limits.maxZipBytes);
-        continue;
-      }
-
-      assertMediaFileCountWithinLimit(mediaPaths.length + 1, limits.maxMediaFiles);
-      totalMediaBytes = await drainMediaZipEntryBytes(zipFile, entry, entryPath, totalMediaBytes, limits);
-      mediaEntriesByPath.set(entryPath, entry);
-      mediaPaths.push(entryPath);
-    }
-  } catch (error) {
-    if (error instanceof HttpError) {
-      throw error;
-    }
-
-    throw createImportPreviewZipInvalidError(`Workspace package ZIP is invalid. reason=${getErrorMessage(error)}`);
-  }
-
-  if (cardsJsonEntryCount !== 1) {
-    throw createImportPreviewZipInvalidError(
-      `Workspace package ZIP must contain exactly one cards.json entry. cardsJsonEntryCount=${cardsJsonEntryCount}`,
-    );
-  }
-
-  try {
-    validateUniquePortableMediaPaths(mediaPaths);
-  } catch (error) {
-    throw createImportPreviewZipInvalidError(
-      `Workspace package ZIP contains duplicate or unsafe media paths. reason=${getErrorMessage(error)}`,
-    );
-  }
-
-  return {
-    cardsJsonBytes,
-    cardsJsonEntryCount,
-    mediaEntriesByPath,
-    mediaPaths,
-  };
-}
-
-function parseCardsJsonBytes(cardsJsonBytes: Buffer): WorkspacePackageCardsJsonV1 {
-  let cardsJsonValue: unknown;
-  try {
-    cardsJsonValue = JSON.parse(cardsJsonBytes.toString("utf8"));
-  } catch (error) {
-    throw createImportPreviewCardsJsonMalformedError(
-      `Workspace package cards.json is malformed JSON. reason=${getErrorMessage(error)}`,
-    );
-  }
-
-  try {
-    return parseWorkspacePackageCardsJsonV1(cardsJsonValue);
-  } catch (error) {
-    throw createImportPreviewCardsJsonInvalidError(
-      `Workspace package cards.json is invalid. reason=${getErrorMessage(error)}`,
-    );
-  }
-}
-
-function assertCardCountWithinLimit(cardCount: number, maxCards: number): void {
-  if (cardCount <= maxCards) {
-    return;
-  }
-
-  throw createImportPreviewTooLargeError(
-    `Workspace package cards.json contains too many cards. cardCount=${cardCount} maxCards=${maxCards}`,
-  );
 }
 
 function toPackageMetadataPreview(cardsJson: WorkspacePackageCardsJsonV1): WorkspacePackageImportPreviewMetadata {
@@ -545,54 +181,6 @@ function getPackageTagValues(
   tagCounts: ReadonlyArray<WorkspacePackageImportPreviewTagCount>,
 ): ReadonlyArray<string> {
   return tagCounts.map((tagCount) => tagCount.tag);
-}
-
-function extractCardMarkdownPortableMediaPaths(markdown: string): ReadonlyArray<string> {
-  try {
-    return extractMarkdownPortableMediaPaths(markdown);
-  } catch (error) {
-    throw createImportPreviewCardsJsonInvalidError(
-      `Workspace package cards.json contains unsafe media references. reason=${getErrorMessage(error)}`,
-    );
-  }
-}
-
-function extractReferencedPortableMediaPaths(
-  cards: ReadonlyArray<PortableWorkspacePackageCardV1>,
-): ReadonlyArray<string> {
-  const referencedMediaPaths = new Set<string>();
-
-  for (const card of cards) {
-    for (const mediaPath of extractCardMarkdownPortableMediaPaths(card.frontText)) {
-      referencedMediaPaths.add(mediaPath);
-    }
-
-    for (const mediaPath of extractCardMarkdownPortableMediaPaths(card.backText)) {
-      referencedMediaPaths.add(mediaPath);
-    }
-  }
-
-  try {
-    return validateUniquePortableMediaPaths([...referencedMediaPaths]);
-  } catch (error) {
-    throw createImportPreviewCardsJsonInvalidError(
-      `Workspace package cards.json contains duplicate or unsafe media references. reason=${getErrorMessage(error)}`,
-    );
-  }
-}
-
-function assertReferencedMediaFilesExist(
-  referencedMediaPaths: ReadonlyArray<string>,
-  mediaEntriesByPath: ReadonlyMap<string, ZipEntry>,
-): void {
-  const missingMediaPaths = referencedMediaPaths.filter((mediaPath) => mediaEntriesByPath.has(mediaPath) === false);
-  if (missingMediaPaths.length === 0) {
-    return;
-  }
-
-  throw createImportPreviewZipInvalidError(
-    `Workspace package cards.json references media files missing from ZIP. missingMediaPaths=${missingMediaPaths.join(",")}`,
-  );
 }
 
 function getLowercaseFileExtension(mediaPath: string): string | null {
@@ -648,7 +236,7 @@ export function normalizeWorkspacePackageImportTagPolicy(
   const removedTags = normalizeUniqueTextValues(tagPolicy.removedTags, "tagPolicy.removedTags");
   const unknownRemovedTags = removedTags.filter((tag) => packageTagSet.has(tag) === false);
   if (unknownRemovedTags.length !== 0) {
-    throw createImportPreviewInputError(
+    throw createWorkspacePackageImportInputError(
       `tagPolicy.removedTags must contain only exact package tag values. unknownTags=${unknownRemovedTags.join(",")}`,
     );
   }
@@ -685,13 +273,13 @@ export async function previewWorkspacePackageZipImportWithLimits(
   input: WorkspacePackageImportPreviewInput,
   limits: WorkspacePackageImportPreviewLimits,
 ): Promise<WorkspacePackageImportPreview> {
-  const normalizedLimits = normalizePreviewLimits(limits);
+  const normalizedLimits = normalizeWorkspacePackageImportZipLimits(limits);
   const suggestedImportTag = buildSuggestedWorkspacePackageImportTag(
     input.generatedAt,
     input.existingWorkspaceTags,
   );
-  const packageBytes = normalizePackageBytes(input.packageBytes, normalizedLimits.maxZipBytes);
-  const zipFile = await openZipFile(packageBytes);
+  const packageBytes = normalizeWorkspacePackageZipBytes(input.packageBytes, normalizedLimits.maxZipBytes);
+  const zipFile = await openWorkspacePackageZipFile(packageBytes);
 
   let collectedZip: CollectedWorkspacePackageZip;
   try {
@@ -702,17 +290,11 @@ export async function previewWorkspacePackageZipImportWithLimits(
     }
   }
 
-  if (collectedZip.cardsJsonBytes === null) {
-    throw createImportPreviewZipInvalidError(
-      `Workspace package ZIP must contain exactly one cards.json entry. cardsJsonEntryCount=${collectedZip.cardsJsonEntryCount}`,
-    );
-  }
-
-  const cardsJson = parseCardsJsonBytes(collectedZip.cardsJsonBytes);
-  assertCardCountWithinLimit(cardsJson.cards.length, normalizedLimits.maxCards);
+  const cardsJson = parseWorkspacePackageCardsJsonBytes(collectedZip.cardsJsonBytes);
+  assertWorkspacePackageCardCountWithinLimit(cardsJson.cards.length, normalizedLimits.maxCards);
   const tagCounts = buildImportPreviewTagCounts(cardsJson.cards);
-  const referencedMediaPaths = extractReferencedPortableMediaPaths(cardsJson.cards);
-  assertReferencedMediaFilesExist(referencedMediaPaths, collectedZip.mediaEntriesByPath);
+  const referencedMediaPaths = extractReferencedWorkspacePackageMediaPaths(cardsJson.cards);
+  assertReferencedWorkspacePackageMediaFilesExist(referencedMediaPaths, collectedZip.mediaEntriesByPath);
 
   return {
     sourceKind: "zip",

--- a/apps/backend/src/workspacePackages/importZip.ts
+++ b/apps/backend/src/workspacePackages/importZip.ts
@@ -1,0 +1,456 @@
+import { Buffer } from "node:buffer";
+import type { Readable } from "node:stream";
+import {
+  fromBufferPromise,
+  type Entry as ZipEntry,
+  type ZipFile,
+} from "yauzl";
+import { HttpError } from "../shared/errors";
+import {
+  extractMarkdownPortableMediaPaths,
+  validatePortableMediaPath,
+  validateUniquePortableMediaPaths,
+} from "./markdownMedia";
+import {
+  parseWorkspacePackageCardsJsonV1,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardsJsonV1,
+} from "./types";
+
+export const workspacePackageImportZipDefaultMaxZipBytes = 80 * 1024 * 1024;
+export const workspacePackageImportZipDefaultMaxEntries = 10_001;
+export const workspacePackageImportZipDefaultMaxCards = 5_000;
+export const workspacePackageImportZipDefaultMaxMediaFiles = 10_000;
+export const workspacePackageImportZipDefaultMaxSingleMediaBytes = 16 * 1024 * 1024;
+export const workspacePackageImportZipDefaultMaxTotalMediaBytes = 64 * 1024 * 1024;
+
+export type WorkspacePackageImportZipLimits = Readonly<{
+  maxZipBytes: number;
+  maxEntries: number;
+  maxCards: number;
+  maxMediaFiles: number;
+  maxSingleMediaBytes: number;
+  maxTotalMediaBytes: number;
+}>;
+
+export type CollectedWorkspacePackageZip = Readonly<{
+  cardsJsonBytes: Buffer;
+  mediaEntriesByPath: ReadonlyMap<string, ZipEntry>;
+  mediaPaths: ReadonlyArray<string>;
+}>;
+
+export const defaultWorkspacePackageImportZipLimits: WorkspacePackageImportZipLimits = {
+  maxZipBytes: workspacePackageImportZipDefaultMaxZipBytes,
+  maxEntries: workspacePackageImportZipDefaultMaxEntries,
+  maxCards: workspacePackageImportZipDefaultMaxCards,
+  maxMediaFiles: workspacePackageImportZipDefaultMaxMediaFiles,
+  maxSingleMediaBytes: workspacePackageImportZipDefaultMaxSingleMediaBytes,
+  maxTotalMediaBytes: workspacePackageImportZipDefaultMaxTotalMediaBytes,
+};
+
+export function createWorkspacePackageImportInputError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_INPUT_INVALID");
+}
+
+function createWorkspacePackageImportZipInvalidError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID");
+}
+
+function createWorkspacePackageImportCardsJsonMalformedError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_MALFORMED");
+}
+
+function createWorkspacePackageImportCardsJsonInvalidError(message: string): HttpError {
+  return new HttpError(400, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_INVALID");
+}
+
+function createWorkspacePackageImportTooLargeError(message: string): HttpError {
+  return new HttpError(413, message, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_TOO_LARGE");
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function assertPositiveSafeInteger(value: number, fieldName: string): void {
+  if (
+    Number.isSafeInteger(value) === false
+    || value < 1
+    || value >= Number.MAX_SAFE_INTEGER
+  ) {
+    throw createWorkspacePackageImportInputError(`${fieldName} must be a positive safe integer`);
+  }
+}
+
+export function normalizeWorkspacePackageImportZipLimits(
+  limits: WorkspacePackageImportZipLimits,
+): WorkspacePackageImportZipLimits {
+  assertPositiveSafeInteger(limits.maxZipBytes, "limits.maxZipBytes");
+  assertPositiveSafeInteger(limits.maxEntries, "limits.maxEntries");
+  assertPositiveSafeInteger(limits.maxCards, "limits.maxCards");
+  assertPositiveSafeInteger(limits.maxMediaFiles, "limits.maxMediaFiles");
+  assertPositiveSafeInteger(limits.maxSingleMediaBytes, "limits.maxSingleMediaBytes");
+  assertPositiveSafeInteger(limits.maxTotalMediaBytes, "limits.maxTotalMediaBytes");
+
+  return limits;
+}
+
+export function normalizeWorkspacePackageZipBytes(
+  packageBytes: Buffer | Uint8Array,
+  maxZipBytes: number,
+): Buffer {
+  const bytes = Buffer.from(packageBytes);
+  if (bytes.byteLength > maxZipBytes) {
+    throw createWorkspacePackageImportTooLargeError(
+      `Workspace package ZIP is too large. zipBytes=${bytes.byteLength} maxZipBytes=${maxZipBytes}`,
+    );
+  }
+
+  return bytes;
+}
+
+function assertZipEntryDataCanBeDecoded(entry: ZipEntry, entryPath: string): void {
+  if (entry.canDecodeFileData()) {
+    return;
+  }
+
+  throw createWorkspacePackageImportZipInvalidError(
+    [
+      "Workspace package ZIP entry uses unsupported compression or encryption.",
+      `entryPath=${entryPath}`,
+      `compressionMethod=${entry.compressionMethod}`,
+      `encrypted=${entry.isEncrypted()}`,
+    ].join(" "),
+  );
+}
+
+function normalizeZipEntryPath(entryPath: string): string {
+  if (entryPath === "") {
+    throw createWorkspacePackageImportZipInvalidError("Workspace package ZIP entry path must not be empty");
+  }
+
+  if (entryPath.includes("\\") || entryPath.includes("\0")) {
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP entry path is unsafe. entryPath=${entryPath}`,
+    );
+  }
+
+  if (entryPath === "cards.json") {
+    return entryPath;
+  }
+
+  if (entryPath.startsWith("media/")) {
+    try {
+      return validatePortableMediaPath(entryPath);
+    } catch (error) {
+      throw createWorkspacePackageImportZipInvalidError(
+        `Workspace package ZIP contains unsafe media path. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  throw createWorkspacePackageImportZipInvalidError(
+    `Workspace package ZIP contains unsupported entry. entryPath=${entryPath}. Only cards.json and media/** are supported.`,
+  );
+}
+
+export async function openWorkspacePackageZipFile(bytes: Buffer): Promise<ZipFile> {
+  try {
+    return await fromBufferPromise(bytes, {
+      autoClose: false,
+      lazyEntries: true,
+      decodeStrings: true,
+      validateEntrySizes: true,
+      strictFileNames: true,
+    });
+  } catch (error) {
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP is invalid. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+export async function readWorkspacePackageZipEntryBytes(
+  zipFile: ZipFile,
+  entry: ZipEntry,
+  maxBytes: number,
+): Promise<Buffer> {
+  let stream: Readable;
+  try {
+    stream = await zipFile.openReadStreamPromise(entry);
+  } catch (error) {
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP entry cannot be read. entryPath=${entry.fileName} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  const chunks: Array<Buffer> = [];
+  let totalBytes = 0;
+
+  try {
+    for await (const chunk of stream) {
+      const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += chunkBuffer.byteLength;
+      if (totalBytes > maxBytes) {
+        throw createWorkspacePackageImportTooLargeError(
+          `Workspace package ZIP entry is too large. entryPath=${entry.fileName} bytes=${totalBytes} maxBytes=${maxBytes}`,
+        );
+      }
+
+      chunks.push(chunkBuffer);
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP entry cannot be read. entryPath=${entry.fileName} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  return Buffer.concat(chunks, totalBytes);
+}
+
+function assertEntryCountWithinLimit(entryCount: number, maxEntries: number): void {
+  if (entryCount <= maxEntries) {
+    return;
+  }
+
+  throw createWorkspacePackageImportTooLargeError(
+    `Workspace package ZIP contains too many entries. entryCount=${entryCount} maxEntries=${maxEntries}`,
+  );
+}
+
+function getReadableChunkByteLength(chunk: unknown): number {
+  if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+    return chunk.byteLength;
+  }
+
+  if (typeof chunk === "string") {
+    return Buffer.byteLength(chunk);
+  }
+
+  throw new Error("ZIP entry stream emitted an unsupported chunk type");
+}
+
+function assertMediaEntryWithinLimit(
+  mediaBytes: number,
+  entryPath: string,
+  maxSingleMediaBytes: number,
+): void {
+  if (mediaBytes > maxSingleMediaBytes) {
+    throw createWorkspacePackageImportTooLargeError(
+      [
+        "Workspace package ZIP media entry is too large.",
+        `entryPath=${entryPath}`,
+        `mediaBytes=${mediaBytes}`,
+        `maxSingleMediaBytes=${maxSingleMediaBytes}`,
+      ].join(" "),
+    );
+  }
+}
+
+function assertMediaFileCountWithinLimit(mediaFileCount: number, maxMediaFiles: number): void {
+  if (mediaFileCount > maxMediaFiles) {
+    throw createWorkspacePackageImportTooLargeError(
+      `Workspace package ZIP contains too many media files. mediaFileCount=${mediaFileCount} maxMediaFiles=${maxMediaFiles}`,
+    );
+  }
+}
+
+function assertTotalMediaBytesWithinLimit(totalMediaBytes: number, maxTotalMediaBytes: number): void {
+  if (Number.isSafeInteger(totalMediaBytes) === false) {
+    throw new Error("Workspace package ZIP media byte total must be a safe integer");
+  }
+
+  if (totalMediaBytes > maxTotalMediaBytes) {
+    throw createWorkspacePackageImportTooLargeError(
+      [
+        "Workspace package ZIP media total is too large.",
+        `totalMediaBytes=${totalMediaBytes}`,
+        `maxTotalMediaBytes=${maxTotalMediaBytes}`,
+      ].join(" "),
+    );
+  }
+}
+
+async function drainMediaZipEntryBytes(
+  zipFile: ZipFile,
+  entry: ZipEntry,
+  entryPath: string,
+  currentTotalMediaBytes: number,
+  limits: WorkspacePackageImportZipLimits,
+): Promise<number> {
+  let stream: Readable;
+  try {
+    stream = await zipFile.openReadStreamPromise(entry);
+  } catch (error) {
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP media entry cannot be read. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  let mediaBytes = 0;
+  let totalMediaBytes = currentTotalMediaBytes;
+
+  try {
+    for await (const chunk of stream) {
+      const chunkByteLength = getReadableChunkByteLength(chunk);
+      mediaBytes += chunkByteLength;
+      if (Number.isSafeInteger(mediaBytes) === false) {
+        throw new Error(`Workspace package ZIP media entry byte count must be a safe integer. entryPath=${entryPath}`);
+      }
+
+      assertMediaEntryWithinLimit(mediaBytes, entryPath, limits.maxSingleMediaBytes);
+      totalMediaBytes += chunkByteLength;
+      assertTotalMediaBytesWithinLimit(totalMediaBytes, limits.maxTotalMediaBytes);
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP media entry cannot be read. entryPath=${entryPath} reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  return totalMediaBytes;
+}
+
+export async function collectWorkspacePackageZipEntries(
+  zipFile: ZipFile,
+  limits: WorkspacePackageImportZipLimits,
+): Promise<CollectedWorkspacePackageZip> {
+  assertEntryCountWithinLimit(zipFile.entryCount, limits.maxEntries);
+
+  let cardsJsonBytes: Buffer | null = null;
+  let cardsJsonEntryCount = 0;
+  const mediaEntriesByPath = new Map<string, ZipEntry>();
+  const mediaPaths: Array<string> = [];
+  let totalMediaBytes = 0;
+
+  try {
+    for await (const entry of zipFile.eachEntry()) {
+      const entryPath = normalizeZipEntryPath(entry.fileName);
+      assertZipEntryDataCanBeDecoded(entry, entryPath);
+
+      if (entryPath === "cards.json") {
+        cardsJsonEntryCount += 1;
+        cardsJsonBytes = await readWorkspacePackageZipEntryBytes(zipFile, entry, limits.maxZipBytes);
+        continue;
+      }
+
+      assertMediaFileCountWithinLimit(mediaPaths.length + 1, limits.maxMediaFiles);
+      totalMediaBytes = await drainMediaZipEntryBytes(zipFile, entry, entryPath, totalMediaBytes, limits);
+      mediaEntriesByPath.set(entryPath, entry);
+      mediaPaths.push(entryPath);
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP is invalid. reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  if (cardsJsonEntryCount !== 1 || cardsJsonBytes === null) {
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP must contain exactly one cards.json entry. cardsJsonEntryCount=${cardsJsonEntryCount}`,
+    );
+  }
+
+  try {
+    validateUniquePortableMediaPaths(mediaPaths);
+  } catch (error) {
+    throw createWorkspacePackageImportZipInvalidError(
+      `Workspace package ZIP contains duplicate or unsafe media paths. reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  return {
+    cardsJsonBytes,
+    mediaEntriesByPath,
+    mediaPaths,
+  };
+}
+
+export function parseWorkspacePackageCardsJsonBytes(cardsJsonBytes: Buffer): WorkspacePackageCardsJsonV1 {
+  let cardsJsonValue: unknown;
+  try {
+    cardsJsonValue = JSON.parse(cardsJsonBytes.toString("utf8"));
+  } catch (error) {
+    throw createWorkspacePackageImportCardsJsonMalformedError(
+      `Workspace package cards.json is malformed JSON. reason=${getErrorMessage(error)}`,
+    );
+  }
+
+  try {
+    return parseWorkspacePackageCardsJsonV1(cardsJsonValue);
+  } catch (error) {
+    throw createWorkspacePackageImportCardsJsonInvalidError(
+      `Workspace package cards.json is invalid. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+export function assertWorkspacePackageCardCountWithinLimit(cardCount: number, maxCards: number): void {
+  if (cardCount <= maxCards) {
+    return;
+  }
+
+  throw createWorkspacePackageImportTooLargeError(
+    `Workspace package cards.json contains too many cards. cardCount=${cardCount} maxCards=${maxCards}`,
+  );
+}
+
+function extractCardMarkdownPortableMediaPaths(markdown: string): ReadonlyArray<string> {
+  try {
+    return extractMarkdownPortableMediaPaths(markdown);
+  } catch (error) {
+    throw createWorkspacePackageImportCardsJsonInvalidError(
+      `Workspace package cards.json contains unsafe media references. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+export function extractReferencedWorkspacePackageMediaPaths(
+  cards: ReadonlyArray<PortableWorkspacePackageCardV1>,
+): ReadonlyArray<string> {
+  const referencedMediaPaths = new Set<string>();
+
+  for (const card of cards) {
+    for (const mediaPath of extractCardMarkdownPortableMediaPaths(card.frontText)) {
+      referencedMediaPaths.add(mediaPath);
+    }
+
+    for (const mediaPath of extractCardMarkdownPortableMediaPaths(card.backText)) {
+      referencedMediaPaths.add(mediaPath);
+    }
+  }
+
+  try {
+    return validateUniquePortableMediaPaths([...referencedMediaPaths]);
+  } catch (error) {
+    throw createWorkspacePackageImportCardsJsonInvalidError(
+      `Workspace package cards.json contains duplicate or unsafe media references. reason=${getErrorMessage(error)}`,
+    );
+  }
+}
+
+export function assertReferencedWorkspacePackageMediaFilesExist(
+  referencedMediaPaths: ReadonlyArray<string>,
+  mediaEntriesByPath: ReadonlyMap<string, ZipEntry>,
+): void {
+  const missingMediaPaths = referencedMediaPaths.filter((mediaPath) => mediaEntriesByPath.has(mediaPath) === false);
+  if (missingMediaPaths.length === 0) {
+    return;
+  }
+
+  throw createWorkspacePackageImportZipInvalidError(
+    `Workspace package cards.json references media files missing from ZIP. missingMediaPaths=${missingMediaPaths.join(",")}`,
+  );
+}

--- a/apps/backend/src/workspacePackages/testZipHelpers.ts
+++ b/apps/backend/src/workspacePackages/testZipHelpers.ts
@@ -1,0 +1,151 @@
+import { Buffer } from "node:buffer";
+import { deflateRawSync } from "node:zlib";
+import type {
+  WorkspacePackageCardsJsonV1,
+} from "./types";
+
+export type TestZipEntry = Readonly<{
+  path: string;
+  bytes: Buffer;
+  compressionMethod?: number;
+  uncompressedSize?: number;
+}>;
+
+type TestCentralDirectoryEntry = Readonly<{
+  pathBytes: Buffer;
+  entry: TestZipEntry;
+  localHeaderOffset: number;
+}>;
+
+const zipLocalFileHeaderSignature = 0x04034b50;
+const zipCentralDirectoryHeaderSignature = 0x02014b50;
+const zipEndOfCentralDirectorySignature = 0x06054b50;
+const zipVersionNeededToExtract = 20;
+const zipStoredCompressionMethod = 0;
+const zipDeflatedCompressionMethod = 8;
+const zipDosTimeMidnight = 0;
+const zipDosDateJanuaryFirst1980 = 33;
+
+export function createCardsJsonBuffer(cardsJson: WorkspacePackageCardsJsonV1): Buffer {
+  return Buffer.from(JSON.stringify(cardsJson), "utf8");
+}
+
+function getTestZipEntryCompressionMethod(entry: TestZipEntry): number {
+  return entry.compressionMethod ?? zipStoredCompressionMethod;
+}
+
+function getTestZipEntryUncompressedSize(entry: TestZipEntry): number {
+  return entry.uncompressedSize ?? entry.bytes.byteLength;
+}
+
+export function createDeflatedZipEntry(
+  path: string,
+  uncompressedBytes: Buffer,
+  declaredUncompressedSize: number,
+): TestZipEntry {
+  return {
+    path,
+    bytes: deflateRawSync(uncompressedBytes),
+    compressionMethod: zipDeflatedCompressionMethod,
+    uncompressedSize: declaredUncompressedSize,
+  };
+}
+
+function createLocalFileHeader(pathBytes: Buffer, entry: TestZipEntry): Buffer {
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(zipLocalFileHeaderSignature, 0);
+  header.writeUInt16LE(zipVersionNeededToExtract, 4);
+  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(getTestZipEntryCompressionMethod(entry), 8);
+  header.writeUInt16LE(zipDosTimeMidnight, 10);
+  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 12);
+  header.writeUInt32LE(0, 14);
+  header.writeUInt32LE(entry.bytes.byteLength, 18);
+  header.writeUInt32LE(getTestZipEntryUncompressedSize(entry), 22);
+  header.writeUInt16LE(pathBytes.byteLength, 26);
+  header.writeUInt16LE(0, 28);
+
+  return Buffer.concat([header, pathBytes]);
+}
+
+function createCentralDirectoryHeader(entry: TestCentralDirectoryEntry): Buffer {
+  const header = Buffer.alloc(46);
+  header.writeUInt32LE(zipCentralDirectoryHeaderSignature, 0);
+  header.writeUInt16LE(zipVersionNeededToExtract, 4);
+  header.writeUInt16LE(zipVersionNeededToExtract, 6);
+  header.writeUInt16LE(0, 8);
+  header.writeUInt16LE(getTestZipEntryCompressionMethod(entry.entry), 10);
+  header.writeUInt16LE(zipDosTimeMidnight, 12);
+  header.writeUInt16LE(zipDosDateJanuaryFirst1980, 14);
+  header.writeUInt32LE(0, 16);
+  header.writeUInt32LE(entry.entry.bytes.byteLength, 20);
+  header.writeUInt32LE(getTestZipEntryUncompressedSize(entry.entry), 24);
+  header.writeUInt16LE(entry.pathBytes.byteLength, 28);
+  header.writeUInt16LE(0, 30);
+  header.writeUInt16LE(0, 32);
+  header.writeUInt16LE(0, 34);
+  header.writeUInt16LE(0, 36);
+  header.writeUInt32LE(0, 38);
+  header.writeUInt32LE(entry.localHeaderOffset, 42);
+
+  return Buffer.concat([header, entry.pathBytes]);
+}
+
+function createEndOfCentralDirectory(
+  entryCount: number,
+  centralDirectorySize: number,
+  centralDirectoryOffset: number,
+): Buffer {
+  const header = Buffer.alloc(22);
+  header.writeUInt32LE(zipEndOfCentralDirectorySignature, 0);
+  header.writeUInt16LE(0, 4);
+  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(entryCount, 8);
+  header.writeUInt16LE(entryCount, 10);
+  header.writeUInt32LE(centralDirectorySize, 12);
+  header.writeUInt32LE(centralDirectoryOffset, 16);
+  header.writeUInt16LE(0, 20);
+
+  return header;
+}
+
+export function createStoredZip(entries: ReadonlyArray<TestZipEntry>): Buffer {
+  const localFileParts: Array<Buffer> = [];
+  const centralDirectoryEntries: Array<TestCentralDirectoryEntry> = [];
+  let localHeaderOffset = 0;
+
+  for (const entry of entries) {
+    const pathBytes = Buffer.from(entry.path, "utf8");
+    const localFileHeader = createLocalFileHeader(pathBytes, entry);
+    localFileParts.push(localFileHeader, entry.bytes);
+    centralDirectoryEntries.push({
+      pathBytes,
+      entry,
+      localHeaderOffset,
+    });
+    localHeaderOffset += localFileHeader.byteLength + entry.bytes.byteLength;
+  }
+
+  const centralDirectoryOffset = localHeaderOffset;
+  const centralDirectoryParts = centralDirectoryEntries.map(createCentralDirectoryHeader);
+  const centralDirectorySize = centralDirectoryParts.reduce((totalSize, part) => totalSize + part.byteLength, 0);
+
+  return Buffer.concat([
+    ...localFileParts,
+    ...centralDirectoryParts,
+    createEndOfCentralDirectory(entries.length, centralDirectorySize, centralDirectoryOffset),
+  ]);
+}
+
+export function createPackageZip(
+  cardsJson: WorkspacePackageCardsJsonV1,
+  mediaEntries: ReadonlyArray<TestZipEntry>,
+): Buffer {
+  return createStoredZip([
+    {
+      path: "cards.json",
+      bytes: createCardsJsonBuffer(cardsJson),
+    },
+    ...mediaEntries,
+  ]);
+}


### PR DESCRIPTION
## Summary
- extract reusable ZIP validation, cards.json parsing, media reference, and size-limit helpers from import preview
- keep import preview behavior and public API unchanged while delegating shared ZIP work to the new internal helper
- move existing preview ZIP fixture code into a shared test helper

## Validation
- npm run test --prefix apps/backend -- workspacePackages (passed 641/641)
- npm run lint --prefix apps/backend (passed)
- git --no-pager diff --check (passed)

## Review
- worker-owned review found no P0-P4 issues and no split recommendation
