### PR TITLE
Wire MCP smoke into AWS web release

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/checks/check-agent-api-smoke.sh'
       - 'scripts/checks/check-api-health.sh'
       - 'scripts/checks/check-demo-cognito-users.sh'
+      - 'scripts/checks/check-mcp-smoke.sh'
       - 'scripts/checks/check-public-endpoints.sh'
       - 'scripts/deploy/deploy-admin.sh'
       - 'scripts/deploy/deploy-web.sh'
@@ -63,7 +64,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          aws_release_script_pattern='^scripts/(checks/(check-agent-api-smoke|check-api-health|check-demo-cognito-users|check-public-endpoints)\.sh|deploy/(deploy-admin|deploy-web|migrate-aws)\.sh|generate/(generate-global-metrics-snapshot\.sh|write-ci-cdk-context\.py))$'
+          aws_release_script_pattern='^scripts/(checks/(check-agent-api-smoke|check-api-health|check-demo-cognito-users|check-mcp-smoke|check-public-endpoints)\.sh|deploy/(deploy-admin|deploy-web|migrate-aws)\.sh|generate/(generate-global-metrics-snapshot\.sh|write-ci-cdk-context\.py))$'
 
           changed_files_path="${RUNNER_TEMP}/changed-files.txt"
           before_sha="${PUSH_BEFORE_SHA:-}"
@@ -214,6 +215,10 @@ jobs:
       - name: Build backend
         if: ${{ needs.changes.outputs.backend_changed == 'true' }}
         run: npm run build --prefix apps/backend
+
+      - name: Test backend MCP protocol
+        if: ${{ needs.changes.outputs.backend_changed == 'true' }}
+        run: npm run test:mcp --prefix apps/backend
 
       - name: Build web app
         if: ${{ needs.changes.outputs.web_changed == 'true' }}
@@ -407,6 +412,7 @@ jobs:
             echo "- Deployed SHA: \`${GITHUB_SHA}\`"
             echo "- Web post-deploy smoke: pending next job"
             echo "- Agent API post-deploy smoke: pending next job"
+            echo "- MCP post-deploy smoke: pending next job"
             echo ""
             echo "Manual admin smoke remains required for \`https://admin.<domain>\`."
           } >> "${GITHUB_STEP_SUMMARY}"
@@ -555,6 +561,39 @@ jobs:
             echo "- Result: \`${{ steps.agent_smoke.outcome }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  mcp_smoke:
+    name: MCP post-deploy smoke
+    needs:
+      - changes
+      - aws_deploy
+    if: ${{ needs.changes.outputs.aws_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run MCP smoke test
+        id: mcp_smoke
+        env:
+          FLASHCARDS_MCP_SMOKE_AUTH_BASE_URL: https://auth.flashcards-open-source-app.com
+          FLASHCARDS_MCP_SMOKE_API_BASE_URL: https://api.flashcards-open-source-app.com/v1
+          FLASHCARDS_MCP_SMOKE_MCP_BASE_URL: https://mcp.flashcards-open-source-app.com
+          FLASHCARDS_MCP_SMOKE_DEMO_EMAIL: google-review@example.com
+          FLASHCARDS_MCP_SMOKE_WORKSPACE_PREFIX: "E2E mcp "
+          FLASHCARDS_MCP_SMOKE_CONNECTION_LABEL_PREFIX: "E2E mcp "
+        run: bash scripts/checks/check-mcp-smoke.sh
+
+      - name: Summarize smoke result
+        if: always()
+        run: |
+          {
+            echo "## MCP post-deploy smoke"
+            echo ""
+            echo "- Deployed SHA: \`${GITHUB_SHA}\`"
+            echo "- Result: \`${{ steps.mcp_smoke.outcome }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   aws_release_status:
     name: Resolve AWS release outcome
     needs:
@@ -563,6 +602,7 @@ jobs:
       - aws_deploy
       - web_smoke
       - agent_api_smoke
+      - mcp_smoke
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     outputs:
@@ -585,6 +625,8 @@ jobs:
               aws_release_status="web_smoke_failed"
             elif [[ "${{ needs.agent_api_smoke.result }}" != "success" ]]; then
               aws_release_status="agent_api_smoke_failed"
+            elif [[ "${{ needs.mcp_smoke.result }}" != "success" ]]; then
+              aws_release_status="mcp_smoke_failed"
             else
               aws_release_status="released"
             fi
@@ -609,6 +651,7 @@ jobs:
       - aws_deploy
       - web_smoke
       - agent_api_smoke
+      - mcp_smoke
       - aws_release_status
     runs-on: ubuntu-24.04
 
@@ -624,6 +667,7 @@ jobs:
             echo "- AWS deploy job: \`${{ needs.aws_deploy.result }}\`"
             echo "- Web smoke job: \`${{ needs.web_smoke.result }}\`"
             echo "- Agent API smoke job: \`${{ needs.agent_api_smoke.result }}\`"
+            echo "- MCP smoke job: \`${{ needs.mcp_smoke.result }}\`"
             echo "- Run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/docs/release-gates.md
+++ b/docs/release-gates.md
@@ -3,22 +3,23 @@
 Pushes to `main` use independent release and check streams:
 
 - `.github/workflows/aws-web-release.yml` handles AWS/backend/web release work
-- when AWS/backend/web changed, it deploys production, runs the native Playwright smoke in `apps/web/e2e/live-smoke.spec.ts`, runs the external agent API smoke in `scripts/checks/check-agent-api-smoke.sh`, and only finishes healthy when both post-deploy checks pass
+- when AWS/backend/web changed, it deploys production, runs the native Playwright smoke in `apps/web/e2e/live-smoke.spec.ts`, runs the external agent API smoke in `scripts/checks/check-agent-api-smoke.sh`, runs the MCP endpoint smoke in `scripts/checks/check-mcp-smoke.sh`, and only finishes healthy when all three post-deploy checks pass
 - rollback is automatic only when the failed AWS release did not include new DB migrations
 - migration-bearing AWS failures are explicit fix-forward cases; the next push must still be allowed to run
 - when Android-impacting files changed, `.github/workflows/android-ci.yml` runs independently and enforces the fast GitHub-hosted Android gate without uploading to Google Play or submitting Firebase Test Lab
 - Android production draft upload is manual-only through `.github/workflows/android-release.yml`; that workflow also requires Firebase Test Lab submission before the Play draft upload starts
 - when iOS changed, Xcode Cloud runs independently for the same `main` SHA
 
-MCP Registry validation is an automatic check for `server.json` changes, but
-registry publication is a separate manual workflow. Trigger `MCP Registry
-Publish` only when the release should publish a new, previously unpublished
-`server.json.version`.
+The MCP endpoint smoke in `AWS/Web Release` verifies the deployed MCP HTTP
+contract. MCP Registry validation is a separate automatic check for
+`server.json` changes, and registry publication is a separate manual workflow.
+Trigger `MCP Registry Publish` only when the release should publish a new,
+previously unpublished `server.json.version`.
 
 Human-operated production release actions for iOS, Android, web, and MCP are
 tracked in [docs/manual-production-release.md](./manual-production-release.md).
 
-When a change lands on `main`, monitor `AWS/Web Release` for backend/web outcome when AWS-impacting files changed, including both post-deploy smoke jobs, monitor `Android CI` when Android-impacting files changed, and monitor Xcode Cloud separately when iOS changed.
+When a change lands on `main`, monitor `AWS/Web Release` for backend/web outcome when AWS-impacting files changed, including the Web, Agent API, and MCP post-deploy smoke jobs, monitor `Android CI` when Android-impacting files changed, and monitor Xcode Cloud separately when iOS changed.
 For Android, a green `Android CI` run always means the GitHub-hosted Android gate passed for that SHA. It does not mean Firebase Test Lab was submitted, a Google Play draft was uploaded, or a release is already live. Run the manual `Android Release` workflow when the Android SHA is ready for release. A green manual `Android Release` run means the GitHub-hosted Android gate passed, Firebase Test Lab submission succeeded, and CI uploaded a production-track Play draft; Firebase Test Lab is submitted asynchronously, so review its matrix result before publishing from Play Console. A non-green `Android Release` run means one of the required release stages failed or was skipped by a failed dependency. Translation review and final publication still happen later in Play Console.
 To trace the exact Android release, open the GitHub Actions run summary for the manual `Android Release` run, note the shared `ANDROID_VERSION_CODE`, the shared release identifier `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`, the Play draft release name `main-draft-<releaseIdentifier>`, and the Firebase results path for that same release identifier. Correlate the run by release name, results path, GitHub run id and attempt, and SHA; Firebase matrix IDs are Google-assigned lookup values, not the shared release identifier.
 If you need to inspect Xcode Cloud directly instead of relying only on the web UI, use `docs/xcode-cloud-data-access.md`. It documents the local `.env` secrets, App Store Connect API flow, example commands, returned data formats, artifact types, and how to extract timing/debugging insights from cloud test runs.


### PR DESCRIPTION
## Summary
- add MCP smoke script to AWS/Web release path detection
- run backend MCP protocol test for backend changes before deploy
- add post-deploy MCP smoke job and release status/summary wiring
- document Web, Agent API, and MCP release smokes separately from MCP Registry publication

## Validation
- base check passed: `git fetch origin main && git merge-base --is-ancestor origin/main HEAD && git status --short`
- `npm run test:mcp --prefix apps/backend` passed after `npm ci --prefix api` and `npm ci --prefix apps/backend`
- `bash -n scripts/checks/check-mcp-smoke.sh` passed
- YAML parse for `.github/workflows/aws-web-release.yml` passed
- `git --no-pager diff --check` passed
- worker-owned review found no P0-P4 issues and no split recommendation

## Residual Risk
- local `actionlint` or repo-configured workflow linter was not available, so workflow validation was YAML parse plus manual/review inspection
