### PR TITLE
Clarify backend package transfer contract

### DIFF
--- a/api/src/components/schemas/WorkspacePackageExportPreviewResponse.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportPreviewResponse.yaml
@@ -11,12 +11,23 @@ properties:
   selectedCardCount:
     type: integer
     minimum: 0
+    description: >-
+      Number of stored workspace cards selected by the export selection before
+      package tag removal.
   availableTagCounts:
     type: array
+    description: >-
+      Tag counts from the selected cards only, before package tag removal. For
+      tag-filtered selections this does not include tags from unselected
+      workspace cards.
     items:
       $ref: ./WorkspacePackageExportTagCount.yaml
   tagsSelectedForRemoval:
     type: array
+    description: >-
+      Tags that will be removed from exported package card metadata, including
+      generated import tags and tagPolicy.additionalRemovedTags present on
+      selected cards.
     items:
       $ref: ./WorkspacePackageExportTagCount.yaml
   referencedMediaCount:

--- a/api/src/components/schemas/WorkspacePackageExportRequest.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportRequest.yaml
@@ -7,7 +7,12 @@ required:
 properties:
   selection:
     $ref: ./WorkspacePackageExportSelection.yaml
+    description: >-
+      Stored workspace cards to include in the export package. Tag-filter
+      selections choose cards; they do not choose which tags remain on packaged
+      cards.
   tagPolicy:
     $ref: ./WorkspacePackageExportTagPolicyInput.yaml
+    description: Tag removal policy applied to package card metadata after card selection.
   packageMetadata:
     $ref: ./WorkspacePackageExportMetadataInput.yaml

--- a/api/src/components/schemas/WorkspacePackageExportSelection.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportSelection.yaml
@@ -1,3 +1,6 @@
+description: >-
+  Selects which stored workspace cards are included in the export package. This
+  is separate from deciding which tags remain on the exported package cards.
 oneOf:
   - $ref: ./WorkspacePackageExportAllActiveCardsSelection.yaml
   - $ref: ./WorkspacePackageExportTagFiltersSelection.yaml

--- a/api/src/components/schemas/WorkspacePackageExportTagFiltersSelection.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportTagFiltersSelection.yaml
@@ -1,4 +1,7 @@
 type: object
+description: >-
+  Selects stored workspace cards by their current tags before packaging. Use
+  tagPolicy.additionalRemovedTags to exclude tags from package card metadata.
 additionalProperties: false
 required:
   - kind
@@ -11,11 +14,15 @@ properties:
       - tagFilters
   includeTags:
     type: array
+    description: >-
+      Stored card tags that select cards for the package. A card is selected
+      when it has at least one include tag and no exclude tag.
     items:
       type: string
       minLength: 1
   excludeTags:
     type: array
+    description: Stored card tags that remove matching cards from this tag-filtered package selection.
     items:
       type: string
       minLength: 1

--- a/api/src/components/schemas/WorkspacePackageExportTagPolicyInput.yaml
+++ b/api/src/components/schemas/WorkspacePackageExportTagPolicyInput.yaml
@@ -5,6 +5,11 @@ required:
 properties:
   additionalRemovedTags:
     type: array
+    description: >-
+      Exact selected-card tags to remove from exported package card metadata.
+      Clients can represent included package tags by sending every omitted
+      selected-card tag here. Generated import tags with the import: prefix are
+      removed automatically even when this array is empty.
     items:
       type: string
       minLength: 1

--- a/api/src/components/schemas/WorkspacePackageImportConfirmOptions.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportConfirmOptions.yaml
@@ -12,11 +12,16 @@ required:
 properties:
   addImportTag:
     type: boolean
+    description: When true, the backend appends importTag to every imported card after applying removeTags.
   importTag:
     type: string
-    minLength: 1
+    description: >-
+      Explicit tag chosen by the client for this import. Required to be
+      non-blank when addImportTag is true, and ignored when addImportTag is
+      false.
   removeTags:
     type: array
+    description: Exact package card tags to remove from imported cards before the optional importTag is added.
     items:
       type: string
       minLength: 1

--- a/api/src/components/schemas/WorkspacePackageImportPreviewResponse.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportPreviewResponse.yaml
@@ -84,13 +84,20 @@ properties:
     properties:
       addImportTag:
         type: boolean
+        description: Whether clients should add an import-session tag when confirming with the default options.
       suggestedImportTag:
         type: string
+        description: >-
+          Concrete default import tag suggested for this preview. Pass this
+          value, or another explicit client-chosen tag, as importTag when
+          confirming with addImportTag true.
       keptTags:
         type: array
+        description: Package card tags kept by the default import tag policy.
         items:
           type: string
       removedTags:
         type: array
+        description: Package card tags removed by the default import tag policy.
         items:
           type: string

--- a/apps/backend/src/routes/workspacePackages/import.test.ts
+++ b/apps/backend/src/routes/workspacePackages/import.test.ts
@@ -408,6 +408,45 @@ test("POST /workspaces/:workspaceId/packages/import parses multipart ZIP bytes a
   assert.equal(confirmCalls, 1);
 });
 
+test("POST /workspaces/:workspaceId/packages/import accepts blank importTag when import tagging is disabled", async () => {
+  const zipBytes = createWorkspacePackageZipBytes();
+  let confirmCalls = 0;
+  const app = createWorkspacePackageTestApp(createWorkspacePackageRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    confirmWorkspacePackageImportFn: async (input) => {
+      confirmCalls += 1;
+      assert.deepEqual(Buffer.from(input.packageBytes), zipBytes);
+      assert.deepEqual(input.options, {
+        addImportTag: false,
+        importTag: "",
+        removeTags: [],
+        importedAt,
+        importId,
+      });
+      return createWorkspacePackageImportConfirmResult();
+    },
+  }));
+  const options = {
+    ...createWorkspacePackageImportConfirmOptions(),
+    addImportTag: false,
+    importTag: "",
+    removeTags: [],
+  };
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/packages/import`, {
+    method: "POST",
+    body: createWorkspacePackageImportConfirmFormData(zipBytes, options),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(confirmCalls, 1);
+});
+
 test("POST /workspaces/:workspaceId/packages/import uses path workspace instead of selected workspace", async () => {
   const zipBytes = createWorkspacePackageZipBytes();
   const requestedWorkspaceIds: Array<string> = [];
@@ -588,6 +627,20 @@ test("POST /workspaces/:workspaceId/packages/import rejects malformed multipart,
       expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
       errorPattern: /options are invalid/,
       detailsPattern: /removeTags/,
+    },
+    {
+      name: "blank import tag when enabled",
+      createRequestInit: () => ({
+        method: "POST",
+        body: createWorkspacePackageImportConfirmFormData(zipBytes, {
+          ...validOptions,
+          importTag: "   ",
+        }),
+      }),
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+      errorPattern: /options are invalid/,
+      detailsPattern: /importTag/,
     },
     {
       name: "invalid options timestamp",

--- a/apps/backend/src/routes/workspacePackages/import.ts
+++ b/apps/backend/src/routes/workspacePackages/import.ts
@@ -64,14 +64,20 @@ const workspacePackageImportConfirmUuidSchema = z.string().uuid().transform(
 
 const workspacePackageImportConfirmRouteOptionsSchema = z.object({
   addImportTag: z.boolean(),
-  importTag: z.string().min(1),
+  importTag: z.string(),
   removeTags: z.array(z.string().min(1)),
   importedAt: workspacePackageImportConfirmTimestampSchema,
   importId: z.string().min(1),
   clientUpdatedAt: workspacePackageImportConfirmTimestampSchema,
   lastModifiedByReplicaId: workspacePackageImportConfirmUuidSchema,
   operationIdPrefix: z.string().min(1),
-}).transform((input): WorkspacePackageImportConfirmRouteOptions => ({
+}).refine(
+  (input): boolean => input.addImportTag === false || input.importTag.trim() !== "",
+  {
+    message: "importTag must not be empty when addImportTag is true",
+    path: ["importTag"],
+  },
+).transform((input): WorkspacePackageImportConfirmRouteOptions => ({
   addImportTag: input.addImportTag,
   importTag: input.importTag,
   removeTags: input.removeTags,

--- a/apps/backend/src/workspacePackages/export/exportPackage.test.ts
+++ b/apps/backend/src/workspacePackages/export/exportPackage.test.ts
@@ -441,6 +441,47 @@ test("package ZIP for text-only cards contains valid cards.json", async () => {
   assert.equal(byteLoader.calls.length, 0);
 });
 
+test("package export applies tag filters to selected cards and strips generated import tags", async () => {
+  const executor = createTestExecutor([
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      "Science prompt",
+      "Science answer",
+      ["science", "keep", "import:2026-07-04-0"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+    createCardRow(
+      cardIdB,
+      workspaceId,
+      "Draft prompt",
+      "Draft answer",
+      ["science", "draft", "import:2026-07-04-1"],
+      "2026-06-02T00:00:00.000Z",
+      null,
+    ),
+  ], []);
+  const byteLoader = createByteLoader(new Map());
+  const packageExport = await exportWorkspacePackageInExecutor(
+    executor,
+    workspaceId,
+    createBasePackageInput({
+      kind: "tagFilters",
+      includeTags: ["science"],
+      excludeTags: ["draft"],
+    }),
+    createPackageLimits(10, 10, 1024, 1024),
+    byteLoader,
+  );
+
+  const cardsJson = parseCardsJson(parseStoredZipEntries(packageExport.bytes));
+  assert.equal(cardsJson.cards.length, 1);
+  assert.equal(cardsJson.cards[0]?.frontText, "Science prompt");
+  assert.deepEqual(cardsJson.cards[0]?.tags, ["science", "keep"]);
+  assert.equal(byteLoader.calls.length, 0);
+});
+
 test("package ZIP rewrites media references to portable media paths", async () => {
   const imageBytes = Buffer.from("image-a");
   const mediaRow = createMediaAssetRow(
@@ -793,17 +834,16 @@ test("package export rejects media size limits before loading objects", async ()
 });
 
 test("package export preserves default import-tag removal and additional tag removals", async () => {
-  const executor = createTestExecutor([
-    createCardRow(
-      cardIdA,
-      workspaceId,
-      "Prompt",
-      "Answer",
-      ["keep", "custom-remove", "import:2026-06-01-0"],
-      "2026-06-01T00:00:00.000Z",
-      null,
-    ),
-  ], []);
+  const sourceCard = createCardRow(
+    cardIdA,
+    workspaceId,
+    "Prompt",
+    "Answer",
+    ["keep", "custom-remove", "import:2026-06-01-0"],
+    "2026-06-01T00:00:00.000Z",
+    null,
+  );
+  const executor = createTestExecutor([sourceCard], []);
   const byteLoader = createByteLoader(new Map());
   const input = createBasePackageInput({ kind: "allActiveCards" });
   const packageExport = await exportWorkspacePackageInExecutor(
@@ -821,4 +861,5 @@ test("package export preserves default import-tag removal and additional tag rem
 
   const entries = parseStoredZipEntries(packageExport.bytes);
   assert.deepEqual(parseCardsJson(entries).cards[0]?.tags, ["keep"]);
+  assert.deepEqual(sourceCard.tags, ["keep", "custom-remove", "import:2026-06-01-0"]);
 });

--- a/apps/backend/src/workspacePackages/export/exportPreview.test.ts
+++ b/apps/backend/src/workspacePackages/export/exportPreview.test.ts
@@ -303,9 +303,33 @@ test("preview selects explicit active card ids", async () => {
 
 test("preview applies include and exclude tag filters", async () => {
   const { executor } = createTestExecutor([
-    createCardRow(cardIdA, workspaceId, "A", "A answer", ["science"], "2026-06-01T00:00:00.000Z", null),
-    createCardRow(cardIdB, workspaceId, "B", "B answer", ["science", "draft"], "2026-06-02T00:00:00.000Z", null),
-    createCardRow(cardIdC, workspaceId, "C", "C answer", ["history"], "2026-06-03T00:00:00.000Z", null),
+    createCardRow(
+      cardIdA,
+      workspaceId,
+      "A",
+      "A answer",
+      ["science", "shared", "import:2026-07-04-0"],
+      "2026-06-01T00:00:00.000Z",
+      null,
+    ),
+    createCardRow(
+      cardIdB,
+      workspaceId,
+      "B",
+      "B answer",
+      ["science", "draft", "import:2026-07-04-1"],
+      "2026-06-02T00:00:00.000Z",
+      null,
+    ),
+    createCardRow(
+      cardIdC,
+      workspaceId,
+      "C",
+      "C answer",
+      ["history", "outside"],
+      "2026-06-03T00:00:00.000Z",
+      null,
+    ),
   ], []);
 
   const preview = await previewWorkspacePackageExportInExecutor(
@@ -321,7 +345,12 @@ test("preview applies include and exclude tag filters", async () => {
 
   assert.equal(preview.selectedCardCount, 1);
   assert.deepEqual(preview.availableTagCounts, [
+    { tag: "import:2026-07-04-0", cardsCount: 1 },
     { tag: "science", cardsCount: 1 },
+    { tag: "shared", cardsCount: 1 },
+  ]);
+  assert.deepEqual(preview.tagsSelectedForRemoval, [
+    { tag: "import:2026-07-04-0", cardsCount: 1 },
   ]);
 });
 

--- a/apps/backend/src/workspacePackages/import/importPlan.test.ts
+++ b/apps/backend/src/workspacePackages/import/importPlan.test.ts
@@ -72,6 +72,32 @@ test("workspace package import plan applies the import tag when enabled", () => 
   });
 });
 
+test("workspace package import plan rejects a blank enabled import tag", () => {
+  assert.throws(
+    () => planWorkspacePackageImport({
+      cardsJson: createCardsJson([
+        createTestCard("Prompt", "Answer", ["biology"], "basic", null),
+      ]),
+      options: createImportOptions(true, "   ", []),
+      mediaAssetIdsByPortablePath: new Map(),
+    }),
+    /options\.importTag must not be empty/u,
+  );
+});
+
+test("workspace package import plan accepts a blank import tag when disabled", () => {
+  const plan = planWorkspacePackageImport({
+    cardsJson: createCardsJson([
+      createTestCard("Prompt", "Answer", ["biology"], "basic", null),
+    ]),
+    options: createImportOptions(false, "   ", []),
+    mediaAssetIdsByPortablePath: new Map(),
+  });
+
+  assert.deepEqual(plan.cards[0]?.tags, ["biology"]);
+  assert.equal(plan.summary.importTag, null);
+});
+
 test("workspace package import plan removes exact tags without partial matches", () => {
   const plan = planWorkspacePackageImport({
     cardsJson: createCardsJson([

--- a/apps/backend/src/workspacePackages/import/importPlan.ts
+++ b/apps/backend/src/workspacePackages/import/importPlan.ts
@@ -104,11 +104,19 @@ function normalizeImportPlanOptions(
 ): WorkspacePackageImportPlanNormalizedOptions {
   return {
     addImportTag: options.addImportTag,
-    importTag: normalizeRequiredText(options.importTag, "options.importTag"),
+    importTag: normalizeImportTag(options.addImportTag, options.importTag),
     removeTags: normalizeRequiredUniqueTextValues(options.removeTags, "options.removeTags"),
     importedAt: normalizeRequiredIsoTimestamp(options.importedAt, "options.importedAt"),
     importId: normalizeRequiredText(options.importId, "options.importId"),
   };
+}
+
+function normalizeImportTag(addImportTag: boolean, importTag: string): string {
+  if (addImportTag) {
+    return normalizeRequiredText(importTag, "options.importTag");
+  }
+
+  return importTag.trim();
 }
 
 function normalizeImportPlanCardsJson(cardsJson: WorkspacePackageCardsJsonV1): WorkspacePackageCardsJsonV1 {


### PR DESCRIPTION
## Summary
- make import confirm validation accept a blank importTag only when import tagging is disabled
- document import/export package tag contracts for client implementers
- add focused backend tests for tag-filter export selection, generated import tag stripping, and package-only tag removal

## Validation
- cd apps/backend && npm run test -- workspacePackages: passed, 756 tests
- cd apps/backend && npm run test -- routes/workspacePackages: passed, 756 tests
- cd api && npm run lint: passed
- cd apps/backend && npm run lint: passed
- contract grep requested by the plan was run
- worker-owned review round: no split recommendation, no P0-P4 findings, green light

## Notes
- local npm ci warned about Node 25 vs package Node 24; tests and lint passed