### PR TITLE
Add package import planned card persistence

### DIFF
--- a/apps/backend/src/workspacePackages/importCards.test.ts
+++ b/apps/backend/src/workspacePackages/importCards.test.ts
@@ -1,0 +1,373 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  BulkCreateCardItem,
+  Card,
+  CardMetadata,
+  CardMutationMetadata,
+  CreateCardInput,
+} from "../cards";
+import type {
+  DatabaseExecutor,
+  WorkspaceDatabaseScope,
+} from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  persistWorkspacePackageImportCardsWithDependencies,
+  type WorkspacePackageImportCardPersistenceDependencies,
+} from "./importCards";
+import {
+  planWorkspacePackageImport,
+  type PortableWorkspacePackageCardV1,
+  type WorkspacePackageCardMetadataV1,
+  type WorkspacePackageImportCardPersistenceInput,
+  type WorkspacePackageImportCardPersistenceResult,
+  type WorkspacePackageImportPlannedCard,
+} from "./index";
+
+const testUserId = "user-1";
+const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
+const testReplicaId = "22222222-2222-4222-8222-222222222222";
+const clientUpdatedAt = "2026-06-30T12:01:00.000Z";
+const importedAt = "2026-06-30T12:00:00.000Z";
+const operationIdPrefix = "import-session-1";
+
+const testMetadata: WorkspacePackageCardMetadataV1 = {
+  version: 1,
+  source: {
+    label: "Package label",
+    author: "Package author",
+    comment: "Package comment",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    importedAt,
+    importId: operationIdPrefix,
+  },
+};
+
+type TransactionCall = Readonly<{
+  scope: WorkspaceDatabaseScope;
+  executor: DatabaseExecutor;
+}>;
+
+type CreateCardCall = Readonly<{
+  executor: DatabaseExecutor;
+  workspaceId: string;
+  input: CreateCardInput;
+  metadata: CardMutationMetadata;
+}>;
+
+type TestPersistenceHarness = Readonly<{
+  dependencies: WorkspacePackageImportCardPersistenceDependencies;
+  transactionCalls: ReadonlyArray<TransactionCall>;
+  createCardCalls: ReadonlyArray<CreateCardCall>;
+}>;
+
+function createPlannedCard(
+  frontText: string,
+  backText: string,
+  tags: ReadonlyArray<string>,
+  cardType: string,
+  metadata: WorkspacePackageCardMetadataV1,
+): WorkspacePackageImportPlannedCard {
+  return {
+    frontText,
+    backText,
+    tags,
+    cardType,
+    metadata,
+  };
+}
+
+function createPortableCard(
+  frontText: string,
+  backText: string,
+): PortableWorkspacePackageCardV1 {
+  return {
+    frontText,
+    backText,
+    tags: ["biology"],
+    cardType: "basic",
+    metadata: {
+      version: 1,
+      source: null,
+    },
+  };
+}
+
+function createPersistenceInput(
+  plannedCards: ReadonlyArray<WorkspacePackageImportPlannedCard>,
+): WorkspacePackageImportCardPersistenceInput {
+  return {
+    userId: testUserId,
+    workspaceId: testWorkspaceId,
+    plannedCards,
+    clientUpdatedAt,
+    lastModifiedByReplicaId: testReplicaId,
+    operationIdPrefix,
+  };
+}
+
+function createCreatedCard(item: BulkCreateCardItem, cardIndex: number): Card {
+  return {
+    cardId: `card-${cardIndex}`,
+    frontText: item.input.frontText,
+    backText: item.input.backText,
+    cardType: item.input.cardType ?? "basic",
+    metadata: item.input.metadata ?? ({ version: 1, source: null } satisfies CardMetadata),
+    tags: item.input.tags,
+    dueAt: null,
+    createdAt: item.metadata.clientUpdatedAt,
+    reps: 0,
+    lapses: 0,
+    fsrsCardState: "new",
+    fsrsStepIndex: null,
+    fsrsStability: null,
+    fsrsDifficulty: null,
+    fsrsLastReviewedAt: null,
+    fsrsScheduledDays: null,
+    clientUpdatedAt: item.metadata.clientUpdatedAt,
+    lastModifiedByReplicaId: item.metadata.lastModifiedByReplicaId,
+    lastOperationId: item.metadata.lastOperationId,
+    updatedAt: item.metadata.clientUpdatedAt,
+    deletedAt: null,
+  };
+}
+
+function createPersistenceHarness(): TestPersistenceHarness {
+  const transactionCalls: Array<TransactionCall> = [];
+  const createCardCalls: Array<CreateCardCall> = [];
+  let createdCardIndex = 0;
+
+  return {
+    transactionCalls,
+    createCardCalls,
+    dependencies: {
+      createCardInExecutorFn: async (
+        executor: DatabaseExecutor,
+        workspaceId: string,
+        input: CreateCardInput,
+        metadata: CardMutationMetadata,
+      ): Promise<Card> => {
+        createCardCalls.push({ executor, workspaceId, input, metadata });
+        const card = createCreatedCard({ input, metadata }, createdCardIndex);
+        createdCardIndex += 1;
+        return card;
+      },
+      transactionWithWorkspaceScopeFn: async (
+        scope: WorkspaceDatabaseScope,
+        callback: (executor: DatabaseExecutor) => Promise<WorkspacePackageImportCardPersistenceResult>,
+      ): Promise<WorkspacePackageImportCardPersistenceResult> => {
+        const executor: DatabaseExecutor = {
+          async query(): Promise<never> {
+            throw new Error("Test executor query should not be called");
+          },
+        };
+        transactionCalls.push({ scope, executor });
+        return callback(executor);
+      },
+    },
+  };
+}
+
+test("workspace package import card persistence returns empty results without opening a transaction", async () => {
+  const harness = createPersistenceHarness();
+
+  const result = await persistWorkspacePackageImportCardsWithDependencies(
+    createPersistenceInput([]),
+    harness.dependencies,
+  );
+
+  assert.deepEqual(result.cards, []);
+  assert.deepEqual(result.summary, {
+    cardCount: 0,
+    batchCount: 0,
+  });
+  assert.deepEqual(harness.transactionCalls, []);
+  assert.deepEqual(harness.createCardCalls, []);
+});
+
+test("workspace package import card persistence maps one planned card inside one transaction", async () => {
+  const plannedCard = createPlannedCard(
+    "Prompt",
+    "Answer",
+    ["biology", "imported"],
+    "basic",
+    testMetadata,
+  );
+  const harness = createPersistenceHarness();
+
+  const result = await persistWorkspacePackageImportCardsWithDependencies(
+    createPersistenceInput([plannedCard]),
+    harness.dependencies,
+  );
+
+  assert.equal(harness.transactionCalls.length, 1);
+  assert.deepEqual(harness.transactionCalls[0]?.scope, {
+    userId: testUserId,
+    workspaceId: testWorkspaceId,
+  });
+  assert.equal(harness.createCardCalls.length, 1);
+  assert.equal(harness.createCardCalls[0]?.executor, harness.transactionCalls[0]?.executor);
+  assert.equal(harness.createCardCalls[0]?.workspaceId, testWorkspaceId);
+  assert.deepEqual(harness.createCardCalls[0]?.input, {
+    frontText: "Prompt",
+    backText: "Answer",
+    tags: ["biology", "imported"],
+    cardType: "basic",
+    metadata: testMetadata,
+  });
+  assert.deepEqual(harness.createCardCalls[0]?.metadata, {
+    clientUpdatedAt,
+    lastModifiedByReplicaId: testReplicaId,
+    lastOperationId: `${operationIdPrefix}:card:0`,
+  });
+  assert.deepEqual(result.summary, {
+    cardCount: 1,
+    batchCount: 1,
+  });
+  assert.equal(result.cards[0]?.frontText, "Prompt");
+  assert.equal(result.cards[0]?.lastOperationId, `${operationIdPrefix}:card:0`);
+});
+
+test("workspace package import card persistence keeps 101 cards ordered inside one transaction", async () => {
+  const plannedCards = Array.from({ length: 101 }, (_value, cardIndex) => createPlannedCard(
+    `Prompt ${cardIndex}`,
+    `Answer ${cardIndex}`,
+    [`tag-${cardIndex}`],
+    "basic",
+    testMetadata,
+  ));
+  const harness = createPersistenceHarness();
+
+  const result = await persistWorkspacePackageImportCardsWithDependencies(
+    createPersistenceInput(plannedCards),
+    harness.dependencies,
+  );
+
+  assert.equal(harness.transactionCalls.length, 1);
+  assert.equal(harness.createCardCalls.length, 101);
+  assert.ok(harness.createCardCalls.every((call) => call.executor === harness.transactionCalls[0]?.executor));
+  assert.equal(harness.createCardCalls[0]?.metadata.lastOperationId, `${operationIdPrefix}:card:0`);
+  assert.equal(harness.createCardCalls[99]?.metadata.lastOperationId, `${operationIdPrefix}:card:99`);
+  assert.equal(harness.createCardCalls[100]?.metadata.lastOperationId, `${operationIdPrefix}:card:100`);
+  assert.deepEqual(
+    result.cards.map((card) => card.cardId),
+    plannedCards.map((_card, cardIndex) => `card-${cardIndex}`),
+  );
+  assert.deepEqual(result.summary, {
+    cardCount: 101,
+    batchCount: 2,
+  });
+});
+
+test("workspace package import card persistence preserves later batch HttpError details with context", async () => {
+  const details = {
+    validationIssues: [
+      {
+        path: "frontText",
+        code: "too_small",
+        message: "frontText must not be empty.",
+      },
+    ],
+  };
+  const transactionCalls: Array<TransactionCall> = [];
+  const createCardCalls: Array<CreateCardCall> = [];
+  const dependencies: WorkspacePackageImportCardPersistenceDependencies = {
+    createCardInExecutorFn: async (
+      executor: DatabaseExecutor,
+      workspaceId: string,
+      input: CreateCardInput,
+      metadata: CardMutationMetadata,
+    ): Promise<Card> => {
+      createCardCalls.push({ executor, workspaceId, input, metadata });
+      if (metadata.lastOperationId === `${operationIdPrefix}:card:100`) {
+        throw new HttpError(400, "Card batch is invalid.", "CARD_BATCH_INVALID", details);
+      }
+
+      return createCreatedCard({ input, metadata }, createCardCalls.length - 1);
+    },
+    transactionWithWorkspaceScopeFn: async (
+      scope: WorkspaceDatabaseScope,
+      callback: (executor: DatabaseExecutor) => Promise<WorkspacePackageImportCardPersistenceResult>,
+    ): Promise<WorkspacePackageImportCardPersistenceResult> => {
+      const executor: DatabaseExecutor = {
+        async query(): Promise<never> {
+          throw new Error("Test executor query should not be called");
+        },
+      };
+      transactionCalls.push({ scope, executor });
+      return callback(executor);
+    },
+  };
+  const plannedCards = Array.from({ length: 101 }, (_value, cardIndex) => createPlannedCard(
+    `Prompt ${cardIndex}`,
+    `Answer ${cardIndex}`,
+    [`tag-${cardIndex}`],
+    "basic",
+    testMetadata,
+  ));
+
+  await assert.rejects(
+    () => persistWorkspacePackageImportCardsWithDependencies(createPersistenceInput(plannedCards), dependencies),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "CARD_BATCH_INVALID");
+      assert.deepEqual(error.details, details);
+      assert.match(error.message, /batchIndex=1/);
+      assert.match(error.message, /cardRange=100-100/);
+      assert.match(error.message, /Card batch is invalid/);
+      return true;
+    },
+  );
+  assert.equal(transactionCalls.length, 1);
+  assert.equal(createCardCalls.length, 101);
+  assert.ok(createCardCalls.every((call) => call.executor === transactionCalls[0]?.executor));
+});
+
+test("workspace package import plan output can be persisted directly", async () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: {
+      formatVersion: 1,
+      label: "Biology package",
+      author: "Author",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      cards: [
+        createPortableCard(
+          "Diagram: ![cell](media/images/cell.png)",
+          "Answer",
+        ),
+      ],
+    },
+    options: {
+      addImportTag: true,
+      importTag: "import:2026-06-30-0",
+      removeTags: [],
+      importedAt,
+      importId: operationIdPrefix,
+    },
+    mediaAssetIdsByPortablePath: new Map([
+      ["media/images/cell.png", "image-asset"],
+    ]),
+  });
+  const harness = createPersistenceHarness();
+
+  await persistWorkspacePackageImportCardsWithDependencies(
+    createPersistenceInput(plan.cards),
+    harness.dependencies,
+  );
+
+  assert.equal(harness.createCardCalls[0]?.input.frontText, "Diagram: ![cell](fcasset:image-asset)");
+  assert.deepEqual(harness.createCardCalls[0]?.input.tags, ["biology", "import:2026-06-30-0"]);
+  assert.deepEqual(harness.createCardCalls[0]?.input.metadata, {
+    version: 1,
+    source: {
+      label: "Biology package",
+      author: "Author",
+      comment: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      importedAt,
+      importId: operationIdPrefix,
+    },
+  });
+});

--- a/apps/backend/src/workspacePackages/importCards.ts
+++ b/apps/backend/src/workspacePackages/importCards.ts
@@ -1,0 +1,204 @@
+import {
+  createCardInExecutor,
+  type BulkCreateCardItem,
+  type Card,
+  type CardMutationMetadata,
+  type CreateCardInput,
+} from "../cards";
+import {
+  transactionWithWorkspaceScope,
+  type DatabaseExecutor,
+  type WorkspaceDatabaseScope,
+} from "../database";
+import { HttpError } from "../shared/errors";
+import type { WorkspacePackageImportPlannedCard } from "./importPlan";
+
+const workspacePackageImportCardPersistenceBatchSize = 100;
+
+export type WorkspacePackageImportCardPersistenceInput = Readonly<{
+  userId: string;
+  workspaceId: string;
+  plannedCards: ReadonlyArray<WorkspacePackageImportPlannedCard>;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  operationIdPrefix: string;
+}>;
+
+export type WorkspacePackageImportCardPersistenceSummary = Readonly<{
+  cardCount: number;
+  batchCount: number;
+}>;
+
+export type WorkspacePackageImportCardPersistenceResult = Readonly<{
+  cards: ReadonlyArray<Card>;
+  summary: WorkspacePackageImportCardPersistenceSummary;
+}>;
+
+export type WorkspacePackageImportCardPersistenceCreateCardInExecutorFn = (
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: CreateCardInput,
+  metadata: CardMutationMetadata,
+) => Promise<Card>;
+
+export type WorkspacePackageImportCardPersistenceTransactionFn = (
+  scope: WorkspaceDatabaseScope,
+  callback: (executor: DatabaseExecutor) => Promise<WorkspacePackageImportCardPersistenceResult>,
+) => Promise<WorkspacePackageImportCardPersistenceResult>;
+
+export type WorkspacePackageImportCardPersistenceDependencies = Readonly<{
+  createCardInExecutorFn: WorkspacePackageImportCardPersistenceCreateCardInExecutorFn;
+  transactionWithWorkspaceScopeFn: WorkspacePackageImportCardPersistenceTransactionFn;
+}>;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function createCardPersistenceError(
+  error: unknown,
+  batchIndex: number,
+  firstCardIndex: number,
+  lastCardIndex: number,
+): Error {
+  const message = [
+    "Workspace package import card persistence failed",
+    `batchIndex=${batchIndex}`,
+    `cardRange=${firstCardIndex}-${lastCardIndex}.`,
+    `reason=${getErrorMessage(error)}`,
+  ].join(" ");
+
+  if (error instanceof HttpError) {
+    return new HttpError(
+      error.statusCode,
+      message,
+      error.code ?? undefined,
+      error.details ?? undefined,
+    );
+  }
+
+  return new Error(message);
+}
+
+function buildImportCardLastOperationId(operationIdPrefix: string, cardIndex: number): string {
+  return `${operationIdPrefix}:card:${cardIndex}`;
+}
+
+function buildBulkCreateCardItem(
+  input: WorkspacePackageImportCardPersistenceInput,
+  plannedCard: WorkspacePackageImportPlannedCard,
+  cardIndex: number,
+): BulkCreateCardItem {
+  return {
+    input: {
+      frontText: plannedCard.frontText,
+      backText: plannedCard.backText,
+      tags: plannedCard.tags,
+      cardType: plannedCard.cardType,
+      metadata: plannedCard.metadata,
+    },
+    metadata: {
+      clientUpdatedAt: input.clientUpdatedAt,
+      lastModifiedByReplicaId: input.lastModifiedByReplicaId,
+      lastOperationId: buildImportCardLastOperationId(input.operationIdPrefix, cardIndex),
+    },
+  };
+}
+
+function splitBulkCreateCardItems(
+  items: ReadonlyArray<BulkCreateCardItem>,
+  batchSize: number,
+): ReadonlyArray<ReadonlyArray<BulkCreateCardItem>> {
+  const batches: Array<ReadonlyArray<BulkCreateCardItem>> = [];
+  for (let startIndex = 0; startIndex < items.length; startIndex += batchSize) {
+    batches.push(items.slice(startIndex, startIndex + batchSize));
+  }
+
+  return batches;
+}
+
+async function persistBulkCreateCardBatchInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  batch: ReadonlyArray<BulkCreateCardItem>,
+  dependencies: WorkspacePackageImportCardPersistenceDependencies,
+): Promise<ReadonlyArray<Card>> {
+  const createdCards: Array<Card> = [];
+  for (const item of batch) {
+    createdCards.push(await dependencies.createCardInExecutorFn(
+      executor,
+      workspaceId,
+      item.input,
+      item.metadata,
+    ));
+  }
+
+  return createdCards;
+}
+
+export async function persistWorkspacePackageImportCardsWithDependencies(
+  input: WorkspacePackageImportCardPersistenceInput,
+  dependencies: WorkspacePackageImportCardPersistenceDependencies,
+): Promise<WorkspacePackageImportCardPersistenceResult> {
+  const items = input.plannedCards.map((plannedCard, cardIndex) => buildBulkCreateCardItem(
+    input,
+    plannedCard,
+    cardIndex,
+  ));
+  const batches = splitBulkCreateCardItems(items, workspacePackageImportCardPersistenceBatchSize);
+  if (batches.length === 0) {
+    return {
+      cards: [],
+      summary: {
+        cardCount: 0,
+        batchCount: 0,
+      },
+    };
+  }
+
+  return dependencies.transactionWithWorkspaceScopeFn(
+    {
+      userId: input.userId,
+      workspaceId: input.workspaceId,
+    },
+    async (executor): Promise<WorkspacePackageImportCardPersistenceResult> => {
+      const cards: Array<Card> = [];
+
+      for (const [batchIndex, batch] of batches.entries()) {
+        const firstCardIndex = batchIndex * workspacePackageImportCardPersistenceBatchSize;
+        const lastCardIndex = firstCardIndex + batch.length - 1;
+        try {
+          const createdCards = await persistBulkCreateCardBatchInExecutor(
+            executor,
+            input.workspaceId,
+            batch,
+            dependencies,
+          );
+          cards.push(...createdCards);
+        } catch (error) {
+          throw createCardPersistenceError(error, batchIndex, firstCardIndex, lastCardIndex);
+        }
+      }
+
+      return {
+        cards,
+        summary: {
+          cardCount: cards.length,
+          batchCount: batches.length,
+        },
+      };
+    }
+  );
+}
+
+export async function persistWorkspacePackageImportCards(
+  input: WorkspacePackageImportCardPersistenceInput,
+): Promise<WorkspacePackageImportCardPersistenceResult> {
+  return persistWorkspacePackageImportCardsWithDependencies(input, {
+    createCardInExecutorFn: createCardInExecutor,
+    transactionWithWorkspaceScopeFn: async (
+      scope: WorkspaceDatabaseScope,
+      callback: (executor: DatabaseExecutor) => Promise<WorkspacePackageImportCardPersistenceResult>,
+    ): Promise<WorkspacePackageImportCardPersistenceResult> => transactionWithWorkspaceScope(scope, callback),
+  });
+}

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -52,6 +52,10 @@ export {
 } from "./importMediaAssets";
 
 export {
+  persistWorkspacePackageImportCards,
+} from "./importCards";
+
+export {
   planWorkspacePackageImport,
 } from "./importPlan";
 
@@ -95,6 +99,12 @@ export type {
   WorkspacePackageImportMediaAssetIngestionInput,
   WorkspacePackageImportMediaAssetIngestionResult,
 } from "./importMediaAssets";
+
+export type {
+  WorkspacePackageImportCardPersistenceInput,
+  WorkspacePackageImportCardPersistenceResult,
+  WorkspacePackageImportCardPersistenceSummary,
+} from "./importCards";
 
 export type {
   WorkspacePackageImportPlan,


### PR DESCRIPTION
## Summary
- Add a route-independent workspace package import helper that persists planned cards through existing card-domain executor code
- Run all import card batches inside one workspace transaction while keeping 100-card batch ranges for context
- Add dependency-injected tests for field mapping, deterministic operation IDs, ordering, transaction use, and failure context

## Validation
- npm run test --prefix apps/backend -- workspacePackages cards
- npm run lint --prefix apps/backend
- git --no-pager diff --check