### PR TITLE
Move workspace package import files

### DIFF
--- a/apps/backend/src/workspacePackages/import/importCards.test.ts
+++ b/apps/backend/src/workspacePackages/import/importCards.test.ts
@@ -6,12 +6,12 @@ import type {
   CardMetadata,
   CardMutationMetadata,
   CreateCardInput,
-} from "../cards";
+} from "../../cards";
 import type {
   DatabaseExecutor,
   WorkspaceDatabaseScope,
-} from "../database";
-import { HttpError } from "../shared/errors";
+} from "../../database";
+import { HttpError } from "../../shared/errors";
 import {
   persistWorkspacePackageImportCardsWithDependencies,
   type WorkspacePackageImportCardPersistenceDependencies,
@@ -23,7 +23,7 @@ import {
   type WorkspacePackageImportCardPersistenceInput,
   type WorkspacePackageImportCardPersistenceResult,
   type WorkspacePackageImportPlannedCard,
-} from "./index";
+} from "../index";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";

--- a/apps/backend/src/workspacePackages/import/importCards.ts
+++ b/apps/backend/src/workspacePackages/import/importCards.ts
@@ -4,13 +4,13 @@ import {
   type Card,
   type CardMutationMetadata,
   type CreateCardInput,
-} from "../cards";
+} from "../../cards";
 import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
   type WorkspaceDatabaseScope,
-} from "../database";
-import { HttpError } from "../shared/errors";
+} from "../../database";
+import { HttpError } from "../../shared/errors";
 import type { WorkspacePackageImportPlannedCard } from "./importPlan";
 
 const workspacePackageImportCardPersistenceBatchSize = 100;

--- a/apps/backend/src/workspacePackages/import/importConfirm.test.ts
+++ b/apps/backend/src/workspacePackages/import/importConfirm.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import type { Card } from "../cards";
+import type { Card } from "../../cards";
 import {
   imageJpegCardMediaBlobMimeType,
   type MediaAsset,
-} from "../mediaAssets/types";
-import type { BackendObservationScope } from "../observability/sentry";
-import { HttpError } from "../shared/errors";
+} from "../../mediaAssets/types";
+import type { BackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
 import {
   confirmWorkspacePackageImportWithDependencies,
   type WorkspacePackageImportConfirmDependencies,
@@ -23,7 +23,7 @@ import {
   type WorkspacePackageImportPlanInput,
   type WorkspacePackageImportReferencedMediaFile,
   type WorkspacePackageImportReferencedMediaInput,
-} from "./index";
+} from "../index";
 import { validateWorkspacePackageImportPlanPreflight } from "./importPlan";
 
 const testUserId = "user-1";

--- a/apps/backend/src/workspacePackages/import/importConfirm.ts
+++ b/apps/backend/src/workspacePackages/import/importConfirm.ts
@@ -1,13 +1,13 @@
 import type { Buffer } from "node:buffer";
-import type { Card } from "../cards";
+import type { Card } from "../../cards";
 import {
   transactionWithWorkspaceScopeReadOnly,
   type DatabaseExecutor,
   type WorkspaceDatabaseScope,
-} from "../database";
-import { assertReplicaBelongsToWorkspaceInExecutor } from "../mediaAssets/workspaceReplicas";
-import type { BackendObservationScope } from "../observability/sentry";
-import { HttpError } from "../shared/errors";
+} from "../../database";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
+import type { BackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
 import {
   ingestWorkspacePackageImportMediaAssets,
   type WorkspacePackageImportedMediaAsset,

--- a/apps/backend/src/workspacePackages/import/importMedia.test.ts
+++ b/apps/backend/src/workspacePackages/import/importMedia.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import { HttpError } from "../shared/errors";
+import { HttpError } from "../../shared/errors";
 import {
   loadWorkspacePackageImportReferencedMedia,
   loadWorkspacePackageImportReferencedMediaWithLimits,
@@ -10,7 +10,7 @@ import {
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageImportReferencedMediaInput,
   type WorkspacePackageImportReferencedMediaLimits,
-} from "./index";
+} from "../index";
 import {
   createPackageZip,
   createStoredZip,

--- a/apps/backend/src/workspacePackages/import/importMedia.ts
+++ b/apps/backend/src/workspacePackages/import/importMedia.ts
@@ -14,7 +14,7 @@ import {
   type CollectedWorkspacePackageZip,
   type WorkspacePackageImportZipLimits,
 } from "./importZip";
-import type { WorkspacePackageCardsJsonV1 } from "./types";
+import type { WorkspacePackageCardsJsonV1 } from "../types";
 
 export type WorkspacePackageImportReferencedMediaInput = Readonly<{
   packageBytes: Buffer | Uint8Array;

--- a/apps/backend/src/workspacePackages/import/importMediaAssets.test.ts
+++ b/apps/backend/src/workspacePackages/import/importMediaAssets.test.ts
@@ -4,13 +4,13 @@ import test from "node:test";
 import {
   imageJpegCardMediaBlobMimeType,
   type MediaAsset,
-} from "../mediaAssets/types";
+} from "../../mediaAssets/types";
 import type {
   ImageMediaAssetIngestionInput,
   ImageMediaAssetIngestionResult,
-} from "../mediaAssets/ingestion";
-import type { BackendObservationScope } from "../observability/sentry";
-import { HttpError } from "../shared/errors";
+} from "../../mediaAssets/ingestion";
+import type { BackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
 import {
   ingestWorkspacePackageImportMediaAssetsWithDependencies,
   type WorkspacePackageImportMediaAssetIngestionDependencies,
@@ -21,7 +21,7 @@ import {
   type WorkspacePackageCardMetadataV1,
   type WorkspacePackageImportMediaAssetIngestionInput,
   type WorkspacePackageImportReferencedMediaFile,
-} from "./index";
+} from "../index";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";

--- a/apps/backend/src/workspacePackages/import/importMediaAssets.ts
+++ b/apps/backend/src/workspacePackages/import/importMediaAssets.ts
@@ -3,11 +3,11 @@ import {
   ingestImageMediaAsset,
   type ImageMediaAssetIngestionInput,
   type ImageMediaAssetIngestionResult,
-} from "../mediaAssets/ingestion";
-import type { MediaAsset } from "../mediaAssets/types";
-import type { BackendObservationScope } from "../observability/sentry";
-import { HttpError } from "../shared/errors";
-import { validateUniquePortableMediaPaths } from "./markdownMedia";
+} from "../../mediaAssets/ingestion";
+import type { MediaAsset } from "../../mediaAssets/types";
+import type { BackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
+import { validateUniquePortableMediaPaths } from "../markdownMedia";
 import type { WorkspacePackageImportReferencedMediaFile } from "./importMedia";
 
 export type WorkspacePackageImportMediaAssetIngestionInput = Readonly<{

--- a/apps/backend/src/workspacePackages/import/importPlan.test.ts
+++ b/apps/backend/src/workspacePackages/import/importPlan.test.ts
@@ -6,7 +6,7 @@ import {
   type WorkspacePackageCardSourceMetadataV1,
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageImportPlanOptions,
-} from "./index";
+} from "../index";
 
 const importedAt = "2026-06-30T12:00:00.000Z";
 const importId = "import-session-1";

--- a/apps/backend/src/workspacePackages/import/importPlan.ts
+++ b/apps/backend/src/workspacePackages/import/importPlan.ts
@@ -1,14 +1,14 @@
-import { normalizeIsoTimestamp } from "../sync/conflicts/lww";
+import { normalizeIsoTimestamp } from "../../sync/conflicts/lww";
 import {
   rewriteMarkdownPortableMediaUrlsToFcAssets,
-} from "./markdownMedia";
+} from "../markdownMedia";
 import {
   parseWorkspacePackageCardsJsonV1,
   type PortableWorkspacePackageCardV1,
   type WorkspacePackageCardMetadataV1,
   type WorkspacePackageCardSourceMetadataV1,
   type WorkspacePackageCardsJsonV1,
-} from "./types";
+} from "../types";
 
 export type WorkspacePackageImportPlanOptions = Readonly<{
   addImportTag: boolean;

--- a/apps/backend/src/workspacePackages/import/importPreview.test.ts
+++ b/apps/backend/src/workspacePackages/import/importPreview.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import { HttpError } from "../shared/errors";
+import { HttpError } from "../../shared/errors";
 import {
   buildSuggestedWorkspacePackageImportTag,
   createDefaultWorkspacePackageImportTagPolicy,
@@ -12,7 +12,7 @@ import {
   type WorkspacePackageCardMetadataV1,
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageImportPreviewInput,
-} from "./index";
+} from "../index";
 import {
   createCardsJsonBuffer,
   createDeflatedZipEntry,

--- a/apps/backend/src/workspacePackages/import/importPreview.ts
+++ b/apps/backend/src/workspacePackages/import/importPreview.ts
@@ -22,7 +22,7 @@ import {
 import type {
   PortableWorkspacePackageCardV1,
   WorkspacePackageCardsJsonV1,
-} from "./types";
+} from "../types";
 
 export const workspacePackageImportPreviewDefaultMaxZipBytes = workspacePackageImportZipDefaultMaxZipBytes;
 export const workspacePackageImportPreviewDefaultMaxEntries = workspacePackageImportZipDefaultMaxEntries;

--- a/apps/backend/src/workspacePackages/import/importZip.ts
+++ b/apps/backend/src/workspacePackages/import/importZip.ts
@@ -5,17 +5,17 @@ import {
   type Entry as ZipEntry,
   type ZipFile,
 } from "yauzl";
-import { HttpError } from "../shared/errors";
+import { HttpError } from "../../shared/errors";
 import {
   extractMarkdownPortableMediaPaths,
   validatePortableMediaPath,
   validateUniquePortableMediaPaths,
-} from "./markdownMedia";
+} from "../markdownMedia";
 import {
   parseWorkspacePackageCardsJsonV1,
   type PortableWorkspacePackageCardV1,
   type WorkspacePackageCardsJsonV1,
-} from "./types";
+} from "../types";
 
 export const workspacePackageImportZipDefaultMaxZipBytes = 80 * 1024 * 1024;
 export const workspacePackageImportZipDefaultMaxEntries = 10_001;

--- a/apps/backend/src/workspacePackages/import/testZipHelpers.ts
+++ b/apps/backend/src/workspacePackages/import/testZipHelpers.ts
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer";
 import { deflateRawSync } from "node:zlib";
 import type {
   WorkspacePackageCardsJsonV1,
-} from "./types";
+} from "../types";
 
 export type TestZipEntry = Readonly<{
   path: string;

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -40,28 +40,28 @@ export {
   workspacePackageImportPreviewDefaultMaxSingleMediaBytes,
   workspacePackageImportPreviewDefaultMaxTotalMediaBytes,
   workspacePackageImportPreviewDefaultMaxZipBytes,
-} from "./importPreview";
+} from "./import/importPreview";
 
 export {
   loadWorkspacePackageImportReferencedMedia,
   loadWorkspacePackageImportReferencedMediaWithLimits,
-} from "./importMedia";
+} from "./import/importMedia";
 
 export {
   ingestWorkspacePackageImportMediaAssets,
-} from "./importMediaAssets";
+} from "./import/importMediaAssets";
 
 export {
   persistWorkspacePackageImportCards,
-} from "./importCards";
+} from "./import/importCards";
 
 export {
   planWorkspacePackageImport,
-} from "./importPlan";
+} from "./import/importPlan";
 
 export {
   confirmWorkspacePackageImport,
-} from "./importConfirm";
+} from "./import/importConfirm";
 
 export type {
   WorkspacePackageExportCardSelection,
@@ -89,26 +89,26 @@ export type {
   WorkspacePackageImportPreviewWarning,
   WorkspacePackageImportTagPolicy,
   WorkspacePackageImportTagPolicyInput,
-} from "./importPreview";
+} from "./import/importPreview";
 
 export type {
   WorkspacePackageImportReferencedMediaFile,
   WorkspacePackageImportReferencedMediaInput,
   WorkspacePackageImportReferencedMediaLimits,
   WorkspacePackageImportReferencedMediaLoadResult,
-} from "./importMedia";
+} from "./import/importMedia";
 
 export type {
   WorkspacePackageImportedMediaAsset,
   WorkspacePackageImportMediaAssetIngestionInput,
   WorkspacePackageImportMediaAssetIngestionResult,
-} from "./importMediaAssets";
+} from "./import/importMediaAssets";
 
 export type {
   WorkspacePackageImportCardPersistenceInput,
   WorkspacePackageImportCardPersistenceResult,
   WorkspacePackageImportCardPersistenceSummary,
-} from "./importCards";
+} from "./import/importCards";
 
 export type {
   WorkspacePackageImportPlan,
@@ -116,13 +116,13 @@ export type {
   WorkspacePackageImportPlanOptions,
   WorkspacePackageImportPlanSummary,
   WorkspacePackageImportPlannedCard,
-} from "./importPlan";
+} from "./import/importPlan";
 
 export type {
   WorkspacePackageImportConfirmInput,
   WorkspacePackageImportConfirmResult,
   WorkspacePackageImportConfirmSummary,
-} from "./importConfirm";
+} from "./import/importConfirm";
 
 export {
   normalizeWorkspacePackageCardMetadataV1,


### PR DESCRIPTION
## Summary
- move workspace package import workflow files into apps/backend/src/workspacePackages/import
- update workspace package barrel exports to the new import paths
- keep export workflow and shared workspace package files in place

## Validation
- cd apps/backend && npm run bundle --prefix ../../api && node --test --import tsx src/workspacePackages/core.test.ts src/workspacePackages/import/*.test.ts src/routes/workspacePackages.test.ts
- npm --prefix apps/backend run lint
- git --no-pager diff --check
- stale flat import searches