### PR TITLE
Add referenced media ZIP loader

### DIFF
--- a/apps/backend/src/workspacePackages/importMedia.test.ts
+++ b/apps/backend/src/workspacePackages/importMedia.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import test from "node:test";
+import { HttpError } from "../shared/errors";
+import {
+  loadWorkspacePackageImportReferencedMedia,
+  loadWorkspacePackageImportReferencedMediaWithLimits,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardMetadataV1,
+  type WorkspacePackageCardsJsonV1,
+  type WorkspacePackageImportReferencedMediaInput,
+  type WorkspacePackageImportReferencedMediaLimits,
+} from "./index";
+import {
+  createPackageZip,
+  createStoredZip,
+} from "./testZipHelpers";
+
+const testMetadata: WorkspacePackageCardMetadataV1 = {
+  version: 1,
+  source: null,
+};
+
+function createTestCard(
+  frontText: string,
+  backText: string,
+  tags: ReadonlyArray<string>,
+  cardType: string,
+): PortableWorkspacePackageCardV1 {
+  return {
+    frontText,
+    backText,
+    tags,
+    cardType,
+    metadata: testMetadata,
+  };
+}
+
+function createLoadInput(packageBytes: Buffer): WorkspacePackageImportReferencedMediaInput {
+  return {
+    packageBytes,
+  };
+}
+
+function createImportMediaLimits(
+  maxSingleMediaBytes: number,
+  maxTotalMediaBytes: number,
+): WorkspacePackageImportReferencedMediaLimits {
+  return {
+    maxZipBytes: 1024 * 1024,
+    maxEntries: 100,
+    maxCards: 100,
+    maxMediaFiles: 100,
+    maxSingleMediaBytes,
+    maxTotalMediaBytes,
+  };
+}
+
+async function assertDefaultLoadRejects(
+  packageBytes: Buffer,
+  messagePattern: RegExp,
+): Promise<void> {
+  await assert.rejects(
+    () => loadWorkspacePackageImportReferencedMedia(createLoadInput(packageBytes)),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.match(error.message, messagePattern);
+      return true;
+    },
+  );
+}
+
+async function assertLimitedLoadRejects(
+  packageBytes: Buffer,
+  limits: WorkspacePackageImportReferencedMediaLimits,
+  messagePattern: RegExp,
+): Promise<void> {
+  await assert.rejects(
+    () => loadWorkspacePackageImportReferencedMediaWithLimits(createLoadInput(packageBytes), limits),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.match(error.message, messagePattern);
+      return true;
+    },
+  );
+}
+
+test("ZIP import media loader returns parsed cards and no media for text-only packages", async () => {
+  const cardsJson: WorkspacePackageCardsJsonV1 = {
+    formatVersion: 1,
+    label: "Text deck",
+    cards: [
+      createTestCard("Capital of France?", "Paris", ["geography"], "basic"),
+    ],
+  };
+
+  const result = await loadWorkspacePackageImportReferencedMedia(createLoadInput(createPackageZip(cardsJson, [])));
+
+  assert.deepEqual(result.cardsJson, cardsJson);
+  assert.deepEqual(result.referencedMediaFiles, []);
+  assert.equal(result.referencedMediaFilesByPath.size, 0);
+});
+
+test("ZIP import media loader returns referenced media bytes by portable path", async () => {
+  const imageBytes = Buffer.from("png bytes", "utf8");
+  const cardsJson: WorkspacePackageCardsJsonV1 = {
+    formatVersion: 1,
+    cards: [
+      createTestCard(
+        "Diagram: ![cell](media/images/cell.png)",
+        "Answer",
+        ["biology"],
+        "basic",
+      ),
+    ],
+  };
+
+  const result = await loadWorkspacePackageImportReferencedMedia(createLoadInput(createPackageZip(cardsJson, [
+    { path: "media/images/cell.png", bytes: imageBytes },
+  ])));
+  const mediaFile = result.referencedMediaFilesByPath.get("media/images/cell.png");
+
+  assert.deepEqual(result.referencedMediaFiles.map((file) => file.portablePath), ["media/images/cell.png"]);
+  assert.ok(mediaFile !== undefined);
+  assert.equal(mediaFile.portablePath, "media/images/cell.png");
+  assert.equal(mediaFile.sizeBytes, imageBytes.byteLength);
+  assert.deepEqual(mediaFile.bytes, imageBytes);
+});
+
+test("ZIP import media loader returns one byte record for duplicate references to the same media path", async () => {
+  const mediaBytes = Buffer.from("shared bytes", "utf8");
+  const cardsJson: WorkspacePackageCardsJsonV1 = {
+    formatVersion: 1,
+    cards: [
+      createTestCard(
+        "Prompt image: ![front](media/shared/image.png)",
+        "Answer image: ![back](media/shared/image.png)",
+        ["shared"],
+        "basic",
+      ),
+      createTestCard(
+        "Prompt link: [again](media/shared/image.png)",
+        "Answer",
+        ["shared"],
+        "basic",
+      ),
+    ],
+  };
+
+  const result = await loadWorkspacePackageImportReferencedMedia(createLoadInput(createPackageZip(cardsJson, [
+    { path: "media/shared/image.png", bytes: mediaBytes },
+  ])));
+
+  assert.equal(result.referencedMediaFiles.length, 1);
+  assert.equal(result.referencedMediaFilesByPath.size, 1);
+  assert.deepEqual(result.referencedMediaFiles[0]?.bytes, mediaBytes);
+});
+
+test("ZIP import media loader validates but does not return unreferenced media files", async () => {
+  const referencedBytes = Buffer.from("referenced bytes", "utf8");
+  const cardsJson: WorkspacePackageCardsJsonV1 = {
+    formatVersion: 1,
+    cards: [
+      createTestCard(
+        "Prompt",
+        "See ![image](media/referenced/image.png)",
+        ["tag"],
+        "basic",
+      ),
+    ],
+  };
+
+  const result = await loadWorkspacePackageImportReferencedMedia(createLoadInput(createPackageZip(cardsJson, [
+    { path: "media/referenced/image.png", bytes: referencedBytes },
+    { path: "media/unreferenced/extra.png", bytes: Buffer.from("unused bytes", "utf8") },
+  ])));
+
+  assert.deepEqual(result.referencedMediaFiles.map((file) => file.portablePath), ["media/referenced/image.png"]);
+  assert.equal(result.referencedMediaFilesByPath.has("media/unreferenced/extra.png"), false);
+});
+
+test("ZIP import media loader rejects missing referenced media files", async () => {
+  await assertDefaultLoadRejects(
+    createPackageZip({
+      formatVersion: 1,
+      cards: [
+        createTestCard("Prompt", "![missing](media/missing.png)", ["tag"], "basic"),
+      ],
+    }, []),
+    /references media files missing from ZIP.*media\/missing\.png/,
+  );
+});
+
+test("ZIP import media loader rejects unsafe media entry traversal through shared ZIP validation", async () => {
+  await assertDefaultLoadRejects(
+    createPackageZip({
+      formatVersion: 1,
+      cards: [
+        createTestCard("Prompt", "Answer", ["tag"], "basic"),
+      ],
+    }, [
+      { path: "media/%2e%2e/image.png", bytes: Buffer.from("image", "utf8") },
+    ]),
+    /unsafe media path.*traversal/,
+  );
+});
+
+test("ZIP import media loader enforces per-file decompressed media limits", async () => {
+  await assertLimitedLoadRejects(
+    createPackageZip({
+      formatVersion: 1,
+      cards: [
+        createTestCard("Prompt", "![large](media/large.bin)", ["tag"], "basic"),
+      ],
+    }, [
+      { path: "media/large.bin", bytes: Buffer.from("large", "utf8") },
+    ]),
+    createImportMediaLimits(4, 100),
+    /media entry is too large.*maxSingleMediaBytes=4/,
+  );
+});
+
+test("ZIP import media loader enforces total decompressed media limits", async () => {
+  await assertLimitedLoadRejects(
+    createPackageZip({
+      formatVersion: 1,
+      cards: [
+        createTestCard(
+          "Prompt ![first](media/first.bin)",
+          "Answer ![second](media/second.bin)",
+          ["tag"],
+          "basic",
+        ),
+      ],
+    }, [
+      { path: "media/first.bin", bytes: Buffer.from("123", "utf8") },
+      { path: "media/second.bin", bytes: Buffer.from("456", "utf8") },
+    ]),
+    createImportMediaLimits(10, 5),
+    /media total is too large.*maxTotalMediaBytes=5/,
+  );
+});
+
+test("ZIP import media loader keeps cards.json parsing and validation errors explicit", async () => {
+  await assertDefaultLoadRejects(
+    createStoredZip([
+      { path: "cards.json", bytes: Buffer.from("{", "utf8") },
+    ]),
+    /cards\.json is malformed JSON/,
+  );
+
+  await assertDefaultLoadRejects(
+    createStoredZip([
+      {
+        path: "cards.json",
+        bytes: Buffer.from(JSON.stringify({
+          formatVersion: 1,
+          cards: [
+            {
+              frontText: " ",
+              backText: "Answer",
+              tags: ["tag"],
+              cardType: "basic",
+              metadata: {
+                version: 1,
+                source: null,
+              },
+            },
+          ],
+        }), "utf8"),
+      },
+    ]),
+    /cards\.json is invalid/,
+  );
+});

--- a/apps/backend/src/workspacePackages/importMedia.ts
+++ b/apps/backend/src/workspacePackages/importMedia.ts
@@ -1,0 +1,137 @@
+import { Buffer } from "node:buffer";
+import type { Entry as ZipEntry, ZipFile } from "yauzl";
+import {
+  assertReferencedWorkspacePackageMediaFilesExist,
+  assertWorkspacePackageCardCountWithinLimit,
+  collectWorkspacePackageZipEntries,
+  defaultWorkspacePackageImportZipLimits,
+  extractReferencedWorkspacePackageMediaPaths,
+  normalizeWorkspacePackageImportZipLimits,
+  normalizeWorkspacePackageZipBytes,
+  openWorkspacePackageZipFile,
+  parseWorkspacePackageCardsJsonBytes,
+  readWorkspacePackageZipEntryBytes,
+  type CollectedWorkspacePackageZip,
+  type WorkspacePackageImportZipLimits,
+} from "./importZip";
+import type { WorkspacePackageCardsJsonV1 } from "./types";
+
+export type WorkspacePackageImportReferencedMediaInput = Readonly<{
+  packageBytes: Buffer | Uint8Array;
+}>;
+
+export type WorkspacePackageImportReferencedMediaLimits = WorkspacePackageImportZipLimits;
+
+export type WorkspacePackageImportReferencedMediaFile = Readonly<{
+  portablePath: string;
+  bytes: Buffer;
+  sizeBytes: number;
+}>;
+
+export type WorkspacePackageImportReferencedMediaLoadResult = Readonly<{
+  cardsJson: WorkspacePackageCardsJsonV1;
+  referencedMediaFiles: ReadonlyArray<WorkspacePackageImportReferencedMediaFile>;
+  referencedMediaFilesByPath: ReadonlyMap<string, WorkspacePackageImportReferencedMediaFile>;
+}>;
+
+const defaultImportMediaLimits: WorkspacePackageImportReferencedMediaLimits = defaultWorkspacePackageImportZipLimits;
+
+function getRequiredReferencedMediaEntry(
+  portablePath: string,
+  mediaEntriesByPath: ReadonlyMap<string, ZipEntry>,
+): ZipEntry {
+  const mediaEntry = mediaEntriesByPath.get(portablePath);
+  if (mediaEntry === undefined) {
+    throw new Error(`Referenced workspace package media entry was not found after validation. portablePath=${portablePath}`);
+  }
+
+  return mediaEntry;
+}
+
+async function readReferencedMediaFile(
+  zipFile: ZipFile,
+  portablePath: string,
+  mediaEntry: ZipEntry,
+  limits: WorkspacePackageImportReferencedMediaLimits,
+): Promise<WorkspacePackageImportReferencedMediaFile> {
+  const bytes = await readWorkspacePackageZipEntryBytes(
+    zipFile,
+    mediaEntry,
+    limits.maxSingleMediaBytes,
+  );
+
+  return {
+    portablePath,
+    bytes,
+    sizeBytes: bytes.byteLength,
+  };
+}
+
+async function readReferencedMediaFiles(
+  zipFile: ZipFile,
+  referencedMediaPaths: ReadonlyArray<string>,
+  collectedZip: CollectedWorkspacePackageZip,
+  limits: WorkspacePackageImportReferencedMediaLimits,
+): Promise<ReadonlyArray<WorkspacePackageImportReferencedMediaFile>> {
+  const referencedMediaFiles: Array<WorkspacePackageImportReferencedMediaFile> = [];
+
+  for (const portablePath of referencedMediaPaths) {
+    const mediaEntry = getRequiredReferencedMediaEntry(portablePath, collectedZip.mediaEntriesByPath);
+    const mediaFile = await readReferencedMediaFile(zipFile, portablePath, mediaEntry, limits);
+    referencedMediaFiles.push(mediaFile);
+  }
+
+  return referencedMediaFiles;
+}
+
+function buildReferencedMediaFilesByPath(
+  referencedMediaFiles: ReadonlyArray<WorkspacePackageImportReferencedMediaFile>,
+): ReadonlyMap<string, WorkspacePackageImportReferencedMediaFile> {
+  return new Map(referencedMediaFiles.map((mediaFile) => [mediaFile.portablePath, mediaFile]));
+}
+
+function buildImportReferencedMediaLoadResult(
+  cardsJson: WorkspacePackageCardsJsonV1,
+  referencedMediaFiles: ReadonlyArray<WorkspacePackageImportReferencedMediaFile>,
+): WorkspacePackageImportReferencedMediaLoadResult {
+  return {
+    cardsJson,
+    referencedMediaFiles,
+    referencedMediaFilesByPath: buildReferencedMediaFilesByPath(referencedMediaFiles),
+  };
+}
+
+export async function loadWorkspacePackageImportReferencedMediaWithLimits(
+  input: WorkspacePackageImportReferencedMediaInput,
+  limits: WorkspacePackageImportReferencedMediaLimits,
+): Promise<WorkspacePackageImportReferencedMediaLoadResult> {
+  const normalizedLimits = normalizeWorkspacePackageImportZipLimits(limits);
+  const packageBytes = normalizeWorkspacePackageZipBytes(input.packageBytes, normalizedLimits.maxZipBytes);
+  const zipFile = await openWorkspacePackageZipFile(packageBytes);
+
+  try {
+    const collectedZip = await collectWorkspacePackageZipEntries(zipFile, normalizedLimits);
+    const cardsJson = parseWorkspacePackageCardsJsonBytes(collectedZip.cardsJsonBytes);
+    assertWorkspacePackageCardCountWithinLimit(cardsJson.cards.length, normalizedLimits.maxCards);
+    const referencedMediaPaths = extractReferencedWorkspacePackageMediaPaths(cardsJson.cards);
+    assertReferencedWorkspacePackageMediaFilesExist(referencedMediaPaths, collectedZip.mediaEntriesByPath);
+    const referencedMediaFiles = await readReferencedMediaFiles(
+      zipFile,
+      referencedMediaPaths,
+      collectedZip,
+      normalizedLimits,
+    );
+
+    return buildImportReferencedMediaLoadResult(cardsJson, referencedMediaFiles);
+  } finally {
+    if (zipFile.isOpen) {
+      zipFile.close();
+    }
+  }
+}
+
+export async function loadWorkspacePackageImportReferencedMedia(
+  input: WorkspacePackageImportReferencedMediaInput,
+): Promise<WorkspacePackageImportReferencedMediaLoadResult> {
+  return loadWorkspacePackageImportReferencedMediaWithLimits(input, defaultImportMediaLimits);
+}

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -43,6 +43,11 @@ export {
 } from "./importPreview";
 
 export {
+  loadWorkspacePackageImportReferencedMedia,
+  loadWorkspacePackageImportReferencedMediaWithLimits,
+} from "./importMedia";
+
+export {
   planWorkspacePackageImport,
 } from "./importPlan";
 
@@ -73,6 +78,13 @@ export type {
   WorkspacePackageImportTagPolicy,
   WorkspacePackageImportTagPolicyInput,
 } from "./importPreview";
+
+export type {
+  WorkspacePackageImportReferencedMediaFile,
+  WorkspacePackageImportReferencedMediaInput,
+  WorkspacePackageImportReferencedMediaLimits,
+  WorkspacePackageImportReferencedMediaLoadResult,
+} from "./importMedia";
 
 export type {
   WorkspacePackageImportPlan,


### PR DESCRIPTION
## Summary
- Add a route-independent ZIP import helper for loading bytes only for media referenced from cards.json.
- Reuse shared workspace package ZIP validation helpers and export the loader/types for future import confirmation.
- Add focused workspace package tests for referenced media loading and validation failures.

## Validation
- npm run test --prefix apps/backend -- workspacePackages
- npm run lint --prefix apps/backend
- git --no-pager diff --check