### PR TITLE
Remove old web ZIP export helper

### DIFF
--- a/apps/web/src/workspaceExport.ts
+++ b/apps/web/src/workspaceExport.ts
@@ -1,6 +1,5 @@
 import { loadAllActiveCardsForSql } from "./localDb/cards/cards";
 import type { Card } from "./types";
-import { createFlashcardsPackage, writeFlashcardsPackageZip } from "./workspacePackage";
 
 type WorkspaceExportUrlApi = Readonly<{
   createObjectURL: (object: Blob) => string;
@@ -25,12 +24,6 @@ type ExportWorkspaceCardsCsvParams = Readonly<{
   workspaceId: string;
   workspaceName: string;
   now: Date;
-  document: Document;
-  urlApi: WorkspaceExportUrlApi;
-}>;
-
-type ExportWorkspaceCardsPackageParams = Readonly<{
-  workspaceId: string;
   document: Document;
   urlApi: WorkspaceExportUrlApi;
 }>;
@@ -83,10 +76,6 @@ export function makeWorkspaceExportFilename(workspaceName: string, now: Date): s
   return `${slugifyWorkspaceName(workspaceName)}-cards-export-${formatExportDate(now)}.csv`;
 }
 
-export function makeFlashcardsPackageExportFilename(): string {
-  return "flashcards.zip";
-}
-
 export function triggerBlobDownload(params: TriggerBlobDownloadParams): void {
   const { blob, filename, document, urlApi } = params;
   if (document.body === null) {
@@ -123,19 +112,6 @@ export async function exportWorkspaceCardsCsv(params: ExportWorkspaceCardsCsvPar
   triggerCsvDownload({
     content,
     filename,
-    document,
-    urlApi,
-  });
-}
-
-export async function exportWorkspaceCardsPackage(params: ExportWorkspaceCardsPackageParams): Promise<void> {
-  const { workspaceId, document, urlApi } = params;
-  const cards = await loadAllActiveCardsForSql(workspaceId);
-  const packageData = createFlashcardsPackage(cards);
-  const zipBytes = writeFlashcardsPackageZip(packageData);
-  triggerBlobDownload({
-    blob: new Blob([zipBytes], { type: "application/zip" }),
-    filename: makeFlashcardsPackageExportFilename(),
     document,
     urlApi,
   });

--- a/apps/web/src/workspacePackage.ts
+++ b/apps/web/src/workspacePackage.ts
@@ -4,7 +4,7 @@ import {
   normalizeCardType,
   normalizeTagKey,
 } from "./appData/domain";
-import type { Card, CardMetadata, CardSourceMetadata } from "./types";
+import type { CardMetadata, CardSourceMetadata } from "./types";
 
 const packageCardsJsonFilename = "cards.json";
 const unsupportedAssetReferencePrefix = "fcasset:";
@@ -156,21 +156,6 @@ export function validateFlashcardsPackage(value: unknown): FlashcardsPackageV1 {
   return {
     formatVersion: 1,
     cards: record.cards.map(validateFlashcardsPackageCard),
-  };
-}
-
-export function createFlashcardsPackage(
-  cards: ReadonlyArray<Pick<Card, "frontText" | "backText" | "tags" | "cardType" | "metadata">>,
-): FlashcardsPackageV1 {
-  return {
-    formatVersion: 1,
-    cards: cards.map((card) => ({
-      frontText: card.frontText,
-      backText: card.backText,
-      tags: card.tags,
-      cardType: card.cardType,
-      metadata: card.metadata,
-    })),
   };
 }
 


### PR DESCRIPTION
## Summary
- Removed the obsolete browser-side ZIP package export path after the backend preview/download export flow.
- Kept CSV export behavior and the shared backend ZIP download helper intact.
- Kept local package reader/writer/import helpers used by parser tests and sync-local import code.

## Validation
- npm run test --prefix apps/web -- WorkspaceExportScreen.package workspacePackage
- ./apps/web/node_modules/.bin/tsc -p apps/web/tsconfig.json --noEmit
- git --no-pager diff --check
- rg "exportWorkspaceCardsPackage|ExportWorkspaceCardsPackageParams|makeFlashcardsPackageExportFilename|createFlashcardsPackage" .