### PR TITLE
Fix Android card editor alignment import

### DIFF
--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
@@ -1,7 +1,6 @@
 package com.flashcardsopensourceapp.feature.cards.editor
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Alignment
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,6 +42,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale


### PR DESCRIPTION
## Summary
- import Compose Alignment from androidx.compose.ui in the card text editor
- fixes the Android CI compile error in CardTextEditorRoute.kt

## Validation
- git diff --check
- GitHub Actions pending