### PR TITLE
Cache web review media downloads

### DIFF
--- a/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
@@ -5,12 +5,15 @@ import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../../i18n";
 import { createStorageMock } from "../../../api/ApiTestSupport";
+import type { MediaBlobCacheRecord } from "../../../localDb/mediaTransfers";
 import type { MediaAsset } from "../../../types";
 import { ReviewCardSide } from "./ReviewCardSide";
 
 const mediaMocks = vi.hoisted(() => ({
   loadMediaAssetDownloadUrlMock: vi.fn(),
   loadMediaAssetRecordMock: vi.fn(),
+  loadMediaBlobCacheRecordMock: vi.fn(),
+  writeMediaBlobCacheRecordMock: vi.fn(),
 }));
 
 vi.mock("../../../api", () => ({
@@ -21,13 +24,54 @@ vi.mock("../../../localDb/mediaAssets", () => ({
   loadMediaAssetRecord: mediaMocks.loadMediaAssetRecordMock,
 }));
 
-function makeMediaAsset(mediaAssetId: string, mimeType: string): MediaAsset {
+vi.mock("../../../localDb/mediaTransfers", () => ({
+  loadMediaBlobCacheRecord: mediaMocks.loadMediaBlobCacheRecordMock,
+  writeMediaBlobCacheRecord: mediaMocks.writeMediaBlobCacheRecordMock,
+}));
+
+const imageSha256 = "11".repeat(32);
+const audioSha256 = "22".repeat(32);
+const videoSha256 = "33".repeat(32);
+const fileSha256 = "44".repeat(32);
+const coldSha256 = "55".repeat(32);
+const refreshedSha256 = "66".repeat(32);
+const badSha256 = "77".repeat(32);
+
+function hexToArrayBuffer(hex: string): ArrayBuffer {
+  if (hex.length % 2 !== 0) {
+    throw new Error(`Invalid hex length: ${hex.length}`);
+  }
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+
+  return bytes.buffer;
+}
+
+function installDigestMock(sha256: string): void {
+  vi.stubGlobal("crypto", {
+    subtle: {
+      digest: vi.fn(async (_algorithm: AlgorithmIdentifier, _data: BufferSource): Promise<ArrayBuffer> => (
+        hexToArrayBuffer(sha256)
+      )),
+    },
+  });
+}
+
+function makeMediaAsset(
+  mediaAssetId: string,
+  mimeType: string,
+  sha256: string,
+  sizeBytes: number,
+): MediaAsset {
   return {
     mediaAssetId,
     workspaceId: "workspace-1",
     mimeType,
-    sizeBytes: 128,
-    sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+    sizeBytes,
+    sha256,
     sourceUrl: null,
     createdAt: "2026-03-10T09:00:00.000Z",
     clientUpdatedAt: "2026-03-10T09:00:00.000Z",
@@ -35,6 +79,41 @@ function makeMediaAsset(mediaAssetId: string, mimeType: string): MediaAsset {
     lastOperationId: `operation-${mediaAssetId}`,
     updatedAt: "2026-03-10T09:00:00.000Z",
     deletedAt: null,
+  };
+}
+
+function makeCacheRecord(mediaAsset: MediaAsset, blob: Blob): MediaBlobCacheRecord {
+  return {
+    sha256: mediaAsset.sha256,
+    mimeType: mediaAsset.mimeType,
+    sizeBytes: mediaAsset.sizeBytes,
+    blob,
+    createdAt: "2026-03-10T09:00:00.000Z",
+    lastAccessedAt: "2026-03-10T09:00:00.000Z",
+    sourceMediaAssetId: mediaAsset.mediaAssetId,
+  };
+}
+
+function createDeferred<Result>(): Readonly<{
+  promise: Promise<Result>;
+  resolve: (value: Result) => void;
+  reject: (error: Error) => void;
+}> {
+  let resolveDeferred: ((value: Result) => void) | null = null;
+  let rejectDeferred: ((error: Error) => void) | null = null;
+  const promise = new Promise<Result>((resolve, reject) => {
+    resolveDeferred = resolve;
+    rejectDeferred = reject;
+  });
+
+  if (resolveDeferred === null || rejectDeferred === null) {
+    throw new Error("Failed to create deferred promise");
+  }
+
+  return {
+    promise,
+    resolve: resolveDeferred,
+    reject: rejectDeferred,
   };
 }
 
@@ -66,6 +145,8 @@ function renderReviewCardSide(container: HTMLDivElement, text: string): ReactDOM
 
 describe("ReviewCardSide managed media rendering", () => {
   let container: HTMLDivElement;
+  let createObjectURLMock: ReturnType<typeof vi.fn<(blob: Blob) => string>>;
+  let revokeObjectURLMock: ReturnType<typeof vi.fn<(url: string) => void>>;
   let root: ReactDOM.Root | null;
 
   beforeEach(() => {
@@ -73,11 +154,28 @@ describe("ReviewCardSide managed media rendering", () => {
       configurable: true,
       value: createStorageMock(),
     });
+    let objectUrlIndex = 0;
+    createObjectURLMock = vi.fn((_: Blob): string => {
+      objectUrlIndex += 1;
+      return `blob:review-media-${objectUrlIndex}`;
+    });
+    revokeObjectURLMock = vi.fn((_url: string): void => undefined);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURLMock,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURLMock,
+    });
     container = document.createElement("div");
     document.body.append(container);
     root = null;
     mediaMocks.loadMediaAssetDownloadUrlMock.mockReset();
     mediaMocks.loadMediaAssetRecordMock.mockReset();
+    mediaMocks.loadMediaBlobCacheRecordMock.mockReset();
+    mediaMocks.writeMediaBlobCacheRecordMock.mockReset();
+    mediaMocks.writeMediaBlobCacheRecordMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -88,33 +186,32 @@ describe("ReviewCardSide managed media rendering", () => {
     }
     container.remove();
     window.localStorage.clear();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("renders managed image, audio, video, and generic attachments from fcasset Markdown", async () => {
+  it("renders managed image, audio, video, and generic attachments from warm blob cache", async () => {
+    const imageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const audioBlob = new Blob([new Uint8Array([4, 5, 6, 7])], { type: "audio/mpeg" });
+    const videoBlob = new Blob([new Uint8Array([8, 9, 10, 11, 12])], { type: "video/mp4" });
+    const fileBlob = new Blob([new Uint8Array([13, 14])], { type: "application/pdf" });
     const mediaAssets = new Map<string, MediaAsset>([
-      ["image-asset", makeMediaAsset("image-asset", "image/png")],
-      ["audio-asset", makeMediaAsset("audio-asset", "audio/mpeg")],
-      ["video-asset", makeMediaAsset("video-asset", "video/mp4")],
-      ["file-asset", makeMediaAsset("file-asset", "application/pdf")],
+      ["image-asset", makeMediaAsset("image-asset", "image/png", imageSha256, imageBlob.size)],
+      ["audio-asset", makeMediaAsset("audio-asset", "audio/mpeg", audioSha256, audioBlob.size)],
+      ["video-asset", makeMediaAsset("video-asset", "video/mp4", videoSha256, videoBlob.size)],
+      ["file-asset", makeMediaAsset("file-asset", "application/pdf", fileSha256, fileBlob.size)],
+    ]);
+    const cacheRecords = new Map<string, MediaBlobCacheRecord>([
+      [imageSha256, makeCacheRecord(mediaAssets.get("image-asset") as MediaAsset, imageBlob)],
+      [audioSha256, makeCacheRecord(mediaAssets.get("audio-asset") as MediaAsset, audioBlob)],
+      [videoSha256, makeCacheRecord(mediaAssets.get("video-asset") as MediaAsset, videoBlob)],
+      [fileSha256, makeCacheRecord(mediaAssets.get("file-asset") as MediaAsset, fileBlob)],
     ]);
     mediaMocks.loadMediaAssetRecordMock.mockImplementation(async (_workspaceId: string, mediaAssetId: string): Promise<MediaAsset | null> => {
       return mediaAssets.get(mediaAssetId) ?? null;
     });
-    mediaMocks.loadMediaAssetDownloadUrlMock.mockImplementation(async (_workspaceId: string, mediaAssetId: string) => {
-      const mediaAsset = mediaAssets.get(mediaAssetId);
-      if (mediaAsset === undefined) {
-        throw new Error(`Missing test media asset: ${mediaAssetId}`);
-      }
-
-      return {
-        mediaAsset,
-        download: {
-          method: "GET" as const,
-          url: `https://media.example.test/${mediaAssetId}`,
-          expiresAt: "2026-03-10T10:00:00.000Z",
-        },
-      };
+    mediaMocks.loadMediaBlobCacheRecordMock.mockImplementation(async (sha256: string): Promise<MediaBlobCacheRecord | null> => {
+      return cacheRecords.get(sha256) ?? null;
     });
 
     root = renderReviewCardSide(container, [
@@ -136,10 +233,77 @@ describe("ReviewCardSide managed media rendering", () => {
       throw new Error("Managed image was not rendered");
     }
     expect(image.alt).toBe("Diagram");
-    expect(image.src).toBe("https://media.example.test/image-asset");
-    expect(container.querySelector("audio.review-markdown-media-control")?.getAttribute("src")).toBe("https://media.example.test/audio-asset");
-    expect(container.querySelector("video.review-markdown-media-control")?.getAttribute("src")).toBe("https://media.example.test/video-asset");
-    expect(container.querySelector("a.review-markdown-media-attachment")?.getAttribute("href")).toBe("https://media.example.test/file-asset");
+    expect(image.getAttribute("src")).toMatch(/^blob:review-media-/);
+    expect(container.querySelector("audio.review-markdown-media-control")?.getAttribute("src")).toMatch(/^blob:review-media-/);
+    expect(container.querySelector("video.review-markdown-media-control")?.getAttribute("src")).toMatch(/^blob:review-media-/);
+    expect(container.querySelector("a.review-markdown-media-attachment")?.getAttribute("href")).toMatch(/^blob:review-media-/);
+    expect(mediaMocks.loadMediaAssetDownloadUrlMock).not.toHaveBeenCalled();
+    expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledTimes(4);
+    expect(createObjectURLMock).toHaveBeenCalledTimes(4);
+
+    act(() => {
+      root?.unmount();
+    });
+    root = null;
+    expect(revokeObjectURLMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("downloads, verifies, caches, and deduplicates cold managed media", async () => {
+    const mediaBytes = new Uint8Array([21, 22, 23, 24]);
+    installDigestMock(coldSha256);
+    const firstMediaAsset = makeMediaAsset("image-asset", "image/png", coldSha256, mediaBytes.byteLength);
+    const secondMediaAsset = makeMediaAsset("image-copy-asset", "image/png", coldSha256, mediaBytes.byteLength);
+    const mediaAssets = new Map<string, MediaAsset>([
+      [firstMediaAsset.mediaAssetId, firstMediaAsset],
+      [secondMediaAsset.mediaAssetId, secondMediaAsset],
+    ]);
+    const downloadUrlDeferred = createDeferred<{
+      mediaAsset: MediaAsset;
+      download: Readonly<{ method: "GET"; url: string; expiresAt: string }>;
+    }>();
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValue(new Response(mediaBytes));
+    vi.stubGlobal("fetch", fetchMock);
+    mediaMocks.loadMediaAssetRecordMock.mockImplementation(async (_workspaceId: string, mediaAssetId: string): Promise<MediaAsset | null> => {
+      return mediaAssets.get(mediaAssetId) ?? null;
+    });
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(null);
+    mediaMocks.loadMediaAssetDownloadUrlMock.mockImplementation(async () => downloadUrlDeferred.promise);
+
+    root = renderReviewCardSide(container, [
+      "![First](fcasset:image-asset)",
+      "![Second](fcasset:image-copy-asset)",
+    ].join("\n\n"));
+
+    await vi.waitFor(() => {
+      expect(mediaMocks.loadMediaBlobCacheRecordMock).toHaveBeenCalledTimes(2);
+      expect(mediaMocks.loadMediaAssetDownloadUrlMock).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    downloadUrlDeferred.resolve({
+      mediaAsset: firstMediaAsset,
+      download: {
+        method: "GET",
+        url: "https://media.example.test/signed-download",
+        expiresAt: "2026-03-10T10:00:00.000Z",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelectorAll(".review-markdown-media-image")).toHaveLength(2);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("https://media.example.test/signed-download", { method: "GET" });
+    expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledTimes(1);
+    expect(mediaMocks.writeMediaBlobCacheRecordMock.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      sha256: coldSha256,
+      mimeType: "image/png",
+      sizeBytes: mediaBytes.byteLength,
+      sourceMediaAssetId: "image-asset",
+    }));
   });
 
   it("keeps external Markdown images on the normal image path", async () => {
@@ -151,6 +315,7 @@ describe("ReviewCardSide managed media rendering", () => {
 
     expect(mediaMocks.loadMediaAssetRecordMock).not.toHaveBeenCalled();
     expect(mediaMocks.loadMediaAssetDownloadUrlMock).not.toHaveBeenCalled();
+    expect(mediaMocks.loadMediaBlobCacheRecordMock).not.toHaveBeenCalled();
   });
 
   it("renders a stable fallback for missing managed media", async () => {
@@ -163,6 +328,94 @@ describe("ReviewCardSide managed media rendering", () => {
       expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
     });
     expect(mediaMocks.loadMediaAssetDownloadUrlMock).not.toHaveBeenCalled();
+    expect(mediaMocks.loadMediaBlobCacheRecordMock).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the signed download URL when the first signed URL fetch fails", async () => {
+    const mediaBytes = new Uint8Array([31, 32, 33, 34, 35]);
+    installDigestMock(refreshedSha256);
+    const mediaAsset = makeMediaAsset("refresh-asset", "image/png", refreshedSha256, mediaBytes.byteLength);
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response("expired", { status: 403, statusText: "Forbidden" }))
+      .mockResolvedValueOnce(new Response(mediaBytes));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => undefined);
+    vi.stubGlobal("fetch", fetchMock);
+    mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(null);
+    mediaMocks.loadMediaAssetDownloadUrlMock
+      .mockResolvedValueOnce({
+        mediaAsset,
+        download: {
+          method: "GET" as const,
+          url: "https://media.example.test/stale-download",
+          expiresAt: "2026-03-10T10:00:00.000Z",
+        },
+      })
+      .mockResolvedValueOnce({
+        mediaAsset,
+        download: {
+          method: "GET" as const,
+          url: "https://media.example.test/fresh-download",
+          expiresAt: "2026-03-10T10:05:00.000Z",
+        },
+      });
+
+    root = renderReviewCardSide(container, "![Refresh](fcasset:refresh-asset)");
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+    });
+
+    expect(mediaMocks.loadMediaAssetDownloadUrlMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://media.example.test/stale-download");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("https://media.example.test/fresh-download");
+    expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledWith(expect.objectContaining({
+      sha256: refreshedSha256,
+      sizeBytes: mediaBytes.byteLength,
+    }));
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "Managed media signed URL download retrying",
+      expect.objectContaining({
+        mediaAssetId: "refresh-asset",
+        sha256: refreshedSha256,
+      }),
+    );
+  });
+
+  it("renders unavailable media when downloaded bytes fail verification", async () => {
+    const mediaBytes = new Uint8Array([41, 42, 43]);
+    installDigestMock(badSha256);
+    const mediaAsset = makeMediaAsset("corrupt-asset", "image/png", coldSha256, mediaBytes.byteLength);
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValue(new Response(mediaBytes));
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => undefined);
+    vi.stubGlobal("fetch", fetchMock);
+    mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(null);
+    mediaMocks.loadMediaAssetDownloadUrlMock.mockResolvedValue({
+      mediaAsset,
+      download: {
+        method: "GET" as const,
+        url: "https://media.example.test/corrupt-download",
+        expiresAt: "2026-03-10T10:00:00.000Z",
+      },
+    });
+
+    root = renderReviewCardSide(container, "![Corrupt](fcasset:corrupt-asset)");
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
+    });
+
+    expect(mediaMocks.loadMediaAssetDownloadUrlMock).toHaveBeenCalledTimes(1);
+    expect(mediaMocks.writeMediaBlobCacheRecordMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "Managed media download unavailable",
+      expect.objectContaining({
+        mediaAssetId: "corrupt-asset",
+        errorMessage: expect.stringContaining("sha256 mismatch"),
+      }),
+    );
   });
 });

--- a/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
+++ b/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
@@ -8,15 +8,27 @@ import { defaultUrlTransform } from "react-markdown";
 import { loadMediaAssetDownloadUrl } from "../../../api";
 import { useI18n } from "../../../i18n";
 import { loadMediaAssetRecord } from "../../../localDb/mediaAssets";
+import {
+  loadMediaBlobCacheRecord,
+  writeMediaBlobCacheRecord,
+  type MediaBlobCacheRecord,
+} from "../../../localDb/mediaTransfers";
 import type { MediaAsset } from "../../../types";
 
 const FCASSET_URL_PREFIX = "fcasset:";
+const MANAGED_MEDIA_DOWNLOAD_ATTEMPT_COUNT = 2;
 
 type ManagedMediaKind = "image" | "audio" | "video" | "attachment";
 type ManagedMediaLoadState =
   | Readonly<{ status: "loading" }>
   | Readonly<{ status: "unavailable"; mediaAsset: MediaAsset | null }>
   | Readonly<{ status: "ready"; mediaAsset: MediaAsset; url: string }>;
+type ManagedMediaBlobLoadResult = Readonly<{
+  mediaAsset: MediaAsset;
+  cacheRecord: MediaBlobCacheRecord;
+}>;
+
+const activeManagedMediaDownloadPromises = new Map<string, Promise<MediaBlobCacheRecord>>();
 
 export function parseManagedMediaAssetId(url: string | null | undefined): string | null {
   if (url === null || url === undefined) {
@@ -60,6 +72,208 @@ function warnManagedMediaUnavailable(workspaceId: string, mediaAssetId: string, 
     errorName: readErrorName(error),
     errorMessage: readErrorMessage(error),
   });
+}
+
+function warnManagedMediaDownloadRetry(
+  workspaceId: string,
+  mediaAssetId: string,
+  sha256: string,
+  attemptNumber: number,
+  error: unknown,
+): void {
+  console.warn("Managed media signed URL download retrying", {
+    workspaceId,
+    mediaAssetId,
+    sha256,
+    attemptNumber,
+    errorName: readErrorName(error),
+    errorMessage: readErrorMessage(error),
+  });
+}
+
+function requireSha256Digest(): SubtleCrypto {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.subtle === undefined) {
+    throw new Error("Managed media verification failed: Web Crypto SHA-256 digest is unavailable");
+  }
+
+  return cryptoApi.subtle;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function calculateSha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await requireSha256Digest().digest("SHA-256", bytes);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+async function readDownloadFailureBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch (error) {
+    return `failed to read response body: ${readErrorMessage(error)}`;
+  }
+}
+
+async function fetchManagedMediaBytes(
+  mediaAsset: MediaAsset,
+  downloadMethod: "GET",
+  downloadUrl: string,
+): Promise<ArrayBuffer> {
+  let response: Response;
+  try {
+    response = await fetch(downloadUrl, { method: downloadMethod });
+  } catch (error) {
+    throw new Error(`Managed media download request failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, error=${readErrorMessage(error)}`);
+  }
+
+  if (response.ok === false) {
+    const responseBody = await readDownloadFailureBody(response);
+    throw new Error(`Managed media download failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, status=${response.status}, statusText=${response.statusText}, responseBody=${responseBody}`);
+  }
+
+  return response.arrayBuffer();
+}
+
+async function verifyManagedMediaBytes(mediaAsset: MediaAsset, bytes: ArrayBuffer): Promise<Blob> {
+  if (bytes.byteLength !== mediaAsset.sizeBytes) {
+    throw new Error(`Managed media download size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, expectedSizeBytes=${mediaAsset.sizeBytes}, actualSizeBytes=${bytes.byteLength}`);
+  }
+
+  const actualSha256 = await calculateSha256Hex(bytes);
+  if (actualSha256 !== mediaAsset.sha256) {
+    throw new Error(`Managed media download sha256 mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, expectedSha256=${mediaAsset.sha256}, actualSha256=${actualSha256}`);
+  }
+
+  return new Blob([bytes], { type: mediaAsset.mimeType });
+}
+
+function assertUsableMediaBlobCacheRecord(
+  mediaAsset: MediaAsset,
+  cacheRecord: MediaBlobCacheRecord,
+): void {
+  if (cacheRecord.sha256 !== mediaAsset.sha256) {
+    throw new Error(`Managed media cache sha256 mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, expectedSha256=${mediaAsset.sha256}, actualSha256=${cacheRecord.sha256}`);
+  }
+
+  if (cacheRecord.sizeBytes !== mediaAsset.sizeBytes) {
+    throw new Error(`Managed media cache size metadata mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, expectedSizeBytes=${mediaAsset.sizeBytes}, actualSizeBytes=${cacheRecord.sizeBytes}`);
+  }
+
+  if (cacheRecord.blob.size !== mediaAsset.sizeBytes) {
+    throw new Error(`Managed media cache blob size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, expectedSizeBytes=${mediaAsset.sizeBytes}, actualSizeBytes=${cacheRecord.blob.size}`);
+  }
+}
+
+function assertDownloadMediaAssetMatchesLocal(localMediaAsset: MediaAsset, downloadMediaAsset: MediaAsset): void {
+  if (downloadMediaAsset.workspaceId !== localMediaAsset.workspaceId) {
+    throw new Error(`Managed media download asset workspace mismatch: expectedWorkspaceId=${localMediaAsset.workspaceId}, actualWorkspaceId=${downloadMediaAsset.workspaceId}, mediaAssetId=${localMediaAsset.mediaAssetId}`);
+  }
+
+  if (downloadMediaAsset.mediaAssetId !== localMediaAsset.mediaAssetId) {
+    throw new Error(`Managed media download asset id mismatch: workspaceId=${localMediaAsset.workspaceId}, expectedMediaAssetId=${localMediaAsset.mediaAssetId}, actualMediaAssetId=${downloadMediaAsset.mediaAssetId}`);
+  }
+
+  if (downloadMediaAsset.sha256 !== localMediaAsset.sha256) {
+    throw new Error(`Managed media download asset sha256 mismatch: workspaceId=${localMediaAsset.workspaceId}, mediaAssetId=${localMediaAsset.mediaAssetId}, expectedSha256=${localMediaAsset.sha256}, actualSha256=${downloadMediaAsset.sha256}`);
+  }
+
+  if (downloadMediaAsset.sizeBytes !== localMediaAsset.sizeBytes) {
+    throw new Error(`Managed media download asset size mismatch: workspaceId=${localMediaAsset.workspaceId}, mediaAssetId=${localMediaAsset.mediaAssetId}, expectedSizeBytes=${localMediaAsset.sizeBytes}, actualSizeBytes=${downloadMediaAsset.sizeBytes}`);
+  }
+
+  if (downloadMediaAsset.deletedAt !== null) {
+    throw new Error(`Managed media download asset is deleted: workspaceId=${localMediaAsset.workspaceId}, mediaAssetId=${localMediaAsset.mediaAssetId}, deletedAt=${downloadMediaAsset.deletedAt}`);
+  }
+}
+
+async function downloadVerifiedMediaBlob(mediaAsset: MediaAsset): Promise<Blob> {
+  let lastError: unknown = null;
+  for (let attemptNumber = 1; attemptNumber <= MANAGED_MEDIA_DOWNLOAD_ATTEMPT_COUNT; attemptNumber += 1) {
+    const downloadResult = await loadMediaAssetDownloadUrl(mediaAsset.workspaceId, mediaAsset.mediaAssetId);
+    assertDownloadMediaAssetMatchesLocal(mediaAsset, downloadResult.mediaAsset);
+    let bytes: ArrayBuffer;
+    try {
+      bytes = await fetchManagedMediaBytes(mediaAsset, downloadResult.download.method, downloadResult.download.url);
+    } catch (error) {
+      lastError = error;
+      if (attemptNumber >= MANAGED_MEDIA_DOWNLOAD_ATTEMPT_COUNT) {
+        break;
+      }
+
+      warnManagedMediaDownloadRetry(
+        mediaAsset.workspaceId,
+        mediaAsset.mediaAssetId,
+        mediaAsset.sha256,
+        attemptNumber,
+        error,
+      );
+      continue;
+    }
+
+    return verifyManagedMediaBytes(mediaAsset, bytes);
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function downloadMediaBlobCacheRecord(mediaAsset: MediaAsset): Promise<MediaBlobCacheRecord> {
+  const activeDownloadPromise = activeManagedMediaDownloadPromises.get(mediaAsset.sha256);
+  if (activeDownloadPromise !== undefined) {
+    return activeDownloadPromise;
+  }
+
+  const downloadPromise = (async (): Promise<MediaBlobCacheRecord> => {
+    const downloadedBlob = await downloadVerifiedMediaBlob(mediaAsset);
+    const now = new Date().toISOString();
+    const cacheRecord: MediaBlobCacheRecord = {
+      sha256: mediaAsset.sha256,
+      mimeType: mediaAsset.mimeType,
+      sizeBytes: mediaAsset.sizeBytes,
+      blob: downloadedBlob,
+      createdAt: now,
+      lastAccessedAt: now,
+      sourceMediaAssetId: mediaAsset.mediaAssetId,
+    };
+    await writeMediaBlobCacheRecord(cacheRecord);
+    return cacheRecord;
+  })().finally(() => {
+    activeManagedMediaDownloadPromises.delete(mediaAsset.sha256);
+  });
+  activeManagedMediaDownloadPromises.set(mediaAsset.sha256, downloadPromise);
+  return downloadPromise;
+}
+
+async function loadMediaBlobForReview(mediaAsset: MediaAsset): Promise<MediaBlobCacheRecord> {
+  const cacheRecord = await loadMediaBlobCacheRecord(mediaAsset.sha256);
+  if (cacheRecord !== null) {
+    assertUsableMediaBlobCacheRecord(mediaAsset, cacheRecord);
+    const accessedRecord: MediaBlobCacheRecord = {
+      ...cacheRecord,
+      lastAccessedAt: new Date().toISOString(),
+    };
+    await writeMediaBlobCacheRecord(accessedRecord);
+    return accessedRecord;
+  }
+
+  return downloadMediaBlobCacheRecord(mediaAsset);
+}
+
+async function loadManagedMediaBlob(
+  workspaceId: string,
+  mediaAssetId: string,
+): Promise<ManagedMediaBlobLoadResult | null> {
+  const mediaAsset = await loadMediaAssetRecord(workspaceId, mediaAssetId);
+  if (mediaAsset === null || mediaAsset.deletedAt !== null) {
+    return null;
+  }
+
+  return {
+    mediaAsset,
+    cacheRecord: await loadMediaBlobForReview(mediaAsset),
+  };
 }
 
 function classifyManagedMediaKind(mimeType: string): ManagedMediaKind {
@@ -152,6 +366,7 @@ export function ManagedMediaReference(props: Readonly<{
 
   useEffect(() => {
     let isCancelled = false;
+    let objectUrlToRevoke: string | null = null;
 
     async function loadManagedMedia(): Promise<void> {
       if (workspaceId === null) {
@@ -160,9 +375,9 @@ export function ManagedMediaReference(props: Readonly<{
       }
 
       setLoadState({ status: "loading" });
-      let mediaAsset: MediaAsset | null;
+      let loadResult: ManagedMediaBlobLoadResult | null;
       try {
-        mediaAsset = await loadMediaAssetRecord(workspaceId, mediaAssetId);
+        loadResult = await loadManagedMediaBlob(workspaceId, mediaAssetId);
       } catch (error) {
         if (isCancelled) {
           return;
@@ -177,36 +392,39 @@ export function ManagedMediaReference(props: Readonly<{
         return;
       }
 
-      if (mediaAsset === null || mediaAsset.deletedAt !== null) {
-        setLoadState({ status: "unavailable", mediaAsset });
+      if (loadResult === null) {
+        setLoadState({ status: "unavailable", mediaAsset: null });
         return;
       }
 
+      let objectUrl: string;
       try {
-        const downloadResult = await loadMediaAssetDownloadUrl(workspaceId, mediaAssetId);
-        if (isCancelled) {
-          return;
-        }
-
-        setLoadState({
-          status: "ready",
-          mediaAsset: downloadResult.mediaAsset,
-          url: downloadResult.download.url,
-        });
+        objectUrl = URL.createObjectURL(loadResult.cacheRecord.blob);
       } catch (error) {
-        if (isCancelled) {
-          return;
-        }
-
         warnManagedMediaUnavailable(workspaceId, mediaAssetId, error);
-        setLoadState({ status: "unavailable", mediaAsset });
+        setLoadState({ status: "unavailable", mediaAsset: loadResult.mediaAsset });
+        return;
       }
+
+      if (isCancelled) {
+        URL.revokeObjectURL(objectUrl);
+        return;
+      }
+      objectUrlToRevoke = objectUrl;
+      setLoadState({
+        status: "ready",
+        mediaAsset: loadResult.mediaAsset,
+        url: objectUrl,
+      });
     }
 
     void loadManagedMedia();
 
     return () => {
       isCancelled = true;
+      if (objectUrlToRevoke !== null) {
+        URL.revokeObjectURL(objectUrlToRevoke);
+      }
     };
   }, [localReadVersion, mediaAssetId, workspaceId]);
 


### PR DESCRIPTION
## Summary
- route managed review media through the local blob cache and render object URLs
- download cold media through transient signed URLs, verify size and sha256, then populate mediaBlobCache
- cover cache hit, cache miss/deduping, unavailable assets, signed URL refresh, and verification failure behavior

## Validation
- npm --prefix apps/web exec vitest run src/screens/review/components/ReviewCardSide.media.test.tsx
- npm --prefix apps/web run test
- npm --prefix apps/web run build
- worker-owned review: no P0-P4 findings

## Residual risk
- Optional local E2E was not run.
- npm install emitted a Node engine warning: local Node v25.6.1 while package asks for 24.x.