### PR TITLE
Flatten web form and invite surfaces

### DIFF
--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -59,10 +59,10 @@
   width: min(420px, calc(100vw - 32px));
   max-height: min(520px, calc(100dvh - 32px));
   padding: var(--cards-filter-popover-padding);
-  border: 1px solid var(--panel-border-strong);
+  border: 0;
   border-radius: var(--cards-filter-popover-radius);
-  background: rgba(20, 20, 24, 0.98);
-  box-shadow: var(--shadow);
+  background: var(--surface);
+  box-shadow: none;
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -95,17 +95,16 @@
   width: 100%;
   min-height: 42px;
   padding: 0 14px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--panel-inner-radius, var(--radius-md));
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface);
   color: var(--text);
   font: inherit;
 }
 
 .cards-search-input:focus {
-  outline: none;
-  border-color: rgba(196, 75, 45, 0.35);
-  box-shadow: 0 0 0 3px rgba(196, 75, 45, 0.12);
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
 }
 
 .cards-scroll {
@@ -235,10 +234,10 @@
   justify-content: center;
   min-height: 30px;
   padding: 0 10px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-pill);
   color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-hover);
   opacity: 0;
   pointer-events: none;
   font-size: 13px;
@@ -344,12 +343,13 @@
   font-family: inherit;
   line-height: 1.5;
   white-space: nowrap;
-  background: rgba(20, 20, 24, 0.98);
+  background: var(--surface);
   color: var(--text);
-  border: 1px solid var(--panel-border-strong);
+  border: 0;
   border-radius: var(--radius-sm);
-  outline: none;
-  box-shadow: var(--shadow);
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+  box-shadow: none;
   box-sizing: border-box;
 }
 
@@ -367,10 +367,10 @@
   max-height: 320px;
   display: flex;
   flex-direction: column;
-  background: rgba(20, 20, 24, 0.98);
-  border: 1px solid var(--panel-border);
+  background: var(--surface);
+  border: 0;
   border-radius: var(--cell-select-overlay-radius);
-  box-shadow: var(--shadow);
+  box-shadow: none;
   box-sizing: border-box;
   font-size: 14px;
   font-family: inherit;
@@ -387,6 +387,11 @@
   padding: 0 12px;
   outline: none;
   box-sizing: border-box;
+}
+
+.cell-select-search:focus {
+  outline: 2px solid var(--text);
+  outline-offset: -2px;
 }
 
 .cell-select-options {

--- a/apps/web/src/styles/features/forms.css
+++ b/apps/web/src/styles/features/forms.css
@@ -13,10 +13,10 @@
 
 .card-meta-panel {
   padding: 18px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--panel-inner-radius, var(--radius-md));
-  background: var(--surface-elevated);
-  box-shadow: var(--shadow-soft);
+  background: var(--surface);
+  box-shadow: none;
 }
 
 .form-label {
@@ -37,7 +37,8 @@
   display: grid;
   gap: 10px;
   margin: 0;
-  border: 1px solid var(--panel-border);
+  padding: 0;
+  border: 0;
 }
 
 .deck-form-label {
@@ -61,11 +62,16 @@
   align-items: center;
   min-height: 36px;
   padding: 0 12px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface);
   cursor: pointer;
   color: var(--text-secondary);
+}
+
+.deck-checkbox-option:focus-within {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
 }
 
 .deck-checkbox-option input {

--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -11,6 +11,9 @@
   width: min(100%, 560px);
   display: grid;
   gap: 16px;
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
 }
 
 .invite-panel > .title,
@@ -29,9 +32,9 @@
   width: 100%;
   min-height: 46px;
   padding: 10px 12px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-hover);
   color: var(--text);
   font-size: 16px;
 }
@@ -41,8 +44,8 @@
 }
 
 .invite-field .text-input:focus {
-  border-color: rgba(196, 75, 45, 0.5);
-  box-shadow: 0 0 0 4px rgba(196, 75, 45, 0.14);
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
 }
 
 .invite-link-grid {
@@ -54,9 +57,9 @@
 .invite-platform-link {
   min-height: 92px;
   padding: 14px 16px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-hover);
   color: var(--text);
   display: flex;
   flex-direction: column;
@@ -66,17 +69,20 @@
   text-decoration: none;
   transition:
     transform 140ms ease,
-    border-color 140ms ease,
     background 140ms ease,
     color 140ms ease,
     opacity 140ms ease;
 }
 
 .invite-platform-link:hover {
-  border-color: var(--panel-border-strong);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-pressed);
   color: var(--text);
   transform: translateY(-1px);
+}
+
+.invite-platform-link:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 3px;
 }
 
 .invite-platform-icon {
@@ -115,9 +121,9 @@
   display: grid;
   gap: 12px;
   padding: 14px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-hover);
 }
 
 .invite-mcp-label,
@@ -177,9 +183,9 @@
   align-items: center;
   min-width: 0;
   padding: 10px 12px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-sm);
-  background: rgba(0, 0, 0, 0.16);
+  background: var(--surface-pressed);
   color: var(--text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 13px;

--- a/apps/web/src/styles/features/tags.css
+++ b/apps/web/src/styles/features/tags.css
@@ -11,15 +11,15 @@
   align-items: center;
   min-height: 46px;
   padding: 8px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface);
   cursor: text;
 }
 
 .tag-input-surface:focus-within {
-  border-color: rgba(196, 75, 45, 0.5);
-  box-shadow: 0 0 0 4px rgba(196, 75, 45, 0.14);
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
 }
 
 .tag-input-field {
@@ -85,9 +85,9 @@
 
 .tag-suggestions {
   overflow: hidden;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-md);
-  background: rgba(20, 20, 24, 0.98);
+  background: var(--surface);
 }
 
 .tag-suggestions-head {
@@ -216,12 +216,11 @@
 }
 
 .tags-summary-card-button:hover {
-  border-color: rgba(196, 75, 45, 0.34);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
 }
 
 .tags-summary-card-button:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--text);
   outline-offset: 3px;
 }
 


### PR DESCRIPTION
## Summary
- Flatten web form metadata and deck form controls
- Flatten cards search/filter/editor surfaces and tag suggestion surfaces
- Flatten invite/share platform and MCP surfaces with simple focus outlines

## Validation
- npm --prefix apps/web ci (Node engine warning only)
- npm --prefix apps/web run build
- npm --prefix apps/web run test -- 'src/screens/share/*.test.tsx' 'src/screens/invite/**/*.test.tsx' (79 files / 614 tests)
- requested CSS scan returned no matches
- git --no-pager diff --check