### PR TITLE
Stop materializing active days on progress reads

### DIFF
--- a/apps/backend/src/progress/progressContract.test.ts
+++ b/apps/backend/src/progress/progressContract.test.ts
@@ -71,7 +71,7 @@ test("progress barrel re-exports the community leaderboard loaders", async () =>
   assert.deepEqual(guestProfile, { status: "linked_account_required" });
 });
 
-test("public progress streak loaders retry transient repeatable-read materialization failures", () => {
+test("public progress streak loaders retry transient repeatable-read failures", () => {
   const source = loadProgressReportsIndexSource();
 
   assert.match(source, /import \{ withTransientDatabaseRetry \} from "\.\.\/\.\.\/database\/transient";/);

--- a/apps/backend/src/progress/reports/index.ts
+++ b/apps/backend/src/progress/reports/index.ts
@@ -11,7 +11,6 @@ import { HttpError } from "../../shared/errors";
 import { listUserWorkspaceIdsInExecutor } from "../../workspaces/queries";
 import {
   loadUserActiveReviewLocalDatesInExecutor,
-  materializeMissingActiveReviewDaysForUserInExecutor,
   rememberProgressTimeZoneInExecutor,
 } from "../activeReviewDays/activeReviewDays";
 import {
@@ -700,17 +699,13 @@ async function buildUserProgressSummaryInExecutor(
       userId: request.userId,
       workspaceId,
     });
-    await materializeMissingActiveReviewDaysForUserInExecutor(
-      executor,
-      request.userId,
-      workspaceId,
-      request.timeZone,
-    );
     reviewHistoryWatermarks = reviewHistoryWatermarks.concat(
       await loadReviewHistoryWatermarksInExecutor(executor, [workspaceId]),
     );
   }
 
+  // Active-day materialization is owned by review writes and the scheduled
+  // backfill; progress reads intentionally do not repair historical rows.
   const activeReviewLocalDates = await loadUserActiveReviewLocalDatesInExecutor(executor, request.userId);
   const activeReviewDateSet = new Set(activeReviewLocalDates);
   const lastReviewedOn = activeReviewLocalDates.at(-1) ?? null;
@@ -801,18 +796,14 @@ async function buildUserProgressSeriesInExecutor(
       to: request.to,
     });
     dailyReviewCounts = addDailyReviewCountRows(dailyReviewCounts, rows);
-    await materializeMissingActiveReviewDaysForUserInExecutor(
-      executor,
-      request.userId,
-      workspaceId,
-      request.timeZone,
-    );
     reviewHistoryWatermarks = reviewHistoryWatermarks.concat(
       await loadReviewHistoryWatermarksInExecutor(executor, [workspaceId]),
     );
   }
 
   const range = createInclusiveLocalDateRange(request.from, request.to);
+  // Active-day materialization is owned by review writes and the scheduled
+  // backfill; progress reads intentionally do not repair historical rows.
   const activeReviewLocalDates = await loadUserActiveReviewLocalDatesInExecutor(executor, request.userId);
   const activeReviewDateSet = new Set(activeReviewLocalDates);
   const today = formatDateAsTimeZoneLocalDate(generatedAtDate, request.timeZone);

--- a/apps/backend/src/progress/reports/progressSeries.test.ts
+++ b/apps/backend/src/progress/reports/progressSeries.test.ts
@@ -183,7 +183,7 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges rating breakdowns a
   ]);
 });
 
-test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_client in the requested timezone", async () => {
+test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_client and reads materialized active days", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
@@ -234,19 +234,11 @@ test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_clie
     "2026-04-12",
   ]);
 
-  const materializationQuery = recordedQueries.find((query) => query.text.includes("WITH target_review_events AS"));
-  if (materializationQuery === undefined) {
-    assert.fail("Expected an active review day materialization query to be recorded");
-  }
-  assert.match(materializationQuery.text, /INSERT INTO progress\.user_active_review_days/);
-  assert.match(materializationQuery.text, /WHERE review_events\.reviewed_by_user_id = \$1/);
-  assert.match(materializationQuery.text, /AND review_events\.workspace_id = \$3/);
-  assert.doesNotMatch(materializationQuery.text, /review_events\.rating/);
-  assert.deepEqual(materializationQuery.params, [
-    "user-1",
-    "America/Los_Angeles",
-    "workspace-1",
-  ]);
+  const materializationQueries = recordedQueries.filter((query) => (
+    query.text.includes("WITH target_review_events AS")
+    && query.text.includes("INSERT INTO progress.user_active_review_days")
+  ));
+  assert.equal(materializationQueries.length, 0);
 
   const activeDayQuery = recordedQueries.find((query) => (
     query.text.includes("FROM progress.user_active_review_days AS active_days")
@@ -312,16 +304,9 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
 
   const materializationQueries = recordedQueries.filter((query) => (
     query.text.includes("WITH target_review_events AS")
+    && query.text.includes("INSERT INTO progress.user_active_review_days")
   ));
-  assert.equal(materializationQueries.length, 2);
-  assert.ok(materializationQueries.every((query) => (
-    query.text.includes("WHERE review_events.reviewed_by_user_id = $1")
-    && query.text.includes("AND review_events.workspace_id = $3")
-  )));
-  assert.deepEqual(materializationQueries.map((query) => query.params), [
-    ["user-1", "Europe/Madrid", "workspace-1"],
-    ["user-1", "Europe/Madrid", "workspace-2"],
-  ]);
+  assert.equal(materializationQueries.length, 0);
 
   const activeDayQueries = recordedQueries.filter((query) => (
     query.text.includes("FROM progress.user_active_review_days AS active_days")

--- a/apps/backend/src/progress/reports/progressSummary.test.ts
+++ b/apps/backend/src/progress/reports/progressSummary.test.ts
@@ -222,7 +222,7 @@ test("loadUserProgressSummaryInExecutor reads user-wide active review dates with
   ]);
 });
 
-test("loadUserProgressSummaryInExecutor materializes and reads active review days in the requested timezone", async () => {
+test("loadUserProgressSummaryInExecutor remembers timezone and reads materialized active review days", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
@@ -258,24 +258,11 @@ test("loadUserProgressSummaryInExecutor materializes and reads active review day
     "America/Los_Angeles",
   ]);
 
-  const materializationQuery = recordedQueries.find((query) => (
+  const materializationQueries = recordedQueries.filter((query) => (
     query.text.includes("WITH target_review_events AS")
+    && query.text.includes("INSERT INTO progress.user_active_review_days")
   ));
-  if (materializationQuery === undefined) {
-    assert.fail("Expected an active review day materialization query to be recorded");
-  }
-  assert.match(
-    materializationQuery.text,
-    /timezone\(COALESCE\(review_events\.reviewed_time_zone, \$2\), review_events\.reviewed_at_client\)::date/,
-  );
-  assert.match(materializationQuery.text, /WHERE review_events\.reviewed_by_user_id = \$1/);
-  assert.match(materializationQuery.text, /AND review_events\.workspace_id = \$3/);
-  assert.match(materializationQuery.text, /INSERT INTO progress\.user_active_review_days/);
-  assert.deepEqual(materializationQuery.params, [
-    "user-1",
-    "America/Los_Angeles",
-    "workspace-1",
-  ]);
+  assert.equal(materializationQueries.length, 0);
 
   const activeDayQuery = recordedQueries.find((query) => (
     query.text.includes("FROM progress.user_active_review_days AS active_days")
@@ -320,16 +307,9 @@ test("loadUserProgressSummaryInExecutor applies user scope while reading user-wi
 
   const materializationQueries = recordedQueries.filter((query) => (
     query.text.includes("WITH target_review_events AS")
+    && query.text.includes("INSERT INTO progress.user_active_review_days")
   ));
-  assert.equal(materializationQueries.length, 2);
-  assert.ok(materializationQueries.every((query) => (
-    query.text.includes("WHERE review_events.reviewed_by_user_id = $1")
-    && query.text.includes("AND review_events.workspace_id = $3")
-  )));
-  assert.deepEqual(materializationQueries.map((query) => query.params), [
-    ["user-1", "Europe/Madrid", "workspace-1"],
-    ["user-1", "Europe/Madrid", "workspace-2"],
-  ]);
+  assert.equal(materializationQueries.length, 0);
 
   const activeDayQueries = recordedQueries.filter((query) => (
     query.text.includes("FROM progress.user_active_review_days AS active_days")


### PR DESCRIPTION
## Summary
- Remove synchronous active-review-day materialization from progress summary and series read builders
- Keep timezone remember, workspace scoping, watermarks, daily review counts, and active-day reads intact
- Update focused progress tests to assert read paths do not issue materialization inserts

## Validation
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend (752 tests)

Review gate: worker-owned review found no P0-P4 issues and no split recommendation.