### PR TITLE
Centralize API network error observability

### DIFF
--- a/apps/web/src/observability/apiNetworkErrorPolicy.ts
+++ b/apps/web/src/observability/apiNetworkErrorPolicy.ts
@@ -1,0 +1,5 @@
+import { ApiNetworkError } from "../api";
+
+export function isBrowserApiNetworkError(error: Error): error is ApiNetworkError {
+  return error instanceof ApiNetworkError;
+}

--- a/apps/web/src/observability/instrument.test.ts
+++ b/apps/web/src/observability/instrument.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import * as Sentry from "@sentry/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiNetworkError } from "../api";
 import {
   prepareSentryEventForSend,
@@ -7,10 +8,43 @@ import {
   sanitizeSentryEventForPrivacy,
 } from "./instrument";
 import {
-  buildWebExceptionFingerprint,
+  captureWebException,
   type WebExceptionEvent,
   type WebObservationScope,
 } from "./webObservability";
+
+vi.mock("@sentry/react", () => {
+  const createScope = () => ({
+    setContext: vi.fn(),
+    setFingerprint: vi.fn(),
+    setLevel: vi.fn(),
+    setTag: vi.fn(),
+    setUser: vi.fn(),
+  });
+
+  return {
+    addBreadcrumb: vi.fn(),
+    captureException: vi.fn(),
+    captureMessage: vi.fn(),
+    ErrorBoundary: vi.fn(),
+    init: vi.fn(),
+    reactErrorHandler: vi.fn(),
+    reactRouterV7BrowserTracingIntegration: vi.fn(() => ({ name: "mock.react_router" })),
+    setUser: vi.fn(),
+    withScope: vi.fn((callback: (scope: ReturnType<typeof createScope>) => void): void => {
+      callback(createScope());
+    }),
+    withSentryReactRouterV7Routing: vi.fn((routes: unknown): unknown => routes),
+  };
+});
+
+vi.mock("./instrument", async () => {
+  const actual = await vi.importActual<typeof import("./instrument")>("./instrument");
+  return {
+    ...actual,
+    isWebSentryEnabled: true,
+  };
+});
 
 type SentryPrivacyEvent = Parameters<typeof sanitizeSentryEventForPrivacy>[0];
 type SentryPrivacyBreadcrumb = Parameters<typeof sanitizeSentryBreadcrumbForPrivacy>[0];
@@ -24,6 +58,10 @@ const sensitiveMessageText = "User message contains the backText private answer.
 function serializeEvent(event: SentryPrivacyEvent): string {
   return JSON.stringify(event);
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("Sentry privacy sanitizer", () => {
   it("scrubs automatic event message, logentry message, and exception values", () => {
@@ -307,7 +345,7 @@ describe("Sentry privacy sanitizer", () => {
     expect(serializeEvent(preparedEvent)).not.toContain(sensitiveCardText);
   });
 
-  it("groups API network errors by transport endpoint", () => {
+  it("does not capture browser API network errors as Sentry exceptions", () => {
     const scope: WebObservationScope = {
       app: "web",
       feature: "chat",
@@ -336,6 +374,37 @@ describe("Sentry privacy sanitizer", () => {
       },
     };
 
-    expect(buildWebExceptionFingerprint(event)).toEqual(["{{ default }}", "api_network_failed", "GET /chat"]);
+    captureWebException(event);
+
+    expect(Sentry.withScope).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("captures non-network exceptions as Sentry exceptions", () => {
+    const scope: WebObservationScope = {
+      app: "web",
+      feature: "app",
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      installationId: "installation-1",
+      route: "/settings",
+      requestId: null,
+      statusCode: null,
+      code: null,
+    };
+    const event: WebExceptionEvent = {
+      action: "app_operation_failed",
+      error: new Error("IndexedDB open failed"),
+      scope,
+      details: {
+        operation: "cards_page_load",
+        entityId: null,
+      },
+    };
+
+    captureWebException(event);
+
+    expect(Sentry.withScope).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/react";
 import type { Scope } from "@sentry/react";
-import { ApiNetworkError } from "../api";
+import { isBrowserApiNetworkError } from "./apiNetworkErrorPolicy";
 import { isWebSentryEnabled } from "./instrument";
 
 export type WebObservationFeature =
@@ -806,18 +806,16 @@ export function captureWebWarning(event: WebWarningEvent): void {
 }
 
 export function captureWebException(event: WebExceptionEvent): void {
+  if (isBrowserApiNetworkError(event.error)) {
+    return;
+  }
+
   if (isWebSentryEnabled === false) {
     return;
   }
 
   Sentry.withScope((scope: Scope): void => {
     applyObservationScope(scope, event.scope, event.action);
-    // Network-level failures are environmental (offline, captive portal,
-    // blocked API host), not app defects; keep them out of the error level.
-    if (event.error instanceof ApiNetworkError) {
-      scope.setLevel("warning");
-    }
-
     scope.setFingerprint(buildWebExceptionFingerprint(event));
     scope.setContext("web.exception", detailsToContext(event.details));
     scope.setContext("web.error", errorMetadataToContext(readErrorMetadata(event.error)));
@@ -826,10 +824,6 @@ export function captureWebException(event: WebExceptionEvent): void {
 }
 
 export function buildWebExceptionFingerprint(event: WebExceptionEvent): Array<string> {
-  if (event.error instanceof ApiNetworkError) {
-    return ["{{ default }}", "api_network_failed", event.error.endpoint];
-  }
-
   if (event.action === "app_operation_failed") {
     return ["{{ default }}", event.action, event.details.operation];
   }


### PR DESCRIPTION
## Summary
- Add a central browser API network error classifier for web observability.
- Suppress ApiNetworkError in captureWebException before Sentry scope/event creation.
- Update observability coverage for network suppression and non-network capture.

## Validation
- cd apps/web && npx vitest run src/observability/instrument.test.ts: passed, 12 tests.
- cd apps/web && npm run build: passed, existing Vite chunk-size warning only.
- Worker review round: no P0-P4 findings, no split recommendation, green light.
- git --no-pager diff --check: passed.