### PR TITLE
Add web media transfer queue primitives

### DIFF
--- a/apps/web/src/localDb/mediaTransfers/mediaTransfers.test.ts
+++ b/apps/web/src/localDb/mediaTransfers/mediaTransfers.test.ts
@@ -5,7 +5,15 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { clearWebSyncCache } from "../core/cache";
 import {
   claimNextDueMediaTransfer,
+  claimNextDueMediaTransferByKind,
   enqueueMediaTransferDownload,
+  enqueueMediaTransferUpload,
+  loadMediaTransferQueueRecord,
+  loadNextPendingMediaTransferAttemptAtByKind,
+  markClaimedMediaTransferSucceeded,
+  markMediaTransferFailed,
+  recoverStaleInProgressMediaTransfersByKind,
+  renewInProgressMediaTransferClaim,
 } from "./mediaTransfers";
 
 describe("localDb media transfers", () => {
@@ -43,5 +51,241 @@ describe("localDb media transfers", () => {
       status: "in_progress",
       claimedAt: "2026-03-10T10:00:00.000Z",
     }));
+  });
+
+  it("claims due upload transfers without taking due download work", async () => {
+    await enqueueMediaTransferDownload({
+      transferId: "download-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "media-asset-download",
+      sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      createdAt: "2026-03-10T09:00:00.000Z",
+      nextAttemptAt: "2026-03-10T09:30:00.000Z",
+    });
+    await enqueueMediaTransferUpload({
+      transferId: "upload-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "media-asset-upload",
+      sha256: "6e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      sourceBlobCacheKey: "6e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      createdAt: "2026-03-10T09:05:00.000Z",
+      nextAttemptAt: "2026-03-10T09:45:00.000Z",
+    });
+
+    await expect(claimNextDueMediaTransferByKind(
+      "workspace-1",
+      "upload",
+      "2026-03-10T10:00:00.000Z",
+    )).resolves.toEqual(expect.objectContaining({
+      transferId: "upload-transfer",
+      kind: "upload",
+      status: "in_progress",
+      claimedAt: "2026-03-10T10:00:00.000Z",
+    }));
+
+    await expect(claimNextDueMediaTransfer(
+      "workspace-1",
+      "2026-03-10T10:01:00.000Z",
+    )).resolves.toEqual(expect.objectContaining({
+      transferId: "download-transfer",
+      kind: "download",
+    }));
+  });
+
+  it("loads the earliest pending upload attempt time without using download work", async () => {
+    await enqueueMediaTransferDownload({
+      transferId: "download-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "media-asset-download",
+      sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      createdAt: "2026-03-10T09:00:00.000Z",
+      nextAttemptAt: "2026-03-10T09:05:00.000Z",
+    });
+    await enqueueMediaTransferUpload({
+      transferId: "queued-upload-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "queued-media-asset-upload",
+      sha256: "6e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      sourceBlobCacheKey: "6e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      createdAt: "2026-03-10T09:10:00.000Z",
+      nextAttemptAt: "2026-03-10T09:40:00.000Z",
+    });
+    await enqueueMediaTransferUpload({
+      transferId: "retry-upload-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "retry-media-asset-upload",
+      sha256: "7e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      sourceBlobCacheKey: "7e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      createdAt: "2026-03-10T09:15:00.000Z",
+      nextAttemptAt: "2026-03-10T09:45:00.000Z",
+    });
+    await markMediaTransferFailed(
+      "retry-upload-transfer",
+      "2026-03-10T09:20:00.000Z",
+      "retryable upload failure",
+      "2026-03-10T09:30:00.000Z",
+    );
+
+    await expect(loadNextPendingMediaTransferAttemptAtByKind(
+      "workspace-1",
+      "upload",
+    )).resolves.toBe("2026-03-10T09:30:00.000Z");
+  });
+
+  it("recovers only stale in-progress upload transfers for retry", async () => {
+    await enqueueMediaTransferUpload({
+      transferId: "stale-upload-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "stale-media-asset-upload",
+      sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      sourceBlobCacheKey: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      createdAt: "2026-03-10T09:00:00.000Z",
+      nextAttemptAt: "2026-03-10T09:00:00.000Z",
+    });
+    await enqueueMediaTransferUpload({
+      transferId: "fresh-upload-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "fresh-media-asset-upload",
+      sha256: "6e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      sourceBlobCacheKey: "6e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      createdAt: "2026-03-10T09:01:00.000Z",
+      nextAttemptAt: "2026-03-10T09:01:00.000Z",
+    });
+    await enqueueMediaTransferDownload({
+      transferId: "stale-download-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "stale-media-asset-download",
+      sha256: "7e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      createdAt: "2026-03-10T09:02:00.000Z",
+      nextAttemptAt: "2026-03-10T09:02:00.000Z",
+    });
+
+    await expect(claimNextDueMediaTransferByKind(
+      "workspace-1",
+      "upload",
+      "2026-03-10T10:00:00.000Z",
+    )).resolves.toEqual(expect.objectContaining({
+      transferId: "stale-upload-transfer",
+      status: "in_progress",
+    }));
+    await expect(claimNextDueMediaTransferByKind(
+      "workspace-1",
+      "upload",
+      "2026-03-10T10:10:00.000Z",
+    )).resolves.toEqual(expect.objectContaining({
+      transferId: "fresh-upload-transfer",
+      status: "in_progress",
+    }));
+    await expect(claimNextDueMediaTransfer(
+      "workspace-1",
+      "2026-03-10T10:00:00.000Z",
+    )).resolves.toEqual(expect.objectContaining({
+      transferId: "stale-download-transfer",
+      status: "in_progress",
+    }));
+
+    await expect(recoverStaleInProgressMediaTransfersByKind({
+      workspaceId: "workspace-1",
+      kind: "upload",
+      staleClaimedBefore: "2026-03-10T10:05:00.000Z",
+      recoveredAt: "2026-03-10T10:30:00.000Z",
+      nextAttemptAt: "2026-03-10T10:30:00.000Z",
+      lastError: "stale upload claim recovered",
+    })).resolves.toBe(1);
+
+    await expect(loadMediaTransferQueueRecord("stale-upload-transfer")).resolves.toEqual(expect.objectContaining({
+      transferId: "stale-upload-transfer",
+      kind: "upload",
+      status: "failed",
+      attemptCount: 1,
+      nextAttemptAt: "2026-03-10T10:30:00.000Z",
+      lastError: "stale upload claim recovered",
+      claimedAt: null,
+      completedAt: null,
+      updatedAt: "2026-03-10T10:30:00.000Z",
+    }));
+    await expect(loadMediaTransferQueueRecord("fresh-upload-transfer")).resolves.toEqual(expect.objectContaining({
+      transferId: "fresh-upload-transfer",
+      kind: "upload",
+      status: "in_progress",
+      claimedAt: "2026-03-10T10:10:00.000Z",
+    }));
+    await expect(loadMediaTransferQueueRecord("stale-download-transfer")).resolves.toEqual(expect.objectContaining({
+      transferId: "stale-download-transfer",
+      kind: "download",
+      status: "in_progress",
+      claimedAt: "2026-03-10T10:00:00.000Z",
+    }));
+  });
+
+  it("renews in-progress upload claims and rejects stale claim tokens", async () => {
+    await enqueueMediaTransferUpload({
+      transferId: "renewed-upload-transfer",
+      workspaceId: "workspace-1",
+      mediaAssetId: "renewed-media-asset-upload",
+      sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      mimeType: "image/png",
+      sizeBytes: 42817,
+      sourceBlobCacheKey: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      createdAt: "2026-03-10T09:00:00.000Z",
+      nextAttemptAt: "2026-03-10T09:00:00.000Z",
+    });
+    await expect(claimNextDueMediaTransferByKind(
+      "workspace-1",
+      "upload",
+      "2026-03-10T10:00:00.000Z",
+    )).resolves.toEqual(expect.objectContaining({
+      transferId: "renewed-upload-transfer",
+      status: "in_progress",
+      claimedAt: "2026-03-10T10:00:00.000Z",
+    }));
+
+    await expect(renewInProgressMediaTransferClaim({
+      transferId: "renewed-upload-transfer",
+      kind: "upload",
+      expectedClaimedAt: "2026-03-10T10:00:00.000Z",
+      renewedAt: "2026-03-10T10:20:00.000Z",
+    })).resolves.toEqual(expect.objectContaining({
+      transferId: "renewed-upload-transfer",
+      status: "in_progress",
+      claimedAt: "2026-03-10T10:20:00.000Z",
+    }));
+
+    await expect(recoverStaleInProgressMediaTransfersByKind({
+      workspaceId: "workspace-1",
+      kind: "upload",
+      staleClaimedBefore: "2026-03-10T10:05:00.000Z",
+      recoveredAt: "2026-03-10T10:30:00.000Z",
+      nextAttemptAt: "2026-03-10T10:30:00.000Z",
+      lastError: "stale upload claim recovered",
+    })).resolves.toBe(0);
+    await expect(markClaimedMediaTransferSucceeded({
+      transferId: "renewed-upload-transfer",
+      kind: "upload",
+      expectedClaimedAt: "2026-03-10T10:00:00.000Z",
+      completedAt: "2026-03-10T10:31:00.000Z",
+    })).rejects.toThrow("transfer claim token mismatch");
+    await expect(markClaimedMediaTransferSucceeded({
+      transferId: "renewed-upload-transfer",
+      kind: "upload",
+      expectedClaimedAt: "2026-03-10T10:20:00.000Z",
+      completedAt: "2026-03-10T10:31:00.000Z",
+    })).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/localDb/mediaTransfers/mediaTransfers.ts
+++ b/apps/web/src/localDb/mediaTransfers/mediaTransfers.ts
@@ -63,6 +63,38 @@ export type EnqueueMediaTransferUploadInput = Readonly<{
 
 type ClaimableMediaTransferStatus = "queued" | "failed";
 
+export type RecoverStaleInProgressMediaTransfersByKindInput = Readonly<{
+  workspaceId: string;
+  kind: MediaTransferKind;
+  staleClaimedBefore: string;
+  recoveredAt: string;
+  nextAttemptAt: string;
+  lastError: string;
+}>;
+
+export type RenewInProgressMediaTransferClaimInput = Readonly<{
+  transferId: string;
+  kind: MediaTransferKind;
+  expectedClaimedAt: string;
+  renewedAt: string;
+}>;
+
+export type MarkClaimedMediaTransferSucceededInput = Readonly<{
+  transferId: string;
+  kind: MediaTransferKind;
+  expectedClaimedAt: string;
+  completedAt: string;
+}>;
+
+export type MarkClaimedMediaTransferFailedInput = Readonly<{
+  transferId: string;
+  kind: MediaTransferKind;
+  expectedClaimedAt: string;
+  failedAt: string;
+  lastError: string;
+  nextAttemptAt: string;
+}>;
+
 function createQueuedMediaTransferRecord(
   input: EnqueueMediaTransferDownloadInput | EnqueueMediaTransferUploadInput,
   kind: MediaTransferKind,
@@ -96,10 +128,18 @@ function makeDueTransferRange(
   return IDBKeyRange.bound([workspaceId, status, ""], [workspaceId, status, dueAt, [], []]);
 }
 
-function readFirstRecord(
-  records: ReadonlyArray<MediaTransferQueueRecord>,
-): MediaTransferQueueRecord | null {
-  return records[0] ?? null;
+function makePendingTransferRange(
+  workspaceId: string,
+  status: ClaimableMediaTransferStatus,
+): IDBKeyRange {
+  return IDBKeyRange.bound([workspaceId, status, ""], [workspaceId, status, []]);
+}
+
+function makeStatusTransferRange(
+  workspaceId: string,
+  status: MediaTransferStatus,
+): IDBKeyRange {
+  return IDBKeyRange.bound([workspaceId, status, ""], [workspaceId, status, []]);
 }
 
 function compareMediaTransferClaimPriority(
@@ -169,6 +209,17 @@ export async function loadMediaBlobCacheRecord(sha256: string): Promise<MediaBlo
   return record ?? null;
 }
 
+export async function loadMediaTransferQueueRecord(
+  transferId: string,
+): Promise<MediaTransferQueueRecord | null> {
+  const record = await closeDatabaseAfter((database) => getFromStore<MediaTransferQueueRecord>(
+    database,
+    "mediaTransferQueue",
+    transferId,
+  ));
+  return record ?? null;
+}
+
 export async function writeMediaBlobCacheRecord(record: MediaBlobCacheRecord): Promise<void> {
   await closeDatabaseAfterWrite(async (database) => {
     await runReadwrite(database, ["mediaBlobCache"], (transaction) => (
@@ -209,16 +260,17 @@ export async function enqueueMediaTransferUpload(
   return record;
 }
 
-export async function claimNextDueMediaTransfer(
+async function claimNextDueMediaTransferWithSelector(
   workspaceId: string,
   claimedAt: string,
+  shouldClaimRecord: (record: MediaTransferQueueRecord) => boolean,
 ): Promise<MediaTransferQueueRecord | null> {
   return closeDatabaseAfter(async (database) => new Promise<MediaTransferQueueRecord | null>((resolve, reject) => {
     const transaction = database.transaction(["mediaTransferQueue"], "readwrite");
     const store = transaction.objectStore("mediaTransferQueue");
     const index = store.index("workspaceId_status_nextAttemptAt_createdAt_transferId");
-    const queuedRequest = index.getAll(makeDueTransferRange(workspaceId, "queued", claimedAt), 1);
-    const failedRequest = index.getAll(makeDueTransferRange(workspaceId, "failed", claimedAt), 1);
+    const queuedRequest = index.openCursor(makeDueTransferRange(workspaceId, "queued", claimedAt));
+    const failedRequest = index.openCursor(makeDueTransferRange(workspaceId, "failed", claimedAt));
     let queuedRecord: MediaTransferQueueRecord | null = null;
     let failedRecord: MediaTransferQueueRecord | null = null;
     let pendingReadCount = 2;
@@ -256,16 +308,40 @@ export async function claimNextDueMediaTransfer(
       rejectOnce(describeIndexedDbError("IndexedDB media transfer queued claim lookup failed", queuedRequest.error));
     };
     queuedRequest.onsuccess = () => {
-      queuedRecord = readFirstRecord(queuedRequest.result as ReadonlyArray<MediaTransferQueueRecord>);
-      claimAfterReadsComplete();
+      const cursor = queuedRequest.result;
+      if (cursor === null) {
+        claimAfterReadsComplete();
+        return;
+      }
+
+      const record = cursor.value as MediaTransferQueueRecord;
+      if (shouldClaimRecord(record)) {
+        queuedRecord = record;
+        claimAfterReadsComplete();
+        return;
+      }
+
+      cursor.continue();
     };
 
     failedRequest.onerror = () => {
       rejectOnce(describeIndexedDbError("IndexedDB media transfer failed claim lookup failed", failedRequest.error));
     };
     failedRequest.onsuccess = () => {
-      failedRecord = readFirstRecord(failedRequest.result as ReadonlyArray<MediaTransferQueueRecord>);
-      claimAfterReadsComplete();
+      const cursor = failedRequest.result;
+      if (cursor === null) {
+        claimAfterReadsComplete();
+        return;
+      }
+
+      const record = cursor.value as MediaTransferQueueRecord;
+      if (shouldClaimRecord(record)) {
+        failedRecord = record;
+        claimAfterReadsComplete();
+        return;
+      }
+
+      cursor.continue();
     };
 
     transaction.onerror = () => {
@@ -282,6 +358,308 @@ export async function claimNextDueMediaTransfer(
       resolve(claimedRecord);
     };
   }));
+}
+
+export async function claimNextDueMediaTransfer(
+  workspaceId: string,
+  claimedAt: string,
+): Promise<MediaTransferQueueRecord | null> {
+  return claimNextDueMediaTransferWithSelector(workspaceId, claimedAt, () => true);
+}
+
+export async function claimNextDueMediaTransferByKind(
+  workspaceId: string,
+  kind: MediaTransferKind,
+  claimedAt: string,
+): Promise<MediaTransferQueueRecord | null> {
+  return claimNextDueMediaTransferWithSelector(
+    workspaceId,
+    claimedAt,
+    (record) => record.kind === kind,
+  );
+}
+
+async function loadNextPendingMediaTransferByStatusAndKind(
+  workspaceId: string,
+  status: ClaimableMediaTransferStatus,
+  kind: MediaTransferKind,
+): Promise<MediaTransferQueueRecord | null> {
+  return closeDatabaseAfter(async (database) => new Promise<MediaTransferQueueRecord | null>((resolve, reject) => {
+    const transaction = database.transaction(["mediaTransferQueue"], "readonly");
+    const index = transaction.objectStore("mediaTransferQueue").index("workspaceId_status_nextAttemptAt_createdAt_transferId");
+    const request = index.openCursor(makePendingTransferRange(workspaceId, status));
+    let matchingRecord: MediaTransferQueueRecord | null = null;
+    let didReject = false;
+
+    const rejectOnce = (error: Error): void => {
+      if (didReject) {
+        return;
+      }
+
+      didReject = true;
+      rejectIndexedDbTransaction(transaction, reject, error);
+    };
+
+    request.onerror = () => {
+      rejectOnce(describeIndexedDbError("IndexedDB pending media transfer lookup failed", request.error));
+    };
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (cursor === null || matchingRecord !== null) {
+        return;
+      }
+
+      const record = cursor.value as MediaTransferQueueRecord;
+      if (record.kind === kind) {
+        matchingRecord = record;
+        return;
+      }
+
+      cursor.continue();
+    };
+
+    transaction.onerror = () => {
+      if (didReject === false) {
+        reject(describeIndexedDbError("IndexedDB pending media transfer lookup failed", transaction.error));
+      }
+    };
+    transaction.onabort = () => {
+      if (didReject === false) {
+        reject(describeIndexedDbError("IndexedDB pending media transfer lookup aborted", transaction.error));
+      }
+    };
+    transaction.oncomplete = () => {
+      resolve(matchingRecord);
+    };
+  }));
+}
+
+export async function loadNextPendingMediaTransferAttemptAtByKind(
+  workspaceId: string,
+  kind: MediaTransferKind,
+): Promise<string | null> {
+  const [queuedRecord, failedRecord] = await Promise.all([
+    loadNextPendingMediaTransferByStatusAndKind(workspaceId, "queued", kind),
+    loadNextPendingMediaTransferByStatusAndKind(workspaceId, "failed", kind),
+  ]);
+  return selectNextDueTransfer(queuedRecord, failedRecord)?.nextAttemptAt ?? null;
+}
+
+export async function recoverStaleInProgressMediaTransfersByKind(
+  input: RecoverStaleInProgressMediaTransfersByKindInput,
+): Promise<number> {
+  return closeDatabaseAfter(async (database) => new Promise<number>((resolve, reject) => {
+    const transaction = database.transaction(["mediaTransferQueue"], "readwrite");
+    const store = transaction.objectStore("mediaTransferQueue");
+    const index = store.index("workspaceId_status_nextAttemptAt_createdAt_transferId");
+    const request = index.openCursor(makeStatusTransferRange(input.workspaceId, "in_progress"));
+    let recoveredCount = 0;
+    let didReject = false;
+
+    const rejectOnce = (error: Error): void => {
+      if (didReject) {
+        return;
+      }
+
+      didReject = true;
+      rejectIndexedDbTransaction(transaction, reject, error);
+    };
+
+    request.onerror = () => {
+      rejectOnce(describeIndexedDbError("IndexedDB stale media transfer recovery lookup failed", request.error));
+    };
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (cursor === null || didReject) {
+        return;
+      }
+
+      const record = cursor.value as MediaTransferQueueRecord;
+      if (
+        record.kind === input.kind
+        && record.claimedAt !== null
+        && record.claimedAt <= input.staleClaimedBefore
+      ) {
+        const updateRequest = cursor.update({
+          ...record,
+          status: "failed",
+          attemptCount: record.attemptCount + 1,
+          nextAttemptAt: input.nextAttemptAt,
+          lastError: input.lastError,
+          updatedAt: input.recoveredAt,
+          claimedAt: null,
+          completedAt: null,
+        } satisfies MediaTransferQueueRecord);
+        recoveredCount += 1;
+        updateRequest.onerror = () => {
+          rejectOnce(describeIndexedDbError("IndexedDB stale media transfer recovery write failed", updateRequest.error));
+        };
+      }
+
+      cursor.continue();
+    };
+
+    transaction.onerror = () => {
+      if (didReject === false) {
+        reject(describeIndexedDbError("IndexedDB stale media transfer recovery failed", transaction.error));
+      }
+    };
+    transaction.onabort = () => {
+      if (didReject === false) {
+        reject(describeIndexedDbError("IndexedDB stale media transfer recovery aborted", transaction.error));
+      }
+    };
+    transaction.oncomplete = () => {
+      resolve(recoveredCount);
+    };
+  }));
+}
+
+function assertClaimedMediaTransferMatchesToken(
+  record: MediaTransferQueueRecord,
+  kind: MediaTransferKind,
+  expectedClaimedAt: string,
+  errorPrefix: string,
+): void {
+  if (record.kind !== kind) {
+    throw new Error(`${errorPrefix}: transfer kind mismatch. transferId=${record.transferId}, expectedKind=${kind}, actualKind=${record.kind}`);
+  }
+
+  if (record.status !== "in_progress") {
+    throw new Error(`${errorPrefix}: transfer is not in progress. transferId=${record.transferId}, status=${record.status}`);
+  }
+
+  if (record.claimedAt !== expectedClaimedAt) {
+    throw new Error(`${errorPrefix}: transfer claim token mismatch. transferId=${record.transferId}, expectedClaimedAt=${expectedClaimedAt}, actualClaimedAt=${record.claimedAt ?? "none"}`);
+  }
+}
+
+async function updateClaimedMediaTransferQueueRecord(
+  transferId: string,
+  kind: MediaTransferKind,
+  expectedClaimedAt: string,
+  updatedAt: string,
+  updateRecord: (record: MediaTransferQueueRecord) => MediaTransferQueueRecord,
+  errorPrefix: string,
+): Promise<MediaTransferQueueRecord> {
+  return closeDatabaseAfter(async (database) => new Promise<MediaTransferQueueRecord>((resolve, reject) => {
+    const transaction = database.transaction(["mediaTransferQueue"], "readwrite");
+    const store = transaction.objectStore("mediaTransferQueue");
+    const request = store.get(transferId);
+    let updatedRecord: MediaTransferQueueRecord | null = null;
+    let didReject = false;
+
+    const rejectOnce = (error: Error): void => {
+      if (didReject) {
+        return;
+      }
+
+      didReject = true;
+      rejectIndexedDbTransaction(transaction, reject, error);
+    };
+
+    request.onerror = () => {
+      rejectOnce(describeIndexedDbError(`${errorPrefix} lookup failed`, request.error));
+    };
+    request.onsuccess = () => {
+      const record = request.result as MediaTransferQueueRecord | undefined;
+      if (record === undefined) {
+        rejectOnce(new Error(`${errorPrefix}: transfer not found. transferId=${transferId}`));
+        return;
+      }
+
+      try {
+        assertClaimedMediaTransferMatchesToken(record, kind, expectedClaimedAt, errorPrefix);
+        updatedRecord = updateRecord({
+          ...record,
+          updatedAt,
+        });
+      } catch (error) {
+        rejectOnce(error instanceof Error ? error : new Error(`${errorPrefix}: transfer update failed`));
+        return;
+      }
+
+      const putRequest = store.put(updatedRecord);
+      putRequest.onerror = () => {
+        rejectOnce(describeIndexedDbError(`${errorPrefix} write failed`, putRequest.error));
+      };
+    };
+
+    transaction.onerror = () => {
+      if (didReject === false) {
+        reject(describeIndexedDbError(errorPrefix, transaction.error));
+      }
+    };
+    transaction.onabort = () => {
+      if (didReject === false) {
+        reject(describeIndexedDbError(`${errorPrefix} aborted`, transaction.error));
+      }
+    };
+    transaction.oncomplete = () => {
+      if (updatedRecord === null) {
+        reject(new Error(`${errorPrefix}: update did not complete. transferId=${transferId}`));
+        return;
+      }
+
+      resolve(updatedRecord);
+    };
+  }));
+}
+
+export async function renewInProgressMediaTransferClaim(
+  input: RenewInProgressMediaTransferClaimInput,
+): Promise<MediaTransferQueueRecord> {
+  return updateClaimedMediaTransferQueueRecord(
+    input.transferId,
+    input.kind,
+    input.expectedClaimedAt,
+    input.renewedAt,
+    (record) => ({
+      ...record,
+      claimedAt: input.renewedAt,
+    }),
+    "IndexedDB media transfer claim renewal failed",
+  );
+}
+
+export async function markClaimedMediaTransferSucceeded(
+  input: MarkClaimedMediaTransferSucceededInput,
+): Promise<void> {
+  await updateClaimedMediaTransferQueueRecord(
+    input.transferId,
+    input.kind,
+    input.expectedClaimedAt,
+    input.completedAt,
+    (record) => ({
+      ...record,
+      status: "completed",
+      lastError: null,
+      claimedAt: null,
+      completedAt: input.completedAt,
+    }),
+    "IndexedDB claimed media transfer success update failed",
+  );
+}
+
+export async function markClaimedMediaTransferFailed(
+  input: MarkClaimedMediaTransferFailedInput,
+): Promise<void> {
+  await updateClaimedMediaTransferQueueRecord(
+    input.transferId,
+    input.kind,
+    input.expectedClaimedAt,
+    input.failedAt,
+    (record) => ({
+      ...record,
+      status: "failed",
+      attemptCount: record.attemptCount + 1,
+      nextAttemptAt: input.nextAttemptAt,
+      lastError: input.lastError,
+      claimedAt: null,
+      completedAt: null,
+    }),
+    "IndexedDB claimed media transfer failure update failed",
+  );
 }
 
 async function updateMediaTransferQueueRecord(


### PR DESCRIPTION
## Summary
- Add cursor-based due media transfer claiming with upload-kind filtering.
- Add stale upload claim recovery for abandoned in-progress upload jobs.
- Add claim renewal and token-checked success/failure transitions.
- Add focused IndexedDB coverage for claim, lease, recovery, renewal, and transition behavior.

## Validation
- npm --prefix apps/web exec -- vitest run src/localDb/mediaTransfers/mediaTransfers.test.ts passed: 1 file / 5 tests.
- npm --prefix apps/web exec -- tsc -b apps/web/tsconfig.json passed.
- git --no-pager diff --check passed.
- Optional local E2E not run.