### PR TITLE
Fix iOS archive compile errors

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/AppNavigationModel.swift
+++ b/apps/ios/Flashcards/Flashcards/App/AppNavigationModel.swift
@@ -33,6 +33,8 @@ func makeSettingsNavigationPath(destination: SettingsNavigationDestination) -> [
         return [.workspaceScheduler]
     case .workspaceExport:
         return [.workspaceExport]
+    case .workspaceImport:
+        return [.workspaceImport]
     case .workspaceDecks:
         return [.workspaceDecks]
     case .workspaceTags:

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewManagedMediaStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewManagedMediaStoreSupport.swift
@@ -217,7 +217,7 @@ extension FlashcardsStore {
             defer {
                 session.invalidateAndCancel()
             }
-            try await downloadReviewManagedMediaBlobFileToCache(
+            return try await downloadReviewManagedMediaBlobFileToCache(
                 downloadURL: downloadURL,
                 databaseURL: databaseURL,
                 mediaAsset: mediaAsset,


### PR DESCRIPTION
## Summary
- return the managed media cache URL from the deduplicated download task
- include workspace import in the settings navigation path builder

## Validation
- git diff --check
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/App/AppNavigationModel.swift
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Review/View/ReviewManagedMediaStoreSupport.swift

Local xcodebuild could not run in this environment because Xcode reported no eligible iOS destinations for the scheme before compilation.