### PR TITLE
Fix iOS technical error observability feature

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -22,6 +22,7 @@ enum IOSObservationFeature: String, Sendable {
     case notifications = "notifications"
     case localData = "local_data"
     case prompts = "prompts"
+    case technicalError = "technical_error"
     case progress = "progress"
     case storeReview = "store_review"
 }

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -647,7 +647,7 @@ final class FlashcardsStore {
         FlashcardsObservability.captureSilentFailure(
             error: error,
             scope: IOSObservationScope(
-                feature: .prompts,
+                feature: .technicalError,
                 userId: self.cloudSettings?.linkedUserId,
                 workspaceId: self.workspace?.workspaceId,
                 requestId: nil,


### PR DESCRIPTION
## Summary
- add a neutral iOS observability feature for globally presented technical errors
- tag the global technical-error presenter with technical_error instead of prompts

## Validation
- rg check for technicalError / .technicalError / .prompts passed
- scoped git diff check passed
- git --no-pager diff --check passed
- iOS simulator-backed tests/build not run because not explicitly allowed