### PR TITLE
Add iOS foreground operation breadcrumb foundation

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -40,6 +40,7 @@ struct IOSObservationScope: Sendable, Hashable {
 
 enum IOSBreadcrumbEvent: Sendable {
     case appLifecycle(AppLifecycleObservation)
+    case foregroundOperation(ForegroundOperationObservation)
     case cloudFlow(CloudFlowObservation)
     case cloudRetry(CloudRetryObservation)
     case aiChatLifecycle(AIChatLifecycleObservation)
@@ -94,6 +95,38 @@ struct AppLifecycleObservation: Sendable, Hashable {
     let isStartupReady: Bool?
     let isRecoveryGateActive: Bool?
     let messageSummary: String?
+}
+
+enum ForegroundOperationAction: String, Sendable, Hashable {
+    case initialStartup = "initial_startup"
+    case visibleTabPresentation = "visible_tab_presentation"
+    case reviewProgressRefresh = "review_progress_refresh"
+    case cloudSync = "cloud_sync"
+    case notificationReconciliation = "notification_reconciliation"
+}
+
+enum ForegroundOperationPhase: String, Sendable, Hashable {
+    case start
+    case success
+    case failure
+}
+
+struct ForegroundOperationObservation: Sendable, Hashable {
+    let scope: IOSObservationScope
+    let action: ForegroundOperationAction
+    let phase: ForegroundOperationPhase
+    let durationMilliseconds: Int?
+    let selectedTab: String?
+    let scenePhase: String?
+    let isStartupReady: Bool?
+    let isRecoveryGateActive: Bool?
+    let cardCount: Int?
+    let deckCount: Int?
+    let pendingOutboxOperationCount: Int?
+    let reviewQueueCount: Int?
+    let reviewDueCount: Int?
+    let cloudSyncBlocked: Bool?
+    let errorSummary: String?
 }
 
 struct CloudFlowObservation: Sendable, Hashable {

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -49,6 +49,19 @@ extension SentryObservabilityAdapter {
                 message: observation.action.rawValue,
                 data: self.appLifecycleContext(observation)
             )
+        case .foregroundOperation(let observation):
+            self.writeLocalRecord(
+                kind: "breadcrumb",
+                feature: observation.scope.feature,
+                action: observation.action.rawValue,
+                fields: self.foregroundOperationFields(observation)
+            )
+            self.addSentryBreadcrumb(
+                category: "ios.foreground_operation",
+                level: .info,
+                message: "\(observation.action.rawValue).\(observation.phase.rawValue)",
+                data: self.foregroundOperationContext(observation)
+            )
         case .cloudFlow(let observation):
             self.logCloudFlow(observation)
             self.addSentryBreadcrumb(
@@ -635,6 +648,29 @@ extension SentryObservabilityAdapter {
 
     private static func appLifecycleFields(_ observation: AppLifecycleObservation) -> [String: String] {
         stringifyContext(self.appLifecycleContext(observation))
+    }
+
+    private static func foregroundOperationContext(_ observation: ForegroundOperationObservation) -> [String: Any] {
+        var context: [String: Any] = self.scopeContext(observation.scope)
+        context["action"] = observation.action.rawValue
+        context["phase"] = observation.phase.rawValue
+        context["duration_milliseconds"] = observation.durationMilliseconds.map { durationMilliseconds in String(durationMilliseconds) } ?? ""
+        context["selected_tab"] = observation.selectedTab ?? ""
+        context["scene_phase"] = observation.scenePhase ?? ""
+        context["is_startup_ready"] = observation.isStartupReady.map { isStartupReady in String(isStartupReady) } ?? ""
+        context["is_recovery_gate_active"] = observation.isRecoveryGateActive.map { isRecoveryGateActive in String(isRecoveryGateActive) } ?? ""
+        context["card_count"] = observation.cardCount.map { cardCount in String(cardCount) } ?? ""
+        context["deck_count"] = observation.deckCount.map { deckCount in String(deckCount) } ?? ""
+        context["pending_outbox_operation_count"] = observation.pendingOutboxOperationCount.map { pendingOutboxOperationCount in String(pendingOutboxOperationCount) } ?? ""
+        context["review_queue_count"] = observation.reviewQueueCount.map { reviewQueueCount in String(reviewQueueCount) } ?? ""
+        context["review_due_count"] = observation.reviewDueCount.map { reviewDueCount in String(reviewDueCount) } ?? ""
+        context["cloud_sync_blocked"] = observation.cloudSyncBlocked.map { cloudSyncBlocked in String(cloudSyncBlocked) } ?? ""
+        context["error_summary"] = observation.errorSummary ?? ""
+        return context
+    }
+
+    private static func foregroundOperationFields(_ observation: ForegroundOperationObservation) -> [String: String] {
+        stringifyContext(self.foregroundOperationContext(observation))
     }
 
     private static func aiChatLifecycleContext(_ observation: AIChatLifecycleObservation) -> [String: Any] {


### PR DESCRIPTION
## Summary
- Add a typed iOS foreground operation breadcrumb event model
- Map foreground operation breadcrumbs to local observability records and Sentry category `ios.foreground_operation`
- Keep this foundation passive with no product-flow instrumentation

## Validation
- `git --no-pager diff --check`
- Worker-owned fresh read-only review subagent: no split recommendation, no P0-P4 findings, green light

## Residual Risk
- Local `xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` was blocked before Swift compilation by local Xcode destination selection / unavailable eligible iOS destination.