### PR TITLE
Add Android ranged media downloads

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloadUrlLoader.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloadUrlLoader.kt
@@ -25,7 +25,11 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 
@@ -33,6 +37,9 @@ private const val reviewMediaAssetDownloadLogTag: String = "ReviewMediaDownload"
 private const val reviewMediaAssetDownloadMaxAttemptCount: Int = 3
 private const val reviewMediaAssetDownloadRetryBaseDelayMillis: Long = 500L
 private const val reviewMediaAssetDownloadErrorBodyLimit: Int = 4_096
+private const val reviewMediaAssetDownloadRangeChunkSizeBytes: Long = 1024L * 1024L
+private const val reviewMediaAssetDownloadBufferSizeBytes: Int = 16 * 1024
+private val reviewMediaAssetContentRangePattern: Regex = Regex("^bytes (\\d+)-(\\d+)/(\\d+)$")
 
 data class DownloadedReviewMediaAsset(
     val sizeBytes: Long,
@@ -110,7 +117,6 @@ class OkHttpReviewMediaAssetDownloader(
                             "delayMs=$delayMillis errorType=${error::class.java.simpleName}",
                         error
                     )
-                    deletePartialReviewMediaDownload(targetFile = targetFile, cause = error)
                     delay(delayMillis)
                     attemptNumber += 1
                 }
@@ -136,36 +142,122 @@ class OkHttpReviewMediaAssetDownloader(
         if (targetFile.exists() && targetFile.delete().not()) {
             throw IOException("Cannot replace managed media download target file: ${targetFile.absolutePath}")
         }
+        val partialFile = resolvePartialReviewMediaDownloadFile(targetFile = targetFile)
+        val shouldRestartAfterResumedValidationFailure: Boolean =
+            hasNonEmptyPartialReviewMediaDownload(partialFile = partialFile)
+        var restartedAfterResumedValidationFailure = false
 
-        val request: Request = Request.Builder()
-            .url(url)
-            .get()
-            .build()
+        while (true) {
+            try {
+                if (expectedSizeBytes == 0L) {
+                    createEmptyPartialReviewMediaDownload(partialFile = partialFile)
+                } else {
+                    while (true) {
+                        currentCoroutineContext().ensureActive()
+                        val partialSizeBytes = checkedPartialReviewMediaDownloadSizeBytes(
+                            partialFile = partialFile,
+                            expectedSizeBytes = expectedSizeBytes
+                        )
+                        if (partialSizeBytes == expectedSizeBytes) {
+                            break
+                        }
 
-        try {
-            httpClient.newCall(request).awaitOkHttpResponse().use { response ->
-                if (response.isSuccessful.not()) {
-                    throw ReviewMediaAssetDownloadHttpException(
-                        statusCode = response.code,
-                        responseBody = readReviewMediaDownloadErrorBody(response = response),
-                        retryEligible = isTransientReviewMediaDownloadStatusCode(statusCode = response.code)
-                    )
+                        val range = createReviewMediaDownloadRange(
+                            startByte = partialSizeBytes,
+                            expectedSizeBytes = expectedSizeBytes
+                        )
+                        downloadReviewMediaRange(
+                            url = url,
+                            partialFile = partialFile,
+                            range = range,
+                            expectedSizeBytes = expectedSizeBytes
+                        )
+                    }
                 }
-                validateReviewMediaDownloadContentLength(
-                    contentLength = response.body.contentLength(),
-                    expectedSizeBytes = expectedSizeBytes
-                )
 
-                return streamReviewMediaResponseToFile(
-                    response = response,
+                return completePartialReviewMediaDownload(
+                    partialFile = partialFile,
                     targetFile = targetFile,
                     expectedSizeBytes = expectedSizeBytes,
                     expectedSha256 = expectedSha256
                 )
+            } catch (error: ReviewMediaAssetDownloadValidationException) {
+                deletePartialReviewMediaDownload(partialFile = partialFile, cause = error)
+                if (shouldRestartAfterResumedValidationFailure && restartedAfterResumedValidationFailure.not()) {
+                    restartedAfterResumedValidationFailure = true
+                    currentCoroutineContext().ensureActive()
+                    continue
+                }
+                throw error
             }
-        } catch (error: IOException) {
-            deletePartialReviewMediaDownload(targetFile = targetFile, cause = error)
-            throw error
+        }
+    }
+
+    private suspend fun downloadReviewMediaRange(
+        url: String,
+        partialFile: File,
+        range: ReviewMediaDownloadRange,
+        expectedSizeBytes: Long
+    ): Unit {
+        val rangeHeader = formatReviewMediaDownloadRangeHeader(range = range)
+        val request: Request = Request.Builder()
+            .url(url)
+            .get()
+            .header("Range", rangeHeader)
+            .build()
+
+        httpClient.newCall(request).awaitOkHttpResponse().use { response ->
+            when (response.code) {
+                206 -> {
+                    validatePartialReviewMediaDownloadResponse(
+                        response = response,
+                        range = range,
+                        expectedSizeBytes = expectedSizeBytes
+                    )
+                    streamReviewMediaResponseToPartialFile(
+                        response = response,
+                        partialFile = partialFile,
+                        writeStartByte = range.startByte,
+                        expectedResponseSizeBytes = range.sizeBytes,
+                        expectedTotalSizeBytes = expectedSizeBytes,
+                        rangeHeader = rangeHeader
+                    )
+                }
+
+                200 -> {
+                    validateFullReviewMediaDownloadResponse(
+                        response = response,
+                        range = range,
+                        expectedSizeBytes = expectedSizeBytes
+                    )
+                    resetPartialReviewMediaDownloadFile(
+                        partialFile = partialFile,
+                        rangeHeader = rangeHeader
+                    )
+                    streamReviewMediaResponseToPartialFile(
+                        response = response,
+                        partialFile = partialFile,
+                        writeStartByte = 0L,
+                        expectedResponseSizeBytes = expectedSizeBytes,
+                        expectedTotalSizeBytes = expectedSizeBytes,
+                        rangeHeader = rangeHeader
+                    )
+                }
+
+                else -> {
+                    if (response.isSuccessful.not()) {
+                        throw ReviewMediaAssetDownloadHttpException(
+                            statusCode = response.code,
+                            responseBody = readReviewMediaDownloadErrorBody(response = response),
+                            retryEligible = isTransientReviewMediaDownloadStatusCode(statusCode = response.code)
+                        )
+                    }
+                    throw ReviewMediaAssetDownloadValidationException(
+                        "Managed media download received unexpected HTTP statusCode=${response.code} " +
+                            "for requested Range='$rangeHeader'."
+                    )
+                }
+            }
         }
     }
 }
@@ -266,34 +358,318 @@ private class ReviewMediaAssetDownloadValidationException(
     message: String
 ) : IOException(message)
 
-private fun streamReviewMediaResponseToFile(
+private data class ReviewMediaDownloadRange(
+    val startByte: Long,
+    val endByteInclusive: Long
+) {
+    val sizeBytes: Long = endByteInclusive - startByte + 1L
+
+    init {
+        require(startByte >= 0L) {
+            "Managed media download range startByte must not be negative."
+        }
+        require(endByteInclusive >= startByte) {
+            "Managed media download range endByteInclusive must be greater than or equal to startByte."
+        }
+    }
+}
+
+private data class ReviewMediaContentRange(
+    val startByte: Long,
+    val endByteInclusive: Long,
+    val completeSizeBytes: Long
+)
+
+private fun resolvePartialReviewMediaDownloadFile(targetFile: File): File {
+    val parentDirectory: File = requireNotNull(targetFile.parentFile) {
+        "Managed media download partial file target must have a parent directory: ${targetFile.absolutePath}"
+    }
+    return File(parentDirectory, "${targetFile.name}.partial")
+}
+
+private fun createEmptyPartialReviewMediaDownload(partialFile: File): Unit {
+    if (partialFile.exists()) {
+        if (partialFile.isFile.not()) {
+            throw IOException("Managed media download partial path is not a file: ${partialFile.absolutePath}")
+        }
+        if (partialFile.length() == 0L) {
+            return
+        }
+        val error = ReviewMediaAssetDownloadValidationException(
+            "Managed media download expected an empty partial file but found ${partialFile.length()} byte(s): " +
+                partialFile.absolutePath
+        )
+        deletePartialReviewMediaDownload(partialFile = partialFile, cause = error)
+        throw error
+    }
+    if (partialFile.createNewFile().not()) {
+        throw IOException("Cannot create empty managed media download partial file: ${partialFile.absolutePath}")
+    }
+}
+
+private fun hasNonEmptyPartialReviewMediaDownload(partialFile: File): Boolean {
+    return partialFile.exists() && partialFile.isFile && partialFile.length() > 0L
+}
+
+private fun checkedPartialReviewMediaDownloadSizeBytes(
+    partialFile: File,
+    expectedSizeBytes: Long
+): Long {
+    if (partialFile.exists().not()) {
+        return 0L
+    }
+    if (partialFile.isFile.not()) {
+        throw IOException("Managed media download partial path is not a file: ${partialFile.absolutePath}")
+    }
+    val partialSizeBytes = partialFile.length()
+    if (partialSizeBytes > expectedSizeBytes) {
+        val error = ReviewMediaAssetDownloadValidationException(
+            "Managed media download partial file is larger than expected: expected at most " +
+                "$expectedSizeBytes byte(s), found $partialSizeBytes byte(s) at ${partialFile.absolutePath}."
+        )
+        deletePartialReviewMediaDownload(partialFile = partialFile, cause = error)
+        throw error
+    }
+    return partialSizeBytes
+}
+
+private fun createReviewMediaDownloadRange(
+    startByte: Long,
+    expectedSizeBytes: Long
+): ReviewMediaDownloadRange {
+    require(startByte >= 0L) {
+        "Managed media download range startByte must not be negative."
+    }
+    require(startByte < expectedSizeBytes) {
+        "Managed media download range startByte must be smaller than expectedSizeBytes."
+    }
+    val endByteInclusive = minOf(
+        startByte + reviewMediaAssetDownloadRangeChunkSizeBytes - 1L,
+        expectedSizeBytes - 1L
+    )
+    return ReviewMediaDownloadRange(
+        startByte = startByte,
+        endByteInclusive = endByteInclusive
+    )
+}
+
+private fun formatReviewMediaDownloadRangeHeader(range: ReviewMediaDownloadRange): String {
+    return "bytes=${range.startByte}-${range.endByteInclusive}"
+}
+
+private fun validatePartialReviewMediaDownloadResponse(
     response: Response,
-    targetFile: File,
-    expectedSizeBytes: Long,
-    expectedSha256: String
-): DownloadedReviewMediaAsset {
-    val digest = MessageDigest.getInstance("SHA-256")
-    var sizeBytes = 0L
+    range: ReviewMediaDownloadRange,
+    expectedSizeBytes: Long
+): Unit {
+    val rangeHeader = formatReviewMediaDownloadRangeHeader(range = range)
+    validateReviewMediaDownloadContentLength(
+        contentLength = response.body.contentLength(),
+        expectedSizeBytes = range.sizeBytes,
+        rangeHeader = rangeHeader
+    )
+    val contentRangeHeader: String = response.header("Content-Range")
+        ?: throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download response is missing Content-Range for requested Range='$rangeHeader'."
+        )
+    val contentRange: ReviewMediaContentRange = parseReviewMediaContentRange(
+        contentRangeHeader = contentRangeHeader,
+        rangeHeader = rangeHeader
+    )
+    if (contentRange.startByte != range.startByte || contentRange.endByteInclusive != range.endByteInclusive) {
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download Content-Range mismatch for requested Range='$rangeHeader': " +
+                "received '$contentRangeHeader'."
+        )
+    }
+    if (contentRange.completeSizeBytes != expectedSizeBytes) {
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download Content-Range total mismatch for requested Range='$rangeHeader': " +
+                "expected $expectedSizeBytes byte(s), received '$contentRangeHeader'."
+        )
+    }
+}
+
+private fun validateFullReviewMediaDownloadResponse(
+    response: Response,
+    range: ReviewMediaDownloadRange,
+    expectedSizeBytes: Long
+): Unit {
+    validateReviewMediaDownloadContentLength(
+        contentLength = response.body.contentLength(),
+        expectedSizeBytes = expectedSizeBytes,
+        rangeHeader = formatReviewMediaDownloadRangeHeader(range = range)
+    )
+}
+
+private fun resetPartialReviewMediaDownloadFile(
+    partialFile: File,
+    rangeHeader: String
+): Unit {
+    if (partialFile.exists().not()) {
+        return
+    }
+    if (partialFile.isFile.not()) {
+        throw IOException(
+            "Managed media download cannot restart full-object response for requested Range='$rangeHeader' " +
+                "because the partial path is not a file: ${partialFile.absolutePath}"
+        )
+    }
+    if (partialFile.delete().not()) {
+        throw IOException(
+            "Cannot restart managed media download full-object response for requested Range='$rangeHeader': " +
+                "failed to delete partial file ${partialFile.absolutePath}."
+        )
+    }
+}
+
+private fun parseReviewMediaContentRange(
+    contentRangeHeader: String,
+    rangeHeader: String
+): ReviewMediaContentRange {
+    val match = reviewMediaAssetContentRangePattern.matchEntire(contentRangeHeader.trim())
+        ?: throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download Content-Range header is invalid for requested Range='$rangeHeader': " +
+                "received '$contentRangeHeader'."
+        )
+    val startByte: Long = match.groupValues[1].toLong()
+    val endByteInclusive: Long = match.groupValues[2].toLong()
+    val completeSizeBytes: Long = match.groupValues[3].toLong()
+    if (endByteInclusive < startByte) {
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download Content-Range has an invalid byte order for requested Range='$rangeHeader': " +
+                "received '$contentRangeHeader'."
+        )
+    }
+    if (completeSizeBytes <= endByteInclusive) {
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download Content-Range total is too small for requested Range='$rangeHeader': " +
+                "received '$contentRangeHeader'."
+        )
+    }
+    return ReviewMediaContentRange(
+        startByte = startByte,
+        endByteInclusive = endByteInclusive,
+        completeSizeBytes = completeSizeBytes
+    )
+}
+
+private fun streamReviewMediaResponseToPartialFile(
+    response: Response,
+    partialFile: File,
+    writeStartByte: Long,
+    expectedResponseSizeBytes: Long,
+    expectedTotalSizeBytes: Long,
+    rangeHeader: String
+): Unit {
+    val currentPartialSizeBytes = partialFile.length()
+    if (currentPartialSizeBytes != writeStartByte) {
+        throw IOException(
+            "Managed media download partial size changed before write for requested Range='$rangeHeader': " +
+                "expected $writeStartByte byte(s), found $currentPartialSizeBytes byte(s)."
+        )
+    }
+    var responseSizeBytes = 0L
 
     response.body.byteStream().use { input ->
-        targetFile.outputStream().use { output ->
-            val buffer = ByteArray(size = 16 * 1024)
+        FileOutputStream(partialFile, true).use { output ->
+            val buffer = ByteArray(size = reviewMediaAssetDownloadBufferSizeBytes)
             while (true) {
                 val readByteCount = input.read(buffer)
                 if (readByteCount == -1) {
                     break
                 }
-                val nextSizeBytes = sizeBytes + readByteCount.toLong()
-                if (nextSizeBytes > expectedSizeBytes) {
+                val nextResponseSizeBytes = responseSizeBytes + readByteCount.toLong()
+                if (nextResponseSizeBytes > expectedResponseSizeBytes) {
                     throw ReviewMediaAssetDownloadValidationException(
-                        "Managed media download exceeded expected size: " +
-                            "expected $expectedSizeBytes byte(s), received at least $nextSizeBytes byte(s)."
+                        "Managed media download response exceeded requested Range='$rangeHeader': " +
+                            "expected $expectedResponseSizeBytes byte(s), received at least " +
+                            "$nextResponseSizeBytes byte(s)."
+                    )
+                }
+                val nextTotalSizeBytes = writeStartByte + nextResponseSizeBytes
+                if (nextTotalSizeBytes > expectedTotalSizeBytes) {
+                    throw ReviewMediaAssetDownloadValidationException(
+                        "Managed media download exceeded expected total size for requested Range='$rangeHeader': " +
+                            "expected $expectedTotalSizeBytes byte(s), received at least " +
+                            "$nextTotalSizeBytes byte(s)."
                     )
                 }
                 output.write(buffer, 0, readByteCount)
-                digest.update(buffer, 0, readByteCount)
-                sizeBytes = nextSizeBytes
+                responseSizeBytes = nextResponseSizeBytes
             }
+        }
+    }
+
+    if (responseSizeBytes != expectedResponseSizeBytes) {
+        throw IOException(
+            "Managed media download response ended early for requested Range='$rangeHeader': " +
+                "expected $expectedResponseSizeBytes byte(s), received $responseSizeBytes byte(s)."
+        )
+    }
+}
+
+private fun completePartialReviewMediaDownload(
+    partialFile: File,
+    targetFile: File,
+    expectedSizeBytes: Long,
+    expectedSha256: String
+): DownloadedReviewMediaAsset {
+    val downloadedMediaAsset = verifyPartialReviewMediaDownload(
+        partialFile = partialFile,
+        expectedSizeBytes = expectedSizeBytes,
+        expectedSha256 = expectedSha256
+    )
+
+    if (targetFile.exists() && targetFile.delete().not()) {
+        throw IOException("Cannot replace managed media download target file: ${targetFile.absolutePath}")
+    }
+    try {
+        Files.move(
+            partialFile.toPath(),
+            targetFile.toPath(),
+            StandardCopyOption.ATOMIC_MOVE
+        )
+    } catch (error: AtomicMoveNotSupportedException) {
+        throw IOException(
+            "Atomic managed media download move is not supported from partial file " +
+                "'${partialFile.absolutePath}' to target file '${targetFile.absolutePath}'.",
+            error
+        )
+    }
+    return downloadedMediaAsset
+}
+
+private fun verifyPartialReviewMediaDownload(
+    partialFile: File,
+    expectedSizeBytes: Long,
+    expectedSha256: String
+): DownloadedReviewMediaAsset {
+    if (partialFile.exists().not()) {
+        throw IOException("Managed media download partial file does not exist: ${partialFile.absolutePath}")
+    }
+    if (partialFile.isFile.not()) {
+        throw IOException("Managed media download partial path is not a file: ${partialFile.absolutePath}")
+    }
+    val digest = MessageDigest.getInstance("SHA-256")
+    var sizeBytes = 0L
+
+    partialFile.inputStream().use { input ->
+        val buffer = ByteArray(size = reviewMediaAssetDownloadBufferSizeBytes)
+        while (true) {
+            val readByteCount = input.read(buffer)
+            if (readByteCount == -1) {
+                break
+            }
+            val nextSizeBytes = sizeBytes + readByteCount.toLong()
+            if (nextSizeBytes > expectedSizeBytes) {
+                throw ReviewMediaAssetDownloadValidationException(
+                    "Managed media download exceeded expected size: " +
+                        "expected $expectedSizeBytes byte(s), received at least $nextSizeBytes byte(s)."
+                )
+            }
+            digest.update(buffer, 0, readByteCount)
+            sizeBytes = nextSizeBytes
         }
     }
 
@@ -311,14 +687,17 @@ private fun streamReviewMediaResponseToFile(
 
 private fun validateReviewMediaDownloadContentLength(
     contentLength: Long,
-    expectedSizeBytes: Long
+    expectedSizeBytes: Long,
+    rangeHeader: String
 ): Unit {
     if (contentLength == -1L) {
-        return
+        throw ReviewMediaAssetDownloadValidationException(
+            "Managed media download response is missing Content-Length for requested Range='$rangeHeader'."
+        )
     }
     if (contentLength != expectedSizeBytes) {
         throw ReviewMediaAssetDownloadValidationException(
-            "Managed media download Content-Length mismatch: " +
+            "Managed media download Content-Length mismatch for requested Range='$rangeHeader': " +
                 "expected $expectedSizeBytes byte(s), received header value $contentLength."
         )
     }
@@ -372,15 +751,15 @@ private fun calculateReviewMediaDownloadRetryDelayMillis(attemptNumber: Int): Lo
 }
 
 private fun deletePartialReviewMediaDownload(
-    targetFile: File,
+    partialFile: File,
     cause: Throwable
 ): Unit {
-    if (targetFile.exists().not()) {
+    if (partialFile.exists().not()) {
         return
     }
-    if (targetFile.delete().not()) {
+    if (partialFile.delete().not()) {
         cause.addSuppressed(
-            IOException("Cannot delete partial managed media download file: ${targetFile.absolutePath}")
+            IOException("Cannot delete partial managed media download file: ${partialFile.absolutePath}")
         )
     }
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloaderTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewMediaAssetDownloaderTest.kt
@@ -1,0 +1,300 @@
+package com.flashcardsopensourceapp.data.local.repository.review
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicReference
+
+private const val testDownloadChunkSizeBytes: Int = 1024 * 1024
+private val testRangePattern: Regex = Regex("^bytes=(\\d+)-(\\d+)$")
+
+class ReviewMediaAssetDownloaderTest {
+    @Test
+    fun downloadMediaAssetRequestsRangesAndVerifiesFile() = runBlocking {
+        val mediaBytes: ByteArray = createTestMediaBytes(sizeBytes = testDownloadChunkSizeBytes + 7)
+        val rangeRequests: MutableList<String> = Collections.synchronizedList(mutableListOf())
+        val server: HttpServer = createRangedMediaServer(
+            mediaBytes = mediaBytes,
+            rangeRequests = rangeRequests
+        )
+        val tempDirectory: File = Files.createTempDirectory("review-media-download-test").toFile()
+        server.start()
+
+        try {
+            val targetFile = File(tempDirectory, "asset.bin")
+            val downloader = OkHttpReviewMediaAssetDownloader(okHttpClient = OkHttpClient())
+
+            val downloadedAsset: DownloadedReviewMediaAsset = downloader.downloadMediaAsset(
+                url = "http://127.0.0.1:${server.address.port}/asset",
+                targetFile = targetFile,
+                expectedSizeBytes = mediaBytes.size.toLong(),
+                expectedSha256 = sha256Hex(bytes = mediaBytes)
+            )
+
+            assertEquals(mediaBytes.size.toLong(), downloadedAsset.sizeBytes)
+            assertEquals(sha256Hex(bytes = mediaBytes), downloadedAsset.sha256)
+            assertArrayEquals(mediaBytes, targetFile.readBytes())
+            assertFalse(File(tempDirectory, "asset.bin.partial").exists())
+            assertEquals(
+                listOf(
+                    "bytes=0-1048575",
+                    "bytes=1048576-1048582"
+                ),
+                rangeRequests.toList()
+            )
+        } finally {
+            server.stop(0)
+            tempDirectory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun downloadMediaAssetResumesExistingPartialFile() = runBlocking {
+        val mediaBytes: ByteArray = "review media bytes for resume".toByteArray(StandardCharsets.UTF_8)
+        val resumeSizeBytes = 6
+        val rangeRequests: MutableList<String> = Collections.synchronizedList(mutableListOf())
+        val server: HttpServer = createRangedMediaServer(
+            mediaBytes = mediaBytes,
+            rangeRequests = rangeRequests
+        )
+        val tempDirectory: File = Files.createTempDirectory("review-media-download-resume-test").toFile()
+        server.start()
+
+        try {
+            val targetFile = File(tempDirectory, "asset.bin")
+            val partialFile = File(tempDirectory, "asset.bin.partial")
+            partialFile.writeBytes(mediaBytes.copyOfRange(0, resumeSizeBytes))
+            val downloader = OkHttpReviewMediaAssetDownloader(okHttpClient = OkHttpClient())
+
+            val downloadedAsset: DownloadedReviewMediaAsset = downloader.downloadMediaAsset(
+                url = "http://127.0.0.1:${server.address.port}/asset",
+                targetFile = targetFile,
+                expectedSizeBytes = mediaBytes.size.toLong(),
+                expectedSha256 = sha256Hex(bytes = mediaBytes)
+            )
+
+            assertEquals(mediaBytes.size.toLong(), downloadedAsset.sizeBytes)
+            assertEquals(sha256Hex(bytes = mediaBytes), downloadedAsset.sha256)
+            assertArrayEquals(mediaBytes, targetFile.readBytes())
+            assertFalse(partialFile.exists())
+            assertEquals(listOf("bytes=6-28"), rangeRequests.toList())
+        } finally {
+            server.stop(0)
+            tempDirectory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun downloadMediaAssetRestartsAfterBadResumedPartialFailsValidation() = runBlocking {
+        val mediaBytes: ByteArray = createTestMediaBytes(sizeBytes = 31)
+        val resumeSizeBytes = 6
+        val rangeRequests: MutableList<String> = Collections.synchronizedList(mutableListOf())
+        val server: HttpServer = createRangedMediaServer(
+            mediaBytes = mediaBytes,
+            rangeRequests = rangeRequests
+        )
+        val tempDirectory: File = Files.createTempDirectory("review-media-download-bad-partial-test").toFile()
+        server.start()
+
+        try {
+            val targetFile = File(tempDirectory, "asset.bin")
+            val partialFile = File(tempDirectory, "asset.bin.partial")
+            partialFile.writeBytes(ByteArray(size = resumeSizeBytes) { 0x7f.toByte() })
+            val downloader = OkHttpReviewMediaAssetDownloader(okHttpClient = OkHttpClient())
+
+            val downloadedAsset: DownloadedReviewMediaAsset = downloader.downloadMediaAsset(
+                url = "http://127.0.0.1:${server.address.port}/asset",
+                targetFile = targetFile,
+                expectedSizeBytes = mediaBytes.size.toLong(),
+                expectedSha256 = sha256Hex(bytes = mediaBytes)
+            )
+
+            assertEquals(mediaBytes.size.toLong(), downloadedAsset.sizeBytes)
+            assertEquals(sha256Hex(bytes = mediaBytes), downloadedAsset.sha256)
+            assertArrayEquals(mediaBytes, targetFile.readBytes())
+            assertFalse(partialFile.exists())
+            assertEquals(
+                listOf(
+                    "bytes=6-30",
+                    "bytes=0-30"
+                ),
+                rangeRequests.toList()
+            )
+        } finally {
+            server.stop(0)
+            tempDirectory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun downloadMediaAssetRestartsPartialFileForExactFullObjectResponse() = runBlocking {
+        val mediaBytes: ByteArray = "full object response bytes".toByteArray(StandardCharsets.UTF_8)
+        val resumeSizeBytes = 5
+        val rangeRequest = AtomicReference<String>()
+        val server: HttpServer = createFullObjectMediaServer(
+            mediaBytes = mediaBytes,
+            rangeRequest = rangeRequest
+        )
+        val tempDirectory: File = Files.createTempDirectory("review-media-download-full-object-test").toFile()
+        server.start()
+
+        try {
+            val targetFile = File(tempDirectory, "asset.bin")
+            val partialFile = File(tempDirectory, "asset.bin.partial")
+            partialFile.writeBytes(mediaBytes.copyOfRange(0, resumeSizeBytes))
+            val downloader = OkHttpReviewMediaAssetDownloader(okHttpClient = OkHttpClient())
+
+            val downloadedAsset: DownloadedReviewMediaAsset = downloader.downloadMediaAsset(
+                url = "http://127.0.0.1:${server.address.port}/asset",
+                targetFile = targetFile,
+                expectedSizeBytes = mediaBytes.size.toLong(),
+                expectedSha256 = sha256Hex(bytes = mediaBytes)
+            )
+
+            assertEquals(mediaBytes.size.toLong(), downloadedAsset.sizeBytes)
+            assertEquals(sha256Hex(bytes = mediaBytes), downloadedAsset.sha256)
+            assertArrayEquals(mediaBytes, targetFile.readBytes())
+            assertFalse(partialFile.exists())
+            assertEquals("bytes=5-25", rangeRequest.get())
+        } finally {
+            server.stop(0)
+            tempDirectory.deleteRecursively()
+        }
+    }
+}
+
+private fun createRangedMediaServer(
+    mediaBytes: ByteArray,
+    rangeRequests: MutableList<String>
+): HttpServer {
+    val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/asset") { exchange ->
+        val rangeHeader: String? = exchange.requestHeaders.getFirst("Range")
+        if (rangeHeader == null) {
+            writeTestResponse(
+                exchange = exchange,
+                statusCode = 400,
+                body = "Missing Range header."
+            )
+            return@createContext
+        }
+        rangeRequests += rangeHeader
+        val requestedRange: TestRange? = parseTestRangeOrNull(rangeHeader = rangeHeader)
+        if (requestedRange == null) {
+            writeTestResponse(
+                exchange = exchange,
+                statusCode = 400,
+                body = "Invalid Range header."
+            )
+            return@createContext
+        }
+        if (requestedRange.endByteInclusive >= mediaBytes.size.toLong()) {
+            writeTestResponse(
+                exchange = exchange,
+                statusCode = 416,
+                body = "Requested range is outside the object."
+            )
+            return@createContext
+        }
+
+        val startIndex = requestedRange.startByte.toInt()
+        val endExclusiveIndex = requestedRange.endByteInclusive.toInt() + 1
+        val responseBytes: ByteArray = mediaBytes.copyOfRange(startIndex, endExclusiveIndex)
+        exchange.responseHeaders.add(
+            "Content-Range",
+            "bytes ${requestedRange.startByte}-${requestedRange.endByteInclusive}/${mediaBytes.size}"
+        )
+        exchange.responseHeaders.add("Accept-Ranges", "bytes")
+        exchange.sendResponseHeaders(206, responseBytes.size.toLong())
+        exchange.responseBody.use { output ->
+            output.write(responseBytes)
+        }
+    }
+    return server
+}
+
+private fun createFullObjectMediaServer(
+    mediaBytes: ByteArray,
+    rangeRequest: AtomicReference<String>
+): HttpServer {
+    val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/asset") { exchange ->
+        val rangeHeader: String? = exchange.requestHeaders.getFirst("Range")
+        if (rangeHeader == null) {
+            writeTestResponse(
+                exchange = exchange,
+                statusCode = 400,
+                body = "Missing Range header."
+            )
+            return@createContext
+        }
+        rangeRequest.set(rangeHeader)
+        exchange.sendResponseHeaders(200, mediaBytes.size.toLong())
+        exchange.responseBody.use { output ->
+            output.write(mediaBytes)
+        }
+    }
+    return server
+}
+
+private data class TestRange(
+    val startByte: Long,
+    val endByteInclusive: Long
+)
+
+private fun parseTestRangeOrNull(rangeHeader: String): TestRange? {
+    val match = testRangePattern.matchEntire(rangeHeader)
+        ?: return null
+    val startByte: Long = match.groupValues[1].toLong()
+    val endByteInclusive: Long = match.groupValues[2].toLong()
+    if (endByteInclusive < startByte) {
+        return null
+    }
+    return TestRange(
+        startByte = startByte,
+        endByteInclusive = endByteInclusive
+    )
+}
+
+private fun createTestMediaBytes(sizeBytes: Int): ByteArray {
+    val bytes = ByteArray(size = sizeBytes)
+    bytes.indices.forEach { index ->
+        bytes[index] = (index % 251).toByte()
+    }
+    return bytes
+}
+
+private fun sha256Hex(bytes: ByteArray): String {
+    val digestBytes: ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+    val hexChars = "0123456789abcdef".toCharArray()
+    val result = CharArray(size = digestBytes.size * 2)
+    digestBytes.forEachIndexed { index, byte ->
+        val value = byte.toInt() and 0xff
+        result[index * 2] = hexChars[value ushr 4]
+        result[(index * 2) + 1] = hexChars[value and 0x0f]
+    }
+    return String(result)
+}
+
+private fun writeTestResponse(
+    exchange: HttpExchange,
+    statusCode: Int,
+    body: String
+): Unit {
+    val responseBytes: ByteArray = body.toByteArray(StandardCharsets.UTF_8)
+    exchange.sendResponseHeaders(statusCode, responseBytes.size.toLong())
+    exchange.responseBody.use { output ->
+        output.write(responseBytes)
+    }
+}


### PR DESCRIPTION
## Summary
- replace Android managed-media downloads with direct presigned URL ranged GETs
- add deterministic partial file resume/restart behavior with final size and SHA-256 verification
- add focused real-HTTP JVM coverage for chunking, resume, full-object restart, and bad partial restart

## Validation
- git --no-pager diff --check
- direct trailing-whitespace check on changed files
- worker-owned review after fix: no split recommendation, no P0-P4 issues

Not run: Gradle tests/builds, because this worker thread did not receive explicit Gradle permission.