### PR TITLE
Document direct media transfer contract

### DIFF
--- a/api/src/components/schemas/CompleteMediaAssetUploadSessionInput.yaml
+++ b/api/src/components/schemas/CompleteMediaAssetUploadSessionInput.yaml
@@ -1,4 +1,8 @@
 type: object
+description: >-
+  Completes a direct S3 multipart upload after every part has been uploaded to
+  its presigned PUT URL. The backend finalizes S3 and records the logical media
+  asset; it does not receive the media bytes.
 additionalProperties: false
 required:
   - parts
@@ -24,7 +28,7 @@ properties:
           type: string
           minLength: 1
           maxLength: 256
-          description: ETag returned after uploading this part.
+          description: ETag returned by S3 after uploading this part to its presigned PUT URL.
         sha256:
           type: string
           pattern: ^[0-9a-fA-F]{64}$

--- a/api/src/components/schemas/MediaAssetDownloadUrlResponse.yaml
+++ b/api/src/components/schemas/MediaAssetDownloadUrlResponse.yaml
@@ -8,6 +8,9 @@ properties:
     $ref: ./MediaAsset.yaml
   download:
     type: object
+    description: >-
+      Direct S3 download transfer descriptor. Fetch bytes from url with method;
+      the backend does not proxy media bytes for this response.
     additionalProperties: false
     required:
       - method
@@ -22,10 +25,15 @@ properties:
       url:
         type: string
         format: uri
+        description: >-
+          Presigned private S3 GET URL for the stored media object. Clients may
+          send standard HTTP Range headers to this URL while it is valid.
       expiresAt:
         type: string
         format: date-time
       rangeRequests:
         type: boolean
         const: true
-        description: Clients may send HTTP Range requests to this signed URL while it is valid.
+        description: >-
+          Always true for workspace media downloads; clients may send
+          Range: bytes=start-end to the signed S3 URL for partial reads.

--- a/api/src/components/schemas/MediaAssetUploadPartUrlsInput.yaml
+++ b/api/src/components/schemas/MediaAssetUploadPartUrlsInput.yaml
@@ -1,4 +1,7 @@
 type: object
+description: >-
+  Request presigned URLs for direct S3 multipart upload parts. This request
+  describes part numbers and checksums only; it never carries media bytes.
 additionalProperties: false
 required:
   - parts

--- a/api/src/components/schemas/MediaAssetUploadPartUrlsResponse.yaml
+++ b/api/src/components/schemas/MediaAssetUploadPartUrlsResponse.yaml
@@ -1,4 +1,7 @@
 type: object
+description: >-
+  Presigned direct S3 multipart upload URLs. Upload bytes with the returned PUT
+  URLs and headers; do not send part bytes to the backend.
 additionalProperties: false
 required:
   - sessionId
@@ -8,6 +11,7 @@ properties:
     $ref: ./UuidString.yaml
   partUrls:
     type: array
+    description: Each item authorizes one direct S3 UploadPart request.
     minItems: 1
     items:
       type: object
@@ -30,11 +34,13 @@ properties:
         url:
           type: string
           format: uri
+          description: Presigned S3 UploadPart URL for this part only.
         expiresAt:
           type: string
           format: date-time
         headers:
           type: object
+          description: Headers that must be included exactly on the direct S3 PUT request.
           additionalProperties:
             type: string
           example:

--- a/api/src/components/schemas/MediaAssetUploadSessionAbortResponse.yaml
+++ b/api/src/components/schemas/MediaAssetUploadSessionAbortResponse.yaml
@@ -1,4 +1,7 @@
 type: object
+description: >-
+  Confirms that a backend-controlled direct S3 multipart upload session was
+  aborted. Any unused presigned part URLs for this session should be discarded.
 additionalProperties: false
 required:
   - sessionId

--- a/api/src/components/schemas/MediaAssetUploadSessionCreateResponse.yaml
+++ b/api/src/components/schemas/MediaAssetUploadSessionCreateResponse.yaml
@@ -1,4 +1,8 @@
 type: object
+description: >-
+  Result of preparing direct S3 media upload. When status is upload_required,
+  the uploadSession only identifies the backend-controlled multipart upload;
+  clients must request presigned part URLs and send bytes directly to S3.
 additionalProperties: false
 required:
   - workspaceId
@@ -21,6 +25,9 @@ properties:
       - $ref: ./MediaAsset.yaml
       - type: 'null'
   uploadSession:
+    description: >-
+      Direct multipart upload session metadata. Null means the media bytes were
+      already available and no upload is needed.
     oneOf:
       - type: object
         additionalProperties: false
@@ -39,8 +46,10 @@ properties:
             type: integer
             format: int64
             minimum: 1
+            description: Size in bytes clients should use for each direct S3 part except the final part.
           partCount:
             type: integer
             minimum: 1
             maximum: 10000
+            description: Number of direct S3 parts clients must upload before completing the session.
       - type: 'null'

--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -46,8 +46,10 @@ tags:
       server-side and are not part of this public contract.
   - name: media-assets
     description: >-
-      Workspace-scoped media asset registry metadata and direct private object
-      transfer URLs.
+      Workspace-scoped media asset registry metadata and direct private S3
+      transfer URLs. Multipart upload bytes go to presigned PUT part URLs, and
+      download bytes come from presigned GET URLs that accept client Range
+      headers while valid.
   - name: workspace-packages
     description: >-
       Workspace-scoped package export, import preview, import confirmation, and

--- a/api/src/paths/_.yaml
+++ b/api/src/paths/_.yaml
@@ -115,14 +115,15 @@ get:
               writes, a clear user request already counts as permission. Ask
               again only for risky or unclear actions. For media assets, create
               JPEG, PNG, or WebP image assets up to 4000000 bytes with POST
-              /v1/workspaces/{workspaceId}/media-assets/images. For other media
-              assets, create a multipart upload session with POST
+              /v1/workspaces/{workspaceId}/media-assets/images. For card-editor
+              media authoring and other direct-transfer media assets, create a
+              multipart upload session with POST
               /v1/workspaces/{workspaceId}/media-assets/upload-sessions. If
               status is already_available, use the returned mediaAsset and skip
               byte upload. If status is upload_required, request signed part
               URLs with POST
               /v1/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/parts,
-              upload each part with the returned signed URL, method, and
+              upload each part directly to S3 with the returned signed URL, method, and
               headers, then complete the upload with POST
               /v1/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/complete.
               Abort unused sessions with POST
@@ -130,7 +131,8 @@ get:
               Use GET /v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
               for registry metadata and GET
               /v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
-              for a range-capable direct download URL. Use POST
+              for a range-capable direct S3 download URL that accepts client
+              Range headers while valid. Use POST
               /v1/workspaces/{workspaceId}/packages/export/preview to preview a
               portable workspace package export, then POST
               /v1/workspaces/{workspaceId}/packages/export to download the ZIP.

--- a/api/src/paths/agent.yaml
+++ b/api/src/paths/agent.yaml
@@ -125,13 +125,14 @@ get:
               again only for risky or unclear actions. Create JPEG, PNG, or
               WebP image assets up to 4000000 bytes with POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/images.
-              For other media assets, create a multipart upload session with POST
+              For card-editor media authoring and other direct-transfer media
+              assets, create a multipart upload session with POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-sessions.
               If status is already_available, use the returned mediaAsset and
               skip byte upload. If status is upload_required, request signed
               part URLs with POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/parts,
-              upload each part with the returned signed URL, method, and
+              upload each part directly to S3 with the returned signed URL, method, and
               headers, then complete the upload with POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/upload-sessions/{sessionId}/complete.
               Abort unused sessions with POST
@@ -140,7 +141,8 @@ get:
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}
               for registry metadata and GET
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/media-assets/{mediaAssetId}/download-url
-              for a range-capable direct download URL. Use POST
+              for a range-capable direct S3 download URL that accepts client
+              Range headers while valid. Use POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export/preview
               to preview a portable workspace package export, then POST
               https://api.flashcards-open-source-app.com/v1/workspaces/{workspaceId}/packages/export

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions.yaml
@@ -6,8 +6,9 @@ post:
     Creates or reuses the logical media asset for final normalized bytes. If
     matching media bytes are already available, the response is already_available
     and no byte upload is needed. Otherwise, the backend creates a short-lived
-    multipart transfer session and returns a backend session id for part URL
-    requests.
+    multipart transfer session and returns a backend session id for presigned
+    part URL requests. Card-editor media authoring should send bytes directly
+    to the returned S3 part URLs, not to this backend route.
   security:
     - ApiKeyHeader: []
   parameters:

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_abort.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_abort.yaml
@@ -3,8 +3,8 @@ post:
     - media-assets
   summary: Abort a multipart media asset upload session
   description: >-
-    Aborts the backend-controlled multipart upload and marks the upload session
-    aborted. No logical media asset is created by this call.
+    Aborts the backend-controlled direct S3 multipart upload and marks the
+    upload session aborted. No logical media asset is created by this call.
   security:
     - ApiKeyHeader: []
   parameters:

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_complete.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_complete.yaml
@@ -3,9 +3,10 @@ post:
     - media-assets
   summary: Complete a multipart media asset upload session
   description: >-
-    Completes the backend-controlled multipart upload, validates the stored
-    object metadata, and creates or idempotently updates the workspace logical
-    media asset.
+    Completes the backend-controlled direct S3 multipart upload after all parts
+    have been uploaded to their presigned PUT URLs, validates the stored object
+    metadata, and creates or idempotently updates the workspace logical media
+    asset.
   security:
     - ApiKeyHeader: []
   parameters:

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_parts.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_parts.yaml
@@ -5,7 +5,8 @@ post:
   description: >-
     Returns presigned PUT URLs for one or more multipart upload parts. The
     returned headers must be sent with each PUT so object storage validates the
-    declared per-part SHA-256 checksum.
+    declared per-part SHA-256 checksum. Upload the bytes directly to S3 with
+    these URLs; the backend only issues the transfer contract.
   security:
     - ApiKeyHeader: []
   parameters:

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
@@ -3,8 +3,9 @@ get:
     - media-assets
   summary: Create a direct media asset download URL
   description: >-
-    Returns a presigned private GET URL for the stored object. Clients may use
-    normal HTTP Range requests against the returned URL for partial reads.
+    Returns a direct presigned private S3 GET URL for the stored object. Clients
+    fetch bytes from that URL, not through the backend, and may use normal HTTP
+    Range requests against the returned URL for partial reads.
   security:
     - ApiKeyHeader: []
   parameters:

--- a/apps/backend/src/mediaAssets/storage/presigned.test.ts
+++ b/apps/backend/src/mediaAssets/storage/presigned.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  createPresignedMediaAssetDownloadWithDependencies,
   createPresignedMediaAssetUploadPartsWithDependencies,
   createPresignedMediaAssetUploadWithDependencies,
 } from ".";
 import {
   createTestS3Client,
   getTestMediaAssetsStorageConfig,
+  testBlobStorageKey,
   testLastOperationId,
   testLastOperationIdSha256,
   testMediaAssetId,
@@ -77,4 +79,29 @@ test("createPresignedMediaAssetUploadPartsWithDependencies signs per-part checks
   const signedHeaders = new URL(partUrl?.url ?? "").searchParams.get("X-Amz-SignedHeaders");
   assert.notEqual(signedHeaders, null);
   assert.ok(new Set(signedHeaders?.split(";") ?? []).has("x-amz-checksum-sha256"));
+});
+
+test("createPresignedMediaAssetDownloadWithDependencies creates a direct range-compatible S3 GET URL", async () => {
+  const download = await createPresignedMediaAssetDownloadWithDependencies(
+    {
+      workspaceId: testWorkspaceId,
+      mediaAssetId: testMediaAssetId,
+      storageKey: testBlobStorageKey,
+      observationScope: testObservationScope,
+    },
+    {
+      s3Client: createTestS3Client(),
+      getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+    },
+  );
+
+  const downloadUrl = new URL(download.url);
+  const signedHeaders = downloadUrl.searchParams.get("X-Amz-SignedHeaders");
+
+  assert.equal(download.method, "GET");
+  assert.equal(download.rangeRequests, true);
+  assert.equal(downloadUrl.protocol, "https:");
+  assert.equal(downloadUrl.hostname, "test-media-assets-bucket.s3.us-east-1.amazonaws.com");
+  assert.equal(decodeURIComponent(downloadUrl.pathname), `/${testBlobStorageKey}`);
+  assert.equal(signedHeaders, "host");
 });


### PR DESCRIPTION
## Summary
- document direct S3 multipart upload and range-capable direct download behavior in OpenAPI/discovery docs
- add a backend contract test that presigned download URLs remain S3 GET URLs with only host signed, so clients can send Range headers

## Validation
- npm run test --prefix apps/backend -- mediaAssets/storage/presigned mediaAssets/storage/multipart routes/mediaAssets: passed, 761 tests, 0 failures
- npm run lint --prefix apps/backend: passed
- npm run bundle --prefix api: passed
- git --no-pager diff --check: passed

Review gate: no split recommendation; no P0-P4 findings.