### PR TITLE
Add mobile app promotion dialog

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -12,6 +12,7 @@
         "fflate": "^0.8.3",
         "heic-to": "^1.5.2",
         "lottie-web": "^5.13.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
@@ -3493,6 +3494,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "fflate": "^0.8.3",
     "heic-to": "^1.5.2",
     "lottie-web": "^5.13.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -786,6 +786,21 @@ const arCatalog: TranslationCatalog = {
     dismiss: "فهمت",
     title: "تذكير سريع",
   },
+  mobileAppPromo: {
+    title: "راجع على هاتفك",
+    body: "ثبّت تطبيق iOS أو Android لمتابعة المراجعة بسرعة مع الوصول دون اتصال.",
+    close: "إغلاق",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "افتح تطبيق iOS في App Store",
+      qrLabel: "رمز QR لرابط تطبيق iOS",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "افتح تطبيق Android في Google Play",
+      qrLabel: "رمز QR لرابط تطبيق Android",
+    },
+  },
   feedback: {
     title: "هل لديك فكرة لـ Flashcards؟",
     body: "شارك ما قد يجعل التطبيق أفضل. يقرأ المنشئ كل رسالة شخصيًا.",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -786,6 +786,21 @@ const deCatalog: TranslationCatalog = {
     dismiss: "Verstanden",
     title: "Kurze Erinnerung",
   },
+  mobileAppPromo: {
+    title: "Auf dem Smartphone wiederholen",
+    body: "Installiere die iOS- oder Android-App, um schnell mit Offline-Zugriff weiterzulernen.",
+    close: "Schließen",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "iOS-App im App Store öffnen",
+      qrLabel: "QR-Code für den iOS-App-Link",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "Android-App in Google Play öffnen",
+      qrLabel: "QR-Code für den Android-App-Link",
+    },
+  },
   feedback: {
     title: "Hast du eine Idee für Flashcards?",
     body: "Teile, was die App besser machen würde. Der Ersteller liest jede Nachricht persönlich.",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -784,6 +784,21 @@ const enCatalog = {
     dismiss: "Got it",
     title: "Quick reminder",
   },
+  mobileAppPromo: {
+    title: "Review on your phone",
+    body: "Install the iOS or Android app to keep reviewing quickly with offline access.",
+    close: "Close",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "Open iOS app in the App Store",
+      qrLabel: "QR code for the iOS app link",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "Open Android app in Google Play",
+      qrLabel: "QR code for the Android app link",
+    },
+  },
   feedback: {
     title: "Have an idea for Flashcards?",
     body: "Share what would make the app better. The creator reads every message personally.",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -786,6 +786,21 @@ const esEsCatalog: TranslationCatalog = {
     dismiss: "Entendido",
     title: "Recordatorio rápido",
   },
+  mobileAppPromo: {
+    title: "Repasa en tu móvil",
+    body: "Instala la app para iOS o Android para seguir repasando rápido con acceso sin conexión.",
+    close: "Cerrar",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "Abrir la app de iOS en App Store",
+      qrLabel: "Código QR para el enlace de la app de iOS",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "Abrir la app de Android en Google Play",
+      qrLabel: "Código QR para el enlace de la app de Android",
+    },
+  },
   feedback: {
     title: "¿Tienes una idea para Flashcards?",
     body: "Comparte qué mejoraría la app. El creador lee personalmente cada mensaje.",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -786,6 +786,21 @@ const esMxCatalog: TranslationCatalog = {
     dismiss: "Entendido",
     title: "Recordatorio rápido",
   },
+  mobileAppPromo: {
+    title: "Repasa en tu celular",
+    body: "Instala la app para iOS o Android para seguir repasando rápido con acceso sin conexión.",
+    close: "Cerrar",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "Abrir la app de iOS en App Store",
+      qrLabel: "Código QR para el enlace de la app de iOS",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "Abrir la app de Android en Google Play",
+      qrLabel: "Código QR para el enlace de la app de Android",
+    },
+  },
   feedback: {
     title: "¿Tienes una idea para Flashcards?",
     body: "Comparte qué mejoraría la app. El creador lee personalmente cada mensaje.",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -786,6 +786,21 @@ const hiCatalog: TranslationCatalog = {
     dismiss: "समझ गया",
     title: "त्वरित याद दिलाना",
   },
+  mobileAppPromo: {
+    title: "अपने फोन पर रिव्यू करें",
+    body: "ऑफलाइन एक्सेस के साथ तेजी से रिव्यू जारी रखने के लिए iOS या Android ऐप इंस्टॉल करें.",
+    close: "बंद करें",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "App Store में iOS ऐप खोलें",
+      qrLabel: "iOS ऐप लिंक का QR कोड",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "Google Play में Android ऐप खोलें",
+      qrLabel: "Android ऐप लिंक का QR कोड",
+    },
+  },
   feedback: {
     title: "Flashcards के लिए कोई विचार है?",
     body: "ऐप को बेहतर बनाने वाली बात साझा करें। निर्माता हर संदेश खुद पढ़ता है।",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -786,6 +786,21 @@ export const jaCatalog = {
     dismiss: "了解",
     title: "クイックリマインダー",
   },
+  mobileAppPromo: {
+    title: "スマートフォンで復習",
+    body: "iOS または Android アプリをインストールして、オフラインでもすばやく復習できます。",
+    close: "閉じる",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "App Store で iOS アプリを開く",
+      qrLabel: "iOS アプリリンクの QR コード",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "Google Play で Android アプリを開く",
+      qrLabel: "Android アプリリンクの QR コード",
+    },
+  },
   feedback: {
     title: "Flashcards へのアイデアがありますか？",
     body: "アプリをより良くするための意見を共有してください。作成者がすべてのメッセージを直接読みます。",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -786,6 +786,21 @@ export const ruCatalog = {
     dismiss: "Понятно",
     title: "Короткое напоминание",
   },
+  mobileAppPromo: {
+    title: "Повторяйте на телефоне",
+    body: "Установите приложение для iOS или Android, чтобы быстро повторять карточки с офлайн-доступом.",
+    close: "Закрыть",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "Открыть приложение для iOS в App Store",
+      qrLabel: "QR-код для ссылки на приложение iOS",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "Открыть приложение для Android в Google Play",
+      qrLabel: "QR-код для ссылки на приложение Android",
+    },
+  },
   feedback: {
     title: "Есть идея для Flashcards?",
     body: "Расскажите, что сделало бы приложение лучше. Создатель лично читает каждое сообщение.",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -786,6 +786,21 @@ export const zhHansCatalog = {
     dismiss: "知道了",
     title: "快速提醒",
   },
+  mobileAppPromo: {
+    title: "在手机上复习",
+    body: "安装 iOS 或 Android 应用，在离线时也能快速继续复习。",
+    close: "关闭",
+    ios: {
+      title: "iOS",
+      storeLinkLabel: "在 App Store 打开 iOS 应用",
+      qrLabel: "iOS 应用链接的二维码",
+    },
+    android: {
+      title: "Android",
+      storeLinkLabel: "在 Google Play 打开 Android 应用",
+      qrLabel: "Android 应用链接的二维码",
+    },
+  },
   feedback: {
     title: "对 Flashcards 有想法吗？",
     body: "告诉我们什么能让应用更好。创建者会亲自阅读每条消息。",

--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
@@ -1,0 +1,263 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import ReactDOM from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../../api/ApiTestSupport";
+import { I18nProvider } from "../../../i18n";
+import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../../i18n/runtime";
+import {
+  MobileAppPromotionDialog,
+  type MobileAppPromotionDialogProps,
+  webReviewMobilePromptStoreLinks,
+} from "./MobileAppPromotionDialog";
+
+function requireElement(container: HTMLElement, selector: string): HTMLElement {
+  const element = container.querySelector(selector);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Expected element for selector "${selector}"`);
+  }
+
+  return element;
+}
+
+function requireAnchor(container: HTMLElement, selector: string): HTMLAnchorElement {
+  const element = container.querySelector(selector);
+  if (!(element instanceof HTMLAnchorElement)) {
+    throw new Error(`Expected anchor for selector "${selector}"`);
+  }
+
+  return element;
+}
+
+function requireSvg(container: HTMLElement, selector: string): SVGSVGElement {
+  const element = container.querySelector(selector);
+  if (!(element instanceof SVGSVGElement)) {
+    throw new Error(`Expected SVG for selector "${selector}"`);
+  }
+
+  return element;
+}
+
+async function dispatchWindowKeyDown(key: string, shiftKey: boolean): Promise<void> {
+  await act(async () => {
+    window.dispatchEvent(new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key,
+      shiftKey,
+    }));
+  });
+}
+
+describe("MobileAppPromotionDialog", () => {
+  let container: HTMLDivElement;
+  let root: ReactDOM.Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+    window.localStorage.setItem(LOCALE_PREFERENCE_STORAGE_KEY, "en");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+  });
+
+  async function renderDialog(props: MobileAppPromotionDialogProps): Promise<void> {
+    await act(async () => {
+      root.render(
+        <I18nProvider>
+          <MobileAppPromotionDialog {...props} />
+        </I18nProvider>,
+      );
+    });
+  }
+
+  it("does not render while closed", async () => {
+    await renderDialog({
+      isOpen: false,
+      onDismiss: () => undefined,
+      storeLinks: webReviewMobilePromptStoreLinks,
+    });
+
+    expect(container.querySelector("[data-testid='mobile-app-promo-dialog']")).toBeNull();
+    expect(container.querySelector("[role='dialog']")).toBeNull();
+  });
+
+  it("renders an accessible dialog and dismisses from the close button", async () => {
+    const onDismiss = vi.fn<() => void>();
+
+    await renderDialog({
+      isOpen: true,
+      onDismiss,
+      storeLinks: webReviewMobilePromptStoreLinks,
+    });
+
+    const dialog = requireElement(container, "[data-testid='mobile-app-promo-dialog']");
+    expect(dialog.getAttribute("role")).toBe("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+
+    const labelledBy = dialog.getAttribute("aria-labelledby");
+    const describedBy = dialog.getAttribute("aria-describedby");
+    expect(labelledBy).toBe("mobile-app-promo-title");
+    expect(describedBy).toBe("mobile-app-promo-body");
+    expect(document.getElementById(labelledBy as string)?.textContent).toBe("Review on your phone");
+    expect(document.getElementById(describedBy as string)?.textContent).toContain("offline access");
+
+    const closeButton = requireElement(container, "[data-testid='mobile-app-promo-close']");
+    expect(closeButton.getAttribute("aria-label")).toBe("Close");
+
+    await act(async () => {
+      closeButton.click();
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves focus into the dialog, dismisses on Escape, and restores prior focus on close", async () => {
+    const onDismiss = vi.fn<() => void>();
+    const previousFocusButton = document.createElement("button");
+    previousFocusButton.type = "button";
+    previousFocusButton.setAttribute("data-testid", "mobile-app-promo-trigger");
+    document.body.appendChild(previousFocusButton);
+
+    try {
+      previousFocusButton.focus();
+      expect(document.activeElement).toBe(previousFocusButton);
+
+      await renderDialog({
+        isOpen: true,
+        onDismiss,
+        storeLinks: webReviewMobilePromptStoreLinks,
+      });
+
+      const closeButton = requireElement(container, "[data-testid='mobile-app-promo-close']");
+      expect(document.activeElement).toBe(closeButton);
+
+      await dispatchWindowKeyDown("Escape", false);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+
+      await renderDialog({
+        isOpen: false,
+        onDismiss,
+        storeLinks: webReviewMobilePromptStoreLinks,
+      });
+
+      expect(document.activeElement).toBe(previousFocusButton);
+    } finally {
+      previousFocusButton.remove();
+    }
+  });
+
+  it("traps tab focus within the dialog", async () => {
+    await renderDialog({
+      isOpen: true,
+      onDismiss: () => undefined,
+      storeLinks: webReviewMobilePromptStoreLinks,
+    });
+
+    const closeButton = requireElement(container, "[data-testid='mobile-app-promo-close']");
+    const androidVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-android']");
+
+    androidVisibleUrl.focus();
+    await dispatchWindowKeyDown("Tab", false);
+    expect(document.activeElement).toBe(closeButton);
+
+    closeButton.focus();
+    await dispatchWindowKeyDown("Tab", true);
+    expect(document.activeElement).toBe(androidVisibleUrl);
+  });
+
+  it("renders store links, platform test ids, and QR output for each platform", async () => {
+    await renderDialog({
+      isOpen: true,
+      onDismiss: () => undefined,
+      storeLinks: webReviewMobilePromptStoreLinks,
+    });
+
+    const platformTestIds: ReadonlyArray<string> = Array.from(
+      container.querySelectorAll("[data-testid^='mobile-app-promo-platform-']"),
+    ).map((element) => {
+      const testId = element.getAttribute("data-testid");
+      if (testId === null) {
+        throw new Error("Expected platform test id");
+      }
+
+      return testId;
+    });
+    expect(platformTestIds).toEqual([
+      "mobile-app-promo-platform-ios",
+      "mobile-app-promo-platform-android",
+    ]);
+
+    const iosPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-ios']");
+    const androidPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-android']");
+    expect(iosPlatform.compareDocumentPosition(androidPlatform) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+
+    const iosBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-ios']");
+    const androidBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-android']");
+    const iosVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-ios']");
+    const androidVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-android']");
+
+    expect(iosBadgeLink.href).toBe(webReviewMobilePromptStoreLinks.ios);
+    expect(androidBadgeLink.href).toBe(webReviewMobilePromptStoreLinks.android);
+    expect(iosVisibleUrl.href).toBe(webReviewMobilePromptStoreLinks.ios);
+    expect(androidVisibleUrl.href).toBe(webReviewMobilePromptStoreLinks.android);
+    expect(iosVisibleUrl.textContent).toBe(webReviewMobilePromptStoreLinks.ios);
+    expect(androidVisibleUrl.textContent).toBe(webReviewMobilePromptStoreLinks.android);
+
+    const iosQr = requireSvg(container, "[data-testid='mobile-app-promo-qr-ios']");
+    const androidQr = requireSvg(container, "[data-testid='mobile-app-promo-qr-android']");
+
+    expect(iosQr.getAttribute("role")).toBe("img");
+    expect(androidQr.getAttribute("role")).toBe("img");
+    expect(iosQr.querySelector("title")?.textContent).toBe("QR code for the iOS app link");
+    expect(androidQr.querySelector("title")?.textContent).toBe("QR code for the Android app link");
+    expect(iosQr.querySelectorAll("path[d]").length).toBeGreaterThanOrEqual(2);
+    expect(androidQr.querySelectorAll("path[d]").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("keeps desktop platform placement left-to-right for rtl locales", async () => {
+    window.localStorage.setItem(LOCALE_PREFERENCE_STORAGE_KEY, "ar");
+
+    await renderDialog({
+      isOpen: true,
+      onDismiss: () => undefined,
+      storeLinks: webReviewMobilePromptStoreLinks,
+    });
+
+    expect(document.documentElement.dir).toBe("rtl");
+
+    const platformGrid = requireElement(container, "[data-testid='mobile-app-promo-platforms']");
+    const iosPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-ios']");
+    const androidPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-android']");
+    const iosPlatformContent = requireElement(container, "[data-testid='mobile-app-promo-content-ios']");
+    const androidPlatformContent = requireElement(container, "[data-testid='mobile-app-promo-content-android']");
+    const iosVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-ios']");
+    const androidVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-android']");
+
+    expect(platformGrid.getAttribute("dir")).toBe("ltr");
+    expect(iosPlatform.getAttribute("dir")).toBe("ltr");
+    expect(androidPlatform.getAttribute("dir")).toBe("ltr");
+    expect(iosPlatformContent.getAttribute("dir")).toBe("rtl");
+    expect(androidPlatformContent.getAttribute("dir")).toBe("rtl");
+    expect(iosVisibleUrl.getAttribute("dir")).toBe("ltr");
+    expect(androidVisibleUrl.getAttribute("dir")).toBe("ltr");
+    expect(iosPlatform.compareDocumentPosition(androidPlatform) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+});

--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useRef, type ReactElement } from "react";
+import { useI18n } from "../../../i18n";
+import {
+  AppStoreBadge,
+  GooglePlayBadge,
+  type AppPlatformStoreLinks,
+} from "../../share/AppPlatformLinks";
+import { MobileAppQrCode } from "./MobileAppQrCode";
+
+export type MobileAppPromotionDialogProps = Readonly<{
+  isOpen: boolean;
+  onDismiss: () => void;
+  storeLinks: AppPlatformStoreLinks;
+}>;
+
+export const webReviewMobilePromptStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=web_review_mobile_prompt&mt=8",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=web_review_mobile_prompt",
+};
+
+const mobileAppPromotionFocusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusableElements(dialog: HTMLElement): ReadonlyArray<HTMLElement> {
+  return Array.from(dialog.querySelectorAll<HTMLElement>(mobileAppPromotionFocusableSelector))
+    .filter((element) => element.tabIndex >= 0 && element.getAttribute("aria-hidden") !== "true");
+}
+
+function trapFocusInsideDialog(event: KeyboardEvent, dialog: HTMLElement): void {
+  const focusableElements = getFocusableElements(dialog);
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  if (firstElement === undefined || lastElement === undefined) {
+    event.preventDefault();
+    dialog.focus();
+    return;
+  }
+
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement) || dialog.contains(activeElement) === false) {
+    event.preventDefault();
+    if (event.shiftKey) {
+      lastElement.focus();
+      return;
+    }
+
+    firstElement.focus();
+    return;
+  }
+
+  if (event.shiftKey && activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus();
+    return;
+  }
+
+  if (!event.shiftKey && activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus();
+  }
+}
+
+export function MobileAppPromotionDialog(props: MobileAppPromotionDialogProps): ReactElement | null {
+  const { isOpen, onDismiss, storeLinks } = props;
+  const { direction, t } = useI18n();
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLElement | null>(null);
+  const onDismissRef = useRef(onDismiss);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (isOpen === false) {
+      return undefined;
+    }
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    closeButtonRef.current?.focus();
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        onDismissRef.current();
+        return;
+      }
+
+      if (event.key === "Tab" && dialogRef.current !== null) {
+        trapFocusInsideDialog(event, dialogRef.current);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return (): void => {
+      window.removeEventListener("keydown", handleKeyDown);
+      const previousFocus = previousFocusRef.current;
+      if (previousFocus !== null && previousFocus.isConnected) {
+        previousFocus.focus();
+      }
+      previousFocusRef.current = null;
+    };
+  }, [isOpen]);
+
+  if (isOpen === false) {
+    return null;
+  }
+
+  return (
+    <div className="mobile-app-promo-overlay">
+      <section
+        ref={dialogRef}
+        className="panel mobile-app-promo-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mobile-app-promo-title"
+        aria-describedby="mobile-app-promo-body"
+        tabIndex={-1}
+        data-testid="mobile-app-promo-dialog"
+      >
+        <div className="mobile-app-promo-header">
+          <div>
+            <h2 id="mobile-app-promo-title" className="title">{t("mobileAppPromo.title")}</h2>
+            <p id="mobile-app-promo-body" className="subtitle mobile-app-promo-body">
+              {t("mobileAppPromo.body")}
+            </p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="ghost-btn mobile-app-promo-close"
+            aria-label={t("mobileAppPromo.close")}
+            onClick={onDismiss}
+            data-testid="mobile-app-promo-close"
+          >
+            {t("mobileAppPromo.close")}
+          </button>
+        </div>
+
+        <div className="mobile-app-promo-platforms" dir="ltr" data-testid="mobile-app-promo-platforms">
+          <section
+            className="mobile-app-promo-platform"
+            aria-labelledby="mobile-app-promo-ios-title"
+            dir="ltr"
+            data-testid="mobile-app-promo-platform-ios"
+          >
+            <div
+              className="mobile-app-promo-platform-content"
+              dir={direction}
+              data-testid="mobile-app-promo-content-ios"
+            >
+              <h3 id="mobile-app-promo-ios-title" className="mobile-app-promo-platform-title">
+                {t("mobileAppPromo.ios.title")}
+              </h3>
+              <a
+                className="mobile-app-promo-badge-link"
+                href={storeLinks.ios}
+                rel="noreferrer"
+                target="_blank"
+                aria-label={t("mobileAppPromo.ios.storeLinkLabel")}
+                data-testid="mobile-app-promo-badge-ios"
+              >
+                <AppStoreBadge />
+              </a>
+              <a
+                className="mobile-app-promo-url"
+                href={storeLinks.ios}
+                rel="noreferrer"
+                target="_blank"
+                dir="ltr"
+                data-testid="mobile-app-promo-url-ios"
+              >
+                {storeLinks.ios}
+              </a>
+              <div className="mobile-app-promo-qr-frame">
+                <MobileAppQrCode
+                  title={t("mobileAppPromo.ios.qrLabel")}
+                  value={storeLinks.ios}
+                  testId="mobile-app-promo-qr-ios"
+                />
+              </div>
+            </div>
+          </section>
+
+          <section
+            className="mobile-app-promo-platform"
+            aria-labelledby="mobile-app-promo-android-title"
+            dir="ltr"
+            data-testid="mobile-app-promo-platform-android"
+          >
+            <div
+              className="mobile-app-promo-platform-content"
+              dir={direction}
+              data-testid="mobile-app-promo-content-android"
+            >
+              <h3 id="mobile-app-promo-android-title" className="mobile-app-promo-platform-title">
+                {t("mobileAppPromo.android.title")}
+              </h3>
+              <a
+                className="mobile-app-promo-badge-link"
+                href={storeLinks.android}
+                rel="noreferrer"
+                target="_blank"
+                aria-label={t("mobileAppPromo.android.storeLinkLabel")}
+                data-testid="mobile-app-promo-badge-android"
+              >
+                <GooglePlayBadge />
+              </a>
+              <a
+                className="mobile-app-promo-url"
+                href={storeLinks.android}
+                rel="noreferrer"
+                target="_blank"
+                dir="ltr"
+                data-testid="mobile-app-promo-url-android"
+              >
+                {storeLinks.android}
+              </a>
+              <div className="mobile-app-promo-qr-frame">
+                <MobileAppQrCode
+                  title={t("mobileAppPromo.android.qrLabel")}
+                  value={storeLinks.android}
+                  testId="mobile-app-promo-qr-android"
+                />
+              </div>
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppQrCode.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppQrCode.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from "react";
+import { QRCodeSVG } from "qrcode.react";
+
+type MobileAppQrCodeProps = Readonly<{
+  title: string;
+  testId: string;
+  value: string;
+}>;
+
+function requireHttpsUrl(value: string): string {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(value);
+  } catch (error) {
+    throw new TypeError(`Mobile app QR code value must be an absolute URL. Received: ${value}`, { cause: error });
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    throw new TypeError(`Mobile app QR code value must use HTTPS. Received protocol: ${parsedUrl.protocol}`);
+  }
+
+  return parsedUrl.toString();
+}
+
+export function MobileAppQrCode(props: MobileAppQrCodeProps): ReactElement {
+  const { title, testId, value } = props;
+  const qrValue = requireHttpsUrl(value);
+
+  return (
+    <QRCodeSVG
+      className="mobile-app-promo-qr-code"
+      data-testid={testId}
+      level="M"
+      marginSize={2}
+      size={164}
+      title={title}
+      value={qrValue}
+    />
+  );
+}

--- a/apps/web/src/screens/share/AppPlatformLinks.tsx
+++ b/apps/web/src/screens/share/AppPlatformLinks.tsx
@@ -14,6 +14,30 @@ export const defaultAppPlatformStoreLinks: AppPlatformStoreLinks = {
   android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&pcampaignid=web_share",
 };
 
+export function AppStoreBadge(): ReactElement {
+  return (
+    <img
+      alt=""
+      className="invite-platform-badge invite-platform-badge-app-store"
+      height={40}
+      src={appStoreBadgeSrc}
+      width={120}
+    />
+  );
+}
+
+export function GooglePlayBadge(): ReactElement {
+  return (
+    <img
+      alt=""
+      className="invite-platform-badge invite-platform-badge-google-play"
+      height={61}
+      src={googlePlayLockupSrc}
+      width={300}
+    />
+  );
+}
+
 export type AppPlatformLinkLabels = Readonly<{
   ios: string;
   android: string;
@@ -66,13 +90,7 @@ export function AppPlatformLinks({
         aria-label={labels.ios}
         data-testid="app-platform-link-ios"
       >
-        <img
-          alt=""
-          className="invite-platform-badge invite-platform-badge-app-store"
-          height={40}
-          src={appStoreBadgeSrc}
-          width={120}
-        />
+        <AppStoreBadge />
       </a>
       <a
         className="invite-platform-link"
@@ -82,13 +100,7 @@ export function AppPlatformLinks({
         aria-label={labels.android}
         data-testid="app-platform-link-android"
       >
-        <img
-          alt=""
-          className="invite-platform-badge invite-platform-badge-google-play"
-          height={61}
-          src={googlePlayLockupSrc}
-          width={300}
-        />
+        <GooglePlayBadge />
       </a>
       <Link
         className="invite-platform-link"

--- a/apps/web/src/styles/features/review/review-dialogs.css
+++ b/apps/web/src/styles/features/review/review-dialogs.css
@@ -43,10 +43,136 @@
   justify-content: flex-end;
 }
 
+.mobile-app-promo-overlay {
+  position: fixed;
+  inset: 0;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.58);
+  display: grid;
+  place-items: center;
+  z-index: 220;
+  backdrop-filter: blur(14px);
+}
+
+.mobile-app-promo-dialog {
+  width: min(780px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  display: grid;
+  gap: 22px;
+}
+
+.mobile-app-promo-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.mobile-app-promo-body {
+  max-width: 60ch;
+}
+
+.mobile-app-promo-close {
+  flex: 0 0 auto;
+}
+
+.mobile-app-promo-platforms {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.mobile-app-promo-platform {
+  min-width: 0;
+}
+
+.mobile-app-promo-platform-content {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+
+.mobile-app-promo-platform + .mobile-app-promo-platform {
+  padding-inline-start: 24px;
+  border-inline-start: 1px solid var(--panel-border);
+}
+
+.mobile-app-promo-platform-title {
+  margin: 0;
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.mobile-app-promo-badge-link {
+  width: fit-content;
+  min-height: 44px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.mobile-app-promo-close:focus-visible,
+.mobile-app-promo-badge-link:focus-visible,
+.mobile-app-promo-url:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.mobile-app-promo-url {
+  color: var(--accent-strong);
+  font-size: 0.85rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.mobile-app-promo-qr-frame {
+  width: 180px;
+  height: 180px;
+  padding: 8px;
+  border-radius: 8px;
+  background: #fff;
+  display: grid;
+  place-items: center;
+}
+
+.mobile-app-promo-qr-code {
+  display: block;
+  width: 164px;
+  height: 164px;
+}
+
 .review-editor-delete-btn {
   color: #ffaea9;
 }
 
 .review-editor-ai-btn {
   color: var(--accent-strong);
+}
+
+@media (max-width: 720px) {
+  .mobile-app-promo-overlay {
+    padding: 16px;
+  }
+
+  .mobile-app-promo-header {
+    display: grid;
+  }
+
+  .mobile-app-promo-platforms {
+    grid-template-columns: 1fr;
+  }
+
+  .mobile-app-promo-platform + .mobile-app-promo-platform {
+    padding-block-start: 20px;
+    padding-inline-start: 0;
+    border-block-start: 1px solid var(--panel-border);
+    border-inline-start: 0;
+  }
+
+  .mobile-app-promo-close {
+    width: 100%;
+  }
 }

--- a/docs/marketing-links.md
+++ b/docs/marketing-links.md
@@ -11,6 +11,7 @@ Current campaign buckets:
 | `share_app` | Future app share pages. |
 | `share_deck` | Future deck share pages, grouped across decks. |
 | `marketplace` | Future deck marketplace surfaces. |
+| `web_review_mobile_prompt` | Web review mobile app promotion prompt. |
 
 ## Google Play
 


### PR DESCRIPTION
## Summary
- Add a presentational web mobile app promotion dialog with iOS and Android links, QR codes, accessibility semantics, focus management, and responsive RTL-safe layout.
- Reuse app store badge components and add campaign-specific store URLs documented in marketing links.
- Add localized copy across all web catalogs and focused component coverage.

## Validation
- `cd apps/web && npx vitest run src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx` passed, 6 tests.
- `cd apps/web && npm run build` passed with the existing Vite chunk-size warning.
- `git --no-pager diff --check` passed.
- Final review gate clean: no P0-P4 actionable findings; no split recommendation.