### PR TITLE
Improve web managed image loading

### DIFF
--- a/apps/web/src/screens/cards/form/CardForm.tsx
+++ b/apps/web/src/screens/cards/form/CardForm.tsx
@@ -225,6 +225,7 @@ function ManagedMediaReferenceStrip(props: Readonly<{
                 altText={reference.altText}
                 localReadVersion={localReadVersion}
                 mediaAssetId={reference.mediaAssetId}
+                referencePresentation="image"
                 workspaceId={workspaceId}
               >
                 {referenceLabel}

--- a/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.media.test.tsx
@@ -160,6 +160,9 @@ function createReviewCardSideRoot(
 describe("ReviewCardSide managed media rendering", () => {
   let container: HTMLDivElement;
   let createObjectURLMock: ReturnType<typeof vi.fn<(blob: Blob) => string>>;
+  let imageDecodeMock: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  let imageNaturalHeight: number;
+  let imageNaturalWidth: number;
   let revokeObjectURLMock: ReturnType<typeof vi.fn<(url: string) => void>>;
   let root: ReactDOM.Root | null;
 
@@ -182,6 +185,22 @@ describe("ReviewCardSide managed media rendering", () => {
       configurable: true,
       value: revokeObjectURLMock,
     });
+    imageNaturalHeight = 600;
+    imageNaturalWidth = 800;
+    imageDecodeMock = vi.fn(async (): Promise<void> => undefined);
+    class ManagedMediaTestImage {
+      complete = false;
+      naturalHeight = imageNaturalHeight;
+      naturalWidth = imageNaturalWidth;
+      onerror: (() => void) | null = null;
+      onload: (() => void) | null = null;
+      src = "";
+
+      decode(): Promise<void> {
+        return imageDecodeMock();
+      }
+    }
+    vi.stubGlobal("Image", ManagedMediaTestImage);
     container = document.createElement("div");
     document.body.append(container);
     root = null;
@@ -202,6 +221,105 @@ describe("ReviewCardSide managed media rendering", () => {
     window.localStorage.clear();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("renders an image-shaped placeholder until a managed image has decoded", async () => {
+    const imageDecodeDeferred = createDeferred<void>();
+    imageDecodeMock.mockImplementation(async (): Promise<void> => imageDecodeDeferred.promise);
+    const imageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const mediaAsset = makeMediaAsset("image-asset", "image/png", imageSha256, imageBlob.size);
+    const cacheRecord = makeCacheRecord(mediaAsset, imageBlob);
+    mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(cacheRecord);
+
+    root = createReviewCardSideRoot(container, "![Diagram](fcasset:image-asset)", 0);
+
+    await vi.waitFor(() => {
+      expect(imageDecodeMock).toHaveBeenCalledTimes(1);
+    });
+
+    const placeholder = container.querySelector(".review-markdown-media-image-loading");
+    if (!(placeholder instanceof HTMLElement)) {
+      throw new Error("Managed image loading placeholder was not rendered");
+    }
+    expect(placeholder.getAttribute("data-fcasset-id")).toBe("image-asset");
+    expect(placeholder.getAttribute("aria-busy")).toBe("true");
+    expect(placeholder.getAttribute("aria-label")).toBeTruthy();
+    expect(container.querySelector(".review-markdown-media-loading")).toBeNull();
+    expect(container.querySelector(".review-markdown-media-image")).toBeNull();
+
+    await act(async () => {
+      imageDecodeDeferred.resolve(undefined);
+      await imageDecodeDeferred.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-image")).not.toBeNull();
+    });
+
+    const image = container.querySelector(".review-markdown-media-image");
+    if (!(image instanceof HTMLImageElement)) {
+      throw new Error("Managed image was not rendered after decode");
+    }
+    expect(image.alt).toBe("Diagram");
+    expect(image.getAttribute("src")).toBe("blob:review-media-1");
+    expect(image.style.aspectRatio).toBe("800 / 600");
+    expect(container.querySelector(".review-markdown-media-image-loading")).toBeNull();
+  });
+
+  it("keeps managed Markdown links on the compact loading and fallback path", async () => {
+    const mediaAssetDeferred = createDeferred<MediaAsset | null>();
+    mediaMocks.loadMediaAssetRecordMock.mockImplementation(async (): Promise<MediaAsset | null> => mediaAssetDeferred.promise);
+
+    root = createReviewCardSideRoot(container, "[Diagram](fcasset:image-asset)", 0);
+
+    const loading = container.querySelector(".review-markdown-media-loading");
+    if (!(loading instanceof HTMLElement)) {
+      throw new Error("Managed link loading placeholder was not rendered");
+    }
+    expect(loading.getAttribute("data-fcasset-id")).toBe("image-asset");
+    expect(loading.getAttribute("aria-busy")).toBe("true");
+    expect(container.querySelector(".review-markdown-media-image-loading")).toBeNull();
+    expect(imageDecodeMock).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => {
+      expect(mediaMocks.loadMediaAssetRecordMock).toHaveBeenCalledWith("workspace-1", "image-asset");
+    });
+    await act(async () => {
+      mediaAssetDeferred.resolve(null);
+      await mediaAssetDeferred.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
+    });
+    expect(container.querySelector(".review-markdown-media-image-loading")).toBeNull();
+  });
+
+  it("renders unavailable media and releases the object URL when managed image decode fails", async () => {
+    const imageBlob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    const mediaAsset = makeMediaAsset("image-asset", "image/png", imageSha256, imageBlob.size);
+    const cacheRecord = makeCacheRecord(mediaAsset, imageBlob);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => undefined);
+    imageDecodeMock.mockRejectedValue(new Error("decode failed"));
+    mediaMocks.loadMediaAssetRecordMock.mockResolvedValue(mediaAsset);
+    mediaMocks.loadMediaBlobCacheRecordMock.mockResolvedValue(cacheRecord);
+
+    root = createReviewCardSideRoot(container, "![Diagram](fcasset:image-asset)", 0);
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".review-markdown-media-fallback")?.textContent).toBe("Media unavailable");
+    });
+
+    expect(container.querySelector(".review-markdown-media-image")).toBeNull();
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:review-media-1");
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "Managed media download unavailable",
+      expect.objectContaining({
+        mediaAssetId: "image-asset",
+        errorMessage: expect.stringContaining("decode failed"),
+      }),
+    );
   });
 
   it("renders managed image, audio, video, and generic attachments from warm blob cache", async () => {
@@ -384,7 +502,7 @@ describe("ReviewCardSide managed media rendering", () => {
     renderReviewCardSide(root, "![Second](fcasset:second-image-asset)", 0);
 
     expect(container.querySelector(".review-markdown-media-image")).toBeNull();
-    expect(container.querySelector(".review-markdown-media-loading")?.getAttribute("data-fcasset-id")).toBe("second-image-asset");
+    expect(container.querySelector(".review-markdown-media-image-loading")?.getAttribute("data-fcasset-id")).toBe("second-image-asset");
     expect(revokeObjectURLMock).toHaveBeenCalledWith(initialSrc);
     expect(createObjectURLMock).toHaveBeenCalledTimes(1);
 

--- a/apps/web/src/screens/review/components/ReviewCardSide.tsx
+++ b/apps/web/src/screens/review/components/ReviewCardSide.tsx
@@ -136,6 +136,7 @@ const reviewMarkdownComponents: Components = {
           altText=""
           localReadVersion={localReadVersion}
           mediaAssetId={mediaAssetId}
+          referencePresentation="link"
           workspaceId={workspaceId}
         >
           {children}
@@ -212,6 +213,7 @@ const reviewMarkdownComponents: Components = {
           altText={alt ?? ""}
           localReadVersion={localReadVersion}
           mediaAssetId={mediaAssetId}
+          referencePresentation="image"
           workspaceId={workspaceId}
         >
           {alt ?? ""}

--- a/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
+++ b/apps/web/src/screens/review/components/ReviewManagedMedia.tsx
@@ -2,6 +2,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type CSSProperties,
   type ReactElement,
   type ReactNode,
 } from "react";
@@ -21,10 +22,16 @@ const MANAGED_MEDIA_DOWNLOAD_ATTEMPT_COUNT = 2;
 const MANAGED_MEDIA_DOWNLOAD_RANGE_SIZE_BYTES = 4 * 1024 * 1024;
 
 type ManagedMediaKind = "image" | "audio" | "video" | "attachment";
+type ManagedMediaReferencePresentation = "image" | "link";
+type ManagedMediaImageDimensions = Readonly<{
+  height: number;
+  width: number;
+}>;
 type ManagedMediaLoadState =
   | Readonly<{ status: "loading" }>
   | Readonly<{ status: "unavailable"; mediaAsset: MediaAsset | null }>
   | Readonly<{
+    imageDimensions: ManagedMediaImageDimensions | null;
     status: "ready";
     mediaAsset: MediaAsset;
     objectUrlLease: ManagedMediaObjectUrlLease;
@@ -504,6 +511,63 @@ function readTextFromReactNode(node: ReactNode): string {
   return "";
 }
 
+function readDecodedManagedImageDimensions(image: HTMLImageElement): ManagedMediaImageDimensions | null {
+  if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+    return {
+      height: image.naturalHeight,
+      width: image.naturalWidth,
+    };
+  }
+
+  return null;
+}
+
+function waitForManagedImageLoad(image: HTMLImageElement, url: string): Promise<void> {
+  if (image.complete) {
+    if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+      return Promise.resolve();
+    }
+
+    return Promise.reject(new Error(`Managed media image load failed: objectUrl=${url}`));
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    image.onload = (): void => {
+      resolve();
+    };
+    image.onerror = (): void => {
+      reject(new Error(`Managed media image load failed: objectUrl=${url}`));
+    };
+  });
+}
+
+async function decodeManagedImageObjectUrl(url: string): Promise<ManagedMediaImageDimensions | null> {
+  const image = new Image();
+  image.src = url;
+
+  try {
+    if (typeof image.decode === "function") {
+      await image.decode();
+    } else {
+      await waitForManagedImageLoad(image, url);
+    }
+  } catch (error) {
+    throw new Error(`Managed media image decode failed: objectUrl=${url}, error=${readErrorMessage(error)}`);
+  }
+
+  return readDecodedManagedImageDimensions(image);
+}
+
+function createManagedImageStyle(imageDimensions: ManagedMediaImageDimensions | null): CSSProperties | undefined {
+  if (imageDimensions === null) {
+    return undefined;
+  }
+
+  return {
+    aspectRatio: `${imageDimensions.width} / ${imageDimensions.height}`,
+  };
+}
+
 function isReadyManagedMediaReference(
   loadState: ManagedMediaLoadState,
   workspaceId: string,
@@ -536,6 +600,7 @@ export function ManagedMediaReference(props: Readonly<{
   children: ReactNode;
   localReadVersion: number;
   mediaAssetId: string;
+  referencePresentation: ManagedMediaReferencePresentation;
   workspaceId: string | null;
 }>): ReactElement {
   const {
@@ -543,6 +608,7 @@ export function ManagedMediaReference(props: Readonly<{
     children,
     localReadVersion,
     mediaAssetId,
+    referencePresentation,
     workspaceId,
   } = props;
   const { t } = useI18n();
@@ -639,12 +705,28 @@ export function ManagedMediaReference(props: Readonly<{
       }
 
       let objectUrlRetention: ManagedMediaObjectUrlRetention;
+      let imageDimensions: ManagedMediaImageDimensions | null = null;
       try {
-        objectUrlRetention = retainObjectUrlForReadyMedia(loadStateRef.current, loadResult.mediaAsset, loadResult.cacheRecord);
+        const currentLoadState = loadStateRef.current;
+        objectUrlRetention = retainObjectUrlForReadyMedia(currentLoadState, loadResult.mediaAsset, loadResult.cacheRecord);
         if (objectUrlRetention.isAcquiredLease) {
           provisionalObjectUrlLease = objectUrlRetention.objectUrlLease;
         }
+
+        if (classifyManagedMediaKind(loadResult.mediaAsset.mimeType) === "image") {
+          imageDimensions = objectUrlRetention.isAcquiredLease
+            ? await decodeManagedImageObjectUrl(objectUrlRetention.objectUrlLease.url)
+            : currentLoadState.status === "ready"
+              ? currentLoadState.imageDimensions
+              : null;
+        }
       } catch (error) {
+        if (isCancelled) {
+          releaseProvisionalObjectUrlLease();
+          return;
+        }
+
+        releaseProvisionalObjectUrlLease();
         warnManagedMediaUnavailable(workspaceId, mediaAssetId, error);
         updateLoadState({ status: "unavailable", mediaAsset: loadResult.mediaAsset });
         return;
@@ -655,6 +737,7 @@ export function ManagedMediaReference(props: Readonly<{
         return;
       }
       updateLoadState({
+        imageDimensions,
         status: "ready",
         mediaAsset: loadResult.mediaAsset,
         objectUrlLease: objectUrlRetention.objectUrlLease,
@@ -674,6 +757,18 @@ export function ManagedMediaReference(props: Readonly<{
   }, [localReadVersion, mediaAssetId, workspaceId]);
 
   if (loadState.status === "loading") {
+    if (referencePresentation === "image") {
+      return (
+        <span
+          className="review-markdown-managed-media review-markdown-media-image-loading"
+          data-fcasset-id={mediaAssetId}
+          aria-busy="true"
+          aria-label={t("reviewScreen.media.loading")}
+          role="status"
+        />
+      );
+    }
+
     return (
       <span
         className="review-markdown-managed-media review-markdown-media-loading"
@@ -713,6 +808,7 @@ export function ManagedMediaReference(props: Readonly<{
         alt={altText.trim() === "" ? t("reviewScreen.media.imageAlt") : altText}
         loading="lazy"
         decoding="async"
+        style={createManagedImageStyle(loadState.imageDimensions)}
       />
     );
   }

--- a/apps/web/src/styles/features/review/review-markdown.css
+++ b/apps/web/src/styles/features/review/review-markdown.css
@@ -135,6 +135,15 @@
   min-width: 0;
 }
 
+.review-markdown-media-image-loading {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--review-managed-media-image-radius, 8px);
+  background: rgba(7, 7, 10, 0.34);
+}
+
 .review-markdown-media-audio,
 .review-markdown-media-video {
   display: flex;


### PR DESCRIPTION
## Summary
- distinguish managed markdown image references from generic managed links on web
- reserve a full-width image-shaped loading placeholder for managed images
- decode managed image object URLs before committing the ready image state and preserve lease cleanup

## Validation
- git --no-pager diff --check
- npm exec --prefix apps/web -- vitest run src/screens/review/components/ReviewCardSide.media.test.tsx
- npm run build --prefix apps/web

Review gate: worker-owned review reported no split recommendation and no P0-P4 findings.