### PR TITLE
Make Android workspace export package-only

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -62,8 +62,8 @@ import com.flashcardsopensourceapp.feature.settings.settingsImportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsRootScreenTag
 import com.flashcardsopensourceapp.feature.settings.settingsSchedulingRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsTagsRowTag
-import com.flashcardsopensourceapp.feature.settings.workspaceExportCsvButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspaceExportScreenTag
+import com.flashcardsopensourceapp.feature.settings.workspacePackageExportPreviewButtonTag
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerApplyButtonTag
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerDesiredRetentionFieldTag
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerLearningStepsFieldTag
@@ -454,13 +454,13 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     @Test
-    fun workspaceExportShowsCsvActionFromEmptyState() {
+    fun workspaceExportShowsPackagePreviewFromEmptyState() {
         waitForCardsEmptyState()
 
         openSettingsRow(rowTag = settingsExportRowTag, destinationTag = workspaceExportScreenTag)
-        waitForTagToExist(tag = workspaceExportCsvButtonTag)
-        waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_title))
-        waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_summary))
+        waitForTagToExist(tag = workspacePackageExportPreviewButtonTag)
+        composeRule.onNodeWithTag(workspacePackageExportPreviewButtonTag).assertIsNotEnabled()
+        waitForTextToExist(text = settingsString(SettingsR.string.settings_export_package_cloud_required))
     }
 
     @Test

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -424,7 +424,6 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
         val context = LocalContext.current
         val workspaceExportViewModel = viewModel<com.flashcardsopensourceapp.feature.settings.workspace.export.WorkspaceExportViewModel>(
             factory = createWorkspaceExportViewModelFactory(
-                workspaceRepository = appGraph.workspaceRepository,
                 cloudAccountRepository = appGraph.cloudAccountRepository,
                 technicalErrorController = appGraph.appMessageBus,
                 applicationContext = context.applicationContext

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/workspace/LocalWorkspaceBootstrapContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/workspace/LocalWorkspaceBootstrapContractTest.kt
@@ -54,21 +54,16 @@ class LocalWorkspaceBootstrapContractTest {
     }
 
     @Test
-    fun workspaceRepositoryExposesDeviceDiagnosticsAndExportDataForEmptyWorkspace(): Unit = runBlocking {
+    fun workspaceRepositoryExposesDeviceDiagnosticsForEmptyWorkspace(): Unit = runBlocking {
         val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = 100L)
         val workspaceRepository = createTestWorkspaceRepository(runtime = runtime)
 
         val diagnostics = workspaceRepository.observeDeviceDiagnostics().first()
-        val exportData = workspaceRepository.loadWorkspaceExportData()
 
         assertEquals(workspaceId, diagnostics?.workspaceId)
         assertEquals(localWorkspaceName, diagnostics?.workspaceName)
         assertEquals(0, diagnostics?.outboxEntriesCount)
         assertEquals(null, diagnostics?.lastSyncCursor)
         assertEquals(null, diagnostics?.lastSyncAttemptAtMillis)
-
-        assertEquals(workspaceId, exportData?.workspaceId)
-        assertEquals(localWorkspaceName, exportData?.workspaceName)
-        assertTrue(exportData?.cards?.isEmpty() == true)
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/workspace/WorkspaceModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/workspace/WorkspaceModels.kt
@@ -26,15 +26,3 @@ data class WorkspaceOverviewSummary(
     val newCount: Int,
     val reviewedCount: Int
 )
-
-data class WorkspaceExportCard(
-    val frontText: String,
-    val backText: String,
-    val tags: List<String>
-)
-
-data class WorkspaceExportData(
-    val workspaceId: String,
-    val workspaceName: String,
-    val cards: List<WorkspaceExportCard>
-)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -62,7 +62,6 @@ import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.review.ReviewSessionSnapshot
 import com.flashcardsopensourceapp.data.local.model.review.ReviewTimelinePage
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceOverviewSummary
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
@@ -99,7 +98,6 @@ interface WorkspaceRepository {
     fun observeWorkspaceSchedulerSettings(): Flow<WorkspaceSchedulerSettings?>
     fun observeWorkspaceTagsSummary(): Flow<WorkspaceTagsSummary>
     fun observeDeviceDiagnostics(): Flow<DeviceDiagnosticsSummary?>
-    suspend fun loadWorkspaceExportData(): WorkspaceExportData?
     suspend fun updateWorkspaceSchedulerSettings(
         desiredRetention: Double,
         learningStepsMinutes: List<Int>,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/workspace/LocalWorkspaceRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/workspace/LocalWorkspaceRepository.kt
@@ -12,8 +12,6 @@ import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.sync.DeviceDiagnosticsSummary
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportCard
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceOverviewSummary
 import com.flashcardsopensourceapp.data.local.model.scheduling.WorkspaceSchedulerSettings
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceSummary
@@ -26,14 +24,12 @@ import com.flashcardsopensourceapp.data.local.model.scheduling.validateWorkspace
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.data.local.repository.cards.toCardSummary
-import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.loadCurrentWorkspaceOrNull
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.observeCurrentWorkspace
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.requireCurrentWorkspace
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.runLocalOutboxMutationTransaction
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -199,30 +195,6 @@ class LocalWorkspaceRepository(
                 )
             }
         }
-    }
-
-    override suspend fun loadWorkspaceExportData(): WorkspaceExportData? {
-        val workspace: WorkspaceEntity = loadCurrentWorkspaceOrNull(
-            database = database,
-            preferencesStore = preferencesStore
-        ) ?: return null
-        val cards: List<CardSummary> = database.cardDao().observeCardsWithRelations().first().map(::toCardSummary)
-        val activeCards: List<CardSummary> = cards.filter { card ->
-            card.workspaceId == workspace.workspaceId &&
-                card.deletedAtMillis == null
-        }
-
-        return WorkspaceExportData(
-            workspaceId = workspace.workspaceId,
-            workspaceName = workspace.name,
-            cards = activeCards.map { card ->
-                WorkspaceExportCard(
-                    frontText = card.frontText,
-                    backText = card.backText,
-                    tags = card.tags
-                )
-            }
-        )
     }
 
     override suspend fun updateWorkspaceSchedulerSettings(

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -287,7 +287,7 @@ fun SettingsRoute(
             item {
                 SettingsRootRow(
                     title = stringResource(R.string.settings_workspace_export_title),
-                    summary = stringResource(R.string.settings_export_csv_summary),
+                    summary = stringResource(R.string.settings_export_package_summary),
                     attentionCount = null,
                     testTag = settingsExportRowTag,
                     onClick = onOpenExport

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
@@ -42,7 +42,6 @@ const val settingsReviewAnimationsToggleTag: String = "settings_review_animation
 const val settingsAiChatSuggestionsToggleTag: String = "settings_ai_chat_suggestions_toggle"
 const val settingsLeaderboardParticipationToggleTag: String = "settings_leaderboard_participation_toggle"
 const val workspaceExportScreenTag: String = "workspace_export_screen"
-const val workspaceExportCsvButtonTag: String = "workspace_export_csv_button"
 const val workspacePackageExportPreviewButtonTag: String = "workspace_package_export_preview_button"
 const val workspacePackageExportSaveButtonTag: String = "workspace_package_export_save_button"
 const val workspacePackageExportShareButtonTag: String = "workspace_package_export_share_button"

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
@@ -45,14 +45,12 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
-import com.flashcardsopensourceapp.feature.settings.workspaceExportCsvButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspaceExportScreenTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportErrorMessageTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportMetadataAuthorFieldTag
@@ -64,7 +62,6 @@ import com.flashcardsopensourceapp.feature.settings.workspacePackageExportPrevie
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportSaveButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportShareButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportTagToggleTag
-import java.time.LocalDate
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -79,46 +76,8 @@ fun WorkspaceExportRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
-    var pendingExportData by remember {
-        mutableStateOf<WorkspaceExportData?>(value = null)
-    }
     var pendingPackageExport by remember {
         mutableStateOf<WorkspacePackageExportDownloadResponse?>(value = null)
-    }
-    val createCsvDocumentLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("text/csv")
-    ) { uri ->
-        val exportData = pendingExportData
-        if (uri == null || exportData == null) {
-            viewModel.finishExport()
-            pendingExportData = null
-            return@rememberLauncherForActivityResult
-        }
-
-        coroutineScope.launch {
-            try {
-                writeWorkspaceExportCsv(
-                    contentResolver = context.contentResolver,
-                    uri = uri,
-                    csv = makeWorkspaceCardsCsv(exportData = exportData)
-                )
-                viewModel.finishExport()
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Exception) {
-                val errorMessage = context.getString(R.string.settings_export_write_failed)
-                viewModel.showExportError(message = errorMessage)
-                technicalErrorController.showTechnicalError(
-                    error = makeAppTechnicalError(
-                        title = context.getString(R.string.settings_technical_error_title),
-                        message = errorMessage,
-                        throwable = error
-                    ),
-                    throwable = error
-                )
-            }
-            pendingExportData = null
-        }
     }
     val createPackageDocumentLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/zip")
@@ -176,44 +135,6 @@ fun WorkspaceExportRoute(
                         message = uiState.errorMessage,
                         color = MaterialTheme.colorScheme.error,
                         testTag = workspacePackageExportErrorMessageTag
-                    )
-                }
-            }
-
-            item {
-                WorkspaceExportCsvCard(uiState = uiState)
-            }
-
-            item {
-                Button(
-                    onClick = {
-                        coroutineScope.launch {
-                            viewModel.clearErrorMessage()
-                            val exportData = viewModel.prepareExportData()
-                            if (exportData == null) {
-                                return@launch
-                            }
-
-                            pendingExportData = exportData
-                            createCsvDocumentLauncher.launch(
-                                makeWorkspaceExportFilename(
-                                    workspaceName = exportData.workspaceName,
-                                    date = LocalDate.now()
-                                )
-                            )
-                        }
-                    },
-                    enabled = uiState.isBusy.not(),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag(tag = workspaceExportCsvButtonTag)
-                ) {
-                    Text(
-                        if (uiState.isExporting) {
-                            stringResource(R.string.settings_export_preparing)
-                        } else {
-                            stringResource(R.string.settings_export_csv_title)
-                        }
                     )
                 }
             }
@@ -355,32 +276,6 @@ private fun MessageCard(
             modifier = Modifier
                 .padding(20.dp)
                 .testTag(tag = testTag)
-        )
-    }
-}
-
-@Composable
-private fun WorkspaceExportCsvCard(uiState: WorkspaceExportUiState) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        ListItem(
-            headlineContent = {
-                Text(stringResource(R.string.settings_export_csv_summary))
-            },
-            supportingContent = {
-                Text(
-                    stringResource(
-                        R.string.settings_export_csv_workspace_summary,
-                        uiState.activeCardsCount,
-                        uiState.workspaceName
-                    )
-                )
-            },
-            leadingContent = {
-                Icon(
-                    imageVector = Icons.Outlined.SaveAlt,
-                    contentDescription = null
-                )
-            }
         )
     }
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportSupport.kt
@@ -4,7 +4,6 @@ import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import androidx.core.content.FileProvider
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDefaultPackageMetadata
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportMetadataInput
@@ -14,7 +13,6 @@ import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageEx
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagPolicyInput
 import com.flashcardsopensourceapp.data.local.model.workspace.isWorkspacePackageExportGeneratedImportTag
 import java.io.File
-import java.time.LocalDate
 
 private const val workspacePackageExportShareDirectoryName: String = "workspace-package-export"
 
@@ -32,29 +30,6 @@ internal data class WorkspacePackageExportTagOptionUiState(
     val isRemoved: Boolean,
     val isAlwaysRemoved: Boolean
 )
-
-fun makeWorkspaceExportFilename(workspaceName: String, date: LocalDate): String {
-    val slug = workspaceName
-        .trim()
-        .lowercase()
-        .replace(Regex("[^a-z0-9]+"), "-")
-        .replace(Regex("^-+|-+$"), "")
-        .ifEmpty { "workspace" }
-
-    return "$slug-cards-export-$date.csv"
-}
-
-fun makeWorkspaceCardsCsv(exportData: WorkspaceExportData): String {
-    val lines = listOf("frontText,backText,tags") + exportData.cards.map { card ->
-        listOf(
-            escapeWorkspaceExportCsvCell(card.frontText),
-            escapeWorkspaceExportCsvCell(card.backText),
-            escapeWorkspaceExportCsvCell(card.tags.joinToString(separator = ", "))
-        ).joinToString(separator = ",")
-    }
-
-    return lines.joinToString(separator = "\r\n") + "\r\n"
-}
 
 fun makeDefaultWorkspacePackageExportPreviewRequest(): WorkspacePackageExportRequest {
     return WorkspacePackageExportRequest(
@@ -126,21 +101,6 @@ internal fun makeWorkspacePackageExportTagOptions(
             isRemoved = isAlwaysRemoved || removedTags.contains(tagCount.tag),
             isAlwaysRemoved = isAlwaysRemoved
         )
-    }
-}
-
-fun writeWorkspaceExportCsv(
-    contentResolver: ContentResolver,
-    uri: Uri,
-    csv: String
-) {
-    val outputStream = requireNotNull(contentResolver.openOutputStream(uri, "wt")) {
-        "Android export destination is unavailable for writing."
-    }
-
-    outputStream.bufferedWriter(charset = Charsets.UTF_8).use { writer ->
-        writer.write(csv)
-        writer.flush()
     }
 }
 
@@ -218,18 +178,4 @@ private fun requireSafeWorkspacePackageExportFileName(fileName: String): String 
         "Android package export share filename must not contain control characters: $trimmedFileName"
     }
     return trimmedFileName
-}
-
-private fun escapeWorkspaceExportCsvCell(value: String): String {
-    val escapedValue = value.replace(oldValue = "\"", newValue = "\"\"")
-    if (
-        escapedValue.contains(",")
-        || escapedValue.contains("\"")
-        || escapedValue.contains("\n")
-        || escapedValue.contains("\r")
-    ) {
-        return "\"$escapedValue\""
-    }
-
-    return escapedValue
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportUiState.kt
@@ -3,9 +3,6 @@ package com.flashcardsopensourceapp.feature.settings.workspace.export
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
 
 data class WorkspaceExportUiState(
-    val workspaceName: String,
-    val activeCardsCount: Int,
-    val isExporting: Boolean,
     val packagePreview: WorkspacePackageExportPreview?,
     val packageMetadataDraft: WorkspacePackageExportMetadataDraft,
     val packageRemovedTags: Set<String>,
@@ -15,7 +12,7 @@ data class WorkspaceExportUiState(
     val errorMessage: String
 ) {
     val isBusy: Boolean
-        get() = isExporting || isPackagePreviewing || isPackageExporting
+        get() = isPackagePreviewing || isPackageExporting
 
     val canPreviewPackageExport: Boolean
         get() = packageAvailabilityMessage.isEmpty() && isBusy.not()

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModel.kt
@@ -10,13 +10,11 @@ import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
 import com.flashcardsopensourceapp.data.local.model.workspace.isWorkspacePackageExportGeneratedImportTag
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncBlockedException
-import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
 import com.flashcardsopensourceapp.feature.settings.cloud.expectedWorkspacePackageExportCloudFailureMessage
@@ -38,7 +36,6 @@ private data class WorkspacePackageExportPreviewIdentity(
 )
 
 private data class WorkspaceExportDraftState(
-    val isExporting: Boolean,
     val packagePreview: WorkspacePackageExportPreview?,
     val packagePreviewIdentity: WorkspacePackageExportPreviewIdentity?,
     val packageMetadataDraft: WorkspacePackageExportMetadataDraft,
@@ -49,7 +46,6 @@ private data class WorkspaceExportDraftState(
 )
 
 class WorkspaceExportViewModel(
-    private val workspaceRepository: WorkspaceRepository,
     private val cloudAccountRepository: CloudAccountRepository,
     private val technicalErrorController: AppTechnicalErrorController,
     private val strings: SettingsStringResolver
@@ -69,7 +65,6 @@ class WorkspaceExportViewModel(
     )
     private val draftState = MutableStateFlow(
         value = WorkspaceExportDraftState(
-            isExporting = false,
             packagePreview = null,
             packagePreviewIdentity = null,
             packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
@@ -83,19 +78,15 @@ class WorkspaceExportViewModel(
     private val latestPackagePreviewRequestId = AtomicLong(0L)
 
     val uiState: StateFlow<WorkspaceExportUiState> = combine(
-        workspaceRepository.observeWorkspaceOverview(),
         cloudSettingsState,
         draftState
-    ) { overview, cloudSettings, draft ->
+    ) { cloudSettings, draft ->
         val currentIdentity: WorkspacePackageExportPreviewIdentity? = makePackagePreviewIdentity(
             cloudSettings = cloudSettings
         )
         val isPackagePreviewCurrent: Boolean = draft.packagePreview != null &&
             draft.packagePreviewIdentity == currentIdentity
         WorkspaceExportUiState(
-            workspaceName = overview?.workspaceName ?: strings.get(R.string.settings_unavailable),
-            activeCardsCount = overview?.totalCards ?: 0,
-            isExporting = draft.isExporting,
             packagePreview = if (isPackagePreviewCurrent) draft.packagePreview else null,
             packageMetadataDraft = if (isPackagePreviewCurrent) {
                 draft.packageMetadataDraft
@@ -115,9 +106,6 @@ class WorkspaceExportViewModel(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
         initialValue = WorkspaceExportUiState(
-            workspaceName = strings.get(R.string.settings_loading),
-            activeCardsCount = 0,
-            isExporting = false,
             packagePreview = null,
             packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
             packageRemovedTags = emptySet(),
@@ -127,47 +115,6 @@ class WorkspaceExportViewModel(
             errorMessage = ""
         )
     )
-
-    suspend fun prepareExportData(): WorkspaceExportData? {
-        draftState.update { state ->
-            state.copy(
-                isExporting = true,
-                errorMessage = ""
-            )
-        }
-
-        return try {
-            val exportData = workspaceRepository.loadWorkspaceExportData()
-            if (exportData == null) {
-                draftState.update { state ->
-                    state.copy(
-                        isExporting = false,
-                        errorMessage = strings.get(R.string.settings_export_unavailable)
-                    )
-                }
-            }
-            exportData
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Exception) {
-            val errorMessage = strings.get(R.string.settings_export_prepare_failed)
-            draftState.update { state ->
-                state.copy(
-                    isExporting = false,
-                    errorMessage = errorMessage
-                )
-            }
-            technicalErrorController.showTechnicalError(
-                error = makeAppTechnicalError(
-                    title = strings.get(R.string.settings_technical_error_title),
-                    message = errorMessage,
-                    throwable = error
-                ),
-                throwable = error
-            )
-            null
-        }
-    }
 
     fun previewPackageExport() {
         val previewRequestId: Long = latestPackagePreviewRequestId.incrementAndGet()
@@ -385,12 +332,6 @@ class WorkspaceExportViewModel(
         }
     }
 
-    fun finishExport() {
-        draftState.update { state ->
-            state.copy(isExporting = false)
-        }
-    }
-
     fun finishPackageExport() {
         draftState.update { state ->
             state.copy(isPackageExporting = false)
@@ -400,7 +341,6 @@ class WorkspaceExportViewModel(
     fun showExportError(message: String) {
         draftState.update { state ->
             state.copy(
-                isExporting = false,
                 isPackageExporting = false,
                 errorMessage = message
             )
@@ -528,7 +468,6 @@ private fun workspacePackageExportAvailabilityMessage(
 }
 
 fun createWorkspaceExportViewModelFactory(
-    workspaceRepository: WorkspaceRepository,
     cloudAccountRepository: CloudAccountRepository,
     technicalErrorController: AppTechnicalErrorController,
     applicationContext: Context
@@ -536,7 +475,6 @@ fun createWorkspaceExportViewModelFactory(
     return viewModelFactory {
         initializer {
             WorkspaceExportViewModel(
-                workspaceRepository = workspaceRepository,
                 cloudAccountRepository = cloudAccountRepository,
                 technicalErrorController = technicalErrorController,
                 strings = createSettingsStringResolver(context = applicationContext)

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsViewModel.kt
@@ -83,7 +83,7 @@ class WorkspaceSettingsViewModel(
             schedulerSummary = schedulerSettings?.let { settings ->
                 formatWorkspaceSchedulerSummary(settings = settings, strings = strings)
             } ?: strings.get(R.string.settings_unavailable),
-            exportSummary = strings.get(R.string.settings_export_csv_summary),
+            exportSummary = strings.get(R.string.settings_export_package_summary),
             isLinked = cloudSettings.cloudState == CloudAccountState.LINKED,
             errorMessage = draft.errorMessage,
             successMessage = draft.successMessage,
@@ -104,7 +104,7 @@ class WorkspaceSettingsViewModel(
             tagCount = 0,
             notificationsSummary = strings.get(R.string.settings_loading),
             schedulerSummary = strings.get(R.string.settings_loading),
-            exportSummary = strings.get(R.string.settings_export_csv_summary),
+            exportSummary = strings.get(R.string.settings_export_package_summary),
             isLinked = false,
             errorMessage = "",
             successMessage = "",

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -440,19 +440,8 @@
     <string name="settings_scheduler_steps_invalid_positive">%1$s must contain positive integers.</string>
 
     <string name="settings_export_title">Export</string>
-    <string name="settings_export_csv_title">Export CSV</string>
-    <string name="settings_export_csv_summary">CSV export</string>
-    <string name="settings_export_csv_workspace_summary">%1$d active cards from %2$s</string>
-    <string name="settings_export_file_picker_title">Save CSV export</string>
-    <string name="settings_export_unavailable">Workspace export is unavailable.</string>
-    <string name="settings_export_prepare_failed">Android export could not be prepared.</string>
-    <string name="settings_export_write_failed">Android export could not be written.</string>
-    <string name="settings_export_preparing">Preparing export...</string>
+    <string name="settings_export_package_summary">Export a Flashcards ZIP package</string>
     <string name="settings_export_dismiss_error">Dismiss error</string>
-    <string name="settings_export_file_name">cards-export</string>
-    <string name="settings_export_csv_header_front">frontText</string>
-    <string name="settings_export_csv_header_back">backText</string>
-    <string name="settings_export_csv_header_tags">tags</string>
     <string name="settings_export_package_section">flashcards.zip package</string>
     <string name="settings_export_package_body">Export all active cards, tags, and referenced media as a portable ZIP package.</string>
     <string name="settings_export_package_preview">Preview package export</string>

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -531,8 +531,7 @@ internal class TestSettingsStringResolver : SettingsStringResolver {
             R.string.settings_export_package_preview_failed -> "Package export preview failed."
             R.string.settings_export_package_download_failed -> "Package export failed."
             R.string.settings_export_package_preview_required -> "Preview this package export before saving."
-            R.string.settings_export_unavailable -> "Workspace export is unavailable."
-            R.string.settings_export_prepare_failed -> "Android export could not be prepared."
+            R.string.settings_export_package_summary -> "Export a Flashcards ZIP package"
             R.string.settings_logout -> "Log out"
             R.string.settings_current_workspace_create_new_title -> "Create new workspace"
             R.string.settings_current_workspace_create_new_summary -> {

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModelTest.kt
@@ -4,25 +4,15 @@ import com.flashcardsopensourceapp.core.ui.AppTechnicalError
 import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
-import com.flashcardsopensourceapp.data.local.model.sync.AppMetadataSummary
-import com.flashcardsopensourceapp.data.local.model.scheduling.WorkspaceSchedulerSettings
-import com.flashcardsopensourceapp.data.local.model.sync.DeviceDiagnosticsSummary
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceExportData
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceOverviewSummary
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDefaultPackageMetadata
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportSelection
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagCount
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceSummary
-import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagsSummary
-import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.feature.settings.FakeCloudAccountRepository
 import com.flashcardsopensourceapp.feature.settings.TestSettingsStringResolver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -116,7 +106,6 @@ class WorkspaceExportViewModelTest {
 
     private fun workspaceExportViewModel(cloudRepository: FakeCloudAccountRepository): WorkspaceExportViewModel {
         return WorkspaceExportViewModel(
-            workspaceRepository = FakeWorkspaceRepository(),
             cloudAccountRepository = cloudRepository,
             technicalErrorController = RecordingTechnicalErrorController(),
             strings = TestSettingsStringResolver()
@@ -169,59 +158,6 @@ private fun workspacePackageExportPreview(): WorkspacePackageExportPreview {
             sourceUrl = "https://example.com/export"
         )
     )
-}
-
-private class FakeWorkspaceRepository : WorkspaceRepository {
-    private val workspaceOverview = MutableStateFlow(
-        WorkspaceOverviewSummary(
-            workspaceId = "workspace-local",
-            workspaceName = "Personal",
-            totalCards = 3,
-            deckCount = 1,
-            tagsCount = 3,
-            dueCount = 0,
-            newCount = 0,
-            reviewedCount = 0
-        )
-    )
-
-    override fun observeWorkspace(): Flow<WorkspaceSummary?> {
-        throw UnsupportedOperationException()
-    }
-
-    override fun observeAppMetadata(): Flow<AppMetadataSummary> {
-        throw UnsupportedOperationException()
-    }
-
-    override fun observeWorkspaceOverview(): Flow<WorkspaceOverviewSummary?> {
-        return workspaceOverview
-    }
-
-    override fun observeWorkspaceSchedulerSettings(): Flow<WorkspaceSchedulerSettings?> {
-        throw UnsupportedOperationException()
-    }
-
-    override fun observeWorkspaceTagsSummary(): Flow<WorkspaceTagsSummary> {
-        throw UnsupportedOperationException()
-    }
-
-    override fun observeDeviceDiagnostics(): Flow<DeviceDiagnosticsSummary?> {
-        throw UnsupportedOperationException()
-    }
-
-    override suspend fun loadWorkspaceExportData(): WorkspaceExportData? {
-        throw UnsupportedOperationException()
-    }
-
-    override suspend fun updateWorkspaceSchedulerSettings(
-        desiredRetention: Double,
-        learningStepsMinutes: List<Int>,
-        relearningStepsMinutes: List<Int>,
-        maximumIntervalDays: Int,
-        enableFuzz: Boolean
-    ) {
-        throw UnsupportedOperationException()
-    }
 }
 
 private class RecordingTechnicalErrorController : AppTechnicalErrorController {


### PR DESCRIPTION
## Summary
- remove Android CSV workspace export UI, state, helpers, and local repository export data API
- keep Android export focused on flashcards.zip package preview, metadata, tag removal, save, and share
- update settings copy and tests for package-only export

## Validation
- rg "workspace_export_csv|settings_export_csv|makeWorkspaceCardsCsv|writeWorkspaceExportCsv|loadWorkspaceExportData|CSV export|Export CSV" apps/android/feature/settings apps/android/data/local/src/main/java: no matches
- broader removed-symbol rg across apps/android: no matches
- git --no-pager diff --check: passed
- Gradle not run per repository no-Gradle-without-explicit-permission rule
- worker review: no split recommendation, no P0-P4 findings