### PR TITLE
Add Android package import data contract

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
@@ -38,6 +38,9 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetPro
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
 import kotlinx.coroutines.CompletableDeferred
 import org.json.JSONObject
 
@@ -546,6 +549,27 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         confirmationText: String
     ): CloudWorkspaceResetProgressResult {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun previewWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        packageBytes: ByteArray
+    ): WorkspacePackageImportPreview {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun confirmWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        fileName: String,
+        packageBytes: ByteArray,
+        lastModifiedByReplicaId: String,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult {
         throw UnsupportedOperationException()
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
@@ -36,6 +36,9 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetPro
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
 import org.json.JSONObject
 
 class CloudHealthValidationException(
@@ -107,6 +110,21 @@ interface CloudRemoteGateway {
         workspaceId: String,
         confirmationText: String
     ): CloudWorkspaceResetProgressResult
+    suspend fun previewWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        packageBytes: ByteArray
+    ): WorkspacePackageImportPreview
+    suspend fun confirmWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        fileName: String,
+        packageBytes: ByteArray,
+        lastModifiedByReplicaId: String,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult
     suspend fun loadProgressSummary(
         apiBaseUrl: String,
         authorizationHeader: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
@@ -20,6 +20,7 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHt
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.NoopCloudHttpObservability
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.createCloudHttpObservationVersions
 import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.CloudAccountWorkspaceRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.CloudWorkspacePackageRemoteApi
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.sync.AccountPreferences
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
@@ -48,6 +49,9 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetPro
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
 import okhttp3.OkHttpClient
 import org.json.JSONObject
 
@@ -95,6 +99,7 @@ class CloudRemoteService private constructor(
     private val mediaAssetApi = CloudMediaAssetRemoteApi(httpClient = httpClient)
     private val agentConnectionApi = CloudAgentConnectionRemoteApi(httpClient = httpClient)
     private val syncApi = CloudSyncRemoteApi(httpClient = httpClient)
+    private val workspacePackageApi = CloudWorkspacePackageRemoteApi(httpClient = httpClient)
 
     override suspend fun validateConfiguration(configuration: CloudServiceConfiguration) {
         requireAuthHealthResponse(
@@ -268,6 +273,40 @@ class CloudRemoteService private constructor(
             bearerToken = bearerToken,
             workspaceId = workspaceId,
             confirmationText = confirmationText
+        )
+    }
+
+    override suspend fun previewWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        packageBytes: ByteArray
+    ): WorkspacePackageImportPreview {
+        return workspacePackageApi.previewWorkspacePackageImport(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            packageBytes = packageBytes
+        )
+    }
+
+    override suspend fun confirmWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        fileName: String,
+        packageBytes: ByteArray,
+        lastModifiedByReplicaId: String,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult {
+        return workspacePackageApi.confirmWorkspacePackageImport(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            fileName = fileName,
+            packageBytes = packageBytes,
+            lastModifiedByReplicaId = lastModifiedByReplicaId,
+            options = options
         )
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
@@ -24,10 +24,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.Response
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
@@ -48,6 +50,7 @@ private const val cloudHealthValidationPath: String = "/health"
 private const val officialCloudApiHost: String = "api.flashcards-open-source-app.com"
 private const val officialCloudAuthHost: String = "auth.flashcards-open-source-app.com"
 private val cloudJsonMediaType = "application/json".toMediaType()
+private val cloudZipMediaType = "application/zip".toMediaType()
 private val transientCloudHttpStatusCodes: Set<Int> = setOf(408, 429, 500, 502, 503, 504)
 private val expectedCloudHttpFailureCodes: Set<String> = setOf(
     "AGENT_API_KEY_INVALID",
@@ -147,6 +150,25 @@ private val expectedCloudHttpFailureCodes: Set<String> = setOf(
     "WORKSPACE_ID_REQUIRED",
     "WORKSPACE_NOT_FOUND",
     "WORKSPACE_OWNER_REQUIRED",
+    "WORKSPACE_PACKAGE_IMPORT_CONTENT_TYPE_UNSUPPORTED",
+    "WORKSPACE_PACKAGE_IMPORT_FILE_EMPTY",
+    "WORKSPACE_PACKAGE_IMPORT_FILE_REQUIRED",
+    "WORKSPACE_PACKAGE_IMPORT_FILE_TOO_LARGE",
+    "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_MEDIA_TYPE_UNSUPPORTED",
+    "WORKSPACE_PACKAGE_IMPORT_MULTIPART_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID_JSON",
+    "WORKSPACE_PACKAGE_IMPORT_OPTIONS_REQUIRED",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_BODY_TOO_LARGE",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_MALFORMED",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CONTENT_TYPE_UNSUPPORTED",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_INPUT_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_TOO_LARGE",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_EMPTY",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_REPLICA_INVALID",
     "WORKSPACE_RESET_PROGRESS_CONFIRMATION_INVALID",
     "WORKSPACE_DELETE_SHARED",
     "WORKSPACE_RESET_SHARED",
@@ -276,6 +298,78 @@ internal class CloudJsonHttpClient(
         )
     }
 
+    suspend fun postZipForJson(
+        baseUrl: String,
+        path: String,
+        authorizationHeader: String?,
+        zipBytes: ByteArray
+    ): JSONObject {
+        require(zipBytes.isNotEmpty()) {
+            "Cloud ZIP request body must not be empty."
+        }
+        return executeBuiltJsonRequest(
+            request = buildCloudRequest(
+                baseUrl = baseUrl,
+                path = path,
+                method = CloudHttpMethod.POST,
+                authorizationHeader = authorizationHeader,
+                requestBody = zipBytes.toRequestBody(cloudZipMediaType),
+                contentTypeHeader = "application/zip"
+            ),
+            path = path,
+            method = CloudHttpMethod.POST,
+            retryEligible = false
+        )
+    }
+
+    suspend fun postMultipartZipForJson(
+        baseUrl: String,
+        path: String,
+        authorizationHeader: String?,
+        fileFieldName: String,
+        fileName: String,
+        zipBytes: ByteArray,
+        jsonFieldName: String,
+        jsonFieldValue: JSONObject
+    ): JSONObject {
+        require(fileFieldName.isNotBlank()) {
+            "Cloud multipart ZIP request file field name must not be blank."
+        }
+        require(fileName.isNotBlank()) {
+            "Cloud multipart ZIP request file name must not be blank."
+        }
+        require(zipBytes.isNotEmpty()) {
+            "Cloud multipart ZIP request file must not be empty."
+        }
+        require(jsonFieldName.isNotBlank()) {
+            "Cloud multipart ZIP request JSON field name must not be blank."
+        }
+
+        val requestBody = MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                fileFieldName,
+                fileName,
+                zipBytes.toRequestBody(cloudZipMediaType)
+            )
+            .addFormDataPart(jsonFieldName, jsonFieldValue.toString())
+            .build()
+
+        return executeBuiltJsonRequest(
+            request = buildCloudRequest(
+                baseUrl = baseUrl,
+                path = path,
+                method = CloudHttpMethod.POST,
+                authorizationHeader = authorizationHeader,
+                requestBody = requestBody,
+                contentTypeHeader = null
+            ),
+            path = path,
+            method = CloudHttpMethod.POST,
+            retryEligible = false
+        )
+    }
+
     suspend fun patchJson(
         baseUrl: String,
         path: String,
@@ -291,26 +385,39 @@ internal class CloudJsonHttpClient(
         )
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     private suspend fun executeJsonRequest(
         baseUrl: String,
         path: String,
         method: CloudHttpMethod,
         authorizationHeader: String?,
         body: JSONObject?
+    ): JSONObject {
+        return executeBuiltJsonRequest(
+            request = buildCloudRequest(
+                baseUrl = baseUrl,
+                path = path,
+                method = method,
+                authorizationHeader = authorizationHeader,
+                requestBody = buildJsonRequestBody(method = method, body = body),
+                contentTypeHeader = "application/json"
+            ),
+            path = path,
+            method = method,
+            retryEligible = isTransientCloudHttpRetryEligible(
+                path = path,
+                method = method,
+                body = body
+            )
+        )
+    }
+
+    @OptIn(InternalCoroutinesApi::class)
+    private suspend fun executeBuiltJsonRequest(
+        request: Request,
+        path: String,
+        method: CloudHttpMethod,
+        retryEligible: Boolean
     ): JSONObject = withContext(Dispatchers.IO) {
-        val request = buildCloudRequest(
-            baseUrl = baseUrl,
-            path = path,
-            method = method,
-            authorizationHeader = authorizationHeader,
-            body = body
-        )
-        val retryEligible = isTransientCloudHttpRetryEligible(
-            path = path,
-            method = method,
-            body = body
-        )
         var attemptNumber = 1
         var completedResponse: JSONObject? = null
 
@@ -475,29 +582,39 @@ internal class CloudJsonHttpClient(
         path: String,
         method: CloudHttpMethod,
         authorizationHeader: String?,
-        body: JSONObject?
+        requestBody: RequestBody?,
+        contentTypeHeader: String?
     ): Request {
         val normalizedBaseUrl = if (baseUrl.endsWith("/")) {
             baseUrl.dropLast(1)
         } else {
             baseUrl
         }
-        val requestBody = when (method) {
-            CloudHttpMethod.GET -> null
-            CloudHttpMethod.POST,
-            CloudHttpMethod.PATCH -> body?.toString()?.toRequestBody(cloudJsonMediaType)
-                ?: ByteArray(size = 0).toRequestBody(cloudJsonMediaType)
-        }
         val requestBuilder = Request.Builder()
             .url("$normalizedBaseUrl$path")
             .method(method.requestMethod, requestBody)
-            .header("Content-Type", "application/json")
+
+        if (contentTypeHeader != null) {
+            requestBuilder.header("Content-Type", contentTypeHeader)
+        }
 
         if (authorizationHeader != null) {
             requestBuilder.header("Authorization", authorizationHeader)
         }
 
         return requestBuilder.build()
+    }
+
+    private fun buildJsonRequestBody(
+        method: CloudHttpMethod,
+        body: JSONObject?
+    ): RequestBody? {
+        return when (method) {
+            CloudHttpMethod.GET -> null
+            CloudHttpMethod.POST,
+            CloudHttpMethod.PATCH -> body?.toString()?.toRequestBody(cloudJsonMediaType)
+                ?: ByteArray(size = 0).toRequestBody(cloudJsonMediaType)
+        }
     }
 
     private fun readCloudResponseBody(response: Response): String {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
@@ -78,6 +78,20 @@ internal fun buildMediaAssetDownloadUrlCloudPath(
         "/media-assets/${encodeCloudPathSegment(value = mediaAssetId)}/download-url"
 }
 
+internal fun buildWorkspacePackageImportPreviewCloudPath(workspaceId: String): String {
+    require(workspaceId.isNotBlank()) {
+        "Workspace package import preview path requires a workspace id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}/packages/import/preview"
+}
+
+internal fun buildWorkspacePackageImportCloudPath(workspaceId: String): String {
+    require(workspaceId.isNotBlank()) {
+        "Workspace package import path requires a workspace id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}/packages/import"
+}
+
 private fun encodeCloudQueryValue(value: String): String {
     return URLEncoder.encode(value, StandardCharsets.UTF_8)
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/workspace/CloudWorkspacePackageRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/workspace/CloudWorkspacePackageRemoteApi.kt
@@ -1,0 +1,211 @@
+package com.flashcardsopensourceapp.data.local.cloud.remote.workspace
+
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildWorkspacePackageImportCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildWorkspacePackageImportPreviewCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableString
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudObject
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
+import com.flashcardsopensourceapp.data.local.cloud.wire.toCloudStringList
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportDefaultOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportMetadata
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportSourceKind
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportTagCount
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportWarning
+import org.json.JSONArray
+import org.json.JSONObject
+
+private const val workspacePackageImportFileFieldName: String = "file"
+private const val workspacePackageImportOptionsFieldName: String = "options"
+
+internal class CloudWorkspacePackageRemoteApi(
+    private val httpClient: CloudJsonHttpClient
+) {
+    suspend fun previewWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        packageBytes: ByteArray
+    ): WorkspacePackageImportPreview {
+        val response = httpClient.postZipForJson(
+            baseUrl = apiBaseUrl,
+            path = buildWorkspacePackageImportPreviewCloudPath(workspaceId = workspaceId),
+            authorizationHeader = authorizationHeader,
+            zipBytes = packageBytes
+        )
+        return parseWorkspacePackageImportPreview(
+            response = response,
+            fieldPath = "workspacePackageImportPreview"
+        )
+    }
+
+    suspend fun confirmWorkspacePackageImport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        fileName: String,
+        packageBytes: ByteArray,
+        lastModifiedByReplicaId: String,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult {
+        val response = httpClient.postMultipartZipForJson(
+            baseUrl = apiBaseUrl,
+            path = buildWorkspacePackageImportCloudPath(workspaceId = workspaceId),
+            authorizationHeader = authorizationHeader,
+            fileFieldName = workspacePackageImportFileFieldName,
+            fileName = fileName,
+            zipBytes = packageBytes,
+            jsonFieldName = workspacePackageImportOptionsFieldName,
+            jsonFieldValue = encodeWorkspacePackageImportConfirmOptions(
+                options = options,
+                lastModifiedByReplicaId = lastModifiedByReplicaId
+            )
+        )
+        return WorkspacePackageImportConfirmResult(
+            summary = parseWorkspacePackageImportConfirmSummary(
+                summary = response.requireCloudObject("summary", "workspacePackageImport.summary"),
+                fieldPath = "workspacePackageImport.summary"
+            )
+        )
+    }
+}
+
+private fun encodeWorkspacePackageImportConfirmOptions(
+    options: WorkspacePackageImportConfirmOptions,
+    lastModifiedByReplicaId: String
+): JSONObject {
+    return JSONObject()
+        .put("addImportTag", options.addImportTag)
+        .put("importTag", options.importTag)
+        .put("removeTags", JSONArray(options.removeTags))
+        .put("importedAt", formatIsoTimestamp(timestampMillis = options.importedAtMillis))
+        .put("importId", options.importId)
+        .put("clientUpdatedAt", formatIsoTimestamp(timestampMillis = options.clientUpdatedAtMillis))
+        .put("lastModifiedByReplicaId", lastModifiedByReplicaId)
+        .put("operationIdPrefix", options.operationIdPrefix)
+}
+
+private fun parseWorkspacePackageImportPreview(
+    response: JSONObject,
+    fieldPath: String
+): WorkspacePackageImportPreview {
+    val packageMetadata = response.requireCloudObject("packageMetadata", "$fieldPath.packageMetadata")
+    val defaultOptions = response.requireCloudObject("defaultOptions", "$fieldPath.defaultOptions")
+    return WorkspacePackageImportPreview(
+        sourceKind = parseWorkspacePackageImportSourceKind(
+            rawValue = response.requireCloudString("sourceKind", "$fieldPath.sourceKind"),
+            fieldPath = "$fieldPath.sourceKind"
+        ),
+        packageMetadata = WorkspacePackageImportMetadata(
+            label = packageMetadata.requireCloudNullableString("label", "$fieldPath.packageMetadata.label"),
+            author = packageMetadata.requireCloudNullableString("author", "$fieldPath.packageMetadata.author"),
+            comment = packageMetadata.requireCloudNullableString("comment", "$fieldPath.packageMetadata.comment"),
+            createdAt = packageMetadata.requireCloudNullableString("createdAt", "$fieldPath.packageMetadata.createdAt"),
+            sourceUrl = packageMetadata.requireCloudNullableString("sourceUrl", "$fieldPath.packageMetadata.sourceUrl")
+        ),
+        cardCount = response.requireCloudInt("cardCount", "$fieldPath.cardCount"),
+        tagCounts = parseWorkspacePackageImportTagCounts(
+            tagCounts = response.requireCloudArray("tagCounts", "$fieldPath.tagCounts"),
+            fieldPath = "$fieldPath.tagCounts"
+        ),
+        referencedMediaCount = response.requireCloudInt("referencedMediaCount", "$fieldPath.referencedMediaCount"),
+        packageMediaFileCount = response.requireCloudInt("packageMediaFileCount", "$fieldPath.packageMediaFileCount"),
+        warnings = parseWorkspacePackageImportWarnings(
+            warnings = response.requireCloudArray("warnings", "$fieldPath.warnings"),
+            fieldPath = "$fieldPath.warnings"
+        ),
+        defaultOptions = WorkspacePackageImportDefaultOptions(
+            addImportTag = defaultOptions.requireCloudBoolean(
+                "addImportTag",
+                "$fieldPath.defaultOptions.addImportTag"
+            ),
+            suggestedImportTag = defaultOptions.requireCloudString(
+                "suggestedImportTag",
+                "$fieldPath.defaultOptions.suggestedImportTag"
+            ),
+            keptTags = defaultOptions.requireCloudArray(
+                "keptTags",
+                "$fieldPath.defaultOptions.keptTags"
+            ).toCloudStringList("$fieldPath.defaultOptions.keptTags"),
+            removedTags = defaultOptions.requireCloudArray(
+                "removedTags",
+                "$fieldPath.defaultOptions.removedTags"
+            ).toCloudStringList("$fieldPath.defaultOptions.removedTags")
+        )
+    )
+}
+
+private fun parseWorkspacePackageImportSourceKind(
+    rawValue: String,
+    fieldPath: String
+): WorkspacePackageImportSourceKind {
+    return when (rawValue) {
+        "zip" -> WorkspacePackageImportSourceKind.ZIP
+        else -> throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected known import source kind, got invalid string \"$rawValue\""
+        )
+    }
+}
+
+private fun parseWorkspacePackageImportTagCounts(
+    tagCounts: JSONArray,
+    fieldPath: String
+): List<WorkspacePackageImportTagCount> {
+    return buildList {
+        for (index in 0 until tagCounts.length()) {
+            val tagCount = tagCounts.requireCloudObject(index = index, fieldPath = "$fieldPath[$index]")
+            add(
+                WorkspacePackageImportTagCount(
+                    tag = tagCount.requireCloudString("tag", "$fieldPath[$index].tag"),
+                    cardsCount = tagCount.requireCloudInt("cardsCount", "$fieldPath[$index].cardsCount")
+                )
+            )
+        }
+    }
+}
+
+private fun parseWorkspacePackageImportWarnings(
+    warnings: JSONArray,
+    fieldPath: String
+): List<WorkspacePackageImportWarning> {
+    return buildList {
+        for (index in 0 until warnings.length()) {
+            val warning = warnings.requireCloudObject(index = index, fieldPath = "$fieldPath[$index]")
+            add(
+                WorkspacePackageImportWarning(
+                    code = warning.requireCloudString("code", "$fieldPath[$index].code"),
+                    message = warning.requireCloudString("message", "$fieldPath[$index].message"),
+                    mediaPath = warning.requireCloudString("mediaPath", "$fieldPath[$index].mediaPath")
+                )
+            )
+        }
+    }
+}
+
+private fun parseWorkspacePackageImportConfirmSummary(
+    summary: JSONObject,
+    fieldPath: String
+): WorkspacePackageImportConfirmSummary {
+    return WorkspacePackageImportConfirmSummary(
+        cardCount = summary.requireCloudInt("cardCount", "$fieldPath.cardCount"),
+        cardBatchCount = summary.requireCloudInt("cardBatchCount", "$fieldPath.cardBatchCount"),
+        referencedMediaCount = summary.requireCloudInt("referencedMediaCount", "$fieldPath.referencedMediaCount"),
+        importedMediaAssetCount = summary.requireCloudInt(
+            "importedMediaAssetCount",
+            "$fieldPath.importedMediaAssetCount"
+        ),
+        appliedMediaAssetCount = summary.requireCloudInt("appliedMediaAssetCount", "$fieldPath.appliedMediaAssetCount"),
+        keptTagCount = summary.requireCloudInt("keptTagCount", "$fieldPath.keptTagCount"),
+        removedTagCount = summary.requireCloudInt("removedTagCount", "$fieldPath.removedTagCount"),
+        importTag = summary.requireCloudNullableString("importTag", "$fieldPath.importTag")
+    )
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/workspace/WorkspacePackageImportModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/workspace/WorkspacePackageImportModels.kt
@@ -1,0 +1,72 @@
+package com.flashcardsopensourceapp.data.local.model.workspace
+
+enum class WorkspacePackageImportSourceKind {
+    ZIP
+}
+
+data class WorkspacePackageImportSource(
+    val kind: WorkspacePackageImportSourceKind,
+    val title: String
+)
+
+data class WorkspacePackageImportMetadata(
+    val label: String?,
+    val author: String?,
+    val comment: String?,
+    val createdAt: String?,
+    val sourceUrl: String?
+)
+
+data class WorkspacePackageImportTagCount(
+    val tag: String,
+    val cardsCount: Int
+)
+
+data class WorkspacePackageImportWarning(
+    val code: String,
+    val message: String,
+    val mediaPath: String
+)
+
+data class WorkspacePackageImportDefaultOptions(
+    val addImportTag: Boolean,
+    val suggestedImportTag: String,
+    val keptTags: List<String>,
+    val removedTags: List<String>
+)
+
+data class WorkspacePackageImportPreview(
+    val sourceKind: WorkspacePackageImportSourceKind,
+    val packageMetadata: WorkspacePackageImportMetadata,
+    val cardCount: Int,
+    val tagCounts: List<WorkspacePackageImportTagCount>,
+    val referencedMediaCount: Int,
+    val packageMediaFileCount: Int,
+    val warnings: List<WorkspacePackageImportWarning>,
+    val defaultOptions: WorkspacePackageImportDefaultOptions
+)
+
+data class WorkspacePackageImportConfirmOptions(
+    val addImportTag: Boolean,
+    val importTag: String,
+    val removeTags: List<String>,
+    val importedAtMillis: Long,
+    val importId: String,
+    val clientUpdatedAtMillis: Long,
+    val operationIdPrefix: String
+)
+
+data class WorkspacePackageImportConfirmSummary(
+    val cardCount: Int,
+    val cardBatchCount: Int,
+    val referencedMediaCount: Int,
+    val importedMediaAssetCount: Int,
+    val appliedMediaAssetCount: Int,
+    val keptTagCount: Int,
+    val removedTagCount: Int,
+    val importTag: String?
+)
+
+data class WorkspacePackageImportConfirmResult(
+    val summary: WorkspacePackageImportConfirmSummary
+)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -63,6 +63,9 @@ import com.flashcardsopensourceapp.data.local.model.review.ReviewTimelinePage
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceOverviewSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
 import com.flashcardsopensourceapp.data.local.model.scheduling.WorkspaceSchedulerSettings
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagsSummary
@@ -202,6 +205,12 @@ interface CloudAccountRepository {
     suspend fun deleteCurrentWorkspace(confirmationText: String): CloudWorkspaceDeleteResult
     suspend fun loadCurrentWorkspaceResetProgressPreview(): CloudWorkspaceResetProgressPreview
     suspend fun resetCurrentWorkspaceProgress(confirmationText: String): CloudWorkspaceResetProgressResult
+    suspend fun previewCurrentWorkspacePackageImport(packageBytes: ByteArray): WorkspacePackageImportPreview
+    suspend fun confirmCurrentWorkspacePackageImport(
+        fileName: String,
+        packageBytes: ByteArray,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult
     suspend fun loadProgressSummary(timeZone: String): CloudProgressSummary
     suspend fun loadProgressSeries(timeZone: String, from: String, to: String): CloudProgressSeries
     suspend fun loadProgressReviewSchedule(timeZone: String): CloudProgressReviewSchedule

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepository.kt
@@ -34,6 +34,9 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreak
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.sync.AccountPreferences
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.guest.loadActiveGuestSessionOrNull
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.progress.CloudProgressRemoteReader
@@ -275,6 +278,24 @@ class LocalCloudAccountRepository(
         confirmationText: String
     ): CloudWorkspaceResetProgressResult {
         return workspaceOperationsCoordinator.resetCurrentWorkspaceProgress(confirmationText = confirmationText)
+    }
+
+    override suspend fun previewCurrentWorkspacePackageImport(
+        packageBytes: ByteArray
+    ): WorkspacePackageImportPreview {
+        return workspaceOperationsCoordinator.previewCurrentWorkspacePackageImport(packageBytes = packageBytes)
+    }
+
+    override suspend fun confirmCurrentWorkspacePackageImport(
+        fileName: String,
+        packageBytes: ByteArray,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult {
+        return workspaceOperationsCoordinator.confirmCurrentWorkspacePackageImport(
+            fileName = fileName,
+            packageBytes = packageBytes,
+            options = options
+        )
     }
 
     override suspend fun loadProgressSeries(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudWorkspaceOperationsCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudWorkspaceOperationsCoordinator.kt
@@ -6,11 +6,15 @@ import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceDeletePreview
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceDeleteResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressPreview
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.AuthenticatedCloudSession
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudOperationCoordinator
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudSessionProvider
@@ -101,7 +105,8 @@ internal class CloudWorkspaceOperationsCoordinator(
     }
 
     suspend fun loadCurrentWorkspaceResetProgressPreview(): CloudWorkspaceResetProgressPreview {
-        require(preferencesStore.currentCloudSettings().cloudState == CloudAccountState.LINKED) {
+        val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+        require(cloudSettings.cloudState == CloudAccountState.LINKED) {
             "Workspace progress reset is available only for linked cloud workspaces."
         }
         return operationCoordinator.runExclusive {
@@ -111,9 +116,10 @@ internal class CloudWorkspaceOperationsCoordinator(
                 preferencesStore = preferencesStore,
                 missingWorkspaceMessage = "Workspace progress reset requires a current local workspace."
             ).workspaceId
-            runLinkedWorkspaceSyncForProgressReset(
+            runLinkedWorkspaceSync(
                 authenticatedSession = authenticatedSession,
-                workspaceId = workspaceId
+                workspaceId = workspaceId,
+                cloudSettings = cloudSettings
             )
             remoteService.loadWorkspaceResetProgressPreview(
                 apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
@@ -125,7 +131,8 @@ internal class CloudWorkspaceOperationsCoordinator(
 
     suspend fun resetCurrentWorkspaceProgress(confirmationText: String): CloudWorkspaceResetProgressResult {
         return operationCoordinator.runExclusive {
-            require(preferencesStore.currentCloudSettings().cloudState == CloudAccountState.LINKED) {
+            val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+            require(cloudSettings.cloudState == CloudAccountState.LINKED) {
                 "Workspace progress reset is available only for linked cloud workspaces."
             }
             val authenticatedSession: AuthenticatedCloudSession = sessionProvider.authenticatedSession()
@@ -134,9 +141,10 @@ internal class CloudWorkspaceOperationsCoordinator(
                 preferencesStore = preferencesStore,
                 missingWorkspaceMessage = "Workspace progress reset requires a current local workspace."
             ).workspaceId
-            runLinkedWorkspaceSyncForProgressReset(
+            runLinkedWorkspaceSync(
                 authenticatedSession = authenticatedSession,
-                workspaceId = currentWorkspaceId
+                workspaceId = currentWorkspaceId,
+                cloudSettings = cloudSettings
             )
             val result: CloudWorkspaceResetProgressResult = remoteService.resetWorkspaceProgress(
                 apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
@@ -144,9 +152,77 @@ internal class CloudWorkspaceOperationsCoordinator(
                 workspaceId = currentWorkspaceId,
                 confirmationText = confirmationText
             )
-            runLinkedWorkspaceSyncForProgressReset(
+            runLinkedWorkspaceSync(
                 authenticatedSession = authenticatedSession,
-                workspaceId = currentWorkspaceId
+                workspaceId = currentWorkspaceId,
+                cloudSettings = cloudSettings
+            )
+            result
+        }
+    }
+
+    suspend fun previewCurrentWorkspacePackageImport(packageBytes: ByteArray): WorkspacePackageImportPreview {
+        return operationCoordinator.runExclusive {
+            require(preferencesStore.currentCloudSettings().cloudState == CloudAccountState.LINKED) {
+                "Workspace package import is available only for linked cloud workspaces."
+            }
+            val authenticatedSession: AuthenticatedCloudSession = sessionProvider.authenticatedSession()
+            val workspaceId: String = requireCurrentWorkspace(
+                database = database,
+                preferencesStore = preferencesStore,
+                missingWorkspaceMessage = "Workspace package import requires a current local workspace."
+            ).workspaceId
+            remoteService.previewWorkspacePackageImport(
+                apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
+                authorizationHeader = "Bearer ${authenticatedSession.credentials.idToken}",
+                workspaceId = workspaceId,
+                packageBytes = packageBytes
+            )
+        }
+    }
+
+    suspend fun confirmCurrentWorkspacePackageImport(
+        fileName: String,
+        packageBytes: ByteArray,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult {
+        return operationCoordinator.runExclusive {
+            val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+            require(cloudSettings.cloudState == CloudAccountState.LINKED) {
+                "Workspace package import is available only for linked cloud workspaces."
+            }
+            val trimmedFileName = fileName.trim()
+            require(trimmedFileName.isNotEmpty()) {
+                "Workspace package import requires a selected ZIP file name."
+            }
+            val authenticatedSession: AuthenticatedCloudSession = sessionProvider.authenticatedSession()
+            val workspaceId: String = requireCurrentWorkspace(
+                database = database,
+                preferencesStore = preferencesStore,
+                missingWorkspaceMessage = "Workspace package import requires a current local workspace."
+            ).workspaceId
+            runLinkedWorkspaceSync(
+                authenticatedSession = authenticatedSession,
+                workspaceId = workspaceId,
+                cloudSettings = cloudSettings
+            )
+            val lastModifiedByReplicaId: String = buildClientWorkspaceReplicaId(
+                workspaceId = workspaceId,
+                installationId = cloudSettings.installationId
+            )
+            val result: WorkspacePackageImportConfirmResult = remoteService.confirmWorkspacePackageImport(
+                apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
+                authorizationHeader = "Bearer ${authenticatedSession.credentials.idToken}",
+                workspaceId = workspaceId,
+                fileName = trimmedFileName,
+                packageBytes = packageBytes,
+                lastModifiedByReplicaId = lastModifiedByReplicaId,
+                options = options
+            )
+            runLinkedWorkspaceSync(
+                authenticatedSession = authenticatedSession,
+                workspaceId = workspaceId,
+                cloudSettings = cloudSettings
             )
             result
         }
@@ -160,12 +236,13 @@ internal class CloudWorkspaceOperationsCoordinator(
         )
     }
 
-    private suspend fun runLinkedWorkspaceSyncForProgressReset(
+    private suspend fun runLinkedWorkspaceSync(
         authenticatedSession: AuthenticatedCloudSession,
-        workspaceId: String
+        workspaceId: String,
+        cloudSettings: CloudSettings
     ) {
         runCloudSyncCore(
-            cloudSettings = preferencesStore.currentCloudSettings(),
+            cloudSettings = cloudSettings,
             workspaceId = workspaceId,
             syncSession = CloudSyncSession(
                 apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudWorkspaceReplicaIdentity.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudWorkspaceReplicaIdentity.kt
@@ -1,0 +1,29 @@
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.UUID
+
+private const val workspaceReplicaUuidByteCount: Int = 16
+
+internal fun buildClientWorkspaceReplicaId(
+    workspaceId: String,
+    installationId: String
+): String {
+    require(workspaceId.isNotBlank()) {
+        "Workspace replica id derivation requires a workspace id."
+    }
+    require(installationId.isNotBlank()) {
+        "Workspace replica id derivation requires an installation id."
+    }
+
+    val seedBytes: ByteArray = "$workspaceId:$installationId".toByteArray(StandardCharsets.UTF_8)
+    val digestBytes: ByteArray = MessageDigest.getInstance("SHA-256").digest(seedBytes)
+    digestBytes[6] = ((digestBytes[6].toInt() and 0x0f) or 0x50).toByte()
+    digestBytes[8] = ((digestBytes[8].toInt() and 0x3f) or 0x80).toByte()
+
+    val replicaUuidBytes: ByteArray = digestBytes.copyOfRange(0, workspaceReplicaUuidByteCount)
+    val replicaUuidBuffer: ByteBuffer = ByteBuffer.wrap(replicaUuidBytes)
+    return UUID(replicaUuidBuffer.long, replicaUuidBuffer.long).toString()
+}

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -33,6 +33,9 @@ import com.flashcardsopensourceapp.data.local.model.sync.AccountPreferences
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.model.sync.defaultAccountPreferences
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import java.util.Locale
@@ -276,6 +279,18 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
     }
 
     override suspend fun resetCurrentWorkspaceProgress(confirmationText: String): CloudWorkspaceResetProgressResult {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun previewCurrentWorkspacePackageImport(packageBytes: ByteArray): WorkspacePackageImportPreview {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun confirmCurrentWorkspacePackageImport(
+        fileName: String,
+        packageBytes: ByteArray,
+        options: WorkspacePackageImportConfirmOptions
+    ): WorkspacePackageImportConfirmResult {
         throw UnsupportedOperationException()
     }
 


### PR DESCRIPTION
## Summary
- add Android package import preview/confirm data models and remote parser/API
- add raw ZIP preview and multipart ZIP confirm HTTP support
- expose package import through cloud remote and account repository data-layer contracts
- derive backend-compatible workspace replica id in the repository and run sync before confirm so the replica row exists

## Validation
- git --no-pager diff --check
- lightweight Kotlin/XML source-shape scan
- untracked Kotlin whitespace check
- replica helper sample check matched backend hash algorithm
- worker-owned review: no split recommendation, no P0-P4 findings

Gradle was not run per repository instruction/no explicit approval.