### PR TITLE
Stabilize Android Firebase Test Lab settings smoke

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt
@@ -124,6 +124,7 @@ class NotificationTapSmokeTest : FirebaseAppInstrumentationTimeoutTest() {
                 }
             }
         } finally {
+            liveSmokeContext.collapseNotificationShadeIfOpen()
             liveSmokeContext.clearAppNotifications(context = appContext)
         }
     }
@@ -188,6 +189,7 @@ class NotificationTapSmokeTest : FirebaseAppInstrumentationTimeoutTest() {
                 liveSmokeContext.waitForReviewReminderBadgeToDisappear()
             }
         } finally {
+            liveSmokeContext.collapseNotificationShadeIfOpen()
             liveSmokeContext.clearReviewReminderAttentionForNotificationSmoke()
             liveSmokeContext.clearAppNotifications(context = appContext)
         }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
@@ -118,6 +118,7 @@ internal fun LiveSmokeContext.activeAppNotificationIds(context: Context): Set<In
 }
 
 internal fun LiveSmokeContext.openNotificationShadeAndTap(frontText: String) {
+    val packageName = composeRule.activity.packageName
     val didOpenNotificationShade = device.openNotification()
     if (didOpenNotificationShade.not()) {
         throw AssertionError("Failed to open the Android notification shade.")
@@ -140,6 +141,14 @@ internal fun LiveSmokeContext.openNotificationShadeAndTap(frontText: String) {
     val contentIntent = statusBarNotification.notification.contentIntent
         ?: throw AssertionError("Review reminder notification '$frontText' did not provide a contentIntent.")
     contentIntent.send()
+    collapseNotificationShadeIfOpen()
+    waitForAppToReachForeground(packageName = packageName)
+}
+
+internal fun LiveSmokeContext.collapseNotificationShadeIfOpen() {
+    runInstrumentationShellCommand(command = "cmd statusbar collapse")
+    device.waitForIdle()
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
 }
 
 internal fun LiveSmokeContext.waitForAppToReachForeground(packageName: String) {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
@@ -424,13 +424,9 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         secondRowTag: String
     ) {
         scrollSettingsRootToTag(targetTag = firstRowTag)
+        waitForSettingsRootTag(targetTag = firstRowTag)
         waitForSettingsRootTag(targetTag = secondRowTag)
-        composeRule.onNodeWithTag(testTag = firstRowTag).performScrollTo()
-        composeRule.onNodeWithTag(testTag = secondRowTag).performScrollTo()
-        waitForSettingsRootTagToBeDisplayed(targetTag = firstRowTag)
-        waitForSettingsRootTagToBeDisplayed(targetTag = secondRowTag)
         composeRule.onNodeWithTag(testTag = firstRowTag).assertIsDisplayed()
-        composeRule.onNodeWithTag(testTag = secondRowTag).assertIsDisplayed()
         val firstTop = composeRule.onNodeWithTag(testTag = firstRowTag).fetchSemanticsNode().boundsInRoot.top
         val secondTop = composeRule.onNodeWithTag(testTag = secondRowTag).fetchSemanticsNode().boundsInRoot.top
         assertTrue("$firstRowTag should appear before $secondRowTag", firstTop < secondTop)


### PR DESCRIPTION
## Summary
- collapse the Android notification shade after notification smoke taps and during cleanup
- make the settings IA order assertion avoid requiring two LazyColumn rows to be simultaneously displayed

## Evidence
- Firebase Test Lab matrix `matrix-10m77zyqqj8au` showed the notification shade covering the app during `SettingsRootRouteTest.rootRowsMatchSharedInformationArchitectureWithoutTestMode`
- Earlier matrices `matrix-fz4s0exwrucqa` and `matrix-1np1asepmn3vj` failed the same test on `settings_row_language` visibility

## Validation
- `git diff --check`
- Local Gradle was not run because repository policy requires explicit approval for local `./gradlew`; the manual Android Release workflow will run the cloud Android gate and Firebase Test Lab after merge.