### PR TITLE
Migrate shell menus to anchored overlay

### DIFF
--- a/apps/web/src/AccountMenu.tsx
+++ b/apps/web/src/AccountMenu.tsx
@@ -1,5 +1,6 @@
-import { type FormEvent, type ReactElement, useEffect, useRef, useState } from "react";
+import { type FormEvent, type ReactElement, useCallback, useEffect, useRef, useState } from "react";
 import { useAppErrorDialog } from "./appError/AppErrorContext";
+import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } from "./floating";
 import { useI18n } from "./i18n";
 import type { WorkspaceSummary } from "./types";
 import { useTransientMessage } from "./useTransientMessage";
@@ -16,6 +17,12 @@ type Props = Readonly<{
   onSelectWorkspace: (workspaceId: string) => Promise<void>;
   onCreateWorkspace: (name: string) => Promise<void>;
 }>;
+
+const accountMenuViewportPaddingPx: number = 12;
+const accountMenuOffsetPx: number = 10;
+const accountMenuMaxWidthPx: number = 280;
+const accountMenuMaxHeightPx: number = 420;
+const accountMenuFirstActionSelector: string = "button:not(:disabled), a[href], input:not(:disabled)";
 
 export function AccountMenu(props: Props): ReactElement {
   const {
@@ -42,27 +49,37 @@ export function AccountMenu(props: Props): ReactElement {
   const { message, showMessage } = useTransientMessage(3000);
   const technicalErrorMessage = t("appError.technicalError.message");
 
+  const closeAndResetMenu = useCallback(function closeAndResetMenu(): void {
+    setIsOpen(false);
+    setIsCreating(false);
+    setNewWorkspaceName("");
+    setErrorMessage("");
+  }, []);
+
+  const focusFirstMenuAction = useCallback(function focusFirstMenuAction(): void {
+    const firstMenuAction = menuRef.current?.querySelector<HTMLElement>(accountMenuFirstActionSelector) ?? null;
+    firstMenuAction?.focus();
+  }, []);
+
+  const closeAndResetMenuAndFocusButton = useCallback(function closeAndResetMenuAndFocusButton(): void {
+    closeAndResetMenu();
+    buttonRef.current?.focus();
+  }, [closeAndResetMenu]);
+
+  useAnchoredFloatingOutsidePointerDismiss({
+    triggerRef: buttonRef,
+    overlayRef: menuRef,
+    enabled: isOpen,
+    onClose: closeAndResetMenu,
+  });
+
   useEffect(() => {
     if (!isOpen) {
       return;
     }
 
-    function handleMouseDown(event: MouseEvent): void {
-      const target = event.target as Node;
-      if (
-        menuRef.current !== null && !menuRef.current.contains(target)
-        && buttonRef.current !== null && !buttonRef.current.contains(target)
-      ) {
-        setIsOpen(false);
-        setIsCreating(false);
-        setNewWorkspaceName("");
-        setErrorMessage("");
-      }
-    }
-
-    document.addEventListener("mousedown", handleMouseDown);
-    return () => document.removeEventListener("mousedown", handleMouseDown);
-  }, [isOpen]);
+    focusFirstMenuAction();
+  }, [focusFirstMenuAction, isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -71,16 +88,13 @@ export function AccountMenu(props: Props): ReactElement {
 
     function handleKeyDown(event: KeyboardEvent): void {
       if (event.key === "Escape") {
-        setIsOpen(false);
-        setIsCreating(false);
-        setNewWorkspaceName("");
-        setErrorMessage("");
+        closeAndResetMenuAndFocusButton();
       }
     }
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
+  }, [closeAndResetMenuAndFocusButton, isOpen]);
 
   useEffect(() => {
     if (isCreating && inputRef.current !== null) {
@@ -153,71 +167,86 @@ export function AccountMenu(props: Props): ReactElement {
           <path d="M20 21a8 8 0 0 0-16 0" />
         </svg>
       </button>
-      {isOpen ? (
-        <div ref={menuRef} className="account-menu-dropdown">
-          {message === "" ? null : <div className="account-menu-banner" role="status">{message}</div>}
-          <div className="account-menu-section-label">{t("accountMenu.currentWorkspaceSection")}</div>
-          {isWorkspaceManagementLocked ? (
-            <button
-              className="account-menu-item account-menu-item-muted"
-              type="button"
-              onClick={() => showMessage(workspaceManagementLockedMessage)}
-            >
-              {currentWorkspaceName}
-            </button>
-          ) : workspaces.length > 0 ? (
-            <>
-              {workspaces.map((workspace) => (
-                <button
-                  key={workspace.workspaceId}
-                  className={`account-menu-item${workspace.workspaceId === currentWorkspaceId ? " account-menu-item-active" : ""}`}
-                  type="button"
-                  onClick={() => void handleWorkspaceSelect(workspace.workspaceId)}
-                  disabled={isBusy}
-                >
-                  <span className="cell-stack">
-                    <span>{workspace.name}</span>
-                    <span className="cell-secondary">{formatDateTime(workspace.createdAt)}</span>
-                  </span>
-                </button>
-              ))}
-            </>
-          ) : null}
-          {isWorkspaceManagementLocked ? null : !isCreating ? (
-            <button
-              className="account-menu-item account-menu-item-create"
-              type="button"
-              onClick={() => {
-                setIsCreating(true);
-                setErrorMessage("");
-              }}
-              disabled={isBusy}
-            >
-              + {t("accountMenu.newWorkspace")}
-            </button>
-          ) : (
-            <form className="account-menu-create-form" onSubmit={(event) => void handleCreateWorkspace(event)}>
-              <input
-                ref={inputRef}
-                className="account-menu-create-input"
-                type="text"
-                placeholder={t("accountMenu.workspaceNamePlaceholder")}
-                value={newWorkspaceName}
-                onChange={(event) => setNewWorkspaceName(event.target.value)}
+      <AnchoredFloatingOverlay
+        isOpen={isOpen}
+        referenceRef={buttonRef}
+        floatingRef={menuRef}
+        placement="bottom-end"
+        viewportPaddingPx={accountMenuViewportPaddingPx}
+        offsetPx={accountMenuOffsetPx}
+        minimumWidth={null}
+        maxWidthPx={accountMenuMaxWidthPx}
+        maxHeightPx={accountMenuMaxHeightPx}
+        className="account-menu-dropdown"
+        id={null}
+        role={null}
+        ariaLabel={null}
+        ariaLabelledBy={null}
+        ariaDescribedBy={null}
+        ariaModal={null}
+      >
+        {message === "" ? null : <div className="account-menu-banner" role="status">{message}</div>}
+        <div className="account-menu-section-label">{t("accountMenu.currentWorkspaceSection")}</div>
+        {isWorkspaceManagementLocked ? (
+          <button
+            className="account-menu-item account-menu-item-muted"
+            type="button"
+            onClick={() => showMessage(workspaceManagementLockedMessage)}
+          >
+            {currentWorkspaceName}
+          </button>
+        ) : workspaces.length > 0 ? (
+          <>
+            {workspaces.map((workspace) => (
+              <button
+                key={workspace.workspaceId}
+                className={`account-menu-item${workspace.workspaceId === currentWorkspaceId ? " account-menu-item-active" : ""}`}
+                type="button"
+                onClick={() => void handleWorkspaceSelect(workspace.workspaceId)}
                 disabled={isBusy}
-              />
-              {errorMessage !== "" ? <div className="account-menu-error">{errorMessage}</div> : null}
-            </form>
-          )}
-          <div className="account-menu-separator" />
-          <a className="account-menu-item account-menu-link" href={accountSettingsUrl}>
-            {t("navigation.settings")}
-          </a>
-          <a className="account-menu-item account-menu-link" href={logoutUrl}>
-            {t("accountMenu.logout")}
-          </a>
-        </div>
-      ) : null}
+              >
+                <span className="cell-stack">
+                  <span>{workspace.name}</span>
+                  <span className="cell-secondary">{formatDateTime(workspace.createdAt)}</span>
+                </span>
+              </button>
+            ))}
+          </>
+        ) : null}
+        {isWorkspaceManagementLocked ? null : !isCreating ? (
+          <button
+            className="account-menu-item account-menu-item-create"
+            type="button"
+            onClick={() => {
+              setIsCreating(true);
+              setErrorMessage("");
+            }}
+            disabled={isBusy}
+          >
+            + {t("accountMenu.newWorkspace")}
+          </button>
+        ) : (
+          <form className="account-menu-create-form" onSubmit={(event) => void handleCreateWorkspace(event)}>
+            <input
+              ref={inputRef}
+              className="account-menu-create-input"
+              type="text"
+              placeholder={t("accountMenu.workspaceNamePlaceholder")}
+              value={newWorkspaceName}
+              onChange={(event) => setNewWorkspaceName(event.target.value)}
+              disabled={isBusy}
+            />
+            {errorMessage !== "" ? <div className="account-menu-error">{errorMessage}</div> : null}
+          </form>
+        )}
+        <div className="account-menu-separator" />
+        <a className="account-menu-item account-menu-link" href={accountSettingsUrl}>
+          {t("navigation.settings")}
+        </a>
+        <a className="account-menu-item account-menu-link" href={logoutUrl}>
+          {t("accountMenu.logout")}
+        </a>
+      </AnchoredFloatingOverlay>
     </div>
   );
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import { ChatDraftProvider } from "./chat/composer/drafts/ChatDraftContext";
 import { ChatLayoutProvider, useChatLayout } from "./chat/layout/ChatLayoutContext";
 import { ChatSessionControllerProvider } from "./chat/sessionController";
 import { ChatToggle } from "./chat/layout/ChatToggle";
+import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss, type AnchoredFloatingOverlayMinimumWidth } from "./floating";
 import { useAppErrorDialog } from "./appError/AppErrorContext";
 import { type TranslationKey, useI18n } from "./i18n";
 import { captureApiContractError } from "./observability/apiContractObservation";
@@ -92,6 +93,12 @@ const primaryNavigationItems: ReadonlyArray<PrimaryNavigationItem> = [
   { route: cardsRoute, labelKey: "navigation.cards" },
   { route: settingsHubRoute, labelKey: "navigation.settings" },
 ];
+
+const mobileNavigationViewportPaddingPx: number = 12;
+const mobileNavigationOffsetPx: number = 8;
+const mobileNavigationMaxHeightPx: number = 420;
+const mobileNavigationMinimumWidth: AnchoredFloatingOverlayMinimumWidth = { kind: "reference" };
+const mobileNavigationFirstLinkSelector: string = "a[href]";
 
 const ChatPanel = lazy(async () => import("./chat/ChatPanel").then((module) => ({ default: module.ChatPanel })));
 const FriendInvitePreviewScreen = lazy(async () => import("./dev/previews/invite/FriendInvitePreviewScreen").then((module) => ({
@@ -356,6 +363,9 @@ export function AppShell(): ReactElement {
   const [accountDeletionTechnicalError, setAccountDeletionTechnicalError] = useState<Error | null>(null);
   const [isAccountDeletionSubmitting, setIsAccountDeletionSubmitting] = useState<boolean>(false);
   const [isMobileNavigationOpen, setIsMobileNavigationOpen] = useState<boolean>(false);
+  const topbarShellRef = useRef<HTMLElement | null>(null);
+  const mobileNavigationToggleRef = useRef<HTMLButtonElement | null>(null);
+  const mobileNavigationMenuRef = useRef<HTMLDivElement | null>(null);
   const shownSessionTechnicalErrorRef = useRef<Error | null>(null);
   const shownGlobalTechnicalErrorRef = useRef<Error | null>(null);
   const sessionRestoringMessage = sessionVerificationState === "unverified" ? t("loading.restoringSession") : "";
@@ -440,9 +450,44 @@ export function AppShell(): ReactElement {
     setIsAccountDeletionPendingState(isAccountDeletionPending());
   }), []);
 
-  useEffect(() => {
+  const closeMobileNavigation = useCallback(function closeMobileNavigation(): void {
     setIsMobileNavigationOpen(false);
-  }, [location.pathname]);
+  }, []);
+
+  const focusFirstMobileNavigationLink = useCallback(function focusFirstMobileNavigationLink(): void {
+    const mobileNavigationMenu = mobileNavigationMenuRef.current;
+    if (mobileNavigationMenu === null) {
+      return;
+    }
+
+    const firstVisibleLink = Array.from(mobileNavigationMenu.querySelectorAll<HTMLElement>(mobileNavigationFirstLinkSelector))
+      .find((element) => element.getClientRects().length > 0) ?? null;
+    firstVisibleLink?.focus();
+  }, []);
+
+  const closeMobileNavigationAndFocusToggle = useCallback(function closeMobileNavigationAndFocusToggle(): void {
+    closeMobileNavigation();
+    mobileNavigationToggleRef.current?.focus();
+  }, [closeMobileNavigation]);
+
+  useAnchoredFloatingOutsidePointerDismiss({
+    triggerRef: mobileNavigationToggleRef,
+    overlayRef: mobileNavigationMenuRef,
+    enabled: isMobileNavigationOpen,
+    onClose: closeMobileNavigation,
+  });
+
+  useEffect(() => {
+    if (isMobileNavigationOpen === false) {
+      return;
+    }
+
+    focusFirstMobileNavigationLink();
+  }, [focusFirstMobileNavigationLink, isMobileNavigationOpen]);
+
+  useEffect(() => {
+    closeMobileNavigation();
+  }, [closeMobileNavigation, location.pathname]);
 
   useEffect(() => {
     if (isMobileNavigationOpen === false) {
@@ -451,7 +496,7 @@ export function AppShell(): ReactElement {
 
     function closeMobileNavigationOnEscape(event: KeyboardEvent): void {
       if (event.key === "Escape") {
-        setIsMobileNavigationOpen(false);
+        closeMobileNavigationAndFocusToggle();
       }
     }
 
@@ -460,7 +505,7 @@ export function AppShell(): ReactElement {
     return () => {
       window.removeEventListener("keydown", closeMobileNavigationOnEscape);
     };
-  }, [isMobileNavigationOpen]);
+  }, [closeMobileNavigationAndFocusToggle, isMobileNavigationOpen]);
 
   useEffect(() => {
     if (
@@ -596,7 +641,7 @@ export function AppShell(): ReactElement {
   return (
     <div className="app-shell">
       <div className="header-sticky">
-        <header className="topbar-shell">
+        <header ref={topbarShellRef} className="topbar-shell">
           <div className="topbar">
             <div className="topbar-brand-block">
               <div className="topbar-brand-row">
@@ -625,6 +670,7 @@ export function AppShell(): ReactElement {
             </nav>
             <div className="topbar-actions">
               <button
+                ref={mobileNavigationToggleRef}
                 className="mobile-nav-toggle"
                 type="button"
                 aria-label={t("shell.primaryNavigation")}
@@ -650,20 +696,35 @@ export function AppShell(): ReactElement {
               />
             </div>
           </div>
-          {isMobileNavigationOpen ? (
-            <nav id="mobile-primary-navigation" className="mobile-nav-menu" aria-label={t("shell.primaryNavigation")}>
-              {primaryNavigationItems.map((item) => (
-                <NavLink
-                  key={item.route}
-                  className={({ isActive }) => `mobile-nav-link${isActive ? " mobile-nav-link-active" : ""}`}
-                  to={item.route}
-                  onClick={() => setIsMobileNavigationOpen(false)}
-                >
-                  {t(item.labelKey)}
-                </NavLink>
-              ))}
-            </nav>
-          ) : null}
+          <AnchoredFloatingOverlay
+            isOpen={isMobileNavigationOpen}
+            referenceRef={topbarShellRef}
+            floatingRef={mobileNavigationMenuRef}
+            placement="bottom-start"
+            viewportPaddingPx={mobileNavigationViewportPaddingPx}
+            offsetPx={mobileNavigationOffsetPx}
+            minimumWidth={mobileNavigationMinimumWidth}
+            maxWidthPx={null}
+            maxHeightPx={mobileNavigationMaxHeightPx}
+            className="mobile-nav-menu"
+            id="mobile-primary-navigation"
+            role="navigation"
+            ariaLabel={t("shell.primaryNavigation")}
+            ariaLabelledBy={null}
+            ariaDescribedBy={null}
+            ariaModal={null}
+          >
+            {primaryNavigationItems.map((item) => (
+              <NavLink
+                key={item.route}
+                className={({ isActive }) => `mobile-nav-link${isActive ? " mobile-nav-link-active" : ""}`}
+                to={item.route}
+                onClick={closeMobileNavigation}
+              >
+                {t(item.labelKey)}
+              </NavLink>
+            ))}
+          </AnchoredFloatingOverlay>
         </header>
       </div>
       {visibleGlobalErrorMessage !== "" ? (

--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -162,9 +162,6 @@
 }
 
 .mobile-nav-menu {
-  position: absolute;
-  top: calc(100% + 8px);
-  inset-inline: 0;
   z-index: 120;
   display: none;
   gap: 4px;
@@ -173,6 +170,8 @@
   border-radius: var(--radius-lg);
   background: rgba(20, 20, 24, 0.98);
   box-shadow: var(--shadow);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .mobile-nav-link {
@@ -196,10 +195,6 @@
 .mobile-nav-link-active {
   color: var(--accent-strong);
   background: var(--accent-soft);
-}
-
-.account-menu-wrap {
-  position: relative;
 }
 
 .account-menu-button {
@@ -229,13 +224,8 @@
 }
 
 .account-menu-dropdown {
-  position: absolute;
-  top: calc(100% + 10px);
-  inset-inline-end: 0;
-  width: min(280px, calc(100vw - (2 * (var(--header-inline-padding) + var(--topbar-shell-inline-padding))) - 8px));
+  width: 280px;
   min-width: 0;
-  max-width: calc(100vw - (2 * (var(--header-inline-padding) + var(--topbar-shell-inline-padding))) - 8px);
-  max-height: min(420px, calc(100dvh - 32px));
   padding: 10px;
   border: 1px solid var(--panel-border);
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- Move the account dropdown to the shared anchored overlay primitive with portal-safe outside dismissal and keyboard focus management
- Move the mobile nav popup to the shared anchored overlay primitive and preserve route/outside/Escape close behavior
- Remove migrated absolute-positioning assumptions from shell menu CSS

## Validation
- Freshness check passed before implementation
- cd apps/web && npm ci passed with Node 25 vs declared Node 24 warning
- cd apps/web && npm run build passed after implementation and after the focus-management fix
- git --no-pager diff --check passed after the focus-management fix
- Worker-owned review after the focus fix found no P0-P4 issues and no split recommendation

Residual risk: manual browser resize/menu check was not run.