### PR TITLE
Add iOS cloud retry transport diagnostics

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
@@ -133,7 +133,12 @@ final class GuestCloudAuthService {
                                 maxAttempts: guestSessionDeleteMaxAttempts,
                                 apiBaseUrl: apiBaseUrl,
                                 messageSummary: Flashcards.errorMessage(error: error),
-                                transportDiagnostics: nil
+                                transportDiagnostics: makeIOSNetworkTransportDiagnostics(
+                                    error: error,
+                                    httpMethod: "POST",
+                                    endpointPath: "/guest-auth/session/delete",
+                                    apiBaseUrl: apiBaseUrl
+                                )
                             )
                         )
                     )

--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -482,7 +482,12 @@ final class CloudSessionRuntime {
                             maxAttempts: 1,
                             apiBaseUrl: self.state.activeCloudSession?.apiBaseUrl,
                             messageSummary: Flashcards.errorMessage(error: error),
-                            transportDiagnostics: nil
+                            transportDiagnostics: makeIOSNetworkTransportDiagnostics(
+                                error: error,
+                                httpMethod: nil,
+                                endpointPath: nil,
+                                apiBaseUrl: self.state.activeCloudSession?.apiBaseUrl
+                            )
                         )
                     )
                 )

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
@@ -698,7 +698,12 @@ struct CloudSyncTransport {
                             maxAttempts: cloudSyncTransportMaxAttempts,
                             apiBaseUrl: apiBaseUrl,
                             messageSummary: Flashcards.errorMessage(error: error),
-                            transportDiagnostics: nil
+                            transportDiagnostics: makeIOSNetworkTransportDiagnostics(
+                                error: error,
+                                httpMethod: request.httpMethod,
+                                endpointPath: request.url?.path,
+                                apiBaseUrl: apiBaseUrl
+                            )
                         )
                     )
                 )
@@ -741,7 +746,11 @@ struct CloudSyncTransport {
                     throw statusError
                 }
 
-                try await self.retryMediaAssetUploadPartPut(error: statusError, attempt: attempt)
+                try await self.retryMediaAssetUploadPartPut(
+                    error: statusError,
+                    request: request,
+                    attempt: attempt
+                )
             } catch let error as CancellationError {
                 throw error
             } catch {
@@ -754,7 +763,11 @@ struct CloudSyncTransport {
                     throw error
                 }
 
-                try await self.retryMediaAssetUploadPartPut(error: error, attempt: attempt)
+                try await self.retryMediaAssetUploadPartPut(
+                    error: error,
+                    request: request,
+                    attempt: attempt
+                )
             }
         }
 
@@ -764,7 +777,7 @@ struct CloudSyncTransport {
         throw lastError
     }
 
-    private func retryMediaAssetUploadPartPut(error: Error, attempt: Int) async throws {
+    private func retryMediaAssetUploadPartPut(error: Error, request: URLRequest, attempt: Int) async throws {
         FlashcardsObservability.addBreadcrumb(
             .cloudRetry(
                 CloudRetryObservation(
@@ -784,7 +797,12 @@ struct CloudSyncTransport {
                     maxAttempts: mediaAssetUploadPartPutMaxAttempts,
                     apiBaseUrl: nil,
                     messageSummary: Flashcards.errorMessage(error: error),
-                    transportDiagnostics: nil
+                    transportDiagnostics: makeIOSNetworkTransportDiagnostics(
+                        error: error,
+                        httpMethod: request.httpMethod,
+                        endpointPath: request.url?.path,
+                        apiBaseUrl: nil
+                    )
                 )
             )
         )

--- a/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
@@ -173,9 +173,9 @@ private struct IOSNetworkTransportCFStreamErrorDiagnostics {
 
 func makeIOSNetworkTransportDiagnostics(
     error: Error,
-    httpMethod: String,
-    endpointPath: String,
-    apiBaseUrl: String
+    httpMethod: String?,
+    endpointPath: String?,
+    apiBaseUrl: String?
 ) -> IOSNetworkTransportDiagnostics {
     let nsError: NSError = error as NSError
     let urlErrorCode: URLError.Code? = flashcardsURLErrorCode(
@@ -188,7 +188,7 @@ func makeIOSNetworkTransportDiagnostics(
     )
     let apiHost: IOSNetworkTransportAPIHostDiagnostics = iosNetworkTransportAPIHostDiagnostics(
         apiBaseUrl: apiBaseUrl
-    )
+    ) ?? IOSNetworkTransportAPIHostDiagnostics(kind: nil, host: nil)
 
     return IOSNetworkTransportDiagnostics(
         nsErrorDomain: safeIOSNetworkTransportIdentifier(nsError.domain),
@@ -197,8 +197,8 @@ func makeIOSNetworkTransportDiagnostics(
         urlErrorName: urlErrorCode.flatMap { code in iosNetworkTransportURLErrorName(code: code) },
         cfStreamErrorDomain: cfStreamError.domain,
         cfStreamErrorCode: cfStreamError.code,
-        httpMethod: safeIOSNetworkTransportHTTPMethod(httpMethod),
-        endpointPath: safeIOSNetworkTransportEndpointPath(endpointPath),
+        httpMethod: httpMethod.flatMap { method in safeIOSNetworkTransportHTTPMethod(method) },
+        endpointPath: endpointPath.flatMap { path in safeIOSNetworkTransportEndpointPath(path) },
         apiHostKind: apiHost.kind,
         apiHost: apiHost.host
     )
@@ -361,12 +361,15 @@ private func shouldRedactIOSNetworkTransportEndpointPathSegment(_ segment: Strin
 }
 
 private func iosNetworkTransportAPIHostDiagnostics(
-    apiBaseUrl: String
-) -> IOSNetworkTransportAPIHostDiagnostics {
+    apiBaseUrl: String?
+) -> IOSNetworkTransportAPIHostDiagnostics? {
+    guard let apiBaseUrl else {
+        return nil
+    }
     let trimmedBaseUrl: String = apiBaseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
     guard let components = URLComponents(string: trimmedBaseUrl),
           let rawHost = components.host else {
-        return IOSNetworkTransportAPIHostDiagnostics(kind: nil, host: nil)
+        return nil
     }
 
     let normalizedHost: String = rawHost.lowercased()

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewManagedMediaStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewManagedMediaStoreSupport.swift
@@ -357,7 +357,13 @@ private func downloadReviewManagedMediaBlob(
                 try await retryReviewManagedMediaDownload(
                     messageSummary: Flashcards.errorMessage(error: statusError),
                     attempt: attempt,
-                    retryScope: retryScope
+                    retryScope: retryScope,
+                    transportDiagnostics: makeIOSNetworkTransportDiagnostics(
+                        error: statusError,
+                        httpMethod: "GET",
+                        endpointPath: downloadURL.path,
+                        apiBaseUrl: nil
+                    )
                 )
                 continue
             }
@@ -382,7 +388,13 @@ private func downloadReviewManagedMediaBlob(
             try await retryReviewManagedMediaDownload(
                 messageSummary: Flashcards.errorMessage(error: safeError),
                 attempt: attempt,
-                retryScope: retryScope
+                retryScope: retryScope,
+                transportDiagnostics: makeIOSNetworkTransportDiagnostics(
+                    error: error,
+                    httpMethod: "GET",
+                    endpointPath: downloadURL.path,
+                    apiBaseUrl: nil
+                )
             )
         }
     }
@@ -396,7 +408,8 @@ private func downloadReviewManagedMediaBlob(
 private func retryReviewManagedMediaDownload(
     messageSummary: String,
     attempt: Int,
-    retryScope: IOSObservationScope
+    retryScope: IOSObservationScope,
+    transportDiagnostics: IOSNetworkTransportDiagnostics?
 ) async throws {
     FlashcardsObservability.addBreadcrumb(
         .cloudRetry(
@@ -407,7 +420,7 @@ private func retryReviewManagedMediaDownload(
                 maxAttempts: reviewManagedMediaDownloadMaxAttempts,
                 apiBaseUrl: nil,
                 messageSummary: messageSummary,
-                transportDiagnostics: nil
+                transportDiagnostics: transportDiagnostics
             )
         )
     )


### PR DESCRIPTION
## Summary
- attach sanitized transport diagnostics to cloud retry breadcrumbs
- include endpoint path, HTTP method, URL/CFStream error details, and safe API host fields where available
- keep retry timing, counts, and retryability unchanged

## Validation
- Worktree freshness check: passed
- `rg -n "CloudRetryObservation\\(" apps/ios/Flashcards/Flashcards`: passed
- `rg -n "api_base_url|endpoint_path|url_error_name|cf_stream_error" apps/ios/Flashcards/Flashcards/Observability apps/ios/Flashcards/Flashcards/Cloud`: passed
- Confirmed `api_host_kind` and `api_host` are mapped and no retry diagnostic raw `url` key was added
- `git --no-pager diff --check`: passed
- `xcrun swiftc -parse ...changed files...`: passed
- Requested generic iOS `xcodebuild` was blocked before compilation by local Xcode iOS 26.5 destination/platform issue
- Worker-owned review: no P0-P4 issues, no split recommendation, green light
