### PR TITLE
Add Android package export data contract

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
@@ -38,6 +38,9 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetPro
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
@@ -549,6 +552,24 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         confirmationText: String
     ): CloudWorkspaceResetProgressResult {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun previewWorkspacePackageExport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun exportWorkspacePackage(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse {
         throw UnsupportedOperationException()
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
@@ -36,6 +36,9 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetPro
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
@@ -110,6 +113,18 @@ interface CloudRemoteGateway {
         workspaceId: String,
         confirmationText: String
     ): CloudWorkspaceResetProgressResult
+    suspend fun previewWorkspacePackageExport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview
+    suspend fun exportWorkspacePackage(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse
     suspend fun previewWorkspacePackageImport(
         apiBaseUrl: String,
         authorizationHeader: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
@@ -49,6 +49,9 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetPro
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
@@ -273,6 +276,34 @@ class CloudRemoteService private constructor(
             bearerToken = bearerToken,
             workspaceId = workspaceId,
             confirmationText = confirmationText
+        )
+    }
+
+    override suspend fun previewWorkspacePackageExport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview {
+        return workspacePackageApi.previewWorkspacePackageExport(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            request = request
+        )
+    }
+
+    override suspend fun exportWorkspacePackage(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse {
+        return workspacePackageApi.exportWorkspacePackage(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            request = request
         )
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
@@ -150,6 +150,20 @@ private val expectedCloudHttpFailureCodes: Set<String> = setOf(
     "WORKSPACE_ID_REQUIRED",
     "WORKSPACE_NOT_FOUND",
     "WORKSPACE_OWNER_REQUIRED",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_CARD_NOT_FOUND",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_INPUT_INVALID",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_ASSET_ID_INVALID",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_ASSET_UNAVAILABLE",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_MEDIA_FILE_COUNT_TOO_LARGE",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_SELECTION_TOO_LARGE",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_SINGLE_MEDIA_TOO_LARGE",
+    "WORKSPACE_PACKAGE_EXPORT_PACKAGE_TOTAL_MEDIA_TOO_LARGE",
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_CARD_NOT_FOUND",
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_INPUT_INVALID",
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_MEDIA_ASSET_ID_INVALID",
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_MEDIA_ASSET_UNAVAILABLE",
+    "WORKSPACE_PACKAGE_EXPORT_PREVIEW_SELECTION_TOO_LARGE",
+    "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID",
     "WORKSPACE_PACKAGE_IMPORT_CONTENT_TYPE_UNSUPPORTED",
     "WORKSPACE_PACKAGE_IMPORT_FILE_EMPTY",
     "WORKSPACE_PACKAGE_IMPORT_FILE_REQUIRED",
@@ -202,6 +216,12 @@ internal data class CloudHttpObservationVersions(
     val appVersion: String?,
     val clientVersion: String?,
     val versionCode: Int?
+)
+
+internal data class CloudBinaryHttpResponse(
+    val bodyBytes: ByteArray,
+    val contentType: String?,
+    val contentDisposition: String?
 )
 
 internal object NoopCloudHttpObservability : AppObservability {
@@ -295,6 +315,38 @@ internal class CloudJsonHttpClient(
             method = CloudHttpMethod.POST,
             authorizationHeader = authorizationHeader,
             body = body
+        )
+    }
+
+    suspend fun postJsonForBytes(
+        baseUrl: String,
+        path: String,
+        authorizationHeader: String?,
+        body: JSONObject,
+        acceptHeader: String
+    ): CloudBinaryHttpResponse {
+        require(acceptHeader.isNotBlank()) {
+            "Cloud binary request Accept header must not be blank."
+        }
+        return executeBuiltBytesRequest(
+            request = buildCloudRequest(
+                baseUrl = baseUrl,
+                path = path,
+                method = CloudHttpMethod.POST,
+                authorizationHeader = authorizationHeader,
+                requestBody = buildJsonRequestBody(method = CloudHttpMethod.POST, body = body),
+                contentTypeHeader = "application/json"
+            )
+                .newBuilder()
+                .header("Accept", acceptHeader)
+                .build(),
+            path = path,
+            method = CloudHttpMethod.POST,
+            retryEligible = isTransientCloudHttpRetryEligible(
+                path = path,
+                method = CloudHttpMethod.POST,
+                body = body
+            )
         )
     }
 
@@ -577,6 +629,164 @@ internal class CloudJsonHttpClient(
         completedResponse ?: throw IllegalStateException("Cloud request retry loop exited without a response.")
     }
 
+    @OptIn(InternalCoroutinesApi::class)
+    private suspend fun executeBuiltBytesRequest(
+        request: Request,
+        path: String,
+        method: CloudHttpMethod,
+        retryEligible: Boolean
+    ): CloudBinaryHttpResponse = withContext(Dispatchers.IO) {
+        var attemptNumber = 1
+        var completedResponse: CloudBinaryHttpResponse? = null
+
+        while (completedResponse == null) {
+            val call = httpClient.newCall(request)
+            val coroutineJob = currentCoroutineContext().job
+            val cancellationRequested = AtomicBoolean(false)
+            val cancellationHandle = coroutineJob.invokeOnCompletion(
+                onCancelling = true,
+                invokeImmediately = true
+            ) { cause ->
+                if (cause != null) {
+                    cancellationRequested.set(true)
+                    call.cancel()
+                }
+            }
+            var retryDelayMs: Long? = null
+            var successfulResponse: CloudBinaryHttpResponse? = null
+
+            try {
+                call.awaitOkHttpResponse().use { response ->
+                    val statusCode = response.code
+                    val requestId = readCloudResponseRequestId(response = response)
+                    val responseContentType = response.body.contentType()
+                        ?.toString()
+                        ?.trim()
+                        ?.ifEmpty { null }
+                    val responseContentDisposition = response.header("Content-Disposition")
+                        ?.trim()
+                        ?.ifEmpty { null }
+                    val responseBodyBytes = readCloudResponseBytes(response = response)
+                    if (response.isSuccessful.not()) {
+                        val responseBody = String(responseBodyBytes, StandardCharsets.UTF_8)
+                        val parsedError = parseCloudErrorPayloadWithHeaderRequestId(
+                            responseBody = responseBody,
+                            requestId = requestId
+                        )
+                        if (
+                            shouldRetryTransientCloudHttpResponse(
+                                retryEligible = retryEligible,
+                                statusCode = statusCode,
+                                attemptNumber = attemptNumber
+                            )
+                        ) {
+                            val delayMs = calculateCloudHttpTransientRetryDelayMs(attemptNumber)
+                            captureCloudHttpTransientRetryObservation(
+                                observability = observability,
+                                observationVersions = observationVersions,
+                                request = request,
+                                path = path,
+                                method = method.requestMethod,
+                                requestId = parsedError?.requestId,
+                                statusCode = statusCode,
+                                code = parsedError?.code,
+                                stage = cloudHttpRetryHttpResponseStage,
+                                attemptNumber = attemptNumber,
+                                delayMs = delayMs
+                            )
+                            retryDelayMs = delayMs
+                        } else {
+                            val androidObservationAlreadyCaptured = captureCloudHttpFailureObservation(
+                                observability = observability,
+                                observationVersions = observationVersions,
+                                request = request,
+                                path = path,
+                                method = method.requestMethod,
+                                requestId = parsedError?.requestId,
+                                statusCode = statusCode,
+                                code = parsedError?.code,
+                                syncConflict = parsedError?.syncConflict
+                            )
+                            throw CloudRemoteException(
+                                message = formatCloudRemoteErrorMessage(
+                                    parsedError = parsedError,
+                                    responseBody = responseBody,
+                                    responseMetadata = CloudErrorResponseMetadata(
+                                        statusCode = statusCode,
+                                        path = cloudObservationEndpointName(path = path),
+                                        requestId = parsedError?.requestId,
+                                        responseBodyLengthBytes = responseBodyBytes.size,
+                                        responseContentType = responseContentType
+                                    )
+                                ),
+                                statusCode = statusCode,
+                                responseBody = responseBody,
+                                errorCode = parsedError?.code,
+                                requestId = parsedError?.requestId,
+                                syncConflict = parsedError?.syncConflict,
+                                androidObservationAlreadyCaptured = androidObservationAlreadyCaptured
+                            )
+                        }
+                    } else {
+                        successfulResponse = CloudBinaryHttpResponse(
+                            bodyBytes = responseBodyBytes,
+                            contentType = responseContentType,
+                            contentDisposition = responseContentDisposition
+                        )
+                    }
+                }
+            } catch (error: IOException) {
+                if (cancellationRequested.get() || coroutineJob.isCancelled) {
+                    throw cancellationException(
+                        message = "Cloud request was cancelled.",
+                        cause = error
+                    )
+                }
+                if (
+                    shouldRetryTransientCloudIOException(
+                        retryEligible = retryEligible,
+                        attemptNumber = attemptNumber
+                    )
+                ) {
+                    val delayMs = calculateCloudHttpTransientRetryDelayMs(attemptNumber)
+                    captureCloudHttpTransientRetryObservation(
+                        observability = observability,
+                        observationVersions = observationVersions,
+                        request = request,
+                        path = path,
+                        method = method.requestMethod,
+                        requestId = null,
+                        statusCode = null,
+                        code = null,
+                        stage = cloudHttpRetryIoExceptionStage,
+                        attemptNumber = attemptNumber,
+                        delayMs = delayMs
+                    )
+                    retryDelayMs = delayMs
+                } else {
+                    throw error
+                }
+            } finally {
+                cancellationHandle.dispose()
+            }
+
+            val attemptResponse = successfulResponse
+            completedResponse = attemptResponse
+
+            if (attemptResponse == null) {
+                val delayMs = retryDelayMs
+                if (delayMs != null) {
+                    delay(delayMs)
+                    attemptNumber += 1
+                    continue
+                }
+
+                throw IllegalStateException("Cloud binary request attempt finished without a response or retry decision.")
+            }
+        }
+        completedResponse ?: throw IllegalStateException("Cloud binary request retry loop exited without a response.")
+    }
+
     private fun buildCloudRequest(
         baseUrl: String,
         path: String,
@@ -622,6 +832,10 @@ internal class CloudJsonHttpClient(
             reader.readText()
         }
     }
+
+    private fun readCloudResponseBytes(response: Response): ByteArray {
+        return response.body.bytes()
+    }
 }
 
 private fun readCloudResponseRequestId(response: Response): String? {
@@ -651,6 +865,8 @@ private fun isTransientCloudHttpRetryEligible(
         pathOnly.endsWith(suffix = "/sync/pull") -> true
         pathOnly.endsWith(suffix = "/sync/review-history/pull") -> true
         pathOnly.endsWith(suffix = "/sync/bootstrap") -> body?.optString("mode") == "pull"
+        pathOnly.endsWith(suffix = "/packages/export/preview") -> true
+        pathOnly.endsWith(suffix = "/packages/export") -> true
         else -> false
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
@@ -92,6 +92,20 @@ internal fun buildWorkspacePackageImportCloudPath(workspaceId: String): String {
     return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}/packages/import"
 }
 
+internal fun buildWorkspacePackageExportPreviewCloudPath(workspaceId: String): String {
+    require(workspaceId.isNotBlank()) {
+        "Workspace package export preview path requires a workspace id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}/packages/export/preview"
+}
+
+internal fun buildWorkspacePackageExportCloudPath(workspaceId: String): String {
+    require(workspaceId.isNotBlank()) {
+        "Workspace package export path requires a workspace id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}/packages/export"
+}
+
 private fun encodeCloudQueryValue(value: String): String {
     return URLEncoder.encode(value, StandardCharsets.UTF_8)
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/workspace/CloudWorkspacePackageRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/workspace/CloudWorkspacePackageRemoteApi.kt
@@ -1,17 +1,31 @@
 package com.flashcardsopensourceapp.data.local.cloud.remote.workspace
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudBinaryHttpResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildWorkspacePackageExportCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildWorkspacePackageExportPreviewCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildWorkspacePackageImportCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildWorkspacePackageImportPreviewCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
+import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull
+import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableString
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudLong
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableString
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudObject
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
 import com.flashcardsopensourceapp.data.local.cloud.wire.toCloudStringList
 import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDefaultPackageMetadata
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportMetadataInput
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportSelection
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagCount
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagPolicyInput
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmSummary
@@ -23,13 +37,53 @@ import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageIm
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportWarning
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.Locale
 
+private const val workspacePackageExportContentType: String = "application/zip"
+private const val workspacePackageExportFilenameFieldPath: String = "workspacePackageExport.fileName"
 private const val workspacePackageImportFileFieldName: String = "file"
 private const val workspacePackageImportOptionsFieldName: String = "options"
 
 internal class CloudWorkspacePackageRemoteApi(
     private val httpClient: CloudJsonHttpClient
 ) {
+    suspend fun previewWorkspacePackageExport(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview {
+        val response = httpClient.postJson(
+            baseUrl = apiBaseUrl,
+            path = buildWorkspacePackageExportPreviewCloudPath(workspaceId = workspaceId),
+            authorizationHeader = authorizationHeader,
+            body = buildWorkspacePackageExportRequestBody(request = request)
+        )
+        return parseWorkspacePackageExportPreviewResponse(
+            response = response,
+            fieldPath = "workspacePackageExportPreview"
+        )
+    }
+
+    suspend fun exportWorkspacePackage(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse {
+        val response = httpClient.postJsonForBytes(
+            baseUrl = apiBaseUrl,
+            path = buildWorkspacePackageExportCloudPath(workspaceId = workspaceId),
+            authorizationHeader = authorizationHeader,
+            body = buildWorkspacePackageExportRequestBody(request = request),
+            acceptHeader = workspacePackageExportContentType
+        )
+        return parseWorkspacePackageExportDownloadResponse(
+            response = response,
+            fieldPath = "workspacePackageExport"
+        )
+    }
+
     suspend fun previewWorkspacePackageImport(
         apiBaseUrl: String,
         authorizationHeader: String,
@@ -77,6 +131,232 @@ internal class CloudWorkspacePackageRemoteApi(
             )
         )
     }
+}
+
+internal fun buildWorkspacePackageExportRequestBody(request: WorkspacePackageExportRequest): JSONObject {
+    return JSONObject()
+        .put("selection", buildWorkspacePackageExportSelection(selection = request.selection))
+        .put("tagPolicy", buildWorkspacePackageExportTagPolicy(tagPolicy = request.tagPolicy))
+        .put("packageMetadata", buildWorkspacePackageExportMetadata(metadata = request.packageMetadata))
+}
+
+private fun buildWorkspacePackageExportSelection(selection: WorkspacePackageExportSelection): JSONObject {
+    return when (selection) {
+        WorkspacePackageExportSelection.AllActiveCards -> JSONObject()
+            .put("kind", "allActiveCards")
+
+        is WorkspacePackageExportSelection.TagFilters -> JSONObject()
+            .put("kind", "tagFilters")
+            .put("includeTags", JSONArray(selection.includeTags))
+            .put("excludeTags", JSONArray(selection.excludeTags))
+
+        is WorkspacePackageExportSelection.ExplicitCardIds -> JSONObject()
+            .put("kind", "explicitCardIds")
+            .put("cardIds", JSONArray(selection.cardIds))
+    }
+}
+
+private fun buildWorkspacePackageExportTagPolicy(
+    tagPolicy: WorkspacePackageExportTagPolicyInput
+): JSONObject {
+    return JSONObject()
+        .put("additionalRemovedTags", JSONArray(tagPolicy.additionalRemovedTags))
+}
+
+private fun buildWorkspacePackageExportMetadata(metadata: WorkspacePackageExportMetadataInput): JSONObject {
+    return JSONObject()
+        .putNullableString("label", metadata.label)
+        .putNullableString("author", metadata.author)
+        .putNullableString("comment", metadata.comment)
+        .putNullableString("createdAt", metadata.createdAt)
+        .putNullableString("sourceUrl", metadata.sourceUrl)
+}
+
+internal fun parseWorkspacePackageExportPreviewResponse(
+    response: JSONObject,
+    fieldPath: String
+): WorkspacePackageExportPreview {
+    val defaultPackageMetadata = response.requireCloudObject(
+        "defaultPackageMetadata",
+        "$fieldPath.defaultPackageMetadata"
+    )
+    return WorkspacePackageExportPreview(
+        selectedCardCount = response.requireWorkspacePackageExportNonNegativeInt(
+            key = "selectedCardCount",
+            fieldPath = "$fieldPath.selectedCardCount"
+        ),
+        availableTagCounts = parseWorkspacePackageExportTagCounts(
+            tagCounts = response.requireCloudArray("availableTagCounts", "$fieldPath.availableTagCounts"),
+            fieldPath = "$fieldPath.availableTagCounts"
+        ),
+        tagsSelectedForRemoval = parseWorkspacePackageExportTagCounts(
+            tagCounts = response.requireCloudArray("tagsSelectedForRemoval", "$fieldPath.tagsSelectedForRemoval"),
+            fieldPath = "$fieldPath.tagsSelectedForRemoval"
+        ),
+        referencedMediaCount = response.requireWorkspacePackageExportNonNegativeInt(
+            key = "referencedMediaCount",
+            fieldPath = "$fieldPath.referencedMediaCount"
+        ),
+        approximateReferencedMediaBytes = response.requireWorkspacePackageExportNonNegativeLong(
+            key = "approximateReferencedMediaBytes",
+            fieldPath = "$fieldPath.approximateReferencedMediaBytes"
+        ),
+        defaultPackageMetadata = WorkspacePackageExportDefaultPackageMetadata(
+            label = defaultPackageMetadata.requireCloudString(
+                "label",
+                "$fieldPath.defaultPackageMetadata.label"
+            ),
+            author = defaultPackageMetadata.optCloudStringOrNull(
+                "author",
+                "$fieldPath.defaultPackageMetadata.author"
+            ),
+            comment = defaultPackageMetadata.optCloudStringOrNull(
+                "comment",
+                "$fieldPath.defaultPackageMetadata.comment"
+            ),
+            createdAt = defaultPackageMetadata.requireCloudString(
+                "createdAt",
+                "$fieldPath.defaultPackageMetadata.createdAt"
+            ),
+            sourceUrl = defaultPackageMetadata.optCloudStringOrNull(
+                "sourceUrl",
+                "$fieldPath.defaultPackageMetadata.sourceUrl"
+            )
+        )
+    )
+}
+
+internal fun parseWorkspacePackageExportDownloadResponse(
+    response: CloudBinaryHttpResponse,
+    fieldPath: String
+): WorkspacePackageExportDownloadResponse {
+    requireWorkspacePackageExportZipContentType(
+        contentType = response.contentType,
+        fieldPath = "$fieldPath.contentType"
+    )
+    return WorkspacePackageExportDownloadResponse(
+        packageBytes = response.bodyBytes,
+        fileName = parseWorkspacePackageExportContentDispositionFileName(
+            contentDisposition = response.contentDisposition,
+            fieldPath = workspacePackageExportFilenameFieldPath
+        ),
+        contentType = response.contentType ?: throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath.contentType: expected application/zip, got missing header"
+        )
+    )
+}
+
+private fun parseWorkspacePackageExportTagCounts(
+    tagCounts: JSONArray,
+    fieldPath: String
+): List<WorkspacePackageExportTagCount> {
+    return buildList {
+        for (index in 0 until tagCounts.length()) {
+            val tagCount = tagCounts.requireCloudObject(index = index, fieldPath = "$fieldPath[$index]")
+            add(
+                WorkspacePackageExportTagCount(
+                    tag = tagCount.requireCloudString("tag", "$fieldPath[$index].tag"),
+                    cardsCount = tagCount.requireWorkspacePackageExportNonNegativeInt(
+                        key = "cardsCount",
+                        fieldPath = "$fieldPath[$index].cardsCount"
+                    )
+                )
+            )
+        }
+    }
+}
+
+private fun JSONObject.requireWorkspacePackageExportNonNegativeInt(
+    key: String,
+    fieldPath: String
+): Int {
+    val value = requireCloudInt(key = key, fieldPath = fieldPath)
+    if (value < 0) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected non-negative integer, got $value"
+        )
+    }
+    return value
+}
+
+private fun JSONObject.requireWorkspacePackageExportNonNegativeLong(
+    key: String,
+    fieldPath: String
+): Long {
+    val value = requireCloudLong(key = key, fieldPath = fieldPath)
+    if (value < 0L) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected non-negative integer, got $value"
+        )
+    }
+    return value
+}
+
+private fun requireWorkspacePackageExportZipContentType(
+    contentType: String?,
+    fieldPath: String
+) {
+    val normalizedContentType = contentType
+        ?.substringBefore(delimiter = ";")
+        ?.trim()
+        ?.lowercase(Locale.US)
+    if (normalizedContentType != workspacePackageExportContentType) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected application/zip, got ${contentType ?: "missing header"}"
+        )
+    }
+}
+
+private fun parseWorkspacePackageExportContentDispositionFileName(
+    contentDisposition: String?,
+    fieldPath: String
+): String {
+    if (contentDisposition.isNullOrBlank()) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected Content-Disposition filename, got missing header"
+        )
+    }
+
+    for (parameter in contentDisposition.split(";").drop(1)) {
+        val separatorIndex = parameter.indexOf("=")
+        if (separatorIndex < 0) {
+            continue
+        }
+        val key = parameter.substring(startIndex = 0, endIndex = separatorIndex).trim().lowercase(Locale.US)
+        if (key != "filename") {
+            continue
+        }
+        val rawFileName = parameter.substring(startIndex = separatorIndex + 1)
+        val fileName = unquoteWorkspacePackageExportContentDispositionValue(value = rawFileName.trim()).trim()
+        if (workspacePackageExportFileNameIsSafe(fileName = fileName)) {
+            return fileName
+        }
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected safe filename, got invalid string \"$fileName\""
+        )
+    }
+
+    throw CloudContractMismatchException(
+        "Cloud contract mismatch for $fieldPath: expected Content-Disposition filename, got missing parameter"
+    )
+}
+
+private fun unquoteWorkspacePackageExportContentDispositionValue(value: String): String {
+    if (value.length < 2 || value.startsWith("\"").not() || value.endsWith("\"").not()) {
+        return value
+    }
+
+    return value.drop(1)
+        .dropLast(1)
+        .replace(oldValue = "\\\"", newValue = "\"")
+        .replace(oldValue = "\\\\", newValue = "\\")
+}
+
+private fun workspacePackageExportFileNameIsSafe(fileName: String): Boolean {
+    return fileName.isNotBlank() &&
+        fileName.contains("/") == false &&
+        fileName.contains("\\") == false &&
+        fileName.any { character -> character.code < 32 || character.code == 127 } == false
 }
 
 private fun encodeWorkspacePackageImportConfirmOptions(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/workspace/WorkspacePackageExportModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/workspace/WorkspacePackageExportModels.kt
@@ -1,0 +1,66 @@
+package com.flashcardsopensourceapp.data.local.model.workspace
+
+const val workspacePackageExportGeneratedImportTagPrefix: String = "import:"
+
+sealed interface WorkspacePackageExportSelection {
+    data object AllActiveCards : WorkspacePackageExportSelection
+
+    data class TagFilters(
+        val includeTags: List<String>,
+        val excludeTags: List<String>
+    ) : WorkspacePackageExportSelection
+
+    data class ExplicitCardIds(
+        val cardIds: List<String>
+    ) : WorkspacePackageExportSelection
+}
+
+data class WorkspacePackageExportTagPolicyInput(
+    val additionalRemovedTags: List<String>
+)
+
+data class WorkspacePackageExportMetadataInput(
+    val label: String?,
+    val author: String?,
+    val comment: String?,
+    val createdAt: String?,
+    val sourceUrl: String?
+)
+
+data class WorkspacePackageExportRequest(
+    val selection: WorkspacePackageExportSelection,
+    val tagPolicy: WorkspacePackageExportTagPolicyInput,
+    val packageMetadata: WorkspacePackageExportMetadataInput
+)
+
+data class WorkspacePackageExportTagCount(
+    val tag: String,
+    val cardsCount: Int
+)
+
+data class WorkspacePackageExportDefaultPackageMetadata(
+    val label: String,
+    val author: String?,
+    val comment: String?,
+    val createdAt: String,
+    val sourceUrl: String?
+)
+
+data class WorkspacePackageExportPreview(
+    val selectedCardCount: Int,
+    val availableTagCounts: List<WorkspacePackageExportTagCount>,
+    val tagsSelectedForRemoval: List<WorkspacePackageExportTagCount>,
+    val referencedMediaCount: Int,
+    val approximateReferencedMediaBytes: Long,
+    val defaultPackageMetadata: WorkspacePackageExportDefaultPackageMetadata
+)
+
+data class WorkspacePackageExportDownloadResponse(
+    val packageBytes: ByteArray,
+    val fileName: String,
+    val contentType: String
+)
+
+fun isWorkspacePackageExportGeneratedImportTag(tag: String): Boolean {
+    return tag.startsWith(prefix = workspacePackageExportGeneratedImportTagPrefix)
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -63,6 +63,9 @@ import com.flashcardsopensourceapp.data.local.model.review.ReviewTimelinePage
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceOverviewSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
@@ -205,6 +208,12 @@ interface CloudAccountRepository {
     suspend fun deleteCurrentWorkspace(confirmationText: String): CloudWorkspaceDeleteResult
     suspend fun loadCurrentWorkspaceResetProgressPreview(): CloudWorkspaceResetProgressPreview
     suspend fun resetCurrentWorkspaceProgress(confirmationText: String): CloudWorkspaceResetProgressResult
+    suspend fun previewCurrentWorkspacePackageExport(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview
+    suspend fun exportCurrentWorkspacePackage(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse
     suspend fun previewCurrentWorkspacePackageImport(packageBytes: ByteArray): WorkspacePackageImportPreview
     suspend fun confirmCurrentWorkspacePackageImport(
         fileName: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepository.kt
@@ -34,6 +34,9 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreak
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.sync.AccountPreferences
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
@@ -278,6 +281,18 @@ class LocalCloudAccountRepository(
         confirmationText: String
     ): CloudWorkspaceResetProgressResult {
         return workspaceOperationsCoordinator.resetCurrentWorkspaceProgress(confirmationText = confirmationText)
+    }
+
+    override suspend fun previewCurrentWorkspacePackageExport(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview {
+        return workspaceOperationsCoordinator.previewCurrentWorkspacePackageExport(request = request)
+    }
+
+    override suspend fun exportCurrentWorkspacePackage(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse {
+        return workspaceOperationsCoordinator.exportCurrentWorkspacePackage(request = request)
     }
 
     override suspend fun previewCurrentWorkspacePackageImport(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudWorkspaceOperationsCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudWorkspaceOperationsCoordinator.kt
@@ -12,6 +12,9 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceDeleteRe
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressPreview
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
@@ -158,6 +161,56 @@ internal class CloudWorkspaceOperationsCoordinator(
                 cloudSettings = cloudSettings
             )
             result
+        }
+    }
+
+    suspend fun previewCurrentWorkspacePackageExport(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview {
+        return operationCoordinator.runExclusive {
+            val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+            require(cloudSettings.cloudState == CloudAccountState.LINKED) {
+                "Workspace package export is available only for linked cloud workspaces."
+            }
+            val authenticatedSession: AuthenticatedCloudSession = sessionProvider.authenticatedSession()
+            val workspaceId: String = requireCurrentWorkspace(
+                database = database,
+                preferencesStore = preferencesStore,
+                missingWorkspaceMessage = "Workspace package export requires a current local workspace."
+            ).workspaceId
+            runLinkedWorkspaceSync(
+                authenticatedSession = authenticatedSession,
+                workspaceId = workspaceId,
+                cloudSettings = cloudSettings
+            )
+            remoteService.previewWorkspacePackageExport(
+                apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
+                authorizationHeader = "Bearer ${authenticatedSession.credentials.idToken}",
+                workspaceId = workspaceId,
+                request = request
+            )
+        }
+    }
+
+    suspend fun exportCurrentWorkspacePackage(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse {
+        return operationCoordinator.runExclusive {
+            require(preferencesStore.currentCloudSettings().cloudState == CloudAccountState.LINKED) {
+                "Workspace package export is available only for linked cloud workspaces."
+            }
+            val authenticatedSession: AuthenticatedCloudSession = sessionProvider.authenticatedSession()
+            val workspaceId: String = requireCurrentWorkspace(
+                database = database,
+                preferencesStore = preferencesStore,
+                missingWorkspaceMessage = "Workspace package export requires a current local workspace."
+            ).workspaceId
+            remoteService.exportWorkspacePackage(
+                apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
+                authorizationHeader = "Bearer ${authenticatedSession.credentials.idToken}",
+                workspaceId = workspaceId,
+                request = request
+            )
         }
     }
 

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -11,7 +11,11 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudPr
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSummaryResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.parseRemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudBinaryHttpResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.parseCloudErrorPayload
+import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.buildWorkspacePackageExportRequestBody
+import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.parseWorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.parseWorkspacePackageExportPreviewResponse
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudFriendInvitationCreateRequest
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
@@ -22,7 +26,12 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreak
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportMetadataInput
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportSelection
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagPolicyInput
 import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -76,6 +85,130 @@ class CloudRemoteServiceTest {
 
         assertEquals("https://app.flashcards-open-source-app.com/invite/raw-token", invitation.inviteUrl)
         assertEquals("2026-06-17T10:00:00.000Z", invitation.expiresAt)
+    }
+
+    @Test
+    fun buildWorkspacePackageExportRequestBodyEncodesTagFiltersAndMetadata() {
+        val request = WorkspacePackageExportRequest(
+            selection = WorkspacePackageExportSelection.TagFilters(
+                includeTags = listOf("spanish", "verbs"),
+                excludeTags = listOf("archived")
+            ),
+            tagPolicy = WorkspacePackageExportTagPolicyInput(
+                additionalRemovedTags = listOf("remove-me")
+            ),
+            packageMetadata = WorkspacePackageExportMetadataInput(
+                label = "Spanish verbs",
+                author = null,
+                comment = "Practice deck",
+                createdAt = "2026-06-30T10:00:00.000Z",
+                sourceUrl = null
+            )
+        )
+
+        val body = buildWorkspacePackageExportRequestBody(request = request)
+
+        val selection = body.getJSONObject("selection")
+        assertEquals("tagFilters", selection.getString("kind"))
+        assertEquals("spanish", selection.getJSONArray("includeTags").getString(0))
+        assertEquals("verbs", selection.getJSONArray("includeTags").getString(1))
+        assertEquals("archived", selection.getJSONArray("excludeTags").getString(0))
+        assertEquals("remove-me", body.getJSONObject("tagPolicy").getJSONArray("additionalRemovedTags").getString(0))
+        val metadata = body.getJSONObject("packageMetadata")
+        assertEquals("Spanish verbs", metadata.getString("label"))
+        assertTrue(metadata.isNull("author"))
+        assertEquals("Practice deck", metadata.getString("comment"))
+        assertEquals("2026-06-30T10:00:00.000Z", metadata.getString("createdAt"))
+        assertTrue(metadata.isNull("sourceUrl"))
+    }
+
+    @Test
+    fun parseWorkspacePackageExportPreviewResponseReadsCountsAndMetadata() {
+        val response = JSONObject(
+            """
+            {
+              "selectedCardCount": 2,
+              "availableTagCounts": [
+                { "tag": "import:2026-06-30", "cardsCount": 2 },
+                { "tag": "spanish", "cardsCount": 1 }
+              ],
+              "tagsSelectedForRemoval": [
+                { "tag": "import:2026-06-30", "cardsCount": 2 }
+              ],
+              "referencedMediaCount": 3,
+              "approximateReferencedMediaBytes": 1234567890123,
+              "defaultPackageMetadata": {
+                "label": "Workspace export",
+                "author": "Kirill",
+                "createdAt": "2026-06-30T10:00:00.000Z",
+                "sourceUrl": "https://flashcards-open-source-app.com"
+              }
+            }
+            """.trimIndent()
+        )
+
+        val preview = parseWorkspacePackageExportPreviewResponse(
+            response = response,
+            fieldPath = "workspacePackageExportPreview"
+        )
+
+        assertEquals(2, preview.selectedCardCount)
+        assertEquals("import:2026-06-30", preview.availableTagCounts[0].tag)
+        assertEquals(2, preview.availableTagCounts[0].cardsCount)
+        assertEquals("spanish", preview.availableTagCounts[1].tag)
+        assertEquals("import:2026-06-30", preview.tagsSelectedForRemoval.single().tag)
+        assertEquals(3, preview.referencedMediaCount)
+        assertEquals(1234567890123L, preview.approximateReferencedMediaBytes)
+        assertEquals("Workspace export", preview.defaultPackageMetadata.label)
+        assertEquals("Kirill", preview.defaultPackageMetadata.author)
+        assertEquals(null, preview.defaultPackageMetadata.comment)
+        assertEquals("2026-06-30T10:00:00.000Z", preview.defaultPackageMetadata.createdAt)
+        assertEquals("https://flashcards-open-source-app.com", preview.defaultPackageMetadata.sourceUrl)
+    }
+
+    @Test
+    fun parseWorkspacePackageExportPreviewResponseRejectsNegativeCounts() {
+        val response = JSONObject(
+            """
+            {
+              "selectedCardCount": -1,
+              "availableTagCounts": [],
+              "tagsSelectedForRemoval": [],
+              "referencedMediaCount": 0,
+              "approximateReferencedMediaBytes": 0,
+              "defaultPackageMetadata": {
+                "label": "Workspace export",
+                "createdAt": "2026-06-30T10:00:00.000Z"
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertThrows(CloudContractMismatchException::class.java) {
+            parseWorkspacePackageExportPreviewResponse(
+                response = response,
+                fieldPath = "workspacePackageExportPreview"
+            )
+        }
+    }
+
+    @Test
+    fun parseWorkspacePackageExportDownloadResponseReadsZipBytesAndFilename() {
+        val bytes = byteArrayOf(0x50.toByte(), 0x4b.toByte(), 0x03.toByte(), 0x04.toByte())
+        val response = CloudBinaryHttpResponse(
+            bodyBytes = bytes,
+            contentType = "application/zip",
+            contentDisposition = "attachment; filename=\"flashcards.zip\""
+        )
+
+        val export = parseWorkspacePackageExportDownloadResponse(
+            response = response,
+            fieldPath = "workspacePackageExport"
+        )
+
+        assertArrayEquals(bytes, export.packageBytes)
+        assertEquals("flashcards.zip", export.fileName)
+        assertEquals("application/zip", export.contentType)
     }
 
     @Test

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import org.json.JSONArray
 import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -141,6 +142,112 @@ class CloudRemoteHttpClientTest {
     }
 
     @Test
+    fun postJsonForBytesSendsJsonAndReadsBinaryResponse() = runBlocking {
+        val zipBytes = byteArrayOf(0x50.toByte(), 0x4b.toByte(), 0x03.toByte(), 0x04.toByte())
+        var requestAcceptHeader: String? = null
+        var requestContentTypeHeader: String? = null
+        var requestBody: String? = null
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/workspaces/workspace-1/packages/export") { exchange ->
+            requestAcceptHeader = exchange.requestHeaders.getFirst("Accept")
+            requestContentTypeHeader = exchange.requestHeaders.getFirst("Content-Type")
+            requestBody = String(exchange.requestBody.readBytes(), StandardCharsets.UTF_8)
+            writeCloudTestBinaryResponse(
+                exchange = exchange,
+                statusCode = 200,
+                body = zipBytes,
+                headers = mapOf(
+                    "Content-Type" to "application/zip",
+                    "Content-Disposition" to "attachment; filename=\"flashcards.zip\""
+                )
+            )
+        }
+        server.start()
+
+        try {
+            val client = CloudJsonHttpClient(okHttpClient = OkHttpClient())
+            val response = client.postJsonForBytes(
+                baseUrl = "http://127.0.0.1:${server.address.port}",
+                path = "/workspaces/workspace-1/packages/export",
+                authorizationHeader = "Bearer token-1",
+                body = JSONObject()
+                    .put("selection", JSONObject().put("kind", "allActiveCards")),
+                acceptHeader = "application/zip"
+            )
+
+            assertEquals("application/zip", requestAcceptHeader)
+            assertEquals("application/json", requestContentTypeHeader)
+            assertEquals("""{"selection":{"kind":"allActiveCards"}}""", requestBody)
+            assertArrayEquals(zipBytes, response.bodyBytes)
+            assertEquals("application/zip", response.contentType)
+            assertEquals("attachment; filename=\"flashcards.zip\"", response.contentDisposition)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun postJsonForBytesRetriesPackageExportTransientGatewayTimeout() = runBlocking {
+        val requestCount = AtomicInteger(0)
+        val observability = RecordingCloudHttpObservability()
+        val zipBytes = byteArrayOf(0x50.toByte(), 0x4b.toByte())
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/workspaces/workspace-1/packages/export") { exchange ->
+            val currentRequestCount = requestCount.incrementAndGet()
+            if (currentRequestCount == 1) {
+                writeCloudTestResponse(
+                    exchange = exchange,
+                    statusCode = 504,
+                    body = "",
+                    headers = mapOf("X-Request-Id" to "request-1")
+                )
+            } else {
+                writeCloudTestBinaryResponse(
+                    exchange = exchange,
+                    statusCode = 200,
+                    body = zipBytes,
+                    headers = mapOf(
+                        "Content-Type" to "application/zip",
+                        "Content-Disposition" to "attachment; filename=\"flashcards.zip\""
+                    )
+                )
+            }
+        }
+        server.start()
+
+        try {
+            val client = CloudJsonHttpClient(
+                okHttpClient = OkHttpClient(),
+                observability = observability,
+                appVersion = testAppVersion,
+                versionCode = 123
+            )
+            val response = client.postJsonForBytes(
+                baseUrl = "http://127.0.0.1:${server.address.port}",
+                path = "/workspaces/workspace-1/packages/export",
+                authorizationHeader = null,
+                body = JSONObject()
+                    .put("selection", JSONObject().put("kind", "allActiveCards")),
+                acceptHeader = "application/zip"
+            )
+
+            assertArrayEquals(zipBytes, response.bodyBytes)
+            assertEquals(2, requestCount.get())
+            assertTrue(observability.warnings.isEmpty())
+            val retryEvent = observability.breadcrumbs.single()
+            assertTrue(retryEvent is AndroidBreadcrumbEvent.HttpTransientRetry)
+            retryEvent as AndroidBreadcrumbEvent.HttpTransientRetry
+            assertEquals("/workspaces/{workspaceId}/packages/export", retryEvent.endpointName)
+            assertEquals("POST", retryEvent.method)
+            assertEquals("request-1", retryEvent.requestId)
+            assertEquals(504, retryEvent.statusCode)
+            assertEquals("http_response", retryEvent.stage)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
     fun mediaAssetDownloadUrlFailureRedactsEndpointIds() = runBlocking {
         val observability = RecordingCloudHttpObservability()
         val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
@@ -182,6 +289,21 @@ class CloudRemoteHttpClientTest {
         } finally {
             server.stop(0)
         }
+    }
+}
+
+private fun writeCloudTestBinaryResponse(
+    exchange: HttpExchange,
+    statusCode: Int,
+    body: ByteArray,
+    headers: Map<String, String>
+) {
+    headers.forEach { (name, value) ->
+        exchange.responseHeaders.add(name, value)
+    }
+    exchange.sendResponseHeaders(statusCode, body.size.toLong())
+    exchange.responseBody.use { output ->
+        output.write(body)
     }
 }
 

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -33,6 +33,9 @@ import com.flashcardsopensourceapp.data.local.model.sync.AccountPreferences
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.model.sync.defaultAccountPreferences
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmOptions
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportConfirmResult
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageImportPreview
@@ -312,6 +315,18 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
     }
 
     override suspend fun resetCurrentWorkspaceProgress(confirmationText: String): CloudWorkspaceResetProgressResult {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun previewCurrentWorkspacePackageExport(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportPreview {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun exportCurrentWorkspacePackage(
+        request: WorkspacePackageExportRequest
+    ): WorkspacePackageExportDownloadResponse {
         throw UnsupportedOperationException()
     }
 


### PR DESCRIPTION
## Summary
- Add Android workspace package export models for preview requests, tag policy, metadata, and ZIP downloads
- Wire package export preview/download routes through Android cloud transport, remote gateway/service, and cloud account repository boundaries
- Add focused contract and transport coverage plus updated fakes for the expanded interfaces

## Validation
- Freshness gate passed before edits
- git --no-pager diff --check
- Kotlin/XML trailing whitespace and CRLF scan
- No XML touched
- No standalone Kotlin parser/linter found locally
- Worker-owned review found no P0-P4 issues and no split blocker
- Gradle/tests not run per instruction