### PR TITLE
Fix API Gateway mock content handling

### DIFF
--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -8,6 +8,8 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Template } from "aws-cdk-lib/assertions";
 import {
+  addTextContentHandlingToMockOptionsMethods,
+  createLegacyAuthNotFoundIntegration,
   createMediaAssetsObjectPolicyStatement,
   createChatLiveFunctionUrlCorsOptions,
   createGatewayErrorResponseHeaders,
@@ -93,6 +95,7 @@ test("global snapshot API Gateway mock preflight allows content type and Sentry 
   globalResource.addResource("snapshot", {
     defaultCorsPreflightOptions: globalMetricsCorsPreflightOptions,
   });
+  addTextContentHandlingToMockOptionsMethods(restApi);
 
   const template = Template.fromStack(stack);
   const methods = template.findResources("AWS::ApiGateway::Method", {
@@ -103,6 +106,11 @@ test("global snapshot API Gateway mock preflight allows content type and Sentry 
   const optionsMethods = Object.values(methods);
 
   assert.equal(optionsMethods.length, 1);
+  assert.equal(optionsMethods[0]?.Properties?.Integration?.ContentHandling, "CONVERT_TO_TEXT");
+  assert.equal(
+    optionsMethods[0]?.Properties?.Integration?.IntegrationResponses?.[0]?.ContentHandling,
+    "CONVERT_TO_TEXT",
+  );
   assert.deepEqual(optionsMethods[0]?.Properties?.Integration?.IntegrationResponses?.[0]?.ResponseParameters, {
     "method.response.header.Access-Control-Allow-Headers": "'content-type,authorization,sentry-trace,baggage'",
     "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'",
@@ -114,6 +122,49 @@ test("global snapshot API Gateway mock preflight allows content type and Sentry 
     ],
     true,
   );
+});
+
+test("legacy auth tombstone API Gateway mock response converts text under binary media types", () => {
+  const stack = new cdk.Stack();
+  const restApi = new apigw.RestApi(stack, "Api", {
+    binaryMediaTypes: ["*/*"],
+  });
+  const legacyAuth = restApi.root.addResource("auth");
+
+  legacyAuth.addMethod("ANY", createLegacyAuthNotFoundIntegration(), {
+    methodResponses: [
+      {
+        statusCode: "404",
+      },
+    ],
+  });
+
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties("AWS::ApiGateway::Method", {
+    HttpMethod: "ANY",
+    Integration: {
+      Type: "MOCK",
+      ContentHandling: "CONVERT_TO_TEXT",
+      IntegrationResponses: [
+        {
+          StatusCode: "404",
+          ContentHandling: "CONVERT_TO_TEXT",
+          ResponseTemplates: {
+            "application/json": "{\"error\":\"Not found\"}",
+          },
+        },
+      ],
+      RequestTemplates: {
+        "application/json": "{\"statusCode\": 404}",
+      },
+    },
+    MethodResponses: [
+      {
+        StatusCode: "404",
+      },
+    ],
+  });
 });
 
 test("chat live Lambda Function URL CORS exposes request id header", () => {

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -197,6 +197,86 @@ export function createGatewayErrorResponseHeaders(): GatewayErrorResponseHeaders
   };
 }
 
+function isConcreteIntegration(
+  integration: apigw.CfnMethod.IntegrationProperty | cdk.IResolvable | undefined,
+): integration is apigw.CfnMethod.IntegrationProperty {
+  return integration !== undefined && !cdk.Token.isUnresolved(integration);
+}
+
+function isConcreteIntegrationResponse(
+  response: apigw.CfnMethod.IntegrationResponseProperty | cdk.IResolvable,
+): response is apigw.CfnMethod.IntegrationResponseProperty {
+  return !cdk.Token.isUnresolved(response);
+}
+
+function addTextContentHandlingToIntegrationResponses(
+  responses: Array<apigw.CfnMethod.IntegrationResponseProperty | cdk.IResolvable> | cdk.IResolvable | undefined,
+  methodNodePath: string,
+): Array<apigw.CfnMethod.IntegrationResponseProperty | cdk.IResolvable> {
+  if (!Array.isArray(responses)) {
+    throw new Error(`Expected API Gateway mock integration responses to be concrete for ${methodNodePath}`);
+  }
+
+  return responses.map((response) => {
+    if (!isConcreteIntegrationResponse(response)) {
+      throw new Error(`Expected API Gateway mock integration response to be concrete for ${methodNodePath}`);
+    }
+
+    return {
+      ...response,
+      contentHandling: apigw.ContentHandling.CONVERT_TO_TEXT,
+    };
+  });
+}
+
+export function addTextContentHandlingToMockOptionsMethods(restApi: apigw.RestApi): void {
+  const latestDeployment = restApi.latestDeployment;
+
+  if (latestDeployment === undefined) {
+    throw new Error("API Gateway mock content handling requires a deployed RestApi so the stage is redeployed");
+  }
+
+  for (const node of restApi.node.findAll()) {
+    if (!apigw.CfnMethod.isCfnMethod(node) || node.httpMethod !== "OPTIONS") {
+      continue;
+    }
+
+    const integration = node.integration;
+
+    if (!isConcreteIntegration(integration) || integration.type !== apigw.IntegrationType.MOCK) {
+      continue;
+    }
+
+    node.integration = {
+      ...integration,
+      contentHandling: apigw.ContentHandling.CONVERT_TO_TEXT,
+      integrationResponses: addTextContentHandlingToIntegrationResponses(integration.integrationResponses, node.node.path),
+    };
+  }
+
+  latestDeployment.addToLogicalId({
+    apiGatewayMockOptionsContentHandling: apigw.ContentHandling.CONVERT_TO_TEXT,
+  });
+}
+
+export function createLegacyAuthNotFoundIntegration(): apigw.MockIntegration {
+  return new apigw.MockIntegration({
+    contentHandling: apigw.ContentHandling.CONVERT_TO_TEXT,
+    requestTemplates: {
+      "application/json": '{"statusCode": 404}',
+    },
+    integrationResponses: [
+      {
+        statusCode: "404",
+        contentHandling: apigw.ContentHandling.CONVERT_TO_TEXT,
+        responseTemplates: {
+          "application/json": '{"error":"Not found"}',
+        },
+      },
+    ],
+  });
+}
+
 function createDockerBundlingEnvironment(): Record<DockerBundlingEnvironmentVariableName, string> {
   return {
     GITHUB_ACTIONS: process.env.GITHUB_ACTIONS ?? "",
@@ -696,19 +776,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     scopePermissionToMethod: false,
   });
 
-  const notFoundIntegration = new apigw.MockIntegration({
-    requestTemplates: {
-      "application/json": '{"statusCode": 404}',
-    },
-    integrationResponses: [
-      {
-        statusCode: "404",
-        responseTemplates: {
-          "application/json": '{"error":"Not found"}',
-        },
-      },
-    ],
-  });
+  const notFoundIntegration = createLegacyAuthNotFoundIntegration();
   const notFoundMethodOptions: apigw.MethodOptions = {
     methodResponses: [
       {
@@ -738,6 +806,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
 
   restApi.root.addMethod("GET", integration);
   restApi.root.addResource("{proxy+}").addMethod("ANY", integration);
+  addTextContentHandlingToMockOptionsMethods(restApi);
 
   if (props.apiCertificateArn) {
     const apiDomainName = `api.${props.baseDomain}`;


### PR DESCRIPTION
## Summary
- set API Gateway mock content handling to CONVERT_TO_TEXT for legacy auth tombstone responses
- patch generated CORS OPTIONS mock methods under the REST API and force a deployment logical ID refresh
- add infra synth tests for tombstone and CORS mock content handling

## Validation
- npm ci --prefix infra/aws passed with only a Node 25 vs package Node 24 engine warning
- npm run test --prefix infra/aws passed: 32/32 tests
- worker-owned review round passed with no split recommendation and no P0-P4 findings