### PR TITLE
Fix web AI chat terminal reconciliation

### DIFF
--- a/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.post-run-sync.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.post-run-sync.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { act } from "react";
 import { describe, expect, it, vi } from "vitest";
 import {
   consumeChatLiveStreamMock,
@@ -347,6 +348,95 @@ describe("ChatPanel post-run sync", () => {
     await flushAsync();
     await flushAsync();
 
+    expect(runSyncMock).toHaveBeenCalledTimes(2);
+    expect(refreshLocalDataMock).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a terminal snapshot when assistant_message_done is not followed by run_terminal", async () => {
+    const refreshLocalDataMock = vi.fn(async (): Promise<void> => undefined);
+    const runSyncMock = vi.fn(async (): Promise<void> => undefined);
+    let snapshotRequestCount = 0;
+    useAppDataMock.mockReturnValue(createVerifiedWorkspaceAppDataMock({
+      refreshLocalData: refreshLocalDataMock,
+      runSync: runSyncMock,
+      setErrorMessage: vi.fn(),
+    }));
+    getChatSnapshotMock.mockImplementation(async (sessionId: string) => {
+      snapshotRequestCount += 1;
+      if (snapshotRequestCount === 1) {
+        return createChatSnapshot({
+          sessionId,
+          conversationScopeId: sessionId,
+        });
+      }
+
+      return createChatSnapshot({
+        sessionId,
+        conversationScopeId: sessionId,
+        activeRun: null,
+        conversation: {
+          updatedAt: 2,
+          mainContentInvalidationVersion: 0,
+          messages: [createCompletedToolCallAssistantMessage({
+            timestamp: 2,
+            isStopped: false,
+            itemId: "item-1",
+            cursor: "cursor-2",
+          })],
+        },
+      });
+    });
+    consumeChatLiveStreamMock.mockImplementation(({ onEvent, runId, sessionId }) => {
+      onEvent({
+        type: "assistant_tool_call",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId,
+        sequenceNumber: 1,
+        streamEpoch: "epoch-1",
+        cursor: "cursor-1",
+        toolCallId: "tool-1",
+        itemId: "item-1",
+        outputIndex: 0,
+        name: "agent_sql",
+        status: "started",
+        input: "update cards set back_text = 'Updated answer'",
+        output: "{\"ok\":true}",
+        providerStatus: null,
+      });
+      onEvent({
+        type: "assistant_message_done",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId,
+        sequenceNumber: 2,
+        streamEpoch: "epoch-1",
+        cursor: "cursor-2",
+        itemId: "item-1",
+        content: [{ type: "text", text: "Updated." }],
+        isError: false,
+        isStopped: false,
+      });
+      return new Promise<void>(() => undefined);
+    });
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("update the current card");
+    await flushAsync();
+    await flushAsync();
+
+    expect(runSyncMock).toHaveBeenCalledTimes(1);
+    expect(refreshLocalDataMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+    await flushAsync();
+    await flushAsync();
+
+    expect(getChatSnapshotMock).toHaveBeenCalledTimes(2);
     expect(runSyncMock).toHaveBeenCalledTimes(2);
     expect(refreshLocalDataMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
@@ -39,6 +39,8 @@ import { useChatLiveSession } from "./useLiveSession";
 import type { ChatHistoryState } from "../../history/useChatHistory";
 import type { ChatLiveEvent } from "../../streaming/liveStream";
 
+const assistantMessageDoneTerminalReconcileDelayMs = 5_000;
+
 type UseChatSessionSnapshotSyncParams = Readonly<{
   controllerId: string;
   workspaceId: string | null;
@@ -432,6 +434,7 @@ export function useChatSessionSnapshotSync(
   const activeToolRunPostSyncPromiseRef = useRef<Promise<void> | null>(null);
   const liveCursorRef = useRef<string | null>(null);
   const resumeAttemptCounterRef = useRef<number>(0);
+  const assistantMessageDoneTerminalReconcileTimerRef = useRef<number | null>(null);
   const reconcileTerminalSnapshotRef = useRef<(sessionId: string | null) => void>(() => {});
   const pendingToolRunPostSyncRef = useRef<boolean>(state.pendingToolRunPostSync);
 
@@ -470,11 +473,41 @@ export function useChatSessionSnapshotSync(
     snapshotRequestVersionRef.current += 1;
   }, []);
 
+  const clearAssistantMessageDoneTerminalReconcileTimer = useCallback((): void => {
+    const timerId = assistantMessageDoneTerminalReconcileTimerRef.current;
+    if (timerId === null) {
+      return;
+    }
+
+    window.clearTimeout(timerId);
+    assistantMessageDoneTerminalReconcileTimerRef.current = null;
+  }, []);
+
+  const scheduleAssistantMessageDoneTerminalReconcile = useCallback((
+    sessionId: string,
+    runId: string,
+  ): void => {
+    clearAssistantMessageDoneTerminalReconcileTimer();
+    assistantMessageDoneTerminalReconcileTimerRef.current = window.setTimeout((): void => {
+      assistantMessageDoneTerminalReconcileTimerRef.current = null;
+      if (
+        currentSessionIdRef.current !== sessionId
+        || runStateRef.current !== "running"
+        || activeRunIdRef.current !== runId
+      ) {
+        return;
+      }
+
+      reconcileTerminalSnapshotRef.current(sessionId);
+    }, assistantMessageDoneTerminalReconcileDelayMs);
+  }, [clearAssistantMessageDoneTerminalReconcileTimer]);
+
   const resetSnapshotTracking = useCallback((updatedAt: number | null): void => {
+    clearAssistantMessageDoneTerminalReconcileTimer();
     lastSnapshotUpdatedAtRef.current = updatedAt;
     activeRunIdRef.current = null;
     liveCursorRef.current = null;
-  }, []);
+  }, [clearAssistantMessageDoneTerminalReconcileTimer]);
 
   const nextResumeAttemptId = useCallback((): number => {
     const nextAttemptId = resumeAttemptCounterRef.current + 1;
@@ -583,6 +616,7 @@ export function useChatSessionSnapshotSync(
         event.isStopped,
       );
       if (didFinish === false) {
+        clearAssistantMessageDoneTerminalReconcileTimer();
         reconcileTerminalSnapshotRef.current(event.sessionId);
         return;
       }
@@ -590,6 +624,7 @@ export function useChatSessionSnapshotSync(
       // The live protocol can finalize the assistant message before the run
       // itself becomes terminal. Keep the run active until run_terminal (or a
       // terminal snapshot recovery path) so post-run sync stays terminal-only.
+      scheduleAssistantMessageDoneTerminalReconcile(event.sessionId, event.runId);
       return;
     }
 
@@ -610,6 +645,7 @@ export function useChatSessionSnapshotSync(
       return;
     }
 
+    clearAssistantMessageDoneTerminalReconcileTimer();
     setKnownActiveRunId(null);
 
     if (event.outcome === "reset_required") {
@@ -630,12 +666,14 @@ export function useChatSessionSnapshotSync(
     });
   }, [
     appendAssistantText,
+    clearAssistantMessageDoneTerminalReconcileTimer,
     completeAssistantReasoningSummary,
     dispatch,
     finishAssistantMessage,
     markPendingToolRunPostSync,
     state.currentSessionId,
     state.mainContentInvalidationVersion,
+    scheduleAssistantMessageDoneTerminalReconcile,
     triggerToolRunPostSyncIfNeeded,
     uiMessages,
     setKnownActiveRunId,
@@ -777,6 +815,7 @@ export function useChatSessionSnapshotSync(
       dispatch({ type: "live_attach_connected" });
     },
     onUnexpectedStreamEnd: (sessionId, runId) => {
+      clearAssistantMessageDoneTerminalReconcileTimer();
       dispatch({
         type: "stop_finished",
         runState: runStateRef.current,
@@ -1010,6 +1049,10 @@ export function useChatSessionSnapshotSync(
   useEffect(() => {
     reconcileTerminalSnapshotRef.current = reconcileTerminalSnapshot;
   }, [reconcileTerminalSnapshot]);
+
+  useEffect(() => () => {
+    clearAssistantMessageDoneTerminalReconcileTimer();
+  }, [clearAssistantMessageDoneTerminalReconcileTimer]);
 
   return {
     isLiveStreamConnected,


### PR DESCRIPTION
## Summary
- add delayed terminal snapshot reconciliation after assistant_message_done when run_terminal is missing
- cover the post-run sync recovery path with a focused ChatPanel lifecycle regression

## Verification
- npm --prefix apps/web exec -- vitest run src/chat/ChatPanel/tests/lifecycle/ChatPanel.post-run-sync.test.tsx
- npm --prefix apps/web run build