### PR TITLE
Make web sync restore warnings volume-aware

### DIFF
--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -30,10 +30,28 @@ const apiMocks = vi.hoisted(() => ({
   pushSyncOperationsMock: vi.fn(),
 }));
 
+const localCardMocks = vi.hoisted(() => ({
+  loadActiveCardCountMock: vi.fn<(workspaceId: string) => Promise<number>>(),
+}));
+
 vi.mock("../../../observability/webObservability", () => ({
   addWebBreadcrumb: observabilityMocks.addWebBreadcrumbMock,
   captureWebWarning: observabilityMocks.captureWebWarningMock,
 }));
+
+vi.mock("../../../localDb/cards/cards", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../localDb/cards/cards")>();
+  return {
+    ...actual,
+    loadActiveCardCount: (workspaceId: string): Promise<number> => {
+      if (localCardMocks.loadActiveCardCountMock.getMockImplementation() !== undefined) {
+        return localCardMocks.loadActiveCardCountMock(workspaceId);
+      }
+
+      return actual.loadActiveCardCount(workspaceId);
+    },
+  };
+});
 
 vi.mock("../../../api", () => ({
   bootstrapPullSyncState: apiMocks.bootstrapPullSyncStateMock,
@@ -91,14 +109,14 @@ function createBootstrapPullResult(input: Readonly<{
   };
 }
 
-function createDeckBootstrapEntry(workspaceId: string): SyncBootstrapEntry {
+function createDeckBootstrapEntryWithId(workspaceId: string, deckId: string): SyncBootstrapEntry {
   const timestamp = "2026-05-01T00:00:00.000Z";
   return {
     entityType: "deck",
-    entityId: "deck-1",
+    entityId: deckId,
     action: "upsert",
     payload: {
-      deckId: "deck-1",
+      deckId,
       workspaceId,
       name: "Deck",
       filterDefinition: {
@@ -113,6 +131,25 @@ function createDeckBootstrapEntry(workspaceId: string): SyncBootstrapEntry {
       deletedAt: null,
     },
   };
+}
+
+function createDeckBootstrapEntry(workspaceId: string): SyncBootstrapEntry {
+  return createDeckBootstrapEntryWithId(workspaceId, "deck-1");
+}
+
+function createDeckBootstrapEntries(
+  workspaceId: string,
+  count: number,
+  idPrefix: string,
+): ReadonlyArray<SyncBootstrapEntry> {
+  if (Number.isInteger(count) === false || count < 0) {
+    throw new Error(`Invalid deck bootstrap entry count: ${count}`);
+  }
+
+  return Array.from(
+    { length: count },
+    (_value, index) => createDeckBootstrapEntryWithId(workspaceId, `${idPrefix}-${index}`),
+  );
 }
 
 type TestClock = Readonly<{
@@ -272,6 +309,12 @@ function findCapturedWarning(action: string): unknown {
     .find((event) => event.action === action) ?? null;
 }
 
+function findAddedBreadcrumb(action: string): unknown {
+  return observabilityMocks.addWebBreadcrumbMock.mock.calls
+    .map((call) => call[0] as Readonly<{ action: string }>)
+    .find((event) => event.action === action) ?? null;
+}
+
 describe("sync lifecycle observation", () => {
   beforeEach(async () => {
     await clearWebSyncCache();
@@ -289,6 +332,7 @@ describe("sync lifecycle observation", () => {
     apiMocks.pullReviewHistorySyncMock.mockReset();
     apiMocks.pullSyncChangesMock.mockReset();
     apiMocks.pushSyncOperationsMock.mockReset();
+    localCardMocks.loadActiveCardCountMock.mockReset();
     primeEmptyRemoteSync();
   });
 
@@ -638,6 +682,171 @@ describe("sync lifecycle observation", () => {
     });
 
     expect(findCapturedWarning("sync_restore_slow")).toBeNull();
+    expect(findAddedBreadcrumb("sync_hot_bootstrap_tolerated_slow")).toBeNull();
+  });
+
+  it("breadcrumbs normal multi-page volume restores without warning", async () => {
+    const clock = installMutableDateNow(0);
+    installPersistentStorageMockWithClock(clock, 0, 7, 0);
+    localCardMocks.loadActiveCardCountMock
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(2001);
+    apiMocks.bootstrapPullSyncStateMock
+      .mockImplementationOnce(async () => {
+        clock.advance(1200);
+        return createBootstrapPullResult({
+          entries: createDeckBootstrapEntries("workspace-1", 1000, "normal-page-1"),
+          bootstrapHotChangeId: 12,
+          nextCursor: "cursor-2",
+          hasMore: true,
+          remoteIsEmpty: false,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        clock.advance(1400);
+        return createBootstrapPullResult({
+          entries: createDeckBootstrapEntries("workspace-1", 1000, "normal-page-2"),
+          bootstrapHotChangeId: 13,
+          nextCursor: "cursor-3",
+          hasMore: true,
+          remoteIsEmpty: false,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        clock.advance(1000);
+        return createBootstrapPullResult({
+          entries: createDeckBootstrapEntries("workspace-1", 64, "normal-page-3"),
+          bootstrapHotChangeId: 14,
+          nextCursor: null,
+          hasMore: false,
+          remoteIsEmpty: false,
+        });
+      });
+
+    await runWorkspaceRemoteSync({
+      ...createRemoteSyncInput(),
+      refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {
+        clock.advance(605);
+      },
+    });
+
+    expect(findCapturedWarning("sync_restore_slow")).toBeNull();
+    expect(findAddedBreadcrumb("sync_hot_bootstrap_tolerated_slow")).toEqual(expect.objectContaining({
+      action: "sync_hot_bootstrap_tolerated_slow",
+      details: expect.objectContaining({
+        durationMs: 4205,
+        pageSize: 1000,
+        pageCount: 3,
+        entriesCount: 2064,
+        localCardCountAfter: 2001,
+        bootstrapPullDurationMs: 3600,
+        applyHotPagesDurationMs: 0,
+        finalRefreshDurationMs: 605,
+        persistentStorageDurationMs: 7,
+        bootstrapPageDurationMs: [1200, 1400, 1000],
+      }),
+    }));
+  });
+
+  it("warns for a small anomalous restore when the local cache already has many cards", async () => {
+    const clock = installMutableDateNow(0);
+    installPersistentStorageMockWithClock(clock, 0, 7, 0);
+    localCardMocks.loadActiveCardCountMock
+      .mockResolvedValueOnce(5000)
+      .mockResolvedValueOnce(5000);
+    apiMocks.bootstrapPullSyncStateMock.mockImplementation(async () => {
+      clock.advance(9200);
+      return createBootstrapPullResult({
+        entries: [createDeckBootstrapEntryWithId("workspace-1", "small-remote-deck")],
+        bootstrapHotChangeId: 12,
+        nextCursor: null,
+        hasMore: false,
+        remoteIsEmpty: false,
+      });
+    });
+
+    await runWorkspaceRemoteSync({
+      ...createRemoteSyncInput(),
+      refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {},
+    });
+
+    expect(findCapturedWarning("sync_restore_slow")).toEqual(expect.objectContaining({
+      action: "sync_restore_slow",
+      details: expect.objectContaining({
+        durationMs: 9200,
+        pageSize: 1000,
+        pageCount: 1,
+        entriesCount: 1,
+        localCardCountBefore: 5000,
+        localCardCountAfter: 5000,
+        bootstrapPullDurationMs: 9200,
+        applyHotPagesDurationMs: 0,
+        finalRefreshDurationMs: 0,
+        persistentStorageDurationMs: 7,
+        bootstrapPageDurationMs: [9200],
+      }),
+    }));
+    expect(findAddedBreadcrumb("sync_hot_bootstrap_tolerated_slow")).toBeNull();
+  });
+
+  it("warns for anomalous multi-page volume restores above the calculated budget", async () => {
+    const clock = installMutableDateNow(0);
+    installPersistentStorageMockWithClock(clock, 0, 7, 0);
+    apiMocks.bootstrapPullSyncStateMock
+      .mockImplementationOnce(async () => {
+        clock.advance(3000);
+        return createBootstrapPullResult({
+          entries: createDeckBootstrapEntries("workspace-1", 1000, "anomalous-page-1"),
+          bootstrapHotChangeId: 12,
+          nextCursor: "cursor-2",
+          hasMore: true,
+          remoteIsEmpty: false,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        clock.advance(3000);
+        return createBootstrapPullResult({
+          entries: createDeckBootstrapEntries("workspace-1", 1000, "anomalous-page-2"),
+          bootstrapHotChangeId: 13,
+          nextCursor: "cursor-3",
+          hasMore: true,
+          remoteIsEmpty: false,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        clock.advance(3000);
+        return createBootstrapPullResult({
+          entries: createDeckBootstrapEntries("workspace-1", 64, "anomalous-page-3"),
+          bootstrapHotChangeId: 14,
+          nextCursor: null,
+          hasMore: false,
+          remoteIsEmpty: false,
+        });
+      });
+
+    await runWorkspaceRemoteSync({
+      ...createRemoteSyncInput(),
+      refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {
+        clock.advance(600);
+      },
+    });
+
+    expect(findCapturedWarning("sync_restore_slow")).toEqual(expect.objectContaining({
+      action: "sync_restore_slow",
+      details: expect.objectContaining({
+        durationMs: 9600,
+        pageSize: 1000,
+        pageCount: 3,
+        entriesCount: 2064,
+        localCardCountAfter: 0,
+        bootstrapPullDurationMs: 9000,
+        applyHotPagesDurationMs: 0,
+        finalRefreshDurationMs: 600,
+        persistentStorageDurationMs: 7,
+        bootstrapPageDurationMs: [3000, 3000, 3000],
+      }),
+    }));
+    expect(findAddedBreadcrumb("sync_hot_bootstrap_tolerated_slow")).toBeNull();
   });
 
   it("keeps warning for a slow non-empty remote bootstrap", async () => {

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
@@ -164,11 +164,11 @@ export function observeSlowHotBootstrap(input: HotBootstrapSlowObservationInput)
   });
 }
 
-// Tolerated-slow single-page bootstrap: slow enough to be worth recording (>= the
-// breadcrumb floor) but below the warning threshold. Mirrors observeSlowHotBootstrap
+// Tolerated-slow bootstrap: slow enough to be worth recording (>= the breadcrumb
+// floor) but below the volume-aware warning threshold. Mirrors observeSlowHotBootstrap
 // but emits a silent breadcrumb (no Sentry issue) so we keep "what was slow before this
-// failure" context without raising noise. The warning path stays mutually exclusive (see
-// bootstrapHotState).
+// failure" context without raising noise. The warning path stays mutually exclusive
+// (see bootstrapHotState).
 export function observeToleratedSlowHotBootstrap(input: HotBootstrapSlowObservationInput): void {
   addWebBreadcrumb({
     action: "sync_hot_bootstrap_tolerated_slow",

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -27,8 +27,11 @@ import {
   type SyncRestoreHistoryEntry,
 } from "../restore/syncRestoreHistory";
 import {
+  slowHotBootstrapBaseWarningBudgetMs,
   slowHotBootstrapBreadcrumbThresholdMs,
-  slowHotBootstrapWarningThresholdMs,
+  slowHotBootstrapMinimumWarningThresholdMs,
+  slowHotBootstrapPerEntryWarningBudgetMs,
+  slowHotBootstrapPerPageWarningBudgetMs,
   syncBootstrapPageSize,
 } from "./constants";
 import {
@@ -61,38 +64,45 @@ function isEmptyRemoteBootstrapNoise(
   return remoteIsEmpty === true && localCardCountAfter === 0 && entriesCount <= 1;
 }
 
-function shouldObserveHotBootstrap(input: Readonly<{
+type HotBootstrapObservationGateInput = Readonly<{
   durationMs: number;
   pageCount: number;
   entriesCount: number;
   localCardCountAfter: number;
   remoteIsEmpty: boolean | null;
-}>): boolean {
-  if (isEmptyRemoteBootstrapNoise(input.remoteIsEmpty, input.entriesCount, input.localCardCountAfter)) {
-    return false;
-  }
+}>;
 
-  return input.durationMs >= slowHotBootstrapWarningThresholdMs || input.pageCount > 1;
+function calculateSlowHotBootstrapWarningThresholdMs(input: Readonly<{
+  pageCount: number;
+  entriesCount: number;
+}>): number {
+  const warningBudgetMs = Math.ceil(
+    slowHotBootstrapBaseWarningBudgetMs
+    + input.pageCount * slowHotBootstrapPerPageWarningBudgetMs
+    + input.entriesCount * slowHotBootstrapPerEntryWarningBudgetMs,
+  );
+  return Math.max(slowHotBootstrapMinimumWarningThresholdMs, warningBudgetMs);
 }
 
-// Tolerated-slow band: a single-page, non-empty bootstrap that is slow enough to record
-// (>= the breadcrumb floor) but below the warning threshold. The warning gate
-// (shouldObserveHotBootstrap) takes precedence, so this stays mutually exclusive with it:
-// the >=8000ms or multi-page case warns, this band only breadcrumbs.
-function shouldBreadcrumbSlowHotBootstrap(input: Readonly<{
-  durationMs: number;
-  pageCount: number;
-  entriesCount: number;
-  localCardCountAfter: number;
-  remoteIsEmpty: boolean | null;
-}>): boolean {
+function shouldObserveHotBootstrap(input: HotBootstrapObservationGateInput): boolean {
   if (isEmptyRemoteBootstrapNoise(input.remoteIsEmpty, input.entriesCount, input.localCardCountAfter)) {
     return false;
   }
 
-  return input.pageCount === 1
-    && input.durationMs >= slowHotBootstrapBreadcrumbThresholdMs
-    && input.durationMs < slowHotBootstrapWarningThresholdMs;
+  return input.durationMs >= calculateSlowHotBootstrapWarningThresholdMs(input);
+}
+
+// Tolerated-slow band: a non-empty bootstrap that is slow enough to record
+// (>= the breadcrumb floor) but below the volume-aware warning threshold. The warning
+// gate takes precedence, so the two paths stay mutually exclusive.
+function shouldBreadcrumbSlowHotBootstrap(input: HotBootstrapObservationGateInput): boolean {
+  if (isEmptyRemoteBootstrapNoise(input.remoteIsEmpty, input.entriesCount, input.localCardCountAfter)) {
+    return false;
+  }
+
+  const warningThresholdMs = calculateSlowHotBootstrapWarningThresholdMs(input);
+  return input.durationMs >= slowHotBootstrapBreadcrumbThresholdMs
+    && input.durationMs < warningThresholdMs;
 }
 
 function determineLocalBootstrapState(
@@ -367,9 +377,9 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         remoteIsEmpty,
         ...readBootstrapTimingDetails(),
       };
-      // Warning wins: the >=8000ms or multi-page case raises a Sentry issue; the
-      // tolerated-slow single-page band only adds a silent breadcrumb. The two predicates
-      // never overlap, so at most one fires.
+      // Warning wins: durations above the volume-aware budget raise a Sentry issue;
+      // tolerated-slow restores only add a silent breadcrumb. The two predicates never
+      // overlap, so at most one fires.
       if (shouldObserveHotBootstrap(slowBootstrapObservation)) {
         observeSlowHotBootstrap(slowHotBootstrapDetails);
       } else if (shouldBreadcrumbSlowHotBootstrap(slowBootstrapObservation)) {

--- a/apps/web/src/appData/sync/remote/constants.ts
+++ b/apps/web/src/appData/sync/remote/constants.ts
@@ -1,6 +1,11 @@
 export const syncIncrementalPageSize = 500;
 export const syncBootstrapPageSize = 1000;
-// Normal cold-start fresh single-page bootstraps run ~6.5s (server/network latency), which is expected; multi-page bootstraps still warn via pageCount > 1.
-export const slowHotBootstrapWarningThresholdMs = 8000;
-// Floor for the tolerated-slow breadcrumb: single-page bootstraps in the 2–8s band emit a silent breadcrumb (no Sentry issue) for debugging context, staying below the 8000ms warning threshold.
+// Multi-page hot-state restores are normal when users have thousands of cards.
+// Warnings should represent abnormal duration after accounting for restored volume.
+export const slowHotBootstrapMinimumWarningThresholdMs = 8000;
+export const slowHotBootstrapBaseWarningBudgetMs = 2000;
+export const slowHotBootstrapPerPageWarningBudgetMs = 1500;
+export const slowHotBootstrapPerEntryWarningBudgetMs = 1.5;
+// Floor for the tolerated-slow breadcrumb: non-empty hot-state restores above this
+// duration emit silent context when they stay below the volume-aware warning threshold.
 export const slowHotBootstrapBreadcrumbThresholdMs = 2000;

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -518,11 +518,10 @@ export type SyncRestoreWarningDetails = SyncBootstrapTimingDetails & Readonly<{
   remoteIsEmpty: boolean | null;
 }>;
 
-// Single-page bootstraps slow enough to be interesting (>= the breadcrumb floor)
-// but below the warning threshold are a tolerated, expected condition (server/network
-// latency), so they are emitted as a silent breadcrumb for debugging context — never a
-// warning. The >= warning-threshold or multi-page case stays a warning (see
-// SyncRestoreWarningDetails); the two are mutually exclusive.
+// Bootstraps slow enough to be interesting (>= the breadcrumb floor) but below
+// the volume-aware warning threshold are a tolerated, expected condition, so they
+// are emitted as a silent breadcrumb for debugging context. Warning and tolerated
+// breadcrumb observations are mutually exclusive.
 export type SyncRestoreToleratedSlowBreadcrumbDetails = SyncBootstrapTimingDetails & Readonly<{
   eventName: "sync_hot_bootstrap_tolerated_slow";
   syncRunId: string;


### PR DESCRIPTION
## Summary
- Replace fixed/multi-page hot restore warning gate with volume-aware budget
- Keep tolerated slow restores as breadcrumbs below the warning threshold
- Add regression coverage for normal multi-page volume restores and large local-cache/small remote restore behavior

## Validation
- npm exec vitest run src/appData/sync/observation/syncLifecycleObservation.test.ts (passed, 15 tests)
- npm run build (passed; existing Vite chunk-size warning)
- git diff --check (passed)
- Final fresh review: no split recommendation; no P0-P4 findings
