### PR TITLE
Stabilize iOS export share sheet

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspaceExportView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspaceExportView.swift
@@ -1,12 +1,59 @@
 import SwiftUI
 
 struct WorkspaceExportView: View {
+    @State private var exportShareItem: WorkspacePackageExportShareItem?
+    @State private var exportCleanupFileURL: URL?
+    @State private var exportCleanupErrorMessage: String = ""
+
     var body: some View {
         List {
-            WorkspacePackageExportSection()
+            WorkspacePackageExportSection(
+                exportCleanupErrorMessage: self.exportCleanupErrorMessage,
+                cleanupExportedFile: self.cleanupExportedFile,
+                presentExportedFile: self.presentExportedFile
+            )
         }
         .listStyle(.insetGrouped)
         .navigationTitle(aiSettingsLocalized("settings.workspace.row.export", "Export"))
+        .sheet(
+            item: self.$exportShareItem,
+            onDismiss: {
+                _ = self.cleanupExportedFile()
+            }
+        ) { shareItem in
+            WorkspaceExportActivitySheet(activityItems: [shareItem.fileURL])
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    private func cleanupExportedFile() -> Bool {
+        guard let exportedFileURL = self.exportCleanupFileURL else {
+            self.exportShareItem = nil
+            self.exportCleanupErrorMessage = ""
+            return true
+        }
+        self.exportShareItem = nil
+
+        do {
+            if FileManager.default.fileExists(atPath: exportedFileURL.path) {
+                try FileManager.default.removeItem(at: exportedFileURL)
+            }
+        } catch {
+            self.exportCleanupErrorMessage = Flashcards.errorMessage(error: error)
+            return false
+        }
+
+        self.exportCleanupFileURL = nil
+        self.exportCleanupErrorMessage = ""
+        return true
+    }
+
+    @MainActor
+    private func presentExportedFile(fileURL: URL) {
+        self.exportCleanupErrorMessage = ""
+        self.exportCleanupFileURL = fileURL
+        self.exportShareItem = WorkspacePackageExportShareItem(id: UUID(), fileURL: fileURL)
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspacePackageExportSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspacePackageExportSection.swift
@@ -3,6 +3,10 @@ import SwiftUI
 struct WorkspacePackageExportSection: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
 
+    let exportCleanupErrorMessage: String
+    let cleanupExportedFile: @MainActor () -> Bool
+    let presentExportedFile: @MainActor (URL) -> Void
+
     @State private var preview: WorkspacePackageExportPreviewResponse?
     @State private var previewWorkspaceId: String = ""
     @State private var metadataDraft: WorkspacePackageExportMetadataDraft = WorkspacePackageExportMetadataDraft(
@@ -20,8 +24,6 @@ struct WorkspacePackageExportSection: View {
     @State private var isExporting: Bool = false
     @State private var errorMessage: String = ""
     @State private var successMessage: String = ""
-    @State private var exportShareItem: WorkspacePackageExportShareItem?
-    @State private var exportCleanupFileURL: URL?
 
     private var isBusy: Bool {
         self.isPreviewing || self.isExporting
@@ -50,6 +52,12 @@ struct WorkspacePackageExportSection: View {
         self.currentPreview == nil && self.cardSelectionTagOptions.isEmpty == false
     }
 
+    private var displayedErrorMessage: String {
+        [self.errorMessage, self.exportCleanupErrorMessage]
+            .filter { $0.isEmpty == false }
+            .joined(separator: "\n")
+    }
+
     private var cloudRequirementMessage: String? {
         switch self.store.cloudSettings?.cloudState {
         case .linked, .guest:
@@ -66,9 +74,9 @@ struct WorkspacePackageExportSection: View {
         Group {
             self.packageSection
 
-            if self.errorMessage.isEmpty == false {
+            if self.displayedErrorMessage.isEmpty == false {
                 Section {
-                    Text(self.errorMessage)
+                    Text(self.displayedErrorMessage)
                         .foregroundStyle(.red)
                         .accessibilityIdentifier(UITestIdentifier.workspacePackageExportErrorMessage)
                 }
@@ -94,14 +102,6 @@ struct WorkspacePackageExportSection: View {
         }
         .onChange(of: self.currentWorkspaceId) { _, _ in
             self.resetWorkspaceExportState()
-        }
-        .sheet(
-            item: self.$exportShareItem,
-            onDismiss: {
-                self.cleanupExportedFile()
-            }
-        ) { shareItem in
-            WorkspaceExportActivitySheet(activityItems: [shareItem.fileURL])
         }
     }
 
@@ -464,8 +464,7 @@ struct WorkspacePackageExportSection: View {
                 "flashcards.zip is ready to share."
             )
             self.isExporting = false
-            self.exportCleanupFileURL = exportedFileURL
-            self.exportShareItem = WorkspacePackageExportShareItem(id: UUID(), fileURL: exportedFileURL)
+            self.presentExportedFile(exportedFileURL)
         } catch {
             if isRequestCancellationError(error: error) {
                 self.isExporting = false
@@ -488,33 +487,15 @@ struct WorkspacePackageExportSection: View {
         self.selectedCardTags = []
         self.cardSelectionTagOptions = []
     }
-
-    @MainActor
-    @discardableResult
-    private func cleanupExportedFile() -> Bool {
-        guard let exportedFileURL = self.exportCleanupFileURL else {
-            self.exportShareItem = nil
-            return true
-        }
-        self.exportShareItem = nil
-
-        do {
-            if FileManager.default.fileExists(atPath: exportedFileURL.path) {
-                try FileManager.default.removeItem(at: exportedFileURL)
-            }
-        } catch {
-            self.errorMessage = Flashcards.errorMessage(error: error)
-            return false
-        }
-
-        self.exportCleanupFileURL = nil
-        return true
-    }
 }
 
 #Preview {
     List {
-        WorkspacePackageExportSection()
+        WorkspacePackageExportSection(
+            exportCleanupErrorMessage: "",
+            cleanupExportedFile: { true },
+            presentExportedFile: { _ in }
+        )
     }
     .environment(FlashcardsStore())
 }


### PR DESCRIPTION
## Summary
- move workspace package export share sheet ownership to the stable export view container
- keep the package section focused on export state and call parent-owned share presentation
- surface parent cleanup errors through the existing export error section

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff -- apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspaceExportView.swift apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspacePackageExportSection.swift apps/ios/Flashcards/Flashcards/Settings/Workspace/Export/WorkspaceExportSupport.swift
- git --no-pager diff --cached --check
- Swift syntax sanity check for @MainActor closure inputs
- xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination "generic/platform=iOS Simulator" build (failed before compilation: no matching iOS Simulator destination/platform installed)

Manual simulator QA was not run because it requires explicit approval.

Review gate: worker-owned review found no P0-P4 issues and no split recommendation.