### PR TITLE
Add iOS media transfer foundation

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+private let mediaSha256AllowedScalars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+private let mediaBlobCacheRelativePathPrefix = "media/blobs/sha256"
+
 // Keep in sync with apps/backend/src/media/assets.ts::MediaAssetRecord and
 // apps/web/src/types.ts::MediaAsset.
 struct MediaAsset: Codable, Identifiable, Hashable, Sendable {
@@ -47,4 +50,86 @@ struct MediaAsset: Codable, Identifiable, Hashable, Sendable {
         self.updatedAt = updatedAt
         self.deletedAt = deletedAt
     }
+}
+
+struct MediaBlobCacheEntry: Hashable, Sendable {
+    let sha256: String
+    let mimeType: String
+    let sizeBytes: Int64
+    let localRelativePath: String
+    let createdAt: String
+    let lastAccessedAt: String
+    let sourceMediaAssetId: String?
+}
+
+struct MediaBlobCacheUpsert: Hashable, Sendable {
+    let sha256: String
+    let mimeType: String
+    let sizeBytes: Int64
+    let createdAt: String
+    let lastAccessedAt: String
+    let sourceMediaAssetId: String?
+}
+
+enum MediaTransferKind: String, Codable, Hashable, Sendable {
+    case upload
+    case download
+}
+
+enum MediaTransferStatus: String, Codable, Hashable, Sendable {
+    case pending
+    case inProgress = "in_progress"
+    case succeeded
+    case failed
+}
+
+struct MediaTransferQueueEntry: Hashable, Sendable {
+    let transferId: String
+    let workspaceId: String
+    let mediaAssetId: String
+    let kind: MediaTransferKind
+    let status: MediaTransferStatus
+    let sha256: String
+    let mimeType: String
+    let sizeBytes: Int64
+    let localRelativePath: String
+    let attemptCount: Int
+    let nextAttemptAt: String?
+    let claimedAt: String?
+    let lastError: String?
+    let createdAt: String
+    let updatedAt: String
+}
+
+struct MediaTransferEnqueueRequest: Hashable, Sendable {
+    let transferId: String
+    let workspaceId: String
+    let mediaAssetId: String
+    let kind: MediaTransferKind
+    let sha256: String
+    let mimeType: String
+    let sizeBytes: Int64
+    let createdAt: String
+}
+
+func normalizedMediaSha256(sha256: String) throws -> String {
+    let normalizedSha256 = sha256.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard normalizedSha256.count == 64 else {
+        throw LocalStoreError.validation("Media SHA-256 digest must be exactly 64 hexadecimal characters")
+    }
+    guard normalizedSha256.unicodeScalars.allSatisfy({ mediaSha256AllowedScalars.contains($0) }) else {
+        throw LocalStoreError.validation("Media SHA-256 digest must contain only hexadecimal characters")
+    }
+
+    return normalizedSha256
+}
+
+func mediaBlobCacheRelativePath(sha256: String) throws -> String {
+    let normalizedSha256 = try normalizedMediaSha256(sha256: sha256)
+    let secondDirectoryStart = normalizedSha256.index(normalizedSha256.startIndex, offsetBy: 2)
+    let secondDirectoryEnd = normalizedSha256.index(secondDirectoryStart, offsetBy: 2)
+    let firstDirectory = String(normalizedSha256.prefix(2))
+    let secondDirectory = String(normalizedSha256[secondDirectoryStart..<secondDirectoryEnd])
+
+    return "\(mediaBlobCacheRelativePathPrefix)/\(firstDirectory)/\(secondDirectory)/\(normalizedSha256)"
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
@@ -259,6 +259,66 @@ final class CloudSyncService: @unchecked Sendable {
         )
     }
 
+    func createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: MediaAssetUploadSessionCreateRequest
+    ) async throws -> MediaAssetUploadSessionCreateResponse {
+        try await self.transport.createMediaAssetUploadSession(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            workspaceId: workspaceId,
+            requestBody: request
+        )
+    }
+
+    func loadMediaAssetUploadPartURLs(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadPartURLsRequest
+    ) async throws -> MediaAssetUploadPartURLsResponse {
+        try await self.transport.loadMediaAssetUploadPartURLs(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            requestBody: request
+        )
+    }
+
+    func completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadSessionCompleteRequest
+    ) async throws -> MediaAssetUploadSessionCompleteResponse {
+        try await self.transport.completeMediaAssetUploadSession(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            requestBody: request
+        )
+    }
+
+    func abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ) async throws -> MediaAssetUploadSessionAbortResponse {
+        try await self.transport.abortMediaAssetUploadSession(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            workspaceId: workspaceId,
+            sessionId: sessionId
+        )
+    }
+
     func previewWorkspacePackageExport(
         apiBaseUrl: String,
         authorizationHeader: String,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
@@ -150,27 +150,101 @@ struct CloudSyncTransport {
     }
 
     func mediaAssetDownloadURLPath(workspaceId: String, mediaAssetId: String) throws -> String {
-        let normalizedWorkspaceId = workspaceId.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalizedMediaAssetId = mediaAssetId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard normalizedWorkspaceId.isEmpty == false else {
-            throw LocalStoreError.validation("Media asset download URL path requires a workspace id")
-        }
-        guard normalizedMediaAssetId.isEmpty == false else {
-            throw LocalStoreError.validation("Media asset download URL path requires a media asset id")
-        }
-
-        guard let encodedWorkspaceId = normalizedWorkspaceId.addingPercentEncoding(
-            withAllowedCharacters: mediaAssetDownloadURLPathSegmentAllowedCharacters
-        ) else {
-            throw LocalStoreError.validation("Media asset workspace id could not be encoded: \(workspaceId)")
-        }
-        guard let encodedMediaAssetId = normalizedMediaAssetId.addingPercentEncoding(
-            withAllowedCharacters: mediaAssetDownloadURLPathSegmentAllowedCharacters
-        ) else {
-            throw LocalStoreError.validation("Media asset id could not be encoded: \(mediaAssetId)")
-        }
+        let encodedWorkspaceId = try self.encodedMediaAssetPathSegment(
+            value: workspaceId,
+            fieldName: "workspace id"
+        )
+        let encodedMediaAssetId = try self.encodedMediaAssetPathSegment(
+            value: mediaAssetId,
+            fieldName: "media asset id"
+        )
 
         return "/workspaces/\(encodedWorkspaceId)/media-assets/\(encodedMediaAssetId)/download-url"
+    }
+
+    func mediaAssetUploadSessionsPath(workspaceId: String) throws -> String {
+        let encodedWorkspaceId = try self.encodedMediaAssetPathSegment(
+            value: workspaceId,
+            fieldName: "workspace id"
+        )
+        return "/workspaces/\(encodedWorkspaceId)/media-assets/upload-sessions"
+    }
+
+    func mediaAssetUploadSessionPartsPath(workspaceId: String, sessionId: String) throws -> String {
+        let basePath = try self.mediaAssetUploadSessionPath(workspaceId: workspaceId, sessionId: sessionId)
+        return "\(basePath)/parts"
+    }
+
+    func mediaAssetUploadSessionCompletePath(workspaceId: String, sessionId: String) throws -> String {
+        let basePath = try self.mediaAssetUploadSessionPath(workspaceId: workspaceId, sessionId: sessionId)
+        return "\(basePath)/complete"
+    }
+
+    func mediaAssetUploadSessionAbortPath(workspaceId: String, sessionId: String) throws -> String {
+        let basePath = try self.mediaAssetUploadSessionPath(workspaceId: workspaceId, sessionId: sessionId)
+        return "\(basePath)/abort"
+    }
+
+    func createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        requestBody: MediaAssetUploadSessionCreateRequest
+    ) async throws -> MediaAssetUploadSessionCreateResponse {
+        try await self.request(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            path: try self.mediaAssetUploadSessionsPath(workspaceId: workspaceId),
+            method: "POST",
+            body: requestBody
+        )
+    }
+
+    func loadMediaAssetUploadPartURLs(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        requestBody: MediaAssetUploadPartURLsRequest
+    ) async throws -> MediaAssetUploadPartURLsResponse {
+        try await self.request(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            path: try self.mediaAssetUploadSessionPartsPath(workspaceId: workspaceId, sessionId: sessionId),
+            method: "POST",
+            body: requestBody
+        )
+    }
+
+    func completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        requestBody: MediaAssetUploadSessionCompleteRequest
+    ) async throws -> MediaAssetUploadSessionCompleteResponse {
+        try await self.request(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            path: try self.mediaAssetUploadSessionCompletePath(workspaceId: workspaceId, sessionId: sessionId),
+            method: "POST",
+            body: requestBody
+        )
+    }
+
+    func abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ) async throws -> MediaAssetUploadSessionAbortResponse {
+        try await self.request(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            path: try self.mediaAssetUploadSessionAbortPath(workspaceId: workspaceId, sessionId: sessionId),
+            method: "POST",
+            body: Optional<String>.none
+        )
     }
 
     func workspacePackageImportPreviewPath(workspaceId: String) throws -> String {
@@ -338,6 +412,33 @@ struct CloudSyncTransport {
         }
 
         return encodedWorkspaceId
+    }
+
+    private func mediaAssetUploadSessionPath(workspaceId: String, sessionId: String) throws -> String {
+        let encodedWorkspaceId = try self.encodedMediaAssetPathSegment(
+            value: workspaceId,
+            fieldName: "workspace id"
+        )
+        let encodedSessionId = try self.encodedMediaAssetPathSegment(
+            value: sessionId,
+            fieldName: "upload session id"
+        )
+        return "/workspaces/\(encodedWorkspaceId)/media-assets/upload-sessions/\(encodedSessionId)"
+    }
+
+    private func encodedMediaAssetPathSegment(value: String, fieldName: String) throws -> String {
+        let normalizedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedValue.isEmpty == false else {
+            throw LocalStoreError.validation("Media asset path requires a \(fieldName)")
+        }
+
+        guard let encodedValue = normalizedValue.addingPercentEncoding(
+            withAllowedCharacters: mediaAssetDownloadURLPathSegmentAllowedCharacters
+        ) else {
+            throw LocalStoreError.validation("Media asset \(fieldName) could not be encoded: \(value)")
+        }
+
+        return encodedValue
     }
 
     private func sendAndDecode<Response: Decodable>(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncWireContracts.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncWireContracts.swift
@@ -656,6 +656,145 @@ struct MediaAssetDownloadURL: Decodable, Hashable, Sendable {
     let expiresAt: String
 }
 
+/// Wire contract for `POST /workspaces/{workspaceId}/media-assets/upload-sessions`.
+struct MediaAssetUploadSessionCreateRequest: Encodable, Hashable, Sendable {
+    let mediaAssetId: String
+    let mimeType: String
+    let sizeBytes: Int64
+    let sha256: String
+    let partSizeBytes: Int64
+    let partCount: Int
+    let sourceUrl: String?
+    let createdAt: String
+    let clientUpdatedAt: String
+    let lastModifiedByReplicaId: String
+    let lastOperationId: String
+}
+
+enum MediaAssetUploadSessionCreateStatus: String, Codable, Hashable, Sendable {
+    case alreadyAvailable = "already_available"
+    case uploadRequired = "upload_required"
+}
+
+struct MediaAssetUploadSessionMetadata: Decodable, Hashable, Sendable {
+    let sessionId: String
+    let expiresAt: String
+    let partSizeBytes: Int64
+    let partCount: Int
+}
+
+struct MediaAssetUploadSessionCreateResponse: Decodable, Hashable, Sendable {
+    let workspaceId: String
+    let mediaAssetId: String
+    let status: MediaAssetUploadSessionCreateStatus
+    let mediaAsset: MediaAsset?
+    let uploadSession: MediaAssetUploadSessionMetadata?
+
+    enum CodingKeys: String, CodingKey {
+        case workspaceId
+        case mediaAssetId
+        case status
+        case mediaAsset
+        case uploadSession
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.workspaceId = try container.decode(String.self, forKey: .workspaceId)
+        self.mediaAssetId = try container.decode(String.self, forKey: .mediaAssetId)
+        self.status = try container.decode(MediaAssetUploadSessionCreateStatus.self, forKey: .status)
+        self.mediaAsset = try container.decode(MediaAsset?.self, forKey: .mediaAsset)
+        self.uploadSession = try container.decode(MediaAssetUploadSessionMetadata?.self, forKey: .uploadSession)
+
+        switch self.status {
+        case .alreadyAvailable:
+            guard self.mediaAsset != nil, self.uploadSession == nil else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .status,
+                    in: container,
+                    debugDescription: "already_available upload session responses require mediaAsset and null uploadSession"
+                )
+            }
+        case .uploadRequired:
+            guard self.mediaAsset == nil, self.uploadSession != nil else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .status,
+                    in: container,
+                    debugDescription: "upload_required upload session responses require null mediaAsset and uploadSession"
+                )
+            }
+        }
+    }
+}
+
+struct MediaAssetUploadPartURLRequestPart: Encodable, Hashable, Sendable {
+    let partNumber: Int
+    let sha256: String
+}
+
+/// Wire contract for `POST /workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/parts`.
+struct MediaAssetUploadPartURLsRequest: Encodable, Hashable, Sendable {
+    let parts: [MediaAssetUploadPartURLRequestPart]
+}
+
+struct MediaAssetUploadPartURL: Decodable, Sendable {
+    let partNumber: Int
+    let method: String
+    let url: String
+    let expiresAt: String
+    let headers: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case partNumber
+        case method
+        case url
+        case expiresAt
+        case headers
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.partNumber = try container.decode(Int.self, forKey: .partNumber)
+        self.method = try container.decode(String.self, forKey: .method)
+        guard self.method == "PUT" else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .method,
+                in: container,
+                debugDescription: "Media asset upload part URLs must use PUT"
+            )
+        }
+        self.url = try container.decode(String.self, forKey: .url)
+        self.expiresAt = try container.decode(String.self, forKey: .expiresAt)
+        self.headers = try container.decode([String: String].self, forKey: .headers)
+    }
+}
+
+struct MediaAssetUploadPartURLsResponse: Decodable, Sendable {
+    let sessionId: String
+    let partUrls: [MediaAssetUploadPartURL]
+}
+
+struct CompletedMediaAssetUploadPart: Encodable, Hashable, Sendable {
+    let partNumber: Int
+    let eTag: String
+    let sha256: String
+}
+
+/// Wire contract for `POST /workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/complete`.
+struct MediaAssetUploadSessionCompleteRequest: Encodable, Hashable, Sendable {
+    let parts: [CompletedMediaAssetUploadPart]
+}
+
+struct MediaAssetUploadSessionCompleteResponse: Decodable, Hashable, Sendable {
+    let mediaAsset: MediaAsset
+    let applied: Bool
+}
+
+struct MediaAssetUploadSessionAbortResponse: Decodable, Hashable, Sendable {
+    let sessionId: String
+    let abortedAt: String
+}
+
 /// Pulled review events are already stamped by the backend with immutable
 /// workspace replica ids. The client must not invent or mutate these ids.
 struct RemoteReviewEventEnvelope: Decodable {

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase.swift
@@ -19,6 +19,7 @@ final class LocalDatabase {
     let cardStore: CardStore
     let deckStore: DeckStore
     let mediaAssetStore: MediaAssetStore
+    let mediaTransferStore: MediaTransferStore
     let outboxStore: OutboxStore
     let syncApplier: SyncApplier
     let workspaceSettingsStore: WorkspaceSettingsStore
@@ -30,6 +31,7 @@ final class LocalDatabase {
         self.cardStore = CardStore(core: core)
         self.deckStore = DeckStore(core: core)
         self.mediaAssetStore = MediaAssetStore(core: core)
+        self.mediaTransferStore = MediaTransferStore(core: core)
         self.outboxStore = OutboxStore(core: core)
         self.syncApplier = SyncApplier(core: core)
         self.workspaceSettingsStore = WorkspaceSettingsStore(core: core)
@@ -42,6 +44,7 @@ final class LocalDatabase {
         self.cardStore = CardStore(core: core)
         self.deckStore = DeckStore(core: core)
         self.mediaAssetStore = MediaAssetStore(core: core)
+        self.mediaTransferStore = MediaTransferStore(core: core)
         self.outboxStore = OutboxStore(core: core)
         self.syncApplier = SyncApplier(core: core)
         self.workspaceSettingsStore = WorkspaceSettingsStore(core: core)

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
@@ -104,6 +104,9 @@ struct LocalDatabaseMigrator {
             case 22:
                 try self.migrateSchemaVersion22To23()
                 schemaVersion = 23
+            case 23:
+                try self.migrateSchemaVersion23To24()
+                schemaVersion = 24
             default:
                 throw LocalStoreError.database("Unsupported local schema version: \(schemaVersion)")
             }
@@ -744,6 +747,94 @@ struct LocalDatabaseMigrator {
             sql: """
             ALTER TABLE media_assets
             DROP COLUMN storage_key
+            """,
+            values: []
+        )
+    }
+
+    private func migrateSchemaVersion23To24() throws {
+        try self.core.execute(
+            sql: """
+            CREATE TABLE IF NOT EXISTS media_blob_cache (
+                sha256 TEXT PRIMARY KEY CHECK (length(trim(sha256)) = 64),
+                mime_type TEXT NOT NULL CHECK (length(trim(mime_type)) > 0),
+                size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0),
+                local_relative_path TEXT NOT NULL UNIQUE CHECK (length(trim(local_relative_path)) > 0),
+                created_at TEXT NOT NULL,
+                last_accessed_at TEXT NOT NULL,
+                source_media_asset_id TEXT
+            )
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE TABLE IF NOT EXISTS media_transfer_queue (
+                transfer_id TEXT PRIMARY KEY,
+                workspace_id TEXT NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+                media_asset_id TEXT NOT NULL CHECK (length(trim(media_asset_id)) > 0),
+                kind TEXT NOT NULL CHECK (kind IN ('upload', 'download')),
+                status TEXT NOT NULL CHECK (status IN ('pending', 'in_progress', 'succeeded', 'failed')),
+                sha256 TEXT NOT NULL CHECK (length(trim(sha256)) = 64),
+                mime_type TEXT NOT NULL CHECK (length(trim(mime_type)) > 0),
+                size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0),
+                local_relative_path TEXT NOT NULL CHECK (length(trim(local_relative_path)) > 0),
+                attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+                next_attempt_at TEXT,
+                claimed_at TEXT,
+                last_error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                CHECK (
+                    (status = 'in_progress' AND claimed_at IS NOT NULL)
+                    OR (status IN ('pending', 'failed', 'succeeded') AND claimed_at IS NULL)
+                )
+            )
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_media_blob_cache_last_accessed_at
+            ON media_blob_cache(last_accessed_at ASC, sha256 ASC)
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_media_blob_cache_source_media_asset_id
+            ON media_blob_cache(source_media_asset_id)
+            WHERE source_media_asset_id IS NOT NULL
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_due
+            ON media_transfer_queue(status, next_attempt_at, created_at ASC, transfer_id ASC)
+            WHERE status IN ('pending', 'failed')
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_stale_claim
+            ON media_transfer_queue(status, claimed_at, updated_at ASC, transfer_id ASC)
+            WHERE status = 'in_progress'
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_workspace_status
+            ON media_transfer_queue(workspace_id, status, updated_at DESC, transfer_id ASC)
+            """,
+            values: []
+        )
+        try self.core.execute(
+            sql: """
+            CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_media_asset
+            ON media_transfer_queue(workspace_id, media_asset_id, status)
             """,
             values: []
         )

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum LocalDatabaseSchema {
-    static let currentVersion: Int = 23
+    static let currentVersion: Int = 24
 
     static var baseMigrationSQL: String {
         let defaultEnableFuzzValue: Int = defaultSchedulerSettingsConfig.enableFuzz ? 1 : 0
@@ -85,6 +85,38 @@ enum LocalDatabaseSchema {
             updated_at TEXT NOT NULL, -- last time the local mirror row was written or merged
             deleted_at TEXT, -- tombstone timestamp; non-NULL means the asset is unavailable but must still sync
             PRIMARY KEY (workspace_id, media_asset_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS media_blob_cache (
+            sha256 TEXT PRIMARY KEY CHECK (length(trim(sha256)) = 64), -- content digest used to dedupe app-private media files
+            mime_type TEXT NOT NULL CHECK (length(trim(mime_type)) > 0), -- MIME type for local rendering without rereading registry rows
+            size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0), -- byte size metadata only; bytes live in app-private files
+            local_relative_path TEXT NOT NULL UNIQUE CHECK (length(trim(local_relative_path)) > 0), -- path below the app media cache root
+            created_at TEXT NOT NULL, -- when this cache entry was first recorded locally
+            last_accessed_at TEXT NOT NULL, -- cache eviction and diagnostics timestamp
+            source_media_asset_id TEXT -- optional registry id that first populated this cache entry
+        );
+
+        CREATE TABLE IF NOT EXISTS media_transfer_queue (
+            transfer_id TEXT PRIMARY KEY, -- client-generated transfer job id
+            workspace_id TEXT NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE, -- workspace that owns the transfer
+            media_asset_id TEXT NOT NULL CHECK (length(trim(media_asset_id)) > 0), -- managed media id associated with the transfer
+            kind TEXT NOT NULL CHECK (kind IN ('upload', 'download')), -- byte transfer direction
+            status TEXT NOT NULL CHECK (status IN ('pending', 'in_progress', 'succeeded', 'failed')), -- queue state independent from the sync outbox
+            sha256 TEXT NOT NULL CHECK (length(trim(sha256)) = 64), -- content digest for cache lookup and upload verification
+            mime_type TEXT NOT NULL CHECK (length(trim(mime_type)) > 0), -- expected media MIME type
+            size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0), -- expected byte count
+            local_relative_path TEXT NOT NULL CHECK (length(trim(local_relative_path)) > 0), -- app-private source or destination path
+            attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0), -- retry counter for transfer diagnostics
+            next_attempt_at TEXT, -- NULL means eligible immediately when status is pending or failed
+            claimed_at TEXT, -- durable lease timestamp while a worker owns this transfer attempt
+            last_error TEXT, -- most recent transfer failure message for diagnostics
+            created_at TEXT NOT NULL, -- when the job entered the queue
+            updated_at TEXT NOT NULL, -- when the queue row last changed
+            CHECK (
+                (status = 'in_progress' AND claimed_at IS NOT NULL)
+                OR (status IN ('pending', 'failed', 'succeeded') AND claimed_at IS NULL)
+            )
         );
 
         CREATE TABLE IF NOT EXISTS review_events (
@@ -173,6 +205,27 @@ enum LocalDatabaseSchema {
         CREATE INDEX IF NOT EXISTS idx_media_assets_workspace_updated_at
             ON media_assets(workspace_id, updated_at DESC, media_asset_id ASC);
 
+        CREATE INDEX IF NOT EXISTS idx_media_blob_cache_last_accessed_at
+            ON media_blob_cache(last_accessed_at ASC, sha256 ASC);
+
+        CREATE INDEX IF NOT EXISTS idx_media_blob_cache_source_media_asset_id
+            ON media_blob_cache(source_media_asset_id)
+            WHERE source_media_asset_id IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_due
+            ON media_transfer_queue(status, next_attempt_at, created_at ASC, transfer_id ASC)
+            WHERE status IN ('pending', 'failed');
+
+        CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_stale_claim
+            ON media_transfer_queue(status, claimed_at, updated_at ASC, transfer_id ASC)
+            WHERE status = 'in_progress';
+
+        CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_workspace_status
+            ON media_transfer_queue(workspace_id, status, updated_at DESC, transfer_id ASC);
+
+        CREATE INDEX IF NOT EXISTS idx_media_transfer_queue_media_asset
+            ON media_transfer_queue(workspace_id, media_asset_id, status);
+
         CREATE INDEX IF NOT EXISTS idx_card_tags_workspace_tag_card
             ON card_tags(workspace_id, tag, card_id);
 
@@ -192,6 +245,8 @@ enum LocalDatabaseSchema {
 
     static let resetSQL: String = """
     DROP TABLE IF EXISTS outbox;
+    DROP TABLE IF EXISTS media_transfer_queue;
+    DROP TABLE IF EXISTS media_blob_cache;
     DROP TABLE IF EXISTS sync_state;
     DROP TABLE IF EXISTS review_events;
     DROP TABLE IF EXISTS media_assets;

--- a/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
@@ -1,0 +1,432 @@
+import Foundation
+
+private let mediaBlobCacheSelectColumnsSQL: String = """
+    sha256,
+    mime_type,
+    size_bytes,
+    local_relative_path,
+    created_at,
+    last_accessed_at,
+    source_media_asset_id
+"""
+
+private let mediaTransferQueueSelectColumnsSQL: String = """
+    transfer_id,
+    workspace_id,
+    media_asset_id,
+    kind,
+    status,
+    sha256,
+    mime_type,
+    size_bytes,
+    local_relative_path,
+    attempt_count,
+    next_attempt_at,
+    claimed_at,
+    last_error,
+    created_at,
+    updated_at
+"""
+
+private func nonEmptyMediaTransferText(value: String, fieldName: String) throws -> String {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedValue.isEmpty == false else {
+        throw LocalStoreError.validation("\(fieldName) must not be empty")
+    }
+
+    return trimmedValue
+}
+
+private func mediaTransferOptionalTextValue(value: String?) -> SQLiteValue {
+    if let value {
+        return .text(value)
+    }
+
+    return .null
+}
+
+struct MediaTransferStore {
+    let core: DatabaseCore
+
+    func upsertBlobCacheEntry(entry: MediaBlobCacheUpsert) throws -> MediaBlobCacheEntry {
+        let normalizedSha256 = try normalizedMediaSha256(sha256: entry.sha256)
+        let localRelativePath = try mediaBlobCacheRelativePath(sha256: normalizedSha256)
+        let mimeType = try nonEmptyMediaTransferText(value: entry.mimeType, fieldName: "Media blob cache MIME type")
+        let sourceMediaAssetId = try entry.sourceMediaAssetId.map { value in
+            try nonEmptyMediaTransferText(value: value, fieldName: "Media blob cache sourceMediaAssetId")
+        }
+        guard entry.sizeBytes >= 0 else {
+            throw LocalStoreError.validation("Media blob cache size must be greater than or equal to zero")
+        }
+
+        try self.core.execute(
+            sql: """
+            INSERT INTO media_blob_cache (
+                sha256,
+                mime_type,
+                size_bytes,
+                local_relative_path,
+                created_at,
+                last_accessed_at,
+                source_media_asset_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(sha256) DO UPDATE SET
+                mime_type = excluded.mime_type,
+                size_bytes = excluded.size_bytes,
+                local_relative_path = excluded.local_relative_path,
+                last_accessed_at = excluded.last_accessed_at,
+                source_media_asset_id = excluded.source_media_asset_id
+            """,
+            values: [
+                .text(normalizedSha256),
+                .text(mimeType),
+                .integer(entry.sizeBytes),
+                .text(localRelativePath),
+                .text(try nonEmptyMediaTransferText(value: entry.createdAt, fieldName: "Media blob cache createdAt")),
+                .text(try nonEmptyMediaTransferText(value: entry.lastAccessedAt, fieldName: "Media blob cache lastAccessedAt")),
+                mediaTransferOptionalTextValue(value: sourceMediaAssetId)
+            ]
+        )
+
+        guard let cacheEntry = try self.loadOptionalBlobCacheEntry(sha256: normalizedSha256) else {
+            throw LocalStoreError.database("Media blob cache upsert did not produce a readable row")
+        }
+
+        return cacheEntry
+    }
+
+    func resolveCacheHit(sha256: String, accessedAt: String) throws -> MediaBlobCacheEntry? {
+        let normalizedSha256 = try normalizedMediaSha256(sha256: sha256)
+        let normalizedAccessedAt = try nonEmptyMediaTransferText(
+            value: accessedAt,
+            fieldName: "Media blob cache accessedAt"
+        )
+
+        return try self.core.inTransaction {
+            guard try self.loadOptionalBlobCacheEntry(sha256: normalizedSha256) != nil else {
+                return nil
+            }
+
+            try self.core.execute(
+                sql: """
+                UPDATE media_blob_cache
+                SET last_accessed_at = ?
+                WHERE sha256 = ?
+                """,
+                values: [
+                    .text(normalizedAccessedAt),
+                    .text(normalizedSha256)
+                ]
+            )
+
+            guard let cacheEntry = try self.loadOptionalBlobCacheEntry(sha256: normalizedSha256) else {
+                throw LocalStoreError.database("Media blob cache row disappeared while resolving sha256=\(normalizedSha256)")
+            }
+
+            return cacheEntry
+        }
+    }
+
+    func enqueueTransfer(request: MediaTransferEnqueueRequest) throws -> MediaTransferQueueEntry {
+        let transferId = try nonEmptyMediaTransferText(value: request.transferId, fieldName: "Media transfer id")
+        let normalizedSha256 = try normalizedMediaSha256(sha256: request.sha256)
+        let localRelativePath = try mediaBlobCacheRelativePath(sha256: normalizedSha256)
+        let createdAt = try nonEmptyMediaTransferText(value: request.createdAt, fieldName: "Media transfer createdAt")
+        let mimeType = try nonEmptyMediaTransferText(value: request.mimeType, fieldName: "Media transfer MIME type")
+        guard request.sizeBytes >= 0 else {
+            throw LocalStoreError.validation("Media transfer size must be greater than or equal to zero")
+        }
+
+        try self.core.execute(
+            sql: """
+            INSERT INTO media_transfer_queue (
+                transfer_id,
+                workspace_id,
+                media_asset_id,
+                kind,
+                status,
+                sha256,
+                mime_type,
+                size_bytes,
+                local_relative_path,
+                attempt_count,
+                next_attempt_at,
+                claimed_at,
+                last_error,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?, 0, NULL, NULL, NULL, ?, ?)
+            """,
+            values: [
+                .text(transferId),
+                .text(try nonEmptyMediaTransferText(value: request.workspaceId, fieldName: "Media transfer workspaceId")),
+                .text(try nonEmptyMediaTransferText(value: request.mediaAssetId, fieldName: "Media transfer mediaAssetId")),
+                .text(request.kind.rawValue),
+                .text(normalizedSha256),
+                .text(mimeType),
+                .integer(request.sizeBytes),
+                .text(localRelativePath),
+                .text(createdAt),
+                .text(createdAt)
+            ]
+        )
+
+        return try self.loadTransfer(transferId: transferId)
+    }
+
+    func claimDueTransfers(
+        now: String,
+        staleClaimedBefore: String,
+        limit: Int
+    ) throws -> [MediaTransferQueueEntry] {
+        guard limit > 0 else {
+            throw LocalStoreError.validation("Media transfer claim limit must be greater than zero")
+        }
+
+        let normalizedNow = try nonEmptyMediaTransferText(value: now, fieldName: "Media transfer claim timestamp")
+        let normalizedStaleClaimedBefore = try nonEmptyMediaTransferText(
+            value: staleClaimedBefore,
+            fieldName: "Media transfer stale claimed-before timestamp"
+        )
+        return try self.core.inTransaction {
+            let transferIds = try self.core.query(
+                sql: """
+                SELECT transfer_id
+                FROM media_transfer_queue
+                WHERE (
+                    status IN ('pending', 'failed')
+                    AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+                ) OR (
+                    status = 'in_progress'
+                    AND claimed_at IS NOT NULL
+                    AND claimed_at <= ?
+                )
+                ORDER BY
+                    CASE WHEN status = 'in_progress' THEN 0 ELSE 1 END ASC,
+                    COALESCE(claimed_at, next_attempt_at, created_at) ASC,
+                    created_at ASC,
+                    transfer_id ASC
+                LIMIT ?
+                """,
+                values: [
+                    .text(normalizedNow),
+                    .text(normalizedStaleClaimedBefore),
+                    .integer(Int64(limit))
+                ]
+            ) { statement in
+                DatabaseCore.columnText(statement: statement, index: 0)
+            }
+
+            for transferId in transferIds {
+                let updatedRows = try self.core.execute(
+                    sql: """
+                    UPDATE media_transfer_queue
+                    SET
+                        status = 'in_progress',
+                        claimed_at = ?,
+                        next_attempt_at = NULL,
+                        updated_at = ?
+                    WHERE transfer_id = ?
+                        AND (
+                            (
+                                status IN ('pending', 'failed')
+                                AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+                            ) OR (
+                                status = 'in_progress'
+                                AND claimed_at IS NOT NULL
+                                AND claimed_at <= ?
+                            )
+                        )
+                    """,
+                    values: [
+                        .text(normalizedNow),
+                        .text(normalizedNow),
+                        .text(transferId),
+                        .text(normalizedNow),
+                        .text(normalizedStaleClaimedBefore)
+                    ]
+                )
+                guard updatedRows > 0 else {
+                    throw LocalStoreError.database("Media transfer claim changed while claiming transferId=\(transferId)")
+                }
+            }
+
+            return try transferIds.map { transferId in
+                try self.loadTransfer(transferId: transferId)
+            }
+        }
+    }
+
+    func markTransferSucceeded(
+        transferId: String,
+        claimedAt: String,
+        updatedAt: String
+    ) throws -> MediaTransferQueueEntry {
+        let normalizedTransferId = try nonEmptyMediaTransferText(value: transferId, fieldName: "Media transfer id")
+        let normalizedClaimedAt = try nonEmptyMediaTransferText(value: claimedAt, fieldName: "Media transfer claimedAt")
+        let normalizedUpdatedAt = try nonEmptyMediaTransferText(value: updatedAt, fieldName: "Media transfer updatedAt")
+        let updatedRows = try self.core.execute(
+            sql: """
+            UPDATE media_transfer_queue
+            SET
+                status = 'succeeded',
+                next_attempt_at = NULL,
+                claimed_at = NULL,
+                last_error = NULL,
+                updated_at = ?
+            WHERE transfer_id = ?
+                AND status = 'in_progress'
+                AND claimed_at = ?
+            """,
+            values: [
+                .text(normalizedUpdatedAt),
+                .text(normalizedTransferId),
+                .text(normalizedClaimedAt)
+            ]
+        )
+        guard updatedRows > 0 else {
+            try self.throwMissingActiveClaimError(transferId: normalizedTransferId)
+        }
+
+        return try self.loadTransfer(transferId: normalizedTransferId)
+    }
+
+    func markTransferFailed(
+        transferId: String,
+        claimedAt: String,
+        errorMessage: String,
+        nextAttemptAt: String?,
+        updatedAt: String
+    ) throws -> MediaTransferQueueEntry {
+        let normalizedTransferId = try nonEmptyMediaTransferText(value: transferId, fieldName: "Media transfer id")
+        let normalizedClaimedAt = try nonEmptyMediaTransferText(value: claimedAt, fieldName: "Media transfer claimedAt")
+        let normalizedErrorMessage = try nonEmptyMediaTransferText(
+            value: errorMessage,
+            fieldName: "Media transfer error message"
+        )
+        let normalizedNextAttemptAt = try nextAttemptAt.map { value in
+            try nonEmptyMediaTransferText(value: value, fieldName: "Media transfer nextAttemptAt")
+        }
+        let normalizedUpdatedAt = try nonEmptyMediaTransferText(value: updatedAt, fieldName: "Media transfer updatedAt")
+        let updatedRows = try self.core.execute(
+            sql: """
+            UPDATE media_transfer_queue
+            SET
+                status = 'failed',
+                attempt_count = attempt_count + 1,
+                next_attempt_at = ?,
+                claimed_at = NULL,
+                last_error = ?,
+                updated_at = ?
+            WHERE transfer_id = ?
+                AND status = 'in_progress'
+                AND claimed_at = ?
+            """,
+            values: [
+                mediaTransferOptionalTextValue(value: normalizedNextAttemptAt),
+                .text(normalizedErrorMessage),
+                .text(normalizedUpdatedAt),
+                .text(normalizedTransferId),
+                .text(normalizedClaimedAt)
+            ]
+        )
+        guard updatedRows > 0 else {
+            try self.throwMissingActiveClaimError(transferId: normalizedTransferId)
+        }
+
+        return try self.loadTransfer(transferId: normalizedTransferId)
+    }
+
+    private func loadOptionalBlobCacheEntry(sha256: String) throws -> MediaBlobCacheEntry? {
+        let rows = try self.core.query(
+            sql: """
+            SELECT
+            \(mediaBlobCacheSelectColumnsSQL)
+            FROM media_blob_cache
+            WHERE sha256 = ?
+            LIMIT 1
+            """,
+            values: [.text(sha256)]
+        ) { statement in
+            self.mapBlobCacheEntry(statement: statement)
+        }
+
+        return rows.first
+    }
+
+    private func loadTransfer(transferId: String) throws -> MediaTransferQueueEntry {
+        guard let entry = try self.loadOptionalTransfer(transferId: transferId) else {
+            throw LocalStoreError.notFound("Media transfer not found: transferId=\(transferId)")
+        }
+
+        return entry
+    }
+
+    private func loadOptionalTransfer(transferId: String) throws -> MediaTransferQueueEntry? {
+        let rows = try self.core.query(
+            sql: """
+            SELECT
+            \(mediaTransferQueueSelectColumnsSQL)
+            FROM media_transfer_queue
+            WHERE transfer_id = ?
+            LIMIT 1
+            """,
+            values: [.text(transferId)]
+        ) { statement in
+            try self.mapTransferQueueEntry(statement: statement)
+        }
+
+        return rows.first
+    }
+
+    private func throwMissingActiveClaimError(transferId: String) throws -> Never {
+        guard try self.loadOptionalTransfer(transferId: transferId) != nil else {
+            throw LocalStoreError.notFound("Media transfer not found: transferId=\(transferId)")
+        }
+
+        throw LocalStoreError.validation("Media transfer is not actively claimed: transferId=\(transferId)")
+    }
+
+    private func mapBlobCacheEntry(statement: OpaquePointer) -> MediaBlobCacheEntry {
+        MediaBlobCacheEntry(
+            sha256: DatabaseCore.columnText(statement: statement, index: 0),
+            mimeType: DatabaseCore.columnText(statement: statement, index: 1),
+            sizeBytes: DatabaseCore.columnInt64(statement: statement, index: 2),
+            localRelativePath: DatabaseCore.columnText(statement: statement, index: 3),
+            createdAt: DatabaseCore.columnText(statement: statement, index: 4),
+            lastAccessedAt: DatabaseCore.columnText(statement: statement, index: 5),
+            sourceMediaAssetId: DatabaseCore.columnOptionalText(statement: statement, index: 6)
+        )
+    }
+
+    private func mapTransferQueueEntry(statement: OpaquePointer) throws -> MediaTransferQueueEntry {
+        let kindRawValue = DatabaseCore.columnText(statement: statement, index: 3)
+        guard let kind = MediaTransferKind(rawValue: kindRawValue) else {
+            throw LocalStoreError.database("Stored media transfer kind is invalid: \(kindRawValue)")
+        }
+        let statusRawValue = DatabaseCore.columnText(statement: statement, index: 4)
+        guard let status = MediaTransferStatus(rawValue: statusRawValue) else {
+            throw LocalStoreError.database("Stored media transfer status is invalid: \(statusRawValue)")
+        }
+
+        return MediaTransferQueueEntry(
+            transferId: DatabaseCore.columnText(statement: statement, index: 0),
+            workspaceId: DatabaseCore.columnText(statement: statement, index: 1),
+            mediaAssetId: DatabaseCore.columnText(statement: statement, index: 2),
+            kind: kind,
+            status: status,
+            sha256: DatabaseCore.columnText(statement: statement, index: 5),
+            mimeType: DatabaseCore.columnText(statement: statement, index: 6),
+            sizeBytes: DatabaseCore.columnInt64(statement: statement, index: 7),
+            localRelativePath: DatabaseCore.columnText(statement: statement, index: 8),
+            attemptCount: Int(DatabaseCore.columnInt64(statement: statement, index: 9)),
+            nextAttemptAt: DatabaseCore.columnOptionalText(statement: statement, index: 10),
+            claimedAt: DatabaseCore.columnOptionalText(statement: statement, index: 11),
+            lastError: DatabaseCore.columnOptionalText(statement: statement, index: 12),
+            createdAt: DatabaseCore.columnText(statement: statement, index: 13),
+            updatedAt: DatabaseCore.columnText(statement: statement, index: 14)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add iOS SQLite media blob cache and media transfer queue schema/migration.
- Add typed media transfer store methods for cache hits, enqueueing, lease-based claiming, success, and failure.
- Add upload-session wire contracts plus CloudSync transport/service wrappers.

## Validation
- `git fetch origin main`: passed.
- `git merge-base --is-ancestor origin/main HEAD`: passed at implementation start.
- `xcrun swiftc -parse ...changed Swift files...`: passed before and after the lease fix.
- Targeted Swift expression checks: passed before and after the lease fix.
- `git --no-pager diff --check`: passed before and after the lease fix.
- Worker-owned review round 2: no split recommendation, no P0-P4 issues, green light for commit.

## Residual risk
- Full Xcode compilation could not run locally because Xcode has no eligible iOS 26.5 destination.
- Simulator-backed tests were not run by instruction.