### PR TITLE
Fix iOS reset progress confirmation phrase

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Types/CloudTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Types/CloudTypes.swift
@@ -1,10 +1,7 @@
 import Foundation
 
-let workspaceResetProgressConfirmationText: String = String(
-    localized: "workspace.reset_progress_confirmation_text",
-    table: "Foundation",
-    comment: "Confirmation phrase for resetting all workspace card progress"
-)
+// Backend validates this exact destructive-action phrase; do not localize it.
+let workspaceResetProgressConfirmationText: String = "reset all progress for all cards in this workspace"
 
 enum CloudAccountState: String, CaseIterable, Codable, Hashable, Identifiable, Sendable {
     case disconnected

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -11918,65 +11918,6 @@
           }
         }
       }
-    },
-    "workspace.reset_progress_confirmation_text" : {
-      "comment" : "Confirmation phrase for resetting all workspace card progress",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة تعيين كل التقدم لجميع البطاقات في مساحة العمل هذه"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "den gesamten Fortschritt aller Karten in diesem Arbeitsbereich zurücksetzen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "reset all progress for all cards in this workspace"
-          }
-        },
-        "es-ES" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "restablecer todo el progreso de todas las tarjetas de este espacio de trabajo"
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "restablecer todo el progreso de todas las tarjetas de este espacio de trabajo"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इस वर्कस्पेस में सभी कार्डों की पूरी प्रगति रीसेट करें"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このワークスペース内のすべてのカードの進捗をすべてリセットする"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "сбросить весь прогресс по всем карточкам в этом рабочем пространстве"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置此工作区中所有卡片的全部进度"
-          }
-        }
-      }
     }
   },
   "version" : "1.0"

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/DangerZone/ResetWorkspaceProgressConfirmationView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/DangerZone/ResetWorkspaceProgressConfirmationView.swift
@@ -83,10 +83,7 @@ struct ResetWorkspaceProgressConfirmationView: View {
         }
 
         TextField(
-            aiSettingsLocalized(
-                "settings.workspace.resetConfirmation.placeholder",
-                "reset all progress for all cards in this workspace"
-            ),
+            workspaceResetProgressConfirmationText,
             text: self.$confirmationText
         )
             .textInputAutocapitalization(.never)

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "تأكيد إعادة الضبط";
 "settings.workspace.resetConfirmation.warning" = "تحذير: هذا الإجراء دائم. سيؤدي إلى مسح تقدم الدراسة لكل بطاقة في مساحة العمل هذه.";
 "settings.workspace.resetConfirmation.description" = "ستبقى البطاقات في مكانها. سيعود تقدم دراستك إلى الجديد.";
-"settings.workspace.resetConfirmation.placeholder" = "إعادة تعيين كل التقدم لجميع البطاقات في مساحة العمل هذه";
 "settings.workspace.resetConfirmation.loadingPreview" = "جارٍ تحميل معاينة إعادة التعيين...";
 "settings.workspace.resetConfirmation.previewWarning" = "تحذير: هذا الإجراء دائم. سيتم إعادة تعيين بطاقات %d إلى %@.";
 "settings.workspace.resetConfirmation.previewDescription" = "ستبقى البطاقات في مساحة العمل. سيتم حذف تقدم دراستك فقط.";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "Bestätigen Sie das Zurücksetzen";
 "settings.workspace.resetConfirmation.warning" = "Achtung: Diese Aktion ist dauerhaft. Dadurch wird der Lernfortschritt jeder Karte in diesem Arbeitsbereich gelöscht.";
 "settings.workspace.resetConfirmation.description" = "Die Karten bleiben an Ort und Stelle. Ihr Lernfortschritt wird wieder auf den neuesten Stand gebracht.";
-"settings.workspace.resetConfirmation.placeholder" = "Setzen Sie den gesamten Fortschritt für alle Karten in diesem Arbeitsbereich zurück";
 "settings.workspace.resetConfirmation.loadingPreview" = "Vorschau zum Zurücksetzen wird geladen...";
 "settings.workspace.resetConfirmation.previewWarning" = "Achtung: Diese Aktion ist dauerhaft. Setzt %d-Karten auf %@ zurück.";
 "settings.workspace.resetConfirmation.previewDescription" = "Die Karten bleiben im Arbeitsbereich. Nur Ihr Lernfortschritt wird gelöscht.";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "Confirmar restablecimiento";
 "settings.workspace.resetConfirmation.warning" = "Advertencia: esta accion es permanente. Borrara el progreso de estudio de cada tarjeta de este espacio de trabajo.";
 "settings.workspace.resetConfirmation.description" = "Las tarjetas permaneceran en su sitio. Su progreso de estudio volvera a nuevo.";
-"settings.workspace.resetConfirmation.placeholder" = "reset all progress for all cards in this workspace";
 "settings.workspace.resetConfirmation.loadingPreview" = "Cargando vista previa del restablecimiento...";
 "settings.workspace.resetConfirmation.previewWarning" = "Advertencia: esta accion es permanente. Restablecera %d tarjetas en %@.";
 "settings.workspace.resetConfirmation.previewDescription" = "Las tarjetas permaneceran en el espacio de trabajo. Solo se borrara su progreso de estudio.";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "Confirmar restablecimiento";
 "settings.workspace.resetConfirmation.warning" = "Advertencia: esta accion es permanente. Borrara el progreso de estudio de cada tarjeta de este espacio de trabajo.";
 "settings.workspace.resetConfirmation.description" = "Las tarjetas permaneceran en su sitio. Su progreso de estudio volvera a nuevo.";
-"settings.workspace.resetConfirmation.placeholder" = "reset all progress for all cards in this workspace";
 "settings.workspace.resetConfirmation.loadingPreview" = "Cargando vista previa del restablecimiento...";
 "settings.workspace.resetConfirmation.previewWarning" = "Advertencia: esta accion es permanente. Restablecera %d tarjetas en %@.";
 "settings.workspace.resetConfirmation.previewDescription" = "Las tarjetas permaneceran en el espacio de trabajo. Solo se borrara su progreso de estudio.";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "रीसेट की पुष्टि करें";
 "settings.workspace.resetConfirmation.warning" = "चेतावनी: यह क्रिया स्थायी है. यह इस कार्यक्षेत्र में प्रत्येक कार्ड की अध्ययन प्रगति को स्पष्ट कर देगा।";
 "settings.workspace.resetConfirmation.description" = "कार्ड यथावत रहेंगे. आपकी अध्ययन प्रगति नई हो जाएगी";
-"settings.workspace.resetConfirmation.placeholder" = "इस कार्यक्षेत्र में सभी कार्डों के लिए सभी प्रगति रीसेट करें";
 "settings.workspace.resetConfirmation.loadingPreview" = "रीसेट पूर्वावलोकन लोड हो रहा है...";
 "settings.workspace.resetConfirmation.previewWarning" = "चेतावनी: यह क्रिया स्थायी है. %d कार्ड को %@ पर रीसेट कर दिया जाएगा।";
 "settings.workspace.resetConfirmation.previewDescription" = "कार्ड कार्यक्षेत्र में ही रहेंगे. केवल आपकी अध्ययन प्रगति हटा दी जाएगी.";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "リセットを確認";
 "settings.workspace.resetConfirmation.warning" = "警告: このアクションは永続的です。このワークスペース内の各カードの学習の進行状況をクリアします。";
 "settings.workspace.resetConfirmation.description" = "カードはそのまま残ります。学習の進捗状況が新しい状態に戻ります。";
-"settings.workspace.resetConfirmation.placeholder" = "このワークスペース内のすべてのカードの進行状況をすべてリセット";
 "settings.workspace.resetConfirmation.loadingPreview" = "リセット プレビューを読み込んでいます...";
 "settings.workspace.resetConfirmation.previewWarning" = "警告: このアクションは永続的です。 %d カードを %@ にリセットします。";
 "settings.workspace.resetConfirmation.previewDescription" = "カードはワークスペースに残ります。学習の進行状況のみが削除されます。";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "Подтвердить сброс";
 "settings.workspace.resetConfirmation.warning" = "Внимание: это действие является постоянным. Это очистит прогресс изучения каждой карты в этом рабочем пространстве.";
 "settings.workspace.resetConfirmation.description" = "Карты останутся на месте. Ваш прогресс в учебе вернется к новому.";
-"settings.workspace.resetConfirmation.placeholder" = "сбросить весь прогресс для всех карточек в этом рабочем пространстве";
 "settings.workspace.resetConfirmation.loadingPreview" = "Загрузка предварительного просмотра сброса...";
 "settings.workspace.resetConfirmation.previewWarning" = "Внимание: это действие является постоянным. Карты %d сбросятся на %@.";
 "settings.workspace.resetConfirmation.previewDescription" = "Карты останутся в рабочей области. Будет удален только ваш прогресс в учебе.";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -533,7 +533,6 @@
 "settings.workspace.resetConfirmation.title" = "确认重置";
 "settings.workspace.resetConfirmation.warning" = "警告：此操作是永久性的。它将清除该工作区中每张卡的学习进度。";
 "settings.workspace.resetConfirmation.description" = "卡片将保留在原处。您的学习进度将恢复新的。";
-"settings.workspace.resetConfirmation.placeholder" = "重置此工作区中所有卡片的所有进度";
 "settings.workspace.resetConfirmation.loadingPreview" = "正在加载重置预览...";
 "settings.workspace.resetConfirmation.previewWarning" = "警告：此操作是永久性的。将 %d 卡重置为 %@。";
 "settings.workspace.resetConfirmation.previewDescription" = "这些卡片将保留在工作区中。仅删除您的学习进度。";


### PR DESCRIPTION
## Summary
- make the iOS reset-progress confirmation phrase a non-localized backend contract constant
- use the canonical phrase for the visible phrase, input gate, and text-field placeholder
- remove the now-unused localized confirmation phrase keys

## Validation
- rg reset-progress confirmation references: passed
- plutil -lint on modified AISettings.strings files: passed
- jq empty Foundation.xcstrings: passed
- xcrun xcstringstool compile --dry-run Foundation.xcstrings: passed
- git --no-pager diff --check: passed
- fresh worker-owned review: no P0-P4 findings

Simulator/manual Russian-locale validation was not run because it is gated on explicit approval.