### PR TITLE
Fix empty iOS sync diagnostics error

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+SyncDiagnostics.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+SyncDiagnostics.swift
@@ -160,11 +160,13 @@ extension LocalDatabase {
                 ),
                 latestMediaTransferError: try self.core.scalarOptionalText(
                     sql: """
-                    SELECT last_error
-                    FROM media_transfer_queue
-                    WHERE workspace_id = ? AND last_error IS NOT NULL
-                    ORDER BY updated_at DESC, transfer_id ASC
-                    LIMIT 1
+                    SELECT (
+                        SELECT last_error
+                        FROM media_transfer_queue
+                        WHERE workspace_id = ? AND last_error IS NOT NULL
+                        ORDER BY updated_at DESC, transfer_id ASC
+                        LIMIT 1
+                    )
                     """,
                     values: [.text(workspaceId)]
                 )


### PR DESCRIPTION
## Summary
- make the latest media-transfer error query return one nullable row
- preserve the workspace/error filters and deterministic ordering

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+SyncDiagnostics.swift
- fresh read-only review: no P0-P4 findings