### PR TITLE
Polish mobile promo dialog layout

### DIFF
--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
@@ -168,15 +168,15 @@ describe("MobileAppPromotionDialog", () => {
     });
 
     const closeButton = requireElement(container, "[data-testid='mobile-app-promo-close']");
-    const androidVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-android']");
+    const androidBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-android']");
 
-    androidVisibleUrl.focus();
+    androidBadgeLink.focus();
     await dispatchWindowKeyDown("Tab", false);
     expect(document.activeElement).toBe(closeButton);
 
     closeButton.focus();
     await dispatchWindowKeyDown("Tab", true);
-    expect(document.activeElement).toBe(androidVisibleUrl);
+    expect(document.activeElement).toBe(androidBadgeLink);
   });
 
   it("renders store links, platform test ids, and QR output for each platform", async () => {
@@ -209,15 +209,11 @@ describe("MobileAppPromotionDialog", () => {
 
     const iosBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-ios']");
     const androidBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-android']");
-    const iosVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-ios']");
-    const androidVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-android']");
 
     expect(iosBadgeLink.href).toBe(webReviewMobilePromptStoreLinks.ios);
     expect(androidBadgeLink.href).toBe(webReviewMobilePromptStoreLinks.android);
-    expect(iosVisibleUrl.href).toBe(webReviewMobilePromptStoreLinks.ios);
-    expect(androidVisibleUrl.href).toBe(webReviewMobilePromptStoreLinks.android);
-    expect(iosVisibleUrl.textContent).toBe(webReviewMobilePromptStoreLinks.ios);
-    expect(androidVisibleUrl.textContent).toBe(webReviewMobilePromptStoreLinks.android);
+    expect(container.querySelector("[data-testid='mobile-app-promo-url-ios']")).toBeNull();
+    expect(container.querySelector("[data-testid='mobile-app-promo-url-android']")).toBeNull();
 
     const iosQr = requireSvg(container, "[data-testid='mobile-app-promo-qr-ios']");
     const androidQr = requireSvg(container, "[data-testid='mobile-app-promo-qr-android']");
@@ -246,16 +242,12 @@ describe("MobileAppPromotionDialog", () => {
     const androidPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-android']");
     const iosPlatformContent = requireElement(container, "[data-testid='mobile-app-promo-content-ios']");
     const androidPlatformContent = requireElement(container, "[data-testid='mobile-app-promo-content-android']");
-    const iosVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-ios']");
-    const androidVisibleUrl = requireAnchor(container, "[data-testid='mobile-app-promo-url-android']");
 
     expect(platformGrid.getAttribute("dir")).toBe("ltr");
     expect(iosPlatform.getAttribute("dir")).toBe("ltr");
     expect(androidPlatform.getAttribute("dir")).toBe("ltr");
     expect(iosPlatformContent.getAttribute("dir")).toBe("rtl");
     expect(androidPlatformContent.getAttribute("dir")).toBe("rtl");
-    expect(iosVisibleUrl.getAttribute("dir")).toBe("ltr");
-    expect(androidVisibleUrl.getAttribute("dir")).toBe("ltr");
     expect(iosPlatform.compareDocumentPosition(androidPlatform) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );

--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
@@ -171,16 +171,6 @@ export function MobileAppPromotionDialog(props: MobileAppPromotionDialogProps): 
               >
                 <AppStoreBadge />
               </a>
-              <a
-                className="mobile-app-promo-url"
-                href={storeLinks.ios}
-                rel="noreferrer"
-                target="_blank"
-                dir="ltr"
-                data-testid="mobile-app-promo-url-ios"
-              >
-                {storeLinks.ios}
-              </a>
               <div className="mobile-app-promo-qr-frame">
                 <MobileAppQrCode
                   title={t("mobileAppPromo.ios.qrLabel")}
@@ -214,16 +204,6 @@ export function MobileAppPromotionDialog(props: MobileAppPromotionDialogProps): 
                 data-testid="mobile-app-promo-badge-android"
               >
                 <GooglePlayBadge />
-              </a>
-              <a
-                className="mobile-app-promo-url"
-                href={storeLinks.android}
-                rel="noreferrer"
-                target="_blank"
-                dir="ltr"
-                data-testid="mobile-app-promo-url-android"
-              >
-                {storeLinks.android}
               </a>
               <div className="mobile-app-promo-qr-frame">
                 <MobileAppQrCode

--- a/apps/web/src/styles/features/review/review-dialogs.css
+++ b/apps/web/src/styles/features/review/review-dialogs.css
@@ -55,6 +55,7 @@
 }
 
 .mobile-app-promo-dialog {
+  --panel-padding: 28px;
   width: min(780px, 100%);
   max-height: calc(100vh - 48px);
   overflow: auto;
@@ -107,25 +108,29 @@
 
 .mobile-app-promo-badge-link {
   width: fit-content;
-  min-height: 44px;
+  height: 44px;
   border-radius: 8px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  text-decoration: none;
 }
 
 .mobile-app-promo-close:focus-visible,
-.mobile-app-promo-badge-link:focus-visible,
-.mobile-app-promo-url:focus-visible {
+.mobile-app-promo-badge-link:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
 
-.mobile-app-promo-url {
-  color: var(--accent-strong);
-  font-size: 0.85rem;
-  line-height: 1.35;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+.mobile-app-promo-badge-link .invite-platform-badge {
+  width: auto;
+  max-width: 100%;
+  height: 40px;
+  object-fit: contain;
+}
+
+.mobile-app-promo-badge-link .invite-platform-badge-google-play {
+  max-height: 40px;
 }
 
 .mobile-app-promo-qr-frame {
@@ -155,6 +160,10 @@
 @media (max-width: 720px) {
   .mobile-app-promo-overlay {
     padding: 16px;
+  }
+
+  .mobile-app-promo-dialog {
+    --panel-padding: 22px;
   }
 
   .mobile-app-promo-header {


### PR DESCRIPTION
## Summary
- remove visible store URLs from the mobile app promo dialog
- keep App Store and Google Play badges as clickable links with equal-height hit areas
- increase the dialog panel padding so content sits farther from the outer frame

## Review
- independent review subagent: No P0-P4 issues found; green light for commit

## Validation
- cd apps/web && npx vitest run src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx
- cd apps/web && npm run build
- git diff --check

Note: npm ci was run first because apps/web/node_modules was missing in this worktree; npm warned local Node v25.6.1 while package expects 24.x.