### PR TITLE
Add web workspace action dialogs

### DIFF
--- a/apps/web/e2e/live-smoke/flows/auth-workspace.ts
+++ b/apps/web/e2e/live-smoke/flows/auth-workspace.ts
@@ -91,7 +91,7 @@ async function createEphemeralWorkspace(session: LiveSmokeSession): Promise<void
     "open current workspace settings",
     page.getByTestId("settings-row-current-workspace"),
   );
-  const workspaceActionCard = page.locator(".settings-nav-card-button[data-workspace-management-state]").first();
+  const workspaceActionCard = page.getByTestId("workspace-change-open");
   await trackedExpectAttribute(
     diagnostics,
     "wait for workspace management readiness",
@@ -100,23 +100,28 @@ async function createEphemeralWorkspace(session: LiveSmokeSession): Promise<void
     "ready",
     externalUiTimeoutMs,
   );
-  await trackedClick(diagnostics, "expand workspace picker card", workspaceActionCard);
+  await trackedClick(diagnostics, "open change workspace dialog", workspaceActionCard);
   await trackedExpectVisible(
     diagnostics,
-    "confirm workspace picker is visible",
-    page.locator(".settings-workspace-picker"),
+    "confirm change workspace dialog is visible",
+    page.getByTestId("workspace-change-dialog"),
     externalUiTimeoutMs,
   );
   await trackedClick(
     diagnostics,
     "open new workspace form",
-    page.locator(".settings-workspace-picker > button.ghost-btn").first(),
+    page.getByTestId("workspace-create-open"),
   );
-  await trackedFill(diagnostics, `fill workspace name ${scenario.workspaceName}`, page.locator(".settings-workspace-create-input"), scenario.workspaceName);
+  await trackedFill(
+    diagnostics,
+    `fill workspace name ${scenario.workspaceName}`,
+    page.getByTestId("workspace-create-name-input"),
+    scenario.workspaceName,
+  );
   await trackedClick(
     diagnostics,
     `submit workspace creation for ${scenario.workspaceName}`,
-    page.locator(".settings-workspace-create-actions .primary-btn"),
+    page.getByTestId("workspace-create-submit"),
   );
   await trackedExpectText(
     diagnostics,

--- a/apps/web/e2e/live-smoke/flows/reset-progress.ts
+++ b/apps/web/e2e/live-smoke/flows/reset-progress.ts
@@ -171,7 +171,7 @@ async function ensureScenarioWorkspaceSelected(
       `open current workspace settings while recovering workspace ${actionSuffix}`,
       page.getByTestId("settings-row-current-workspace"),
     );
-    const workspaceActionCard = page.locator(".settings-nav-card-button[data-workspace-management-state]").first();
+    const workspaceActionCard = page.getByTestId("workspace-change-open");
     await trackedExpectAttribute(
       diagnostics,
       `wait for workspace picker readiness while recovering workspace ${actionSuffix}`,
@@ -182,19 +182,21 @@ async function ensureScenarioWorkspaceSelected(
     );
     await trackedClick(
       diagnostics,
-      `expand workspace picker while recovering workspace ${actionSuffix}`,
+      `open change workspace dialog while recovering workspace ${actionSuffix}`,
       workspaceActionCard,
     );
     await trackedExpectVisible(
       diagnostics,
-      `confirm workspace picker is visible while recovering workspace ${actionSuffix}`,
-      page.locator(".settings-workspace-picker"),
+      `confirm change workspace dialog is visible while recovering workspace ${actionSuffix}`,
+      page.getByTestId("workspace-change-dialog"),
       externalUiTimeoutMs,
     );
     await trackedClick(
       diagnostics,
       `select scenario workspace ${scenario.workspaceName} while recovering workspace ${actionSuffix}`,
-      page.locator(".settings-workspace-choice").filter({ hasText: scenario.workspaceName }).first(),
+      page.locator(
+        `[data-testid="workspace-change-choice"][data-workspace-name=${JSON.stringify(scenario.workspaceName)}]`,
+      ),
     );
   }
 

--- a/apps/web/src/appError/AppErrorDialog.tsx
+++ b/apps/web/src/appError/AppErrorDialog.tsx
@@ -8,10 +8,56 @@ export type AppErrorDialogProps = Readonly<{
   onDismiss: () => void;
 }>;
 
+const appErrorDialogFocusableSelector: string = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "summary",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusableElements(dialog: HTMLElement): ReadonlyArray<HTMLElement> {
+  return Array.from(dialog.querySelectorAll<HTMLElement>(appErrorDialogFocusableSelector))
+    .filter((element) => element.tabIndex >= 0 && element.getAttribute("aria-hidden") !== "true");
+}
+
+function trapFocusInsideDialog(event: KeyboardEvent, dialog: HTMLElement): void {
+  const focusableElements = getFocusableElements(dialog);
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  if (firstElement === undefined || lastElement === undefined) {
+    event.preventDefault();
+    dialog.focus();
+    return;
+  }
+
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement) || dialog.contains(activeElement) === false) {
+    event.preventDefault();
+    (event.shiftKey ? lastElement : firstElement).focus();
+    return;
+  }
+
+  if (event.shiftKey && activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus();
+    return;
+  }
+
+  if (event.shiftKey === false && activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus();
+  }
+}
+
 export function AppErrorDialog(props: AppErrorDialogProps): ReactElement | null {
   const { presentation, onDismiss } = props;
   const { t } = useI18n();
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -26,13 +72,23 @@ export function AppErrorDialog(props: AppErrorDialogProps): ReactElement | null 
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
         onDismiss();
+        return;
+      }
+
+      if (event.key === "Tab") {
+        event.stopImmediatePropagation();
+        if (dialogRef.current !== null) {
+          trapFocusInsideDialog(event, dialogRef.current);
+        }
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
     return (): void => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
       previousFocusRef.current?.focus();
       previousFocusRef.current = null;
     };
@@ -51,11 +107,13 @@ export function AppErrorDialog(props: AppErrorDialogProps): ReactElement | null 
   return createPortal(
     <div className="app-error-dialog-backdrop" onMouseDown={dismissFromBackdrop}>
       <section
+        ref={dialogRef}
         className="panel app-error-dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="app-error-dialog-title"
         aria-describedby="app-error-dialog-message"
+        tabIndex={-1}
         data-testid="app-error-dialog"
       >
         <div className="cell-stack">

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -450,8 +450,10 @@ const arCatalog: TranslationCatalog = {
   settingsCurrentWorkspace: {
     title: "مساحة العمل",
     subtitle: "اختر مساحة العمل النشطة في هذا المتصفح أو أنشئ مساحة عمل جديدة لهذا الحساب.",
-    workspaceCardTitle: "مساحة العمل",
-    workspaceCardDescription: "غيّر مساحة العمل النشطة أو أنشئ مساحة عمل جديدة لهذا الحساب.",
+    currentWorkspaceLabel: "مساحة العمل الحالية",
+    changeWorkspaceTitle: "تغيير مساحة العمل",
+    changeWorkspaceDescription: "بدّل مساحة العمل النشطة أو أنشئ مساحة عمل جديدة لهذا الحساب.",
+    changeWorkspaceDialogDescription: "اختر مساحة عمل مرتبطة أو أنشئ مساحة عمل جديدة لهذا الحساب.",
     newWorkspace: "مساحة عمل جديدة",
     workspaceNamePlaceholder: "اسم مساحة العمل",
     workspaceNameRequired: "اسم مساحة العمل مطلوب",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -450,8 +450,10 @@ const deCatalog: TranslationCatalog = {
   settingsCurrentWorkspace: {
     title: "Arbeitsbereich",
     subtitle: "Wähle, welcher Arbeitsbereich in diesem Browser aktiv ist, oder erstelle einen neuen Arbeitsbereich für dieses Konto.",
-    workspaceCardTitle: "Arbeitsbereich",
-    workspaceCardDescription: "Ändere den aktiven Arbeitsbereich oder erstelle einen neuen Arbeitsbereich für dieses Konto.",
+    currentWorkspaceLabel: "Aktueller Arbeitsbereich",
+    changeWorkspaceTitle: "Arbeitsbereich wechseln",
+    changeWorkspaceDescription: "Wechsle den aktiven Arbeitsbereich oder erstelle einen neuen Arbeitsbereich für dieses Konto.",
+    changeWorkspaceDialogDescription: "Wähle einen verknüpften Arbeitsbereich oder erstelle einen neuen Arbeitsbereich für dieses Konto.",
     newWorkspace: "Neuer Arbeitsbereich",
     workspaceNamePlaceholder: "Name des Arbeitsbereichs",
     workspaceNameRequired: "Der Name des Arbeitsbereichs ist erforderlich",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -448,8 +448,10 @@ const enCatalog = {
   settingsCurrentWorkspace: {
     title: "Workspace",
     subtitle: "Choose which workspace is active in this browser or create a new workspace for this account.",
-    workspaceCardTitle: "Workspace",
-    workspaceCardDescription: "Change the active workspace or create a new workspace for this account.",
+    currentWorkspaceLabel: "Current workspace",
+    changeWorkspaceTitle: "Change workspace",
+    changeWorkspaceDescription: "Switch the active workspace or create a new workspace for this account.",
+    changeWorkspaceDialogDescription: "Choose a linked workspace or create a new workspace for this account.",
     newWorkspace: "New workspace",
     workspaceNamePlaceholder: "Workspace name",
     workspaceNameRequired: "Workspace name is required",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -450,8 +450,10 @@ const esEsCatalog: TranslationCatalog = {
   settingsCurrentWorkspace: {
     title: "Espacio de trabajo",
     subtitle: "Elige qué espacio de trabajo está activo en este navegador o crea uno nuevo para esta cuenta.",
-    workspaceCardTitle: "Espacio de trabajo",
-    workspaceCardDescription: "Cambia el espacio de trabajo activo o crea uno nuevo para esta cuenta.",
+    currentWorkspaceLabel: "Espacio de trabajo actual",
+    changeWorkspaceTitle: "Cambiar de espacio de trabajo",
+    changeWorkspaceDescription: "Cambia el espacio de trabajo activo o crea uno nuevo para esta cuenta.",
+    changeWorkspaceDialogDescription: "Elige un espacio de trabajo vinculado o crea uno nuevo para esta cuenta.",
     newWorkspace: "Nuevo espacio de trabajo",
     workspaceNamePlaceholder: "Nombre del espacio de trabajo",
     workspaceNameRequired: "El nombre del espacio de trabajo es obligatorio",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -450,8 +450,10 @@ const esMxCatalog: TranslationCatalog = {
   settingsCurrentWorkspace: {
     title: "Espacio de trabajo",
     subtitle: "Elige qué espacio de trabajo está activo en este navegador o crea uno nuevo para esta cuenta.",
-    workspaceCardTitle: "Espacio de trabajo",
-    workspaceCardDescription: "Cambia el espacio de trabajo activo o crea uno nuevo para esta cuenta.",
+    currentWorkspaceLabel: "Espacio de trabajo actual",
+    changeWorkspaceTitle: "Cambiar de espacio de trabajo",
+    changeWorkspaceDescription: "Cambia el espacio de trabajo activo o crea uno nuevo para esta cuenta.",
+    changeWorkspaceDialogDescription: "Elige un espacio de trabajo vinculado o crea uno nuevo para esta cuenta.",
     newWorkspace: "Nuevo espacio de trabajo",
     workspaceNamePlaceholder: "Nombre del espacio de trabajo",
     workspaceNameRequired: "El nombre del espacio de trabajo es obligatorio",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -450,8 +450,10 @@ const hiCatalog: TranslationCatalog = {
   settingsCurrentWorkspace: {
     title: "वर्कस्पेस",
     subtitle: "चुनें कि इस ब्राउज़र में कौन-सा वर्कस्पेस सक्रिय है या इस खाते के लिए नया वर्कस्पेस बनाएँ।",
-    workspaceCardTitle: "वर्कस्पेस",
-    workspaceCardDescription: "सक्रिय वर्कस्पेस बदलें या इस खाते के लिए नया वर्कस्पेस बनाएँ।",
+    currentWorkspaceLabel: "मौजूदा वर्कस्पेस",
+    changeWorkspaceTitle: "वर्कस्पेस बदलें",
+    changeWorkspaceDescription: "सक्रिय वर्कस्पेस बदलें या इस खाते के लिए नया वर्कस्पेस बनाएँ।",
+    changeWorkspaceDialogDescription: "लिंक किया गया वर्कस्पेस चुनें या इस खाते के लिए नया वर्कस्पेस बनाएँ।",
     newWorkspace: "नया वर्कस्पेस",
     workspaceNamePlaceholder: "वर्कस्पेस का नाम",
     workspaceNameRequired: "वर्कस्पेस का नाम आवश्यक है",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -450,8 +450,10 @@ export const jaCatalog = {
   settingsCurrentWorkspace: {
     title: "ワークスペース",
     subtitle: "このブラウザでどのワークスペースをアクティブにするか選ぶか、このアカウント用に新しいワークスペースを作成します。",
-    workspaceCardTitle: "ワークスペース",
-    workspaceCardDescription: "アクティブなワークスペースを切り替えるか、このアカウント用に新しいワークスペースを作成します。",
+    currentWorkspaceLabel: "現在のワークスペース",
+    changeWorkspaceTitle: "ワークスペースを切り替える",
+    changeWorkspaceDescription: "アクティブなワークスペースを切り替えるか、このアカウント用に新しいワークスペースを作成します。",
+    changeWorkspaceDialogDescription: "リンク済みのワークスペースを選ぶか、このアカウント用に新しいワークスペースを作成します。",
     newWorkspace: "新しいワークスペース",
     workspaceNamePlaceholder: "ワークスペース名",
     workspaceNameRequired: "ワークスペース名は必須です",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -450,8 +450,10 @@ export const ruCatalog = {
   settingsCurrentWorkspace: {
     title: "Рабочее пространство",
     subtitle: "Выберите, какое рабочее пространство активно в этом браузере, или создайте новое для этого аккаунта.",
-    workspaceCardTitle: "Рабочее пространство",
-    workspaceCardDescription: "Смените активное рабочее пространство или создайте новое для этого аккаунта.",
+    currentWorkspaceLabel: "Текущее рабочее пространство",
+    changeWorkspaceTitle: "Сменить рабочее пространство",
+    changeWorkspaceDescription: "Смените активное рабочее пространство или создайте новое для этого аккаунта.",
+    changeWorkspaceDialogDescription: "Выберите связанное рабочее пространство или создайте новое для этого аккаунта.",
     newWorkspace: "Новое рабочее пространство",
     workspaceNamePlaceholder: "Название рабочего пространства",
     workspaceNameRequired: "Название рабочего пространства обязательно",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -450,8 +450,10 @@ export const zhHansCatalog = {
   settingsCurrentWorkspace: {
     title: "工作区",
     subtitle: "选择此浏览器中当前活动的工作区，或为此账户创建新的工作区。",
-    workspaceCardTitle: "工作区",
-    workspaceCardDescription: "切换当前活动工作区，或为此账户创建新的工作区。",
+    currentWorkspaceLabel: "当前工作区",
+    changeWorkspaceTitle: "切换工作区",
+    changeWorkspaceDescription: "切换当前活动的工作区，或为此账户创建新的工作区。",
+    changeWorkspaceDialogDescription: "选择已连接的工作区，或为此账户创建新的工作区。",
     newWorkspace: "新建工作区",
     workspaceNamePlaceholder: "工作区名称",
     workspaceNameRequired: "工作区名称为必填项",

--- a/apps/web/src/screens/settings/workspace/CurrentWorkspaceScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/CurrentWorkspaceScreen.tsx
@@ -1,4 +1,11 @@
-import { type FormEvent, type ReactElement, useEffect, useState } from "react";
+import {
+  type FormEvent,
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { ApiContractError } from "../../../api";
 import { useAppData } from "../../../appData";
 import { useAppErrorDialog } from "../../../appError/AppErrorContext";
@@ -8,6 +15,7 @@ import { addWebBreadcrumb } from "../../../observability/webObservability";
 import { useTransientMessage } from "../../../useTransientMessage";
 import { isWorkspaceManagementLocked } from "../../../workspaceManagement";
 import { SettingsActionCard, SettingsGroup, SettingsShell } from "../SettingsShared";
+import { WorkspaceActionDialog } from "./WorkspaceActionDialog";
 
 export function CurrentWorkspaceScreen(): ReactElement {
   const {
@@ -21,16 +29,26 @@ export function CurrentWorkspaceScreen(): ReactElement {
     isSessionVerified,
     cloudSettings,
     renameWorkspace,
+    errorMessage: workspaceActionErrorMessage,
+    technicalError: workspaceActionTechnicalError,
+    setErrorMessage: setWorkspaceActionErrorMessage,
   } = useAppData();
   const { showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatDateTime } = useI18n();
-  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const [isChangeDialogOpen, setIsChangeDialogOpen] = useState<boolean>(false);
   const [isCreating, setIsCreating] = useState<boolean>(false);
   const [newWorkspaceName, setNewWorkspaceName] = useState<string>("");
-  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [changeErrorMessage, setChangeErrorMessage] = useState<string>("");
+  const [pendingWorkspaceId, setPendingWorkspaceId] = useState<string | null>(null);
+  const [isRenameDialogOpen, setIsRenameDialogOpen] = useState<boolean>(false);
   const [workspaceName, setWorkspaceName] = useState<string>("");
   const [renameErrorMessage, setRenameErrorMessage] = useState<string>("");
   const [isRenameSubmitting, setIsRenameSubmitting] = useState<boolean>(false);
+  const changeDialogInitialFocusRef = useRef<HTMLButtonElement | null>(null);
+  const changeDialogOperationFocusRef = useRef<HTMLElement | null>(null);
+  const newWorkspaceNameInputRef = useRef<HTMLInputElement | null>(null);
+  const renameDialogOperationFocusRef = useRef<HTMLElement | null>(null);
+  const renameInputRef = useRef<HTMLInputElement | null>(null);
   const { message, showMessage } = useTransientMessage(3000);
   const isWorkspaceLocked = isWorkspaceManagementLocked(isSessionVerified, cloudSettings);
   const currentWorkspaceName = activeWorkspace?.name ?? t("common.unavailable");
@@ -45,10 +63,58 @@ export function CurrentWorkspaceScreen(): ReactElement {
     || isRenameSubmitting;
   const technicalErrorMessage = t("appError.technicalError.message");
 
-  useEffect(() => {
+  const closeChangeDialog = useCallback(function closeChangeDialog(): void {
+    setIsChangeDialogOpen(false);
+    setIsCreating(false);
+    setNewWorkspaceName("");
+    setChangeErrorMessage("");
+    setPendingWorkspaceId(null);
+    changeDialogOperationFocusRef.current = null;
+  }, []);
+
+  const closeRenameDialog = useCallback(function closeRenameDialog(): void {
+    setIsRenameDialogOpen(false);
     setWorkspaceName(activeWorkspace?.name ?? "");
     setRenameErrorMessage("");
-  }, [activeWorkspace?.name, activeWorkspace?.workspaceId]);
+    renameDialogOperationFocusRef.current = null;
+  }, [activeWorkspace?.name]);
+
+  useEffect(() => {
+    if (isCreating) {
+      newWorkspaceNameInputRef.current?.focus();
+      return;
+    }
+
+    if (isChangeDialogOpen) {
+      changeDialogInitialFocusRef.current?.focus();
+    }
+  }, [isChangeDialogOpen, isCreating]);
+
+  useEffect(() => {
+    if (pendingWorkspaceId === null || isChoosingWorkspace) {
+      return;
+    }
+
+    if (activeWorkspace?.workspaceId === pendingWorkspaceId) {
+      closeChangeDialog();
+      return;
+    }
+
+    if (workspaceActionErrorMessage !== "") {
+      setChangeErrorMessage(
+        workspaceActionTechnicalError === null ? workspaceActionErrorMessage : technicalErrorMessage,
+      );
+      setPendingWorkspaceId(null);
+    }
+  }, [
+    activeWorkspace?.workspaceId,
+    closeChangeDialog,
+    isChoosingWorkspace,
+    pendingWorkspaceId,
+    technicalErrorMessage,
+    workspaceActionErrorMessage,
+    workspaceActionTechnicalError,
+  ]);
 
   function buildWorkspaceInteractionLogDetails(workspaceId: string | null, errorMessage: string | null): Readonly<{
     sessionVerificationState: string;
@@ -72,12 +138,73 @@ export function CurrentWorkspaceScreen(): ReactElement {
     };
   }
 
-  async function handleWorkspaceSelect(workspaceId: string): Promise<void> {
-    setErrorMessage("");
-    await chooseWorkspace(workspaceId);
-    setIsExpanded(false);
+  function showWorkspaceManagementLockedMessage(): void {
+    const details = buildWorkspaceInteractionLogDetails(null, null);
+    addWebBreadcrumb({
+      action: "workspace_transition",
+      scope: {
+        app: "web",
+        feature: "workspace",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        route: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+        requestId: null,
+        statusCode: null,
+        code: null,
+      },
+      details: {
+        eventName: "workspace_management_interaction_blocked",
+        sessionVerificationState: details.sessionVerificationState,
+        isSessionVerified: details.isSessionVerified,
+        cloudState: details.cloudState,
+        workspaceId: details.workspaceId,
+        deletedWorkspaceId: null,
+        replacementWorkspaceId: null,
+        selectedWorkspaceId: details.selectedWorkspaceId,
+        activeWorkspaceId: details.activeWorkspaceId,
+        availableWorkspaceIds: details.availableWorkspaceIds,
+        nextWorkspaceIds: [],
+        redirected: false,
+        errorMessage: details.errorMessage,
+        bootstrapPhase: null,
+        syncRunId: null,
+      },
+    });
+    showMessage(workspaceManagementLockedMessage);
+  }
+
+  function runWorkspaceManagementAction(openDialog: () => void): void {
+    if (isWorkspaceLocked) {
+      showWorkspaceManagementLockedMessage();
+      return;
+    }
+
+    openDialog();
+  }
+
+  function openChangeDialog(): void {
+    setChangeErrorMessage("");
+    setPendingWorkspaceId(null);
     setIsCreating(false);
     setNewWorkspaceName("");
+    changeDialogOperationFocusRef.current = null;
+    setIsChangeDialogOpen(true);
+  }
+
+  function openRenameDialog(): void {
+    setWorkspaceName(activeWorkspace?.name ?? "");
+    setRenameErrorMessage("");
+    renameDialogOperationFocusRef.current = null;
+    setIsRenameDialogOpen(true);
+  }
+
+  async function handleWorkspaceSelect(workspaceId: string, focusTarget: HTMLButtonElement): Promise<void> {
+    setChangeErrorMessage("");
+    setWorkspaceActionErrorMessage("");
+    setPendingWorkspaceId(workspaceId);
+    changeDialogOperationFocusRef.current = focusTarget;
+    await chooseWorkspace(workspaceId);
   }
 
   async function handleCreateWorkspace(event: FormEvent<HTMLFormElement>): Promise<void> {
@@ -85,28 +212,28 @@ export function CurrentWorkspaceScreen(): ReactElement {
 
     const trimmedName = newWorkspaceName.trim();
     if (trimmedName === "") {
-      setErrorMessage(t("settingsCurrentWorkspace.workspaceNameRequired"));
+      setChangeErrorMessage(t("settingsCurrentWorkspace.workspaceNameRequired"));
       return;
     }
 
     try {
-      setErrorMessage("");
+      setChangeErrorMessage("");
+      setWorkspaceActionErrorMessage("");
+      changeDialogOperationFocusRef.current = newWorkspaceNameInputRef.current;
       await createWorkspace(trimmedName);
-      setIsExpanded(false);
-      setIsCreating(false);
-      setNewWorkspaceName("");
+      closeChangeDialog();
     } catch (error) {
       const nextErrorMessage = error instanceof Error ? error.message : String(error);
       const isExpectedError = nextErrorMessage === t("app.sessionUnavailable")
         || nextErrorMessage === t("app.sessionRestoringActionLocked")
         || nextErrorMessage === t("settingsCurrentWorkspace.workspaceNameRequired");
       if (isExpectedError) {
-        setErrorMessage(nextErrorMessage);
+        setChangeErrorMessage(nextErrorMessage);
         return;
       }
 
       showCapturedTechnicalError(error);
-      setErrorMessage(technicalErrorMessage);
+      setChangeErrorMessage(technicalErrorMessage);
     }
   }
 
@@ -135,9 +262,11 @@ export function CurrentWorkspaceScreen(): ReactElement {
 
     setIsRenameSubmitting(true);
     setRenameErrorMessage("");
+    renameDialogOperationFocusRef.current = renameInputRef.current;
 
     try {
       await renameWorkspace(activeWorkspace.workspaceId, trimmedWorkspaceName);
+      closeRenameDialog();
     } catch (error) {
       if (error instanceof ApiContractError === false) {
         const wasCaptured = captureAppOperationError(error, {
@@ -169,165 +298,201 @@ export function CurrentWorkspaceScreen(): ReactElement {
     }
   }
 
-  function handleWorkspaceRowClick(): void {
-    if (isWorkspaceLocked) {
-      const details = buildWorkspaceInteractionLogDetails(null, null);
-      addWebBreadcrumb({
-        action: "workspace_transition",
-        scope: {
-          app: "web",
-          feature: "workspace",
-          userId: session?.userId ?? null,
-          workspaceId: activeWorkspace?.workspaceId ?? null,
-          installationId: cloudSettings?.installationId ?? null,
-          route: `${window.location.pathname}${window.location.search}${window.location.hash}`,
-          requestId: null,
-          statusCode: null,
-          code: null,
-        },
-        details: {
-          eventName: "workspace_management_interaction_blocked",
-          sessionVerificationState: details.sessionVerificationState,
-          isSessionVerified: details.isSessionVerified,
-          cloudState: details.cloudState,
-          workspaceId: details.workspaceId,
-          deletedWorkspaceId: null,
-          replacementWorkspaceId: null,
-          selectedWorkspaceId: details.selectedWorkspaceId,
-          activeWorkspaceId: details.activeWorkspaceId,
-          availableWorkspaceIds: details.availableWorkspaceIds,
-          nextWorkspaceIds: [],
-          redirected: false,
-          errorMessage: details.errorMessage,
-          bootstrapPhase: null,
-          syncRunId: null,
-        },
-      });
-      showMessage(workspaceManagementLockedMessage);
-      return;
-    }
-
-    setErrorMessage("");
-    setIsExpanded((currentValue) => !currentValue);
-  }
-
   return (
-    <SettingsShell
-      title={t("settingsCurrentWorkspace.title")}
-      subtitle={t("settingsCurrentWorkspace.subtitle")}
-      activeTab="current-workspace"
-    >
-      {message === "" ? null : <p className="settings-temporary-banner" role="status">{message}</p>}
+    <>
+      <SettingsShell
+        title={t("settingsCurrentWorkspace.title")}
+        subtitle={t("settingsCurrentWorkspace.subtitle")}
+        activeTab="current-workspace"
+      >
+        {message === "" ? null : <p className="settings-temporary-banner" role="status">{message}</p>}
 
-      <SettingsGroup>
-        <div className="settings-nav-list">
-          <SettingsActionCard
-            title={t("settingsCurrentWorkspace.workspaceCardTitle")}
-            description={t("settingsCurrentWorkspace.workspaceCardDescription")}
-            value={currentWorkspaceName}
-            onClick={handleWorkspaceRowClick}
-            isMuted={isWorkspaceLocked}
-            workspaceManagementState={workspaceManagementState}
-          />
+        <SettingsGroup>
+          <article className="content-card settings-workspace-current-summary" data-testid="workspace-current-summary">
+            <span className="cell-secondary">{t("settingsCurrentWorkspace.currentWorkspaceLabel")}</span>
+            <strong className="panel-subtitle" data-testid="workspace-current-value">{currentWorkspaceName}</strong>
+          </article>
+        </SettingsGroup>
+
+        <SettingsGroup>
+          <div className="settings-nav-list">
+            <SettingsActionCard
+              title={t("settingsCurrentWorkspace.changeWorkspaceTitle")}
+              description={t("settingsCurrentWorkspace.changeWorkspaceDescription")}
+              value={currentWorkspaceName}
+              onClick={() => runWorkspaceManagementAction(openChangeDialog)}
+              testId="workspace-change-open"
+              isMuted={isWorkspaceLocked}
+              workspaceManagementState={workspaceManagementState}
+            />
+            <SettingsActionCard
+              title={t("workspaceOverview.rename.title")}
+              description={t("workspaceOverview.rename.description")}
+              value={null}
+              onClick={() => runWorkspaceManagementAction(openRenameDialog)}
+              testId="workspace-rename-open"
+              isMuted={isWorkspaceLocked}
+              workspaceManagementState={workspaceManagementState}
+            />
+          </div>
+        </SettingsGroup>
+      </SettingsShell>
+
+      <WorkspaceActionDialog
+        isOpen={isChangeDialogOpen}
+        titleId="workspace-change-dialog-title"
+        title={t("settingsCurrentWorkspace.changeWorkspaceTitle")}
+        descriptionId="workspace-change-dialog-description"
+        description={t("settingsCurrentWorkspace.changeWorkspaceDialogDescription")}
+        testId="workspace-change-dialog"
+        initialFocusRef={changeDialogInitialFocusRef}
+        operationReturnFocusRef={changeDialogOperationFocusRef}
+        isOperationSubmitting={isChoosingWorkspace}
+        onDismiss={closeChangeDialog}
+      >
+        <div className="settings-workspace-choice-list">
+          {availableWorkspaces.map((workspace) => {
+            const isCurrentWorkspace = workspace.workspaceId === activeWorkspace?.workspaceId;
+            return (
+              <button
+                key={workspace.workspaceId}
+                className={`settings-workspace-choice${isCurrentWorkspace ? " settings-workspace-choice-active" : ""}`}
+                type="button"
+                onClick={(event) => void handleWorkspaceSelect(workspace.workspaceId, event.currentTarget)}
+                disabled={isChoosingWorkspace || isCurrentWorkspace}
+                aria-current={isCurrentWorkspace ? "true" : undefined}
+                data-testid="workspace-change-choice"
+                data-workspace-id={workspace.workspaceId}
+                data-workspace-name={workspace.name}
+              >
+                <span className="settings-workspace-choice-name">{workspace.name}</span>
+                <span className="settings-workspace-choice-meta">{formatDateTime(workspace.createdAt)}</span>
+              </button>
+            );
+          })}
         </div>
 
-        {isExpanded && isWorkspaceLocked === false ? (
-          <div className="settings-workspace-picker">
-            <div className="settings-workspace-choice-list">
-              {availableWorkspaces.map((workspace) => (
-                <button
-                  key={workspace.workspaceId}
-                  className={`settings-workspace-choice${workspace.workspaceId === activeWorkspace?.workspaceId ? " settings-workspace-choice-active" : ""}`}
-                  type="button"
-                  onClick={() => void handleWorkspaceSelect(workspace.workspaceId)}
-                  disabled={isChoosingWorkspace}
-                >
-                  <span className="settings-workspace-choice-name">{workspace.name}</span>
-                  <span className="settings-workspace-choice-meta">{formatDateTime(workspace.createdAt)}</span>
-                </button>
-              ))}
-            </div>
-
-            {!isCreating ? (
+        {!isCreating ? (
+          <button
+            ref={changeDialogInitialFocusRef}
+            className="ghost-btn"
+            type="button"
+            onClick={() => {
+              setIsCreating(true);
+              setChangeErrorMessage("");
+            }}
+            disabled={isChoosingWorkspace}
+            data-testid="workspace-create-open"
+          >
+            {t("settingsCurrentWorkspace.newWorkspace")}
+          </button>
+        ) : (
+          <form className="settings-workspace-create-form" onSubmit={(event) => void handleCreateWorkspace(event)}>
+            <input
+              ref={newWorkspaceNameInputRef}
+              className="settings-input"
+              type="text"
+              placeholder={t("settingsCurrentWorkspace.workspaceNamePlaceholder")}
+              value={newWorkspaceName}
+              onChange={(event) => setNewWorkspaceName(event.target.value)}
+              disabled={isChoosingWorkspace}
+              data-testid="workspace-create-name-input"
+            />
+            <div className="settings-workspace-create-actions">
+              <button
+                className="primary-btn"
+                type="submit"
+                disabled={isChoosingWorkspace}
+                data-testid="workspace-create-submit"
+              >
+                {t("settingsCurrentWorkspace.createWorkspace")}
+              </button>
               <button
                 className="ghost-btn"
                 type="button"
                 onClick={() => {
-                  setIsCreating(true);
-                  setErrorMessage("");
+                  setIsCreating(false);
+                  setNewWorkspaceName("");
+                  setChangeErrorMessage("");
                 }}
                 disabled={isChoosingWorkspace}
+                data-testid="workspace-create-cancel"
               >
-                {t("settingsCurrentWorkspace.newWorkspace")}
-              </button>
-            ) : (
-              <form className="settings-workspace-create-form" onSubmit={(event) => void handleCreateWorkspace(event)}>
-                <input
-                  className="settings-workspace-create-input"
-                  type="text"
-                  placeholder={t("settingsCurrentWorkspace.workspaceNamePlaceholder")}
-                  value={newWorkspaceName}
-                  onChange={(event) => setNewWorkspaceName(event.target.value)}
-                  disabled={isChoosingWorkspace}
-                />
-                <div className="settings-workspace-create-actions">
-                  <button className="primary-btn" type="submit" disabled={isChoosingWorkspace}>
-                    {t("settingsCurrentWorkspace.createWorkspace")}
-                  </button>
-                  <button
-                    className="ghost-btn"
-                    type="button"
-                    onClick={() => {
-                      setIsCreating(false);
-                      setNewWorkspaceName("");
-                      setErrorMessage("");
-                    }}
-                    disabled={isChoosingWorkspace}
-                  >
-                    {t("common.cancel")}
-                  </button>
-                </div>
-              </form>
-            )}
-
-            {errorMessage === "" ? null : <p className="error-banner">{errorMessage}</p>}
-          </div>
-        ) : null}
-      </SettingsGroup>
-
-      <SettingsGroup>
-        <article className="content-card settings-overview-card">
-          <form className="cell-stack" onSubmit={(event) => void handleRenameSubmit(event)}>
-            <div className="cell-stack">
-              <h2 className="panel-subtitle">{t("workspaceOverview.rename.title")}</h2>
-              <p className="subtitle">{t("workspaceOverview.rename.description")}</p>
-            </div>
-            <label className="cell-stack" htmlFor="current-workspace-name">
-              <span className="cell-secondary">{t("workspaceOverview.rename.fieldLabel")}</span>
-              <input
-                id="current-workspace-name"
-                className="settings-input"
-                type="text"
-                value={workspaceName}
-                autoComplete="off"
-                disabled={isWorkspaceLocked}
-                onChange={(event) => {
-                  setWorkspaceName(event.target.value);
-                  setRenameErrorMessage("");
-                }}
-              />
-            </label>
-            {renameErrorMessage !== "" ? <p className="error-banner">{renameErrorMessage}</p> : null}
-            {isSessionVerified === false ? <p className="subtitle">{t("loading.restoringSession")}</p> : null}
-            {isWorkspaceLocked ? <p className="subtitle">{workspaceManagementLockedMessage}</p> : null}
-            <div className="screen-actions">
-              <button className="primary-btn" type="submit" disabled={isRenameDisabled}>
-                {isRenameSubmitting ? t("workspaceOverview.rename.saving") : t("workspaceOverview.rename.save")}
+                {t("common.cancel")}
               </button>
             </div>
           </form>
-        </article>
-      </SettingsGroup>
-    </SettingsShell>
+        )}
+
+        {isChoosingWorkspace ? <p className="subtitle" role="status">{t("common.loading")}</p> : null}
+        {changeErrorMessage === "" ? null : <p className="error-banner" role="alert">{changeErrorMessage}</p>}
+        <div className="screen-actions">
+          <button
+            className="ghost-btn"
+            type="button"
+            onClick={closeChangeDialog}
+            disabled={isChoosingWorkspace}
+            data-testid="workspace-change-cancel"
+          >
+            {t("common.cancel")}
+          </button>
+        </div>
+      </WorkspaceActionDialog>
+
+      <WorkspaceActionDialog
+        isOpen={isRenameDialogOpen}
+        titleId="workspace-rename-dialog-title"
+        title={t("workspaceOverview.rename.title")}
+        descriptionId="workspace-rename-dialog-description"
+        description={t("workspaceOverview.rename.description")}
+        testId="workspace-rename-dialog"
+        initialFocusRef={renameInputRef}
+        operationReturnFocusRef={renameDialogOperationFocusRef}
+        isOperationSubmitting={isRenameSubmitting}
+        onDismiss={closeRenameDialog}
+      >
+        <form className="cell-stack" onSubmit={(event) => void handleRenameSubmit(event)}>
+          <label className="cell-stack" htmlFor="current-workspace-name">
+            <span className="cell-secondary">{t("workspaceOverview.rename.fieldLabel")}</span>
+            <input
+              ref={renameInputRef}
+              id="current-workspace-name"
+              className="settings-input"
+              type="text"
+              value={workspaceName}
+              autoComplete="off"
+              disabled={isWorkspaceLocked || isRenameSubmitting}
+              onChange={(event) => {
+                setWorkspaceName(event.target.value);
+                setRenameErrorMessage("");
+              }}
+              data-testid="workspace-rename-name-input"
+            />
+          </label>
+          {renameErrorMessage !== "" ? <p className="error-banner" role="alert">{renameErrorMessage}</p> : null}
+          {isSessionVerified === false ? <p className="subtitle">{t("loading.restoringSession")}</p> : null}
+          {isWorkspaceLocked ? <p className="subtitle">{workspaceManagementLockedMessage}</p> : null}
+          <div className="screen-actions">
+            <button
+              className="ghost-btn"
+              type="button"
+              onClick={closeRenameDialog}
+              disabled={isRenameSubmitting}
+              data-testid="workspace-rename-cancel"
+            >
+              {t("common.cancel")}
+            </button>
+            <button
+              className="primary-btn"
+              type="submit"
+              disabled={isRenameDisabled}
+              data-testid="workspace-rename-save"
+            >
+              {isRenameSubmitting ? t("workspaceOverview.rename.saving") : t("workspaceOverview.rename.save")}
+            </button>
+          </div>
+        </form>
+      </WorkspaceActionDialog>
+    </>
   );
 }

--- a/apps/web/src/screens/settings/workspace/WorkspaceActionDialog.tsx
+++ b/apps/web/src/screens/settings/workspace/WorkspaceActionDialog.tsx
@@ -1,0 +1,217 @@
+import {
+  type FocusEvent,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
+import { createPortal } from "react-dom";
+
+type WorkspaceActionDialogProps = Readonly<{
+  isOpen: boolean;
+  titleId: string;
+  title: string;
+  descriptionId: string;
+  description: string;
+  testId: string;
+  initialFocusRef: RefObject<HTMLElement | null>;
+  operationReturnFocusRef: RefObject<HTMLElement | null>;
+  isOperationSubmitting: boolean;
+  onDismiss: () => void;
+  children: ReactNode;
+}>;
+
+const workspaceDialogFocusableSelector: string = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusableElements(dialog: HTMLElement): ReadonlyArray<HTMLElement> {
+  return Array.from(dialog.querySelectorAll<HTMLElement>(workspaceDialogFocusableSelector))
+    .filter((element) => element.tabIndex >= 0 && element.getAttribute("aria-hidden") !== "true");
+}
+
+function trapFocusInsideDialog(event: KeyboardEvent, dialog: HTMLElement): void {
+  const focusableElements = getFocusableElements(dialog);
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  if (firstElement === undefined || lastElement === undefined) {
+    event.preventDefault();
+    dialog.focus();
+    return;
+  }
+
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement) || dialog.contains(activeElement) === false) {
+    event.preventDefault();
+    (event.shiftKey ? lastElement : firstElement).focus();
+    return;
+  }
+
+  if (event.shiftKey && activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus();
+    return;
+  }
+
+  if (event.shiftKey === false && activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus();
+  }
+}
+
+function focusAvailableElement(element: HTMLElement | null): boolean {
+  if (
+    element === null
+    || element.isConnected === false
+    || element.tabIndex < 0
+    || element.matches(":disabled")
+    || element.getAttribute("aria-hidden") === "true"
+  ) {
+    return false;
+  }
+
+  element.focus();
+  return document.activeElement === element;
+}
+
+export function WorkspaceActionDialog(props: WorkspaceActionDialogProps): ReactElement | null {
+  const {
+    isOpen,
+    titleId,
+    title,
+    descriptionId,
+    description,
+    testId,
+    initialFocusRef,
+    operationReturnFocusRef,
+    isOperationSubmitting,
+    onDismiss,
+    children,
+  } = props;
+  const dialogRef = useRef<HTMLElement | null>(null);
+  const isOperationSubmittingRef = useRef<boolean>(isOperationSubmitting);
+  const onDismissRef = useRef<() => void>(onDismiss);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const wasOperationSubmittingRef = useRef<boolean>(false);
+
+  useLayoutEffect(() => {
+    isOperationSubmittingRef.current = isOperationSubmitting;
+    const wasOperationSubmitting = wasOperationSubmittingRef.current;
+    wasOperationSubmittingRef.current = isOpen && isOperationSubmitting;
+
+    if (isOpen === false) {
+      return;
+    }
+
+    if (wasOperationSubmitting === false && isOperationSubmitting) {
+      dialogRef.current?.focus();
+      return;
+    }
+
+    if (wasOperationSubmitting && isOperationSubmitting === false) {
+      const dialog = dialogRef.current;
+      const activeElement = document.activeElement;
+      const isAnotherSurfaceFocused = activeElement instanceof HTMLElement
+        && activeElement !== document.body
+        && dialog?.contains(activeElement) === false;
+      if (isAnotherSurfaceFocused) {
+        return;
+      }
+
+      if (focusAvailableElement(operationReturnFocusRef.current)) {
+        return;
+      }
+
+      if (focusAvailableElement(initialFocusRef.current)) {
+        return;
+      }
+
+      dialog?.focus();
+    }
+  }, [initialFocusRef, isOpen, isOperationSubmitting, operationReturnFocusRef]);
+
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (isOpen === false) {
+      return undefined;
+    }
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    const initialFocusElement = initialFocusRef.current;
+    if (initialFocusElement === null || initialFocusElement.isConnected === false) {
+      dialogRef.current?.focus();
+    } else {
+      initialFocusElement.focus();
+    }
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape" && isOperationSubmittingRef.current === false) {
+        onDismissRef.current();
+        return;
+      }
+
+      if (event.key === "Tab" && dialogRef.current !== null) {
+        trapFocusInsideDialog(event, dialogRef.current);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return (): void => {
+      window.removeEventListener("keydown", handleKeyDown);
+      const previousFocus = previousFocusRef.current;
+      if (previousFocus !== null && previousFocus.isConnected) {
+        previousFocus.focus();
+      }
+      previousFocusRef.current = null;
+    };
+  }, [initialFocusRef, isOpen]);
+
+  if (isOpen === false || typeof document === "undefined") {
+    return null;
+  }
+
+  function handleDialogFocus(event: FocusEvent<HTMLElement>): void {
+    if (event.target !== event.currentTarget || isOperationSubmittingRef.current) {
+      return;
+    }
+
+    focusAvailableElement(operationReturnFocusRef.current);
+  }
+
+  return createPortal(
+    <div className="settings-workspace-dialog-backdrop">
+      <section
+        ref={dialogRef}
+        className="panel settings-workspace-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        aria-busy={isOperationSubmitting}
+        tabIndex={-1}
+        data-testid={testId}
+        onFocus={handleDialogFocus}
+      >
+        <div className="cell-stack">
+          <h2 id={titleId} className="panel-subtitle">{title}</h2>
+          <p id={descriptionId} className="subtitle">{description}</p>
+        </div>
+        {children}
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -452,10 +452,32 @@
   word-break: break-word;
 }
 
-.settings-workspace-picker {
+.settings-workspace-current-summary {
   display: grid;
-  gap: 14px;
-  padding: 0 4px 4px;
+  gap: 8px;
+}
+
+.settings-workspace-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 220;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  overflow-y: auto;
+  background: rgba(9, 10, 15, 0.8);
+  backdrop-filter: blur(10px);
+}
+
+.settings-workspace-dialog {
+  width: min(100%, 560px);
+  max-height: calc(100vh - 40px);
+  display: grid;
+  gap: 18px;
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
+  overflow-y: auto;
 }
 
 .settings-workspace-choice-list {
@@ -505,22 +527,6 @@
 .settings-workspace-create-form {
   display: grid;
   gap: 12px;
-}
-
-.settings-workspace-create-input {
-  width: 100%;
-  min-height: 46px;
-  padding: 0 14px;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text);
-  font: inherit;
-}
-
-.settings-workspace-create-input:focus {
-  border-color: rgba(196, 75, 45, 0.5);
-  box-shadow: 0 0 0 4px rgba(196, 75, 45, 0.14);
 }
 
 .settings-workspace-create-actions {
@@ -705,5 +711,22 @@
   .workspace-import-preview-stats,
   .workspace-import-preview-metadata-row {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .settings-workspace-dialog-backdrop {
+    align-items: end;
+    padding: 12px;
+  }
+
+  .settings-workspace-dialog {
+    width: 100%;
+    max-height: calc(100vh - 24px);
+  }
+
+  .settings-workspace-choice {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- replace the inline workspace picker and permanent rename form with explicit accessible dialogs
- preserve workspace operation, error, and focus behavior across change/create/rename flows
- update all web catalogs and stable Playwright smoke selectors

## Validation
- `git diff --check`
- `cd apps/web && npm run build`
- local E2E unavailable because auth/backend ports 8081/8080 were down
- fresh review found no P0-P4 issues