### PR TITLE
Refactor media asset workflows

### DIFF
--- a/apps/backend/src/mediaAssets/ingestion/imageNormalization.test.ts
+++ b/apps/backend/src/mediaAssets/ingestion/imageNormalization.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import sharp from "sharp";
-import { HttpError } from "../shared/errors";
+import { HttpError } from "../../shared/errors";
 import {
   imageJpegCardMaxSidePixels,
   imageJpegCardTransparentPixelLightCardGray,
   normalizeImageBytesForCard,
 } from "./imageNormalization";
-import { imageJpegCardMediaBlobMimeType } from "./types";
+import { imageJpegCardMediaBlobMimeType } from "../types";
 
 type RgbPixel = Readonly<{
   red: number;

--- a/apps/backend/src/mediaAssets/ingestion/imageNormalization.ts
+++ b/apps/backend/src/mediaAssets/ingestion/imageNormalization.ts
@@ -1,6 +1,6 @@
 import sharp, { type Metadata } from "sharp";
-import { HttpError } from "../shared/errors";
-import { imageJpegCardMediaBlobMimeType } from "./types";
+import { HttpError } from "../../shared/errors";
+import { imageJpegCardMediaBlobMimeType } from "../types";
 
 export const imageJpegCardMaxSidePixels = 1_200;
 export const imageJpegCardJpegQuality = 82;

--- a/apps/backend/src/mediaAssets/ingestion/index.test.ts
+++ b/apps/backend/src/mediaAssets/ingestion/index.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
-import { createBackendObservationScope } from "../observability/sentry";
-import { ingestImageMediaAssetWithDependencies, type ImageMediaAssetIngestionDependencies } from "./ingestion";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+import { createBackendObservationScope } from "../../observability/sentry";
+import { ingestImageMediaAssetWithDependencies, type ImageMediaAssetIngestionDependencies } from "./index";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 import {
   imageJpegCardMediaBlobMimeType,
   imageJpegCardMediaBlobNormalizationVersion,
@@ -12,7 +12,7 @@ import {
   type MediaAssetImageIngestionMetadataInput,
   type MediaBlob,
   type NormalizedImageMediaAssetInput,
-} from "./types";
+} from "../types";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";

--- a/apps/backend/src/mediaAssets/ingestion/index.ts
+++ b/apps/backend/src/mediaAssets/ingestion/index.ts
@@ -2,9 +2,9 @@ import { createHash } from "node:crypto";
 import {
   createImageNormalizedMediaAssetForWorkspace,
   loadReusableImageMediaBlobForWorkspace,
-} from ".";
-import { storeMediaAssetBlobBytesIfAbsent } from "./storage";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+} from "..";
+import { storeMediaAssetBlobBytesIfAbsent } from "../storage";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 import {
   normalizeImageBytesForCard,
   type NormalizedImageBytes,
@@ -13,8 +13,8 @@ import type {
   MediaAsset,
   MediaAssetImageIngestionMetadataInput,
   NormalizedImageMediaAssetInput,
-} from "./types";
-import type { BackendObservationScope } from "../observability/sentry";
+} from "../types";
+import type { BackendObservationScope } from "../../observability/sentry";
 
 export type ImageMediaAssetIngestionInput = Readonly<{
   userId: string;

--- a/apps/backend/src/mediaAssets/uploadSessions/index.test.ts
+++ b/apps/backend/src/mediaAssets/uploadSessions/index.test.ts
@@ -1,17 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../database";
-import { HttpError } from "../shared/errors";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { HttpError } from "../../shared/errors";
 import {
   beginMediaAssetUploadSessionCompletionInExecutor,
   recoverMediaAssetUploadSessionCompletionInExecutor,
-} from "./uploadSessions";
+} from "./index";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "./storageKeys";
-import type { MediaAssetUploadSessionRow } from "./types";
+} from "../storageKeys";
+import type { MediaAssetUploadSessionRow } from "../types";
 
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
 const testMediaAssetId = "22222222-2222-4222-8222-222222222222";

--- a/apps/backend/src/mediaAssets/uploadSessions/index.ts
+++ b/apps/backend/src/mediaAssets/uploadSessions/index.ts
@@ -2,8 +2,8 @@ import {
   queryWithWorkspaceScopeReadOnly,
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
-} from "../database";
-import { HttpError } from "../shared/errors";
+} from "../../database";
+import { HttpError } from "../../shared/errors";
 import {
   assertMediaBlobMatchesInput,
   findMediaAssetRowForUpdateInExecutor,
@@ -15,7 +15,7 @@ import {
   toOptionalIsoString,
   toSafeNumber,
   upsertMediaAssetSnapshotInExecutor,
-} from "./persistence";
+} from "../persistence";
 import type {
   MediaAsset,
   MediaAssetMutationMetadata,
@@ -29,8 +29,8 @@ import type {
   MediaAssetUploadSessionRow,
   MediaAssetUploadSessionState,
   MediaBlobRow,
-} from "./types";
-import { assertReplicaBelongsToWorkspaceInExecutor } from "./workspaceReplicas";
+} from "../types";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../workspaceReplicas";
 
 const MEDIA_UPLOAD_SESSION_COLUMNS = [
   "media_upload_session_id",


### PR DESCRIPTION
## Summary
- Move media upload session workflow into mediaAssets/uploadSessions/index.ts
- Move image ingestion and normalization workflow into mediaAssets/ingestion/
- Preserve existing media asset package import paths through folder entrypoints

## Validation
- git --no-pager diff --check
- git --no-pager diff HEAD --check
- npm --prefix apps/backend run lint
- cd apps/backend && node --test --import tsx src/mediaAssets/uploadSessions/index.test.ts src/mediaAssets/ingestion/index.test.ts src/mediaAssets/ingestion/imageNormalization.test.ts src/mediaAssets/index.test.ts