### PR TITLE
Guard progress series invariants

### DIFF
--- a/apps/backend/src/progress/reports/index.ts
+++ b/apps/backend/src/progress/reports/index.ts
@@ -561,6 +561,51 @@ function createStreakDays(
   });
 }
 
+function validateProgressSeriesDayInvariant(
+  progressSeries: ProgressSeries,
+  request: ProgressSeriesRequest,
+): void {
+  const dailyReviewsByDate: ReadonlyMap<string, DailyReviewPoint> = new Map(
+    progressSeries.dailyReviews.map((dailyReview) => [dailyReview.date, dailyReview]),
+  );
+  const streakStatesByDate: ReadonlyMap<string, StreakDayState> = new Map(
+    progressSeries.streakDays.map((streakDay) => [streakDay.date, streakDay.state]),
+  );
+
+  for (const dailyReview of dailyReviewsByDate.values()) {
+    const streakState = streakStatesByDate.get(dailyReview.date);
+    if (streakState === undefined) {
+      throw new Error(
+        [
+          "Progress series day invariant failed",
+          `userId=${request.userId}`,
+          `timeZone=${request.timeZone}`,
+          `from=${request.from}`,
+          `to=${request.to}`,
+          `date=${dailyReview.date}`,
+          `reviewCount=${dailyReview.reviewCount}`,
+          "streakState=missing",
+        ].join("; "),
+      );
+    }
+
+    if ((dailyReview.reviewCount > 0) !== (streakState === "reviewed")) {
+      throw new Error(
+        [
+          "Progress series day invariant failed",
+          `userId=${request.userId}`,
+          `timeZone=${request.timeZone}`,
+          `from=${request.from}`,
+          `to=${request.to}`,
+          `date=${dailyReview.date}`,
+          `reviewCount=${dailyReview.reviewCount}`,
+          `streakState=${streakState}`,
+        ].join("; "),
+      );
+    }
+  }
+}
+
 async function loadReviewHistoryWatermarksInExecutor(
   executor: DatabaseExecutor,
   workspaceIds: ReadonlyArray<string>,
@@ -821,8 +866,7 @@ async function buildUserProgressSeriesInExecutor(
     today,
     streakFreezePolicy,
   );
-
-  return {
+  const progressSeries: ProgressSeries = {
     timeZone: request.timeZone,
     from: request.from,
     to: request.to,
@@ -839,6 +883,9 @@ async function buildUserProgressSeriesInExecutor(
     generatedAt: generatedAtDate.toISOString(),
     reviewHistoryWatermarks: sortReviewHistoryWatermarks(reviewHistoryWatermarks),
   };
+  validateProgressSeriesDayInvariant(progressSeries, request);
+
+  return progressSeries;
 }
 
 export async function loadUserProgressSummaryInExecutor(

--- a/apps/backend/src/progress/reports/progressSeries.test.ts
+++ b/apps/backend/src/progress/reports/progressSeries.test.ts
@@ -219,7 +219,11 @@ test("loadUserProgressSeriesInExecutor counts reviews by canonical reviewed_loca
         },
       ],
     },
-    activeReviewDateRowsByUser: {},
+    activeReviewDateRowsByUser: {
+      "user-1": [
+        { review_date: "2026-04-11" },
+      ],
+    },
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 1,
@@ -300,6 +304,47 @@ test("loadUserProgressSeriesInExecutor counts reviews by canonical reviewed_loca
   );
 });
 
+test("loadUserProgressSeriesInExecutor rejects daily review counts without matching reviewed streak state", async () => {
+  const { executor } = createProgressExecutor({
+    workspaceIdsByUser: {
+      "user-1": ["workspace-1"],
+    },
+    reviewRowsByRequest: {
+      "workspace-1|user-1|2026-04-26|2026-04-26": [
+        {
+          review_date: "2026-04-26",
+          review_count: 9,
+          again_count: 1,
+          hard_count: 2,
+          good_count: 3,
+          easy_count: 3,
+        },
+      ],
+    },
+    activeReviewDateRowsByUser: {},
+    reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 9,
+    },
+  });
+
+  await assert.rejects(
+    async () => loadUserProgressSeriesInExecutor(executor, {
+      userId: "user-1",
+      timeZone: "Europe/Madrid",
+      from: "2026-04-26",
+      to: "2026-04-26",
+    }),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /date=2026-04-26/);
+      assert.match(error.message, /reviewCount=9/);
+      assert.match(error.message, /streakState=missed/);
+      return true;
+    },
+  );
+});
+
 test("loadUserProgressSeriesInExecutor applies user scope for memberships and workspace scope for each review query", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
@@ -327,7 +372,12 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
         },
       ],
     },
-    activeReviewDateRowsByUser: {},
+    activeReviewDateRowsByUser: {
+      "user-1": [
+        { review_date: "2026-04-11" },
+        { review_date: "2026-04-14" },
+      ],
+    },
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 3,

--- a/apps/backend/src/progress/reports/progressSummary.test.ts
+++ b/apps/backend/src/progress/reports/progressSummary.test.ts
@@ -120,7 +120,26 @@ test("loadUserProgressSummaryInExecutor resets a gap larger than available freez
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
     },
-    reviewRowsByRequest: {},
+    reviewRowsByRequest: {
+      [`workspace-1|user-1|${sixDaysAgo}|${today}`]: [
+        {
+          review_date: sixDaysAgo,
+          review_count: 1,
+          again_count: 0,
+          hard_count: 0,
+          good_count: 1,
+          easy_count: 0,
+        },
+        {
+          review_date: today,
+          review_count: 1,
+          again_count: 0,
+          hard_count: 0,
+          good_count: 1,
+          easy_count: 0,
+        },
+      ],
+    },
     activeReviewDateRowsByUser: {
       "user-1": [
         { review_date: sixDaysAgo },


### PR DESCRIPTION
## Summary
- add backend-side progress series day invariant validation before returning series payloads
- add malformed fixture coverage for mismatched daily review and streak state
- keep existing progress summary series fixture consistent with the stricter invariant

## Validation
- cd apps/backend && node --test --import tsx src/progress/reports/*.test.ts
- npm run lint --prefix apps/backend

## Review
- Fresh worker-owned review after the P1 fix reported no P0-P4 issues and no split recommendation.