### PR TITLE
Instrument iOS startup and tab breadcrumbs

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -72,7 +72,7 @@ private func nextProgressContextRolloverDate(now: Date) -> Date {
     return nextDay
 }
 
-private func appLifecycleTabName(tab: AppTab) -> String {
+func appForegroundOperationTabName(tab: AppTab) -> String {
     switch tab {
     case .review:
         return "review"
@@ -87,6 +87,10 @@ private func appLifecycleTabName(tab: AppTab) -> String {
     }
 }
 
+private func appLifecycleTabName(tab: AppTab) -> String {
+    appForegroundOperationTabName(tab: tab)
+}
+
 private func appLifecycleScenePhaseName(scenePhase: ScenePhase) -> String {
     switch scenePhase {
     case .active:
@@ -98,6 +102,20 @@ private func appLifecycleScenePhaseName(scenePhase: ScenePhase) -> String {
     @unknown default:
         return "unknown"
     }
+}
+
+func appForegroundOperationSelectionName(selectedTab: AppTab, previousTab: AppTab?) -> String {
+    let selectedTabName = appForegroundOperationTabName(tab: selectedTab)
+    guard let previousTab,
+          previousTab != selectedTab else {
+        return selectedTabName
+    }
+
+    return "\(appForegroundOperationTabName(tab: previousTab))->\(selectedTabName)"
+}
+
+func appForegroundOperationDurationMilliseconds(startedAt: Date, finishedAt: Date) -> Int {
+    max(0, Int((finishedAt.timeIntervalSince(startedAt) * 1_000).rounded()))
 }
 
 @MainActor
@@ -119,6 +137,112 @@ private func makeAppLifecycleScope(store: FlashcardsStore?) -> IOSObservationSco
         runId: nil,
         cloudState: store?.cloudSettings?.cloudState,
         configurationMode: configurationMode
+    )
+}
+
+@MainActor
+func makeAppForegroundOperationScope(store: FlashcardsStore) -> IOSObservationScope {
+    IOSObservationScope(
+        feature: .appStartup,
+        userId: store.cloudSettings?.linkedUserId,
+        workspaceId: store.workspace?.workspaceId,
+        requestId: nil,
+        clientRequestId: nil,
+        sessionId: nil,
+        runId: nil,
+        cloudState: store.cloudSettings?.cloudState,
+        configurationMode: try? store.currentCloudServiceConfiguration().mode
+    )
+}
+
+@MainActor
+func logAppForegroundOperationBreadcrumb(
+    action: ForegroundOperationAction,
+    phase: ForegroundOperationPhase,
+    store: FlashcardsStore,
+    selectedTab: AppTab,
+    previousTab: AppTab?,
+    scenePhase: ScenePhase?,
+    isStartupReady: Bool?,
+    isRecoveryGateActive: Bool?,
+    startedAt: Date?,
+    finishedAt: Date?,
+    error: Error?
+) {
+    let scenePhaseName: String?
+    if let scenePhase {
+        scenePhaseName = appLifecycleScenePhaseName(scenePhase: scenePhase)
+    } else {
+        scenePhaseName = nil
+    }
+
+    let durationMilliseconds: Int?
+    if let startedAt,
+       let finishedAt {
+        durationMilliseconds = appForegroundOperationDurationMilliseconds(startedAt: startedAt, finishedAt: finishedAt)
+    } else {
+        durationMilliseconds = nil
+    }
+
+    FlashcardsObservability.addBreadcrumb(
+        .foregroundOperation(
+            ForegroundOperationObservation(
+                scope: makeAppForegroundOperationScope(store: store),
+                action: action,
+                phase: phase,
+                durationMilliseconds: durationMilliseconds,
+                selectedTab: appForegroundOperationSelectionName(selectedTab: selectedTab, previousTab: previousTab),
+                scenePhase: scenePhaseName,
+                isStartupReady: isStartupReady,
+                isRecoveryGateActive: isRecoveryGateActive,
+                cardCount: store.cards.count,
+                deckCount: store.decks.count,
+                pendingOutboxOperationCount: nil,
+                reviewQueueCount: store.reviewQueue.count,
+                reviewDueCount: store.homeSnapshot.dueCount,
+                cloudSyncBlocked: store.isCloudSyncBlocked,
+                errorSummary: error.map { operationError in Flashcards.errorMessage(error: operationError) }
+            )
+        )
+    )
+}
+
+@MainActor
+func prepareVisibleTabForPresentationWithBreadcrumb(
+    store: FlashcardsStore,
+    selectedTab: AppTab,
+    previousTab: AppTab?,
+    scenePhase: ScenePhase?,
+    isStartupReady: Bool?,
+    isRecoveryGateActive: Bool?,
+    now: Date
+) {
+    logAppForegroundOperationBreadcrumb(
+        action: .visibleTabPresentation,
+        phase: .start,
+        store: store,
+        selectedTab: selectedTab,
+        previousTab: previousTab,
+        scenePhase: scenePhase,
+        isStartupReady: isStartupReady,
+        isRecoveryGateActive: isRecoveryGateActive,
+        startedAt: nil,
+        finishedAt: nil,
+        error: nil
+    )
+    store.prepareVisibleTabForPresentation(tab: selectedTab, now: now)
+    logAppForegroundOperationBreadcrumb(
+        action: .visibleTabPresentation,
+        phase: .success,
+        store: store,
+        selectedTab: selectedTab,
+        previousTab: previousTab,
+        scenePhase: scenePhase,
+        isStartupReady: isStartupReady,
+        isRecoveryGateActive: isRecoveryGateActive,
+        startedAt: now,
+        finishedAt: Date(),
+        error: nil
     )
 }
 
@@ -307,7 +431,15 @@ struct FlashcardsApp: App {
                 isRecoveryGateActive: false,
                 messageSummary: nil
             )
-            store.prepareVisibleTabForPresentation(tab: selectedTab, now: Date())
+            prepareVisibleTabForPresentationWithBreadcrumb(
+                store: store,
+                selectedTab: selectedTab,
+                previousTab: nil,
+                scenePhase: nil,
+                isStartupReady: false,
+                isRecoveryGateActive: false,
+                now: Date()
+            )
             logAppLifecycleBreadcrumb(
                 action: .visibleTabPrepareSuccess,
                 store: store,
@@ -469,6 +601,20 @@ struct FlashcardsApp: App {
             return
         }
 
+        let initialStartupStartedAt = Date()
+        logAppForegroundOperationBreadcrumb(
+            action: .initialStartup,
+            phase: .start,
+            store: self.store,
+            selectedTab: self.navigation.selectedTab,
+            previousTab: nil,
+            scenePhase: self.scenePhase,
+            isStartupReady: self.isStartupReadyForBackgroundWork,
+            isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+            startedAt: nil,
+            finishedAt: nil,
+            error: nil
+        )
         self.hasRunInitialStartup = true
         self.isStartupReadyForBackgroundWork = false
 
@@ -490,7 +636,34 @@ struct FlashcardsApp: App {
                 isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
                 messageSummary: nil
             )
+            let progressContextRefreshStartedAt = Date()
+            logAppForegroundOperationBreadcrumb(
+                action: .initialProgressContextRefresh,
+                phase: .start,
+                store: self.store,
+                selectedTab: self.navigation.selectedTab,
+                previousTab: nil,
+                scenePhase: self.scenePhase,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                startedAt: nil,
+                finishedAt: nil,
+                error: nil
+            )
             self.refreshProgressContext(now: now, restartWatcher: false)
+            logAppForegroundOperationBreadcrumb(
+                action: .initialProgressContextRefresh,
+                phase: .success,
+                store: self.store,
+                selectedTab: self.navigation.selectedTab,
+                previousTab: nil,
+                scenePhase: self.scenePhase,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                startedAt: progressContextRefreshStartedAt,
+                finishedAt: Date(),
+                error: nil
+            )
             if self.uiTestLaunchScenario == nil {
                 logAppLifecycleBreadcrumb(
                     action: .launchCloudSyncTriggered,
@@ -524,8 +697,35 @@ struct FlashcardsApp: App {
                 isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
                 messageSummary: nil
             )
+            let notificationReconcileStartedAt = Date()
+            logAppForegroundOperationBreadcrumb(
+                action: .initialNotificationReconcile,
+                phase: .start,
+                store: self.store,
+                selectedTab: self.navigation.selectedTab,
+                previousTab: nil,
+                scenePhase: self.scenePhase,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                startedAt: nil,
+                finishedAt: nil,
+                error: nil
+            )
             self.store.reconcileReviewNotifications(trigger: .appActive, now: now)
             self.store.reconcileStrictReminders(trigger: .appActive, now: now)
+            logAppForegroundOperationBreadcrumb(
+                action: .initialNotificationReconcile,
+                phase: .success,
+                store: self.store,
+                selectedTab: self.navigation.selectedTab,
+                previousTab: nil,
+                scenePhase: self.scenePhase,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                startedAt: notificationReconcileStartedAt,
+                finishedAt: Date(),
+                error: nil
+            )
 
             if let launchScenario = self.uiTestLaunchScenario {
                 self.store.uiTestLaunchPreparationStatus = .ready(launchScenario: launchScenario)
@@ -541,6 +741,19 @@ struct FlashcardsApp: App {
                 isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
                 messageSummary: nil
             )
+            logAppForegroundOperationBreadcrumb(
+                action: .initialStartup,
+                phase: .success,
+                store: self.store,
+                selectedTab: self.navigation.selectedTab,
+                previousTab: nil,
+                scenePhase: self.scenePhase,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                startedAt: initialStartupStartedAt,
+                finishedAt: Date(),
+                error: nil
+            )
         } catch {
             self.store.globalErrorMessage = Flashcards.errorMessage(error: error)
             logAppLifecycleBreadcrumb(
@@ -552,6 +765,19 @@ struct FlashcardsApp: App {
                 isStartupReady: self.isStartupReadyForBackgroundWork,
                 isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
                 messageSummary: Flashcards.errorMessage(error: error)
+            )
+            logAppForegroundOperationBreadcrumb(
+                action: .initialStartup,
+                phase: .failure,
+                store: self.store,
+                selectedTab: self.navigation.selectedTab,
+                previousTab: nil,
+                scenePhase: self.scenePhase,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                startedAt: initialStartupStartedAt,
+                finishedAt: Date(),
+                error: error
             )
             if let launchScenario = self.uiTestLaunchScenario {
                 self.store.uiTestLaunchPreparationStatus = .failed(

--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -265,7 +265,16 @@ struct RootTabView: View {
             return
         }
 
-        self.store.prepareVisibleTabForPresentation(tab: nextTab, now: Date())
+        let previousTab = self.store.currentVisibleTab
+        prepareVisibleTabForPresentationWithBreadcrumb(
+            store: self.store,
+            selectedTab: nextTab,
+            previousTab: previousTab,
+            scenePhase: self.scenePhase,
+            isStartupReady: nil,
+            isRecoveryGateActive: self.store.cloudCredentialRecoveryState != nil,
+            now: Date()
+        )
     }
 
     @MainActor
@@ -321,7 +330,16 @@ struct RootTabView: View {
                 navigation.selectedTab
             },
             set: { nextTab in
-                self.store.prepareVisibleTabForPresentation(tab: nextTab, now: Date())
+                let previousTab = navigation.selectedTab
+                prepareVisibleTabForPresentationWithBreadcrumb(
+                    store: self.store,
+                    selectedTab: nextTab,
+                    previousTab: previousTab,
+                    scenePhase: self.scenePhase,
+                    isStartupReady: nil,
+                    isRecoveryGateActive: self.store.cloudCredentialRecoveryState != nil,
+                    now: Date()
+                )
                 navigation.selectedTab = nextTab
             }
         )
@@ -339,7 +357,16 @@ struct RootTabView: View {
         self.tabRootBase
         .tabBarMinimizeBehavior(.never)
         .task {
-            store.prepareVisibleTabForPresentation(tab: self.navigation.selectedTab, now: Date())
+            let previousTab = store.currentVisibleTab
+            prepareVisibleTabForPresentationWithBreadcrumb(
+                store: self.store,
+                selectedTab: self.navigation.selectedTab,
+                previousTab: previousTab,
+                scenePhase: self.scenePhase,
+                isStartupReady: nil,
+                isRecoveryGateActive: self.store.cloudCredentialRecoveryState != nil,
+                now: Date()
+            )
             self.reconcileGuestSignInAfterReviewPrompt()
         }
         .task(id: self.guestSignInAfterReviewPromptRecheckTaskID) {

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -100,6 +100,8 @@ struct AppLifecycleObservation: Sendable, Hashable {
 
 enum ForegroundOperationAction: String, Sendable, Hashable {
     case initialStartup = "initial_startup"
+    case initialProgressContextRefresh = "initial_progress_context_refresh"
+    case initialNotificationReconcile = "initial_notification_reconcile"
     case visibleTabPresentation = "visible_tab_presentation"
     case reviewProgressRefresh = "review_progress_refresh"
     case cloudSync = "cloud_sync"

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -13,6 +13,7 @@ let emptyBackTextPlaceholder: String = String(localized: "No back text", table: 
 private let reviewQueuePreviewPageSize: Int = 50
 
 struct ReviewView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(FlashcardsStore.self) var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
 
@@ -519,13 +520,26 @@ struct ReviewView: View {
         )
     }
 
+    @MainActor
+    private func openProgressWithPresentationBreadcrumb(target: ProgressPresentationTarget) {
+        prepareVisibleTabForPresentationWithBreadcrumb(
+            store: self.store,
+            selectedTab: .progress,
+            previousTab: self.navigation.selectedTab,
+            scenePhase: self.scenePhase,
+            isStartupReady: nil,
+            isRecoveryGateActive: self.store.cloudCredentialRecoveryState != nil,
+            now: Date()
+        )
+        self.navigation.openProgress(target: target)
+    }
+
     private var reviewProgressBadgeButton: some View {
         let badgeState = self.store.reviewProgressBadgeState
         let badgePresentation = makeReviewProgressBadgePresentation(badgeState: badgeState)
 
         return Button {
-            self.store.prepareVisibleTabForPresentation(tab: .progress, now: Date())
-            self.navigation.openProgress(target: .streak)
+            self.openProgressWithPresentationBreadcrumb(target: .streak)
         } label: {
             HStack(spacing: reviewToolbarBadgeSpacing) {
                 Image(systemName: badgePresentation.iconSystemName)
@@ -554,8 +568,7 @@ struct ReviewView: View {
         let badgeState = self.store.reviewLeaderboardBadgeState
 
         return Button {
-            self.store.prepareVisibleTabForPresentation(tab: .progress, now: Date())
-            self.navigation.openProgress(target: .leaderboard)
+            self.openProgressWithPresentationBreadcrumb(target: .leaderboard)
         } label: {
             if let rank = badgeState.rank {
                 HStack(spacing: reviewToolbarBadgeSpacing) {


### PR DESCRIPTION
## Summary
- Add foreground-operation breadcrumb helpers for app startup and visible-tab preparation
- Instrument initial startup, progress-context refresh, notification reconcile, and tab preparation paths
- Route Review toolbar Progress shortcuts through the breadcrumb-covered tab preparation helper

## Validation
- git --no-pager diff --check
- rg -n "prepareVisibleTabForPresentation\\(" apps/ios/Flashcards/Flashcards
- Second worker-owned review: no split recommendation, no P0-P4 findings, green light

## Residual risk
- The requested generic iOS xcodebuild validation is blocked before compilation in this local environment because Xcode reports no eligible iOS destination / iOS 26.5 is not installed.
