### PR TITLE
Migrate cards overlays to anchored floating

### DIFF
--- a/apps/web/src/screens/cards/form/CardFormTagsField.tsx
+++ b/apps/web/src/screens/cards/form/CardFormTagsField.tsx
@@ -3,21 +3,12 @@ import {
   useEffect,
   useRef,
   useState,
-  type CSSProperties,
-  type RefObject,
   type ReactElement,
 } from "react";
-import { createPortal } from "react-dom";
+import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } from "../../../floating";
 import { useI18n } from "../../../i18n";
 import type { TagSuggestion } from "../../../types";
 import { areSameTags, CardTagsInput, CardTagsValue, type CardTagsInputHandle } from "../CardTagsInput";
-
-type OverlayRect = Readonly<{
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}>;
 
 type CardFormTagsFieldProps = Readonly<{
   value: ReadonlyArray<string>;
@@ -28,91 +19,16 @@ type CardFormTagsFieldProps = Readonly<{
   disabled: boolean;
 }>;
 
-function getOverlayRect(element: HTMLElement): OverlayRect {
-  const rect = element.getBoundingClientRect();
-  return {
-    top: rect.top,
-    left: rect.left,
-    width: rect.width,
-    height: rect.height,
-  };
-}
-
-function getTagsOverlayStyle(rect: OverlayRect): CSSProperties {
-  const width = Math.max(rect.width, 320);
-  const maxLeft = Math.max(window.innerWidth - width - 12, 12);
-  const maxTop = Math.max(window.innerHeight - 320, 12);
-
-  return {
-    top: Math.min(rect.top, maxTop),
-    left: Math.min(rect.left, maxLeft),
-    width,
-  };
-}
-
-function useOverlayTracking(
-  isOpen: boolean,
-  anchorRef: RefObject<HTMLElement | null>,
-  onUpdate: (rect: OverlayRect) => void,
-): void {
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    function handleViewportChange(): void {
-      if (anchorRef.current === null) {
-        return;
-      }
-
-      onUpdate(getOverlayRect(anchorRef.current));
-    }
-
-    window.addEventListener("resize", handleViewportChange);
-    window.addEventListener("scroll", handleViewportChange, true);
-
-    return () => {
-      window.removeEventListener("resize", handleViewportChange);
-      window.removeEventListener("scroll", handleViewportChange, true);
-    };
-  }, [anchorRef, isOpen, onUpdate]);
-}
-
-function useOutsidePointerClose(
-  isOpen: boolean,
-  triggerRef: RefObject<HTMLElement | null>,
-  overlayRef: RefObject<HTMLElement | null>,
-  onClose: () => void,
-): void {
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    function handlePointerDown(event: MouseEvent): void {
-      const target = event.target as Node;
-
-      if (overlayRef.current !== null && overlayRef.current.contains(target)) {
-        return;
-      }
-
-      if (triggerRef.current !== null && triggerRef.current.contains(target)) {
-        return;
-      }
-
-      onClose();
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [isOpen, onClose, overlayRef, triggerRef]);
-}
+const tagsOverlayViewportPaddingPx = 12;
+const tagsOverlayOffsetPx = 8;
+const tagsOverlayMinimumWidthPx = 320;
+const tagsOverlayMaximumWidthPx = 420;
+const tagsOverlayMaximumHeightPx = 320;
 
 export function CardFormTagsField(props: CardFormTagsFieldProps): ReactElement {
   const { value, suggestions, inputId, inputName, onChange, disabled } = props;
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [overlayRect, setOverlayRect] = useState<OverlayRect | null>(null);
   const [draftTags, setDraftTags] = useState<ReadonlyArray<string>>(value);
   const triggerRef = useRef<HTMLDivElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -120,12 +36,15 @@ export function CardFormTagsField(props: CardFormTagsFieldProps): ReactElement {
 
   const handleCancel = useCallback((): void => {
     setIsOpen(false);
-    setOverlayRect(null);
     setDraftTags(value);
   }, [value]);
 
-  useOverlayTracking(isOpen, triggerRef, setOverlayRect);
-  useOutsidePointerClose(isOpen, triggerRef, overlayRef, handleCommit);
+  useAnchoredFloatingOutsidePointerDismiss({
+    triggerRef,
+    overlayRef,
+    enabled: isOpen,
+    onClose: handleCommit,
+  });
 
   useEffect(() => {
     if (!isOpen || editorRef.current === null) {
@@ -143,20 +62,23 @@ export function CardFormTagsField(props: CardFormTagsFieldProps): ReactElement {
     setDraftTags(value);
   }, [isOpen, value]);
 
-  function handleOpen(): void {
+  function handleTriggerClick(): void {
     if (disabled || triggerRef.current === null) {
       return;
     }
 
+    if (isOpen) {
+      handleCommit();
+      return;
+    }
+
     setDraftTags(value);
-    setOverlayRect(getOverlayRect(triggerRef.current));
     setIsOpen(true);
   }
 
   function handleCommit(): void {
     const nextTags = editorRef.current === null ? draftTags : editorRef.current.flushDraft();
     setIsOpen(false);
-    setOverlayRect(null);
 
     if (areSameTags(nextTags, value)) {
       setDraftTags(value);
@@ -166,7 +88,6 @@ export function CardFormTagsField(props: CardFormTagsFieldProps): ReactElement {
     onChange(nextTags);
   }
 
-  const overlayStyle = overlayRect === null ? null : getTagsOverlayStyle(overlayRect);
   const triggerClassName = `settings-input card-form-tags-trigger${disabled ? " cards-cell-disabled" : ""}`;
 
   return (
@@ -174,27 +95,41 @@ export function CardFormTagsField(props: CardFormTagsFieldProps): ReactElement {
       <div
         ref={triggerRef}
         className={triggerClassName}
-        onClick={disabled ? undefined : handleOpen}
+        onClick={disabled ? undefined : handleTriggerClick}
         data-testid="card-form-tags-trigger"
       >
         <CardTagsValue tags={value} emptyLabel={t("cardTags.triggerEmpty")} />
       </div>
 
-      {isOpen && overlayStyle !== null && createPortal(
-        <div ref={overlayRef} className="cell-select-overlay cell-tags-overlay card-form-tags-overlay" style={overlayStyle}>
-          <CardTagsInput
-            ref={editorRef}
-            value={draftTags}
-            suggestions={suggestions}
-            placeholder={t("cardTags.inputPlaceholder")}
-            inputId={inputId}
-            inputName={inputName}
-            onChange={setDraftTags}
-            onEscape={handleCancel}
-          />
-        </div>,
-        document.body,
-      )}
+      <AnchoredFloatingOverlay
+        isOpen={isOpen}
+        referenceRef={triggerRef}
+        floatingRef={overlayRef}
+        placement="bottom-start"
+        viewportPaddingPx={tagsOverlayViewportPaddingPx}
+        offsetPx={tagsOverlayOffsetPx}
+        minimumWidth={{ kind: "reference-or-pixels", pixels: tagsOverlayMinimumWidthPx }}
+        maxWidthPx={tagsOverlayMaximumWidthPx}
+        maxHeightPx={tagsOverlayMaximumHeightPx}
+        className="cell-select-overlay cell-tags-overlay"
+        id={null}
+        role={null}
+        ariaLabel={null}
+        ariaLabelledBy={null}
+        ariaDescribedBy={null}
+        ariaModal={null}
+      >
+        <CardTagsInput
+          ref={editorRef}
+          value={draftTags}
+          suggestions={suggestions}
+          placeholder={t("cardTags.inputPlaceholder")}
+          inputId={inputId}
+          inputName={inputName}
+          onChange={setDraftTags}
+          onEscape={handleCancel}
+        />
+      </AnchoredFloatingOverlay>
     </>
   );
 }

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link } from "react-router-dom";
 import { useAppData } from "../../../appData";
 import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 import { getCardFilterActiveDimensionCount, normalizeCardFilter } from "../../../cardFilters";
+import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } from "../../../floating";
 import { useI18n } from "../../../i18n";
 import { CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
 import { getExpectedCardMutationInlineErrorMessage } from "../cardMutationErrors";
@@ -155,6 +156,18 @@ export function CardsScreen(): ReactElement {
     installationId: cloudSettings?.installationId ?? null,
   };
 
+  const closeFilterPopoverWithoutApply = useCallback((): void => {
+    setIsFilterPopoverOpen(false);
+    setDraftCardFilter(cardFilter);
+  }, [cardFilter]);
+
+  useAnchoredFloatingOutsidePointerDismiss({
+    triggerRef: filterWrapRef,
+    overlayRef: filterPopoverRef,
+    enabled: isFilterPopoverOpen,
+    onClose: closeFilterPopoverWithoutApply,
+  });
+
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
       setDebouncedSearchText(searchText);
@@ -305,35 +318,17 @@ export function CardsScreen(): ReactElement {
       return;
     }
 
-    function handleMouseDown(event: MouseEvent): void {
-      const target = event.target as Node;
-      if (
-        filterWrapRef.current !== null
-        && filterWrapRef.current.contains(target)
-      ) {
-        return;
-      }
-
-      setIsFilterPopoverOpen(false);
-      setDraftCardFilter(cardFilter);
-    }
-
     function handleKeyDown(event: KeyboardEvent): void {
       if (event.key !== "Escape") {
         return;
       }
 
-      setIsFilterPopoverOpen(false);
-      setDraftCardFilter(cardFilter);
+      closeFilterPopoverWithoutApply();
     }
 
-    document.addEventListener("mousedown", handleMouseDown);
     document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleMouseDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [cardFilter, isFilterPopoverOpen]);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [closeFilterPopoverWithoutApply, isFilterPopoverOpen]);
 
   useEffect(() => {
     if (!isFilterPopoverOpen || filterTagsInputRef.current === null) {
@@ -434,8 +429,7 @@ export function CardsScreen(): ReactElement {
 
   function handleFilterToggle(): void {
     if (isFilterPopoverOpen) {
-      setIsFilterPopoverOpen(false);
-      setDraftCardFilter(cardFilter);
+      closeFilterPopoverWithoutApply();
       return;
     }
 
@@ -444,8 +438,7 @@ export function CardsScreen(): ReactElement {
   }
 
   function handleFilterCancel(): void {
-    setIsFilterPopoverOpen(false);
-    setDraftCardFilter(cardFilter);
+    closeFilterPopoverWithoutApply();
   }
 
   function handleFilterClear(): void {
@@ -518,37 +511,47 @@ export function CardsScreen(): ReactElement {
             >
               <span>{filterButtonLabel}</span>
             </button>
-            {isFilterPopoverOpen ? (
-              <div
-                ref={filterPopoverRef}
-                className="cards-filter-popover"
-                role="dialog"
-                aria-label={t("cardsScreen.filters.ariaLabel")}
-              >
-                <div className="cards-filter-section">
-                  <span className="deck-form-label">{t("cardsScreen.filters.tags")}</span>
-                  <CardTagsInput
-                    ref={filterTagsInputRef}
-                    value={draftFilterValue.tags}
-                    suggestions={tagSuggestions}
-                    placeholder={t("cardTags.inputPlaceholder")}
-                    inputName="cards-filter-tags"
-                    onChange={(nextTags) => setDraftCardFilter({
-                      tags: nextTags,
-                    })}
-                    onEscape={handleFilterCancel}
-                  />
-                </div>
-
-                <p className="subtitle cards-filter-summary">{formatCardFilterSummary(normalizeCardFilter(draftFilterValue), t)}</p>
-
-                <div className="cards-filter-actions">
-                  <button type="button" className="ghost-btn" onClick={handleFilterClear}>{t("cardsScreen.filters.actions.clear")}</button>
-                  <button type="button" className="ghost-btn" onClick={handleFilterCancel}>{t("common.cancel")}</button>
-                  <button type="button" className="primary-btn" onClick={handleFilterApply}>{t("cardsScreen.filters.actions.apply")}</button>
-                </div>
+            <AnchoredFloatingOverlay
+              isOpen={isFilterPopoverOpen}
+              referenceRef={filterWrapRef}
+              floatingRef={filterPopoverRef}
+              placement="bottom-end"
+              viewportPaddingPx={16}
+              offsetPx={10}
+              minimumWidth={{ kind: "reference-or-pixels", pixels: 420 }}
+              maxWidthPx={420}
+              maxHeightPx={520}
+              className="cards-filter-popover"
+              id={null}
+              role="dialog"
+              ariaLabel={t("cardsScreen.filters.ariaLabel")}
+              ariaLabelledBy={null}
+              ariaDescribedBy={null}
+              ariaModal={null}
+            >
+              <div className="cards-filter-section">
+                <span className="deck-form-label">{t("cardsScreen.filters.tags")}</span>
+                <CardTagsInput
+                  ref={filterTagsInputRef}
+                  value={draftFilterValue.tags}
+                  suggestions={tagSuggestions}
+                  placeholder={t("cardTags.inputPlaceholder")}
+                  inputName="cards-filter-tags"
+                  onChange={(nextTags) => setDraftCardFilter({
+                    tags: nextTags,
+                  })}
+                  onEscape={handleFilterCancel}
+                />
               </div>
-            ) : null}
+
+              <p className="subtitle cards-filter-summary">{formatCardFilterSummary(normalizeCardFilter(draftFilterValue), t)}</p>
+
+              <div className="cards-filter-actions">
+                <button type="button" className="ghost-btn" onClick={handleFilterClear}>{t("cardsScreen.filters.actions.clear")}</button>
+                <button type="button" className="ghost-btn" onClick={handleFilterCancel}>{t("common.cancel")}</button>
+                <button type="button" className="primary-btn" onClick={handleFilterApply}>{t("cardsScreen.filters.actions.apply")}</button>
+              </div>
+            </AnchoredFloatingOverlay>
           </div>
         </div>
 

--- a/apps/web/src/screens/cards/list/CardsTableEditors.tsx
+++ b/apps/web/src/screens/cards/list/CardsTableEditors.tsx
@@ -4,23 +4,15 @@ import {
   useRef,
   useState,
   type ChangeEvent,
-  type CSSProperties,
   type KeyboardEvent,
-  type RefObject,
+  type PointerEvent,
   type ReactElement,
 } from "react";
-import { createPortal } from "react-dom";
 
+import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } from "../../../floating";
 import { useI18n } from "../../../i18n";
 import type { TagSuggestion } from "../../../types";
 import { areSameTags, CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
-
-type OverlayRect = Readonly<{
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}>;
 
 type EditableTextCellProps = Readonly<{
   value: string;
@@ -39,100 +31,22 @@ type EditableTagsCellProps = Readonly<{
   cellClassName: string;
 }>;
 
-function getOverlayRect(element: HTMLTableCellElement): OverlayRect {
-  const rect = element.getBoundingClientRect();
-  return {
-    top: rect.top,
-    left: rect.left,
-    width: rect.width,
-    height: rect.height,
-  };
-}
-
-function getTextOverlayStyle(rect: OverlayRect, multiline: boolean): CSSProperties {
-  const width = multiline ? Math.max(rect.width, 360) : rect.width;
-  const height = multiline ? Math.max(rect.height * 3, 120) : rect.height;
-  const maxLeft = Math.max(window.innerWidth - width - 12, 12);
-
-  return {
-    top: rect.top,
-    left: Math.min(rect.left, maxLeft),
-    width,
-    height,
-  };
-}
-
-function getTagsOverlayStyle(rect: OverlayRect): CSSProperties {
-  const width = Math.max(rect.width, 320);
-  const maxLeft = Math.max(window.innerWidth - width - 12, 12);
-  const maxTop = Math.max(window.innerHeight - 320, 12);
-
-  return {
-    top: Math.min(rect.top, maxTop),
-    left: Math.min(rect.left, maxLeft),
-    width,
-  };
-}
-
-function useOverlayTracking(
-  isOpen: boolean,
-  cellRef: RefObject<HTMLTableCellElement | null>,
-  onUpdate: (rect: OverlayRect) => void,
-): void {
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    function handleViewportChange(): void {
-      if (cellRef.current === null) {
-        return;
-      }
-
-      onUpdate(getOverlayRect(cellRef.current));
-    }
-
-    window.addEventListener("resize", handleViewportChange);
-    window.addEventListener("scroll", handleViewportChange, true);
-
-    return () => {
-      window.removeEventListener("resize", handleViewportChange);
-      window.removeEventListener("scroll", handleViewportChange, true);
-    };
-  }, [cellRef, isOpen, onUpdate]);
-}
-
-function useOutsidePointerClose(
-  isOpen: boolean,
-  overlayRef: RefObject<HTMLElement | null>,
-  onClose: () => void,
-): void {
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    function handlePointerDown(event: MouseEvent): void {
-      if (overlayRef.current !== null && !overlayRef.current.contains(event.target as Node)) {
-        onClose();
-      }
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [isOpen, onClose, overlayRef]);
-}
+const floatingEditorViewportPaddingPx = 12;
+const multilineTextEditorMinimumWidthPx = 360;
+const multilineTextEditorMaximumWidthPx = 720;
+const multilineTextEditorMaximumHeightPx = 520;
+const tagsEditorMinimumWidthPx = 320;
+const tagsEditorMaximumWidthPx = 420;
+const tagsEditorMaximumHeightPx = 320;
 
 export function EditableCardTextCell(props: EditableTextCellProps): ReactElement {
   const { value, displayValue, multiline, saving, onCommit, cellClassName } = props;
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [draftValue, setDraftValue] = useState<string>(value);
-  const [overlayRect, setOverlayRect] = useState<OverlayRect | null>(null);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-
-  useOverlayTracking(isEditing, cellRef, setOverlayRect);
 
   useEffect(() => {
     const activeElement = multiline ? textareaRef.current : inputRef.current;
@@ -146,17 +60,28 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
 
   function closeEditor(): void {
     setIsEditing(false);
-    setOverlayRect(null);
   }
 
   function startEditing(): void {
-    if (saving || cellRef.current === null) {
+    if (saving || isEditing || cellRef.current === null) {
       return;
     }
 
     setDraftValue(value);
-    setOverlayRect(getOverlayRect(cellRef.current));
     setIsEditing(true);
+  }
+
+  function handleCellPointerDown(event: PointerEvent<HTMLTableCellElement>): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    if (isEditing) {
+      event.preventDefault();
+      return;
+    }
+
+    startEditing();
   }
 
   function commitEdit(): void {
@@ -196,19 +121,37 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
   const displayContent = multiline
     ? <span className="cards-cell-multiline-display">{displayText}</span>
     : displayText;
-  const overlayStyle = overlayRect === null ? null : getTextOverlayStyle(overlayRect, multiline);
+  const overlayClassName = multiline
+    ? "cell-editor-overlay cell-editor-overlay-multiline"
+    : "cell-editor-overlay";
 
   return (
-    <td ref={cellRef} className={className} onClick={saving ? undefined : startEditing}>
+    <td ref={cellRef} className={className} onPointerDown={saving ? undefined : handleCellPointerDown}>
       {displayContent}
-      {isEditing && overlayStyle !== null && createPortal(
-        multiline ? (
+      <AnchoredFloatingOverlay
+        isOpen={isEditing}
+        referenceRef={cellRef}
+        floatingRef={overlayRef}
+        placement="bottom-start"
+        viewportPaddingPx={floatingEditorViewportPaddingPx}
+        offsetPx={0}
+        minimumWidth={multiline ? { kind: "reference-or-pixels", pixels: multilineTextEditorMinimumWidthPx } : { kind: "reference" }}
+        maxWidthPx={multiline ? multilineTextEditorMaximumWidthPx : null}
+        maxHeightPx={multiline ? multilineTextEditorMaximumHeightPx : null}
+        className={overlayClassName}
+        id={null}
+        role={null}
+        ariaLabel={null}
+        ariaLabelledBy={null}
+        ariaDescribedBy={null}
+        ariaModal={null}
+      >
+        {multiline ? (
           <textarea
             ref={textareaRef}
             name="card-cell-textarea"
-            className="cell-editor-overlay cell-editor-overlay-multiline"
+            className="cell-editor-field cell-editor-field-multiline"
             value={draftValue}
-            style={overlayStyle}
             onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setDraftValue(event.target.value)}
             onBlur={commitEdit}
             onKeyDown={handleKeyDown}
@@ -217,17 +160,15 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
           <input
             ref={inputRef}
             name="card-cell-input"
-            className="cell-editor-overlay"
+            className="cell-editor-field"
             type="text"
             value={draftValue}
-            style={overlayStyle}
             onChange={(event: ChangeEvent<HTMLInputElement>) => setDraftValue(event.target.value)}
             onBlur={commitEdit}
             onKeyDown={handleKeyDown}
           />
-        ),
-        document.body,
-      )}
+        )}
+      </AnchoredFloatingOverlay>
     </td>
   );
 }
@@ -236,7 +177,6 @@ export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement
   const { value, suggestions, saving, onCommit, cellClassName } = props;
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [overlayRect, setOverlayRect] = useState<OverlayRect | null>(null);
   const [draftTags, setDraftTags] = useState<ReadonlyArray<string>>(value);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -244,12 +184,15 @@ export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement
 
   const handleClose = useCallback((): void => {
     setIsOpen(false);
-    setOverlayRect(null);
     setDraftTags(value);
   }, [value]);
 
-  useOverlayTracking(isOpen, cellRef, setOverlayRect);
-  useOutsidePointerClose(isOpen, overlayRef, handleCommit);
+  useAnchoredFloatingOutsidePointerDismiss({
+    triggerRef: cellRef,
+    overlayRef,
+    enabled: isOpen,
+    onClose: handleCommit,
+  });
 
   useEffect(() => {
     if (!isOpen || editorRef.current === null) {
@@ -267,20 +210,23 @@ export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement
     setDraftTags(value);
   }, [isOpen, value]);
 
-  function handleOpen(): void {
+  function handleCellClick(): void {
     if (saving || cellRef.current === null) {
       return;
     }
 
+    if (isOpen) {
+      handleCommit();
+      return;
+    }
+
     setDraftTags(value);
-    setOverlayRect(getOverlayRect(cellRef.current));
     setIsOpen(true);
   }
 
   function handleCommit(): void {
     const nextTags = editorRef.current === null ? draftTags : editorRef.current.flushDraft();
     setIsOpen(false);
-    setOverlayRect(null);
 
     if (areSameTags(nextTags, value)) {
       setDraftTags(value);
@@ -291,10 +237,9 @@ export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement
   }
 
   const className = `txn-cell ${cellClassName}${saving ? " cards-cell-disabled" : " drilldown-editable"}`;
-  const overlayStyle = overlayRect === null ? null : getTagsOverlayStyle(overlayRect);
 
   return (
-    <td ref={cellRef} className={className} onClick={saving ? undefined : handleOpen}>
+    <td ref={cellRef} className={className} onClick={saving ? undefined : handleCellClick}>
       {value.length === 0 ? <span className="tag-value-empty">—</span> : (
         <span className="tag-value-list">
           {value.map((tag) => (
@@ -304,20 +249,34 @@ export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement
           ))}
         </span>
       )}
-      {isOpen && overlayStyle !== null && createPortal(
-        <div ref={overlayRef} className="cell-select-overlay cell-tags-overlay" style={overlayStyle}>
-          <CardTagsInput
-            ref={editorRef}
-            value={draftTags}
-            suggestions={suggestions}
-            placeholder={t("cardTags.inputPlaceholder")}
-            inputName="card-tags-editor"
-            onChange={setDraftTags}
-            onEscape={handleClose}
-          />
-        </div>,
-        document.body,
-      )}
+      <AnchoredFloatingOverlay
+        isOpen={isOpen}
+        referenceRef={cellRef}
+        floatingRef={overlayRef}
+        placement="bottom-start"
+        viewportPaddingPx={floatingEditorViewportPaddingPx}
+        offsetPx={6}
+        minimumWidth={{ kind: "reference-or-pixels", pixels: tagsEditorMinimumWidthPx }}
+        maxWidthPx={tagsEditorMaximumWidthPx}
+        maxHeightPx={tagsEditorMaximumHeightPx}
+        className="cell-select-overlay cell-tags-overlay"
+        id={null}
+        role={null}
+        ariaLabel={null}
+        ariaLabelledBy={null}
+        ariaDescribedBy={null}
+        ariaModal={null}
+      >
+        <CardTagsInput
+          ref={editorRef}
+          value={draftTags}
+          suggestions={suggestions}
+          placeholder={t("cardTags.inputPlaceholder")}
+          inputName="card-tags-editor"
+          onChange={setDraftTags}
+          onEscape={handleClose}
+        />
+      </AnchoredFloatingOverlay>
     </td>
   );
 }

--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -50,19 +50,15 @@
 .cards-filter-popover {
   --cards-filter-popover-padding: 16px;
   --cards-filter-popover-radius: var(--radius-xl);
-  position: absolute;
-  top: calc(100% + 10px);
-  inset-inline-end: 0;
-  z-index: 30;
+  z-index: 200;
   display: grid;
   gap: 16px;
-  width: min(420px, calc(100vw - 32px));
-  max-height: min(520px, calc(100dvh - 32px));
   padding: var(--cards-filter-popover-padding);
   border: 0;
   border-radius: var(--cards-filter-popover-radius);
   background: var(--surface);
   box-shadow: none;
+  box-sizing: border-box;
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -336,13 +332,13 @@
 }
 
 .cell-editor-overlay {
-  position: fixed;
   z-index: 200;
-  padding: 10px 12px;
+  display: flex;
+  min-width: 0;
+  min-height: 42px;
   font-size: 16px;
   font-family: inherit;
   line-height: 1.5;
-  white-space: nowrap;
   background: var(--surface);
   color: var(--text);
   border: 0;
@@ -351,9 +347,31 @@
   outline-offset: 2px;
   box-shadow: none;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 .cell-editor-overlay-multiline {
+  min-height: 120px;
+}
+
+.cell-editor-field {
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  min-height: 42px;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.cell-editor-field-multiline {
+  min-height: 120px;
   white-space: pre-wrap;
   resize: vertical;
 }
@@ -362,9 +380,7 @@
   --cell-select-overlay-padding: 6px;
   --cell-select-overlay-radius: var(--radius-md);
   --cell-select-overlay-inner-radius: max(0px, calc(var(--cell-select-overlay-radius) - var(--cell-select-overlay-padding)));
-  position: fixed;
   z-index: 200;
-  max-height: 320px;
   display: flex;
   flex-direction: column;
   background: var(--surface);
@@ -637,12 +653,6 @@
 
   .cards-filter-trigger {
     width: 100%;
-  }
-
-  .cards-filter-popover {
-    inset-inline-start: 0;
-    inset-inline-end: auto;
-    width: min(100%, 420px);
   }
 
   .deck-detail-layout,

--- a/apps/web/src/styles/features/tags.css
+++ b/apps/web/src/styles/features/tags.css
@@ -169,7 +169,6 @@
 }
 
 .cell-tags-overlay {
-  max-height: none;
   padding: 10px;
 }
 
@@ -183,10 +182,6 @@
   align-items: flex-start;
   min-height: 46px;
   cursor: pointer;
-}
-
-.card-form-tags-overlay {
-  max-height: none;
 }
 
 .tags-page {


### PR DESCRIPTION
## Summary
- migrate cards filter popover, table editors, and form tag editor to AnchoredFloatingOverlay
- remove manual overlay rect, viewport clamp, and scroll/resize tracking from cards editors
- keep overlay stacking in feature CSS without changing the shared primitive API

## Validation
- cd apps/web && npm ci (passed; Node 25.6.1 warning because package declares 24.x)
- cd apps/web && npm run build
- git --no-pager diff --check
- worker review round after fixes: no P0-P4 issues

Manual narrow-browser /cards validation was not run.