### PR TITLE
Add iOS transport diagnostics core

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
@@ -132,7 +132,8 @@ final class GuestCloudAuthService {
                                 attempt: attempt,
                                 maxAttempts: guestSessionDeleteMaxAttempts,
                                 apiBaseUrl: apiBaseUrl,
-                                messageSummary: Flashcards.errorMessage(error: error)
+                                messageSummary: Flashcards.errorMessage(error: error),
+                                transportDiagnostics: nil
                             )
                         )
                     )

--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -481,7 +481,8 @@ final class CloudSessionRuntime {
                             attempt: 1,
                             maxAttempts: 1,
                             apiBaseUrl: self.state.activeCloudSession?.apiBaseUrl,
-                            messageSummary: Flashcards.errorMessage(error: error)
+                            messageSummary: Flashcards.errorMessage(error: error),
+                            transportDiagnostics: nil
                         )
                     )
                 )

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
@@ -697,7 +697,8 @@ struct CloudSyncTransport {
                             attempt: attempt,
                             maxAttempts: cloudSyncTransportMaxAttempts,
                             apiBaseUrl: apiBaseUrl,
-                            messageSummary: Flashcards.errorMessage(error: error)
+                            messageSummary: Flashcards.errorMessage(error: error),
+                            transportDiagnostics: nil
                         )
                     )
                 )
@@ -782,7 +783,8 @@ struct CloudSyncTransport {
                     attempt: attempt,
                     maxAttempts: mediaAssetUploadPartPutMaxAttempts,
                     apiBaseUrl: nil,
-                    messageSummary: Flashcards.errorMessage(error: error)
+                    messageSummary: Flashcards.errorMessage(error: error),
+                    transportDiagnostics: nil
                 )
             )
         )

--- a/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
@@ -156,6 +156,241 @@ func flashcardsURLErrorCode(error: Error, remainingDepth: Int) -> URLError.Code?
     return flashcardsURLErrorCode(error: underlyingError, remainingDepth: remainingDepth - 1)
 }
 
+private let iosNetworkTransportDiagnosticsUnderlyingErrorDepth: Int = 4
+private let iosNetworkTransportOfficialAPIHost: String = "api.flashcards-open-source-app.com"
+private let cfStreamErrorDomainUserInfoKey: String = "_kCFStreamErrorDomainKey"
+private let cfStreamErrorCodeUserInfoKey: String = "_kCFStreamErrorCodeKey"
+
+private struct IOSNetworkTransportAPIHostDiagnostics {
+    let kind: String?
+    let host: String?
+}
+
+private struct IOSNetworkTransportCFStreamErrorDiagnostics {
+    let domain: Int?
+    let code: Int?
+}
+
+func makeIOSNetworkTransportDiagnostics(
+    error: Error,
+    httpMethod: String,
+    endpointPath: String,
+    apiBaseUrl: String
+) -> IOSNetworkTransportDiagnostics {
+    let nsError: NSError = error as NSError
+    let urlErrorCode: URLError.Code? = flashcardsURLErrorCode(
+        error: error,
+        remainingDepth: iosNetworkTransportDiagnosticsUnderlyingErrorDepth
+    )
+    let cfStreamError: IOSNetworkTransportCFStreamErrorDiagnostics = iosNetworkTransportCFStreamErrorDiagnostics(
+        error: error,
+        remainingDepth: iosNetworkTransportDiagnosticsUnderlyingErrorDepth
+    )
+    let apiHost: IOSNetworkTransportAPIHostDiagnostics = iosNetworkTransportAPIHostDiagnostics(
+        apiBaseUrl: apiBaseUrl
+    )
+
+    return IOSNetworkTransportDiagnostics(
+        nsErrorDomain: safeIOSNetworkTransportIdentifier(nsError.domain),
+        nsErrorCode: nsError.code,
+        urlErrorCode: urlErrorCode?.rawValue,
+        urlErrorName: urlErrorCode.flatMap { code in iosNetworkTransportURLErrorName(code: code) },
+        cfStreamErrorDomain: cfStreamError.domain,
+        cfStreamErrorCode: cfStreamError.code,
+        httpMethod: safeIOSNetworkTransportHTTPMethod(httpMethod),
+        endpointPath: safeIOSNetworkTransportEndpointPath(endpointPath),
+        apiHostKind: apiHost.kind,
+        apiHost: apiHost.host
+    )
+}
+
+private func iosNetworkTransportURLErrorName(code: URLError.Code) -> String? {
+    switch code {
+    case .timedOut:
+        return "timed_out"
+    case .cannotFindHost:
+        return "cannot_find_host"
+    case .cannotConnectToHost:
+        return "cannot_connect_to_host"
+    case .dnsLookupFailed:
+        return "dns_lookup_failed"
+    case .networkConnectionLost:
+        return "network_connection_lost"
+    case .notConnectedToInternet:
+        return "not_connected_to_internet"
+    case .internationalRoamingOff:
+        return "international_roaming_off"
+    case .callIsActive:
+        return "call_is_active"
+    case .dataNotAllowed:
+        return "data_not_allowed"
+    case .cannotLoadFromNetwork:
+        return "cannot_load_from_network"
+    case .cancelled:
+        return "cancelled"
+    default:
+        return nil
+    }
+}
+
+private func iosNetworkTransportCFStreamErrorDiagnostics(
+    error: Error,
+    remainingDepth: Int
+) -> IOSNetworkTransportCFStreamErrorDiagnostics {
+    let nsError: NSError = error as NSError
+    let domain: Int? = iosNetworkTransportUserInfoInteger(
+        nsError.userInfo[cfStreamErrorDomainUserInfoKey]
+    )
+    let code: Int? = iosNetworkTransportUserInfoInteger(
+        nsError.userInfo[cfStreamErrorCodeUserInfoKey]
+    )
+    if domain != nil || code != nil {
+        return IOSNetworkTransportCFStreamErrorDiagnostics(domain: domain, code: code)
+    }
+
+    guard remainingDepth > 0 else {
+        return IOSNetworkTransportCFStreamErrorDiagnostics(domain: nil, code: nil)
+    }
+
+    guard let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error else {
+        return IOSNetworkTransportCFStreamErrorDiagnostics(domain: nil, code: nil)
+    }
+
+    return iosNetworkTransportCFStreamErrorDiagnostics(
+        error: underlyingError,
+        remainingDepth: remainingDepth - 1
+    )
+}
+
+private func iosNetworkTransportUserInfoInteger(_ value: Any?) -> Int? {
+    if let intValue = value as? Int {
+        return intValue
+    }
+    if let numberValue = value as? NSNumber {
+        return numberValue.intValue
+    }
+    if let stringValue = value as? String {
+        return Int(stringValue.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return nil
+}
+
+private func safeIOSNetworkTransportHTTPMethod(_ httpMethod: String) -> String? {
+    let normalizedMethod: String = httpMethod
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .uppercased()
+    return safeIOSNetworkTransportIdentifier(normalizedMethod)
+}
+
+private func safeIOSNetworkTransportEndpointPath(_ endpointPath: String) -> String? {
+    let trimmedPath: String = endpointPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedPath.isEmpty == false else {
+        return nil
+    }
+
+    let rawPath: String
+    if let components = URLComponents(string: trimmedPath) {
+        if components.path.isEmpty == false {
+            rawPath = components.path
+        } else if components.scheme != nil || components.host != nil {
+            return nil
+        } else {
+            rawPath = fallbackIOSNetworkTransportEndpointPath(trimmedPath)
+        }
+    } else {
+        guard trimmedPath.contains("://") == false else {
+            return nil
+        }
+        rawPath = fallbackIOSNetworkTransportEndpointPath(trimmedPath)
+    }
+    let normalizedPath: String = rawPath.hasPrefix("/") ? rawPath : "/\(rawPath)"
+    guard normalizedPath.count <= 240 else {
+        return nil
+    }
+
+    let redactedPath: String = normalizedPath
+        .split(separator: "/", omittingEmptySubsequences: false)
+        .map { segment in
+            let segmentValue: String = String(segment)
+            guard shouldRedactIOSNetworkTransportEndpointPathSegment(segmentValue) else {
+                return segmentValue
+            }
+            return filteredDiagnosticValue
+        }
+        .joined(separator: "/")
+    guard redactedPath.rangeOfCharacter(from: iosNetworkTransportEndpointPathAllowedCharacters.inverted) == nil else {
+        return nil
+    }
+    return redactedPath
+}
+
+private func fallbackIOSNetworkTransportEndpointPath(_ endpointPath: String) -> String {
+    let queryStrippedPath: String = endpointPath
+        .split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+        .first
+        .map(String.init) ?? ""
+    return queryStrippedPath
+        .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)
+        .first
+        .map(String.init) ?? ""
+}
+
+private let iosNetworkTransportEndpointPathAllowedCharacters: CharacterSet = CharacterSet(
+    charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._~:/-%[]"
+)
+
+private func shouldRedactIOSNetworkTransportEndpointPathSegment(_ segment: String) -> Bool {
+    let decodedSegment: String = segment.removingPercentEncoding ?? segment
+    guard decodedSegment.isEmpty == false else {
+        return false
+    }
+
+    if decodedSegment.range(
+        of: #"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"#,
+        options: .regularExpression
+    ) != nil {
+        return true
+    }
+
+    if decodedSegment.count >= 20,
+       decodedSegment.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil {
+        return true
+    }
+
+    return safeIOSNetworkTransportIdentifier(decodedSegment) == nil
+}
+
+private func iosNetworkTransportAPIHostDiagnostics(
+    apiBaseUrl: String
+) -> IOSNetworkTransportAPIHostDiagnostics {
+    let trimmedBaseUrl: String = apiBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let components = URLComponents(string: trimmedBaseUrl),
+          let rawHost = components.host else {
+        return IOSNetworkTransportAPIHostDiagnostics(kind: nil, host: nil)
+    }
+
+    let normalizedHost: String = rawHost.lowercased()
+    if normalizedHost == iosNetworkTransportOfficialAPIHost {
+        return IOSNetworkTransportAPIHostDiagnostics(
+            kind: "official",
+            host: iosNetworkTransportOfficialAPIHost
+        )
+    }
+
+    return IOSNetworkTransportAPIHostDiagnostics(
+        kind: "custom",
+        host: safeIOSNetworkTransportIdentifier(normalizedHost)
+    )
+}
+
+private func safeIOSNetworkTransportIdentifier(_ value: String) -> String? {
+    let candidate: String = safeDiagnosticIdentifier(value)
+    guard candidate != filteredDiagnosticValue else {
+        return nil
+    }
+    return candidate
+}
+
 func isRetryableNetworkTransportFailure(error: Error) -> Bool {
     guard let urlErrorCode: URLError.Code = flashcardsURLErrorCode(error: error, remainingDepth: 4) else {
         return false

--- a/apps/ios/Flashcards/Flashcards/Observability/FlashcardsObservability.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/FlashcardsObservability.swift
@@ -30,6 +30,50 @@ enum FlashcardsObservability {
         backendCode: String?,
         requestId: String?
     ) {
+        self.captureSilentFailure(
+            error: error,
+            scope: scope,
+            action: action,
+            stage: stage,
+            statusCode: statusCode,
+            backendCode: backendCode,
+            requestId: requestId,
+            transportDiagnostics: nil
+        )
+    }
+
+    static func captureSilentFailure(
+        error: Error,
+        scope: IOSObservationScope,
+        action: String,
+        stage: String?,
+        statusCode: Int?,
+        backendCode: String?,
+        requestId: String?,
+        transportDiagnostics: IOSNetworkTransportDiagnostics
+    ) {
+        self.captureSilentFailure(
+            error: error,
+            scope: scope,
+            action: action,
+            stage: stage,
+            statusCode: statusCode,
+            backendCode: backendCode,
+            requestId: requestId,
+            transportDiagnostics: .some(transportDiagnostics)
+        )
+    }
+
+    private static func captureSilentFailure(
+        error: Error,
+        scope: IOSObservationScope,
+        action: String,
+        stage: String?,
+        statusCode: Int?,
+        backendCode: String?,
+        requestId: String?,
+        transportDiagnostics: IOSNetworkTransportDiagnostics?
+    ) {
         self.captureException(
             .silentFailure(
                 error: error,
@@ -40,7 +84,8 @@ enum FlashcardsObservability {
                     statusCode: statusCode,
                     backendCode: backendCode,
                     requestId: requestId,
-                    messageSummary: Flashcards.errorMessage(error: error)
+                    messageSummary: Flashcards.errorMessage(error: error),
+                    transportDiagnostics: transportDiagnostics
                 )
             )
         )

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -304,6 +304,19 @@ struct NotificationSchedulingFailureWarning: Sendable, Hashable {
     let diagnostics: NotificationSchedulingDiagnostics
 }
 
+struct IOSNetworkTransportDiagnostics: Sendable, Hashable {
+    let nsErrorDomain: String?
+    let nsErrorCode: Int?
+    let urlErrorCode: Int?
+    let urlErrorName: String?
+    let cfStreamErrorDomain: Int?
+    let cfStreamErrorCode: Int?
+    let httpMethod: String?
+    let endpointPath: String?
+    let apiHostKind: String?
+    let apiHost: String?
+}
+
 struct CloudRetryObservation: Sendable, Hashable {
     let action: String
     let scope: IOSObservationScope
@@ -311,6 +324,7 @@ struct CloudRetryObservation: Sendable, Hashable {
     let maxAttempts: Int
     let apiBaseUrl: String?
     let messageSummary: String?
+    let transportDiagnostics: IOSNetworkTransportDiagnostics?
 }
 
 struct LocalDataRepairWarning: Sendable, Hashable {
@@ -410,4 +424,5 @@ struct SilentFailureDetails: Sendable, Hashable {
     let backendCode: String?
     let requestId: String?
     let messageSummary: String?
+    let transportDiagnostics: IOSNetworkTransportDiagnostics?
 }

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -519,13 +519,16 @@ extension SentryObservabilityAdapter {
                 )
             )
         case .silentFailure(let error, let scope, let details):
-            let context: [String: Any] = [
-                "stage": details.stage ?? "",
-                "status_code": details.statusCode.map { statusCode in String(statusCode) } ?? "",
-                "backend_code": details.backendCode ?? "",
-                "request_id": details.requestId ?? "",
-                "message_summary": details.messageSummary ?? ""
-            ]
+            let context: [String: Any] = self.contextWithTransportDiagnostics(
+                context: [
+                    "stage": details.stage ?? "",
+                    "status_code": details.statusCode.map { statusCode in String(statusCode) } ?? "",
+                    "backend_code": details.backendCode ?? "",
+                    "request_id": details.requestId ?? "",
+                    "message_summary": details.messageSummary ?? ""
+                ],
+                transportDiagnostics: details.transportDiagnostics
+            )
             return ExceptionPayload(
                 error: error,
                 observation: ObservationPayload(
@@ -610,12 +613,15 @@ extension SentryObservabilityAdapter {
     }
 
     private static func cloudRetryContext(_ observation: CloudRetryObservation) -> [String: Any] {
-        [
-            "attempt": observation.attempt,
-            "max_attempts": observation.maxAttempts,
-            "api_base_url": observation.apiBaseUrl ?? "",
-            "message_summary": observation.messageSummary ?? ""
-        ]
+        self.contextWithTransportDiagnostics(
+            context: [
+                "attempt": observation.attempt,
+                "max_attempts": observation.maxAttempts,
+                "api_base_url": observation.apiBaseUrl ?? "",
+                "message_summary": observation.messageSummary ?? ""
+            ],
+            transportDiagnostics: observation.transportDiagnostics
+        )
     }
 
     private static func cloudRetryFields(_ observation: CloudRetryObservation) -> [String: String] {
@@ -737,6 +743,38 @@ extension SentryObservabilityAdapter {
             "decoder_summary_length": diagnostics.decoderSummary.map { decoderSummary in String(decoderSummary.count) } ?? "",
             "continuation_attempt": diagnostics.continuationAttempt.map { continuationAttempt in String(continuationAttempt) } ?? "",
             "continuation_tool_call_count": String(diagnostics.continuationToolCallIds.count)
+        ]
+    }
+
+    private static func contextWithTransportDiagnostics(
+        context: [String: Any],
+        transportDiagnostics: IOSNetworkTransportDiagnostics?
+    ) -> [String: Any] {
+        guard let transportDiagnostics else {
+            return context
+        }
+
+        var enrichedContext: [String: Any] = context
+        for (key, value) in self.transportDiagnosticsContext(transportDiagnostics) {
+            enrichedContext[key] = value
+        }
+        return enrichedContext
+    }
+
+    private static func transportDiagnosticsContext(
+        _ diagnostics: IOSNetworkTransportDiagnostics
+    ) -> [String: Any] {
+        [
+            "url_error_code": diagnostics.urlErrorCode.map { urlErrorCode in String(urlErrorCode) } ?? "",
+            "url_error_name": diagnostics.urlErrorName ?? "",
+            "ns_error_domain": diagnostics.nsErrorDomain ?? "",
+            "ns_error_code": diagnostics.nsErrorCode.map { nsErrorCode in String(nsErrorCode) } ?? "",
+            "cf_stream_error_domain": diagnostics.cfStreamErrorDomain.map { cfStreamErrorDomain in String(cfStreamErrorDomain) } ?? "",
+            "cf_stream_error_code": diagnostics.cfStreamErrorCode.map { cfStreamErrorCode in String(cfStreamErrorCode) } ?? "",
+            "http_method": diagnostics.httpMethod ?? "",
+            "endpoint_path": diagnostics.endpointPath ?? "",
+            "api_host_kind": diagnostics.apiHostKind ?? "",
+            "api_host": diagnostics.apiHost ?? ""
         ]
     }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewManagedMediaStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewManagedMediaStoreSupport.swift
@@ -406,7 +406,8 @@ private func retryReviewManagedMediaDownload(
                 attempt: attempt,
                 maxAttempts: reviewManagedMediaDownloadMaxAttempts,
                 apiBaseUrl: nil,
-                messageSummary: messageSummary
+                messageSummary: messageSummary,
+                transportDiagnostics: nil
             )
         )
     )


### PR DESCRIPTION
## Summary
- add typed iOS network transport diagnostics for URL, NSError, CFStream, endpoint, and API host context
- include diagnostics in cloud retry breadcrumbs and silent failure Sentry details
- keep existing retry and silent failure call sites working with explicit nil diagnostics

## Validation
- rg -n "CloudRetryObservation\\(|SilentFailureDetails\\(" apps/ios/Flashcards/Flashcards
- git --no-pager diff --check
- xcrun swiftc -frontend -parse edited Swift files
- xcodebuild generic iOS build blocked before compilation by local iOS 26.5 destination-discovery issue