### PR TITLE
Add Android media transfer foundation

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration28To29Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration28To29Test.kt
@@ -1,0 +1,93 @@
+package com.flashcardsopensourceapp.data.local.migrations
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.database.migrations.migration28To29
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val migration28To29DatabaseName: String = "migration-28-to-29-test.db"
+
+@RunWith(AndroidJUnit4::class)
+class AppDatabaseMigration28To29Test {
+    @After
+    fun tearDown(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        deleteMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration28To29DatabaseName
+        )
+    }
+
+    @Test
+    fun migration28To29AddsMediaCacheAndTransferQueueTables(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        createVersion28Database(context = context)
+
+        val openHelper: SupportSQLiteOpenHelper = openMigrationDatabaseAtVersion(
+            context = context,
+            databaseName = migration28To29DatabaseName,
+            version = 28
+        )
+        val database: SupportSQLiteDatabase = openHelper.writableDatabase
+
+        try {
+            migration28To29.migrate(database)
+
+            assertTrue(
+                migrationTableExists(
+                    database = database,
+                    tableName = "media_blob_cache"
+                )
+            )
+            assertTrue(
+                migrationTableExists(
+                    database = database,
+                    tableName = "media_transfer_queue"
+                )
+            )
+            assertEquals(
+                listOf("workspaceId", "status", "nextAttemptAtMillis", "createdAtMillis"),
+                readMigrationIndexColumns(
+                    database = database,
+                    indexName = "index_media_transfer_queue_workspaceId_status_nextAttemptAtMillis_createdAtMillis"
+                )
+            )
+            assertEquals(
+                listOf("localRelativePath"),
+                readMigrationIndexColumns(
+                    database = database,
+                    indexName = "index_media_blob_cache_localRelativePath"
+                )
+            )
+        } finally {
+            database.close()
+            openHelper.close()
+        }
+    }
+
+    private fun createVersion28Database(context: Context): Unit {
+        createMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration28To29DatabaseName,
+            version = 28
+        ) { sqliteDatabase: SQLiteDatabase ->
+            sqliteDatabase.execSQL(
+                """
+                CREATE TABLE workspaces (
+                    workspaceId TEXT NOT NULL PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    createdAtMillis INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
@@ -15,7 +15,14 @@ import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackSubmissionRequest
+import com.flashcardsopensourceapp.data.local.model.media.CompleteMediaAssetUploadSessionRequest
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadCompletion
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsResponse
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionAbort
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateResponse
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeReconciliation
@@ -667,6 +674,44 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         mediaAssetId: String
     ): MediaAssetDownloadUrl {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: MediaAssetUploadSessionCreateRequest
+    ): MediaAssetUploadSessionCreateResponse {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun createMediaAssetUploadPartUrls(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadPartUrlsRequest
+    ): MediaAssetUploadPartUrlsResponse {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: CompleteMediaAssetUploadSessionRequest
+    ): MediaAssetUploadCompletion {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ): MediaAssetUploadSessionAbort {
         throw UnsupportedOperationException()
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
@@ -13,7 +13,14 @@ import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackSubmissionRequest
+import com.flashcardsopensourceapp.data.local.model.media.CompleteMediaAssetUploadSessionRequest
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadCompletion
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsResponse
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionAbort
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateResponse
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
@@ -201,6 +208,32 @@ interface CloudRemoteGateway {
         workspaceId: String,
         mediaAssetId: String
     ): MediaAssetDownloadUrl
+    suspend fun createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: MediaAssetUploadSessionCreateRequest
+    ): MediaAssetUploadSessionCreateResponse
+    suspend fun createMediaAssetUploadPartUrls(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadPartUrlsRequest
+    ): MediaAssetUploadPartUrlsResponse
+    suspend fun completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: CompleteMediaAssetUploadSessionRequest
+    ): MediaAssetUploadCompletion
+    suspend fun abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ): MediaAssetUploadSessionAbort
 
     suspend fun deleteAccount(apiBaseUrl: String, bearerToken: String, confirmationText: String)
     suspend fun listAgentConnections(apiBaseUrl: String, bearerToken: String): AgentApiKeyConnectionsResult

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
@@ -27,7 +27,14 @@ import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackSubmissionRequest
+import com.flashcardsopensourceapp.data.local.model.media.CompleteMediaAssetUploadSessionRequest
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadCompletion
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsResponse
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionAbort
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateResponse
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
@@ -492,6 +499,66 @@ class CloudRemoteService private constructor(
             authorizationHeader = authorizationHeader,
             workspaceId = workspaceId,
             mediaAssetId = mediaAssetId
+        )
+    }
+
+    override suspend fun createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: MediaAssetUploadSessionCreateRequest
+    ): MediaAssetUploadSessionCreateResponse {
+        return mediaAssetApi.createMediaAssetUploadSession(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            request = request
+        )
+    }
+
+    override suspend fun createMediaAssetUploadPartUrls(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadPartUrlsRequest
+    ): MediaAssetUploadPartUrlsResponse {
+        return mediaAssetApi.createMediaAssetUploadPartUrls(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            sessionId = sessionId,
+            request = request
+        )
+    }
+
+    override suspend fun completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: CompleteMediaAssetUploadSessionRequest
+    ): MediaAssetUploadCompletion {
+        return mediaAssetApi.completeMediaAssetUploadSession(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            sessionId = sessionId,
+            request = request
+        )
+    }
+
+    override suspend fun abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ): MediaAssetUploadSessionAbort {
+        return mediaAssetApi.abortMediaAssetUploadSession(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader,
+            workspaceId = workspaceId,
+            sessionId = sessionId
         )
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/media/CloudMediaAssetRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/media/CloudMediaAssetRemoteApi.kt
@@ -2,18 +2,39 @@ package com.flashcardsopensourceapp.data.local.cloud.remote.media
 
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildMediaAssetDownloadUrlCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildMediaAssetUploadSessionAbortCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildMediaAssetUploadSessionCompleteCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildMediaAssetUploadSessionCreateCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildMediaAssetUploadSessionPartsCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
+import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableString
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudIsoTimestampMillis
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudLong
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableIsoTimestampMillis
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableString
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudObject
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
+import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
+import com.flashcardsopensourceapp.data.local.model.media.CompleteMediaAssetUploadSessionRequest
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadCompletion
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrl
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsResponse
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSession
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionAbort
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateResponse
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateStatus
+import org.json.JSONArray
 import org.json.JSONObject
 
 private const val mediaAssetDownloadHttpMethod: String = "GET"
+private const val mediaAssetUploadPartHttpMethod: String = "PUT"
 
 internal class CloudMediaAssetRemoteApi(
     private val httpClient: CloudJsonHttpClient
@@ -37,6 +58,135 @@ internal class CloudMediaAssetRemoteApi(
             fieldPath = "mediaAssetDownloadUrl"
         )
     }
+
+    suspend fun createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: MediaAssetUploadSessionCreateRequest
+    ): MediaAssetUploadSessionCreateResponse {
+        val response = httpClient.postJson(
+            baseUrl = apiBaseUrl,
+            path = buildMediaAssetUploadSessionCreateCloudPath(workspaceId = workspaceId),
+            authorizationHeader = authorizationHeader,
+            body = buildMediaAssetUploadSessionCreateRequestBody(request = request)
+        )
+        return parseMediaAssetUploadSessionCreateResponse(
+            response = response,
+            fieldPath = "mediaAssetUploadSessionCreate"
+        )
+    }
+
+    suspend fun createMediaAssetUploadPartUrls(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadPartUrlsRequest
+    ): MediaAssetUploadPartUrlsResponse {
+        val response = httpClient.postJson(
+            baseUrl = apiBaseUrl,
+            path = buildMediaAssetUploadSessionPartsCloudPath(
+                workspaceId = workspaceId,
+                sessionId = sessionId
+            ),
+            authorizationHeader = authorizationHeader,
+            body = buildMediaAssetUploadPartUrlsRequestBody(request = request)
+        )
+        return parseMediaAssetUploadPartUrlsResponse(
+            response = response,
+            fieldPath = "mediaAssetUploadPartUrls"
+        )
+    }
+
+    suspend fun completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: CompleteMediaAssetUploadSessionRequest
+    ): MediaAssetUploadCompletion {
+        val response = httpClient.postJson(
+            baseUrl = apiBaseUrl,
+            path = buildMediaAssetUploadSessionCompleteCloudPath(
+                workspaceId = workspaceId,
+                sessionId = sessionId
+            ),
+            authorizationHeader = authorizationHeader,
+            body = buildCompleteMediaAssetUploadSessionRequestBody(request = request)
+        )
+        return parseCompleteMediaAssetUploadSessionResponse(
+            response = response,
+            fieldPath = "completeMediaAssetUploadSession"
+        )
+    }
+
+    suspend fun abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ): MediaAssetUploadSessionAbort {
+        val response = httpClient.postJson(
+            baseUrl = apiBaseUrl,
+            path = buildMediaAssetUploadSessionAbortCloudPath(
+                workspaceId = workspaceId,
+                sessionId = sessionId
+            ),
+            authorizationHeader = authorizationHeader,
+            body = null
+        )
+        return parseMediaAssetUploadSessionAbortResponse(
+            response = response,
+            fieldPath = "mediaAssetUploadSessionAbort"
+        )
+    }
+}
+
+internal fun buildMediaAssetUploadSessionCreateRequestBody(request: MediaAssetUploadSessionCreateRequest): JSONObject {
+    return JSONObject()
+        .put("mediaAssetId", request.mediaAssetId)
+        .put("mimeType", request.mimeType)
+        .put("sizeBytes", request.sizeBytes)
+        .put("sha256", request.sha256)
+        .put("partSizeBytes", request.partSizeBytes)
+        .put("partCount", request.partCount)
+        .putNullableString("sourceUrl", request.sourceUrl)
+        .put("createdAt", formatIsoTimestamp(request.createdAtMillis))
+        .put("clientUpdatedAt", formatIsoTimestamp(request.clientUpdatedAtMillis))
+        .put("lastModifiedByReplicaId", request.lastModifiedByReplicaId)
+        .put("lastOperationId", request.lastOperationId)
+}
+
+internal fun buildMediaAssetUploadPartUrlsRequestBody(request: MediaAssetUploadPartUrlsRequest): JSONObject {
+    return JSONObject()
+        .put(
+            "parts",
+            JSONArray(
+                request.parts.map { part ->
+                    JSONObject()
+                        .put("partNumber", part.partNumber)
+                        .put("sha256", part.sha256)
+                }
+            )
+        )
+}
+
+internal fun buildCompleteMediaAssetUploadSessionRequestBody(
+    request: CompleteMediaAssetUploadSessionRequest
+): JSONObject {
+    return JSONObject()
+        .put(
+            "parts",
+            JSONArray(
+                request.parts.map { part ->
+                    JSONObject()
+                        .put("partNumber", part.partNumber)
+                        .put("eTag", part.eTag)
+                        .put("sha256", part.sha256)
+                }
+            )
+        )
 }
 
 internal fun parseMediaAssetDownloadUrlResponse(
@@ -60,6 +210,89 @@ internal fun parseMediaAssetDownloadUrlResponse(
         mediaAsset = mediaAsset,
         url = download.requireCloudString("url", "$fieldPath.download.url"),
         expiresAtMillis = download.requireCloudIsoTimestampMillis("expiresAt", "$fieldPath.download.expiresAt")
+    )
+}
+
+internal fun parseMediaAssetUploadSessionCreateResponse(
+    response: JSONObject,
+    fieldPath: String
+): MediaAssetUploadSessionCreateResponse {
+    val status = parseMediaAssetUploadSessionCreateStatus(
+        rawStatus = response.requireCloudString("status", "$fieldPath.status"),
+        fieldPath = "$fieldPath.status"
+    )
+    val mediaAsset = response.requireCloudNullableObject(
+        key = "mediaAsset",
+        fieldPath = "$fieldPath.mediaAsset"
+    )?.let { mediaAssetObject ->
+        parseCloudMediaAsset(
+            mediaAsset = mediaAssetObject,
+            fieldPath = "$fieldPath.mediaAsset"
+        )
+    }
+    val uploadSession = response.requireCloudNullableObject(
+        key = "uploadSession",
+        fieldPath = "$fieldPath.uploadSession"
+    )?.let { uploadSessionObject ->
+        parseMediaAssetUploadSession(
+            uploadSession = uploadSessionObject,
+            fieldPath = "$fieldPath.uploadSession"
+        )
+    }
+    requireMediaAssetUploadSessionCreateShape(
+        status = status,
+        mediaAsset = mediaAsset,
+        uploadSession = uploadSession,
+        fieldPath = fieldPath
+    )
+    return MediaAssetUploadSessionCreateResponse(
+        workspaceId = response.requireCloudString("workspaceId", "$fieldPath.workspaceId"),
+        mediaAssetId = response.requireCloudString("mediaAssetId", "$fieldPath.mediaAssetId"),
+        status = status,
+        mediaAsset = mediaAsset,
+        uploadSession = uploadSession
+    )
+}
+
+internal fun parseMediaAssetUploadPartUrlsResponse(
+    response: JSONObject,
+    fieldPath: String
+): MediaAssetUploadPartUrlsResponse {
+    val partUrls = response.requireCloudArray("partUrls", "$fieldPath.partUrls")
+    if (partUrls.length() == 0) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath.partUrls: expected non-empty array, got empty array"
+        )
+    }
+    return MediaAssetUploadPartUrlsResponse(
+        sessionId = response.requireCloudString("sessionId", "$fieldPath.sessionId"),
+        partUrls = parseMediaAssetUploadPartUrls(
+            partUrls = partUrls,
+            fieldPath = "$fieldPath.partUrls"
+        )
+    )
+}
+
+internal fun parseCompleteMediaAssetUploadSessionResponse(
+    response: JSONObject,
+    fieldPath: String
+): MediaAssetUploadCompletion {
+    return MediaAssetUploadCompletion(
+        mediaAsset = parseCloudMediaAsset(
+            mediaAsset = response.requireCloudObject("mediaAsset", "$fieldPath.mediaAsset"),
+            fieldPath = "$fieldPath.mediaAsset"
+        ),
+        applied = response.requireCloudBoolean("applied", "$fieldPath.applied")
+    )
+}
+
+internal fun parseMediaAssetUploadSessionAbortResponse(
+    response: JSONObject,
+    fieldPath: String
+): MediaAssetUploadSessionAbort {
+    return MediaAssetUploadSessionAbort(
+        sessionId = response.requireCloudString("sessionId", "$fieldPath.sessionId"),
+        abortedAtMillis = response.requireCloudIsoTimestampMillis("abortedAt", "$fieldPath.abortedAt")
     )
 }
 
@@ -87,4 +320,163 @@ private fun parseCloudMediaAsset(
         updatedAtMillis = mediaAsset.requireCloudIsoTimestampMillis("updatedAt", "$fieldPath.updatedAt"),
         deletedAtMillis = mediaAsset.requireCloudNullableIsoTimestampMillis("deletedAt", "$fieldPath.deletedAt")
     )
+}
+
+private fun parseMediaAssetUploadSessionCreateStatus(
+    rawStatus: String,
+    fieldPath: String
+): MediaAssetUploadSessionCreateStatus {
+    return try {
+        MediaAssetUploadSessionCreateStatus.fromWireKey(wireKey = rawStatus)
+    } catch (error: IllegalArgumentException) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected one of [already_available, upload_required], " +
+                "got invalid string \"$rawStatus\"",
+            error
+        )
+    }
+}
+
+private fun parseMediaAssetUploadSession(
+    uploadSession: JSONObject,
+    fieldPath: String
+): MediaAssetUploadSession {
+    return MediaAssetUploadSession(
+        sessionId = uploadSession.requireCloudString("sessionId", "$fieldPath.sessionId"),
+        expiresAtMillis = uploadSession.requireCloudIsoTimestampMillis("expiresAt", "$fieldPath.expiresAt"),
+        partSizeBytes = uploadSession.requireCloudPositiveLong(
+            key = "partSizeBytes",
+            fieldPath = "$fieldPath.partSizeBytes"
+        ),
+        partCount = uploadSession.requireCloudPositiveInt(
+            key = "partCount",
+            fieldPath = "$fieldPath.partCount"
+        )
+    )
+}
+
+private fun requireMediaAssetUploadSessionCreateShape(
+    status: MediaAssetUploadSessionCreateStatus,
+    mediaAsset: MediaAsset?,
+    uploadSession: MediaAssetUploadSession?,
+    fieldPath: String
+) {
+    when (status) {
+        MediaAssetUploadSessionCreateStatus.ALREADY_AVAILABLE -> {
+            if (mediaAsset == null || uploadSession != null) {
+                throw CloudContractMismatchException(
+                    "Cloud contract mismatch for $fieldPath: already_available requires mediaAsset and null uploadSession."
+                )
+            }
+        }
+
+        MediaAssetUploadSessionCreateStatus.UPLOAD_REQUIRED -> {
+            if (mediaAsset != null || uploadSession == null) {
+                throw CloudContractMismatchException(
+                    "Cloud contract mismatch for $fieldPath: upload_required requires null mediaAsset and uploadSession."
+                )
+            }
+        }
+    }
+}
+
+private fun parseMediaAssetUploadPartUrls(
+    partUrls: JSONArray,
+    fieldPath: String
+): List<MediaAssetUploadPartUrl> {
+    return buildList {
+        for (index in 0 until partUrls.length()) {
+            val partUrl = partUrls.requireCloudObject(index = index, fieldPath = "$fieldPath[$index]")
+            add(
+                parseMediaAssetUploadPartUrl(
+                    partUrl = partUrl,
+                    fieldPath = "$fieldPath[$index]"
+                )
+            )
+        }
+    }
+}
+
+private fun parseMediaAssetUploadPartUrl(
+    partUrl: JSONObject,
+    fieldPath: String
+): MediaAssetUploadPartUrl {
+    val method = partUrl.requireCloudString("method", "$fieldPath.method")
+    if (method != mediaAssetUploadPartHttpMethod) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath.method: " +
+                "expected \"$mediaAssetUploadPartHttpMethod\", got invalid string \"$method\""
+        )
+    }
+    return MediaAssetUploadPartUrl(
+        partNumber = partUrl.requireCloudPositiveInt("partNumber", "$fieldPath.partNumber"),
+        method = method,
+        url = partUrl.requireCloudString("url", "$fieldPath.url"),
+        expiresAtMillis = partUrl.requireCloudIsoTimestampMillis("expiresAt", "$fieldPath.expiresAt"),
+        headers = parseMediaAssetUploadPartHeaders(
+            headers = partUrl.requireCloudObject("headers", "$fieldPath.headers"),
+            fieldPath = "$fieldPath.headers"
+        )
+    )
+}
+
+private fun parseMediaAssetUploadPartHeaders(
+    headers: JSONObject,
+    fieldPath: String
+): Map<String, String> {
+    val headerNames: Iterator<String> = headers.keys()
+    return buildMap {
+        while (headerNames.hasNext()) {
+            val headerName: String = headerNames.next()
+            put(
+                headerName,
+                headers.requireCloudString(headerName, "$fieldPath.$headerName")
+            )
+        }
+    }
+}
+
+private fun JSONObject.requireCloudNullableObject(
+    key: String,
+    fieldPath: String
+): JSONObject? {
+    if (has(key).not()) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected object or null, got missing"
+        )
+    }
+    val value = get(key)
+    return when {
+        value === JSONObject.NULL -> null
+        value is JSONObject -> value
+        else -> throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected object or null, got invalid value"
+        )
+    }
+}
+
+private fun JSONObject.requireCloudPositiveInt(
+    key: String,
+    fieldPath: String
+): Int {
+    val value: Int = requireCloudInt(key = key, fieldPath = fieldPath)
+    if (value <= 0) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected positive integer, got $value"
+        )
+    }
+    return value
+}
+
+private fun JSONObject.requireCloudPositiveLong(
+    key: String,
+    fieldPath: String
+): Long {
+    val value: Long = requireCloudLong(key = key, fieldPath = fieldPath)
+    if (value <= 0L) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected positive integer, got $value"
+        )
+    }
+    return value
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
@@ -78,6 +78,55 @@ internal fun buildMediaAssetDownloadUrlCloudPath(
         "/media-assets/${encodeCloudPathSegment(value = mediaAssetId)}/download-url"
 }
 
+internal fun buildMediaAssetUploadSessionCreateCloudPath(workspaceId: String): String {
+    require(workspaceId.isNotBlank()) {
+        "Media asset upload session create path requires a workspace id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}/media-assets/upload-sessions"
+}
+
+internal fun buildMediaAssetUploadSessionPartsCloudPath(
+    workspaceId: String,
+    sessionId: String
+): String {
+    require(workspaceId.isNotBlank()) {
+        "Media asset upload session parts path requires a workspace id."
+    }
+    require(sessionId.isNotBlank()) {
+        "Media asset upload session parts path requires a session id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}" +
+        "/media-assets/upload-sessions/${encodeCloudPathSegment(value = sessionId)}/parts"
+}
+
+internal fun buildMediaAssetUploadSessionCompleteCloudPath(
+    workspaceId: String,
+    sessionId: String
+): String {
+    require(workspaceId.isNotBlank()) {
+        "Media asset upload session complete path requires a workspace id."
+    }
+    require(sessionId.isNotBlank()) {
+        "Media asset upload session complete path requires a session id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}" +
+        "/media-assets/upload-sessions/${encodeCloudPathSegment(value = sessionId)}/complete"
+}
+
+internal fun buildMediaAssetUploadSessionAbortCloudPath(
+    workspaceId: String,
+    sessionId: String
+): String {
+    require(workspaceId.isNotBlank()) {
+        "Media asset upload session abort path requires a workspace id."
+    }
+    require(sessionId.isNotBlank()) {
+        "Media asset upload session abort path requires a session id."
+    }
+    return "/workspaces/${encodeCloudPathSegment(value = workspaceId)}" +
+        "/media-assets/upload-sessions/${encodeCloudPathSegment(value = sessionId)}/abort"
+}
+
 internal fun buildWorkspacePackageImportPreviewCloudPath(workspaceId: String): String {
     require(workspaceId.isNotBlank()) {
         "Workspace package import preview path requires a workspace id."

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -15,6 +15,8 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaBlobCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaTransferQueueEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressLocalCacheStateEntity
@@ -31,6 +33,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.database.migrations.createAppDatabaseMigrations
 import com.flashcardsopensourceapp.data.local.database.media.MediaAssetDao
+import com.flashcardsopensourceapp.data.local.database.media.MediaTransferDao
 import com.flashcardsopensourceapp.data.local.database.progress.ProgressCardDao
 import com.flashcardsopensourceapp.data.local.database.progress.ProgressLocalCacheDao
 import com.flashcardsopensourceapp.data.local.database.progress.ProgressRemoteCacheDao
@@ -50,6 +53,8 @@ private const val appDatabaseName: String = "flashcards-android.db"
         WorkspaceSchedulerSettingsEntity::class,
         DeckEntity::class,
         MediaAssetEntity::class,
+        MediaBlobCacheEntity::class,
+        MediaTransferQueueEntity::class,
         CardEntity::class,
         TagEntity::class,
         CardTagEntity::class,
@@ -65,7 +70,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 28,
+    version = 29,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)
@@ -75,6 +80,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun workspaceSchedulerSettingsDao(): WorkspaceSchedulerSettingsDao
     abstract fun deckDao(): DeckDao
     abstract fun mediaAssetDao(): MediaAssetDao
+    abstract fun mediaTransferDao(): MediaTransferDao
     abstract fun cardDao(): CardDao
     abstract fun reviewQueueDao(): ReviewQueueDao
     abstract fun reviewCardSelectionDao(): ReviewCardSelectionDao

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/MediaTransferEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/MediaTransferEntities.kt
@@ -1,0 +1,58 @@
+package com.flashcardsopensourceapp.data.local.database.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "media_blob_cache",
+    indices = [
+        Index(value = ["localRelativePath"], unique = true),
+        Index(value = ["sourceMediaAssetId"]),
+        Index(value = ["lastAccessedAtMillis"])
+    ]
+)
+data class MediaBlobCacheEntity(
+    @PrimaryKey val sha256: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val localRelativePath: String,
+    val createdAtMillis: Long,
+    val lastAccessedAtMillis: Long,
+    val sourceMediaAssetId: String?
+)
+
+@Entity(
+    tableName = "media_transfer_queue",
+    foreignKeys = [
+        ForeignKey(
+            entity = WorkspaceEntity::class,
+            parentColumns = ["workspaceId"],
+            childColumns = ["workspaceId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("workspaceId"),
+        Index(value = ["workspaceId", "status", "nextAttemptAtMillis", "createdAtMillis"]),
+        Index(value = ["sha256"]),
+        Index(value = ["mediaAssetId"])
+    ]
+)
+data class MediaTransferQueueEntity(
+    @PrimaryKey val transferId: String,
+    val workspaceId: String,
+    val mediaAssetId: String,
+    val kind: String,
+    val status: String,
+    val sha256: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val localRelativePath: String,
+    val attemptCount: Int,
+    val nextAttemptAtMillis: Long,
+    val lastError: String?,
+    val createdAtMillis: Long,
+    val updatedAtMillis: Long
+)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
@@ -1,0 +1,124 @@
+package com.flashcardsopensourceapp.data.local.database.media
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.flashcardsopensourceapp.data.local.database.entities.MediaBlobCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaTransferQueueEntity
+
+@Dao
+interface MediaTransferDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertMediaBlobCache(mediaBlobCache: MediaBlobCacheEntity)
+
+    @Query("SELECT * FROM media_blob_cache WHERE sha256 = :sha256 LIMIT 1")
+    suspend fun loadMediaBlobCache(sha256: String): MediaBlobCacheEntity?
+
+    @Query(
+        """
+        SELECT * FROM media_blob_cache
+        WHERE sourceMediaAssetId = :mediaAssetId
+        ORDER BY lastAccessedAtMillis DESC, sha256 ASC
+        """
+    )
+    suspend fun loadMediaBlobCachesForMediaAsset(mediaAssetId: String): List<MediaBlobCacheEntity>
+
+    @Query(
+        """
+        UPDATE media_blob_cache
+        SET lastAccessedAtMillis = :lastAccessedAtMillis
+        WHERE sha256 = :sha256
+        """
+    )
+    suspend fun updateMediaBlobCacheLastAccessed(
+        sha256: String,
+        lastAccessedAtMillis: Long
+    )
+
+    @Query("DELETE FROM media_blob_cache WHERE sha256 = :sha256")
+    suspend fun deleteMediaBlobCache(sha256: String)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertMediaTransfer(mediaTransfer: MediaTransferQueueEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertMediaTransfers(mediaTransfers: List<MediaTransferQueueEntity>)
+
+    @Query("SELECT * FROM media_transfer_queue WHERE transferId = :transferId LIMIT 1")
+    suspend fun loadMediaTransfer(transferId: String): MediaTransferQueueEntity?
+
+    @Query(
+        """
+        SELECT * FROM media_transfer_queue
+        WHERE workspaceId = :workspaceId
+            AND status = :status
+            AND nextAttemptAtMillis <= :nowMillis
+        ORDER BY nextAttemptAtMillis ASC, createdAtMillis ASC, transferId ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun loadDueMediaTransfers(
+        workspaceId: String,
+        status: String,
+        nowMillis: Long,
+        limit: Int
+    ): List<MediaTransferQueueEntity>
+
+    @Query(
+        """
+        UPDATE media_transfer_queue
+        SET status = :claimedStatus,
+            updatedAtMillis = :updatedAtMillis
+        WHERE transferId IN (:transferIds)
+            AND status = :expectedStatus
+        """
+    )
+    suspend fun markMediaTransfersClaimed(
+        transferIds: List<String>,
+        expectedStatus: String,
+        claimedStatus: String,
+        updatedAtMillis: Long
+    )
+
+    @Query(
+        """
+        UPDATE media_transfer_queue
+        SET status = :status,
+            lastError = :lastError,
+            updatedAtMillis = :updatedAtMillis
+        WHERE transferId = :transferId
+        """
+    )
+    suspend fun updateMediaTransferStatus(
+        transferId: String,
+        status: String,
+        lastError: String?,
+        updatedAtMillis: Long
+    )
+
+    @Query(
+        """
+        UPDATE media_transfer_queue
+        SET status = :status,
+            attemptCount = attemptCount + 1,
+            nextAttemptAtMillis = :nextAttemptAtMillis,
+            lastError = :lastError,
+            updatedAtMillis = :updatedAtMillis
+        WHERE transferId = :transferId
+        """
+    )
+    suspend fun markMediaTransferAttemptFailed(
+        transferId: String,
+        status: String,
+        nextAttemptAtMillis: Long,
+        lastError: String,
+        updatedAtMillis: Long
+    )
+
+    @Query("DELETE FROM media_transfer_queue WHERE transferId = :transferId")
+    suspend fun deleteMediaTransfer(transferId: String)
+
+    @Query("DELETE FROM media_transfer_queue WHERE workspaceId = :workspaceId")
+    suspend fun deleteMediaTransfersForWorkspace(workspaceId: String)
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -42,7 +42,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration24To25,
         migration25To26,
         migration26To27,
-        migration27To28
+        migration27To28,
+        migration28To29
     )
 }
 
@@ -984,6 +985,72 @@ val migration27To28: Migration = object : Migration(27, 28) {
             ON media_assets(workspaceId, sha256, mediaAssetId)
             """.trimIndent()
         )
+    }
+}
+
+val migration28To29: Migration = object : Migration(28, 29) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS media_blob_cache (
+                sha256 TEXT NOT NULL PRIMARY KEY,
+                mimeType TEXT NOT NULL,
+                sizeBytes INTEGER NOT NULL,
+                localRelativePath TEXT NOT NULL,
+                createdAtMillis INTEGER NOT NULL,
+                lastAccessedAtMillis INTEGER NOT NULL,
+                sourceMediaAssetId TEXT
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS index_media_blob_cache_localRelativePath
+            ON media_blob_cache(localRelativePath)
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_media_blob_cache_sourceMediaAssetId
+            ON media_blob_cache(sourceMediaAssetId)
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_media_blob_cache_lastAccessedAtMillis
+            ON media_blob_cache(lastAccessedAtMillis)
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS media_transfer_queue (
+                transferId TEXT NOT NULL PRIMARY KEY,
+                workspaceId TEXT NOT NULL,
+                mediaAssetId TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                status TEXT NOT NULL,
+                sha256 TEXT NOT NULL,
+                mimeType TEXT NOT NULL,
+                sizeBytes INTEGER NOT NULL,
+                localRelativePath TEXT NOT NULL,
+                attemptCount INTEGER NOT NULL,
+                nextAttemptAtMillis INTEGER NOT NULL,
+                lastError TEXT,
+                createdAtMillis INTEGER NOT NULL,
+                updatedAtMillis INTEGER NOT NULL,
+                FOREIGN KEY(workspaceId) REFERENCES workspaces(workspaceId) ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_media_transfer_queue_workspaceId ON media_transfer_queue(workspaceId)")
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_media_transfer_queue_workspaceId_status_nextAttemptAtMillis_createdAtMillis
+            ON media_transfer_queue(workspaceId, status, nextAttemptAtMillis, createdAtMillis)
+            """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_media_transfer_queue_sha256 ON media_transfer_queue(sha256)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_media_transfer_queue_mediaAssetId ON media_transfer_queue(mediaAssetId)")
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaTransferModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaTransferModels.kt
@@ -1,0 +1,320 @@
+package com.flashcardsopensourceapp.data.local.model.media
+
+import java.util.Locale
+
+private val mediaSha256Pattern: Regex = Regex("^[0-9a-f]{64}$")
+
+fun normalizeMediaSha256(rawSha256: String): String {
+    val normalizedSha256: String = rawSha256.trim().lowercase(Locale.US)
+    require(mediaSha256Pattern.matches(normalizedSha256)) {
+        "Media SHA-256 must be exactly 64 lowercase hexadecimal characters after normalization."
+    }
+    return normalizedSha256
+}
+
+fun buildMediaBlobCacheRelativePath(sha256: String): String {
+    val normalizedSha256: String = normalizeMediaSha256(rawSha256 = sha256)
+    return "media/blobs/sha256/${normalizedSha256.substring(0, 2)}/${normalizedSha256.substring(2, 4)}/$normalizedSha256"
+}
+
+data class MediaBlobCache(
+    val sha256: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val localRelativePath: String,
+    val createdAtMillis: Long,
+    val lastAccessedAtMillis: Long,
+    val sourceMediaAssetId: String?
+) {
+    init {
+        require(sha256 == normalizeMediaSha256(rawSha256 = sha256)) {
+            "Media blob cache sha256 must already be normalized."
+        }
+        require(mimeType.isNotBlank()) {
+            "Media blob cache mimeType must not be blank."
+        }
+        require(sizeBytes >= 0L) {
+            "Media blob cache sizeBytes must not be negative."
+        }
+        require(localRelativePath == buildMediaBlobCacheRelativePath(sha256 = sha256)) {
+            "Media blob cache localRelativePath must match the deterministic SHA-256 path."
+        }
+    }
+}
+
+enum class MediaTransferKind(
+    val wireKey: String
+) {
+    UPLOAD("upload"),
+    DOWNLOAD("download");
+
+    companion object {
+        private val orderedEntries: List<MediaTransferKind> = listOf(
+            UPLOAD,
+            DOWNLOAD
+        )
+
+        fun fromWireKey(wireKey: String): MediaTransferKind {
+            return orderedEntries.firstOrNull { kind -> kind.wireKey == wireKey }
+                ?: throw IllegalArgumentException("Unknown media transfer kind '$wireKey'.")
+        }
+    }
+}
+
+enum class MediaTransferStatus(
+    val wireKey: String
+) {
+    QUEUED("queued"),
+    IN_PROGRESS("in_progress"),
+    SUCCEEDED("succeeded"),
+    FAILED("failed"),
+    ABORTED("aborted");
+
+    companion object {
+        private val orderedEntries: List<MediaTransferStatus> = listOf(
+            QUEUED,
+            IN_PROGRESS,
+            SUCCEEDED,
+            FAILED,
+            ABORTED
+        )
+
+        fun fromWireKey(wireKey: String): MediaTransferStatus {
+            return orderedEntries.firstOrNull { status -> status.wireKey == wireKey }
+                ?: throw IllegalArgumentException("Unknown media transfer status '$wireKey'.")
+        }
+    }
+}
+
+data class MediaTransferQueueItem(
+    val transferId: String,
+    val workspaceId: String,
+    val mediaAssetId: String,
+    val kind: MediaTransferKind,
+    val status: MediaTransferStatus,
+    val sha256: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val localRelativePath: String,
+    val attemptCount: Int,
+    val nextAttemptAtMillis: Long,
+    val lastError: String?,
+    val createdAtMillis: Long,
+    val updatedAtMillis: Long
+) {
+    init {
+        require(transferId.isNotBlank()) {
+            "Media transfer queue item transferId must not be blank."
+        }
+        require(workspaceId.isNotBlank()) {
+            "Media transfer queue item workspaceId must not be blank."
+        }
+        require(mediaAssetId.isNotBlank()) {
+            "Media transfer queue item mediaAssetId must not be blank."
+        }
+        require(sha256 == normalizeMediaSha256(rawSha256 = sha256)) {
+            "Media transfer queue item sha256 must already be normalized."
+        }
+        require(mimeType.isNotBlank()) {
+            "Media transfer queue item mimeType must not be blank."
+        }
+        require(sizeBytes >= 0L) {
+            "Media transfer queue item sizeBytes must not be negative."
+        }
+        require(localRelativePath == buildMediaBlobCacheRelativePath(sha256 = sha256)) {
+            "Media transfer queue item localRelativePath must match the deterministic SHA-256 path."
+        }
+        require(attemptCount >= 0) {
+            "Media transfer queue item attemptCount must not be negative."
+        }
+    }
+}
+
+data class MediaAssetUploadSessionCreateRequest(
+    val mediaAssetId: String,
+    val mimeType: String,
+    val sizeBytes: Long,
+    val sha256: String,
+    val partSizeBytes: Long,
+    val partCount: Int,
+    val sourceUrl: String?,
+    val createdAtMillis: Long,
+    val clientUpdatedAtMillis: Long,
+    val lastModifiedByReplicaId: String,
+    val lastOperationId: String
+) {
+    init {
+        require(mediaAssetId.isNotBlank()) {
+            "Media asset upload session create request mediaAssetId must not be blank."
+        }
+        require(mimeType.isNotBlank()) {
+            "Media asset upload session create request mimeType must not be blank."
+        }
+        require(sizeBytes > 0L) {
+            "Media asset upload session create request sizeBytes must be positive."
+        }
+        require(sha256 == normalizeMediaSha256(rawSha256 = sha256)) {
+            "Media asset upload session create request sha256 must already be normalized."
+        }
+        require(partSizeBytes > 0L) {
+            "Media asset upload session create request partSizeBytes must be positive."
+        }
+        require(partCount > 0) {
+            "Media asset upload session create request partCount must be positive."
+        }
+        require(lastModifiedByReplicaId.isNotBlank()) {
+            "Media asset upload session create request lastModifiedByReplicaId must not be blank."
+        }
+        require(lastOperationId.isNotBlank()) {
+            "Media asset upload session create request lastOperationId must not be blank."
+        }
+    }
+}
+
+enum class MediaAssetUploadSessionCreateStatus(
+    val wireKey: String
+) {
+    ALREADY_AVAILABLE("already_available"),
+    UPLOAD_REQUIRED("upload_required");
+
+    companion object {
+        private val orderedEntries: List<MediaAssetUploadSessionCreateStatus> = listOf(
+            ALREADY_AVAILABLE,
+            UPLOAD_REQUIRED
+        )
+
+        fun fromWireKey(wireKey: String): MediaAssetUploadSessionCreateStatus {
+            return orderedEntries.firstOrNull { status -> status.wireKey == wireKey }
+                ?: throw IllegalArgumentException("Unknown media asset upload session status '$wireKey'.")
+        }
+    }
+}
+
+data class MediaAssetUploadSession(
+    val sessionId: String,
+    val expiresAtMillis: Long,
+    val partSizeBytes: Long,
+    val partCount: Int
+) {
+    init {
+        require(sessionId.isNotBlank()) {
+            "Media asset upload session sessionId must not be blank."
+        }
+        require(partSizeBytes > 0L) {
+            "Media asset upload session partSizeBytes must be positive."
+        }
+        require(partCount > 0) {
+            "Media asset upload session partCount must be positive."
+        }
+    }
+}
+
+data class MediaAssetUploadSessionCreateResponse(
+    val workspaceId: String,
+    val mediaAssetId: String,
+    val status: MediaAssetUploadSessionCreateStatus,
+    val mediaAsset: MediaAsset?,
+    val uploadSession: MediaAssetUploadSession?
+)
+
+data class MediaAssetUploadPartRequest(
+    val partNumber: Int,
+    val sha256: String
+) {
+    init {
+        require(partNumber > 0) {
+            "Media asset upload part request partNumber must be positive."
+        }
+        require(sha256 == normalizeMediaSha256(rawSha256 = sha256)) {
+            "Media asset upload part request sha256 must already be normalized."
+        }
+    }
+}
+
+data class MediaAssetUploadPartUrlsRequest(
+    val parts: List<MediaAssetUploadPartRequest>
+) {
+    init {
+        require(parts.isNotEmpty()) {
+            "Media asset upload part URL request parts must not be empty."
+        }
+    }
+}
+
+data class MediaAssetUploadPartUrl(
+    val partNumber: Int,
+    val method: String,
+    val url: String,
+    val expiresAtMillis: Long,
+    val headers: Map<String, String>
+) {
+    init {
+        require(partNumber > 0) {
+            "Media asset upload part URL partNumber must be positive."
+        }
+        require(method == "PUT") {
+            "Media asset upload part URL method must be PUT."
+        }
+        require(url.isNotBlank()) {
+            "Media asset upload part URL url must not be blank."
+        }
+    }
+}
+
+data class MediaAssetUploadPartUrlsResponse(
+    val sessionId: String,
+    val partUrls: List<MediaAssetUploadPartUrl>
+) {
+    init {
+        require(sessionId.isNotBlank()) {
+            "Media asset upload part URLs response sessionId must not be blank."
+        }
+        require(partUrls.isNotEmpty()) {
+            "Media asset upload part URLs response partUrls must not be empty."
+        }
+    }
+}
+
+data class CompleteMediaAssetUploadPart(
+    val partNumber: Int,
+    val eTag: String,
+    val sha256: String
+) {
+    init {
+        require(partNumber > 0) {
+            "Complete media asset upload part partNumber must be positive."
+        }
+        require(eTag.isNotBlank()) {
+            "Complete media asset upload part eTag must not be blank."
+        }
+        require(sha256 == normalizeMediaSha256(rawSha256 = sha256)) {
+            "Complete media asset upload part sha256 must already be normalized."
+        }
+    }
+}
+
+data class CompleteMediaAssetUploadSessionRequest(
+    val parts: List<CompleteMediaAssetUploadPart>
+) {
+    init {
+        require(parts.isNotEmpty()) {
+            "Complete media asset upload session request parts must not be empty."
+        }
+    }
+}
+
+data class MediaAssetUploadCompletion(
+    val mediaAsset: MediaAsset,
+    val applied: Boolean
+)
+
+data class MediaAssetUploadSessionAbort(
+    val sessionId: String,
+    val abortedAtMillis: Long
+) {
+    init {
+        require(sessionId.isNotBlank()) {
+            "Media asset upload session abort sessionId must not be blank."
+        }
+    }
+}

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -4,7 +4,14 @@ import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRe
 import com.flashcardsopensourceapp.data.local.cloud.remote.community.buildCloudFriendInvitationCreateRequest
 import com.flashcardsopensourceapp.data.local.cloud.remote.community.parseCloudFriendInvitationCreateResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.guest.buildGuestUpgradeCompleteRequest
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.buildCompleteMediaAssetUploadSessionRequestBody
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.buildMediaAssetUploadPartUrlsRequestBody
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.buildMediaAssetUploadSessionCreateRequestBody
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.parseCompleteMediaAssetUploadSessionResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.media.parseMediaAssetDownloadUrlResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.parseMediaAssetUploadPartUrlsResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.parseMediaAssetUploadSessionAbortResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.media.parseMediaAssetUploadSessionCreateResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressReviewScheduleResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSeriesResponse
@@ -19,6 +26,12 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.parseWorksp
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudFriendInvitationCreateRequest
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
+import com.flashcardsopensourceapp.data.local.model.media.CompleteMediaAssetUploadPart
+import com.flashcardsopensourceapp.data.local.model.media.CompleteMediaAssetUploadSessionRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadPartUrlsRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateRequest
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetUploadSessionCreateStatus
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
@@ -272,6 +285,228 @@ class CloudRemoteServiceTest {
         assertEquals("image/png", parsedResponse.mediaAsset.mimeType)
         assertEquals("https://media.example.test/media-asset-1", parsedResponse.url)
         assertEquals(Instant.parse("2026-03-10T10:00:00.000Z").toEpochMilli(), parsedResponse.expiresAtMillis)
+    }
+
+    @Test
+    fun buildMediaAssetUploadSessionCreateRequestBodyEncodesUploadMetadata() {
+        val request = MediaAssetUploadSessionCreateRequest(
+            mediaAssetId = "media-asset-1",
+            mimeType = "image/png",
+            sizeBytes = 128,
+            sha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+            partSizeBytes = 128,
+            partCount = 1,
+            sourceUrl = null,
+            createdAtMillis = Instant.parse("2026-03-10T09:00:00.000Z").toEpochMilli(),
+            clientUpdatedAtMillis = Instant.parse("2026-03-10T09:01:00.000Z").toEpochMilli(),
+            lastModifiedByReplicaId = "device-1",
+            lastOperationId = "operation-1"
+        )
+
+        val body = buildMediaAssetUploadSessionCreateRequestBody(request = request)
+
+        assertEquals("media-asset-1", body.getString("mediaAssetId"))
+        assertEquals("image/png", body.getString("mimeType"))
+        assertEquals(128L, body.getLong("sizeBytes"))
+        assertTrue(body.isNull("sourceUrl"))
+        assertEquals("2026-03-10T09:00:00.000Z", body.getString("createdAt"))
+        assertEquals("2026-03-10T09:01:00.000Z", body.getString("clientUpdatedAt"))
+    }
+
+    @Test
+    fun buildMediaAssetUploadSessionPartRequestsEncodeParts() {
+        val sha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+        val partUrlsBody = buildMediaAssetUploadPartUrlsRequestBody(
+            request = MediaAssetUploadPartUrlsRequest(
+                parts = listOf(MediaAssetUploadPartRequest(partNumber = 1, sha256 = sha256))
+            )
+        )
+        val completeBody = buildCompleteMediaAssetUploadSessionRequestBody(
+            request = CompleteMediaAssetUploadSessionRequest(
+                parts = listOf(
+                    CompleteMediaAssetUploadPart(
+                        partNumber = 1,
+                        eTag = "\"etag-1\"",
+                        sha256 = sha256
+                    )
+                )
+            )
+        )
+
+        assertEquals(1, partUrlsBody.getJSONArray("parts").getJSONObject(0).getInt("partNumber"))
+        assertEquals(sha256, partUrlsBody.getJSONArray("parts").getJSONObject(0).getString("sha256"))
+        assertEquals("\"etag-1\"", completeBody.getJSONArray("parts").getJSONObject(0).getString("eTag"))
+    }
+
+    @Test
+    fun parseMediaAssetUploadSessionCreateResponseReadsUploadRequiredSession() {
+        val response = JSONObject(
+            """
+            {
+              "workspaceId": "workspace-1",
+              "mediaAssetId": "media-asset-1",
+              "status": "upload_required",
+              "mediaAsset": null,
+              "uploadSession": {
+                "sessionId": "session-1",
+                "expiresAt": "2026-03-10T10:00:00.000Z",
+                "partSizeBytes": 8388608,
+                "partCount": 2
+              }
+            }
+            """.trimIndent()
+        )
+
+        val parsedResponse = parseMediaAssetUploadSessionCreateResponse(
+            response = response,
+            fieldPath = "mediaAssetUploadSessionCreate"
+        )
+
+        assertEquals(MediaAssetUploadSessionCreateStatus.UPLOAD_REQUIRED, parsedResponse.status)
+        assertEquals(null, parsedResponse.mediaAsset)
+        assertEquals("session-1", parsedResponse.uploadSession?.sessionId)
+        assertEquals(2, parsedResponse.uploadSession?.partCount)
+    }
+
+    @Test
+    fun parseMediaAssetUploadSessionCreateResponseRejectsInconsistentStatusPayload() {
+        val response = JSONObject(
+            """
+            {
+              "workspaceId": "workspace-1",
+              "mediaAssetId": "media-asset-1",
+              "status": "upload_required",
+              "mediaAsset": {
+                "mediaAssetId": "media-asset-1",
+                "workspaceId": "workspace-1",
+                "mimeType": "image/png",
+                "sizeBytes": 128,
+                "sha256": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+                "sourceUrl": null,
+                "createdAt": "2026-03-10T09:00:00.000Z",
+                "clientUpdatedAt": "2026-03-10T09:01:00.000Z",
+                "lastModifiedByReplicaId": "device-1",
+                "lastOperationId": "operation-1",
+                "updatedAt": "2026-03-10T09:02:00.000Z",
+                "deletedAt": null
+              },
+              "uploadSession": null
+            }
+            """.trimIndent()
+        )
+
+        assertThrows(CloudContractMismatchException::class.java) {
+            parseMediaAssetUploadSessionCreateResponse(
+                response = response,
+                fieldPath = "mediaAssetUploadSessionCreate"
+            )
+        }
+    }
+
+    @Test
+    fun parseMediaAssetUploadPartUrlsResponseReadsPutUrlsAndHeaders() {
+        val response = JSONObject(
+            """
+            {
+              "sessionId": "session-1",
+              "partUrls": [
+                {
+                  "partNumber": 1,
+                  "method": "PUT",
+                  "url": "https://media.example.test/session-1/part-1",
+                  "expiresAt": "2026-03-10T10:00:00.000Z",
+                  "headers": {
+                    "x-amz-checksum-sha256": "checksum-1"
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val parsedResponse = parseMediaAssetUploadPartUrlsResponse(
+            response = response,
+            fieldPath = "mediaAssetUploadPartUrls"
+        )
+
+        assertEquals("session-1", parsedResponse.sessionId)
+        assertEquals(1, parsedResponse.partUrls.single().partNumber)
+        assertEquals("PUT", parsedResponse.partUrls.single().method)
+        assertEquals("checksum-1", parsedResponse.partUrls.single().headers["x-amz-checksum-sha256"])
+    }
+
+    @Test
+    fun parseMediaAssetUploadPartUrlsResponseRejectsNonPutMethods() {
+        val response = JSONObject(
+            """
+            {
+              "sessionId": "session-1",
+              "partUrls": [
+                {
+                  "partNumber": 1,
+                  "method": "POST",
+                  "url": "https://media.example.test/session-1/part-1",
+                  "expiresAt": "2026-03-10T10:00:00.000Z",
+                  "headers": {}
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertThrows(CloudContractMismatchException::class.java) {
+            parseMediaAssetUploadPartUrlsResponse(
+                response = response,
+                fieldPath = "mediaAssetUploadPartUrls"
+            )
+        }
+    }
+
+    @Test
+    fun parseCompleteAndAbortMediaAssetUploadSessionResponses() {
+        val completionResponse = JSONObject(
+            """
+            {
+              "mediaAsset": {
+                "mediaAssetId": "media-asset-1",
+                "workspaceId": "workspace-1",
+                "mimeType": "image/png",
+                "sizeBytes": 128,
+                "sha256": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+                "sourceUrl": null,
+                "createdAt": "2026-03-10T09:00:00.000Z",
+                "clientUpdatedAt": "2026-03-10T09:01:00.000Z",
+                "lastModifiedByReplicaId": "device-1",
+                "lastOperationId": "operation-1",
+                "updatedAt": "2026-03-10T09:02:00.000Z",
+                "deletedAt": null
+              },
+              "applied": true
+            }
+            """.trimIndent()
+        )
+        val abortResponse = JSONObject(
+            """
+            {
+              "sessionId": "session-1",
+              "abortedAt": "2026-03-10T10:00:00.000Z"
+            }
+            """.trimIndent()
+        )
+
+        val completion = parseCompleteMediaAssetUploadSessionResponse(
+            response = completionResponse,
+            fieldPath = "completeMediaAssetUploadSession"
+        )
+        val abort = parseMediaAssetUploadSessionAbortResponse(
+            response = abortResponse,
+            fieldPath = "mediaAssetUploadSessionAbort"
+        )
+
+        assertEquals("media-asset-1", completion.mediaAsset.mediaAssetId)
+        assertEquals(true, completion.applied)
+        assertEquals("session-1", abort.sessionId)
+        assertEquals(Instant.parse("2026-03-10T10:00:00.000Z").toEpochMilli(), abort.abortedAtMillis)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add Android Room media blob cache and media transfer queue tables, DAO, migration, and model types.
- Add media upload-session route builders and strict remote request/response parsing for create, parts, complete, and abort.
- Expose the upload-session API through CloudRemoteGateway and CloudRemoteService, with focused contract and migration tests.

## Validation
- git fetch origin main: passed
- git merge-base --is-ancestor origin/main HEAD: passed
- git --no-pager diff --check: passed
- Static rg sweeps for gateway implementations, schema version/migration wiring, and persisted storage/blob/url leakage: passed
- Worker-owned review: no split recommendation, no P0-P4 issues, green light for commit

## Residual Risk
- Gradle was not run because repository instructions require explicit current-task approval for local Gradle runs.