### PR TITLE
Add Android managed image authoring foundation

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -72,6 +72,7 @@ import com.flashcardsopensourceapp.data.local.repository.cloudsync.account.Local
 import com.flashcardsopensourceapp.data.local.repository.cards.LocalCardsRepository
 import com.flashcardsopensourceapp.data.local.repository.decks.LocalDecksRepository
 import com.flashcardsopensourceapp.data.local.repository.feedback.LocalFeedbackRepository
+import com.flashcardsopensourceapp.data.local.repository.media.LocalManagedMediaAuthoringRepository
 import com.flashcardsopensourceapp.data.local.repository.media.LocalMediaUploadTransferRepository
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.progress.LocalProgressRepository
@@ -279,6 +280,14 @@ class AppGraph(
         guestSessionStore = guestAiSessionStore,
         mediaFileRootDirectory = applicationContext.filesDir,
         signedPutUploader = OkHttpSignedPutUploader(okHttpClient = okHttpClient),
+        timeProvider = SystemTimeProvider
+    )
+    val managedMediaAuthoringRepository = LocalManagedMediaAuthoringRepository(
+        contentResolver = applicationContext.contentResolver,
+        database = database,
+        preferencesStore = cloudPreferencesStore,
+        mediaFileRootDirectory = applicationContext.filesDir,
+        ioDispatcher = Dispatchers.IO,
         timeProvider = SystemTimeProvider
     )
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
@@ -17,11 +17,14 @@ import com.flashcardsopensourceapp.data.local.cloud.sync.ReviewHistoryChangedEve
 import com.flashcardsopensourceapp.data.local.cloud.sync.emptySyncStateEntity
 import com.flashcardsopensourceapp.data.local.cloud.wire.toRemoteValue
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferKind
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.scheduling.encodeSchedulerStepListJson
 import com.flashcardsopensourceapp.data.local.model.scheduling.makeDefaultWorkspaceSchedulerSettings
-import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.buildClientWorkspaceReplicaId
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.loadCurrentWorkspaceOrNull
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
 import java.util.UUID
 
@@ -290,11 +293,15 @@ internal class WorkspaceIdentityLocalStore(
         ) {
             "Cannot fork workspace identity because current local workspace '$currentLocalWorkspaceId' does not exist."
         }
-        val mediaAssetCount = database.mediaAssetDao().countMediaAssets(workspaceId = currentLocalWorkspaceId)
-        require(mediaAssetCount == 0) {
+        val registeredMediaAssetCount = database.mediaAssetDao().countMediaAssetsExcludingPendingUploads(
+            workspaceId = currentLocalWorkspaceId,
+            uploadKind = MediaTransferKind.UPLOAD.wireKey,
+            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey
+        )
+        require(registeredMediaAssetCount == 0) {
             "Cannot fork workspace identity from workspace '$currentLocalWorkspaceId' to " +
-                "'${destinationWorkspace.workspaceId}' because the source workspace has $mediaAssetCount media asset " +
-                "registry row(s). Android cannot reassign managed media assets in this sync/storage split."
+                "'${destinationWorkspace.workspaceId}' because the source workspace has $registeredMediaAssetCount " +
+                "registered media asset row(s). Android can only reassign pending media uploads."
         }
         val snapshot = loadWorkspaceForkSnapshot(workspaceId = currentLocalWorkspaceId)
         val forkMappings = buildWorkspaceForkIdMappings(
@@ -347,6 +354,10 @@ internal class WorkspaceIdentityLocalStore(
                     newWorkspaceId = destinationWorkspace.workspaceId
                 )
             }
+            reassignPendingMediaUploadsForWorkspaceFork(
+                oldWorkspaceId = currentLocalWorkspaceId,
+                newWorkspaceId = destinationWorkspace.workspaceId
+            )
             localProgressCacheStore.reassignWorkspaceInTransaction(
                 oldWorkspaceId = currentLocalWorkspaceId,
                 newWorkspaceId = destinationWorkspace.workspaceId
@@ -478,6 +489,32 @@ internal class WorkspaceIdentityLocalStore(
         }
 
         replaceSyncStateWithEmptyProgress(workspaceId = destinationWorkspace.workspaceId)
+    }
+
+    private suspend fun reassignPendingMediaUploadsForWorkspaceFork(
+        oldWorkspaceId: String,
+        newWorkspaceId: String
+    ) {
+        val updatedAtMillis: Long = System.currentTimeMillis()
+        val lastModifiedByReplicaId: String = buildClientWorkspaceReplicaId(
+            workspaceId = newWorkspaceId,
+            installationId = preferencesStore.currentCloudSettings().installationId
+        )
+        database.mediaAssetDao().reassignPendingUploadMediaAssets(
+            oldWorkspaceId = oldWorkspaceId,
+            newWorkspaceId = newWorkspaceId,
+            uploadKind = MediaTransferKind.UPLOAD.wireKey,
+            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey,
+            lastModifiedByReplicaId = lastModifiedByReplicaId,
+            updatedAtMillis = updatedAtMillis
+        )
+        database.mediaTransferDao().reassignPendingUploadMediaTransfers(
+            oldWorkspaceId = oldWorkspaceId,
+            newWorkspaceId = newWorkspaceId,
+            uploadKind = MediaTransferKind.UPLOAD.wireKey,
+            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey,
+            updatedAtMillis = updatedAtMillis
+        )
     }
 
     private suspend fun loadWorkspaceForkSnapshot(workspaceId: String): WorkspaceForkSnapshot {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
@@ -9,6 +9,8 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.buildMediaAssetBootstra
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildReviewHistoryImportEventJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildWorkspaceSchedulerSettingsBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.toCardSummary
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferKind
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import kotlinx.coroutines.flow.first
 import org.json.JSONArray
@@ -54,7 +56,11 @@ internal class SyncBootstrapLocalStore(
                 )
             }
 
-        database.mediaAssetDao().loadMediaAssets(workspaceId = workspaceId)
+        database.mediaAssetDao().loadMediaAssetsExcludingPendingUploads(
+            workspaceId = workspaceId,
+            uploadKind = MediaTransferKind.UPLOAD.wireKey,
+            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey
+        )
             .forEach { mediaAsset ->
                 entries.put(
                     buildMediaAssetBootstrapEntryJson(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
@@ -18,9 +18,74 @@ interface MediaAssetDao {
     @Query("SELECT * FROM media_assets WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, mediaAssetId ASC")
     suspend fun loadMediaAssets(workspaceId: String): List<MediaAssetEntity>
 
+    @Query(
+        """
+        SELECT * FROM media_assets
+        WHERE workspaceId = :workspaceId
+            AND NOT EXISTS (
+                SELECT 1 FROM media_transfer_queue
+                WHERE media_transfer_queue.workspaceId = media_assets.workspaceId
+                    AND media_transfer_queue.mediaAssetId = media_assets.mediaAssetId
+                    AND media_transfer_queue.kind = :uploadKind
+                    AND media_transfer_queue.status != :succeededStatus
+            )
+        ORDER BY createdAtMillis ASC, mediaAssetId ASC
+        """
+    )
+    suspend fun loadMediaAssetsExcludingPendingUploads(
+        workspaceId: String,
+        uploadKind: String,
+        succeededStatus: String
+    ): List<MediaAssetEntity>
+
     @Query("SELECT * FROM media_assets WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, mediaAssetId ASC")
     fun observeMediaAssets(workspaceId: String): Flow<List<MediaAssetEntity>>
 
     @Query("SELECT COUNT(*) FROM media_assets WHERE workspaceId = :workspaceId")
     suspend fun countMediaAssets(workspaceId: String): Int
+
+    @Query(
+        """
+        SELECT COUNT(*) FROM media_assets
+        WHERE workspaceId = :workspaceId
+            AND NOT EXISTS (
+                SELECT 1 FROM media_transfer_queue
+                WHERE media_transfer_queue.workspaceId = media_assets.workspaceId
+                    AND media_transfer_queue.mediaAssetId = media_assets.mediaAssetId
+                    AND media_transfer_queue.kind = :uploadKind
+                    AND media_transfer_queue.status != :succeededStatus
+            )
+        """
+    )
+    suspend fun countMediaAssetsExcludingPendingUploads(
+        workspaceId: String,
+        uploadKind: String,
+        succeededStatus: String
+    ): Int
+
+    @Query(
+        """
+        UPDATE media_assets
+        SET workspaceId = :newWorkspaceId,
+            clientUpdatedAtMillis = :updatedAtMillis,
+            lastModifiedByReplicaId = :lastModifiedByReplicaId,
+            updatedAtMillis = :updatedAtMillis
+        WHERE workspaceId = :oldWorkspaceId
+            AND EXISTS (
+                SELECT 1 FROM media_transfer_queue
+                WHERE media_transfer_queue.workspaceId = media_assets.workspaceId
+                    AND media_transfer_queue.mediaAssetId = media_assets.mediaAssetId
+                    AND media_transfer_queue.kind = :uploadKind
+                    AND media_transfer_queue.status != :succeededStatus
+            )
+        """
+    )
+    suspend fun reassignPendingUploadMediaAssets(
+        oldWorkspaceId: String,
+        newWorkspaceId: String,
+        uploadKind: String,
+        succeededStatus: String,
+        lastModifiedByReplicaId: String,
+        updatedAtMillis: Long
+    )
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
@@ -180,6 +180,24 @@ interface MediaTransferDao {
     @Query("DELETE FROM media_transfer_queue WHERE transferId = :transferId")
     suspend fun deleteMediaTransfer(transferId: String)
 
+    @Query(
+        """
+        UPDATE media_transfer_queue
+        SET workspaceId = :newWorkspaceId,
+            updatedAtMillis = :updatedAtMillis
+        WHERE workspaceId = :oldWorkspaceId
+            AND kind = :uploadKind
+            AND status != :succeededStatus
+        """
+    )
+    suspend fun reassignPendingUploadMediaTransfers(
+        oldWorkspaceId: String,
+        newWorkspaceId: String,
+        uploadKind: String,
+        succeededStatus: String,
+        updatedAtMillis: Long
+    )
+
     @Query("DELETE FROM media_transfer_queue WHERE workspaceId = :workspaceId")
     suspend fun deleteMediaTransfersForWorkspace(workspaceId: String)
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
@@ -1,0 +1,37 @@
+package com.flashcardsopensourceapp.data.local.model.media
+
+private const val managedMediaAssetSchemePrefix: String = "fcasset:"
+private const val managedImageFallbackAltText: String = "Image"
+
+fun managedImageMarkdownReference(
+    mediaAssetId: String,
+    altText: String
+): String {
+    val normalizedMediaAssetId: String = normalizeManagedMediaAssetId(mediaAssetId = mediaAssetId)
+    val normalizedAltText: String = normalizeManagedMediaLabel(label = altText)
+    return "![$normalizedAltText]($managedMediaAssetSchemePrefix$normalizedMediaAssetId)"
+}
+
+private fun normalizeManagedMediaAssetId(mediaAssetId: String): String {
+    val normalizedMediaAssetId: String = mediaAssetId.trim()
+    require(normalizedMediaAssetId.isNotBlank()) {
+        "Managed media asset id must not be blank."
+    }
+    require(normalizedMediaAssetId.none { character -> character.isWhitespace() }) {
+        "Managed media asset id must not contain whitespace."
+    }
+    require(normalizedMediaAssetId.contains(')').not()) {
+        "Managed media asset id must not contain a closing parenthesis."
+    }
+    return normalizedMediaAssetId
+}
+
+private fun normalizeManagedMediaLabel(label: String): String {
+    val normalizedLabel: String = label
+        .replace(oldChar = '[', newChar = '(')
+        .replace(oldChar = ']', newChar = ')')
+        .lineSequence()
+        .joinToString(separator = " ") { line -> line.trim() }
+        .trim()
+    return normalizedLabel.ifBlank { managedImageFallbackAltText }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/LocalManagedMediaAuthoringRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/LocalManagedMediaAuthoringRepository.kt
@@ -1,0 +1,223 @@
+package com.flashcardsopensourceapp.data.local.repository.media
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.room.withTransaction
+import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
+import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaBlobCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaTransferQueueEntity
+import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferKind
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferStatus
+import com.flashcardsopensourceapp.data.local.model.media.buildMediaBlobCacheRelativePath
+import com.flashcardsopensourceapp.data.local.model.media.managedImageMarkdownReference
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.buildClientWorkspaceReplicaId
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.requireCurrentWorkspace
+import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.UUID
+
+data class ManagedMediaAuthoringResult(
+    val workspaceId: String,
+    val mediaAssetId: String,
+    val transferId: String,
+    val markdown: String
+) {
+    init {
+        require(workspaceId.isNotBlank()) {
+            "Managed media authoring result workspaceId must not be blank."
+        }
+        require(mediaAssetId.isNotBlank()) {
+            "Managed media authoring result mediaAssetId must not be blank."
+        }
+        require(transferId.isNotBlank()) {
+            "Managed media authoring result transferId must not be blank."
+        }
+        require(markdown.isNotBlank()) {
+            "Managed media authoring result markdown must not be blank."
+        }
+    }
+}
+
+class LocalManagedMediaAuthoringRepository(
+    private val contentResolver: ContentResolver,
+    private val database: AppDatabase,
+    private val preferencesStore: CloudPreferencesStore,
+    private val mediaFileRootDirectory: File,
+    private val ioDispatcher: CoroutineDispatcher,
+    private val timeProvider: TimeProvider
+) {
+    suspend fun authorManagedImageFromUri(
+        uri: Uri,
+        altText: String
+    ): ManagedMediaAuthoringResult {
+        val preparedImage: PreparedManagedImage = prepareManagedImageFromUri(
+            contentResolver = contentResolver,
+            uri = uri,
+            ioDispatcher = ioDispatcher
+        )
+
+        return withContext(ioDispatcher) {
+            persistManagedImage(
+                preparedImage = preparedImage,
+                altText = altText
+            )
+        }
+    }
+
+    private suspend fun persistManagedImage(
+        preparedImage: PreparedManagedImage,
+        altText: String
+    ): ManagedMediaAuthoringResult {
+        val workspace: WorkspaceEntity = requireCurrentWorkspace(
+            database = database,
+            preferencesStore = preferencesStore,
+            missingWorkspaceMessage = "Workspace is required before adding managed media."
+        )
+        val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+        val nowMillis: Long = timeProvider.currentTimeMillis()
+        val mediaAssetId: String = UUID.randomUUID().toString()
+        val transferId: String = UUID.randomUUID().toString()
+        val localRelativePath: String = buildMediaBlobCacheRelativePath(sha256 = preparedImage.sha256)
+        writeManagedMediaBlobCacheFile(
+            mediaFileRootDirectory = mediaFileRootDirectory,
+            localRelativePath = localRelativePath,
+            bytes = preparedImage.bytes
+        )
+
+        val mediaAsset = MediaAssetEntity(
+            mediaAssetId = mediaAssetId,
+            workspaceId = workspace.workspaceId,
+            mimeType = preparedImage.mimeType,
+            sizeBytes = preparedImage.sizeBytes,
+            sha256 = preparedImage.sha256,
+            sourceUrl = null,
+            createdAtMillis = nowMillis,
+            clientUpdatedAtMillis = nowMillis,
+            lastModifiedByReplicaId = buildClientWorkspaceReplicaId(
+                workspaceId = workspace.workspaceId,
+                installationId = cloudSettings.installationId
+            ),
+            lastOperationId = transferId,
+            updatedAtMillis = nowMillis,
+            deletedAtMillis = null
+        )
+        val mediaBlobCache = MediaBlobCacheEntity(
+            sha256 = preparedImage.sha256,
+            mimeType = preparedImage.mimeType,
+            sizeBytes = preparedImage.sizeBytes,
+            localRelativePath = localRelativePath,
+            createdAtMillis = nowMillis,
+            lastAccessedAtMillis = nowMillis,
+            sourceMediaAssetId = mediaAssetId
+        )
+        val mediaTransfer = MediaTransferQueueEntity(
+            transferId = transferId,
+            workspaceId = workspace.workspaceId,
+            mediaAssetId = mediaAssetId,
+            kind = MediaTransferKind.UPLOAD.wireKey,
+            status = MediaTransferStatus.QUEUED.wireKey,
+            sha256 = preparedImage.sha256,
+            mimeType = preparedImage.mimeType,
+            sizeBytes = preparedImage.sizeBytes,
+            localRelativePath = localRelativePath,
+            attemptCount = 0,
+            nextAttemptAtMillis = nowMillis,
+            lastError = null,
+            createdAtMillis = nowMillis,
+            updatedAtMillis = nowMillis
+        )
+
+        database.withTransaction {
+            database.mediaAssetDao().insertMediaAsset(mediaAsset = mediaAsset)
+            database.mediaTransferDao().upsertMediaBlobCache(mediaBlobCache = mediaBlobCache)
+            database.mediaTransferDao().upsertMediaTransfer(mediaTransfer = mediaTransfer)
+        }
+
+        return ManagedMediaAuthoringResult(
+            workspaceId = workspace.workspaceId,
+            mediaAssetId = mediaAssetId,
+            transferId = transferId,
+            markdown = managedImageMarkdownReference(
+                mediaAssetId = mediaAssetId,
+                altText = altText
+            )
+        )
+    }
+}
+
+private fun writeManagedMediaBlobCacheFile(
+    mediaFileRootDirectory: File,
+    localRelativePath: String,
+    bytes: ByteArray
+) {
+    val targetFile: File = resolveManagedMediaBlobCacheFile(
+        mediaFileRootDirectory = mediaFileRootDirectory,
+        localRelativePath = localRelativePath
+    )
+    val parentDirectory: File = requireNotNull(targetFile.parentFile) {
+        "Managed media cache target file must have a parent directory: ${targetFile.absolutePath}"
+    }
+    if (parentDirectory.exists().not() && parentDirectory.mkdirs().not()) {
+        throw IOException("Cannot create managed media cache directory: ${parentDirectory.absolutePath}")
+    }
+
+    val temporaryFile = File(
+        parentDirectory,
+        "${targetFile.name}.${UUID.randomUUID()}.tmp"
+    )
+    try {
+        FileOutputStream(temporaryFile).use { outputStream ->
+            outputStream.write(bytes)
+        }
+        if (targetFile.exists() && targetFile.delete().not()) {
+            throw IOException("Cannot replace managed media cache file: ${targetFile.absolutePath}")
+        }
+        if (temporaryFile.renameTo(targetFile).not()) {
+            throw IOException(
+                "Cannot move managed media cache file '${temporaryFile.absolutePath}' " +
+                    "to '${targetFile.absolutePath}'."
+            )
+        }
+    } catch (error: Throwable) {
+        deleteTemporaryManagedMediaFile(
+            temporaryFile = temporaryFile,
+            cause = error
+        )
+        throw error
+    }
+}
+
+private fun resolveManagedMediaBlobCacheFile(
+    mediaFileRootDirectory: File,
+    localRelativePath: String
+): File {
+    val rootDirectory: File = mediaFileRootDirectory.canonicalFile
+    val cacheFile: File = File(rootDirectory, localRelativePath).canonicalFile
+    val rootPath: String = rootDirectory.path
+    val cacheFilePath: String = cacheFile.path
+    if (cacheFilePath != rootPath && cacheFilePath.startsWith(prefix = "$rootPath${File.separator}").not()) {
+        throw IOException(
+            "Managed media cache path escapes file root: root='$rootPath' relativePath='$localRelativePath'."
+        )
+    }
+    return cacheFile
+}
+
+private fun deleteTemporaryManagedMediaFile(
+    temporaryFile: File,
+    cause: Throwable
+) {
+    if (temporaryFile.exists() && temporaryFile.delete().not()) {
+        cause.addSuppressed(
+            IOException("Cannot delete temporary managed media cache file: ${temporaryFile.absolutePath}")
+        )
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/ManagedImagePreparation.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/ManagedImagePreparation.kt
@@ -1,0 +1,275 @@
+package com.flashcardsopensourceapp.data.local.repository.media
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.ImageDecoder
+import android.graphics.drawable.AnimatedImageDrawable
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import com.flashcardsopensourceapp.data.local.model.media.normalizeMediaSha256
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.security.MessageDigest
+import java.util.Locale
+
+internal const val managedImageMimeType: String = "image/jpeg"
+
+private const val managedImageMaxSidePixels: Int = 1_200
+private const val managedImageJpegQuality: Int = 82
+private const val managedImageFlattenBackgroundRed: Int = 0xf1
+private const val managedImageFlattenBackgroundGreen: Int = 0xf3
+private const val managedImageFlattenBackgroundBlue: Int = 0xf4
+
+private val unsupportedManagedImageMimeTypes: Set<String> = setOf(
+    "image/gif",
+    "image/heic-sequence",
+    "image/heif-sequence",
+    "image/avif-sequence"
+)
+
+class ManagedMediaAuthoringImportException(
+    message: String,
+    cause: Throwable?
+) : Exception(message, cause)
+
+internal data class PreparedManagedImage(
+    val mimeType: String,
+    val bytes: ByteArray,
+    val sizeBytes: Long,
+    val sha256: String
+) {
+    init {
+        require(mimeType == managedImageMimeType) {
+            "Prepared managed image mimeType must be '$managedImageMimeType'."
+        }
+        require(bytes.isNotEmpty()) {
+            "Prepared managed image bytes must not be empty."
+        }
+        require(sizeBytes == bytes.size.toLong()) {
+            "Prepared managed image sizeBytes must match bytes size."
+        }
+        require(sha256 == normalizeMediaSha256(rawSha256 = sha256)) {
+            "Prepared managed image sha256 must already be normalized."
+        }
+    }
+}
+
+internal suspend fun prepareManagedImageFromUri(
+    contentResolver: ContentResolver,
+    uri: Uri,
+    ioDispatcher: CoroutineDispatcher
+): PreparedManagedImage {
+    return withContext(ioDispatcher) {
+        prepareManagedImageFromUriBlocking(
+            contentResolver = contentResolver,
+            uri = uri
+        )
+    }
+}
+
+private fun prepareManagedImageFromUriBlocking(
+    contentResolver: ContentResolver,
+    uri: Uri
+): PreparedManagedImage {
+    return try {
+        val resolverMimeType: String? = contentResolver.getType(uri)
+        requireSupportedManagedImageMimeType(mimeType = resolverMimeType)
+
+        val source: ImageDecoder.Source = ImageDecoder.createSource(contentResolver, uri)
+        val drawable: Drawable = ImageDecoder.decodeDrawable(source) { decoder, info, _ ->
+            requireSupportedManagedImageMimeType(mimeType = info.mimeType)
+            if (info.isAnimated) {
+                throw ManagedMediaAuthoringImportException(
+                    message = "Animated images are not supported. Select a still image.",
+                    cause = null
+                )
+            }
+            decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+            val dimensions: ManagedImageDimensions = scaledManagedImageDimensions(
+                width = info.size.width,
+                height = info.size.height,
+                maxSidePixels = managedImageMaxSidePixels
+            )
+            decoder.setTargetSize(dimensions.width, dimensions.height)
+        }
+        if (drawable is AnimatedImageDrawable) {
+            throw ManagedMediaAuthoringImportException(
+                message = "Animated images are not supported. Select a still image.",
+                cause = null
+            )
+        }
+
+        val dimensions: ManagedImageDimensions = requireDecodedDrawableDimensions(drawable = drawable)
+        val flattenedBitmap: Bitmap = flattenDrawableToBitmap(
+            drawable = drawable,
+            dimensions = dimensions
+        )
+        val jpegBytes: ByteArray = try {
+            compressBitmapToManagedJpegBytes(bitmap = flattenedBitmap)
+        } finally {
+            flattenedBitmap.recycle()
+        }
+        val sha256: String = normalizeMediaSha256(rawSha256 = sha256Hex(bytes = jpegBytes))
+        PreparedManagedImage(
+            mimeType = managedImageMimeType,
+            bytes = jpegBytes,
+            sizeBytes = jpegBytes.size.toLong(),
+            sha256 = sha256
+        )
+    } catch (error: ManagedMediaAuthoringImportException) {
+        throw error
+    } catch (error: SecurityException) {
+        throw ManagedMediaAuthoringImportException(
+            message = "Cannot read the selected image. Grant photo access and try again.",
+            cause = error
+        )
+    } catch (error: IOException) {
+        throw ManagedMediaAuthoringImportException(
+            message = "Cannot read the selected image. Select a different image and try again.",
+            cause = error
+        )
+    } catch (error: IllegalArgumentException) {
+        throw ManagedMediaAuthoringImportException(
+            message = "Cannot prepare the selected image because its data is invalid.",
+            cause = error
+        )
+    }
+}
+
+private data class ManagedImageDimensions(
+    val width: Int,
+    val height: Int
+) {
+    init {
+        require(width > 0) {
+            "Managed image width must be positive."
+        }
+        require(height > 0) {
+            "Managed image height must be positive."
+        }
+    }
+}
+
+private fun scaledManagedImageDimensions(
+    width: Int,
+    height: Int,
+    maxSidePixels: Int
+): ManagedImageDimensions {
+    require(width > 0 && height > 0) {
+        "Selected image dimensions must be positive."
+    }
+    require(maxSidePixels > 0) {
+        "Managed image max side pixels must be positive."
+    }
+
+    val longestSide: Int = maxOf(width, height)
+    if (longestSide <= maxSidePixels) {
+        return ManagedImageDimensions(width = width, height = height)
+    }
+
+    val scale: Double = maxSidePixels.toDouble() / longestSide.toDouble()
+    return ManagedImageDimensions(
+        width = maxOf(1, kotlin.math.round(width.toDouble() * scale).toInt()),
+        height = maxOf(1, kotlin.math.round(height.toDouble() * scale).toInt())
+    )
+}
+
+private fun requireDecodedDrawableDimensions(drawable: Drawable): ManagedImageDimensions {
+    val width: Int = drawable.intrinsicWidth
+    val height: Int = drawable.intrinsicHeight
+    if (width <= 0 || height <= 0) {
+        throw ManagedMediaAuthoringImportException(
+            message = "Cannot prepare the selected image because its dimensions are invalid.",
+            cause = null
+        )
+    }
+    return ManagedImageDimensions(width = width, height = height)
+}
+
+private fun flattenDrawableToBitmap(
+    drawable: Drawable,
+    dimensions: ManagedImageDimensions
+): Bitmap {
+    val bitmap: Bitmap = Bitmap.createBitmap(
+        dimensions.width,
+        dimensions.height,
+        Bitmap.Config.ARGB_8888
+    )
+    val canvas = Canvas(bitmap)
+    canvas.drawColor(
+        Color.rgb(
+            managedImageFlattenBackgroundRed,
+            managedImageFlattenBackgroundGreen,
+            managedImageFlattenBackgroundBlue
+        )
+    )
+    drawable.setBounds(0, 0, dimensions.width, dimensions.height)
+    drawable.draw(canvas)
+    return bitmap
+}
+
+private fun compressBitmapToManagedJpegBytes(bitmap: Bitmap): ByteArray {
+    val outputStream = ByteArrayOutputStream()
+    val didCompress: Boolean = bitmap.compress(
+        Bitmap.CompressFormat.JPEG,
+        managedImageJpegQuality,
+        outputStream
+    )
+    if (didCompress.not()) {
+        throw ManagedMediaAuthoringImportException(
+            message = "Cannot encode the selected image as JPEG.",
+            cause = null
+        )
+    }
+
+    val bytes: ByteArray = outputStream.toByteArray()
+    if (bytes.isEmpty()) {
+        throw ManagedMediaAuthoringImportException(
+            message = "Cannot encode the selected image because JPEG output is empty.",
+            cause = null
+        )
+    }
+    return bytes
+}
+
+private fun requireSupportedManagedImageMimeType(mimeType: String?) {
+    val normalizedMimeType: String = mimeType
+        ?.substringBefore(delimiter = ';')
+        ?.trim()
+        ?.lowercase(Locale.US)
+        ?: return
+    if (normalizedMimeType.isEmpty() || normalizedMimeType == "application/octet-stream") {
+        return
+    }
+    if (normalizedMimeType.startsWith(prefix = "image/").not()) {
+        throw ManagedMediaAuthoringImportException(
+            message = "The selected file is not an image.",
+            cause = null
+        )
+    }
+    if (unsupportedManagedImageMimeTypes.contains(normalizedMimeType)) {
+        throw ManagedMediaAuthoringImportException(
+            message = "Animated or multipage images are not supported. Select a still image.",
+            cause = null
+        )
+    }
+}
+
+private fun sha256Hex(bytes: ByteArray): String {
+    return encodeDigestHex(bytes = MessageDigest.getInstance("SHA-256").digest(bytes))
+}
+
+private fun encodeDigestHex(bytes: ByteArray): String {
+    val hexChars: CharArray = "0123456789abcdef".toCharArray()
+    val result = CharArray(size = bytes.size * 2)
+    bytes.forEachIndexed { index, byte ->
+        val value: Int = byte.toInt() and 0xff
+        result[index * 2] = hexChars[value ushr 4]
+        result[(index * 2) + 1] = hexChars[value and 0x0f]
+    }
+    return String(result)
+}


### PR DESCRIPTION
## Summary
- add Android non-UI managed image preparation for selected URIs
- persist local media blob cache, media asset metadata, and queued multipart upload transfer
- keep pending uploads out of bootstrap media sync and allow pending media reassignment during workspace identity fork

## Validation
- fresh read-only review after fixes: no P0-P4 issues
- git --no-pager diff --check
- trailing-whitespace scan on changed/new files
- guard search for /media-assets/images and image-ingestion references
- targeted source search confirmed bootstrap uses loadMediaAssetsExcludingPendingUploads

Gradle was not run because this worker did not receive explicit Gradle permission.