### PR TITLE
Add Android review media cache loading

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -123,6 +123,11 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onCreateCard = {},
                     onCreateCardWithAi = {},
                     onSwitchToAllCards = {},
+                    onLoadManagedMediaFile = { mediaAssetId ->
+                        throw UnsupportedOperationException(
+                            "ReviewRouteTest does not load managed media files. mediaAssetId=$mediaAssetId"
+                        )
+                    },
                     onLoadManagedMediaDownloadUrl = { mediaAssetId ->
                         throw UnsupportedOperationException(
                             "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -74,6 +74,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalPro
 import com.flashcardsopensourceapp.data.local.repository.progress.LocalProgressRepository
 import com.flashcardsopensourceapp.data.local.repository.review.CloudReviewMediaAssetDownloadUrlLoader
 import com.flashcardsopensourceapp.data.local.repository.review.LocalReviewRepository
+import com.flashcardsopensourceapp.data.local.repository.review.OkHttpReviewMediaAssetDownloader
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.LocalSyncRepository
 import com.flashcardsopensourceapp.data.local.repository.workspace.LocalWorkspaceRepository
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
@@ -315,13 +316,15 @@ class AppGraph(
         syncLocalStore = syncLocalStore,
         localProgressCacheStore = localProgressCacheStore,
         timeProvider = SystemTimeProvider,
+        mediaAssetFileCacheRootDirectory = context.filesDir,
         mediaAssetDownloadUrlLoader = CloudReviewMediaAssetDownloadUrlLoader(
             preferencesStore = cloudPreferencesStore,
             remoteService = cloudRemoteService,
             operationCoordinator = cloudOperationCoordinator,
             guestSessionStore = guestAiSessionStore,
             resetCoordinator = cloudIdentityResetCoordinator
-        )
+        ),
+        mediaAssetDownloader = OkHttpReviewMediaAssetDownloader(okHttpClient = okHttpClient)
     )
     val feedbackRepository: FeedbackRepository = LocalFeedbackRepository(
         database = database,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -178,6 +178,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 onSwitchToAllCards = {
                     reviewViewModel.selectFilter(reviewFilter = ReviewFilter.AllCards)
                 },
+                onLoadManagedMediaFile = reviewViewModel::loadManagedMediaFile,
                 onLoadManagedMediaDownloadUrl = reviewViewModel::loadManagedMediaDownloadUrl,
                 onRevealAnswer = reviewViewModel::revealAnswer,
                 onRateAgain = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.AGAIN) },

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewMediaCacheContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewMediaCacheContractTest.kt
@@ -1,0 +1,351 @@
+package com.flashcardsopensourceapp.data.local.review
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaBlobCacheEntity
+import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
+import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.buildMediaBlobCacheRelativePath
+import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
+import com.flashcardsopensourceapp.data.local.repository.review.DownloadedReviewMediaAsset
+import com.flashcardsopensourceapp.data.local.repository.review.LocalReviewRepository
+import com.flashcardsopensourceapp.data.local.repository.review.ReviewMediaAssetDownloader
+import com.flashcardsopensourceapp.data.local.repository.review.ReviewMediaAssetDownloadUrlLoader
+import com.flashcardsopensourceapp.data.local.repository.shared.SystemTimeProvider
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.security.MessageDigest
+
+@RunWith(AndroidJUnit4::class)
+class LocalReviewMediaCacheContractTest {
+    private lateinit var runtime: LocalDatabaseTestRuntime
+    private val database: AppDatabase
+        get() = runtime.database
+
+    @Before
+    fun setUp() = runBlocking {
+        runtime = createLocalDatabaseTestRuntime()
+    }
+
+    @After
+    fun tearDown() {
+        if (::runtime.isInitialized) {
+            closeLocalDatabaseTestRuntime(runtime = runtime)
+        }
+    }
+
+    @Test
+    fun reviewMediaFileUsesValidCacheWithoutRequestingSignedUrl(): Unit = runBlocking {
+        val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = 100L)
+        val mediaBytes: ByteArray = "cached image bytes".toByteArray()
+        val mediaAsset: MediaAssetEntity = makeReviewMediaAssetEntity(
+            mediaAssetId = "media-cache-hit",
+            workspaceId = workspaceId,
+            mimeType = "image/png",
+            bytes = mediaBytes,
+            createdAtMillis = 110L,
+            deletedAtMillis = null
+        )
+        database.mediaAssetDao().insertMediaAsset(mediaAsset = mediaAsset)
+
+        val cacheRootDirectory: File = createCleanCacheRootDirectory(directoryName = "review-media-cache-hit")
+        val localRelativePath: String = buildMediaBlobCacheRelativePath(sha256 = mediaAsset.sha256)
+        val cachedFile = File(cacheRootDirectory, localRelativePath)
+        createParentDirectory(file = cachedFile)
+        cachedFile.writeBytes(mediaBytes)
+        database.mediaTransferDao().upsertMediaBlobCache(
+            mediaBlobCache = MediaBlobCacheEntity(
+                sha256 = mediaAsset.sha256,
+                mimeType = mediaAsset.mimeType,
+                sizeBytes = mediaAsset.sizeBytes,
+                localRelativePath = localRelativePath,
+                createdAtMillis = 120L,
+                lastAccessedAtMillis = 130L,
+                sourceMediaAssetId = mediaAsset.mediaAssetId
+            )
+        )
+        val repository: ReviewRepository = createReviewMediaRepository(
+            cacheRootDirectory = cacheRootDirectory,
+            downloadUrlLoader = ThrowingReviewMediaAssetDownloadUrlLoader,
+            downloader = ThrowingReviewMediaAssetDownloader
+        )
+
+        val mediaFile = repository.loadReviewMediaAssetFile(mediaAssetId = " ${mediaAsset.mediaAssetId} ")
+
+        assertEquals(mediaAsset.mediaAssetId, mediaFile.mediaAsset.mediaAssetId)
+        assertEquals(Uri.fromFile(cachedFile.canonicalFile).toString(), mediaFile.uri)
+        val updatedCache: MediaBlobCacheEntity = requireNotNull(
+            database.mediaTransferDao().loadMediaBlobCache(sha256 = mediaAsset.sha256)
+        )
+        assertTrue(updatedCache.lastAccessedAtMillis > 130L)
+    }
+
+    @Test
+    fun reviewMediaFileDownloadsVerifiesAndPersistsCacheOnMiss(): Unit = runBlocking {
+        val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = 200L)
+        val mediaBytes: ByteArray = "downloaded image bytes".toByteArray()
+        val mediaAsset: MediaAssetEntity = makeReviewMediaAssetEntity(
+            mediaAssetId = "media-cache-miss",
+            workspaceId = workspaceId,
+            mimeType = "image/jpeg",
+            bytes = mediaBytes,
+            createdAtMillis = 210L,
+            deletedAtMillis = null
+        )
+        database.mediaAssetDao().insertMediaAsset(mediaAsset = mediaAsset)
+
+        val signedDownloadUrl: String = "https://signed.example/review-media-cache-miss"
+        val downloadUrlLoader = FakeReviewMediaAssetDownloadUrlLoader(
+            responsesByMediaAssetId = mapOf(
+                mediaAsset.mediaAssetId to MediaAssetDownloadUrl(
+                    mediaAsset = toReviewMediaAsset(mediaAsset = mediaAsset),
+                    url = signedDownloadUrl,
+                    expiresAtMillis = 500L
+                )
+            )
+        )
+        val downloader = FakeReviewMediaAssetDownloader(
+            bytesByUrl = mapOf(signedDownloadUrl to mediaBytes)
+        )
+        val cacheRootDirectory: File = createCleanCacheRootDirectory(directoryName = "review-media-cache-miss")
+        val repository: ReviewRepository = createReviewMediaRepository(
+            cacheRootDirectory = cacheRootDirectory,
+            downloadUrlLoader = downloadUrlLoader,
+            downloader = downloader
+        )
+
+        val mediaFile = repository.loadReviewMediaAssetFile(mediaAssetId = mediaAsset.mediaAssetId)
+
+        val cachedFile: File = File(
+            cacheRootDirectory,
+            buildMediaBlobCacheRelativePath(sha256 = mediaAsset.sha256)
+        ).canonicalFile
+        assertEquals(Uri.fromFile(cachedFile).toString(), mediaFile.uri)
+        assertArrayEquals(mediaBytes, cachedFile.readBytes())
+        val mediaBlobCache: MediaBlobCacheEntity = requireNotNull(
+            database.mediaTransferDao().loadMediaBlobCache(sha256 = mediaAsset.sha256)
+        )
+        assertEquals(mediaAsset.mediaAssetId, mediaBlobCache.sourceMediaAssetId)
+        assertEquals(mediaAsset.sizeBytes, mediaBlobCache.sizeBytes)
+        assertEquals(
+            listOf(ReviewMediaAssetDownloadRequest(workspaceId = workspaceId, mediaAssetId = mediaAsset.mediaAssetId)),
+            downloadUrlLoader.requests
+        )
+        assertEquals(listOf(signedDownloadUrl), downloader.downloadedUrls)
+    }
+
+    @Test
+    fun reviewMediaFileRejectsDeletedMediaAsset(): Unit = runBlocking {
+        val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = 300L)
+        val mediaBytes: ByteArray = "deleted image bytes".toByteArray()
+        val mediaAsset: MediaAssetEntity = makeReviewMediaAssetEntity(
+            mediaAssetId = "media-deleted",
+            workspaceId = workspaceId,
+            mimeType = "image/png",
+            bytes = mediaBytes,
+            createdAtMillis = 310L,
+            deletedAtMillis = 320L
+        )
+        database.mediaAssetDao().insertMediaAsset(mediaAsset = mediaAsset)
+        val repository: ReviewRepository = createReviewMediaRepository(
+            cacheRootDirectory = createCleanCacheRootDirectory(directoryName = "review-media-cache-deleted"),
+            downloadUrlLoader = ThrowingReviewMediaAssetDownloadUrlLoader,
+            downloader = ThrowingReviewMediaAssetDownloader
+        )
+
+        try {
+            repository.loadReviewMediaAssetFile(mediaAssetId = mediaAsset.mediaAssetId)
+            fail("Deleted review media asset should not load as a cached file.")
+        } catch (error: IllegalArgumentException) {
+            assertTrue(error.message.orEmpty().contains("Cannot load deleted media asset"))
+        }
+    }
+
+    private fun createReviewMediaRepository(
+        cacheRootDirectory: File,
+        downloadUrlLoader: ReviewMediaAssetDownloadUrlLoader,
+        downloader: ReviewMediaAssetDownloader
+    ): ReviewRepository {
+        return LocalReviewRepository(
+            database = runtime.database,
+            preferencesStore = runtime.preferencesStore,
+            syncLocalStore = runtime.syncLocalStore,
+            localProgressCacheStore = LocalProgressCacheStore(
+                database = runtime.database,
+                timeProvider = SystemTimeProvider
+            ),
+            timeProvider = SystemTimeProvider,
+            mediaAssetFileCacheRootDirectory = cacheRootDirectory,
+            mediaAssetDownloadUrlLoader = downloadUrlLoader,
+            mediaAssetDownloader = downloader
+        )
+    }
+
+    private fun createCleanCacheRootDirectory(directoryName: String): File {
+        val cacheRootDirectory = File(runtime.context.filesDir, directoryName)
+        if (cacheRootDirectory.exists() && cacheRootDirectory.deleteRecursively().not()) {
+            throw IllegalStateException("Cannot delete existing test media cache directory: ${cacheRootDirectory.absolutePath}")
+        }
+        return cacheRootDirectory
+    }
+
+    private fun createParentDirectory(file: File): Unit {
+        val parentDirectory = requireNotNull(file.parentFile) {
+            "Test file must have a parent directory: ${file.absolutePath}"
+        }
+        if (parentDirectory.exists().not() && parentDirectory.mkdirs().not()) {
+            throw IllegalStateException("Cannot create test media cache directory: ${parentDirectory.absolutePath}")
+        }
+    }
+}
+
+private data class ReviewMediaAssetDownloadRequest(
+    val workspaceId: String,
+    val mediaAssetId: String
+)
+
+private class FakeReviewMediaAssetDownloadUrlLoader(
+    private val responsesByMediaAssetId: Map<String, MediaAssetDownloadUrl>
+) : ReviewMediaAssetDownloadUrlLoader {
+    val requests: MutableList<ReviewMediaAssetDownloadRequest> = mutableListOf()
+
+    override suspend fun loadMediaAssetDownloadUrl(
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl {
+        requests += ReviewMediaAssetDownloadRequest(
+            workspaceId = workspaceId,
+            mediaAssetId = mediaAssetId
+        )
+        return requireNotNull(responsesByMediaAssetId[mediaAssetId]) {
+            "Missing fake review media download URL response for mediaAssetId=$mediaAssetId workspaceId=$workspaceId."
+        }
+    }
+}
+
+private class FakeReviewMediaAssetDownloader(
+    private val bytesByUrl: Map<String, ByteArray>
+) : ReviewMediaAssetDownloader {
+    val downloadedUrls: MutableList<String> = mutableListOf()
+
+    override suspend fun downloadMediaAsset(
+        url: String,
+        targetFile: File,
+        expectedSizeBytes: Long,
+        expectedSha256: String
+    ): DownloadedReviewMediaAsset {
+        downloadedUrls += url
+        val bytes: ByteArray = requireNotNull(bytesByUrl[url]) {
+            "Missing fake review media bytes for url=$url."
+        }
+        val actualSha256: String = sha256Hex(bytes = bytes)
+        require(expectedSizeBytes == bytes.size.toLong()) {
+            "Fake review media expected sizeBytes mismatch for url=$url: " +
+                "expectedSizeBytes=$expectedSizeBytes actualSizeBytes=${bytes.size}."
+        }
+        require(expectedSha256 == actualSha256) {
+            "Fake review media expected SHA-256 mismatch for url=$url: " +
+                "expectedSha256=$expectedSha256 actualSha256=$actualSha256."
+        }
+        targetFile.writeBytes(bytes)
+        return DownloadedReviewMediaAsset(
+            sizeBytes = bytes.size.toLong(),
+            sha256 = actualSha256
+        )
+    }
+}
+
+private object ThrowingReviewMediaAssetDownloadUrlLoader : ReviewMediaAssetDownloadUrlLoader {
+    override suspend fun loadMediaAssetDownloadUrl(
+        workspaceId: String,
+        mediaAssetId: String
+    ): MediaAssetDownloadUrl {
+        throw AssertionError(
+            "Review media cache hit should not request a signed URL. " +
+                "workspaceId=$workspaceId mediaAssetId=$mediaAssetId"
+        )
+    }
+}
+
+private object ThrowingReviewMediaAssetDownloader : ReviewMediaAssetDownloader {
+    override suspend fun downloadMediaAsset(
+        url: String,
+        targetFile: File,
+        expectedSizeBytes: Long,
+        expectedSha256: String
+    ): DownloadedReviewMediaAsset {
+        throw AssertionError(
+            "Review media cache hit should not download bytes. " +
+                "url=$url targetFile=${targetFile.absolutePath} expectedSizeBytes=$expectedSizeBytes " +
+                "expectedSha256=$expectedSha256"
+        )
+    }
+}
+
+private fun makeReviewMediaAssetEntity(
+    mediaAssetId: String,
+    workspaceId: String,
+    mimeType: String,
+    bytes: ByteArray,
+    createdAtMillis: Long,
+    deletedAtMillis: Long?
+): MediaAssetEntity {
+    return MediaAssetEntity(
+        mediaAssetId = mediaAssetId,
+        workspaceId = workspaceId,
+        mimeType = mimeType,
+        sizeBytes = bytes.size.toLong(),
+        sha256 = sha256Hex(bytes = bytes),
+        sourceUrl = null,
+        createdAtMillis = createdAtMillis,
+        clientUpdatedAtMillis = createdAtMillis,
+        lastModifiedByReplicaId = "android-test-replica",
+        lastOperationId = "$mediaAssetId-operation",
+        updatedAtMillis = createdAtMillis,
+        deletedAtMillis = deletedAtMillis
+    )
+}
+
+private fun toReviewMediaAsset(mediaAsset: MediaAssetEntity): MediaAsset {
+    return MediaAsset(
+        mediaAssetId = mediaAsset.mediaAssetId,
+        workspaceId = mediaAsset.workspaceId,
+        mimeType = mediaAsset.mimeType,
+        sizeBytes = mediaAsset.sizeBytes,
+        sha256 = mediaAsset.sha256,
+        sourceUrl = mediaAsset.sourceUrl,
+        createdAtMillis = mediaAsset.createdAtMillis,
+        clientUpdatedAtMillis = mediaAsset.clientUpdatedAtMillis,
+        lastModifiedByReplicaId = mediaAsset.lastModifiedByReplicaId,
+        lastOperationId = mediaAsset.lastOperationId,
+        updatedAtMillis = mediaAsset.updatedAtMillis,
+        deletedAtMillis = mediaAsset.deletedAtMillis
+    )
+}
+
+private fun sha256Hex(bytes: ByteArray): String {
+    val digest: ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+    val hexChars: CharArray = "0123456789abcdef".toCharArray()
+    val result = CharArray(size = digest.size * 2)
+    digest.forEachIndexed { index, byte ->
+        val value = byte.toInt() and 0xff
+        result[index * 2] = hexChars[value ushr 4]
+        result[(index * 2) + 1] = hexChars[value and 0x0f]
+    }
+    return String(result)
+}

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
@@ -20,7 +20,9 @@ import com.flashcardsopensourceapp.data.local.repository.DecksRepository
 import com.flashcardsopensourceapp.data.local.repository.cards.LocalCardsRepository
 import com.flashcardsopensourceapp.data.local.repository.decks.LocalDecksRepository
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
+import com.flashcardsopensourceapp.data.local.repository.review.DownloadedReviewMediaAsset
 import com.flashcardsopensourceapp.data.local.repository.review.LocalReviewRepository
+import com.flashcardsopensourceapp.data.local.repository.review.ReviewMediaAssetDownloader
 import com.flashcardsopensourceapp.data.local.repository.review.ReviewMediaAssetDownloadUrlLoader
 import com.flashcardsopensourceapp.data.local.repository.workspace.LocalWorkspaceRepository
 import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
@@ -31,6 +33,7 @@ import com.flashcardsopensourceapp.data.local.review.SharedPreferencesReviewPref
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
 
 internal data class LocalDatabaseTestRuntime(
     val context: Context,
@@ -130,7 +133,9 @@ internal fun createTestReviewRepository(runtime: LocalDatabaseTestRuntime): Revi
             timeProvider = SystemTimeProvider
         ),
         timeProvider = SystemTimeProvider,
-        mediaAssetDownloadUrlLoader = UnsupportedTestReviewMediaAssetDownloadUrlLoader
+        mediaAssetFileCacheRootDirectory = File(runtime.context.filesDir, "managed-media-test-cache"),
+        mediaAssetDownloadUrlLoader = UnsupportedTestReviewMediaAssetDownloadUrlLoader,
+        mediaAssetDownloader = UnsupportedTestReviewMediaAssetDownloader
     )
 }
 
@@ -142,6 +147,21 @@ private object UnsupportedTestReviewMediaAssetDownloadUrlLoader : ReviewMediaAss
         throw UnsupportedOperationException(
             "Test review repository does not support managed media download URLs. " +
                 "workspaceId=$workspaceId mediaAssetId=$mediaAssetId"
+        )
+    }
+}
+
+private object UnsupportedTestReviewMediaAssetDownloader : ReviewMediaAssetDownloader {
+    override suspend fun downloadMediaAsset(
+        url: String,
+        targetFile: File,
+        expectedSizeBytes: Long,
+        expectedSha256: String
+    ): DownloadedReviewMediaAsset {
+        throw UnsupportedOperationException(
+            "Test review repository does not support managed media file downloads. " +
+                "url=$url targetFile=${targetFile.absolutePath} expectedSizeBytes=$expectedSizeBytes " +
+                "expectedSha256=$expectedSha256"
         )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/MediaAssetModels.kt
@@ -20,3 +20,14 @@ data class MediaAssetDownloadUrl(
     val url: String,
     val expiresAtMillis: Long
 )
+
+data class ReviewMediaAssetFile(
+    val mediaAsset: MediaAsset,
+    val uri: String
+) {
+    init {
+        require(uri.isNotBlank()) {
+            "Review media asset file URI must not be blank."
+        }
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -40,6 +40,7 @@ import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackTrigger
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnection
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnectionsResult
@@ -116,6 +117,8 @@ interface ReviewRepository {
     ): Flow<ReviewSessionSnapshot>
 
     fun observeReviewMediaAssets(): Flow<List<MediaAsset>>
+
+    suspend fun loadReviewMediaAssetFile(mediaAssetId: String): ReviewMediaAssetFile
 
     suspend fun loadReviewMediaAssetDownloadUrl(mediaAssetId: String): MediaAssetDownloadUrl
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
@@ -1,11 +1,13 @@
 package com.flashcardsopensourceapp.data.local.repository.review
 
+import android.net.Uri
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardWithRelations
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaBlobCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
@@ -15,6 +17,9 @@ import com.flashcardsopensourceapp.data.local.model.cards.DeckSummary
 import com.flashcardsopensourceapp.data.local.model.feedback.FeedbackPromptReviewActivity
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
+import com.flashcardsopensourceapp.data.local.model.media.buildMediaBlobCacheRelativePath
+import com.flashcardsopensourceapp.data.local.model.media.normalizeMediaSha256
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCardQueueStatus
@@ -53,6 +58,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -62,8 +74,13 @@ class LocalReviewRepository(
     private val syncLocalStore: SyncLocalStore,
     private val localProgressCacheStore: LocalProgressCacheStore,
     private val timeProvider: TimeProvider,
-    private val mediaAssetDownloadUrlLoader: ReviewMediaAssetDownloadUrlLoader
+    private val mediaAssetFileCacheRootDirectory: File,
+    private val mediaAssetDownloadUrlLoader: ReviewMediaAssetDownloadUrlLoader,
+    private val mediaAssetDownloader: ReviewMediaAssetDownloader
 ) : ReviewRepository {
+    private val mediaAssetDownloadLocksMutex = Mutex()
+    private val mediaAssetDownloadLocks: MutableMap<String, Mutex> = mutableMapOf()
+
     override fun observeReviewSession(
         selectedFilter: ReviewFilter,
         pendingReviewedCards: Set<PendingReviewedCard>,
@@ -250,6 +267,42 @@ class LocalReviewRepository(
     }
 
     override suspend fun loadReviewMediaAssetDownloadUrl(mediaAssetId: String): MediaAssetDownloadUrl {
+        val reviewMediaAsset: ReviewMediaAssetLookup = loadActiveReviewMediaAsset(mediaAssetId = mediaAssetId)
+
+        val downloadUrl: MediaAssetDownloadUrl = mediaAssetDownloadUrlLoader.loadMediaAssetDownloadUrl(
+            workspaceId = reviewMediaAsset.workspaceId,
+            mediaAssetId = reviewMediaAsset.mediaAsset.mediaAssetId
+        )
+        return validateReviewMediaAssetDownloadUrl(
+            downloadUrl = downloadUrl,
+            mediaAsset = reviewMediaAsset.mediaAsset,
+            workspaceId = reviewMediaAsset.workspaceId
+        )
+    }
+
+    override suspend fun loadReviewMediaAssetFile(mediaAssetId: String): ReviewMediaAssetFile {
+        val reviewMediaAsset: ReviewMediaAssetLookup = loadActiveReviewMediaAsset(mediaAssetId = mediaAssetId)
+        val mediaAsset: MediaAssetEntity = reviewMediaAsset.mediaAsset
+        val sha256: String = normalizeMediaSha256(rawSha256 = mediaAsset.sha256)
+        val localFile: File = mediaDownloadLock(sha256 = sha256).withLock {
+            loadUsableCachedReviewMediaFile(
+                mediaAsset = mediaAsset,
+                sha256 = sha256,
+                nowMillis = System.currentTimeMillis()
+            ) ?: downloadReviewMediaFile(
+                mediaAsset = mediaAsset,
+                workspaceId = reviewMediaAsset.workspaceId,
+                sha256 = sha256
+            )
+        }
+
+        return ReviewMediaAssetFile(
+            mediaAsset = toMediaAsset(mediaAsset = mediaAsset),
+            uri = Uri.fromFile(localFile).toString()
+        )
+    }
+
+    private suspend fun loadActiveReviewMediaAsset(mediaAssetId: String): ReviewMediaAssetLookup {
         val normalizedMediaAssetId = mediaAssetId.trim()
         require(normalizedMediaAssetId.isNotEmpty()) {
             "Managed media download requires a media asset id."
@@ -266,25 +319,121 @@ class LocalReviewRepository(
         val mediaAsset: MediaAssetEntity = requireNotNull(
             database.mediaAssetDao().loadMediaAsset(mediaAssetId = normalizedMediaAssetId)
         ) {
-            "Cannot load download URL for missing media asset: $normalizedMediaAssetId"
+            "Cannot load managed media asset: $normalizedMediaAssetId"
         }
         require(mediaAsset.workspaceId == workspace.workspaceId) {
             "Cannot load media asset '${mediaAsset.mediaAssetId}' from workspace '${mediaAsset.workspaceId}' " +
                 "while current workspace is '${workspace.workspaceId}'."
         }
         require(mediaAsset.deletedAtMillis == null) {
-            "Cannot load download URL for deleted media asset: ${mediaAsset.mediaAssetId}"
+            "Cannot load deleted media asset: ${mediaAsset.mediaAssetId}"
         }
 
-        val downloadUrl: MediaAssetDownloadUrl = mediaAssetDownloadUrlLoader.loadMediaAssetDownloadUrl(
+        return ReviewMediaAssetLookup(
             workspaceId = workspace.workspaceId,
-            mediaAssetId = mediaAsset.mediaAssetId
+            mediaAsset = mediaAsset
         )
-        return validateReviewMediaAssetDownloadUrl(
-            downloadUrl = downloadUrl,
+    }
+
+    private suspend fun mediaDownloadLock(sha256: String): Mutex {
+        return mediaAssetDownloadLocksMutex.withLock {
+            mediaAssetDownloadLocks.getOrPut(sha256) {
+                Mutex()
+            }
+        }
+    }
+
+    private suspend fun loadUsableCachedReviewMediaFile(
+        mediaAsset: MediaAssetEntity,
+        sha256: String,
+        nowMillis: Long
+    ): File? {
+        val mediaBlobCache: MediaBlobCacheEntity = database.mediaTransferDao()
+            .loadMediaBlobCache(sha256 = sha256)
+            ?: return null
+        validateReviewMediaBlobCache(
+            mediaBlobCache = mediaBlobCache,
             mediaAsset = mediaAsset,
-            workspaceId = workspace.workspaceId
+            sha256 = sha256
         )
+
+        val cachedFile: File = resolveMediaBlobCacheFile(localRelativePath = mediaBlobCache.localRelativePath)
+        if (isUsableCachedReviewMediaFile(
+                cachedFile = cachedFile,
+                mediaBlobCache = mediaBlobCache
+            )
+        ) {
+            database.mediaTransferDao().updateMediaBlobCacheLastAccessed(
+                sha256 = sha256,
+                lastAccessedAtMillis = nowMillis
+            )
+            return cachedFile
+        }
+
+        database.mediaTransferDao().deleteMediaBlobCache(sha256 = sha256)
+        deleteInvalidReviewMediaFile(cachedFile = cachedFile)
+        return null
+    }
+
+    private suspend fun downloadReviewMediaFile(
+        mediaAsset: MediaAssetEntity,
+        workspaceId: String,
+        sha256: String
+    ): File {
+        val downloadUrl: MediaAssetDownloadUrl = validateReviewMediaAssetDownloadUrl(
+            downloadUrl = mediaAssetDownloadUrlLoader.loadMediaAssetDownloadUrl(
+                workspaceId = workspaceId,
+                mediaAssetId = mediaAsset.mediaAssetId
+            ),
+            mediaAsset = mediaAsset,
+            workspaceId = workspaceId
+        )
+        val localRelativePath: String = buildMediaBlobCacheRelativePath(sha256 = sha256)
+        val targetFile: File = resolveMediaBlobCacheFile(localRelativePath = localRelativePath)
+        val parentDirectory: File = requireNotNull(targetFile.parentFile) {
+            "Managed media cache target file must have a parent directory: ${targetFile.absolutePath}"
+        }
+        if (parentDirectory.exists().not() && parentDirectory.mkdirs().not()) {
+            throw IOException("Cannot create managed media cache directory: ${parentDirectory.absolutePath}")
+        }
+        val temporaryFile = File(
+            parentDirectory,
+            "${targetFile.name}.download"
+        )
+
+        try {
+            val downloadedMediaAsset: DownloadedReviewMediaAsset = mediaAssetDownloader.downloadMediaAsset(
+                url = downloadUrl.url,
+                targetFile = temporaryFile,
+                expectedSizeBytes = mediaAsset.sizeBytes,
+                expectedSha256 = sha256
+            )
+            validateDownloadedReviewMediaAsset(
+                downloadedMediaAsset = downloadedMediaAsset,
+                mediaAsset = mediaAsset,
+                sha256 = sha256
+            )
+            moveReviewMediaFileIntoCacheAtomically(
+                temporaryFile = temporaryFile,
+                targetFile = targetFile
+            )
+            val nowMillis = System.currentTimeMillis()
+            database.mediaTransferDao().upsertMediaBlobCache(
+                mediaBlobCache = MediaBlobCacheEntity(
+                    sha256 = sha256,
+                    mimeType = mediaAsset.mimeType,
+                    sizeBytes = mediaAsset.sizeBytes,
+                    localRelativePath = localRelativePath,
+                    createdAtMillis = nowMillis,
+                    lastAccessedAtMillis = nowMillis,
+                    sourceMediaAssetId = mediaAsset.mediaAssetId
+                )
+            )
+            return targetFile
+        } catch (error: Throwable) {
+            deleteTemporaryReviewMediaFile(temporaryFile = temporaryFile, cause = error)
+            throw error
+        }
     }
 
     override suspend fun loadReviewTimelinePage(
@@ -499,7 +648,116 @@ class LocalReviewRepository(
             )
         }
     }
+
+    private fun resolveMediaBlobCacheFile(localRelativePath: String): File {
+        val cacheRootDirectory = mediaAssetFileCacheRootDirectory.canonicalFile
+        val cacheFile = File(cacheRootDirectory, localRelativePath).canonicalFile
+        val cacheRootPath = cacheRootDirectory.path
+        val cacheFilePath = cacheFile.path
+        require(cacheFilePath == cacheRootPath || cacheFilePath.startsWith(prefix = "$cacheRootPath${File.separator}")) {
+            "Managed media cache path escapes cache root: root='$cacheRootPath' relativePath='$localRelativePath'."
+        }
+        return cacheFile
+    }
+
+    private fun validateReviewMediaBlobCache(
+        mediaBlobCache: MediaBlobCacheEntity,
+        mediaAsset: MediaAssetEntity,
+        sha256: String
+    ): Unit {
+        check(mediaBlobCache.sha256 == sha256) {
+            "Managed media cache SHA-256 mismatch: expected '$sha256' but found '${mediaBlobCache.sha256}'."
+        }
+        check(mediaBlobCache.localRelativePath == buildMediaBlobCacheRelativePath(sha256 = sha256)) {
+            "Managed media cache path mismatch for sha256 '$sha256': " +
+                "expected '${buildMediaBlobCacheRelativePath(sha256 = sha256)}' " +
+                "but found '${mediaBlobCache.localRelativePath}'."
+        }
+        check(mediaBlobCache.sizeBytes == mediaAsset.sizeBytes) {
+            "Managed media cache size mismatch for asset '${mediaAsset.mediaAssetId}' sha256 '$sha256': " +
+                "asset sizeBytes=${mediaAsset.sizeBytes} cache sizeBytes=${mediaBlobCache.sizeBytes}."
+        }
+    }
+
+    private fun isUsableCachedReviewMediaFile(
+        cachedFile: File,
+        mediaBlobCache: MediaBlobCacheEntity
+    ): Boolean {
+        if (cachedFile.exists().not()) {
+            return false
+        }
+        if (cachedFile.isFile.not()) {
+            return false
+        }
+        return cachedFile.length() == mediaBlobCache.sizeBytes
+    }
+
+    private fun deleteInvalidReviewMediaFile(cachedFile: File): Unit {
+        if (cachedFile.exists().not()) {
+            return
+        }
+        if (cachedFile.deleteRecursively().not()) {
+            throw IOException("Cannot delete invalid managed media cache file: ${cachedFile.absolutePath}")
+        }
+    }
+
+    private fun validateDownloadedReviewMediaAsset(
+        downloadedMediaAsset: DownloadedReviewMediaAsset,
+        mediaAsset: MediaAssetEntity,
+        sha256: String
+    ): Unit {
+        check(downloadedMediaAsset.sizeBytes == mediaAsset.sizeBytes) {
+            "Managed media download size mismatch for asset '${mediaAsset.mediaAssetId}': " +
+                "expected ${mediaAsset.sizeBytes} byte(s) but received ${downloadedMediaAsset.sizeBytes} byte(s)."
+        }
+        check(downloadedMediaAsset.sha256 == sha256) {
+            "Managed media download SHA-256 mismatch for asset '${mediaAsset.mediaAssetId}': " +
+                "expected '$sha256' but received '${downloadedMediaAsset.sha256}'."
+        }
+    }
+
+    private fun moveReviewMediaFileIntoCacheAtomically(
+        temporaryFile: File,
+        targetFile: File
+    ): Unit {
+        if (targetFile.exists() && targetFile.deleteRecursively().not()) {
+            throw IOException("Cannot replace existing managed media cache file: ${targetFile.absolutePath}")
+        }
+
+        try {
+            Files.move(
+                temporaryFile.toPath(),
+                targetFile.toPath(),
+                StandardCopyOption.ATOMIC_MOVE
+            )
+        } catch (error: AtomicMoveNotSupportedException) {
+            throw IOException(
+                "Atomic managed media cache move is not supported from temporary file " +
+                    "'${temporaryFile.absolutePath}' to '${targetFile.absolutePath}'.",
+                error
+            )
+        }
+    }
+
+    private fun deleteTemporaryReviewMediaFile(
+        temporaryFile: File,
+        cause: Throwable
+    ): Unit {
+        if (temporaryFile.exists().not()) {
+            return
+        }
+        if (temporaryFile.delete().not()) {
+            cause.addSuppressed(
+                IOException("Cannot delete temporary managed media download file: ${temporaryFile.absolutePath}")
+            )
+        }
+    }
 }
+
+private data class ReviewMediaAssetLookup(
+    val workspaceId: String,
+    val mediaAsset: MediaAssetEntity
+)
 
 private fun toMediaAsset(mediaAsset: MediaAssetEntity): MediaAsset {
     return MediaAsset(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloadUrlLoader.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloadUrlLoader.kt
@@ -1,18 +1,174 @@
 package com.flashcardsopensourceapp.data.local.repository.review
 
+import android.util.Log
 import com.flashcardsopensourceapp.data.local.ai.store.GuestAiSessionStore
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.network.awaitOkHttpResponse
 import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.normalizeMediaSha256
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.account.CloudIdentityResetCoordinator
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.guest.loadActiveGuestSessionOrNull
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.AuthenticatedCloudSession
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudOperationCoordinator
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudSessionProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.File
+import java.io.IOException
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
+
+private const val reviewMediaAssetDownloadLogTag: String = "ReviewMediaDownload"
+private const val reviewMediaAssetDownloadMaxAttemptCount: Int = 3
+private const val reviewMediaAssetDownloadRetryBaseDelayMillis: Long = 500L
+private const val reviewMediaAssetDownloadErrorBodyLimit: Int = 4_096
+
+data class DownloadedReviewMediaAsset(
+    val sizeBytes: Long,
+    val sha256: String
+) {
+    init {
+        require(sizeBytes >= 0L) {
+            "Downloaded review media asset sizeBytes must not be negative."
+        }
+        require(sha256 == normalizeMediaSha256(rawSha256 = sha256)) {
+            "Downloaded review media asset sha256 must already be normalized."
+        }
+    }
+}
+
+interface ReviewMediaAssetDownloader {
+    suspend fun downloadMediaAsset(
+        url: String,
+        targetFile: File,
+        expectedSizeBytes: Long,
+        expectedSha256: String
+    ): DownloadedReviewMediaAsset
+}
+
+class OkHttpReviewMediaAssetDownloader(
+    okHttpClient: OkHttpClient
+) : ReviewMediaAssetDownloader {
+    private val httpClient: OkHttpClient = okHttpClient.newBuilder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .writeTimeout(120, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .build()
+
+    override suspend fun downloadMediaAsset(
+        url: String,
+        targetFile: File,
+        expectedSizeBytes: Long,
+        expectedSha256: String
+    ): DownloadedReviewMediaAsset {
+        require(url.isNotBlank()) {
+            "Managed media download URL must not be blank."
+        }
+        require(expectedSizeBytes >= 0L) {
+            "Managed media download expected sizeBytes must not be negative."
+        }
+        val normalizedExpectedSha256: String = normalizeMediaSha256(rawSha256 = expectedSha256)
+
+        return withContext(Dispatchers.IO) {
+            var attemptNumber = 1
+            while (attemptNumber <= reviewMediaAssetDownloadMaxAttemptCount) {
+                currentCoroutineContext().ensureActive()
+                try {
+                    return@withContext downloadMediaAssetAttempt(
+                        url = url,
+                        targetFile = targetFile,
+                        expectedSizeBytes = expectedSizeBytes,
+                        expectedSha256 = normalizedExpectedSha256
+                    )
+                } catch (error: IOException) {
+                    currentCoroutineContext().ensureActive()
+                    val shouldRetry = shouldRetryReviewMediaDownloadError(
+                        error = error,
+                        attemptNumber = attemptNumber
+                    )
+                    if (shouldRetry.not()) {
+                        throw error
+                    }
+
+                    val delayMillis = calculateReviewMediaDownloadRetryDelayMillis(
+                        attemptNumber = attemptNumber
+                    )
+                    Log.w(
+                        reviewMediaAssetDownloadLogTag,
+                        "event=review_media_download_retry attemptNumber=$attemptNumber " +
+                            "delayMs=$delayMillis errorType=${error::class.java.simpleName}",
+                        error
+                    )
+                    deletePartialReviewMediaDownload(targetFile = targetFile, cause = error)
+                    delay(delayMillis)
+                    attemptNumber += 1
+                }
+            }
+
+            throw IllegalStateException("Managed media download retry loop exited without a terminal result.")
+        }
+    }
+
+    private suspend fun downloadMediaAssetAttempt(
+        url: String,
+        targetFile: File,
+        expectedSizeBytes: Long,
+        expectedSha256: String
+    ): DownloadedReviewMediaAsset {
+        val parentDirectory = targetFile.parentFile
+        require(parentDirectory != null) {
+            "Managed media download target file must have a parent directory: ${targetFile.absolutePath}"
+        }
+        if (parentDirectory.exists().not() && parentDirectory.mkdirs().not()) {
+            throw IOException("Cannot create managed media download directory: ${parentDirectory.absolutePath}")
+        }
+        if (targetFile.exists() && targetFile.delete().not()) {
+            throw IOException("Cannot replace managed media download target file: ${targetFile.absolutePath}")
+        }
+
+        val request: Request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+
+        try {
+            httpClient.newCall(request).awaitOkHttpResponse().use { response ->
+                if (response.isSuccessful.not()) {
+                    throw ReviewMediaAssetDownloadHttpException(
+                        statusCode = response.code,
+                        responseBody = readReviewMediaDownloadErrorBody(response = response),
+                        retryEligible = isTransientReviewMediaDownloadStatusCode(statusCode = response.code)
+                    )
+                }
+                validateReviewMediaDownloadContentLength(
+                    contentLength = response.body.contentLength(),
+                    expectedSizeBytes = expectedSizeBytes
+                )
+
+                return streamReviewMediaResponseToFile(
+                    response = response,
+                    targetFile = targetFile,
+                    expectedSizeBytes = expectedSizeBytes,
+                    expectedSha256 = expectedSha256
+                )
+            }
+        } catch (error: IOException) {
+            deletePartialReviewMediaDownload(targetFile = targetFile, cause = error)
+            throw error
+        }
+    }
+}
 
 interface ReviewMediaAssetDownloadUrlLoader {
     suspend fun loadMediaAssetDownloadUrl(workspaceId: String, mediaAssetId: String): MediaAssetDownloadUrl
@@ -97,3 +253,145 @@ private data class ReviewMediaCloudSession(
     val apiBaseUrl: String,
     val authorizationHeader: String
 )
+
+private class ReviewMediaAssetDownloadHttpException(
+    val statusCode: Int,
+    val responseBody: String,
+    val retryEligible: Boolean
+) : IOException(
+    "Managed media download failed with HTTP statusCode=$statusCode responseBody='$responseBody'."
+)
+
+private class ReviewMediaAssetDownloadValidationException(
+    message: String
+) : IOException(message)
+
+private fun streamReviewMediaResponseToFile(
+    response: Response,
+    targetFile: File,
+    expectedSizeBytes: Long,
+    expectedSha256: String
+): DownloadedReviewMediaAsset {
+    val digest = MessageDigest.getInstance("SHA-256")
+    var sizeBytes = 0L
+
+    response.body.byteStream().use { input ->
+        targetFile.outputStream().use { output ->
+            val buffer = ByteArray(size = 16 * 1024)
+            while (true) {
+                val readByteCount = input.read(buffer)
+                if (readByteCount == -1) {
+                    break
+                }
+                val nextSizeBytes = sizeBytes + readByteCount.toLong()
+                if (nextSizeBytes > expectedSizeBytes) {
+                    throw ReviewMediaAssetDownloadValidationException(
+                        "Managed media download exceeded expected size: " +
+                            "expected $expectedSizeBytes byte(s), received at least $nextSizeBytes byte(s)."
+                    )
+                }
+                output.write(buffer, 0, readByteCount)
+                digest.update(buffer, 0, readByteCount)
+                sizeBytes = nextSizeBytes
+            }
+        }
+    }
+
+    val downloadedMediaAsset = DownloadedReviewMediaAsset(
+        sizeBytes = sizeBytes,
+        sha256 = encodeReviewMediaDigestHex(bytes = digest.digest())
+    )
+    validateCompletedReviewMediaDownload(
+        downloadedMediaAsset = downloadedMediaAsset,
+        expectedSizeBytes = expectedSizeBytes,
+        expectedSha256 = expectedSha256
+    )
+    return downloadedMediaAsset
+}
+
+private fun validateReviewMediaDownloadContentLength(
+    contentLength: Long,
+    expectedSizeBytes: Long
+): Unit {
+    if (contentLength == -1L) {
+        return
+    }
+    if (contentLength != expectedSizeBytes) {
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download Content-Length mismatch: " +
+                "expected $expectedSizeBytes byte(s), received header value $contentLength."
+        )
+    }
+}
+
+private fun validateCompletedReviewMediaDownload(
+    downloadedMediaAsset: DownloadedReviewMediaAsset,
+    expectedSizeBytes: Long,
+    expectedSha256: String
+): Unit {
+    if (downloadedMediaAsset.sizeBytes != expectedSizeBytes) {
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download size mismatch: expected $expectedSizeBytes byte(s) " +
+                "but received ${downloadedMediaAsset.sizeBytes} byte(s)."
+        )
+    }
+    if (downloadedMediaAsset.sha256 != expectedSha256) {
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download SHA-256 mismatch: expected '$expectedSha256' " +
+                "but received '${downloadedMediaAsset.sha256}'."
+        )
+    }
+}
+
+private fun readReviewMediaDownloadErrorBody(response: Response): String {
+    return response.body.string().take(n = reviewMediaAssetDownloadErrorBodyLimit)
+}
+
+private fun shouldRetryReviewMediaDownloadError(
+    error: IOException,
+    attemptNumber: Int
+): Boolean {
+    if (attemptNumber >= reviewMediaAssetDownloadMaxAttemptCount) {
+        return false
+    }
+    if (error is ReviewMediaAssetDownloadHttpException) {
+        return error.retryEligible
+    }
+    if (error is ReviewMediaAssetDownloadValidationException) {
+        return false
+    }
+    return true
+}
+
+private fun isTransientReviewMediaDownloadStatusCode(statusCode: Int): Boolean {
+    return statusCode == 408 || statusCode == 429 || statusCode in 500..599
+}
+
+private fun calculateReviewMediaDownloadRetryDelayMillis(attemptNumber: Int): Long {
+    return reviewMediaAssetDownloadRetryBaseDelayMillis * attemptNumber
+}
+
+private fun deletePartialReviewMediaDownload(
+    targetFile: File,
+    cause: Throwable
+): Unit {
+    if (targetFile.exists().not()) {
+        return
+    }
+    if (targetFile.delete().not()) {
+        cause.addSuppressed(
+            IOException("Cannot delete partial managed media download file: ${targetFile.absolutePath}")
+        )
+    }
+}
+
+private fun encodeReviewMediaDigestHex(bytes: ByteArray): String {
+    val hexChars = "0123456789abcdef".toCharArray()
+    val result = CharArray(size = bytes.size * 2)
+    bytes.forEachIndexed { index, byte ->
+        val value = byte.toInt() and 0xff
+        result[index * 2] = hexChars[value ushr 4]
+        result[(index * 2) + 1] = hexChars[value and 0x0f]
+    }
+    return String(result)
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionEvent
@@ -59,6 +60,7 @@ fun ReviewRoute(
     onCreateCard: () -> Unit,
     onCreateCardWithAi: () -> Unit,
     onSwitchToAllCards: () -> Unit,
+    onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onRevealAnswer: () -> Unit,
     onRateAgain: () -> Unit,
@@ -231,6 +233,7 @@ fun ReviewRoute(
                 onCreateCard = onCreateCard,
                 onCreateCardWithAi = onCreateCardWithAi,
                 onSwitchToAllCards = onSwitchToAllCards,
+                onLoadManagedMediaFile = onLoadManagedMediaFile,
                 onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                 onToggleFrontSpeech = {
                     uiState.preparedCurrentCard?.let { currentCard ->

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreenRepository
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
@@ -263,6 +264,10 @@ class ReviewViewModel(
 
     suspend fun loadManagedMediaDownloadUrl(mediaAssetId: String): MediaAssetDownloadUrl {
         return reviewRepository.loadReviewMediaAssetDownloadUrl(mediaAssetId = mediaAssetId)
+    }
+
+    suspend fun loadManagedMediaFile(mediaAssetId: String): ReviewMediaAssetFile {
+        return reviewRepository.loadReviewMediaAssetFile(mediaAssetId = mediaAssetId)
     }
 
     fun handleNotificationPermissionGranted() {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.core.ui.bidiWrap
 import com.flashcardsopensourceapp.core.ui.currentResourceLocale
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 
 private val reviewShowAnswerContentBottomPadding = 120.dp
 private val reviewAnswerGridContentBottomPadding = 184.dp
@@ -79,6 +80,7 @@ internal fun ReviewContent(
     onCreateCard: () -> Unit,
     onCreateCardWithAi: () -> Unit,
     onSwitchToAllCards: () -> Unit,
+    onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit,
@@ -131,6 +133,7 @@ internal fun ReviewContent(
                                 card.tags
                             )
                         },
+                        onLoadManagedMediaFile = onLoadManagedMediaFile,
                         onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                         onToggleFrontSpeech = onToggleFrontSpeech,
                         onToggleBackSpeech = onToggleBackSpeech
@@ -225,6 +228,7 @@ private fun ReviewCardContent(
     activeSpeechSide: ReviewSpeechSide?,
     onOpenCurrentCard: () -> Unit,
     onOpenCurrentCardWithAi: () -> Unit,
+    onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit
@@ -288,6 +292,7 @@ private fun ReviewCardContent(
                     label = stringResource(id = R.string.review_front_label),
                     content = currentCard.frontContent,
                     contentModifier = Modifier.testTag(reviewCurrentCardFrontContentTag),
+                    onLoadManagedMediaFile = onLoadManagedMediaFile,
                     onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                     isSpeechPlaying = activeSpeechSide == ReviewSpeechSide.FRONT,
                     onToggleSpeech = onToggleFrontSpeech,
@@ -301,6 +306,7 @@ private fun ReviewCardContent(
                         label = stringResource(id = R.string.review_back_label),
                         content = currentCard.backContent,
                         contentModifier = Modifier,
+                        onLoadManagedMediaFile = onLoadManagedMediaFile,
                         onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                         isSpeechPlaying = activeSpeechSide == ReviewSpeechSide.BACK,
                         onToggleSpeech = onToggleBackSpeech,
@@ -344,6 +350,7 @@ private fun ReviewCardSideSection(
     label: String,
     content: ReviewRenderedContent,
     contentModifier: Modifier,
+    onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     isSpeechPlaying: Boolean,
     onToggleSpeech: () -> Unit,
@@ -365,6 +372,7 @@ private fun ReviewCardSideSection(
         )
         ReviewRenderedContentView(
             content = content,
+            onLoadManagedMediaFile = onLoadManagedMediaFile,
             onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
             modifier = contentModifier
         )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
@@ -49,6 +49,7 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
@@ -67,14 +68,14 @@ private enum class ReviewManagedMediaCategory {
     ATTACHMENT
 }
 
-private sealed interface ReviewManagedMediaDownloadState {
-    data object Loading : ReviewManagedMediaDownloadState
+private sealed interface ReviewManagedMediaFileState {
+    data object Loading : ReviewManagedMediaFileState
 
     data class Ready(
-        val downloadUrl: MediaAssetDownloadUrl
-    ) : ReviewManagedMediaDownloadState
+        val mediaFile: ReviewMediaAssetFile
+    ) : ReviewManagedMediaFileState
 
-    data object Unavailable : ReviewManagedMediaDownloadState
+    data object Unavailable : ReviewManagedMediaFileState
 }
 
 private enum class ReviewManagedMediaAttachmentActionState {
@@ -87,6 +88,7 @@ private enum class ReviewManagedMediaAttachmentActionState {
 @Composable
 internal fun ReviewManagedMediaContent(
     reference: ReviewManagedMediaReference,
+    onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl
 ) {
     val mediaAsset = reference.mediaAsset
@@ -111,12 +113,10 @@ internal fun ReviewManagedMediaContent(
     }
 
     when (category) {
-        ReviewManagedMediaCategory.IMAGE -> ReviewDownloadableManagedMedia(
+        ReviewManagedMediaCategory.IMAGE -> ReviewManagedMediaImageFile(
             mediaAsset = checkNotNull(mediaAsset),
-            category = category,
-            categoryLabel = categoryLabel,
             label = label,
-            onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
+            onLoadManagedMediaFile = onLoadManagedMediaFile
         )
 
         ReviewManagedMediaCategory.ATTACHMENT -> ReviewManagedMediaAttachment(
@@ -136,77 +136,59 @@ internal fun ReviewManagedMediaContent(
 }
 
 @Composable
-private fun ReviewDownloadableManagedMedia(
+private fun ReviewManagedMediaImageFile(
     mediaAsset: MediaAsset,
-    category: ReviewManagedMediaCategory,
-    categoryLabel: String,
     label: String,
-    onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl
+    onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile
 ) {
-    val currentLoadManagedMediaDownloadUrl = rememberUpdatedState(newValue = onLoadManagedMediaDownloadUrl)
-    val downloadState by produceState<ReviewManagedMediaDownloadState>(
-        initialValue = ReviewManagedMediaDownloadState.Loading,
+    val currentLoadManagedMediaFile = rememberUpdatedState(newValue = onLoadManagedMediaFile)
+    val mediaFileState by produceState<ReviewManagedMediaFileState>(
+        initialValue = ReviewManagedMediaFileState.Loading,
         key1 = mediaAsset.mediaAssetId,
         key2 = mediaAsset.updatedAtMillis,
         key3 = mediaAsset.deletedAtMillis
     ) {
         value = try {
-            ReviewManagedMediaDownloadState.Ready(
-                downloadUrl = currentLoadManagedMediaDownloadUrl.value(mediaAsset.mediaAssetId)
+            ReviewManagedMediaFileState.Ready(
+                mediaFile = currentLoadManagedMediaFile.value(mediaAsset.mediaAssetId)
             )
         } catch (error: Throwable) {
             if (error is CancellationException) {
                 throw error
             }
-            ReviewManagedMediaDownloadState.Unavailable
+            ReviewManagedMediaFileState.Unavailable
         }
     }
 
-    when (val state = downloadState) {
-        ReviewManagedMediaDownloadState.Loading -> ReviewManagedMediaPlaceholderRow(
+    when (val state = mediaFileState) {
+        ReviewManagedMediaFileState.Loading -> ReviewManagedMediaPlaceholderRow(
             label = label,
             supportingText = stringResource(id = R.string.review_media_loading),
-            icon = reviewManagedMediaCategoryIcon(category = category)
+            icon = Icons.Outlined.Image
         )
 
-        ReviewManagedMediaDownloadState.Unavailable -> ReviewManagedMediaPlaceholderRow(
+        ReviewManagedMediaFileState.Unavailable -> ReviewManagedMediaPlaceholderRow(
             label = label,
             supportingText = stringResource(id = R.string.review_media_unavailable),
             icon = Icons.Outlined.WarningAmber
         )
 
-        is ReviewManagedMediaDownloadState.Ready -> when (category) {
-            ReviewManagedMediaCategory.IMAGE -> ReviewManagedMediaImage(
-                label = label,
-                url = state.downloadUrl.url
-            )
-
-            ReviewManagedMediaCategory.ATTACHMENT -> ReviewManagedMediaAttachment(
-                mediaAssetId = mediaAsset.mediaAssetId,
-                label = label,
-                categoryLabel = categoryLabel,
-                onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
-            )
-
-            ReviewManagedMediaCategory.AUDIO,
-            ReviewManagedMediaCategory.VIDEO -> ReviewManagedMediaPlaceholderRow(
-                label = label,
-                supportingText = categoryLabel,
-                icon = reviewManagedMediaCategoryIcon(category = category)
-            )
-        }
+        is ReviewManagedMediaFileState.Ready -> ReviewManagedMediaImage(
+            label = label,
+            uri = state.mediaFile.uri
+        )
     }
 }
 
 @Composable
 private fun ReviewManagedMediaImage(
     label: String,
-    url: String
+    uri: String
 ) {
     val context = LocalContext.current
-    val imageRequest = remember(context, url) {
+    val imageRequest = remember(context, uri) {
         ImageRequest.Builder(context)
-            .data(url)
+            .data(uri)
             .diskCachePolicy(CachePolicy.DISABLED)
             .build()
     }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
@@ -21,10 +21,12 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 
 @Composable
 fun ReviewRenderedContentView(
     content: ReviewRenderedContent,
+    onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     modifier: Modifier
 ) {
@@ -144,6 +146,7 @@ fun ReviewRenderedContentView(
 
                         is ReviewRichBlock.ManagedMedia -> ReviewManagedMediaContent(
                             reference = block.reference,
+                            onLoadManagedMediaFile = onLoadManagedMediaFile,
                             onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
                         )
                     }


### PR DESCRIPTION
## Summary
- Load Android review managed media from the local blob cache when available.
- Populate the cache through transient backend-signed download URLs on cache miss.
- Preserve attachment signed URL behavior and audio/video placeholder behavior while rendering images from cached local URIs.

## Validation
- Worker freshness check passed before implementation.
- `git --no-pager diff --check` passed across fix passes.
- `git --no-pager diff --cached --check` passed before commit.
- Targeted non-Gradle searches/checks passed: direct `ReviewRoute` calls updated, downloader call sites updated, no non-atomic cache move fallback, temp filename no longer uses `mediaAssetId`, trailing whitespace/long-line checks on affected files passed.
- Fresh worker-owned review after all fixes reported no P0/P1 and no split blocker; green light for commit.

## Residual Risk
- P4: bounded error-body read improvement remains in the downloader.
- `./gradlew` was not run because repository policy requires explicit approval and approval was not given.
