### PR TITLE
Add backend MCP protocol smoke test

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,7 +8,8 @@
     "build": "npm run bundle --prefix ../../api && npm run clean && tsc",
     "start": "node dist/entrypoints/index.js",
     "lint": "tsc --noEmit",
-    "test": "npm run bundle --prefix ../../api && node scripts/run-tests.mjs"
+    "test": "npm run bundle --prefix ../../api && node scripts/run-tests.mjs",
+    "test:mcp": "npm run bundle --prefix ../../api && node --test --import tsx src/entrypoints/lambda-mcp.test.ts src/mcp/server.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1077.0",

--- a/apps/backend/src/mcp/server.test.ts
+++ b/apps/backend/src/mcp/server.test.ts
@@ -1,0 +1,327 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  SQL_EXECUTE_TOOL_NAME,
+  SQL_QUERY_TOOL_NAME,
+} from "../aiTools/toolContract/sqlToolContract";
+import type { AgentSqlContext, AgentSqlExecutionResult } from "../aiTools/agentSql/shared";
+import type { AuthenticatedMcpAccessToken } from "../auth/mcpTokens";
+import type { WorkspaceRequestContext } from "../server/requestContext";
+import type { WorkspaceSummaryWithStats } from "../workspaces";
+import {
+  createMcpServerWithDependencies,
+  type McpServerDependencies,
+} from "./server";
+
+const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
+const RESOURCE_URL = "https://mcp.flashcards-open-source-app.com/mcp";
+const WEBSITE_URL = "https://flashcards-open-source-app.com";
+const ICON_URL = "https://mcp.flashcards-open-source-app.com/icon.svg";
+
+type ResolveWorkspaceCall = Readonly<{
+  requestContext: WorkspaceRequestContext;
+  explicitWorkspaceId: string | undefined;
+}>;
+
+type SqlToolCall = Readonly<{
+  context: AgentSqlContext;
+  sql: string;
+}>;
+
+type ListWorkspacesCall = Readonly<{
+  userId: string;
+  selectedWorkspaceId: string | null;
+}>;
+
+type FakeDependencyCalls = {
+  resolveAccessibleMcpWorkspaceIds: ResolveWorkspaceCall[];
+  sqlQueries: SqlToolCall[];
+  sqlExecutes: SqlToolCall[];
+  listWorkspaces: ListWorkspacesCall[];
+};
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonObject | ReadonlyArray<JsonValue>;
+
+type JsonObject = {
+  readonly [key: string]: JsonValue;
+};
+
+type AgentEnvelopeJson = Readonly<{
+  ok: true;
+  data: JsonObject;
+  instructions: string;
+  docs: Readonly<{
+    openapiUrl: string;
+  }>;
+}>;
+
+type ClientToolList = Awaited<ReturnType<Client["listTools"]>>;
+type ListedTool = ClientToolList["tools"][number];
+type ClientToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && Array.isArray(value) === false;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return isRecord(value);
+}
+
+function readJsonObject(record: JsonObject, key: string): JsonObject {
+  const value = record[key];
+  assert.ok(isJsonObject(value), `Expected ${key} to be a JSON object`);
+  return value;
+}
+
+function readJsonString(record: JsonObject, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string") {
+    throw new Error(`Expected ${key} to be a string`);
+  }
+
+  return value;
+}
+
+function parseAgentEnvelope(text: string): AgentEnvelopeJson {
+  const value: unknown = JSON.parse(text);
+  assert.ok(isJsonObject(value), "Expected tool result text to contain a JSON object");
+  assert.equal(value.ok, true);
+
+  const data = readJsonObject(value, "data");
+  const instructions = readJsonString(value, "instructions");
+  const docs = readJsonObject(value, "docs");
+  const openapiUrl = readJsonString(docs, "openapiUrl");
+
+  return {
+    ok: true,
+    data,
+    instructions,
+    docs: { openapiUrl },
+  };
+}
+
+function readSingleTextContent(result: ClientToolResult): string {
+  const resultRecord: Readonly<Record<string, unknown>> = result;
+  assert.notEqual(resultRecord.isError, true, "Expected MCP tool call to succeed");
+  assert.ok(Array.isArray(resultRecord.content), "Expected MCP tool call to return content");
+  assert.equal(resultRecord.content.length, 1);
+
+  const content = resultRecord.content[0];
+  assert.notEqual(content, undefined);
+  assert.ok(isRecord(content), "Expected MCP content item to be an object");
+
+  if (content.type !== "text") {
+    throw new Error(`Expected text content, received ${content.type}`);
+  }
+
+  const text = content.text;
+  if (typeof text !== "string") {
+    throw new Error("Expected text content item to include text.");
+  }
+
+  return text;
+}
+
+function requireTool(tools: ReadonlyArray<ListedTool>, name: string): ListedTool {
+  const tool = tools.find((listedTool) => listedTool.name === name);
+  if (tool === undefined) {
+    throw new Error(`Expected ${name} tool to be listed`);
+  }
+
+  return tool;
+}
+
+function createFakeDependencyCalls(): FakeDependencyCalls {
+  return {
+    resolveAccessibleMcpWorkspaceIds: [],
+    sqlQueries: [],
+    sqlExecutes: [],
+    listWorkspaces: [],
+  };
+}
+
+function createFakeDependencies(
+  calls: FakeDependencyCalls,
+  workspaces: ReadonlyArray<WorkspaceSummaryWithStats>,
+): McpServerDependencies {
+  return {
+    resolveAccessibleMcpWorkspaceId: async (
+      requestContext: WorkspaceRequestContext,
+      explicitWorkspaceId: string | undefined,
+    ): Promise<string> => {
+      calls.resolveAccessibleMcpWorkspaceIds.push({ requestContext, explicitWorkspaceId });
+
+      if (explicitWorkspaceId !== undefined) {
+        return explicitWorkspaceId;
+      }
+
+      if (requestContext.selectedWorkspaceId === null) {
+        throw new Error("Fake MCP dependency requires a selected workspace for implicit resolution.");
+      }
+
+      return requestContext.selectedWorkspaceId;
+    },
+    runSqlQuery: async (
+      context: AgentSqlContext,
+      sql: string,
+    ): Promise<AgentSqlExecutionResult> => {
+      calls.sqlQueries.push({ context, sql });
+
+      return {
+        data: {
+          statementType: "select",
+          resource: "cards",
+          sql,
+          normalizedSql: sql,
+          rows: [{
+            card_id: "card-1",
+            front_text: "Capital of France?",
+            back_text: "Paris",
+          }],
+          rowCount: 1,
+          limit: null,
+          offset: null,
+          hasMore: false,
+        },
+        instructions: "Use the returned rows to answer the user.",
+      };
+    },
+    runSqlExecute: async (
+      context: AgentSqlContext,
+      sql: string,
+    ): Promise<AgentSqlExecutionResult> => {
+      calls.sqlExecutes.push({ context, sql });
+
+      return {
+        data: {
+          statementType: "update",
+          resource: "cards",
+          sql,
+          normalizedSql: sql,
+          rows: [],
+          affectedCount: 1,
+        },
+        instructions: "The mutation completed.",
+      };
+    },
+    listUserWorkspacesWithStatsForSelectedWorkspace: async (
+      userId: string,
+      selectedWorkspaceId: string | null,
+    ): Promise<ReadonlyArray<WorkspaceSummaryWithStats>> => {
+      calls.listWorkspaces.push({ userId, selectedWorkspaceId });
+      return workspaces;
+    },
+  };
+}
+
+test("MCP server exposes workspace and SQL tools through the protocol path", async () => {
+  const selectedWorkspaceId = "11111111-1111-4111-8111-111111111111";
+  const requestedWorkspaceId = "22222222-2222-4222-8222-222222222222";
+  const connection: AuthenticatedMcpAccessToken = {
+    userId: "user-mcp-smoke",
+    connectionId: "connection-mcp-smoke",
+    selectedWorkspaceId,
+  };
+  const workspaces: ReadonlyArray<WorkspaceSummaryWithStats> = [{
+    workspaceId: selectedWorkspaceId,
+    name: "Personal",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    isSelected: true,
+    cardCount: 7,
+    lastActivityAt: "2026-01-02T00:00:00.000Z",
+  }, {
+    workspaceId: requestedWorkspaceId,
+    name: "Travel",
+    createdAt: "2026-01-03T00:00:00.000Z",
+    isSelected: false,
+    cardCount: 3,
+    lastActivityAt: null,
+  }];
+  const calls = createFakeDependencyCalls();
+  const server = createMcpServerWithDependencies(
+    connection,
+    RESOURCE_URL,
+    WEBSITE_URL,
+    ICON_URL,
+    createFakeDependencies(calls, workspaces),
+  );
+  const client = new Client({ name: "mcp-protocol-smoke", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    const capabilities = client.getServerCapabilities();
+    assert.equal(capabilities?.resources, undefined);
+
+    const toolList = await client.listTools();
+    const toolNames = toolList.tools.map((tool) => tool.name).sort();
+    assert.deepEqual(toolNames, [
+      LIST_WORKSPACES_TOOL_NAME,
+      SQL_EXECUTE_TOOL_NAME,
+      SQL_QUERY_TOOL_NAME,
+    ]);
+    assert.equal(toolNames.some((toolName) => toolName.includes("media_assets")), false);
+
+    const sqlQueryTool = requireTool(toolList.tools, SQL_QUERY_TOOL_NAME);
+    const sqlExecuteTool = requireTool(toolList.tools, SQL_EXECUTE_TOOL_NAME);
+    assert.deepEqual(sqlQueryTool.annotations, {
+      readOnlyHint: true,
+      openWorldHint: false,
+      idempotentHint: true,
+    });
+    assert.deepEqual(sqlExecuteTool.annotations, {
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: false,
+    });
+
+    const listWorkspacesResult = await client.callTool({
+      name: LIST_WORKSPACES_TOOL_NAME,
+      arguments: {},
+    });
+    const listWorkspacesEnvelope = parseAgentEnvelope(readSingleTextContent(listWorkspacesResult));
+    assert.deepEqual(listWorkspacesEnvelope.data, { workspaces });
+    assert.notEqual(listWorkspacesEnvelope.instructions, "");
+    assert.notEqual(listWorkspacesEnvelope.docs.openapiUrl, "");
+
+    const sql = "SELECT card_id, front_text, back_text FROM cards LIMIT 1";
+    const sqlQueryResult = await client.callTool({
+      name: SQL_QUERY_TOOL_NAME,
+      arguments: { sql, workspaceId: requestedWorkspaceId },
+    });
+    const sqlQueryEnvelope = parseAgentEnvelope(readSingleTextContent(sqlQueryResult));
+    assert.equal(sqlQueryEnvelope.data.sql, sql);
+    assert.notEqual(sqlQueryEnvelope.instructions, "");
+    assert.notEqual(sqlQueryEnvelope.docs.openapiUrl, "");
+
+    assert.deepEqual(calls.listWorkspaces, [{
+      userId: connection.userId,
+      selectedWorkspaceId: connection.selectedWorkspaceId,
+    }]);
+    assert.deepEqual(calls.resolveAccessibleMcpWorkspaceIds, [{
+      requestContext: {
+        userId: connection.userId,
+        selectedWorkspaceId: connection.selectedWorkspaceId,
+      },
+      explicitWorkspaceId: requestedWorkspaceId,
+    }]);
+    assert.deepEqual(calls.sqlQueries, [{
+      context: {
+        userId: connection.userId,
+        workspaceId: requestedWorkspaceId,
+        selectedWorkspaceId: connection.selectedWorkspaceId,
+        connectionId: connection.connectionId,
+      },
+      sql,
+    }]);
+    assert.deepEqual(calls.sqlExecutes, []);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { runSqlExecute, runSqlQuery } from "../aiTools/agentSql";
+import type { AgentSqlContext, AgentSqlExecutionResult } from "../aiTools/agentSql/shared";
 import {
   FRONT_BACK_CONTRACT,
   SQL_EXECUTE_TOOL_DESCRIPTION,
@@ -9,7 +10,10 @@ import {
   SQL_QUERY_TOOL_DESCRIPTION,
   SQL_QUERY_TOOL_NAME,
 } from "../aiTools/toolContract/sqlToolContract";
-import { resolveAccessibleMcpWorkspaceId } from "../server/requestContext";
+import {
+  resolveAccessibleMcpWorkspaceId,
+  type WorkspaceRequestContext,
+} from "../server/requestContext";
 import { createAgentEnvelope, createAgentErrorEnvelope } from "../agent/envelope";
 import { createPublicHttpErrorDetails, HttpError } from "../shared/errors";
 import {
@@ -45,6 +49,26 @@ const SERVER_INSTRUCTIONS =
 const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
 const LIST_WORKSPACES_TOOL_DESCRIPTION =
   "Lists the workspaces you can access, each with its workspaceId, name, active card count, last activity timestamp, and an isSelected flag marking your current default workspace. Use the returned workspaceId values for the sql_query and sql_execute workspaceId argument; pick the isSelected one to stay on the default.";
+
+export type McpServerDependencies = Readonly<{
+  resolveAccessibleMcpWorkspaceId: (
+    requestContext: WorkspaceRequestContext,
+    explicitWorkspaceId: string | undefined,
+  ) => Promise<string>;
+  runSqlQuery: (context: AgentSqlContext, sql: string) => Promise<AgentSqlExecutionResult>;
+  runSqlExecute: (context: AgentSqlContext, sql: string) => Promise<AgentSqlExecutionResult>;
+  listUserWorkspacesWithStatsForSelectedWorkspace: (
+    userId: string,
+    selectedWorkspaceId: string | null,
+  ) => Promise<ReadonlyArray<WorkspaceSummaryWithStats>>;
+}>;
+
+const DEFAULT_MCP_SERVER_DEPENDENCIES: McpServerDependencies = {
+  resolveAccessibleMcpWorkspaceId,
+  runSqlQuery,
+  runSqlExecute,
+  listUserWorkspacesWithStatsForSelectedWorkspace,
+};
 
 function buildToolResultText(payload: unknown): string {
   return JSON.stringify(payload, null, 2);
@@ -100,8 +124,9 @@ function createMcpToolInstructions(code: string | null, statusCode: number, tool
 // `error.details.workspaces` on WORKSPACE_SELECTION_REQUIRED.
 async function buildWorkspaceSelectionDetails(
   connection: AuthenticatedMcpAccessToken,
+  dependencies: McpServerDependencies,
 ): Promise<{ workspaces: ReadonlyArray<WorkspaceSummaryWithStats> }> {
-  const workspaces = await listUserWorkspacesWithStatsForSelectedWorkspace(
+  const workspaces = await dependencies.listUserWorkspacesWithStatsForSelectedWorkspace(
     connection.userId,
     connection.selectedWorkspaceId,
   );
@@ -128,6 +153,7 @@ async function buildToolErrorResult(
   resourceUrl: string,
   connection: AuthenticatedMcpAccessToken,
   toolName: string,
+  dependencies: McpServerDependencies,
 ): Promise<CallToolResult> {
   const userId = connection.userId;
   if (error instanceof HttpError) {
@@ -187,7 +213,10 @@ async function buildToolErrorResult(
       // WORKSPACE_SELECTION_REQUIRED envelope so the model still receives the
       // correct code + remediation text instead of an unhandled rejection.
       try {
-        const workspaceSelectionDetails = await buildWorkspaceSelectionDetails(connection);
+        const workspaceSelectionDetails = await buildWorkspaceSelectionDetails(
+          connection,
+          dependencies,
+        );
         return {
           isError: true,
           content: buildToolResult({
@@ -312,6 +341,22 @@ export function createMcpServer(
   websiteUrl: string,
   iconUrl: string,
 ): McpServer {
+  return createMcpServerWithDependencies(
+    connection,
+    resourceUrl,
+    websiteUrl,
+    iconUrl,
+    DEFAULT_MCP_SERVER_DEPENDENCIES,
+  );
+}
+
+export function createMcpServerWithDependencies(
+  connection: AuthenticatedMcpAccessToken,
+  resourceUrl: string,
+  websiteUrl: string,
+  iconUrl: string,
+  dependencies: McpServerDependencies,
+): McpServer {
   const server = new McpServer(
     {
       name: SERVER_NAME,
@@ -326,7 +371,7 @@ export function createMcpServer(
   );
 
   async function resolveWorkspaceId(requestedWorkspaceId: string | undefined): Promise<string> {
-    return resolveAccessibleMcpWorkspaceId(
+    return dependencies.resolveAccessibleMcpWorkspaceId(
       {
         userId: connection.userId,
         selectedWorkspaceId: connection.selectedWorkspaceId,
@@ -366,7 +411,7 @@ export function createMcpServer(
     async ({ sql, workspaceId: requestedWorkspaceId }): Promise<CallToolResult> => {
       try {
         const workspaceId = await resolveWorkspaceId(requestedWorkspaceId);
-        const result = await runSqlQuery({
+        const result = await dependencies.runSqlQuery({
           userId: connection.userId,
           workspaceId,
           selectedWorkspaceId: connection.selectedWorkspaceId,
@@ -377,7 +422,13 @@ export function createMcpServer(
           createAgentEnvelope(resourceUrl, result.data, result.instructions),
         );
       } catch (error) {
-        return buildToolErrorResult(error, resourceUrl, connection, SQL_QUERY_TOOL_NAME);
+        return buildToolErrorResult(
+          error,
+          resourceUrl,
+          connection,
+          SQL_QUERY_TOOL_NAME,
+          dependencies,
+        );
       }
     },
   );
@@ -411,7 +462,7 @@ export function createMcpServer(
     async ({ sql, workspaceId: requestedWorkspaceId }): Promise<CallToolResult> => {
       try {
         const workspaceId = await resolveWorkspaceId(requestedWorkspaceId);
-        const result = await runSqlExecute({
+        const result = await dependencies.runSqlExecute({
           userId: connection.userId,
           workspaceId,
           selectedWorkspaceId: connection.selectedWorkspaceId,
@@ -422,7 +473,13 @@ export function createMcpServer(
           createAgentEnvelope(resourceUrl, result.data, result.instructions),
         );
       } catch (error) {
-        return buildToolErrorResult(error, resourceUrl, connection, SQL_EXECUTE_TOOL_NAME);
+        return buildToolErrorResult(
+          error,
+          resourceUrl,
+          connection,
+          SQL_EXECUTE_TOOL_NAME,
+          dependencies,
+        );
       }
     },
   );
@@ -437,7 +494,7 @@ export function createMcpServer(
     },
     async (): Promise<CallToolResult> => {
       try {
-        const workspaces = await listUserWorkspacesWithStatsForSelectedWorkspace(
+        const workspaces = await dependencies.listUserWorkspacesWithStatsForSelectedWorkspace(
           connection.userId,
           connection.selectedWorkspaceId,
         );
@@ -450,7 +507,13 @@ export function createMcpServer(
           ),
         );
       } catch (error) {
-        return buildToolErrorResult(error, resourceUrl, connection, LIST_WORKSPACES_TOOL_NAME);
+        return buildToolErrorResult(
+          error,
+          resourceUrl,
+          connection,
+          LIST_WORKSPACES_TOOL_NAME,
+          dependencies,
+        );
       }
     },
   );


### PR DESCRIPTION
## Summary
- add injectable MCP server dependencies while keeping createMcpServer(...) as the production entrypoint
- add a protocol-level MCP smoke test using SDK Client and InMemoryTransport
- add a focused backend test:mcp script for the MCP smoke files

## Validation
- npm run test:mcp --prefix apps/backend passed: 2 tests passed
- npm run lint --prefix apps/backend passed
- worker-owned review: no split recommendation, no P0-P4 issues, green light for commit

Note: local npm ci --prefix api and npm ci --prefix apps/backend were needed because dependencies were absent in the worker; both completed with Node engine warnings because shell Node is v25.6.1 while packages declare 24.x.