### PR TITLE
Split workspace package route modules

### DIFF
--- a/apps/backend/src/routes/workspacePackages/export.ts
+++ b/apps/backend/src/routes/workspacePackages/export.ts
@@ -1,0 +1,244 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  exportWorkspacePackage,
+  previewWorkspacePackageExport,
+  type WorkspacePackageExportCardSelection,
+  type WorkspacePackageExportMetadataInput,
+  type WorkspacePackageExportPackage,
+  type WorkspacePackageExportPackageInput,
+  type WorkspacePackageExportPreview,
+  type WorkspacePackageExportPreviewInput,
+  type WorkspacePackageExportTagPolicyInput,
+} from "../../workspacePackages";
+import { assertUserHasWorkspaceAccess } from "../../workspaces";
+import {
+  loadRequestContextFromRequest,
+  parseWorkspaceIdParam,
+  type RequestContext,
+} from "../../server/requestContext";
+import { parseJsonBody } from "../../server/requestParsing";
+import { createBackendFailureDetails } from "../../server/logging";
+import {
+  addBackendBreadcrumb,
+  normalizeCaughtError,
+} from "../../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../../observability/reporting";
+import { HttpError } from "../../shared/errors";
+import type { AppEnv } from "../../server/app";
+import {
+  createWorkspacePackageScope,
+  getRequestContextUserId,
+  summarizeValidationDetails,
+} from "./shared";
+
+export type WorkspacePackageExportRoutesOptions = Readonly<{
+  allowedOrigins: ReadonlyArray<string>;
+  loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
+  assertUserHasWorkspaceAccessFn?: typeof assertUserHasWorkspaceAccess;
+  previewWorkspacePackageExportFn?: typeof previewWorkspacePackageExport;
+  exportWorkspacePackageFn?: typeof exportWorkspacePackage;
+}>;
+
+export type WorkspacePackageExportRouteInput = Readonly<{
+  selection: WorkspacePackageExportCardSelection;
+  tagPolicy: WorkspacePackageExportTagPolicyInput;
+  packageMetadata: WorkspacePackageExportMetadataInput;
+}>;
+
+type WorkspacePackageExportPreviewResponse = WorkspacePackageExportPreview;
+
+const allActiveCardsSelectionSchema = z.object({
+  kind: z.literal("allActiveCards"),
+});
+
+const tagFiltersSelectionSchema = z.object({
+  kind: z.literal("tagFilters"),
+  includeTags: z.array(z.string()),
+  excludeTags: z.array(z.string()),
+});
+
+const explicitCardIdsSelectionSchema = z.object({
+  kind: z.literal("explicitCardIds"),
+  cardIds: z.array(z.string()).min(1),
+});
+
+const workspacePackageExportSelectionSchema = z.discriminatedUnion("kind", [
+  allActiveCardsSelectionSchema,
+  tagFiltersSelectionSchema,
+  explicitCardIdsSelectionSchema,
+]).transform((selection): WorkspacePackageExportCardSelection => {
+  switch (selection.kind) {
+  case "allActiveCards":
+    return {
+      kind: "allActiveCards",
+    };
+  case "tagFilters":
+    return {
+      kind: "tagFilters",
+      includeTags: selection.includeTags,
+      excludeTags: selection.excludeTags,
+    };
+  case "explicitCardIds":
+    return {
+      kind: "explicitCardIds",
+      cardIds: selection.cardIds,
+    };
+  }
+});
+
+const workspacePackageExportTagPolicySchema = z.object({
+  additionalRemovedTags: z.array(z.string()),
+}).transform((tagPolicy): WorkspacePackageExportTagPolicyInput => ({
+  additionalRemovedTags: tagPolicy.additionalRemovedTags,
+}));
+
+const workspacePackageExportMetadataSchema = z.object({
+  label: z.string().nullable(),
+  author: z.string().nullable(),
+  comment: z.string().nullable(),
+  createdAt: z.string().nullable(),
+  sourceUrl: z.string().nullable(),
+}).transform((packageMetadata): WorkspacePackageExportMetadataInput => ({
+  label: packageMetadata.label,
+  author: packageMetadata.author,
+  comment: packageMetadata.comment,
+  createdAt: packageMetadata.createdAt,
+  sourceUrl: packageMetadata.sourceUrl,
+}));
+
+const workspacePackageExportRouteInputSchema = z.object({
+  selection: workspacePackageExportSelectionSchema,
+  tagPolicy: workspacePackageExportTagPolicySchema,
+  packageMetadata: workspacePackageExportMetadataSchema,
+}).transform((input): WorkspacePackageExportRouteInput => ({
+  selection: input.selection,
+  tagPolicy: input.tagPolicy,
+  packageMetadata: input.packageMetadata,
+}));
+
+export function parseWorkspacePackageExportRouteInput(value: unknown): WorkspacePackageExportRouteInput {
+  const parsedInput = workspacePackageExportRouteInputSchema.safeParse(value);
+  if (parsedInput.success) {
+    return parsedInput.data;
+  }
+
+  throw new HttpError(
+    400,
+    "Workspace package export request is invalid.",
+    "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID",
+    summarizeValidationDetails(parsedInput.error),
+  );
+}
+
+function createWorkspacePackageExportInput(
+  routeInput: WorkspacePackageExportRouteInput,
+  generatedAt: string,
+): WorkspacePackageExportPreviewInput {
+  return {
+    selection: routeInput.selection,
+    tagPolicy: routeInput.tagPolicy,
+    packageMetadata: routeInput.packageMetadata,
+    generatedAt,
+  };
+}
+
+function createContentDispositionHeader(packageExport: WorkspacePackageExportPackage): string {
+  return `attachment; filename="${packageExport.fileName}"`;
+}
+
+export function createWorkspacePackageExportRoutes(options: WorkspacePackageExportRoutesOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
+  const assertUserHasWorkspaceAccessFn = options.assertUserHasWorkspaceAccessFn ?? assertUserHasWorkspaceAccess;
+  const previewWorkspacePackageExportFn = options.previewWorkspacePackageExportFn ?? previewWorkspacePackageExport;
+  const exportWorkspacePackageFn = options.exportWorkspacePackageFn ?? exportWorkspacePackage;
+
+  app.post("/workspaces/:workspaceId/packages/export/preview", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
+      const routeInput = parseWorkspacePackageExportRouteInput(await parseJsonBody(context.req.raw));
+      const input = createWorkspacePackageExportInput(routeInput, new Date().toISOString());
+      const preview = await previewWorkspacePackageExportFn(requestContext.userId, workspaceId, input);
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      addBackendBreadcrumb({
+        action: "workspace_package_export_preview",
+        scope,
+        details: {
+          statusCode: 200,
+          selectedCardCount: preview.selectedCardCount,
+          referencedMediaCount: preview.referencedMediaCount,
+        },
+      });
+
+      return context.json(preview satisfies WorkspacePackageExportPreviewResponse);
+    } catch (error) {
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        selectedCardCount: null,
+        referencedMediaCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_package_export_preview_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_package_export_preview_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.post("/workspaces/:workspaceId/packages/export", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let workspaceId: string | null = null;
+
+    try {
+      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+      requestContext = loadedContext.requestContext;
+      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
+      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const routeInput = parseWorkspacePackageExportRouteInput(await parseJsonBody(context.req.raw));
+      const input: WorkspacePackageExportPackageInput = {
+        ...createWorkspacePackageExportInput(routeInput, new Date().toISOString()),
+        observationScope: scope,
+      };
+      const packageExport = await exportWorkspacePackageFn(requestContext.userId, workspaceId, input);
+      addBackendBreadcrumb({
+        action: "workspace_package_export",
+        scope,
+        details: {
+          statusCode: 200,
+          bytesCount: packageExport.bytes.byteLength,
+        },
+      });
+
+      context.header("Content-Disposition", createContentDispositionHeader(packageExport));
+      context.header("Content-Length", packageExport.bytes.byteLength.toString());
+      context.header("Content-Type", packageExport.contentType);
+      return context.body(new Uint8Array(packageExport.bytes), 200);
+    } catch (error) {
+      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
+      const details = {
+        bytesCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_package_export_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_package_export_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  return app;
+}

--- a/apps/backend/src/routes/workspacePackages/import.ts
+++ b/apps/backend/src/routes/workspacePackages/import.ts
@@ -1,59 +1,43 @@
 import { Buffer } from "node:buffer";
 import { Hono } from "hono";
 import { z } from "zod";
-import { listWorkspaceTagsSummary } from "../cards";
+import { listWorkspaceTagsSummary } from "../../cards";
 import {
   confirmWorkspacePackageImport,
-  exportWorkspacePackage,
-  previewWorkspacePackageExport,
   previewWorkspacePackageZipImport,
-  type WorkspacePackageExportCardSelection,
-  type WorkspacePackageExportMetadataInput,
-  type WorkspacePackageExportPackage,
-  type WorkspacePackageExportPackageInput,
-  type WorkspacePackageExportPreview,
-  type WorkspacePackageExportPreviewInput,
-  type WorkspacePackageExportTagPolicyInput,
   type WorkspacePackageImportConfirmResult,
   type WorkspacePackageImportPlanOptions,
   type WorkspacePackageImportPreview,
-} from "../workspacePackages";
-import { assertUserHasWorkspaceAccess } from "../workspaces";
+} from "../../workspacePackages";
+import { assertUserHasWorkspaceAccess } from "../../workspaces";
 import {
   loadRequestContextFromRequest,
   parseWorkspaceIdParam,
   type RequestContext,
-} from "../server/requestContext";
-import { parseJsonBody } from "../server/requestParsing";
-import { createBackendFailureDetails } from "../server/logging";
+} from "../../server/requestContext";
+import { createBackendFailureDetails } from "../../server/logging";
 import {
   addBackendBreadcrumb,
-  createBackendObservationScope,
   normalizeCaughtError,
-  type BackendObservationScope,
-} from "../observability/sentry";
-import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
-import { HttpError, type HttpErrorDetails, type ValidationIssueSummary } from "../shared/errors";
-import type { AppEnv } from "../server/app";
+} from "../../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../../observability/reporting";
+import { HttpError } from "../../shared/errors";
+import type { AppEnv } from "../../server/app";
+import {
+  createWorkspacePackageScope,
+  getRequestContextUserId,
+  summarizeValidationDetails,
+} from "./shared";
 
-type WorkspacePackageRoutesOptions = Readonly<{
+export type WorkspacePackageImportRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
   loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
   assertUserHasWorkspaceAccessFn?: typeof assertUserHasWorkspaceAccess;
-  previewWorkspacePackageExportFn?: typeof previewWorkspacePackageExport;
-  exportWorkspacePackageFn?: typeof exportWorkspacePackage;
   listWorkspaceTagsSummaryFn?: typeof listWorkspaceTagsSummary;
   previewWorkspacePackageZipImportFn?: typeof previewWorkspacePackageZipImport;
   confirmWorkspacePackageImportFn?: typeof confirmWorkspacePackageImport;
 }>;
 
-type WorkspacePackageExportRouteInput = Readonly<{
-  selection: WorkspacePackageExportCardSelection;
-  tagPolicy: WorkspacePackageExportTagPolicyInput;
-  packageMetadata: WorkspacePackageExportMetadataInput;
-}>;
-
-type WorkspacePackageExportPreviewResponse = WorkspacePackageExportPreview;
 type WorkspacePackageImportPreviewResponse = WorkspacePackageImportPreview;
 type WorkspacePackageImportConfirmResponse = WorkspacePackageImportConfirmResult;
 
@@ -70,75 +54,6 @@ type WorkspacePackageImportConfirmUpload = Readonly<{
 
 export const workspacePackageImportPreviewRouteMaxZipBytes = 4_000_000;
 export const workspacePackageImportConfirmRouteMaxZipBytes = workspacePackageImportPreviewRouteMaxZipBytes;
-
-const allActiveCardsSelectionSchema = z.object({
-  kind: z.literal("allActiveCards"),
-});
-
-const tagFiltersSelectionSchema = z.object({
-  kind: z.literal("tagFilters"),
-  includeTags: z.array(z.string()),
-  excludeTags: z.array(z.string()),
-});
-
-const explicitCardIdsSelectionSchema = z.object({
-  kind: z.literal("explicitCardIds"),
-  cardIds: z.array(z.string()).min(1),
-});
-
-const workspacePackageExportSelectionSchema = z.discriminatedUnion("kind", [
-  allActiveCardsSelectionSchema,
-  tagFiltersSelectionSchema,
-  explicitCardIdsSelectionSchema,
-]).transform((selection): WorkspacePackageExportCardSelection => {
-  switch (selection.kind) {
-  case "allActiveCards":
-    return {
-      kind: "allActiveCards",
-    };
-  case "tagFilters":
-    return {
-      kind: "tagFilters",
-      includeTags: selection.includeTags,
-      excludeTags: selection.excludeTags,
-    };
-  case "explicitCardIds":
-    return {
-      kind: "explicitCardIds",
-      cardIds: selection.cardIds,
-    };
-  }
-});
-
-const workspacePackageExportTagPolicySchema = z.object({
-  additionalRemovedTags: z.array(z.string()),
-}).transform((tagPolicy): WorkspacePackageExportTagPolicyInput => ({
-  additionalRemovedTags: tagPolicy.additionalRemovedTags,
-}));
-
-const workspacePackageExportMetadataSchema = z.object({
-  label: z.string().nullable(),
-  author: z.string().nullable(),
-  comment: z.string().nullable(),
-  createdAt: z.string().nullable(),
-  sourceUrl: z.string().nullable(),
-}).transform((packageMetadata): WorkspacePackageExportMetadataInput => ({
-  label: packageMetadata.label,
-  author: packageMetadata.author,
-  comment: packageMetadata.comment,
-  createdAt: packageMetadata.createdAt,
-  sourceUrl: packageMetadata.sourceUrl,
-}));
-
-const workspacePackageExportRouteInputSchema = z.object({
-  selection: workspacePackageExportSelectionSchema,
-  tagPolicy: workspacePackageExportTagPolicySchema,
-  packageMetadata: workspacePackageExportMetadataSchema,
-}).transform((input): WorkspacePackageExportRouteInput => ({
-  selection: input.selection,
-  tagPolicy: input.tagPolicy,
-  packageMetadata: input.packageMetadata,
-}));
 
 const workspacePackageImportConfirmTimestampSchema = z.string().datetime().transform(
   (value): string => new Date(value).toISOString(),
@@ -166,86 +81,6 @@ const workspacePackageImportConfirmRouteOptionsSchema = z.object({
   lastModifiedByReplicaId: input.lastModifiedByReplicaId,
   operationIdPrefix: input.operationIdPrefix,
 }));
-
-function summarizeValidationPath(path: ReadonlyArray<PropertyKey>): string {
-  if (path.length === 0) {
-    return "<root>";
-  }
-
-  return path.join(".");
-}
-
-function summarizeValidationIssue(issue: z.core.$ZodIssue): ValidationIssueSummary {
-  return {
-    path: summarizeValidationPath(issue.path),
-    code: issue.code,
-    message: issue.message,
-  };
-}
-
-function summarizeValidationDetails(error: z.ZodError): HttpErrorDetails {
-  return {
-    validationIssues: error.issues.map(summarizeValidationIssue),
-  };
-}
-
-export function parseWorkspacePackageExportRouteInput(value: unknown): WorkspacePackageExportRouteInput {
-  const parsedInput = workspacePackageExportRouteInputSchema.safeParse(value);
-  if (parsedInput.success) {
-    return parsedInput.data;
-  }
-
-  throw new HttpError(
-    400,
-    "Workspace package export request is invalid.",
-    "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID",
-    summarizeValidationDetails(parsedInput.error),
-  );
-}
-
-function createWorkspacePackageExportInput(
-  routeInput: WorkspacePackageExportRouteInput,
-  generatedAt: string,
-): WorkspacePackageExportPreviewInput {
-  return {
-    selection: routeInput.selection,
-    tagPolicy: routeInput.tagPolicy,
-    packageMetadata: routeInput.packageMetadata,
-    generatedAt,
-  };
-}
-
-function createWorkspacePackageScope(
-  requestId: string,
-  route: string,
-  method: string,
-  userId: string | null,
-  workspaceId: string | null,
-  clientAppVersion: string | null,
-  clientPlatform: string | null,
-): BackendObservationScope {
-  return createBackendObservationScope(
-    "backend-api",
-    requestId,
-    route,
-    method,
-    userId,
-    workspaceId,
-    null,
-    null,
-    null,
-    clientAppVersion,
-    clientPlatform,
-  );
-}
-
-function getRequestContextUserId(requestContext: RequestContext | null): string | null {
-  return requestContext === null ? null : requestContext.userId;
-}
-
-function createContentDispositionHeader(packageExport: WorkspacePackageExportPackage): string {
-  return `attachment; filename="${packageExport.fileName}"`;
-}
 
 function assertWorkspacePackageImportPreviewContentType(headers: Headers): void {
   const contentTypeHeader = headers.get("content-type");
@@ -427,101 +262,13 @@ async function readWorkspacePackageImportPreviewZipBytes(request: Request): Prom
   return bytes;
 }
 
-export function createWorkspacePackageRoutes(options: WorkspacePackageRoutesOptions): Hono<AppEnv> {
+export function createWorkspacePackageImportRoutes(options: WorkspacePackageImportRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
   const assertUserHasWorkspaceAccessFn = options.assertUserHasWorkspaceAccessFn ?? assertUserHasWorkspaceAccess;
-  const previewWorkspacePackageExportFn = options.previewWorkspacePackageExportFn ?? previewWorkspacePackageExport;
-  const exportWorkspacePackageFn = options.exportWorkspacePackageFn ?? exportWorkspacePackage;
   const listWorkspaceTagsSummaryFn = options.listWorkspaceTagsSummaryFn ?? listWorkspaceTagsSummary;
   const previewWorkspacePackageZipImportFn = options.previewWorkspacePackageZipImportFn ?? previewWorkspacePackageZipImport;
   const confirmWorkspacePackageImportFn = options.confirmWorkspacePackageImportFn ?? confirmWorkspacePackageImport;
-
-  app.post("/workspaces/:workspaceId/packages/export/preview", async (context) => {
-    const requestId = context.get("requestId");
-    let requestContext: RequestContext | null = null;
-    let workspaceId: string | null = null;
-
-    try {
-      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
-      requestContext = loadedContext.requestContext;
-      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
-      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
-      const routeInput = parseWorkspacePackageExportRouteInput(await parseJsonBody(context.req.raw));
-      const input = createWorkspacePackageExportInput(routeInput, new Date().toISOString());
-      const preview = await previewWorkspacePackageExportFn(requestContext.userId, workspaceId, input);
-      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
-      addBackendBreadcrumb({
-        action: "workspace_package_export_preview",
-        scope,
-        details: {
-          statusCode: 200,
-          selectedCardCount: preview.selectedCardCount,
-          referencedMediaCount: preview.referencedMediaCount,
-        },
-      });
-
-      return context.json(preview satisfies WorkspacePackageExportPreviewResponse);
-    } catch (error) {
-      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
-      const details = {
-        selectedCardCount: null,
-        referencedMediaCount: null,
-        ...createBackendFailureDetails(error),
-      };
-      reportBackendExceptionOrBreadcrumb(
-        error,
-        { action: "workspace_package_export_preview_error", error: normalizeCaughtError(error), scope, details },
-        { action: "workspace_package_export_preview_error", scope, details },
-      );
-      throw error;
-    }
-  });
-
-  app.post("/workspaces/:workspaceId/packages/export", async (context) => {
-    const requestId = context.get("requestId");
-    let requestContext: RequestContext | null = null;
-    let workspaceId: string | null = null;
-
-    try {
-      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
-      requestContext = loadedContext.requestContext;
-      workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
-      await assertUserHasWorkspaceAccessFn(requestContext.userId, workspaceId);
-      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
-      const routeInput = parseWorkspacePackageExportRouteInput(await parseJsonBody(context.req.raw));
-      const input: WorkspacePackageExportPackageInput = {
-        ...createWorkspacePackageExportInput(routeInput, new Date().toISOString()),
-        observationScope: scope,
-      };
-      const packageExport = await exportWorkspacePackageFn(requestContext.userId, workspaceId, input);
-      addBackendBreadcrumb({
-        action: "workspace_package_export",
-        scope,
-        details: {
-          statusCode: 200,
-          bytesCount: packageExport.bytes.byteLength,
-        },
-      });
-
-      context.header("Content-Disposition", createContentDispositionHeader(packageExport));
-      context.header("Content-Length", packageExport.bytes.byteLength.toString());
-      context.header("Content-Type", packageExport.contentType);
-      return context.body(new Uint8Array(packageExport.bytes), 200);
-    } catch (error) {
-      const scope = createWorkspacePackageScope(requestId, context.req.path, context.req.method, getRequestContextUserId(requestContext), workspaceId, context.get("clientAppVersion"), context.get("clientPlatform"));
-      const details = {
-        bytesCount: null,
-        ...createBackendFailureDetails(error),
-      };
-      reportBackendExceptionOrBreadcrumb(
-        error,
-        { action: "workspace_package_export_error", error: normalizeCaughtError(error), scope, details },
-        { action: "workspace_package_export_error", scope, details },
-      );
-      throw error;
-    }
-  });
 
   app.post("/workspaces/:workspaceId/packages/import/preview", async (context) => {
     const requestId = context.get("requestId");

--- a/apps/backend/src/routes/workspacePackages/index.ts
+++ b/apps/backend/src/routes/workspacePackages/index.ts
@@ -1,0 +1,36 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../../server/app";
+import {
+  createWorkspacePackageExportRoutes,
+  type WorkspacePackageExportRoutesOptions,
+} from "./export";
+import {
+  createWorkspacePackageImportRoutes,
+  type WorkspacePackageImportRoutesOptions,
+} from "./import";
+
+export {
+  parseWorkspacePackageExportRouteInput,
+} from "./export";
+export {
+  workspacePackageImportConfirmRouteMaxZipBytes,
+  workspacePackageImportPreviewRouteMaxZipBytes,
+} from "./import";
+
+export type {
+  WorkspacePackageExportRouteInput,
+  WorkspacePackageExportRoutesOptions,
+} from "./export";
+export type {
+  WorkspacePackageImportRoutesOptions,
+} from "./import";
+
+export type WorkspacePackageRoutesOptions =
+  WorkspacePackageExportRoutesOptions & WorkspacePackageImportRoutesOptions;
+
+export function createWorkspacePackageRoutes(options: WorkspacePackageRoutesOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.route("/", createWorkspacePackageExportRoutes(options));
+  app.route("/", createWorkspacePackageImportRoutes(options));
+  return app;
+}

--- a/apps/backend/src/routes/workspacePackages/shared.ts
+++ b/apps/backend/src/routes/workspacePackages/shared.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import {
+  createBackendObservationScope,
+  type BackendObservationScope,
+} from "../../observability/sentry";
+import type { RequestContext } from "../../server/requestContext";
+import type { HttpErrorDetails, ValidationIssueSummary } from "../../shared/errors";
+
+function summarizeValidationPath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) {
+    return "<root>";
+  }
+
+  return path.join(".");
+}
+
+function summarizeValidationIssue(issue: z.core.$ZodIssue): ValidationIssueSummary {
+  return {
+    path: summarizeValidationPath(issue.path),
+    code: issue.code,
+    message: issue.message,
+  };
+}
+
+export function summarizeValidationDetails(error: z.ZodError): HttpErrorDetails {
+  return {
+    validationIssues: error.issues.map(summarizeValidationIssue),
+  };
+}
+
+export function getRequestContextUserId(requestContext: RequestContext | null): string | null {
+  return requestContext === null ? null : requestContext.userId;
+}
+
+export function createWorkspacePackageScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string | null,
+  workspaceId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+    clientAppVersion,
+    clientPlatform,
+  );
+}


### PR DESCRIPTION
## Summary
- Split the backend workspace package route module into route composer, export, import, and shared helper modules.
- Preserved the existing route paths, public exports, ZIP limits, request validation, response behavior, and observability action/detail names.

## Validation
- Freshness checks passed after rebasing this branch onto current `origin/main`: `git fetch origin main`, `git merge-base --is-ancestor origin/main HEAD`.
- `git --no-pager diff --check` passed.
- `npm ci --prefix apps/backend` passed with the existing Node v25.6.1 vs package Node 24.x engine warning.
- `npm --prefix apps/backend run lint` passed.
- `cd apps/backend && node --test --import tsx src/routes/workspacePackages.test.ts` passed 14/14.

## Review
- Worker-owned review reported no P0-P4 findings, no split recommendation, and green light for commit.
- The review also ran backend lint, the direct workspace package route test, and `git --no-pager diff --check`.

## Labels
- Requested labels `codex` and `codex-automation` were unavailable in this repository and were skipped.