### PR TITLE
Fix iOS Safari web input zoom

### DIFF
--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -317,7 +317,7 @@
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.04);
   color: var(--text);
-  font-size: 14px;
+  font-size: 16px;
 }
 
 .account-menu-create-input:focus {

--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -340,7 +340,7 @@
   position: fixed;
   z-index: 200;
   padding: 10px 12px;
-  font-size: 15px;
+  font-size: 16px;
   font-family: inherit;
   line-height: 1.5;
   white-space: nowrap;
@@ -375,6 +375,10 @@
   font-size: 14px;
   font-family: inherit;
   overflow: hidden;
+}
+
+.cell-select-overlay .tag-input-field {
+  font-size: 16px;
 }
 
 .cell-select-search {


### PR DESCRIPTION
## Summary
- set account-menu workspace create input to 16px
- set cards inline editor overlay to 16px
- set only the tags input inside the cell select overlay to 16px

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- npm ci in apps/web (passed with Node v25.6.1 vs package 24.x engine warning)
- npm run build in apps/web
- git --no-pager diff --check
- focused text-entry control scan
- worker-owned read-only review: no P0-P4 findings