### PR TITLE
Fix iOS archive compile errors

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
@@ -721,6 +721,8 @@ private func cardEditorSingleSelectionRange(text: String, selection: TextSelecti
         return range
     case .multiSelection:
         return text.endIndex..<text.endIndex
+    @unknown default:
+        return text.endIndex..<text.endIndex
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/Media/ReviewManagedMediaCacheSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Media/ReviewManagedMediaCacheSupport.swift
@@ -185,25 +185,19 @@ func publishReviewManagedMediaPartialBlobFile(
         }
     }
 
-    var resultingURL: NSURL?
     do {
-        try FileManager.default.replaceItemAt(
+        let resultingURL = try FileManager.default.replaceItemAt(
             destinationURL,
             withItemAt: partialFileURL,
             backupItemName: nil,
-            options: [],
-            resultingItemURL: &resultingURL
+            options: []
         )
+        return resultingURL ?? destinationURL
     } catch {
         throw LocalStoreError.database(
             "Managed media cache publish replace failed for mediaAssetId=\(mediaAssetId) from=\(partialFileURL.path) to=\(destinationURL.path): \(Flashcards.errorMessage(error: error))"
         )
     }
-
-    if let resultingURL {
-        return resultingURL as URL
-    }
-    return destinationURL
 }
 
 private func removeReviewManagedMediaPartialDownload(


### PR DESCRIPTION
## Summary
- add an @unknown default for the CardEditor TextSelection switch
- update managed media cache replacement to use the current FileManager.replaceItemAt return value

## Validation
- git --no-pager diff --check
- swiftc typecheck snippets against iPhoneOS 26 SDK for TextSelection and FileManager.replaceItemAt
- attempted generic iOS xcodebuild; stopped after xcodebuild stayed idle without compiler child processes or diagnostics