### PR TITLE
Split catalog source workflows

### DIFF
--- a/apps/backend/src/catalog/authoring/authors.ts
+++ b/apps/backend/src/catalog/authoring/authors.ts
@@ -1,21 +1,21 @@
-import type { DatabaseExecutor } from "../database";
-import { unsafeTransaction } from "../database/core";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor } from "../../database";
+import { unsafeTransaction } from "../../database/core";
+import { HttpError } from "../../shared/errors";
 import {
   normalizeNonEmptyString,
   normalizeNullableString,
   normalizeSlug,
-} from "./common";
-import { rethrowCatalogPersistenceError } from "./errors";
+} from "../common";
+import { rethrowCatalogPersistenceError } from "../errors";
 import {
   catalogAuthorColumns,
   mapCatalogAuthorRow,
-} from "./rows";
+} from "../rows";
 import type {
   CatalogAuthor,
   CatalogAuthorRow,
   UpsertCatalogAuthorInput,
-} from "./types";
+} from "../types";
 
 function normalizeCatalogAuthorInput(input: UpsertCatalogAuthorInput): UpsertCatalogAuthorInput {
   return {

--- a/apps/backend/src/catalog/authoring/draftMedia.ts
+++ b/apps/backend/src/catalog/authoring/draftMedia.ts
@@ -1,22 +1,22 @@
-import type { DatabaseExecutor } from "../database";
-import { unsafeTransaction } from "../database/core";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor } from "../../database";
+import { unsafeTransaction } from "../../database/core";
+import { HttpError } from "../../shared/errors";
 import {
   normalizeNullableString,
   normalizePackageMediaKey,
-} from "./common";
-import { rethrowCatalogPersistenceError } from "./errors";
+} from "../common";
+import { rethrowCatalogPersistenceError } from "../errors";
 import {
   catalogPackageMediaAssetColumns,
   lockCatalogPackageInExecutor,
   mapCatalogPackageMediaAssetRow,
-} from "./rows";
+} from "../rows";
 import type {
   AttachCatalogPackageMediaAssetInput,
   CatalogPackageMediaAsset,
   CatalogPackageMediaAssetRow,
   CatalogPackageVersionMediaAssetInput,
-} from "./types";
+} from "../types";
 
 type PackageMediaKeyRow = Readonly<{ package_media_key: string }>;
 

--- a/apps/backend/src/catalog/authoring/drafts.ts
+++ b/apps/backend/src/catalog/authoring/drafts.ts
@@ -1,21 +1,21 @@
-import type { DatabaseExecutor } from "../database";
-import { unsafeTransaction } from "../database/core";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor } from "../../database";
+import { unsafeTransaction } from "../../database/core";
+import { HttpError } from "../../shared/errors";
 import {
   normalizeNonEmptyString,
   normalizeNullableString,
   normalizePackageMediaKey,
   normalizeSlug,
   normalizeTextArray,
-} from "./common";
+} from "../common";
 import { assertDraftMediaKeysExistInExecutor } from "./draftMedia";
-import { rethrowCatalogPersistenceError } from "./errors";
+import { rethrowCatalogPersistenceError } from "../errors";
 import {
   catalogPackageColumns,
   catalogPackageMediaAssetColumns,
   mapCatalogPackageMediaAssetRow,
   mapCatalogPackageRow,
-} from "./rows";
+} from "../rows";
 import type {
   CatalogPackage,
   CatalogPackageDraft,
@@ -23,7 +23,7 @@ import type {
   CatalogPackageRow,
   CreateCatalogPackageDraftInput,
   UpdateCatalogPackageDraftInput,
-} from "./types";
+} from "../types";
 
 function normalizeCreateCatalogPackageDraftInput(
   input: CreateCatalogPackageDraftInput,

--- a/apps/backend/src/catalog/authoring/versions.ts
+++ b/apps/backend/src/catalog/authoring/versions.ts
@@ -2,9 +2,9 @@ import { randomUUID } from "node:crypto";
 import {
   applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
-} from "../database";
-import { unsafeTransaction } from "../database/core";
-import { HttpError } from "../shared/errors";
+} from "../../database";
+import { unsafeTransaction } from "../../database/core";
+import { HttpError } from "../../shared/errors";
 import {
   normalizeAdminEmail,
   normalizeNonEmptyString,
@@ -12,22 +12,22 @@ import {
   normalizePackageMediaKey,
   normalizeTextArray,
   toSafeNumber,
-} from "./common";
+} from "../common";
 import {
   assertDraftMediaKeysExistInExecutor,
   insertCatalogPackageVersionMediaAssetsInExecutor,
   loadCatalogPackageDraftMediaKeysInExecutor,
 } from "./draftMedia";
-import { rethrowCatalogPersistenceError } from "./errors";
+import { rethrowCatalogPersistenceError } from "../errors";
 import {
   catalogPackageVersionColumns,
   lockCatalogPackageInExecutor,
   mapCatalogPackageVersionRow,
-} from "./rows";
+} from "../rows";
 import {
   extractMarkdownFcAssetIds,
   rewriteMarkdownFcAssetUrlsToFcAssets,
-} from "../workspacePackages";
+} from "../../workspacePackages";
 import type {
   CatalogPackageCardSnapshotInput,
   CatalogPackageStatus,
@@ -38,7 +38,7 @@ import type {
   CreateCatalogPackageVersionFromWorkspaceInput,
   CreateCatalogPackageVersionInput,
   UpdateCatalogPackageVersionStatusInput,
-} from "./types";
+} from "../types";
 
 const reviewStatusRouteTargets: ReadonlySet<CatalogPackageStatus> = new Set([
   "draft",

--- a/apps/backend/src/catalog/distribution/install.ts
+++ b/apps/backend/src/catalog/distribution/install.ts
@@ -3,24 +3,24 @@ import {
   transactionWithWorkspaceScope,
   transactionWithWorkspaceScopeReadOnly,
   type DatabaseExecutor,
-} from "../database";
-import type { CardMetadata, CardSourceMetadata } from "../cards/types";
-import { normalizeCardMetadata } from "../cards/shared";
-import { assertReplicaBelongsToWorkspaceInExecutor } from "../mediaAssets/workspaceReplicas";
-import { HttpError } from "../shared/errors";
-import { normalizeIsoTimestamp } from "../sync/conflicts/lww";
+} from "../../database";
+import type { CardMetadata, CardSourceMetadata } from "../../cards/types";
+import { normalizeCardMetadata } from "../../cards/shared";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
+import { HttpError } from "../../shared/errors";
+import { normalizeIsoTimestamp } from "../../sync/conflicts/lww";
 import {
   insertSyncChange,
   lockWorkspaceSyncMetadataForHotChangesInExecutor,
   type HotChangeWriteLock,
-} from "../sync/replication/changes";
-import { rewriteMarkdownFcAssetUrlsToFcAssets } from "../workspacePackages";
+} from "../../sync/replication/changes";
+import { rewriteMarkdownFcAssetUrlsToFcAssets } from "../../workspacePackages";
 import {
   normalizeNonEmptyString,
   toIsoString,
   toOptionalIsoString,
   toSafeNumber,
-} from "./common";
+} from "../common";
 import type {
   CatalogPackageStatus,
   TimestampValue,
@@ -30,7 +30,7 @@ import type {
   CatalogPackageInstallPackageVersion,
   CatalogInstalledCard,
   CatalogInstalledMediaAsset,
-} from "./types";
+} from "../types";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 

--- a/apps/backend/src/catalog/distribution/public.ts
+++ b/apps/backend/src/catalog/distribution/public.ts
@@ -1,6 +1,6 @@
-import type { DatabaseExecutor, SqlValue } from "../database";
-import { unsafeRepeatableReadReadOnlyTransaction } from "../database/core";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { unsafeRepeatableReadReadOnlyTransaction } from "../../database/core";
+import { HttpError } from "../../shared/errors";
 import {
   containsUnsafePublicPackageMediaReference,
   isUnsafePublicPackageMediaDestination,
@@ -10,11 +10,11 @@ import {
   normalizeSlug,
   toIsoString,
   toSafeNumber,
-} from "./common";
+} from "../common";
 import {
   extractMarkdownLinkDestinationUrls,
   extractMarkdownNonCodeTextSegments,
-} from "../workspacePackages";
+} from "../../workspacePackages";
 import type {
   CatalogPublicAuthor,
   CatalogPublicPackageCardPreview,
@@ -26,7 +26,7 @@ import type {
   CatalogPublicPackageSummary,
   CatalogPublicPackageVersionSummary,
   TimestampValue,
-} from "./types";
+} from "../types";
 
 type PublicCatalogQuery = Readonly<{
   text: string;

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -3,11 +3,11 @@ export {
   createCatalogAuthorInExecutor,
   updateCatalogAuthor,
   updateCatalogAuthorInExecutor,
-} from "./authors";
+} from "./authoring/authors";
 export {
   attachCatalogPackageDraftMediaAsset,
   attachCatalogPackageDraftMediaAssetInExecutor,
-} from "./draftMedia";
+} from "./authoring/draftMedia";
 export {
   createCatalogPackageDraft,
   createCatalogPackageDraftInExecutor,
@@ -15,7 +15,7 @@ export {
   loadCatalogPackageDraftInExecutor,
   updateCatalogPackageDraft,
   updateCatalogPackageDraftInExecutor,
-} from "./drafts";
+} from "./authoring/drafts";
 export {
   assertCatalogPackageVersionStatusTransitionAllowed,
   createCatalogPackageVersionFromCards,
@@ -29,7 +29,7 @@ export {
   publishCatalogPackageVersionInExecutor,
   updateCatalogPackageVersionReviewStatus,
   updateCatalogPackageVersionReviewStatusInExecutor,
-} from "./versions";
+} from "./authoring/versions";
 export {
   listPublicCatalogPackages,
   listPublicCatalogPackagesInExecutor,
@@ -39,10 +39,10 @@ export {
   loadPublicCatalogPackageMediaForDownloadInExecutor,
   loadPublicCatalogPackageVersionCardPreview,
   loadPublicCatalogPackageVersionCardPreviewInExecutor,
-} from "./public";
+} from "./distribution/public";
 export {
   installCatalogPackageVersion,
   installCatalogPackageVersionInExecutor,
   previewCatalogPackageInstall,
   previewCatalogPackageInstallInExecutor,
-} from "./install";
+} from "./distribution/install";


### PR DESCRIPTION
## Summary
- move catalog authoring/admin source files into catalog/authoring
- move catalog public/install source files into catalog/distribution
- preserve the catalog barrel exports from catalog/index.ts

## Validation
- npm --prefix apps/backend run lint
- cd apps/backend && node --test --import tsx src/catalog/index.test.ts
- git --no-pager diff --check