### PR TITLE
Move web workspace package screens

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -185,10 +185,10 @@ const TagsScreen = lazy(async () => import("./screens/settings/workspace/TagsScr
 const WorkspaceSchedulerScreen = lazy(async () => import("./screens/settings/workspace/WorkspaceSchedulerScreen").then((module) => ({
   default: module.WorkspaceSchedulerScreen,
 })));
-const WorkspaceExportScreen = lazy(async () => import("./screens/settings/workspace/WorkspaceExportScreen").then((module) => ({
+const WorkspaceExportScreen = lazy(async () => import("./screens/settings/workspace/packages/WorkspaceExportScreen").then((module) => ({
   default: module.WorkspaceExportScreen,
 })));
-const WorkspaceImportScreen = lazy(async () => import("./screens/settings/workspace/WorkspaceImportScreen").then((module) => ({
+const WorkspaceImportScreen = lazy(async () => import("./screens/settings/workspace/packages/WorkspaceImportScreen").then((module) => ({
   default: module.WorkspaceImportScreen,
 })));
 

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceExportScreen.package.test.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceExportScreen.package.test.tsx
@@ -2,9 +2,9 @@
 import { act } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppDataContextValue } from "../../../appData";
-import { AppErrorDialogProvider } from "../../../appError/AppErrorContext";
-import { I18nProvider } from "../../../i18n";
+import type { AppDataContextValue } from "../../../../appData";
+import { AppErrorDialogProvider } from "../../../../appError/AppErrorContext";
+import { I18nProvider } from "../../../../i18n";
 import type {
   Card,
   Deck,
@@ -14,7 +14,7 @@ import type {
   WorkspacePackageExportPreviewResponse,
   WorkspacePackageExportRequest,
   WorkspaceResetProgressPreview,
-} from "../../../types";
+} from "../../../../types";
 import { WorkspaceExportScreen } from "./WorkspaceExportScreen";
 
 const {
@@ -33,8 +33,8 @@ const {
   useAppDataMock: vi.fn<() => AppDataContextValue>(),
 }));
 
-vi.mock("../../../api", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../api")>();
+vi.mock("../../../../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../api")>();
   return {
     ...actual,
     downloadWorkspacePackageExport: downloadWorkspacePackageExportMock,
@@ -42,7 +42,7 @@ vi.mock("../../../api", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../appData", () => ({
+vi.mock("../../../../appData", () => ({
   useAppData: useAppDataMock,
 }));
 

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceExportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceExportScreen.tsx
@@ -2,16 +2,16 @@ import { useEffect, useState, type ReactElement } from "react";
 import {
   downloadWorkspacePackageExport,
   previewWorkspacePackageExport,
-} from "../../../api";
-import { useAppData } from "../../../appData";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
-import { useI18n } from "../../../i18n";
-import { captureAppOperationError } from "../../../observability/appOperationObservation";
+} from "../../../../api";
+import { useAppData } from "../../../../appData";
+import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import { useI18n } from "../../../../i18n";
+import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type {
   WorkspacePackageExportPreviewResponse,
   WorkspacePackageExportRequest,
-} from "../../../types";
-import { SettingsShell } from "../SettingsShared";
+} from "../../../../types";
+import { SettingsShell } from "../../SettingsShared";
 
 type PackageMetadataRow = Readonly<{
   label: string;

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.package.test.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.package.test.tsx
@@ -2,9 +2,9 @@
 import { act } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppDataContextValue } from "../../../appData";
-import { AppErrorDialogProvider } from "../../../appError/AppErrorContext";
-import { I18nProvider } from "../../../i18n";
+import type { AppDataContextValue } from "../../../../appData";
+import { AppErrorDialogProvider } from "../../../../appError/AppErrorContext";
+import { I18nProvider } from "../../../../i18n";
 import type {
   Card,
   Deck,
@@ -14,7 +14,7 @@ import type {
   WorkspacePackageImportConfirmResponse,
   WorkspacePackageImportPreviewResponse,
   WorkspaceResetProgressPreview,
-} from "../../../types";
+} from "../../../../types";
 import { WorkspaceImportScreen } from "./WorkspaceImportScreen";
 
 const {
@@ -34,8 +34,8 @@ const {
   useAppDataMock: vi.fn<() => AppDataContextValue>(),
 }));
 
-vi.mock("../../../api", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../api")>();
+vi.mock("../../../../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../api")>();
   return {
     ...actual,
     confirmWorkspacePackageImport: confirmWorkspacePackageImportMock,
@@ -43,7 +43,7 @@ vi.mock("../../../api", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../appData", () => ({
+vi.mock("../../../../appData", () => ({
   useAppData: useAppDataMock,
 }));
 

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
@@ -2,17 +2,17 @@ import { useEffect, useRef, useState, type ReactElement } from "react";
 import {
   confirmWorkspacePackageImport,
   previewWorkspacePackageImport,
-} from "../../../api";
-import { useAppData } from "../../../appData";
-import { requireCloudInstallationId } from "../../../appData/sync/local/syncCloudSettings";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
-import { useI18n } from "../../../i18n";
-import { captureAppOperationError } from "../../../observability/appOperationObservation";
+} from "../../../../api";
+import { useAppData } from "../../../../appData";
+import { requireCloudInstallationId } from "../../../../appData/sync/local/syncCloudSettings";
+import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import { useI18n } from "../../../../i18n";
+import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type {
   WorkspacePackageImportConfirmOptions,
   WorkspacePackageImportPreviewResponse,
-} from "../../../types";
-import { SettingsShell } from "../SettingsShared";
+} from "../../../../types";
+import { SettingsShell } from "../../SettingsShared";
 
 type PackageMetadataRow = Readonly<{
   label: string;


### PR DESCRIPTION
## Summary
- Move web workspace import/export package screens into the workspace packages subdirectory
- Move the matching package tests with those screens
- Update App lazy imports for the moved screens

## Validation
- git --no-pager diff --check
- git grep stale old workspace import/export screen paths under apps/web/src: no matches
- cd apps/web && npx vitest run src/screens/settings/workspace/packages/WorkspaceImportScreen.package.test.tsx src/screens/settings/workspace/packages/WorkspaceExportScreen.package.test.tsx
- npm --prefix apps/web run build

Note: npm ci emitted the existing Node engine warning because the web package expects Node 24.x and this environment uses Node v25.6.1.