### PR TITLE
Flatten web state and dialog surfaces

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -191,7 +191,7 @@ function RouteContentFallback(props: Readonly<{ messageKey: TranslationKey }>): 
 
   return (
     <main className="container">
-      <section className="panel">
+      <section className="panel panel-center state-panel">
         <p className="subtitle">{t(messageKey)}</p>
       </section>
     </main>

--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -349,12 +349,12 @@
 
 .global-error {
   padding: 13px 16px;
-  border: 1px solid rgba(255, 77, 87, 0.26);
+  border: 0;
   border-radius: var(--radius-md);
   color: #ffd6d9;
   background: rgba(112, 20, 28, 0.46);
   font-size: 14px;
-  box-shadow: var(--shadow-soft);
+  box-shadow: none;
 }
 
 .container {

--- a/apps/web/src/styles/features/feedback.css
+++ b/apps/web/src/styles/features/feedback.css
@@ -12,6 +12,9 @@
 .feedback-dialog {
   width: min(620px, 100%);
   max-height: calc(100vh - 48px);
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
   overflow: auto;
   display: grid;
   gap: 18px;

--- a/apps/web/src/styles/features/review/review-dialogs.css
+++ b/apps/web/src/styles/features/review/review-dialogs.css
@@ -12,6 +12,9 @@
 .review-editor-modal {
   width: min(1120px, 100%);
   max-height: calc(100vh - 48px);
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
   overflow: auto;
 }
 
@@ -29,6 +32,9 @@
 .review-hard-reminder-modal {
   width: min(620px, 100%);
   max-height: calc(100vh - 48px);
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
   overflow: auto;
   display: grid;
   gap: 20px;
@@ -58,6 +64,9 @@
   --panel-padding: 28px;
   width: min(780px, 100%);
   max-height: calc(100vh - 48px);
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
   overflow: auto;
   display: grid;
   gap: 22px;

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -315,6 +315,9 @@
   max-height: calc(100vh - 40px);
   display: grid;
   gap: 18px;
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
   overflow-y: auto;
 }
 

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -126,6 +126,24 @@
   box-shadow: none;
 }
 
+.panel.state-panel,
+.panel.workspace-modal,
+.panel.app-error-dialog {
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
+}
+
+.panel.state-panel {
+  gap: 18px;
+}
+
+.chat-main-content > .container > .panel.state-panel {
+  min-height: 0;
+  border-radius: var(--panel-radius);
+  background: var(--surface);
+}
+
 .panel-center {
   max-width: 520px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- Flatten web state panels and deferred route fallback surfaces
- Remove inherited panel borders and shadows from targeted review, settings, app error, and feedback dialogs
- Keep normal route panels and dialog semantics unchanged

## Validation
- npm --prefix apps/web run build
- npm exec -- vitest run src/screens/review src/screens/settings src/feedback
- git --no-pager diff --check
- plan rg audit reported only expected base panel/control matches