### PR TITLE
Add workspace package import confirm route

### DIFF
--- a/api/src/components/schemas/AgentDiscoveryData.yaml
+++ b/api/src/components/schemas/AgentDiscoveryData.yaml
@@ -67,6 +67,7 @@ properties:
       - workspacePackageExportPreviewUrlTemplate
       - workspacePackageExportUrlTemplate
       - workspacePackageImportPreviewUrlTemplate
+      - workspacePackageImportUrlTemplate
     properties:
       accountUrl:
         type: string
@@ -95,6 +96,8 @@ properties:
       workspacePackageExportUrlTemplate:
         type: string
       workspacePackageImportPreviewUrlTemplate:
+        type: string
+      workspacePackageImportUrlTemplate:
         type: string
   mcp:
     type: object

--- a/api/src/components/schemas/Card.yaml
+++ b/api/src/components/schemas/Card.yaml
@@ -1,0 +1,98 @@
+type: object
+additionalProperties: false
+required:
+  - cardId
+  - frontText
+  - backText
+  - cardType
+  - metadata
+  - tags
+  - dueAt
+  - createdAt
+  - reps
+  - lapses
+  - fsrsCardState
+  - fsrsStepIndex
+  - fsrsStability
+  - fsrsDifficulty
+  - fsrsLastReviewedAt
+  - fsrsScheduledDays
+  - clientUpdatedAt
+  - lastModifiedByReplicaId
+  - lastOperationId
+  - updatedAt
+  - deletedAt
+properties:
+  cardId:
+    $ref: ./UuidString.yaml
+  frontText:
+    type: string
+  backText:
+    type: string
+  cardType:
+    type: string
+  metadata:
+    $ref: ./CatalogCardMetadata.yaml
+  tags:
+    type: array
+    items:
+      type: string
+  dueAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  createdAt:
+    type: string
+    format: date-time
+  reps:
+    type: integer
+    minimum: 0
+  lapses:
+    type: integer
+    minimum: 0
+  fsrsCardState:
+    type: string
+    enum:
+      - new
+      - learning
+      - review
+      - relearning
+  fsrsStepIndex:
+    type:
+      - integer
+      - 'null'
+    minimum: 0
+  fsrsStability:
+    type:
+      - number
+      - 'null'
+  fsrsDifficulty:
+    type:
+      - number
+      - 'null'
+  fsrsLastReviewedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  fsrsScheduledDays:
+    type:
+      - integer
+      - 'null'
+    minimum: 0
+  clientUpdatedAt:
+    type: string
+    format: date-time
+  lastModifiedByReplicaId:
+    $ref: ./UuidString.yaml
+  lastOperationId:
+    type: string
+  updatedAt:
+    type: string
+    format: date-time
+  deletedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time

--- a/api/src/components/schemas/WorkspacePackageImportConfirmOptions.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportConfirmOptions.yaml
@@ -1,0 +1,36 @@
+type: object
+additionalProperties: false
+required:
+  - addImportTag
+  - importTag
+  - removeTags
+  - importedAt
+  - importId
+  - clientUpdatedAt
+  - lastModifiedByReplicaId
+  - operationIdPrefix
+properties:
+  addImportTag:
+    type: boolean
+  importTag:
+    type: string
+    minLength: 1
+  removeTags:
+    type: array
+    items:
+      type: string
+      minLength: 1
+  importedAt:
+    type: string
+    format: date-time
+  importId:
+    type: string
+    minLength: 1
+  clientUpdatedAt:
+    type: string
+    format: date-time
+  lastModifiedByReplicaId:
+    $ref: ./UuidString.yaml
+  operationIdPrefix:
+    type: string
+    minLength: 1

--- a/api/src/components/schemas/WorkspacePackageImportConfirmResponse.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportConfirmResponse.yaml
@@ -1,0 +1,17 @@
+type: object
+additionalProperties: false
+required:
+  - cards
+  - importedMediaAssets
+  - summary
+properties:
+  cards:
+    type: array
+    items:
+      $ref: ./Card.yaml
+  importedMediaAssets:
+    type: array
+    items:
+      $ref: ./WorkspacePackageImportedMediaAsset.yaml
+  summary:
+    $ref: ./WorkspacePackageImportConfirmSummary.yaml

--- a/api/src/components/schemas/WorkspacePackageImportConfirmSummary.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportConfirmSummary.yaml
@@ -1,0 +1,37 @@
+type: object
+additionalProperties: false
+required:
+  - cardCount
+  - cardBatchCount
+  - referencedMediaCount
+  - importedMediaAssetCount
+  - appliedMediaAssetCount
+  - keptTagCount
+  - removedTagCount
+  - importTag
+properties:
+  cardCount:
+    type: integer
+    minimum: 0
+  cardBatchCount:
+    type: integer
+    minimum: 0
+  referencedMediaCount:
+    type: integer
+    minimum: 0
+  importedMediaAssetCount:
+    type: integer
+    minimum: 0
+  appliedMediaAssetCount:
+    type: integer
+    minimum: 0
+  keptTagCount:
+    type: integer
+    minimum: 0
+  removedTagCount:
+    type: integer
+    minimum: 0
+  importTag:
+    type:
+      - string
+      - 'null'

--- a/api/src/components/schemas/WorkspacePackageImportedMediaAsset.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportedMediaAsset.yaml
@@ -1,0 +1,13 @@
+type: object
+additionalProperties: false
+required:
+  - portablePath
+  - mediaAsset
+  - applied
+properties:
+  portablePath:
+    type: string
+  mediaAsset:
+    $ref: ./MediaAsset.yaml
+  applied:
+    type: boolean

--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -50,7 +50,8 @@ tags:
       transfer URLs.
   - name: workspace-packages
     description: >-
-      Workspace-scoped package export, import preview, and portable ZIP download.
+      Workspace-scoped package export, import preview, import confirmation, and
+      portable ZIP download.
   - name: admin-catalog
     description: >-
       Admin-only catalog authoring surface for marketplace authors, packages,
@@ -94,6 +95,8 @@ paths:
     $ref: paths/workspaces_{workspaceId}_packages_export.yaml
   /workspaces/{workspaceId}/packages/import/preview:
     $ref: paths/workspaces_{workspaceId}_packages_import_preview.yaml
+  /workspaces/{workspaceId}/packages/import:
+    $ref: paths/workspaces_{workspaceId}_packages_import.yaml
   /admin/catalog/authors:
     $ref: paths/admin_catalog_authors.yaml
   /admin/catalog/authors/{authorId}:

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -35,7 +35,7 @@ get:
                 - Ingest JPEG, PNG, and WebP media images through the workspace-scoped image endpoint
                 - Upload and complete media assets through workspace-scoped direct transfer endpoints
                 - Read media asset metadata and create download URLs through workspace-scoped media endpoints
-                - Preview and download portable workspace package ZIP exports, and preview ZIP imports
+                - Preview and download portable workspace package ZIP exports, and preview or confirm ZIP imports
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -53,6 +53,7 @@ get:
                 workspacePackageExportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
                 workspacePackageExportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
                 workspacePackageImportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import/preview
+                workspacePackageImportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -117,7 +118,10 @@ get:
               Use POST
               /v1/workspaces/{workspaceId}/packages/import/preview with
               application/zip bytes up to 4000000 bytes to preview a portable
-              workspace package import.
+              workspace package import. Confirm with POST
+              /v1/workspaces/{workspaceId}/packages/import as
+              multipart/form-data with file ZIP bytes up to 4000000 bytes and
+              an options JSON string.
               Use docs.openapiUrl for the published external agent contract.
             links:
               websiteUrl: https://flashcards-open-source-app.com/

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -33,7 +33,7 @@ get:
                 - Ingest JPEG, PNG, and WebP media images through the workspace-scoped image endpoint
                 - Upload and complete media assets through workspace-scoped direct transfer endpoints
                 - Read media asset metadata and create download URLs through workspace-scoped media endpoints
-                - Preview and download portable workspace package ZIP exports, and preview ZIP imports
+                - Preview and download portable workspace package ZIP exports, and preview or confirm ZIP imports
               authBaseUrl: https://auth.flashcards-open-source-app.com
               apiBaseUrl: https://api.flashcards-open-source-app.com/v1
               surface:
@@ -51,6 +51,7 @@ get:
                 workspacePackageExportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
                 workspacePackageExportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export
                 workspacePackageImportPreviewUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import/preview
+                workspacePackageImportUrlTemplate: https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import
               mcp:
                 url: https://mcp.flashcards-open-source-app.com/mcp
                 description: >-
@@ -125,7 +126,10 @@ get:
               to download the ZIP. Use POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import/preview
               with application/zip bytes up to 4000000 bytes to preview a
-              portable workspace package import. SELECT returns at most
+              portable workspace package import. Confirm with POST
+              https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/import
+              as multipart/form-data with file ZIP bytes up to 4000000 bytes
+              and an options JSON string. SELECT returns at most
               100 rows per statement, and INSERT, UPDATE, and DELETE may affect
               at most 100 rows per statement. If you need more than 100
               writes, split the work into multiple batches of at most 100

--- a/api/src/paths/workspaces_{workspaceId}_packages_import.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_import.yaml
@@ -1,0 +1,55 @@
+post:
+  tags:
+    - workspace-packages
+  summary: Import a workspace package ZIP
+  description: >-
+    Confirms a portable workspace package ZIP import, creating cards and
+    importing referenced media assets into the path workspace. The path
+    workspaceId is authoritative for workspace access and import scope. Direct
+    ZIP file parts are limited to 4000000 bytes for the buffered API transport.
+  security:
+    - ApiKeyHeader: []
+  parameters:
+    - name: workspaceId
+      in: path
+      required: true
+      schema:
+        $ref: ../components/schemas/UuidString.yaml
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          additionalProperties: false
+          required:
+            - file
+            - options
+          properties:
+            file:
+              type: string
+              format: binary
+              maxLength: 4000000
+              description: Portable workspace package ZIP bytes.
+            options:
+              type: string
+              contentMediaType: application/json
+              contentSchema:
+                $ref: ../components/schemas/WorkspacePackageImportConfirmOptions.yaml
+              description: JSON string containing import confirmation options.
+        encoding:
+          file:
+            contentType: application/zip
+  responses:
+    '200':
+      description: Workspace package import result
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/WorkspacePackageImportConfirmResponse.yaml
+    default:
+      description: Authenticated request error
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -1,6 +1,9 @@
 import { getPublicAgentDocs, getPublicApiBaseUrl, getPublicLegalLinks } from "../shared/publicUrls";
 import { maximumImageIngestionOriginalBytes } from "../mediaAssets/validators";
-import { workspacePackageImportPreviewRouteMaxZipBytes } from "../routes/workspacePackages";
+import {
+  workspacePackageImportConfirmRouteMaxZipBytes,
+  workspacePackageImportPreviewRouteMaxZipBytes,
+} from "../routes/workspacePackages";
 
 type AgentDiscoveryEnvelope = Readonly<{
   ok: true;
@@ -33,6 +36,7 @@ type AgentDiscoveryEnvelope = Readonly<{
       workspacePackageExportPreviewUrlTemplate: string;
       workspacePackageExportUrlTemplate: string;
       workspacePackageImportPreviewUrlTemplate: string;
+      workspacePackageImportUrlTemplate: string;
     }>;
     mcp: Readonly<{
       url: string;
@@ -120,6 +124,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
   const workspacePackageExportPreviewUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/export/preview`;
   const workspacePackageExportUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/export`;
   const workspacePackageImportPreviewUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/import/preview`;
+  const workspacePackageImportUrlTemplate = `${apiBaseUrl}/workspaces/{workspaceId}/packages/import`;
 
   return {
     ok: true,
@@ -144,7 +149,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         "Ingest JPEG, PNG, and WebP image bytes through the workspace-scoped image media endpoint",
         "Upload and complete media assets through workspace-scoped direct transfer endpoints",
         "Read media asset metadata and create download URLs through workspace-scoped media endpoints",
-        "Preview and download portable workspace package ZIP exports, and preview ZIP imports",
+        "Preview and download portable workspace package ZIP exports, and preview or confirm ZIP imports",
       ],
       authBaseUrl,
       apiBaseUrl,
@@ -163,6 +168,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
         workspacePackageExportPreviewUrlTemplate,
         workspacePackageExportUrlTemplate,
         workspacePackageImportPreviewUrlTemplate,
+        workspacePackageImportUrlTemplate,
       },
       mcp: {
         url: `${mcpBaseUrl}/mcp`,
@@ -185,7 +191,7 @@ export function createAgentDiscoveryEnvelope(requestUrl: string): AgentDiscovery
     },
     links,
     instructions:
-      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when creating media assets. Use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For JPEG, PNG, or WebP images up to ${maximumImageIngestionOriginalBytes} bytes, prefer POST ${mediaAssetImageIngestionUrlTemplate} with the image bytes as the request body and x-media-asset-id, x-media-created-at, x-media-client-updated-at, x-media-last-modified-by-replica-id, and x-media-last-operation-id headers; the backend normalizes to canonical JPEG bytes and returns the mediaAsset. For other media assets, create a multipart upload session with POST ${mediaAssetUploadSessionCreateUrlTemplate}; if status is already_available, use the returned mediaAsset and skip byte upload. If status is upload_required, request signed part URLs with POST ${mediaAssetUploadSessionPartsUrlTemplate}, upload each part with the returned signed URL, method, and headers, then complete the upload with POST ${mediaAssetUploadSessionCompleteUrlTemplate}. Abort unused sessions with POST ${mediaAssetUploadSessionAbortUrlTemplate}. Use GET ${mediaAssetMetadataUrlTemplate} for registry metadata and GET ${mediaAssetDownloadUrlTemplate} for a range-capable direct download URL. Use POST ${workspacePackageExportPreviewUrlTemplate} to preview a portable workspace package export, then POST ${workspacePackageExportUrlTemplate} to download the ZIP. Use POST ${workspacePackageImportPreviewUrlTemplate} with application/zip bytes up to ${workspacePackageImportPreviewRouteMaxZipBytes} bytes to preview a portable workspace package import. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
+      `Start with POST ${authBaseUrl}/api/agent/send-code using the user's email. After send-code, follow the returned instructions: normal accounts require the 8-digit email code, while configured review/demo accounts use a deterministic 8-digit placeholder and do not send email. Do not immediately replay send-code. Then POST ${authBaseUrl}/api/agent/verify-code with the otpSessionToken, code, and label to obtain an API key. After login, call GET ${apiBaseUrl}/agent/me, then GET ${apiBaseUrl}/agent/workspaces?limit=100. If no workspace is selected for this API key, call POST ${apiBaseUrl}/agent/workspaces/{workspaceId}/select or create one with POST ${apiBaseUrl}/agent/workspaces using {"name":"Personal"}. After workspace bootstrap, call GET ${apiBaseUrl}/agent/me and use data.agentWorkspaceReplicaId as lastModifiedByReplicaId when creating media assets. Use POST ${apiBaseUrl}/agent/sql/query for all shared card and deck reads (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT) and POST ${apiBaseUrl}/agent/sql/execute for all writes (INSERT, UPDATE, DELETE). For JPEG, PNG, or WebP images up to ${maximumImageIngestionOriginalBytes} bytes, prefer POST ${mediaAssetImageIngestionUrlTemplate} with the image bytes as the request body and x-media-asset-id, x-media-created-at, x-media-client-updated-at, x-media-last-modified-by-replica-id, and x-media-last-operation-id headers; the backend normalizes to canonical JPEG bytes and returns the mediaAsset. For other media assets, create a multipart upload session with POST ${mediaAssetUploadSessionCreateUrlTemplate}; if status is already_available, use the returned mediaAsset and skip byte upload. If status is upload_required, request signed part URLs with POST ${mediaAssetUploadSessionPartsUrlTemplate}, upload each part with the returned signed URL, method, and headers, then complete the upload with POST ${mediaAssetUploadSessionCompleteUrlTemplate}. Abort unused sessions with POST ${mediaAssetUploadSessionAbortUrlTemplate}. Use GET ${mediaAssetMetadataUrlTemplate} for registry metadata and GET ${mediaAssetDownloadUrlTemplate} for a range-capable direct download URL. Use POST ${workspacePackageExportPreviewUrlTemplate} to preview a portable workspace package export, then POST ${workspacePackageExportUrlTemplate} to download the ZIP. Use POST ${workspacePackageImportPreviewUrlTemplate} with application/zip bytes up to ${workspacePackageImportPreviewRouteMaxZipBytes} bytes to preview a portable workspace package import; confirm with POST ${workspacePackageImportUrlTemplate} as multipart/form-data with file ZIP bytes up to ${workspacePackageImportConfirmRouteMaxZipBytes} bytes and an options JSON string. For routine low-risk writes, a clear user request already counts as permission. Ask again only for risky or unclear actions. SELECT returns at most 100 rows per statement, and INSERT, UPDATE, and DELETE may affect at most 100 rows per statement. If you need more than 100 writes, split the work into multiple batches of at most 100 records across separate SQL statements or separate tool calls. Use ${docs.openapiUrl} for the published external agent contract. The SQL surface is intentionally limited and is not full PostgreSQL.`,
     docs,
   };
 }

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -269,6 +269,15 @@ export type WorkspacePackageImportPreviewDetails = Readonly<{
   packageMediaFileCount: number | null;
 }>;
 
+export type WorkspacePackageImportDetails = Readonly<{
+  statusCode: number;
+  bytesCount: number | null;
+  cardCount: number | null;
+  referencedMediaCount: number | null;
+  importedMediaAssetCount: number | null;
+  appliedMediaAssetCount: number | null;
+}>;
+
 export type MediaAssetRouteDetails = Readonly<{
   statusCode: number;
   mediaAssetId: string | null;
@@ -786,6 +795,8 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"workspace_package_export_error", FailureDetailsFor<WorkspacePackageExportDetails>>
   | EventByAction<"workspace_package_import_preview", WorkspacePackageImportPreviewDetails>
   | EventByAction<"workspace_package_import_preview_error", FailureDetailsFor<WorkspacePackageImportPreviewDetails>>
+  | EventByAction<"workspace_package_import", WorkspacePackageImportDetails>
+  | EventByAction<"workspace_package_import_error", FailureDetailsFor<WorkspacePackageImportDetails>>
   | EventByAction<"media_asset_image_ingest", MediaAssetRouteDetails>
   | EventByAction<"media_asset_image_ingest_error", FailureDetailsFor<MediaAssetRouteDetails>>
   | EventByAction<"media_asset_upload_session_media_reuse", MediaAssetRouteDetails>
@@ -935,6 +946,10 @@ export type BackendExceptionEvent =
   )
   | (
     EventByAction<"workspace_package_import_preview_error", FailureDetailsFor<WorkspacePackageImportPreviewDetails>>
+    & Readonly<{ error: Error }>
+  )
+  | (
+    EventByAction<"workspace_package_import_error", FailureDetailsFor<WorkspacePackageImportDetails>>
     & Readonly<{ error: Error }>
   )
   | (

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -10,7 +10,10 @@ import {
 } from "../../agent/setup";
 import { loadOpenApiDocument } from "../../shared/openapi";
 import { maximumImageIngestionOriginalBytes } from "../../mediaAssets/validators";
-import { workspacePackageImportPreviewRouteMaxZipBytes } from "../workspacePackages";
+import {
+  workspacePackageImportConfirmRouteMaxZipBytes,
+  workspacePackageImportPreviewRouteMaxZipBytes,
+} from "../workspacePackages";
 import type { RequestContext } from "../../server/requestContext";
 import type { WorkspaceSummary } from "../../workspaces";
 
@@ -22,6 +25,7 @@ type OpenApiBinarySchemaForTest = Readonly<{
   type?: string;
   format?: string;
   maxLength?: number;
+  properties?: Readonly<Record<string, OpenApiBinarySchemaForTest>>;
 }>;
 type OpenApiMediaTypeForTest = Readonly<{
   schema?: OpenApiBinarySchemaForTest;
@@ -74,6 +78,7 @@ const expectedPublishedApiMethods = {
   "/workspaces/{workspaceId}/packages/export/preview": ["post"],
   "/workspaces/{workspaceId}/packages/export": ["post"],
   "/workspaces/{workspaceId}/packages/import/preview": ["post"],
+  "/workspaces/{workspaceId}/packages/import": ["post"],
   "/admin/catalog/authors": ["post"],
   "/admin/catalog/authors/{authorId}": ["put"],
   "/admin/catalog/packages": ["post"],
@@ -98,6 +103,7 @@ const expectedMediaDiscoverySurfaceTemplates = {
   workspacePackageExportPreviewUrlTemplate: "/workspaces/{workspaceId}/packages/export/preview",
   workspacePackageExportUrlTemplate: "/workspaces/{workspaceId}/packages/export",
   workspacePackageImportPreviewUrlTemplate: "/workspaces/{workspaceId}/packages/import/preview",
+  workspacePackageImportUrlTemplate: "/workspaces/{workspaceId}/packages/import",
 } as const;
 const supportedImageIngestionOpenApiContentTypes = [
   "application/octet-stream",
@@ -159,6 +165,12 @@ function loadWorkspacePackageImportPreviewOperation(openApiDocument: OpenApiDocu
   return operation as OpenApiOperationForTest;
 }
 
+function loadWorkspacePackageImportOperation(openApiDocument: OpenApiDocumentForTest): OpenApiOperationForTest {
+  const operation = openApiDocument.paths?.["/workspaces/{workspaceId}/packages/import"]?.post;
+  assert.ok(operation !== undefined);
+  return operation as OpenApiOperationForTest;
+}
+
 test("API Gateway predeclares PATCH /me/preferences", () => {
   const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
   const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
@@ -180,10 +192,8 @@ test("API Gateway predeclares package export and import preview routes and ZIP b
   assert.match(apiGatewaySource, /binaryMediaTypes: \[[^\]]*"application\/zip"/);
   assert.match(apiGatewaySource, /workspacePackageExport\.addMethod\("POST", integration\);/);
   assert.match(apiGatewaySource, /workspacePackageExport\.addResource\("preview"\)\.addMethod\("POST", integration\);/);
-  assert.match(
-    apiGatewaySource,
-    /workspacePackages\s*\.addResource\("import"\)\s*\.addResource\("preview"\)\s*\.addMethod\("POST", integration\);/,
-  );
+  assert.match(apiGatewaySource, /workspacePackageImport\.addMethod\("POST", integration\);/);
+  assert.match(apiGatewaySource, /workspacePackageImport\.addResource\("preview"\)\.addMethod\("POST", integration\);/);
 });
 
 test("published OpenAPI exposes the curated agent, media transfer, and admin catalog contract", () => {
@@ -261,6 +271,7 @@ test("agent discovery advertises the published media transfer surface", () => {
   assert.match(discoveryEnvelope.instructions, /packages\/export\/preview/);
   assert.match(discoveryEnvelope.instructions, /packages\/export/);
   assert.match(discoveryEnvelope.instructions, /packages\/import\/preview/);
+  assert.match(discoveryEnvelope.instructions, /packages\/import/);
   assert.match(discoveryEnvelope.instructions, /data\.agentWorkspaceReplicaId/);
   assert.match(discoveryEnvelope.instructions, /lastModifiedByReplicaId/);
 });
@@ -311,6 +322,31 @@ test("workspace package import preview publishes the direct route body limit", (
   assert.match(
     JSON.stringify(openApiDocument.paths?.["/agent"] ?? {}),
     new RegExp(`up to ${workspacePackageImportPreviewRouteMaxZipBytes} bytes`),
+  );
+});
+
+test("workspace package import confirm publishes the direct route file limit", () => {
+  assert.ok(workspacePackageImportConfirmRouteMaxZipBytes <= maximumLambdaProxySafeImageIngestionOriginalBytes);
+
+  const apiBaseUrl = "https://api.flashcards-open-source-app.com/v1";
+  const discoveryEnvelope = createAgentDiscoveryEnvelope(`${apiBaseUrl}/agent`);
+  const openApiDocument = loadPublishedOpenApiDocument();
+  const operation = loadWorkspacePackageImportOperation(openApiDocument);
+  const requestBodyContent = operation.requestBody?.content ?? {};
+
+  assert.match(operation.description ?? "", new RegExp(`${workspacePackageImportConfirmRouteMaxZipBytes} bytes`));
+  assert.match(discoveryEnvelope.instructions, new RegExp(`up to ${workspacePackageImportConfirmRouteMaxZipBytes} bytes`));
+  assert.equal(
+    requestBodyContent["multipart/form-data"]?.schema?.properties?.file?.maxLength,
+    workspacePackageImportConfirmRouteMaxZipBytes,
+  );
+  assert.match(
+    JSON.stringify(openApiDocument.paths?.["/"] ?? {}),
+    new RegExp(`up to ${workspacePackageImportConfirmRouteMaxZipBytes} bytes`),
+  );
+  assert.match(
+    JSON.stringify(openApiDocument.paths?.["/agent"] ?? {}),
+    new RegExp(`up to ${workspacePackageImportConfirmRouteMaxZipBytes} bytes`),
   );
 });
 

--- a/apps/backend/src/routes/workspacePackages.test.ts
+++ b/apps/backend/src/routes/workspacePackages.test.ts
@@ -5,14 +5,19 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
   createWorkspacePackageRoutes,
+  workspacePackageImportConfirmRouteMaxZipBytes,
   workspacePackageImportPreviewRouteMaxZipBytes,
 } from "./workspacePackages";
 import { HttpError } from "../shared/errors";
 import type { AppEnv } from "../server/app";
 import type { RequestContext } from "../server/requestContext";
+import type { Card } from "../cards";
+import type { MediaAsset } from "../mediaAssets/types";
 import type {
   WorkspacePackageExportPackageInput,
   WorkspacePackageExportPreviewInput,
+  WorkspacePackageImportConfirmInput,
+  WorkspacePackageImportConfirmResult,
   WorkspacePackageImportPreview,
   WorkspacePackageImportPreviewInput,
 } from "../workspacePackages";
@@ -20,6 +25,11 @@ import type {
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 const otherWorkspaceId = "22222222-2222-4222-8222-222222222222";
 const cardId = "33333333-3333-4333-8333-333333333333";
+const replicaId = "44444444-4444-4444-8444-444444444444";
+const importedAt = "2026-06-30T12:00:00.000Z";
+const clientUpdatedAt = "2026-06-30T12:01:00.000Z";
+const importId = "import-session-1";
+const operationIdPrefix = "workspace-package-import-1";
 
 type ErrorResponseBody = Readonly<{
   error: string;
@@ -101,8 +111,111 @@ function createWorkspacePackageImportPreviewResponse(): WorkspacePackageImportPr
   };
 }
 
+function createWorkspacePackageImportConfirmOptions(): Record<string, unknown> {
+  return {
+    addImportTag: true,
+    importTag: "import:2026-06-30-1",
+    removeTags: ["legacy"],
+    importedAt,
+    importId,
+    clientUpdatedAt,
+    lastModifiedByReplicaId: replicaId,
+    operationIdPrefix,
+  };
+}
+
+function createWorkspacePackageImportConfirmFormData(
+  zipBytes: Buffer,
+  options: unknown,
+): FormData {
+  const formData = new FormData();
+  formData.set("file", new File([new Uint8Array(zipBytes)], "flashcards.zip", { type: "application/zip" }));
+  formData.set("options", JSON.stringify(options));
+  return formData;
+}
+
+function createWorkspacePackageImportConfirmCard(): Card {
+  return {
+    cardId,
+    frontText: "Pregunta",
+    backText: "Respuesta",
+    cardType: "basic",
+    metadata: {
+      version: 1,
+      source: {
+        label: "Imported deck",
+        author: null,
+        comment: null,
+        createdAt: "2026-06-29T12:00:00.000Z",
+        importedAt,
+        importId,
+      },
+    },
+    tags: ["spanish", "import:2026-06-30-1"],
+    dueAt: null,
+    createdAt: clientUpdatedAt,
+    reps: 0,
+    lapses: 0,
+    fsrsCardState: "new",
+    fsrsStepIndex: null,
+    fsrsStability: null,
+    fsrsDifficulty: null,
+    fsrsLastReviewedAt: null,
+    fsrsScheduledDays: null,
+    clientUpdatedAt,
+    lastModifiedByReplicaId: replicaId,
+    lastOperationId: `${operationIdPrefix}:card:0`,
+    updatedAt: clientUpdatedAt,
+    deletedAt: null,
+  };
+}
+
+function createWorkspacePackageImportConfirmMediaAsset(): MediaAsset {
+  return {
+    mediaAssetId: "55555555-5555-4555-8555-555555555555",
+    workspaceId,
+    mimeType: "image/jpeg",
+    sizeBytes: 1024,
+    sha256: "0".repeat(64),
+    sourceUrl: null,
+    createdAt: importedAt,
+    clientUpdatedAt,
+    lastModifiedByReplicaId: replicaId,
+    lastOperationId: `${operationIdPrefix}:media:0`,
+    updatedAt: clientUpdatedAt,
+    deletedAt: null,
+  };
+}
+
+function createWorkspacePackageImportConfirmResult(): WorkspacePackageImportConfirmResult {
+  return {
+    cards: [createWorkspacePackageImportConfirmCard()],
+    importedMediaAssets: [
+      {
+        portablePath: "media/images/cell.jpg",
+        mediaAsset: createWorkspacePackageImportConfirmMediaAsset(),
+        applied: true,
+      },
+    ],
+    summary: {
+      cardCount: 1,
+      cardBatchCount: 1,
+      referencedMediaCount: 1,
+      importedMediaAssetCount: 1,
+      appliedMediaAssetCount: 1,
+      keptTagCount: 1,
+      removedTagCount: 1,
+      importTag: "import:2026-06-30-1",
+    },
+  };
+}
+
 function createOversizedWorkspacePackageImportPreviewZipBytes(): Buffer {
   return Buffer.alloc(workspacePackageImportPreviewRouteMaxZipBytes + 1, 0x61);
+}
+
+function createOversizedWorkspacePackageImportConfirmZipBytes(): Buffer {
+  return Buffer.alloc(workspacePackageImportConfirmRouteMaxZipBytes + 1, 0x61);
 }
 
 function createWorkspacePackageTestApp(routes: Hono<AppEnv>): Hono<AppEnv> {
@@ -163,6 +276,29 @@ function assertImportPreviewInput(
     "import:2026-06-30-0",
     "draft",
   ]);
+}
+
+function assertImportConfirmInput(
+  input: WorkspacePackageImportConfirmInput,
+  zipBytes: Buffer,
+): void {
+  assert.equal(input.userId, "user-1");
+  assert.equal(input.workspaceId, workspaceId);
+  assert.deepEqual(Buffer.from(input.packageBytes), zipBytes);
+  assert.deepEqual(input.options, {
+    addImportTag: true,
+    importTag: "import:2026-06-30-1",
+    removeTags: ["legacy"],
+    importedAt,
+    importId,
+  });
+  assert.equal(input.createdAt, importedAt);
+  assert.equal(input.clientUpdatedAt, clientUpdatedAt);
+  assert.equal(input.lastModifiedByReplicaId, replicaId);
+  assert.equal(input.operationIdPrefix, operationIdPrefix);
+  assert.equal(input.observationScope.service, "backend-api");
+  assert.equal(input.observationScope.requestId, "request-1");
+  assert.equal(input.observationScope.workspaceId, workspaceId);
 }
 
 test("POST /workspaces/:workspaceId/packages/export/preview returns preview JSON for the path workspace", async () => {
@@ -426,6 +562,282 @@ test("POST /workspaces/:workspaceId/packages/import/preview rejects actual body 
   assert.match(body.error, new RegExp(workspacePackageImportPreviewRouteMaxZipBytes.toString()));
   assert.equal(tagSummaryCalls, 0);
   assert.equal(previewCalls, 0);
+});
+
+test("POST /workspaces/:workspaceId/packages/import parses multipart ZIP bytes and options", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const confirmJson = createWorkspacePackageImportConfirmResult();
+  let accessChecks = 0;
+  let confirmCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
+      accessChecks += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(checkedWorkspaceId, workspaceId);
+    },
+    confirmWorkspacePackageImportFn: async (input) => {
+      confirmCalls += 1;
+      assertImportConfirmInput(input, zipBytes);
+      return confirmJson;
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import`, {
+    method: "POST",
+    body: createWorkspacePackageImportConfirmFormData(zipBytes, createWorkspacePackageImportConfirmOptions()),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), confirmJson);
+  assert.equal(accessChecks, 1);
+  assert.equal(confirmCalls, 1);
+});
+
+test("POST /workspaces/:workspaceId/packages/import uses path workspace instead of selected workspace", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const requestedWorkspaceIds: Array<string> = [];
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (_userId, checkedWorkspaceId) => {
+      requestedWorkspaceIds.push(checkedWorkspaceId);
+    },
+    confirmWorkspacePackageImportFn: async (input) => {
+      requestedWorkspaceIds.push(input.workspaceId);
+      return createWorkspacePackageImportConfirmResult();
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import`, {
+    method: "POST",
+    body: createWorkspacePackageImportConfirmFormData(zipBytes, createWorkspacePackageImportConfirmOptions()),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(requestedWorkspaceIds, [workspaceId, workspaceId]);
+  assert.notEqual(workspaceId, createRequestContext().selectedWorkspaceId);
+});
+
+test("workspace package import confirm route stops before multipart and confirm service calls when workspace access is denied", async () => {
+  let confirmCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => {
+      throw new HttpError(403, "Workspace access denied", "WORKSPACE_ACCESS_DENIED");
+    },
+    confirmWorkspacePackageImportFn: async () => {
+      confirmCalls += 1;
+      throw new Error("Import confirm service must not be called when workspace access is denied.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: "not multipart",
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 403);
+  assert.equal(body.code, "WORKSPACE_ACCESS_DENIED");
+  assert.equal(confirmCalls, 0);
+});
+
+test("POST /workspaces/:workspaceId/packages/import rejects malformed multipart, file, and options inputs", async () => {
+  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const validOptions = createWorkspacePackageImportConfirmOptions();
+  const cases: ReadonlyArray<Readonly<{
+    name: string;
+    createRequestInit: () => RequestInit;
+    expectedStatus: number;
+    expectedCode: string;
+    errorPattern: RegExp;
+    detailsPattern?: RegExp;
+  }>> = [
+    {
+      name: "unsupported content type",
+      createRequestInit: () => ({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(validOptions),
+      }),
+      expectedStatus: 415,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_CONTENT_TYPE_UNSUPPORTED",
+      errorPattern: /multipart\/form-data/,
+    },
+    {
+      name: "invalid multipart",
+      createRequestInit: () => ({
+        method: "POST",
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+        body: "not multipart",
+      }),
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_MULTIPART_INVALID",
+      errorPattern: /Invalid multipart form data/,
+    },
+    {
+      name: "missing file",
+      createRequestInit: () => {
+        const formData = new FormData();
+        formData.set("options", JSON.stringify(validOptions));
+        return {
+          method: "POST",
+          body: formData,
+        };
+      },
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_FILE_REQUIRED",
+      errorPattern: /file is required/,
+    },
+    {
+      name: "empty file",
+      createRequestInit: () => {
+        const formData = new FormData();
+        formData.set("file", new File([""], "flashcards.zip", { type: "application/zip" }));
+        formData.set("options", JSON.stringify(validOptions));
+        return {
+          method: "POST",
+          body: formData,
+        };
+      },
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_FILE_EMPTY",
+      errorPattern: /must not be empty/,
+    },
+    {
+      name: "oversized file",
+      createRequestInit: () => ({
+        method: "POST",
+        body: createWorkspacePackageImportConfirmFormData(
+          createOversizedWorkspacePackageImportConfirmZipBytes(),
+          validOptions,
+        ),
+      }),
+      expectedStatus: 413,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_FILE_TOO_LARGE",
+      errorPattern: new RegExp(workspacePackageImportConfirmRouteMaxZipBytes.toString()),
+    },
+    {
+      name: "missing options",
+      createRequestInit: () => {
+        const formData = new FormData();
+        formData.set("file", new File([new Uint8Array(zipBytes)], "flashcards.zip", { type: "application/zip" }));
+        return {
+          method: "POST",
+          body: formData,
+        };
+      },
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_REQUIRED",
+      errorPattern: /options is required/,
+    },
+    {
+      name: "malformed options JSON",
+      createRequestInit: () => {
+        const formData = new FormData();
+        formData.set("file", new File([new Uint8Array(zipBytes)], "flashcards.zip", { type: "application/zip" }));
+        formData.set("options", "{not json");
+        return {
+          method: "POST",
+          body: formData,
+        };
+      },
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID_JSON",
+      errorPattern: /valid JSON string/,
+    },
+    {
+      name: "invalid options shape",
+      createRequestInit: () => ({
+        method: "POST",
+        body: createWorkspacePackageImportConfirmFormData(zipBytes, {
+          ...validOptions,
+          removeTags: "legacy",
+        }),
+      }),
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+      errorPattern: /options are invalid/,
+      detailsPattern: /removeTags/,
+    },
+    {
+      name: "invalid options timestamp",
+      createRequestInit: () => ({
+        method: "POST",
+        body: createWorkspacePackageImportConfirmFormData(zipBytes, {
+          ...validOptions,
+          importedAt: "not-a-timestamp",
+        }),
+      }),
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+      errorPattern: /options are invalid/,
+      detailsPattern: /importedAt/,
+    },
+    {
+      name: "invalid replica id",
+      createRequestInit: () => ({
+        method: "POST",
+        body: createWorkspacePackageImportConfirmFormData(zipBytes, {
+          ...validOptions,
+          lastModifiedByReplicaId: "not-a-uuid",
+        }),
+      }),
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+      errorPattern: /options are invalid/,
+      detailsPattern: /lastModifiedByReplicaId/,
+    },
+  ];
+
+  for (const testCase of cases) {
+    let confirmCalls = 0;
+    const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+      allowedOrigins: [],
+      loadRequestContextFromRequestFn: async () => ({
+        requestAuthInputs: {} as never,
+        requestContext: createRequestContext(),
+      }),
+      assertUserHasWorkspaceAccessFn: async () => undefined,
+      confirmWorkspacePackageImportFn: async () => {
+        confirmCalls += 1;
+        throw new Error("Import confirm service must not be called for malformed import requests.");
+      },
+    }));
+
+    const response = await app.request(
+      `http://localhost/workspaces/${workspaceId}/packages/import`,
+      testCase.createRequestInit(),
+    );
+    const body = await response.json() as ErrorResponseBody;
+
+    assert.equal(response.status, testCase.expectedStatus, testCase.name);
+    assert.equal(body.code, testCase.expectedCode, testCase.name);
+    assert.match(body.error, testCase.errorPattern, testCase.name);
+    if (testCase.detailsPattern !== undefined) {
+      assert.match(JSON.stringify(body.details), testCase.detailsPattern, testCase.name);
+    }
+    assert.equal(confirmCalls, 0, testCase.name);
+  }
 });
 
 test("POST /workspaces/:workspaceId/packages/export returns ZIP bytes with download headers", async () => {

--- a/apps/backend/src/routes/workspacePackages.ts
+++ b/apps/backend/src/routes/workspacePackages.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { listWorkspaceTagsSummary } from "../cards";
 import {
+  confirmWorkspacePackageImport,
   exportWorkspacePackage,
   previewWorkspacePackageExport,
   previewWorkspacePackageZipImport,
@@ -13,6 +14,8 @@ import {
   type WorkspacePackageExportPreview,
   type WorkspacePackageExportPreviewInput,
   type WorkspacePackageExportTagPolicyInput,
+  type WorkspacePackageImportConfirmResult,
+  type WorkspacePackageImportPlanOptions,
   type WorkspacePackageImportPreview,
 } from "../workspacePackages";
 import { assertUserHasWorkspaceAccess } from "../workspaces";
@@ -41,6 +44,7 @@ type WorkspacePackageRoutesOptions = Readonly<{
   exportWorkspacePackageFn?: typeof exportWorkspacePackage;
   listWorkspaceTagsSummaryFn?: typeof listWorkspaceTagsSummary;
   previewWorkspacePackageZipImportFn?: typeof previewWorkspacePackageZipImport;
+  confirmWorkspacePackageImportFn?: typeof confirmWorkspacePackageImport;
 }>;
 
 type WorkspacePackageExportRouteInput = Readonly<{
@@ -51,8 +55,21 @@ type WorkspacePackageExportRouteInput = Readonly<{
 
 type WorkspacePackageExportPreviewResponse = WorkspacePackageExportPreview;
 type WorkspacePackageImportPreviewResponse = WorkspacePackageImportPreview;
+type WorkspacePackageImportConfirmResponse = WorkspacePackageImportConfirmResult;
+
+type WorkspacePackageImportConfirmRouteOptions = WorkspacePackageImportPlanOptions & Readonly<{
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  operationIdPrefix: string;
+}>;
+
+type WorkspacePackageImportConfirmUpload = Readonly<{
+  packageBytes: Buffer;
+  options: WorkspacePackageImportConfirmRouteOptions;
+}>;
 
 export const workspacePackageImportPreviewRouteMaxZipBytes = 4_000_000;
+export const workspacePackageImportConfirmRouteMaxZipBytes = workspacePackageImportPreviewRouteMaxZipBytes;
 
 const allActiveCardsSelectionSchema = z.object({
   kind: z.literal("allActiveCards"),
@@ -121,6 +138,33 @@ const workspacePackageExportRouteInputSchema = z.object({
   selection: input.selection,
   tagPolicy: input.tagPolicy,
   packageMetadata: input.packageMetadata,
+}));
+
+const workspacePackageImportConfirmTimestampSchema = z.string().datetime().transform(
+  (value): string => new Date(value).toISOString(),
+);
+const workspacePackageImportConfirmUuidSchema = z.string().uuid().transform(
+  (value): string => value.toLowerCase(),
+);
+
+const workspacePackageImportConfirmRouteOptionsSchema = z.object({
+  addImportTag: z.boolean(),
+  importTag: z.string().min(1),
+  removeTags: z.array(z.string().min(1)),
+  importedAt: workspacePackageImportConfirmTimestampSchema,
+  importId: z.string().min(1),
+  clientUpdatedAt: workspacePackageImportConfirmTimestampSchema,
+  lastModifiedByReplicaId: workspacePackageImportConfirmUuidSchema,
+  operationIdPrefix: z.string().min(1),
+}).transform((input): WorkspacePackageImportConfirmRouteOptions => ({
+  addImportTag: input.addImportTag,
+  importTag: input.importTag,
+  removeTags: input.removeTags,
+  importedAt: input.importedAt,
+  importId: input.importId,
+  clientUpdatedAt: input.clientUpdatedAt,
+  lastModifiedByReplicaId: input.lastModifiedByReplicaId,
+  operationIdPrefix: input.operationIdPrefix,
 }));
 
 function summarizeValidationPath(path: ReadonlyArray<PropertyKey>): string {
@@ -215,6 +259,18 @@ function assertWorkspacePackageImportPreviewContentType(headers: Headers): void 
   }
 }
 
+function assertWorkspacePackageImportConfirmContentType(headers: Headers): void {
+  const contentTypeHeader = headers.get("content-type");
+  const contentType = contentTypeHeader?.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (contentType !== "multipart/form-data") {
+    throw new HttpError(
+      415,
+      "content-type must be multipart/form-data",
+      "WORKSPACE_PACKAGE_IMPORT_CONTENT_TYPE_UNSUPPORTED",
+    );
+  }
+}
+
 function assertWorkspacePackageImportPreviewZipBytesNotEmpty(byteLength: number): void {
   if (byteLength === 0) {
     throw new HttpError(
@@ -237,6 +293,107 @@ function assertWorkspacePackageImportPreviewZipBytesWithinRouteLimit(byteLength:
   if (byteLength > workspacePackageImportPreviewRouteMaxZipBytes) {
     throw createWorkspacePackageImportPreviewBodyTooLargeError(byteLength);
   }
+}
+
+function createWorkspacePackageImportConfirmFileTooLargeError(byteLength: number): HttpError {
+  return new HttpError(
+    413,
+    `Direct workspace package import ZIP is too large for this endpoint. zipBytes=${byteLength} maxZipBytes=${workspacePackageImportConfirmRouteMaxZipBytes}`,
+    "WORKSPACE_PACKAGE_IMPORT_FILE_TOO_LARGE",
+  );
+}
+
+function assertWorkspacePackageImportConfirmZipBytesNotEmpty(byteLength: number): void {
+  if (byteLength === 0) {
+    throw new HttpError(
+      400,
+      "Workspace package import file must not be empty",
+      "WORKSPACE_PACKAGE_IMPORT_FILE_EMPTY",
+    );
+  }
+}
+
+function assertWorkspacePackageImportConfirmZipBytesWithinRouteLimit(byteLength: number): void {
+  if (byteLength > workspacePackageImportConfirmRouteMaxZipBytes) {
+    throw createWorkspacePackageImportConfirmFileTooLargeError(byteLength);
+  }
+}
+
+function parseWorkspacePackageImportConfirmOptions(value: string): WorkspacePackageImportConfirmRouteOptions {
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(value);
+  } catch {
+    throw new HttpError(
+      400,
+      "options must be a valid JSON string",
+      "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID_JSON",
+    );
+  }
+
+  const parsedOptions = workspacePackageImportConfirmRouteOptionsSchema.safeParse(parsedJson);
+  if (parsedOptions.success) {
+    return parsedOptions.data;
+  }
+
+  throw new HttpError(
+    400,
+    "Workspace package import options are invalid.",
+    "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+    summarizeValidationDetails(parsedOptions.error),
+  );
+}
+
+async function readWorkspacePackageImportConfirmUpload(request: Request): Promise<WorkspacePackageImportConfirmUpload> {
+  assertWorkspacePackageImportConfirmContentType(request.headers);
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    throw new HttpError(
+      400,
+      "Invalid multipart form data",
+      "WORKSPACE_PACKAGE_IMPORT_MULTIPART_INVALID",
+    );
+  }
+
+  const fileValue = formData.get("file");
+  if (!(fileValue instanceof File)) {
+    throw new HttpError(
+      400,
+      "file is required",
+      "WORKSPACE_PACKAGE_IMPORT_FILE_REQUIRED",
+    );
+  }
+
+  assertWorkspacePackageImportConfirmZipBytesNotEmpty(fileValue.size);
+  assertWorkspacePackageImportConfirmZipBytesWithinRouteLimit(fileValue.size);
+  const packageBytes = Buffer.from(await fileValue.arrayBuffer());
+  assertWorkspacePackageImportConfirmZipBytesNotEmpty(packageBytes.byteLength);
+  assertWorkspacePackageImportConfirmZipBytesWithinRouteLimit(packageBytes.byteLength);
+
+  const optionsValue = formData.get("options");
+  if (optionsValue === null) {
+    throw new HttpError(
+      400,
+      "options is required",
+      "WORKSPACE_PACKAGE_IMPORT_OPTIONS_REQUIRED",
+    );
+  }
+
+  if (typeof optionsValue !== "string") {
+    throw new HttpError(
+      400,
+      "options must be a JSON string",
+      "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID_JSON",
+    );
+  }
+
+  return {
+    packageBytes,
+    options: parseWorkspacePackageImportConfirmOptions(optionsValue),
+  };
 }
 
 function parseWorkspacePackageImportPreviewContentLength(headers: Headers): number | null {
@@ -278,6 +435,7 @@ export function createWorkspacePackageRoutes(options: WorkspacePackageRoutesOpti
   const exportWorkspacePackageFn = options.exportWorkspacePackageFn ?? exportWorkspacePackage;
   const listWorkspaceTagsSummaryFn = options.listWorkspaceTagsSummaryFn ?? listWorkspaceTagsSummary;
   const previewWorkspacePackageZipImportFn = options.previewWorkspacePackageZipImportFn ?? previewWorkspacePackageZipImport;
+  const confirmWorkspacePackageImportFn = options.confirmWorkspacePackageImportFn ?? confirmWorkspacePackageImport;
 
   app.post("/workspaces/:workspaceId/packages/export/preview", async (context) => {
     const requestId = context.get("requestId");
@@ -411,6 +569,68 @@ export function createWorkspacePackageRoutes(options: WorkspacePackageRoutesOpti
         error,
         { action: "workspace_package_import_preview_error", error: normalizeCaughtError(error), scope, details },
         { action: "workspace_package_import_preview_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.post("/workspaces/:workspaceId/packages/import", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const upload = await readWorkspacePackageImportConfirmUpload(context.req.raw);
+      const result = await confirmWorkspacePackageImportFn({
+        userId: requestContext.userId,
+        workspaceId,
+        packageBytes: upload.packageBytes,
+        options: {
+          addImportTag: upload.options.addImportTag,
+          importTag: upload.options.importTag,
+          removeTags: upload.options.removeTags,
+          importedAt: upload.options.importedAt,
+          importId: upload.options.importId,
+        },
+        createdAt: upload.options.importedAt,
+        clientUpdatedAt: upload.options.clientUpdatedAt,
+        lastModifiedByReplicaId: upload.options.lastModifiedByReplicaId,
+        operationIdPrefix: upload.options.operationIdPrefix,
+        observationScope: scope,
+      });
+      addBackendBreadcrumb({
+        action: "workspace_package_import",
+        scope,
+        details: {
+          statusCode: 200,
+          bytesCount: upload.packageBytes.byteLength,
+          cardCount: result.summary.cardCount,
+          referencedMediaCount: result.summary.referencedMediaCount,
+          importedMediaAssetCount: result.summary.importedMediaAssetCount,
+          appliedMediaAssetCount: result.summary.appliedMediaAssetCount,
+        },
+      });
+
+      return context.json(result satisfies WorkspacePackageImportConfirmResponse);
+    } catch (error) {
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        bytesCount: null,
+        cardCount: null,
+        referencedMediaCount: null,
+        importedMediaAssetCount: null,
+        appliedMediaAssetCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_package_import_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_package_import_error", scope, details },
       );
       throw error;
     }

--- a/apps/backend/src/workspacePackages/importConfirm.test.ts
+++ b/apps/backend/src/workspacePackages/importConfirm.test.ts
@@ -7,6 +7,7 @@ import {
   type MediaAsset,
 } from "../mediaAssets/types";
 import type { BackendObservationScope } from "../observability/sentry";
+import { HttpError } from "../shared/errors";
 import {
   confirmWorkspacePackageImportWithDependencies,
   type WorkspacePackageImportConfirmDependencies,
@@ -23,6 +24,7 @@ import {
   type WorkspacePackageImportReferencedMediaFile,
   type WorkspacePackageImportReferencedMediaInput,
 } from "./index";
+import { validateWorkspacePackageImportPlanPreflight } from "./importPlan";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
@@ -212,6 +214,16 @@ function createConfirmHarness(cardsJson: WorkspacePackageCardsJsonV1): ConfirmHa
           ]),
         };
       },
+      assertReplicaBelongsToWorkspaceFn: async (userId, workspaceId, replicaId) => {
+        order.push("replica");
+        assert.equal(userId, testUserId);
+        assert.equal(workspaceId, testWorkspaceId);
+        assert.equal(replicaId, testReplicaId);
+      },
+      validatePlanPreflightFn: (input) => {
+        order.push("preflight");
+        validateWorkspacePackageImportPlanPreflight(input);
+      },
       planImportFn: (input) => {
         order.push("plan");
         planInputs.push(input);
@@ -239,7 +251,7 @@ test("workspace package import confirmation orchestrates media load, ingestion, 
 
   const result = await confirmWorkspacePackageImportWithDependencies(input, harness.dependencies);
 
-  assert.deepEqual(harness.calls.order, ["load", "ingest", "plan", "persist"]);
+  assert.deepEqual(harness.calls.order, ["replica", "load", "preflight", "ingest", "plan", "persist"]);
   assert.deepEqual(harness.calls.loadInputs, [{ packageBytes }]);
   assert.equal(harness.calls.ingestInputs.length, 1);
   const ingestInput = harness.calls.ingestInputs[0];
@@ -294,6 +306,70 @@ test("workspace package import confirmation lets persistence failures surface wi
     () => confirmWorkspacePackageImportWithDependencies(createConfirmInput(), dependencies),
     (error: unknown): boolean => error === expectedError,
   );
-  assert.deepEqual(harness.calls.order, ["load", "ingest", "plan", "persist"]);
+  assert.deepEqual(harness.calls.order, ["replica", "load", "preflight", "ingest", "plan", "persist"]);
   assert.equal(harness.calls.persistInputs.length, 1);
+});
+
+test("workspace package import confirmation rejects wrong workspace replica before media ingestion", async () => {
+  const harness = createConfirmHarness(createCardsJson());
+  const expectedError = new HttpError(
+    400,
+    "lastModifiedByReplicaId must reference a workspace replica for this workspace.",
+    "WORKSPACE_PACKAGE_IMPORT_REPLICA_INVALID",
+  );
+  const dependencies: WorkspacePackageImportConfirmDependencies = {
+    ...harness.dependencies,
+    assertReplicaBelongsToWorkspaceFn: async () => {
+      harness.calls.order.push("replica");
+      throw expectedError;
+    },
+    loadReferencedMediaFn: async (input) => {
+      harness.calls.order.push("load");
+      harness.calls.loadInputs.push(input);
+      throw new Error("ZIP import media loader must not be called when replica ownership is invalid.");
+    },
+    ingestMediaAssetsFn: async (input) => {
+      harness.calls.order.push("ingest");
+      harness.calls.ingestInputs.push(input);
+      throw new Error("Media ingestion must not be called when replica ownership is invalid.");
+    },
+    persistCardsFn: async (input) => {
+      harness.calls.order.push("persist");
+      harness.calls.persistInputs.push(input);
+      throw new Error("Card persistence must not be called when replica ownership is invalid.");
+    },
+  };
+
+  await assert.rejects(
+    () => confirmWorkspacePackageImportWithDependencies(createConfirmInput(), dependencies),
+    (error: unknown): boolean => error === expectedError,
+  );
+  assert.deepEqual(harness.calls.order, ["replica"]);
+  assert.equal(harness.calls.ingestInputs.length, 0);
+  assert.equal(harness.calls.persistInputs.length, 0);
+});
+
+test("workspace package import confirmation validates semantic options before media ingestion", async () => {
+  const harness = createConfirmHarness(createCardsJson());
+  const baseInput = createConfirmInput();
+  const input: WorkspacePackageImportConfirmInput = {
+    ...baseInput,
+    options: {
+      ...baseInput.options,
+      removeTags: ["unknown-tag"],
+    },
+  };
+
+  await assert.rejects(
+    () => confirmWorkspacePackageImportWithDependencies(input, harness.dependencies),
+    (error: unknown): boolean => (
+      error instanceof HttpError
+      && error.statusCode === 400
+      && error.code === "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID"
+      && /unknown-tag/.test(error.message)
+    ),
+  );
+  assert.deepEqual(harness.calls.order, ["replica", "load", "preflight"]);
+  assert.equal(harness.calls.ingestInputs.length, 0);
+  assert.equal(harness.calls.persistInputs.length, 0);
 });

--- a/apps/backend/src/workspacePackages/importConfirm.ts
+++ b/apps/backend/src/workspacePackages/importConfirm.ts
@@ -1,6 +1,13 @@
 import type { Buffer } from "node:buffer";
 import type { Card } from "../cards";
+import {
+  transactionWithWorkspaceScopeReadOnly,
+  type DatabaseExecutor,
+  type WorkspaceDatabaseScope,
+} from "../database";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../mediaAssets/workspaceReplicas";
 import type { BackendObservationScope } from "../observability/sentry";
+import { HttpError } from "../shared/errors";
 import {
   ingestWorkspacePackageImportMediaAssets,
   type WorkspacePackageImportedMediaAsset,
@@ -19,9 +26,11 @@ import {
 } from "./importCards";
 import {
   planWorkspacePackageImport,
+  validateWorkspacePackageImportPlanPreflight,
   type WorkspacePackageImportPlan,
   type WorkspacePackageImportPlanInput,
   type WorkspacePackageImportPlanOptions,
+  type WorkspacePackageImportPlanPreflightInput,
 } from "./importPlan";
 
 export type WorkspacePackageImportConfirmInput = Readonly<{
@@ -60,6 +69,12 @@ export type WorkspacePackageImportConfirmDependencies = Readonly<{
   ingestMediaAssetsFn: (
     input: WorkspacePackageImportMediaAssetIngestionInput,
   ) => Promise<WorkspacePackageImportMediaAssetIngestionResult>;
+  assertReplicaBelongsToWorkspaceFn: (
+    userId: string,
+    workspaceId: string,
+    replicaId: string,
+  ) => Promise<void>;
+  validatePlanPreflightFn: (input: WorkspacePackageImportPlanPreflightInput) => void;
   planImportFn: (input: WorkspacePackageImportPlanInput) => WorkspacePackageImportPlan;
   persistCardsFn: (
     input: WorkspacePackageImportCardPersistenceInput,
@@ -91,6 +106,16 @@ function createImportPlanInput(
     cardsJson: mediaLoadResult.cardsJson,
     options: input.options,
     mediaAssetIdsByPortablePath: mediaAssetIngestionResult.mediaAssetIdsByPortablePath,
+  };
+}
+
+function createImportPlanPreflightInput(
+  input: WorkspacePackageImportConfirmInput,
+  mediaLoadResult: WorkspacePackageImportReferencedMediaLoadResult,
+): WorkspacePackageImportPlanPreflightInput {
+  return {
+    cardsJson: mediaLoadResult.cardsJson,
+    options: input.options,
   };
 }
 
@@ -135,13 +160,77 @@ function createConfirmResult(
   };
 }
 
+function toWorkspacePackageImportInputError(error: unknown): Error {
+  if (error instanceof TypeError && error.message.startsWith("Invalid workspace package import plan input:")) {
+    return new HttpError(400, error.message, "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID");
+  }
+
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function toWorkspacePackageImportReplicaError(error: unknown): Error {
+  if (error instanceof HttpError && error.code === "MEDIA_ASSET_REPLICA_INVALID") {
+    return new HttpError(
+      400,
+      "lastModifiedByReplicaId must reference a workspace replica for this workspace.",
+      "WORKSPACE_PACKAGE_IMPORT_REPLICA_INVALID",
+      error.details ?? undefined,
+    );
+  }
+
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function validatePlanPreflight(
+  input: WorkspacePackageImportPlanPreflightInput,
+  validatePlanPreflightFn: (preflightInput: WorkspacePackageImportPlanPreflightInput) => void,
+): void {
+  try {
+    validatePlanPreflightFn(input);
+  } catch (error) {
+    throw toWorkspacePackageImportInputError(error);
+  }
+}
+
+async function assertImportReplicaBelongsToWorkspaceInTransaction(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  replicaId: string,
+): Promise<void> {
+  await assertReplicaBelongsToWorkspaceInExecutor(executor, workspaceId, replicaId);
+}
+
+async function assertImportReplicaBelongsToWorkspace(
+  userId: string,
+  workspaceId: string,
+  replicaId: string,
+): Promise<void> {
+  try {
+    await transactionWithWorkspaceScopeReadOnly(
+      { userId, workspaceId } satisfies WorkspaceDatabaseScope,
+      async (executor) => assertImportReplicaBelongsToWorkspaceInTransaction(executor, workspaceId, replicaId),
+    );
+  } catch (error) {
+    throw toWorkspacePackageImportReplicaError(error);
+  }
+}
+
 export async function confirmWorkspacePackageImportWithDependencies(
   input: WorkspacePackageImportConfirmInput,
   dependencies: WorkspacePackageImportConfirmDependencies,
 ): Promise<WorkspacePackageImportConfirmResult> {
+  await dependencies.assertReplicaBelongsToWorkspaceFn(
+    input.userId,
+    input.workspaceId,
+    input.lastModifiedByReplicaId,
+  );
   const mediaLoadResult = await dependencies.loadReferencedMediaFn({
     packageBytes: input.packageBytes,
   });
+  validatePlanPreflight(
+    createImportPlanPreflightInput(input, mediaLoadResult),
+    dependencies.validatePlanPreflightFn,
+  );
   const mediaAssetIngestionResult = await dependencies.ingestMediaAssetsFn(
     createMediaAssetIngestionInput(input, mediaLoadResult),
   );
@@ -157,6 +246,8 @@ export async function confirmWorkspacePackageImport(
   return confirmWorkspacePackageImportWithDependencies(input, {
     loadReferencedMediaFn: loadWorkspacePackageImportReferencedMedia,
     ingestMediaAssetsFn: ingestWorkspacePackageImportMediaAssets,
+    assertReplicaBelongsToWorkspaceFn: assertImportReplicaBelongsToWorkspace,
+    validatePlanPreflightFn: validateWorkspacePackageImportPlanPreflight,
     planImportFn: planWorkspacePackageImport,
     persistCardsFn: persistWorkspacePackageImportCards,
   });

--- a/apps/backend/src/workspacePackages/importPlan.ts
+++ b/apps/backend/src/workspacePackages/importPlan.ts
@@ -24,6 +24,11 @@ export type WorkspacePackageImportPlanInput = Readonly<{
   mediaAssetIdsByPortablePath: ReadonlyMap<string, string>;
 }>;
 
+export type WorkspacePackageImportPlanPreflightInput = Readonly<{
+  cardsJson: WorkspacePackageCardsJsonV1;
+  options: WorkspacePackageImportPlanOptions;
+}>;
+
 export type WorkspacePackageImportPlannedCard = Readonly<{
   frontText: string;
   backText: string;
@@ -313,4 +318,12 @@ export function planWorkspacePackageImport(input: WorkspacePackageImportPlanInpu
       referencedMediaCount: referencedMediaPaths.size,
     },
   };
+}
+
+export function validateWorkspacePackageImportPlanPreflight(
+  input: WorkspacePackageImportPlanPreflightInput,
+): void {
+  const cardsJson = normalizeImportPlanCardsJson(input.cardsJson);
+  const options = normalizeImportPlanOptions(input.options);
+  buildImportPlanTagPolicy(cardsJson.cards, options);
 }

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -828,10 +828,9 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   const workspacePackageExport = workspacePackages.addResource("export");
   workspacePackageExport.addMethod("POST", integration);
   workspacePackageExport.addResource("preview").addMethod("POST", integration);
-  workspacePackages
-    .addResource("import")
-    .addResource("preview")
-    .addMethod("POST", integration);
+  const workspacePackageImport = workspacePackages.addResource("import");
+  workspacePackageImport.addMethod("POST", integration);
+  workspacePackageImport.addResource("preview").addMethod("POST", integration);
   const workspaceMediaAssets = workspaceById.addResource("media-assets");
   workspaceMediaAssets.addResource("images").addMethod("POST", integration);
   const workspaceMediaAssetUploadSessions = workspaceMediaAssets.addResource("upload-sessions");


### PR DESCRIPTION
## Summary
- add backend multipart ZIP import confirm route for workspace packages
- add import confirm OpenAPI contract, API Gateway route, and discovery updates
- add route/service tests for confirm parsing, access, replica ownership, and preflight validation

## Validation
- npm run test --prefix apps/backend -- workspacePackages/importConfirm workspacePackages/importPlan routes/workspacePackages: 677 pass, 0 fail
- npm run test --prefix apps/backend -- workspacePackages routes system/contracts: 677 pass, 0 fail
- npm run lint --prefix apps/backend: passed
- npm run bundle --prefix api: passed
- git --no-pager diff --check: passed
- worker-owned final review: no split recommendation and no P0-P4 findings