### PR TITLE
Add backend ZIP import preview route

### DIFF
--- a/api/src/components/schemas/AgentDiscoveryData.yaml
+++ b/api/src/components/schemas/AgentDiscoveryData.yaml
@@ -66,6 +66,7 @@ properties:
       - mediaAssetDownloadUrlTemplate
       - workspacePackageExportPreviewUrlTemplate
       - workspacePackageExportUrlTemplate
+      - workspacePackageImportPreviewUrlTemplate
     properties:
       accountUrl:
         type: string
@@ -92,6 +93,8 @@ properties:
       workspacePackageExportPreviewUrlTemplate:
         type: string
       workspacePackageExportUrlTemplate:
+        type: string
+      workspacePackageImportPreviewUrlTemplate:
         type: string
   mcp:
     type: object

--- a/api/src/components/schemas/WorkspacePackageImportPreviewResponse.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportPreviewResponse.yaml
@@ -1,0 +1,96 @@
+type: object
+additionalProperties: false
+required:
+  - sourceKind
+  - packageMetadata
+  - cardCount
+  - tagCounts
+  - referencedMediaCount
+  - packageMediaFileCount
+  - warnings
+  - defaultOptions
+properties:
+  sourceKind:
+    type: string
+    enum:
+      - zip
+  packageMetadata:
+    type: object
+    additionalProperties: false
+    required:
+      - label
+      - author
+      - comment
+      - createdAt
+      - sourceUrl
+    properties:
+      label:
+        type:
+          - string
+          - 'null'
+      author:
+        type:
+          - string
+          - 'null'
+      comment:
+        type:
+          - string
+          - 'null'
+      createdAt:
+        type:
+          - string
+          - 'null'
+      sourceUrl:
+        type:
+          - string
+          - 'null'
+  cardCount:
+    type: integer
+    minimum: 0
+  tagCounts:
+    type: array
+    items:
+      $ref: ./WorkspacePackageExportTagCount.yaml
+  referencedMediaCount:
+    type: integer
+    minimum: 0
+  packageMediaFileCount:
+    type: integer
+    minimum: 0
+  warnings:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+        - mediaPath
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        mediaPath:
+          type: string
+  defaultOptions:
+    type: object
+    additionalProperties: false
+    required:
+      - addImportTag
+      - suggestedImportTag
+      - keptTags
+      - removedTags
+    properties:
+      addImportTag:
+        type: boolean
+      suggestedImportTag:
+        type: string
+      keptTags:
+        type: array
+        items:
+          type: string
+      removedTags:
+        type: array
+        items:
+          type: string

--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -50,7 +50,7 @@ tags:
       transfer URLs.
   - name: workspace-packages
     description: >-
-      Workspace-scoped package export preview and portable ZIP download.
+      Workspace-scoped package export, import preview, and portable ZIP download.
   - name: admin-catalog
     description: >-
       Admin-only catalog authoring surface for marketplace authors, packages,
@@ -92,6 +92,8 @@ paths:
     $ref: paths/workspaces_{workspaceId}_packages_export_preview.yaml
   /workspaces/{workspaceId}/packages/export:
     $ref: paths/workspaces_{workspaceId}_packages_export.yaml
+  /workspaces/{workspaceId}/packages/import/preview:
+    $ref: paths/workspaces_{workspaceId}_packages_import_preview.yaml
   /admin/catalog/authors:
     $ref: paths/admin_catalog_authors.yaml
   /admin/catalog/authors/{authorId}:

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -35,7 +35,7 @@ get:
                 - Ingest JPEG, PNG, and WebP media images through the workspace-scoped image endpoint
                 - Upload and complete media assets through workspace-scoped direct transfer endpoints
                 - Read media asset metadata and create download URLs through workspace-scoped media endpoints
-                - Preview and download portable workspace package ZIP exports
+                - Preview and download portable workspace package ZIP exports, and preview ZIP imports
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -52,6 +52,7 @@ get:
                 mediaAssetDownloadUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
                 workspacePackageExportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
                 workspacePackageExportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
+                workspacePackageImportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import/preview
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -113,6 +114,10 @@ get:
               /v1/workspaces/{workspaceId}/packages/export/preview to preview a
               portable workspace package export, then POST
               /v1/workspaces/{workspaceId}/packages/export to download the ZIP.
+              Use POST
+              /v1/workspaces/{workspaceId}/packages/import/preview with
+              application/zip bytes up to 4000000 bytes to preview a portable
+              workspace package import.
               Use docs.openapiUrl for the published external agent contract.
             links:
               websiteUrl: https://flashcards-open-source-app.com/

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -33,7 +33,7 @@ get:
                 - Ingest JPEG, PNG, and WebP media images through the workspace-scoped image endpoint
                 - Upload and complete media assets through workspace-scoped direct transfer endpoints
                 - Read media asset metadata and create download URLs through workspace-scoped media endpoints
-                - Preview and download portable workspace package ZIP exports
+                - Preview and download portable workspace package ZIP exports, and preview ZIP imports
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -50,6 +50,7 @@ get:
                 mediaAssetDownloadUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
                 workspacePackageExportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
                 workspacePackageExportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
+                workspacePackageImportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import/preview
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -121,7 +122,10 @@ get:
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
               to preview a portable workspace package export, then POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
-              to download the ZIP. SELECT returns at most
+              to download the ZIP. Use POST
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import/preview
+              with application/zip bytes up to 4000000 bytes to preview a
+              portable workspace package import. SELECT returns at most
               100 rows per statement, and INSERT, UPDATE, and DELETE may affect
               at most 100 rows per statement. If you need more than 100
               writes, split the work into multiple batches of at most 100

--- a/api/src/paths/workspaces_{workspaceId}_packages_import_preview.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_import_preview.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - workspace-packages
+  summary: Preview a workspace package import
+  description: >-
+    Reads a portable workspace package ZIP and returns the import preview JSON
+    without creating cards, media assets, or persistent import state. Direct
+    request bodies are limited to 4000000 bytes for the buffered API transport.
+    The path workspaceId is authoritative for workspace access and existing tag
+    context.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      application/zip:
+        schema:
+          type: string
+          format: binary
+          maxLength: 4000000
+  responses:
+    '200':
+      description: Workspace package import preview
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/WorkspacePackageImportPreviewResponse.yaml
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -1,5 +1,6 @@
 import { getPublicAgentDocs, getPublicApiBaseUrl, getPublicLegalLinks } from "../shared/publicUrls";
 import { maximumImageIngestionOriginalBytes } from "../mediaAssets/validators";
+import { workspacePackageImportPreviewRouteMaxZipBytes } from "../routes/workspacePackages";
 
 type AgentDiscoveryEnvelope = Readonly<{
   ok: true;
@@ -31,6 +32,7 @@ type AgentDiscoveryEnvelope = Readonly<{
       mediaAssetDownloadUrlTemplate: string;
       workspacePackageExportPreviewUrlTemplate: string;
       workspacePackageExportUrlTemplate: string;
+      workspacePackageImportPreviewUrlTemplate: string;
     }>;
     mcp: Readonly<{
       url: string;
@@ -117,6 +119,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
   const mediaAssetDownloadUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url`;
   const workspacePackageExportPreviewUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/export/preview`;
   const workspacePackageExportUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/export`;
+  const workspacePackageImportPreviewUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/import/preview`;
 
   return {
     ok: true,
@@ -141,7 +144,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         "Ingest JPEG, PNG, and WebP image bytes through the workspace-scoped image media endpoint",
         "Upload and complete media assets through workspace-scoped direct transfer endpoints",
         "Read media asset metadata and create download URLs through workspace-scoped media endpoints",
-        "Preview and download portable workspace package ZIP exports",
+        "Preview and download portable workspace package ZIP exports, and preview ZIP imports",
       ],
       authBaseUrl,
       apiBaseUrl,
@@ -159,6 +162,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         mediaAssetDownloadUrlTemplate,
         workspacePackageExportPreviewUrlTemplate,
         workspacePackageExportUrlTemplate,
+        workspacePackageImportPreviewUrlTemplate,
       },
       mcp: {
         url: `${mcpBaseUrl}/mcp`,
@@ -181,7 +185,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
     },
     links,
     instructions:
-      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when creating media assets. Use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For JPEG, PNG, or WebP images up to ${maximumImageIngestionOriginalBytes} bytes, prefer POST ${mediaAssetImageIngestionUrlTemplate} with the image bytes as the request body and x-media-asset-id, x-media-created-at, x-media-client-updated-at, x-media-last-modified-by-replica-id, and x-media-last-operation-id headers; the backend normalizes to canonical JPEG bytes and returns the mediaAsset. For other media assets, create a multipart upload session with POST ${mediaAssetUploadSessionCreateUrlTemplate}; if status is already_available, use the returned mediaAsset and skip byte upload. If status is upload_required, request signed part URLs with POST ${mediaAssetUploadSessionPartsUrlTemplate}, upload each part with the returned signed URL, method, and headers, then complete the upload with POST ${mediaAssetUploadSessionCompleteUrlTemplate}. Abort unused sessions with POST ${mediaAssetUploadSessionAbortUrlTemplate}. Use GET ${mediaAssetMetadataUrlTemplate} for registry metadata and GET ${mediaAssetDownloadUrlTemplate} for a range-capable direct download URL. Use POST ${workspacePackageExportPreviewUrlTemplate} to preview a portable workspace package export, then POST ${workspacePackageExportUrlTemplate} to download the ZIP. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
+      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when creating media assets. Use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For JPEG, PNG, or WebP images up to ${maximumImageIngestionOriginalBytes} bytes, prefer POST ${mediaAssetImageIngestionUrlTemplate} with the image bytes as the request body and x-media-asset-id, x-media-created-at, x-media-client-updated-at, x-media-last-modified-by-replica-id, and x-media-last-operation-id headers; the backend normalizes to canonical JPEG bytes and returns the mediaAsset. For other media assets, create a multipart upload session with POST ${mediaAssetUploadSessionCreateUrlTemplate}; if status is already_available, use the returned mediaAsset and skip byte upload. If status is upload_required, request signed part URLs with POST ${mediaAssetUploadSessionPartsUrlTemplate}, upload each part with the returned signed URL, method, and headers, then complete the upload with POST ${mediaAssetUploadSessionCompleteUrlTemplate}. Abort unused sessions with POST ${mediaAssetUploadSessionAbortUrlTemplate}. Use GET ${mediaAssetMetadataUrlTemplate} for registry metadata and GET ${mediaAssetDownloadUrlTemplate} for a range-capable direct download URL. Use POST ${workspacePackageExportPreviewUrlTemplate} to preview a portable workspace package export, then POST ${workspacePackageExportUrlTemplate} to download the ZIP. Use POST ${workspacePackageImportPreviewUrlTemplate} with application/zip bytes up to ${workspacePackageImportPreviewRouteMaxZipBytes} bytes to preview a portable workspace package import. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
     docs,
   };
 }

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -261,6 +261,14 @@ export type WorkspacePackageExportDetails = Readonly<{
   bytesCount: number | null;
 }>;
 
+export type WorkspacePackageImportPreviewDetails = Readonly<{
+  statusCode: number;
+  bytesCount: number | null;
+  cardCount: number | null;
+  referencedMediaCount: number | null;
+  packageMediaFileCount: number | null;
+}>;
+
 export type MediaAssetRouteDetails = Readonly<{
   statusCode: number;
   mediaAssetId: string | null;
@@ -776,6 +784,8 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"workspace_package_export_preview_error", FailureDetailsFor<WorkspacePackageExportPreviewDetails>>
   | EventByAction<"workspace_package_export", WorkspacePackageExportDetails>
   | EventByAction<"workspace_package_export_error", FailureDetailsFor<WorkspacePackageExportDetails>>
+  | EventByAction<"workspace_package_import_preview", WorkspacePackageImportPreviewDetails>
+  | EventByAction<"workspace_package_import_preview_error", FailureDetailsFor<WorkspacePackageImportPreviewDetails>>
   | EventByAction<"media_asset_image_ingest", MediaAssetRouteDetails>
   | EventByAction<"media_asset_image_ingest_error", FailureDetailsFor<MediaAssetRouteDetails>>
   | EventByAction<"media_asset_upload_session_media_reuse", MediaAssetRouteDetails>
@@ -921,6 +931,10 @@ export type BackendExceptionEvent =
   )
   | (
     EventByAction<"workspace_package_export_error", FailureDetailsFor<WorkspacePackageExportDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"workspace_package_import_preview_error", FailureDetailsFor<WorkspacePackageImportPreviewDetails>>
     & Readonly<{ error: Error }>
   )
   | (

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../agent/setup";
 import { loadOpenApiDocument } from "../../shared/openapi";
 import { maximumImageIngestionOriginalBytes } from "../../mediaAssets/validators";
+import { workspacePackageImportPreviewRouteMaxZipBytes } from "../workspacePackages";
 import type { RequestContext } from "../../server/requestContext";
 import type { WorkspaceSummary } from "../../workspaces";
 
@@ -72,6 +73,7 @@ const expectedPublishedApiMethods = {
   "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url": ["get"],
   "/workspaces/{workspaceId}/packages/export/preview": ["post"],
   "/workspaces/{workspaceId}/packages/export": ["post"],
+  "/workspaces/{workspaceId}/packages/import/preview": ["post"],
   "/admin/catalog/authors": ["post"],
   "/admin/catalog/authors/{authorId}": ["put"],
   "/admin/catalog/packages": ["post"],
@@ -95,6 +97,7 @@ const expectedMediaDiscoverySurfaceTemplates = {
   mediaAssetDownloadUrlTemplate: "/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url",
   workspacePackageExportPreviewUrlTemplate: "/workspaces/{workspaceId}/packages/export/preview",
   workspacePackageExportUrlTemplate: "/workspaces/{workspaceId}/packages/export",
+  workspacePackageImportPreviewUrlTemplate: "/workspaces/{workspaceId}/packages/import/preview",
 } as const;
 const supportedImageIngestionOpenApiContentTypes = [
   "application/octet-stream",
@@ -150,6 +153,12 @@ function loadMediaAssetImageIngestionOperation(openApiDocument: OpenApiDocumentF
   return operation as OpenApiOperationForTest;
 }
 
+function loadWorkspacePackageImportPreviewOperation(openApiDocument: OpenApiDocumentForTest): OpenApiOperationForTest {
+  const operation = openApiDocument.paths?.["/workspaces/{workspaceId}/packages/import/preview"]?.post;
+  assert.ok(operation !== undefined);
+  return operation as OpenApiOperationForTest;
+}
+
 test("API Gateway predeclares PATCH /me/preferences", () => {
   const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
   const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
@@ -164,13 +173,17 @@ test("API Gateway predeclares POST /workspaces/{workspaceId}/media-assets/images
   assert.match(apiGatewaySource, /workspaceMediaAssets\.addResource\("images"\)\.addMethod\("POST", integration\);/);
 });
 
-test("API Gateway predeclares package export routes and ZIP binary media", () => {
+test("API Gateway predeclares package export and import preview routes and ZIP binary media", () => {
   const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
   const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
 
   assert.match(apiGatewaySource, /binaryMediaTypes: \[[^\]]*"application\/zip"/);
   assert.match(apiGatewaySource, /workspacePackageExport\.addMethod\("POST", integration\);/);
   assert.match(apiGatewaySource, /workspacePackageExport\.addResource\("preview"\)\.addMethod\("POST", integration\);/);
+  assert.match(
+    apiGatewaySource,
+    /workspacePackages\s*\.addResource\("import"\)\s*\.addResource\("preview"\)\s*\.addMethod\("POST", integration\);/,
+  );
 });
 
 test("published OpenAPI exposes the curated agent, media transfer, and admin catalog contract", () => {
@@ -247,6 +260,7 @@ test("agent discovery advertises the published media transfer surface", () => {
   assert.match(discoveryEnvelope.instructions, /media-assets\/\{mediaAssetId\}\/download-url/);
   assert.match(discoveryEnvelope.instructions, /packages\/export\/preview/);
   assert.match(discoveryEnvelope.instructions, /packages\/export/);
+  assert.match(discoveryEnvelope.instructions, /packages\/import\/preview/);
   assert.match(discoveryEnvelope.instructions, /data\.agentWorkspaceReplicaId/);
   assert.match(discoveryEnvelope.instructions, /lastModifiedByReplicaId/);
 });
@@ -272,6 +286,31 @@ test("media asset image ingestion publishes the transport-safe original body lim
   assert.match(
     JSON.stringify(openApiDocument.paths?.["/agent"] ?? {}),
     new RegExp(`up to ${maximumImageIngestionOriginalBytes} bytes`),
+  );
+});
+
+test("workspace package import preview publishes the direct route body limit", () => {
+  assert.ok(workspacePackageImportPreviewRouteMaxZipBytes <= maximumLambdaProxySafeImageIngestionOriginalBytes);
+
+  const apiBaseUrl = "https://api.flashcards-open-source-app.com/v1";
+  const discoveryEnvelope = createAgentDiscoveryEnvelope(`${apiBaseUrl}/agent`);
+  const openApiDocument = loadPublishedOpenApiDocument();
+  const operation = loadWorkspacePackageImportPreviewOperation(openApiDocument);
+  const requestBodyContent = operation.requestBody?.content ?? {};
+
+  assert.match(operation.description ?? "", new RegExp(`${workspacePackageImportPreviewRouteMaxZipBytes} bytes`));
+  assert.match(discoveryEnvelope.instructions, new RegExp(`up to ${workspacePackageImportPreviewRouteMaxZipBytes} bytes`));
+  assert.equal(
+    requestBodyContent["application/zip"]?.schema?.maxLength,
+    workspacePackageImportPreviewRouteMaxZipBytes,
+  );
+  assert.match(
+    JSON.stringify(openApiDocument.paths?.["/"] ?? {}),
+    new RegExp(`up to ${workspacePackageImportPreviewRouteMaxZipBytes} bytes`),
+  );
+  assert.match(
+    JSON.stringify(openApiDocument.paths?.["/agent"] ?? {}),
+    new RegExp(`up to ${workspacePackageImportPreviewRouteMaxZipBytes} bytes`),
   );
 });
 

--- a/apps/backend/src/routes/workspacePackages.test.ts
+++ b/apps/backend/src/routes/workspacePackages.test.ts
@@ -3,13 +3,18 @@ import { Buffer } from "node:buffer";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { createWorkspacePackageRoutes } from "./workspacePackages";
+import {
+  createWorkspacePackageRoutes,
+  workspacePackageImportPreviewRouteMaxZipBytes,
+} from "./workspacePackages";
 import { HttpError } from "../shared/errors";
 import type { AppEnv } from "../server/app";
 import type { RequestContext } from "../server/requestContext";
 import type {
   WorkspacePackageExportPackageInput,
   WorkspacePackageExportPreviewInput,
+  WorkspacePackageImportPreview,
+  WorkspacePackageImportPreviewInput,
 } from "../workspacePackages";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
@@ -61,6 +66,45 @@ function createWorkspacePackageExportRequestBody(): Record<string, unknown> {
   };
 }
 
+function createWorkspacePackageImportPreviewResponse(): WorkspacePackageImportPreview {
+  return {
+    sourceKind: "zip",
+    packageMetadata: {
+      label: "Imported deck",
+      author: null,
+      comment: null,
+      createdAt: "2026-06-30T00:00:00.000Z",
+      sourceUrl: null,
+    },
+    cardCount: 2,
+    tagCounts: [
+      {
+        tag: "spanish",
+        cardsCount: 2,
+      },
+    ],
+    referencedMediaCount: 1,
+    packageMediaFileCount: 1,
+    warnings: [
+      {
+        code: "WORKSPACE_PACKAGE_IMPORT_MEDIA_TYPE_UNSUPPORTED",
+        message: "Referenced package media may not be supported by the import confirmation flow.",
+        mediaPath: "media/audio.wav",
+      },
+    ],
+    defaultOptions: {
+      addImportTag: true,
+      suggestedImportTag: "import:2026-06-30-1",
+      keptTags: ["spanish"],
+      removedTags: [],
+    },
+  };
+}
+
+function createOversizedWorkspacePackageImportPreviewZipBytes(): Buffer {
+  return Buffer.alloc(workspacePackageImportPreviewRouteMaxZipBytes + 1, 0x61);
+}
+
 function createWorkspacePackageTestApp(routes: Hono<AppEnv>): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   app.use("*", async (context, next) => {
@@ -107,6 +151,18 @@ function assertExportInput(input: WorkspacePackageExportPreviewInput): void {
     sourceUrl: null,
   });
   assert.equal(new Date(input.generatedAt).toISOString(), input.generatedAt);
+}
+
+function assertImportPreviewInput(
+  input: WorkspacePackageImportPreviewInput,
+  zipBytes: Buffer,
+): void {
+  assert.deepEqual(Buffer.from(input.packageBytes), zipBytes);
+  assert.equal(new Date(input.generatedAt).toISOString(), input.generatedAt);
+  assert.deepEqual(input.existingWorkspaceTags, [
+    "import:2026-06-30-0",
+    "draft",
+  ]);
 }
 
 test("POST /workspaces/:workspaceId/packages/export/preview returns preview JSON for the path workspace", async () => {
@@ -205,6 +261,173 @@ test("POST /workspaces/:workspaceId/packages/export/preview returns preview JSON
   assert.equal(previewCalls, 1);
 });
 
+test("POST /workspaces/:workspaceId/packages/import/preview passes ZIP bytes and existing tags to preview service", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const previewJson = createWorkspacePackageImportPreviewResponse();
+  let accessChecks = 0;
+  let tagSummaryCalls = 0;
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
+      accessChecks += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(checkedWorkspaceId, workspaceId);
+    },
+    listWorkspaceTagsSummaryFn: async (userId, requestedWorkspaceId) => {
+      tagSummaryCalls += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, workspaceId);
+
+      return {
+        totalCards: 3,
+        tags: [
+          {
+            tag: "import:2026-06-30-0",
+            cardsCount: 1,
+          },
+          {
+            tag: "draft",
+            cardsCount: 2,
+          },
+        ],
+      };
+    },
+    previewWorkspacePackageZipImportFn: async (input) => {
+      previewCalls += 1;
+      assertImportPreviewInput(input, zipBytes);
+      return previewJson;
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/zip",
+    },
+    body: zipBytes,
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), previewJson);
+  assert.equal(accessChecks, 1);
+  assert.equal(tagSummaryCalls, 1);
+  assert.equal(previewCalls, 1);
+});
+
+test("POST /workspaces/:workspaceId/packages/import/preview uses path workspace instead of selected workspace", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const checkedWorkspaceIds: Array<string> = [];
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (_userId, checkedWorkspaceId) => {
+      checkedWorkspaceIds.push(checkedWorkspaceId);
+    },
+    listWorkspaceTagsSummaryFn: async (_userId, requestedWorkspaceId) => {
+      checkedWorkspaceIds.push(requestedWorkspaceId);
+      return {
+        totalCards: 0,
+        tags: [],
+      };
+    },
+    previewWorkspacePackageZipImportFn: async () => createWorkspacePackageImportPreviewResponse(),
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/zip",
+    },
+    body: zipBytes,
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(checkedWorkspaceIds, [workspaceId, workspaceId]);
+  assert.notEqual(workspaceId, createRequestContext().selectedWorkspaceId);
+});
+
+test("POST /workspaces/:workspaceId/packages/import/preview rejects content-length over the direct route limit", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  let tagSummaryCalls = 0;
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    listWorkspaceTagsSummaryFn: async () => {
+      tagSummaryCalls += 1;
+      throw new Error("Tag summary service must not be called when import preview body is too large.");
+    },
+    previewWorkspacePackageZipImportFn: async () => {
+      previewCalls += 1;
+      throw new Error("Import preview service must not be called when import preview body is too large.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Length": (workspacePackageImportPreviewRouteMaxZipBytes + 1).toString(),
+      "Content-Type": "application/zip",
+    },
+    body: zipBytes,
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 413);
+  assert.equal(body.code, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_BODY_TOO_LARGE");
+  assert.match(body.error, new RegExp(workspacePackageImportPreviewRouteMaxZipBytes.toString()));
+  assert.equal(tagSummaryCalls, 0);
+  assert.equal(previewCalls, 0);
+});
+
+test("POST /workspaces/:workspaceId/packages/import/preview rejects actual body bytes over the direct route limit", async () => {
+  let tagSummaryCalls = 0;
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    listWorkspaceTagsSummaryFn: async () => {
+      tagSummaryCalls += 1;
+      throw new Error("Tag summary service must not be called when import preview body is too large.");
+    },
+    previewWorkspacePackageZipImportFn: async () => {
+      previewCalls += 1;
+      throw new Error("Import preview service must not be called when import preview body is too large.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/zip",
+    },
+    body: createOversizedWorkspacePackageImportPreviewZipBytes(),
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 413);
+  assert.equal(body.code, "WORKSPACE_PACKAGE_IMPORT_PREVIEW_BODY_TOO_LARGE");
+  assert.match(body.error, new RegExp(workspacePackageImportPreviewRouteMaxZipBytes.toString()));
+  assert.equal(tagSummaryCalls, 0);
+  assert.equal(previewCalls, 0);
+});
+
 test("POST /workspaces/:workspaceId/packages/export returns ZIP bytes with download headers", async () => {
   const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
   let exportCalls = 0;
@@ -249,6 +472,44 @@ test("POST /workspaces/:workspaceId/packages/export returns ZIP bytes with downl
   assert.equal(response.headers.get("content-length"), zipBytes.byteLength.toString());
   assert.deepEqual(Buffer.from(await response.arrayBuffer()), zipBytes);
   assert.equal(exportCalls, 1);
+});
+
+test("workspace package import preview route stops before tag and preview service calls when workspace access is denied", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  let tagSummaryCalls = 0;
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => {
+      throw new HttpError(403, "Workspace access denied", "WORKSPACE_ACCESS_DENIED");
+    },
+    listWorkspaceTagsSummaryFn: async () => {
+      tagSummaryCalls += 1;
+      throw new Error("Tag summary service must not be called when workspace access is denied.");
+    },
+    previewWorkspacePackageZipImportFn: async () => {
+      previewCalls += 1;
+      throw new Error("Import preview service must not be called when workspace access is denied.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/zip",
+    },
+    body: zipBytes,
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 403);
+  assert.equal(body.code, "WORKSPACE_ACCESS_DENIED");
+  assert.equal(tagSummaryCalls, 0);
+  assert.equal(previewCalls, 0);
 });
 
 test("workspace package export routes stop before service calls when workspace access is denied", async () => {

--- a/apps/backend/src/routes/workspacePackages.ts
+++ b/apps/backend/src/routes/workspacePackages.ts
@@ -1,8 +1,11 @@
+import { Buffer } from "node:buffer";
 import { Hono } from "hono";
 import { z } from "zod";
+import { listWorkspaceTagsSummary } from "../cards";
 import {
   exportWorkspacePackage,
   previewWorkspacePackageExport,
+  previewWorkspacePackageZipImport,
   type WorkspacePackageExportCardSelection,
   type WorkspacePackageExportMetadataInput,
   type WorkspacePackageExportPackage,
@@ -10,6 +13,7 @@ import {
   type WorkspacePackageExportPreview,
   type WorkspacePackageExportPreviewInput,
   type WorkspacePackageExportTagPolicyInput,
+  type WorkspacePackageImportPreview,
 } from "../workspacePackages";
 import { assertUserHasWorkspaceAccess } from "../workspaces";
 import {
@@ -35,6 +39,8 @@ type WorkspacePackageRoutesOptions = Readonly<{
   assertUserHasWorkspaceAccessFn?: typeof assertUserHasWorkspaceAccess;
   previewWorkspacePackageExportFn?: typeof previewWorkspacePackageExport;
   exportWorkspacePackageFn?: typeof exportWorkspacePackage;
+  listWorkspaceTagsSummaryFn?: typeof listWorkspaceTagsSummary;
+  previewWorkspacePackageZipImportFn?: typeof previewWorkspacePackageZipImport;
 }>;
 
 type WorkspacePackageExportRouteInput = Readonly<{
@@ -44,6 +50,9 @@ type WorkspacePackageExportRouteInput = Readonly<{
 }>;
 
 type WorkspacePackageExportPreviewResponse = WorkspacePackageExportPreview;
+type WorkspacePackageImportPreviewResponse = WorkspacePackageImportPreview;
+
+export const workspacePackageImportPreviewRouteMaxZipBytes = 4_000_000;
 
 const allActiveCardsSelectionSchema = z.object({
   kind: z.literal("allActiveCards"),
@@ -194,12 +203,81 @@ function createContentDispositionHeader(packageExport: WorkspacePackageExportPac
   return `attachment; filename="${packageExport.fileName}"`;
 }
 
+function assertWorkspacePackageImportPreviewContentType(headers: Headers): void {
+  const contentTypeHeader = headers.get("content-type");
+  const contentType = contentTypeHeader?.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (contentType !== "application/zip") {
+    throw new HttpError(
+      415,
+      "content-type must be application/zip",
+      "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CONTENT_TYPE_UNSUPPORTED",
+    );
+  }
+}
+
+function assertWorkspacePackageImportPreviewZipBytesNotEmpty(byteLength: number): void {
+  if (byteLength === 0) {
+    throw new HttpError(
+      400,
+      "Workspace package ZIP request body must not be empty",
+      "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_EMPTY",
+    );
+  }
+}
+
+function createWorkspacePackageImportPreviewBodyTooLargeError(byteLength: number): HttpError {
+  return new HttpError(
+    413,
+    `Direct workspace package import preview ZIP is too large for this endpoint. zipBytes=${byteLength} maxZipBytes=${workspacePackageImportPreviewRouteMaxZipBytes}`,
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_BODY_TOO_LARGE",
+  );
+}
+
+function assertWorkspacePackageImportPreviewZipBytesWithinRouteLimit(byteLength: number): void {
+  if (byteLength > workspacePackageImportPreviewRouteMaxZipBytes) {
+    throw createWorkspacePackageImportPreviewBodyTooLargeError(byteLength);
+  }
+}
+
+function parseWorkspacePackageImportPreviewContentLength(headers: Headers): number | null {
+  const contentLengthHeader = headers.get("content-length");
+  if (contentLengthHeader === null) {
+    return null;
+  }
+
+  if (/^\d+$/.test(contentLengthHeader) === false) {
+    throw new HttpError(400, "content-length must be a non-negative safe integer", "CONTENT_LENGTH_INVALID");
+  }
+
+  const contentLength = Number.parseInt(contentLengthHeader, 10);
+  if (Number.isSafeInteger(contentLength) === false) {
+    throw new HttpError(400, "content-length must be a non-negative safe integer", "CONTENT_LENGTH_INVALID");
+  }
+
+  return contentLength;
+}
+
+async function readWorkspacePackageImportPreviewZipBytes(request: Request): Promise<Buffer> {
+  assertWorkspacePackageImportPreviewContentType(request.headers);
+  const contentLength = parseWorkspacePackageImportPreviewContentLength(request.headers);
+  if (contentLength !== null) {
+    assertWorkspacePackageImportPreviewZipBytesWithinRouteLimit(contentLength);
+  }
+
+  const bytes = Buffer.from(await request.arrayBuffer());
+  assertWorkspacePackageImportPreviewZipBytesNotEmpty(bytes.byteLength);
+  assertWorkspacePackageImportPreviewZipBytesWithinRouteLimit(bytes.byteLength);
+  return bytes;
+}
+
 export function createWorkspacePackageRoutes(options: WorkspacePackageRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
   const assertUserHasWorkspaceAccessFn = options.assertUserHasWorkspaceAccessFn ?? assertUserHasWorkspaceAccess;
   const previewWorkspacePackageExportFn = options.previewWorkspacePackageExportFn ?? previewWorkspacePackageExport;
   const exportWorkspacePackageFn = options.exportWorkspacePackageFn ?? exportWorkspacePackage;
+  const listWorkspaceTagsSummaryFn = options.listWorkspaceTagsSummaryFn ?? listWorkspaceTagsSummary;
+  const previewWorkspacePackageZipImportFn = options.previewWorkspacePackageZipImportFn ?? previewWorkspacePackageZipImport;
 
   app.post("/workspaces/:workspaceId/packages/export/preview", async (context) => {
     const requestId = context.get("requestId");
@@ -282,6 +360,57 @@ export function createWorkspacePackageRoutes(options: WorkspacePackageRoutesOpti
         error,
         { action: "workspace_package_export_error", error: normalizeCaughtError(error), scope, details },
         { action: "workspace_package_export_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.post("/workspaces/:workspaceId/packages/import/preview", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
+      const packageBytes = await readWorkspacePackageImportPreviewZipBytes(context.req.raw);
+      const existingWorkspaceTags = (await listWorkspaceTagsSummaryFn(requestContext.userId, workspaceId))
+        .tags
+        .map((tagSummary) => tagSummary.tag);
+      const preview = await previewWorkspacePackageZipImportFn({
+        packageBytes,
+        generatedAt: new Date().toISOString(),
+        existingWorkspaceTags,
+      });
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      addBackendBreadcrumb({
+        action: "workspace_package_import_preview",
+        scope,
+        details: {
+          statusCode: 200,
+          bytesCount: packageBytes.byteLength,
+          cardCount: preview.cardCount,
+          referencedMediaCount: preview.referencedMediaCount,
+          packageMediaFileCount: preview.packageMediaFileCount,
+        },
+      });
+
+      return context.json(preview satisfies WorkspacePackageImportPreviewResponse);
+    } catch (error) {
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        bytesCount: null,
+        cardCount: null,
+        referencedMediaCount: null,
+        packageMediaFileCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_package_import_preview_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_package_import_preview_error", scope, details },
       );
       throw error;
     }

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -828,6 +828,10 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   const workspacePackageExport = workspacePackages.addResource("export");
   workspacePackageExport.addMethod("POST", integration);
   workspacePackageExport.addResource("preview").addMethod("POST", integration);
+  workspacePackages
+    .addResource("import")
+    .addResource("preview")
+    .addMethod("POST", integration);
   const workspaceMediaAssets = workspaceById.addResource("media-assets");
   workspaceMediaAssets.addResource("images").addMethod("POST", integration);
   const workspaceMediaAssetUploadSessions = workspaceMediaAssets.addResource("upload-sessions");


### PR DESCRIPTION
## Summary
- add POST /workspaces/:workspaceId/packages/import/preview for raw application/zip preview requests
- load existing workspace tags and call the existing ZIP import preview service after workspace access checks
- publish the route in OpenAPI, API Gateway, and agent discovery with a transport-safe direct body limit

## Validation
- npm run test --prefix apps/backend -- workspacePackages routes system/contracts (passed, 670 tests)
- npm run lint --prefix apps/backend (passed)
- npm run bundle --prefix api (passed)
- git --no-pager diff --check (passed)
- final worker-owned review: no split recommendation, no P0-P4 findings

Residual risk: local validation ran under Node 25.6.1 while the repo declares Node 24.x; accepted by orchestration.