### PR TITLE
Fix mixed-scope progress series invariant

### DIFF
--- a/apps/backend/src/progress/reports/index.ts
+++ b/apps/backend/src/progress/reports/index.ts
@@ -590,6 +590,14 @@ function validateProgressSeriesDayInvariant(
       );
     }
 
+    // Progress is temporarily mixed-scope: daily review bars still reflect the
+    // current legacy review-event scope, while streak days are user-wide. A
+    // user-wide reviewed streak day can therefore have zero reviews in the
+    // daily series until Progress filtering is rebuilt around one shared scope.
+    if (dailyReview.reviewCount === 0 && streakState === "reviewed") {
+      continue;
+    }
+
     if ((dailyReview.reviewCount > 0) !== (streakState === "reviewed")) {
       throw new Error(
         [

--- a/apps/backend/src/progress/reports/progressSeries.test.ts
+++ b/apps/backend/src/progress/reports/progressSeries.test.ts
@@ -470,6 +470,38 @@ test("loadUserProgressSeriesInExecutor rejects daily and streak day invariant mi
   );
 });
 
+test("loadUserProgressSeriesInExecutor allows user-wide streak days outside the legacy daily review scope", async () => {
+  const { executor } = createProgressExecutor({
+    workspaceIdsByUser: {
+      "user-1": ["workspace-1"],
+    },
+    reviewRowsByRequest: {},
+    activeReviewDateRowsByUser: {
+      "user-1": [
+        { review_date: "2026-06-20" },
+      ],
+    },
+    reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 0,
+    },
+  });
+
+  const progress = await loadUserProgressSeriesInExecutor(executor, {
+    userId: "user-1",
+    timeZone: "America/Los_Angeles",
+    from: "2026-06-20",
+    to: "2026-06-20",
+  });
+
+  assert.deepEqual(progress.dailyReviews, [
+    { date: "2026-06-20", reviewCount: 0, againCount: 0, hardCount: 0, goodCount: 0, easyCount: 0 },
+  ]);
+  assert.deepEqual(progress.streakDays, [
+    { date: "2026-06-20", state: "reviewed" },
+  ]);
+});
+
 test("loadUserProgressSeriesInExecutor applies user scope for memberships and workspace scope for each review query", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {


### PR DESCRIPTION
## Summary
- allow temporary mixed Progress semantics where user-wide streak days can be reviewed while legacy daily review bars are zero
- keep positive daily-review mismatches failing
- add regression coverage for the production backend 500 case

## Validation
- node --test --import tsx src/progress/reports/progressSeries.test.ts
- npm run lint --prefix apps/backend