### PR TITLE
Add Android workspace import core

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudExpectedFailureSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudExpectedFailureSupport.kt
@@ -23,6 +23,28 @@ private val expectedWorkspaceCloudFailureCodes: Set<String> = setOf(
     "WORKSPACE_SELECTION_REQUIRED"
 )
 
+private val expectedWorkspacePackageImportCloudFailureCodes: Set<String> = expectedWorkspaceCloudFailureCodes + setOf(
+    "WORKSPACE_PACKAGE_IMPORT_CONTENT_TYPE_UNSUPPORTED",
+    "WORKSPACE_PACKAGE_IMPORT_FILE_EMPTY",
+    "WORKSPACE_PACKAGE_IMPORT_FILE_REQUIRED",
+    "WORKSPACE_PACKAGE_IMPORT_FILE_TOO_LARGE",
+    "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_MEDIA_TYPE_UNSUPPORTED",
+    "WORKSPACE_PACKAGE_IMPORT_MULTIPART_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID_JSON",
+    "WORKSPACE_PACKAGE_IMPORT_OPTIONS_REQUIRED",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_BODY_TOO_LARGE",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_MALFORMED",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CONTENT_TYPE_UNSUPPORTED",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_INPUT_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_TOO_LARGE",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_EMPTY",
+    "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID",
+    "WORKSPACE_PACKAGE_IMPORT_REPLICA_INVALID"
+)
+
 private val expectedAgentCloudFailureCodes: Set<String> = setOf(
     "ACCOUNT_SIGN_IN_REQUIRED",
     "AGENT_API_KEY_INVALID",
@@ -42,6 +64,18 @@ internal fun expectedWorkspaceCloudFailureMessage(
     expectedSettingsFailureMessage(
         error = error,
         expectedCloudFailureCodes = expectedWorkspaceCloudFailureCodes,
+        fallbackMessage = fallbackMessage
+    )?.let { message -> return message }
+    return null
+}
+
+internal fun expectedWorkspacePackageImportCloudFailureMessage(
+    error: Throwable,
+    fallbackMessage: String
+): String? {
+    expectedSettingsFailureMessage(
+        error = error,
+        expectedCloudFailureCodes = expectedWorkspacePackageImportCloudFailureCodes,
         fallbackMessage = fallbackMessage
     )?.let { message -> return message }
     return null

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportSupport.kt
@@ -1,0 +1,303 @@
+package com.flashcardsopensourceapp.feature.settings.workspace.importing
+
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
+import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
+import java.io.ByteArrayOutputStream
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.InputStream
+import java.util.Locale
+
+private const val workspaceImportMaximumZipBytes: Long = 4_000_000L
+private const val workspaceImportMaximumZipMegabytes: Int = 4
+private const val workspaceImportReadBufferBytes: Int = 64 * 1024
+
+internal data class WorkspaceImportSelectedFile(
+    val fileName: String,
+    val packageBytes: ByteArray
+)
+
+internal data class WorkspaceImportTagOptionUiState(
+    val tag: String,
+    val cardsCount: Int,
+    val isKept: Boolean
+)
+
+internal class WorkspaceImportUserException(
+    message: String,
+    cause: Throwable?
+) : Exception(message, cause)
+
+internal fun workspaceImportDocumentPickerMimeTypes(): Array<String> {
+    return arrayOf(
+        "application/zip",
+        "application/x-zip-compressed",
+        "application/octet-stream"
+    )
+}
+
+internal fun readWorkspaceImportSelectedFile(
+    context: Context,
+    uri: Uri,
+    strings: SettingsStringResolver
+): WorkspaceImportSelectedFile {
+    return try {
+        readWorkspaceImportSelectedFileUnchecked(
+            context = context,
+            uri = uri,
+            strings = strings
+        )
+    } catch (error: WorkspaceImportUserException) {
+        throw error
+    } catch (error: SecurityException) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_read_failed),
+            cause = error
+        )
+    } catch (error: IllegalArgumentException) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_read_failed),
+            cause = error
+        )
+    }
+}
+
+private fun readWorkspaceImportSelectedFileUnchecked(
+    context: Context,
+    uri: Uri,
+    strings: SettingsStringResolver
+): WorkspaceImportSelectedFile {
+    val fileName: String = queryDisplayName(context = context, uri = uri)
+        ?: throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_name_unavailable),
+            cause = null
+        )
+    val trimmedFileName: String = fileName.trim()
+    if (trimmedFileName.lowercase(Locale.US).endsWith(".zip").not()) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_invalid_file),
+            cause = null
+        )
+    }
+
+    val declaredSizeBytes: Long? = querySizeBytes(context = context, uri = uri)
+    if (declaredSizeBytes != null && declaredSizeBytes > workspaceImportMaximumZipBytes) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_too_large, workspaceImportMaximumZipMegabytes),
+            cause = null
+        )
+    }
+
+    val packageBytes: ByteArray = readWorkspaceImportBytes(
+        context = context,
+        uri = uri,
+        strings = strings
+    )
+    if (packageBytes.isEmpty()) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_empty),
+            cause = null
+        )
+    }
+    if (packageBytes.size.toLong() > workspaceImportMaximumZipBytes) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_too_large, workspaceImportMaximumZipMegabytes),
+            cause = null
+        )
+    }
+
+    return WorkspaceImportSelectedFile(
+        fileName = trimmedFileName,
+        packageBytes = packageBytes.copyOf()
+    )
+}
+
+internal fun makeWorkspaceImportTagOptions(
+    preview: WorkspacePackageImportPreview,
+    removedTags: Set<String>
+): List<WorkspaceImportTagOptionUiState> {
+    return preview.tagCounts.map { tagCount ->
+        WorkspaceImportTagOptionUiState(
+            tag = tagCount.tag,
+            cardsCount = tagCount.cardsCount,
+            isKept = removedTags.contains(tagCount.tag).not()
+        )
+    }
+}
+
+internal fun makeWorkspaceImportConfirmOptions(
+    preview: WorkspacePackageImportPreview,
+    addImportTag: Boolean,
+    removedTags: Set<String>,
+    importedAtMillis: Long,
+    importId: String,
+    missingImportTagMessage: String
+): WorkspacePackageImportConfirmOptions {
+    val importTag: String = preview.defaultOptions.suggestedImportTag.trim()
+    if (importTag.isEmpty()) {
+        throw WorkspaceImportUserException(
+            message = missingImportTagMessage,
+            cause = null
+        )
+    }
+
+    return WorkspacePackageImportConfirmOptions(
+        addImportTag = addImportTag,
+        importTag = importTag,
+        removeTags = makeWorkspaceImportRemovedTags(
+            preview = preview,
+            removedTags = removedTags
+        ),
+        importedAtMillis = importedAtMillis,
+        importId = importId,
+        clientUpdatedAtMillis = importedAtMillis,
+        operationIdPrefix = importId
+    )
+}
+
+internal fun workspaceImportSuccessMessage(
+    summary: WorkspacePackageImportConfirmSummary,
+    strings: SettingsStringResolver
+): String {
+    val importTag: String? = summary.importTag?.trim()?.ifEmpty { null }
+    if (importTag != null) {
+        return strings.getQuantity(
+            R.plurals.settings_import_success_with_tag,
+            summary.cardCount,
+            summary.cardCount,
+            importTag
+        )
+    }
+    return strings.getQuantity(
+        R.plurals.settings_import_success,
+        summary.cardCount,
+        summary.cardCount
+    )
+}
+
+private fun makeWorkspaceImportRemovedTags(
+    preview: WorkspacePackageImportPreview,
+    removedTags: Set<String>
+): List<String> {
+    return preview.tagCounts
+        .map { tagCount -> tagCount.tag }
+        .filter { tag -> removedTags.contains(tag) }
+}
+
+private fun readWorkspaceImportBytes(
+    context: Context,
+    uri: Uri,
+    strings: SettingsStringResolver
+): ByteArray {
+    return try {
+        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+            readWorkspaceImportBytesBounded(
+                inputStream = inputStream,
+                maximumBytes = workspaceImportMaximumZipBytes,
+                tooLargeMessage = strings.get(
+                    R.string.settings_import_file_too_large,
+                    workspaceImportMaximumZipMegabytes
+                )
+            )
+        } ?: throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_read_failed),
+            cause = null
+        )
+    } catch (error: WorkspaceImportUserException) {
+        throw error
+    } catch (error: FileNotFoundException) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_read_failed),
+            cause = error
+        )
+    } catch (error: SecurityException) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_read_failed),
+            cause = error
+        )
+    } catch (error: IOException) {
+        throw WorkspaceImportUserException(
+            message = strings.get(R.string.settings_import_file_read_failed),
+            cause = error
+        )
+    }
+}
+
+private fun readWorkspaceImportBytesBounded(
+    inputStream: InputStream,
+    maximumBytes: Long,
+    tooLargeMessage: String
+): ByteArray {
+    val outputStream = ByteArrayOutputStream()
+    val buffer = ByteArray(workspaceImportReadBufferBytes)
+    var totalBytes = 0L
+
+    while (true) {
+        val readCount: Int = inputStream.read(buffer)
+        if (readCount == -1) {
+            break
+        }
+        totalBytes += readCount.toLong()
+        if (totalBytes > maximumBytes) {
+            throw WorkspaceImportUserException(message = tooLargeMessage, cause = null)
+        }
+        outputStream.write(buffer, 0, readCount)
+    }
+
+    return outputStream.toByteArray()
+}
+
+private fun queryDisplayName(
+    context: Context,
+    uri: Uri
+): String? {
+    return queryOpenableColumn(context = context, uri = uri, columnName = OpenableColumns.DISPLAY_NAME) { cursor, index ->
+        cursor.getString(index)?.trim()?.ifEmpty { null }
+    }
+}
+
+private fun querySizeBytes(
+    context: Context,
+    uri: Uri
+): Long? {
+    return queryOpenableColumn(context = context, uri = uri, columnName = OpenableColumns.SIZE) { cursor, index ->
+        if (cursor.isNull(index)) {
+            null
+        } else {
+            cursor.getLong(index)
+        }
+    }
+}
+
+private fun <T> queryOpenableColumn(
+    context: Context,
+    uri: Uri,
+    columnName: String,
+    readValue: (Cursor, Int) -> T?
+): T? {
+    val cursor: Cursor = context.contentResolver.query(
+        uri,
+        arrayOf(columnName),
+        null,
+        null,
+        null
+    ) ?: return null
+
+    cursor.use {
+        if (it.moveToFirst().not()) {
+            return null
+        }
+        val columnIndex: Int = it.getColumnIndex(columnName)
+        if (columnIndex == -1) {
+            return null
+        }
+        return readValue(it, columnIndex)
+    }
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportUiState.kt
@@ -1,0 +1,24 @@
+package com.flashcardsopensourceapp.feature.settings.workspace.importing
+
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
+
+data class WorkspaceImportUiState(
+    val selectedFileName: String?,
+    val preview: WorkspacePackageImportPreview?,
+    val addImportTag: Boolean,
+    val removedTags: Set<String>,
+    val isPreviewing: Boolean,
+    val isImporting: Boolean,
+    val availabilityMessage: String,
+    val errorMessage: String,
+    val successMessage: String
+) {
+    val isBusy: Boolean
+        get() = isPreviewing || isImporting
+
+    val canChoosePackage: Boolean
+        get() = availabilityMessage.isEmpty() && isBusy.not()
+
+    val canConfirmImport: Boolean
+        get() = availabilityMessage.isEmpty() && preview != null && selectedFileName != null && isBusy.not()
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModel.kt
@@ -1,0 +1,535 @@
+package com.flashcardsopensourceapp.feature.settings.workspace.importing
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
+import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
+import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
+import com.flashcardsopensourceapp.data.local.repository.SyncBlockedException
+import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
+import com.flashcardsopensourceapp.feature.settings.cloud.expectedWorkspacePackageImportCloudFailureMessage
+import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private data class WorkspaceImportPreviewIdentity(
+    val activeWorkspaceId: String,
+    val installationId: String
+)
+
+private data class WorkspaceImportDraftState(
+    val selectedFile: WorkspaceImportSelectedFile?,
+    val preview: WorkspacePackageImportPreview?,
+    val previewIdentity: WorkspaceImportPreviewIdentity?,
+    val addImportTag: Boolean,
+    val removedTags: Set<String>,
+    val isPreviewing: Boolean,
+    val isImporting: Boolean,
+    val errorMessage: String,
+    val successMessage: String
+)
+
+class WorkspaceImportViewModel(
+    private val cloudAccountRepository: CloudAccountRepository,
+    private val technicalErrorController: AppTechnicalErrorController,
+    private val strings: SettingsStringResolver,
+    private val currentTimeMillis: () -> Long,
+    private val newImportId: () -> String
+) : ViewModel() {
+    private val cloudSettingsState: StateFlow<CloudSettings> = cloudAccountRepository.observeCloudSettings().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = CloudSettings(
+            installationId = "",
+            cloudState = CloudAccountState.DISCONNECTED,
+            linkedUserId = null,
+            linkedWorkspaceId = null,
+            linkedEmail = null,
+            activeWorkspaceId = null,
+            updatedAtMillis = 0L
+        )
+    )
+    private val draftState = MutableStateFlow(
+        value = WorkspaceImportDraftState(
+            selectedFile = null,
+            preview = null,
+            previewIdentity = null,
+            addImportTag = true,
+            removedTags = emptySet(),
+            isPreviewing = false,
+            isImporting = false,
+            errorMessage = "",
+            successMessage = ""
+        )
+    )
+    private val isConfirmImportRunning = AtomicBoolean(false)
+    private val latestPreviewRequestId = AtomicLong(0L)
+
+    val uiState: StateFlow<WorkspaceImportUiState> = combine(
+        cloudSettingsState,
+        draftState
+    ) { cloudSettings, draft ->
+        val currentIdentity: WorkspaceImportPreviewIdentity? = makePreviewIdentity(cloudSettings = cloudSettings)
+        val isPreviewCurrent: Boolean = draft.preview != null &&
+            draft.selectedFile != null &&
+            draft.previewIdentity == currentIdentity
+        WorkspaceImportUiState(
+            selectedFileName = if (isPreviewCurrent || draft.isPreviewing) {
+                draft.selectedFile?.fileName
+            } else {
+                null
+            },
+            preview = if (isPreviewCurrent) draft.preview else null,
+            addImportTag = draft.addImportTag,
+            removedTags = draft.removedTags,
+            isPreviewing = draft.isPreviewing,
+            isImporting = draft.isImporting,
+            availabilityMessage = workspaceImportAvailabilityMessage(
+                cloudSettings = cloudSettings,
+                strings = strings
+            ),
+            errorMessage = draft.errorMessage,
+            successMessage = draft.successMessage
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = WorkspaceImportUiState(
+            selectedFileName = null,
+            preview = null,
+            addImportTag = true,
+            removedTags = emptySet(),
+            isPreviewing = false,
+            isImporting = false,
+            availabilityMessage = strings.get(R.string.settings_import_cloud_required),
+            errorMessage = "",
+            successMessage = ""
+        )
+    )
+
+    fun beginPreviewRequest(): Long {
+        val previewRequestId: Long = latestPreviewRequestId.incrementAndGet()
+        draftState.update { state ->
+            state.copy(
+                selectedFile = null,
+                preview = null,
+                previewIdentity = null,
+                addImportTag = true,
+                removedTags = emptySet(),
+                isPreviewing = true,
+                isImporting = false,
+                errorMessage = "",
+                successMessage = ""
+            )
+        }
+        return previewRequestId
+    }
+
+    fun previewSelectedFile(selectedFile: WorkspaceImportSelectedFile) {
+        val previewRequestId: Long = beginPreviewRequest()
+        previewSelectedFile(
+            previewRequestId = previewRequestId,
+            selectedFile = selectedFile
+        )
+    }
+
+    fun previewSelectedFile(
+        previewRequestId: Long,
+        selectedFile: WorkspaceImportSelectedFile
+    ) {
+        viewModelScope.launch {
+            previewSelectedFileAsync(
+                previewRequestId = previewRequestId,
+                selectedFile = selectedFile
+            )
+        }
+    }
+
+    private suspend fun previewSelectedFileAsync(
+        previewRequestId: Long,
+        selectedFile: WorkspaceImportSelectedFile
+    ) {
+        val previewIdentity: WorkspaceImportPreviewIdentity? = makePreviewIdentity(cloudSettings = cloudSettingsState.value)
+        if (isCurrentPreviewRequest(previewRequestId = previewRequestId).not()) {
+            return
+        }
+        if (previewIdentity == null) {
+            updateDraftStateForPreviewRequest(previewRequestId = previewRequestId) { state ->
+                state.copy(
+                    selectedFile = null,
+                    preview = null,
+                    previewIdentity = null,
+                    isPreviewing = false,
+                    isImporting = false,
+                    errorMessage = workspaceImportAvailabilityMessage(
+                        cloudSettings = cloudSettingsState.value,
+                        strings = strings
+                    ),
+                    successMessage = ""
+                )
+            }
+            return
+        }
+
+        updateDraftStateForPreviewRequest(previewRequestId = previewRequestId) { state ->
+            state.copy(
+                selectedFile = selectedFile,
+                preview = null,
+                previewIdentity = previewIdentity,
+                addImportTag = true,
+                removedTags = emptySet(),
+                isPreviewing = true,
+                isImporting = false,
+                errorMessage = "",
+                successMessage = ""
+            )
+        }
+
+        try {
+            val preview: WorkspacePackageImportPreview = cloudAccountRepository.previewCurrentWorkspacePackageImport(
+                packageBytes = selectedFile.packageBytes.copyOf()
+            )
+            updateDraftStateForPreviewRequest(previewRequestId = previewRequestId) { state ->
+                state.copy(
+                    selectedFile = selectedFile,
+                    preview = preview,
+                    previewIdentity = previewIdentity,
+                    addImportTag = preview.defaultOptions.addImportTag,
+                    removedTags = preview.defaultOptions.removedTags.toSet(),
+                    isPreviewing = false,
+                    errorMessage = "",
+                    successMessage = ""
+                )
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: SyncBlockedException) {
+            updateDraftStateForPreviewRequest(previewRequestId = previewRequestId) { state ->
+                state.copy(
+                    selectedFile = null,
+                    preview = null,
+                    previewIdentity = null,
+                    isPreviewing = false,
+                    errorMessage = strings.get(R.string.settings_account_status_sync_blocked_body),
+                    successMessage = ""
+                )
+            }
+        } catch (error: Exception) {
+            handlePreviewImportFailure(
+                error = error,
+                fallbackMessage = strings.get(R.string.settings_import_preview_failed),
+                previewRequestId = previewRequestId
+            )
+        }
+    }
+
+    fun showSelectedFileError(
+        previewRequestId: Long,
+        message: String
+    ) {
+        updateDraftStateForPreviewRequest(previewRequestId = previewRequestId) { state ->
+            state.copy(
+                selectedFile = null,
+                preview = null,
+                previewIdentity = null,
+                isPreviewing = false,
+                isImporting = false,
+                errorMessage = message,
+                successMessage = ""
+            )
+        }
+    }
+
+    fun updateAddImportTag(isEnabled: Boolean) {
+        draftState.update { state ->
+            state.copy(
+                addImportTag = isEnabled,
+                errorMessage = "",
+                successMessage = ""
+            )
+        }
+    }
+
+    fun toggleTag(tag: String) {
+        val preview: WorkspacePackageImportPreview = requireNotNull(uiState.value.preview) {
+            "Workspace package import tag toggles require a current preview."
+        }
+        require(preview.tagCounts.any { tagCount -> tagCount.tag == tag }) {
+            "Workspace package import tag toggle requires an existing preview tag."
+        }
+        draftState.update { state ->
+            val nextRemovedTags: Set<String> = if (state.removedTags.contains(tag)) {
+                state.removedTags - tag
+            } else {
+                state.removedTags + tag
+            }
+            state.copy(
+                removedTags = nextRemovedTags,
+                errorMessage = "",
+                successMessage = ""
+            )
+        }
+    }
+
+    fun confirmImport() {
+        if (isConfirmImportRunning.compareAndSet(false, true).not()) {
+            return
+        }
+        viewModelScope.launch {
+            try {
+                confirmImportAsync()
+            } finally {
+                isConfirmImportRunning.set(false)
+            }
+        }
+    }
+
+    private suspend fun confirmImportAsync() {
+        val currentUiState: WorkspaceImportUiState = uiState.value
+        val selectedFile: WorkspaceImportSelectedFile = draftState.value.selectedFile ?: run {
+            draftState.update { state ->
+                state.copy(errorMessage = strings.get(R.string.settings_import_preview_required))
+            }
+            return
+        }
+        val preview: WorkspacePackageImportPreview = currentUiState.preview ?: run {
+            draftState.update { state ->
+                state.copy(errorMessage = strings.get(R.string.settings_import_preview_required))
+            }
+            return
+        }
+        if (currentUiState.availabilityMessage.isNotEmpty()) {
+            draftState.update { state ->
+                state.copy(
+                    preview = null,
+                    selectedFile = null,
+                    previewIdentity = null,
+                    errorMessage = currentUiState.availabilityMessage,
+                    successMessage = ""
+                )
+            }
+            return
+        }
+
+        val importedAtMillis: Long = currentTimeMillis()
+        val importId: String = newImportId().trim().lowercase(Locale.US)
+        val options = try {
+            makeWorkspaceImportConfirmOptions(
+                preview = preview,
+                addImportTag = currentUiState.addImportTag,
+                removedTags = currentUiState.removedTags,
+                importedAtMillis = importedAtMillis,
+                importId = importId,
+                missingImportTagMessage = strings.get(R.string.settings_import_missing_import_tag)
+            )
+        } catch (error: WorkspaceImportUserException) {
+            draftState.update { state ->
+                state.copy(
+                    errorMessage = error.message ?: strings.get(R.string.settings_import_confirm_failed),
+                    successMessage = ""
+                )
+            }
+            return
+        }
+
+        draftState.update { state ->
+            state.copy(
+                isImporting = true,
+                errorMessage = "",
+                successMessage = ""
+            )
+        }
+
+        try {
+            val result: WorkspacePackageImportConfirmResult = cloudAccountRepository.confirmCurrentWorkspacePackageImport(
+                fileName = selectedFile.fileName,
+                packageBytes = selectedFile.packageBytes.copyOf(),
+                options = options
+            )
+            draftState.update { state ->
+                state.copy(
+                    selectedFile = null,
+                    preview = null,
+                    previewIdentity = null,
+                    addImportTag = true,
+                    removedTags = emptySet(),
+                    isImporting = false,
+                    errorMessage = "",
+                    successMessage = workspaceImportSuccessMessage(
+                        summary = result.summary,
+                        strings = strings
+                    )
+                )
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: SyncBlockedException) {
+            draftState.update { state ->
+                state.copy(
+                    isImporting = false,
+                    errorMessage = strings.get(R.string.settings_account_status_sync_blocked_body),
+                    successMessage = ""
+                )
+            }
+        } catch (error: Exception) {
+            handleImportFailure(
+                error = error,
+                fallbackMessage = strings.get(R.string.settings_import_confirm_failed),
+                isPreviewing = false
+            )
+        }
+    }
+
+    fun clearErrorMessage() {
+        draftState.update { state ->
+            state.copy(errorMessage = "")
+        }
+    }
+
+    private fun handlePreviewImportFailure(
+        error: Exception,
+        fallbackMessage: String,
+        previewRequestId: Long
+    ) {
+        val expectedErrorMessage: String? = expectedWorkspacePackageImportCloudFailureMessage(
+            error = error,
+            fallbackMessage = fallbackMessage
+        )
+        var didHandleCurrentRequest = false
+        updateDraftStateForPreviewRequest(previewRequestId = previewRequestId) { state ->
+            didHandleCurrentRequest = true
+            state.copy(
+                selectedFile = null,
+                preview = null,
+                previewIdentity = null,
+                isPreviewing = false,
+                isImporting = false,
+                errorMessage = expectedErrorMessage ?: fallbackMessage,
+                successMessage = ""
+            )
+        }
+        if (didHandleCurrentRequest && expectedErrorMessage == null) {
+            technicalErrorController.showTechnicalError(
+                error = makeAppTechnicalError(
+                    title = strings.get(R.string.settings_technical_error_title),
+                    message = fallbackMessage,
+                    throwable = error
+                ),
+                throwable = error
+            )
+        }
+    }
+
+    private fun handleImportFailure(
+        error: Exception,
+        fallbackMessage: String,
+        isPreviewing: Boolean
+    ) {
+        val expectedErrorMessage: String? = expectedWorkspacePackageImportCloudFailureMessage(
+            error = error,
+            fallbackMessage = fallbackMessage
+        )
+        draftState.update { state ->
+            state.copy(
+                selectedFile = if (isPreviewing) null else state.selectedFile,
+                preview = if (isPreviewing) null else state.preview,
+                previewIdentity = if (isPreviewing) null else state.previewIdentity,
+                isPreviewing = false,
+                isImporting = false,
+                errorMessage = expectedErrorMessage ?: fallbackMessage,
+                successMessage = ""
+            )
+        }
+        if (expectedErrorMessage == null) {
+            technicalErrorController.showTechnicalError(
+                error = makeAppTechnicalError(
+                    title = strings.get(R.string.settings_technical_error_title),
+                    message = fallbackMessage,
+                    throwable = error
+                ),
+                throwable = error
+            )
+        }
+    }
+
+    private fun updateDraftStateForPreviewRequest(
+        previewRequestId: Long,
+        transform: (WorkspaceImportDraftState) -> WorkspaceImportDraftState
+    ) {
+        draftState.update { state ->
+            if (isCurrentPreviewRequest(previewRequestId = previewRequestId)) {
+                transform(state)
+            } else {
+                state
+            }
+        }
+    }
+
+    private fun isCurrentPreviewRequest(previewRequestId: Long): Boolean {
+        return latestPreviewRequestId.get() == previewRequestId
+    }
+}
+
+private fun makePreviewIdentity(cloudSettings: CloudSettings): WorkspaceImportPreviewIdentity? {
+    if (cloudSettings.cloudState != CloudAccountState.LINKED) {
+        return null
+    }
+    val activeWorkspaceId: String = cloudSettings.activeWorkspaceId?.trim()?.ifEmpty { null } ?: return null
+    val installationId: String = cloudSettings.installationId.trim().ifEmpty { null } ?: return null
+    return WorkspaceImportPreviewIdentity(
+        activeWorkspaceId = activeWorkspaceId,
+        installationId = installationId
+    )
+}
+
+private fun workspaceImportAvailabilityMessage(
+    cloudSettings: CloudSettings,
+    strings: SettingsStringResolver
+): String {
+    if (cloudSettings.cloudState != CloudAccountState.LINKED) {
+        return strings.get(R.string.settings_import_cloud_required)
+    }
+    if (cloudSettings.activeWorkspaceId?.trim().isNullOrEmpty()) {
+        return strings.get(R.string.settings_import_workspace_unavailable)
+    }
+    return ""
+}
+
+fun createWorkspaceImportViewModelFactory(
+    cloudAccountRepository: CloudAccountRepository,
+    technicalErrorController: AppTechnicalErrorController,
+    applicationContext: Context
+): ViewModelProvider.Factory {
+    return viewModelFactory {
+        initializer {
+            WorkspaceImportViewModel(
+                cloudAccountRepository = cloudAccountRepository,
+                technicalErrorController = technicalErrorController,
+                strings = createSettingsStringResolver(context = applicationContext),
+                currentTimeMillis = System::currentTimeMillis,
+                newImportId = {
+                    UUID.randomUUID().toString().lowercase(Locale.US)
+                }
+            )
+        }
+    }
+}

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -454,6 +454,18 @@
     <string name="settings_export_csv_header_back">backText</string>
     <string name="settings_export_csv_header_tags">tags</string>
 
+    <string name="settings_import_cloud_required">Media ZIP import requires a linked cloud workspace in this version.</string>
+    <string name="settings_import_workspace_unavailable">Workspace is unavailable. Reload the current workspace and try again.</string>
+    <string name="settings_import_invalid_file">Choose a Flashcards ZIP package.</string>
+    <string name="settings_import_file_too_large">Choose a ZIP package up to %1$d MB.</string>
+    <string name="settings_import_file_empty">The selected ZIP package is empty.</string>
+    <string name="settings_import_file_name_unavailable">The selected package file name is unavailable.</string>
+    <string name="settings_import_file_read_failed">Android could not read the selected package.</string>
+    <string name="settings_import_preview_failed">Package preview failed.</string>
+    <string name="settings_import_confirm_failed">Package import failed.</string>
+    <string name="settings_import_preview_required">Preview a package before importing.</string>
+    <string name="settings_import_missing_import_tag">Package preview did not include an import tag.</string>
+
     <string name="settings_device_title">Device</string>
     <string name="settings_device_workspace_name_label">Workspace name</string>
     <string name="settings_device_workspace_id_label">Workspace ID</string>
@@ -652,6 +664,14 @@
     <plurals name="settings_tags_count">
         <item quantity="one">%d tag</item>
         <item quantity="other">%d tags</item>
+    </plurals>
+    <plurals name="settings_import_success">
+        <item quantity="one">Imported %1$d card.</item>
+        <item quantity="other">Imported %1$d cards.</item>
+    </plurals>
+    <plurals name="settings_import_success_with_tag">
+        <item quantity="one">Imported %1$d card with tag %2$s.</item>
+        <item quantity="other">Imported %1$d cards with tag %2$s.</item>
     </plurals>
     <plurals name="settings_workspace_deck_card_summary">
         <item quantity="one">%1$d card</item>

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -92,6 +92,17 @@ internal fun makeRecoveryState(): CloudCredentialRecoveryState {
     )
 }
 
+internal data class CapturedWorkspacePackageImportConfirm(
+    val fileName: String,
+    val packageBytes: ByteArray,
+    val options: WorkspacePackageImportConfirmOptions
+)
+
+internal data class QueuedWorkspacePackageImportPreview(
+    val gate: CompletableDeferred<Unit>,
+    val preview: WorkspacePackageImportPreview
+)
+
 internal class FakeCloudAccountRepository : CloudAccountRepository {
     private val cloudSettings = MutableStateFlow(
         CloudSettings(
@@ -114,12 +125,18 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
     private val completeCloudLinkErrors = ArrayDeque<Exception>()
     private val completeCloudLinkResults = ArrayDeque<CompletableDeferred<CloudWorkspaceSummary>>()
     private val preparedLinkContexts = mutableMapOf<String, CompletableDeferred<CloudWorkspaceLinkContext>>()
+    private val queuedWorkspacePackageImportPreviews = ArrayDeque<QueuedWorkspacePackageImportPreview>()
     val completeCloudLinkSelections = mutableListOf<CloudWorkspaceLinkSelection>()
     val validatedCustomOrigins = mutableListOf<String>()
     val appliedCustomServerConfigurations = mutableListOf<CloudServiceConfiguration>()
+    val previewedWorkspacePackageImportBytes = mutableListOf<ByteArray>()
+    val confirmedWorkspacePackageImports = mutableListOf<CapturedWorkspacePackageImportConfirm>()
     var validateCustomServerError: Exception? = null
     var applyCustomServerError: Exception? = null
     var nextValidatedCustomServerConfiguration: CloudServiceConfiguration? = null
+    var nextWorkspacePackageImportPreview: WorkspacePackageImportPreview? = null
+    var nextWorkspacePackageImportConfirmGate: CompletableDeferred<Unit>? = null
+    var nextWorkspacePackageImportConfirmResult: WorkspacePackageImportConfirmResult? = null
     var resetInvalidCloudCredentialRecoveryStateCalls: Int = 0
         private set
     var logoutCalls: Int = 0
@@ -145,11 +162,27 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
         completeCloudLinkResults.addLast(result)
     }
 
+    fun setCloudSettings(settings: CloudSettings) {
+        cloudSettings.value = settings
+    }
+
     fun enqueuePreparedLinkContext(
         idToken: String,
         result: CompletableDeferred<CloudWorkspaceLinkContext>
     ) {
         preparedLinkContexts[idToken] = result
+    }
+
+    fun enqueueWorkspacePackageImportPreview(
+        gate: CompletableDeferred<Unit>,
+        preview: WorkspacePackageImportPreview
+    ) {
+        queuedWorkspacePackageImportPreviews.addLast(
+            QueuedWorkspacePackageImportPreview(
+                gate = gate,
+                preview = preview
+            )
+        )
     }
 
     override fun observeCloudSettings(): Flow<CloudSettings> {
@@ -283,7 +316,15 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
     }
 
     override suspend fun previewCurrentWorkspacePackageImport(packageBytes: ByteArray): WorkspacePackageImportPreview {
-        throw UnsupportedOperationException()
+        previewedWorkspacePackageImportBytes += packageBytes.copyOf()
+        if (queuedWorkspacePackageImportPreviews.isNotEmpty()) {
+            val queuedPreview: QueuedWorkspacePackageImportPreview = queuedWorkspacePackageImportPreviews.removeFirst()
+            queuedPreview.gate.await()
+            return queuedPreview.preview
+        }
+        return requireNotNull(nextWorkspacePackageImportPreview) {
+            "Missing workspace package import preview test result."
+        }
     }
 
     override suspend fun confirmCurrentWorkspacePackageImport(
@@ -291,7 +332,15 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
         packageBytes: ByteArray,
         options: WorkspacePackageImportConfirmOptions
     ): WorkspacePackageImportConfirmResult {
-        throw UnsupportedOperationException()
+        confirmedWorkspacePackageImports += CapturedWorkspacePackageImportConfirm(
+            fileName = fileName,
+            packageBytes = packageBytes.copyOf(),
+            options = options
+        )
+        nextWorkspacePackageImportConfirmGate?.await()
+        return requireNotNull(nextWorkspacePackageImportConfirmResult) {
+            "Missing workspace package import confirm test result."
+        }
     }
 
     override suspend fun loadProgressSummary(timeZone: String): CloudProgressSummary {
@@ -411,6 +460,18 @@ internal class TestSettingsStringResolver : SettingsStringResolver {
             R.string.settings_server_apply_failed -> "Could not apply custom server."
             R.string.settings_server_validate_failed -> "Custom server validation failed."
             R.string.settings_server_reset_failed -> "Could not reset the official server."
+            R.string.settings_import_cloud_required -> {
+                "Media ZIP import requires a linked cloud workspace in this version."
+            }
+
+            R.string.settings_import_workspace_unavailable -> {
+                "Workspace is unavailable. Reload the current workspace and try again."
+            }
+
+            R.string.settings_import_preview_failed -> "Package preview failed."
+            R.string.settings_import_confirm_failed -> "Package import failed."
+            R.string.settings_import_preview_required -> "Preview a package before importing."
+            R.string.settings_import_missing_import_tag -> "Package preview did not include an import tag."
             R.string.settings_logout -> "Log out"
             R.string.settings_current_workspace_create_new_title -> "Create new workspace"
             R.string.settings_current_workspace_create_new_summary -> {
@@ -479,7 +540,22 @@ internal class TestSettingsStringResolver : SettingsStringResolver {
     }
 
     override fun getQuantity(pluralsResId: Int, quantity: Int, vararg formatArgs: Any): String {
-        error("Unexpected plurals resource id in CloudSignInViewModelTest: $pluralsResId")
+        val pattern = when (pluralsResId) {
+            R.plurals.settings_import_success -> {
+                if (quantity == 1) "Imported %1\$d card." else "Imported %1\$d cards."
+            }
+
+            R.plurals.settings_import_success_with_tag -> {
+                if (quantity == 1) {
+                    "Imported %1\$d card with tag %2\$s."
+                } else {
+                    "Imported %1\$d cards with tag %2\$s."
+                }
+            }
+
+            else -> error("Unexpected plurals resource id in CloudSignInViewModelTest: $pluralsResId")
+        }
+        return String.format(Locale.ENGLISH, pattern, *formatArgs)
     }
 
     override fun locale(): Locale {

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModelTest.kt
@@ -1,0 +1,267 @@
+package com.flashcardsopensourceapp.feature.settings.workspace.importing
+
+import com.flashcardsopensourceapp.core.ui.AppTechnicalError
+import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportDefaultOptions
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportMetadata
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportSourceKind
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportTagCount
+import com.flashcardsopensourceapp.feature.settings.FakeCloudAccountRepository
+import com.flashcardsopensourceapp.feature.settings.TestSettingsStringResolver
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WorkspaceImportViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun previewSelectedFileAppliesServerDefaultImportOptions() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.setCloudSettings(settings = linkedCloudSettings())
+        val preview = workspacePackageImportPreview()
+        repository.nextWorkspacePackageImportPreview = preview
+        val viewModel = workspaceImportViewModel(repository = repository)
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewSelectedFile(
+            selectedFile = WorkspaceImportSelectedFile(
+                fileName = "flashcards.zip",
+                packageBytes = byteArrayOf(1, 2, 3)
+            )
+        )
+        advanceUntilIdle()
+
+        assertArrayEquals(byteArrayOf(1, 2, 3), repository.previewedWorkspacePackageImportBytes.single())
+        assertSame(preview, viewModel.uiState.value.preview)
+        assertEquals("flashcards.zip", viewModel.uiState.value.selectedFileName)
+        assertEquals(preview.defaultOptions.addImportTag, viewModel.uiState.value.addImportTag)
+        assertEquals(setOf("drop"), viewModel.uiState.value.removedTags)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun previewSelectedFileIgnoresStaleResultAfterNewerSelection() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.setCloudSettings(settings = linkedCloudSettings())
+        val firstPreviewGate = CompletableDeferred<Unit>()
+        val secondPreviewGate = CompletableDeferred<Unit>()
+        val firstPreview = workspacePackageImportPreviewWithLabel(label = "First package")
+        val secondPreview = workspacePackageImportPreviewWithLabel(label = "Second package")
+        repository.enqueueWorkspacePackageImportPreview(
+            gate = firstPreviewGate,
+            preview = firstPreview
+        )
+        repository.enqueueWorkspacePackageImportPreview(
+            gate = secondPreviewGate,
+            preview = secondPreview
+        )
+        val viewModel = workspaceImportViewModel(repository = repository)
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewSelectedFile(
+            selectedFile = WorkspaceImportSelectedFile(
+                fileName = "first.zip",
+                packageBytes = byteArrayOf(1)
+            )
+        )
+        advanceUntilIdle()
+        viewModel.previewSelectedFile(
+            selectedFile = WorkspaceImportSelectedFile(
+                fileName = "second.zip",
+                packageBytes = byteArrayOf(2)
+            )
+        )
+        advanceUntilIdle()
+
+        secondPreviewGate.complete(Unit)
+        advanceUntilIdle()
+        assertSame(secondPreview, viewModel.uiState.value.preview)
+        assertEquals("second.zip", viewModel.uiState.value.selectedFileName)
+
+        firstPreviewGate.complete(Unit)
+        advanceUntilIdle()
+        assertSame(secondPreview, viewModel.uiState.value.preview)
+        assertEquals("second.zip", viewModel.uiState.value.selectedFileName)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun confirmImportSendsSelectedOptionsAndClearsPreview() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.setCloudSettings(settings = linkedCloudSettings())
+        repository.nextWorkspacePackageImportPreview = workspacePackageImportPreview()
+        val confirmGate = CompletableDeferred<Unit>()
+        repository.nextWorkspacePackageImportConfirmGate = confirmGate
+        repository.nextWorkspacePackageImportConfirmResult = WorkspacePackageImportConfirmResult(
+            summary = WorkspacePackageImportConfirmSummary(
+                cardCount = 1,
+                cardBatchCount = 1,
+                referencedMediaCount = 2,
+                importedMediaAssetCount = 2,
+                appliedMediaAssetCount = 2,
+                keptTagCount = 0,
+                removedTagCount = 2,
+                importTag = null
+            )
+        )
+        val viewModel = workspaceImportViewModel(
+            repository = repository,
+            currentTimeMillis = { 123_456L },
+            newImportId = { "IMPORT-ID-1" }
+        )
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewSelectedFile(
+            selectedFile = WorkspaceImportSelectedFile(
+                fileName = "flashcards.zip",
+                packageBytes = byteArrayOf(4, 5, 6)
+            )
+        )
+        advanceUntilIdle()
+        viewModel.updateAddImportTag(isEnabled = false)
+        viewModel.toggleTag(tag = "keep")
+        advanceUntilIdle()
+        viewModel.confirmImport()
+        viewModel.confirmImport()
+        advanceUntilIdle()
+        assertEquals(1, repository.confirmedWorkspacePackageImports.size)
+        confirmGate.complete(Unit)
+        advanceUntilIdle()
+
+        val confirmedImport = repository.confirmedWorkspacePackageImports.single()
+        assertEquals("flashcards.zip", confirmedImport.fileName)
+        assertArrayEquals(byteArrayOf(4, 5, 6), confirmedImport.packageBytes)
+        assertEquals(false, confirmedImport.options.addImportTag)
+        assertEquals("import-tag", confirmedImport.options.importTag)
+        assertEquals(listOf("keep", "drop"), confirmedImport.options.removeTags)
+        assertEquals(123_456L, confirmedImport.options.importedAtMillis)
+        assertEquals(123_456L, confirmedImport.options.clientUpdatedAtMillis)
+        assertEquals("import-id-1", confirmedImport.options.importId)
+        assertEquals("import-id-1", confirmedImport.options.operationIdPrefix)
+        assertNull(viewModel.uiState.value.preview)
+        assertEquals("Imported 1 card.", viewModel.uiState.value.successMessage)
+
+        stateJob.cancel()
+    }
+
+    private fun workspaceImportViewModel(
+        repository: FakeCloudAccountRepository,
+        currentTimeMillis: () -> Long,
+        newImportId: () -> String
+    ): WorkspaceImportViewModel {
+        return WorkspaceImportViewModel(
+            cloudAccountRepository = repository,
+            technicalErrorController = RecordingTechnicalErrorController(),
+            strings = TestSettingsStringResolver(),
+            currentTimeMillis = currentTimeMillis,
+            newImportId = newImportId
+        )
+    }
+
+    private fun workspaceImportViewModel(repository: FakeCloudAccountRepository): WorkspaceImportViewModel {
+        return workspaceImportViewModel(
+            repository = repository,
+            currentTimeMillis = { 100L },
+            newImportId = { "import-id" }
+        )
+    }
+}
+
+private fun linkedCloudSettings(): CloudSettings {
+    return CloudSettings(
+        installationId = "installation-1",
+        cloudState = CloudAccountState.LINKED,
+        linkedUserId = "user-1",
+        linkedWorkspaceId = "workspace-local",
+        linkedEmail = "person@example.com",
+        activeWorkspaceId = "workspace-local",
+        updatedAtMillis = 1L
+    )
+}
+
+private fun workspacePackageImportPreview(): WorkspacePackageImportPreview {
+    return workspacePackageImportPreviewWithLabel(label = "Shared deck")
+}
+
+private fun workspacePackageImportPreviewWithLabel(label: String): WorkspacePackageImportPreview {
+    return WorkspacePackageImportPreview(
+        sourceKind = WorkspacePackageImportSourceKind.ZIP,
+        packageMetadata = WorkspacePackageImportMetadata(
+            label = label,
+            author = "Author",
+            comment = "Comment",
+            createdAt = "2026-01-01T00:00:00.000Z",
+            sourceUrl = "https://example.com/package"
+        ),
+        cardCount = 3,
+        tagCounts = listOf(
+            WorkspacePackageImportTagCount(
+                tag = "keep",
+                cardsCount = 2
+            ),
+            WorkspacePackageImportTagCount(
+                tag = "drop",
+                cardsCount = 1
+            )
+        ),
+        referencedMediaCount = 2,
+        packageMediaFileCount = 2,
+        warnings = emptyList(),
+        defaultOptions = WorkspacePackageImportDefaultOptions(
+            addImportTag = true,
+            suggestedImportTag = "import-tag",
+            keptTags = listOf("keep"),
+            removedTags = listOf("drop")
+        )
+    )
+}
+
+private class RecordingTechnicalErrorController : AppTechnicalErrorController {
+    val errors: MutableList<AppTechnicalError> = mutableListOf()
+
+    override fun showTechnicalError(
+        error: AppTechnicalError,
+        throwable: Throwable
+    ) {
+        errors += error
+    }
+}


### PR DESCRIPTION
## Summary
- add Android workspace package import ViewModel state/action logic
- add ZIP document read/support helpers, option mapping, and expected cloud failure handling
- add focused ViewModel tests and fake repository support for preview/confirm races

## Validation
- git --no-pager diff --check
- git --no-pager diff --cached --check
- xmllint --noout apps/android/feature/settings/src/main/res/values/strings.xml
- modified/staged Kotlin/XML trailing whitespace check
- no standalone Kotlin parser/linter found
- Gradle/tests not run per instruction

Split note: UI/navigation/Compose route is deferred to Stage 3M4b. Full combined patch was saved locally at /tmp/stage3m4-android-import-combined.patch.