### PR TITLE
Prevent binary chat drafts from persisting

### DIFF
--- a/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx
@@ -95,11 +95,26 @@ describe("ChatPanel send recovered drafts", () => {
     expect(recoveredSessionId).not.toBe(staleSessionId);
     expect(createNewChatSessionMock).toHaveBeenCalledTimes(2);
     expect(startChatRunMock).toHaveBeenCalledTimes(2);
+    expect(startChatRunMock.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      sessionId: recoveredSessionId,
+      content: [
+        {
+          type: "file",
+          mediaType: "text/plain",
+          base64Data: "YXR0YWNoZWQ=",
+          fileName: "attached.txt",
+        },
+        {
+          type: "text",
+          text: "keep this draft after retry failure",
+        },
+      ],
+    }));
     expect(textarea?.value).toBe("keep this draft after retry failure");
     expect(readStoredDraftInputText("workspace-1", staleSessionId as string)).toBeNull();
     expect(readStoredDraftInputText("workspace-1", recoveredSessionId as string)).toBe("keep this draft after retry failure");
     expect(readStoredDraftPendingAttachmentCount("workspace-1", staleSessionId as string)).toBe(0);
-    expect(readStoredDraftPendingAttachmentCount("workspace-1", recoveredSessionId as string)).toBe(1);
+    expect(readStoredDraftPendingAttachmentCount("workspace-1", recoveredSessionId as string)).toBe(0);
     expect(getContainer().querySelector(".chat-msg")).toBeNull();
     expect(getContainer().querySelector('[role="dialog"]')).not.toBeNull();
     expect(getContainer().textContent).toContain("Chat request failed.");

--- a/apps/web/src/chat/composer/drafts/ChatDraftContext.tsx
+++ b/apps/web/src/chat/composer/drafts/ChatDraftContext.tsx
@@ -9,6 +9,7 @@ import {
   replaceChatDraftForSession,
   storeChatDraftWorkspaceState,
   subscribeToChatDraftWorkspaceStateChanges,
+  toPersistableChatDraftContent,
   type ChatDraftContent,
   type StoredChatDraft,
 } from "./chatDraftStorage";
@@ -247,7 +248,7 @@ export function ChatDraftProvider(props: Props): ReactElement {
       && sourceDraft !== null
       && sourceDraftUpdatedAt !== null
       && sourceDraft.updatedAt === sourceDraftUpdatedAt
-      && areChatDraftContentsEqual(sourceDraft, nextDraft);
+      && areChatDraftContentsEqual(sourceDraft, toPersistableChatDraftContent(nextDraft));
     const nextDraftsBySessionId = shouldClearSourceDraft === false
       ? targetDraftsBySessionId
       : replaceChatDraftForSession(

--- a/apps/web/src/chat/composer/drafts/chatDraftStorage.test.ts
+++ b/apps/web/src/chat/composer/drafts/chatDraftStorage.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BinaryPendingAttachment, CardPendingAttachment } from "../../attachments/FileAttachment";
 import {
+  clearStoredChatDraftForSessionIfUnchanged,
   loadChatDraftWorkspaceState,
   readChatDraftForSession,
   readStoredChatDraftForSession,
@@ -40,6 +42,26 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
 });
+
+function createBinaryAttachment(): BinaryPendingAttachment {
+  return {
+    type: "binary",
+    fileName: "diagram.png",
+    mediaType: "image/png",
+    base64Data: "base64-payload",
+  };
+}
+
+function createCardAttachment(): CardPendingAttachment {
+  return {
+    type: "card",
+    attachmentId: "card-attachment-1",
+    cardId: "card-1",
+    frontText: "Question",
+    backText: "Answer",
+    tags: ["tag-1"],
+  };
+}
 
 describe("chatDraftStorage", () => {
   it("prunes empty drafts and ignores unresolved null session ids", () => {
@@ -103,5 +125,177 @@ describe("chatDraftStorage", () => {
     expect(typeof firstUpdatedAt).toBe("number");
     expect(typeof secondUpdatedAt).toBe("number");
     expect(secondUpdatedAt).toBeGreaterThan(firstUpdatedAt as number);
+  });
+
+  it("does not persist binary attachment payloads to localStorage", () => {
+    const drafts = replaceChatDraftForSession({}, "session-1", {
+      inputText: "saved text",
+      pendingAttachments: [createBinaryAttachment()],
+    });
+
+    storeChatDraftWorkspaceState("workspace-1", drafts);
+
+    const rawValue = window.localStorage.getItem("flashcards-chat-drafts::workspace-1");
+    expect(rawValue).not.toBeNull();
+    expect(rawValue).not.toContain("base64-payload");
+    expect(readChatDraftForSession(loadChatDraftWorkspaceState("workspace-1"), "session-1")).toEqual({
+      inputText: "saved text",
+      pendingAttachments: [],
+    });
+  });
+
+  it("prunes drafts that only have binary attachments after storage projection", () => {
+    const drafts = replaceChatDraftForSession({}, "session-1", {
+      inputText: "",
+      pendingAttachments: [createBinaryAttachment()],
+    });
+
+    storeChatDraftWorkspaceState("workspace-1", drafts);
+
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+  });
+
+  it("persists card attachments and drops binary attachments from mixed drafts", () => {
+    const cardAttachment = createCardAttachment();
+    const drafts = replaceChatDraftForSession({}, "session-1", {
+      inputText: "mixed draft",
+      pendingAttachments: [createBinaryAttachment(), cardAttachment],
+    });
+
+    storeChatDraftWorkspaceState("workspace-1", drafts);
+
+    const rawValue = window.localStorage.getItem("flashcards-chat-drafts::workspace-1");
+    expect(rawValue).not.toBeNull();
+    expect(rawValue).not.toContain("base64-payload");
+    expect(readChatDraftForSession(loadChatDraftWorkspaceState("workspace-1"), "session-1")).toEqual({
+      inputText: "mixed draft",
+      pendingAttachments: [cardAttachment],
+    });
+  });
+
+  it("ignores legacy stored binary attachments when loading drafts", () => {
+    const cardAttachment = createCardAttachment();
+    window.localStorage.setItem("flashcards-chat-drafts::workspace-1", JSON.stringify({
+      version: 1,
+      draftsBySessionId: {
+        "session-1": {
+          inputText: "legacy draft",
+          pendingAttachments: [
+            createBinaryAttachment(),
+            cardAttachment,
+          ],
+          updatedAt: 1000,
+        },
+      },
+    }));
+
+    expect(readChatDraftForSession(loadChatDraftWorkspaceState("workspace-1"), "session-1")).toEqual({
+      inputText: "legacy draft",
+      pendingAttachments: [cardAttachment],
+    });
+    const cleanedRawValue = window.localStorage.getItem("flashcards-chat-drafts::workspace-1");
+    expect(cleanedRawValue).not.toBeNull();
+    expect(cleanedRawValue).not.toContain("base64-payload");
+  });
+
+  it("ignores legacy stored drafts that only contain binary attachments", () => {
+    window.localStorage.setItem("flashcards-chat-drafts::workspace-1", JSON.stringify({
+      version: 1,
+      draftsBySessionId: {
+        "session-1": {
+          inputText: "",
+          pendingAttachments: [createBinaryAttachment()],
+          updatedAt: 1000,
+        },
+      },
+    }));
+
+    const loadedDrafts = loadChatDraftWorkspaceState("workspace-1");
+    expect(readChatDraftForSession(loadedDrafts, "session-1")).toBeNull();
+    expect(readStoredChatDraftForSession(loadedDrafts, "session-1")).toBeNull();
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+  });
+
+  it("rethrows non-quota cleanup errors when loading legacy binary attachments", () => {
+    const cardAttachment = createCardAttachment();
+    window.localStorage.setItem("flashcards-chat-drafts::workspace-1", JSON.stringify({
+      version: 1,
+      draftsBySessionId: {
+        "session-1": {
+          inputText: "legacy draft",
+          pendingAttachments: [
+            createBinaryAttachment(),
+            cardAttachment,
+          ],
+          updatedAt: 1000,
+        },
+      },
+    }));
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is unavailable.", "SecurityError");
+    });
+
+    expect(() => loadChatDraftWorkspaceState("workspace-1")).toThrow("Storage is unavailable.");
+  });
+
+  it("clears stored text drafts when the accepted draft also had binary attachments", () => {
+    const drafts = replaceChatDraftForSession({}, "session-1", {
+      inputText: "accepted draft",
+      pendingAttachments: [],
+    });
+    storeChatDraftWorkspaceState("workspace-1", drafts);
+    const storedDraft = readStoredChatDraftForSession(loadChatDraftWorkspaceState("workspace-1"), "session-1");
+    if (storedDraft === null) {
+      throw new Error("Expected stored draft to exist.");
+    }
+
+    clearStoredChatDraftForSessionIfUnchanged(
+      "workspace-1",
+      "session-1",
+      {
+        inputText: "accepted draft",
+        pendingAttachments: [createBinaryAttachment()],
+      },
+      storedDraft.updatedAt,
+    );
+
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+  });
+
+  it("clears the workspace draft key when localStorage quota blocks persistence", () => {
+    window.localStorage.setItem("flashcards-chat-drafts::workspace-1", JSON.stringify({
+      version: 1,
+      draftsBySessionId: {
+        "session-1": {
+          inputText: "previous draft",
+          pendingAttachments: [],
+          updatedAt: 1000,
+        },
+      },
+    }));
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage quota exceeded.", "QuotaExceededError");
+    });
+
+    const drafts = replaceChatDraftForSession({}, "session-1", {
+      inputText: "next draft",
+      pendingAttachments: [createCardAttachment()],
+    });
+
+    expect(() => storeChatDraftWorkspaceState("workspace-1", drafts)).not.toThrow();
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+  });
+
+  it("rethrows non-quota localStorage persistence errors", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is unavailable.", "SecurityError");
+    });
+
+    const drafts = replaceChatDraftForSession({}, "session-1", {
+      inputText: "next draft",
+      pendingAttachments: [createCardAttachment()],
+    });
+
+    expect(() => storeChatDraftWorkspaceState("workspace-1", drafts)).toThrow("Storage is unavailable.");
   });
 });

--- a/apps/web/src/chat/composer/drafts/chatDraftStorage.ts
+++ b/apps/web/src/chat/composer/drafts/chatDraftStorage.ts
@@ -1,4 +1,4 @@
-import type { PendingAttachment } from "../../attachments/FileAttachment";
+import type { CardPendingAttachment, PendingAttachment } from "../../attachments/FileAttachment";
 import type { LegacyEffortLevel } from "../../../types";
 import { appendLegacyEffortTag } from "../../../legacyEffort";
 
@@ -70,20 +70,7 @@ function parsePendingAttachment(value: unknown): PendingAttachment | null {
   }
 
   if (value.type === "binary") {
-    if (
-      typeof value.fileName !== "string"
-      || typeof value.mediaType !== "string"
-      || typeof value.base64Data !== "string"
-    ) {
-      return null;
-    }
-
-    return {
-      type: "binary",
-      fileName: value.fileName,
-      mediaType: value.mediaType,
-      base64Data: value.base64Data,
-    };
+    return null;
   }
 
   if (value.type === "card") {
@@ -131,6 +118,21 @@ function parseChatDraftContent(value: unknown): ChatDraftContent | null {
   };
 }
 
+function hasPersistedBinaryPendingAttachment(value: unknown): boolean {
+  if (isRecord(value) === false || isRecord(value.draftsBySessionId) === false) {
+    return false;
+  }
+
+  return Object.values(value.draftsBySessionId).some((draftValue) => {
+    if (isRecord(draftValue) === false || Array.isArray(draftValue.pendingAttachments) === false) {
+      return false;
+    }
+
+    return draftValue.pendingAttachments.some((attachmentValue) =>
+      isRecord(attachmentValue) && attachmentValue.type === "binary");
+  });
+}
+
 function parseStoredChatDraftWorkspaceState(value: unknown): StoredChatDraftWorkspaceState | null {
   if (isRecord(value) === false || value.version !== CHAT_DRAFT_STORAGE_VERSION) {
     return null;
@@ -151,9 +153,14 @@ function parseStoredChatDraftWorkspaceState(value: unknown): StoredChatDraftWork
       continue;
     }
 
+    const persistableDraft = toPersistableChatDraftContent(parsedDraft);
+    if (isDraftEmpty(persistableDraft)) {
+      continue;
+    }
+
     draftsBySessionId[sessionId] = {
-      inputText: parsedDraft.inputText,
-      pendingAttachments: parsedDraft.pendingAttachments,
+      inputText: persistableDraft.inputText,
+      pendingAttachments: persistableDraft.pendingAttachments,
       updatedAt: draftValue.updatedAt,
     };
   }
@@ -187,6 +194,41 @@ function normalizeWorkspaceId(workspaceId: string | null): string | null {
 
 function isDraftEmpty(draft: ChatDraftContent): boolean {
   return draft.inputText.trim() === "" && draft.pendingAttachments.length === 0;
+}
+
+function isPersistablePendingAttachment(attachment: PendingAttachment): attachment is CardPendingAttachment {
+  return attachment.type === "card";
+}
+
+export function toPersistableChatDraftContent(draft: ChatDraftContent): ChatDraftContent {
+  return {
+    inputText: draft.inputText,
+    pendingAttachments: draft.pendingAttachments.filter(isPersistablePendingAttachment),
+  };
+}
+
+function toPersistableDraftsBySessionId(
+  draftsBySessionId: Readonly<Record<string, StoredChatDraft>>,
+): Record<string, StoredChatDraft> {
+  const nextDraftsBySessionId: Record<string, StoredChatDraft> = {};
+  for (const [sessionId, draft] of Object.entries(draftsBySessionId)) {
+    const persistableDraft = toPersistableChatDraftContent(draft);
+    if (isDraftEmpty(persistableDraft)) {
+      continue;
+    }
+
+    nextDraftsBySessionId[sessionId] = {
+      inputText: persistableDraft.inputText,
+      pendingAttachments: persistableDraft.pendingAttachments,
+      updatedAt: draft.updatedAt,
+    };
+  }
+
+  return nextDraftsBySessionId;
+}
+
+function isQuotaExceededError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "QuotaExceededError";
 }
 
 function createNextDraftUpdatedAt(): number {
@@ -285,7 +327,8 @@ function loadWorkspaceDraftState(workspaceId: string | null): StoredChatDraftWor
     };
   }
 
-  const rawValue = storage.getItem(resolveWorkspaceStorageKey(normalizedWorkspaceId));
+  const storageKey = resolveWorkspaceStorageKey(normalizedWorkspaceId);
+  const rawValue = storage.getItem(storageKey);
   if (rawValue === null) {
     return {
       version: CHAT_DRAFT_STORAGE_VERSION,
@@ -293,25 +336,31 @@ function loadWorkspaceDraftState(workspaceId: string | null): StoredChatDraftWor
     };
   }
 
+  let parsedValue: unknown;
   try {
-    const parsedValue = JSON.parse(rawValue) as unknown;
-    const parsedState = parseStoredChatDraftWorkspaceState(parsedValue);
-    if (parsedState === null) {
-      storage.removeItem(resolveWorkspaceStorageKey(normalizedWorkspaceId));
-      return {
-        version: CHAT_DRAFT_STORAGE_VERSION,
-        draftsBySessionId: {},
-      };
-    }
-
-    return parsedState;
+    parsedValue = JSON.parse(rawValue) as unknown;
   } catch {
-    storage.removeItem(resolveWorkspaceStorageKey(normalizedWorkspaceId));
+    storage.removeItem(storageKey);
     return {
       version: CHAT_DRAFT_STORAGE_VERSION,
       draftsBySessionId: {},
     };
   }
+
+  const parsedState = parseStoredChatDraftWorkspaceState(parsedValue);
+  if (parsedState === null) {
+    storage.removeItem(storageKey);
+    return {
+      version: CHAT_DRAFT_STORAGE_VERSION,
+      draftsBySessionId: {},
+    };
+  }
+
+  if (hasPersistedBinaryPendingAttachment(parsedValue)) {
+    storeWorkspaceDraftState(normalizedWorkspaceId, parsedState);
+  }
+
+  return parsedState;
 }
 
 function storeWorkspaceDraftState(
@@ -328,27 +377,29 @@ function storeWorkspaceDraftState(
     return;
   }
 
-  const nextDraftsBySessionId: Record<string, StoredChatDraft> = {};
-  for (const [sessionId, draft] of Object.entries(state.draftsBySessionId)) {
-    if (isDraftEmpty(draft)) {
-      continue;
-    }
-
-    nextDraftsBySessionId[sessionId] = draft;
-  }
+  const storageKey = resolveWorkspaceStorageKey(normalizedWorkspaceId);
+  const nextDraftsBySessionId = toPersistableDraftsBySessionId(state.draftsBySessionId);
 
   if (Object.keys(nextDraftsBySessionId).length === 0) {
-    storage.removeItem(resolveWorkspaceStorageKey(normalizedWorkspaceId));
+    storage.removeItem(storageKey);
     return;
   }
 
-  storage.setItem(
-    resolveWorkspaceStorageKey(normalizedWorkspaceId),
-    JSON.stringify({
-      version: CHAT_DRAFT_STORAGE_VERSION,
-      draftsBySessionId: nextDraftsBySessionId,
-    }),
-  );
+  try {
+    storage.setItem(
+      storageKey,
+      JSON.stringify({
+        version: CHAT_DRAFT_STORAGE_VERSION,
+        draftsBySessionId: nextDraftsBySessionId,
+      }),
+    );
+  } catch (error) {
+    if (isQuotaExceededError(error) === false) {
+      throw error;
+    }
+
+    storage.removeItem(storageKey);
+  }
 }
 
 export function buildChatDraftSessionKey(sessionId: string | null): string {
@@ -400,10 +451,11 @@ export function clearStoredChatDraftForSessionIfUnchanged(
 
   const currentState = loadWorkspaceDraftState(workspaceId);
   const currentDraft = readStoredChatDraftForSession(currentState.draftsBySessionId, sessionId);
+  const persistableExpectedDraft = toPersistableChatDraftContent(expectedDraft);
   if (
     currentDraft === null
     || currentDraft.updatedAt !== expectedUpdatedAt
-    || areChatDraftContentsEqual(currentDraft, expectedDraft) === false
+    || areChatDraftContentsEqual(currentDraft, persistableExpectedDraft) === false
   ) {
     return;
   }


### PR DESCRIPTION
## Summary
- Project chat draft persistence to text plus card attachments only
- Drop and clean legacy persisted binary/base64 draft attachments on load
- Preserve transient in-memory binary attach/send/retry behavior

## Validation
- cd apps/web && npx vitest run src/chat/composer/drafts/chatDraftStorage.test.ts (1 file, 12 tests)
- cd apps/web && npm run test -- src/chat/composer/drafts/chatDraftStorage.test.ts src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx src/chat/ChatPanel/tests/send/ChatPanel.send-preflight.test.tsx (79 files, 609 tests)
- git --no-pager diff --check

## Review
- Worker-owned final review passed with no P0-P4 findings and no split recommendation
