### PR TITLE
Add web ZIP import API foundation

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -57,6 +57,10 @@ export {
   loadMediaAssetDownloadUrl,
 } from "./api/endpoints/mediaAssets";
 export {
+  confirmWorkspacePackageImport,
+  previewWorkspacePackageImport,
+} from "./api/endpoints/workspacePackageImport";
+export {
   bootstrapPullSyncState,
   bootstrapPushSyncState,
   importReviewHistorySync,

--- a/apps/web/src/api/endpoints/workspacePackageImport.test.ts
+++ b/apps/web/src/api/endpoints/workspacePackageImport.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import "./endpointsTestSupport";
+import type {
+  Card,
+  MediaAsset,
+  WorkspacePackageImportConfirmOptions,
+  WorkspacePackageImportConfirmResponse,
+  WorkspacePackageImportPreviewResponse,
+} from "../../types";
+import { createJsonResponse } from "../ApiTestSupport";
+import { primeSessionCsrfToken } from "../transport/transport";
+import {
+  confirmWorkspacePackageImport,
+  previewWorkspacePackageImport,
+} from "./workspacePackageImport";
+
+const cardFixture: Card = {
+  cardId: "card-1",
+  frontText: "Question",
+  backText: "Answer",
+  cardType: "basic",
+  metadata: {
+    version: 1,
+    source: {
+      label: "Shared deck",
+      author: "Author",
+      comment: null,
+      createdAt: "2026-04-01T09:00:00.000Z",
+      importedAt: "2026-04-10T09:00:00.000Z",
+      importId: "import-1",
+    },
+  },
+  tags: ["shared"],
+  dueAt: null,
+  createdAt: "2026-04-01T09:00:00.000Z",
+  reps: 0,
+  lapses: 0,
+  fsrsCardState: "new",
+  fsrsStepIndex: null,
+  fsrsStability: null,
+  fsrsDifficulty: null,
+  fsrsLastReviewedAt: null,
+  fsrsScheduledDays: null,
+  clientUpdatedAt: "2026-04-10T09:00:00.000Z",
+  lastModifiedByReplicaId: "replica-1",
+  lastOperationId: "import-1:card:0",
+  updatedAt: "2026-04-10T09:00:00.000Z",
+  deletedAt: null,
+};
+
+const mediaAssetFixture: MediaAsset = {
+  mediaAssetId: "media-asset-1",
+  workspaceId: "workspace-1",
+  mimeType: "image/png",
+  sizeBytes: 128,
+  sha256: "sha256-1",
+  sourceUrl: null,
+  createdAt: "2026-04-10T09:00:00.000Z",
+  clientUpdatedAt: "2026-04-10T09:00:00.000Z",
+  lastModifiedByReplicaId: "replica-1",
+  lastOperationId: "import-1:media:0",
+  updatedAt: "2026-04-10T09:00:00.000Z",
+  deletedAt: null,
+};
+
+const previewResponse: WorkspacePackageImportPreviewResponse = {
+  sourceKind: "zip",
+  packageMetadata: {
+    label: "Shared deck",
+    author: "Author",
+    comment: null,
+    createdAt: "2026-04-01T09:00:00.000Z",
+    sourceUrl: null,
+  },
+  cardCount: 1,
+  tagCounts: [
+    { tag: "shared", cardsCount: 1 },
+  ],
+  referencedMediaCount: 1,
+  packageMediaFileCount: 1,
+  warnings: [],
+  defaultOptions: {
+    addImportTag: true,
+    suggestedImportTag: "imported-2026-04-10",
+    keptTags: ["shared"],
+    removedTags: [],
+  },
+};
+
+const confirmOptions: WorkspacePackageImportConfirmOptions = {
+  addImportTag: true,
+  importTag: "imported-2026-04-10",
+  removeTags: [],
+  importedAt: "2026-04-10T09:00:00.000Z",
+  importId: "import-1",
+  clientUpdatedAt: "2026-04-10T09:00:00.000Z",
+  lastModifiedByReplicaId: "replica-1",
+  operationIdPrefix: "import-1",
+};
+
+const confirmResponse: WorkspacePackageImportConfirmResponse = {
+  cards: [cardFixture],
+  importedMediaAssets: [
+    {
+      portablePath: "media/example.png",
+      mediaAsset: mediaAssetFixture,
+      applied: true,
+    },
+  ],
+  summary: {
+    cardCount: 1,
+    cardBatchCount: 1,
+    referencedMediaCount: 1,
+    importedMediaAssetCount: 1,
+    appliedMediaAssetCount: 1,
+    keptTagCount: 1,
+    removedTagCount: 0,
+    importTag: "imported-2026-04-10",
+  },
+};
+
+describe("workspace package import API endpoints", () => {
+  it("sends raw ZIP bytes for import preview and parses preview JSON", async () => {
+    primeSessionCsrfToken("csrf-token-1");
+    const zipBlob = new Blob([new Uint8Array([80, 75, 3, 4])], { type: "application/zip" });
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createJsonResponse(previewResponse));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(previewWorkspacePackageImport("workspace-1", zipBlob)).resolves.toEqual(previewResponse);
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/workspaces/workspace-1/packages/import/preview");
+    expect(requestInit?.method).toBe("POST");
+    expect(requestInit?.body).toBe(zipBlob);
+    expect(requestInit?.headers).toBeInstanceOf(Headers);
+    if (!(requestInit?.headers instanceof Headers)) {
+      throw new Error("Expected request headers");
+    }
+
+    expect(requestInit.headers.get("Content-Type")).toBe("application/zip");
+  });
+
+  it("sends ZIP file and JSON options as multipart form data for import confirm", async () => {
+    primeSessionCsrfToken("csrf-token-1");
+    const zipFile = new File([new Uint8Array([80, 75, 3, 4])], "workspace-package.zip", { type: "application/zip" });
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createJsonResponse(confirmResponse));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(confirmWorkspacePackageImport("workspace-1", zipFile, confirmOptions)).resolves.toEqual(confirmResponse);
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/workspaces/workspace-1/packages/import");
+    expect(requestInit?.method).toBe("POST");
+    expect(requestInit?.body).toBeInstanceOf(FormData);
+    expect(requestInit?.headers).toBeInstanceOf(Headers);
+    if (!(requestInit?.body instanceof FormData)) {
+      throw new Error("Expected FormData request body");
+    }
+    if (!(requestInit.headers instanceof Headers)) {
+      throw new Error("Expected request headers");
+    }
+
+    expect(requestInit.body.get("file")).toBe(zipFile);
+    expect(requestInit.body.get("options")).toBe(JSON.stringify(confirmOptions));
+    expect(requestInit.headers.get("Content-Type")).toBeNull();
+  });
+});

--- a/apps/web/src/api/endpoints/workspacePackageImport.ts
+++ b/apps/web/src/api/endpoints/workspacePackageImport.ts
@@ -1,0 +1,39 @@
+import {
+  parseWorkspacePackageImportConfirmResponse,
+  parseWorkspacePackageImportPreviewResponse,
+} from "../../apiContracts/workspacePackageImport";
+import type {
+  WorkspacePackageImportConfirmOptions,
+  WorkspacePackageImportConfirmResponse,
+  WorkspacePackageImportPreviewResponse,
+} from "../../types";
+import { parseContractResponse } from "../transport/response";
+import { allowAuthRecovery, requestJson } from "../transport/transport";
+
+export async function previewWorkspacePackageImport(
+  workspaceId: string,
+  fileOrBlob: Blob,
+): Promise<WorkspacePackageImportPreviewResponse> {
+  return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/packages/import/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/zip",
+    },
+    body: fileOrBlob,
+  }, allowAuthRecovery), `POST /workspaces/${workspaceId}/packages/import/preview`, parseWorkspacePackageImportPreviewResponse);
+}
+
+export async function confirmWorkspacePackageImport(
+  workspaceId: string,
+  file: File,
+  options: WorkspacePackageImportConfirmOptions,
+): Promise<WorkspacePackageImportConfirmResponse> {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("options", JSON.stringify(options));
+
+  return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/packages/import`, {
+    method: "POST",
+    body: formData,
+  }, allowAuthRecovery), `POST /workspaces/${workspaceId}/packages/import`, parseWorkspacePackageImportConfirmResponse);
+}

--- a/apps/web/src/apiContracts.ts
+++ b/apps/web/src/apiContracts.ts
@@ -36,6 +36,10 @@ export {
   parseFeedbackSubmissionResponse,
 } from "./apiContracts/feedback";
 export {
+  parseWorkspacePackageImportConfirmResponse,
+  parseWorkspacePackageImportPreviewResponse,
+} from "./apiContracts/workspacePackageImport";
+export {
   parseProgressReviewScheduleResponse,
   parseProgressSeriesResponse,
   parseProgressSummaryResponse,

--- a/apps/web/src/apiContracts/workspacePackageImport.test.ts
+++ b/apps/web/src/apiContracts/workspacePackageImport.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Card,
+  MediaAsset,
+  WorkspacePackageImportConfirmResponse,
+  WorkspacePackageImportPreviewResponse,
+} from "../types";
+import {
+  parseWorkspacePackageImportConfirmResponse,
+  parseWorkspacePackageImportPreviewResponse,
+} from "./workspacePackageImport";
+
+const cardFixture: Card = {
+  cardId: "card-1",
+  frontText: "Question",
+  backText: "Answer",
+  cardType: "basic",
+  metadata: {
+    version: 1,
+    source: {
+      label: "Shared deck",
+      author: "Author",
+      comment: null,
+      createdAt: "2026-04-01T09:00:00.000Z",
+      importedAt: "2026-04-10T09:00:00.000Z",
+      importId: "import-1",
+    },
+  },
+  tags: ["shared"],
+  dueAt: null,
+  createdAt: "2026-04-01T09:00:00.000Z",
+  reps: 0,
+  lapses: 0,
+  fsrsCardState: "new",
+  fsrsStepIndex: null,
+  fsrsStability: null,
+  fsrsDifficulty: null,
+  fsrsLastReviewedAt: null,
+  fsrsScheduledDays: null,
+  clientUpdatedAt: "2026-04-10T09:00:00.000Z",
+  lastModifiedByReplicaId: "replica-1",
+  lastOperationId: "import-1:card:0",
+  updatedAt: "2026-04-10T09:00:00.000Z",
+  deletedAt: null,
+};
+
+const mediaAssetFixture: MediaAsset = {
+  mediaAssetId: "media-asset-1",
+  workspaceId: "workspace-1",
+  mimeType: "image/png",
+  sizeBytes: 128,
+  sha256: "sha256-1",
+  sourceUrl: null,
+  createdAt: "2026-04-10T09:00:00.000Z",
+  clientUpdatedAt: "2026-04-10T09:00:00.000Z",
+  lastModifiedByReplicaId: "replica-1",
+  lastOperationId: "import-1:media:0",
+  updatedAt: "2026-04-10T09:00:00.000Z",
+  deletedAt: null,
+};
+
+const previewFixture: WorkspacePackageImportPreviewResponse = {
+  sourceKind: "zip",
+  packageMetadata: {
+    label: "Shared deck",
+    author: "Author",
+    comment: null,
+    createdAt: "2026-04-01T09:00:00.000Z",
+    sourceUrl: null,
+  },
+  cardCount: 1,
+  tagCounts: [
+    { tag: "shared", cardsCount: 1 },
+  ],
+  referencedMediaCount: 1,
+  packageMediaFileCount: 1,
+  warnings: [
+    {
+      code: "UNUSED_MEDIA_FILE",
+      message: "Package media file is not referenced by imported cards.",
+      mediaPath: "media/unused.png",
+    },
+  ],
+  defaultOptions: {
+    addImportTag: true,
+    suggestedImportTag: "imported-2026-04-10",
+    keptTags: ["shared"],
+    removedTags: [],
+  },
+};
+
+const confirmFixture: WorkspacePackageImportConfirmResponse = {
+  cards: [cardFixture],
+  importedMediaAssets: [
+    {
+      portablePath: "media/example.png",
+      mediaAsset: mediaAssetFixture,
+      applied: true,
+    },
+  ],
+  summary: {
+    cardCount: 1,
+    cardBatchCount: 1,
+    referencedMediaCount: 1,
+    importedMediaAssetCount: 1,
+    appliedMediaAssetCount: 1,
+    keptTagCount: 1,
+    removedTagCount: 0,
+    importTag: "imported-2026-04-10",
+  },
+};
+
+describe("workspace package import API contracts", () => {
+  it("parses ZIP import preview responses", () => {
+    expect(parseWorkspacePackageImportPreviewResponse(
+      previewFixture,
+      "POST /workspaces/workspace-1/packages/import/preview",
+    )).toEqual(previewFixture);
+  });
+
+  it("parses ZIP import confirm responses with cards and media assets", () => {
+    expect(parseWorkspacePackageImportConfirmResponse(
+      confirmFixture,
+      "POST /workspaces/workspace-1/packages/import",
+    )).toEqual(confirmFixture);
+  });
+
+  it("rejects malformed required preview count fields", () => {
+    expect(() => parseWorkspacePackageImportPreviewResponse({
+      ...previewFixture,
+      cardCount: -1,
+    }, "POST /workspaces/workspace-1/packages/import/preview")).toThrow(
+      "Invalid API response for POST /workspaces/workspace-1/packages/import/preview: cardCount must be non-negative integer",
+    );
+  });
+});

--- a/apps/web/src/apiContracts/workspacePackageImport.ts
+++ b/apps/web/src/apiContracts/workspacePackageImport.ts
@@ -1,0 +1,192 @@
+import type {
+  WorkspacePackageImportedMediaAsset,
+  WorkspacePackageImportConfirmResponse,
+  WorkspacePackageImportConfirmSummary,
+  WorkspacePackageImportDefaultOptions,
+  WorkspacePackageImportPreviewMetadata,
+  WorkspacePackageImportPreviewResponse,
+  WorkspacePackageImportPreviewTagCount,
+  WorkspacePackageImportPreviewWarning,
+} from "../types";
+import {
+  ApiContractError,
+  describePath,
+  parseArray,
+  parseBoolean,
+  parseLiteral,
+  parseNullableString,
+  parseNumber,
+  parseObject,
+  parseRequiredField,
+  parseString,
+  parseStringArray,
+} from "./core";
+import { parseMediaAsset } from "./mediaAssets";
+import { parseCard } from "./studyData";
+
+function parseNonNegativeInteger(value: unknown, endpoint: string, path: string): number {
+  const parsedValue = parseNumber(value, endpoint, path);
+  if (Number.isInteger(parsedValue) === false || parsedValue < 0) {
+    throw new ApiContractError(endpoint, describePath(path), "non-negative integer");
+  }
+
+  return parsedValue;
+}
+
+function parseWorkspacePackageImportPreviewMetadata(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageImportPreviewMetadata {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    label: parseRequiredField(objectValue, "label", endpoint, path, parseNullableString),
+    author: parseRequiredField(objectValue, "author", endpoint, path, parseNullableString),
+    comment: parseRequiredField(objectValue, "comment", endpoint, path, parseNullableString),
+    createdAt: parseRequiredField(objectValue, "createdAt", endpoint, path, parseNullableString),
+    sourceUrl: parseRequiredField(objectValue, "sourceUrl", endpoint, path, parseNullableString),
+  };
+}
+
+function parseWorkspacePackageImportPreviewTagCount(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageImportPreviewTagCount {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    tag: parseRequiredField(objectValue, "tag", endpoint, path, parseString),
+    cardsCount: parseRequiredField(objectValue, "cardsCount", endpoint, path, parseNonNegativeInteger),
+  };
+}
+
+function parseWorkspacePackageImportPreviewWarning(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageImportPreviewWarning {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    code: parseRequiredField(objectValue, "code", endpoint, path, parseString),
+    message: parseRequiredField(objectValue, "message", endpoint, path, parseString),
+    mediaPath: parseRequiredField(objectValue, "mediaPath", endpoint, path, parseString),
+  };
+}
+
+function parseWorkspacePackageImportDefaultOptions(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageImportDefaultOptions {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    addImportTag: parseRequiredField(objectValue, "addImportTag", endpoint, path, parseBoolean),
+    suggestedImportTag: parseRequiredField(objectValue, "suggestedImportTag", endpoint, path, parseString),
+    keptTags: parseRequiredField(objectValue, "keptTags", endpoint, path, parseStringArray),
+    removedTags: parseRequiredField(objectValue, "removedTags", endpoint, path, parseStringArray),
+  };
+}
+
+function parseWorkspacePackageImportedMediaAsset(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageImportedMediaAsset {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    portablePath: parseRequiredField(objectValue, "portablePath", endpoint, path, parseString),
+    mediaAsset: parseRequiredField(objectValue, "mediaAsset", endpoint, path, parseMediaAsset),
+    applied: parseRequiredField(objectValue, "applied", endpoint, path, parseBoolean),
+  };
+}
+
+function parseWorkspacePackageImportConfirmSummary(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageImportConfirmSummary {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    cardCount: parseRequiredField(objectValue, "cardCount", endpoint, path, parseNonNegativeInteger),
+    cardBatchCount: parseRequiredField(objectValue, "cardBatchCount", endpoint, path, parseNonNegativeInteger),
+    referencedMediaCount: parseRequiredField(objectValue, "referencedMediaCount", endpoint, path, parseNonNegativeInteger),
+    importedMediaAssetCount: parseRequiredField(objectValue, "importedMediaAssetCount", endpoint, path, parseNonNegativeInteger),
+    appliedMediaAssetCount: parseRequiredField(objectValue, "appliedMediaAssetCount", endpoint, path, parseNonNegativeInteger),
+    keptTagCount: parseRequiredField(objectValue, "keptTagCount", endpoint, path, parseNonNegativeInteger),
+    removedTagCount: parseRequiredField(objectValue, "removedTagCount", endpoint, path, parseNonNegativeInteger),
+    importTag: parseRequiredField(objectValue, "importTag", endpoint, path, parseNullableString),
+  };
+}
+
+export function parseWorkspacePackageImportPreviewResponse(
+  value: unknown,
+  endpoint: string,
+): WorkspacePackageImportPreviewResponse {
+  const objectValue = parseObject(value, endpoint, "");
+  return {
+    sourceKind: parseLiteral(
+      parseRequiredField(objectValue, "sourceKind", endpoint, "", parseString),
+      endpoint,
+      "sourceKind",
+      "zip",
+    ),
+    packageMetadata: parseRequiredField(objectValue, "packageMetadata", endpoint, "", parseWorkspacePackageImportPreviewMetadata),
+    cardCount: parseRequiredField(objectValue, "cardCount", endpoint, "", parseNonNegativeInteger),
+    tagCounts: parseRequiredField(
+      objectValue,
+      "tagCounts",
+      endpoint,
+      "",
+      (tagCountsValue, tagCountsEndpoint, tagCountsPath) => parseArray(
+        tagCountsValue,
+        tagCountsEndpoint,
+        tagCountsPath,
+        parseWorkspacePackageImportPreviewTagCount,
+      ),
+    ),
+    referencedMediaCount: parseRequiredField(objectValue, "referencedMediaCount", endpoint, "", parseNonNegativeInteger),
+    packageMediaFileCount: parseRequiredField(objectValue, "packageMediaFileCount", endpoint, "", parseNonNegativeInteger),
+    warnings: parseRequiredField(
+      objectValue,
+      "warnings",
+      endpoint,
+      "",
+      (warningsValue, warningsEndpoint, warningsPath) => parseArray(
+        warningsValue,
+        warningsEndpoint,
+        warningsPath,
+        parseWorkspacePackageImportPreviewWarning,
+      ),
+    ),
+    defaultOptions: parseRequiredField(objectValue, "defaultOptions", endpoint, "", parseWorkspacePackageImportDefaultOptions),
+  };
+}
+
+export function parseWorkspacePackageImportConfirmResponse(
+  value: unknown,
+  endpoint: string,
+): WorkspacePackageImportConfirmResponse {
+  const objectValue = parseObject(value, endpoint, "");
+  return {
+    cards: parseRequiredField(
+      objectValue,
+      "cards",
+      endpoint,
+      "",
+      (cardsValue, cardsEndpoint, cardsPath) => parseArray(cardsValue, cardsEndpoint, cardsPath, parseCard),
+    ),
+    importedMediaAssets: parseRequiredField(
+      objectValue,
+      "importedMediaAssets",
+      endpoint,
+      "",
+      (mediaAssetsValue, mediaAssetsEndpoint, mediaAssetsPath) => parseArray(
+        mediaAssetsValue,
+        mediaAssetsEndpoint,
+        mediaAssetsPath,
+        parseWorkspacePackageImportedMediaAsset,
+      ),
+    ),
+    summary: parseRequiredField(objectValue, "summary", endpoint, "", parseWorkspacePackageImportConfirmSummary),
+  };
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -7,3 +7,4 @@ export * from "./types/chat";
 export * from "./types/mediaAssets";
 export * from "./types/study";
 export * from "./types/sync";
+export * from "./types/workspacePackageImport";

--- a/apps/web/src/types/workspacePackageImport.ts
+++ b/apps/web/src/types/workspacePackageImport.ts
@@ -1,0 +1,73 @@
+import type { MediaAsset } from "./mediaAssets";
+import type { Card } from "./study";
+
+export type WorkspacePackageImportPreviewMetadata = Readonly<{
+  label: string | null;
+  author: string | null;
+  comment: string | null;
+  createdAt: string | null;
+  sourceUrl: string | null;
+}>;
+
+export type WorkspacePackageImportPreviewTagCount = Readonly<{
+  tag: string;
+  cardsCount: number;
+}>;
+
+export type WorkspacePackageImportPreviewWarning = Readonly<{
+  code: string;
+  message: string;
+  mediaPath: string;
+}>;
+
+export type WorkspacePackageImportDefaultOptions = Readonly<{
+  addImportTag: boolean;
+  suggestedImportTag: string;
+  keptTags: ReadonlyArray<string>;
+  removedTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageImportPreviewResponse = Readonly<{
+  sourceKind: "zip";
+  packageMetadata: WorkspacePackageImportPreviewMetadata;
+  cardCount: number;
+  tagCounts: ReadonlyArray<WorkspacePackageImportPreviewTagCount>;
+  referencedMediaCount: number;
+  packageMediaFileCount: number;
+  warnings: ReadonlyArray<WorkspacePackageImportPreviewWarning>;
+  defaultOptions: WorkspacePackageImportDefaultOptions;
+}>;
+
+export type WorkspacePackageImportConfirmOptions = Readonly<{
+  addImportTag: boolean;
+  importTag: string;
+  removeTags: ReadonlyArray<string>;
+  importedAt: string;
+  importId: string;
+  clientUpdatedAt: string;
+  lastModifiedByReplicaId: string;
+  operationIdPrefix: string;
+}>;
+
+export type WorkspacePackageImportConfirmSummary = Readonly<{
+  cardCount: number;
+  cardBatchCount: number;
+  referencedMediaCount: number;
+  importedMediaAssetCount: number;
+  appliedMediaAssetCount: number;
+  keptTagCount: number;
+  removedTagCount: number;
+  importTag: string | null;
+}>;
+
+export type WorkspacePackageImportedMediaAsset = Readonly<{
+  portablePath: string;
+  mediaAsset: MediaAsset;
+  applied: boolean;
+}>;
+
+export type WorkspacePackageImportConfirmResponse = Readonly<{
+  cards: ReadonlyArray<Card>;
+  importedMediaAssets: ReadonlyArray<WorkspacePackageImportedMediaAsset>;
+  summary: WorkspacePackageImportConfirmSummary;
+}>;


### PR DESCRIPTION
## Summary
- add typed web API models for workspace package ZIP import preview and confirm
- add strict response parsers that reuse existing card and media asset parsers
- add authenticated endpoint wrappers for raw ZIP preview and multipart confirm uploads
- add focused endpoint and parser coverage

## Validation
- npm ci --prefix apps/web: passed with Node 25.6.1 vs package Node 24.x engine warning
- npm run test --prefix apps/web -- src/api/endpoints src/apiContracts: passed, 70 files / 525 tests
- ./apps/web/node_modules/.bin/tsc -p apps/web/tsconfig.json --noEmit: passed
- git --no-pager diff --check: passed
- npm run lint --prefix apps/web: not runnable because apps/web/package.json has no lint script
- worker-owned review: no split recommendation, no P0-P4 findings, green light for commit