### PR TITLE
Use ranged downloads for web managed media

### DIFF
--- a/apps/web/src/apiContracts/mediaAssets.test.ts
+++ b/apps/web/src/apiContracts/mediaAssets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { MediaAsset } from "../types";
 import {
+  parseMediaAssetDownloadUrlResponse,
   parseMediaAssetUploadSessionAbortResponse,
   parseMediaAssetUploadSessionCompleteResponse,
   parseMediaAssetUploadSessionCreateResponse,
@@ -24,6 +25,34 @@ const mediaAssetFixture: MediaAsset = {
 };
 
 describe("media asset API contracts", () => {
+  it("parses direct media download URLs with range support", () => {
+    const result = parseMediaAssetDownloadUrlResponse({
+      mediaAsset: {
+        ...mediaAssetFixture,
+        deletedAt: null,
+      },
+      download: {
+        method: "GET",
+        url: "https://downloads.example.test/media-object",
+        expiresAt: "2026-03-10T10:00:00.000Z",
+        rangeRequests: true,
+      },
+    }, "GET /workspaces/workspace-1/media-assets/media-asset-1/download-url");
+
+    expect(result).toEqual({
+      mediaAsset: {
+        ...mediaAssetFixture,
+        deletedAt: null,
+      },
+      download: {
+        method: "GET",
+        url: "https://downloads.example.test/media-object",
+        expiresAt: "2026-03-10T10:00:00.000Z",
+        rangeRequests: true,
+      },
+    });
+  });
+
   it("parses media asset hot sync tombstones", () => {
     const result = parseSyncPullResultResponse({
       changes: [

--- a/apps/web/src/apiContracts/mediaAssets.ts
+++ b/apps/web/src/apiContracts/mediaAssets.ts
@@ -57,6 +57,12 @@ function parsePresignedMediaAssetDownload(
     ),
     url: parseRequiredField(objectValue, "url", endpoint, path, parseString),
     expiresAt: parseRequiredField(objectValue, "expiresAt", endpoint, path, parseString),
+    rangeRequests: parseLiteral(
+      parseRequiredField(objectValue, "rangeRequests", endpoint, path, parseBoolean),
+      endpoint,
+      joinPath(path, "rangeRequests"),
+      true,
+    ),
   };
 }
 

--- a/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
@@ -36,6 +36,8 @@ const fileSha256 = "44".repeat(32);
 const coldSha256 = "55".repeat(32);
 const refreshedSha256 = "66".repeat(32);
 const badSha256 = "77".repeat(32);
+const largeSha256 = "88".repeat(32);
+const testDownloadRangeSizeBytes = 4 * 1024 * 1024;
 
 function hexToArrayBuffer(hex: string): ArrayBuffer {
   if (hex.length % 2 !== 0) {
@@ -259,10 +261,10 @@ describe("ReviewCardSide managed media rendering", () => {
     ]);
     const downloadUrlDeferred = createDeferred<{
       mediaAsset: MediaAsset;
-      download: Readonly<{ method: "GET"; url: string; expiresAt: string }>;
+      download: Readonly<{ method: "GET"; url: string; expiresAt: string; rangeRequests: true }>;
     }>();
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
-      .mockResolvedValue(new Response(mediaBytes));
+      .mockResolvedValue(new Response(mediaBytes, { status: 206 }));
     vi.stubGlobal("fetch", fetchMock);
     mediaMocks.loadMediaAssetRecordMock.mockImplementation(async (_workspaceId: string, mediaAssetId: string): Promise<MediaAsset | null> => {
       return mediaAssets.get(mediaAssetId) ?? null;
@@ -288,6 +290,7 @@ describe("ReviewCardSide managed media rendering", () => {
         method: "GET",
         url: "https://media.example.test/signed-download",
         expiresAt: "2026-03-10T10:00:00.000Z",
+        rangeRequests: true,
       },
     });
 
@@ -296,7 +299,12 @@ describe("ReviewCardSide managed media rendering", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith("https://media.example.test/signed-download", { method: "GET" });
+    expect(fetchMock).toHaveBeenCalledWith("https://media.example.test/signed-download", {
+      method: "GET",
+      headers: {
+        Range: "bytes=0-3",
+      },
+    });
     expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledTimes(1);
     expect(mediaMocks.writeMediaBlobCacheRecordMock.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
       sha256: coldSha256,
@@ -304,6 +312,54 @@ describe("ReviewCardSide managed media rendering", () => {
       sizeBytes: mediaBytes.byteLength,
       sourceMediaAssetId: "image-asset",
     }));
+  });
+
+  it("downloads cold managed media in direct byte ranges", async () => {
+    const mediaBytes = new Uint8Array(testDownloadRangeSizeBytes + 3);
+    mediaBytes.set([61, 62, 63], testDownloadRangeSizeBytes);
+    installDigestMock(largeSha256);
+    const mediaAsset = makeMediaAsset("large-image-asset", "image/png", largeSha256, mediaBytes.byteLength);
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(mediaBytes.slice(0, testDownloadRangeSizeBytes), { status: 206 }))
+      .mockResolvedValueOnce(new Response(mediaBytes.slice(testDownloadRangeSizeBytes), { status: 206 }));
+    vi.stubGlobal("fetch", fetchMock);
+    mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(null);
+    mediaMocks.loadMediaAssetDownloadUrlMock.mockResolvedValue({
+      mediaAsset,
+      download: {
+        method: "GET" as const,
+        url: "https://media.example.test/large-signed-download",
+        expiresAt: "2026-03-10T10:00:00.000Z",
+        rangeRequests: true,
+      },
+    });
+
+    root = renderReviewCardSide(container, "![Large](fcasset:large-image-asset)");
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "https://media.example.test/large-signed-download", {
+      method: "GET",
+      headers: {
+        Range: "bytes=0-4194303",
+      },
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "https://media.example.test/large-signed-download", {
+      method: "GET",
+      headers: {
+        Range: "bytes=4194304-4194306",
+      },
+    });
+    expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledWith(expect.objectContaining({
+      sha256: largeSha256,
+      sizeBytes: mediaBytes.byteLength,
+    }));
+    const cacheRecord = mediaMocks.writeMediaBlobCacheRecordMock.mock.calls[0]?.[0] as MediaBlobCacheRecord | undefined;
+    expect(cacheRecord?.blob.size).toBe(mediaBytes.byteLength);
   });
 
   it("keeps external Markdown images on the normal image path", async () => {
@@ -338,7 +394,7 @@ describe("ReviewCardSide managed media rendering", () => {
     const mediaAsset = makeMediaAsset("refresh-asset", "image/png", refreshedSha256, mediaBytes.byteLength);
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(new Response("expired", { status: 403, statusText: "Forbidden" }))
-      .mockResolvedValueOnce(new Response(mediaBytes));
+      .mockResolvedValueOnce(new Response(mediaBytes, { status: 206 }));
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => undefined);
     vi.stubGlobal("fetch", fetchMock);
     mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
@@ -350,6 +406,7 @@ describe("ReviewCardSide managed media rendering", () => {
           method: "GET" as const,
           url: "https://media.example.test/stale-download",
           expiresAt: "2026-03-10T10:00:00.000Z",
+          rangeRequests: true,
         },
       })
       .mockResolvedValueOnce({
@@ -358,6 +415,7 @@ describe("ReviewCardSide managed media rendering", () => {
           method: "GET" as const,
           url: "https://media.example.test/fresh-download",
           expiresAt: "2026-03-10T10:05:00.000Z",
+          rangeRequests: true,
         },
       });
 
@@ -370,6 +428,18 @@ describe("ReviewCardSide managed media rendering", () => {
     expect(mediaMocks.loadMediaAssetDownloadUrlMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://media.example.test/stale-download");
     expect(fetchMock.mock.calls[1]?.[0]).toBe("https://media.example.test/fresh-download");
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual({
+      method: "GET",
+      headers: {
+        Range: "bytes=0-4",
+      },
+    });
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual({
+      method: "GET",
+      headers: {
+        Range: "bytes=0-4",
+      },
+    });
     expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledWith(expect.objectContaining({
       sha256: refreshedSha256,
       sizeBytes: mediaBytes.byteLength,
@@ -388,7 +458,7 @@ describe("ReviewCardSide managed media rendering", () => {
     installDigestMock(badSha256);
     const mediaAsset = makeMediaAsset("corrupt-asset", "image/png", coldSha256, mediaBytes.byteLength);
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
-      .mockResolvedValue(new Response(mediaBytes));
+      .mockResolvedValue(new Response(mediaBytes, { status: 206 }));
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => undefined);
     vi.stubGlobal("fetch", fetchMock);
     mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
@@ -399,6 +469,7 @@ describe("ReviewCardSide managed media rendering", () => {
         method: "GET" as const,
         url: "https://media.example.test/corrupt-download",
         expiresAt: "2026-03-10T10:00:00.000Z",
+        rangeRequests: true,
       },
     });
 

--- a/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
+++ b/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
@@ -17,6 +17,7 @@ import type { MediaAsset } from "../../../types";
 
 const FCASSET_URL_PREFIX = "fcasset:";
 const MANAGED_MEDIA_DOWNLOAD_ATTEMPT_COUNT = 2;
+const MANAGED_MEDIA_DOWNLOAD_RANGE_SIZE_BYTES = 4 * 1024 * 1024;
 
 type ManagedMediaKind = "image" | "audio" | "video" | "attachment";
 type ManagedMediaLoadState =
@@ -26,6 +27,10 @@ type ManagedMediaLoadState =
 type ManagedMediaBlobLoadResult = Readonly<{
   mediaAsset: MediaAsset;
   cacheRecord: MediaBlobCacheRecord;
+}>;
+type ManagedMediaDownloadRange = Readonly<{
+  startByte: number;
+  endByte: number;
 }>;
 
 const activeManagedMediaDownloadPromises = new Map<string, Promise<MediaBlobCacheRecord>>();
@@ -117,24 +122,117 @@ async function readDownloadFailureBody(response: Response): Promise<string> {
   }
 }
 
+function planManagedMediaDownloadRanges(sizeBytes: number, rangeSizeBytes: number): ReadonlyArray<ManagedMediaDownloadRange> {
+  if (Number.isSafeInteger(sizeBytes) === false || sizeBytes < 0) {
+    throw new RangeError(`Managed media download range planning failed: sizeBytes must be a non-negative safe integer, actualSizeBytes=${sizeBytes}`);
+  }
+
+  if (Number.isSafeInteger(rangeSizeBytes) === false || rangeSizeBytes < 1) {
+    throw new RangeError(`Managed media download range planning failed: rangeSizeBytes must be a positive safe integer, actualRangeSizeBytes=${rangeSizeBytes}`);
+  }
+
+  const ranges: Array<ManagedMediaDownloadRange> = [];
+  for (let startByte = 0; startByte < sizeBytes; startByte += rangeSizeBytes) {
+    ranges.push({
+      startByte,
+      endByte: Math.min(startByte + rangeSizeBytes - 1, sizeBytes - 1),
+    });
+  }
+
+  return ranges;
+}
+
+function readManagedMediaDownloadRangeSize(range: ManagedMediaDownloadRange): number {
+  return range.endByte - range.startByte + 1;
+}
+
+async function readManagedMediaResponseBytes(
+  mediaAsset: MediaAsset,
+  response: Response,
+  rangeHeader: string,
+): Promise<ArrayBuffer> {
+  try {
+    return await response.arrayBuffer();
+  } catch (error) {
+    throw new Error(`Managed media download response body read failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, status=${response.status}, error=${readErrorMessage(error)}`);
+  }
+}
+
+async function fetchManagedMediaRangeBytes(
+  mediaAsset: MediaAsset,
+  downloadMethod: "GET",
+  downloadUrl: string,
+  range: ManagedMediaDownloadRange,
+  isSingleRange: boolean,
+): Promise<ArrayBuffer> {
+  const rangeHeader = `bytes=${range.startByte}-${range.endByte}`;
+  let response: Response;
+  try {
+    response = await fetch(downloadUrl, {
+      method: downloadMethod,
+      headers: {
+        Range: rangeHeader,
+      },
+    });
+  } catch (error) {
+    throw new Error(`Managed media ranged download request failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, error=${readErrorMessage(error)}`);
+  }
+
+  if (response.status === 206) {
+    const bytes = await readManagedMediaResponseBytes(mediaAsset, response, rangeHeader);
+    const expectedRangeSizeBytes = readManagedMediaDownloadRangeSize(range);
+    if (bytes.byteLength !== expectedRangeSizeBytes) {
+      throw new Error(`Managed media ranged download size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, expectedRangeSizeBytes=${expectedRangeSizeBytes}, actualRangeSizeBytes=${bytes.byteLength}, status=${response.status}`);
+    }
+
+    return bytes;
+  }
+
+  if (isSingleRange && response.status === 200) {
+    const bytes = await readManagedMediaResponseBytes(mediaAsset, response, rangeHeader);
+    if (bytes.byteLength !== mediaAsset.sizeBytes) {
+      throw new Error(`Managed media full download size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, expectedSizeBytes=${mediaAsset.sizeBytes}, actualSizeBytes=${bytes.byteLength}, status=${response.status}`);
+    }
+
+    return bytes;
+  }
+
+  if (response.ok === false) {
+    const responseBody = await readDownloadFailureBody(response);
+    throw new Error(`Managed media ranged download failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, status=${response.status}, statusText=${response.statusText}, responseBody=${responseBody}`);
+  }
+
+  throw new Error(`Managed media ranged download returned unexpected status: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, expectedStatus=206, actualStatus=${response.status}, statusText=${response.statusText}`);
+}
+
+function combineManagedMediaRangeBytes(mediaAsset: MediaAsset, chunks: ReadonlyArray<ArrayBuffer>): ArrayBuffer {
+  const totalByteLength = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  if (totalByteLength !== mediaAsset.sizeBytes) {
+    throw new Error(`Managed media ranged download total size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, expectedSizeBytes=${mediaAsset.sizeBytes}, actualSizeBytes=${totalByteLength}`);
+  }
+
+  const bytes: Uint8Array<ArrayBuffer> = new Uint8Array(totalByteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(new Uint8Array(chunk), offset);
+    offset += chunk.byteLength;
+  }
+
+  return bytes.buffer;
+}
+
 async function fetchManagedMediaBytes(
   mediaAsset: MediaAsset,
   downloadMethod: "GET",
   downloadUrl: string,
 ): Promise<ArrayBuffer> {
-  let response: Response;
-  try {
-    response = await fetch(downloadUrl, { method: downloadMethod });
-  } catch (error) {
-    throw new Error(`Managed media download request failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, error=${readErrorMessage(error)}`);
+  const ranges = planManagedMediaDownloadRanges(mediaAsset.sizeBytes, MANAGED_MEDIA_DOWNLOAD_RANGE_SIZE_BYTES);
+  const chunks: Array<ArrayBuffer> = [];
+  for (const range of ranges) {
+    chunks.push(await fetchManagedMediaRangeBytes(mediaAsset, downloadMethod, downloadUrl, range, ranges.length === 1));
   }
 
-  if (response.ok === false) {
-    const responseBody = await readDownloadFailureBody(response);
-    throw new Error(`Managed media download failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, status=${response.status}, statusText=${response.statusText}, responseBody=${responseBody}`);
-  }
-
-  return response.arrayBuffer();
+  return combineManagedMediaRangeBytes(mediaAsset, chunks);
 }
 
 async function verifyManagedMediaBytes(mediaAsset: MediaAsset, bytes: ArrayBuffer): Promise<Blob> {

--- a/apps/web/src/types/mediaAssets.ts
+++ b/apps/web/src/types/mediaAssets.ts
@@ -28,6 +28,7 @@ export type PresignedMediaAssetDownload = Readonly<{
   method: "GET";
   url: string;
   expiresAt: string;
+  rangeRequests: true;
 }>;
 
 export type MediaAssetDownloadUrlResult = Readonly<{


### PR DESCRIPTION
## Summary
- fetch managed media from presigned S3 GET URLs with client Range headers
- validate direct download URL range support in the web API contract
- keep SHA-256 and size verification before writing the IndexedDB blob cache

## Validation
- git fetch origin main plus git merge-base --is-ancestor origin/main HEAD
- npm ci --prefix apps/web (Node warning: package expects 24.x, shell had v25.6.1)
- npm run test --prefix apps/web -- src/localDb/mediaTransfers/mediaTransfers.test.ts src/screens/review
- npm run build --prefix apps/web
- git --no-pager diff --check
- worker-owned review: no split recommendation, no P0-P4 findings

## Residual Risk
- manual browser smoke with real remote managed image, S3 Range inspection, and offline reload was not run
