### PR TITLE
Bump product version to 1.16.0

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-api",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-api",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "devDependencies": {
         "@redocly/cli": "^2.36.0"
       },

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-api",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "bundle": "redocly bundle src/openapi.yaml --output dist/openapi.json --ext json",

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-admin",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "d3": "^7.9.0",
         "react": "^19.2.7",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -142,7 +142,7 @@ android {
         minSdk = androidMinSdk
         targetSdk = 36
         versionCode = androidVersionCode ?: 1
-        versionName = "1.15.0"
+        versionName = "1.16.0"
         testInstrumentationRunner = "com.flashcardsopensourceapp.app.FlashcardsAndroidTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
         buildConfigField("int", "ANDROID_MIN_SDK", androidMinSdk.toString())

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-auth",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-auth",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1077.0",
         "@hono/node-server": "^2.0.6",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-auth",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-backend",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1077.0",
         "@aws-sdk/client-lambda": "^3.1077.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "dev": "npm run bundle --prefix ../../api && tsx watch src/entrypoints/index.ts",

--- a/apps/ios/Flashcards/Config/Base.xcconfig
+++ b/apps/ios/Flashcards/Config/Base.xcconfig
@@ -1,6 +1,6 @@
 APP_DISPLAY_NAME = Flashcards
 APP_BUNDLE_IDENTIFIER = com.flashcards-open-source-app.app
-APP_MARKETING_VERSION = 1.15.0
+APP_MARKETING_VERSION = 1.16.0
 // Keep the repository default build number stable. Signed archives should
 // override this locally or in CI when a higher App Store Connect build number is required.
 APP_CURRENT_PROJECT_VERSION = 1

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-web",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.8",
         "@sentry/react": "^10.62.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-aws",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.0",
         "@aws-sdk/client-cloudwatch": "^3.1077.0",

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "com.flashcards-open-source-app/flashcards",
   "title": "Flashcards Open Source App",
   "description": "Read and write open-source flashcards through split read/write MCP tools.",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "websiteUrl": "https://flashcards-open-source-app.com",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- bump shared product version surfaces from 1.15.0 to 1.16.0
- keep backend, web, Android, iOS, and MCP registry manifest versions aligned

## Verification
- npm ci --prefix apps/web
- npm run build --prefix apps/web
- targeted stale-version search: remaining 1.15.0 literals are dependency versions only