### PR TITLE
Stabilize Android settings row visibility tests

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -2,10 +2,12 @@
 
 package com.flashcardsopensourceapp.app.livesmoke.flows
 
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollTo
@@ -15,6 +17,7 @@ import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickNode
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickText
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.tapBackIcon
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTagToExist
+import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilWithMitigation
 import com.flashcardsopensourceapp.app.livesmoke.support.LiveSmokeContext
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.navigation.ReviewDestination
@@ -87,14 +90,11 @@ internal fun LiveSmokeContext.openSettingsRow(rowTag: String, rowLabel: String) 
     openSettingsTab()
     val rowMatcher = hasTestTag(rowTag).and(other = hasClickAction())
 
-    composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
-        .performScrollToNode(matcher = rowMatcher)
-    waitForTagToExist(
-        tag = rowTag,
-        timeoutMillis = internalUiTimeoutMillis,
-        context = "while waiting for settings row '$rowLabel'"
+    scrollSettingsRootTargetIntoView(
+        targetTag = rowTag,
+        targetLabel = rowLabel,
+        targetMatcher = rowMatcher
     )
-    composeRule.onNodeWithTag(testTag = rowTag).performScrollTo()
     clickNode(matcher = rowMatcher, label = rowLabel)
 }
 
@@ -117,12 +117,10 @@ internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
     ).forEach { section ->
         val sectionTag = section.first
         val sectionLabel = section.second
-        composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
-            .performScrollToNode(matcher = hasTestTag(sectionTag))
-        waitForTagToExist(
-            tag = sectionTag,
-            timeoutMillis = internalUiTimeoutMillis,
-            context = "while verifying settings section '$sectionLabel'"
+        scrollSettingsRootTargetIntoView(
+            targetTag = sectionTag,
+            targetLabel = sectionLabel,
+            targetMatcher = hasTestTag(sectionTag)
         )
     }
 
@@ -151,12 +149,10 @@ internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
     ).forEach { row ->
         val rowTag = row.first
         val rowLabel = row.second
-        composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
-            .performScrollToNode(matcher = hasTestTag(rowTag).and(other = hasClickAction()))
-        waitForTagToExist(
-            tag = rowTag,
-            timeoutMillis = internalUiTimeoutMillis,
-            context = "while verifying settings row '$rowLabel'"
+        scrollSettingsRootTargetIntoView(
+            targetTag = rowTag,
+            targetLabel = rowLabel,
+            targetMatcher = hasTestTag(rowTag).and(other = hasClickAction())
         )
     }
 }
@@ -244,3 +240,34 @@ private data class SettingsDetailProbe(
     val rowLabel: String,
     val destinationTag: String
 )
+
+private fun LiveSmokeContext.scrollSettingsRootTargetIntoView(
+    targetTag: String,
+    targetLabel: String,
+    targetMatcher: SemanticsMatcher
+) {
+    composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
+        .performScrollToNode(matcher = targetMatcher)
+    waitForTagToExist(
+        tag = targetTag,
+        timeoutMillis = internalUiTimeoutMillis,
+        context = "while waiting for settings root target '$targetLabel'"
+    )
+    composeRule.onNodeWithTag(testTag = targetTag).performScrollTo()
+    waitForSettingsRootTargetToBeDisplayed(
+        targetTag = targetTag,
+        targetLabel = targetLabel
+    )
+}
+
+private fun LiveSmokeContext.waitForSettingsRootTargetToBeDisplayed(
+    targetTag: String,
+    targetLabel: String
+) {
+    waitUntilWithMitigation(
+        timeoutMillis = internalUiTimeoutMillis,
+        context = "while waiting for settings root target '$targetLabel' to be displayed"
+    ) {
+        composeRule.onNodeWithTag(testTag = targetTag).isDisplayed()
+    }
+}

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -426,6 +427,8 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         waitForSettingsRootTag(targetTag = secondRowTag)
         composeRule.onNodeWithTag(testTag = firstRowTag).performScrollTo()
         composeRule.onNodeWithTag(testTag = secondRowTag).performScrollTo()
+        waitForSettingsRootTagToBeDisplayed(targetTag = firstRowTag)
+        waitForSettingsRootTagToBeDisplayed(targetTag = secondRowTag)
         composeRule.onNodeWithTag(testTag = firstRowTag).assertIsDisplayed()
         composeRule.onNodeWithTag(testTag = secondRowTag).assertIsDisplayed()
         val firstTop = composeRule.onNodeWithTag(testTag = firstRowTag).fetchSemanticsNode().boundsInRoot.top
@@ -448,6 +451,7 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
     private fun scrollSettingsRootTargetIntoView(targetTag: String) {
         scrollSettingsRootToTag(targetTag = targetTag)
         composeRule.onNodeWithTag(testTag = targetTag).performScrollTo()
+        waitForSettingsRootTagToBeDisplayed(targetTag = targetTag)
     }
 
     private fun scrollSettingsRootToTag(targetTag: String) {
@@ -459,6 +463,12 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
     private fun waitForSettingsRootTag(targetTag: String) {
         composeRule.waitUntil(timeoutMillis = settingsRouteUiTimeoutMillis) {
             composeRule.onAllNodesWithTag(testTag = targetTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun waitForSettingsRootTagToBeDisplayed(targetTag: String) {
+        composeRule.waitUntil(timeoutMillis = settingsRouteUiTimeoutMillis) {
+            composeRule.onNodeWithTag(testTag = targetTag).isDisplayed()
         }
     }
 


### PR DESCRIPTION
## Summary
- wait for Settings root LazyColumn targets to become displayed after scroll actions
- apply the same visible-target wait to live-smoke Settings traversal

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff --check
- git --no-pager diff --cached --check
- local Compose API inspection for isDisplayed()
- worker-owned review: no split recommendation, no P0-P4 findings

Gradle was not run because repository policy requires explicit approval for local Gradle runs.