### PR TITLE
Fix iOS export preview placement

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspacePackageExportSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspacePackageExportSection.swift
@@ -42,6 +42,14 @@ struct WorkspacePackageExportSection: View {
         return self.preview
     }
 
+    private var shouldShowInitialPreviewButton: Bool {
+        self.currentPreview == nil && self.cardSelectionTagOptions.isEmpty
+    }
+
+    private var shouldShowStalePreviewSection: Bool {
+        self.currentPreview == nil && self.cardSelectionTagOptions.isEmpty == false
+    }
+
     private var cloudRequirementMessage: String? {
         switch self.store.cloudSettings?.cloudState {
         case .linked, .guest:
@@ -79,8 +87,9 @@ struct WorkspacePackageExportSection: View {
                 self.metadataSection
                 self.tagsSection(preview: currentPreview)
                 self.confirmSection(preview: currentPreview)
-            } else if self.cardSelectionTagOptions.isEmpty == false {
+            } else if self.shouldShowStalePreviewSection {
                 self.cardSelectionSection
+                self.previewSection
             }
         }
         .onChange(of: self.currentWorkspaceId) { _, _ in
@@ -110,21 +119,33 @@ struct WorkspacePackageExportSection: View {
             )
             .foregroundStyle(.secondary)
 
-            Button {
-                Task { @MainActor in
-                    await self.previewPackageExport()
-                }
-            } label: {
-                Label(self.previewButtonTitle, systemImage: "archivebox")
+            if self.shouldShowInitialPreviewButton {
+                self.previewButton
             }
-            .disabled(self.isBusy || self.cloudRequirementMessage != nil)
-            .accessibilityIdentifier(UITestIdentifier.workspacePackageExportPreviewButton)
 
             if let cloudRequirementMessage {
                 Text(cloudRequirementMessage)
                     .foregroundStyle(.secondary)
             }
         }
+    }
+
+    private var previewSection: some View {
+        Section {
+            self.previewButton
+        }
+    }
+
+    private var previewButton: some View {
+        Button {
+            Task { @MainActor in
+                await self.previewPackageExport()
+            }
+        } label: {
+            Label(self.previewButtonTitle, systemImage: "archivebox")
+        }
+        .disabled(self.isBusy || self.cloudRequirementMessage != nil)
+        .accessibilityIdentifier(UITestIdentifier.workspacePackageExportPreviewButton)
     }
 
     private var metadataSection: some View {


### PR DESCRIPTION
## Summary
- keep the initial package export preview action in the intro section
- move the stale-selection preview action below the Cards section after tag selection changes
- reuse the existing preview button identifier with only one visible preview action at a time

## Validation
- git --no-pager diff --check
- xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'generic/platform=iOS' build (failed before compilation: required iOS 26.5 platform support is not installed in this worker environment)

Review gate: worker-owned fresh review subagent reported no split recommendation, no P0-P4 findings, green light for commit.