### PR TITLE
Add iOS media upload worker

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -113,6 +113,7 @@ extension FlashcardsStore {
                 now: now,
                 trigger: trigger
             )
+            await self.processMediaUploadTransfersAfterCloudSync(linkedSession: activeSession)
         } catch {
             if isRequestCancellationError(error: error) {
                 self.syncStatus = .idle
@@ -655,6 +656,55 @@ extension FlashcardsStore {
         }
 
         self.enqueueTransientBanner(banner: makeCardsUpdatedFromCloudBanner())
+    }
+
+    private func processMediaUploadTransfersAfterCloudSync(linkedSession: CloudLinkedSession) async {
+        guard let database = self.database,
+              let cloudSyncService = self.dependencies.cloudSyncService,
+              self.workspace?.workspaceId == linkedSession.workspaceId else {
+            return
+        }
+
+        do {
+            try await self.withCloudSessionPreservingStableContext(linkedSession: linkedSession) { refreshedSession in
+                try await MediaUploadTransferRunner(
+                    database: database,
+                    cloudSyncService: cloudSyncService
+                ).processDueUploads(linkedSession: refreshedSession, now: Date())
+            }
+        } catch {
+            if isRequestCancellationError(error: error) {
+                return
+            }
+            self.captureMediaUploadTransferProcessingFailure(error: error, linkedSession: linkedSession)
+        }
+    }
+
+    private func captureMediaUploadTransferProcessingFailure(error: Error, linkedSession: CloudLinkedSession) {
+        if isRetryableNetworkTransportFailure(error: error) {
+            return
+        }
+
+        let diagnostics = cloudSyncFailureDiagnostics(error: error)
+        FlashcardsObservability.captureSilentFailure(
+            error: error,
+            scope: IOSObservationScope(
+                feature: .cloudSync,
+                userId: linkedSession.userId,
+                workspaceId: linkedSession.workspaceId,
+                requestId: diagnostics.requestId,
+                clientRequestId: nil,
+                sessionId: nil,
+                runId: nil,
+                cloudState: self.cloudSettings?.cloudState,
+                configurationMode: linkedSession.configurationMode
+            ),
+            action: "media_upload_transfer_process",
+            stage: "after_cloud_sync",
+            statusCode: diagnostics.statusCode,
+            backendCode: diagnostics.backendCode,
+            requestId: diagnostics.requestId
+        )
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
@@ -319,6 +319,13 @@ final class CloudSyncService: @unchecked Sendable {
         )
     }
 
+    func uploadMediaAssetPart(
+        partURL: MediaAssetUploadPartURL,
+        body: Data
+    ) async throws -> String {
+        try await self.transport.uploadMediaAssetPart(partURL: partURL, body: body)
+    }
+
     func previewWorkspacePackageExport(
         apiBaseUrl: String,
         authorizationHeader: String,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
@@ -7,6 +7,9 @@ private let cloudSyncPackageExportContentDispositionInvalidCode: String =
     "WORKSPACE_PACKAGE_EXPORT_CONTENT_DISPOSITION_INVALID"
 private let cloudSyncResponseDecodingFailedCode: String = "RESPONSE_DECODING_FAILED"
 private let cloudSyncResponseDecodingFailedMessage: String = "Failed to decode cloud sync response"
+private let mediaAssetUploadPartPutMaxAttempts: Int = 3
+private let mediaAssetUploadPartPutRetryDelayNanoseconds: UInt64 = 500_000_000
+private let mediaAssetUploadPartPutResponseBodyMaxBytes: Int = 2_048
 private let cloudSyncTransportMaxAttempts: Int = 3
 private let cloudSyncTransportRetryDelayNanoseconds: UInt64 = 500_000_000
 private let progressLeaderboardProfileBasePath: String = "/me/progress/leaderboards/profiles"
@@ -34,6 +37,28 @@ private protocol CloudSyncBootstrapModeRequest {
 
 extension BootstrapPullRequest: CloudSyncBootstrapModeRequest {}
 extension BootstrapPushRequest: CloudSyncBootstrapModeRequest {}
+
+struct MediaAssetUploadPartHTTPError: LocalizedError, Sendable {
+    let partNumber: Int
+    let statusCode: Int
+    let responseBody: String
+
+    var errorDescription: String? {
+        "Media asset upload part PUT failed with status \(self.statusCode) for partNumber=\(self.partNumber) responseBody=\(self.responseBody)"
+    }
+}
+
+private func mediaAssetUploadPartPutStatusIsRetryable(statusCode: Int) -> Bool {
+    statusCode == 408 || statusCode == 429 || (statusCode >= 500 && statusCode <= 599)
+}
+
+private func mediaAssetUploadPartPutResponseBodySummary(data: Data) -> String {
+    guard data.isEmpty == false else {
+        return ""
+    }
+
+    return String(decoding: data.prefix(mediaAssetUploadPartPutResponseBodyMaxBytes), as: UTF8.self)
+}
 
 struct CloudSyncTransport {
     private let session: URLSession
@@ -245,6 +270,42 @@ struct CloudSyncTransport {
             method: "POST",
             body: Optional<String>.none
         )
+    }
+
+    func uploadMediaAssetPart(
+        partURL: MediaAssetUploadPartURL,
+        body: Data
+    ) async throws -> String {
+        guard let uploadURL = URL(string: partURL.url),
+              uploadURL.scheme?.isEmpty == false,
+              uploadURL.host?.isEmpty == false else {
+            throw LocalStoreError.validation(
+                "Media asset upload part URL is invalid for partNumber=\(partURL.partNumber)"
+            )
+        }
+
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = partURL.method
+        request.httpShouldHandleCookies = false
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        for (headerName, headerValue) in partURL.headers {
+            request.setValue(headerValue, forHTTPHeaderField: headerName)
+        }
+
+        let response = try await self.sendMediaAssetUploadPartWithRetry(
+            request: request,
+            body: body,
+            partNumber: partURL.partNumber
+        )
+        let eTag = response.value(forHTTPHeaderField: "ETag")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let eTag, eTag.isEmpty == false else {
+            throw LocalStoreError.validation(
+                "Media asset upload part PUT response was missing ETag for partNumber=\(partURL.partNumber)"
+            )
+        }
+
+        return eTag
     }
 
     func workspacePackageImportPreviewPath(workspaceId: String) throws -> String {
@@ -648,6 +709,84 @@ struct CloudSyncTransport {
             throw LocalStoreError.database("Cloud sync transport retry failed without an error")
         }
         throw lastError
+    }
+
+    private func sendMediaAssetUploadPartWithRetry(
+        request: URLRequest,
+        body: Data,
+        partNumber: Int
+    ) async throws -> HTTPURLResponse {
+        var lastError: Error?
+        for attempt in 1...mediaAssetUploadPartPutMaxAttempts {
+            do {
+                let (data, response) = try await self.session.upload(for: request, from: body)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw LocalStoreError.database(
+                        "Media asset upload part PUT did not receive an HTTP response for partNumber=\(partNumber)"
+                    )
+                }
+                if httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 {
+                    return httpResponse
+                }
+
+                let statusError = MediaAssetUploadPartHTTPError(
+                    partNumber: partNumber,
+                    statusCode: httpResponse.statusCode,
+                    responseBody: mediaAssetUploadPartPutResponseBodySummary(data: data)
+                )
+                lastError = statusError
+                guard mediaAssetUploadPartPutStatusIsRetryable(statusCode: httpResponse.statusCode),
+                      attempt < mediaAssetUploadPartPutMaxAttempts else {
+                    throw statusError
+                }
+
+                try await self.retryMediaAssetUploadPartPut(error: statusError, attempt: attempt)
+            } catch let error as CancellationError {
+                throw error
+            } catch {
+                if isRequestCancellationError(error: error) {
+                    throw error
+                }
+                lastError = error
+                guard isRetryableNetworkTransportFailure(error: error),
+                      attempt < mediaAssetUploadPartPutMaxAttempts else {
+                    throw error
+                }
+
+                try await self.retryMediaAssetUploadPartPut(error: error, attempt: attempt)
+            }
+        }
+
+        guard let lastError else {
+            throw LocalStoreError.database("Media asset upload part PUT retry failed without an error")
+        }
+        throw lastError
+    }
+
+    private func retryMediaAssetUploadPartPut(error: Error, attempt: Int) async throws {
+        FlashcardsObservability.addBreadcrumb(
+            .cloudRetry(
+                CloudRetryObservation(
+                    action: "media_asset_upload_part_put_retry",
+                    scope: IOSObservationScope(
+                        feature: .cloudSync,
+                        userId: nil,
+                        workspaceId: nil,
+                        requestId: nil,
+                        clientRequestId: nil,
+                        sessionId: nil,
+                        runId: nil,
+                        cloudState: nil,
+                        configurationMode: nil
+                    ),
+                    attempt: attempt,
+                    maxAttempts: mediaAssetUploadPartPutMaxAttempts,
+                    apiBaseUrl: nil,
+                    messageSummary: Flashcards.errorMessage(error: error)
+                )
+            )
+        )
+        try await Task.sleep(nanoseconds: mediaAssetUploadPartPutRetryDelayNanoseconds)
     }
 
     private func phase<Body: Encodable>(for path: String, method: String, body: Body?) -> CloudFlowPhase {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/MediaUploadTransferFilePlan.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/MediaUploadTransferFilePlan.swift
@@ -1,0 +1,286 @@
+import CryptoKit
+import Foundation
+
+struct MediaUploadPartPlan: Sendable {
+    let partNumber: Int
+    let offsetBytes: UInt64
+    let sizeBytes: Int
+    let sha256: String
+}
+
+struct MediaUploadTransferPlan: Sendable {
+    let fileURL: URL
+    let sha256: String
+    let sizeBytes: Int64
+    let partSizeBytes: Int64
+    let parts: [MediaUploadPartPlan]
+}
+
+private struct MediaUploadFilePlanScan: Sendable {
+    let sha256: String
+    let sizeBytes: Int64
+    let parts: [MediaUploadPartPlan]
+}
+
+func makeMediaUploadTransferPlanOffMain(
+    databaseURL: URL,
+    entry: MediaTransferQueueEntry
+) async throws -> MediaUploadTransferPlan {
+    let task = Task.detached(priority: .utility) {
+        try Task.checkCancellation()
+        return try makeMediaUploadTransferPlan(databaseURL: databaseURL, entry: entry)
+    }
+    return try await withTaskCancellationHandler {
+        try await task.value
+    } onCancel: {
+        task.cancel()
+    }
+}
+
+func makeMediaUploadTransferPlan(databaseURL: URL, entry: MediaTransferQueueEntry) throws -> MediaUploadTransferPlan {
+    guard entry.kind == .upload else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media transfer runner received non-upload transferId=\(entry.transferId) kind=\(entry.kind.rawValue)"
+        )
+    }
+    guard entry.sizeBytes > 0 else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload size must be positive transferId=\(entry.transferId) sizeBytes=\(entry.sizeBytes)"
+        )
+    }
+
+    let normalizedSha256 = try normalizedMediaSha256(sha256: entry.sha256)
+    let expectedRelativePath = try mediaBlobCacheRelativePath(sha256: normalizedSha256)
+    guard entry.localRelativePath == expectedRelativePath else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload local path mismatch transferId=\(entry.transferId) expected=\(expectedRelativePath) actual=\(entry.localRelativePath)"
+        )
+    }
+
+    let fileURL = databaseURL
+        .deletingLastPathComponent()
+        .appendingPathComponent(entry.localRelativePath, isDirectory: false)
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload local file is missing transferId=\(entry.transferId) path=\(entry.localRelativePath)"
+        )
+    }
+
+    let partSizeBytes = min(entry.sizeBytes, mediaUploadMultipartPartSizeBytes)
+    let scan = try streamMediaUploadFilePlan(
+        fileURL: fileURL,
+        mediaAssetId: entry.mediaAssetId,
+        partSizeBytes: partSizeBytes
+    )
+    guard scan.sizeBytes == entry.sizeBytes else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload file size mismatch transferId=\(entry.transferId) expected=\(entry.sizeBytes) actual=\(scan.sizeBytes)"
+        )
+    }
+    guard scan.sha256 == normalizedSha256 else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload SHA-256 mismatch transferId=\(entry.transferId) expected=\(normalizedSha256) actual=\(scan.sha256)"
+        )
+    }
+
+    return MediaUploadTransferPlan(
+        fileURL: fileURL,
+        sha256: scan.sha256,
+        sizeBytes: scan.sizeBytes,
+        partSizeBytes: partSizeBytes,
+        parts: scan.parts
+    )
+}
+
+private func streamMediaUploadFilePlan(
+    fileURL: URL,
+    mediaAssetId: String,
+    partSizeBytes: Int64
+) throws -> MediaUploadFilePlanScan {
+    guard partSizeBytes > 0 && partSizeBytes <= Int64(Int.max) else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload part size is invalid mediaAssetId=\(mediaAssetId) partSizeBytes=\(partSizeBytes)"
+        )
+    }
+
+    let fileHandle = try FileHandle(forReadingFrom: fileURL)
+    let scan = try scanMediaUploadFileHandle(
+        fileHandle: fileHandle,
+        mediaAssetId: mediaAssetId,
+        partSizeBytes: partSizeBytes
+    )
+    try closeMediaUploadFileHandle(fileHandle: fileHandle, mediaAssetId: mediaAssetId)
+    return scan
+}
+
+private func scanMediaUploadFileHandle(
+    fileHandle: FileHandle,
+    mediaAssetId: String,
+    partSizeBytes: Int64
+) throws -> MediaUploadFilePlanScan {
+    do {
+        var nextParts: [MediaUploadPartPlan] = []
+        var offsetBytes: UInt64 = 0
+        var sizeBytes: Int64 = 0
+        var fullHasher = SHA256()
+        while true {
+            try Task.checkCancellation()
+            let partData = try readMediaUploadChunk(
+                fileHandle: fileHandle,
+                maxSizeBytes: Int(partSizeBytes)
+            )
+            guard partData.isEmpty == false else {
+                break
+            }
+
+            nextParts.append(
+                MediaUploadPartPlan(
+                    partNumber: nextParts.count + 1,
+                    offsetBytes: offsetBytes,
+                    sizeBytes: partData.count,
+                    sha256: hexSHA256(data: partData)
+                )
+            )
+            fullHasher.update(data: partData)
+            sizeBytes += Int64(partData.count)
+            offsetBytes += UInt64(partData.count)
+        }
+        guard nextParts.isEmpty == false else {
+            throw MediaUploadTransferFailure(
+                policy: .permanent,
+                message: "Media upload file produced no upload parts mediaAssetId=\(mediaAssetId)"
+            )
+        }
+        let scan = MediaUploadFilePlanScan(
+            sha256: hexSHA256(digest: fullHasher.finalize()),
+            sizeBytes: sizeBytes,
+            parts: nextParts
+        )
+        return scan
+    } catch {
+        try closeMediaUploadFileHandleAfterFailure(
+            fileHandle: fileHandle,
+            mediaAssetId: mediaAssetId,
+            failure: error
+        )
+    }
+}
+
+func readMediaUploadPartDataOffMain(
+    fileURL: URL,
+    part: MediaUploadPartPlan,
+    mediaAssetId: String
+) async throws -> Data {
+    let task = Task.detached(priority: .utility) {
+        try Task.checkCancellation()
+        return try readMediaUploadPartData(fileURL: fileURL, part: part, mediaAssetId: mediaAssetId)
+    }
+    return try await withTaskCancellationHandler {
+        try await task.value
+    } onCancel: {
+        task.cancel()
+    }
+}
+
+func readMediaUploadPartData(
+    fileURL: URL,
+    part: MediaUploadPartPlan,
+    mediaAssetId: String
+) throws -> Data {
+    let fileHandle = try FileHandle(forReadingFrom: fileURL)
+    let partData = try readMediaUploadPartDataFromHandle(
+        fileHandle: fileHandle,
+        part: part,
+        mediaAssetId: mediaAssetId
+    )
+    try closeMediaUploadFileHandle(fileHandle: fileHandle, mediaAssetId: mediaAssetId)
+    return partData
+}
+
+private func readMediaUploadPartDataFromHandle(
+    fileHandle: FileHandle,
+    part: MediaUploadPartPlan,
+    mediaAssetId: String
+) throws -> Data {
+    do {
+        try fileHandle.seek(toOffset: part.offsetBytes)
+        let partData = try readMediaUploadChunk(fileHandle: fileHandle, maxSizeBytes: part.sizeBytes)
+        guard partData.count == part.sizeBytes else {
+            throw MediaUploadTransferFailure(
+                policy: .permanent,
+                message: "Media upload part read size mismatch mediaAssetId=\(mediaAssetId) partNumber=\(part.partNumber) expected=\(part.sizeBytes) actual=\(partData.count)"
+            )
+        }
+        guard hexSHA256(data: partData) == part.sha256 else {
+            throw MediaUploadTransferFailure(
+                policy: .permanent,
+                message: "Media upload part SHA-256 changed while uploading mediaAssetId=\(mediaAssetId) partNumber=\(part.partNumber)"
+            )
+        }
+        return partData
+    } catch {
+        try closeMediaUploadFileHandleAfterFailure(
+            fileHandle: fileHandle,
+            mediaAssetId: mediaAssetId,
+            failure: error
+        )
+    }
+}
+
+private func readMediaUploadChunk(fileHandle: FileHandle, maxSizeBytes: Int) throws -> Data {
+    var data = Data()
+    while data.count < maxSizeBytes {
+        try Task.checkCancellation()
+        guard let chunk = try fileHandle.read(upToCount: maxSizeBytes - data.count),
+              chunk.isEmpty == false else {
+            break
+        }
+        data.append(chunk)
+    }
+    return data
+}
+
+private func closeMediaUploadFileHandle(fileHandle: FileHandle, mediaAssetId: String) throws {
+    do {
+        try fileHandle.close()
+    } catch {
+        throw MediaUploadTransferFailure(
+            policy: .transient,
+            message: "Media upload file close failed mediaAssetId=\(mediaAssetId): \(Flashcards.errorMessage(error: error))"
+        )
+    }
+}
+
+private func closeMediaUploadFileHandleAfterFailure(
+    fileHandle: FileHandle,
+    mediaAssetId: String,
+    failure: Error
+) throws -> Never {
+    do {
+        try fileHandle.close()
+    } catch {
+        throw MediaUploadTransferFailure(
+            policy: mediaUploadFailure(error: failure).policy,
+            message: "Media upload file operation failed and close failed mediaAssetId=\(mediaAssetId): operationError=\(Flashcards.errorMessage(error: failure)); closeError=\(Flashcards.errorMessage(error: error))"
+        )
+    }
+
+    throw failure
+}
+
+private func hexSHA256(data: Data) -> String {
+    hexSHA256(digest: SHA256.hash(data: data))
+}
+
+private func hexSHA256(digest: SHA256.Digest) -> String {
+    digest.map { byte in
+        String(format: "%02x", byte)
+    }.joined()
+}

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/MediaUploadTransferRunner.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/MediaUploadTransferRunner.swift
@@ -1,0 +1,357 @@
+import Foundation
+
+@MainActor
+struct MediaUploadTransferRunner {
+    private static var activeWorkspaceIds: Set<String> = []
+
+    let database: LocalDatabase
+    let cloudSyncService: any CloudSyncServing
+
+    init(database: LocalDatabase, cloudSyncService: any CloudSyncServing) {
+        self.database = database
+        self.cloudSyncService = cloudSyncService
+    }
+
+    func processDueUploads(linkedSession: CloudLinkedSession, now: Date) async throws {
+        guard Self.activeWorkspaceIds.insert(linkedSession.workspaceId).inserted else {
+            return
+        }
+        defer {
+            Self.activeWorkspaceIds.remove(linkedSession.workspaceId)
+        }
+
+        let cloudSettings = try self.database.loadBootstrapSnapshot().cloudSettings
+        var claimNow = now
+
+        while true {
+            if Task.isCancelled {
+                throw CancellationError()
+            }
+
+            let claimedEntries = try self.database.mediaTransferStore.claimDueTransfers(
+                workspaceId: linkedSession.workspaceId,
+                kind: .upload,
+                now: formatIsoTimestamp(date: claimNow),
+                staleClaimedBefore: formatIsoTimestamp(
+                    date: claimNow.addingTimeInterval(-mediaUploadTransferClaimLeaseSeconds)
+                ),
+                limit: mediaUploadTransferClaimLimit
+            )
+            guard claimedEntries.isEmpty == false else {
+                return
+            }
+
+            for entry in claimedEntries {
+                try await self.processClaimedUpload(
+                    entry: entry,
+                    linkedSession: linkedSession,
+                    installationId: cloudSettings.installationId
+                )
+            }
+
+            claimNow = Date()
+        }
+    }
+
+    private func processClaimedUpload(
+        entry: MediaTransferQueueEntry,
+        linkedSession: CloudLinkedSession,
+        installationId: String
+    ) async throws {
+        guard let claimedAt = entry.claimedAt else {
+            throw LocalStoreError.database("Claimed media upload transfer is missing claimedAt transferId=\(entry.transferId)")
+        }
+        var claim = MediaUploadTransferClaim(entry: entry, claimedAt: claimedAt)
+
+        do {
+            let mediaAsset = try await self.uploadClaimedEntry(
+                entry: entry,
+                linkedSession: linkedSession,
+                installationId: installationId,
+                claim: &claim
+            )
+            try self.persistSucceededUpload(
+                entry: entry,
+                claimedAt: claim.claimedAt,
+                mediaAsset: mediaAsset
+            )
+        } catch {
+            if isRequestCancellationError(error: error) {
+                throw error
+            }
+
+            try self.recordFailedUpload(
+                entry: entry,
+                claimedAt: claim.claimedAt,
+                error: error
+            )
+        }
+    }
+
+    private func uploadClaimedEntry(
+        entry: MediaTransferQueueEntry,
+        linkedSession: CloudLinkedSession,
+        installationId: String,
+        claim: inout MediaUploadTransferClaim
+    ) async throws -> MediaAsset {
+        try self.renewUploadClaim(claim: &claim)
+        let plan = try await makeMediaUploadTransferPlanOffMain(databaseURL: self.database.databaseURL, entry: entry)
+        try self.renewUploadClaim(claim: &claim)
+        let createResponse = try await self.cloudSyncService.createMediaAssetUploadSession(
+            apiBaseUrl: linkedSession.apiBaseUrl,
+            authorizationHeader: linkedSession.authorization.headerValue,
+            workspaceId: entry.workspaceId,
+            request: MediaAssetUploadSessionCreateRequest(
+                mediaAssetId: entry.mediaAssetId,
+                mimeType: entry.mimeType,
+                sizeBytes: plan.sizeBytes,
+                sha256: plan.sha256,
+                partSizeBytes: plan.partSizeBytes,
+                partCount: plan.parts.count,
+                sourceUrl: nil,
+                createdAt: entry.createdAt,
+                clientUpdatedAt: entry.createdAt,
+                lastModifiedByReplicaId: mediaUploadWorkspaceReplicaId(
+                    workspaceId: entry.workspaceId,
+                    installationId: installationId
+                ),
+                lastOperationId: entry.transferId
+            )
+        )
+        try self.renewUploadClaim(claim: &claim)
+        try validateMediaUploadSessionCreateResponse(
+            response: createResponse,
+            entry: entry,
+            plan: plan
+        )
+
+        switch createResponse.status {
+        case .alreadyAvailable:
+            guard let mediaAsset = createResponse.mediaAsset else {
+                throw MediaUploadTransferFailure(
+                    policy: .permanent,
+                    message: "Media upload session already_available response did not include mediaAsset transferId=\(entry.transferId)"
+                )
+            }
+            try validateUploadedMediaAsset(mediaAsset: mediaAsset, entry: entry, plan: plan)
+            return mediaAsset
+        case .uploadRequired:
+            guard let uploadSession = createResponse.uploadSession else {
+                throw MediaUploadTransferFailure(
+                    policy: .permanent,
+                    message: "Media upload session upload_required response did not include uploadSession transferId=\(entry.transferId)"
+                )
+            }
+            return try await self.uploadRequiredSession(
+                entry: entry,
+                linkedSession: linkedSession,
+                uploadSession: uploadSession,
+                plan: plan,
+                claim: &claim
+            )
+        }
+    }
+
+    private func uploadRequiredSession(
+        entry: MediaTransferQueueEntry,
+        linkedSession: CloudLinkedSession,
+        uploadSession: MediaAssetUploadSessionMetadata,
+        plan: MediaUploadTransferPlan,
+        claim: inout MediaUploadTransferClaim
+    ) async throws -> MediaAsset {
+        let completeResponse: MediaAssetUploadSessionCompleteResponse
+        do {
+            let completedParts = try await self.uploadParts(
+                entry: entry,
+                linkedSession: linkedSession,
+                uploadSession: uploadSession,
+                plan: plan,
+                claim: &claim
+            )
+            try self.renewUploadClaim(claim: &claim)
+            completeResponse = try await self.cloudSyncService.completeMediaAssetUploadSession(
+                apiBaseUrl: linkedSession.apiBaseUrl,
+                authorizationHeader: linkedSession.authorization.headerValue,
+                workspaceId: entry.workspaceId,
+                sessionId: uploadSession.sessionId,
+                request: MediaAssetUploadSessionCompleteRequest(parts: completedParts)
+            )
+        } catch {
+            if isRequestCancellationError(error: error) {
+                throw error
+            }
+
+            let uploadFailure = mediaUploadFailure(error: error)
+            do {
+                _ = try await self.cloudSyncService.abortMediaAssetUploadSession(
+                    apiBaseUrl: linkedSession.apiBaseUrl,
+                    authorizationHeader: linkedSession.authorization.headerValue,
+                    workspaceId: entry.workspaceId,
+                    sessionId: uploadSession.sessionId
+                )
+            } catch {
+                if isRequestCancellationError(error: error) {
+                    throw error
+                }
+
+                let abortFailure = mediaUploadFailure(error: error)
+                let combinedPolicy: MediaUploadTransferFailurePolicy
+                switch (uploadFailure.policy, abortFailure.policy) {
+                case (.transient, _), (_, .transient):
+                    combinedPolicy = .transient
+                case (.permanent, .permanent):
+                    combinedPolicy = .permanent
+                }
+                throw MediaUploadTransferFailure(
+                    policy: combinedPolicy,
+                    message: "\(uploadFailure.message); abort failed for sessionId=\(uploadSession.sessionId): \(abortFailure.message)"
+                )
+            }
+
+            throw error
+        }
+
+        try validateUploadedMediaAsset(mediaAsset: completeResponse.mediaAsset, entry: entry, plan: plan)
+        return completeResponse.mediaAsset
+    }
+
+    private func uploadParts(
+        entry: MediaTransferQueueEntry,
+        linkedSession: CloudLinkedSession,
+        uploadSession: MediaAssetUploadSessionMetadata,
+        plan: MediaUploadTransferPlan,
+        claim: inout MediaUploadTransferClaim
+    ) async throws -> [CompletedMediaAssetUploadPart] {
+        var completedParts: [CompletedMediaAssetUploadPart] = []
+        let batches = try mediaUploadPartPlanBatches(parts: plan.parts, batchSize: mediaUploadPartURLBatchSize)
+
+        for batch in batches {
+            try self.renewUploadClaim(claim: &claim)
+            let partURLResponse = try await self.cloudSyncService.loadMediaAssetUploadPartURLs(
+                apiBaseUrl: linkedSession.apiBaseUrl,
+                authorizationHeader: linkedSession.authorization.headerValue,
+                workspaceId: entry.workspaceId,
+                sessionId: uploadSession.sessionId,
+                request: MediaAssetUploadPartURLsRequest(
+                    parts: batch.map { part in
+                        MediaAssetUploadPartURLRequestPart(
+                            partNumber: part.partNumber,
+                            sha256: part.sha256
+                        )
+                    }
+                )
+            )
+            try self.renewUploadClaim(claim: &claim)
+            let partURLsByNumber = try mediaUploadPartURLsByPartNumber(
+                response: partURLResponse,
+                uploadSession: uploadSession,
+                expectedParts: batch
+            )
+
+            for part in batch {
+                guard let partURL = partURLsByNumber[part.partNumber] else {
+                    throw MediaUploadTransferFailure(
+                        policy: .permanent,
+                        message: "Media upload part URL response omitted partNumber=\(part.partNumber) transferId=\(entry.transferId)"
+                    )
+                }
+
+                try validateMediaUploadPartURLFresh(partURL: partURL, now: Date())
+                try self.renewUploadClaim(claim: &claim)
+                let partData = try await readMediaUploadPartDataOffMain(
+                    fileURL: plan.fileURL,
+                    part: part,
+                    mediaAssetId: entry.mediaAssetId
+                )
+                try self.renewUploadClaim(claim: &claim)
+                try validateMediaUploadPartURLFresh(partURL: partURL, now: Date())
+                let eTag = try await self.cloudSyncService.uploadMediaAssetPart(
+                    partURL: partURL,
+                    body: partData
+                )
+                try self.renewUploadClaim(claim: &claim)
+                completedParts.append(
+                    CompletedMediaAssetUploadPart(
+                        partNumber: part.partNumber,
+                        eTag: eTag,
+                        sha256: part.sha256
+                    )
+                )
+            }
+        }
+
+        return completedParts.sorted { left, right in
+            left.partNumber < right.partNumber
+        }
+    }
+
+    private func renewUploadClaim(claim: inout MediaUploadTransferClaim) throws {
+        let renewedAt = nowIsoTimestamp()
+        let renewedEntry = try self.database.mediaTransferStore.renewTransferClaim(
+            transferId: claim.transferId,
+            workspaceId: claim.workspaceId,
+            kind: claim.kind,
+            claimedAt: claim.claimedAt,
+            renewedAt: renewedAt
+        )
+        guard let renewedClaimedAt = renewedEntry.claimedAt else {
+            throw LocalStoreError.database("Renewed media upload transfer is missing claimedAt transferId=\(claim.transferId)")
+        }
+        claim.claimedAt = renewedClaimedAt
+    }
+
+    private func persistSucceededUpload(
+        entry: MediaTransferQueueEntry,
+        claimedAt: String,
+        mediaAsset: MediaAsset
+    ) throws {
+        let now = nowIsoTimestamp()
+        try self.database.core.inTransaction {
+            try self.database.mediaAssetStore.upsertMediaAsset(
+                workspaceId: entry.workspaceId,
+                mediaAsset: mediaAsset
+            )
+            _ = try self.database.mediaTransferStore.upsertBlobCacheEntry(
+                entry: MediaBlobCacheUpsert(
+                    sha256: mediaAsset.sha256,
+                    mimeType: mediaAsset.mimeType,
+                    sizeBytes: mediaAsset.sizeBytes,
+                    createdAt: now,
+                    lastAccessedAt: now,
+                    sourceMediaAssetId: mediaAsset.mediaAssetId
+                )
+            )
+            _ = try self.database.mediaTransferStore.markTransferSucceeded(
+                transferId: entry.transferId,
+                claimedAt: claimedAt,
+                updatedAt: now
+            )
+        }
+    }
+
+    private func recordFailedUpload(
+        entry: MediaTransferQueueEntry,
+        claimedAt: String,
+        error: Error
+    ) throws {
+        let failure = mediaUploadFailure(error: error)
+        let now = Date()
+        let nextAttemptAt: String
+        switch failure.policy {
+        case .transient:
+            nextAttemptAt = formatIsoTimestamp(
+                date: now.addingTimeInterval(mediaUploadRetryDelaySeconds(attemptCount: entry.attemptCount))
+            )
+        case .permanent:
+            nextAttemptAt = mediaUploadPermanentFailureNextAttemptAt
+        }
+
+        _ = try self.database.mediaTransferStore.markTransferFailed(
+            transferId: entry.transferId,
+            claimedAt: claimedAt,
+            errorMessage: failure.message,
+            nextAttemptAt: nextAttemptAt,
+            updatedAt: formatIsoTimestamp(date: now)
+        )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/MediaUploadTransferSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/MediaUploadTransferSupport.swift
@@ -1,0 +1,244 @@
+import CryptoKit
+import Foundation
+
+let mediaUploadBaseRetryDelaySeconds: TimeInterval = 60
+let mediaUploadMaxRetryDelaySeconds: TimeInterval = 3_600
+let mediaUploadMultipartPartSizeBytes: Int64 = 8_388_608
+let mediaUploadPartURLBatchSize: Int = 1
+let mediaUploadPartURLExpirationSafetyMarginSeconds: TimeInterval = 300
+let mediaUploadPermanentFailureNextAttemptAt: String = "9999-12-31T00:00:00.000Z"
+let mediaUploadResponseDecodingFailedCode: String = "RESPONSE_DECODING_FAILED"
+let mediaUploadTransferClaimLeaseSeconds: TimeInterval = 900
+let mediaUploadTransferClaimLimit: Int = 3
+
+enum MediaUploadTransferFailurePolicy: Sendable {
+    case transient
+    case permanent
+}
+
+struct MediaUploadTransferFailure: LocalizedError, Sendable {
+    let policy: MediaUploadTransferFailurePolicy
+    let message: String
+
+    var errorDescription: String? {
+        self.message
+    }
+}
+
+struct MediaUploadTransferClaim: Sendable {
+    let transferId: String
+    let workspaceId: String
+    let kind: MediaTransferKind
+    var claimedAt: String
+
+    init(entry: MediaTransferQueueEntry, claimedAt: String) {
+        self.transferId = entry.transferId
+        self.workspaceId = entry.workspaceId
+        self.kind = entry.kind
+        self.claimedAt = claimedAt
+    }
+}
+
+func validateMediaUploadSessionCreateResponse(
+    response: MediaAssetUploadSessionCreateResponse,
+    entry: MediaTransferQueueEntry,
+    plan: MediaUploadTransferPlan
+) throws {
+    guard response.workspaceId == entry.workspaceId,
+          response.mediaAssetId == entry.mediaAssetId else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload session response identity mismatch transferId=\(entry.transferId)"
+        )
+    }
+
+    if let uploadSession = response.uploadSession {
+        guard uploadSession.partSizeBytes == plan.partSizeBytes,
+              uploadSession.partCount == plan.parts.count else {
+            throw MediaUploadTransferFailure(
+                policy: .permanent,
+                message: "Media upload session multipart shape mismatch transferId=\(entry.transferId)"
+            )
+        }
+    }
+}
+
+func validateUploadedMediaAsset(
+    mediaAsset: MediaAsset,
+    entry: MediaTransferQueueEntry,
+    plan: MediaUploadTransferPlan
+) throws {
+    guard mediaAsset.workspaceId == entry.workspaceId,
+          mediaAsset.mediaAssetId == entry.mediaAssetId,
+          mediaAsset.deletedAt == nil else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload completed asset identity mismatch transferId=\(entry.transferId)"
+        )
+    }
+    guard mediaAsset.sizeBytes == plan.sizeBytes,
+          try normalizedMediaSha256(sha256: mediaAsset.sha256) == plan.sha256,
+          mediaAsset.mimeType.lowercased() == entry.mimeType.lowercased() else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload completed asset metadata mismatch transferId=\(entry.transferId)"
+        )
+    }
+}
+
+func mediaUploadPartURLsByPartNumber(
+    response: MediaAssetUploadPartURLsResponse,
+    uploadSession: MediaAssetUploadSessionMetadata,
+    expectedParts: [MediaUploadPartPlan]
+) throws -> [Int: MediaAssetUploadPartURL] {
+    guard response.sessionId == uploadSession.sessionId else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload part URL response session mismatch sessionId=\(uploadSession.sessionId)"
+        )
+    }
+
+    var partURLsByNumber: [Int: MediaAssetUploadPartURL] = [:]
+    for partURL in response.partUrls {
+        if partURLsByNumber[partURL.partNumber] != nil {
+            throw MediaUploadTransferFailure(
+                policy: .permanent,
+                message: "Media upload part URL response duplicated partNumber=\(partURL.partNumber) sessionId=\(uploadSession.sessionId)"
+            )
+        }
+        partURLsByNumber[partURL.partNumber] = partURL
+    }
+
+    let expectedPartNumbers = Set(expectedParts.map(\.partNumber))
+    guard Set(partURLsByNumber.keys) == expectedPartNumbers else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload part URL response did not match requested part numbers sessionId=\(uploadSession.sessionId)"
+        )
+    }
+
+    return partURLsByNumber
+}
+
+func validateMediaUploadPartURLFresh(partURL: MediaAssetUploadPartURL, now: Date) throws {
+    guard let expiresAt = parseStrictIsoTimestamp(value: partURL.expiresAt) else {
+        throw MediaUploadTransferFailure(
+            policy: .permanent,
+            message: "Media upload part URL response has invalid expiresAt partNumber=\(partURL.partNumber)"
+        )
+    }
+    guard expiresAt.timeIntervalSince(now) > mediaUploadPartURLExpirationSafetyMarginSeconds else {
+        throw MediaUploadTransferFailure(
+            policy: .transient,
+            message: "Media upload part URL expires too soon partNumber=\(partURL.partNumber) expiresAt=\(partURL.expiresAt)"
+        )
+    }
+}
+
+func mediaUploadPartPlanBatches(
+    parts: [MediaUploadPartPlan],
+    batchSize: Int
+) throws -> [[MediaUploadPartPlan]] {
+    guard batchSize > 0 else {
+        throw LocalStoreError.validation("Media upload part URL batch size must be positive")
+    }
+
+    var batches: [[MediaUploadPartPlan]] = []
+    var startIndex = 0
+    while startIndex < parts.count {
+        let endIndex = min(startIndex + batchSize, parts.count)
+        batches.append(Array(parts[startIndex..<endIndex]))
+        startIndex = endIndex
+    }
+    return batches
+}
+
+func mediaUploadWorkspaceReplicaId(workspaceId: String, installationId: String) -> String {
+    let seed = "\(workspaceId):\(installationId)"
+    var bytes = Array(SHA256.hash(data: Data(seed.utf8)).prefix(16))
+    bytes[6] = (bytes[6] & 0x0f) | 0x50
+    bytes[8] = (bytes[8] & 0x3f) | 0x80
+    return UUID(uuid: (
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15]
+    )).uuidString.lowercased()
+}
+
+func mediaUploadRetryDelaySeconds(attemptCount: Int) -> TimeInterval {
+    let boundedAttemptCount = max(0, min(attemptCount, 5))
+    let multiplier = pow(2.0, Double(boundedAttemptCount))
+    return min(mediaUploadMaxRetryDelaySeconds, mediaUploadBaseRetryDelaySeconds * multiplier)
+}
+
+func mediaUploadAuthOrRetryStatusIsTransient(statusCode: Int) -> Bool {
+    statusCode == 401 || statusCode == 408 || statusCode == 429 || statusCode >= 500
+}
+
+func mediaUploadPartPutStatusIsTransient(statusCode: Int) -> Bool {
+    statusCode == 403 || mediaUploadAuthOrRetryStatusIsTransient(statusCode: statusCode)
+}
+
+func mediaUploadFailure(error: Error) -> MediaUploadTransferFailure {
+    if let failure = error as? MediaUploadTransferFailure {
+        return failure
+    }
+    if let partHTTPError = error as? MediaAssetUploadPartHTTPError {
+        let policy: MediaUploadTransferFailurePolicy
+        if mediaUploadPartPutStatusIsTransient(statusCode: partHTTPError.statusCode) {
+            policy = .transient
+        } else {
+            policy = .permanent
+        }
+        return MediaUploadTransferFailure(
+            policy: policy,
+            message: Flashcards.errorMessage(error: error)
+        )
+    }
+    if let cloudError = error as? CloudSyncError {
+        switch cloudError {
+        case .invalidBaseUrl:
+            return MediaUploadTransferFailure(policy: .permanent, message: Flashcards.errorMessage(error: error))
+        case .invalidResponse(let details, let statusCode):
+            if details.code == mediaUploadResponseDecodingFailedCode {
+                return MediaUploadTransferFailure(policy: .permanent, message: Flashcards.errorMessage(error: error))
+            }
+            if details.code == "MEDIA_ASSET_UPLOAD_SESSION_EXPIRED" {
+                return MediaUploadTransferFailure(policy: .transient, message: Flashcards.errorMessage(error: error))
+            }
+            if mediaUploadAuthOrRetryStatusIsTransient(statusCode: statusCode) {
+                return MediaUploadTransferFailure(policy: .transient, message: Flashcards.errorMessage(error: error))
+            }
+            if statusCode >= 400 && statusCode < 500 {
+                return MediaUploadTransferFailure(policy: .permanent, message: Flashcards.errorMessage(error: error))
+            }
+            return MediaUploadTransferFailure(policy: .transient, message: Flashcards.errorMessage(error: error))
+        }
+    }
+    if isRetryableNetworkTransportFailure(error: error) {
+        return MediaUploadTransferFailure(policy: .transient, message: Flashcards.errorMessage(error: error))
+    }
+    if let localError = error as? LocalStoreError {
+        switch localError {
+        case .validation, .notFound:
+            return MediaUploadTransferFailure(policy: .permanent, message: Flashcards.errorMessage(error: error))
+        case .database, .uninitialized:
+            return MediaUploadTransferFailure(policy: .transient, message: Flashcards.errorMessage(error: error))
+        }
+    }
+
+    return MediaUploadTransferFailure(policy: .transient, message: Flashcards.errorMessage(error: error))
+}

--- a/apps/ios/Flashcards/Flashcards/Database/MediaAssetStore/MediaAssetStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/MediaAssetStore/MediaAssetStore.swift
@@ -56,6 +56,53 @@ struct MediaAssetStore {
         return mediaAssets.first
     }
 
+    func upsertMediaAsset(workspaceId: String, mediaAsset: MediaAsset) throws {
+        try self.core.execute(
+            sql: """
+            INSERT INTO media_assets (
+                media_asset_id,
+                workspace_id,
+                mime_type,
+                size_bytes,
+                sha256,
+                source_url,
+                created_at,
+                client_updated_at,
+                last_modified_by_replica_id,
+                last_operation_id,
+                updated_at,
+                deleted_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(workspace_id, media_asset_id) DO UPDATE SET
+                mime_type = excluded.mime_type,
+                size_bytes = excluded.size_bytes,
+                sha256 = excluded.sha256,
+                source_url = excluded.source_url,
+                created_at = excluded.created_at,
+                client_updated_at = excluded.client_updated_at,
+                last_modified_by_replica_id = excluded.last_modified_by_replica_id,
+                last_operation_id = excluded.last_operation_id,
+                updated_at = excluded.updated_at,
+                deleted_at = excluded.deleted_at
+            """,
+            values: [
+                .text(mediaAsset.mediaAssetId),
+                .text(workspaceId),
+                .text(mediaAsset.mimeType),
+                .integer(mediaAsset.sizeBytes),
+                .text(mediaAsset.sha256),
+                mediaAsset.sourceUrl.map(SQLiteValue.text) ?? .null,
+                .text(mediaAsset.createdAt),
+                .text(mediaAsset.clientUpdatedAt),
+                .text(mediaAsset.lastModifiedByReplicaId),
+                .text(mediaAsset.lastOperationId),
+                .text(mediaAsset.updatedAt),
+                mediaAsset.deletedAt.map(SQLiteValue.text) ?? .null
+            ]
+        )
+    }
+
     func mapMediaAsset(statement: OpaquePointer) -> MediaAsset {
         MediaAsset(
             mediaAssetId: DatabaseCore.columnText(statement: statement, index: 0),

--- a/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
@@ -181,6 +181,53 @@ struct MediaTransferStore {
         staleClaimedBefore: String,
         limit: Int
     ) throws -> [MediaTransferQueueEntry] {
+        try self.claimDueTransfersMatchingKind(
+            workspaceId: nil,
+            kind: nil,
+            now: now,
+            staleClaimedBefore: staleClaimedBefore,
+            limit: limit
+        )
+    }
+
+    func claimDueTransfers(
+        kind: MediaTransferKind,
+        now: String,
+        staleClaimedBefore: String,
+        limit: Int
+    ) throws -> [MediaTransferQueueEntry] {
+        try self.claimDueTransfersMatchingKind(
+            workspaceId: nil,
+            kind: kind,
+            now: now,
+            staleClaimedBefore: staleClaimedBefore,
+            limit: limit
+        )
+    }
+
+    func claimDueTransfers(
+        workspaceId: String,
+        kind: MediaTransferKind,
+        now: String,
+        staleClaimedBefore: String,
+        limit: Int
+    ) throws -> [MediaTransferQueueEntry] {
+        try self.claimDueTransfersMatchingKind(
+            workspaceId: workspaceId,
+            kind: kind,
+            now: now,
+            staleClaimedBefore: staleClaimedBefore,
+            limit: limit
+        )
+    }
+
+    private func claimDueTransfersMatchingKind(
+        workspaceId: String?,
+        kind: MediaTransferKind?,
+        now: String,
+        staleClaimedBefore: String,
+        limit: Int
+    ) throws -> [MediaTransferQueueEntry] {
         guard limit > 0 else {
             throw LocalStoreError.validation("Media transfer claim limit must be greater than zero")
         }
@@ -190,19 +237,26 @@ struct MediaTransferStore {
             value: staleClaimedBefore,
             fieldName: "Media transfer stale claimed-before timestamp"
         )
+        let normalizedWorkspaceId = try workspaceId.map { value in
+            try nonEmptyMediaTransferText(value: value, fieldName: "Media transfer workspaceId")
+        }
         return try self.core.inTransaction {
             let transferIds = try self.core.query(
                 sql: """
                 SELECT transfer_id
                 FROM media_transfer_queue
-                WHERE (
-                    status IN ('pending', 'failed')
-                    AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
-                ) OR (
-                    status = 'in_progress'
-                    AND claimed_at IS NOT NULL
-                    AND claimed_at <= ?
-                )
+                WHERE (? IS NULL OR workspace_id = ?)
+                    AND (? IS NULL OR kind = ?)
+                    AND (
+                        (
+                            status IN ('pending', 'failed')
+                            AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+                        ) OR (
+                            status = 'in_progress'
+                            AND claimed_at IS NOT NULL
+                            AND claimed_at <= ?
+                        )
+                    )
                 ORDER BY
                     CASE WHEN status = 'in_progress' THEN 0 ELSE 1 END ASC,
                     COALESCE(claimed_at, next_attempt_at, created_at) ASC,
@@ -211,6 +265,10 @@ struct MediaTransferStore {
                 LIMIT ?
                 """,
                 values: [
+                    mediaTransferOptionalTextValue(value: normalizedWorkspaceId),
+                    mediaTransferOptionalTextValue(value: normalizedWorkspaceId),
+                    mediaTransferOptionalTextValue(value: kind?.rawValue),
+                    mediaTransferOptionalTextValue(value: kind?.rawValue),
                     .text(normalizedNow),
                     .text(normalizedStaleClaimedBefore),
                     .integer(Int64(limit))
@@ -229,6 +287,8 @@ struct MediaTransferStore {
                         next_attempt_at = NULL,
                         updated_at = ?
                     WHERE transfer_id = ?
+                        AND (? IS NULL OR workspace_id = ?)
+                        AND (? IS NULL OR kind = ?)
                         AND (
                             (
                                 status IN ('pending', 'failed')
@@ -244,6 +304,10 @@ struct MediaTransferStore {
                         .text(normalizedNow),
                         .text(normalizedNow),
                         .text(transferId),
+                        mediaTransferOptionalTextValue(value: normalizedWorkspaceId),
+                        mediaTransferOptionalTextValue(value: normalizedWorkspaceId),
+                        mediaTransferOptionalTextValue(value: kind?.rawValue),
+                        mediaTransferOptionalTextValue(value: kind?.rawValue),
                         .text(normalizedNow),
                         .text(normalizedStaleClaimedBefore)
                     ]
@@ -283,6 +347,45 @@ struct MediaTransferStore {
             values: [
                 .text(normalizedUpdatedAt),
                 .text(normalizedTransferId),
+                .text(normalizedClaimedAt)
+            ]
+        )
+        guard updatedRows > 0 else {
+            try self.throwMissingActiveClaimError(transferId: normalizedTransferId)
+        }
+
+        return try self.loadTransfer(transferId: normalizedTransferId)
+    }
+
+    func renewTransferClaim(
+        transferId: String,
+        workspaceId: String,
+        kind: MediaTransferKind,
+        claimedAt: String,
+        renewedAt: String
+    ) throws -> MediaTransferQueueEntry {
+        let normalizedTransferId = try nonEmptyMediaTransferText(value: transferId, fieldName: "Media transfer id")
+        let normalizedWorkspaceId = try nonEmptyMediaTransferText(value: workspaceId, fieldName: "Media transfer workspaceId")
+        let normalizedClaimedAt = try nonEmptyMediaTransferText(value: claimedAt, fieldName: "Media transfer claimedAt")
+        let normalizedRenewedAt = try nonEmptyMediaTransferText(value: renewedAt, fieldName: "Media transfer renewedAt")
+        let updatedRows = try self.core.execute(
+            sql: """
+            UPDATE media_transfer_queue
+            SET
+                claimed_at = ?,
+                updated_at = ?
+            WHERE transfer_id = ?
+                AND workspace_id = ?
+                AND kind = ?
+                AND status = 'in_progress'
+                AND claimed_at = ?
+            """,
+            values: [
+                .text(normalizedRenewedAt),
+                .text(normalizedRenewedAt),
+                .text(normalizedTransferId),
+                .text(normalizedWorkspaceId),
+                .text(kind.rawValue),
                 .text(normalizedClaimedAt)
             ]
         )

--- a/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
@@ -64,7 +64,7 @@ struct SyncApplier {
                 return .skipped
             }
 
-            try self.upsertRemoteMediaAsset(workspaceId: workspaceId, mediaAsset: mediaAsset)
+            try mediaAssetStore.upsertMediaAsset(workspaceId: workspaceId, mediaAsset: mediaAsset)
             return SyncApplyResult(didApply: true, reviewScheduleImpact: false)
         case .workspaceSchedulerSettings(let settings):
             let existingSettings = try workspaceSettingsStore.loadWorkspaceSchedulerSettings(workspaceId: workspaceId)
@@ -313,53 +313,6 @@ struct SyncApplier {
                 .text(settings.lastOperationId),
                 .text(settings.updatedAt),
                 .text(workspaceId)
-            ]
-        )
-    }
-
-    private func upsertRemoteMediaAsset(workspaceId: String, mediaAsset: MediaAsset) throws {
-        try self.core.execute(
-            sql: """
-            INSERT INTO media_assets (
-                media_asset_id,
-                workspace_id,
-                mime_type,
-                size_bytes,
-                sha256,
-                source_url,
-                created_at,
-                client_updated_at,
-                last_modified_by_replica_id,
-                last_operation_id,
-                updated_at,
-                deleted_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(workspace_id, media_asset_id) DO UPDATE SET
-                mime_type = excluded.mime_type,
-                size_bytes = excluded.size_bytes,
-                sha256 = excluded.sha256,
-                source_url = excluded.source_url,
-                created_at = excluded.created_at,
-                client_updated_at = excluded.client_updated_at,
-                last_modified_by_replica_id = excluded.last_modified_by_replica_id,
-                last_operation_id = excluded.last_operation_id,
-                updated_at = excluded.updated_at,
-                deleted_at = excluded.deleted_at
-            """,
-            values: [
-                .text(mediaAsset.mediaAssetId),
-                .text(workspaceId),
-                .text(mediaAsset.mimeType),
-                .integer(mediaAsset.sizeBytes),
-                .text(mediaAsset.sha256),
-                mediaAsset.sourceUrl.map(SQLiteValue.text) ?? .null,
-                .text(mediaAsset.createdAt),
-                .text(mediaAsset.clientUpdatedAt),
-                .text(mediaAsset.lastModifiedByReplicaId),
-                .text(mediaAsset.lastOperationId),
-                .text(mediaAsset.updatedAt),
-                mediaAsset.deletedAt.map(SQLiteValue.text) ?? .null
             ]
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
@@ -138,6 +138,36 @@ protocol CloudSyncServing {
         workspaceId: String,
         mediaAssetId: String
     ) async throws -> MediaAssetDownloadURLResponse
+    func createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: MediaAssetUploadSessionCreateRequest
+    ) async throws -> MediaAssetUploadSessionCreateResponse
+    func loadMediaAssetUploadPartURLs(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadPartURLsRequest
+    ) async throws -> MediaAssetUploadPartURLsResponse
+    func completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadSessionCompleteRequest
+    ) async throws -> MediaAssetUploadSessionCompleteResponse
+    func abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ) async throws -> MediaAssetUploadSessionAbortResponse
+    func uploadMediaAssetPart(
+        partURL: MediaAssetUploadPartURL,
+        body: Data
+    ) async throws -> String
     func previewWorkspacePackageExport(
         apiBaseUrl: String,
         authorizationHeader: String,
@@ -211,6 +241,71 @@ extension CloudSyncServing {
         _ = workspaceId
         _ = mediaAssetId
         throw LocalStoreError.validation("Media asset download URL loading is unavailable")
+    }
+
+    func createMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        request: MediaAssetUploadSessionCreateRequest
+    ) async throws -> MediaAssetUploadSessionCreateResponse {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        _ = workspaceId
+        _ = request
+        throw LocalStoreError.validation("Media asset upload session creation is unavailable")
+    }
+
+    func loadMediaAssetUploadPartURLs(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadPartURLsRequest
+    ) async throws -> MediaAssetUploadPartURLsResponse {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        _ = workspaceId
+        _ = sessionId
+        _ = request
+        throw LocalStoreError.validation("Media asset upload part URL loading is unavailable")
+    }
+
+    func completeMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String,
+        request: MediaAssetUploadSessionCompleteRequest
+    ) async throws -> MediaAssetUploadSessionCompleteResponse {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        _ = workspaceId
+        _ = sessionId
+        _ = request
+        throw LocalStoreError.validation("Media asset upload session completion is unavailable")
+    }
+
+    func abortMediaAssetUploadSession(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        sessionId: String
+    ) async throws -> MediaAssetUploadSessionAbortResponse {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        _ = workspaceId
+        _ = sessionId
+        throw LocalStoreError.validation("Media asset upload session abort is unavailable")
+    }
+
+    func uploadMediaAssetPart(
+        partURL: MediaAssetUploadPartURL,
+        body: Data
+    ) async throws -> String {
+        _ = partURL
+        _ = body
+        throw LocalStoreError.validation("Media asset upload part PUT is unavailable")
     }
 
     func previewWorkspacePackageExport(


### PR DESCRIPTION
## Summary
- Add an upload-only iOS media transfer runner for queued managed media uploads.
- Plan uploads from app-private local files and validate exact whole-file and per-part SHA-256 values before sending bytes.
- Implement the backend multipart upload session flow: create session, request signed part URLs, signed PUT parts, complete sessions, and abort active sessions when completion is not known to have succeeded.
- Keep signed part URLs transient in memory only; no signed URLs, S3 keys, blob ids, or large bytes are stored in SQLite.
- Add upload claim renewal and workspace single-flight behavior to avoid duplicate long-running uploads while preserving stale abandoned-job recovery.
- Treat API 401/auth-context failures, part PUT 401 failures, and transient abort-combination failures as retryable while keeping true contract/client errors permanent.

## Validation
- git --no-pager diff --check: passed.
- xcrun swiftc -parse on all modified/new Swift files: passed.
- Final review found no P0-P4 issues and no split recommendation.
- No simulator-backed tests were run because they were not allowed for this task.
- Full local Xcode compile remains blocked by the accepted local iOS 26.5 destination/platform issue.