### PR TITLE
Move workspace package export files

### DIFF
--- a/apps/backend/src/workspacePackages/export/exportPackage.test.ts
+++ b/apps/backend/src/workspacePackages/export/exportPackage.test.ts
@@ -2,21 +2,23 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
 import pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../database";
+import type { DatabaseExecutor, SqlValue } from "../../database";
 import type {
   LoadedMediaAssetObjectBytes,
   LoadMediaAssetObjectBytesInput,
-} from "../mediaAssets/storage";
-import type { BackendObservationScope } from "../observability/sentry";
-import { HttpError } from "../shared/errors";
+} from "../../mediaAssets/storage";
+import type { BackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
 import {
   exportWorkspacePackageInExecutor,
+  type WorkspacePackageExportPackageInput,
+  type WorkspacePackageExportPackageLimits,
+} from "./exportPackage";
+import {
   parseWorkspacePackageCardsJsonV1,
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageCardMetadataV1,
-  type WorkspacePackageExportPackageInput,
-  type WorkspacePackageExportPackageLimits,
-} from "./index";
+} from "../types";
 
 type TestCardRow = Readonly<{
   card_id: string;

--- a/apps/backend/src/workspacePackages/export/exportPackage.ts
+++ b/apps/backend/src/workspacePackages/export/exportPackage.ts
@@ -2,20 +2,20 @@ import { Buffer } from "node:buffer";
 import {
   transactionWithWorkspaceScopeReadOnly,
   type DatabaseExecutor,
-} from "../database";
-import { MEDIA_ASSET_JOIN_CLAUSE } from "../mediaAssets";
+} from "../../database";
+import { MEDIA_ASSET_JOIN_CLAUSE } from "../../mediaAssets";
 import {
   loadMediaAssetObjectBytes,
   type LoadedMediaAssetObjectBytes,
   type LoadMediaAssetObjectBytesInput,
-} from "../mediaAssets/storage";
-import type { BackendObservationScope } from "../observability/sentry";
-import { normalizeCardMetadata } from "../cards/shared";
-import { HttpError } from "../shared/errors";
+} from "../../mediaAssets/storage";
+import type { BackendObservationScope } from "../../observability/sentry";
+import { normalizeCardMetadata } from "../../cards/shared";
+import { HttpError } from "../../shared/errors";
 import {
   rewriteMarkdownFcAssetUrlsToSharedPortablePaths,
   validatePortableMediaPath,
-} from "./markdownMedia";
+} from "../markdownMedia";
 import {
   buildAvailableWorkspacePackageExportTagCounts,
   buildWorkspacePackageExportSelectedCardsQuery,
@@ -35,7 +35,7 @@ import {
   workspacePackageFormatVersion,
   type PortableWorkspacePackageCardV1,
   type WorkspacePackageCardsJsonV1,
-} from "./types";
+} from "../types";
 
 export const workspacePackageExportPackageDefaultMaxSelectedCards = 5_000;
 export const workspacePackageExportPackageDefaultMaxMediaFiles = 10_000;

--- a/apps/backend/src/workspacePackages/export/exportPreview.test.ts
+++ b/apps/backend/src/workspacePackages/export/exportPreview.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../database";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { HttpError } from "../../shared/errors";
 import {
   previewWorkspacePackageExportInExecutor,
   type WorkspacePackageExportPreviewInput,

--- a/apps/backend/src/workspacePackages/export/exportPreview.ts
+++ b/apps/backend/src/workspacePackages/export/exportPreview.ts
@@ -2,11 +2,11 @@ import {
   transactionWithWorkspaceScopeReadOnly,
   type DatabaseExecutor,
   type SqlValue,
-} from "../database";
-import { MEDIA_ASSET_JOIN_CLAUSE } from "../mediaAssets";
-import { HttpError } from "../shared/errors";
-import { extractMarkdownFcAssetIds } from "./markdownMedia";
-import type { WorkspacePackageMetadataV1 } from "./types";
+} from "../../database";
+import { MEDIA_ASSET_JOIN_CLAUSE } from "../../mediaAssets";
+import { HttpError } from "../../shared/errors";
+import { extractMarkdownFcAssetIds } from "../markdownMedia";
+import type { WorkspacePackageMetadataV1 } from "../types";
 
 export const workspacePackageExportPreviewDefaultMaxSelectedCards = 5_000;
 

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -17,7 +17,7 @@ export type {
 
 export {
   previewWorkspacePackageExport,
-} from "./exportPreview";
+} from "./export/exportPreview";
 
 export {
   exportWorkspacePackage,
@@ -26,7 +26,7 @@ export {
   workspacePackageExportPackageDefaultMaxSelectedCards,
   workspacePackageExportPackageDefaultMaxSingleMediaBytes,
   workspacePackageExportPackageDefaultMaxTotalMediaBytes,
-} from "./exportPackage";
+} from "./export/exportPackage";
 
 export {
   buildSuggestedWorkspacePackageImportTag,
@@ -70,14 +70,14 @@ export type {
   WorkspacePackageExportPreviewInput,
   WorkspacePackageExportPreviewTagCount,
   WorkspacePackageExportTagPolicyInput,
-} from "./exportPreview";
+} from "./export/exportPreview";
 
 export type {
   WorkspacePackageExportPackage,
   WorkspacePackageExportPackageDependencies,
   WorkspacePackageExportPackageInput,
   WorkspacePackageExportPackageLimits,
-} from "./exportPackage";
+} from "./export/exportPackage";
 
 export type {
   WorkspacePackageImportDefaultOptions,


### PR DESCRIPTION
## Summary
- move workspace package export preview and package assembly files under src/workspacePackages/export
- update export workflow relative imports after the move
- update the workspacePackages barrel to preserve public exports

## Validation
- cd apps/backend && npm run bundle --prefix ../../api && node --test --import tsx src/workspacePackages/core.test.ts src/workspacePackages/export/*.test.ts src/routes/workspacePackages.test.ts
- npm --prefix apps/backend run lint

Review gate: worker-owned review found no P0-P4 issues and no split recommendation.

Residual risk: local dependency install emitted Node v25.6.1 vs package 24.x engine warnings, but requested validation passed.