### PR TITLE
Stop showing retryable progress refresh transport errors

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -87,6 +87,10 @@ extension FlashcardsStore {
                 return
             }
 
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
+                return
+            }
+
             if self.shouldPresentProgressRefreshTechnicalError(error: error) {
                 self.presentTechnicalError(error)
             }
@@ -132,6 +136,10 @@ extension FlashcardsStore {
                 return
             }
 
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
+                return
+            }
+
             if self.shouldPresentProgressRefreshTechnicalError(error: error) {
                 self.presentTechnicalError(error)
             }
@@ -174,6 +182,10 @@ extension FlashcardsStore {
             }
 
             if self.isCloudSyncBlocked {
+                return
+            }
+
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
                 return
             }
 
@@ -278,6 +290,10 @@ extension FlashcardsStore {
                 return
             }
 
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
+                return
+            }
+
             if self.shouldPresentProgressRefreshTechnicalError(error: error) {
                 self.presentTechnicalError(error)
             }
@@ -337,6 +353,10 @@ extension FlashcardsStore {
             }
 
             if self.isCloudSyncBlocked {
+                return
+            }
+
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
                 return
             }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressRefresh.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressRefresh.swift
@@ -19,7 +19,7 @@ extension FlashcardsStore {
             return false
         }
 
-        if isRetryableNetworkTransportFailure(error: error) {
+        if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
             return false
         }
 
@@ -133,6 +133,10 @@ extension FlashcardsStore {
                 return
             }
 
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
+                return
+            }
+
             self.presentProgressRefreshTechnicalError(
                 error: error,
                 refreshKind: "progress_summary_refresh_failed",
@@ -198,6 +202,10 @@ extension FlashcardsStore {
             }
 
             guard self.isCurrentProgressSeriesRefresh(scopeKey: scopeKey, refreshToken: refreshToken) else {
+                return
+            }
+
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
                 return
             }
 
@@ -276,6 +284,10 @@ extension FlashcardsStore {
                 return
             }
 
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
+                return
+            }
+
             self.presentProgressRefreshTechnicalError(
                 error: error,
                 refreshKind: "progress_review_schedule_refresh_failed",
@@ -346,6 +358,10 @@ extension FlashcardsStore {
             }
 
             guard self.isCurrentProgressLeaderboardRefresh(scopeKey: scopeKey, refreshToken: refreshToken) else {
+                return
+            }
+
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
                 return
             }
 
@@ -423,6 +439,10 @@ extension FlashcardsStore {
             }
 
             guard self.isCurrentProgressStreakLeaderboardRefresh(scopeKey: scopeKey, refreshToken: refreshToken) else {
+                return
+            }
+
+            if self.isNonCriticalProgressRefreshTransportFailure(error: error) {
                 return
             }
 
@@ -823,5 +843,9 @@ extension FlashcardsStore {
         self.progressActiveStreakLeaderboardRefreshScopeKey == scopeKey
             && self.progressActiveStreakLeaderboardRefreshToken == refreshToken
             && self.progressStreakLeaderboardRefreshToken == refreshToken
+    }
+
+    func isNonCriticalProgressRefreshTransportFailure(error: Error) -> Bool {
+        isRetryableNetworkTransportFailure(error: error)
     }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressBadgeRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressBadgeRefreshTests.swift
@@ -439,7 +439,7 @@ final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
     }
 
     @MainActor
-    func testProgressLeaderboardRetryableNetworkRefreshErrorsStayInline() async throws {
+    func testProgressLeaderboardRetryableNetworkRefreshErrorsStaySilent() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
         let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
@@ -488,7 +488,7 @@ final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
             linkedSession: linkedSession
         )
         XCTAssertNil(context.store.presentedTechnicalError)
-        XCTAssertFalse(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
+        XCTAssertTrue(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
         XCTAssertTrue(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
 
         context.store.clearProgressLeaderboardRefreshErrorMessage()
@@ -500,7 +500,7 @@ final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
         )
         XCTAssertNil(context.store.presentedTechnicalError)
         XCTAssertTrue(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
-        XCTAssertFalse(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
+        XCTAssertTrue(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
     }
 
     @MainActor

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressRefreshTransportErrorTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressRefreshTransportErrorTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import XCTest
+@testable import Flashcards
+
+final class ProgressRefreshTransportErrorTests: ProgressStoreTestCase {
+    @MainActor
+    func testRetryableCredentialRefreshTransportFailureDoesNotPresentProgressRefreshErrors() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T11:59:00.000Z"
+        )
+        let refreshedToken = CloudIdentityToken(
+            idToken: "id-token-refreshed",
+            idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+        )
+        let cloudAuthService = ProgressCloudAuthService(refreshedToken: refreshedToken)
+        cloudAuthService.refreshIdTokenError = URLError(.timedOut)
+        let suiteName = "progress-auth-transport-error-\(UUID().uuidString.lowercased())"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked,
+            suiteName: suiteName,
+            userDefaults: userDefaults,
+            cloudAuthService: cloudAuthService
+        )
+        defer { context.tearDown() }
+
+        try context.credentialStore.saveCredentials(
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token-1",
+                idToken: "id-token-expired",
+                idTokenExpiresAt: "2020-01-01T00:00:00.000Z"
+            )
+        )
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        context.store.cloudRuntime.setActiveCloudSession(
+            linkedSession: CloudLinkedSession(
+                userId: linkedUserId,
+                workspaceId: workspace.workspaceId,
+                email: nil,
+                configurationMode: .official,
+                apiBaseUrl: context.apiBaseUrl,
+                authorization: .bearer("id-token-expired")
+            )
+        )
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        XCTAssertEqual(1, cloudAuthService.refreshIdTokenCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressSummaryCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressSeriesCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressReviewScheduleCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressLeaderboardCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressStreakLeaderboardCallCount)
+        assertProgressTransportMissIsSilent(store: context.store, file: #filePath, line: #line)
+    }
+
+    @MainActor
+    func testRetryableTransportFailuresDoNotPresentProgressRefreshErrors() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        let linkedSession = makeProgressLinkedSessionForTransportErrorTests(
+            userId: linkedUserId,
+            workspaceId: workspace.workspaceId,
+            apiBaseUrl: context.apiBaseUrl
+        )
+        let scopeKey = try context.store.prepareProgressScope(now: now)
+        let summaryScopeKey = progressSummaryScopeKey(seriesScopeKey: scopeKey)
+        let scheduleScopeKey = reviewScheduleScopeKey(seriesScopeKey: scopeKey)
+        let leaderboardScopeKey = context.store.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+        let transportError = URLError(.timedOut)
+
+        context.cloudSyncService.loadProgressSummaryError = transportError
+        await context.store.refreshProgressSummaryServerBase(
+            scopeKey: summaryScopeKey,
+            linkedSession: linkedSession
+        )
+        assertProgressTransportMissIsSilent(store: context.store, file: #filePath, line: #line)
+
+        context.cloudSyncService.loadProgressSeriesError = transportError
+        await context.store.refreshProgressSeriesServerBase(
+            scopeKey: scopeKey,
+            linkedSession: linkedSession
+        )
+        assertProgressTransportMissIsSilent(store: context.store, file: #filePath, line: #line)
+
+        context.cloudSyncService.loadProgressReviewScheduleError = transportError
+        await context.store.refreshProgressReviewScheduleServerBase(
+            scopeKey: scheduleScopeKey,
+            linkedSession: linkedSession
+        )
+        assertProgressTransportMissIsSilent(store: context.store, file: #filePath, line: #line)
+
+        context.cloudSyncService.loadProgressLeaderboardError = transportError
+        await context.store.refreshProgressLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        assertProgressTransportMissIsSilent(store: context.store, file: #filePath, line: #line)
+
+        context.cloudSyncService.loadProgressStreakLeaderboardError = transportError
+        await context.store.refreshProgressStreakLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        assertProgressTransportMissIsSilent(store: context.store, file: #filePath, line: #line)
+    }
+}
+
+@MainActor
+private func assertProgressTransportMissIsSilent(
+    store: FlashcardsStore,
+    file: StaticString,
+    line: UInt
+) {
+    XCTAssertNil(store.presentedTechnicalError, file: file, line: line)
+    XCTAssertTrue(store.progressErrorMessage.isEmpty, file: file, line: line)
+    XCTAssertEqual(makeEmptyProgressErrorState(), store.progressErrorState, file: file, line: line)
+    XCTAssertFalse(store.isProgressRefreshing, file: file, line: line)
+}
+
+private func makeProgressLinkedSessionForTransportErrorTests(
+    userId: String,
+    workspaceId: String,
+    apiBaseUrl: String
+) -> CloudLinkedSession {
+    CloudLinkedSession(
+        userId: userId,
+        workspaceId: workspaceId,
+        email: nil,
+        configurationMode: .official,
+        apiBaseUrl: apiBaseUrl,
+        authorization: .bearer("id-token-1")
+    )
+}

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressSummarySeriesRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressSummarySeriesRefreshTests.swift
@@ -820,7 +820,7 @@ final class ProgressSummarySeriesRefreshTests: ProgressStoreTestCase {
     }
 
     @MainActor
-    func testRefreshProgressIfNeededKeepsRetryableSummaryRefreshFailureInline() async throws {
+    func testRefreshProgressIfNeededKeepsRetryableSummaryRefreshFailureSilent() async throws {
         let database = try self.makeDatabase()
         let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
@@ -856,7 +856,7 @@ final class ProgressSummarySeriesRefreshTests: ProgressStoreTestCase {
         await context.store.refreshProgressIfNeeded(now: now)
 
         XCTAssertNil(context.store.presentedTechnicalError)
-        XCTAssertFalse(context.store.progressErrorState.summaryRefreshMessage.isEmpty)
+        XCTAssertTrue(context.store.progressErrorState.summaryRefreshMessage.isEmpty)
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
     }
 

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressCloudSyncService.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressCloudSyncService.swift
@@ -5,12 +5,14 @@ import XCTest
 @MainActor
 final class ProgressCloudAuthService: CloudAuthServing {
     let refreshedToken: CloudIdentityToken
+    var refreshIdTokenError: Error?
     private(set) var refreshIdTokenCallCount: Int
     private(set) var lastRefreshToken: String?
     private(set) var lastAuthBaseUrl: String?
 
     init(refreshedToken: CloudIdentityToken) {
         self.refreshedToken = refreshedToken
+        self.refreshIdTokenError = nil
         self.refreshIdTokenCallCount = 0
         self.lastRefreshToken = nil
         self.lastAuthBaseUrl = nil
@@ -37,6 +39,9 @@ final class ProgressCloudAuthService: CloudAuthServing {
         self.refreshIdTokenCallCount += 1
         self.lastRefreshToken = refreshToken
         self.lastAuthBaseUrl = authBaseUrl
+        if let refreshIdTokenError {
+            throw refreshIdTokenError
+        }
         return self.refreshedToken
     }
 


### PR DESCRIPTION
## Summary
- Treat retryable progress refresh transport failures as non-critical refresh misses on iOS.
- Keep non-retryable progress refresh failures on the existing technical-error path.
- Add focused progress refresh coverage for timed-out transport failures across the relevant refresh surfaces.

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff -- apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressRefresh.swift | cat
- git --no-pager diff --check
- lightweight Swift literal check

iOS simulator-backed XCTest was not run because repository instructions require explicit permission and none was granted.

Worker-owned review: no split recommendation, no P0-P4 findings, green light for commit.