### PR TITLE
Flatten web progress surfaces

### DIFF
--- a/apps/web/src/styles/features/progress/leaderboard.css
+++ b/apps/web/src/styles/features/progress/leaderboard.css
@@ -36,9 +36,8 @@
 .progress-leaderboard-info {
   margin: 0;
   padding: 10px 12px;
-  border: 1px solid var(--panel-border);
   border-radius: var(--content-card-inner-radius, var(--radius-md));
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-hover);
   color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.4;
@@ -52,15 +51,15 @@
 
 .progress-leaderboard-period-btn {
   padding: 6px 12px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-hover);
   color: var(--text-secondary);
   font-size: 13px;
   line-height: 1;
   font-weight: 600;
   cursor: pointer;
-  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+  transition: background-color 120ms ease, color 120ms ease;
 }
 
 .progress-leaderboard-period-btn:focus-visible {
@@ -69,7 +68,6 @@
 }
 
 .progress-leaderboard-period-btn.is-selected {
-  border-color: var(--accent);
   background: var(--accent);
   color: #fff5f2;
 }
@@ -93,7 +91,6 @@
   min-height: 40px;
   padding: 8px 10px;
   border-radius: var(--content-card-inner-radius, var(--radius-sm));
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .progress-leaderboard-row-actionable {
@@ -131,7 +128,6 @@
 }
 
 .progress-leaderboard-row-viewer {
-  border-bottom-color: transparent;
   background: var(--accent-soft);
 }
 
@@ -342,9 +338,8 @@
   gap: 6px;
   min-width: 0;
   padding: 12px;
-  border: 1px solid var(--panel-border);
   border-radius: var(--content-card-inner-radius, var(--radius-md));
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-hover);
 }
 
 .progress-leaderboard-profile-metric-label,
@@ -385,9 +380,8 @@
   height: 76px;
   margin: 0;
   padding: 10px;
-  border: 1px solid var(--panel-border);
   border-radius: var(--content-card-inner-radius, var(--radius-md));
-  background: rgba(255, 255, 255, 0.035);
+  background: var(--surface-hover);
   list-style: none;
 }
 
@@ -417,8 +411,8 @@
   gap: 6px;
   min-width: 0;
   padding: 12px;
-  border: 1px solid var(--panel-border);
   border-radius: var(--content-card-inner-radius, var(--radius-md));
+  background: var(--surface-hover);
 }
 
 .progress-leaderboard-profile-stat dd {

--- a/apps/web/src/styles/features/progress/review-schedule.css
+++ b/apps/web/src/styles/features/progress/review-schedule.css
@@ -14,15 +14,11 @@
 
 svg.progress-review-schedule-donut {
   overflow: visible;
-  filter: drop-shadow(0 18px 36px rgba(0, 0, 0, 0.18));
 }
 
 .progress-review-schedule-donut-empty {
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    inset 0 0 0 1px var(--panel-border);
+  background: var(--surface-hover);
 }
 
 .progress-donut-segment {
@@ -50,7 +46,6 @@ svg.progress-review-schedule-donut {
 }
 
 .progress-review-schedule-row {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--content-card-inner-radius, 8px);
   transition: background-color 120ms ease, opacity 120ms ease;
 }
@@ -65,7 +60,6 @@ svg.progress-review-schedule-donut {
 
 .progress-review-schedule-row.is-selected {
   background: var(--accent-soft);
-  border-bottom-color: transparent;
 }
 
 .progress-review-schedule-row-button {
@@ -96,7 +90,6 @@ svg.progress-review-schedule-donut {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.08);
 }
 
 .progress-review-schedule-label {

--- a/apps/web/src/styles/features/progress/reviews-chart.css
+++ b/apps/web/src/styles/features/progress/reviews-chart.css
@@ -110,13 +110,11 @@
 }
 
 .progress-chart-column-today .progress-chart-bar-shell {
-  border-color: var(--accent-muted);
   background: var(--accent-soft);
 }
 
 .progress-chart-column.is-selected .progress-chart-bar-shell {
-  border-color: var(--accent);
-  background: var(--accent-soft);
+  background: rgba(196, 75, 45, 0.32);
 }
 
 .progress-chart-column.is-dimmed .progress-chart-labels {
@@ -129,7 +127,6 @@
   justify-content: center;
   height: 100%;
   padding: 8px 3px 0;
-  border: 1px solid transparent;
   border-radius: 12px;
 }
 
@@ -146,7 +143,6 @@
 .progress-chart-bar-active {
   min-height: 8px;
   background: rgba(255, 255, 255, 0.1);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
 .progress-chart-bar-segment {
@@ -195,6 +191,13 @@
   font-weight: 700;
 }
 
+.progress-chart-column.is-selected .progress-chart-day,
+.progress-chart-column.is-selected .progress-chart-month,
+.progress-chart-column.is-selected .progress-chart-weekday {
+  color: #fff5f2;
+  font-weight: 800;
+}
+
 .progress-chart-rating-list {
   display: grid;
   gap: 8px;
@@ -204,7 +207,6 @@
 }
 
 .progress-chart-rating-row {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--content-card-inner-radius, 8px);
   transition: background-color 120ms ease, opacity 120ms ease;
 }
@@ -215,7 +217,6 @@
 
 .progress-chart-rating-row.is-selected {
   background: var(--accent-soft);
-  border-bottom-color: transparent;
 }
 
 .progress-chart-rating-row.is-dimmed {
@@ -250,7 +251,6 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.08);
 }
 
 .progress-chart-rating-label {

--- a/apps/web/src/styles/features/progress/streak.css
+++ b/apps/web/src/styles/features/progress/streak.css
@@ -12,7 +12,7 @@
   gap: 6px;
   min-height: 34px;
   padding: 0 10px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--radius-pill);
   background: var(--surface-hover);
   color: var(--text-secondary);
@@ -39,7 +39,7 @@ button.progress-streak-chip:focus-visible {
 }
 
 .progress-streak-value-chip {
-  border-color: rgba(196, 75, 45, 0.55);
+  background: var(--accent-soft);
   color: var(--text);
 }
 
@@ -48,7 +48,7 @@ button.progress-streak-chip:focus-visible {
 }
 
 .progress-streak-value-chip:not(.is-active) {
-  border-color: rgba(235, 235, 245, 0.24);
+  background: var(--surface-hover);
   color: var(--text-secondary);
 }
 
@@ -57,12 +57,12 @@ button.progress-streak-chip:focus-visible {
 }
 
 .progress-streak-freeze-chip {
-  border-color: rgba(157, 216, 255, 0.78);
+  background: rgba(157, 216, 255, 0.16);
   color: var(--text);
 }
 
 .progress-streak-freeze-chip .streak-freeze-icon {
-  color: #2a7fc2;
+  color: #9dd8ff;
 }
 
 .progress-streak-freeze-info-icon {
@@ -124,7 +124,7 @@ button.progress-streak-chip:focus-visible {
   justify-content: center;
   width: 38px;
   height: 38px;
-  border: 1px solid rgba(235, 235, 245, 0.22);
+  border: 0;
   border-radius: 50%;
   background: rgba(235, 235, 245, 0.08);
   color: var(--text);
@@ -136,28 +136,22 @@ button.progress-streak-chip:focus-visible {
 }
 
 .progress-streak-day-complete .progress-streak-marker {
-  border-color: var(--accent);
   background: var(--accent);
   color: #fff5f2;
-  box-shadow: none;
 }
 
 .progress-streak-day-today .progress-streak-marker {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff5f2;
   font-weight: 700;
 }
 
 .progress-streak-day-frozen .progress-streak-marker {
-  border-color: #9dd8ff;
-  background: #ffffff;
-  color: #2a7fc2;
-  box-shadow: none;
+  background: rgba(157, 216, 255, 0.22);
+  color: #9dd8ff;
 }
 
 .progress-streak-day-future .progress-streak-marker {
-  border-color: rgba(235, 235, 245, 0.14);
   background: transparent;
   color: var(--text-tertiary);
 }


### PR DESCRIPTION
## Summary
- flatten remaining progress page info blocks, rows, schedule cells, chart controls, and streak markers
- keep selected/current/frozen states visible with flat color treatments
- preserve progress component/data behavior

## Validation
- npm --prefix apps/web run build
- npm exec vitest run src/screens/progress/*.render.test.tsx (from apps/web)
- rg -n "linear-gradient|radial-gradient|box-shadow|border: 1px" apps/web/src/styles/features/progress
- git --no-pager diff --check