### PR TITLE
Fix auth input zoom on iOS Safari

### DIFF
--- a/apps/auth/src/templates/authorize.ts
+++ b/apps/auth/src/templates/authorize.ts
@@ -151,7 +151,7 @@ export const renderAuthorizePage = (
       background: var(--surface-muted);
       color: var(--text);
       font-family: inherit;
-      font-size: 14px;
+      font-size: 16px;
       transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease;
     }
 

--- a/apps/auth/src/templates/login.ts
+++ b/apps/auth/src/templates/login.ts
@@ -355,7 +355,7 @@ export const renderLoginPage = (redirectUri: string, websiteHomeUrl: string, loc
       background: var(--surface-muted);
       color: var(--text);
       font-family: inherit;
-      font-size: 14px;
+      font-size: 16px;
       transition:
         border-color 140ms ease,
         background 140ms ease,


### PR DESCRIPTION
## Summary
- Increase auth login and authorize input font size to 16px to avoid iOS Safari focus zoom
- Keep viewport scaling and surrounding labels/buttons/hints unchanged

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- npm ci (apps/auth; passed with Node v25.6.1 vs package 24.x engine warning)
- npm run build (apps/auth)
- static CSS check for 16px login inputs and no mobile override
- worker-owned read-only review: no P0-P4 findings