### PR TITLE
Flatten web chat surfaces

### DIFF
--- a/apps/web/src/styles/features/chat/composer.css
+++ b/apps/web/src/styles/features/chat/composer.css
@@ -15,10 +15,9 @@
 }
 
 .chat-composer-notice {
-  border: 1px solid rgba(196, 75, 45, 0.32);
   border-radius: var(--chat-sidebar-inner-radius, var(--radius-md));
   padding: 10px 12px;
-  background: rgba(196, 75, 45, 0.08);
+  background: var(--surface);
   color: var(--text-secondary);
   font-size: 14px;
   line-height: 1.4;
@@ -47,7 +46,7 @@
 .chat-loading-chip-accent {
   margin-inline-start: auto;
   width: 84px;
-  background: linear-gradient(90deg, rgba(196, 75, 45, 0.5), rgba(196, 75, 45, 0.7), rgba(196, 75, 45, 0.5));
+  background: var(--surface-hover);
 }
 
 .chat-error-dialog-backdrop {
@@ -67,6 +66,9 @@
   flex-direction: column;
   gap: 14px;
   padding: 20px;
+  border: none;
+  background: var(--surface);
+  box-shadow: none;
 }
 
 .chat-error-dialog h2,
@@ -87,9 +89,9 @@
   resize: none;
   font-size: 16px;
   padding: 11px 13px;
-  border: 1px solid var(--panel-border);
+  border: 1px solid transparent;
   border-radius: var(--chat-sidebar-inner-radius, var(--radius-md));
-  background: rgba(0, 0, 0, 0.28);
+  background: var(--surface);
   color: var(--text);
   min-height: 84px;
   max-height: 320px;
@@ -100,8 +102,10 @@
 }
 
 .chat-textarea:focus {
-  border-color: rgba(196, 75, 45, 0.5);
-  box-shadow: 0 0 0 4px rgba(196, 75, 45, 0.14);
+  border-color: transparent;
+  box-shadow: none;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .chat-send-btn,
@@ -118,7 +122,7 @@
 .chat-attach-btn {
   font-size: 14px;
   padding: 0 14px;
-  border: 1px solid var(--panel-border);
+  border: 1px solid transparent;
   color: var(--text-secondary);
   cursor: pointer;
 }
@@ -158,8 +162,8 @@
 }
 
 .chat-send-btn:disabled {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: var(--panel-border);
+  background: var(--surface);
+  border-color: transparent;
   color: var(--text-tertiary);
   cursor: default;
 }
@@ -173,7 +177,7 @@
   flex: 0 0 40px;
   padding: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface);
   color: var(--text);
 }
 
@@ -186,12 +190,12 @@
   flex: 0 0 40px;
   padding: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface);
 }
 
 .chat-mic-btn:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-hover);
 }
 
 .chat-mic-btn:disabled {
@@ -235,16 +239,13 @@
   gap: 12px;
   min-height: 84px;
   padding: 14px 16px;
-  border: 1px solid rgba(196, 75, 45, 0.32);
   border-radius: var(--chat-sidebar-inner-radius, var(--radius-md));
-  background:
-    radial-gradient(circle at top, rgba(196, 75, 45, 0.16), transparent 48%),
-    rgba(0, 0, 0, 0.28);
+  background: var(--surface);
 }
 
 .chat-attach-btn:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-hover);
 }
 
 .chat-attach-btn:disabled {
@@ -261,12 +262,12 @@
   flex: 0 0 40px;
   padding: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface);
 }
 
 .chat-stop-btn:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-hover);
 }
 
 .chat-stop-btn-icon {
@@ -343,17 +344,17 @@
 .chat-composer-suggestion {
   min-height: 36px;
   padding: 0 12px;
-  border: 1px solid rgba(196, 75, 45, 0.22);
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  background: rgba(196, 75, 45, 0.08);
+  background: var(--surface);
   color: var(--text);
   font-size: 13px;
   cursor: pointer;
 }
 
 .chat-composer-suggestion:hover {
-  background: rgba(196, 75, 45, 0.14);
-  border-color: rgba(196, 75, 45, 0.34);
+  background: var(--surface-hover);
+  border-color: transparent;
 }
 
 .chat-attachment-chip {
@@ -362,14 +363,13 @@
   gap: 8px;
   min-height: 30px;
   padding: 0 10px;
-  border: 1px solid var(--panel-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface);
 }
 
 .chat-attachment-chip-card {
-  border-color: rgba(196, 75, 45, 0.32);
-  background: rgba(196, 75, 45, 0.16);
+  background: var(--surface-hover);
 }
 
 .chat-attachment-remove {
@@ -393,7 +393,6 @@
   align-items: center;
   justify-content: center;
   background: rgba(6, 6, 8, 0.86);
-  border: 2px dashed rgba(196, 75, 45, 0.4);
   color: #ffffff;
   font-size: 15px;
   font-weight: 600;

--- a/apps/web/src/styles/features/chat/messages.css
+++ b/apps/web/src/styles/features/chat/messages.css
@@ -15,14 +15,14 @@
 .chat-msg-user {
   align-self: flex-end;
   background: rgba(95, 25, 11, 0.54);
-  border-color: rgba(196, 75, 45, 0.18);
+  border-color: transparent;
   color: #fff2ee;
 }
 
 .chat-msg-assistant {
   align-self: flex-start;
   background: var(--surface-elevated);
-  border-color: var(--panel-border);
+  border-color: transparent;
 }
 
 .chat-streaming-indicator {
@@ -55,9 +55,8 @@
   display: block;
   margin: 10px 0 6px;
   overflow: hidden;
-  border: 1px solid var(--panel-border);
   border-radius: var(--chat-msg-inner-radius, var(--radius-sm));
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-hover);
 }
 
 .chat-card-part-summary {
@@ -110,7 +109,7 @@
   margin: 0;
   padding: 12px;
   border-radius: var(--chat-card-part-inner-radius, var(--radius-sm));
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-pressed);
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.5;
@@ -118,9 +117,8 @@
 }
 
 .chat-card-part-context {
-  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: var(--chat-card-part-inner-radius, var(--radius-sm));
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--surface-pressed);
   overflow: hidden;
 }
 

--- a/apps/web/src/styles/features/chat/shell.css
+++ b/apps/web/src/styles/features/chat/shell.css
@@ -126,9 +126,9 @@
 .chat-close-btn {
   min-height: 36px;
   padding: 0 14px;
-  border: 1px solid var(--panel-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface);
   font-size: 14px;
   cursor: pointer;
   color: var(--text-secondary);
@@ -137,7 +137,7 @@
 
 .chat-close-btn:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-hover);
 }
 
 .chat-messages {
@@ -163,9 +163,8 @@
 
 .chat-empty {
   padding: 12px;
-  border: 1px solid var(--panel-border);
   border-radius: var(--chat-sidebar-inner-radius, var(--radius-md));
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface);
   color: var(--text-secondary);
   font-size: 14px;
 }
@@ -195,7 +194,7 @@
 .chat-loading-chip {
   display: block;
   border-radius: var(--radius-pill);
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.05));
+  background: var(--surface-hover);
 }
 
 .chat-loading-line {
@@ -224,16 +223,16 @@
   z-index: 60;
   min-height: 52px;
   padding: 0 22px;
-  border: 1px solid var(--panel-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  background: rgba(24, 24, 28, 0.84);
-  backdrop-filter: var(--blur);
+  background: var(--surface);
   color: var(--text-secondary);
   cursor: pointer;
-  box-shadow: var(--shadow-soft);
+  box-shadow: none;
 }
 
 .chat-toggle-floating:hover {
   color: var(--text);
-  border-color: var(--panel-border-strong);
+  border-color: transparent;
+  background: var(--surface-hover);
 }

--- a/apps/web/src/styles/features/chat/tool-calls.css
+++ b/apps/web/src/styles/features/chat/tool-calls.css
@@ -1,10 +1,9 @@
 .chat-tool-call {
   display: block;
   overflow: hidden;
-  border: 1px solid var(--panel-border);
   border-radius: var(--chat-msg-inner-radius, var(--radius-sm));
   margin: 10px 0 6px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-hover);
   font-size: 12px;
   scroll-margin-block-end: 24px;
 }
@@ -53,14 +52,6 @@
 
 .chat-tool-call-summary::-webkit-details-marker {
   display: none;
-}
-
-.chat-tool-call-started {
-  border-style: dashed;
-}
-
-.chat-tool-call-completed {
-  border-style: solid;
 }
 
 .chat-tool-call-section {


### PR DESCRIPTION
## Summary
- flatten web chat composer, shell, message, and tool-call surfaces
- remove decorative gradients, shadows, borders, and orange glow from chat UI CSS
- keep embedded chat artifacts distinct with flat surface tokens

## Validation
- npm --prefix apps/web run build
- rg -n "linear-gradient|radial-gradient" apps/web/src/styles/features/chat apps/web/src/chat
- git --no-pager diff --check
- local mocked Playwright layout smoke for /chat and /review chat launcher/sidebar desktop/mobile

Review gate: no P0-P4 findings and no split recommendation.