### PR TITLE
Add web ZIP export API foundation

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -57,6 +57,10 @@ export {
   loadMediaAssetDownloadUrl,
 } from "./api/endpoints/mediaAssets";
 export {
+  downloadWorkspacePackageExport,
+  previewWorkspacePackageExport,
+} from "./api/endpoints/workspacePackageExport";
+export {
   confirmWorkspacePackageImport,
   previewWorkspacePackageImport,
 } from "./api/endpoints/workspacePackageImport";

--- a/apps/web/src/api/endpoints/workspacePackageExport.test.ts
+++ b/apps/web/src/api/endpoints/workspacePackageExport.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import "./endpointsTestSupport";
+import type {
+  WorkspacePackageExportPreviewResponse,
+  WorkspacePackageExportRequest,
+} from "../../types";
+import { createJsonResponse } from "../ApiTestSupport";
+import { primeSessionCsrfToken } from "../transport/transport";
+import {
+  downloadWorkspacePackageExport,
+  previewWorkspacePackageExport,
+} from "./workspacePackageExport";
+
+const exportRequest: WorkspacePackageExportRequest = {
+  selection: {
+    kind: "explicitCardIds",
+    cardIds: ["99782554-9362-416c-93c7-0eb1d8079948"],
+  },
+  tagPolicy: {
+    additionalRemovedTags: ["draft"],
+  },
+  packageMetadata: {
+    label: "Starter deck",
+    author: null,
+    comment: null,
+    createdAt: null,
+    sourceUrl: null,
+  },
+};
+
+const previewResponse: WorkspacePackageExportPreviewResponse = {
+  selectedCardCount: 1,
+  availableTagCounts: [
+    { tag: "draft", cardsCount: 1 },
+  ],
+  tagsSelectedForRemoval: [
+    { tag: "draft", cardsCount: 1 },
+  ],
+  referencedMediaCount: 1,
+  approximateReferencedMediaBytes: 512,
+  defaultPackageMetadata: {
+    label: "Starter deck",
+    createdAt: "2026-04-10T09:00:00.000Z",
+  },
+};
+
+describe("workspace package export API endpoints", () => {
+  it("sends JSON for export preview and parses preview JSON", async () => {
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createJsonResponse(previewResponse));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(previewWorkspacePackageExport("workspace-1", exportRequest)).resolves.toEqual(previewResponse);
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/workspaces/workspace-1/packages/export/preview");
+    expect(requestInit?.method).toBe("POST");
+    expect(requestInit?.body).toBe(JSON.stringify(exportRequest));
+    expect(requestInit?.headers).toBeInstanceOf(Headers);
+    if (!(requestInit?.headers instanceof Headers)) {
+      throw new Error("Expected request headers");
+    }
+
+    expect(requestInit.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("sends JSON for export download and returns ZIP blob metadata", async () => {
+    primeSessionCsrfToken("csrf-token-1");
+    const zipBytes = new Uint8Array([80, 75, 3, 4]);
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(zipBytes, {
+        status: 200,
+        headers: {
+          "Content-Disposition": "attachment; filename=\"flashcards.zip\"",
+          "Content-Type": "application/zip",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await downloadWorkspacePackageExport("workspace-1", exportRequest);
+
+    expect(result.filename).toBe("flashcards.zip");
+    expect(result.contentType).toBe("application/zip");
+    expect(result.blob).toBeInstanceOf(Blob);
+    expect([...new Uint8Array(await result.blob.arrayBuffer())]).toEqual([...zipBytes]);
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/workspaces/workspace-1/packages/export");
+    expect(requestInit?.method).toBe("POST");
+    expect(requestInit?.body).toBe(JSON.stringify(exportRequest));
+    expect(requestInit?.headers).toBeInstanceOf(Headers);
+    if (!(requestInit?.headers instanceof Headers)) {
+      throw new Error("Expected request headers");
+    }
+
+    expect(requestInit.headers.get("Accept")).toBe("application/zip");
+    expect(requestInit.headers.get("Content-Type")).toBe("application/json");
+  });
+});

--- a/apps/web/src/api/endpoints/workspacePackageExport.ts
+++ b/apps/web/src/api/endpoints/workspacePackageExport.ts
@@ -1,0 +1,38 @@
+import {
+  parseWorkspacePackageExportDownloadMetadata,
+  parseWorkspacePackageExportPreviewResponse,
+} from "../../apiContracts/workspacePackageExport";
+import type {
+  WorkspacePackageExportDownloadResult,
+  WorkspacePackageExportPreviewResponse,
+  WorkspacePackageExportRequest,
+} from "../../types";
+import { parseContractResponse } from "../transport/response";
+import { allowAuthRecovery, requestBlob, requestJson } from "../transport/transport";
+
+export async function previewWorkspacePackageExport(
+  workspaceId: string,
+  request: WorkspacePackageExportRequest,
+): Promise<WorkspacePackageExportPreviewResponse> {
+  return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/packages/export/preview`, {
+    method: "POST",
+    body: JSON.stringify(request),
+  }, allowAuthRecovery), `POST /workspaces/${workspaceId}/packages/export/preview`, parseWorkspacePackageExportPreviewResponse);
+}
+
+export async function downloadWorkspacePackageExport(
+  workspaceId: string,
+  request: WorkspacePackageExportRequest,
+): Promise<WorkspacePackageExportDownloadResult> {
+  const response = await requestBlob(`/workspaces/${workspaceId}/packages/export`, {
+    method: "POST",
+    headers: {
+      Accept: "application/zip",
+    },
+    body: JSON.stringify(request),
+  }, allowAuthRecovery);
+  return {
+    blob: response.blob,
+    ...parseWorkspacePackageExportDownloadMetadata(response.headers),
+  };
+}

--- a/apps/web/src/api/transport/transport.test.ts
+++ b/apps/web/src/api/transport/transport.test.ts
@@ -30,6 +30,7 @@ import {
   allowAuthRecovery,
   getSession,
   primeSessionCsrfToken,
+  requestBlob,
   requestJson,
   resetApiClientStateForTests,
   setNavigationHandlerForTests,
@@ -896,5 +897,38 @@ describe("API transport network retry", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("API transport binary responses", () => {
+  it("converts non-OK JSON errors into ApiError metadata", async () => {
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: "Workspace package export failed.",
+        code: "WORKSPACE_PACKAGE_EXPORT_FAILED",
+        requestId: "body-request-id",
+      }), {
+        status: 413,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Request-Id": "header-request-id",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(requestBlob("/workspaces/workspace-1/packages/export", {
+      method: "POST",
+      body: JSON.stringify({ ok: true }),
+    }, allowAuthRecovery)).rejects.toMatchObject({
+      statusCode: 413,
+      message: "Workspace package export failed.",
+      code: "WORKSPACE_PACKAGE_EXPORT_FAILED",
+      requestId: "header-request-id",
+      endpoint: "POST /workspaces/workspace-1/packages/export",
+      responseBodyKind: "json",
+    } satisfies Partial<ApiError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/api/transport/transport.ts
+++ b/apps/web/src/api/transport/transport.ts
@@ -18,6 +18,11 @@ export type AuthRecoveryMode = "allow" | "skip";
 export type NetworkRetryMode = "none" | "transient";
 type NavigateToUrl = (url: string) => void;
 type PrepareForAuthRedirect = () => void;
+export type BlobResponsePayload = Readonly<{
+  blob: Blob;
+  headers: Headers;
+  statusCode: number;
+}>;
 export type RequestOptions = Readonly<{
   authRecoveryMode: AuthRecoveryMode;
   networkRetryMode: NetworkRetryMode;
@@ -620,6 +625,25 @@ export async function requestJson(
 ): Promise<ParsedResponsePayload> {
   const response = await requestResponse(pathname, init, options);
   return parseJsonPayload(response, buildRequestEndpoint(pathname, init));
+}
+
+export async function requestBlob(
+  pathname: string,
+  init: RequestInit,
+  options: RequestOptions,
+): Promise<BlobResponsePayload> {
+  const response = await requestResponse(pathname, init, options);
+  const endpoint = buildRequestEndpoint(pathname, init);
+  if (!response.ok) {
+    await parseJsonPayload(response, endpoint);
+    throw new Error(`Non-OK blob response for ${endpoint} did not raise an API error`);
+  }
+
+  return {
+    blob: await response.blob(),
+    headers: response.headers,
+    statusCode: response.status,
+  };
 }
 
 /**

--- a/apps/web/src/apiContracts.ts
+++ b/apps/web/src/apiContracts.ts
@@ -36,6 +36,10 @@ export {
   parseFeedbackSubmissionResponse,
 } from "./apiContracts/feedback";
 export {
+  parseWorkspacePackageExportDownloadMetadata,
+  parseWorkspacePackageExportPreviewResponse,
+} from "./apiContracts/workspacePackageExport";
+export {
   parseWorkspacePackageImportConfirmResponse,
   parseWorkspacePackageImportPreviewResponse,
 } from "./apiContracts/workspacePackageImport";

--- a/apps/web/src/apiContracts/core.ts
+++ b/apps/web/src/apiContracts/core.ts
@@ -82,6 +82,15 @@ export function parseNumber(value: unknown, endpoint: string, path: string): num
   return value;
 }
 
+export function parseNonNegativeInteger(value: unknown, endpoint: string, path: string): number {
+  const parsedValue = parseNumber(value, endpoint, path);
+  if (Number.isInteger(parsedValue) === false || parsedValue < 0) {
+    throw new ApiContractError(endpoint, describePath(path), "non-negative integer");
+  }
+
+  return parsedValue;
+}
+
 export function parseNullableNumber(value: unknown, endpoint: string, path: string): number | null {
   if (value === null) {
     return null;

--- a/apps/web/src/apiContracts/workspacePackageExport.test.ts
+++ b/apps/web/src/apiContracts/workspacePackageExport.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspacePackageExportPreviewResponse } from "../types";
+import {
+  parseWorkspacePackageExportDownloadMetadata,
+  parseWorkspacePackageExportPreviewResponse,
+} from "./workspacePackageExport";
+
+const previewFixture: WorkspacePackageExportPreviewResponse = {
+  selectedCardCount: 2,
+  availableTagCounts: [
+    { tag: "english", cardsCount: 2 },
+    { tag: "import:starter", cardsCount: 1 },
+  ],
+  tagsSelectedForRemoval: [
+    { tag: "import:starter", cardsCount: 1 },
+  ],
+  referencedMediaCount: 1,
+  approximateReferencedMediaBytes: 350,
+  defaultPackageMetadata: {
+    label: "Starter deck",
+    author: "Author",
+    comment: "Shared package",
+    createdAt: "2026-04-10T09:00:00.000Z",
+    sourceUrl: "https://example.com/package",
+  },
+};
+
+describe("workspace package export API contracts", () => {
+  it("parses ZIP export preview responses", () => {
+    expect(parseWorkspacePackageExportPreviewResponse(
+      previewFixture,
+      "POST /workspaces/workspace-1/packages/export/preview",
+    )).toEqual(previewFixture);
+  });
+
+  it("rejects malformed required preview count fields", () => {
+    expect(() => parseWorkspacePackageExportPreviewResponse({
+      ...previewFixture,
+      referencedMediaCount: -1,
+    }, "POST /workspaces/workspace-1/packages/export/preview")).toThrow(
+      "Invalid API response for POST /workspaces/workspace-1/packages/export/preview: referencedMediaCount must be non-negative integer",
+    );
+  });
+
+  it("derives ZIP download metadata with safe fallbacks", () => {
+    expect(parseWorkspacePackageExportDownloadMetadata(new Headers({
+      "Content-Disposition": "attachment; filename=\"flashcards.zip\"",
+      "Content-Type": "application/zip",
+    }))).toEqual({
+      filename: "flashcards.zip",
+      contentType: "application/zip",
+    });
+
+    expect(parseWorkspacePackageExportDownloadMetadata(new Headers())).toEqual({
+      filename: "flashcards.zip",
+      contentType: "application/octet-stream",
+    });
+  });
+});

--- a/apps/web/src/apiContracts/workspacePackageExport.ts
+++ b/apps/web/src/apiContracts/workspacePackageExport.ts
@@ -1,0 +1,154 @@
+import type {
+  WorkspacePackageExportDefaultPackageMetadata,
+  WorkspacePackageExportDownloadMetadata,
+  WorkspacePackageExportPreviewResponse,
+  WorkspacePackageExportTagCount,
+} from "../types";
+import {
+  parseArray,
+  parseNonNegativeInteger,
+  parseObject,
+  parseOptionalField,
+  parseRequiredField,
+  parseString,
+} from "./core";
+
+const defaultWorkspacePackageExportFilename = "flashcards.zip";
+const defaultWorkspacePackageExportContentType = "application/octet-stream";
+const unsafeFilenamePattern = /[/\\\u0000-\u001f\u007f]/u;
+
+function parseWorkspacePackageExportTagCount(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageExportTagCount {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    tag: parseRequiredField(objectValue, "tag", endpoint, path, parseString),
+    cardsCount: parseRequiredField(objectValue, "cardsCount", endpoint, path, parseNonNegativeInteger),
+  };
+}
+
+function parseWorkspacePackageExportDefaultPackageMetadata(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): WorkspacePackageExportDefaultPackageMetadata {
+  const objectValue = parseObject(value, endpoint, path);
+  const author = parseOptionalField(objectValue, "author", endpoint, path, parseString);
+  const comment = parseOptionalField(objectValue, "comment", endpoint, path, parseString);
+  const sourceUrl = parseOptionalField(objectValue, "sourceUrl", endpoint, path, parseString);
+
+  return {
+    label: parseRequiredField(objectValue, "label", endpoint, path, parseString),
+    ...(author === undefined ? {} : { author }),
+    ...(comment === undefined ? {} : { comment }),
+    createdAt: parseRequiredField(objectValue, "createdAt", endpoint, path, parseString),
+    ...(sourceUrl === undefined ? {} : { sourceUrl }),
+  };
+}
+
+function sanitizeDownloadFilename(filename: string): string {
+  const trimmedFilename = filename.trim();
+  if (trimmedFilename === "" || unsafeFilenamePattern.test(trimmedFilename)) {
+    return defaultWorkspacePackageExportFilename;
+  }
+
+  return trimmedFilename;
+}
+
+function unquoteContentDispositionValue(value: string): string {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length >= 2 && trimmedValue.startsWith("\"") && trimmedValue.endsWith("\"")) {
+    return trimmedValue.slice(1, -1).replace(/\\(["\\])/gu, "$1");
+  }
+
+  return trimmedValue;
+}
+
+function parseContentDispositionFilename(contentDisposition: string | null): string {
+  if (contentDisposition === null) {
+    return defaultWorkspacePackageExportFilename;
+  }
+
+  const parameters = contentDisposition.split(";").slice(1);
+  const filenameParameter = parameters.find((parameter: string): boolean => {
+    const [key] = parameter.split("=", 1);
+    return key?.trim().toLowerCase() === "filename";
+  });
+  if (filenameParameter === undefined) {
+    return defaultWorkspacePackageExportFilename;
+  }
+
+  const valueStartIndex = filenameParameter.indexOf("=");
+  if (valueStartIndex < 0) {
+    return defaultWorkspacePackageExportFilename;
+  }
+
+  return sanitizeDownloadFilename(unquoteContentDispositionValue(filenameParameter.slice(valueStartIndex + 1)));
+}
+
+function parseResponseContentType(headers: Headers): string {
+  const contentType = headers.get("Content-Type");
+  if (contentType === null || contentType.trim() === "") {
+    return defaultWorkspacePackageExportContentType;
+  }
+
+  return contentType;
+}
+
+export function parseWorkspacePackageExportPreviewResponse(
+  value: unknown,
+  endpoint: string,
+): WorkspacePackageExportPreviewResponse {
+  const objectValue = parseObject(value, endpoint, "");
+  return {
+    selectedCardCount: parseRequiredField(objectValue, "selectedCardCount", endpoint, "", parseNonNegativeInteger),
+    availableTagCounts: parseRequiredField(
+      objectValue,
+      "availableTagCounts",
+      endpoint,
+      "",
+      (tagCountsValue, tagCountsEndpoint, tagCountsPath) => parseArray(
+        tagCountsValue,
+        tagCountsEndpoint,
+        tagCountsPath,
+        parseWorkspacePackageExportTagCount,
+      ),
+    ),
+    tagsSelectedForRemoval: parseRequiredField(
+      objectValue,
+      "tagsSelectedForRemoval",
+      endpoint,
+      "",
+      (tagCountsValue, tagCountsEndpoint, tagCountsPath) => parseArray(
+        tagCountsValue,
+        tagCountsEndpoint,
+        tagCountsPath,
+        parseWorkspacePackageExportTagCount,
+      ),
+    ),
+    referencedMediaCount: parseRequiredField(objectValue, "referencedMediaCount", endpoint, "", parseNonNegativeInteger),
+    approximateReferencedMediaBytes: parseRequiredField(
+      objectValue,
+      "approximateReferencedMediaBytes",
+      endpoint,
+      "",
+      parseNonNegativeInteger,
+    ),
+    defaultPackageMetadata: parseRequiredField(
+      objectValue,
+      "defaultPackageMetadata",
+      endpoint,
+      "",
+      parseWorkspacePackageExportDefaultPackageMetadata,
+    ),
+  };
+}
+
+export function parseWorkspacePackageExportDownloadMetadata(headers: Headers): WorkspacePackageExportDownloadMetadata {
+  return {
+    filename: parseContentDispositionFilename(headers.get("Content-Disposition")),
+    contentType: parseResponseContentType(headers),
+  };
+}

--- a/apps/web/src/apiContracts/workspacePackageImport.ts
+++ b/apps/web/src/apiContracts/workspacePackageImport.ts
@@ -9,13 +9,11 @@ import type {
   WorkspacePackageImportPreviewWarning,
 } from "../types";
 import {
-  ApiContractError,
-  describePath,
   parseArray,
   parseBoolean,
   parseLiteral,
+  parseNonNegativeInteger,
   parseNullableString,
-  parseNumber,
   parseObject,
   parseRequiredField,
   parseString,
@@ -23,15 +21,6 @@ import {
 } from "./core";
 import { parseMediaAsset } from "./mediaAssets";
 import { parseCard } from "./studyData";
-
-function parseNonNegativeInteger(value: unknown, endpoint: string, path: string): number {
-  const parsedValue = parseNumber(value, endpoint, path);
-  if (Number.isInteger(parsedValue) === false || parsedValue < 0) {
-    throw new ApiContractError(endpoint, describePath(path), "non-negative integer");
-  }
-
-  return parsedValue;
-}
 
 function parseWorkspacePackageImportPreviewMetadata(
   value: unknown,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -7,4 +7,5 @@ export * from "./types/chat";
 export * from "./types/mediaAssets";
 export * from "./types/study";
 export * from "./types/sync";
+export * from "./types/workspacePackageExport";
 export * from "./types/workspacePackageImport";

--- a/apps/web/src/types/workspacePackageExport.ts
+++ b/apps/web/src/types/workspacePackageExport.ts
@@ -1,0 +1,68 @@
+export type WorkspacePackageExportAllActiveCardsSelection = Readonly<{
+  kind: "allActiveCards";
+}>;
+
+export type WorkspacePackageExportTagFiltersSelection = Readonly<{
+  kind: "tagFilters";
+  includeTags: ReadonlyArray<string>;
+  excludeTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageExportExplicitCardIdsSelection = Readonly<{
+  kind: "explicitCardIds";
+  cardIds: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageExportSelection =
+  | WorkspacePackageExportAllActiveCardsSelection
+  | WorkspacePackageExportTagFiltersSelection
+  | WorkspacePackageExportExplicitCardIdsSelection;
+
+export type WorkspacePackageExportTagPolicyInput = Readonly<{
+  additionalRemovedTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspacePackageExportMetadataInput = Readonly<{
+  label: string | null;
+  author: string | null;
+  comment: string | null;
+  createdAt: string | null;
+  sourceUrl: string | null;
+}>;
+
+export type WorkspacePackageExportRequest = Readonly<{
+  selection: WorkspacePackageExportSelection;
+  tagPolicy: WorkspacePackageExportTagPolicyInput;
+  packageMetadata: WorkspacePackageExportMetadataInput;
+}>;
+
+export type WorkspacePackageExportTagCount = Readonly<{
+  tag: string;
+  cardsCount: number;
+}>;
+
+export type WorkspacePackageExportDefaultPackageMetadata = Readonly<{
+  label: string;
+  author?: string;
+  comment?: string;
+  createdAt: string;
+  sourceUrl?: string;
+}>;
+
+export type WorkspacePackageExportPreviewResponse = Readonly<{
+  selectedCardCount: number;
+  availableTagCounts: ReadonlyArray<WorkspacePackageExportTagCount>;
+  tagsSelectedForRemoval: ReadonlyArray<WorkspacePackageExportTagCount>;
+  referencedMediaCount: number;
+  approximateReferencedMediaBytes: number;
+  defaultPackageMetadata: WorkspacePackageExportDefaultPackageMetadata;
+}>;
+
+export type WorkspacePackageExportDownloadMetadata = Readonly<{
+  filename: string;
+  contentType: string;
+}>;
+
+export type WorkspacePackageExportDownloadResult = WorkspacePackageExportDownloadMetadata & Readonly<{
+  blob: Blob;
+}>;


### PR DESCRIPTION
Summary
- Add typed web API contracts for workspace package ZIP export preview and download metadata.
- Add preview/download endpoints and a focused binary transport helper that keeps auth recovery and CSRF behavior.
- Add endpoint, parser, and transport tests for the export API foundation.

Validation
- npm ci --prefix apps/web: passed with Node 25.6.1 vs package Node 24.x engine warning.
- npm run test --prefix apps/web -- src/api/endpoints src/apiContracts src/api/transport: passed, 72 files / 531 tests.
- npm run lint --prefix apps/web: not runnable because apps/web/package.json has no lint script.
- ./apps/web/node_modules/.bin/tsc -p apps/web/tsconfig.json --noEmit: passed.
- git --no-pager diff --check: passed.
- Worker-owned review: no split recommendation, no P0-P4 findings.