### PR TITLE
Suppress progress API network captures

### DIFF
--- a/apps/web/src/appData/progress/source/pipelines/progressSourcePipelineHelpers.ts
+++ b/apps/web/src/appData/progress/source/pipelines/progressSourcePipelineHelpers.ts
@@ -5,6 +5,7 @@ import {
   isAuthRedirectError,
 } from "../../../../api";
 import { captureApiContractError } from "../../../../observability/apiContractObservation";
+import { isBrowserApiNetworkError } from "../../../../observability/apiNetworkErrorPolicy";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import {
   captureWebException,
@@ -138,6 +139,10 @@ function shouldCaptureProgressServerLoadError(error: Error): boolean {
   }
 
   if (isAuthRedirectError(error)) {
+    return false;
+  }
+
+  if (isBrowserApiNetworkError(error)) {
     return false;
   }
 

--- a/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { ApiError } from "../../../api";
+import { ApiError, ApiNetworkError } from "../../../api";
 import type {
   ProgressSeries,
   ProgressSummaryPayload,
@@ -133,6 +133,30 @@ describe("useProgressSource lifecycle", () => {
 
     expect(harness.getApi().progressSourceState.summary.errorMessage).toBe("Authentication required.");
     expect(harness.getApi().progressSourceState.summary.technicalError).toBeNull();
+    expect(captureWebExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps leaderboard API network failures inline without technical capture", async () => {
+    const networkError = new ApiNetworkError({
+      endpoint: "GET /me/progress/leaderboard",
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Failed to fetch",
+      attemptCount: 3,
+    });
+    loadProgressLeaderboardMock.mockRejectedValueOnce(networkError);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: leaderboardOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.leaderboard.errorMessage).toBe(networkError.message);
+    expect(harness.getApi().progressSourceState.leaderboard.technicalError).toBeNull();
+    expect(harness.getApi().progressSourceState.leaderboard.isNetworkError).toBe(true);
     expect(captureWebExceptionMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/observability/appOperationObservation.ts
+++ b/apps/web/src/observability/appOperationObservation.ts
@@ -1,4 +1,5 @@
 import { ApiContractError, ApiError, AuthRedirectError } from "../api";
+import { isBrowserApiNetworkError } from "./apiNetworkErrorPolicy";
 import {
   captureWebException,
   normalizeCaughtError,
@@ -109,6 +110,10 @@ function isExpectedAppOperationError(error: Error, context: AppOperationObservat
   }
 
   if (error instanceof AuthRedirectError) {
+    return true;
+  }
+
+  if (isBrowserApiNetworkError(error)) {
     return true;
   }
 

--- a/apps/web/src/observability/instrument.test.ts
+++ b/apps/web/src/observability/instrument.test.ts
@@ -12,6 +12,7 @@ import {
   type WebExceptionEvent,
   type WebObservationScope,
 } from "./webObservability";
+import { captureAppOperationError } from "./appOperationObservation";
 
 vi.mock("@sentry/react", () => {
   const createScope = () => ({
@@ -376,6 +377,29 @@ describe("Sentry privacy sanitizer", () => {
 
     captureWebException(event);
 
+    expect(Sentry.withScope).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("treats browser API network app operation errors as expected", () => {
+    const wasCaptured = captureAppOperationError(
+      new ApiNetworkError({
+        endpoint: "GET /me",
+        originalErrorName: "TypeError",
+        originalErrorMessage: "Failed to fetch",
+        attemptCount: 3,
+      }),
+      {
+        feature: "app",
+        operation: "cards_page_load",
+        userId: "user-1",
+        workspaceId: "workspace-1",
+        installationId: "installation-1",
+        entityId: null,
+      },
+    );
+
+    expect(wasCaptured).toBe(false);
     expect(Sentry.withScope).not.toHaveBeenCalled();
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Treat progress server-load ApiNetworkError failures as expected environmental failures.
- Treat generic app-operation ApiNetworkError failures as expected so captureAppOperationError returns false.
- Add progress lifecycle and observability coverage for the policy.

## Validation
- cd apps/web && npx vitest run src/appData/progress/source/progressSource.lifecycle.test.tsx src/observability/instrument.test.ts
- cd apps/web && npm run build