### PR TITLE
Preserve workspace media in catalog versions

### DIFF
--- a/apps/backend/src/catalog/draftMedia.ts
+++ b/apps/backend/src/catalog/draftMedia.ts
@@ -15,6 +15,7 @@ import type {
   AttachCatalogPackageMediaAssetInput,
   CatalogPackageMediaAsset,
   CatalogPackageMediaAssetRow,
+  CatalogPackageVersionMediaAssetInput,
 } from "./types";
 
 type PackageMediaKeyRow = Readonly<{ package_media_key: string }>;
@@ -29,6 +30,15 @@ function normalizePackageMediaAssetInput(
     altText: normalizeNullableString(input.altText, "altText"),
     credit: normalizeNullableString(input.credit, "credit"),
     license: normalizeNullableString(input.license, "license"),
+  };
+}
+
+function normalizePackageVersionMediaAssetInput(
+  input: CatalogPackageVersionMediaAssetInput,
+): CatalogPackageVersionMediaAssetInput {
+  return {
+    packageMediaKey: normalizePackageMediaKey(input.packageMediaKey, "packageMediaKey"),
+    mediaBlobId: input.mediaBlobId,
   };
 }
 
@@ -60,6 +70,23 @@ export async function assertDraftMediaKeysExistInExecutor(
       "CATALOG_PACKAGE_MEDIA_REFERENCE_NOT_FOUND",
     );
   }
+}
+
+export async function loadCatalogPackageDraftMediaKeysInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+): Promise<ReadonlySet<string>> {
+  const result = await executor.query<PackageMediaKeyRow>(
+    [
+      "SELECT package_media_key",
+      "FROM catalog.package_media_assets",
+      "WHERE package_id = $1",
+      "AND package_version_id IS NULL",
+    ].join(" "),
+    [packageId],
+  );
+
+  return new Set(result.rows.map((row: PackageMediaKeyRow) => row.package_media_key));
 }
 
 export async function attachCatalogPackageDraftMediaAssetInExecutor(
@@ -105,6 +132,29 @@ export async function attachCatalogPackageDraftMediaAssetInExecutor(
     return mapCatalogPackageMediaAssetRow(row);
   } catch (error) {
     rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function insertCatalogPackageVersionMediaAssetsInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  packageVersionId: string,
+  mediaAssets: ReadonlyArray<CatalogPackageVersionMediaAssetInput>,
+): Promise<void> {
+  for (const mediaAsset of mediaAssets.map((input) => normalizePackageVersionMediaAssetInput(input))) {
+    await executor.query(
+      [
+        "INSERT INTO catalog.package_media_assets",
+        "(package_media_asset_id, package_id, package_version_id, package_media_key, media_blob_id, alt_text, credit, license)",
+        "VALUES (gen_random_uuid(), $1, $2, $3, $4, NULL, NULL, NULL)",
+      ].join(" "),
+      [
+        packageId,
+        packageVersionId,
+        mediaAsset.packageMediaKey,
+        mediaAsset.mediaBlobId,
+      ],
+    );
   }
 }
 

--- a/apps/backend/src/catalog/index.test.ts
+++ b/apps/backend/src/catalog/index.test.ts
@@ -29,33 +29,14 @@ const testMediaBlobId = "44444444-4444-4444-8444-444444444444";
 const testPackageMediaAssetId = "55555555-5555-4555-8555-555555555555";
 const testWorkspaceId = "66666666-6666-4666-8666-666666666666";
 const testWorkspaceCardId = "77777777-7777-4777-8777-777777777777";
+const testWorkspaceMediaAssetId = "88888888-8888-4888-8888-888888888888";
+const testSecondWorkspaceMediaAssetId = "99999999-9999-4999-8999-999999999999";
+const testSecondMediaBlobId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const testTimestamp = "2026-04-18T10:00:00.000Z";
 
-const managedMediaReferenceExamples: ReadonlyArray<Readonly<{
-  name: string;
-  frontText: string;
-  backText: string;
-  expectedField: "frontText" | "backText";
-}>> = [
-  {
-    name: "UUID refs",
-    frontText: "Question",
-    backText: `![audio](fcasset:${testMediaBlobId})`,
-    expectedField: "backText",
-  },
-  {
-    name: "non-UUID refs",
-    frontText: "![image](fcasset:image-asset)",
-    backText: "Answer",
-    expectedField: "frontText",
-  },
-  {
-    name: "URL-like refs",
-    frontText: "Question",
-    backText: `![audio](FCASSET://${testMediaBlobId}?download=1)`,
-    expectedField: "backText",
-  },
-];
+const testPackageMediaKey = `w-${testWorkspaceMediaAssetId}`;
+const testCollisionSafePackageMediaKey = `${testPackageMediaKey}.1`;
+const testSecondPackageMediaKey = `w-${testSecondWorkspaceMediaAssetId}`;
 
 function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
   return {
@@ -486,57 +467,258 @@ test("workspace-selected catalog versions generate fresh package card ids", asyn
   assert.notEqual(insertedPackageCardId, null);
 });
 
-for (const example of managedMediaReferenceExamples) {
-  test(`workspace-selected catalog versions reject managed media references in ${example.name}`, async () => {
-    const queries: Array<string> = [];
-    const executor: DatabaseExecutor = {
-      async query<Row extends pg.QueryResultRow>(
-        text: string,
-        params: ReadonlyArray<SqlValue>,
-      ): Promise<pg.QueryResult<Row>> {
-        queries.push(text);
-        if (text.includes("set_config('app.user_id'")) {
-          assert.deepEqual(params, ["admin-user-id", testWorkspaceId]);
+test("workspace-selected catalog versions preserve managed media as package media", async () => {
+  const versionMediaInsertParams: Array<ReadonlyArray<SqlValue>> = [];
+  let insertedPackageCardId: string | null = null;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("set_config('app.user_id'")) {
+        assert.deepEqual(params, ["admin-user-id", testWorkspaceId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("FROM content.cards")) {
+        assert.deepEqual(params, [testWorkspaceId, [testWorkspaceCardId]]);
+        return createQueryResult([{
+          card_id: testWorkspaceCardId,
+          front_text: `Prompt ![diagram](fcasset:${testWorkspaceMediaAssetId})`,
+          back_text: `Answer [audio](fcasset:${testSecondWorkspaceMediaAssetId}) and again ![same](fcasset:${testWorkspaceMediaAssetId})`,
+          card_type: "basic",
+          metadata: { version: 1, source: null },
+          tags: ["media"],
+        } as unknown as Row]);
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets")) {
+        assert.match(text, /INNER JOIN content\.media_blobs AS media_blobs/);
+        assert.doesNotMatch(text, /\bstorage_key\b/);
+        assert.doesNotMatch(text, /\bsha256\b/);
+        assert.doesNotMatch(text, /\bsource_url\b/);
+        assert.deepEqual(params, [testWorkspaceId, [
+          testWorkspaceMediaAssetId,
+          testSecondWorkspaceMediaAssetId,
+        ]]);
+        return createQueryResult([
+          {
+            media_asset_id: testWorkspaceMediaAssetId,
+            media_blob_id: testMediaBlobId,
+          } as unknown as Row,
+          {
+            media_asset_id: testSecondWorkspaceMediaAssetId,
+            media_blob_id: testSecondMediaBlobId,
+          } as unknown as Row,
+        ]);
+      }
+
+      if (text.includes("FROM catalog.packages") && text.includes("FOR UPDATE")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([createPackageRow() as unknown as Row]);
+      }
+
+      if (text.includes("SELECT package_media_key")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([{
+          package_media_key: testPackageMediaKey,
+        } as unknown as Row]);
+      }
+
+      if (text.includes("FROM catalog.package_versions") && text.includes("status IN")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("FROM catalog.package_versions") && text.includes("ORDER BY version_number DESC")) {
+        assert.deepEqual(params, [testPackageId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("INSERT INTO catalog.package_versions")) {
+        assert.equal(params[0], testPackageVersionId);
+        assert.equal(params[12], testWorkspaceId);
+        return createQueryResult([{
+          ...createPackageVersionRow("draft"),
+          source_workspace_id: testWorkspaceId,
+        } as unknown as Row]);
+      }
+
+      if (text.includes("INSERT INTO catalog.package_media_assets")) {
+        assert.doesNotMatch(text, /\bstorage_key\b/);
+        assert.doesNotMatch(text, /\bsha256\b/);
+        assert.doesNotMatch(text, /\bsource_url\b/);
+
+        if (text.includes("SELECT gen_random_uuid(), package_id")) {
+          assert.deepEqual(params, [testPackageId, testPackageVersionId]);
           return createQueryResult([]);
         }
 
-        if (text.includes("FROM content.cards")) {
-          assert.deepEqual(params, [testWorkspaceId, [testWorkspaceCardId]]);
-          return createQueryResult([{
-            card_id: testWorkspaceCardId,
-            front_text: example.frontText,
-            back_text: example.backText,
-            card_type: "basic",
-            metadata: { version: 1, source: null },
-            tags: [],
-          } as unknown as Row]);
-        }
+        versionMediaInsertParams.push(params);
+        return createQueryResult([]);
+      }
 
-        throw new Error(`Unexpected query: ${text}`);
-      },
-    };
+      if (text.includes("INSERT INTO catalog.package_cards")) {
+        insertedPackageCardId = String(params[0]);
+        assert.notEqual(insertedPackageCardId, testWorkspaceCardId);
+        assert.match(insertedPackageCardId, /^[0-9a-f-]{36}$/);
+        assert.deepEqual(params.slice(1), [
+          testPackageVersionId,
+          testWorkspaceCardId,
+          1,
+          `Prompt ![diagram](fcasset:${testCollisionSafePackageMediaKey})`,
+          `Answer [audio](fcasset:${testSecondPackageMediaKey}) and again ![same](fcasset:${testCollisionSafePackageMediaKey})`,
+          "basic",
+          JSON.stringify({ version: 1, source: null }),
+          ["media"],
+          [testCollisionSafePackageMediaKey, testSecondPackageMediaKey],
+        ]);
+        return createQueryResult([]);
+      }
 
-    await assert.rejects(
-      createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
-        executor,
-        testPackageId,
-        {
-          packageVersionId: testPackageVersionId,
-          workspaceId: testWorkspaceId,
-          cardIds: [testWorkspaceCardId],
-        },
-        "admin-user-id",
-        "admin@example.com",
-      ),
-      (error: unknown) => {
-        assert.equal(error instanceof HttpError, true);
-        assert.equal((error as HttpError).statusCode, 400);
-        assert.equal((error as HttpError).code, "CATALOG_WORKSPACE_CARD_MEDIA_REFERENCE_UNSUPPORTED");
-        assert.match((error as HttpError).message, new RegExp(`cardId=${testWorkspaceCardId}`));
-        assert.match((error as HttpError).message, new RegExp(`field=${example.expectedField}`));
-        return true;
+      if (text.includes("INSERT INTO catalog.package_review_events")) {
+        assert.deepEqual(params, [
+          testPackageId,
+          testPackageVersionId,
+          null,
+          "draft",
+          "admin@example.com",
+          null,
+        ]);
+        return createQueryResult([]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const packageVersion = await createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+    executor,
+    testPackageId,
+    {
+      packageVersionId: testPackageVersionId,
+      workspaceId: testWorkspaceId,
+      cardIds: [testWorkspaceCardId],
+    },
+    "admin-user-id",
+    "admin@example.com",
+  );
+
+  assert.equal(packageVersion.packageVersionId, testPackageVersionId);
+  assert.equal(packageVersion.sourceWorkspaceId, testWorkspaceId);
+  assert.notEqual(insertedPackageCardId, null);
+  assert.deepEqual(versionMediaInsertParams, [
+    [testPackageId, testPackageVersionId, testCollisionSafePackageMediaKey, testMediaBlobId],
+    [testPackageId, testPackageVersionId, testSecondPackageMediaKey, testSecondMediaBlobId],
+  ]);
+});
+
+test("workspace-selected catalog versions fail when referenced media is missing", async () => {
+  const queries: Array<string> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      queries.push(text);
+      if (text.includes("set_config('app.user_id'")) {
+        assert.deepEqual(params, ["admin-user-id", testWorkspaceId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("FROM content.cards")) {
+        assert.deepEqual(params, [testWorkspaceId, [testWorkspaceCardId]]);
+        return createQueryResult([{
+          card_id: testWorkspaceCardId,
+          front_text: `Prompt ![diagram](fcasset:${testWorkspaceMediaAssetId})`,
+          back_text: "Answer",
+          card_type: "basic",
+          metadata: { version: 1, source: null },
+          tags: [],
+        } as unknown as Row]);
+      }
+
+      if (text.includes("FROM content.media_assets AS media_assets")) {
+        assert.deepEqual(params, [testWorkspaceId, [testWorkspaceMediaAssetId]]);
+        return createQueryResult([]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  await assert.rejects(
+    createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+      executor,
+      testPackageId,
+      {
+        packageVersionId: testPackageVersionId,
+        workspaceId: testWorkspaceId,
+        cardIds: [testWorkspaceCardId],
       },
-    );
-    assert.equal(queries.length, 2);
-  });
-}
+      "admin-user-id",
+      "admin@example.com",
+    ),
+    (error: unknown) => {
+      assert.equal(error instanceof HttpError, true);
+      assert.equal((error as HttpError).statusCode, 400);
+      assert.equal((error as HttpError).code, "CATALOG_WORKSPACE_MEDIA_ASSET_NOT_FOUND");
+      assert.match((error as HttpError).message, new RegExp(`workspaceId=${testWorkspaceId}`));
+      assert.match((error as HttpError).message, new RegExp(`missingMediaAssetIds=${testWorkspaceMediaAssetId}`));
+      return true;
+    },
+  );
+  assert.equal(queries.length, 3);
+});
+
+test("workspace-selected catalog versions reject invalid managed media references", async () => {
+  const queries: Array<string> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      queries.push(text);
+      if (text.includes("set_config('app.user_id'")) {
+        assert.deepEqual(params, ["admin-user-id", testWorkspaceId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("FROM content.cards")) {
+        assert.deepEqual(params, [testWorkspaceId, [testWorkspaceCardId]]);
+        return createQueryResult([{
+          card_id: testWorkspaceCardId,
+          front_text: "Prompt ![diagram](fcasset:not-a-uuid)",
+          back_text: "Answer",
+          card_type: "basic",
+          metadata: { version: 1, source: null },
+          tags: [],
+        } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  await assert.rejects(
+    createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+      executor,
+      testPackageId,
+      {
+        packageVersionId: testPackageVersionId,
+        workspaceId: testWorkspaceId,
+        cardIds: [testWorkspaceCardId],
+      },
+      "admin-user-id",
+      "admin@example.com",
+    ),
+    (error: unknown) => {
+      assert.equal(error instanceof HttpError, true);
+      assert.equal((error as HttpError).statusCode, 400);
+      assert.equal((error as HttpError).code, "CATALOG_WORKSPACE_MEDIA_ASSET_ID_INVALID");
+      assert.match((error as HttpError).message, /mediaAssetIds=not-a-uuid/);
+      return true;
+    },
+  );
+  assert.equal(queries.length, 2);
+});

--- a/apps/backend/src/catalog/types.ts
+++ b/apps/backend/src/catalog/types.ts
@@ -142,6 +142,11 @@ export type AttachCatalogPackageMediaAssetInput = Readonly<{
   license: string | null;
 }>;
 
+export type CatalogPackageVersionMediaAssetInput = Readonly<{
+  packageMediaKey: string;
+  mediaBlobId: string;
+}>;
+
 export type CatalogPackageVersionRow = Readonly<{
   package_version_id: string;
   package_id: string;

--- a/apps/backend/src/catalog/versions.ts
+++ b/apps/backend/src/catalog/versions.ts
@@ -13,17 +13,26 @@ import {
   normalizeTextArray,
   toSafeNumber,
 } from "./common";
-import { assertDraftMediaKeysExistInExecutor } from "./draftMedia";
+import {
+  assertDraftMediaKeysExistInExecutor,
+  insertCatalogPackageVersionMediaAssetsInExecutor,
+  loadCatalogPackageDraftMediaKeysInExecutor,
+} from "./draftMedia";
 import { rethrowCatalogPersistenceError } from "./errors";
 import {
   catalogPackageVersionColumns,
   lockCatalogPackageInExecutor,
   mapCatalogPackageVersionRow,
 } from "./rows";
+import {
+  extractMarkdownFcAssetIds,
+  rewriteMarkdownFcAssetUrlsToFcAssets,
+} from "../workspacePackages";
 import type {
   CatalogPackageCardSnapshotInput,
   CatalogPackageStatus,
   CatalogPackageVersion,
+  CatalogPackageVersionMediaAssetInput,
   CatalogPackageVersionRow,
   CatalogWorkspaceCardRow,
   CreateCatalogPackageVersionFromWorkspaceInput,
@@ -38,7 +47,12 @@ const reviewStatusRouteTargets: ReadonlySet<CatalogPackageStatus> = new Set([
   "approved",
   "rejected",
 ]);
-const managedMediaReferencePattern = /fcasset:/iu;
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+type CatalogWorkspaceMediaAssetRow = Readonly<{
+  media_asset_id: string;
+  media_blob_id: string;
+}>;
 
 export function isCatalogPackageVersionStatusTransitionAllowed(
   fromStatus: CatalogPackageStatus,
@@ -154,6 +168,27 @@ function assertUniqueCardSnapshots(cards: ReadonlyArray<CatalogPackageCardSnapsh
 
 function getAllCardMediaAssetKeys(cards: ReadonlyArray<CatalogPackageCardSnapshotInput>): ReadonlyArray<string> {
   return [...new Set(cards.flatMap((card) => card.mediaAssetKeys))];
+}
+
+function getVersionMediaAssetKeys(
+  versionMediaAssets: ReadonlyArray<CatalogPackageVersionMediaAssetInput>,
+): ReadonlySet<string> {
+  return new Set(versionMediaAssets.map((mediaAsset) => (
+    normalizePackageMediaKey(mediaAsset.packageMediaKey, "versionMediaAssets.packageMediaKey")
+  )));
+}
+
+function getDraftMediaAssetKeysForPackageVersion(
+  coverPackageMediaKey: string | null,
+  cards: ReadonlyArray<CatalogPackageCardSnapshotInput>,
+  versionMediaAssetKeys: ReadonlySet<string>,
+): ReadonlyArray<string> {
+  return [
+    ...(coverPackageMediaKey === null ? [] : [coverPackageMediaKey]),
+    ...getAllCardMediaAssetKeys(cards).filter((mediaAssetKey) => (
+      versionMediaAssetKeys.has(mediaAssetKey) === false
+    )),
+  ];
 }
 
 async function loadPackageVersionForUpdateInExecutor(
@@ -314,16 +349,19 @@ async function createPackageVersionFromNormalizedCardsInExecutor(
   input: CreateCatalogPackageVersionInput,
   sourceWorkspaceId: string | null,
   adminEmail: string,
+  versionMediaAssets: ReadonlyArray<CatalogPackageVersionMediaAssetInput>,
 ): Promise<CatalogPackageVersion> {
   const catalogPackage = await lockCatalogPackageInExecutor(executor, packageId);
   await assertNoMutablePackageVersionInExecutor(executor, packageId);
+  const versionMediaAssetKeys = getVersionMediaAssetKeys(versionMediaAssets);
   await assertDraftMediaKeysExistInExecutor(
     executor,
     packageId,
-    [
-      ...(catalogPackage.cover_package_media_key === null ? [] : [catalogPackage.cover_package_media_key]),
-      ...getAllCardMediaAssetKeys(input.cards),
-    ],
+    getDraftMediaAssetKeysForPackageVersion(
+      catalogPackage.cover_package_media_key,
+      input.cards,
+      versionMediaAssetKeys,
+    ),
   );
   const versionNumber = await getNextPackageVersionNumberInExecutor(executor, packageId);
   const result = await executor.query<CatalogPackageVersionRow>(
@@ -362,6 +400,12 @@ async function createPackageVersionFromNormalizedCardsInExecutor(
   }
 
   await copyDraftMediaAssetsToPackageVersionInExecutor(executor, packageId, input.packageVersionId);
+  await insertCatalogPackageVersionMediaAssetsInExecutor(
+    executor,
+    packageId,
+    input.packageVersionId,
+    versionMediaAssets,
+  );
   await insertPackageCardsInExecutor(executor, input.packageVersionId, input.cards);
   await insertPackageVersionStatusEventInExecutor(executor, {
     packageId,
@@ -394,38 +438,126 @@ function normalizeWorkspaceVersionInput(
   };
 }
 
+function normalizeWorkspaceMediaAssetIds(mediaAssetIds: ReadonlyArray<string>): ReadonlyArray<string> {
+  const normalizedMediaAssetIds = mediaAssetIds.map((mediaAssetId) => mediaAssetId.toLowerCase());
+  const invalidMediaAssetIds = normalizedMediaAssetIds.filter((mediaAssetId) => (
+    uuidPattern.test(mediaAssetId) === false
+  ));
+  if (invalidMediaAssetIds.length !== 0) {
+    throw new HttpError(
+      400,
+      `Workspace catalog version source references invalid media asset ids. mediaAssetIds=${invalidMediaAssetIds.join(",")}`,
+      "CATALOG_WORKSPACE_MEDIA_ASSET_ID_INVALID",
+    );
+  }
+
+  return [...new Set(normalizedMediaAssetIds)];
+}
+
+function getWorkspaceCardMediaAssetIds(row: CatalogWorkspaceCardRow): ReadonlyArray<string> {
+  return normalizeWorkspaceMediaAssetIds([
+    ...extractMarkdownFcAssetIds(row.front_text),
+    ...extractMarkdownFcAssetIds(row.back_text),
+  ]);
+}
+
+function getWorkspaceCardsMediaAssetIds(rows: ReadonlyArray<CatalogWorkspaceCardRow>): ReadonlyArray<string> {
+  return normalizeWorkspaceMediaAssetIds(rows.flatMap((row) => [
+    ...extractMarkdownFcAssetIds(row.front_text),
+    ...extractMarkdownFcAssetIds(row.back_text),
+  ]));
+}
+
+function buildPackageMediaKeyFromWorkspaceMediaAssetId(mediaAssetId: string): string {
+  return normalizePackageMediaKey(`w-${mediaAssetId.toLowerCase()}`, "workspaceMediaAssetId");
+}
+
+function buildCollisionFreePackageMediaKey(
+  basePackageMediaKey: string,
+  reservedPackageMediaKeys: ReadonlySet<string>,
+): string {
+  if (reservedPackageMediaKeys.has(basePackageMediaKey) === false) {
+    return basePackageMediaKey;
+  }
+
+  let suffix = 1;
+  while (reservedPackageMediaKeys.has(`${basePackageMediaKey}.${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${basePackageMediaKey}.${suffix}`;
+}
+
+function buildWorkspacePackageMediaKeyMap(
+  rows: ReadonlyArray<CatalogWorkspaceMediaAssetRow>,
+  reservedPackageMediaKeys: ReadonlySet<string>,
+): ReadonlyMap<string, string> {
+  const usedPackageMediaKeys = new Set(reservedPackageMediaKeys);
+  return new Map(rows.map((row) => {
+    const packageMediaKey = buildCollisionFreePackageMediaKey(
+      buildPackageMediaKeyFromWorkspaceMediaAssetId(row.media_asset_id),
+      usedPackageMediaKeys,
+    );
+    usedPackageMediaKeys.add(packageMediaKey);
+
+    return [
+      row.media_asset_id.toLowerCase(),
+      packageMediaKey,
+    ];
+  }));
+}
+
+function resolveWorkspacePackageMediaKey(
+  packageMediaKeysByWorkspaceMediaAssetId: ReadonlyMap<string, string>,
+  workspaceMediaAssetId: string,
+): string {
+  const packageMediaKey = packageMediaKeysByWorkspaceMediaAssetId.get(workspaceMediaAssetId.toLowerCase());
+  if (packageMediaKey === undefined) {
+    throw new Error(`Workspace media asset package key was not loaded. mediaAssetId=${workspaceMediaAssetId}`);
+  }
+
+  return packageMediaKey;
+}
+
+function rewriteWorkspaceCardTextMediaKeys(
+  markdown: string,
+  packageMediaKeysByWorkspaceMediaAssetId: ReadonlyMap<string, string>,
+): string {
+  return rewriteMarkdownFcAssetUrlsToFcAssets(markdown, (workspaceMediaAssetId) => (
+    resolveWorkspacePackageMediaKey(packageMediaKeysByWorkspaceMediaAssetId, workspaceMediaAssetId)
+  ));
+}
+
 function mapWorkspaceCardsToSnapshots(
   rows: ReadonlyArray<CatalogWorkspaceCardRow>,
+  packageMediaKeysByWorkspaceMediaAssetId: ReadonlyMap<string, string>,
 ): ReadonlyArray<CatalogPackageCardSnapshotInput> {
   return rows.map((row, index) => ({
     packageCardId: randomUUID(),
     stableCardKey: row.card_id,
     ordinal: index + 1,
-    frontText: row.front_text,
-    backText: row.back_text,
+    frontText: rewriteWorkspaceCardTextMediaKeys(row.front_text, packageMediaKeysByWorkspaceMediaAssetId),
+    backText: rewriteWorkspaceCardTextMediaKeys(row.back_text, packageMediaKeysByWorkspaceMediaAssetId),
     cardType: row.card_type,
     metadata: row.metadata,
     tags: [...row.tags],
-    mediaAssetKeys: [],
+    mediaAssetKeys: getWorkspaceCardMediaAssetIds(row).map((mediaAssetId) => (
+      resolveWorkspacePackageMediaKey(packageMediaKeysByWorkspaceMediaAssetId, mediaAssetId)
+    )),
   }));
 }
 
-function assertWorkspaceCardHasNoManagedMediaReferences(row: CatalogWorkspaceCardRow): void {
-  if (managedMediaReferencePattern.test(row.front_text)) {
-    throw new HttpError(
-      400,
-      `Workspace card contains a managed media reference that cannot be copied into a catalog package yet. cardId=${row.card_id} field=frontText`,
-      "CATALOG_WORKSPACE_CARD_MEDIA_REFERENCE_UNSUPPORTED",
-    );
-  }
-
-  if (managedMediaReferencePattern.test(row.back_text)) {
-    throw new HttpError(
-      400,
-      `Workspace card contains a managed media reference that cannot be copied into a catalog package yet. cardId=${row.card_id} field=backText`,
-      "CATALOG_WORKSPACE_CARD_MEDIA_REFERENCE_UNSUPPORTED",
-    );
-  }
+function mapWorkspaceMediaRowsToPackageVersionMediaAssets(
+  rows: ReadonlyArray<CatalogWorkspaceMediaAssetRow>,
+  packageMediaKeysByWorkspaceMediaAssetId: ReadonlyMap<string, string>,
+): ReadonlyArray<CatalogPackageVersionMediaAssetInput> {
+  return rows.map((row) => ({
+    packageMediaKey: resolveWorkspacePackageMediaKey(
+      packageMediaKeysByWorkspaceMediaAssetId,
+      row.media_asset_id,
+    ),
+    mediaBlobId: row.media_blob_id,
+  }));
 }
 
 async function loadWorkspaceCardsForCatalogVersionInExecutor(
@@ -454,8 +586,46 @@ async function loadWorkspaceCardsForCatalogVersionInExecutor(
     );
   }
 
-  for (const row of result.rows) {
-    assertWorkspaceCardHasNoManagedMediaReferences(row);
+  return result.rows;
+}
+
+async function loadWorkspaceMediaAssetsForCatalogVersionInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  mediaAssetIds: ReadonlyArray<string>,
+): Promise<ReadonlyArray<CatalogWorkspaceMediaAssetRow>> {
+  const normalizedMediaAssetIds = normalizeWorkspaceMediaAssetIds(mediaAssetIds);
+  if (normalizedMediaAssetIds.length === 0) {
+    return [];
+  }
+
+  const result = await executor.query<CatalogWorkspaceMediaAssetRow>(
+    [
+      "SELECT",
+      "media_assets.media_asset_id AS media_asset_id,",
+      "media_blobs.media_blob_id AS media_blob_id",
+      "FROM content.media_assets AS media_assets",
+      "INNER JOIN content.media_blobs AS media_blobs",
+      "ON media_blobs.media_blob_id = media_assets.media_blob_id",
+      "WHERE media_assets.workspace_id = $1",
+      "AND media_assets.media_asset_id = ANY($2::uuid[])",
+      "AND media_assets.deleted_at IS NULL",
+      "ORDER BY array_position($2::uuid[], media_assets.media_asset_id)",
+    ].join(" "),
+    [workspaceId, normalizedMediaAssetIds],
+  );
+  const returnedMediaAssetIds = new Set(result.rows.map((row: CatalogWorkspaceMediaAssetRow) => (
+    row.media_asset_id.toLowerCase()
+  )));
+  const missingMediaAssetIds = normalizedMediaAssetIds.filter((mediaAssetId) => (
+    returnedMediaAssetIds.has(mediaAssetId) === false
+  ));
+  if (missingMediaAssetIds.length !== 0) {
+    throw new HttpError(
+      400,
+      `Workspace catalog version source is missing media assets. workspaceId=${workspaceId} missingMediaAssetIds=${missingMediaAssetIds.join(",")}`,
+      "CATALOG_WORKSPACE_MEDIA_ASSET_NOT_FOUND",
+    );
   }
 
   return result.rows;
@@ -476,6 +646,7 @@ export async function createCatalogPackageVersionFromCardsInExecutor(
       normalizedInput,
       null,
       normalizedAdminEmail,
+      [],
     );
   } catch (error) {
     rethrowCatalogPersistenceError(error);
@@ -501,9 +672,24 @@ export async function createCatalogPackageVersionFromWorkspaceSelectionInExecuto
       normalizedInput.workspaceId,
       normalizedInput.cardIds,
     );
+    const workspaceMediaAssets = await loadWorkspaceMediaAssetsForCatalogVersionInExecutor(
+      executor,
+      normalizedInput.workspaceId,
+      getWorkspaceCardsMediaAssetIds(workspaceCards),
+    );
+    if (workspaceMediaAssets.length !== 0) {
+      await lockCatalogPackageInExecutor(executor, packageId);
+    }
+    const reservedPackageMediaKeys = workspaceMediaAssets.length === 0
+      ? new Set<string>()
+      : await loadCatalogPackageDraftMediaKeysInExecutor(executor, packageId);
+    const packageMediaKeysByWorkspaceMediaAssetId = buildWorkspacePackageMediaKeyMap(
+      workspaceMediaAssets,
+      reservedPackageMediaKeys,
+    );
     const packageVersionInput = normalizeCreatePackageVersionInput({
       packageVersionId: normalizedInput.packageVersionId,
-      cards: mapWorkspaceCardsToSnapshots(workspaceCards),
+      cards: mapWorkspaceCardsToSnapshots(workspaceCards, packageMediaKeysByWorkspaceMediaAssetId),
     });
 
     return await createPackageVersionFromNormalizedCardsInExecutor(
@@ -512,6 +698,10 @@ export async function createCatalogPackageVersionFromWorkspaceSelectionInExecuto
       packageVersionInput,
       normalizedInput.workspaceId,
       normalizedAdminEmail,
+      mapWorkspaceMediaRowsToPackageVersionMediaAssets(
+        workspaceMediaAssets,
+        packageMediaKeysByWorkspaceMediaAssetId,
+      ),
     );
   } catch (error) {
     rethrowCatalogPersistenceError(error);

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -3,6 +3,7 @@ export {
   extractMarkdownPortableMediaPaths,
   rewriteMarkdownFcAssetUrlsToPortablePaths,
   rewriteMarkdownFcAssetUrlsToPortablePathsFromMap,
+  rewriteMarkdownFcAssetUrlsToFcAssets,
   rewriteMarkdownFcAssetUrlsToSharedPortablePaths,
   rewriteMarkdownPortableMediaUrlsToFcAssets,
   rewriteMarkdownPortableMediaUrlsToFcAssetsFromMap,
@@ -11,6 +12,7 @@ export {
 } from "./markdownMedia";
 
 export type {
+  FcAssetIdResolver,
   FcAssetPortablePathResolver,
   PortableMediaAssetIdResolver,
 } from "./markdownMedia";

--- a/apps/backend/src/workspacePackages/markdownMedia.ts
+++ b/apps/backend/src/workspacePackages/markdownMedia.ts
@@ -18,6 +18,7 @@ type MarkdownFence = Readonly<{
 }>;
 
 export type FcAssetPortablePathResolver = (assetId: string) => string;
+export type FcAssetIdResolver = (assetId: string) => string;
 export type PortableMediaAssetIdResolver = (portableMediaPath: string) => string;
 
 const fcAssetUrlPattern = /^fcasset:([A-Za-z0-9][A-Za-z0-9._-]*)$/;
@@ -561,6 +562,20 @@ export function rewriteMarkdownFcAssetUrlsToSharedPortablePaths(
     }
 
     return validatePortableMediaPath(resolvePortablePath(assetId));
+  });
+}
+
+export function rewriteMarkdownFcAssetUrlsToFcAssets(
+  markdown: string,
+  resolveAssetId: FcAssetIdResolver,
+): string {
+  return rewriteMarkdownUrls(markdown, (url) => {
+    const assetId = matchFcAssetId(url);
+    if (assetId === null) {
+      return null;
+    }
+
+    return `fcasset:${assertFcAssetId(resolveAssetId(assetId), "Resolved fcasset id")}`;
   });
 }
 


### PR DESCRIPTION
## Summary
- preserve workspace fcasset references when creating catalog package versions from workspace selections
- add version-bound package media rows backed by existing content.media_blobs
- rewrite catalog card markdown to package-local media keys and cover missing/invalid media tests

## Validation
- git --no-pager diff --check
- npm run lint --prefix apps/backend
- cd apps/backend && node --test --import tsx src/catalog/index.test.ts