### PR TITLE
Add shared floating overlay primitive

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "flashcards-open-source-app-web",
       "version": "1.15.0",
       "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
         "@sentry/react": "^10.62.0",
         "heic-to": "^1.5.2",
         "lottie-web": "^5.13.0",
@@ -538,6 +539,44 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "test:e2e:prod": "FLASHCARDS_E2E_TARGET=prod playwright test"
   },
   "dependencies": {
+    "@floating-ui/react-dom": "^2.1.8",
     "@sentry/react": "^10.62.0",
     "heic-to": "^1.5.2",
     "lottie-web": "^5.13.0",

--- a/apps/web/src/floating/AnchoredFloatingOverlay.tsx
+++ b/apps/web/src/floating/AnchoredFloatingOverlay.tsx
@@ -1,0 +1,257 @@
+import {
+  autoUpdate,
+  flip,
+  offset as floatingOffset,
+  shift,
+  size,
+  useFloating,
+  type Placement,
+} from "@floating-ui/react-dom";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  type AriaRole,
+  type ReactNode,
+  type ReactPortal,
+  type RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+
+export type AnchoredFloatingOverlayMinimumWidth =
+  | Readonly<{ kind: "reference" }>
+  | Readonly<{ kind: "pixels"; pixels: number }>
+  | Readonly<{ kind: "reference-or-pixels"; pixels: number }>;
+
+export type AnchoredFloatingOverlayProps = Readonly<{
+  isOpen: boolean;
+  referenceRef: RefObject<HTMLElement | null>;
+  floatingRef: RefObject<HTMLDivElement | null>;
+  placement: Placement;
+  viewportPaddingPx: number;
+  offsetPx: number;
+  minimumWidth: AnchoredFloatingOverlayMinimumWidth | null;
+  maxWidthPx: number | null;
+  maxHeightPx: number | null;
+  className: string | null;
+  id: string | null;
+  role: AriaRole | null;
+  ariaLabel: string | null;
+  ariaLabelledBy: string | null;
+  ariaDescribedBy: string | null;
+  ariaModal: boolean | null;
+  children: ReactNode;
+}>;
+
+export type AnchoredFloatingOutsidePointerDismissOptions = Readonly<{
+  triggerRef: RefObject<HTMLElement | null>;
+  overlayRef: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  onClose: () => void;
+}>;
+
+function assertFiniteNumber(value: number, label: string): void {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`${label} must be a finite number.`);
+  }
+}
+
+function assertNonNegativeFiniteNumber(value: number, label: string): void {
+  assertFiniteNumber(value, label);
+
+  if (value < 0) {
+    throw new RangeError(`${label} must be greater than or equal to 0.`);
+  }
+}
+
+function assertOptionalNonNegativeFiniteNumber(value: number | null, label: string): void {
+  if (value === null) {
+    return;
+  }
+
+  assertNonNegativeFiniteNumber(value, label);
+}
+
+function validateMinimumWidth(minimumWidth: AnchoredFloatingOverlayMinimumWidth | null): void {
+  if (minimumWidth === null) {
+    return;
+  }
+
+  switch (minimumWidth.kind) {
+    case "reference":
+      return;
+    case "pixels":
+    case "reference-or-pixels":
+      assertNonNegativeFiniteNumber(minimumWidth.pixels, "Anchored floating overlay minimum width");
+      return;
+  }
+}
+
+function validateOverlayProps(
+  viewportPaddingPx: number,
+  offsetPx: number,
+  minimumWidth: AnchoredFloatingOverlayMinimumWidth | null,
+  maxWidthPx: number | null,
+  maxHeightPx: number | null,
+): void {
+  assertNonNegativeFiniteNumber(viewportPaddingPx, "Anchored floating overlay viewport padding");
+  assertFiniteNumber(offsetPx, "Anchored floating overlay offset");
+  assertOptionalNonNegativeFiniteNumber(maxWidthPx, "Anchored floating overlay maximum width");
+  assertOptionalNonNegativeFiniteNumber(maxHeightPx, "Anchored floating overlay maximum height");
+  validateMinimumWidth(minimumWidth);
+}
+
+function getViewportCappedSizePx(availableSizePx: number, configuredMaximumPx: number | null): number {
+  const availablePx = Math.max(availableSizePx, 0);
+
+  if (configuredMaximumPx === null) {
+    return availablePx;
+  }
+
+  return Math.min(configuredMaximumPx, availablePx);
+}
+
+function getMinimumWidthPx(
+  minimumWidth: AnchoredFloatingOverlayMinimumWidth | null,
+  referenceWidthPx: number,
+  maximumWidthPx: number,
+): number | null {
+  if (minimumWidth === null) {
+    return null;
+  }
+
+  const unconstrainedMinimumPx = (() => {
+    switch (minimumWidth.kind) {
+      case "reference":
+        return referenceWidthPx;
+      case "pixels":
+        return minimumWidth.pixels;
+      case "reference-or-pixels":
+        return Math.max(referenceWidthPx, minimumWidth.pixels);
+    }
+  })();
+
+  return Math.min(unconstrainedMinimumPx, maximumWidthPx);
+}
+
+function containsEventTarget(element: HTMLElement | null, target: Node): boolean {
+  return element !== null && element.contains(target);
+}
+
+export function useAnchoredFloatingOutsidePointerDismiss(
+  options: AnchoredFloatingOutsidePointerDismissOptions,
+): void {
+  const { triggerRef, overlayRef, enabled, onClose } = options;
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    function handlePointerDown(event: PointerEvent): void {
+      if (!(event.target instanceof Node)) {
+        onClose();
+        return;
+      }
+
+      if (containsEventTarget(triggerRef.current, event.target)) {
+        return;
+      }
+
+      if (containsEventTarget(overlayRef.current, event.target)) {
+        return;
+      }
+
+      onClose();
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [enabled, onClose, overlayRef, triggerRef]);
+}
+
+export function AnchoredFloatingOverlay(props: AnchoredFloatingOverlayProps): ReactPortal | null {
+  const {
+    isOpen,
+    referenceRef,
+    floatingRef,
+    placement,
+    viewportPaddingPx,
+    offsetPx,
+    minimumWidth,
+    maxWidthPx,
+    maxHeightPx,
+    className,
+    id,
+    role,
+    ariaLabel,
+    ariaLabelledBy,
+    ariaDescribedBy,
+    ariaModal,
+    children,
+  } = props;
+
+  validateOverlayProps(viewportPaddingPx, offsetPx, minimumWidth, maxWidthPx, maxHeightPx);
+
+  const middleware = useMemo(
+    () => [
+      floatingOffset(offsetPx),
+      flip({ padding: viewportPaddingPx }),
+      shift({ padding: viewportPaddingPx }),
+      size({
+        padding: viewportPaddingPx,
+        apply({ availableWidth, availableHeight, rects, elements }): void {
+          const cappedMaxWidthPx = getViewportCappedSizePx(availableWidth, maxWidthPx);
+          const cappedMaxHeightPx = getViewportCappedSizePx(availableHeight, maxHeightPx);
+          const minimumWidthPx = getMinimumWidthPx(minimumWidth, rects.reference.width, cappedMaxWidthPx);
+
+          elements.floating.style.maxWidth = `${cappedMaxWidthPx}px`;
+          elements.floating.style.maxHeight = `${cappedMaxHeightPx}px`;
+          elements.floating.style.minWidth = minimumWidthPx === null ? "" : `${minimumWidthPx}px`;
+        },
+      }),
+    ],
+    [maxHeightPx, maxWidthPx, minimumWidth, offsetPx, viewportPaddingPx],
+  );
+
+  const { floatingStyles, refs } = useFloating<HTMLElement>({
+    elements: {
+      reference: isOpen ? referenceRef.current : null,
+    },
+    middleware,
+    open: isOpen,
+    placement,
+    strategy: "fixed",
+    transform: false,
+    whileElementsMounted: autoUpdate,
+  });
+
+  const setFloatingElement = useCallback(
+    (element: HTMLDivElement | null): void => {
+      floatingRef.current = element;
+      refs.setFloating(element);
+    },
+    [floatingRef, refs],
+  );
+
+  if (!isOpen || referenceRef.current === null || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={setFloatingElement}
+      id={id ?? undefined}
+      className={className ?? undefined}
+      role={role ?? undefined}
+      aria-label={ariaLabel ?? undefined}
+      aria-labelledby={ariaLabelledBy ?? undefined}
+      aria-describedby={ariaDescribedBy ?? undefined}
+      aria-modal={ariaModal ?? undefined}
+      style={floatingStyles}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/floating/index.ts
+++ b/apps/web/src/floating/index.ts
@@ -1,0 +1,7 @@
+export {
+  AnchoredFloatingOverlay,
+  useAnchoredFloatingOutsidePointerDismiss,
+  type AnchoredFloatingOverlayMinimumWidth,
+  type AnchoredFloatingOverlayProps,
+  type AnchoredFloatingOutsidePointerDismissOptions,
+} from "./AnchoredFloatingOverlay";


### PR DESCRIPTION
## Summary
- add @floating-ui/react-dom to the web app
- add a shared anchored floating overlay primitive rendered through a body portal
- add a portal-aware outside pointer dismiss helper

## Validation
- npm run build in apps/web passed
- review subagent found no P0-P4 issues