### PR TITLE
Polish Android managed image placeholders

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
@@ -69,6 +69,7 @@ import java.io.IOException
 
 private val reviewManagedMediaIconSize = 22.dp
 private val reviewManagedMediaActionIconSize = 18.dp
+private const val reviewManagedMediaImagePlaceholderAspectRatio = 4f / 3f
 private val reviewManagedMediaImagePlaceholderHeight = 180.dp
 private val reviewManagedMediaSurfaceCornerRadius = 12.dp
 private val reviewManagedMediaImageCornerRadius = 6.dp
@@ -184,7 +185,7 @@ private fun ReviewManagedMediaImageFile(
             showProgress = true,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(reviewManagedMediaImagePlaceholderHeight)
+                .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
         )
 
         ReviewManagedMediaFileState.Unavailable -> ReviewManagedMediaImageState(
@@ -194,7 +195,7 @@ private fun ReviewManagedMediaImageFile(
             showProgress = false,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(reviewManagedMediaImagePlaceholderHeight)
+                .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
         )
 
         is ReviewManagedMediaFileState.Ready -> ReviewManagedMediaImage(


### PR DESCRIPTION
## Summary
- use a default 4:3 aspect-ratio placeholder for Android review managed image loading/unavailable states
- keep ready images using local file dimensions and existing Coil local-file loading/cache behavior

## Validation
- git --no-pager diff --check
- xmllint --noout apps/android/feature/cards/src/main/res/values/strings.xml apps/android/feature/review/src/main/res/values/strings.xml
- rg -n "ContentScale\.Crop" apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt returned no matches as expected

Gradle was not run per repository instruction for this task.