### PR TITLE
Add Android card editor image UI

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
@@ -1,6 +1,14 @@
 package com.flashcardsopensourceapp.app.navigation.cards
 
+import android.content.Context
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -11,6 +19,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.enqueueMediaUploadWorker
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
@@ -19,9 +28,11 @@ import com.flashcardsopensourceapp.feature.cards.cardEditorBackTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorFrontTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.createCardEditorViewModelFactory
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorRoute
+import com.flashcardsopensourceapp.feature.cards.editor.CardEditorTextField
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorViewModel
 import com.flashcardsopensourceapp.feature.cards.editor.CardTagsRoute
 import com.flashcardsopensourceapp.feature.cards.editor.CardTextEditorRoute
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -177,28 +188,100 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 )
             )
             val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
+            val editorTextField = resolveEditorTextField(field = field)
+            val context = LocalContext.current
+            val managedImageAltText = stringResource(id = CardsR.string.cards_editor_image_label)
+            var isAddingImage by remember {
+                mutableStateOf(value = false)
+            }
+            val imagePickerLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.PickVisualMedia()
+            ) { uri ->
+                if (uri == null) {
+                    return@rememberLauncherForActivityResult
+                }
+
+                isAddingImage = true
+                coroutineScope.launch {
+                    try {
+                        val authoringResult = appGraph.managedMediaAuthoringRepository.authorManagedImageFromUri(
+                            uri = uri,
+                            altText = managedImageAltText
+                        )
+                        editorViewModel.insertManagedImageMarkdown(
+                            field = editorTextField,
+                            markdown = authoringResult.markdown
+                        )
+                        enqueueMediaUploadWorker(
+                            context = context.applicationContext,
+                            initialDelayMillis = 0L
+                        )
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Exception) {
+                        appGraph.appMessageBus.showMessage(
+                            message = cardEditorImageInsertFailureMessage(
+                                context = context,
+                                error = error
+                            )
+                        )
+                    } finally {
+                        isAddingImage = false
+                    }
+                }
+            }
 
             CardTextEditorRoute(
-                title = if (field == "front") {
+                title = if (editorTextField == CardEditorTextField.FRONT) {
                     stringResource(id = CardsR.string.cards_front_title)
                 } else {
                     stringResource(id = CardsR.string.cards_back_title)
                 },
-                supportingText = if (field == "front") {
+                supportingText = if (editorTextField == CardEditorTextField.FRONT) {
                     stringResource(id = CardsR.string.cards_front_supporting_text)
                 } else {
                     stringResource(id = CardsR.string.cards_back_supporting_text)
                 },
-                text = if (field == "front") uiState.frontText else uiState.backText,
-                textFieldTag = if (field == "front") {
+                text = if (editorTextField == CardEditorTextField.FRONT) uiState.frontText else uiState.backText,
+                selection = if (editorTextField == CardEditorTextField.FRONT) {
+                    uiState.frontTextSelection
+                } else {
+                    uiState.backTextSelection
+                },
+                managedImageReferences = if (editorTextField == CardEditorTextField.FRONT) {
+                    uiState.frontManagedImageReferences
+                } else {
+                    uiState.backManagedImageReferences
+                },
+                textFieldTag = if (editorTextField == CardEditorTextField.FRONT) {
                     cardEditorFrontTextFieldTag
                 } else {
                     cardEditorBackTextFieldTag
                 },
-                onTextChange = if (field == "front") {
+                isAddingMedia = isAddingImage,
+                onTextChange = if (editorTextField == CardEditorTextField.FRONT) {
                     editorViewModel::updateFrontText
                 } else {
                     editorViewModel::updateBackText
+                },
+                onSelectionChange = if (editorTextField == CardEditorTextField.FRONT) {
+                    editorViewModel::updateFrontTextSelection
+                } else {
+                    editorViewModel::updateBackTextSelection
+                },
+                onInsertImage = {
+                    imagePickerLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    )
+                },
+                onRemoveManagedImageReference = { referenceKey ->
+                    editorViewModel.removeManagedImageReference(
+                        field = editorTextField,
+                        referenceKey = referenceKey
+                    )
+                },
+                onLoadManagedImageUri = { mediaAssetId ->
+                    appGraph.reviewRepository.loadReviewMediaAssetFile(mediaAssetId = mediaAssetId).uri
                 },
                 onBack = {
                     navController.popBackStack()
@@ -251,4 +334,30 @@ private fun resolveEditingCardId(editingArgument: String): String? {
     } else {
         editingArgument
     }
+}
+
+private fun resolveEditorTextField(field: String): CardEditorTextField {
+    return when (field) {
+        "front" -> CardEditorTextField.FRONT
+        "back" -> CardEditorTextField.BACK
+        else -> throw IllegalArgumentException(
+            "Card text editor field must be 'front' or 'back', found '$field'."
+        )
+    }
+}
+
+private fun cardEditorImageInsertFailureMessage(
+    context: Context,
+    error: Exception
+): String {
+    val errorMessage = error.message?.trim()
+    val reason = if (errorMessage.isNullOrBlank()) {
+        context.getString(CardsR.string.cards_editor_add_image_unknown_error)
+    } else {
+        errorMessage
+    }
+    return context.getString(
+        CardsR.string.cards_editor_add_image_failed,
+        reason
+    )
 }

--- a/apps/android/feature/cards/build.gradle.kts
+++ b/apps/android/feature/cards/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.coil.compose)
 
     testImplementation(libs.junit4)
 }

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
@@ -16,7 +16,8 @@ data class CardsTextProvider(
     val editCardTitle: String,
     val enterTagBeforeAdding: String,
     val frontTextRequired: String,
-    val backTextRequired: String
+    val backTextRequired: String,
+    val imageReferenceMissing: String
 )
 
 fun cardsTextProvider(context: Context): CardsTextProvider {
@@ -26,7 +27,8 @@ fun cardsTextProvider(context: Context): CardsTextProvider {
         editCardTitle = context.getString(R.string.cards_edit_card_title),
         enterTagBeforeAdding = context.getString(R.string.cards_enter_tag_before_adding),
         frontTextRequired = context.getString(R.string.cards_front_text_required),
-        backTextRequired = context.getString(R.string.cards_back_text_required)
+        backTextRequired = context.getString(R.string.cards_back_text_required),
+        imageReferenceMissing = context.getString(R.string.cards_editor_image_reference_missing)
     )
 }
 

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsTestTags.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsTestTags.kt
@@ -11,5 +11,11 @@ const val cardEditorTagsSummaryCardTag: String = "card_editor_tags_summary_card"
 const val cardEditorSaveButtonTag: String = "card_editor_save_button"
 const val cardEditorFrontTextFieldTag: String = "card_editor_front_text_field"
 const val cardEditorBackTextFieldTag: String = "card_editor_back_text_field"
+const val cardTextEditorAddMediaButtonTag: String = "card_text_editor_add_media_button"
+const val cardTextEditorManagedMediaPreviewStripTag: String = "card_text_editor_managed_media_preview_strip"
 const val cardTagsInputFieldTag: String = "card_tags_input_field"
 const val cardTagsAddButtonTag: String = "card_tags_add_button"
+
+fun cardTextEditorManagedMediaPreviewItemTag(mediaAssetId: String): String {
+    return "card_text_editor_managed_media_preview_item_$mediaAssetId"
+}

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
@@ -2,12 +2,53 @@ package com.flashcardsopensourceapp.feature.cards.editor
 
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
 
+enum class CardEditorTextField {
+    FRONT,
+    BACK
+}
+
+data class CardEditorTextSelection(
+    val start: Int,
+    val end: Int
+) {
+    init {
+        require(start >= 0) {
+            "Card editor text selection start must not be negative."
+        }
+        require(end >= start) {
+            "Card editor text selection end must be greater than or equal to start."
+        }
+    }
+}
+
+data class CardEditorManagedImageReference(
+    val referenceKey: String,
+    val mediaAssetId: String,
+    val label: String?
+) {
+    init {
+        require(referenceKey.isNotBlank()) {
+            "Card editor managed image reference key must not be blank."
+        }
+        require(mediaAssetId.isNotBlank()) {
+            "Card editor managed image asset id must not be blank."
+        }
+        require(label == null || label.isNotBlank()) {
+            "Card editor managed image label must not be blank when present."
+        }
+    }
+}
+
 data class CardEditorUiState(
     val isLoading: Boolean,
     val title: String,
     val isEditing: Boolean,
     val frontText: String,
     val backText: String,
+    val frontTextSelection: CardEditorTextSelection,
+    val backTextSelection: CardEditorTextSelection,
+    val frontManagedImageReferences: List<CardEditorManagedImageReference>,
+    val backManagedImageReferences: List<CardEditorManagedImageReference>,
     val selectedTags: List<String>,
     val availableTagSuggestions: List<WorkspaceTagSummary>,
     val frontTextErrorMessage: String,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.launch
 private data class CardEditorDraftState(
     val frontText: String,
     val backText: String,
+    val frontTextSelection: CardEditorTextSelection,
+    val backTextSelection: CardEditorTextSelection,
     val selectedTags: List<String>,
     val frontTextErrorMessage: String,
     val backTextErrorMessage: String,
@@ -41,6 +43,8 @@ class CardEditorViewModel(
         value = CardEditorDraftState(
             frontText = "",
             backText = "",
+            frontTextSelection = CardEditorTextSelection(start = 0, end = 0),
+            backTextSelection = CardEditorTextSelection(start = 0, end = 0),
             selectedTags = emptyList(),
             frontTextErrorMessage = "",
             backTextErrorMessage = "",
@@ -88,6 +92,16 @@ class CardEditorViewModel(
                 isEditing = editingCardId != null,
                 frontText = currentState.frontText,
                 backText = currentState.backText,
+                frontTextSelection = clampCardEditorTextSelection(
+                    selection = currentState.frontTextSelection,
+                    text = currentState.frontText
+                ),
+                backTextSelection = clampCardEditorTextSelection(
+                    selection = currentState.backTextSelection,
+                    text = currentState.backText
+                ),
+                frontManagedImageReferences = parseManagedImageReferences(text = currentState.frontText),
+                backManagedImageReferences = parseManagedImageReferences(text = currentState.backText),
                 selectedTags = normalizeTags(
                     values = currentState.selectedTags,
                     referenceTags = tagsSummary.tags.map(WorkspaceTagSummary::tag)
@@ -108,6 +122,10 @@ class CardEditorViewModel(
                 isEditing = editingCardId != null,
                 frontText = "",
                 backText = "",
+                frontTextSelection = CardEditorTextSelection(start = 0, end = 0),
+                backTextSelection = CardEditorTextSelection(start = 0, end = 0),
+                frontManagedImageReferences = emptyList(),
+                backManagedImageReferences = emptyList(),
                 selectedTags = emptyList(),
                 availableTagSuggestions = emptyList(),
                 frontTextErrorMessage = "",
@@ -119,10 +137,17 @@ class CardEditorViewModel(
         )
     }
 
-    fun updateFrontText(frontText: String) {
+    fun updateFrontText(
+        frontText: String,
+        selection: CardEditorTextSelection
+    ) {
         inputState.update { state ->
             state.copy(
                 frontText = frontText,
+                frontTextSelection = clampCardEditorTextSelection(
+                    selection = selection,
+                    text = frontText
+                ),
                 frontTextErrorMessage = "",
                 errorMessage = "",
                 isDirty = true
@@ -130,14 +155,134 @@ class CardEditorViewModel(
         }
     }
 
-    fun updateBackText(backText: String) {
+    fun updateBackText(
+        backText: String,
+        selection: CardEditorTextSelection
+    ) {
         inputState.update { state ->
             state.copy(
                 backText = backText,
+                backTextSelection = clampCardEditorTextSelection(
+                    selection = selection,
+                    text = backText
+                ),
                 backTextErrorMessage = "",
                 errorMessage = "",
                 isDirty = true
             )
+        }
+    }
+
+    fun updateFrontTextSelection(selection: CardEditorTextSelection) {
+        inputState.update { state ->
+            state.copy(
+                frontTextSelection = clampCardEditorTextSelection(
+                    selection = selection,
+                    text = state.frontText
+                )
+            )
+        }
+    }
+
+    fun updateBackTextSelection(selection: CardEditorTextSelection) {
+        inputState.update { state ->
+            state.copy(
+                backTextSelection = clampCardEditorTextSelection(
+                    selection = selection,
+                    text = state.backText
+                )
+            )
+        }
+    }
+
+    fun insertManagedImageMarkdown(
+        field: CardEditorTextField,
+        markdown: String
+    ) {
+        val normalizedMarkdown = markdown.trim()
+        require(normalizedMarkdown.isNotBlank()) {
+            "Managed image markdown must not be blank."
+        }
+
+        inputState.update { state ->
+            when (field) {
+                CardEditorTextField.FRONT -> {
+                    val edit = insertMarkdownAtSelection(
+                        text = state.frontText,
+                        selection = state.frontTextSelection,
+                        markdown = normalizedMarkdown
+                    )
+                    state.copy(
+                        frontText = edit.text,
+                        frontTextSelection = edit.selection,
+                        frontTextErrorMessage = "",
+                        errorMessage = "",
+                        isDirty = true
+                    )
+                }
+
+                CardEditorTextField.BACK -> {
+                    val edit = insertMarkdownAtSelection(
+                        text = state.backText,
+                        selection = state.backTextSelection,
+                        markdown = normalizedMarkdown
+                    )
+                    state.copy(
+                        backText = edit.text,
+                        backTextSelection = edit.selection,
+                        backTextErrorMessage = "",
+                        errorMessage = "",
+                        isDirty = true
+                    )
+                }
+            }
+        }
+    }
+
+    fun removeManagedImageReference(
+        field: CardEditorTextField,
+        referenceKey: String
+    ) {
+        require(referenceKey.isNotBlank()) {
+            "Managed image reference key must not be blank."
+        }
+
+        inputState.update { state ->
+            when (field) {
+                CardEditorTextField.FRONT -> {
+                    val edit = removeManagedImageReferenceFromText(
+                        text = state.frontText,
+                        selection = state.frontTextSelection,
+                        referenceKey = referenceKey
+                    ) ?: return@update state.copy(
+                        errorMessage = textProvider.imageReferenceMissing
+                    )
+                    state.copy(
+                        frontText = edit.text,
+                        frontTextSelection = edit.selection,
+                        frontTextErrorMessage = "",
+                        errorMessage = "",
+                        isDirty = true
+                    )
+                }
+
+                CardEditorTextField.BACK -> {
+                    val edit = removeManagedImageReferenceFromText(
+                        text = state.backText,
+                        selection = state.backTextSelection,
+                        referenceKey = referenceKey
+                    ) ?: return@update state.copy(
+                        errorMessage = textProvider.imageReferenceMissing
+                    )
+                    state.copy(
+                        backText = edit.text,
+                        backTextSelection = edit.selection,
+                        backTextErrorMessage = "",
+                        errorMessage = "",
+                        isDirty = true
+                    )
+                }
+            }
         }
     }
 
@@ -273,6 +418,17 @@ private data class CardEditorValidationResult(
     val errorMessage: String
 )
 
+private data class CardEditorTextEditResult(
+    val text: String,
+    val selection: CardEditorTextSelection
+)
+
+private data class ManagedImageReferenceMatch(
+    val reference: CardEditorManagedImageReference,
+    val startIndex: Int,
+    val endIndexExclusive: Int
+)
+
 private fun validateCardEditorInput(
     frontText: String,
     backText: String,
@@ -305,4 +461,132 @@ private fun toggleTagSelection(selectedTags: List<String>, tag: String): List<St
     }
 
     return selectedTags + tag
+}
+
+private val managedImageMarkdownRegex = Regex("""!\[([^\]\n]*)]\(fcasset:([^\s)]+)\)""")
+
+private fun insertMarkdownAtSelection(
+    text: String,
+    selection: CardEditorTextSelection,
+    markdown: String
+): CardEditorTextEditResult {
+    val normalizedSelection = clampCardEditorTextSelection(selection = selection, text = text)
+    val prefix = if (text.substring(startIndex = 0, endIndex = normalizedSelection.start).endsWith("\n") ||
+        normalizedSelection.start == 0
+    ) {
+        ""
+    } else {
+        "\n\n"
+    }
+    val suffix = if (text.substring(startIndex = normalizedSelection.end).startsWith("\n") ||
+        normalizedSelection.end == text.length
+    ) {
+        ""
+    } else {
+        "\n\n"
+    }
+    val insertedMarkdown = "$prefix$markdown$suffix"
+    val updatedText = text.replaceRange(
+        startIndex = normalizedSelection.start,
+        endIndex = normalizedSelection.end,
+        replacement = insertedMarkdown
+    )
+    val cursorIndex = normalizedSelection.start + insertedMarkdown.length
+    return CardEditorTextEditResult(
+        text = updatedText,
+        selection = CardEditorTextSelection(start = cursorIndex, end = cursorIndex)
+    )
+}
+
+private fun removeManagedImageReferenceFromText(
+    text: String,
+    selection: CardEditorTextSelection,
+    referenceKey: String
+): CardEditorTextEditResult? {
+    val match = findManagedImageReferenceMatches(text = text).firstOrNull { currentMatch ->
+        currentMatch.reference.referenceKey == referenceKey
+    } ?: return null
+    val updatedText = text.removeRange(
+        startIndex = match.startIndex,
+        endIndex = match.endIndexExclusive
+    )
+    return CardEditorTextEditResult(
+        text = updatedText,
+        selection = shiftSelectionAfterRemoval(
+            selection = selection,
+            removedStartIndex = match.startIndex,
+            removedEndIndexExclusive = match.endIndexExclusive
+        )
+    )
+}
+
+private fun parseManagedImageReferences(text: String): List<CardEditorManagedImageReference> {
+    return findManagedImageReferenceMatches(text = text).map(ManagedImageReferenceMatch::reference)
+}
+
+private fun findManagedImageReferenceMatches(text: String): List<ManagedImageReferenceMatch> {
+    return managedImageMarkdownRegex.findAll(input = text).map { match ->
+        val startIndex = match.range.first
+        val endIndexExclusive = match.range.last + 1
+        val rawLabel = match.groupValues[1].trim()
+        val label = if (rawLabel.isEmpty()) null else rawLabel
+        val mediaAssetId = match.groupValues[2].trim()
+        ManagedImageReferenceMatch(
+            reference = CardEditorManagedImageReference(
+                referenceKey = "$startIndex:$endIndexExclusive:$mediaAssetId",
+                mediaAssetId = mediaAssetId,
+                label = label
+            ),
+            startIndex = startIndex,
+            endIndexExclusive = endIndexExclusive
+        )
+    }.toList()
+}
+
+private fun clampCardEditorTextSelection(
+    selection: CardEditorTextSelection,
+    text: String
+): CardEditorTextSelection {
+    val start = selection.start.coerceIn(minimumValue = 0, maximumValue = text.length)
+    val end = selection.end.coerceIn(minimumValue = 0, maximumValue = text.length)
+    val normalizedStart = minOf(start, end)
+    val normalizedEnd = maxOf(start, end)
+    return CardEditorTextSelection(start = normalizedStart, end = normalizedEnd)
+}
+
+private fun shiftSelectionAfterRemoval(
+    selection: CardEditorTextSelection,
+    removedStartIndex: Int,
+    removedEndIndexExclusive: Int
+): CardEditorTextSelection {
+    val removedLength = removedEndIndexExclusive - removedStartIndex
+    val shiftedStart = shiftTextOffsetAfterRemoval(
+        offset = selection.start,
+        removedStartIndex = removedStartIndex,
+        removedEndIndexExclusive = removedEndIndexExclusive,
+        removedLength = removedLength
+    )
+    val shiftedEnd = shiftTextOffsetAfterRemoval(
+        offset = selection.end,
+        removedStartIndex = removedStartIndex,
+        removedEndIndexExclusive = removedEndIndexExclusive,
+        removedLength = removedLength
+    )
+    return CardEditorTextSelection(
+        start = minOf(shiftedStart, shiftedEnd),
+        end = maxOf(shiftedStart, shiftedEnd)
+    )
+}
+
+private fun shiftTextOffsetAfterRemoval(
+    offset: Int,
+    removedStartIndex: Int,
+    removedEndIndexExclusive: Int,
+    removedLength: Int
+): Int {
+    return when {
+        offset <= removedStartIndex -> offset
+        offset >= removedEndIndexExclusive -> offset - removedLength
+        else -> removedStartIndex
+    }
 }

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
@@ -1,26 +1,73 @@
 package com.flashcardsopensourceapp.feature.cards.editor
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Alignment
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.AddPhotoAlternate
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
 import com.flashcardsopensourceapp.feature.cards.R
+import com.flashcardsopensourceapp.feature.cards.cardTextEditorAddMediaButtonTag
+import com.flashcardsopensourceapp.feature.cards.cardTextEditorManagedMediaPreviewItemTag
+import com.flashcardsopensourceapp.feature.cards.cardTextEditorManagedMediaPreviewStripTag
+import kotlinx.coroutines.CancellationException
+
+private sealed interface CardEditorManagedImagePreviewState {
+    data object Loading : CardEditorManagedImagePreviewState
+    data class Ready(val uri: String) : CardEditorManagedImagePreviewState
+    data object Unavailable : CardEditorManagedImagePreviewState
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -28,15 +75,67 @@ fun CardTextEditorRoute(
     title: String,
     supportingText: String,
     text: String,
+    selection: CardEditorTextSelection,
+    managedImageReferences: List<CardEditorManagedImageReference>,
     textFieldTag: String,
-    onTextChange: (String) -> Unit,
+    isAddingMedia: Boolean,
+    onTextChange: (String, CardEditorTextSelection) -> Unit,
+    onSelectionChange: (CardEditorTextSelection) -> Unit,
+    onInsertImage: () -> Unit,
+    onRemoveManagedImageReference: (String) -> Unit,
+    onLoadManagedImageUri: suspend (String) -> String,
     onBack: () -> Unit
 ) {
+    val addingImageContentDescription = stringResource(
+        id = R.string.cards_editor_adding_image_content_description
+    )
+    var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(
+            value = TextFieldValue(
+                text,
+                textRangeFromCardSelection(selection = selection, text = text)
+            )
+        )
+    }
+    val latestTextRange = textRangeFromCardSelection(selection = selection, text = text)
+    LaunchedEffect(text, latestTextRange) {
+        if (textFieldValue.text != text || textFieldValue.selection != latestTextRange) {
+            textFieldValue = TextFieldValue(
+                text,
+                latestTextRange
+            )
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
                 title = {
                     Text(title)
+                },
+                actions = {
+                    IconButton(
+                        onClick = onInsertImage,
+                        enabled = isAddingMedia.not(),
+                        modifier = Modifier.testTag(cardTextEditorAddMediaButtonTag)
+                    ) {
+                        if (isAddingMedia) {
+                            CircularProgressIndicator(
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .semantics {
+                                        contentDescription = addingImageContentDescription
+                                    }
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Outlined.AddPhotoAlternate,
+                                contentDescription = stringResource(
+                                    id = R.string.cards_editor_add_image_content_description
+                                )
+                            )
+                        }
+                    }
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
@@ -65,9 +164,28 @@ fun CardTextEditorRoute(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
+            if (managedImageReferences.isNotEmpty()) {
+                CardEditorManagedImagePreviewStrip(
+                    references = managedImageReferences,
+                    onRemoveManagedImageReference = onRemoveManagedImageReference,
+                    onLoadManagedImageUri = onLoadManagedImageUri
+                )
+            }
+
             OutlinedTextField(
-                value = text,
-                onValueChange = onTextChange,
+                value = textFieldValue,
+                onValueChange = { nextValue ->
+                    textFieldValue = nextValue
+                    val nextSelection = cardSelectionFromTextRange(
+                        range = nextValue.selection,
+                        text = nextValue.text
+                    )
+                    if (nextValue.text != text) {
+                        onTextChange(nextValue.text, nextSelection)
+                    } else if (nextSelection != selection) {
+                        onSelectionChange(nextSelection)
+                    }
+                },
                 label = {
                     Text(title)
                 },
@@ -79,4 +197,210 @@ fun CardTextEditorRoute(
             )
         }
     }
+}
+
+@Composable
+private fun CardEditorManagedImagePreviewStrip(
+    references: List<CardEditorManagedImageReference>,
+    onRemoveManagedImageReference: (String) -> Unit,
+    onLoadManagedImageUri: suspend (String) -> String
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(cardTextEditorManagedMediaPreviewStripTag)
+    ) {
+        items(
+            items = references,
+            key = CardEditorManagedImageReference::referenceKey
+        ) { reference ->
+            CardEditorManagedImagePreviewItem(
+                reference = reference,
+                onRemoveManagedImageReference = onRemoveManagedImageReference,
+                onLoadManagedImageUri = onLoadManagedImageUri
+            )
+        }
+    }
+}
+
+@Composable
+private fun CardEditorManagedImagePreviewItem(
+    reference: CardEditorManagedImageReference,
+    onRemoveManagedImageReference: (String) -> Unit,
+    onLoadManagedImageUri: suspend (String) -> String
+) {
+    val currentLoadManagedImageUri = rememberUpdatedState(newValue = onLoadManagedImageUri)
+    val previewState by produceState<CardEditorManagedImagePreviewState>(
+        initialValue = CardEditorManagedImagePreviewState.Loading,
+        key1 = reference.mediaAssetId
+    ) {
+        value = try {
+            CardEditorManagedImagePreviewState.Ready(
+                uri = currentLoadManagedImageUri.value(reference.mediaAssetId)
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            CardEditorManagedImagePreviewState.Unavailable
+        }
+    }
+    val label = reference.label ?: stringResource(id = R.string.cards_editor_image_label)
+
+    Card(
+        modifier = Modifier
+            .width(184.dp)
+            .testTag(cardTextEditorManagedMediaPreviewItemTag(mediaAssetId = reference.mediaAssetId))
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(12.dp)
+        ) {
+            CardEditorManagedImagePreviewSurface(
+                state = previewState,
+                label = label
+            )
+            Text(
+                text = label,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            TextButton(
+                onClick = {
+                    onRemoveManagedImageReference(reference.referenceKey)
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Close,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = stringResource(id = R.string.cards_editor_remove_image))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CardEditorManagedImagePreviewSurface(
+    state: CardEditorManagedImagePreviewState,
+    label: String
+) {
+    when (state) {
+        CardEditorManagedImagePreviewState.Loading -> CardEditorManagedImagePlaceholder(
+            label = stringResource(id = R.string.cards_editor_image_loading),
+            isLoading = true
+        )
+
+        CardEditorManagedImagePreviewState.Unavailable -> CardEditorManagedImagePlaceholder(
+            label = stringResource(id = R.string.cards_editor_image_unavailable),
+            isLoading = false
+        )
+
+        is CardEditorManagedImagePreviewState.Ready -> CardEditorManagedImage(
+            uri = state.uri,
+            label = label
+        )
+    }
+}
+
+@Composable
+private fun CardEditorManagedImage(
+    uri: String,
+    label: String
+) {
+    val context = LocalContext.current
+    val imageRequest = remember(context, uri) {
+        ImageRequest.Builder(context)
+            .data(uri)
+            .diskCachePolicy(CachePolicy.DISABLED)
+            .build()
+    }
+    SubcomposeAsyncImage(
+        model = imageRequest,
+        contentDescription = label,
+        contentScale = ContentScale.Crop,
+        loading = {
+            CardEditorManagedImagePlaceholder(
+                label = stringResource(id = R.string.cards_editor_image_loading),
+                isLoading = true
+            )
+        },
+        error = {
+            CardEditorManagedImagePlaceholder(
+                label = stringResource(id = R.string.cards_editor_image_unavailable),
+                isLoading = false
+            )
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(104.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
+    )
+}
+
+@Composable
+private fun CardEditorManagedImagePlaceholder(
+    label: String,
+    isLoading: Boolean
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 104.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(12.dp)
+        ) {
+            if (isLoading) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+            } else {
+                Icon(
+                    imageVector = Icons.Outlined.WarningAmber,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+            Icon(
+                imageVector = Icons.Outlined.Image,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+            Text(
+                text = label,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}
+
+private fun textRangeFromCardSelection(
+    selection: CardEditorTextSelection,
+    text: String
+): TextRange {
+    return TextRange(
+        selection.start.coerceIn(minimumValue = 0, maximumValue = text.length),
+        selection.end.coerceIn(minimumValue = 0, maximumValue = text.length)
+    )
+}
+
+private fun cardSelectionFromTextRange(
+    range: TextRange,
+    text: String
+): CardEditorTextSelection {
+    val start = range.min.coerceIn(minimumValue = 0, maximumValue = text.length)
+    val end = range.max.coerceIn(minimumValue = 0, maximumValue = text.length)
+    return CardEditorTextSelection(start = start, end = end)
 }

--- a/apps/android/feature/cards/src/main/res/values/strings.xml
+++ b/apps/android/feature/cards/src/main/res/values/strings.xml
@@ -38,6 +38,15 @@
     <string name="cards_front_text_required">Front text is required.</string>
     <string name="cards_back_text_required">Back text is required.</string>
     <string name="cards_editor_back_content_description">Back</string>
+    <string name="cards_editor_add_image_content_description">Add image</string>
+    <string name="cards_editor_adding_image_content_description">Adding image</string>
+    <string name="cards_editor_image_label">Image</string>
+    <string name="cards_editor_image_loading">Loading image</string>
+    <string name="cards_editor_image_unavailable">Image unavailable</string>
+    <string name="cards_editor_remove_image">Remove</string>
+    <string name="cards_editor_image_reference_missing">The image reference is no longer in this card text.</string>
+    <string name="cards_editor_add_image_failed">Could not add image: %1$s</string>
+    <string name="cards_editor_add_image_unknown_error">Unknown import error.</string>
     <string name="cards_editor_guidance">Front text stays the review prompt. Back text stays the answer. Both can be long-form and are edited on dedicated Android surfaces.</string>
     <string name="cards_edit_with_ai">Edit with AI</string>
     <string name="cards_text_section">Text</string>


### PR DESCRIPTION
## Summary
- Add native Compose image insertion controls to the Android card text editor
- Persist picked images through the managed media authoring repository before inserting Markdown
- Show local managed-image previews and allow removing Markdown references without deleting blobs
- Enqueue media upload work after successful local authoring

## Validation
- git --no-pager diff --check
- xmllint --noout apps/android/feature/cards/src/main/res/values/strings.xml
- rg check confirmed no feature:cards -> feature:review dependency
- rg check confirmed no stale imagePickerTargetField/targetField state remains
- Final read-only review found no P0-P4 issues and no split blocker

Gradle build and emulator/manual smoke were not run because they were not authorized.