### PR TITLE
Fix web managed image rendering stability

### DIFF
--- a/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
@@ -119,8 +119,11 @@ function createDeferred<Result>(): Readonly<{
   };
 }
 
-function renderReviewCardSide(container: HTMLDivElement, text: string): ReactDOM.Root {
-  const root = ReactDOM.createRoot(container);
+function renderReviewCardSide(
+  root: ReactDOM.Root,
+  text: string,
+  localReadVersion: number,
+): void {
   act(() => {
     root.render(
       <I18nProvider>
@@ -129,7 +132,7 @@ function renderReviewCardSide(container: HTMLDivElement, text: string): ReactDOM
           contentClassName="review-front"
           isSpeaking={false}
           label="Front"
-          localReadVersion={0}
+          localReadVersion={localReadVersion}
           onOpenAi={null}
           onToggleSpeech={() => undefined}
           showAiButton={false}
@@ -142,6 +145,15 @@ function renderReviewCardSide(container: HTMLDivElement, text: string): ReactDOM
       </I18nProvider>,
     );
   });
+}
+
+function createReviewCardSideRoot(
+  container: HTMLDivElement,
+  text: string,
+  localReadVersion: number,
+): ReactDOM.Root {
+  const root = ReactDOM.createRoot(container);
+  renderReviewCardSide(root, text, localReadVersion);
   return root;
 }
 
@@ -216,12 +228,12 @@ describe("ReviewCardSide managed media rendering", () => {
       return cacheRecords.get(sha256) ?? null;
     });
 
-    root = renderReviewCardSide(container, [
+    root = createReviewCardSideRoot(container, [
       "![Diagram](fcasset:image-asset)",
       "[Audio clip](fcasset:audio-asset)",
       "[Video clip](fcasset:video-asset)",
       "[Worksheet](fcasset:file-asset)",
-    ].join("\n\n"));
+    ].join("\n\n"), 0);
 
     await vi.waitFor(() => {
       expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
@@ -250,6 +262,287 @@ describe("ReviewCardSide managed media rendering", () => {
     expect(revokeObjectURLMock).toHaveBeenCalledTimes(4);
   });
 
+  it("keeps a ready managed image rendered while local data refreshes the same media identity", async () => {
+    const imageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const mediaAsset = makeMediaAsset("image-asset", "image/png", imageSha256, imageBlob.size);
+    const cacheRecord = makeCacheRecord(mediaAsset, imageBlob);
+    const refreshMediaAsset = createDeferred<MediaAsset | null>();
+    mediaMocks.loadMediaAssetRecordMock
+      .mockResolvedValueOnce(mediaAsset)
+      .mockImplementation(async (_workspaceId: string, _mediaAssetId: string): Promise<MediaAsset | null> => {
+        return refreshMediaAsset.promise;
+      });
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(cacheRecord);
+
+    root = createReviewCardSideRoot(container, "![Diagram](fcasset:image-asset)", 0);
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+    });
+
+    const initialImage = container.querySelector(".review-markdown-media-image");
+    if (!(initialImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered");
+    }
+    const initialSrc = initialImage.getAttribute("src");
+    expect(initialSrc).toBe("blob:review-media-1");
+    expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledTimes(1);
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+
+    renderReviewCardSide(root, "![Diagram](fcasset:image-asset)", 1);
+
+    await vi.waitFor(() => {
+      expect(mediaMocks.loadMediaAssetRecordMock).toHaveBeenCalledTimes(2);
+    });
+    const refreshingImage = container.querySelector(".review-markdown-media-image");
+    if (!(refreshingImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered during refresh");
+    }
+    expect(refreshingImage.getAttribute("src")).toBe(initialSrc);
+    expect(container.querySelector(".review-markdown-media-loading")).toBeNull();
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      refreshMediaAsset.resolve(mediaAsset);
+      await refreshMediaAsset.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledTimes(2);
+    });
+    const refreshedImage = container.querySelector(".review-markdown-media-image");
+    if (!(refreshedImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered after refresh");
+    }
+    expect(refreshedImage.getAttribute("src")).toBe(initialSrc);
+    expect(container.querySelector(".review-markdown-media-loading")).toBeNull();
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a newly acquired managed image URL when unmounted before ready state commits", async () => {
+    const imageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const mediaAsset = makeMediaAsset("image-asset", "image/png", imageSha256, imageBlob.size);
+    const cacheRecord = makeCacheRecord(mediaAsset, imageBlob);
+    mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(cacheRecord);
+    createObjectURLMock.mockImplementation((_: Blob): string => {
+      const objectUrl = "blob:review-media-uncommitted";
+      act(() => {
+        root?.unmount();
+        root = null;
+      });
+      return objectUrl;
+    });
+
+    root = createReviewCardSideRoot(container, "![Diagram](fcasset:image-asset)", 0);
+
+    await vi.waitFor(() => {
+      expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:review-media-uncommitted");
+    });
+    expect(container.querySelector(".review-markdown-media-image")).toBeNull();
+  });
+
+  it("does not render a previous managed image when the markdown reference changes at the same position", async () => {
+    const firstImageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const secondImageBlob = new Blob([new Uint8Array([4, 5, 6, 7])], { type: "image/png" });
+    const firstMediaAsset = makeMediaAsset("first-image-asset", "image/png", imageSha256, firstImageBlob.size);
+    const secondMediaAsset = makeMediaAsset("second-image-asset", "image/png", refreshedSha256, secondImageBlob.size);
+    const secondMediaAssetDeferred = createDeferred<MediaAsset | null>();
+    const cacheRecords = new Map<string, MediaBlobCacheRecord>([
+      [firstMediaAsset.sha256, makeCacheRecord(firstMediaAsset, firstImageBlob)],
+      [secondMediaAsset.sha256, makeCacheRecord(secondMediaAsset, secondImageBlob)],
+    ]);
+    mediaMocks.loadMediaAssetRecordMock.mockImplementation(async (_workspaceId: string, mediaAssetId: string): Promise<MediaAsset | null> => {
+      if (mediaAssetId === firstMediaAsset.mediaAssetId) {
+        return firstMediaAsset;
+      }
+
+      if (mediaAssetId === secondMediaAsset.mediaAssetId) {
+        return secondMediaAssetDeferred.promise;
+      }
+
+      return null;
+    });
+    mediaMocks.loadMediaBlobCacheRecordMock.mockImplementation(async (sha256: string): Promise<MediaBlobCacheRecord | null> => {
+      return cacheRecords.get(sha256) ?? null;
+    });
+
+    root = createReviewCardSideRoot(container, "![First](fcasset:first-image-asset)", 0);
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+    });
+
+    const initialImage = container.querySelector(".review-markdown-media-image");
+    if (!(initialImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered");
+    }
+    const initialSrc = initialImage.getAttribute("src");
+    expect(initialSrc).toBe("blob:review-media-1");
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+
+    renderReviewCardSide(root, "![Second](fcasset:second-image-asset)", 0);
+
+    expect(container.querySelector(".review-markdown-media-image")).toBeNull();
+    expect(container.querySelector(".review-markdown-media-loading")?.getAttribute("data-fcasset-id")).toBe("second-image-asset");
+    expect(revokeObjectURLMock).toHaveBeenCalledWith(initialSrc);
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => {
+      expect(mediaMocks.loadMediaAssetRecordMock).toHaveBeenCalledWith("workspace-1", "second-image-asset");
+    });
+    await act(async () => {
+      secondMediaAssetDeferred.resolve(secondMediaAsset);
+      await secondMediaAssetDeferred.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(createObjectURLMock).toHaveBeenCalledTimes(2);
+    });
+    const refreshedImage = container.querySelector(".review-markdown-media-image");
+    if (!(refreshedImage instanceof HTMLImageElement)) {
+      throw new Error("Updated managed image was not rendered");
+    }
+    expect(refreshedImage.getAttribute("src")).toBe("blob:review-media-2");
+  });
+
+  it("creates a new managed image object URL when refreshed media identity changes", async () => {
+    const imageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const refreshedImageBlob = new Blob([new Uint8Array([4, 5, 6, 7])], { type: "image/png" });
+    const mediaAsset = makeMediaAsset("image-asset", "image/png", imageSha256, imageBlob.size);
+    const refreshedMediaAsset = makeMediaAsset("image-asset", "image/png", refreshedSha256, refreshedImageBlob.size);
+    const cacheRecords = new Map<string, MediaBlobCacheRecord>([
+      [mediaAsset.sha256, makeCacheRecord(mediaAsset, imageBlob)],
+      [refreshedMediaAsset.sha256, makeCacheRecord(refreshedMediaAsset, refreshedImageBlob)],
+    ]);
+    const refreshMediaAsset = createDeferred<MediaAsset | null>();
+    mediaMocks.loadMediaAssetRecordMock
+      .mockResolvedValueOnce(mediaAsset)
+      .mockImplementation(async (_workspaceId: string, _mediaAssetId: string): Promise<MediaAsset | null> => {
+        return refreshMediaAsset.promise;
+      });
+    mediaMocks.loadMediaBlobCacheRecordMock.mockImplementation(async (sha256: string): Promise<MediaBlobCacheRecord | null> => {
+      return cacheRecords.get(sha256) ?? null;
+    });
+
+    root = createReviewCardSideRoot(container, "![Diagram](fcasset:image-asset)", 0);
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+    });
+
+    const initialImage = container.querySelector(".review-markdown-media-image");
+    if (!(initialImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered");
+    }
+    const initialSrc = initialImage.getAttribute("src");
+    expect(initialSrc).toBe("blob:review-media-1");
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+
+    let releasedAfterNewImageCommit = false;
+    revokeObjectURLMock.mockImplementation((url: string): void => {
+      if (url !== initialSrc) {
+        return;
+      }
+
+      const imageAtRelease = container.querySelector(".review-markdown-media-image");
+      if (!(imageAtRelease instanceof HTMLImageElement)) {
+        throw new Error("Managed image was not rendered when the previous URL was released");
+      }
+      expect(imageAtRelease.getAttribute("src")).toBe("blob:review-media-2");
+      releasedAfterNewImageCommit = true;
+    });
+
+    renderReviewCardSide(root, "![Diagram](fcasset:image-asset)", 1);
+
+    await vi.waitFor(() => {
+      expect(mediaMocks.loadMediaAssetRecordMock).toHaveBeenCalledTimes(2);
+    });
+    const refreshingImage = container.querySelector(".review-markdown-media-image");
+    if (!(refreshingImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered during refresh");
+    }
+    expect(refreshingImage.getAttribute("src")).toBe(initialSrc);
+    expect(container.querySelector(".review-markdown-media-loading")).toBeNull();
+
+    await act(async () => {
+      refreshMediaAsset.resolve(refreshedMediaAsset);
+      await refreshMediaAsset.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(createObjectURLMock).toHaveBeenCalledTimes(2);
+    });
+    const refreshedImage = container.querySelector(".review-markdown-media-image");
+    if (!(refreshedImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered after refreshed identity loaded");
+    }
+    expect(refreshedImage.getAttribute("src")).toBe("blob:review-media-2");
+    expect(revokeObjectURLMock).toHaveBeenCalledWith(initialSrc);
+    expect(releasedAfterNewImageCommit).toBe(true);
+  });
+
+  it("releases a previous managed image URL only after unavailable fallback renders", async () => {
+    const imageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const mediaAsset = makeMediaAsset("image-asset", "image/png", imageSha256, imageBlob.size);
+    const cacheRecord = makeCacheRecord(mediaAsset, imageBlob);
+    const refreshMediaAsset = createDeferred<MediaAsset | null>();
+    mediaMocks.loadMediaAssetRecordMock
+      .mockResolvedValueOnce(mediaAsset)
+      .mockImplementation(async (_workspaceId: string, _mediaAssetId: string): Promise<MediaAsset | null> => {
+        return refreshMediaAsset.promise;
+      });
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(cacheRecord);
+
+    root = createReviewCardSideRoot(container, "![Diagram](fcasset:image-asset)", 0);
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+    });
+
+    const initialImage = container.querySelector(".review-markdown-media-image");
+    if (!(initialImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered");
+    }
+    const initialSrc = initialImage.getAttribute("src");
+    expect(initialSrc).toBe("blob:review-media-1");
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+
+    let releasedAfterFallbackCommit = false;
+    revokeObjectURLMock.mockImplementation((url: string): void => {
+      if (url !== initialSrc) {
+        return;
+      }
+
+      expect(container.querySelector(".review-markdown-media-image")).toBeNull();
+      expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
+      releasedAfterFallbackCommit = true;
+    });
+
+    renderReviewCardSide(root, "![Diagram](fcasset:image-asset)", 1);
+
+    await vi.waitFor(() => {
+      expect(mediaMocks.loadMediaAssetRecordMock).toHaveBeenCalledTimes(2);
+    });
+    const refreshingImage = container.querySelector(".review-markdown-media-image");
+    if (!(refreshingImage instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered during refresh");
+    }
+    expect(refreshingImage.getAttribute("src")).toBe(initialSrc);
+    expect(revokeObjectURLMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      refreshMediaAsset.resolve(null);
+      await refreshMediaAsset.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
+    });
+    expect(revokeObjectURLMock).toHaveBeenCalledWith(initialSrc);
+    expect(releasedAfterFallbackCommit).toBe(true);
+  });
+
   it("downloads, verifies, caches, and deduplicates cold managed media", async () => {
     const mediaBytes = new Uint8Array([21, 22, 23, 24]);
     installDigestMock(coldSha256);
@@ -272,10 +565,10 @@ describe("ReviewCardSide managed media rendering", () => {
     mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(null);
     mediaMocks.loadMediaAssetDownloadUrlMock.mockImplementation(async () => downloadUrlDeferred.promise);
 
-    root = renderReviewCardSide(container, [
+    root = createReviewCardSideRoot(container, [
       "![First](fcasset:image-asset)",
       "![Second](fcasset:image-copy-asset)",
-    ].join("\n\n"));
+    ].join("\n\n"), 0);
 
     await vi.waitFor(() => {
       expect(mediaMocks.loadMediaBlobCacheRecordMock).toHaveBeenCalledTimes(2);
@@ -335,7 +628,7 @@ describe("ReviewCardSide managed media rendering", () => {
       },
     });
 
-    root = renderReviewCardSide(container, "![Large](fcasset:large-image-asset)");
+    root = createReviewCardSideRoot(container, "![Large](fcasset:large-image-asset)", 0);
 
     await vi.waitFor(() => {
       expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
@@ -363,7 +656,7 @@ describe("ReviewCardSide managed media rendering", () => {
   });
 
   it("keeps external Markdown images on the normal image path", async () => {
-    root = renderReviewCardSide(container, "![External](https://example.test/image.png)");
+    root = createReviewCardSideRoot(container, "![External](https://example.test/image.png)", 0);
 
     await vi.waitFor(() => {
       expect(container.querySelector("img.review-markdown-img")).not.toBeNull();
@@ -378,7 +671,7 @@ describe("ReviewCardSide managed media rendering", () => {
     mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(null);
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => undefined);
 
-    root = renderReviewCardSide(container, "![Missing](fcasset:missing-asset)");
+    root = createReviewCardSideRoot(container, "![Missing](fcasset:missing-asset)", 0);
 
     await vi.waitFor(() => {
       expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
@@ -419,7 +712,7 @@ describe("ReviewCardSide managed media rendering", () => {
         },
       });
 
-    root = renderReviewCardSide(container, "![Refresh](fcasset:refresh-asset)");
+    root = createReviewCardSideRoot(container, "![Refresh](fcasset:refresh-asset)", 0);
 
     await vi.waitFor(() => {
       expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
@@ -473,7 +766,7 @@ describe("ReviewCardSide managed media rendering", () => {
       },
     });
 
-    root = renderReviewCardSide(container, "![Corrupt](fcasset:corrupt-asset)");
+    root = createReviewCardSideRoot(container, "![Corrupt](fcasset:corrupt-asset)", 0);
 
     await vi.waitFor(() => {
       expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");

--- a/apps/web/src/screens/review/components/ReviewCardSide.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.tsx
@@ -1,5 +1,9 @@
-import type { ReactElement } from "react";
-import ReactMarkdown from "react-markdown";
+import {
+  createContext,
+  useContext,
+  type ReactElement,
+} from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import {
   ManagedMediaReference,
   parseManagedMediaAssetId,
@@ -11,6 +15,12 @@ const REVIEW_MARKDOWN_FENCE_PATTERN = /^\s{0,3}(`{3,}|~{3,})/;
 const REVIEW_MARKDOWN_SYMBOL_ONLY_LIST_ITEM_PATTERN = /^(\s{0,3}[-*+]\s+)([+*\-#>])(\s*)$/;
 
 type MarkdownFenceMarker = "`" | "~";
+type ReviewMarkdownRenderContextValue = Readonly<{
+  localReadVersion: number;
+  workspaceId: string | null;
+}>;
+
+const ReviewMarkdownRenderContext = createContext<ReviewMarkdownRenderContextValue | null>(null);
 
 export type ReviewCardSideProps = Readonly<{
   aiButtonAriaLabel: string | null;
@@ -41,6 +51,19 @@ export type ReviewCardSpeechButtonProps = Readonly<{
 
 function reviewMarkdownClassName(tagName: string): string {
   return `review-markdown-${tagName}`;
+}
+
+function createManagedMediaReferenceKey(workspaceId: string | null, mediaAssetId: string): string {
+  return JSON.stringify([workspaceId, mediaAssetId]);
+}
+
+function useReviewMarkdownRenderContext(): ReviewMarkdownRenderContextValue {
+  const contextValue = useContext(ReviewMarkdownRenderContext);
+  if (contextValue === null) {
+    throw new Error("Review markdown render context is unavailable");
+  }
+
+  return contextValue;
 }
 
 function toMarkdownFenceMarker(line: string): MarkdownFenceMarker | null {
@@ -102,6 +125,120 @@ export function normalizeReviewMarkdownForWeb(text: string): string {
   return normalizedLines.join("\n");
 }
 
+const reviewMarkdownComponents: Components = {
+  a: function ReviewMarkdownAnchor({ children, href, title }) {
+    const { localReadVersion, workspaceId } = useReviewMarkdownRenderContext();
+    const mediaAssetId = parseManagedMediaAssetId(href);
+    if (mediaAssetId !== null) {
+      return (
+        <ManagedMediaReference
+          key={createManagedMediaReferenceKey(workspaceId, mediaAssetId)}
+          altText=""
+          localReadVersion={localReadVersion}
+          mediaAssetId={mediaAssetId}
+          workspaceId={workspaceId}
+        >
+          {children}
+        </ManagedMediaReference>
+      );
+    }
+
+    return <a className={reviewMarkdownClassName("a")} href={href} title={title}>{children}</a>;
+  },
+  h1: function ReviewMarkdownH1({ children }) {
+    return <h1 className={reviewMarkdownClassName("h1")}>{children}</h1>;
+  },
+  h2: function ReviewMarkdownH2({ children }) {
+    return <h2 className={reviewMarkdownClassName("h2")}>{children}</h2>;
+  },
+  h3: function ReviewMarkdownH3({ children }) {
+    return <h3 className={reviewMarkdownClassName("h3")}>{children}</h3>;
+  },
+  h4: function ReviewMarkdownH4({ children }) {
+    return <h4 className={reviewMarkdownClassName("h4")}>{children}</h4>;
+  },
+  h5: function ReviewMarkdownH5({ children }) {
+    return <h5 className={reviewMarkdownClassName("h5")}>{children}</h5>;
+  },
+  h6: function ReviewMarkdownH6({ children }) {
+    return <h6 className={reviewMarkdownClassName("h6")}>{children}</h6>;
+  },
+  p: function ReviewMarkdownParagraph({ children }) {
+    return <p className={reviewMarkdownClassName("p")}>{children}</p>;
+  },
+  ul: function ReviewMarkdownUnorderedList({ children }) {
+    return <ul className={reviewMarkdownClassName("ul")}>{children}</ul>;
+  },
+  ol: function ReviewMarkdownOrderedList({ children }) {
+    return <ol className={reviewMarkdownClassName("ol")}>{children}</ol>;
+  },
+  li: function ReviewMarkdownListItem({ children }) {
+    return <li className={reviewMarkdownClassName("li")}>{children}</li>;
+  },
+  blockquote: function ReviewMarkdownBlockquote({ children }) {
+    return <blockquote className={reviewMarkdownClassName("blockquote")}>{children}</blockquote>;
+  },
+  hr: function ReviewMarkdownHorizontalRule() {
+    return <hr className={reviewMarkdownClassName("hr")} />;
+  },
+  table: function ReviewMarkdownTable({ children }) {
+    return <table className={reviewMarkdownClassName("table")}>{children}</table>;
+  },
+  thead: function ReviewMarkdownTableHead({ children }) {
+    return <thead className={reviewMarkdownClassName("thead")}>{children}</thead>;
+  },
+  tbody: function ReviewMarkdownTableBody({ children }) {
+    return <tbody className={reviewMarkdownClassName("tbody")}>{children}</tbody>;
+  },
+  tr: function ReviewMarkdownTableRow({ children }) {
+    return <tr className={reviewMarkdownClassName("tr")}>{children}</tr>;
+  },
+  th: function ReviewMarkdownTableHeaderCell({ children }) {
+    return <th className={reviewMarkdownClassName("th")}>{children}</th>;
+  },
+  td: function ReviewMarkdownTableCell({ children }) {
+    return <td className={reviewMarkdownClassName("td")}>{children}</td>;
+  },
+  pre: function ReviewMarkdownPre({ children }) {
+    return <pre className={reviewMarkdownClassName("pre")}>{children}</pre>;
+  },
+  img: function ReviewMarkdownImage({ alt, src, title }) {
+    const { localReadVersion, workspaceId } = useReviewMarkdownRenderContext();
+    const mediaAssetId = parseManagedMediaAssetId(src);
+    if (mediaAssetId !== null) {
+      return (
+        <ManagedMediaReference
+          key={createManagedMediaReferenceKey(workspaceId, mediaAssetId)}
+          altText={alt ?? ""}
+          localReadVersion={localReadVersion}
+          mediaAssetId={mediaAssetId}
+          workspaceId={workspaceId}
+        >
+          {alt ?? ""}
+        </ManagedMediaReference>
+      );
+    }
+
+    return (
+      <img
+        className="review-markdown-img"
+        src={src}
+        alt={alt ?? ""}
+        title={title}
+        loading="lazy"
+        decoding="async"
+      />
+    );
+  },
+  code: function ReviewMarkdownCode({ children, className }) {
+    return (
+      <code className={`${reviewMarkdownClassName("code")}${className === undefined ? "" : ` ${className}`}`}>
+        {children}
+      </code>
+    );
+  },
+};
+
 function ReviewCardMarkdown(props: Readonly<{
   localReadVersion: number;
   text: string;
@@ -115,80 +252,14 @@ function ReviewCardMarkdown(props: Readonly<{
   const normalizedText = normalizeReviewMarkdownForWeb(text);
 
   return (
-    <ReactMarkdown
-      urlTransform={reviewMarkdownUrlTransform}
-      components={{
-        a: ({ children, href, title }) => {
-          const mediaAssetId = parseManagedMediaAssetId(href);
-          if (mediaAssetId !== null) {
-            return (
-              <ManagedMediaReference
-                altText=""
-                localReadVersion={localReadVersion}
-                mediaAssetId={mediaAssetId}
-                workspaceId={workspaceId}
-              >
-                {children}
-              </ManagedMediaReference>
-            );
-          }
-
-          return <a className={reviewMarkdownClassName("a")} href={href} title={title}>{children}</a>;
-        },
-        h1: ({ children }) => <h1 className={reviewMarkdownClassName("h1")}>{children}</h1>,
-        h2: ({ children }) => <h2 className={reviewMarkdownClassName("h2")}>{children}</h2>,
-        h3: ({ children }) => <h3 className={reviewMarkdownClassName("h3")}>{children}</h3>,
-        h4: ({ children }) => <h4 className={reviewMarkdownClassName("h4")}>{children}</h4>,
-        h5: ({ children }) => <h5 className={reviewMarkdownClassName("h5")}>{children}</h5>,
-        h6: ({ children }) => <h6 className={reviewMarkdownClassName("h6")}>{children}</h6>,
-        p: ({ children }) => <p className={reviewMarkdownClassName("p")}>{children}</p>,
-        ul: ({ children }) => <ul className={reviewMarkdownClassName("ul")}>{children}</ul>,
-        ol: ({ children }) => <ol className={reviewMarkdownClassName("ol")}>{children}</ol>,
-        li: ({ children }) => <li className={reviewMarkdownClassName("li")}>{children}</li>,
-        blockquote: ({ children }) => <blockquote className={reviewMarkdownClassName("blockquote")}>{children}</blockquote>,
-        hr: () => <hr className={reviewMarkdownClassName("hr")} />,
-        table: ({ children }) => <table className={reviewMarkdownClassName("table")}>{children}</table>,
-        thead: ({ children }) => <thead className={reviewMarkdownClassName("thead")}>{children}</thead>,
-        tbody: ({ children }) => <tbody className={reviewMarkdownClassName("tbody")}>{children}</tbody>,
-        tr: ({ children }) => <tr className={reviewMarkdownClassName("tr")}>{children}</tr>,
-        th: ({ children }) => <th className={reviewMarkdownClassName("th")}>{children}</th>,
-        td: ({ children }) => <td className={reviewMarkdownClassName("td")}>{children}</td>,
-        pre: ({ children }) => <pre className={reviewMarkdownClassName("pre")}>{children}</pre>,
-        img: ({ alt, src, title }) => {
-          const mediaAssetId = parseManagedMediaAssetId(src);
-          if (mediaAssetId !== null) {
-            return (
-              <ManagedMediaReference
-                altText={alt ?? ""}
-                localReadVersion={localReadVersion}
-                mediaAssetId={mediaAssetId}
-                workspaceId={workspaceId}
-              >
-                {alt ?? ""}
-              </ManagedMediaReference>
-            );
-          }
-
-          return (
-            <img
-              className="review-markdown-img"
-              src={src}
-              alt={alt ?? ""}
-              title={title}
-              loading="lazy"
-              decoding="async"
-            />
-          );
-        },
-        code: ({ children, className }) => (
-          <code className={`${reviewMarkdownClassName("code")}${className === undefined ? "" : ` ${className}`}`}>
-            {children}
-          </code>
-        ),
-      }}
-    >
-      {normalizedText}
-    </ReactMarkdown>
+    <ReviewMarkdownRenderContext.Provider value={{ localReadVersion, workspaceId }}>
+      <ReactMarkdown
+        urlTransform={reviewMarkdownUrlTransform}
+        components={reviewMarkdownComponents}
+      >
+        {normalizedText}
+      </ReactMarkdown>
+    </ReviewMarkdownRenderContext.Provider>
   );
 }
 

--- a/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
+++ b/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useRef,
   useState,
   type ReactElement,
   type ReactNode,
@@ -23,17 +24,36 @@ type ManagedMediaKind = "image" | "audio" | "video" | "attachment";
 type ManagedMediaLoadState =
   | Readonly<{ status: "loading" }>
   | Readonly<{ status: "unavailable"; mediaAsset: MediaAsset | null }>
-  | Readonly<{ status: "ready"; mediaAsset: MediaAsset; url: string }>;
+  | Readonly<{
+    status: "ready";
+    mediaAsset: MediaAsset;
+    objectUrlLease: ManagedMediaObjectUrlLease;
+    releaseProvisionalObjectUrlLease: (() => void) | null;
+    url: string;
+  }>;
 type ManagedMediaBlobLoadResult = Readonly<{
   mediaAsset: MediaAsset;
   cacheRecord: MediaBlobCacheRecord;
 }>;
+type ManagedMediaObjectUrlLease = Readonly<{
+  key: string;
+  url: string;
+}>;
+type ManagedMediaObjectUrlRetention = Readonly<{
+  isAcquiredLease: boolean;
+  objectUrlLease: ManagedMediaObjectUrlLease;
+}>;
+type ManagedMediaObjectUrlCacheEntry = {
+  referenceCount: number;
+  url: string;
+};
 type ManagedMediaDownloadRange = Readonly<{
   startByte: number;
   endByte: number;
 }>;
 
 const activeManagedMediaDownloadPromises = new Map<string, Promise<MediaBlobCacheRecord>>();
+const managedMediaObjectUrlCache = new Map<string, ManagedMediaObjectUrlCacheEntry>();
 
 export function parseManagedMediaAssetId(url: string | null | undefined): string | null {
   if (url === null || url === undefined) {
@@ -94,6 +114,62 @@ function warnManagedMediaDownloadRetry(
     errorName: readErrorName(error),
     errorMessage: readErrorMessage(error),
   });
+}
+
+function createManagedMediaObjectUrlKey(mediaAsset: MediaAsset): string {
+  return JSON.stringify([
+    mediaAsset.workspaceId,
+    mediaAsset.mediaAssetId,
+    mediaAsset.sha256,
+    mediaAsset.mimeType,
+    mediaAsset.sizeBytes,
+  ]);
+}
+
+function acquireManagedMediaObjectUrl(mediaAsset: MediaAsset, blob: Blob): ManagedMediaObjectUrlLease {
+  const key = createManagedMediaObjectUrlKey(mediaAsset);
+  const cachedEntry = managedMediaObjectUrlCache.get(key);
+  if (cachedEntry !== undefined) {
+    cachedEntry.referenceCount += 1;
+    return {
+      key,
+      url: cachedEntry.url,
+    };
+  }
+
+  const url = URL.createObjectURL(blob);
+  managedMediaObjectUrlCache.set(key, {
+    referenceCount: 1,
+    url,
+  });
+  return {
+    key,
+    url,
+  };
+}
+
+function releaseManagedMediaObjectUrl(lease: ManagedMediaObjectUrlLease): void {
+  const cachedEntry = managedMediaObjectUrlCache.get(lease.key);
+  if (cachedEntry === undefined) {
+    throw new Error(`Managed media object URL release failed: cache entry was missing for key=${lease.key}`);
+  }
+
+  if (cachedEntry.url !== lease.url) {
+    throw new Error(`Managed media object URL release failed: cache URL mismatch for key=${lease.key}`);
+  }
+
+  if (cachedEntry.referenceCount < 1) {
+    throw new RangeError(`Managed media object URL release failed: invalid referenceCount=${cachedEntry.referenceCount} for key=${lease.key}`);
+  }
+
+  const nextReferenceCount = cachedEntry.referenceCount - 1;
+  if (nextReferenceCount === 0) {
+    URL.revokeObjectURL(cachedEntry.url);
+    managedMediaObjectUrlCache.delete(lease.key);
+    return;
+  }
+
+  cachedEntry.referenceCount = nextReferenceCount;
 }
 
 function requireSha256Digest(): SubtleCrypto {
@@ -428,6 +504,16 @@ function readTextFromReactNode(node: ReactNode): string {
   return "";
 }
 
+function isReadyManagedMediaReference(
+  loadState: ManagedMediaLoadState,
+  workspaceId: string,
+  mediaAssetId: string,
+): boolean {
+  return loadState.status === "ready"
+    && loadState.mediaAsset.workspaceId === workspaceId
+    && loadState.mediaAsset.mediaAssetId === mediaAssetId;
+}
+
 function ManagedMediaFallback(props: Readonly<{
   mediaAssetId: string;
   message: string;
@@ -461,18 +547,75 @@ export function ManagedMediaReference(props: Readonly<{
   } = props;
   const { t } = useI18n();
   const [loadState, setLoadState] = useState<ManagedMediaLoadState>({ status: "loading" });
+  const loadStateRef = useRef<ManagedMediaLoadState>(loadState);
+
+  function updateLoadState(nextLoadState: ManagedMediaLoadState): void {
+    loadStateRef.current = nextLoadState;
+    setLoadState(nextLoadState);
+  }
+
+  function retainObjectUrlForReadyMedia(
+    currentLoadState: ManagedMediaLoadState,
+    mediaAsset: MediaAsset,
+    cacheRecord: MediaBlobCacheRecord,
+  ): ManagedMediaObjectUrlRetention {
+    const nextKey = createManagedMediaObjectUrlKey(mediaAsset);
+    if (currentLoadState.status === "ready" && currentLoadState.objectUrlLease.key === nextKey) {
+      return {
+        isAcquiredLease: false,
+        objectUrlLease: currentLoadState.objectUrlLease,
+      };
+    }
+
+    return {
+      isAcquiredLease: true,
+      objectUrlLease: acquireManagedMediaObjectUrl(mediaAsset, cacheRecord.blob),
+    };
+  }
+
+  const committedObjectUrlLease = loadState.status === "ready" ? loadState.objectUrlLease : null;
+
+  useEffect(() => {
+    if (committedObjectUrlLease === null) {
+      return undefined;
+    }
+
+    if (loadState.status === "ready") {
+      loadState.releaseProvisionalObjectUrlLease?.();
+    }
+
+    return () => {
+      releaseManagedMediaObjectUrl(committedObjectUrlLease);
+    };
+  }, [committedObjectUrlLease]);
 
   useEffect(() => {
     let isCancelled = false;
-    let objectUrlToRevoke: string | null = null;
+    let provisionalObjectUrlLease: ManagedMediaObjectUrlLease | null = null;
 
-    async function loadManagedMedia(): Promise<void> {
-      if (workspaceId === null) {
-        setLoadState({ status: "unavailable", mediaAsset: null });
+    function clearProvisionalObjectUrlLease(): void {
+      provisionalObjectUrlLease = null;
+    }
+
+    function releaseProvisionalObjectUrlLease(): void {
+      if (provisionalObjectUrlLease === null) {
         return;
       }
 
-      setLoadState({ status: "loading" });
+      releaseManagedMediaObjectUrl(provisionalObjectUrlLease);
+      provisionalObjectUrlLease = null;
+    }
+
+    async function loadManagedMedia(): Promise<void> {
+      if (workspaceId === null) {
+        updateLoadState({ status: "unavailable", mediaAsset: null });
+        return;
+      }
+
+      if (isReadyManagedMediaReference(loadStateRef.current, workspaceId, mediaAssetId) === false) {
+        updateLoadState({ status: "loading" });
+      }
+
       let loadResult: ManagedMediaBlobLoadResult | null;
       try {
         loadResult = await loadManagedMediaBlob(workspaceId, mediaAssetId);
@@ -482,7 +625,7 @@ export function ManagedMediaReference(props: Readonly<{
         }
 
         warnManagedMediaUnavailable(workspaceId, mediaAssetId, error);
-        setLoadState({ status: "unavailable", mediaAsset: null });
+        updateLoadState({ status: "unavailable", mediaAsset: null });
         return;
       }
 
@@ -491,28 +634,34 @@ export function ManagedMediaReference(props: Readonly<{
       }
 
       if (loadResult === null) {
-        setLoadState({ status: "unavailable", mediaAsset: null });
+        updateLoadState({ status: "unavailable", mediaAsset: null });
         return;
       }
 
-      let objectUrl: string;
+      let objectUrlRetention: ManagedMediaObjectUrlRetention;
       try {
-        objectUrl = URL.createObjectURL(loadResult.cacheRecord.blob);
+        objectUrlRetention = retainObjectUrlForReadyMedia(loadStateRef.current, loadResult.mediaAsset, loadResult.cacheRecord);
+        if (objectUrlRetention.isAcquiredLease) {
+          provisionalObjectUrlLease = objectUrlRetention.objectUrlLease;
+        }
       } catch (error) {
         warnManagedMediaUnavailable(workspaceId, mediaAssetId, error);
-        setLoadState({ status: "unavailable", mediaAsset: loadResult.mediaAsset });
+        updateLoadState({ status: "unavailable", mediaAsset: loadResult.mediaAsset });
         return;
       }
 
       if (isCancelled) {
-        URL.revokeObjectURL(objectUrl);
+        releaseProvisionalObjectUrlLease();
         return;
       }
-      objectUrlToRevoke = objectUrl;
-      setLoadState({
+      updateLoadState({
         status: "ready",
         mediaAsset: loadResult.mediaAsset,
-        url: objectUrl,
+        objectUrlLease: objectUrlRetention.objectUrlLease,
+        releaseProvisionalObjectUrlLease: objectUrlRetention.isAcquiredLease
+          ? clearProvisionalObjectUrlLease
+          : null,
+        url: objectUrlRetention.objectUrlLease.url,
       });
     }
 
@@ -520,9 +669,7 @@ export function ManagedMediaReference(props: Readonly<{
 
     return () => {
       isCancelled = true;
-      if (objectUrlToRevoke !== null) {
-        URL.revokeObjectURL(objectUrlToRevoke);
-      }
+      releaseProvisionalObjectUrlLease();
     };
   }, [localReadVersion, mediaAssetId, workspaceId]);
 

--- a/apps/web/src/styles/features/forms.css
+++ b/apps/web/src/styles/features/forms.css
@@ -180,6 +180,7 @@
 .card-form-managed-media-preview .review-markdown-media-image,
 .card-form-managed-media-preview .review-markdown-img {
   width: 100%;
+  max-width: 100%;
   height: 72px;
   max-height: 72px;
   object-fit: cover;

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -4,6 +4,7 @@
   --review-pane-radius: var(--panel-inner-radius, var(--radius-lg));
   --review-pane-inner-radius: max(0px, calc(var(--review-pane-radius) - var(--review-pane-padding)));
   --review-card-radius: var(--panel-inner-radius, var(--radius-lg));
+  --review-managed-media-image-radius: max(0px, calc(var(--review-card-radius) - 4px));
   display: grid;
   gap: 10px;
   min-width: 0;

--- a/apps/web/src/styles/features/review/review-markdown.css
+++ b/apps/web/src/styles/features/review/review-markdown.css
@@ -120,14 +120,14 @@
 }
 
 .review-markdown-img,
-.review-markdown-media-image,
-.review-markdown-media-video {
+.review-markdown-media-image {
   display: block;
-  width: auto;
+  width: 100%;
+  height: auto;
   max-width: 100%;
-  max-height: 24rem;
-  border-radius: 8px;
+  border-radius: var(--review-managed-media-image-radius, 8px);
   background: rgba(7, 7, 10, 0.34);
+  object-fit: contain;
 }
 
 .review-markdown-managed-media {


### PR DESCRIPTION
## Summary
- keep ready managed images visible across local data refreshes
- reuse and safely release managed image object URLs with committed/provisional lease handling
- make review images full-width with derived radius while preserving editor thumbnail cropping

## Validation
- npm exec --prefix apps/web -- vitest run src/screens/review/components/ReviewCardSide.media.test.tsx passed, 12 tests
- git --no-pager diff --check passed
- npm run build --prefix apps/web passed

Node 25 vs declared Node 24 warning is accepted as an environment/toolchain note.

## Review
Final fresh review found no split recommendation and no P0-P4 issues.