### PR TITLE
Fix progress series local dates

### DIFF
--- a/apps/backend/src/progress/reports/index.ts
+++ b/apps/backend/src/progress/reports/index.ts
@@ -11,6 +11,7 @@ import { HttpError } from "../../shared/errors";
 import { listUserWorkspaceIdsInExecutor } from "../../workspaces/queries";
 import {
   loadUserActiveReviewLocalDatesInExecutor,
+  materializeMissingActiveReviewDaysForUserInExecutor,
   rememberProgressTimeZoneInExecutor,
 } from "../activeReviewDays/activeReviewDays";
 import {
@@ -172,7 +173,10 @@ type WorkspaceProgressReviewScheduleRequest = Readonly<{
 
 type WorkspaceProgressSeriesRequest = Readonly<{
   workspaceId: string;
-}> & ProgressSeriesInput;
+  userId: string;
+  from: string;
+  to: string;
+}>;
 
 const maximumInclusiveProgressRangeDays = 366;
 const localDatePattern = /^\d{4}-\d{2}-\d{2}$/;
@@ -594,14 +598,14 @@ async function loadDailyReviewCountRowsInExecutor(
 ): Promise<ReadonlyArray<DailyReviewCountRow>> {
   const queryParams: ReadonlyArray<SqlValue> = [
     request.workspaceId,
-    request.timeZone,
+    request.userId,
     request.from,
     request.to,
   ];
   const result = await executor.query<DailyReviewCountRow>(
     [
       "SELECT",
-      "to_char(timezone($2, review_events.reviewed_at_client)::date, 'YYYY-MM-DD') AS review_date,",
+      "to_char(review_events.reviewed_local_date, 'YYYY-MM-DD') AS review_date,",
       "COUNT(*)::int AS review_count,",
       "COUNT(*) FILTER (WHERE review_events.rating = 0)::int AS again_count,",
       "COUNT(*) FILTER (WHERE review_events.rating = 1)::int AS hard_count,",
@@ -609,10 +613,11 @@ async function loadDailyReviewCountRowsInExecutor(
       "COUNT(*) FILTER (WHERE review_events.rating = 3)::int AS easy_count",
       "FROM content.review_events AS review_events",
       "WHERE review_events.workspace_id = $1",
-      "AND review_events.reviewed_at_client >= (($3::date)::timestamp AT TIME ZONE $2)",
-      "AND review_events.reviewed_at_client < (((($4::date) + 1)::timestamp) AT TIME ZONE $2)",
-      "GROUP BY review_date",
-      "ORDER BY review_date ASC",
+      "AND review_events.reviewed_by_user_id = $2",
+      "AND review_events.reviewed_local_date >= $3::date",
+      "AND review_events.reviewed_local_date <= $4::date",
+      "GROUP BY review_events.reviewed_local_date",
+      "ORDER BY review_events.reviewed_local_date ASC",
     ].join(" "),
     queryParams,
   );
@@ -776,22 +781,28 @@ async function buildUserProgressSeriesInExecutor(
 ): Promise<ProgressSeries> {
   let dailyReviewCounts: ReadonlyMap<string, DailyReviewCounts> = new Map<string, DailyReviewCounts>();
   await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
-  // Daily review counts stay on the bounded raw range query, while streak
-  // state comes from the user-wide materialized active-day table below.
+  // Daily review counts and streak state both use materialized canonical
+  // local review days, with review_events reads still bounded by workspace RLS.
   const workspaceIds = await listUserWorkspaceIdsInExecutor(executor, request.userId);
   await rememberProgressTimeZoneInExecutor(executor, request.userId, request.timeZone);
   let reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> = [];
 
   for (const workspaceId of workspaceIds) {
-    // review_events reads are workspace-scoped by RLS, so aggregate one
-    // workspace at a time after resolving the user's accessible memberships.
+    // review_events reads are workspace-scoped by RLS, so materialize and
+    // aggregate one workspace at a time after resolving memberships.
     await applyWorkspaceDatabaseScopeInExecutor(executor, {
       userId: request.userId,
       workspaceId,
     });
+    await materializeMissingActiveReviewDaysForUserInExecutor(
+      executor,
+      request.userId,
+      workspaceId,
+      request.timeZone,
+    );
     const rows = await loadDailyReviewCountRowsInExecutor(executor, {
       workspaceId,
-      timeZone: request.timeZone,
+      userId: request.userId,
       from: request.from,
       to: request.to,
     });
@@ -802,8 +813,6 @@ async function buildUserProgressSeriesInExecutor(
   }
 
   const range = createInclusiveLocalDateRange(request.from, request.to);
-  // Active-day materialization is owned by review writes and the scheduled
-  // backfill; progress reads intentionally do not repair historical rows.
   const activeReviewLocalDates = await loadUserActiveReviewLocalDatesInExecutor(executor, request.userId);
   const activeReviewDateSet = new Set(activeReviewLocalDates);
   const today = formatDateAsTimeZoneLocalDate(generatedAtDate, request.timeZone);

--- a/apps/backend/src/progress/reports/progressSeries.test.ts
+++ b/apps/backend/src/progress/reports/progressSeries.test.ts
@@ -65,7 +65,7 @@ test("loadUserProgressSeriesInExecutor marks today without review as pending", a
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {
-      [`workspace-1|${timeZone}|${yesterday}|${today}`]: [
+      [`workspace-1|user-1|${yesterday}|${today}`]: [
         {
           review_date: yesterday,
           review_count: 1,
@@ -111,7 +111,7 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges rating breakdowns a
       "user-1": ["workspace-1", "workspace-2"],
     },
     reviewRowsByRequest: {
-      "workspace-1|Europe/Madrid|2026-04-11|2026-04-14": [
+      "workspace-1|user-1|2026-04-11|2026-04-14": [
         {
           review_date: "2026-04-11",
           review_count: 1,
@@ -129,7 +129,7 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges rating breakdowns a
           easy_count: "1",
         },
       ],
-      "workspace-2|Europe/Madrid|2026-04-11|2026-04-14": [
+      "workspace-2|user-1|2026-04-11|2026-04-14": [
         {
           review_date: "2026-04-11",
           review_count: 2,
@@ -148,7 +148,13 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges rating breakdowns a
         },
       ],
     },
-    activeReviewDateRowsByUser: {},
+    activeReviewDateRowsByUser: {
+      "user-1": [
+        { review_date: "2026-04-11" },
+        { review_date: "2026-04-13" },
+        { review_date: "2026-04-14" },
+      ],
+    },
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 4,
@@ -169,6 +175,19 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges rating breakdowns a
     { date: "2026-04-13", reviewCount: 4, againCount: 1, hardCount: 1, goodCount: 1, easyCount: 1 },
     { date: "2026-04-14", reviewCount: 3, againCount: 1, hardCount: 0, goodCount: 1, easyCount: 1 },
   ]);
+  assert.deepEqual(
+    progress.dailyReviews.map((day, index) => ({
+      date: day.date,
+      hasReviews: day.reviewCount > 0,
+      hasReviewedStreak: progress.streakDays[index]?.state === "reviewed",
+    })),
+    [
+      { date: "2026-04-11", hasReviews: true, hasReviewedStreak: true },
+      { date: "2026-04-12", hasReviews: false, hasReviewedStreak: false },
+      { date: "2026-04-13", hasReviews: true, hasReviewedStreak: true },
+      { date: "2026-04-14", hasReviews: true, hasReviewedStreak: true },
+    ],
+  );
   const mixedRatingDay = progress.dailyReviews[0];
   if (mixedRatingDay === undefined) {
     assert.fail("Expected the mixed-rating day to be returned");
@@ -183,13 +202,13 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges rating breakdowns a
   ]);
 });
 
-test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_client and reads materialized active days", async () => {
+test("loadUserProgressSeriesInExecutor counts reviews by canonical reviewed_local_date", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {
-      "workspace-1|America/Los_Angeles|2026-04-11|2026-04-12": [
+      "workspace-1|user-1|2026-04-11|2026-04-12": [
         {
           review_date: "2026-04-11",
           review_count: 1,
@@ -214,31 +233,56 @@ test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_clie
     to: "2026-04-12",
   });
 
-  const reviewQuery = recordedQueries.find((query) => query.text.includes("COUNT(*)::int AS review_count"));
+  const reviewQueryIndex = recordedQueries.findIndex((query) => query.text.includes("easy_count"));
+  if (reviewQueryIndex < 0) {
+    assert.fail("Expected a review_events chart query to be recorded");
+  }
+  const reviewQuery = recordedQueries[reviewQueryIndex];
   if (reviewQuery === undefined) {
     assert.fail("Expected a review_events chart query to be recorded");
   }
-  assert.match(reviewQuery.text, /timezone\(\$2, review_events\.reviewed_at_client\)::date/);
+
+  const materializationQueryIndex = recordedQueries.findIndex((query) => (
+    query.text.includes("WITH target_review_events AS")
+  ));
+  if (materializationQueryIndex < 0) {
+    assert.fail("Expected an active review day materialization query to be recorded");
+  }
+  assert.ok(materializationQueryIndex < reviewQueryIndex);
+  const materializationQuery = recordedQueries[materializationQueryIndex];
+  if (materializationQuery === undefined) {
+    assert.fail("Expected an active review day materialization query to be recorded");
+  }
+
+  assert.match(reviewQuery.text, /to_char\(review_events\.reviewed_local_date, 'YYYY-MM-DD'\) AS review_date/);
   assert.match(reviewQuery.text, /COUNT\(\*\)::int AS review_count/);
   assert.match(reviewQuery.text, /COUNT\(\*\) FILTER \(WHERE review_events\.rating = 0\)::int AS again_count/);
   assert.match(reviewQuery.text, /COUNT\(\*\) FILTER \(WHERE review_events\.rating = 1\)::int AS hard_count/);
   assert.match(reviewQuery.text, /COUNT\(\*\) FILTER \(WHERE review_events\.rating = 2\)::int AS good_count/);
   assert.match(reviewQuery.text, /COUNT\(\*\) FILTER \(WHERE review_events\.rating = 3\)::int AS easy_count/);
-  assert.match(reviewQuery.text, /review_events\.reviewed_at_client >= \(\(\$3::date\)::timestamp AT TIME ZONE \$2\)/);
-  assert.match(reviewQuery.text, /review_events\.reviewed_at_client < \(\(\(\(\$4::date\) \+ 1\)::timestamp\) AT TIME ZONE \$2\)/);
+  assert.match(reviewQuery.text, /WHERE review_events\.workspace_id = \$1/);
+  assert.match(reviewQuery.text, /AND review_events\.reviewed_by_user_id = \$2/);
+  assert.match(reviewQuery.text, /AND review_events\.reviewed_local_date >= \$3::date/);
+  assert.match(reviewQuery.text, /AND review_events\.reviewed_local_date <= \$4::date/);
+  assert.match(reviewQuery.text, /GROUP BY review_events\.reviewed_local_date/);
+  assert.doesNotMatch(reviewQuery.text, /timezone\(\$2, review_events\.reviewed_at_client\)::date/);
   assert.doesNotMatch(reviewQuery.text, /reviewed_at_server/);
   assert.deepEqual(reviewQuery.params, [
     "workspace-1",
-    "America/Los_Angeles",
+    "user-1",
     "2026-04-11",
     "2026-04-12",
   ]);
 
-  const materializationQueries = recordedQueries.filter((query) => (
-    query.text.includes("WITH target_review_events AS")
-    && query.text.includes("INSERT INTO progress.user_active_review_days")
-  ));
-  assert.equal(materializationQueries.length, 0);
+  assert.match(materializationQuery.text, /INSERT INTO progress\.user_active_review_days/);
+  assert.match(materializationQuery.text, /WHERE review_events\.reviewed_by_user_id = \$1/);
+  assert.match(materializationQuery.text, /AND review_events\.workspace_id = \$3/);
+  assert.doesNotMatch(materializationQuery.text, /review_events\.rating/);
+  assert.deepEqual(materializationQuery.params, [
+    "user-1",
+    "America/Los_Angeles",
+    "workspace-1",
+  ]);
 
   const activeDayQuery = recordedQueries.find((query) => (
     query.text.includes("FROM progress.user_active_review_days AS active_days")
@@ -262,7 +306,7 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
       "user-1": ["workspace-1", "workspace-2"],
     },
     reviewRowsByRequest: {
-      "workspace-1|Europe/Madrid|2026-04-11|2026-04-14": [
+      "workspace-1|user-1|2026-04-11|2026-04-14": [
         {
           review_date: "2026-04-11",
           review_count: 3,
@@ -272,7 +316,7 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
           easy_count: 0,
         },
       ],
-      "workspace-2|Europe/Madrid|2026-04-11|2026-04-14": [
+      "workspace-2|user-1|2026-04-11|2026-04-14": [
         {
           review_date: "2026-04-14",
           review_count: 1,
@@ -306,7 +350,15 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
     query.text.includes("WITH target_review_events AS")
     && query.text.includes("INSERT INTO progress.user_active_review_days")
   ));
-  assert.equal(materializationQueries.length, 0);
+  assert.equal(materializationQueries.length, 2);
+  assert.ok(materializationQueries.every((query) => (
+    query.text.includes("WHERE review_events.reviewed_by_user_id = $1")
+    && query.text.includes("AND review_events.workspace_id = $3")
+  )));
+  assert.deepEqual(materializationQueries.map((query) => query.params), [
+    ["user-1", "Europe/Madrid", "workspace-1"],
+    ["user-1", "Europe/Madrid", "workspace-2"],
+  ]);
 
   const activeDayQueries = recordedQueries.filter((query) => (
     query.text.includes("FROM progress.user_active_review_days AS active_days")

--- a/apps/backend/src/progress/reports/progressSummary.test.ts
+++ b/apps/backend/src/progress/reports/progressSummary.test.ts
@@ -120,26 +120,7 @@ test("loadUserProgressSummaryInExecutor resets a gap larger than available freez
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
     },
-    reviewRowsByRequest: {
-      [`workspace-1|${timeZone}|${sixDaysAgo}|${today}`]: [
-        {
-          review_date: sixDaysAgo,
-          review_count: 1,
-          again_count: 0,
-          hard_count: 0,
-          good_count: 1,
-          easy_count: 0,
-        },
-        {
-          review_date: today,
-          review_count: 1,
-          again_count: 0,
-          hard_count: 0,
-          good_count: 1,
-          easy_count: 0,
-        },
-      ],
-    },
+    reviewRowsByRequest: {},
     activeReviewDateRowsByUser: {
       "user-1": [
         { review_date: sixDaysAgo },

--- a/apps/backend/src/progress/reports/progressTestSupport.ts
+++ b/apps/backend/src/progress/reports/progressTestSupport.ts
@@ -362,14 +362,14 @@ export function createProgressExecutor(
         && text.includes("COUNT(*)::int AS review_count")
       ) {
         const workspaceId = typeof params[0] === "string" ? params[0] : String(params[0]);
-        const timeZone = typeof params[1] === "string" ? params[1] : String(params[1]);
+        const userId = typeof params[1] === "string" ? params[1] : String(params[1]);
         const from = typeof params[2] === "string" ? params[2] : String(params[2]);
         const to = typeof params[3] === "string" ? params[3] : String(params[3]);
-        if (scope.userId === null || scope.workspaceId !== workspaceId) {
-          throw new Error("Review history query requires matching workspace scope");
+        if (scope.userId !== userId || scope.workspaceId !== workspaceId) {
+          throw new Error("Review history query requires matching user and workspace scope");
         }
 
-        const key = `${workspaceId}|${timeZone}|${from}|${to}`;
+        const key = `${workspaceId}|${userId}|${from}|${to}`;
         return createQueryResult<DailyReviewCountRow>(
           fixture.reviewRowsByRequest[key] ?? [],
         ) as unknown as pg.QueryResult<Row>;

--- a/db/migrations/0087_progress_series_reviewed_local_date_index.sql
+++ b/db/migrations/0087_progress_series_reviewed_local_date_index.sql
@@ -1,0 +1,9 @@
+-- Migration status: Current / additive.
+-- Introduces: backend-facing review-event index support for Progress series local-date reads.
+-- Schemas touched/read explicitly: content.
+
+CREATE INDEX IF NOT EXISTS idx_review_events_workspace_reviewer_local_date
+  ON content.review_events(workspace_id, reviewed_by_user_id, reviewed_local_date);
+
+COMMENT ON INDEX content.idx_review_events_workspace_reviewer_local_date IS
+  'Supports Progress series review-count reads by workspace, reviewer, and canonical reviewed_local_date.';


### PR DESCRIPTION
## Summary
- build progress daily review counts from canonical reviewed_local_date after materializing active days
- update progress report tests and fake executor query shape for user-scoped local-date counts
- add a content.review_events index for the new progress series query path

## Validation
- cd apps/backend && node --test --import tsx src/progress/reports/progressSeries.test.ts
- cd apps/backend && node --test --import tsx src/progress/reports/progressSummary.test.ts
- npm run lint --prefix apps/backend