### PR TITLE
Fix iOS progress refresh network errors

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -87,7 +87,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressErrorMessage(message: localizedProgressUnavailableErrorMessage())
         }
     }
@@ -130,7 +132,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressErrorMessage(message: localizedProgressUnavailableErrorMessage())
         }
     }
@@ -173,7 +177,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressLeaderboardRefreshErrorMessage(
                 message: localizedProgressLeaderboardRefreshErrorMessage()
             )
@@ -272,7 +278,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressErrorMessage(message: localizedProgressUnavailableErrorMessage())
         }
     }
@@ -332,7 +340,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressErrorMessage(message: localizedProgressUnavailableErrorMessage())
         }
     }
@@ -618,7 +628,13 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.isCloudSyncBlocked {
+                return
+            }
+
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressErrorMessage(message: localizedProgressUnavailableErrorMessage())
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressRefresh.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressRefresh.swift
@@ -2,6 +2,22 @@ import Foundation
 
 @MainActor
 extension FlashcardsStore {
+    func shouldPresentProgressRefreshTechnicalError(error: Error) -> Bool {
+        if isRequestCancellationError(error: error) {
+            return false
+        }
+
+        if self.isCloudSyncBlocked {
+            return false
+        }
+
+        if isRetryableNetworkTransportFailure(error: error) {
+            return false
+        }
+
+        return true
+    }
+
     func refreshProgressSummaryServerBase(
         scopeKey: ProgressSummaryScopeKey,
         linkedSession: CloudLinkedSession
@@ -68,7 +84,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressSummaryRefreshErrorMessage(
                 message: localizedProgressSummaryRefreshErrorMessage()
             )
@@ -130,7 +148,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressSeriesRefreshErrorMessage(
                 message: localizedProgressSeriesRefreshErrorMessage()
             )
@@ -199,7 +219,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressReviewScheduleRefreshErrorMessage(
                 message: localizedProgressReviewScheduleRefreshErrorMessage()
             )
@@ -266,7 +288,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressLeaderboardRefreshErrorMessage(
                 message: localizedProgressLeaderboardRefreshErrorMessage()
             )
@@ -337,7 +361,9 @@ extension FlashcardsStore {
                 return
             }
 
-            self.presentTechnicalError(error)
+            if self.shouldPresentProgressRefreshTechnicalError(error: error) {
+                self.presentTechnicalError(error)
+            }
             self.replaceProgressStreakLeaderboardRefreshErrorMessage(
                 message: localizedProgressStreakLeaderboardRefreshErrorMessage()
             )

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressBadgeRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressBadgeRefreshTests.swift
@@ -439,6 +439,71 @@ final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
     }
 
     @MainActor
+    func testProgressLeaderboardRetryableNetworkRefreshErrorsStayInline() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:30:00.000Z"))
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        let linkedSession = makeProgressLinkedSessionForBadgeTests(
+            userId: linkedUserId,
+            workspaceId: workspace.workspaceId,
+            apiBaseUrl: context.apiBaseUrl
+        )
+        let scopeKey = try context.store.prepareProgressScope(now: now)
+        let leaderboardScopeKey = context.store.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+
+        context.cloudSyncService.loadProgressLeaderboardError = URLError(.notConnectedToInternet)
+        await context.store.refreshProgressLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        XCTAssertNil(context.store.presentedTechnicalError)
+        XCTAssertFalse(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
+        XCTAssertTrue(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
+
+        context.store.clearProgressLeaderboardRefreshErrorMessage()
+        context.cloudSyncService.loadProgressLeaderboardError = nil
+        context.cloudSyncService.loadProgressStreakLeaderboardError = URLError(.networkConnectionLost)
+        await context.store.refreshProgressStreakLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        XCTAssertNil(context.store.presentedTechnicalError)
+        XCTAssertTrue(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
+        XCTAssertFalse(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
+    }
+
+    @MainActor
     func testLeaderboardParticipationChangeClearsRatingAndStreakCaches() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressSummarySeriesRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressSummarySeriesRefreshTests.swift
@@ -820,6 +820,88 @@ final class ProgressSummarySeriesRefreshTests: ProgressStoreTestCase {
     }
 
     @MainActor
+    func testRefreshProgressIfNeededKeepsRetryableSummaryRefreshFailureInline() async throws {
+        let database = try self.makeDatabase()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: URLError(.notConnectedToInternet),
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        XCTAssertNil(context.store.presentedTechnicalError)
+        XCTAssertFalse(context.store.progressErrorState.summaryRefreshMessage.isEmpty)
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededPresentsTechnicalErrorForUnexpectedSummaryRefreshFailure() async throws {
+        let database = try self.makeDatabase()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: LocalStoreError.validation("Summary refresh failed"),
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        XCTAssertNotNil(context.store.presentedTechnicalError)
+        XCTAssertFalse(context.store.progressErrorState.summaryRefreshMessage.isEmpty)
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
+    }
+
+    @MainActor
     func testRefreshProgressIfNeededUpdatesRemoteSummaryWhenSeriesRefreshFails() async throws {
         let database = try self.makeDatabase()
         let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()


### PR DESCRIPTION
## Summary
- Suppress technical error presentation for retryable transport failures during iOS progress refreshes
- Keep inline progress refresh error messages and unexpected technical errors
- Add focused progress refresh coverage

## Validation
- git --no-pager diff --check
- Review subagent: no P0-P4 issues
- iOS simulator-backed tests not run (not allowed)