### PR TITLE
Add iOS cloud sync breadcrumbs

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -410,7 +410,43 @@ final class CloudSessionRuntime {
     ) async throws -> CloudSyncResult {
         if let activeCloudSyncTask = self.state.activeCloudSyncTask {
             self.state.pendingCloudResync = true
-            return try await activeCloudSyncTask.task.value
+            let startedAt = Date()
+            self.addCloudSyncRuntimeBreadcrumb(
+                stage: "wait_active_sync",
+                phase: .start,
+                startedAt: nil,
+                hadActiveTask: true,
+                pendingResync: self.state.pendingCloudResync,
+                waitOutcome: nil,
+                syncResult: nil,
+                error: nil
+            )
+            do {
+                let syncResult = try await activeCloudSyncTask.task.value
+                self.addCloudSyncRuntimeBreadcrumb(
+                    stage: "wait_active_sync",
+                    phase: .success,
+                    startedAt: startedAt,
+                    hadActiveTask: true,
+                    pendingResync: self.state.pendingCloudResync,
+                    waitOutcome: "success",
+                    syncResult: syncResult,
+                    error: nil
+                )
+                return syncResult
+            } catch {
+                self.addCloudSyncRuntimeBreadcrumb(
+                    stage: "wait_active_sync",
+                    phase: .failure,
+                    startedAt: startedAt,
+                    hadActiveTask: true,
+                    pendingResync: self.state.pendingCloudResync,
+                    waitOutcome: isRequestCancellationError(error: error) ? "cancellation" : "failure",
+                    syncResult: nil,
+                    error: error
+                )
+                throw error
+            }
         }
 
         return try await self.startCloudSyncTask(operation: operation)
@@ -419,6 +455,17 @@ final class CloudSessionRuntime {
     private func startCloudSyncTask(
         operation: @escaping @MainActor () async throws -> CloudSyncResult
     ) async throws -> CloudSyncResult {
+        let startedAt = Date()
+        self.addCloudSyncRuntimeBreadcrumb(
+            stage: "start_active_sync_task",
+            phase: .start,
+            startedAt: nil,
+            hadActiveTask: self.state.activeCloudSyncTask != nil,
+            pendingResync: self.state.pendingCloudResync,
+            waitOutcome: nil,
+            syncResult: nil,
+            error: nil
+        )
         let syncOperation = CloudSyncOperationState(
             id: UUID().uuidString.lowercased(),
             task: Task { @MainActor in
@@ -429,9 +476,29 @@ final class CloudSessionRuntime {
 
         do {
             let syncResult = try await syncOperation.task.value
+            self.addCloudSyncRuntimeBreadcrumb(
+                stage: "start_active_sync_task",
+                phase: .success,
+                startedAt: startedAt,
+                hadActiveTask: true,
+                pendingResync: self.state.pendingCloudResync,
+                waitOutcome: nil,
+                syncResult: syncResult,
+                error: nil
+            )
             self.clearActiveCloudSyncTaskIfCurrent(id: syncOperation.id)
             return syncResult
         } catch {
+            self.addCloudSyncRuntimeBreadcrumb(
+                stage: "start_active_sync_task",
+                phase: .failure,
+                startedAt: startedAt,
+                hadActiveTask: true,
+                pendingResync: self.state.pendingCloudResync,
+                waitOutcome: isRequestCancellationError(error: error) ? "cancellation" : "failure",
+                syncResult: nil,
+                error: error
+            )
             self.clearActiveCloudSyncTaskIfCurrent(id: syncOperation.id)
             throw error
         }
@@ -456,13 +523,54 @@ final class CloudSessionRuntime {
 
     private func waitForActiveCloudSyncToSettle() async {
         while let activeCloudSyncTask = self.state.activeCloudSyncTask {
+            let startedAt = Date()
+            self.addCloudSyncRuntimeBreadcrumb(
+                stage: "wait_active_sync_to_settle",
+                phase: .start,
+                startedAt: nil,
+                hadActiveTask: true,
+                pendingResync: self.state.pendingCloudResync,
+                waitOutcome: nil,
+                syncResult: nil,
+                error: nil
+            )
             do {
-                _ = try await activeCloudSyncTask.task.value
+                let syncResult = try await activeCloudSyncTask.task.value
+                self.addCloudSyncRuntimeBreadcrumb(
+                    stage: "wait_active_sync_to_settle",
+                    phase: .success,
+                    startedAt: startedAt,
+                    hadActiveTask: true,
+                    pendingResync: self.state.pendingCloudResync,
+                    waitOutcome: "success",
+                    syncResult: syncResult,
+                    error: nil
+                )
             } catch {
                 if isRequestCancellationError(error: error) {
+                    self.addCloudSyncRuntimeBreadcrumb(
+                        stage: "wait_active_sync_to_settle",
+                        phase: .success,
+                        startedAt: startedAt,
+                        hadActiveTask: true,
+                        pendingResync: self.state.pendingCloudResync,
+                        waitOutcome: "cancellation",
+                        syncResult: nil,
+                        error: nil
+                    )
                     self.clearActiveCloudSyncTaskIfCurrent(id: activeCloudSyncTask.id)
                     continue
                 }
+                self.addCloudSyncRuntimeBreadcrumb(
+                    stage: "wait_active_sync_to_settle",
+                    phase: .success,
+                    startedAt: startedAt,
+                    hadActiveTask: true,
+                    pendingResync: self.state.pendingCloudResync,
+                    waitOutcome: "swallowed_error",
+                    syncResult: nil,
+                    error: error
+                )
                 FlashcardsObservability.addBreadcrumb(
                     .cloudRetry(
                         CloudRetryObservation(
@@ -501,8 +609,122 @@ final class CloudSessionRuntime {
             return
         }
 
+        self.addCloudSyncRuntimeBreadcrumb(
+            stage: "clear_active_sync_task",
+            phase: .success,
+            startedAt: nil,
+            hadActiveTask: true,
+            pendingResync: self.state.pendingCloudResync,
+            waitOutcome: nil,
+            syncResult: nil,
+            error: nil
+        )
         self.state.activeCloudSyncTask = nil
         self.state.pendingCloudResync = false
+    }
+
+    private func cancelAndClearActiveCloudSyncTask(stage: String) {
+        guard let activeCloudSyncTask = self.state.activeCloudSyncTask else {
+            self.state.pendingCloudResync = false
+            return
+        }
+
+        activeCloudSyncTask.task.cancel()
+        self.addCloudSyncRuntimeBreadcrumb(
+            stage: stage,
+            phase: .success,
+            startedAt: nil,
+            hadActiveTask: true,
+            pendingResync: self.state.pendingCloudResync,
+            waitOutcome: "cancellation",
+            syncResult: nil,
+            error: nil
+        )
+        self.state.activeCloudSyncTask = nil
+        self.state.pendingCloudResync = false
+    }
+
+    private func addCloudSyncRuntimeBreadcrumb(
+        stage: String,
+        phase: ForegroundOperationPhase,
+        startedAt: Date?,
+        hadActiveTask: Bool?,
+        pendingResync: Bool?,
+        waitOutcome: String?,
+        syncResult: CloudSyncResult?,
+        error: Error?
+    ) {
+        let activeCloudSession = self.state.activeCloudSession
+        let durationMilliseconds = startedAt.map { startDate in
+            iosObservationDurationMilliseconds(startedAt: startDate, finishedAt: Date())
+        }
+        let cloudState: CloudAccountState?
+        if let activeCloudSession {
+            cloudState = activeCloudSession.authorization.isGuest ? .guest : .linked
+        } else {
+            cloudState = nil
+        }
+        FlashcardsObservability.addBreadcrumb(
+            .foregroundOperation(
+                ForegroundOperationObservation(
+                    scope: IOSObservationScope(
+                        feature: .cloudSync,
+                        userId: activeCloudSession?.userId,
+                        workspaceId: activeCloudSession?.workspaceId,
+                        requestId: nil,
+                        clientRequestId: nil,
+                        sessionId: nil,
+                        runId: nil,
+                        cloudState: cloudState,
+                        configurationMode: activeCloudSession?.configurationMode
+                    ),
+                    action: .cloudSync,
+                    phase: phase,
+                    durationMilliseconds: durationMilliseconds,
+                    operationStage: stage,
+                    operationTrigger: nil,
+                    selectedTab: nil,
+                    scenePhase: nil,
+                    isStartupReady: nil,
+                    isRecoveryGateActive: nil,
+                    cardCount: nil,
+                    deckCount: nil,
+                    pendingOutboxOperationCount: nil,
+                    reviewQueueCount: nil,
+                    reviewDueCount: nil,
+                    reviewNewCount: nil,
+                    reviewPendingCount: nil,
+                    reviewTotalCount: nil,
+                    reviewFilterKind: nil,
+                    reviewRefreshMode: nil,
+                    reviewLoadKind: nil,
+                    progressSummaryRefreshNeeded: nil,
+                    progressSeriesRefreshNeeded: nil,
+                    progressReviewScheduleRefreshNeeded: nil,
+                    progressLeaderboardRefreshNeeded: nil,
+                    progressStreakLeaderboardRefreshNeeded: nil,
+                    cloudSyncBlocked: nil,
+                    cloudSyncExtendsFastPolling: nil,
+                    cloudSyncUsesImmediateStartDebounce: nil,
+                    cloudSyncImmediateStartSkipped: nil,
+                    cloudSyncSkipReason: nil,
+                    cloudSyncHadActiveTask: hadActiveTask,
+                    cloudSyncPendingResync: pendingResync,
+                    cloudSyncWaitOutcome: waitOutcome,
+                    cloudSyncAcknowledgedOperationCount: syncResult?.acknowledgedOperationCount,
+                    cloudSyncAppliedPullChangeCount: syncResult?.appliedPullChangeCount,
+                    cloudSyncChangedEntityTypeCount: syncResult?.changedEntityTypes.count,
+                    cloudSyncLocalIdRepairEntityTypeCount: syncResult?.localIdRepairEntityTypes.count,
+                    cloudSyncReviewScheduleImpactingPullChangeCount: syncResult?.reviewScheduleImpactingPullChangeCount,
+                    cloudSyncAcknowledgedReviewEventOperationCount: syncResult?.acknowledgedReviewEventOperationCount,
+                    cloudSyncAcknowledgedReviewScheduleImpactingOperationCount: syncResult?.acknowledgedReviewScheduleImpactingOperationCount,
+                    cloudSyncCleanedUpOperationCount: syncResult?.cleanedUpOperationCount,
+                    cloudSyncCleanedUpReviewScheduleImpactingOperationCount: syncResult?.cleanedUpReviewScheduleImpactingOperationCount,
+                    cloudSyncCleanedUpReviewEventOperationCount: syncResult?.cleanedUpReviewEventOperationCount,
+                    errorSummary: error.map { operationError in Flashcards.errorMessage(error: operationError) }
+                )
+            )
+        )
     }
 
     func isCloudAuthorizationError(_ error: Error) -> Bool {
@@ -536,9 +758,7 @@ final class CloudSessionRuntime {
     }
 
     func cancelForWorkspaceSwitch() {
-        self.state.activeCloudSyncTask?.task.cancel()
-        self.state.activeCloudSyncTask = nil
-        self.state.pendingCloudResync = false
+        self.cancelAndClearActiveCloudSyncTask(stage: "clear_active_sync_task_workspace_switch")
         self.state.activeAIChatSessionPreparation?.task.cancel()
         self.state.activeAIChatSessionPreparation = nil
         self.state.activeGuestCloudSessionPreparation?.task.cancel()
@@ -548,9 +768,7 @@ final class CloudSessionRuntime {
     func cancelForAccountDeletion() {
         self.state.activeCloudLinkTask?.task.cancel()
         self.state.activeCloudLinkTask = nil
-        self.state.activeCloudSyncTask?.task.cancel()
-        self.state.activeCloudSyncTask = nil
-        self.state.pendingCloudResync = false
+        self.cancelAndClearActiveCloudSyncTask(stage: "clear_active_sync_task_account_deletion")
         self.state.activeAIChatSessionPreparation?.task.cancel()
         self.state.activeAIChatSessionPreparation = nil
         self.state.activeGuestCloudSessionPreparation?.task.cancel()

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -62,9 +62,109 @@ extension FlashcardsStore {
         self.currentVisibleTab = tab
     }
 
+    private func addCloudSyncForegroundOperationBreadcrumb(
+        stage: String,
+        phase: ForegroundOperationPhase,
+        trigger: CloudSyncTrigger,
+        startedAt: Date?,
+        immediateStartSkipped: Bool?,
+        skipReason: String?,
+        syncResult: CloudSyncResult?,
+        error: Error?
+    ) {
+        let durationMilliseconds = startedAt.map { startDate in
+            iosObservationDurationMilliseconds(startedAt: startDate, finishedAt: Date())
+        }
+        let scope = IOSObservationScope(
+            feature: .cloudSync,
+            userId: self.cloudSettings?.linkedUserId,
+            workspaceId: self.workspace?.workspaceId,
+            requestId: nil,
+            clientRequestId: nil,
+            sessionId: nil,
+            runId: nil,
+            cloudState: self.cloudSettings?.cloudState,
+            configurationMode: try? self.currentCloudServiceConfiguration().mode
+        )
+
+        FlashcardsObservability.addBreadcrumb(
+            .foregroundOperation(
+                ForegroundOperationObservation(
+                    scope: scope,
+                    action: .cloudSync,
+                    phase: phase,
+                    durationMilliseconds: durationMilliseconds,
+                    operationStage: stage,
+                    operationTrigger: trigger.source.diagnosticValue,
+                    selectedTab: nil,
+                    scenePhase: nil,
+                    isStartupReady: nil,
+                    isRecoveryGateActive: nil,
+                    cardCount: self.cards.count,
+                    deckCount: self.decks.count,
+                    pendingOutboxOperationCount: nil,
+                    reviewQueueCount: nil,
+                    reviewDueCount: nil,
+                    reviewNewCount: nil,
+                    reviewPendingCount: nil,
+                    reviewTotalCount: nil,
+                    reviewFilterKind: nil,
+                    reviewRefreshMode: nil,
+                    reviewLoadKind: nil,
+                    progressSummaryRefreshNeeded: nil,
+                    progressSeriesRefreshNeeded: nil,
+                    progressReviewScheduleRefreshNeeded: nil,
+                    progressLeaderboardRefreshNeeded: nil,
+                    progressStreakLeaderboardRefreshNeeded: nil,
+                    cloudSyncBlocked: self.isCloudSyncBlocked,
+                    cloudSyncExtendsFastPolling: trigger.extendsFastPolling,
+                    cloudSyncUsesImmediateStartDebounce: trigger.source.usesImmediateStartDebounce,
+                    cloudSyncImmediateStartSkipped: immediateStartSkipped,
+                    cloudSyncSkipReason: skipReason,
+                    cloudSyncHadActiveTask: nil,
+                    cloudSyncPendingResync: nil,
+                    cloudSyncWaitOutcome: nil,
+                    cloudSyncAcknowledgedOperationCount: syncResult?.acknowledgedOperationCount,
+                    cloudSyncAppliedPullChangeCount: syncResult?.appliedPullChangeCount,
+                    cloudSyncChangedEntityTypeCount: syncResult?.changedEntityTypes.count,
+                    cloudSyncLocalIdRepairEntityTypeCount: syncResult?.localIdRepairEntityTypes.count,
+                    cloudSyncReviewScheduleImpactingPullChangeCount: syncResult?.reviewScheduleImpactingPullChangeCount,
+                    cloudSyncAcknowledgedReviewEventOperationCount: syncResult?.acknowledgedReviewEventOperationCount,
+                    cloudSyncAcknowledgedReviewScheduleImpactingOperationCount: syncResult?.acknowledgedReviewScheduleImpactingOperationCount,
+                    cloudSyncCleanedUpOperationCount: syncResult?.cleanedUpOperationCount,
+                    cloudSyncCleanedUpReviewScheduleImpactingOperationCount: syncResult?.cleanedUpReviewScheduleImpactingOperationCount,
+                    cloudSyncCleanedUpReviewEventOperationCount: syncResult?.cleanedUpReviewEventOperationCount,
+                    errorSummary: error.map { operationError in Flashcards.errorMessage(error: operationError) }
+                )
+            )
+        )
+    }
+
     func syncCloudNow(trigger: CloudSyncTrigger) async throws {
+        let startedAt = Date()
+        self.addCloudSyncForegroundOperationBreadcrumb(
+            stage: "sync_now",
+            phase: .start,
+            trigger: trigger,
+            startedAt: nil,
+            immediateStartSkipped: nil,
+            skipReason: nil,
+            syncResult: nil,
+            error: nil
+        )
+        do {
         try self.throwIfInvalidStoredCloudCredentialRecoveryRequired()
         if try await self.resumePendingGuestUpgradeIfNeeded(trigger: trigger) {
+            self.addCloudSyncForegroundOperationBreadcrumb(
+                stage: "sync_now",
+                phase: .success,
+                trigger: trigger,
+                startedAt: startedAt,
+                immediateStartSkipped: nil,
+                skipReason: "guest_upgrade_resumed",
+                syncResult: nil,
+                error: nil
+            )
             return
         }
         try self.throwIfCloudCredentialRecoveryRequired()
@@ -72,6 +172,16 @@ extension FlashcardsStore {
             try self.throwIfCloudCredentialRecoveryRequired()
         }
         if try await self.cloudRuntime.waitForActiveCloudCompletionIfNeeded() {
+            self.addCloudSyncForegroundOperationBreadcrumb(
+                stage: "sync_now",
+                phase: .success,
+                trigger: trigger,
+                startedAt: startedAt,
+                immediateStartSkipped: nil,
+                skipReason: "active_cloud_completion_waited",
+                syncResult: nil,
+                error: nil
+            )
             return
         }
         if case .blocked(let message) = self.syncStatus {
@@ -81,10 +191,30 @@ extension FlashcardsStore {
             if self.cloudSettings?.cloudState == .guest {
                 let restoredGuestSession = try await self.restoreGuestCloudSessionIfNeeded(trigger: trigger)
                 if restoredGuestSession.didRunSync {
+                    self.addCloudSyncForegroundOperationBreadcrumb(
+                        stage: "sync_now",
+                        phase: .success,
+                        trigger: trigger,
+                        startedAt: startedAt,
+                        immediateStartSkipped: nil,
+                        skipReason: "guest_session_restore_ran_sync",
+                        syncResult: nil,
+                        error: nil
+                    )
                     return
                 }
             } else {
                 try await self.restoreCloudLinkFromStoredCredentials(trigger: trigger)
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_now",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "cloud_link_restored",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
         }
@@ -114,6 +244,16 @@ extension FlashcardsStore {
                 trigger: trigger
             )
             await self.processMediaUploadTransfersAfterCloudSync(linkedSession: activeSession)
+            self.addCloudSyncForegroundOperationBreadcrumb(
+                stage: "sync_now",
+                phase: .success,
+                trigger: trigger,
+                startedAt: startedAt,
+                immediateStartSkipped: nil,
+                skipReason: nil,
+                syncResult: syncResult,
+                error: nil
+            )
         } catch {
             if isRequestCancellationError(error: error) {
                 self.syncStatus = .idle
@@ -161,23 +301,87 @@ extension FlashcardsStore {
             }
             throw didCapture ? markTechnicalErrorObserved(error: failureError) : failureError
         }
+        } catch {
+            self.addCloudSyncForegroundOperationBreadcrumb(
+                stage: "sync_now",
+                phase: .failure,
+                trigger: trigger,
+                startedAt: startedAt,
+                immediateStartSkipped: nil,
+                skipReason: nil,
+                syncResult: nil,
+                error: error
+            )
+            throw error
+        }
     }
 
     func syncCloudIfLinked(trigger: CloudSyncTrigger) async {
+        let startedAt = Date()
+        self.addCloudSyncForegroundOperationBreadcrumb(
+            stage: "sync_if_linked",
+            phase: .start,
+            trigger: trigger,
+            startedAt: nil,
+            immediateStartSkipped: nil,
+            skipReason: nil,
+            syncResult: nil,
+            error: nil
+        )
         if self.userDefaults.bool(forKey: accountDeletionPendingUserDefaultsKey) {
             await self.resumePendingAccountDeletionIfNeeded()
+            self.addCloudSyncForegroundOperationBreadcrumb(
+                stage: "sync_if_linked",
+                phase: .success,
+                trigger: trigger,
+                startedAt: startedAt,
+                immediateStartSkipped: nil,
+                skipReason: "account_deletion_pending",
+                syncResult: nil,
+                error: nil
+            )
             return
         }
 
         do {
             try self.throwIfInvalidStoredCloudCredentialRecoveryRequired()
             if try await self.resumePendingGuestUpgradeIfNeeded(trigger: trigger) {
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "guest_upgrade_resumed",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
             if self.blockCloudSyncForCredentialRecoveryIfNeeded() {
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "credential_recovery_block",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
             if self.isCloudSyncBlocked {
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "sync_blocked",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
 
@@ -189,10 +393,30 @@ extension FlashcardsStore {
                 hasStoredCredentials = resolvedHasStoredCredentials
                 hasStoredGuestSession = resolvedHasStoredGuestSession
             case .stopSync:
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "persisted_cloud_state_reconciled",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
 
             if try await self.cloudRuntime.waitForActiveCloudCompletionIfNeeded() {
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "active_cloud_completion_waited",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
 
@@ -203,22 +427,72 @@ extension FlashcardsStore {
                     try self.logoutCloudAccount()
                 }
 
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "no_stored_cloud_session",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
 
             try await self.syncCloudNow(trigger: trigger)
+            self.addCloudSyncForegroundOperationBreadcrumb(
+                stage: "sync_if_linked",
+                phase: .success,
+                trigger: trigger,
+                startedAt: startedAt,
+                immediateStartSkipped: nil,
+                skipReason: nil,
+                syncResult: nil,
+                error: nil
+            )
         } catch {
             if isRequestCancellationError(error: error) {
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "cancelled",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
             if self.isCloudAccountDeletedError(error) {
                 self.handleRemoteAccountDeletedCleanup()
+                self.addCloudSyncForegroundOperationBreadcrumb(
+                    stage: "sync_if_linked",
+                    phase: .success,
+                    trigger: trigger,
+                    startedAt: startedAt,
+                    immediateStartSkipped: nil,
+                    skipReason: "remote_account_deleted",
+                    syncResult: nil,
+                    error: nil
+                )
                 return
             }
 
             if trigger.surfacesGlobalErrorMessage {
                 self.globalErrorMessage = Flashcards.errorMessage(error: error)
             }
+            self.addCloudSyncForegroundOperationBreadcrumb(
+                stage: "sync_if_linked",
+                phase: .failure,
+                trigger: trigger,
+                startedAt: startedAt,
+                immediateStartSkipped: nil,
+                skipReason: nil,
+                syncResult: nil,
+                error: error
+            )
         }
     }
 
@@ -623,7 +897,18 @@ extension FlashcardsStore {
         if trigger.extendsFastPolling {
             self.extendCloudSyncFastPolling(now: trigger.now)
         }
-        if self.shouldSkipImmediateCloudSyncStart(trigger: trigger) {
+        let immediateStartSkipped = self.shouldSkipImmediateCloudSyncStart(trigger: trigger)
+        self.addCloudSyncForegroundOperationBreadcrumb(
+            stage: "trigger_received",
+            phase: .start,
+            trigger: trigger,
+            startedAt: nil,
+            immediateStartSkipped: immediateStartSkipped,
+            skipReason: immediateStartSkipped ? "immediate_start_debounce" : nil,
+            syncResult: nil,
+            error: nil
+        )
+        if immediateStartSkipped {
             return
         }
         Task { @MainActor in

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
@@ -38,6 +38,27 @@ enum CloudSyncTriggerSource: Hashable, Sendable {
             return false
         }
     }
+
+    var diagnosticValue: String {
+        switch self {
+        case .appLaunch:
+            return "app_launch"
+        case .appForeground:
+            return "app_foreground"
+        case .reviewTabSelected:
+            return "review_tab_selected"
+        case .cardsTabSelected:
+            return "cards_tab_selected"
+        case .polling:
+            return "polling"
+        case .localMutation:
+            return "local_mutation"
+        case .manualSyncNow:
+            return "manual_sync_now"
+        case .postAuth:
+            return "post_auth"
+        }
+    }
 }
 
 struct CloudSyncTrigger: Hashable, Sendable {

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -126,6 +126,8 @@ struct ForegroundOperationObservation: Sendable, Hashable {
     let action: ForegroundOperationAction
     let phase: ForegroundOperationPhase
     let durationMilliseconds: Int?
+    let operationStage: String?
+    let operationTrigger: String?
     let selectedTab: String?
     let scenePhase: String?
     let isStartupReady: Bool?
@@ -147,10 +149,104 @@ struct ForegroundOperationObservation: Sendable, Hashable {
     let progressLeaderboardRefreshNeeded: Bool?
     let progressStreakLeaderboardRefreshNeeded: Bool?
     let cloudSyncBlocked: Bool?
+    let cloudSyncExtendsFastPolling: Bool?
+    let cloudSyncUsesImmediateStartDebounce: Bool?
+    let cloudSyncImmediateStartSkipped: Bool?
+    let cloudSyncSkipReason: String?
+    let cloudSyncHadActiveTask: Bool?
+    let cloudSyncPendingResync: Bool?
+    let cloudSyncWaitOutcome: String?
+    let cloudSyncAcknowledgedOperationCount: Int?
+    let cloudSyncAppliedPullChangeCount: Int?
+    let cloudSyncChangedEntityTypeCount: Int?
+    let cloudSyncLocalIdRepairEntityTypeCount: Int?
+    let cloudSyncReviewScheduleImpactingPullChangeCount: Int?
+    let cloudSyncAcknowledgedReviewEventOperationCount: Int?
+    let cloudSyncAcknowledgedReviewScheduleImpactingOperationCount: Int?
+    let cloudSyncCleanedUpOperationCount: Int?
+    let cloudSyncCleanedUpReviewScheduleImpactingOperationCount: Int?
+    let cloudSyncCleanedUpReviewEventOperationCount: Int?
     let errorSummary: String?
 }
 
 extension ForegroundOperationObservation {
+    init(
+        scope: IOSObservationScope,
+        action: ForegroundOperationAction,
+        phase: ForegroundOperationPhase,
+        durationMilliseconds: Int?,
+        selectedTab: String?,
+        scenePhase: String?,
+        isStartupReady: Bool?,
+        isRecoveryGateActive: Bool?,
+        cardCount: Int?,
+        deckCount: Int?,
+        pendingOutboxOperationCount: Int?,
+        reviewQueueCount: Int?,
+        reviewDueCount: Int?,
+        reviewNewCount: Int?,
+        reviewPendingCount: Int?,
+        reviewTotalCount: Int?,
+        reviewFilterKind: String?,
+        reviewRefreshMode: String?,
+        reviewLoadKind: String?,
+        progressSummaryRefreshNeeded: Bool?,
+        progressSeriesRefreshNeeded: Bool?,
+        progressReviewScheduleRefreshNeeded: Bool?,
+        progressLeaderboardRefreshNeeded: Bool?,
+        progressStreakLeaderboardRefreshNeeded: Bool?,
+        cloudSyncBlocked: Bool?,
+        errorSummary: String?
+    ) {
+        self.init(
+            scope: scope,
+            action: action,
+            phase: phase,
+            durationMilliseconds: durationMilliseconds,
+            operationStage: nil,
+            operationTrigger: nil,
+            selectedTab: selectedTab,
+            scenePhase: scenePhase,
+            isStartupReady: isStartupReady,
+            isRecoveryGateActive: isRecoveryGateActive,
+            cardCount: cardCount,
+            deckCount: deckCount,
+            pendingOutboxOperationCount: pendingOutboxOperationCount,
+            reviewQueueCount: reviewQueueCount,
+            reviewDueCount: reviewDueCount,
+            reviewNewCount: reviewNewCount,
+            reviewPendingCount: reviewPendingCount,
+            reviewTotalCount: reviewTotalCount,
+            reviewFilterKind: reviewFilterKind,
+            reviewRefreshMode: reviewRefreshMode,
+            reviewLoadKind: reviewLoadKind,
+            progressSummaryRefreshNeeded: progressSummaryRefreshNeeded,
+            progressSeriesRefreshNeeded: progressSeriesRefreshNeeded,
+            progressReviewScheduleRefreshNeeded: progressReviewScheduleRefreshNeeded,
+            progressLeaderboardRefreshNeeded: progressLeaderboardRefreshNeeded,
+            progressStreakLeaderboardRefreshNeeded: progressStreakLeaderboardRefreshNeeded,
+            cloudSyncBlocked: cloudSyncBlocked,
+            cloudSyncExtendsFastPolling: nil,
+            cloudSyncUsesImmediateStartDebounce: nil,
+            cloudSyncImmediateStartSkipped: nil,
+            cloudSyncSkipReason: nil,
+            cloudSyncHadActiveTask: nil,
+            cloudSyncPendingResync: nil,
+            cloudSyncWaitOutcome: nil,
+            cloudSyncAcknowledgedOperationCount: nil,
+            cloudSyncAppliedPullChangeCount: nil,
+            cloudSyncChangedEntityTypeCount: nil,
+            cloudSyncLocalIdRepairEntityTypeCount: nil,
+            cloudSyncReviewScheduleImpactingPullChangeCount: nil,
+            cloudSyncAcknowledgedReviewEventOperationCount: nil,
+            cloudSyncAcknowledgedReviewScheduleImpactingOperationCount: nil,
+            cloudSyncCleanedUpOperationCount: nil,
+            cloudSyncCleanedUpReviewScheduleImpactingOperationCount: nil,
+            cloudSyncCleanedUpReviewEventOperationCount: nil,
+            errorSummary: errorSummary
+        )
+    }
+
     init(
         scope: IOSObservationScope,
         action: ForegroundOperationAction,
@@ -173,6 +269,8 @@ extension ForegroundOperationObservation {
             action: action,
             phase: phase,
             durationMilliseconds: durationMilliseconds,
+            operationStage: nil,
+            operationTrigger: nil,
             selectedTab: selectedTab,
             scenePhase: scenePhase,
             isStartupReady: isStartupReady,
@@ -194,6 +292,23 @@ extension ForegroundOperationObservation {
             progressLeaderboardRefreshNeeded: nil,
             progressStreakLeaderboardRefreshNeeded: nil,
             cloudSyncBlocked: cloudSyncBlocked,
+            cloudSyncExtendsFastPolling: nil,
+            cloudSyncUsesImmediateStartDebounce: nil,
+            cloudSyncImmediateStartSkipped: nil,
+            cloudSyncSkipReason: nil,
+            cloudSyncHadActiveTask: nil,
+            cloudSyncPendingResync: nil,
+            cloudSyncWaitOutcome: nil,
+            cloudSyncAcknowledgedOperationCount: nil,
+            cloudSyncAppliedPullChangeCount: nil,
+            cloudSyncChangedEntityTypeCount: nil,
+            cloudSyncLocalIdRepairEntityTypeCount: nil,
+            cloudSyncReviewScheduleImpactingPullChangeCount: nil,
+            cloudSyncAcknowledgedReviewEventOperationCount: nil,
+            cloudSyncAcknowledgedReviewScheduleImpactingOperationCount: nil,
+            cloudSyncCleanedUpOperationCount: nil,
+            cloudSyncCleanedUpReviewScheduleImpactingOperationCount: nil,
+            cloudSyncCleanedUpReviewEventOperationCount: nil,
             errorSummary: errorSummary
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -661,6 +661,8 @@ extension SentryObservabilityAdapter {
         context["action"] = observation.action.rawValue
         context["phase"] = observation.phase.rawValue
         context["duration_milliseconds"] = observation.durationMilliseconds.map { durationMilliseconds in String(durationMilliseconds) } ?? ""
+        context["operation_stage"] = observation.operationStage ?? ""
+        context["operation_trigger"] = observation.operationTrigger ?? ""
         context["selected_tab"] = observation.selectedTab ?? ""
         context["scene_phase"] = observation.scenePhase ?? ""
         context["is_startup_ready"] = observation.isStartupReady.map { isStartupReady in String(isStartupReady) } ?? ""
@@ -682,6 +684,23 @@ extension SentryObservabilityAdapter {
         context["progress_leaderboard_refresh_needed"] = observation.progressLeaderboardRefreshNeeded.map { progressLeaderboardRefreshNeeded in String(progressLeaderboardRefreshNeeded) } ?? ""
         context["progress_streak_leaderboard_refresh_needed"] = observation.progressStreakLeaderboardRefreshNeeded.map { progressStreakLeaderboardRefreshNeeded in String(progressStreakLeaderboardRefreshNeeded) } ?? ""
         context["cloud_sync_blocked"] = observation.cloudSyncBlocked.map { cloudSyncBlocked in String(cloudSyncBlocked) } ?? ""
+        context["cloud_sync_extends_fast_polling"] = observation.cloudSyncExtendsFastPolling.map { extendsFastPolling in String(extendsFastPolling) } ?? ""
+        context["cloud_sync_uses_immediate_start_debounce"] = observation.cloudSyncUsesImmediateStartDebounce.map { usesImmediateStartDebounce in String(usesImmediateStartDebounce) } ?? ""
+        context["cloud_sync_immediate_start_skipped"] = observation.cloudSyncImmediateStartSkipped.map { immediateStartSkipped in String(immediateStartSkipped) } ?? ""
+        context["cloud_sync_skip_reason"] = observation.cloudSyncSkipReason ?? ""
+        context["cloud_sync_had_active_task"] = observation.cloudSyncHadActiveTask.map { hadActiveTask in String(hadActiveTask) } ?? ""
+        context["cloud_sync_pending_resync"] = observation.cloudSyncPendingResync.map { pendingResync in String(pendingResync) } ?? ""
+        context["cloud_sync_wait_outcome"] = observation.cloudSyncWaitOutcome ?? ""
+        context["cloud_sync_acknowledged_operation_count"] = observation.cloudSyncAcknowledgedOperationCount.map { acknowledgedOperationCount in String(acknowledgedOperationCount) } ?? ""
+        context["cloud_sync_applied_pull_change_count"] = observation.cloudSyncAppliedPullChangeCount.map { appliedPullChangeCount in String(appliedPullChangeCount) } ?? ""
+        context["cloud_sync_changed_entity_type_count"] = observation.cloudSyncChangedEntityTypeCount.map { changedEntityTypeCount in String(changedEntityTypeCount) } ?? ""
+        context["cloud_sync_local_id_repair_entity_type_count"] = observation.cloudSyncLocalIdRepairEntityTypeCount.map { localIdRepairEntityTypeCount in String(localIdRepairEntityTypeCount) } ?? ""
+        context["cloud_sync_review_schedule_impacting_pull_change_count"] = observation.cloudSyncReviewScheduleImpactingPullChangeCount.map { reviewScheduleImpactingPullChangeCount in String(reviewScheduleImpactingPullChangeCount) } ?? ""
+        context["cloud_sync_acknowledged_review_event_operation_count"] = observation.cloudSyncAcknowledgedReviewEventOperationCount.map { acknowledgedReviewEventOperationCount in String(acknowledgedReviewEventOperationCount) } ?? ""
+        context["cloud_sync_acknowledged_review_schedule_impacting_operation_count"] = observation.cloudSyncAcknowledgedReviewScheduleImpactingOperationCount.map { acknowledgedReviewScheduleImpactingOperationCount in String(acknowledgedReviewScheduleImpactingOperationCount) } ?? ""
+        context["cloud_sync_cleaned_up_operation_count"] = observation.cloudSyncCleanedUpOperationCount.map { cleanedUpOperationCount in String(cleanedUpOperationCount) } ?? ""
+        context["cloud_sync_cleaned_up_review_schedule_impacting_operation_count"] = observation.cloudSyncCleanedUpReviewScheduleImpactingOperationCount.map { cleanedUpReviewScheduleImpactingOperationCount in String(cleanedUpReviewScheduleImpactingOperationCount) } ?? ""
+        context["cloud_sync_cleaned_up_review_event_operation_count"] = observation.cloudSyncCleanedUpReviewEventOperationCount.map { cleanedUpReviewEventOperationCount in String(cleanedUpReviewEventOperationCount) } ?? ""
         context["error_summary"] = observation.errorSummary ?? ""
         return context
     }


### PR DESCRIPTION
## Summary
- Add foreground cloud sync breadcrumbs for triggers, skips, sync start/success/failure, and aggregate result counts
- Add CloudSessionRuntime breadcrumbs for active sync waits, task lifecycle, and cancellation clears
- Map new cloud sync observation fields into Sentry/local breadcrumb context

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
- xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build (blocked before compilation: local iOS 26.5 platform is not installed)

## Review
- Final worker-owned review: no split recommendation, no P0-P4 issues, green light for commit