### PR TITLE
Android package import/export controls

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
@@ -51,10 +51,12 @@ const val workspacePackageExportMetadataAuthorFieldTag: String = "workspace_pack
 const val workspacePackageExportMetadataCreatedAtFieldTag: String = "workspace_package_export_metadata_created_at_field"
 const val workspacePackageExportMetadataSourceUrlFieldTag: String = "workspace_package_export_metadata_source_url_field"
 const val workspacePackageExportMetadataCommentFieldTag: String = "workspace_package_export_metadata_comment_field"
-const val workspacePackageExportTagToggleTagPrefix: String = "workspace_package_export_tag_toggle:"
+const val workspacePackageExportCardSelectionTagToggleTagPrefix: String = "workspace_package_export_card_selection_tag_toggle:"
+const val workspacePackageExportIncludedTagToggleTagPrefix: String = "workspace_package_export_included_tag_toggle:"
 const val workspaceImportScreenTag: String = "workspace_import_screen"
 const val workspaceImportChooseFileButtonTag: String = "workspace_import_choose_file_button"
 const val workspaceImportAddImportTagToggleTag: String = "workspace_import_add_import_tag_toggle"
+const val workspaceImportTagFieldTag: String = "workspace_import_tag_field"
 const val workspaceImportConfirmButtonTag: String = "workspace_import_confirm_button"
 const val workspaceImportErrorMessageTag: String = "workspace_import_error_message"
 const val workspaceImportTagToggleTagPrefix: String = "workspace_import_tag_toggle:"
@@ -63,6 +65,10 @@ fun workspaceImportTagToggleTag(tag: String): String {
     return workspaceImportTagToggleTagPrefix + tag
 }
 
-fun workspacePackageExportTagToggleTag(tag: String): String {
-    return workspacePackageExportTagToggleTagPrefix + tag
+fun workspacePackageExportCardSelectionTagToggleTag(tag: String): String {
+    return workspacePackageExportCardSelectionTagToggleTagPrefix + tag
+}
+
+fun workspacePackageExportIncludedTagToggleTag(tag: String): String {
+    return workspacePackageExportIncludedTagToggleTagPrefix + tag
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
@@ -47,12 +47,15 @@ import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.isWorkspacePackageExportGeneratedImportTag
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
 import com.flashcardsopensourceapp.feature.settings.workspaceExportScreenTag
+import com.flashcardsopensourceapp.feature.settings.workspacePackageExportCardSelectionTagToggleTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportErrorMessageTag
+import com.flashcardsopensourceapp.feature.settings.workspacePackageExportIncludedTagToggleTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportMetadataAuthorFieldTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportMetadataCommentFieldTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportMetadataCreatedAtFieldTag
@@ -61,7 +64,6 @@ import com.flashcardsopensourceapp.feature.settings.workspacePackageExportMetada
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportPreviewButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportSaveButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspacePackageExportShareButtonTag
-import com.flashcardsopensourceapp.feature.settings.workspacePackageExportTagToggleTag
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -163,11 +165,21 @@ fun WorkspaceExportRoute(
                     )
                 }
                 item {
-                    WorkspacePackageExportTagsCard(
-                        preview = packagePreview,
-                        removedTags = uiState.packageRemovedTags,
+                    WorkspacePackageExportCardSelectionCard(
+                        tagOptions = makeWorkspacePackageExportCardSelectionTagOptions(
+                            tagCounts = uiState.packageCardSelectionTagCounts,
+                            selectedTags = uiState.packageCardSelectionTags
+                        ),
                         isBusy = uiState.isBusy,
-                        onToggleRemovedTag = viewModel::togglePackageRemovedTag
+                        onToggleSelectionTag = viewModel::togglePackageCardSelectionTag
+                    )
+                }
+                item {
+                    WorkspacePackageExportIncludedTagsCard(
+                        preview = packagePreview,
+                        includedTags = uiState.packageIncludedTags,
+                        isBusy = uiState.isBusy,
+                        onToggleIncludedTag = viewModel::togglePackageIncludedTag
                     )
                 }
                 item {
@@ -445,48 +457,101 @@ private fun WorkspacePackageExportMetadataCard(
 }
 
 @Composable
-private fun WorkspacePackageExportTagsCard(
-    preview: WorkspacePackageExportPreview,
-    removedTags: Set<String>,
+private fun WorkspacePackageExportCardSelectionCard(
+    tagOptions: List<WorkspacePackageExportTagOptionUiState>,
     isBusy: Boolean,
-    onToggleRemovedTag: (String) -> Unit
+    onToggleSelectionTag: (String) -> Unit
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            SectionHeader(title = stringResource(R.string.settings_export_package_card_selection_section))
+            if (tagOptions.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.settings_export_package_card_selection_all_active),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                )
+            } else {
+                if (tagOptions.none { tagOption -> tagOption.isSelected }) {
+                    Text(
+                        text = stringResource(R.string.settings_export_package_card_selection_all_active),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                    )
+                }
+                tagOptions.forEach { tagOption ->
+                    ToggleListItem(
+                        title = stringResource(R.string.settings_export_package_select_cards_with_tag, tagOption.tag),
+                        supportingText = pluralStringResource(
+                            R.plurals.settings_tag_cards_count,
+                            tagOption.cardsCount,
+                            tagOption.cardsCount
+                        ),
+                        checked = tagOption.isSelected,
+                        enabled = isBusy.not(),
+                        testTag = workspacePackageExportCardSelectionTagToggleTag(tag = tagOption.tag),
+                        onCheckedChange = {
+                            onToggleSelectionTag(tagOption.tag)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkspacePackageExportIncludedTagsCard(
+    preview: WorkspacePackageExportPreview,
+    includedTags: Set<String>,
+    isBusy: Boolean,
+    onToggleIncludedTag: (String) -> Unit
 ) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(vertical = 8.dp)) {
             SectionHeader(title = stringResource(R.string.settings_export_package_tags_section))
-            val tagOptions: List<WorkspacePackageExportTagOptionUiState> = makeWorkspacePackageExportTagOptions(
+            val tagOptions: List<WorkspacePackageExportTagOptionUiState> = makeWorkspacePackageExportIncludedTagOptions(
                 preview = preview,
-                removedTags = removedTags
+                includedTags = includedTags
             )
+            val hasGeneratedImportTags: Boolean = preview.availableTagCounts.any { tagCount ->
+                isWorkspacePackageExportGeneratedImportTag(tag = tagCount.tag)
+            }
             if (tagOptions.isEmpty()) {
                 Text(
                     text = stringResource(R.string.settings_export_package_tags_empty),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
                 )
+                if (hasGeneratedImportTags) {
+                    Text(
+                        text = stringResource(R.string.settings_export_package_generated_import_tag_removed),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                    )
+                }
             } else {
                 tagOptions.forEach { tagOption ->
                     ToggleListItem(
-                        title = if (tagOption.isAlwaysRemoved) {
-                            stringResource(R.string.settings_export_package_always_remove_tag, tagOption.tag)
-                        } else {
-                            stringResource(R.string.settings_export_package_remove_tag, tagOption.tag)
-                        },
-                        supportingText = if (tagOption.isAlwaysRemoved) {
-                            stringResource(R.string.settings_export_package_generated_import_tag_removed)
-                        } else {
-                            pluralStringResource(
-                                R.plurals.settings_tag_cards_count,
-                                tagOption.cardsCount,
-                                tagOption.cardsCount
-                            )
-                        },
-                        checked = tagOption.isRemoved,
-                        enabled = isBusy.not() && tagOption.isAlwaysRemoved.not(),
-                        testTag = workspacePackageExportTagToggleTag(tag = tagOption.tag),
+                        title = stringResource(R.string.settings_export_package_include_tag, tagOption.tag),
+                        supportingText = pluralStringResource(
+                            R.plurals.settings_tag_cards_count,
+                            tagOption.cardsCount,
+                            tagOption.cardsCount
+                        ),
+                        checked = tagOption.isSelected,
+                        enabled = isBusy.not(),
+                        testTag = workspacePackageExportIncludedTagToggleTag(tag = tagOption.tag),
                         onCheckedChange = {
-                            onToggleRemovedTag(tagOption.tag)
+                            onToggleIncludedTag(tagOption.tag)
                         }
+                    )
+                }
+                if (hasGeneratedImportTags) {
+                    Text(
+                        text = stringResource(R.string.settings_export_package_generated_import_tag_removed),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
                     )
                 }
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportSupport.kt
@@ -10,6 +10,7 @@ import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageEx
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportRequest
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportSelection
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagCount
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagPolicyInput
 import com.flashcardsopensourceapp.data.local.model.workspace.isWorkspacePackageExportGeneratedImportTag
 import java.io.File
@@ -27,13 +28,12 @@ data class WorkspacePackageExportMetadataDraft(
 internal data class WorkspacePackageExportTagOptionUiState(
     val tag: String,
     val cardsCount: Int,
-    val isRemoved: Boolean,
-    val isAlwaysRemoved: Boolean
+    val isSelected: Boolean
 )
 
-fun makeDefaultWorkspacePackageExportPreviewRequest(): WorkspacePackageExportRequest {
+fun makeWorkspacePackageExportPreviewRequest(selectedCardTags: Set<String>): WorkspacePackageExportRequest {
     return WorkspacePackageExportRequest(
-        selection = WorkspacePackageExportSelection.AllActiveCards,
+        selection = makeWorkspacePackageExportSelection(selectedCardTags = selectedCardTags),
         tagPolicy = WorkspacePackageExportTagPolicyInput(additionalRemovedTags = emptyList()),
         packageMetadata = WorkspacePackageExportMetadataInput(
             label = null,
@@ -57,26 +57,27 @@ fun makeWorkspacePackageExportMetadataDraft(
     )
 }
 
-fun makeWorkspacePackageExportInitialRemovedTags(preview: WorkspacePackageExportPreview): Set<String> {
-    return (
-        preview.tagsSelectedForRemoval.map { tagCount -> tagCount.tag } +
-            preview.availableTagCounts
-                .map { tagCount -> tagCount.tag }
-                .filter { tag -> isWorkspacePackageExportGeneratedImportTag(tag = tag) }
-        ).toSet()
+fun makeWorkspacePackageExportIncludedTags(
+    preview: WorkspacePackageExportPreview,
+    excludedTags: Set<String>
+): Set<String> {
+    return makeWorkspacePackageExportAvailableRegularTags(preview = preview)
+        .filter { tag -> excludedTags.contains(tag).not() }
+        .toSet()
 }
 
 fun makeWorkspacePackageExportRequest(
     preview: WorkspacePackageExportPreview,
     metadataDraft: WorkspacePackageExportMetadataDraft,
-    removedTags: Set<String>
+    selectedCardTags: Set<String>,
+    excludedTags: Set<String>
 ): WorkspacePackageExportRequest {
     return WorkspacePackageExportRequest(
-        selection = WorkspacePackageExportSelection.AllActiveCards,
+        selection = makeWorkspacePackageExportSelection(selectedCardTags = selectedCardTags),
         tagPolicy = WorkspacePackageExportTagPolicyInput(
-            additionalRemovedTags = makeWorkspacePackageExportRemovedTags(
+            additionalRemovedTags = makeWorkspacePackageExportAdditionalRemovedTags(
                 preview = preview,
-                removedTags = removedTags
+                excludedTags = excludedTags
             )
         ),
         packageMetadata = WorkspacePackageExportMetadataInput(
@@ -89,19 +90,32 @@ fun makeWorkspacePackageExportRequest(
     )
 }
 
-internal fun makeWorkspacePackageExportTagOptions(
-    preview: WorkspacePackageExportPreview,
-    removedTags: Set<String>
+internal fun makeWorkspacePackageExportCardSelectionTagOptions(
+    tagCounts: List<WorkspacePackageExportTagCount>,
+    selectedTags: Set<String>
 ): List<WorkspacePackageExportTagOptionUiState> {
-    return preview.availableTagCounts.map { tagCount ->
-        val isAlwaysRemoved: Boolean = isWorkspacePackageExportGeneratedImportTag(tag = tagCount.tag)
+    return tagCounts.map { tagCount ->
         WorkspacePackageExportTagOptionUiState(
             tag = tagCount.tag,
             cardsCount = tagCount.cardsCount,
-            isRemoved = isAlwaysRemoved || removedTags.contains(tagCount.tag),
-            isAlwaysRemoved = isAlwaysRemoved
+            isSelected = selectedTags.contains(tagCount.tag)
         )
     }
+}
+
+internal fun makeWorkspacePackageExportIncludedTagOptions(
+    preview: WorkspacePackageExportPreview,
+    includedTags: Set<String>
+): List<WorkspacePackageExportTagOptionUiState> {
+    return preview.availableTagCounts
+        .filter { tagCount -> isWorkspacePackageExportGeneratedImportTag(tag = tagCount.tag).not() }
+        .map { tagCount ->
+            WorkspacePackageExportTagOptionUiState(
+                tag = tagCount.tag,
+                cardsCount = tagCount.cardsCount,
+                isSelected = includedTags.contains(tagCount.tag)
+            )
+        }
 }
 
 fun writeWorkspacePackageExportZip(
@@ -151,14 +165,35 @@ fun prepareWorkspacePackageExportShareUri(
     )
 }
 
-private fun makeWorkspacePackageExportRemovedTags(
+private fun makeWorkspacePackageExportSelection(selectedCardTags: Set<String>): WorkspacePackageExportSelection {
+    val normalizedSelectedCardTags: List<String> = selectedCardTags
+        .map { tag -> tag.trim() }
+        .filter { tag -> tag.isNotEmpty() }
+        .distinct()
+        .sorted()
+    if (normalizedSelectedCardTags.isEmpty()) {
+        return WorkspacePackageExportSelection.AllActiveCards
+    }
+    return WorkspacePackageExportSelection.TagFilters(
+        includeTags = normalizedSelectedCardTags,
+        excludeTags = emptyList()
+    )
+}
+
+private fun makeWorkspacePackageExportAvailableRegularTags(preview: WorkspacePackageExportPreview): List<String> {
+    return preview.availableTagCounts
+        .map { tagCount -> tagCount.tag }
+        .filter { tag -> isWorkspacePackageExportGeneratedImportTag(tag = tag).not() }
+}
+
+private fun makeWorkspacePackageExportAdditionalRemovedTags(
     preview: WorkspacePackageExportPreview,
-    removedTags: Set<String>
+    excludedTags: Set<String>
 ): List<String> {
     return preview.availableTagCounts
         .map { tagCount -> tagCount.tag }
         .filter { tag ->
-            isWorkspacePackageExportGeneratedImportTag(tag = tag) || removedTags.contains(tag)
+            isWorkspacePackageExportGeneratedImportTag(tag = tag).not() && excludedTags.contains(tag)
         }
 }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportUiState.kt
@@ -1,11 +1,14 @@
 package com.flashcardsopensourceapp.feature.settings.workspace.export
 
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagCount
 
 data class WorkspaceExportUiState(
     val packagePreview: WorkspacePackageExportPreview?,
     val packageMetadataDraft: WorkspacePackageExportMetadataDraft,
-    val packageRemovedTags: Set<String>,
+    val packageCardSelectionTags: Set<String>,
+    val packageCardSelectionTagCounts: List<WorkspacePackageExportTagCount>,
+    val packageIncludedTags: Set<String>,
     val isPackagePreviewing: Boolean,
     val isPackageExporting: Boolean,
     val packageAvailabilityMessage: String,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModel.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportDownloadResponse
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportPreview
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspacePackageExportTagCount
 import com.flashcardsopensourceapp.data.local.model.workspace.isWorkspacePackageExportGeneratedImportTag
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncBlockedException
@@ -35,11 +36,22 @@ private data class WorkspacePackageExportPreviewIdentity(
     val installationId: String
 )
 
+private data class WorkspacePackageExportPreservedDraft(
+    val preview: WorkspacePackageExportPreview,
+    val previewIdentity: WorkspacePackageExportPreviewIdentity,
+    val metadataDraft: WorkspacePackageExportMetadataDraft,
+    val cardSelectionTags: Set<String>,
+    val cardSelectionTagCounts: List<WorkspacePackageExportTagCount>,
+    val excludedTags: Set<String>
+)
+
 private data class WorkspaceExportDraftState(
     val packagePreview: WorkspacePackageExportPreview?,
     val packagePreviewIdentity: WorkspacePackageExportPreviewIdentity?,
     val packageMetadataDraft: WorkspacePackageExportMetadataDraft,
-    val packageRemovedTags: Set<String>,
+    val packageCardSelectionTags: Set<String>,
+    val packageCardSelectionTagCounts: List<WorkspacePackageExportTagCount>,
+    val packageExcludedTags: Set<String>,
     val isPackagePreviewing: Boolean,
     val isPackageExporting: Boolean,
     val errorMessage: String
@@ -68,7 +80,9 @@ class WorkspaceExportViewModel(
             packagePreview = null,
             packagePreviewIdentity = null,
             packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
-            packageRemovedTags = emptySet(),
+            packageCardSelectionTags = emptySet(),
+            packageCardSelectionTagCounts = emptyList(),
+            packageExcludedTags = emptySet(),
             isPackagePreviewing = false,
             isPackageExporting = false,
             errorMessage = ""
@@ -86,14 +100,32 @@ class WorkspaceExportViewModel(
         )
         val isPackagePreviewCurrent: Boolean = draft.packagePreview != null &&
             draft.packagePreviewIdentity == currentIdentity
+        val currentPackagePreview: WorkspacePackageExportPreview? = if (isPackagePreviewCurrent) {
+            draft.packagePreview
+        } else {
+            null
+        }
         WorkspaceExportUiState(
-            packagePreview = if (isPackagePreviewCurrent) draft.packagePreview else null,
-            packageMetadataDraft = if (isPackagePreviewCurrent) {
+            packagePreview = currentPackagePreview,
+            packageMetadataDraft = if (currentPackagePreview != null) {
                 draft.packageMetadataDraft
             } else {
                 emptyWorkspacePackageExportMetadataDraft()
             },
-            packageRemovedTags = if (isPackagePreviewCurrent) draft.packageRemovedTags else emptySet(),
+            packageCardSelectionTags = if (currentPackagePreview != null) draft.packageCardSelectionTags else emptySet(),
+            packageCardSelectionTagCounts = if (currentPackagePreview != null) {
+                draft.packageCardSelectionTagCounts
+            } else {
+                emptyList()
+            },
+            packageIncludedTags = if (currentPackagePreview != null) {
+                makeWorkspacePackageExportIncludedTags(
+                    preview = currentPackagePreview,
+                    excludedTags = draft.packageExcludedTags
+                )
+            } else {
+                emptySet()
+            },
             isPackagePreviewing = draft.isPackagePreviewing,
             isPackageExporting = draft.isPackageExporting,
             packageAvailabilityMessage = workspacePackageExportAvailabilityMessage(
@@ -108,7 +140,9 @@ class WorkspaceExportViewModel(
         initialValue = WorkspaceExportUiState(
             packagePreview = null,
             packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
-            packageRemovedTags = emptySet(),
+            packageCardSelectionTags = emptySet(),
+            packageCardSelectionTagCounts = emptyList(),
+            packageIncludedTags = emptySet(),
             isPackagePreviewing = false,
             isPackageExporting = false,
             packageAvailabilityMessage = strings.get(R.string.settings_export_package_cloud_required),
@@ -117,13 +151,35 @@ class WorkspaceExportViewModel(
     )
 
     fun previewPackageExport() {
+        requestPackageExportPreview(
+            selectedCardTags = emptySet(),
+            preservedCardSelectionTagCounts = emptyList(),
+            preservedDraft = null
+        )
+    }
+
+    private fun requestPackageExportPreview(
+        selectedCardTags: Set<String>,
+        preservedCardSelectionTagCounts: List<WorkspacePackageExportTagCount>,
+        preservedDraft: WorkspacePackageExportPreservedDraft?
+    ) {
         val previewRequestId: Long = latestPackagePreviewRequestId.incrementAndGet()
         viewModelScope.launch {
-            previewPackageExportAsync(previewRequestId = previewRequestId)
+            previewPackageExportAsync(
+                previewRequestId = previewRequestId,
+                selectedCardTags = selectedCardTags,
+                preservedCardSelectionTagCounts = preservedCardSelectionTagCounts,
+                preservedDraft = preservedDraft
+            )
         }
     }
 
-    private suspend fun previewPackageExportAsync(previewRequestId: Long) {
+    private suspend fun previewPackageExportAsync(
+        previewRequestId: Long,
+        selectedCardTags: Set<String>,
+        preservedCardSelectionTagCounts: List<WorkspacePackageExportTagCount>,
+        preservedDraft: WorkspacePackageExportPreservedDraft?
+    ) {
         val previewIdentity: WorkspacePackageExportPreviewIdentity? = makePackagePreviewIdentity(
             cloudSettings = cloudSettingsState.value
         )
@@ -136,7 +192,9 @@ class WorkspaceExportViewModel(
                     packagePreview = null,
                     packagePreviewIdentity = null,
                     packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
-                    packageRemovedTags = emptySet(),
+                    packageCardSelectionTags = emptySet(),
+                    packageCardSelectionTagCounts = emptyList(),
+                    packageExcludedTags = emptySet(),
                     isPackagePreviewing = false,
                     isPackageExporting = false,
                     errorMessage = workspacePackageExportAvailabilityMessage(
@@ -152,8 +210,10 @@ class WorkspaceExportViewModel(
             state.copy(
                 packagePreview = null,
                 packagePreviewIdentity = previewIdentity,
-                packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
-                packageRemovedTags = emptySet(),
+                packageMetadataDraft = preservedDraft?.metadataDraft ?: emptyWorkspacePackageExportMetadataDraft(),
+                packageCardSelectionTags = selectedCardTags,
+                packageCardSelectionTagCounts = preservedCardSelectionTagCounts,
+                packageExcludedTags = preservedDraft?.excludedTags ?: emptySet(),
                 isPackagePreviewing = true,
                 isPackageExporting = false,
                 errorMessage = ""
@@ -162,16 +222,23 @@ class WorkspaceExportViewModel(
 
         try {
             val preview: WorkspacePackageExportPreview = cloudAccountRepository.previewCurrentWorkspacePackageExport(
-                request = makeDefaultWorkspacePackageExportPreviewRequest()
+                request = makeWorkspacePackageExportPreviewRequest(selectedCardTags = selectedCardTags)
             )
             updateDraftStateForPackagePreviewRequest(previewRequestId = previewRequestId) { state ->
+                val nextCardSelectionTagCounts: List<WorkspacePackageExportTagCount> = if (selectedCardTags.isEmpty()) {
+                    preview.availableTagCounts
+                } else {
+                    preservedCardSelectionTagCounts.ifEmpty { preview.availableTagCounts }
+                }
+                val nextMetadataDraft: WorkspacePackageExportMetadataDraft = preservedDraft?.metadataDraft
+                    ?: makeWorkspacePackageExportMetadataDraft(defaultPackageMetadata = preview.defaultPackageMetadata)
                 state.copy(
                     packagePreview = preview,
                     packagePreviewIdentity = previewIdentity,
-                    packageMetadataDraft = makeWorkspacePackageExportMetadataDraft(
-                        defaultPackageMetadata = preview.defaultPackageMetadata
-                    ),
-                    packageRemovedTags = makeWorkspacePackageExportInitialRemovedTags(preview = preview),
+                    packageMetadataDraft = nextMetadataDraft,
+                    packageCardSelectionTags = selectedCardTags,
+                    packageCardSelectionTagCounts = nextCardSelectionTagCounts,
+                    packageExcludedTags = preservedDraft?.excludedTags ?: emptySet(),
                     isPackagePreviewing = false,
                     errorMessage = ""
                 )
@@ -180,12 +247,9 @@ class WorkspaceExportViewModel(
             throw error
         } catch (error: SyncBlockedException) {
             updateDraftStateForPackagePreviewRequest(previewRequestId = previewRequestId) { state ->
-                state.copy(
-                    packagePreview = null,
-                    packagePreviewIdentity = null,
-                    packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
-                    packageRemovedTags = emptySet(),
-                    isPackagePreviewing = false,
+                restoreWorkspacePackageExportDraftAfterPreviewFailure(
+                    state = state,
+                    preservedDraft = preservedDraft,
                     errorMessage = strings.get(R.string.settings_account_status_sync_blocked_body)
                 )
             }
@@ -193,7 +257,8 @@ class WorkspaceExportViewModel(
             handlePackageExportFailureForPreviewRequest(
                 error = error,
                 fallbackMessage = strings.get(R.string.settings_export_package_preview_failed),
-                previewRequestId = previewRequestId
+                previewRequestId = previewRequestId,
+                preservedDraft = preservedDraft
             )
         }
     }
@@ -223,7 +288,9 @@ class WorkspaceExportViewModel(
                     packagePreview = null,
                     packagePreviewIdentity = null,
                     packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
-                    packageRemovedTags = emptySet(),
+                    packageCardSelectionTags = emptySet(),
+                    packageCardSelectionTagCounts = emptyList(),
+                    packageExcludedTags = emptySet(),
                     errorMessage = currentUiState.packageAvailabilityMessage
                 )
             }
@@ -242,7 +309,8 @@ class WorkspaceExportViewModel(
                 request = makeWorkspacePackageExportRequest(
                     preview = preview,
                     metadataDraft = currentUiState.packageMetadataDraft,
-                    removedTags = currentUiState.packageRemovedTags
+                    selectedCardTags = currentUiState.packageCardSelectionTags,
+                    excludedTags = draftState.value.packageExcludedTags
                 )
             )
         } catch (error: CancellationException) {
@@ -309,7 +377,35 @@ class WorkspaceExportViewModel(
         }
     }
 
-    fun togglePackageRemovedTag(tag: String) {
+    fun togglePackageCardSelectionTag(tag: String) {
+        val currentState: WorkspaceExportDraftState = draftState.value
+        require(currentState.packageCardSelectionTagCounts.any { tagCount -> tagCount.tag == tag }) {
+            "Workspace package export card selection tag toggle requires an existing preview tag."
+        }
+        val nextSelectedTags: Set<String> = if (currentState.packageCardSelectionTags.contains(tag)) {
+            currentState.packageCardSelectionTags - tag
+        } else {
+            currentState.packageCardSelectionTags + tag
+        }
+        requestPackageExportPreview(
+            selectedCardTags = nextSelectedTags,
+            preservedCardSelectionTagCounts = currentState.packageCardSelectionTagCounts,
+            preservedDraft = WorkspacePackageExportPreservedDraft(
+                preview = requireNotNull(currentState.packagePreview) {
+                    "Workspace package export card selection refresh requires a current preview."
+                },
+                previewIdentity = requireNotNull(currentState.packagePreviewIdentity) {
+                    "Workspace package export card selection refresh requires a current preview identity."
+                },
+                metadataDraft = currentState.packageMetadataDraft,
+                cardSelectionTags = currentState.packageCardSelectionTags,
+                cardSelectionTagCounts = currentState.packageCardSelectionTagCounts,
+                excludedTags = currentState.packageExcludedTags
+            )
+        )
+    }
+
+    fun togglePackageIncludedTag(tag: String) {
         val preview: WorkspacePackageExportPreview = requireNotNull(uiState.value.packagePreview) {
             "Workspace package export tag toggles require a current preview."
         }
@@ -320,13 +416,13 @@ class WorkspaceExportViewModel(
             "Workspace package export generated import tags cannot be kept."
         }
         draftState.update { state ->
-            val nextRemovedTags: Set<String> = if (state.packageRemovedTags.contains(tag)) {
-                state.packageRemovedTags - tag
+            val nextExcludedTags: Set<String> = if (state.packageExcludedTags.contains(tag)) {
+                state.packageExcludedTags - tag
             } else {
-                state.packageRemovedTags + tag
+                state.packageExcludedTags + tag
             }
             state.copy(
-                packageRemovedTags = nextRemovedTags,
+                packageExcludedTags = nextExcludedTags,
                 errorMessage = ""
             )
         }
@@ -356,7 +452,8 @@ class WorkspaceExportViewModel(
     private fun handlePackageExportFailureForPreviewRequest(
         error: Exception,
         fallbackMessage: String,
-        previewRequestId: Long
+        previewRequestId: Long,
+        preservedDraft: WorkspacePackageExportPreservedDraft?
     ) {
         val expectedErrorMessage: String? = expectedWorkspacePackageExportCloudFailureMessage(
             error = error,
@@ -365,13 +462,9 @@ class WorkspaceExportViewModel(
         var didHandleCurrentRequest = false
         updateDraftStateForPackagePreviewRequest(previewRequestId = previewRequestId) { state ->
             didHandleCurrentRequest = true
-            state.copy(
-                packagePreview = null,
-                packagePreviewIdentity = null,
-                packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
-                packageRemovedTags = emptySet(),
-                isPackagePreviewing = false,
-                isPackageExporting = false,
+            restoreWorkspacePackageExportDraftAfterPreviewFailure(
+                state = state,
+                preservedDraft = preservedDraft,
                 errorMessage = expectedErrorMessage ?: fallbackMessage
             )
         }
@@ -439,6 +532,37 @@ private fun emptyWorkspacePackageExportMetadataDraft(): WorkspacePackageExportMe
         comment = "",
         createdAt = "",
         sourceUrl = ""
+    )
+}
+
+private fun restoreWorkspacePackageExportDraftAfterPreviewFailure(
+    state: WorkspaceExportDraftState,
+    preservedDraft: WorkspacePackageExportPreservedDraft?,
+    errorMessage: String
+): WorkspaceExportDraftState {
+    if (preservedDraft == null) {
+        return state.copy(
+            packagePreview = null,
+            packagePreviewIdentity = null,
+            packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
+            packageCardSelectionTags = emptySet(),
+            packageCardSelectionTagCounts = emptyList(),
+            packageExcludedTags = emptySet(),
+            isPackagePreviewing = false,
+            isPackageExporting = false,
+            errorMessage = errorMessage
+        )
+    }
+    return state.copy(
+        packagePreview = preservedDraft.preview,
+        packagePreviewIdentity = preservedDraft.previewIdentity,
+        packageMetadataDraft = preservedDraft.metadataDraft,
+        packageCardSelectionTags = preservedDraft.cardSelectionTags,
+        packageCardSelectionTagCounts = preservedDraft.cardSelectionTagCounts,
+        packageExcludedTags = preservedDraft.excludedTags,
+        isPackagePreviewing = false,
+        isPackageExporting = false,
+        errorMessage = errorMessage
     )
 }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportRoute.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,6 +49,7 @@ import com.flashcardsopensourceapp.feature.settings.workspaceImportChooseFileBut
 import com.flashcardsopensourceapp.feature.settings.workspaceImportConfirmButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspaceImportErrorMessageTag
 import com.flashcardsopensourceapp.feature.settings.workspaceImportScreenTag
+import com.flashcardsopensourceapp.feature.settings.workspaceImportTagFieldTag
 import com.flashcardsopensourceapp.feature.settings.workspaceImportTagToggleTag
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -152,9 +154,11 @@ fun WorkspaceImportRoute(
                     WorkspaceImportOptionsCard(
                         preview = preview,
                         addImportTag = uiState.addImportTag,
+                        importTag = uiState.importTag,
                         removedTags = uiState.removedTags,
                         isBusy = uiState.isBusy,
                         onAddImportTagChange = viewModel::updateAddImportTag,
+                        onImportTagChange = viewModel::updateImportTag,
                         onToggleTag = viewModel::toggleTag
                     )
                 }
@@ -362,9 +366,11 @@ private fun WorkspaceImportCountsCard(preview: WorkspacePackageImportPreview) {
 private fun WorkspaceImportOptionsCard(
     preview: WorkspacePackageImportPreview,
     addImportTag: Boolean,
+    importTag: String,
     removedTags: Set<String>,
     isBusy: Boolean,
     onAddImportTagChange: (Boolean) -> Unit,
+    onImportTagChange: (String) -> Unit,
     onToggleTag: (String) -> Unit
 ) {
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -379,9 +385,18 @@ private fun WorkspaceImportOptionsCard(
                 onCheckedChange = onAddImportTagChange
             )
             if (addImportTag) {
-                MetadataListItem(
-                    label = stringResource(R.string.settings_import_import_tag),
-                    value = preview.defaultOptions.suggestedImportTag
+                OutlinedTextField(
+                    value = importTag,
+                    onValueChange = onImportTagChange,
+                    enabled = isBusy.not(),
+                    singleLine = true,
+                    label = {
+                        Text(stringResource(R.string.settings_import_import_tag))
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag(tag = workspaceImportTagFieldTag)
                 )
             }
             makeWorkspaceImportTagOptions(

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportSupport.kt
@@ -135,13 +135,14 @@ internal fun makeWorkspaceImportTagOptions(
 internal fun makeWorkspaceImportConfirmOptions(
     preview: WorkspacePackageImportPreview,
     addImportTag: Boolean,
+    importTag: String,
     removedTags: Set<String>,
     importedAtMillis: Long,
     importId: String,
     missingImportTagMessage: String
 ): WorkspacePackageImportConfirmOptions {
-    val importTag: String = preview.defaultOptions.suggestedImportTag.trim()
-    if (importTag.isEmpty()) {
+    val normalizedImportTag: String = importTag.trim()
+    if (addImportTag && normalizedImportTag.isEmpty()) {
         throw WorkspaceImportUserException(
             message = missingImportTagMessage,
             cause = null
@@ -150,7 +151,7 @@ internal fun makeWorkspaceImportConfirmOptions(
 
     return WorkspacePackageImportConfirmOptions(
         addImportTag = addImportTag,
-        importTag = importTag,
+        importTag = normalizedImportTag,
         removeTags = makeWorkspaceImportRemovedTags(
             preview = preview,
             removedTags = removedTags

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportUiState.kt
@@ -6,6 +6,7 @@ data class WorkspaceImportUiState(
     val selectedFileName: String?,
     val preview: WorkspacePackageImportPreview?,
     val addImportTag: Boolean,
+    val importTag: String,
     val removedTags: Set<String>,
     val isPreviewing: Boolean,
     val isImporting: Boolean,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModel.kt
@@ -41,6 +41,7 @@ private data class WorkspaceImportDraftState(
     val preview: WorkspacePackageImportPreview?,
     val previewIdentity: WorkspaceImportPreviewIdentity?,
     val addImportTag: Boolean,
+    val importTag: String,
     val removedTags: Set<String>,
     val isPreviewing: Boolean,
     val isImporting: Boolean,
@@ -74,6 +75,7 @@ class WorkspaceImportViewModel(
             preview = null,
             previewIdentity = null,
             addImportTag = true,
+            importTag = "",
             removedTags = emptySet(),
             isPreviewing = false,
             isImporting = false,
@@ -100,6 +102,7 @@ class WorkspaceImportViewModel(
             },
             preview = if (isPreviewCurrent) draft.preview else null,
             addImportTag = draft.addImportTag,
+            importTag = draft.importTag,
             removedTags = draft.removedTags,
             isPreviewing = draft.isPreviewing,
             isImporting = draft.isImporting,
@@ -117,6 +120,7 @@ class WorkspaceImportViewModel(
             selectedFileName = null,
             preview = null,
             addImportTag = true,
+            importTag = "",
             removedTags = emptySet(),
             isPreviewing = false,
             isImporting = false,
@@ -134,6 +138,7 @@ class WorkspaceImportViewModel(
                 preview = null,
                 previewIdentity = null,
                 addImportTag = true,
+                importTag = "",
                 removedTags = emptySet(),
                 isPreviewing = true,
                 isImporting = false,
@@ -178,6 +183,7 @@ class WorkspaceImportViewModel(
                     selectedFile = null,
                     preview = null,
                     previewIdentity = null,
+                    importTag = "",
                     isPreviewing = false,
                     isImporting = false,
                     errorMessage = workspaceImportAvailabilityMessage(
@@ -196,6 +202,7 @@ class WorkspaceImportViewModel(
                 preview = null,
                 previewIdentity = previewIdentity,
                 addImportTag = true,
+                importTag = "",
                 removedTags = emptySet(),
                 isPreviewing = true,
                 isImporting = false,
@@ -214,6 +221,7 @@ class WorkspaceImportViewModel(
                     preview = preview,
                     previewIdentity = previewIdentity,
                     addImportTag = preview.defaultOptions.addImportTag,
+                    importTag = preview.defaultOptions.suggestedImportTag,
                     removedTags = preview.defaultOptions.removedTags.toSet(),
                     isPreviewing = false,
                     errorMessage = "",
@@ -228,6 +236,7 @@ class WorkspaceImportViewModel(
                     selectedFile = null,
                     preview = null,
                     previewIdentity = null,
+                    importTag = "",
                     isPreviewing = false,
                     errorMessage = strings.get(R.string.settings_account_status_sync_blocked_body),
                     successMessage = ""
@@ -251,6 +260,7 @@ class WorkspaceImportViewModel(
                 selectedFile = null,
                 preview = null,
                 previewIdentity = null,
+                importTag = "",
                 isPreviewing = false,
                 isImporting = false,
                 errorMessage = message,
@@ -263,6 +273,16 @@ class WorkspaceImportViewModel(
         draftState.update { state ->
             state.copy(
                 addImportTag = isEnabled,
+                errorMessage = "",
+                successMessage = ""
+            )
+        }
+    }
+
+    fun updateImportTag(importTag: String) {
+        draftState.update { state ->
+            state.copy(
+                importTag = importTag,
                 errorMessage = "",
                 successMessage = ""
             )
@@ -323,6 +343,7 @@ class WorkspaceImportViewModel(
                     preview = null,
                     selectedFile = null,
                     previewIdentity = null,
+                    importTag = "",
                     errorMessage = currentUiState.availabilityMessage,
                     successMessage = ""
                 )
@@ -336,6 +357,7 @@ class WorkspaceImportViewModel(
             makeWorkspaceImportConfirmOptions(
                 preview = preview,
                 addImportTag = currentUiState.addImportTag,
+                importTag = currentUiState.importTag,
                 removedTags = currentUiState.removedTags,
                 importedAtMillis = importedAtMillis,
                 importId = importId,
@@ -371,6 +393,7 @@ class WorkspaceImportViewModel(
                     preview = null,
                     previewIdentity = null,
                     addImportTag = true,
+                    importTag = "",
                     removedTags = emptySet(),
                     isImporting = false,
                     errorMessage = "",
@@ -421,6 +444,7 @@ class WorkspaceImportViewModel(
                 selectedFile = null,
                 preview = null,
                 previewIdentity = null,
+                importTag = "",
                 isPreviewing = false,
                 isImporting = false,
                 errorMessage = expectedErrorMessage ?: fallbackMessage,
@@ -453,6 +477,7 @@ class WorkspaceImportViewModel(
                 selectedFile = if (isPreviewing) null else state.selectedFile,
                 preview = if (isPreviewing) null else state.preview,
                 previewIdentity = if (isPreviewing) null else state.previewIdentity,
+                importTag = if (isPreviewing) "" else state.importTag,
                 isPreviewing = false,
                 isImporting = false,
                 errorMessage = expectedErrorMessage ?: fallbackMessage,

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -443,7 +443,7 @@
     <string name="settings_export_package_summary">Export a Flashcards ZIP package</string>
     <string name="settings_export_dismiss_error">Dismiss error</string>
     <string name="settings_export_package_section">flashcards.zip package</string>
-    <string name="settings_export_package_body">Export all active cards, tags, and referenced media as a portable ZIP package.</string>
+    <string name="settings_export_package_body">Export active cards, included tags, and referenced media as a portable ZIP package.</string>
     <string name="settings_export_package_preview">Preview package export</string>
     <string name="settings_export_package_previewing">Previewing...</string>
     <string name="settings_export_package_exporting">Exporting...</string>
@@ -467,11 +467,13 @@
     <string name="settings_export_package_metadata_created_at">Created</string>
     <string name="settings_export_package_metadata_source_url">Source URL</string>
     <string name="settings_export_package_metadata_comment">Comment</string>
-    <string name="settings_export_package_tags_section">Tags</string>
-    <string name="settings_export_package_tags_empty">No tags.</string>
-    <string name="settings_export_package_remove_tag">Remove %1$s</string>
-    <string name="settings_export_package_always_remove_tag">Always remove %1$s</string>
-    <string name="settings_export_package_generated_import_tag_removed">Generated import tags are always removed from package exports.</string>
+    <string name="settings_export_package_card_selection_section">Cards to export</string>
+    <string name="settings_export_package_card_selection_all_active">All active cards will be exported.</string>
+    <string name="settings_export_package_select_cards_with_tag">Cards tagged %1$s</string>
+    <string name="settings_export_package_tags_section">Package tags</string>
+    <string name="settings_export_package_tags_empty">No package tags.</string>
+    <string name="settings_export_package_include_tag">Include %1$s</string>
+    <string name="settings_export_package_generated_import_tag_removed">Generated import tags are not included in package exports.</string>
 
     <string name="settings_import_title">Import</string>
     <string name="settings_import_zip_summary">Import a Flashcards ZIP package</string>
@@ -493,7 +495,7 @@
     <string name="settings_import_preview_failed">Package preview failed.</string>
     <string name="settings_import_confirm_failed">Package import failed.</string>
     <string name="settings_import_preview_required">Preview a package before importing.</string>
-    <string name="settings_import_missing_import_tag">Package preview did not include an import tag.</string>
+    <string name="settings_import_missing_import_tag">Enter an import tag.</string>
     <string name="settings_import_source_section">Source</string>
     <string name="settings_import_source_kind">Type</string>
     <string name="settings_import_source_title">Title</string>

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -519,7 +519,7 @@ internal class TestSettingsStringResolver : SettingsStringResolver {
             R.string.settings_import_preview_failed -> "Package preview failed."
             R.string.settings_import_confirm_failed -> "Package import failed."
             R.string.settings_import_preview_required -> "Preview a package before importing."
-            R.string.settings_import_missing_import_tag -> "Package preview did not include an import tag."
+            R.string.settings_import_missing_import_tag -> "Enter an import tag."
             R.string.settings_export_package_cloud_required -> {
                 "Media ZIP export requires a linked cloud workspace in this version."
             }

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModelTest.kt
@@ -59,13 +59,15 @@ class WorkspaceExportViewModelTest {
         assertSame(preview, viewModel.uiState.value.packagePreview)
         assertEquals("Primary export", viewModel.uiState.value.packageMetadataDraft.label)
         assertEquals("Export author", viewModel.uiState.value.packageMetadataDraft.author)
-        assertEquals(setOf("temporary", "import:old"), viewModel.uiState.value.packageRemovedTags)
+        assertEquals(emptySet<String>(), viewModel.uiState.value.packageCardSelectionTags)
+        assertEquals(preview.availableTagCounts, viewModel.uiState.value.packageCardSelectionTagCounts)
+        assertEquals(setOf("geography", "temporary"), viewModel.uiState.value.packageIncludedTags)
 
         stateJob.cancel()
     }
 
     @Test
-    fun preparePackageExportDownloadSendsEditedMetadataAndRemovedTags() = runTest(dispatcher) {
+    fun preparePackageExportDownloadSendsAllCardsSelectionAndIncludedTags() = runTest(dispatcher) {
         Dispatchers.setMain(dispatcher)
         val cloudRepository = FakeCloudAccountRepository()
         cloudRepository.setCloudSettings(settings = linkedCloudSettings())
@@ -88,18 +90,168 @@ class WorkspaceExportViewModelTest {
         viewModel.updatePackageCreatedAt(createdAt = "2026-07-01T10:00:00.000Z")
         viewModel.updatePackageSourceUrl(sourceUrl = "https://example.com/edited")
         viewModel.updatePackageComment(comment = "Edited comment")
-        viewModel.togglePackageRemovedTag(tag = "geography")
+        viewModel.togglePackageIncludedTag(tag = "geography")
         advanceUntilIdle()
         val response = viewModel.preparePackageExportDownload()
 
         val request = cloudRepository.exportedWorkspacePackageRequests.single()
         assertArrayEquals(byteArrayOf(80, 75, 3, 4), response?.packageBytes)
-        assertEquals(listOf("geography", "temporary", "import:old"), request.tagPolicy.additionalRemovedTags)
+        assertEquals(WorkspacePackageExportSelection.AllActiveCards, request.selection)
+        assertEquals(listOf("geography"), request.tagPolicy.additionalRemovedTags)
         assertEquals("Edited export", request.packageMetadata.label)
         assertEquals("Edited author", request.packageMetadata.author)
         assertEquals("Edited comment", request.packageMetadata.comment)
         assertEquals("2026-07-01T10:00:00.000Z", request.packageMetadata.createdAt)
         assertEquals("https://example.com/edited", request.packageMetadata.sourceUrl)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun preparePackageExportDownloadPreservesDraftAfterCardSelectionRefresh() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val cloudRepository = FakeCloudAccountRepository()
+        cloudRepository.setCloudSettings(settings = linkedCloudSettings())
+        cloudRepository.nextWorkspacePackageExportPreview = workspacePackageExportPreview()
+        cloudRepository.nextWorkspacePackageExportDownloadResponse = WorkspacePackageExportDownloadResponse(
+            packageBytes = byteArrayOf(80, 75, 3, 4),
+            fileName = "flashcards.zip",
+            contentType = "application/zip"
+        )
+        val viewModel = workspaceExportViewModel(cloudRepository = cloudRepository)
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewPackageExport()
+        advanceUntilIdle()
+        viewModel.updatePackageLabel(label = "Filtered export")
+        viewModel.updatePackageAuthor(author = "Filtered author")
+        viewModel.updatePackageCreatedAt(createdAt = "2026-07-02T10:00:00.000Z")
+        viewModel.updatePackageSourceUrl(sourceUrl = "https://example.com/filtered")
+        viewModel.updatePackageComment(comment = "Filtered comment")
+        viewModel.togglePackageIncludedTag(tag = "geography")
+        advanceUntilIdle()
+        viewModel.togglePackageCardSelectionTag(tag = "geography")
+        advanceUntilIdle()
+        val response = viewModel.preparePackageExportDownload()
+
+        val request = cloudRepository.exportedWorkspacePackageRequests.single()
+        assertArrayEquals(byteArrayOf(80, 75, 3, 4), response?.packageBytes)
+        assertEquals(
+            WorkspacePackageExportSelection.TagFilters(
+                includeTags = listOf("geography"),
+                excludeTags = emptyList()
+            ),
+            cloudRepository.previewedWorkspacePackageExportRequests.last().selection
+        )
+        assertEquals(
+            WorkspacePackageExportSelection.TagFilters(
+                includeTags = listOf("geography"),
+                excludeTags = emptyList()
+            ),
+            request.selection
+        )
+        assertEquals(listOf("geography"), request.tagPolicy.additionalRemovedTags)
+        assertEquals("Filtered export", request.packageMetadata.label)
+        assertEquals("Filtered author", request.packageMetadata.author)
+        assertEquals("Filtered comment", request.packageMetadata.comment)
+        assertEquals("2026-07-02T10:00:00.000Z", request.packageMetadata.createdAt)
+        assertEquals("https://example.com/filtered", request.packageMetadata.sourceUrl)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun cardSelectionRefreshPreservesOnlyExplicitlyExcludedPackageTags() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val cloudRepository = FakeCloudAccountRepository()
+        cloudRepository.setCloudSettings(settings = linkedCloudSettings())
+        cloudRepository.nextWorkspacePackageExportPreview = workspacePackageExportPreview()
+        cloudRepository.nextWorkspacePackageExportDownloadResponse = WorkspacePackageExportDownloadResponse(
+            packageBytes = byteArrayOf(80, 75, 3, 4),
+            fileName = "flashcards.zip",
+            contentType = "application/zip"
+        )
+        val viewModel = workspaceExportViewModel(cloudRepository = cloudRepository)
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewPackageExport()
+        advanceUntilIdle()
+        viewModel.togglePackageIncludedTag(tag = "geography")
+        advanceUntilIdle()
+        cloudRepository.nextWorkspacePackageExportPreview = workspacePackageExportPreviewWithoutTemporary()
+        viewModel.togglePackageCardSelectionTag(tag = "geography")
+        advanceUntilIdle()
+        cloudRepository.nextWorkspacePackageExportPreview = workspacePackageExportPreview()
+        viewModel.togglePackageCardSelectionTag(tag = "geography")
+        advanceUntilIdle()
+        val response = viewModel.preparePackageExportDownload()
+
+        val request = cloudRepository.exportedWorkspacePackageRequests.single()
+        assertArrayEquals(byteArrayOf(80, 75, 3, 4), response?.packageBytes)
+        assertEquals(WorkspacePackageExportSelection.AllActiveCards, request.selection)
+        assertEquals(listOf("geography"), request.tagPolicy.additionalRemovedTags)
+        assertEquals(setOf("temporary"), viewModel.uiState.value.packageIncludedTags)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun failedCardSelectionRefreshRestoresPreviousDraft() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val cloudRepository = FakeCloudAccountRepository()
+        cloudRepository.setCloudSettings(settings = linkedCloudSettings())
+        cloudRepository.nextWorkspacePackageExportPreview = workspacePackageExportPreview()
+        cloudRepository.nextWorkspacePackageExportDownloadResponse = WorkspacePackageExportDownloadResponse(
+            packageBytes = byteArrayOf(80, 75, 3, 4),
+            fileName = "flashcards.zip",
+            contentType = "application/zip"
+        )
+        val viewModel = workspaceExportViewModel(cloudRepository = cloudRepository)
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewPackageExport()
+        advanceUntilIdle()
+        viewModel.updatePackageLabel(label = "Recoverable export")
+        viewModel.updatePackageAuthor(author = "Recoverable author")
+        viewModel.updatePackageCreatedAt(createdAt = "2026-07-03T10:00:00.000Z")
+        viewModel.updatePackageSourceUrl(sourceUrl = "https://example.com/recoverable")
+        viewModel.updatePackageComment(comment = "Recoverable comment")
+        viewModel.togglePackageIncludedTag(tag = "geography")
+        advanceUntilIdle()
+        cloudRepository.nextWorkspacePackageExportPreview = null
+        viewModel.togglePackageCardSelectionTag(tag = "geography")
+        advanceUntilIdle()
+
+        assertEquals("Package export preview failed.", viewModel.uiState.value.errorMessage)
+        assertEquals(
+            WorkspacePackageExportSelection.TagFilters(
+                includeTags = listOf("geography"),
+                excludeTags = emptyList()
+            ),
+            cloudRepository.previewedWorkspacePackageExportRequests.last().selection
+        )
+        assertEquals(emptySet<String>(), viewModel.uiState.value.packageCardSelectionTags)
+        assertEquals(setOf("temporary"), viewModel.uiState.value.packageIncludedTags)
+        val response = viewModel.preparePackageExportDownload()
+
+        val request = cloudRepository.exportedWorkspacePackageRequests.single()
+        assertArrayEquals(byteArrayOf(80, 75, 3, 4), response?.packageBytes)
+        assertEquals(WorkspacePackageExportSelection.AllActiveCards, request.selection)
+        assertEquals(listOf("geography"), request.tagPolicy.additionalRemovedTags)
+        assertEquals("Recoverable export", request.packageMetadata.label)
+        assertEquals("Recoverable author", request.packageMetadata.author)
+        assertEquals("Recoverable comment", request.packageMetadata.comment)
+        assertEquals("2026-07-03T10:00:00.000Z", request.packageMetadata.createdAt)
+        assertEquals("https://example.com/recoverable", request.packageMetadata.sourceUrl)
 
         stateJob.cancel()
     }
@@ -126,8 +278,7 @@ private fun linkedCloudSettings(): CloudSettings {
 }
 
 private fun workspacePackageExportPreview(): WorkspacePackageExportPreview {
-    return WorkspacePackageExportPreview(
-        selectedCardCount = 3,
+    return workspacePackageExportPreviewWithAvailableTags(
         availableTagCounts = listOf(
             WorkspacePackageExportTagCount(
                 tag = "geography",
@@ -141,10 +292,34 @@ private fun workspacePackageExportPreview(): WorkspacePackageExportPreview {
                 tag = "import:old",
                 cardsCount = 1
             )
-        ),
+        )
+    )
+}
+
+private fun workspacePackageExportPreviewWithoutTemporary(): WorkspacePackageExportPreview {
+    return workspacePackageExportPreviewWithAvailableTags(
+        availableTagCounts = listOf(
+            WorkspacePackageExportTagCount(
+                tag = "geography",
+                cardsCount = 2
+            ),
+            WorkspacePackageExportTagCount(
+                tag = "import:old",
+                cardsCount = 1
+            )
+        )
+    )
+}
+
+private fun workspacePackageExportPreviewWithAvailableTags(
+    availableTagCounts: List<WorkspacePackageExportTagCount>
+): WorkspacePackageExportPreview {
+    return WorkspacePackageExportPreview(
+        selectedCardCount = 3,
+        availableTagCounts = availableTagCounts,
         tagsSelectedForRemoval = listOf(
             WorkspacePackageExportTagCount(
-                tag = "temporary",
+                tag = "import:old",
                 cardsCount = 1
             )
         ),

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/import/WorkspaceImportViewModelTest.kt
@@ -64,6 +64,7 @@ class WorkspaceImportViewModelTest {
         assertSame(preview, viewModel.uiState.value.preview)
         assertEquals("flashcards.zip", viewModel.uiState.value.selectedFileName)
         assertEquals(preview.defaultOptions.addImportTag, viewModel.uiState.value.addImportTag)
+        assertEquals("import-tag", viewModel.uiState.value.importTag)
         assertEquals(setOf("drop"), viewModel.uiState.value.removedTags)
 
         stateJob.cancel()
@@ -157,6 +158,7 @@ class WorkspaceImportViewModelTest {
             )
         )
         advanceUntilIdle()
+        viewModel.updateImportTag(importTag = "edited-import-tag")
         viewModel.updateAddImportTag(isEnabled = false)
         viewModel.toggleTag(tag = "keep")
         advanceUntilIdle()
@@ -171,7 +173,7 @@ class WorkspaceImportViewModelTest {
         assertEquals("flashcards.zip", confirmedImport.fileName)
         assertArrayEquals(byteArrayOf(4, 5, 6), confirmedImport.packageBytes)
         assertEquals(false, confirmedImport.options.addImportTag)
-        assertEquals("import-tag", confirmedImport.options.importTag)
+        assertEquals("edited-import-tag", confirmedImport.options.importTag)
         assertEquals(listOf("keep", "drop"), confirmedImport.options.removeTags)
         assertEquals(123_456L, confirmedImport.options.importedAtMillis)
         assertEquals(123_456L, confirmedImport.options.clientUpdatedAtMillis)
@@ -179,6 +181,35 @@ class WorkspaceImportViewModelTest {
         assertEquals("import-id-1", confirmedImport.options.operationIdPrefix)
         assertNull(viewModel.uiState.value.preview)
         assertEquals("Imported 1 card.", viewModel.uiState.value.successMessage)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun confirmImportRejectsBlankImportTagWhenEnabled() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.setCloudSettings(settings = linkedCloudSettings())
+        repository.nextWorkspacePackageImportPreview = workspacePackageImportPreview()
+        val viewModel = workspaceImportViewModel(repository = repository)
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewSelectedFile(
+            selectedFile = WorkspaceImportSelectedFile(
+                fileName = "flashcards.zip",
+                packageBytes = byteArrayOf(7, 8, 9)
+            )
+        )
+        advanceUntilIdle()
+        viewModel.updateImportTag(importTag = " ")
+        viewModel.confirmImport()
+        advanceUntilIdle()
+
+        assertEquals(0, repository.confirmedWorkspacePackageImports.size)
+        assertEquals("Enter an import tag.", viewModel.uiState.value.errorMessage)
 
         stateJob.cancel()
     }


### PR DESCRIPTION
## Summary
- Add editable Android import tag controls with non-blank validation when enabled.
- Replace export remove-tags UI with positive card-selection and included-package-tag controls.
- Preserve export metadata and durable explicit package-tag exclusions across preview refreshes and failures.

## Validation
- git diff --check
- rg "suggestedImportTag|additionalRemovedTags|TagFilters|Remove .*from export|settings_export_package_remove" apps/android/feature/settings
- Gradle not run because ./gradlew was not approved for this task.