### PR TITLE
Fix Android workspace import visibility

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModel.kt
@@ -144,7 +144,7 @@ class WorkspaceImportViewModel(
         return previewRequestId
     }
 
-    fun previewSelectedFile(selectedFile: WorkspaceImportSelectedFile) {
+    internal fun previewSelectedFile(selectedFile: WorkspaceImportSelectedFile) {
         val previewRequestId: Long = beginPreviewRequest()
         previewSelectedFile(
             previewRequestId = previewRequestId,
@@ -152,7 +152,7 @@ class WorkspaceImportViewModel(
         )
     }
 
-    fun previewSelectedFile(
+    internal fun previewSelectedFile(
         previewRequestId: Long,
         selectedFile: WorkspaceImportSelectedFile
     ) {


### PR DESCRIPTION
## Summary
- make workspace import selected-file ViewModel entrypoints internal so they do not expose an internal parameter type

## Validation
- inspected failing Android Release logs: :feature:settings:compileDebugKotlin failed because public functions exposed internal WorkspaceImportSelectedFile
- local ./gradlew not run per repo instruction requiring explicit permission for Gradle runs