### PR TITLE
Split workspace package route tests

### DIFF
--- a/apps/backend/src/routes/workspacePackages/export.test.ts
+++ b/apps/backend/src/routes/workspacePackages/export.test.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import test from "node:test";
+import { HttpError } from "../../shared/errors";
+import type {
+  WorkspacePackageExportPackageInput,
+  WorkspacePackageExportPreviewInput,
+} from "../../workspacePackages";
+import { createWorkspacePackageRoutes } from "./index";
+import {
+  cardId,
+  createRequestContext,
+  createWorkspacePackageTestApp,
+  createWorkspacePackageZipBytes,
+  type ErrorResponseBody,
+  workspaceId,
+} from "./testSupport";
+
+function createWorkspacePackageExportRequestBody(): Record<string, unknown> {
+  return {
+    workspaceId: createRequestContext().selectedWorkspaceId,
+    selection: {
+      kind: "explicitCardIds",
+      cardIds: [cardId],
+    },
+    tagPolicy: {
+      additionalRemovedTags: ["draft"],
+    },
+    packageMetadata: {
+      label: "Starter deck",
+      author: null,
+      comment: null,
+      createdAt: null,
+      sourceUrl: null,
+    },
+  };
+}
+
+function assertExportInput(input: WorkspacePackageExportPreviewInput): void {
+  assert.deepEqual(input.selection, {
+    kind: "explicitCardIds",
+    cardIds: [cardId],
+  });
+  assert.deepEqual(input.tagPolicy, {
+    additionalRemovedTags: ["draft"],
+  });
+  assert.deepEqual(input.packageMetadata, {
+    label: "Starter deck",
+    author: null,
+    comment: null,
+    createdAt: null,
+    sourceUrl: null,
+  });
+  assert.equal(new Date(input.generatedAt).toISOString(), input.generatedAt);
+}
+
+test("POST /workspaces/:workspaceId/packages/export/preview returns preview JSON for the path workspace", async () => {
+  let accessChecks = 0;
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
+      accessChecks += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(checkedWorkspaceId, workspaceId);
+    },
+    previewWorkspacePackageExportFn: async (userId, requestedWorkspaceId, input) => {
+      previewCalls += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, workspaceId);
+      assertExportInput(input);
+
+      return {
+        selectedCardCount: 1,
+        availableTagCounts: [
+          {
+            tag: "draft",
+            cardsCount: 1,
+          },
+        ],
+        tagsSelectedForRemoval: [
+          {
+            tag: "draft",
+            cardsCount: 1,
+          },
+        ],
+        referencedMediaCount: 0,
+        approximateReferencedMediaBytes: 0,
+        defaultPackageMetadata: {
+          label: "Starter deck",
+          createdAt: input.generatedAt,
+        },
+      };
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
+  });
+
+  assert.equal(response.status, 200);
+  const responseBody = await response.json() as Readonly<{
+    selectedCardCount: number;
+    availableTagCounts: ReadonlyArray<Readonly<{
+      tag: string;
+      cardsCount: number;
+    }>>;
+    tagsSelectedForRemoval: ReadonlyArray<Readonly<{
+      tag: string;
+      cardsCount: number;
+    }>>;
+    referencedMediaCount: number;
+    approximateReferencedMediaBytes: number;
+    defaultPackageMetadata: Readonly<{
+      label: string;
+      createdAt: string;
+    }>;
+  }>;
+  assert.equal(new Date(responseBody.defaultPackageMetadata.createdAt).toISOString(), responseBody.defaultPackageMetadata.createdAt);
+  assert.deepEqual(responseBody, {
+    selectedCardCount: 1,
+    availableTagCounts: [
+      {
+        tag: "draft",
+        cardsCount: 1,
+      },
+    ],
+    tagsSelectedForRemoval: [
+      {
+        tag: "draft",
+        cardsCount: 1,
+      },
+    ],
+    referencedMediaCount: 0,
+    approximateReferencedMediaBytes: 0,
+    defaultPackageMetadata: {
+      label: "Starter deck",
+      createdAt: responseBody.defaultPackageMetadata.createdAt,
+    },
+  });
+  assert.equal(accessChecks, 1);
+  assert.equal(previewCalls, 1);
+});
+
+test("POST /workspaces/:workspaceId/packages/export returns ZIP bytes with download headers", async () => {
+  const zipBytes = createWorkspacePackageZipBytes();
+  let exportCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
+      assert.equal(userId, "user-1");
+      assert.equal(checkedWorkspaceId, workspaceId);
+    },
+    exportWorkspacePackageFn: async (userId, requestedWorkspaceId, input: WorkspacePackageExportPackageInput) => {
+      exportCalls += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, workspaceId);
+      assertExportInput(input);
+      assert.equal(input.observationScope.service, "backend-api");
+      assert.equal(input.observationScope.requestId, "request-1");
+      assert.equal(input.observationScope.workspaceId, workspaceId);
+
+      return {
+        fileName: "flashcards.zip",
+        contentType: "application/zip",
+        bytes: zipBytes,
+      };
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "application/zip");
+  assert.equal(response.headers.get("content-disposition"), 'attachment; filename="flashcards.zip"');
+  assert.equal(response.headers.get("content-length"), zipBytes.byteLength.toString());
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), zipBytes);
+  assert.equal(exportCalls, 1);
+});
+
+test("workspace package export routes stop before service calls when workspace access is denied", async () => {
+  let previewCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => {
+      throw new HttpError(403, "Workspace access denied", "WORKSPACE_ACCESS_DENIED");
+    },
+    previewWorkspacePackageExportFn: async () => {
+      previewCalls += 1;
+      throw new Error("Preview service must not be called when workspace access is denied.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export/preview`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 403);
+  assert.equal(body.code, "WORKSPACE_ACCESS_DENIED");
+  assert.equal(previewCalls, 0);
+});
+
+test("workspace package export routes reject malformed requests before service calls", async () => {
+  let exportCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    exportWorkspacePackageFn: async () => {
+      exportCalls += 1;
+      throw new Error("Export service must not be called for malformed requests.");
+    },
+  }));
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      selection: {
+        kind: "explicitCardIds",
+        cardIds: [cardId],
+      },
+      tagPolicy: {
+        additionalRemovedTags: "draft",
+      },
+      packageMetadata: {
+        label: "Starter deck",
+        author: null,
+        comment: null,
+        createdAt: null,
+        sourceUrl: null,
+      },
+    }),
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.code, "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID");
+  assert.match(JSON.stringify(body.details), /tagPolicy\.additionalRemovedTags/);
+  assert.equal(exportCalls, 0);
+});
+
+test("workspace package export routes reject empty explicit card id selections before service calls", async () => {
+  let exportCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    exportWorkspacePackageFn: async () => {
+      exportCalls += 1;
+      throw new Error("Export service must not be called for empty explicit card id selections.");
+    },
+  }));
+
+  const requestBody = createWorkspacePackageExportRequestBody();
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ...requestBody,
+      selection: {
+        kind: "explicitCardIds",
+        cardIds: [],
+      },
+    }),
+  });
+  const body = await response.json() as ErrorResponseBody;
+
+  assert.equal(response.status, 400);
+  assert.equal(body.code, "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID");
+  assert.match(JSON.stringify(body.details), /selection\.cardIds/);
+  assert.equal(exportCalls, 0);
+});

--- a/apps/backend/src/routes/workspacePackages/import.test.ts
+++ b/apps/backend/src/routes/workspacePackages/import.test.ts
@@ -1,80 +1,34 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import { Hono } from "hono";
-import type { ContentfulStatusCode } from "hono/utils/http-status";
-import {
-  createWorkspacePackageRoutes,
-  workspacePackageImportConfirmRouteMaxZipBytes,
-  workspacePackageImportPreviewRouteMaxZipBytes,
-} from "./workspacePackages";
-import { HttpError } from "../shared/errors";
-import type { AppEnv } from "../server/app";
-import type { RequestContext } from "../server/requestContext";
-import type { Card } from "../cards";
-import type { MediaAsset } from "../mediaAssets/types";
+import type { Card } from "../../cards";
+import type { MediaAsset } from "../../mediaAssets/types";
+import { HttpError } from "../../shared/errors";
 import type {
-  WorkspacePackageExportPackageInput,
-  WorkspacePackageExportPreviewInput,
   WorkspacePackageImportConfirmInput,
   WorkspacePackageImportConfirmResult,
   WorkspacePackageImportPreview,
   WorkspacePackageImportPreviewInput,
-} from "../workspacePackages";
+} from "../../workspacePackages";
+import {
+  createWorkspacePackageRoutes,
+  workspacePackageImportConfirmRouteMaxZipBytes,
+  workspacePackageImportPreviewRouteMaxZipBytes,
+} from "./index";
+import {
+  cardId,
+  createRequestContext,
+  createWorkspacePackageTestApp,
+  createWorkspacePackageZipBytes,
+  type ErrorResponseBody,
+  workspaceId,
+} from "./testSupport";
 
-const workspaceId = "11111111-1111-4111-8111-111111111111";
-const otherWorkspaceId = "22222222-2222-4222-8222-222222222222";
-const cardId = "33333333-3333-4333-8333-333333333333";
 const replicaId = "44444444-4444-4444-8444-444444444444";
 const importedAt = "2026-06-30T12:00:00.000Z";
 const clientUpdatedAt = "2026-06-30T12:01:00.000Z";
 const importId = "import-session-1";
 const operationIdPrefix = "workspace-package-import-1";
-
-type ErrorResponseBody = Readonly<{
-  error: string;
-  requestId: string;
-  code: string | null;
-  details?: unknown;
-}>;
-
-function createRequestContext(): RequestContext {
-  return {
-    userId: "user-1",
-    subjectUserId: "subject-1",
-    selectedWorkspaceId: otherWorkspaceId,
-    email: "user@example.com",
-    locale: "en",
-    userSettingsCreatedAt: "2026-06-30T00:00:00.000Z",
-    preferences: {
-      reviewReactionAnimationsEnabled: true,
-    },
-    transport: "bearer",
-    connectionId: null,
-    guestSessionId: null,
-    guestPlatform: null,
-  };
-}
-
-function createWorkspacePackageExportRequestBody(): Record<string, unknown> {
-  return {
-    workspaceId: otherWorkspaceId,
-    selection: {
-      kind: "explicitCardIds",
-      cardIds: [cardId],
-    },
-    tagPolicy: {
-      additionalRemovedTags: ["draft"],
-    },
-    packageMetadata: {
-      label: "Starter deck",
-      author: null,
-      comment: null,
-      createdAt: null,
-      sourceUrl: null,
-    },
-  };
-}
 
 function createWorkspacePackageImportPreviewResponse(): WorkspacePackageImportPreview {
   return {
@@ -218,54 +172,6 @@ function createOversizedWorkspacePackageImportConfirmZipBytes(): Buffer {
   return Buffer.alloc(workspacePackageImportConfirmRouteMaxZipBytes + 1, 0x61);
 }
 
-function createWorkspacePackageTestApp(routes: Hono<AppEnv>): Hono<AppEnv> {
-  const app = new Hono<AppEnv>();
-  app.use("*", async (context, next) => {
-    context.set("requestId", "request-1");
-    context.set("clientAppVersion", null);
-    context.set("clientPlatform", null);
-    await next();
-  });
-  app.onError((error, context) => {
-    if (error instanceof HttpError) {
-      context.status(error.statusCode as ContentfulStatusCode);
-      return context.json({
-        error: error.message,
-        requestId: context.get("requestId"),
-        code: error.code,
-        ...(error.details === null ? {} : { details: error.details }),
-      } satisfies ErrorResponseBody);
-    }
-
-    context.status(500);
-    return context.json({
-      error: "Request failed. Try again.",
-      requestId: context.get("requestId"),
-      code: "INTERNAL_ERROR",
-    } satisfies ErrorResponseBody);
-  });
-  app.route("/", routes);
-  return app;
-}
-
-function assertExportInput(input: WorkspacePackageExportPreviewInput): void {
-  assert.deepEqual(input.selection, {
-    kind: "explicitCardIds",
-    cardIds: [cardId],
-  });
-  assert.deepEqual(input.tagPolicy, {
-    additionalRemovedTags: ["draft"],
-  });
-  assert.deepEqual(input.packageMetadata, {
-    label: "Starter deck",
-    author: null,
-    comment: null,
-    createdAt: null,
-    sourceUrl: null,
-  });
-  assert.equal(new Date(input.generatedAt).toISOString(), input.generatedAt);
-}
-
 function assertImportPreviewInput(
   input: WorkspacePackageImportPreviewInput,
   zipBytes: Buffer,
@@ -301,104 +207,8 @@ function assertImportConfirmInput(
   assert.equal(input.observationScope.workspaceId, workspaceId);
 }
 
-test("POST /workspaces/:workspaceId/packages/export/preview returns preview JSON for the path workspace", async () => {
-  let accessChecks = 0;
-  let previewCalls = 0;
-  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
-    allowedOrigins: [],
-    loadRequestContextFromRequestFn: async () => ({
-      requestAuthInputs: {} as never,
-      requestContext: createRequestContext(),
-    }),
-    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
-      accessChecks += 1;
-      assert.equal(userId, "user-1");
-      assert.equal(checkedWorkspaceId, workspaceId);
-    },
-    previewWorkspacePackageExportFn: async (userId, requestedWorkspaceId, input) => {
-      previewCalls += 1;
-      assert.equal(userId, "user-1");
-      assert.equal(requestedWorkspaceId, workspaceId);
-      assertExportInput(input);
-
-      return {
-        selectedCardCount: 1,
-        availableTagCounts: [
-          {
-            tag: "draft",
-            cardsCount: 1,
-          },
-        ],
-        tagsSelectedForRemoval: [
-          {
-            tag: "draft",
-            cardsCount: 1,
-          },
-        ],
-        referencedMediaCount: 0,
-        approximateReferencedMediaBytes: 0,
-        defaultPackageMetadata: {
-          label: "Starter deck",
-          createdAt: input.generatedAt,
-        },
-      };
-    },
-  }));
-
-  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export/preview`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
-  });
-
-  assert.equal(response.status, 200);
-  const responseBody = await response.json() as Readonly<{
-    selectedCardCount: number;
-    availableTagCounts: ReadonlyArray<Readonly<{
-      tag: string;
-      cardsCount: number;
-    }>>;
-    tagsSelectedForRemoval: ReadonlyArray<Readonly<{
-      tag: string;
-      cardsCount: number;
-    }>>;
-    referencedMediaCount: number;
-    approximateReferencedMediaBytes: number;
-    defaultPackageMetadata: Readonly<{
-      label: string;
-      createdAt: string;
-    }>;
-  }>;
-  assert.equal(new Date(responseBody.defaultPackageMetadata.createdAt).toISOString(), responseBody.defaultPackageMetadata.createdAt);
-  assert.deepEqual(responseBody, {
-    selectedCardCount: 1,
-    availableTagCounts: [
-      {
-        tag: "draft",
-        cardsCount: 1,
-      },
-    ],
-    tagsSelectedForRemoval: [
-      {
-        tag: "draft",
-        cardsCount: 1,
-      },
-    ],
-    referencedMediaCount: 0,
-    approximateReferencedMediaBytes: 0,
-    defaultPackageMetadata: {
-      label: "Starter deck",
-      createdAt: responseBody.defaultPackageMetadata.createdAt,
-    },
-  });
-  assert.equal(accessChecks, 1);
-  assert.equal(previewCalls, 1);
-});
-
 test("POST /workspaces/:workspaceId/packages/import/preview passes ZIP bytes and existing tags to preview service", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const zipBytes = createWorkspacePackageZipBytes();
   const previewJson = createWorkspacePackageImportPreviewResponse();
   let accessChecks = 0;
   let tagSummaryCalls = 0;
@@ -456,7 +266,7 @@ test("POST /workspaces/:workspaceId/packages/import/preview passes ZIP bytes and
 });
 
 test("POST /workspaces/:workspaceId/packages/import/preview uses path workspace instead of selected workspace", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const zipBytes = createWorkspacePackageZipBytes();
   const checkedWorkspaceIds: Array<string> = [];
   const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
     allowedOrigins: [],
@@ -491,7 +301,7 @@ test("POST /workspaces/:workspaceId/packages/import/preview uses path workspace 
 });
 
 test("POST /workspaces/:workspaceId/packages/import/preview rejects content-length over the direct route limit", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const zipBytes = createWorkspacePackageZipBytes();
   let tagSummaryCalls = 0;
   let previewCalls = 0;
   const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
@@ -565,7 +375,7 @@ test("POST /workspaces/:workspaceId/packages/import/preview rejects actual body 
 });
 
 test("POST /workspaces/:workspaceId/packages/import parses multipart ZIP bytes and options", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const zipBytes = createWorkspacePackageZipBytes();
   const confirmJson = createWorkspacePackageImportConfirmResult();
   let accessChecks = 0;
   let confirmCalls = 0;
@@ -599,7 +409,7 @@ test("POST /workspaces/:workspaceId/packages/import parses multipart ZIP bytes a
 });
 
 test("POST /workspaces/:workspaceId/packages/import uses path workspace instead of selected workspace", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const zipBytes = createWorkspacePackageZipBytes();
   const requestedWorkspaceIds: Array<string> = [];
   const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
     allowedOrigins: [],
@@ -658,7 +468,7 @@ test("workspace package import confirm route stops before multipart and confirm 
 });
 
 test("POST /workspaces/:workspaceId/packages/import rejects malformed multipart, file, and options inputs", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const zipBytes = createWorkspacePackageZipBytes();
   const validOptions = createWorkspacePackageImportConfirmOptions();
   const cases: ReadonlyArray<Readonly<{
     name: string;
@@ -840,54 +650,8 @@ test("POST /workspaces/:workspaceId/packages/import rejects malformed multipart,
   }
 });
 
-test("POST /workspaces/:workspaceId/packages/export returns ZIP bytes with download headers", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
-  let exportCalls = 0;
-  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
-    allowedOrigins: [],
-    loadRequestContextFromRequestFn: async () => ({
-      requestAuthInputs: {} as never,
-      requestContext: createRequestContext(),
-    }),
-    assertUserHasWorkspaceAccessFn: async (userId, checkedWorkspaceId) => {
-      assert.equal(userId, "user-1");
-      assert.equal(checkedWorkspaceId, workspaceId);
-    },
-    exportWorkspacePackageFn: async (userId, requestedWorkspaceId, input: WorkspacePackageExportPackageInput) => {
-      exportCalls += 1;
-      assert.equal(userId, "user-1");
-      assert.equal(requestedWorkspaceId, workspaceId);
-      assertExportInput(input);
-      assert.equal(input.observationScope.service, "backend-api");
-      assert.equal(input.observationScope.requestId, "request-1");
-      assert.equal(input.observationScope.workspaceId, workspaceId);
-
-      return {
-        fileName: "flashcards.zip",
-        contentType: "application/zip",
-        bytes: zipBytes,
-      };
-    },
-  }));
-
-  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
-  });
-
-  assert.equal(response.status, 200);
-  assert.equal(response.headers.get("content-type"), "application/zip");
-  assert.equal(response.headers.get("content-disposition"), 'attachment; filename="flashcards.zip"');
-  assert.equal(response.headers.get("content-length"), zipBytes.byteLength.toString());
-  assert.deepEqual(Buffer.from(await response.arrayBuffer()), zipBytes);
-  assert.equal(exportCalls, 1);
-});
-
 test("workspace package import preview route stops before tag and preview service calls when workspace access is denied", async () => {
-  const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+  const zipBytes = createWorkspacePackageZipBytes();
   let tagSummaryCalls = 0;
   let previewCalls = 0;
   const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
@@ -922,117 +686,4 @@ test("workspace package import preview route stops before tag and preview servic
   assert.equal(body.code, "WORKSPACE_ACCESS_DENIED");
   assert.equal(tagSummaryCalls, 0);
   assert.equal(previewCalls, 0);
-});
-
-test("workspace package export routes stop before service calls when workspace access is denied", async () => {
-  let previewCalls = 0;
-  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
-    allowedOrigins: [],
-    loadRequestContextFromRequestFn: async () => ({
-      requestAuthInputs: {} as never,
-      requestContext: createRequestContext(),
-    }),
-    assertUserHasWorkspaceAccessFn: async () => {
-      throw new HttpError(403, "Workspace access denied", "WORKSPACE_ACCESS_DENIED");
-    },
-    previewWorkspacePackageExportFn: async () => {
-      previewCalls += 1;
-      throw new Error("Preview service must not be called when workspace access is denied.");
-    },
-  }));
-
-  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export/preview`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(createWorkspacePackageExportRequestBody()),
-  });
-  const body = await response.json() as ErrorResponseBody;
-
-  assert.equal(response.status, 403);
-  assert.equal(body.code, "WORKSPACE_ACCESS_DENIED");
-  assert.equal(previewCalls, 0);
-});
-
-test("workspace package export routes reject malformed requests before service calls", async () => {
-  let exportCalls = 0;
-  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
-    allowedOrigins: [],
-    loadRequestContextFromRequestFn: async () => ({
-      requestAuthInputs: {} as never,
-      requestContext: createRequestContext(),
-    }),
-    assertUserHasWorkspaceAccessFn: async () => undefined,
-    exportWorkspacePackageFn: async () => {
-      exportCalls += 1;
-      throw new Error("Export service must not be called for malformed requests.");
-    },
-  }));
-
-  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      selection: {
-        kind: "explicitCardIds",
-        cardIds: [cardId],
-      },
-      tagPolicy: {
-        additionalRemovedTags: "draft",
-      },
-      packageMetadata: {
-        label: "Starter deck",
-        author: null,
-        comment: null,
-        createdAt: null,
-        sourceUrl: null,
-      },
-    }),
-  });
-  const body = await response.json() as ErrorResponseBody;
-
-  assert.equal(response.status, 400);
-  assert.equal(body.code, "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID");
-  assert.match(JSON.stringify(body.details), /tagPolicy\.additionalRemovedTags/);
-  assert.equal(exportCalls, 0);
-});
-
-test("workspace package export routes reject empty explicit card id selections before service calls", async () => {
-  let exportCalls = 0;
-  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
-    allowedOrigins: [],
-    loadRequestContextFromRequestFn: async () => ({
-      requestAuthInputs: {} as never,
-      requestContext: createRequestContext(),
-    }),
-    assertUserHasWorkspaceAccessFn: async () => undefined,
-    exportWorkspacePackageFn: async () => {
-      exportCalls += 1;
-      throw new Error("Export service must not be called for empty explicit card id selections.");
-    },
-  }));
-
-  const requestBody = createWorkspacePackageExportRequestBody();
-  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/export`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      ...requestBody,
-      selection: {
-        kind: "explicitCardIds",
-        cardIds: [],
-      },
-    }),
-  });
-  const body = await response.json() as ErrorResponseBody;
-
-  assert.equal(response.status, 400);
-  assert.equal(body.code, "WORKSPACE_PACKAGE_EXPORT_REQUEST_INVALID");
-  assert.match(JSON.stringify(body.details), /selection\.cardIds/);
-  assert.equal(exportCalls, 0);
 });

--- a/apps/backend/src/routes/workspacePackages/testSupport.ts
+++ b/apps/backend/src/routes/workspacePackages/testSupport.ts
@@ -1,0 +1,69 @@
+import { Buffer } from "node:buffer";
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AppEnv } from "../../server/app";
+import type { RequestContext } from "../../server/requestContext";
+import { HttpError } from "../../shared/errors";
+
+export const workspaceId = "11111111-1111-4111-8111-111111111111";
+const otherWorkspaceId = "22222222-2222-4222-8222-222222222222";
+export const cardId = "33333333-3333-4333-8333-333333333333";
+
+export type ErrorResponseBody = Readonly<{
+  error: string;
+  requestId: string;
+  code: string | null;
+  details?: unknown;
+}>;
+
+export function createRequestContext(): RequestContext {
+  return {
+    userId: "user-1",
+    subjectUserId: "subject-1",
+    selectedWorkspaceId: otherWorkspaceId,
+    email: "user@example.com",
+    locale: "en",
+    userSettingsCreatedAt: "2026-06-30T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
+    transport: "bearer",
+    connectionId: null,
+    guestSessionId: null,
+    guestPlatform: null,
+  };
+}
+
+export function createWorkspacePackageZipBytes(): Buffer {
+  return Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+}
+
+export function createWorkspacePackageTestApp(routes: Hono<AppEnv>): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-1");
+    context.set("clientAppVersion", null);
+    context.set("clientPlatform", null);
+    await next();
+  });
+  app.onError((error, context) => {
+    if (error instanceof HttpError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: error.message,
+        requestId: context.get("requestId"),
+        code: error.code,
+        ...(error.details === null ? {} : { details: error.details }),
+      } satisfies ErrorResponseBody);
+    }
+
+    context.status(500);
+    return context.json({
+      error: "Request failed. Try again.",
+      requestId: context.get("requestId"),
+      code: "INTERNAL_ERROR",
+    } satisfies ErrorResponseBody);
+  });
+  app.route("/", routes);
+  return app;
+}


### PR DESCRIPTION
## Summary
- Split the mixed workspace package route test into export-focused and import-focused suites.
- Moved shared route-test harness, request context, shared IDs, and ZIP fixture helper into workspacePackages/testSupport.ts.
- Kept tests integration-style against createWorkspacePackageRoutes.

## Validation
- Freshness checks passed: git fetch origin main; git merge-base --is-ancestor origin/main HEAD.
- git --no-pager diff --check passed.
- Additional whitespace check for new untracked files passed before commit.
- npm --prefix apps/backend ci passed with the existing Node v25.6.1 vs package Node 24.x engine warning.
- npm --prefix apps/backend run lint passed.
- cd apps/backend && node --test --import tsx src/routes/workspacePackages/export.test.ts src/routes/workspacePackages/import.test.ts passed 14/14.
- Verified apps/backend/scripts/run-tests.mjs recurses through src, so nested tests remain discoverable.

## Review
- Worker-owned review reported no P0-P4 findings, no split recommendation, and green light for commit.

## Labels
- Requested labels codex and codex-automation were not available in this repository, so they were not applied.