### PR TITLE
Give background notification reconcile time to finish

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -8,6 +8,43 @@ private let flashcardsUITestAIHandoffCardEnvironmentKey: String = "FLASHCARDS_UI
 @MainActor
 private var hasConsumedFlashcardsUITestAppNotificationTapEnvironment: Bool = false
 
+@MainActor
+private func runAppBackgroundTask(
+    name: String,
+    operation: @escaping @MainActor () async -> Void
+) {
+    var backgroundTaskIdentifier: UIBackgroundTaskIdentifier = .invalid
+    var operationTask: Task<Void, Never>?
+    var hasBackgroundTaskExpired: Bool = false
+
+    func endBackgroundTaskIfNeeded() {
+        let identifier = backgroundTaskIdentifier
+        backgroundTaskIdentifier = .invalid
+        guard identifier != .invalid else {
+            return
+        }
+
+        UIApplication.shared.endBackgroundTask(identifier)
+    }
+
+    backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: name) {
+        hasBackgroundTaskExpired = true
+        operationTask?.cancel()
+        endBackgroundTaskIfNeeded()
+    }
+
+    operationTask = Task { @MainActor in
+        defer {
+            endBackgroundTaskIfNeeded()
+        }
+        guard hasBackgroundTaskExpired == false else {
+            return
+        }
+
+        await operation()
+    }
+}
+
 private enum FlashcardsUITestSelectedTab: String {
     case review
     case progress
@@ -512,8 +549,10 @@ struct FlashcardsApp: App {
                         store.reconcileReviewNotifications(trigger: .appActive, now: now)
                         store.reconcileStrictReminders(trigger: .appActive, now: now)
                     } else if nextPhase == .background {
-                        store.reconcileReviewNotifications(trigger: .appBackground, now: Date())
-                        store.reconcileStrictReminders(trigger: .appBackground, now: Date())
+                        let now = Date()
+                        runAppBackgroundTask(name: "AppBackgroundNotificationReconcile") {
+                            await store.reconcileAppBackgroundNotifications(now: now)
+                        }
                     }
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
@@ -45,6 +45,17 @@ extension FlashcardsStore {
         }
     }
 
+    func reconcileAppBackgroundNotifications(now: Date) async {
+        self.reconcileReviewNotifications(trigger: .appBackground, now: now)
+        self.reconcileStrictReminders(trigger: .appBackground, now: now)
+        await self.waitForReviewNotificationsReconcileToSettle()
+        guard Task.isCancelled == false else {
+            return
+        }
+
+        await self.waitForStrictRemindersReconcileToSettle()
+    }
+
     private func reconcileNotificationsAfterStrictRemindersSettingsChanged(now: Date) {
         guard self.strictRemindersSettings.isEnabled else {
             self.reconcileStrictReminders(trigger: .settingsChanged, now: now)


### PR DESCRIPTION
## Summary
- wrap app-background notification reconciliation in a short UIKit background task
- add an awaitable app-background notification reconcile path that waits for review and strict scheduling to settle
- preserve active/startup/settings/permission/review-recorded reconcile behavior

## Validation
- git --no-pager diff --check
- focused SDK type-check for the UIKit background-task helper

Review gate completed externally with no P0-P4 issues and no split recommendation.