### PR TITLE
Suppress chat and sync API network captures

### DIFF
--- a/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
@@ -28,12 +28,17 @@ import {
   isBrowserReauthRequired,
   markBrowserReauthRequired,
 } from "../../accountDeletion";
+import { ApiNetworkError } from "../../api";
 import { INSTALLATION_ID_STORAGE_KEY } from "../../clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../i18n/runtime";
 import { loadCloudSettings } from "../../localDb/sync/cloudSettings";
 import type { WorkspaceSummary } from "../../types";
 import { loadWarmStartSnapshot, WARM_START_SNAPSHOT_STORAGE_KEY } from "./activation/warmStart";
 import { captureWorkspaceTransitionError } from "./observation/workspaceSessionObservation";
+import {
+  attachSyncFailureObservation,
+  observeSyncFailure,
+} from "../sync/observation/syncErrorObservation";
 
 const observabilityMocks = getObservabilityMocks();
 
@@ -205,6 +210,66 @@ describe("useWorkspaceSession bootstrap", () => {
     });
 
     expect(observabilityMocks.captureWebExceptionMock).not.toHaveBeenCalled();
+    expect(latestState?.sessionTechnicalError).toBeNull();
+    expect(latestState?.technicalError).toBeNull();
+  });
+
+  it("does not capture exhausted API network sync failures", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const networkSyncError = new ApiNetworkError({
+      endpoint: "POST /sync/push",
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Failed to fetch",
+      attemptCount: 4,
+    });
+    const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {
+      const wasCaptured = observeSyncFailure({
+        error: networkSyncError,
+        userId: seededSession.userId,
+        workspaceId: seededWorkspace.workspaceId,
+        installationId: seededCloudSettings.installationId,
+      });
+      throw attachSyncFailureObservation(networkSyncError, wasCaptured);
+    });
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={vi.fn(async (): Promise<void> => {})}
+          runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
+          onActionsChange={null}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionErrorMessage).toBe(networkSyncError.message);
+    });
+
+    expect(observabilityMocks.captureWebExceptionMock).not.toHaveBeenCalled();
+    expect(networkSyncError).toEqual(expect.objectContaining({
+      syncFailureWasCaptured: false,
+    }));
     expect(latestState?.sessionTechnicalError).toBeNull();
     expect(latestState?.technicalError).toBeNull();
   });

--- a/apps/web/src/appData/sync/observation/syncErrorObservation.ts
+++ b/apps/web/src/appData/sync/observation/syncErrorObservation.ts
@@ -8,6 +8,7 @@ import {
   captureWebException,
   type WebObservationScope,
 } from "../../../observability/webObservability";
+import { isBrowserApiNetworkError } from "../../../observability/apiNetworkErrorPolicy";
 
 const workspaceNotFoundErrorCode = "WORKSPACE_NOT_FOUND";
 const workspaceSyncDiscardedErrorName = "WorkspaceSyncDiscardedError";
@@ -136,6 +137,10 @@ function shouldCaptureUnexpectedSyncError(error: Error): boolean {
   }
 
   if (isAuthRedirectError(error)) {
+    return false;
+  }
+
+  if (isBrowserApiNetworkError(error)) {
     return false;
   }
 

--- a/apps/web/src/chat/ChatPanel/tests/ChatPanel.error-observation.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/ChatPanel.error-observation.test.tsx
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ApiErrorMock,
+  ApiNetworkErrorMock,
   AuthRedirectErrorMock,
   captureWebExceptionMock,
   setupChatPanelTest,
@@ -97,6 +98,24 @@ describe("ChatPanel error observation", () => {
     await renderChatPanel();
     await flushAsync();
     await sendMessage("expired session");
+    await flushAsync();
+    await flushAsync();
+
+    expect(captureWebExceptionMock).not.toHaveBeenCalled();
+    expect(getContainer().textContent).toContain("Chat request failed.");
+  });
+
+  it("does not capture exhausted API network chat request failures", async () => {
+    startChatRunMock.mockRejectedValue(new ApiNetworkErrorMock({
+      endpoint: "POST /chat/new",
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Failed to fetch",
+      attemptCount: 4,
+    }));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("network unavailable");
     await flushAsync();
     await flushAsync();
 

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -16,6 +16,7 @@ import {
 
 const {
   ApiErrorMock,
+  ApiNetworkErrorMock,
   AuthRedirectErrorMock,
   ApiContractErrorMock,
   ChatLiveContractErrorMock,
@@ -51,6 +52,34 @@ const {
       this.statusCode = statusCode;
       this.code = code;
       this.requestId = null;
+    }
+  },
+  ApiNetworkErrorMock: class ApiNetworkError extends Error {
+    readonly statusCode: number;
+    readonly code: string;
+    readonly requestId: string | null;
+    readonly endpoint: string;
+    readonly responseBodyKind: "empty";
+    readonly originalErrorName: string;
+    readonly originalErrorMessage: string;
+    readonly attemptCount: number;
+
+    constructor(params: Readonly<{
+      endpoint: string;
+      originalErrorName: string;
+      originalErrorMessage: string;
+      attemptCount: number;
+    }>) {
+      super(`The API is unavailable. Try again. (${params.endpoint}; ${params.originalErrorName}: ${params.originalErrorMessage})`);
+      this.name = "ApiNetworkError";
+      this.statusCode = 0;
+      this.code = "API_NETWORK_ERROR";
+      this.requestId = null;
+      this.endpoint = params.endpoint;
+      this.responseBodyKind = "empty";
+      this.originalErrorName = params.originalErrorName;
+      this.originalErrorMessage = params.originalErrorMessage;
+      this.attemptCount = params.attemptCount;
     }
   },
   AuthRedirectErrorMock: class AuthRedirectError extends Error {
@@ -164,6 +193,7 @@ vi.mock("../../../layout/ChatLayoutContext", () => ({
 
 vi.mock("../../../../api", () => ({
   ApiError: ApiErrorMock,
+  ApiNetworkError: ApiNetworkErrorMock,
   AuthRedirectError: AuthRedirectErrorMock,
   ApiContractError: ApiContractErrorMock,
   getChatSnapshot: getChatSnapshotMock,
@@ -283,6 +313,7 @@ export type MessagesScrollerMetrics = Readonly<{
 export {
   ApiContractErrorMock,
   ApiErrorMock,
+  ApiNetworkErrorMock,
   AuthRedirectErrorMock,
   ChatLiveContractErrorMock,
   ChatLiveHttpErrorMock,

--- a/apps/web/src/chat/sessionController/actions/useActions.ts
+++ b/apps/web/src/chat/sessionController/actions/useActions.ts
@@ -13,6 +13,7 @@ import {
   type ChatRunRequestFailureDetails,
   type WebObservationScope,
 } from "../../../observability/webObservability";
+import { isBrowserApiNetworkError } from "../../../observability/apiNetworkErrorPolicy";
 import type { Locale } from "../../../i18n/types";
 import type {
   NewChatSessionResponse,
@@ -121,6 +122,10 @@ function shouldCaptureChatRunRequestError(error: Error): boolean {
   }
 
   if (error instanceof AuthRedirectError) {
+    return false;
+  }
+
+  if (isBrowserApiNetworkError(error)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Treat browser ApiNetworkError chat request failures as expected environment failures.
- Treat sync ApiNetworkError failures as unobserved expected sync failures.
- Add chat and bootstrap/session coverage for the new policy.

## Validation
- cd apps/web && npx vitest run src/chat/ChatPanel/tests/ChatPanel.error-observation.test.tsx src/appData/session/useWorkspaceSession.bootstrap.test.tsx
- cd apps/web && npm run build