### PR TITLE
Allow Android release without explicit SHA

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       target_sha:
-        description: Git SHA to release
-        required: true
+        description: Git SHA to release. Leave empty to release the selected workflow ref.
+        required: false
         type: string
 
 permissions:
@@ -27,21 +27,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.target_sha }}
+          ref: ${{ inputs.target_sha || github.sha }}
           fetch-depth: 0
 
       - name: Resolve release target
         id: resolve
         env:
           INPUT_TARGET_SHA: ${{ inputs.target_sha }}
+          WORKFLOW_TARGET_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
           target_sha="${INPUT_TARGET_SHA}"
 
           if [[ -z "${target_sha}" ]]; then
-            echo "Target SHA is required." >&2
-            exit 1
+            target_sha="${WORKFLOW_TARGET_SHA}"
           fi
 
           target_sha="$(git rev-parse "${target_sha}")"

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -98,7 +98,7 @@ The automatic Android CI flow is:
 
 The manual Android release flow is:
 
-1. `android-release.yml` starts only through manual `workflow_dispatch` with an explicit `target_sha`
+1. `android-release.yml` starts only through manual `workflow_dispatch`; optional `target_sha` pins a specific release commit, otherwise the selected workflow ref SHA is used
 2. The workflow resolves one shared `ANDROID_VERSION_CODE` and one shared Android release identifier for the run
 3. The reusable Android CI gate runs for the target SHA
 4. Firebase Test Lab app instrumentation is submitted for the debug APKs produced by the CI gate

--- a/docs/manual-production-release.md
+++ b/docs/manual-production-release.md
@@ -24,9 +24,10 @@ urgent local upload is required, use the local App Store archive flow in
 
 ## Android
 
-1. Run the manual `Android Release` GitHub Actions workflow for the latest
-   release SHA; it runs the Android gate, submits Firebase Test Lab, and uploads
-   the Play draft.
+1. Run the manual `Android Release` GitHub Actions workflow. Leave `Git SHA to
+   release` empty for the selected workflow ref, or fill it to pin a specific
+   release SHA; the workflow runs the Android gate, submits Firebase Test Lab,
+   and uploads the Play draft.
 2. Fix any non-green workflow result and review the Firebase Test Lab matrix
    result before continuing.
 3. Confirm the production-track draft release is present in Google Play Console.


### PR DESCRIPTION
## Summary
- make Android Release target SHA optional
- resolve empty target SHA to the selected workflow ref SHA
- update Android release docs

## Validation
- ruby YAML parse for android-release.yml
- local empty-target preflight resolution simulation
- git diff --check