### PR TITLE
Fix agent smoke catalog install paths

### DIFF
--- a/scripts/checks/check-agent-api-smoke.sh
+++ b/scripts/checks/check-agent-api-smoke.sh
@@ -206,6 +206,8 @@ required_paths = {
     "/workspaces/{workspaceId}/packages/export/preview",
     "/workspaces/{workspaceId}/packages/import",
     "/workspaces/{workspaceId}/packages/import/preview",
+    "/workspaces/{workspaceId}/catalog/package-versions/{packageVersionId}/install",
+    "/workspaces/{workspaceId}/catalog/package-versions/{packageVersionId}/install/preview",
     "/admin/catalog/authors",
     "/admin/catalog/authors/{authorId}",
     "/admin/catalog/package-versions/{packageVersionId}/delist",


### PR DESCRIPTION
## Summary
- add catalog install endpoints to the live agent API smoke OpenAPI path allowlist

## Verification
- bash -n scripts/checks/check-agent-api-smoke.sh
- FLASHCARDS_AGENT_SMOKE_RUN_ID=codex-1783000760 bash scripts/checks/check-agent-api-smoke.sh