### PR TITLE
Refactor workspace package import workflows

### DIFF
--- a/apps/backend/src/workspacePackages/import/apply/importCards.test.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importCards.test.ts
@@ -6,12 +6,12 @@ import type {
   CardMetadata,
   CardMutationMetadata,
   CreateCardInput,
-} from "../../cards";
+} from "../../../cards";
 import type {
   DatabaseExecutor,
   WorkspaceDatabaseScope,
-} from "../../database";
-import { HttpError } from "../../shared/errors";
+} from "../../../database";
+import { HttpError } from "../../../shared/errors";
 import {
   persistWorkspacePackageImportCardsWithDependencies,
   type WorkspacePackageImportCardPersistenceDependencies,
@@ -23,7 +23,7 @@ import {
   type WorkspacePackageImportCardPersistenceInput,
   type WorkspacePackageImportCardPersistenceResult,
   type WorkspacePackageImportPlannedCard,
-} from "../index";
+} from "../../index";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";

--- a/apps/backend/src/workspacePackages/import/apply/importCards.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importCards.ts
@@ -4,14 +4,14 @@ import {
   type Card,
   type CardMutationMetadata,
   type CreateCardInput,
-} from "../../cards";
+} from "../../../cards";
 import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
   type WorkspaceDatabaseScope,
-} from "../../database";
-import { HttpError } from "../../shared/errors";
-import type { WorkspacePackageImportPlannedCard } from "./importPlan";
+} from "../../../database";
+import { HttpError } from "../../../shared/errors";
+import type { WorkspacePackageImportPlannedCard } from "../planning/importPlan";
 
 const workspacePackageImportCardPersistenceBatchSize = 100;
 

--- a/apps/backend/src/workspacePackages/import/apply/importConfirm.test.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importConfirm.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import type { Card } from "../../cards";
+import type { Card } from "../../../cards";
 import {
   imageJpegCardMediaBlobMimeType,
   type MediaAsset,
-} from "../../mediaAssets/types";
-import type { BackendObservationScope } from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
+} from "../../../mediaAssets/types";
+import type { BackendObservationScope } from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
 import {
   confirmWorkspacePackageImportWithDependencies,
   type WorkspacePackageImportConfirmDependencies,
@@ -23,8 +23,8 @@ import {
   type WorkspacePackageImportPlanInput,
   type WorkspacePackageImportReferencedMediaFile,
   type WorkspacePackageImportReferencedMediaInput,
-} from "../index";
-import { validateWorkspacePackageImportPlanPreflight } from "./importPlan";
+} from "../../index";
+import { validateWorkspacePackageImportPlanPreflight } from "../planning/importPlan";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";

--- a/apps/backend/src/workspacePackages/import/apply/importConfirm.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importConfirm.ts
@@ -1,24 +1,24 @@
 import type { Buffer } from "node:buffer";
-import type { Card } from "../../cards";
+import type { Card } from "../../../cards";
 import {
   transactionWithWorkspaceScopeReadOnly,
   type DatabaseExecutor,
   type WorkspaceDatabaseScope,
-} from "../../database";
-import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
-import type { BackendObservationScope } from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
+} from "../../../database";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../../../mediaAssets/workspaceReplicas";
+import type { BackendObservationScope } from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
 import {
   ingestWorkspacePackageImportMediaAssets,
   type WorkspacePackageImportedMediaAsset,
   type WorkspacePackageImportMediaAssetIngestionInput,
   type WorkspacePackageImportMediaAssetIngestionResult,
-} from "./importMediaAssets";
+} from "../media/importMediaAssets";
 import {
   loadWorkspacePackageImportReferencedMedia,
   type WorkspacePackageImportReferencedMediaInput,
   type WorkspacePackageImportReferencedMediaLoadResult,
-} from "./importMedia";
+} from "../media/importMedia";
 import {
   persistWorkspacePackageImportCards,
   type WorkspacePackageImportCardPersistenceInput,
@@ -31,7 +31,7 @@ import {
   type WorkspacePackageImportPlanInput,
   type WorkspacePackageImportPlanOptions,
   type WorkspacePackageImportPlanPreflightInput,
-} from "./importPlan";
+} from "../planning/importPlan";
 
 export type WorkspacePackageImportConfirmInput = Readonly<{
   userId: string;

--- a/apps/backend/src/workspacePackages/import/media/importMedia.test.ts
+++ b/apps/backend/src/workspacePackages/import/media/importMedia.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import { HttpError } from "../../shared/errors";
+import { HttpError } from "../../../shared/errors";
 import {
   loadWorkspacePackageImportReferencedMedia,
   loadWorkspacePackageImportReferencedMediaWithLimits,
@@ -10,11 +10,11 @@ import {
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageImportReferencedMediaInput,
   type WorkspacePackageImportReferencedMediaLimits,
-} from "../index";
+} from "../../index";
 import {
   createPackageZip,
   createStoredZip,
-} from "./testZipHelpers";
+} from "../testZipHelpers";
 
 const testMetadata: WorkspacePackageCardMetadataV1 = {
   version: 1,

--- a/apps/backend/src/workspacePackages/import/media/importMedia.ts
+++ b/apps/backend/src/workspacePackages/import/media/importMedia.ts
@@ -13,8 +13,8 @@ import {
   readWorkspacePackageZipEntryBytes,
   type CollectedWorkspacePackageZip,
   type WorkspacePackageImportZipLimits,
-} from "./importZip";
-import type { WorkspacePackageCardsJsonV1 } from "../types";
+} from "../importZip";
+import type { WorkspacePackageCardsJsonV1 } from "../../types";
 
 export type WorkspacePackageImportReferencedMediaInput = Readonly<{
   packageBytes: Buffer | Uint8Array;

--- a/apps/backend/src/workspacePackages/import/media/importMediaAssets.test.ts
+++ b/apps/backend/src/workspacePackages/import/media/importMediaAssets.test.ts
@@ -4,13 +4,13 @@ import test from "node:test";
 import {
   imageJpegCardMediaBlobMimeType,
   type MediaAsset,
-} from "../../mediaAssets/types";
+} from "../../../mediaAssets/types";
 import type {
   ImageMediaAssetIngestionInput,
   ImageMediaAssetIngestionResult,
-} from "../../mediaAssets/ingestion";
-import type { BackendObservationScope } from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
+} from "../../../mediaAssets/ingestion";
+import type { BackendObservationScope } from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
 import {
   ingestWorkspacePackageImportMediaAssetsWithDependencies,
   type WorkspacePackageImportMediaAssetIngestionDependencies,
@@ -21,7 +21,7 @@ import {
   type WorkspacePackageCardMetadataV1,
   type WorkspacePackageImportMediaAssetIngestionInput,
   type WorkspacePackageImportReferencedMediaFile,
-} from "../index";
+} from "../../index";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";

--- a/apps/backend/src/workspacePackages/import/media/importMediaAssets.ts
+++ b/apps/backend/src/workspacePackages/import/media/importMediaAssets.ts
@@ -3,11 +3,11 @@ import {
   ingestImageMediaAsset,
   type ImageMediaAssetIngestionInput,
   type ImageMediaAssetIngestionResult,
-} from "../../mediaAssets/ingestion";
-import type { MediaAsset } from "../../mediaAssets/types";
-import type { BackendObservationScope } from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
-import { validateUniquePortableMediaPaths } from "../markdownMedia";
+} from "../../../mediaAssets/ingestion";
+import type { MediaAsset } from "../../../mediaAssets/types";
+import type { BackendObservationScope } from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
+import { validateUniquePortableMediaPaths } from "../../markdownMedia";
 import type { WorkspacePackageImportReferencedMediaFile } from "./importMedia";
 
 export type WorkspacePackageImportMediaAssetIngestionInput = Readonly<{

--- a/apps/backend/src/workspacePackages/import/planning/importPlan.test.ts
+++ b/apps/backend/src/workspacePackages/import/planning/importPlan.test.ts
@@ -6,7 +6,7 @@ import {
   type WorkspacePackageCardSourceMetadataV1,
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageImportPlanOptions,
-} from "../index";
+} from "../../index";
 
 const importedAt = "2026-06-30T12:00:00.000Z";
 const importId = "import-session-1";

--- a/apps/backend/src/workspacePackages/import/planning/importPlan.ts
+++ b/apps/backend/src/workspacePackages/import/planning/importPlan.ts
@@ -1,14 +1,14 @@
-import { normalizeIsoTimestamp } from "../../sync/conflicts/lww";
+import { normalizeIsoTimestamp } from "../../../sync/conflicts/lww";
 import {
   rewriteMarkdownPortableMediaUrlsToFcAssets,
-} from "../markdownMedia";
+} from "../../markdownMedia";
 import {
   parseWorkspacePackageCardsJsonV1,
   type PortableWorkspacePackageCardV1,
   type WorkspacePackageCardMetadataV1,
   type WorkspacePackageCardSourceMetadataV1,
   type WorkspacePackageCardsJsonV1,
-} from "../types";
+} from "../../types";
 
 export type WorkspacePackageImportPlanOptions = Readonly<{
   addImportTag: boolean;

--- a/apps/backend/src/workspacePackages/import/planning/importPreview.test.ts
+++ b/apps/backend/src/workspacePackages/import/planning/importPreview.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import test from "node:test";
-import { HttpError } from "../../shared/errors";
+import { HttpError } from "../../../shared/errors";
 import {
   buildSuggestedWorkspacePackageImportTag,
   createDefaultWorkspacePackageImportTagPolicy,
@@ -12,13 +12,13 @@ import {
   type WorkspacePackageCardMetadataV1,
   type WorkspacePackageCardsJsonV1,
   type WorkspacePackageImportPreviewInput,
-} from "../index";
+} from "../../index";
 import {
   createCardsJsonBuffer,
   createDeflatedZipEntry,
   createPackageZip,
   createStoredZip,
-} from "./testZipHelpers";
+} from "../testZipHelpers";
 
 const generatedAt = "2026-06-30T12:00:00.000Z";
 

--- a/apps/backend/src/workspacePackages/import/planning/importPreview.ts
+++ b/apps/backend/src/workspacePackages/import/planning/importPreview.ts
@@ -18,11 +18,11 @@ import {
   workspacePackageImportZipDefaultMaxZipBytes,
   type CollectedWorkspacePackageZip,
   type WorkspacePackageImportZipLimits,
-} from "./importZip";
+} from "../importZip";
 import type {
   PortableWorkspacePackageCardV1,
   WorkspacePackageCardsJsonV1,
-} from "../types";
+} from "../../types";
 
 export const workspacePackageImportPreviewDefaultMaxZipBytes = workspacePackageImportZipDefaultMaxZipBytes;
 export const workspacePackageImportPreviewDefaultMaxEntries = workspacePackageImportZipDefaultMaxEntries;

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -44,28 +44,28 @@ export {
   workspacePackageImportPreviewDefaultMaxSingleMediaBytes,
   workspacePackageImportPreviewDefaultMaxTotalMediaBytes,
   workspacePackageImportPreviewDefaultMaxZipBytes,
-} from "./import/importPreview";
+} from "./import/planning/importPreview";
 
 export {
   loadWorkspacePackageImportReferencedMedia,
   loadWorkspacePackageImportReferencedMediaWithLimits,
-} from "./import/importMedia";
+} from "./import/media/importMedia";
 
 export {
   ingestWorkspacePackageImportMediaAssets,
-} from "./import/importMediaAssets";
+} from "./import/media/importMediaAssets";
 
 export {
   persistWorkspacePackageImportCards,
-} from "./import/importCards";
+} from "./import/apply/importCards";
 
 export {
   planWorkspacePackageImport,
-} from "./import/importPlan";
+} from "./import/planning/importPlan";
 
 export {
   confirmWorkspacePackageImport,
-} from "./import/importConfirm";
+} from "./import/apply/importConfirm";
 
 export type {
   WorkspacePackageExportCardSelection,
@@ -93,26 +93,26 @@ export type {
   WorkspacePackageImportPreviewWarning,
   WorkspacePackageImportTagPolicy,
   WorkspacePackageImportTagPolicyInput,
-} from "./import/importPreview";
+} from "./import/planning/importPreview";
 
 export type {
   WorkspacePackageImportReferencedMediaFile,
   WorkspacePackageImportReferencedMediaInput,
   WorkspacePackageImportReferencedMediaLimits,
   WorkspacePackageImportReferencedMediaLoadResult,
-} from "./import/importMedia";
+} from "./import/media/importMedia";
 
 export type {
   WorkspacePackageImportedMediaAsset,
   WorkspacePackageImportMediaAssetIngestionInput,
   WorkspacePackageImportMediaAssetIngestionResult,
-} from "./import/importMediaAssets";
+} from "./import/media/importMediaAssets";
 
 export type {
   WorkspacePackageImportCardPersistenceInput,
   WorkspacePackageImportCardPersistenceResult,
   WorkspacePackageImportCardPersistenceSummary,
-} from "./import/importCards";
+} from "./import/apply/importCards";
 
 export type {
   WorkspacePackageImportPlan,
@@ -120,13 +120,13 @@ export type {
   WorkspacePackageImportPlanOptions,
   WorkspacePackageImportPlanSummary,
   WorkspacePackageImportPlannedCard,
-} from "./import/importPlan";
+} from "./import/planning/importPlan";
 
 export type {
   WorkspacePackageImportConfirmInput,
   WorkspacePackageImportConfirmResult,
   WorkspacePackageImportConfirmSummary,
-} from "./import/importConfirm";
+} from "./import/apply/importConfirm";
 
 export {
   normalizeWorkspacePackageCardMetadataV1,


### PR DESCRIPTION
## Summary
- Move workspace package import planning modules into import/planning
- Move referenced media ingestion modules into import/media
- Move apply and confirm persistence modules into import/apply
- Preserve public workspace package exports through the existing barrel

## Validation
- git --no-pager diff --check
- npm --prefix apps/backend run lint
- cd apps/backend && node --test --import tsx src/workspacePackages/import/planning/importPlan.test.ts src/workspacePackages/import/planning/importPreview.test.ts src/workspacePackages/import/media/importMedia.test.ts src/workspacePackages/import/media/importMediaAssets.test.ts src/workspacePackages/import/apply/importCards.test.ts src/workspacePackages/import/apply/importConfirm.test.ts

Note: npm ci emitted a local engine warning because this machine uses Node v25.6.1 while the backend declares Node 24.x.