### PR TITLE
Split Android CI and release workflows

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,32 @@
+name: Android CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/android/**'
+      - '!apps/android/README.md'
+      - '!apps/android/docs/**'
+      - 'cloudbuild.android.yaml'
+      - 'scripts/android/run-android-ci.sh'
+      - 'scripts/android/run-android-firebase-test-lab.sh'
+      - 'scripts/android/run-android-release.sh'
+      - 'scripts/android/setup-github-android.sh'
+      - '.github/workflows/android-ci.yml'
+      - '.github/workflows/android-ci-reusable.yml'
+      - '.github/workflows/android-release.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  android_ci:
+    name: Android CI
+    concurrency:
+      group: android-ci-main
+      cancel-in-progress: true
+    uses: ./.github/workflows/android-ci-reusable.yml
+    with:
+      target_ref: ${{ github.sha }}
+      android_version_code: ${{ github.run_number }}
+    secrets: inherit

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,35 +1,12 @@
 name: Android Release
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/android/**'
-      - '!apps/android/README.md'
-      - '!apps/android/docs/**'
-      - 'cloudbuild.android.yaml'
-      - 'scripts/android/run-android-ci.sh'
-      - 'scripts/android/run-android-firebase-test-lab.sh'
-      - 'scripts/android/run-android-release.sh'
-      - 'scripts/android/setup-github-android.sh'
-      - '.github/workflows/android-ci-reusable.yml'
-      - '.github/workflows/android-release.yml'
   workflow_dispatch:
     inputs:
       target_sha:
         description: Git SHA to release
         required: true
         type: string
-      upload_to_play_draft:
-        description: Upload the signed bundle to Google Play as a draft production release after Android CI succeeds
-        required: true
-        default: false
-        type: boolean
-      run_firebase_test_lab:
-        description: Submit Firebase Test Lab app instrumentation after Android CI succeeds
-        required: true
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -41,9 +18,6 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       target_sha: ${{ steps.resolve.outputs.target_sha }}
-      compare_base_sha: ${{ steps.resolve.outputs.compare_base_sha }}
-      android_changed: ${{ steps.resolve.outputs.android_changed }}
-      block_reason: ${{ steps.resolve.outputs.block_reason }}
       android_version_code: ${{ steps.release-metadata.outputs.android_version_code }}
       android_version_name: ${{ steps.release-metadata.outputs.android_version_name }}
       android_target_short_sha: ${{ steps.release-metadata.outputs.android_target_short_sha }}
@@ -53,14 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'push' && github.sha || inputs.target_sha }}
+          ref: ${{ inputs.target_sha }}
           fetch-depth: 0
 
       - name: Resolve release target
         id: resolve
         env:
-          INPUT_TARGET_SHA: ${{ github.event_name == 'push' && github.sha || inputs.target_sha }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          INPUT_TARGET_SHA: ${{ inputs.target_sha }}
         run: |
           set -euo pipefail
 
@@ -72,60 +45,10 @@ jobs:
           fi
 
           target_sha="$(git rev-parse "${target_sha}")"
-          compare_base_sha=""
-          before_sha="${PUSH_BEFORE_SHA:-}"
-
-          if [[ "${GITHUB_EVENT_NAME}" == "push" ]] && [[ -n "${before_sha}" ]] && [[ "${before_sha}" != "0000000000000000000000000000000000000000" ]]; then
-            compare_base_sha="${before_sha}"
-          elif git rev-parse "${target_sha}^" >/dev/null 2>&1; then
-            compare_base_sha="$(git rev-parse "${target_sha}^")"
-          fi
-
-          changed_files_path="${RUNNER_TEMP}/android-release-changed-files.txt"
-          if [[ -n "${compare_base_sha}" ]]; then
-            git diff --name-only "${compare_base_sha}" "${target_sha}" > "${changed_files_path}"
-          else
-            git ls-tree -r --name-only "${target_sha}" > "${changed_files_path}"
-          fi
-
-          android_changed=false
-          while IFS= read -r changed_path; do
-            case "${changed_path}" in
-              apps/android/README.md) ;;
-              apps/android/docs/*) ;;
-              apps/android/*|cloudbuild.android.yaml|scripts/android/run-android-ci.sh|scripts/android/run-android-firebase-test-lab.sh|scripts/android/run-android-release.sh|scripts/android/setup-github-android.sh|.github/workflows/android-ci-reusable.yml|.github/workflows/android-release.yml)
-                android_changed=true
-                break
-                ;;
-            esac
-          done < "${changed_files_path}"
-
-          block_reason=""
-          if [[ "${android_changed}" != "true" ]]; then
-            block_reason="android_not_changed"
-          fi
 
           {
             echo "target_sha=${target_sha}"
-            echo "compare_base_sha=${compare_base_sha}"
-            echo "android_changed=${android_changed}"
-            echo "block_reason=${block_reason}"
           } >> "${GITHUB_OUTPUT}"
-
-      - name: Validate Android release target
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
-          ANDROID_CHANGED: ${{ steps.resolve.outputs.android_changed }}
-          BLOCK_REASON: ${{ steps.resolve.outputs.block_reason }}
-          UPLOAD_TO_PLAY_DRAFT: ${{ inputs.upload_to_play_draft }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${ANDROID_CHANGED}" != "true" ]] && [[ "${EVENT_NAME}" == "push" || "${UPLOAD_TO_PLAY_DRAFT}" == "true" ]]; then
-            echo "Android release requires Android changes for ${TARGET_SHA}. Block reason: ${BLOCK_REASON}." >&2
-            exit 1
-          fi
 
       - name: Resolve Android release metadata
         id: release-metadata
@@ -173,28 +96,18 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Summarize preflight
-        env:
-          PLAY_UPLOAD_REQUESTED: ${{ github.event_name == 'push' || inputs.upload_to_play_draft }}
         run: |
           {
             echo "## Android release preflight"
             echo ""
             echo "- Target SHA: \`${{ steps.resolve.outputs.target_sha }}\`"
-            echo "- Compare base SHA: \`${{ steps.resolve.outputs.compare_base_sha || 'n/a' }}\`"
-            echo "- Android changed: \`${{ steps.resolve.outputs.android_changed }}\`"
-            echo "- Block reason: \`${{ steps.resolve.outputs.block_reason || 'n/a' }}\`"
             echo "- Version code: \`${{ steps.release-metadata.outputs.android_version_code }}\`"
             echo "- Version name: \`${{ steps.release-metadata.outputs.android_version_name }}\`"
             echo "- Release ID: \`${{ steps.release-metadata.outputs.android_release_id }}\`"
             echo "- Play release name: \`${{ steps.release-metadata.outputs.android_play_release_name }}\`"
-            echo "- Event: \`${{ github.event_name }}\`"
-            echo "- Upload draft to Play: \`${PLAY_UPLOAD_REQUESTED}\`"
-            echo "- Run Firebase Test Lab: \`${{ github.event_name == 'workflow_dispatch' && inputs.run_firebase_test_lab }}\`"
-            if [[ "${PLAY_UPLOAD_REQUESTED}" == "true" ]]; then
-              echo "- Play publish mode: \`draft production release uploaded by CI; final publish happens later in Play Console\`"
-            else
-              echo "- Play publish mode: \`not requested; no Play draft upload in this run\`"
-            fi
+            echo "- Upload draft to Play: \`true\`"
+            echo "- Run Firebase Test Lab: \`true\`"
+            echo "- Play publish mode: \`draft production release uploaded by CI; final publish happens later in Play Console\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   android_ci:
@@ -215,7 +128,7 @@ jobs:
     needs:
       - preflight
       - android_ci
-    if: ${{ needs.android_ci.result == 'success' && github.event_name == 'workflow_dispatch' && inputs.run_firebase_test_lab }}
+    if: ${{ needs.android_ci.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     permissions:
@@ -449,12 +362,25 @@ jobs:
             echo "- Device: \`${DEVICE_DESCRIPTOR:-n/a}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: Require Firebase Test Lab submission
+        if: always()
+        env:
+          SUBMISSION_STATE: ${{ steps.collect.outputs.submission_state }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${SUBMISSION_STATE}" != "submitted" ]]; then
+            echo "Firebase Test Lab submission is required for Android Release. Submission state: ${SUBMISSION_STATE:-unknown}." >&2
+            exit 1
+          fi
+
   publish_android:
     name: Upload Android bundle to Google Play production draft release
     needs:
       - preflight
       - android_ci
-    if: ${{ needs.android_ci.result == 'success' && (github.event_name == 'push' || inputs.upload_to_play_draft) }}
+      - firebase_test_lab_submission
+    if: ${{ needs.android_ci.result == 'success' && needs.firebase_test_lab_submission.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     concurrency:
@@ -634,7 +560,7 @@ jobs:
             echo "- GitHub run: \`${{ github.run_id }}\` attempt \`${{ github.run_attempt }}\`"
             echo "- GitHub run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             echo "- Upload state: \`draft\`"
-            echo "- Firebase Test Lab: \`manual-only through run_firebase_test_lab on Android Release workflow_dispatch runs\`"
+            echo "- Firebase Test Lab: \`required submission in this Android Release run\`"
             echo "- Next step: review Play App strings translations in Play Console, then publish the release manually."
           } >> "${GITHUB_STEP_SUMMARY}"
 
@@ -650,31 +576,23 @@ jobs:
 
     steps:
       - name: Summarize Android release outcome
-        env:
-          PLAY_UPLOAD_REQUESTED: ${{ github.event_name == 'push' || inputs.upload_to_play_draft }}
         run: |
           {
             echo "## Android release summary"
             echo ""
             echo "- Target SHA: \`${{ needs.preflight.outputs.target_sha }}\`"
-            echo "- Android changed: \`${{ needs.preflight.outputs.android_changed }}\`"
-            echo "- Block reason: \`${{ needs.preflight.outputs.block_reason || 'n/a' }}\`"
             echo "- Version code: \`${{ needs.preflight.outputs.android_version_code || 'n/a' }}\`"
             echo "- Release ID: \`${{ needs.preflight.outputs.android_release_id || 'n/a' }}\`"
             echo "- Play release name: \`${{ needs.preflight.outputs.android_play_release_name || 'n/a' }}\`"
             echo "- Android CI result: \`${{ needs.android_ci.result }}\`"
-            echo "- Firebase Test Lab requested: \`${{ github.event_name == 'workflow_dispatch' && inputs.run_firebase_test_lab }}\`"
             echo "- Firebase Test Lab submission result: \`${{ needs.firebase_test_lab_submission.result }}\`"
-            echo "- Play draft upload requested: \`${PLAY_UPLOAD_REQUESTED}\`"
+            echo "- Firebase Test Lab requested: \`true\`"
+            echo "- Play draft upload requested: \`true\`"
             echo "- Android Play draft upload result: \`${{ needs.publish_android.result }}\`"
             echo "- Firebase Test Lab submission: \`${{ needs.firebase_test_lab_submission.outputs.submission_state || 'n/a' }}\`"
             echo "- Firebase Test Lab matrix ID: \`${{ needs.firebase_test_lab_submission.outputs.matrix_id || 'n/a' }}\`"
             echo "- Firebase Test Lab results path: \`${{ needs.firebase_test_lab_submission.outputs.results_path || 'n/a' }}\`"
             echo "- Firebase Test Lab device: \`${{ needs.firebase_test_lab_submission.outputs.device_descriptor || 'n/a' }}\`"
-            if [[ "${PLAY_UPLOAD_REQUESTED}" == "true" ]]; then
-              echo "- Play publish mode: \`CI uploads a production-track draft only; Play Console publication remains manual\`"
-            else
-              echo "- Play publish mode: \`not requested; no Play draft upload in this run\`"
-            fi
+            echo "- Play publish mode: \`CI uploads a production-track draft only; Play Console publication remains manual\`"
             echo "- Run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -179,7 +179,7 @@ The Android app uses native Android and Compose testing:
 
 - targeted integration coverage runs through native instrumentation and Compose UI testing in `apps/android/app/src/androidTest` and `apps/android/data/local/src/androidTest`
 - shared FSRS scheduler parity stays in `apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/model/FsrsSchedulerParityTest.kt` and uses `tests/fsrs-full-vectors.json`
-- manual Firebase Test Lab app UI instrumentation runs through the full `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app` instrumentation tree when `run_firebase_test_lab=true`, with `livesmoke/LiveSmokeTest.kt` and `notifications/NotificationTapSmokeTest.kt` kept as the highest-confidence stateful flows there
+- manual Firebase Test Lab app UI instrumentation runs through the full `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app` instrumentation tree as part of the manual `Android Release` workflow, with `livesmoke/LiveSmokeTest.kt` and `notifications/NotificationTapSmokeTest.kt` kept as the highest-confidence stateful flows there
 - the live smoke flow relies on stable Compose test tags from the production UI modules, not on a separate mock shell
 
 The Android live smoke scenario matches the other clients on purpose:
@@ -199,13 +199,13 @@ The repository policy for Android CI/CD is:
 - Firebase Test Lab is the cloud device test runner
 - `cloudbuild.android.yaml` is the Google-native Cloud Build entrypoint
 - Google auth from GitHub must use Workload Identity Federation, not a JSON key
-- the GitHub-hosted Android release gate is unit tests plus build/lint first, then GitHub-hosted `data:local` instrumentation; after that succeeds, CI uploads a Google Play production-track draft
+- automatic Android CI on `main` runs unit tests, debug builds, lint, and GitHub-hosted `data:local` instrumentation without uploading to Google Play or submitting Firebase Test Lab
+- the manual `Android Release` workflow runs the same GitHub-hosted Android gate, submits Firebase Test Lab app instrumentation, then uploads a Google Play production-track draft
 - one shared `ANDROID_VERSION_CODE` is resolved once per release run and reused across Android release artifacts and the Play draft bundle
 - one shared manager-readable release identifier, currently `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`, is reused in the Play release name and Firebase Test Lab result naming so the same release stays traceable across GitHub, Play, and Firebase
-- Firebase Test Lab app instrumentation is manual-only from the top-level `firebase_test_lab_submission` job with `run_firebase_test_lab=true`; it uses the same SHA and release metadata, can run without Play upload, and does not block the Play draft upload path
-- after pushing to `main`, watch `Android Release` when Android-impacting files changed; it runs independently from the AWS/Web release workflow
+- Firebase Test Lab app instrumentation is manual-only from the top-level `firebase_test_lab_submission` job in `Android Release`; submission is required before the Play draft upload starts
+- after pushing to `main`, watch `Android CI` when Android-impacting files changed; it runs independently from the AWS/Web release workflow
 - after the workflow uploads the AAB, review Play App strings translations in Play Console, confirm the Play language set still matches the app's explicit supported-language list, verify the Play-delivered build, and publish the release there manually
-- manual Android workflow runs also go through `Android Release`; Play draft upload and Firebase Test Lab submission are independent opt-ins there
 
 ## Respect Existing Code
 

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -1,13 +1,14 @@
 # Android CI/CD
 
-This repository uses one reusable Android validation workflow plus one dedicated Android release entry workflow:
+This repository uses one reusable Android validation workflow plus separate automatic CI and manual release entry workflows:
 
 - GitHub Actions is the primary Android CI/CD entrypoint on `main`
-- Firebase Test Lab is available as a manual instrumentation runner on Google-managed devices
 - `.github/workflows/android-ci-reusable.yml` contains the actual Android CI implementation
-- `.github/workflows/android-release.yml` is the canonical Android workflow for `push main` and manual runs
-- Android release is fully independent from the AWS/Web release workflow on `main`
-- the Android release workflow uploads a production-track draft release to Google Play; final publication still happens later in Play Console
+- `.github/workflows/android-ci.yml` is the automatic `push main` Android validation workflow
+- `.github/workflows/android-release.yml` is the manual Android release workflow
+- Firebase Test Lab runs only from the manual release workflow on Google-managed devices
+- automatic Android CI and manual Android release are fully independent from the AWS/Web release workflow
+- the manual Android release workflow uploads a production-track draft release to Google Play; final publication still happens later in Play Console
 - `cloudbuild.android.yaml` is the Google-native entrypoint for Cloud Build triggers in the Google Cloud console
 
 This setup keeps repository-native checks in GitHub while still allowing Google-managed device testing and avoiding long-lived Google service account keys.
@@ -16,7 +17,7 @@ For release runs, the workflow resolves one shared `ANDROID_VERSION_CODE` and on
 
 ## Required GitHub repository variables
 
-The manual Firebase Test Lab job depends on these repository variables:
+The manual Android release workflow Firebase Test Lab job depends on these repository variables:
 
 - `GCP_PROJECT_ID`
 - `GCP_WORKLOAD_IDENTITY_PROVIDER`
@@ -59,6 +60,13 @@ This Android-specific sync is separate from the AWS deploy bootstrap script `bas
 
 ## What runs
 
+Automatic GitHub Actions workflow: `.github/workflows/android-ci.yml`
+
+- Starts on `push main` when Android-impacting files change
+- Calls `.github/workflows/android-ci-reusable.yml`
+- Does not upload a Google Play draft
+- Does not submit Firebase Test Lab
+
 GitHub Actions reusable workflow: `.github/workflows/android-ci-reusable.yml`
 
 - Runs `test` for the whole Android Gradle project
@@ -71,37 +79,44 @@ GitHub Actions reusable workflow: `.github/workflows/android-ci-reusable.yml`
 - Boots a headless Android 16 / API 36 emulator in GitHub Actions with `-gpu auto`
 - Runs `:data:local:connectedDebugAndroidTest` on that emulator
 - Uploads `data:local` instrumentation reports from the emulator run when the Gradle task produced them
-- Reuses one shared `ANDROID_VERSION_CODE` across Android CI/build artifacts and the signed Play bundle in the same release run instead of resolving separate version codes per stage
+- Reuses the caller-provided `ANDROID_VERSION_CODE` across Android CI/build artifacts
 - Uses the Sentry release name `com.flashcardsopensourceapp.app@<versionName>+<versionCode>` for Android release artifact correlation; the workflow summary also prints the manager-readable Play release identifier, but runtime Sentry event tags/contexts are controlled by app runtime code
 
 Top-level release workflow Firebase job: `.github/workflows/android-release.yml` job `firebase_test_lab_submission`
 
-- Starts only on manual `workflow_dispatch` runs when `run_firebase_test_lab=true` and `android_ci` succeeds
-- Runs outside the Play draft critical path; when a manual run also sets `upload_to_play_draft=true`, it runs in parallel with `publish_android`
+- Starts on every manual `Android Release` run after `android_ci` succeeds
 - Validates Firebase Test Lab configuration, authenticates to Google Cloud, downloads the debug APK artifacts, and submits the full app instrumentation package `com.flashcardsopensourceapp.app`, excluding `com.flashcardsopensourceapp.app.ManualOnlyAndroidTest`
 - Reuses the shared release identifier `vc<versionCode>-r<runId>a<attempt>-s<shortSha>` in Firebase result naming and traces results under `${ANDROID_FTL_RESULTS_DIR}/<releaseIdentifier>`
-- Surfaces Firebase submission outcomes such as configuration, auth, setup, artifact, or submission failures as summary/output states instead of failing the Android release gate by default
+- Requires Firebase Test Lab submission before the Play draft upload starts; the submission is asynchronous, so review the Firebase matrix result before publishing from Play Console
 
-The Android release flow is:
+The automatic Android CI flow is:
 
-1. `android-release.yml` resolves the target SHA, one shared `ANDROID_VERSION_CODE`, and one shared Android release identifier for the run
+1. `android-ci.yml` starts on `push main` for Android-impacting changes
 2. Android unit tests, debug builds, and lint run in GitHub Actions
 3. `data:local` Android instrumentation runs on a GitHub-hosted Android 16 emulator
-4. After that fast GitHub-hosted gate succeeds, push-triggered runs upload the Google Play production-track draft automatically; manual runs upload a Play draft only with `upload_to_play_draft=true` and submit Firebase Test Lab app instrumentation only with `run_firebase_test_lab=true`
-5. When requested, Firebase Test Lab continues outside the Play draft upload critical path; review its results before publishing from Play Console
+4. The workflow stops there: no Firebase Test Lab submission and no Google Play draft upload
 
-After pushing to `main`, watch `Android Release` separately when Android-impacting files changed.
+The manual Android release flow is:
 
-`Android Release` runs independently on `push main` for Android-impacting changes and on manual `workflow_dispatch` with an explicit target SHA. Push-triggered runs upload a Play draft automatically after the GitHub-hosted Android gate succeeds and do not start Firebase Test Lab. Manual runs execute the same GitHub-hosted gate, upload a Play draft only when `upload_to_play_draft=true`, and submit Firebase Test Lab app instrumentation only when `run_firebase_test_lab=true`. Those manual inputs are independent, so Firebase can run for a specific `target_sha` while `upload_to_play_draft=false`.
+1. `android-release.yml` starts only through manual `workflow_dispatch` with an explicit `target_sha`
+2. The workflow resolves one shared `ANDROID_VERSION_CODE` and one shared Android release identifier for the run
+3. The reusable Android CI gate runs for the target SHA
+4. Firebase Test Lab app instrumentation is submitted for the debug APKs produced by the CI gate
+5. After Firebase submission succeeds, the signed Android App Bundle is uploaded as a Google Play production-track draft
+6. Review the Firebase matrix result and Play Console draft before publishing manually
 
-For Android, a green `Android Release` run always means the GitHub-hosted Android gate passed for that SHA. On `push main` runs and manual runs with `upload_to_play_draft=true`, it also means CI uploaded the Play draft successfully. On manual runs with `upload_to_play_draft=false`, the workflow can still finish green with the Play draft upload intentionally skipped. It does not mean Firebase Test Lab was requested, submitted, finished, or passed. Firebase Test Lab submission or completion is not part of the Play draft upload critical path, and Firebase submission/configuration problems surface through the Firebase summary/output state instead of failing the Android release gate by default. A non-green `Android Release` run means the GitHub-hosted gate failed, or the Play draft upload failed in a run that was supposed to upload it. It also does not mean the release is already live.
+After pushing to `main`, watch `Android CI` separately when Android-impacting files changed.
 
-To match a Play draft or manual Firebase submission to the exact SHA and GitHub run:
+For Android, a green `Android CI` run means the GitHub-hosted Android gate passed for that SHA. It does not mean Firebase Test Lab was submitted, a Google Play draft was uploaded, or a release is ready to publish.
+
+A green manual `Android Release` run means the GitHub-hosted Android gate passed, Firebase Test Lab submission succeeded, and CI uploaded a Play draft. It still does not mean Firebase Test Lab finished or passed, and it does not mean the release is already live. Translation review, Firebase matrix review, Play-delivered build verification, and final publication still happen later in Play Console. A non-green `Android Release` run means one of the required release stages failed or was skipped by a failed dependency.
+
+To match a Play draft or Firebase submission to the exact SHA and GitHub run:
 
 - use the `Android release preflight` summary to get the target SHA, shared `ANDROID_VERSION_CODE`, and shared release identifier `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`
-- when a Play draft was uploaded, use the `Android Play draft upload` summary to get the Play draft release name `main-draft-<releaseIdentifier>` and version code
+- use the `Android Play draft upload` summary to get the Play draft release name `main-draft-<releaseIdentifier>` and version code
 - use the `Run details` link in the release summary to open the exact GitHub Actions run
-- when `run_firebase_test_lab=true`, use the Firebase summaries to get the Google-assigned matrix ID and the Firebase results path `${ANDROID_FTL_RESULTS_DIR}/<releaseIdentifier>` in the configured results bucket
+- use the Firebase summaries to get the Google-assigned matrix ID and the Firebase results path `${ANDROID_FTL_RESULTS_DIR}/<releaseIdentifier>` in the configured results bucket
 - correlate everything by the shared release identifier, GitHub run id and attempt, and target SHA; the Firebase matrix ID is useful for lookup after submission but it is not the manager-readable release identifier
 
 ## Local Firebase Test Lab diagnostics
@@ -323,7 +338,7 @@ Then set:
 
 ## GitHub repository variables
 
-Set the required repository variables listed above before requesting the Firebase Test Lab job in GitHub Actions.
+Set the required repository variables listed above before running the manual `Android Release` workflow.
 
 Set the Google Play release variables and secrets before expecting `.github/workflows/android-release.yml` to upload a draft release successfully.
 

--- a/docs/manual-production-release.md
+++ b/docs/manual-production-release.md
@@ -25,13 +25,15 @@ urgent local upload is required, use the local App Store archive flow in
 ## Android
 
 1. Run the manual `Android Release` GitHub Actions workflow for the latest
-   release SHA, including the Android tests needed for the release decision.
-2. Fix anything that is not green before continuing.
+   release SHA; it runs the Android gate, submits Firebase Test Lab, and uploads
+   the Play draft.
+2. Fix any non-green workflow result and review the Firebase Test Lab matrix
+   result before continuing.
 3. Confirm the production-track draft release is present in Google Play Console.
 4. Publish the new version manually in Google Play Console after the draft is
    reviewed and ready.
 
-The Android CI/CD details, Firebase Test Lab inputs, Play draft upload behavior,
+The Android CI/CD details, Firebase Test Lab submission behavior,
 and Play Console publishing notes are documented in
 [docs/android-ci-cd.md](./android-ci-cd.md).
 

--- a/docs/release-gates.md
+++ b/docs/release-gates.md
@@ -1,12 +1,13 @@
 # Release Gates and Monitoring
 
-Pushes to `main` use three independent release streams:
+Pushes to `main` use independent release and check streams:
 
 - `.github/workflows/aws-web-release.yml` handles AWS/backend/web release work
 - when AWS/backend/web changed, it deploys production, runs the native Playwright smoke in `apps/web/e2e/live-smoke.spec.ts`, runs the external agent API smoke in `scripts/checks/check-agent-api-smoke.sh`, and only finishes healthy when both post-deploy checks pass
 - rollback is automatic only when the failed AWS release did not include new DB migrations
 - migration-bearing AWS failures are explicit fix-forward cases; the next push must still be allowed to run
-- when Android-impacting files changed, `.github/workflows/android-release.yml` runs independently, enforces the fast GitHub-hosted Android gate, and uploads the Google Play production-track draft; Firebase Test Lab is manual-only through `run_firebase_test_lab=true` on `workflow_dispatch` runs
+- when Android-impacting files changed, `.github/workflows/android-ci.yml` runs independently and enforces the fast GitHub-hosted Android gate without uploading to Google Play or submitting Firebase Test Lab
+- Android production draft upload is manual-only through `.github/workflows/android-release.yml`; that workflow also requires Firebase Test Lab submission before the Play draft upload starts
 - when iOS changed, Xcode Cloud runs independently for the same `main` SHA
 
 MCP Registry validation is an automatic check for `server.json` changes, but
@@ -17,9 +18,9 @@ Publish` only when the release should publish a new, previously unpublished
 Human-operated production release actions for iOS, Android, web, and MCP are
 tracked in [docs/manual-production-release.md](./manual-production-release.md).
 
-When a change lands on `main`, monitor `AWS/Web Release` for backend/web outcome when AWS-impacting files changed, including both post-deploy smoke jobs, monitor `Android Release` when Android-impacting files changed, and monitor Xcode Cloud separately when iOS changed.
-For Android, a green `Android Release` run always means the GitHub-hosted Android gate passed for that SHA. On `push main` runs and manual runs with `upload_to_play_draft=true`, it also means CI uploaded a Play draft successfully. On manual runs with `upload_to_play_draft=false`, the workflow can still finish green with the Play draft upload intentionally skipped. It does not mean Firebase Test Lab was requested, submitted, finished, or passed. Firebase Test Lab is requested only on manual runs with `run_firebase_test_lab=true`, and its submission or completion does not block the Play draft upload path. Firebase submission/configuration problems surface in the release summaries as state outputs instead of failing the release gate by default. It also does not mean the release is already live. A non-green `Android Release` run means the GitHub-hosted gate failed, or the Play draft upload failed in a run that was supposed to upload it. Translation review and final publication still happen later in Play Console.
-To trace the exact Android release, open the GitHub Actions run summary for the target SHA, note the shared `ANDROID_VERSION_CODE`, the shared release identifier `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`, and the Play draft release name `main-draft-<releaseIdentifier>` shown there when a Play draft was uploaded. If Firebase Test Lab was requested, inspect the results stored under the configured results path for that same release identifier. Correlate the run by release name, results path, GitHub run id and attempt, and SHA; Firebase matrix IDs are Google-assigned lookup values, not the shared release identifier.
+When a change lands on `main`, monitor `AWS/Web Release` for backend/web outcome when AWS-impacting files changed, including both post-deploy smoke jobs, monitor `Android CI` when Android-impacting files changed, and monitor Xcode Cloud separately when iOS changed.
+For Android, a green `Android CI` run always means the GitHub-hosted Android gate passed for that SHA. It does not mean Firebase Test Lab was submitted, a Google Play draft was uploaded, or a release is already live. Run the manual `Android Release` workflow when the Android SHA is ready for release. A green manual `Android Release` run means the GitHub-hosted Android gate passed, Firebase Test Lab submission succeeded, and CI uploaded a production-track Play draft; Firebase Test Lab is submitted asynchronously, so review its matrix result before publishing from Play Console. A non-green `Android Release` run means one of the required release stages failed or was skipped by a failed dependency. Translation review and final publication still happen later in Play Console.
+To trace the exact Android release, open the GitHub Actions run summary for the manual `Android Release` run, note the shared `ANDROID_VERSION_CODE`, the shared release identifier `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`, the Play draft release name `main-draft-<releaseIdentifier>`, and the Firebase results path for that same release identifier. Correlate the run by release name, results path, GitHub run id and attempt, and SHA; Firebase matrix IDs are Google-assigned lookup values, not the shared release identifier.
 If you need to inspect Xcode Cloud directly instead of relying only on the web UI, use `docs/xcode-cloud-data-access.md`. It documents the local `.env` secrets, App Store Connect API flow, example commands, returned data formats, artifact types, and how to extract timing/debugging insights from cloud test runs.
 
 Cross-client live smoke references:
@@ -30,5 +31,5 @@ Cross-client live smoke references:
 - Web: `apps/web/e2e/live-smoke.spec.ts`
 
 These live smoke flows are the highest-confidence checks in the repository because they exercise the real app closest to production conditions.
-On Android, these live smoke flows run as part of the broader Firebase Test Lab app instrumentation suite only when `run_firebase_test_lab=true` is requested manually.
+On Android, these live smoke flows run as part of the broader Firebase Test Lab app instrumentation suite in the manual `Android Release` workflow.
 When a code change affects a primary user flow, main screen, or cross-client navigation path, check the relevant live smoke or targeted integration tests in the same change and update them when the expected behavior changed. We do not try to guard every internal detail with tests. For small internal or low-risk changes that do not affect the main user journey, updating those tests is optional.


### PR DESCRIPTION
## Summary
- add automatic Android CI workflow for push-to-main validation without Play or Firebase release work
- make Android Release manual-only with mandatory Firebase Test Lab submission before Play draft upload
- update Android release and monitoring docs for the new split

## Validation
- ruby YAML parse for Android workflow files
- git --no-pager diff --check
- review-kirill: no P0-P4 issues found

Gradle was not run locally per repository policy.