### PR TITLE
Add mobile promo preview in test settings

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -498,6 +498,11 @@ const arCatalog: TranslationCatalog = {
       description: "عاين مربع حوار الأخطاء التقنية المشترك.",
       value: "معاينة",
     },
+    mobileAppPromo: {
+      title: "مربع حوار ترويج التطبيق",
+      description: "عاين مطالبة تثبيت iOS وAndroid.",
+      value: "معاينة",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -498,6 +498,11 @@ const deCatalog: TranslationCatalog = {
       description: "Zeige eine Vorschau des gemeinsamen Dialogs für technische Fehler.",
       value: "Vorschau",
     },
+    mobileAppPromo: {
+      title: "Dialog für App-Werbung",
+      description: "Zeige die iOS- und Android-Installationsaufforderung.",
+      value: "Vorschau",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -496,6 +496,11 @@ const enCatalog = {
       description: "Preview the shared technical-error dialog.",
       value: "Preview",
     },
+    mobileAppPromo: {
+      title: "Mobile app promo dialog",
+      description: "Preview the iOS and Android install prompt.",
+      value: "Preview",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -498,6 +498,11 @@ const esEsCatalog: TranslationCatalog = {
       description: "Previsualiza el diálogo compartido de error técnico.",
       value: "Vista previa",
     },
+    mobileAppPromo: {
+      title: "Diálogo de promoción móvil",
+      description: "Previsualiza el aviso de instalación para iOS y Android.",
+      value: "Vista previa",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -498,6 +498,11 @@ const esMxCatalog: TranslationCatalog = {
       description: "Previsualiza el diálogo compartido de error técnico.",
       value: "Vista previa",
     },
+    mobileAppPromo: {
+      title: "Diálogo de promoción móvil",
+      description: "Previsualiza el aviso de instalación para iOS y Android.",
+      value: "Vista previa",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -498,6 +498,11 @@ const hiCatalog: TranslationCatalog = {
       description: "साझा तकनीकी-त्रुटि डायलॉग का प्रीव्यू देखें।",
       value: "प्रीव्यू",
     },
+    mobileAppPromo: {
+      title: "मोबाइल ऐप प्रोमो डायलॉग",
+      description: "iOS और Android इंस्टॉल प्रॉम्प्ट का प्रीव्यू देखें।",
+      value: "प्रीव्यू",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -498,6 +498,11 @@ export const jaCatalog = {
       description: "共通の技術エラーダイアログをプレビューします。",
       value: "プレビュー",
     },
+    mobileAppPromo: {
+      title: "モバイルアプリ案内ダイアログ",
+      description: "iOS と Android のインストール案内をプレビューします。",
+      value: "プレビュー",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -498,6 +498,11 @@ export const ruCatalog = {
       description: "Предпросмотр общего диалога технической ошибки.",
       value: "Предпросмотр",
     },
+    mobileAppPromo: {
+      title: "Диалог продвижения приложения",
+      description: "Предпросмотр предложения установить iOS- и Android-приложение.",
+      value: "Предпросмотр",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -498,6 +498,11 @@ export const zhHansCatalog = {
       description: "预览共享技术错误对话框。",
       value: "预览",
     },
+    mobileAppPromo: {
+      title: "移动应用推广对话框",
+      description: "预览 iOS 和 Android 安装提示。",
+      value: "预览",
+    },
   },
   settingsWorkspace: {
     decks: {

--- a/apps/web/src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import ReactDOM from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AppErrorDialogProvider } from "../../appError/AppErrorContext";
+import { createStorageMock } from "../../api/ApiTestSupport";
+import { I18nProvider } from "../../i18n";
+import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../i18n/runtime";
+import { TestSettingsScreen } from "./TestSettingsScreen";
+
+function requireElement(container: HTMLElement, testId: string): HTMLElement {
+  const element = container.querySelector(`[data-testid='${testId}']`);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Expected element with test id "${testId}"`);
+  }
+
+  return element;
+}
+
+describe("TestSettingsScreen mobile app promotion preview", () => {
+  let container: HTMLDivElement;
+  let root: ReactDOM.Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+    window.localStorage.setItem(LOCALE_PREFERENCE_STORAGE_KEY, "en");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+  });
+
+  async function renderTestSettingsScreen(): Promise<void> {
+    await act(async () => {
+      root.render(
+        <I18nProvider>
+          <AppErrorDialogProvider>
+            <MemoryRouter>
+              <TestSettingsScreen />
+            </MemoryRouter>
+          </AppErrorDialogProvider>
+        </I18nProvider>,
+      );
+    });
+  }
+
+  it("opens and dismisses the mobile app promo dialog from the test settings action", async () => {
+    await renderTestSettingsScreen();
+
+    const promoRow = requireElement(container, "test-settings-mobile-app-promo-row");
+    expect(promoRow).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      promoRow.click();
+    });
+
+    expect(requireElement(container, "mobile-app-promo-dialog")).toBeTruthy();
+    expect(requireElement(container, "mobile-app-promo-platform-ios")).toBeTruthy();
+    expect(requireElement(container, "mobile-app-promo-platform-android")).toBeTruthy();
+
+    const closeButton = requireElement(container, "mobile-app-promo-close");
+    await act(async () => {
+      closeButton.click();
+    });
+
+    expect(container.querySelector("[data-testid='mobile-app-promo-dialog']")).toBeNull();
+  });
+});

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -3,6 +3,10 @@ import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import { settingsTestAnimationsRoute } from "../../routes";
 import {
+  MobileAppPromotionDialog,
+  webReviewMobilePromptStoreLinks,
+} from "../review/mobileAppPromo/MobileAppPromotionDialog";
+import {
   appendReviewReactionEvent,
   matchesReducedReviewReactionMotion,
   reviewReactionCleanupDelayMillis,
@@ -38,6 +42,7 @@ const probabilityFormatOptions: Readonly<Intl.NumberFormatOptions> = {
 export function TestSettingsScreen(): ReactElement {
   const { t } = useI18n();
   const { showTechnicalErrorPreview } = useAppErrorDialog();
+  const [isMobileAppPromotionDialogOpen, setIsMobileAppPromotionDialogOpen] = useState<boolean>(false);
 
   return (
     <SettingsShell
@@ -62,9 +67,21 @@ export function TestSettingsScreen(): ReactElement {
               onClick={showTechnicalErrorPreview}
               testId="test-settings-technical-error-row"
             />
+            <SettingsActionCard
+              title={t("settingsTest.mobileAppPromo.title")}
+              description={t("settingsTest.mobileAppPromo.description")}
+              value={t("settingsTest.mobileAppPromo.value")}
+              onClick={() => setIsMobileAppPromotionDialogOpen(true)}
+              testId="test-settings-mobile-app-promo-row"
+            />
           </div>
         </SettingsGroup>
       </div>
+      <MobileAppPromotionDialog
+        isOpen={isMobileAppPromotionDialogOpen}
+        onDismiss={() => setIsMobileAppPromotionDialogOpen(false)}
+        storeLinks={webReviewMobilePromptStoreLinks}
+      />
     </SettingsShell>
   );
 }


### PR DESCRIPTION
## Summary
- Add a hidden Tests settings row that opens the existing mobile app promotion dialog on demand.
- Reuse the existing MobileAppPromotionDialog and webReviewMobilePromptStoreLinks.
- Add localized settingsTest.mobileAppPromo copy across all existing web catalogs.

## Validation
- cd apps/web && npx vitest run src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
- cd apps/web && npm run build