### PR TITLE
Align Android package export tag parity

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
@@ -525,7 +525,7 @@ private fun WorkspacePackageExportIncludedTagsCard(
                 )
                 if (hasGeneratedImportTags) {
                     Text(
-                        text = stringResource(R.string.settings_export_package_generated_import_tag_removed),
+                        text = stringResource(R.string.settings_export_package_generated_import_tag_not_included),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
                     )
@@ -549,7 +549,7 @@ private fun WorkspacePackageExportIncludedTagsCard(
                 }
                 if (hasGeneratedImportTags) {
                     Text(
-                        text = stringResource(R.string.settings_export_package_generated_import_tag_removed),
+                        text = stringResource(R.string.settings_export_package_generated_import_tag_not_included),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
                     )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportSupport.kt
@@ -57,27 +57,38 @@ fun makeWorkspacePackageExportMetadataDraft(
     )
 }
 
-fun makeWorkspacePackageExportIncludedTags(
-    preview: WorkspacePackageExportPreview,
-    excludedTags: Set<String>
+fun makeWorkspacePackageExportInitialIncludedTags(preview: WorkspacePackageExportPreview): Set<String> {
+    return makeWorkspacePackageExportKnownRegularTags(preview = preview)
+}
+
+fun makeWorkspacePackageExportKnownRegularTags(preview: WorkspacePackageExportPreview): Set<String> {
+    return makeWorkspacePackageExportAvailableRegularTags(preview = preview).toSet()
+}
+
+fun makeWorkspacePackageExportRefreshedIncludedTags(
+    knownRegularTags: Set<String>,
+    includedTags: Set<String>,
+    refreshedPreview: WorkspacePackageExportPreview
 ): Set<String> {
-    return makeWorkspacePackageExportAvailableRegularTags(preview = preview)
-        .filter { tag -> excludedTags.contains(tag).not() }
+    val excludedKnownTags: Set<String> = knownRegularTags - includedTags
+    val includedRefreshedTags: Set<String> = makeWorkspacePackageExportAvailableRegularTags(preview = refreshedPreview)
+        .filter { tag -> excludedKnownTags.contains(tag).not() }
         .toSet()
+    return includedTags + includedRefreshedTags
 }
 
 fun makeWorkspacePackageExportRequest(
     preview: WorkspacePackageExportPreview,
     metadataDraft: WorkspacePackageExportMetadataDraft,
     selectedCardTags: Set<String>,
-    excludedTags: Set<String>
+    includedTags: Set<String>
 ): WorkspacePackageExportRequest {
     return WorkspacePackageExportRequest(
         selection = makeWorkspacePackageExportSelection(selectedCardTags = selectedCardTags),
         tagPolicy = WorkspacePackageExportTagPolicyInput(
             additionalRemovedTags = makeWorkspacePackageExportAdditionalRemovedTags(
                 preview = preview,
-                excludedTags = excludedTags
+                includedTags = includedTags
             )
         ),
         packageMetadata = WorkspacePackageExportMetadataInput(
@@ -188,12 +199,12 @@ private fun makeWorkspacePackageExportAvailableRegularTags(preview: WorkspacePac
 
 private fun makeWorkspacePackageExportAdditionalRemovedTags(
     preview: WorkspacePackageExportPreview,
-    excludedTags: Set<String>
+    includedTags: Set<String>
 ): List<String> {
     return preview.availableTagCounts
         .map { tagCount -> tagCount.tag }
         .filter { tag ->
-            isWorkspacePackageExportGeneratedImportTag(tag = tag).not() && excludedTags.contains(tag)
+            isWorkspacePackageExportGeneratedImportTag(tag = tag).not() && includedTags.contains(tag).not()
         }
 }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModel.kt
@@ -42,7 +42,8 @@ private data class WorkspacePackageExportPreservedDraft(
     val metadataDraft: WorkspacePackageExportMetadataDraft,
     val cardSelectionTags: Set<String>,
     val cardSelectionTagCounts: List<WorkspacePackageExportTagCount>,
-    val excludedTags: Set<String>
+    val knownRegularTags: Set<String>,
+    val includedTags: Set<String>
 )
 
 private data class WorkspaceExportDraftState(
@@ -51,7 +52,8 @@ private data class WorkspaceExportDraftState(
     val packageMetadataDraft: WorkspacePackageExportMetadataDraft,
     val packageCardSelectionTags: Set<String>,
     val packageCardSelectionTagCounts: List<WorkspacePackageExportTagCount>,
-    val packageExcludedTags: Set<String>,
+    val packageKnownRegularTags: Set<String>,
+    val packageIncludedTags: Set<String>,
     val isPackagePreviewing: Boolean,
     val isPackageExporting: Boolean,
     val errorMessage: String
@@ -82,7 +84,8 @@ class WorkspaceExportViewModel(
             packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
             packageCardSelectionTags = emptySet(),
             packageCardSelectionTagCounts = emptyList(),
-            packageExcludedTags = emptySet(),
+            packageKnownRegularTags = emptySet(),
+            packageIncludedTags = emptySet(),
             isPackagePreviewing = false,
             isPackageExporting = false,
             errorMessage = ""
@@ -119,10 +122,7 @@ class WorkspaceExportViewModel(
                 emptyList()
             },
             packageIncludedTags = if (currentPackagePreview != null) {
-                makeWorkspacePackageExportIncludedTags(
-                    preview = currentPackagePreview,
-                    excludedTags = draft.packageExcludedTags
-                )
+                draft.packageIncludedTags
             } else {
                 emptySet()
             },
@@ -194,7 +194,8 @@ class WorkspaceExportViewModel(
                     packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
                     packageCardSelectionTags = emptySet(),
                     packageCardSelectionTagCounts = emptyList(),
-                    packageExcludedTags = emptySet(),
+                    packageKnownRegularTags = emptySet(),
+                    packageIncludedTags = emptySet(),
                     isPackagePreviewing = false,
                     isPackageExporting = false,
                     errorMessage = workspacePackageExportAvailabilityMessage(
@@ -213,7 +214,8 @@ class WorkspaceExportViewModel(
                 packageMetadataDraft = preservedDraft?.metadataDraft ?: emptyWorkspacePackageExportMetadataDraft(),
                 packageCardSelectionTags = selectedCardTags,
                 packageCardSelectionTagCounts = preservedCardSelectionTagCounts,
-                packageExcludedTags = preservedDraft?.excludedTags ?: emptySet(),
+                packageKnownRegularTags = preservedDraft?.knownRegularTags ?: emptySet(),
+                packageIncludedTags = preservedDraft?.includedTags ?: emptySet(),
                 isPackagePreviewing = true,
                 isPackageExporting = false,
                 errorMessage = ""
@@ -232,13 +234,24 @@ class WorkspaceExportViewModel(
                 }
                 val nextMetadataDraft: WorkspacePackageExportMetadataDraft = preservedDraft?.metadataDraft
                     ?: makeWorkspacePackageExportMetadataDraft(defaultPackageMetadata = preview.defaultPackageMetadata)
+                val nextKnownRegularTags: Set<String> = makeWorkspacePackageExportKnownRegularTags(preview = preview)
+                val nextIncludedTags: Set<String> = preservedDraft?.let { draft ->
+                    makeWorkspacePackageExportRefreshedIncludedTags(
+                        knownRegularTags = draft.knownRegularTags,
+                        includedTags = draft.includedTags,
+                        refreshedPreview = preview
+                    )
+                } ?: makeWorkspacePackageExportInitialIncludedTags(preview = preview)
                 state.copy(
                     packagePreview = preview,
                     packagePreviewIdentity = previewIdentity,
                     packageMetadataDraft = nextMetadataDraft,
                     packageCardSelectionTags = selectedCardTags,
                     packageCardSelectionTagCounts = nextCardSelectionTagCounts,
-                    packageExcludedTags = preservedDraft?.excludedTags ?: emptySet(),
+                    packageKnownRegularTags = preservedDraft?.knownRegularTags
+                        ?.plus(nextKnownRegularTags)
+                        ?: nextKnownRegularTags,
+                    packageIncludedTags = nextIncludedTags,
                     isPackagePreviewing = false,
                     errorMessage = ""
                 )
@@ -290,7 +303,8 @@ class WorkspaceExportViewModel(
                     packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
                     packageCardSelectionTags = emptySet(),
                     packageCardSelectionTagCounts = emptyList(),
-                    packageExcludedTags = emptySet(),
+                    packageKnownRegularTags = emptySet(),
+                    packageIncludedTags = emptySet(),
                     errorMessage = currentUiState.packageAvailabilityMessage
                 )
             }
@@ -310,7 +324,7 @@ class WorkspaceExportViewModel(
                     preview = preview,
                     metadataDraft = currentUiState.packageMetadataDraft,
                     selectedCardTags = currentUiState.packageCardSelectionTags,
-                    excludedTags = draftState.value.packageExcludedTags
+                    includedTags = currentUiState.packageIncludedTags
                 )
             )
         } catch (error: CancellationException) {
@@ -400,7 +414,8 @@ class WorkspaceExportViewModel(
                 metadataDraft = currentState.packageMetadataDraft,
                 cardSelectionTags = currentState.packageCardSelectionTags,
                 cardSelectionTagCounts = currentState.packageCardSelectionTagCounts,
-                excludedTags = currentState.packageExcludedTags
+                knownRegularTags = currentState.packageKnownRegularTags,
+                includedTags = currentState.packageIncludedTags
             )
         )
     }
@@ -413,16 +428,16 @@ class WorkspaceExportViewModel(
             "Workspace package export tag toggle requires an existing preview tag."
         }
         require(isWorkspacePackageExportGeneratedImportTag(tag = tag).not()) {
-            "Workspace package export generated import tags cannot be kept."
+            "Workspace package export generated import tags cannot be included."
         }
         draftState.update { state ->
-            val nextExcludedTags: Set<String> = if (state.packageExcludedTags.contains(tag)) {
-                state.packageExcludedTags - tag
+            val nextIncludedTags: Set<String> = if (state.packageIncludedTags.contains(tag)) {
+                state.packageIncludedTags - tag
             } else {
-                state.packageExcludedTags + tag
+                state.packageIncludedTags + tag
             }
             state.copy(
-                packageExcludedTags = nextExcludedTags,
+                packageIncludedTags = nextIncludedTags,
                 errorMessage = ""
             )
         }
@@ -547,7 +562,8 @@ private fun restoreWorkspacePackageExportDraftAfterPreviewFailure(
             packageMetadataDraft = emptyWorkspacePackageExportMetadataDraft(),
             packageCardSelectionTags = emptySet(),
             packageCardSelectionTagCounts = emptyList(),
-            packageExcludedTags = emptySet(),
+            packageKnownRegularTags = emptySet(),
+            packageIncludedTags = emptySet(),
             isPackagePreviewing = false,
             isPackageExporting = false,
             errorMessage = errorMessage
@@ -559,7 +575,8 @@ private fun restoreWorkspacePackageExportDraftAfterPreviewFailure(
         packageMetadataDraft = preservedDraft.metadataDraft,
         packageCardSelectionTags = preservedDraft.cardSelectionTags,
         packageCardSelectionTagCounts = preservedDraft.cardSelectionTagCounts,
-        packageExcludedTags = preservedDraft.excludedTags,
+        packageKnownRegularTags = preservedDraft.knownRegularTags,
+        packageIncludedTags = preservedDraft.includedTags,
         isPackagePreviewing = false,
         isPackageExporting = false,
         errorMessage = errorMessage

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -473,7 +473,7 @@
     <string name="settings_export_package_tags_section">Package tags</string>
     <string name="settings_export_package_tags_empty">No package tags.</string>
     <string name="settings_export_package_include_tag">Include %1$s</string>
-    <string name="settings_export_package_generated_import_tag_removed">Generated import tags are not included in package exports.</string>
+    <string name="settings_export_package_generated_import_tag_not_included">Generated import tags are not included in package exports.</string>
 
     <string name="settings_import_title">Import</string>
     <string name="settings_import_zip_summary">Import a Flashcards ZIP package</string>

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportViewModelTest.kt
@@ -164,7 +164,7 @@ class WorkspaceExportViewModelTest {
     }
 
     @Test
-    fun cardSelectionRefreshPreservesOnlyExplicitlyExcludedPackageTags() = runTest(dispatcher) {
+    fun cardSelectionRefreshPreservesIncludedPackageTags() = runTest(dispatcher) {
         Dispatchers.setMain(dispatcher)
         val cloudRepository = FakeCloudAccountRepository()
         cloudRepository.setCloudSettings(settings = linkedCloudSettings())
@@ -197,6 +197,47 @@ class WorkspaceExportViewModelTest {
         assertEquals(WorkspacePackageExportSelection.AllActiveCards, request.selection)
         assertEquals(listOf("geography"), request.tagPolicy.additionalRemovedTags)
         assertEquals(setOf("temporary"), viewModel.uiState.value.packageIncludedTags)
+
+        stateJob.cancel()
+    }
+
+    @Test
+    fun cardSelectionRefreshIncludesNewPackageTagsByDefault() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val cloudRepository = FakeCloudAccountRepository()
+        cloudRepository.setCloudSettings(settings = linkedCloudSettings())
+        cloudRepository.nextWorkspacePackageExportPreview = workspacePackageExportPreview()
+        cloudRepository.nextWorkspacePackageExportDownloadResponse = WorkspacePackageExportDownloadResponse(
+            packageBytes = byteArrayOf(80, 75, 3, 4),
+            fileName = "flashcards.zip",
+            contentType = "application/zip"
+        )
+        val viewModel = workspaceExportViewModel(cloudRepository = cloudRepository)
+        val stateJob = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        advanceUntilIdle()
+
+        viewModel.previewPackageExport()
+        advanceUntilIdle()
+        viewModel.togglePackageIncludedTag(tag = "geography")
+        advanceUntilIdle()
+        cloudRepository.nextWorkspacePackageExportPreview = workspacePackageExportPreviewWithSharedTag()
+        viewModel.togglePackageCardSelectionTag(tag = "geography")
+        advanceUntilIdle()
+        val response = viewModel.preparePackageExportDownload()
+
+        val request = cloudRepository.exportedWorkspacePackageRequests.single()
+        assertArrayEquals(byteArrayOf(80, 75, 3, 4), response?.packageBytes)
+        assertEquals(
+            WorkspacePackageExportSelection.TagFilters(
+                includeTags = listOf("geography"),
+                excludeTags = emptyList()
+            ),
+            request.selection
+        )
+        assertEquals(listOf("geography"), request.tagPolicy.additionalRemovedTags)
+        assertEquals(setOf("temporary", "shared"), viewModel.uiState.value.packageIncludedTags)
 
         stateJob.cancel()
     }
@@ -302,6 +343,29 @@ private fun workspacePackageExportPreviewWithoutTemporary(): WorkspacePackageExp
             WorkspacePackageExportTagCount(
                 tag = "geography",
                 cardsCount = 2
+            ),
+            WorkspacePackageExportTagCount(
+                tag = "import:old",
+                cardsCount = 1
+            )
+        )
+    )
+}
+
+private fun workspacePackageExportPreviewWithSharedTag(): WorkspacePackageExportPreview {
+    return workspacePackageExportPreviewWithAvailableTags(
+        availableTagCounts = listOf(
+            WorkspacePackageExportTagCount(
+                tag = "geography",
+                cardsCount = 2
+            ),
+            WorkspacePackageExportTagCount(
+                tag = "temporary",
+                cardsCount = 1
+            ),
+            WorkspacePackageExportTagCount(
+                tag = "shared",
+                cardsCount = 1
             ),
             WorkspacePackageExportTagCount(
                 tag = "import:old",


### PR DESCRIPTION
## Summary
- align Android package export state around included package tags
- keep generated import tags out of editable included-tag controls
- preserve user-excluded known tags while default-including newly available regular tags during refreshed previews

## Validation
- git fetch origin main: passed
- git merge-base --is-ancestor origin/main HEAD: passed before implementation
- git --no-pager diff --check: passed
- stale export-remove copy search: no matches
- package transfer contract search: expected references found
- targeted stale excluded/remove key scan: no matches
- review gate: no split recommendation, no P0-P4 findings

Android Gradle was not run because ./gradlew was not approved for this task.