### PR TITLE
Render invite friend as settings row

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -336,14 +336,13 @@ struct SettingsView: View {
         Button {
             self.openFriendInviteFlow()
         } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "person.crop.circle.badge.plus")
-                    .accessibilityHidden(true)
-                Text(aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"))
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
+            SettingsNavigationRow(
+                title: aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"),
+                value: nil,
+                systemImage: "person.crop.circle.badge.plus",
+                attentionCount: nil
+            )
         }
-        .buttonStyle(.borderedProminent)
         .accessibilityIdentifier(UITestIdentifier.settingsInviteFriendButton)
         .accessibilityLabel(aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"))
     }


### PR DESCRIPTION
## Summary
- Render the Settings Share section Invite Friend action with the existing SettingsNavigationRow pattern
- Keep the existing invite flow and accessibility hooks
- Remove the prominent centered button styling so both share actions appear as normal rows

## Validation
- git --no-pager diff -- apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
- git --no-pager diff --check -- apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
- Worker-owned review: no P0-P4 issues found

No iOS simulator-backed tests were run because they were not explicitly allowed.