### PR TITLE
Add iOS managed image authoring foundation

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/Media/ManagedImageAuthoring.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Media/ManagedImageAuthoring.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+struct ManagedImageAuthoringResult: Hashable, Sendable {
+    let mediaAsset: MediaAsset
+    let cacheEntry: MediaBlobCacheEntry
+    let transferEntry: MediaTransferQueueEntry
+    let markdown: String
+}
+
+func authorManagedImage(
+    database: LocalDatabase,
+    workspaceId: String,
+    installationId: String,
+    sourceImageData: Data,
+    altText: String
+) throws -> ManagedImageAuthoringResult {
+    let normalizedWorkspaceId = try nonEmptyManagedImageAuthoringText(
+        value: workspaceId,
+        fieldName: "Managed image workspace id"
+    )
+    let normalizedInstallationId = try nonEmptyManagedImageAuthoringText(
+        value: installationId,
+        fieldName: "Managed image installation id"
+    )
+    let preparedImage = try prepareManagedImageData(sourceImageData: sourceImageData)
+    let mediaAssetId = UUID().uuidString.lowercased()
+    let transferId = UUID().uuidString.lowercased()
+    let createdAt = nowIsoTimestamp()
+    let cacheURL = try managedImageBlobCacheFileURL(
+        databaseURL: database.databaseURL,
+        sha256: preparedImage.sha256
+    )
+    let cacheFileExistedBeforeWrite = FileManager.default.fileExists(atPath: cacheURL.path)
+
+    try writeManagedImageBlobCacheFile(data: preparedImage.data, fileURL: cacheURL)
+
+    do {
+        let result = try database.core.inTransaction {
+            let cacheEntry = try database.mediaTransferStore.upsertBlobCacheEntry(
+                entry: MediaBlobCacheUpsert(
+                    sha256: preparedImage.sha256,
+                    mimeType: preparedImage.mimeType,
+                    sizeBytes: preparedImage.sizeBytes,
+                    createdAt: createdAt,
+                    lastAccessedAt: createdAt,
+                    sourceMediaAssetId: mediaAssetId
+                )
+            )
+            let mediaAsset = MediaAsset(
+                mediaAssetId: mediaAssetId,
+                workspaceId: normalizedWorkspaceId,
+                mimeType: preparedImage.mimeType,
+                sizeBytes: preparedImage.sizeBytes,
+                sha256: preparedImage.sha256,
+                sourceUrl: nil,
+                createdAt: createdAt,
+                clientUpdatedAt: createdAt,
+                lastModifiedByReplicaId: mediaUploadWorkspaceReplicaId(
+                    workspaceId: normalizedWorkspaceId,
+                    installationId: normalizedInstallationId
+                ),
+                lastOperationId: transferId,
+                updatedAt: createdAt,
+                deletedAt: nil
+            )
+            try database.mediaAssetStore.upsertMediaAsset(
+                workspaceId: normalizedWorkspaceId,
+                mediaAsset: mediaAsset
+            )
+            let transferEntry = try database.mediaTransferStore.enqueueTransfer(
+                request: MediaTransferEnqueueRequest(
+                    transferId: transferId,
+                    workspaceId: normalizedWorkspaceId,
+                    mediaAssetId: mediaAssetId,
+                    kind: .upload,
+                    sha256: preparedImage.sha256,
+                    mimeType: preparedImage.mimeType,
+                    sizeBytes: preparedImage.sizeBytes,
+                    createdAt: createdAt
+                )
+            )
+
+            return ManagedImageAuthoringResult(
+                mediaAsset: mediaAsset,
+                cacheEntry: cacheEntry,
+                transferEntry: transferEntry,
+                markdown: try managedImageMarkdownReference(
+                    mediaAssetId: mediaAssetId,
+                    altText: altText
+                )
+            )
+        }
+
+        return result
+    } catch {
+        if cacheFileExistedBeforeWrite == false {
+            try removeManagedImageBlobCacheFileAfterFailure(fileURL: cacheURL, failure: error)
+        }
+        throw error
+    }
+}
+
+private func nonEmptyManagedImageAuthoringText(value: String, fieldName: String) throws -> String {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedValue.isEmpty == false else {
+        throw LocalStoreError.validation("\(fieldName) must not be empty")
+    }
+
+    return trimmedValue
+}
+
+private func managedImageBlobCacheFileURL(databaseURL: URL, sha256: String) throws -> URL {
+    let localRelativePath = try mediaBlobCacheRelativePath(sha256: sha256)
+    return databaseURL
+        .deletingLastPathComponent()
+        .appendingPathComponent(localRelativePath, isDirectory: false)
+}
+
+private func writeManagedImageBlobCacheFile(data: Data, fileURL: URL) throws {
+    do {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try data.write(to: fileURL, options: [.atomic])
+    } catch {
+        throw LocalStoreError.database(
+            "Managed image blob cache write failed path=\(fileURL.path): \(Flashcards.errorMessage(error: error))"
+        )
+    }
+}
+
+private func removeManagedImageBlobCacheFileAfterFailure(fileURL: URL, failure: Error) throws {
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        return
+    }
+
+    do {
+        try FileManager.default.removeItem(at: fileURL)
+    } catch {
+        throw LocalStoreError.database(
+            "Managed image authoring failed and cache cleanup failed path=\(fileURL.path): authoringError=\(Flashcards.errorMessage(error: failure)); cleanupError=\(Flashcards.errorMessage(error: error))"
+        )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Cards/Media/ManagedImagePreparation.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Media/ManagedImagePreparation.swift
@@ -1,0 +1,196 @@
+import CryptoKit
+import Foundation
+import ImageIO
+import UIKit
+
+let managedImageMaxSidePixels: Int = 1_200
+let managedImageJPEGCompressionQuality: CGFloat = 0.82
+let managedImageMIMEType: String = "image/jpeg"
+let managedImageMaximumDecodedPixels: Int64 = 24_000_000
+
+struct PreparedManagedImage: Hashable, Sendable {
+    let data: Data
+    let mimeType: String
+    let sizeBytes: Int64
+    let sha256: String
+}
+
+func prepareManagedImageData(sourceImageData: Data) throws -> PreparedManagedImage {
+    guard sourceImageData.isEmpty == false else {
+        throw LocalStoreError.validation("Managed image source data must not be empty")
+    }
+    let imageSourceOptions: [CFString: Any] = [
+        kCGImageSourceShouldCache: false
+    ]
+    guard let imageSource = CGImageSourceCreateWithData(
+        sourceImageData as CFData,
+        imageSourceOptions as CFDictionary
+    ) else {
+        throw LocalStoreError.validation("Managed image source data is not a readable image")
+    }
+
+    let imageCount = CGImageSourceGetCount(imageSource)
+    guard imageCount == 1 else {
+        throw LocalStoreError.validation("Managed image source must contain exactly one frame or page; received \(imageCount)")
+    }
+
+    let sourceMetadata = try managedImageSourceMetadata(imageSource: imageSource)
+    try validateManagedImageDecodedPixelCount(sourceMetadata: sourceMetadata)
+    let thumbnail = try createManagedImageThumbnail(imageSource: imageSource)
+    let image = UIImage(cgImage: thumbnail, scale: 1, orientation: .up)
+    let targetSize = try managedImageTargetPixelSize(thumbnail: thumbnail)
+    let preparedData = try encodeManagedImageJPEG(image: image, targetSize: targetSize)
+    let sha256 = try normalizedMediaSha256(sha256: managedImageHexSHA256(data: preparedData))
+
+    return PreparedManagedImage(
+        data: preparedData,
+        mimeType: managedImageMIMEType,
+        sizeBytes: Int64(preparedData.count),
+        sha256: sha256
+    )
+}
+
+private struct ManagedImageSourceMetadata: Hashable {
+    let width: Int
+    let height: Int
+}
+
+private func managedImageSourceMetadata(imageSource: CGImageSource) throws -> ManagedImageSourceMetadata {
+    guard let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any] else {
+        throw LocalStoreError.validation("Managed image source metadata could not be read")
+    }
+
+    if let rawOrientation = properties[kCGImagePropertyOrientation],
+       managedImageCGImageOrientation(rawValue: rawOrientation) == nil {
+        throw LocalStoreError.validation("Managed image source has invalid orientation metadata: \(rawOrientation)")
+    }
+
+    return ManagedImageSourceMetadata(
+        width: try managedImagePixelDimension(
+            rawValue: properties[kCGImagePropertyPixelWidth],
+            fieldName: "width"
+        ),
+        height: try managedImagePixelDimension(
+            rawValue: properties[kCGImagePropertyPixelHeight],
+            fieldName: "height"
+        )
+    )
+}
+
+private func managedImageCGImageOrientation(rawValue: Any) -> CGImagePropertyOrientation? {
+    if let orientationNumber = rawValue as? NSNumber {
+        return CGImagePropertyOrientation(rawValue: orientationNumber.uint32Value)
+    }
+    if let orientationValue = rawValue as? UInt32 {
+        return CGImagePropertyOrientation(rawValue: orientationValue)
+    }
+    if let orientationValue = rawValue as? Int {
+        guard let unsignedValue = UInt32(exactly: orientationValue) else {
+            return nil
+        }
+
+        return CGImagePropertyOrientation(rawValue: unsignedValue)
+    }
+
+    return nil
+}
+
+private func managedImagePixelDimension(rawValue: Any?, fieldName: String) throws -> Int {
+    guard let rawValue else {
+        throw LocalStoreError.validation("Managed image source \(fieldName) could not be read from metadata")
+    }
+
+    let dimension: Int64?
+    if let number = rawValue as? NSNumber {
+        dimension = number.int64Value
+    } else if let value = rawValue as? Int {
+        dimension = Int64(value)
+    } else if let value = rawValue as? Int64 {
+        dimension = value
+    } else {
+        dimension = nil
+    }
+
+    guard let dimension,
+          dimension > 0,
+          dimension <= Int64(Int.max) else {
+        throw LocalStoreError.validation("Managed image source \(fieldName) must be a positive integer: \(rawValue)")
+    }
+
+    return Int(dimension)
+}
+
+private func validateManagedImageDecodedPixelCount(sourceMetadata: ManagedImageSourceMetadata) throws {
+    let width = Int64(sourceMetadata.width)
+    let height = Int64(sourceMetadata.height)
+    guard width <= managedImageMaximumDecodedPixels / height else {
+        throw LocalStoreError.validation("Managed image decoded dimensions must be at most \(managedImageMaximumDecodedPixels) pixels")
+    }
+    guard width * height <= managedImageMaximumDecodedPixels else {
+        throw LocalStoreError.validation("Managed image decoded dimensions must be at most \(managedImageMaximumDecodedPixels) pixels")
+    }
+}
+
+private func createManagedImageThumbnail(imageSource: CGImageSource) throws -> CGImage {
+    let thumbnailOptions: [CFString: Any] = [
+        kCGImageSourceCreateThumbnailFromImageAlways: true,
+        kCGImageSourceCreateThumbnailWithTransform: true,
+        kCGImageSourceShouldCacheImmediately: true,
+        kCGImageSourceThumbnailMaxPixelSize: managedImageMaxSidePixels
+    ]
+    guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+        imageSource,
+        0,
+        thumbnailOptions as CFDictionary
+    ) else {
+        throw LocalStoreError.validation("Managed image source frame could not be decoded")
+    }
+
+    return thumbnail
+}
+
+private func managedImageTargetPixelSize(thumbnail: CGImage) throws -> CGSize {
+    guard thumbnail.width > 0, thumbnail.height > 0 else {
+        throw LocalStoreError.validation(
+            "Managed image thumbnail dimensions must be positive: width=\(thumbnail.width) height=\(thumbnail.height)"
+        )
+    }
+    guard max(thumbnail.width, thumbnail.height) <= managedImageMaxSidePixels else {
+        throw LocalStoreError.validation(
+            "Managed image thumbnail maximum side must be at most \(managedImageMaxSidePixels) pixels: width=\(thumbnail.width) height=\(thumbnail.height)"
+        )
+    }
+
+    return CGSize(width: thumbnail.width, height: thumbnail.height)
+}
+
+private func encodeManagedImageJPEG(image: UIImage, targetSize: CGSize) throws -> Data {
+    let rendererFormat = UIGraphicsImageRendererFormat.default()
+    rendererFormat.scale = 1
+    rendererFormat.opaque = true
+    rendererFormat.preferredRange = .standard
+
+    let renderedImage = UIGraphicsImageRenderer(size: targetSize, format: rendererFormat).image { _ in
+        UIColor(
+            red: CGFloat(0xF1) / 255,
+            green: CGFloat(0xF3) / 255,
+            blue: CGFloat(0xF4) / 255,
+            alpha: 1
+        ).setFill()
+        UIRectFill(CGRect(origin: .zero, size: targetSize))
+        image.draw(in: CGRect(origin: .zero, size: targetSize))
+    }
+
+    guard let data = renderedImage.jpegData(compressionQuality: managedImageJPEGCompressionQuality),
+          data.isEmpty == false else {
+        throw LocalStoreError.validation("Managed image JPEG encoding failed")
+    }
+
+    return data
+}
+
+private func managedImageHexSHA256(data: Data) -> String {
+    SHA256.hash(data: data).map { byte in
+        String(format: "%02x", byte)
+    }.joined()
+}

--- a/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
@@ -2,6 +2,13 @@ import Foundation
 
 private let mediaSha256AllowedScalars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
 private let mediaBlobCacheRelativePathPrefix = "media/blobs/sha256"
+let managedMediaAssetReferenceSchemePrefix = "fcasset:"
+private let managedMediaAssetReferenceExpression = makeManagedMediaAssetRegularExpression(
+    pattern: #"(!)?\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)"#
+)
+private let managedMediaFenceExpression = makeManagedMediaAssetRegularExpression(
+    pattern: #"^\s{0,3}(`{3,}|~{3,})"#
+)
 
 // Keep in sync with apps/backend/src/media/assets.ts::MediaAssetRecord and
 // apps/web/src/types.ts::MediaAsset.
@@ -132,4 +139,107 @@ func mediaBlobCacheRelativePath(sha256: String) throws -> String {
     let secondDirectory = String(normalizedSha256[secondDirectoryStart..<secondDirectoryEnd])
 
     return "\(mediaBlobCacheRelativePathPrefix)/\(firstDirectory)/\(secondDirectory)/\(normalizedSha256)"
+}
+
+func managedImageMarkdownReference(mediaAssetId: String, altText: String) throws -> String {
+    let trimmedMediaAssetId = mediaAssetId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedMediaAssetId.isEmpty == false else {
+        throw LocalStoreError.validation("Managed media asset id must not be empty")
+    }
+
+    return "![\(parserSafeManagedImageMarkdownAltText(altText: altText))](\(managedMediaAssetReferenceSchemePrefix)\(trimmedMediaAssetId))"
+}
+
+func managedMediaAssetId(reference: String) -> String? {
+    let trimmedReference = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedReference.lowercased().hasPrefix(managedMediaAssetReferenceSchemePrefix) else {
+        return nil
+    }
+
+    var rawAssetId = String(trimmedReference.dropFirst(managedMediaAssetReferenceSchemePrefix.count))
+    while rawAssetId.hasPrefix("/") {
+        rawAssetId.removeFirst()
+    }
+
+    let fragmentOrQueryStart = rawAssetId.firstIndex { character in
+        character == "?" || character == "#"
+    }
+    if let fragmentOrQueryStart {
+        rawAssetId = String(rawAssetId[..<fragmentOrQueryStart])
+    }
+
+    let mediaAssetId = rawAssetId.trimmingCharacters(in: .whitespacesAndNewlines)
+    return mediaAssetId.isEmpty ? nil : mediaAssetId
+}
+
+func managedMediaAssetIdsReferencedInMarkdown(text: String) -> Set<String> {
+    var activeFenceMarker: String?
+    var mediaAssetIds = Set<String>()
+
+    for line in text.components(separatedBy: .newlines) {
+        let fenceMarker = managedMediaFenceMarker(line: line)
+
+        if let currentFenceMarker = activeFenceMarker {
+            if fenceMarker == currentFenceMarker {
+                activeFenceMarker = nil
+            }
+            continue
+        }
+
+        if let fenceMarker {
+            activeFenceMarker = fenceMarker
+            continue
+        }
+
+        mediaAssetIds.formUnion(managedMediaAssetIdsReferencedInLine(line: line))
+    }
+
+    return mediaAssetIds
+}
+
+private func parserSafeManagedImageMarkdownAltText(altText: String) -> String {
+    altText
+        .replacingOccurrences(of: "\r\n", with: " ")
+        .replacingOccurrences(of: "\r", with: " ")
+        .replacingOccurrences(of: "\n", with: " ")
+        .replacingOccurrences(of: "[", with: " ")
+        .replacingOccurrences(of: "]", with: " ")
+}
+
+private func managedMediaAssetIdsReferencedInLine(line: String) -> Set<String> {
+    let fullRange = NSRange(line.startIndex..<line.endIndex, in: line)
+    let matches = managedMediaAssetReferenceExpression.matches(in: line, options: [], range: fullRange)
+    var mediaAssetIds = Set<String>()
+
+    for match in matches {
+        guard let urlRange = Range(match.range(at: 3), in: line),
+              let mediaAssetId = managedMediaAssetId(reference: String(line[urlRange])) else {
+            continue
+        }
+
+        mediaAssetIds.insert(mediaAssetId)
+    }
+
+    return mediaAssetIds
+}
+
+private func managedMediaFenceMarker(line: String) -> String? {
+    let range = NSRange(line.startIndex..<line.endIndex, in: line)
+    guard let match = managedMediaFenceExpression.firstMatch(in: line, options: [], range: range),
+          let markerRange = Range(match.range(at: 1), in: line) else {
+        return nil
+    }
+
+    return String(line[markerRange])
+}
+
+private func makeManagedMediaAssetRegularExpression(pattern: String) -> NSRegularExpression {
+    do {
+        return try NSRegularExpression(
+            pattern: pattern,
+            options: [.anchorsMatchLines]
+        )
+    } catch {
+        fatalError("Invalid managed media asset regex pattern: \(pattern)")
+    }
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/CloudSyncBootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/Runner/CloudSyncBootstrap.swift
@@ -185,6 +185,7 @@ extension CloudSyncRunner {
         installationId: String,
         syncBasePath: String
     ) async throws -> CloudSyncResult {
+        try self.database.prepareReferencedMediaAssetUploadsForHotBootstrap(workspaceId: workspaceId)
         let bootstrapEntries = try self.database.loadHotBootstrapEntries(workspaceId: workspaceId)
         let reviewEvents = try self.database.loadReviewEvents(workspaceId: workspaceId)
         let pendingOutboxEntries = try self.database.loadOutboxEntries(workspaceId: workspaceId, limit: Int.max)

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Sync.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Sync.swift
@@ -1,4 +1,12 @@
+import CryptoKit
 import Foundation
+
+private let referencedMediaAssetCacheValidationChunkSizeBytes: Int = 1_048_576
+
+private struct ReferencedMediaAssetCacheFileValidation: Hashable {
+    let sizeBytes: Int64
+    let sha256: String
+}
 
 extension LocalDatabase {
     /// Loads the next FIFO outbox page for one batched push request.
@@ -221,14 +229,6 @@ extension LocalDatabase {
                 payload: .deck(deck)
             )
         }
-        let mediaAssets = try self.mediaAssetStore.loadMediaAssetsIncludingDeleted(workspaceId: workspaceId).map { mediaAsset in
-            SyncBootstrapEntry(
-                entityType: .mediaAsset,
-                entityId: mediaAsset.mediaAssetId,
-                action: .upsert,
-                payload: .mediaAsset(mediaAsset)
-            )
-        }
         let schedulerSettings = try self.workspaceSettingsStore.loadWorkspaceSchedulerSettings(workspaceId: workspaceId)
         let schedulerEntry = SyncBootstrapEntry(
             entityType: .workspaceSchedulerSettings,
@@ -237,7 +237,36 @@ extension LocalDatabase {
             payload: .workspaceSchedulerSettings(schedulerSettings)
         )
 
-        return cards + decks + mediaAssets + [schedulerEntry]
+        // Media assets are registered remotely only through the upload API.
+        // Keep local rows for offline rendering, but never bootstrap-push them.
+        return cards + decks + [schedulerEntry]
+    }
+
+    @discardableResult
+    func prepareReferencedMediaAssetUploadsForHotBootstrap(workspaceId: String) throws -> [MediaTransferQueueEntry] {
+        let activeCards = try self.cardStore.loadCardsIncludingDeleted(workspaceId: workspaceId).filter { card in
+            card.deletedAt == nil
+        }
+        let referencedMediaAssetIds = managedMediaAssetIdsReferencedByCards(cards: activeCards)
+        guard referencedMediaAssetIds.isEmpty == false else {
+            return []
+        }
+
+        let createdAt = nowIsoTimestamp()
+        return try self.core.inTransaction {
+            var transferEntries: [MediaTransferQueueEntry] = []
+            for mediaAssetId in referencedMediaAssetIds.sorted() {
+                if let transferEntry = try self.prepareReferencedMediaAssetUploadForHotBootstrap(
+                    workspaceId: workspaceId,
+                    mediaAssetId: mediaAssetId,
+                    createdAt: createdAt
+                ) {
+                    transferEntries.append(transferEntry)
+                }
+            }
+
+            return transferEntries
+        }
     }
 
     func loadOptionalMediaAssetIncludingDeleted(workspaceId: String, mediaAssetId: String) throws -> MediaAsset? {
@@ -278,4 +307,197 @@ extension LocalDatabase {
             try self.syncApplier.applySyncChange(workspaceId: workspaceId, change: change)
         }
     }
+
+    private func prepareReferencedMediaAssetUploadForHotBootstrap(
+        workspaceId: String,
+        mediaAssetId: String,
+        createdAt: String
+    ) throws -> MediaTransferQueueEntry? {
+        guard let mediaAsset = try self.mediaAssetStore.loadOptionalMediaAssetIncludingDeleted(
+            workspaceId: workspaceId,
+            mediaAssetId: mediaAssetId
+        ) else {
+            throw LocalStoreError.validation(
+                "Cannot bootstrap workspace because a card references a missing media asset: workspaceId=\(workspaceId) mediaAssetId=\(mediaAssetId)"
+            )
+        }
+        guard mediaAsset.deletedAt == nil else {
+            throw LocalStoreError.validation(
+                "Cannot bootstrap workspace because a card references a deleted media asset: workspaceId=\(workspaceId) mediaAssetId=\(mediaAssetId)"
+            )
+        }
+
+        let normalizedSha256 = try normalizedMediaSha256(sha256: mediaAsset.sha256)
+        guard let cacheEntry = try self.mediaTransferStore.loadOptionalBlobCacheEntry(sha256: normalizedSha256) else {
+            throw LocalStoreError.validation(
+                "Cannot bootstrap workspace because referenced media is not cached for upload: workspaceId=\(workspaceId) mediaAssetId=\(mediaAssetId) sha256=\(normalizedSha256)"
+            )
+        }
+        try validateReferencedMediaAssetCacheForHotBootstrap(
+            databaseURL: self.databaseURL,
+            mediaAsset: mediaAsset,
+            cacheEntry: cacheEntry
+        )
+
+        guard try self.mediaTransferStore.hasPendingUploadTransferMatchingAsset(
+            workspaceId: workspaceId,
+            mediaAssetId: mediaAssetId,
+            sha256: normalizedSha256,
+            mimeType: mediaAsset.mimeType,
+            sizeBytes: mediaAsset.sizeBytes
+        ) == false else {
+            return nil
+        }
+
+        return try self.mediaTransferStore.enqueueTransfer(
+            request: MediaTransferEnqueueRequest(
+                transferId: UUID().uuidString.lowercased(),
+                workspaceId: workspaceId,
+                mediaAssetId: mediaAssetId,
+                kind: .upload,
+                sha256: normalizedSha256,
+                mimeType: mediaAsset.mimeType,
+                sizeBytes: mediaAsset.sizeBytes,
+                createdAt: createdAt
+            )
+        )
+    }
+}
+
+private func managedMediaAssetIdsReferencedByCards(cards: [Card]) -> Set<String> {
+    cards.reduce(into: Set<String>()) { result, card in
+        result.formUnion(managedMediaAssetIdsReferencedInMarkdown(text: card.frontText))
+        result.formUnion(managedMediaAssetIdsReferencedInMarkdown(text: card.backText))
+    }
+}
+
+private func validateReferencedMediaAssetCacheForHotBootstrap(
+    databaseURL: URL,
+    mediaAsset: MediaAsset,
+    cacheEntry: MediaBlobCacheEntry
+) throws {
+    let normalizedSha256 = try normalizedMediaSha256(sha256: mediaAsset.sha256)
+    let expectedRelativePath = try mediaBlobCacheRelativePath(sha256: normalizedSha256)
+    guard mediaAsset.sizeBytes > 0 else {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media asset size must be positive: mediaAssetId=\(mediaAsset.mediaAssetId) sizeBytes=\(mediaAsset.sizeBytes)"
+        )
+    }
+    guard cacheEntry.sha256 == normalizedSha256,
+          cacheEntry.localRelativePath == expectedRelativePath,
+          cacheEntry.mimeType.lowercased() == mediaAsset.mimeType.lowercased(),
+          cacheEntry.sizeBytes == mediaAsset.sizeBytes else {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media cache metadata does not match the media asset: mediaAssetId=\(mediaAsset.mediaAssetId)"
+        )
+    }
+
+    let cacheURL = databaseURL
+        .deletingLastPathComponent()
+        .appendingPathComponent(cacheEntry.localRelativePath, isDirectory: false)
+    guard FileManager.default.fileExists(atPath: cacheURL.path) else {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media cache file is missing: mediaAssetId=\(mediaAsset.mediaAssetId) path=\(cacheEntry.localRelativePath)"
+        )
+    }
+
+    let fileValidation = try streamReferencedMediaAssetCacheFileValidation(
+        fileURL: cacheURL,
+        mediaAssetId: mediaAsset.mediaAssetId
+    )
+    guard fileValidation.sizeBytes == mediaAsset.sizeBytes else {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media cache file size does not match the media asset: mediaAssetId=\(mediaAsset.mediaAssetId) expected=\(mediaAsset.sizeBytes) actual=\(fileValidation.sizeBytes)"
+        )
+    }
+    guard fileValidation.sha256 == normalizedSha256 else {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media cache file SHA-256 does not match the media asset: mediaAssetId=\(mediaAsset.mediaAssetId) expected=\(normalizedSha256) actual=\(fileValidation.sha256)"
+        )
+    }
+}
+
+private func streamReferencedMediaAssetCacheFileValidation(
+    fileURL: URL,
+    mediaAssetId: String
+) throws -> ReferencedMediaAssetCacheFileValidation {
+    do {
+        let fileHandle = try FileHandle(forReadingFrom: fileURL)
+        return try scanReferencedMediaAssetCacheFile(
+            fileHandle: fileHandle,
+            mediaAssetId: mediaAssetId
+        )
+    } catch let error as LocalStoreError {
+        throw error
+    } catch {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media cache file is unreadable: mediaAssetId=\(mediaAssetId) path=\(fileURL.path) error=\(Flashcards.errorMessage(error: error))"
+        )
+    }
+}
+
+private func scanReferencedMediaAssetCacheFile(
+    fileHandle: FileHandle,
+    mediaAssetId: String
+) throws -> ReferencedMediaAssetCacheFileValidation {
+    do {
+        var sizeBytes: Int64 = 0
+        var hasher = SHA256()
+        while true {
+            guard let chunk = try fileHandle.read(upToCount: referencedMediaAssetCacheValidationChunkSizeBytes),
+                  chunk.isEmpty == false else {
+                break
+            }
+
+            hasher.update(data: chunk)
+            sizeBytes += Int64(chunk.count)
+        }
+
+        try closeReferencedMediaAssetCacheFileHandle(fileHandle: fileHandle, mediaAssetId: mediaAssetId)
+        return ReferencedMediaAssetCacheFileValidation(
+            sizeBytes: sizeBytes,
+            sha256: referencedMediaAssetHexSHA256(digest: hasher.finalize())
+        )
+    } catch {
+        try closeReferencedMediaAssetCacheFileHandleAfterFailure(
+            fileHandle: fileHandle,
+            mediaAssetId: mediaAssetId,
+            failure: error
+        )
+    }
+}
+
+private func closeReferencedMediaAssetCacheFileHandle(
+    fileHandle: FileHandle,
+    mediaAssetId: String
+) throws {
+    do {
+        try fileHandle.close()
+    } catch {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media cache file close failed: mediaAssetId=\(mediaAssetId) error=\(Flashcards.errorMessage(error: error))"
+        )
+    }
+}
+
+private func closeReferencedMediaAssetCacheFileHandleAfterFailure(
+    fileHandle: FileHandle,
+    mediaAssetId: String,
+    failure: Error
+) throws -> Never {
+    do {
+        try fileHandle.close()
+    } catch {
+        throw LocalStoreError.validation(
+            "Cannot bootstrap workspace because referenced media cache file validation and close failed: mediaAssetId=\(mediaAssetId) validationError=\(Flashcards.errorMessage(error: failure)); closeError=\(Flashcards.errorMessage(error: error))"
+        )
+    }
+
+    throw failure
+}
+
+private func referencedMediaAssetHexSHA256(digest: SHA256.Digest) -> String {
+    digest.map { byte in
+        String(format: "%02x", byte)
+    }.joined()
 }

--- a/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
@@ -128,6 +128,56 @@ struct MediaTransferStore {
         }
     }
 
+    func hasPendingUploadTransferMatchingAsset(
+        workspaceId: String,
+        mediaAssetId: String,
+        sha256: String,
+        mimeType: String,
+        sizeBytes: Int64
+    ) throws -> Bool {
+        let normalizedWorkspaceId = try nonEmptyMediaTransferText(
+            value: workspaceId,
+            fieldName: "Media transfer workspaceId"
+        )
+        let normalizedMediaAssetId = try nonEmptyMediaTransferText(
+            value: mediaAssetId,
+            fieldName: "Media transfer mediaAssetId"
+        )
+        let normalizedSha256 = try normalizedMediaSha256(sha256: sha256)
+        let normalizedMimeType = try nonEmptyMediaTransferText(value: mimeType, fieldName: "Media transfer MIME type")
+        let localRelativePath = try mediaBlobCacheRelativePath(sha256: normalizedSha256)
+        guard sizeBytes > 0 else {
+            throw LocalStoreError.validation("Media transfer size must be greater than zero")
+        }
+        let rows = try self.core.query(
+            sql: """
+            SELECT 1
+            FROM media_transfer_queue
+            WHERE workspace_id = ?
+                AND media_asset_id = ?
+                AND kind = 'upload'
+                AND status = 'pending'
+                AND sha256 = ?
+                AND LOWER(mime_type) = LOWER(?)
+                AND size_bytes = ?
+                AND local_relative_path = ?
+            LIMIT 1
+            """,
+            values: [
+                .text(normalizedWorkspaceId),
+                .text(normalizedMediaAssetId),
+                .text(normalizedSha256),
+                .text(normalizedMimeType),
+                .integer(sizeBytes),
+                .text(localRelativePath)
+            ]
+        ) { statement in
+            DatabaseCore.columnInt64(statement: statement, index: 0)
+        }
+
+        return rows.isEmpty == false
+    }
+
     func enqueueTransfer(request: MediaTransferEnqueueRequest) throws -> MediaTransferQueueEntry {
         let transferId = try nonEmptyMediaTransferText(value: request.transferId, fieldName: "Media transfer id")
         let normalizedSha256 = try normalizedMediaSha256(sha256: request.sha256)
@@ -442,7 +492,8 @@ struct MediaTransferStore {
         return try self.loadTransfer(transferId: normalizedTransferId)
     }
 
-    private func loadOptionalBlobCacheEntry(sha256: String) throws -> MediaBlobCacheEntry? {
+    func loadOptionalBlobCacheEntry(sha256: String) throws -> MediaBlobCacheEntry? {
+        let normalizedSha256 = try normalizedMediaSha256(sha256: sha256)
         let rows = try self.core.query(
             sql: """
             SELECT
@@ -451,7 +502,7 @@ struct MediaTransferStore {
             WHERE sha256 = ?
             LIMIT 1
             """,
-            values: [.text(sha256)]
+            values: [.text(normalizedSha256)]
         ) { statement in
             self.mapBlobCacheEntry(statement: statement)
         }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
@@ -70,7 +70,6 @@ private let reviewContentTableSeparatorExpression = makeReviewContentRegularExpr
 private let reviewManagedMediaReferenceExpression = makeReviewContentRegularExpression(
     pattern: #"(!)?\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)"#
 )
-private let reviewManagedMediaSchemePrefix: String = "fcasset:"
 
 func classifyReviewContentPresentation(text: String) -> ReviewContentPresentationMode {
     let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -123,25 +122,7 @@ func makeReviewRenderedContent(text: String) -> ReviewRenderedContent {
 }
 
 func parseManagedMediaAssetId(reference: String) -> String? {
-    let trimmedReference = reference.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard trimmedReference.lowercased().hasPrefix(reviewManagedMediaSchemePrefix) else {
-        return nil
-    }
-
-    var rawAssetId = String(trimmedReference.dropFirst(reviewManagedMediaSchemePrefix.count))
-    while rawAssetId.hasPrefix("/") {
-        rawAssetId.removeFirst()
-    }
-
-    let fragmentOrQueryStart = rawAssetId.firstIndex { character in
-        character == "?" || character == "#"
-    }
-    if let fragmentOrQueryStart {
-        rawAssetId = String(rawAssetId[..<fragmentOrQueryStart])
-    }
-
-    let mediaAssetId = rawAssetId.trimmingCharacters(in: .whitespacesAndNewlines)
-    return mediaAssetId.isEmpty ? nil : mediaAssetId
+    managedMediaAssetId(reference: reference)
 }
 
 func makeReviewSpeakableText(text: String) -> String {

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import XCTest
 @testable import Flashcards
@@ -169,7 +170,7 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
         XCTAssertEqual(workspace.workspaceId, userSettings.workspaceId)
     }
 
-    func testMediaAssetRegistryMetadataPersistsAndExportsHotBootstrapEntry() throws {
+    func testMediaAssetRegistryMetadataPersistsWithoutHotBootstrapExport() throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
         let mediaAsset = self.makeMediaAsset(workspaceId: workspace.workspaceId, deletedAt: nil)
@@ -197,14 +198,9 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
         XCTAssertEqual(storedMediaAsset, mediaAsset)
 
         let bootstrapEntries = try database.loadHotBootstrapEntries(workspaceId: workspace.workspaceId)
-        let mediaEntry = try XCTUnwrap(bootstrapEntries.first { entry in
+        XCTAssertFalse(bootstrapEntries.contains { entry in
             entry.entityType == .mediaAsset && entry.entityId == mediaAsset.mediaAssetId
         })
-        guard case .mediaAsset(let exportedMediaAsset) = mediaEntry.payload else {
-            XCTFail("Expected media asset bootstrap payload")
-            return
-        }
-        XCTAssertEqual(exportedMediaAsset, mediaAsset)
 
         let tombstone = self.makeMediaAsset(
             workspaceId: workspace.workspaceId,
@@ -229,13 +225,231 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
         XCTAssertEqual(storedTombstone.deletedAt, "2026-04-25T10:00:00.000Z")
     }
 
+    func testReferencedCachedMediaAssetQueuesUploadBeforeHotBootstrap() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let mediaBytes = Data([0x01, 0x02, 0x03, 0x04])
+        let mediaSha256 = self.hexSHA256(data: mediaBytes)
+        let mediaAssetId = "00000000-0000-4000-8000-000000000011"
+        let mediaAsset = MediaAsset(
+            mediaAssetId: mediaAssetId,
+            workspaceId: workspace.workspaceId,
+            mimeType: "image/jpeg",
+            sizeBytes: Int64(mediaBytes.count),
+            sha256: mediaSha256,
+            sourceUrl: nil,
+            createdAt: "2026-04-24T10:00:00.000Z",
+            clientUpdatedAt: "2026-04-24T10:00:01.000Z",
+            lastModifiedByReplicaId: "replica-1",
+            lastOperationId: "operation-media-1",
+            updatedAt: "2026-04-24T10:00:02.000Z",
+            deletedAt: nil
+        )
+        try database.mediaAssetStore.upsertMediaAsset(
+            workspaceId: workspace.workspaceId,
+            mediaAsset: mediaAsset
+        )
+        let cacheEntry = try database.mediaTransferStore.upsertBlobCacheEntry(
+            entry: MediaBlobCacheUpsert(
+                sha256: mediaSha256,
+                mimeType: mediaAsset.mimeType,
+                sizeBytes: mediaAsset.sizeBytes,
+                createdAt: mediaAsset.createdAt,
+                lastAccessedAt: mediaAsset.createdAt,
+                sourceMediaAssetId: mediaAssetId
+            )
+        )
+        try self.writeMediaCacheFile(database: database, cacheEntry: cacheEntry, data: mediaBytes)
+
+        let markdown = try managedImageMarkdownReference(mediaAssetId: mediaAssetId, altText: "cached media")
+        _ = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: markdown,
+                backText: "Answer",
+                tags: [],
+            ),
+            cardId: nil
+        )
+
+        let failedTransfer = try database.mediaTransferStore.enqueueTransfer(
+            request: MediaTransferEnqueueRequest(
+                transferId: "00000000-0000-4000-8000-000000000012",
+                workspaceId: workspace.workspaceId,
+                mediaAssetId: mediaAssetId,
+                kind: .upload,
+                sha256: mediaSha256,
+                mimeType: mediaAsset.mimeType,
+                sizeBytes: mediaAsset.sizeBytes,
+                createdAt: mediaAsset.createdAt
+            )
+        )
+        try database.core.execute(
+            sql: """
+            UPDATE media_transfer_queue
+            SET
+                status = 'failed',
+                next_attempt_at = ?,
+                last_error = ?,
+                updated_at = ?
+            WHERE transfer_id = ?
+            """,
+            values: [
+                .text(mediaUploadPermanentFailureNextAttemptAt),
+                .text("Permanent previous failure"),
+                .text("2026-04-24T10:00:03.000Z"),
+                .text(failedTransfer.transferId)
+            ]
+        )
+
+        let transferEntries = try database.prepareReferencedMediaAssetUploadsForHotBootstrap(
+            workspaceId: workspace.workspaceId
+        )
+
+        XCTAssertEqual(transferEntries.count, 1)
+        XCTAssertEqual(transferEntries.first?.workspaceId, workspace.workspaceId)
+        XCTAssertEqual(transferEntries.first?.mediaAssetId, mediaAssetId)
+        XCTAssertEqual(transferEntries.first?.kind, .upload)
+        XCTAssertEqual(transferEntries.first?.status, .pending)
+        XCTAssertEqual(transferEntries.first?.sha256, mediaSha256)
+        XCTAssertEqual(transferEntries.first?.localRelativePath, cacheEntry.localRelativePath)
+        XCTAssertTrue(
+            try database.mediaTransferStore.hasPendingUploadTransferMatchingAsset(
+                workspaceId: workspace.workspaceId,
+                mediaAssetId: mediaAssetId,
+                sha256: mediaSha256,
+                mimeType: mediaAsset.mimeType,
+                sizeBytes: mediaAsset.sizeBytes
+            )
+        )
+
+        let duplicateTransferEntries = try database.prepareReferencedMediaAssetUploadsForHotBootstrap(
+            workspaceId: workspace.workspaceId
+        )
+        XCTAssertEqual(duplicateTransferEntries.count, 0)
+        XCTAssertEqual(
+            2,
+            try database.core.scalarInt(
+                sql: """
+                SELECT COUNT(*)
+                FROM media_transfer_queue
+                WHERE workspace_id = ? AND media_asset_id = ? AND kind = 'upload'
+                """,
+                values: [
+                    .text(workspace.workspaceId),
+                    .text(mediaAssetId)
+                ]
+            )
+        )
+        XCTAssertEqual(
+            1,
+            try database.core.scalarInt(
+                sql: """
+                SELECT COUNT(*)
+                FROM media_transfer_queue
+                WHERE workspace_id = ? AND media_asset_id = ? AND kind = 'upload' AND status = 'pending'
+                """,
+                values: [
+                    .text(workspace.workspaceId),
+                    .text(mediaAssetId)
+                ]
+            )
+        )
+
+        let bootstrapEntries = try database.loadHotBootstrapEntries(workspaceId: workspace.workspaceId)
+        XCTAssertTrue(bootstrapEntries.contains { entry in
+            entry.entityType == .card
+        })
+        XCTAssertFalse(bootstrapEntries.contains { entry in
+            entry.entityType == .mediaAsset
+        })
+
+        try self.writeMediaCacheFile(
+            database: database,
+            cacheEntry: cacheEntry,
+            data: Data([0x04, 0x03, 0x02, 0x01])
+        )
+        XCTAssertThrowsError(
+            try database.prepareReferencedMediaAssetUploadsForHotBootstrap(workspaceId: workspace.workspaceId)
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("SHA-256"))
+        }
+    }
+
+    func testManagedImageAuthoringCreatesLocalCacheTransferAndParserSafeMarkdown() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let sourceImageData = try self.tinyTransparentPNGData()
+
+        let result = try authorManagedImage(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: "installation-1",
+            sourceImageData: sourceImageData,
+            altText: "source[bracket]\nalt"
+        )
+
+        XCTAssertEqual(result.mediaAsset.workspaceId, workspace.workspaceId)
+        XCTAssertEqual(result.mediaAsset.mimeType, managedImageMIMEType)
+        XCTAssertGreaterThan(result.mediaAsset.sizeBytes, 0)
+        XCTAssertEqual(result.mediaAsset.sizeBytes, result.cacheEntry.sizeBytes)
+        XCTAssertEqual(result.mediaAsset.sizeBytes, result.transferEntry.sizeBytes)
+        XCTAssertEqual(result.mediaAsset.sha256, result.cacheEntry.sha256)
+        XCTAssertEqual(result.mediaAsset.sha256, result.transferEntry.sha256)
+        XCTAssertEqual(result.transferEntry.kind, .upload)
+        XCTAssertEqual(result.transferEntry.status, .pending)
+        XCTAssertEqual(result.transferEntry.mediaAssetId, result.mediaAsset.mediaAssetId)
+        XCTAssertEqual(result.transferEntry.localRelativePath, result.cacheEntry.localRelativePath)
+
+        let storedMediaAsset = try XCTUnwrap(
+            try database.loadOptionalMediaAssetIncludingDeleted(
+                workspaceId: workspace.workspaceId,
+                mediaAssetId: result.mediaAsset.mediaAssetId
+            )
+        )
+        XCTAssertEqual(storedMediaAsset, result.mediaAsset)
+        let storedCacheEntry = try XCTUnwrap(
+            try database.mediaTransferStore.loadOptionalBlobCacheEntry(sha256: result.mediaAsset.sha256)
+        )
+        XCTAssertEqual(storedCacheEntry, result.cacheEntry)
+
+        let cacheURL = database.databaseURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(result.cacheEntry.localRelativePath, isDirectory: false)
+        let cachedData = try Data(contentsOf: cacheURL)
+        XCTAssertEqual([UInt8](cachedData.prefix(2)), [0xff, 0xd8])
+        XCTAssertEqual(Int64(cachedData.count), result.mediaAsset.sizeBytes)
+
+        XCTAssertEqual(
+            managedMediaAssetIdsReferencedInMarkdown(text: result.markdown),
+            Set([result.mediaAsset.mediaAssetId])
+        )
+        guard case .managedMarkdown(let renderedContent) = makeReviewRenderedContent(text: result.markdown) else {
+            XCTFail("Expected authored managed image Markdown to render as managed media")
+            return
+        }
+        let renderedReferences = renderedContent.blocks.compactMap { block in
+            if case .managedMedia(let reference) = block {
+                return reference
+            }
+            return nil
+        }
+        XCTAssertEqual(renderedReferences.count, 1)
+        XCTAssertEqual(renderedReferences.first?.mediaAssetId, result.mediaAsset.mediaAssetId)
+        XCTAssertEqual(renderedReferences.first?.isImageSyntax, true)
+        let renderedLabel = try XCTUnwrap(renderedReferences.first?.label)
+        XCTAssertFalse(renderedLabel.contains("["))
+        XCTAssertFalse(renderedLabel.contains("]"))
+        XCTAssertFalse(renderedLabel.contains("\n"))
+    }
+
     private func makeMediaAsset(workspaceId: String, deletedAt: String?) -> MediaAsset {
         MediaAsset(
             mediaAssetId: "00000000-0000-4000-8000-000000000001",
             workspaceId: workspaceId,
             mimeType: "image/png",
             sizeBytes: 1234,
-            sha256: "sha",
+            sha256: String(repeating: "a", count: 64),
             sourceUrl: nil,
             createdAt: "2026-04-24T10:00:00.000Z",
             clientUpdatedAt: deletedAt == nil ? "2026-04-24T10:00:01.000Z" : "2026-04-25T10:00:00.000Z",
@@ -244,5 +458,32 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
             updatedAt: deletedAt == nil ? "2026-04-24T10:00:02.000Z" : "2026-04-25T10:00:01.000Z",
             deletedAt: deletedAt
         )
+    }
+
+    private func tinyTransparentPNGData() throws -> Data {
+        let base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+        guard let data = Data(base64Encoded: base64) else {
+            throw LocalStoreError.validation("Tiny managed image test fixture is invalid")
+        }
+
+        return data
+    }
+
+    private func writeMediaCacheFile(database: LocalDatabase, cacheEntry: MediaBlobCacheEntry, data: Data) throws {
+        let cacheURL = database.databaseURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(cacheEntry.localRelativePath, isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try data.write(to: cacheURL, options: [.atomic])
+    }
+
+    private func hexSHA256(data: Data) -> String {
+        SHA256.hash(data: data).map { byte in
+            String(format: "%02x", byte)
+        }.joined()
     }
 }


### PR DESCRIPTION
## Summary
- Add non-UI iOS managed image preparation and authoring helpers for local JPEG normalization, media asset/cache rows, upload transfer queueing, and fcasset Markdown references.
- Keep media assets out of bootstrap sync writes while preflighting referenced cached media and queueing verified direct uploads.
- Share parser-safe fcasset parsing between authoring/bootstrap and review rendering.

## Validation
- Worker-owned fresh review after SHA-256/cache and actionable-transfer fixes found no P0-P4 issues and gave green light.
- git --no-pager diff --check: passed.
- Swift parser pass with iPhoneOS SDK on touched Swift files: passed.
- xcodebuild -list -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj": passed.
- Targeted checks: no /media-assets/images, no PhotosPicker, no CGImageSourceCreateImageAtIndex, no escaped-bracket alt replacements: passed.
- New-file trailing whitespace check: passed.

Simulator-backed iOS build/tests/smokes were not run because they were not explicitly authorized.