### PR TITLE
Add Android ZIP import UI flow

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToNodeAction
@@ -57,6 +58,7 @@ import com.flashcardsopensourceapp.feature.settings.settingsDecksRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsDeleteAccountRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsDeviceDiagnosticsRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsExportRowTag
+import com.flashcardsopensourceapp.feature.settings.settingsImportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsRootScreenTag
 import com.flashcardsopensourceapp.feature.settings.settingsSchedulingRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsTagsRowTag
@@ -69,6 +71,8 @@ import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerSaveButto
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceNameTag
 import com.flashcardsopensourceapp.feature.settings.workspace.export.workspaceExportCsvButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspace.export.workspaceExportScreenTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportChooseFileButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportScreenTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagCardsCountTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagRowTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagsSearchFieldTag
@@ -457,6 +461,16 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         waitForTagToExist(tag = workspaceExportCsvButtonTag)
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_title))
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_summary))
+    }
+
+    @Test
+    fun workspaceImportShowsCloudRequiredStateFromEmptyState() {
+        waitForCardsEmptyState()
+
+        openSettingsRow(rowTag = settingsImportRowTag, destinationTag = workspaceImportScreenTag)
+        waitForTagToExist(tag = workspaceImportChooseFileButtonTag)
+        composeRule.onNodeWithTag(workspaceImportChooseFileButtonTag).assertIsNotEnabled()
+        waitForTextToExist(text = settingsString(SettingsR.string.settings_import_cloud_required))
     }
 
     @Test

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -40,6 +40,7 @@ import com.flashcardsopensourceapp.feature.settings.settingsDeviceDiagnosticsRow
 import com.flashcardsopensourceapp.feature.settings.settingsExportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsFeedbackRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsGeneralSectionTag
+import com.flashcardsopensourceapp.feature.settings.settingsImportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsLanguageRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsLeaderboardParticipationRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsLegalRowTag
@@ -134,6 +135,7 @@ internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
         settingsAccessRowTag to "Access",
         settingsDecksRowTag to "Decks",
         settingsTagsRowTag to "Tags",
+        settingsImportRowTag to "Import",
         settingsExportRowTag to "Export",
         settingsFeedbackRowTag to "Send feedback",
         settingsSupportRowTag to "Support",

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
@@ -32,6 +32,7 @@ import com.flashcardsopensourceapp.feature.settings.settingsDeviceDiagnosticsRow
 import com.flashcardsopensourceapp.feature.settings.settingsExportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsFeedbackRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsGeneralSectionTag
+import com.flashcardsopensourceapp.feature.settings.settingsImportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsInviteFriendButtonTag
 import com.flashcardsopensourceapp.feature.settings.settingsLanguageRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsLeaderboardParticipationRowTag
@@ -98,6 +99,7 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
             settingsAccessRowTag,
             settingsDecksRowTag,
             settingsTagsRowTag,
+            settingsImportRowTag,
             settingsExportRowTag,
             settingsFeedbackRowTag,
             settingsSupportRowTag,
@@ -132,6 +134,10 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         assertRootRowOrder(
             firstRowTag = settingsReviewAnimationsRowTag,
             secondRowTag = settingsAiChatSuggestionsRowTag
+        )
+        assertRootRowOrder(
+            firstRowTag = settingsImportRowTag,
+            secondRowTag = settingsExportRowTag
         )
         assertRootRowOrder(
             firstRowTag = settingsAiChatSuggestionsRowTag,
@@ -195,6 +201,11 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         assertRowClick(
             rowTag = settingsServerRowTag,
             expectedClick = "server",
+            clickedRows = clickedRows
+        )
+        assertRowClick(
+            rowTag = settingsImportRowTag,
+            expectedClick = "import",
             clickedRows = clickedRows
         )
         assertRowClick(
@@ -347,6 +358,9 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     },
                     onOpenTags = {
                         clickedRows += "tags"
+                    },
+                    onOpenImport = {
+                        clickedRows += "import"
                     },
                     onOpenExport = {
                         clickedRows += "export"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
@@ -80,6 +80,10 @@ data object SettingsWorkspaceExportDestination {
     const val route: String = "settings/export"
 }
 
+data object SettingsWorkspaceImportDestination {
+    const val route: String = "settings/import"
+}
+
 data object SettingsWorkspaceResetStudyProgressDestination {
     const val route: String = "settings/workspace/reset-study-progress"
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
@@ -165,6 +165,9 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
             onOpenTags = {
                 navController.navigate(route = SettingsWorkspaceTagsDestination.route)
             },
+            onOpenImport = {
+                navController.navigate(route = SettingsWorkspaceImportDestination.route)
+            },
             onOpenExport = {
                 navController.navigate(route = SettingsWorkspaceExportDestination.route)
             },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -30,6 +30,8 @@ import com.flashcardsopensourceapp.feature.settings.scheduler.createSchedulerSet
 import com.flashcardsopensourceapp.feature.settings.workspace.delete.DeleteCurrentWorkspaceRoute
 import com.flashcardsopensourceapp.feature.settings.workspace.export.WorkspaceExportRoute
 import com.flashcardsopensourceapp.feature.settings.workspace.export.createWorkspaceExportViewModelFactory
+import com.flashcardsopensourceapp.feature.settings.workspace.importing.WorkspaceImportRoute
+import com.flashcardsopensourceapp.feature.settings.workspace.importing.createWorkspaceImportViewModelFactory
 import com.flashcardsopensourceapp.feature.settings.workspace.overview.createWorkspaceOverviewViewModelFactory
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.ResetStudyProgressRoute
 import com.flashcardsopensourceapp.feature.settings.workspace.settings.createWorkspaceSettingsViewModelFactory
@@ -431,6 +433,24 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
         WorkspaceExportRoute(
             viewModel = workspaceExportViewModel,
             technicalErrorController = appGraph.appMessageBus,
+            onBack = {
+                navController.popBackStack()
+            }
+        )
+    }
+
+    composable(route = SettingsWorkspaceImportDestination.route) {
+        val context = LocalContext.current
+        val workspaceImportViewModel = viewModel<com.flashcardsopensourceapp.feature.settings.workspace.importing.WorkspaceImportViewModel>(
+            factory = createWorkspaceImportViewModelFactory(
+                cloudAccountRepository = appGraph.cloudAccountRepository,
+                technicalErrorController = appGraph.appMessageBus,
+                applicationContext = context.applicationContext
+            )
+        )
+
+        WorkspaceImportRoute(
+            viewModel = workspaceImportViewModel,
             onBack = {
                 navController.popBackStack()
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -99,6 +99,7 @@ fun SettingsRoute(
     onOpenAccess: () -> Unit,
     onOpenDecks: () -> Unit,
     onOpenTags: () -> Unit,
+    onOpenImport: () -> Unit,
     onOpenExport: () -> Unit,
     onOpenFeedback: () -> Unit,
     onOpenLegal: () -> Unit,
@@ -270,6 +271,16 @@ fun SettingsRoute(
                     attentionCount = null,
                     testTag = settingsTagsRowTag,
                     onClick = onOpenTags
+                )
+            }
+
+            item {
+                SettingsRootRow(
+                    title = stringResource(R.string.settings_import_title),
+                    summary = stringResource(R.string.settings_import_zip_summary),
+                    attentionCount = null,
+                    testTag = settingsImportRowTag,
+                    onClick = onOpenImport
                 )
             }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
@@ -13,6 +13,7 @@ const val settingsLanguageRowTag: String = "settings_row_language"
 const val settingsAccessRowTag: String = "settings_row_access"
 const val settingsDecksRowTag: String = "settings_row_decks"
 const val settingsTagsRowTag: String = "settings_row_tags"
+const val settingsImportRowTag: String = "settings_row_import"
 const val settingsExportRowTag: String = "settings_row_export"
 const val settingsFeedbackRowTag: String = "settings_row_feedback"
 const val settingsLegalRowTag: String = "settings_row_legal"
@@ -40,3 +41,13 @@ const val notificationDiagnosticsScreenTag: String = "notification_diagnostics_s
 const val settingsReviewAnimationsToggleTag: String = "settings_review_animations_toggle"
 const val settingsAiChatSuggestionsToggleTag: String = "settings_ai_chat_suggestions_toggle"
 const val settingsLeaderboardParticipationToggleTag: String = "settings_leaderboard_participation_toggle"
+const val workspaceImportScreenTag: String = "workspace_import_screen"
+const val workspaceImportChooseFileButtonTag: String = "workspace_import_choose_file_button"
+const val workspaceImportAddImportTagToggleTag: String = "workspace_import_add_import_tag_toggle"
+const val workspaceImportConfirmButtonTag: String = "workspace_import_confirm_button"
+const val workspaceImportErrorMessageTag: String = "workspace_import_error_message"
+const val workspaceImportTagToggleTagPrefix: String = "workspace_import_tag_toggle:"
+
+fun workspaceImportTagToggleTag(tag: String): String {
+    return workspaceImportTagToggleTagPrefix + tag
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportRoute.kt
@@ -1,0 +1,538 @@
+package com.flashcardsopensourceapp.feature.settings.workspace.importing
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SaveAlt
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportMetadata
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportSourceKind
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportWarning
+import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
+import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
+import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
+import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
+import com.flashcardsopensourceapp.feature.settings.workspaceImportAddImportTagToggleTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportChooseFileButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportConfirmButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportErrorMessageTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportScreenTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportTagToggleTag
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Composable
+fun WorkspaceImportRoute(
+    viewModel: WorkspaceImportViewModel,
+    onBack: () -> Unit
+) {
+    val uiState: WorkspaceImportUiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val strings = remember(context) {
+        createSettingsStringResolver(context = context.applicationContext)
+    }
+    val openDocumentLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri == null) {
+            return@rememberLauncherForActivityResult
+        }
+        val previewRequestId: Long = viewModel.beginPreviewRequest()
+        coroutineScope.launch {
+            try {
+                val selectedFile: WorkspaceImportSelectedFile = withContext(Dispatchers.IO) {
+                    readWorkspaceImportSelectedFile(
+                        context = context,
+                        uri = uri,
+                        strings = strings
+                    )
+                }
+                viewModel.previewSelectedFile(
+                    previewRequestId = previewRequestId,
+                    selectedFile = selectedFile
+                )
+            } catch (error: WorkspaceImportUserException) {
+                viewModel.showSelectedFileError(
+                    previewRequestId = previewRequestId,
+                    message = error.message ?: context.getString(R.string.settings_import_file_read_failed)
+                )
+            }
+        }
+    }
+
+    SettingsScreenScaffold(
+        title = stringResource(R.string.settings_import_title),
+        onBack = onBack,
+        isBackEnabled = uiState.isBusy.not()
+    ) { innerPadding ->
+        LazyColumn(
+            contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
+            verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = workspaceImportScreenTag)
+        ) {
+            if (uiState.errorMessage.isNotEmpty()) {
+                item {
+                    MessageCard(
+                        message = uiState.errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        testTag = workspaceImportErrorMessageTag
+                    )
+                }
+            }
+
+            if (uiState.successMessage.isNotEmpty()) {
+                item {
+                    MessageCard(
+                        message = uiState.successMessage,
+                        color = MaterialTheme.colorScheme.primary,
+                        testTag = null
+                    )
+                }
+            }
+
+            item {
+                WorkspaceImportPackageCard(
+                    uiState = uiState,
+                    onChoosePackage = {
+                        openDocumentLauncher.launch(workspaceImportDocumentPickerMimeTypes())
+                    }
+                )
+            }
+
+            val preview: WorkspacePackageImportPreview? = uiState.preview
+            if (preview != null) {
+                item {
+                    WorkspaceImportSourceCard(
+                        selectedFileName = uiState.selectedFileName,
+                        preview = preview
+                    )
+                }
+                item {
+                    WorkspaceImportMetadataCard(metadata = preview.packageMetadata)
+                }
+                item {
+                    WorkspaceImportCountsCard(preview = preview)
+                }
+                item {
+                    WorkspaceImportOptionsCard(
+                        preview = preview,
+                        addImportTag = uiState.addImportTag,
+                        removedTags = uiState.removedTags,
+                        isBusy = uiState.isBusy,
+                        onAddImportTagChange = viewModel::updateAddImportTag,
+                        onToggleTag = viewModel::toggleTag
+                    )
+                }
+                item {
+                    WorkspaceImportWarningsCard(warnings = preview.warnings)
+                }
+                item {
+                    WorkspaceImportConfirmButton(
+                        uiState = uiState,
+                        onConfirmImport = viewModel::confirmImport
+                    )
+                }
+            }
+
+            item {
+                OutlinedButton(
+                    onClick = viewModel::clearErrorMessage,
+                    enabled = uiState.errorMessage.isNotEmpty(),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.settings_import_dismiss_error))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MessageCard(
+    message: String,
+    color: Color,
+    testTag: String?
+) {
+    val modifier: Modifier = if (testTag == null) {
+        Modifier.padding(20.dp)
+    } else {
+        Modifier
+            .padding(20.dp)
+            .testTag(tag = testTag)
+    }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = message,
+            color = color,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun WorkspaceImportPackageCard(
+    uiState: WorkspaceImportUiState,
+    onChoosePackage: () -> Unit
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(20.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.settings_import_package_section),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = stringResource(R.string.settings_import_package_body),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (uiState.selectedFileName != null) {
+                Text(
+                    text = stringResource(R.string.settings_import_selected_file, uiState.selectedFileName),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (uiState.availabilityMessage.isNotEmpty()) {
+                Text(
+                    text = uiState.availabilityMessage,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            OutlinedButton(
+                onClick = onChoosePackage,
+                enabled = uiState.canChoosePackage,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(tag = workspaceImportChooseFileButtonTag)
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (uiState.isPreviewing) {
+                        CircularProgressIndicator(
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Outlined.SaveAlt,
+                            contentDescription = null
+                        )
+                    }
+                    Text(
+                        if (uiState.isPreviewing) {
+                            stringResource(R.string.settings_import_previewing)
+                        } else {
+                            stringResource(R.string.settings_import_choose_package)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkspaceImportSourceCard(
+    selectedFileName: String?,
+    preview: WorkspacePackageImportPreview
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            SectionHeader(title = stringResource(R.string.settings_import_source_section))
+            MetadataListItem(
+                label = stringResource(R.string.settings_import_source_kind),
+                value = workspaceImportSourceKindTitle(sourceKind = preview.sourceKind)
+            )
+            if (selectedFileName != null) {
+                MetadataListItem(
+                    label = stringResource(R.string.settings_import_source_title),
+                    value = selectedFileName
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkspaceImportMetadataCard(metadata: WorkspacePackageImportMetadata) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            SectionHeader(title = stringResource(R.string.settings_import_metadata_section))
+            val metadataRows: List<Pair<String, String>> = workspaceImportMetadataRows(metadata = metadata)
+            if (metadataRows.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.settings_import_metadata_empty),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                )
+            } else {
+                metadataRows.forEach { row ->
+                    MetadataListItem(
+                        label = row.first,
+                        value = row.second
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun workspaceImportMetadataRows(metadata: WorkspacePackageImportMetadata): List<Pair<String, String>> {
+    return listOfNotNull(
+        metadata.label?.trim()?.ifEmpty { null }?.let { value ->
+            stringResource(R.string.settings_import_metadata_label) to value
+        },
+        metadata.author?.trim()?.ifEmpty { null }?.let { value ->
+            stringResource(R.string.settings_import_metadata_author) to value
+        },
+        metadata.createdAt?.trim()?.ifEmpty { null }?.let { value ->
+            stringResource(R.string.settings_import_metadata_created) to value
+        },
+        metadata.sourceUrl?.trim()?.ifEmpty { null }?.let { value ->
+            stringResource(R.string.settings_import_metadata_source_url) to value
+        },
+        metadata.comment?.trim()?.ifEmpty { null }?.let { value ->
+            stringResource(R.string.settings_import_metadata_comment) to value
+        }
+    )
+}
+
+@Composable
+private fun WorkspaceImportCountsCard(preview: WorkspacePackageImportPreview) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            SectionHeader(title = stringResource(R.string.settings_import_contents_section))
+            MetadataListItem(
+                label = stringResource(R.string.settings_import_cards),
+                value = preview.cardCount.toString()
+            )
+            MetadataListItem(
+                label = stringResource(R.string.settings_import_referenced_media),
+                value = preview.referencedMediaCount.toString()
+            )
+            MetadataListItem(
+                label = stringResource(R.string.settings_import_package_media),
+                value = preview.packageMediaFileCount.toString()
+            )
+        }
+    }
+}
+
+@Composable
+private fun WorkspaceImportOptionsCard(
+    preview: WorkspacePackageImportPreview,
+    addImportTag: Boolean,
+    removedTags: Set<String>,
+    isBusy: Boolean,
+    onAddImportTagChange: (Boolean) -> Unit,
+    onToggleTag: (String) -> Unit
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            SectionHeader(title = stringResource(R.string.settings_import_options_section))
+            ToggleListItem(
+                title = stringResource(R.string.settings_import_add_import_tag),
+                supportingText = stringResource(R.string.settings_import_add_import_tag_body),
+                checked = addImportTag,
+                enabled = isBusy.not(),
+                testTag = workspaceImportAddImportTagToggleTag,
+                onCheckedChange = onAddImportTagChange
+            )
+            if (addImportTag) {
+                MetadataListItem(
+                    label = stringResource(R.string.settings_import_import_tag),
+                    value = preview.defaultOptions.suggestedImportTag
+                )
+            }
+            makeWorkspaceImportTagOptions(
+                preview = preview,
+                removedTags = removedTags
+            ).forEach { tagOption ->
+                ToggleListItem(
+                    title = stringResource(R.string.settings_import_keep_tag, tagOption.tag),
+                    supportingText = pluralStringResource(
+                        R.plurals.settings_tag_cards_count,
+                        tagOption.cardsCount,
+                        tagOption.cardsCount
+                    ),
+                    checked = tagOption.isKept,
+                    enabled = isBusy.not(),
+                    testTag = workspaceImportTagToggleTag(tag = tagOption.tag),
+                    onCheckedChange = {
+                        onToggleTag(tagOption.tag)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkspaceImportWarningsCard(warnings: List<WorkspacePackageImportWarning>) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(20.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.settings_import_warnings_section),
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (warnings.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.settings_import_warnings_empty),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                warnings.forEach { warning ->
+                    Text(
+                        text = workspaceImportWarningMessage(warning = warning),
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkspaceImportConfirmButton(
+    uiState: WorkspaceImportUiState,
+    onConfirmImport: () -> Unit
+) {
+    Button(
+        onClick = onConfirmImport,
+        enabled = uiState.canConfirmImport,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(tag = workspaceImportConfirmButtonTag)
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (uiState.isImporting) {
+                CircularProgressIndicator(
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            Text(
+                if (uiState.isImporting) {
+                    stringResource(R.string.settings_import_importing)
+                } else {
+                    stringResource(R.string.settings_import_confirm_button)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ToggleListItem(
+    title: String,
+    supportingText: String,
+    checked: Boolean,
+    enabled: Boolean,
+    testTag: String,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    ListItem(
+        headlineContent = {
+            Text(title)
+        },
+        supportingContent = {
+            Text(supportingText)
+        },
+        trailingContent = {
+            Switch(
+                checked = checked,
+                enabled = enabled,
+                onCheckedChange = onCheckedChange,
+                modifier = Modifier.testTag(tag = testTag)
+            )
+        },
+        modifier = Modifier.clickable(enabled = enabled) {
+            onCheckedChange(checked.not())
+        }
+    )
+}
+
+@Composable
+private fun MetadataListItem(
+    label: String,
+    value: String
+) {
+    ListItem(
+        headlineContent = {
+            Text(label)
+        },
+        supportingContent = {
+            Text(value)
+        }
+    )
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+    )
+}
+
+@Composable
+private fun workspaceImportSourceKindTitle(sourceKind: WorkspacePackageImportSourceKind): String {
+    return when (sourceKind) {
+        WorkspacePackageImportSourceKind.ZIP -> stringResource(R.string.settings_import_source_zip)
+    }
+}
+
+@Composable
+private fun workspaceImportWarningMessage(warning: WorkspacePackageImportWarning): String {
+    if (warning.mediaPath.isEmpty()) {
+        return warning.message
+    }
+    return stringResource(R.string.settings_import_warning_with_path, warning.mediaPath, warning.message)
+}

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -454,6 +454,16 @@
     <string name="settings_export_csv_header_back">backText</string>
     <string name="settings_export_csv_header_tags">tags</string>
 
+    <string name="settings_import_title">Import</string>
+    <string name="settings_import_zip_summary">Import a Flashcards ZIP package</string>
+    <string name="settings_import_package_section">Package</string>
+    <string name="settings_import_package_body">Choose a portable Flashcards ZIP package to preview before importing.</string>
+    <string name="settings_import_choose_package">Choose ZIP package</string>
+    <string name="settings_import_previewing">Previewing...</string>
+    <string name="settings_import_importing">Importing...</string>
+    <string name="settings_import_confirm_button">Import package</string>
+    <string name="settings_import_dismiss_error">Dismiss error</string>
+    <string name="settings_import_selected_file">File: %1$s</string>
     <string name="settings_import_cloud_required">Media ZIP import requires a linked cloud workspace in this version.</string>
     <string name="settings_import_workspace_unavailable">Workspace is unavailable. Reload the current workspace and try again.</string>
     <string name="settings_import_invalid_file">Choose a Flashcards ZIP package.</string>
@@ -465,6 +475,29 @@
     <string name="settings_import_confirm_failed">Package import failed.</string>
     <string name="settings_import_preview_required">Preview a package before importing.</string>
     <string name="settings_import_missing_import_tag">Package preview did not include an import tag.</string>
+    <string name="settings_import_source_section">Source</string>
+    <string name="settings_import_source_kind">Type</string>
+    <string name="settings_import_source_title">Title</string>
+    <string name="settings_import_source_zip">ZIP package</string>
+    <string name="settings_import_metadata_section">Metadata</string>
+    <string name="settings_import_metadata_label">Label</string>
+    <string name="settings_import_metadata_author">Author</string>
+    <string name="settings_import_metadata_created">Created</string>
+    <string name="settings_import_metadata_source_url">Source URL</string>
+    <string name="settings_import_metadata_comment">Comment</string>
+    <string name="settings_import_metadata_empty">No package metadata.</string>
+    <string name="settings_import_contents_section">Contents</string>
+    <string name="settings_import_cards">Cards</string>
+    <string name="settings_import_referenced_media">Referenced media</string>
+    <string name="settings_import_package_media">Package media files</string>
+    <string name="settings_import_options_section">Options</string>
+    <string name="settings_import_add_import_tag">Add import tag</string>
+    <string name="settings_import_add_import_tag_body">Adds a unique import tag to this package import.</string>
+    <string name="settings_import_import_tag">Import tag</string>
+    <string name="settings_import_keep_tag">Keep %1$s</string>
+    <string name="settings_import_warnings_section">Warnings</string>
+    <string name="settings_import_warnings_empty">No warnings.</string>
+    <string name="settings_import_warning_with_path">%1$s: %2$s</string>
 
     <string name="settings_device_title">Device</string>
     <string name="settings_device_workspace_name_label">Workspace name</string>


### PR DESCRIPTION
## Summary
- Add Settings import row, destination, and Android navigation for ZIP package import
- Add Material 3 import screen using the merged WorkspaceImportViewModel/support APIs
- Add document picker integration, preview metadata/counts/warnings, tag toggles, import-tag toggle, confirm states, strings, and stable test tags
- Add narrow app route coverage for disconnected/cloud-required import state

## Validation
- git --no-pager diff --check
- xmllint --noout apps/android/feature/settings/src/main/res/values/strings.xml
- modified/untracked Kotlin/XML whitespace scan
- worker-owned review: no P0-P4 findings, no split blocker

Gradle/tests were not run per instruction.