### PR TITLE
Handle missing iOS deck detail locally

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
@@ -539,7 +539,14 @@ private struct DeckDetailScreen: View {
                     cards: cards
                 )
             case .deck(let deckId):
-                let deck = try store.loadDeck(deckId: deckId)
+                let deck: Deck
+                do {
+                    deck = try store.loadDeck(deckId: deckId)
+                } catch LocalStoreError.notFound(_) {
+                    self.detailState = nil
+                    return
+                }
+
                 let cards = try store.loadCardsMatchingDeck(filterDefinition: deck.filterDefinition)
                 self.detailState = .deck(
                     deckItem: makeDeckListItem(deck: deck, cards: cards, now: Date()),


### PR DESCRIPTION
## Summary
- Treat a missing selected deck during iOS deck detail reload as an expected stale-navigation state
- Preserve technical-error presentation for other reload failures

## Validation
- git --no-pager diff --check
- Review subagent found no P0-P4 issues
- iOS simulator-backed tests were not run because they were not explicitly allowed