### PR TITLE
feat(android): add workspace action modals

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -70,7 +70,9 @@ import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerLearningS
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerMaximumIntervalFieldTag
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerRelearningStepsFieldTag
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerSaveButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceChangeActionTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceNameTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceRenameActionTag
 import com.flashcardsopensourceapp.feature.settings.workspaceImportChooseFileButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspaceImportScreenTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagCardsCountTag
@@ -400,11 +402,29 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     @Test
-    fun currentWorkspaceShowsRenameNoticeFromEmptyState() {
+    fun currentWorkspaceShowsActionsAndSignInGuidanceFromEmptyState() {
         waitForCardsEmptyState()
 
         openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag)
-        composeRule.onNodeWithText(settingsString(SettingsR.string.settings_workspace_rename_guidance)).fetchSemanticsNode()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            listOf(
+                currentWorkspaceChangeActionTag,
+                currentWorkspaceRenameActionTag
+            ).all { tag: String ->
+                composeRule.onAllNodesWithTag(tag)
+                    .fetchSemanticsNodes()
+                    .singleOrNull()
+                    ?.config
+                    ?.contains(SemanticsProperties.Disabled)
+                    ?.not()
+                    ?: false
+            }
+        }
+        composeRule.onNodeWithTag(currentWorkspaceChangeActionTag).fetchSemanticsNode()
+        composeRule.onNodeWithTag(currentWorkspaceRenameActionTag).fetchSemanticsNode()
+        composeRule.onNodeWithText(
+            settingsString(SettingsR.string.settings_current_workspace_load_sign_in_message)
+        ).fetchSemanticsNode()
     }
 
     @Test

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
@@ -5,7 +5,6 @@ package com.flashcardsopensourceapp.app.livesmoke.flows
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
@@ -20,7 +19,6 @@ import com.flashcardsopensourceapp.app.livesmoke.diagnostics.nodeSummary
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.tapBackIcon
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForFlowValue
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTagToExist
-import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilAtLeastOneExistsOrFail
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilWithMitigation
 import com.flashcardsopensourceapp.app.livesmoke.support.LiveSmokeContext
 import com.flashcardsopensourceapp.app.livesmoke.support.appGraph
@@ -30,11 +28,13 @@ import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceErrorMe
 import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceNameOrNull
 import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceOperationMessageOrNull
 import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceSummaryOrNull
+import com.flashcardsopensourceapp.app.livesmoke.support.dismissCurrentWorkspaceChangeSheet
 import com.flashcardsopensourceapp.app.livesmoke.support.externalCloudWorkspaceTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.externalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.selectedWorkspaceSummary
 import com.flashcardsopensourceapp.app.livesmoke.support.selectedWorkspaceSummaryOrNull
+import com.flashcardsopensourceapp.app.livesmoke.support.waitForCurrentWorkspaceChangeSheetToSettle
 import com.flashcardsopensourceapp.app.livesmoke.support.waitForCurrentWorkspaceName
 import com.flashcardsopensourceapp.app.livesmoke.support.waitForCurrentWorkspaceScreenToSettle
 import com.flashcardsopensourceapp.app.livesmoke.support.waitForSelectedWorkspaceSummary
@@ -44,9 +44,12 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.feature.settings.settingsCurrentWorkspaceRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsDeleteCurrentWorkspaceRowTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceCreateButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceChangeSheetListTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceChangeSheetTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceExistingRowTag
-import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceListTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceNameFieldTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceRenameActionTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceRenameDialogTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceSaveNameButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspace.delete.workspaceOverviewDeleteConfirmationButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspace.delete.workspaceOverviewDeleteConfirmationDialogTag
@@ -83,10 +86,7 @@ internal data class EphemeralWorkspaceHandle(
 internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): EphemeralWorkspaceHandle {
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
     waitForCurrentWorkspaceScreenToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
-    waitUntilAtLeastOneExistsOrFail(
-        matcher = hasText("Create new workspace"),
-        timeoutMillis = internalUiTimeoutMillis
-    )
+    waitForCurrentWorkspaceChangeSheetToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
     waitForSelectedWorkspaceSummary(
         context = "before creating a linked workspace",
         timeoutMillis = internalUiTimeoutMillis
@@ -97,7 +97,7 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
     val selectedWorkspaceIdBeforeCreate: String = currentWorkspaceIdOrThrow(
         context = "before creating a linked workspace"
     )
-    composeRule.onNodeWithTag(currentWorkspaceListTag).performScrollToNode(
+    composeRule.onNodeWithTag(currentWorkspaceChangeSheetListTag).performScrollToNode(
         matcher = hasTestTag(currentWorkspaceCreateButtonTag)
     )
     clickTag(tag = currentWorkspaceCreateButtonTag, label = "Create new workspace")
@@ -106,13 +106,21 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
         timeoutMillis = externalCloudWorkspaceTimeoutMillis,
         context = "after creating a linked workspace"
     )
+    waitForCurrentWorkspaceOperationToFinish(
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis
+    )
+    waitForCurrentWorkspaceChangeSheetToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
     waitForSelectedWorkspaceSummaryToChange(
         beforeSummary = selectedWorkspaceSummaryBeforeCreate,
         context = "after creating a linked workspace",
         timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
-    waitForCurrentWorkspaceOperationToFinish(
-        timeoutMillis = externalCloudWorkspaceTimeoutMillis
+    dismissCurrentWorkspaceChangeSheet(timeoutMillis = internalUiTimeoutMillis)
+    clickTag(tag = currentWorkspaceRenameActionTag, label = "Rename workspace")
+    waitForTagToExist(
+        tag = currentWorkspaceRenameDialogTag,
+        timeoutMillis = internalUiTimeoutMillis,
+        context = "while opening the Rename workspace dialog"
     )
     waitForCurrentWorkspaceRenameReady(
         expectedWorkspaceName = workspaceName,
@@ -154,11 +162,9 @@ internal fun LiveSmokeContext.deleteEphemeralWorkspace(workspaceHandle: Ephemera
     )
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
     waitForCurrentWorkspaceScreenToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
-    waitUntilAtLeastOneExistsOrFail(
-        matcher = hasText("Create new workspace"),
-        timeoutMillis = internalUiTimeoutMillis
-    )
+    waitForCurrentWorkspaceChangeSheetToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
     if (composeRule.onAllNodesWithText(workspaceHandle.workspaceName).fetchSemanticsNodes().isEmpty()) {
+        dismissCurrentWorkspaceChangeSheet(timeoutMillis = internalUiTimeoutMillis)
         tapBackIcon()
         return
     }
@@ -166,6 +172,7 @@ internal fun LiveSmokeContext.deleteEphemeralWorkspace(workspaceHandle: Ephemera
         context = "before deleting the isolated linked workspace",
         timeoutMillis = internalUiTimeoutMillis
     )
+    dismissCurrentWorkspaceChangeSheet(timeoutMillis = internalUiTimeoutMillis)
     tapBackIcon()
 
     openSettingsRow(rowTag = settingsDeleteCurrentWorkspaceRowTag, rowLabel = "Delete current workspace")
@@ -200,10 +207,7 @@ internal fun LiveSmokeContext.deleteEphemeralWorkspace(workspaceHandle: Ephemera
             context = "while waiting for workspace deletion to finish"
         ) {
             val currentWorkspaceName: String? = currentWorkspaceNameOrNull()
-            val selectedSummary: String? = selectedWorkspaceSummaryOrNull()
-            composeRule.onAllNodesWithText(workspaceHandle.workspaceName).fetchSemanticsNodes().isEmpty() &&
-                currentWorkspaceName != workspaceHandle.workspaceName &&
-                selectedSummary?.contains(other = workspaceHandle.workspaceName) != true
+            currentWorkspaceName != workspaceHandle.workspaceName
         }
     } catch (error: Throwable) {
         throw AssertionError(
@@ -217,10 +221,30 @@ internal fun LiveSmokeContext.deleteEphemeralWorkspace(workspaceHandle: Ephemera
             error
         )
     }
+    waitForCurrentWorkspaceChangeSheetToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
+    try {
+        waitUntilWithMitigation(
+            timeoutMillis = externalCloudWorkspaceTimeoutMillis,
+            context = "while waiting for the deleted workspace to leave the selector"
+        ) {
+            val selectedSummary: String? = selectedWorkspaceSummaryOrNull()
+            composeRule.onAllNodesWithText(workspaceHandle.workspaceName).fetchSemanticsNodes().isEmpty() &&
+                selectedSummary?.contains(other = workspaceHandle.workspaceName) != true
+        }
+    } catch (error: Throwable) {
+        throw AssertionError(
+            "Deleted workspace remained visible in the selector. " +
+                "Workspace=${workspaceHandle.workspaceName} " +
+                "SelectedRow=${selectedWorkspaceSummaryOrNull()} " +
+                "VisibleRows=${captureVisibleWorkspaceRows(rowTag = currentWorkspaceExistingRowTag)}",
+            error
+        )
+    }
     waitForSelectedWorkspaceSummary(
         context = "after deleting the isolated linked workspace",
         timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
+    dismissCurrentWorkspaceChangeSheet(timeoutMillis = internalUiTimeoutMillis)
     tapBackIcon()
 }
 
@@ -257,6 +281,7 @@ internal fun LiveSmokeContext.forceLinkedSyncAndWaitForWorkspace(
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
     waitForCurrentWorkspaceScreenToSettle(timeoutMillis = timeoutMillis)
     waitForCurrentWorkspaceName(expectedWorkspaceName = workspaceHandle.workspaceName)
+    waitForCurrentWorkspaceChangeSheetToSettle(timeoutMillis = timeoutMillis)
     waitForSelectedWorkspaceSummary(
         context = "after forcing linked sync before cleanup",
         timeoutMillis = timeoutMillis
@@ -274,6 +299,7 @@ internal fun LiveSmokeContext.forceLinkedSyncAndWaitForWorkspace(
                 "CurrentWorkspace=${currentWorkspaceSummaryOrNull()}"
         )
     }
+    dismissCurrentWorkspaceChangeSheet(timeoutMillis = internalUiTimeoutMillis)
     tapBackIcon()
 }
 
@@ -392,9 +418,11 @@ private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToFinish(timeoutMil
             timeoutMillis = timeoutMillis,
             context = "while waiting for current workspace operation to finish"
         ) {
-            currentWorkspaceOperationMessageOrNull() == null &&
-                currentWorkspaceNameOrNull() != "Unavailable" &&
-                selectedWorkspaceSummaryOrNull() != null
+            composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetTag)
+                .fetchSemanticsNodes()
+                .isEmpty() &&
+                currentWorkspaceOperationMessageOrNull() == null &&
+                currentWorkspaceNameOrNull() != "Unavailable"
         }
     } catch (error: Throwable) {
         throw AssertionError(
@@ -416,10 +444,10 @@ private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToLeaveSwitchingSta
             timeoutMillis = timeoutMillis,
             context = "while waiting for current workspace operation to leave switching"
         ) {
-            currentWorkspaceOperationMessageOrNull()
-                ?.startsWith(prefix = "Switching to")
-                ?.not()
-                ?: true
+            currentWorkspaceErrorMessageOrNull() != null ||
+                composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetTag)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
         }
     } catch (error: Throwable) {
         throw AssertionError(
@@ -442,13 +470,17 @@ private fun LiveSmokeContext.waitForCurrentWorkspaceRenameOutcome(
             timeoutMillis = timeoutMillis,
             context = "while waiting for workspace rename to persist"
         ) {
-            currentWorkspaceNameFieldValueOrNull() == expectedWorkspaceName &&
+            composeRule.onAllNodesWithTag(currentWorkspaceRenameDialogTag)
+                .fetchSemanticsNodes()
+                .isEmpty() &&
+                currentWorkspaceNameOrNull() == expectedWorkspaceName &&
                 hasVisibleText(text = "Saving...", substring = false).not()
         }
     } catch (error: Throwable) {
         throw AssertionError(
             "Workspace rename did not persist on the Workspace screen. " +
-                "FieldValue=${currentWorkspaceNameFieldValueOrNull()} " +
+                "WorkspaceName=${currentWorkspaceNameOrNull()} " +
+                "DialogVisible=${composeRule.onAllNodesWithTag(currentWorkspaceRenameDialogTag).fetchSemanticsNodes().isNotEmpty()} " +
                 "Error=${currentWorkspaceErrorMessageOrNull()}",
             error
         )

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
@@ -2,22 +2,26 @@
 
 package com.flashcardsopensourceapp.app.livesmoke.support
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.nodeSummary
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.nodeSummaryIncludingDescendants
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilWithMitigation
-import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceCreateButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceChangeActionTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceChangeSheetListTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceChangeSheetTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceErrorMessageTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceExistingRowTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceListTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceLoadingStateTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceNameTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceOperationMessageTag
-import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceReloadButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceRenameActionTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceSelectedSummaryTag
 import com.flashcardsopensourceapp.feature.settings.workspace.delete.workspaceOverviewErrorMessageTag
 import kotlinx.coroutines.flow.first
@@ -37,6 +41,77 @@ internal fun LiveSmokeContext.waitForSelectedWorkspaceSummary(context: String, t
             "Workspace selection did not settle $context. " +
                 "Visible linked workspaces=${captureVisibleWorkspaceRows(rowTag = currentWorkspaceExistingRowTag)} " +
                 "WorkspaceName=${currentWorkspaceNameOrNull()}",
+            error
+        )
+    }
+}
+
+internal fun LiveSmokeContext.openCurrentWorkspaceChangeSheet(timeoutMillis: Long) {
+    if (
+        composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetTag)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+    ) {
+        return
+    }
+    composeRule.onNodeWithTag(currentWorkspaceListTag).performScrollToNode(
+        matcher = hasTestTag(currentWorkspaceChangeActionTag)
+    )
+    composeRule.onNodeWithTag(currentWorkspaceChangeActionTag).performClick()
+    waitUntilWithMitigation(
+        timeoutMillis = timeoutMillis,
+        context = "while opening the Change workspace sheet"
+    ) {
+        composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetTag)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+    }
+}
+
+internal fun LiveSmokeContext.dismissCurrentWorkspaceChangeSheet(timeoutMillis: Long) {
+    if (
+        composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetTag)
+            .fetchSemanticsNodes()
+            .isEmpty()
+    ) {
+        return
+    }
+    device.pressBack()
+    waitUntilWithMitigation(
+        timeoutMillis = timeoutMillis,
+        context = "while dismissing the Change workspace sheet"
+    ) {
+        composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetTag)
+            .fetchSemanticsNodes()
+            .isEmpty()
+    }
+}
+
+internal fun LiveSmokeContext.waitForCurrentWorkspaceChangeSheetToSettle(timeoutMillis: Long) {
+    openCurrentWorkspaceChangeSheet(timeoutMillis = timeoutMillis)
+    try {
+        waitUntilWithMitigation(
+            timeoutMillis = timeoutMillis,
+            context = "while waiting for the Change workspace sheet to settle"
+        ) {
+            val visibleError: String? = currentWorkspaceVisibleErrorMessageOrNull()
+            if (visibleError != null) {
+                throw AssertionError("Change workspace settled with an error: $visibleError")
+            }
+
+            val isLoading: Boolean = composeRule.onAllNodesWithTag(currentWorkspaceLoadingStateTag)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+            isLoading.not() && composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetListTag)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    } catch (error: Throwable) {
+        throw AssertionError(
+            "Change workspace sheet did not settle. " +
+                "Loading=${composeRule.onAllNodesWithTag(currentWorkspaceLoadingStateTag).fetchSemanticsNodes().isNotEmpty()} " +
+                "Error=${currentWorkspaceVisibleErrorMessageOrNull()} " +
+                "VisibleRows=${captureVisibleWorkspaceRows(rowTag = currentWorkspaceExistingRowTag)}",
             error
         )
     }
@@ -79,24 +154,24 @@ internal fun LiveSmokeContext.waitForCurrentWorkspaceScreenToSettle(timeoutMilli
                 throw AssertionError("Workspace settled with an error: $visibleError")
             }
 
-            val isLoading: Boolean = composeRule.onAllNodesWithTag(currentWorkspaceLoadingStateTag)
+            val changeAction = composeRule.onAllNodesWithTag(currentWorkspaceChangeActionTag)
                 .fetchSemanticsNodes()
-                .isNotEmpty()
-            isLoading.not() && (
-                composeRule.onAllNodesWithTag(currentWorkspaceCreateButtonTag)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty() ||
-                    composeRule.onAllNodesWithTag(currentWorkspaceReloadButtonTag)
-                        .fetchSemanticsNodes()
-                        .isNotEmpty()
-                )
+                .singleOrNull()
+            val renameAction = composeRule.onAllNodesWithTag(currentWorkspaceRenameActionTag)
+                .fetchSemanticsNodes()
+                .singleOrNull()
+            currentWorkspaceNameOrNull() != null &&
+                changeAction != null &&
+                changeAction.config.contains(SemanticsProperties.Disabled).not() &&
+                renameAction != null &&
+                renameAction.config.contains(SemanticsProperties.Disabled).not()
         }
     } catch (error: Throwable) {
         throw AssertionError(
             "Workspace screen did not settle. " +
-                "Loading=${composeRule.onAllNodesWithTag(currentWorkspaceLoadingStateTag).fetchSemanticsNodes().isNotEmpty()} " +
+                "ChangeAction=${composeRule.onAllNodesWithTag(currentWorkspaceChangeActionTag).fetchSemanticsNodes().isNotEmpty()} " +
                 "Error=${currentWorkspaceVisibleErrorMessageOrNull()} " +
-                "SelectedRow=${selectedWorkspaceSummaryOrNull()}",
+                "WorkspaceName=${currentWorkspaceNameOrNull()}",
             error
         )
     }
@@ -191,17 +266,24 @@ internal fun LiveSmokeContext.currentWorkspaceOperationMessageOrNull(): String? 
 }
 
 private fun LiveSmokeContext.scrollCurrentWorkspaceListToSelectedWorkspace() {
-    if (composeRule.onAllNodesWithTag(currentWorkspaceListTag).fetchSemanticsNodes().isEmpty()) {
+    if (composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetListTag).fetchSemanticsNodes().isEmpty()) {
         return
     }
     runCatching {
-        composeRule.onNodeWithTag(currentWorkspaceListTag).performScrollToNode(
+        composeRule.onNodeWithTag(currentWorkspaceChangeSheetListTag).performScrollToNode(
             matcher = hasTestTag(currentWorkspaceSelectedSummaryTag)
         )
     }
 }
 
 private fun LiveSmokeContext.scrollCurrentWorkspaceListToTopCard() {
+    if (
+        composeRule.onAllNodesWithTag(currentWorkspaceChangeSheetTag)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+    ) {
+        return
+    }
     if (composeRule.onAllNodesWithTag(currentWorkspaceListTag).fetchSemanticsNodes().isEmpty()) {
         return
     }
@@ -213,7 +295,7 @@ private fun LiveSmokeContext.scrollCurrentWorkspaceListToTopCard() {
 internal fun LiveSmokeContext.captureVisibleWorkspaceRows(rowTag: String): List<String> {
     return composeRule.onAllNodesWithTag(rowTag)
         .fetchSemanticsNodes()
-        .map(::nodeSummary)
+        .map(::nodeSummaryIncludingDescendants)
 }
 
 internal fun LiveSmokeContext.currentCloudSettingsSummary(): String {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/current/CurrentWorkspaceRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/current/CurrentWorkspaceRoute.kt
@@ -2,28 +2,51 @@ package com.flashcardsopensourceapp.feature.settings.workspace.current
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
 
+const val currentWorkspaceChangeActionTag: String = "current_workspace_change_action"
+const val currentWorkspaceRenameActionTag: String = "current_workspace_rename_action"
+const val currentWorkspaceChangeSheetTag: String = "current_workspace_change_sheet"
+const val currentWorkspaceChangeSheetListTag: String = "current_workspace_change_sheet_list"
+const val currentWorkspaceRenameDialogTag: String = "current_workspace_rename_dialog"
 const val currentWorkspaceCreateButtonTag: String = "current_workspace_create_button"
 const val currentWorkspaceExistingRowTag: String = "current_workspace_existing_row"
 const val currentWorkspaceSelectedSummaryTag: String = "current_workspace_selected_summary"
@@ -46,6 +69,7 @@ fun currentWorkspaceSelectedIndicatorTag(workspaceId: String): String {
     return currentWorkspaceSelectedIndicatorTagPrefix + workspaceId
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CurrentWorkspaceRoute(
     uiState: CurrentWorkspaceUiState,
@@ -53,27 +77,67 @@ fun CurrentWorkspaceRoute(
     onSwitchToExistingWorkspace: (String) -> Unit,
     onCreateWorkspace: () -> Unit,
     onWorkspaceNameChange: (String) -> Unit,
-    onSaveWorkspaceName: () -> Unit,
+    onSaveWorkspaceName: () -> String,
     onOpenSignIn: () -> Unit,
     onRetryLastWorkspaceAction: () -> Unit,
     onBack: () -> Unit
 ) {
+    var isChangeSheetVisible by rememberSaveable { mutableStateOf(false) }
+    var isRenameDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var hasSubmittedWorkspaceAction by rememberSaveable { mutableStateOf(false) }
+    var pendingRenameSubmissionId: String? by rememberSaveable {
+        mutableStateOf<String?>(null)
+    }
+
     LaunchedEffect(
         uiState.isLinked,
+        uiState.isLinkingReady,
         uiState.workspaceLoadState
     ) {
         if (
-            uiState.isLinked
+            (uiState.isLinked || uiState.isLinkingReady)
             && uiState.workspaceLoadState == CurrentWorkspaceLoadState.Loading
         ) {
             onReload()
         }
     }
 
+    LaunchedEffect(
+        uiState.operation,
+        uiState.errorMessage
+    ) {
+        if (
+            isChangeSheetVisible
+            && hasSubmittedWorkspaceAction
+            && uiState.operation == CurrentWorkspaceOperation.IDLE
+        ) {
+            if (uiState.errorMessage.isEmpty()) {
+                isChangeSheetVisible = false
+            }
+            hasSubmittedWorkspaceAction = false
+        }
+    }
+
+    LaunchedEffect(
+        uiState.renameCompletion,
+        pendingRenameSubmissionId
+    ) {
+        val completion = uiState.renameCompletion
+        if (
+            completion != null
+            && completion.submissionId == pendingRenameSubmissionId
+        ) {
+            if (completion.result == CurrentWorkspaceRenameResult.SUCCEEDED) {
+                isRenameDialogVisible = false
+            }
+            pendingRenameSubmissionId = null
+        }
+    }
+
     SettingsScreenScaffold(
         title = stringResource(R.string.settings_root_current_workspace_title),
         onBack = onBack,
-        isBackEnabled = uiState.isSwitching.not()
+        isBackEnabled = uiState.isSwitching.not() && uiState.isSavingName.not()
     ) { innerPadding ->
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
@@ -89,7 +153,7 @@ fun CurrentWorkspaceRoute(
                         modifier = Modifier.padding(20.dp)
                     ) {
                         Text(
-                            text = stringResource(R.string.settings_root_current_workspace_title),
+                            text = stringResource(R.string.settings_current_workspace_current_title),
                             style = MaterialTheme.typography.titleMedium
                         )
                         Text(
@@ -108,37 +172,25 @@ fun CurrentWorkspaceRoute(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
-                        if (uiState.pendingWorkspaceTitle != null) {
-                            Text(
-                                text = when (uiState.operation) {
-                                    CurrentWorkspaceOperation.SWITCHING -> stringResource(
-                                        R.string.settings_current_workspace_switching,
-                                        uiState.pendingWorkspaceTitle
-                                    )
-                                    CurrentWorkspaceOperation.SYNCING -> stringResource(
-                                        R.string.settings_current_workspace_syncing,
-                                        uiState.pendingWorkspaceTitle
-                                    )
-                                    CurrentWorkspaceOperation.IDLE,
-                                    CurrentWorkspaceOperation.LOADING -> ""
-                                },
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.testTag(tag = currentWorkspaceOperationMessageTag)
-                            )
-                        }
+                        WorkspaceOperationMessage(
+                            uiState = uiState,
+                            modifier = Modifier.testTag(tag = currentWorkspaceOperationMessageTag)
+                        )
                     }
                 }
             }
 
-            if (uiState.errorMessage.isNotEmpty() && uiState.operation == CurrentWorkspaceOperation.IDLE) {
+            if (
+                uiState.errorMessage.isNotEmpty()
+                && uiState.operation == CurrentWorkspaceOperation.IDLE
+                && isChangeSheetVisible.not()
+                && isRenameDialogVisible.not()
+            ) {
                 item {
                     Card(modifier = Modifier.fillMaxWidth()) {
-                        Text(
-                            text = uiState.errorMessage,
-                            color = MaterialTheme.colorScheme.error,
-                            modifier = Modifier
-                                .padding(20.dp)
-                                .testTag(tag = currentWorkspaceErrorMessageTag)
+                        WorkspaceErrorMessage(
+                            errorMessage = uiState.errorMessage,
+                            modifier = Modifier.padding(20.dp)
                         )
                     }
                 }
@@ -162,179 +214,372 @@ fun CurrentWorkspaceRoute(
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier.padding(20.dp)
                     ) {
-                        Text(
-                            text = stringResource(R.string.settings_workspace_name_section_title),
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        if (uiState.isLinked) {
-                            OutlinedTextField(
-                                value = uiState.workspaceNameDraft,
-                                onValueChange = onWorkspaceNameChange,
-                                enabled = uiState.isSavingName.not() && uiState.isSwitching.not(),
-                                label = {
-                                    Text(stringResource(R.string.settings_workspace_name_label))
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .testTag(tag = currentWorkspaceNameFieldTag)
-                            )
-                            Button(
-                                onClick = onSaveWorkspaceName,
-                                enabled = uiState.isSavingName.not() &&
-                                    uiState.isSwitching.not() &&
-                                    uiState.workspaceNameDraft.trim().isNotEmpty() &&
-                                    uiState.workspaceNameDraft != uiState.currentWorkspaceName,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .testTag(tag = currentWorkspaceSaveNameButtonTag)
-                            ) {
-                                Text(
-                                    if (uiState.isSavingName) {
-                                        stringResource(R.string.settings_saving)
-                                    } else {
-                                        stringResource(R.string.settings_workspace_save_name_button)
-                                    }
-                                )
-                            }
-                        } else {
+                        if (
+                            uiState.isInitialized
+                            && uiState.isLinked.not()
+                            && uiState.isLinkingReady.not()
+                        ) {
                             Text(
-                                text = stringResource(R.string.settings_workspace_rename_guidance),
+                                text = if (uiState.isGuest) {
+                                    stringResource(R.string.settings_current_workspace_load_guest_message)
+                                } else {
+                                    stringResource(R.string.settings_current_workspace_load_sign_in_message)
+                                },
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                        }
+                        Button(
+                            onClick = {
+                                if (uiState.isLinked || uiState.isLinkingReady) {
+                                    isChangeSheetVisible = true
+                                } else {
+                                    onOpenSignIn()
+                                }
+                            },
+                            enabled = uiState.isInitialized &&
+                                uiState.isSwitching.not() &&
+                                uiState.isSavingName.not(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(tag = currentWorkspaceChangeActionTag)
+                        ) {
+                            Text(stringResource(R.string.settings_current_workspace_change_action))
+                        }
+                        OutlinedButton(
+                            onClick = {
+                                when {
+                                    uiState.isLinked -> {
+                                        onWorkspaceNameChange(uiState.currentWorkspaceName)
+                                        pendingRenameSubmissionId = null
+                                        isRenameDialogVisible = true
+                                    }
+                                    uiState.isLinkingReady -> {
+                                        isChangeSheetVisible = true
+                                    }
+                                    else -> {
+                                        onOpenSignIn()
+                                    }
+                                }
+                            },
+                            enabled = uiState.isInitialized &&
+                                uiState.isSwitching.not() &&
+                                uiState.isSavingName.not(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(tag = currentWorkspaceRenameActionTag)
+                        ) {
+                            Text(stringResource(R.string.settings_current_workspace_rename_action))
                         }
                     }
                 }
             }
+        }
+    }
 
+    if (isChangeSheetVisible) {
+        CurrentWorkspaceChangeSheet(
+            uiState = uiState,
+            onReload = onReload,
+            onSwitchToExistingWorkspace = { workspaceId ->
+                hasSubmittedWorkspaceAction = true
+                onSwitchToExistingWorkspace(workspaceId)
+            },
+            onCreateWorkspace = {
+                hasSubmittedWorkspaceAction = true
+                onCreateWorkspace()
+            },
+            onOpenSignIn = onOpenSignIn,
+            onRetryLastWorkspaceAction = {
+                hasSubmittedWorkspaceAction = true
+                onRetryLastWorkspaceAction()
+            },
+            onDismiss = {
+                if (uiState.isSwitching.not()) {
+                    isChangeSheetVisible = false
+                    hasSubmittedWorkspaceAction = false
+                }
+            }
+        )
+    }
+
+    if (isRenameDialogVisible) {
+        CurrentWorkspaceRenameDialog(
+            uiState = uiState,
+            onWorkspaceNameChange = onWorkspaceNameChange,
+            onSaveWorkspaceName = {
+                pendingRenameSubmissionId = onSaveWorkspaceName()
+            },
+            onDismiss = {
+                if (uiState.isSavingName.not()) {
+                    onWorkspaceNameChange(uiState.currentWorkspaceName)
+                    pendingRenameSubmissionId = null
+                    isRenameDialogVisible = false
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun WorkspaceOperationMessage(
+    uiState: CurrentWorkspaceUiState,
+    modifier: Modifier
+) {
+    if (uiState.pendingWorkspaceTitle == null) {
+        return
+    }
+    Text(
+        text = when (uiState.operation) {
+            CurrentWorkspaceOperation.SWITCHING -> stringResource(
+                R.string.settings_current_workspace_switching,
+                uiState.pendingWorkspaceTitle
+            )
+            CurrentWorkspaceOperation.SYNCING -> stringResource(
+                R.string.settings_current_workspace_syncing,
+                uiState.pendingWorkspaceTitle
+            )
+            CurrentWorkspaceOperation.IDLE,
+            CurrentWorkspaceOperation.LOADING -> ""
+        },
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun WorkspaceErrorMessage(
+    errorMessage: String,
+    modifier: Modifier
+) {
+    Text(
+        text = errorMessage,
+        color = MaterialTheme.colorScheme.error,
+        modifier = modifier.testTag(tag = currentWorkspaceErrorMessageTag)
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CurrentWorkspaceChangeSheet(
+    uiState: CurrentWorkspaceUiState,
+    onReload: () -> Unit,
+    onSwitchToExistingWorkspace: (String) -> Unit,
+    onCreateWorkspace: () -> Unit,
+    onOpenSignIn: () -> Unit,
+    onRetryLastWorkspaceAction: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val isSwitching: Boolean by rememberUpdatedState(newValue = uiState.isSwitching)
+    val sheetState: SheetState = rememberModalBottomSheetState(
+        confirmValueChange = { nextValue: SheetValue ->
+            nextValue != SheetValue.Hidden || isSwitching.not()
+        }
+    )
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = Modifier.testTag(tag = currentWorkspaceChangeSheetTag)
+    ) {
+        LazyColumn(
+            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(tag = currentWorkspaceChangeSheetListTag)
+        ) {
             item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        modifier = Modifier.padding(20.dp)
-                    ) {
+                Text(
+                    text = stringResource(R.string.settings_current_workspace_change_sheet_title),
+                    style = MaterialTheme.typography.titleLarge
+                )
+            }
+
+            if (uiState.pendingWorkspaceTitle != null) {
+                item {
+                    WorkspaceOperationMessage(
+                        uiState = uiState,
+                        modifier = Modifier
+                    )
+                }
+            }
+
+            when {
+                uiState.isLinked.not() && uiState.isLinkingReady.not() -> {
+                    item {
                         Text(
-                            text = stringResource(R.string.settings_cloud_status_choose_workspace),
-                            style = MaterialTheme.typography.titleMedium
+                            text = if (uiState.isGuest) {
+                                stringResource(R.string.settings_current_workspace_load_guest_message)
+                            } else {
+                                stringResource(R.string.settings_current_workspace_load_sign_in_message)
+                            },
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        when {
-                            uiState.isLinked.not() && uiState.isLinkingReady.not() -> {
-                                Text(
-                                    text = if (uiState.isGuest) {
-                                        stringResource(R.string.settings_current_workspace_load_guest_message)
-                                    } else {
-                                        stringResource(R.string.settings_current_workspace_load_sign_in_message)
-                                    },
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                                Button(
-                                    onClick = onOpenSignIn,
-                                    modifier = Modifier.fillMaxWidth()
-                                ) {
-                                    Text(stringResource(R.string.settings_account_status_sign_in_button))
-                                }
-                            }
+                    }
+                    item {
+                        Button(
+                            onClick = onOpenSignIn,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(stringResource(R.string.settings_account_status_sign_in_button))
+                        }
+                    }
+                }
 
-                            uiState.workspaceLoadState == CurrentWorkspaceLoadState.Loading -> {
-                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.testTag(tag = currentWorkspaceLoadingStateTag)
-                                    )
-                                    Text(stringResource(R.string.settings_loading))
-                                }
-                            }
+                uiState.workspaceLoadState == CurrentWorkspaceLoadState.Loading -> {
+                    item {
+                        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.testTag(tag = currentWorkspaceLoadingStateTag)
+                            )
+                            Text(stringResource(R.string.settings_loading))
+                        }
+                    }
+                }
 
-                            uiState.workspaceLoadState == CurrentWorkspaceLoadState.Failed -> {
-                                Button(
-                                    onClick = onReload,
-                                    enabled = uiState.isSwitching.not(),
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .testTag(tag = currentWorkspaceReloadButtonTag)
-                                ) {
-                                    Text(stringResource(R.string.settings_reload))
-                                }
-                            }
+                uiState.workspaceLoadState == CurrentWorkspaceLoadState.Failed -> {
+                    if (uiState.errorMessage.isNotEmpty()) {
+                        item {
+                            WorkspaceErrorMessage(
+                                errorMessage = uiState.errorMessage,
+                                modifier = Modifier
+                            )
+                        }
+                    }
+                    item {
+                        Button(
+                            onClick = onReload,
+                            enabled = uiState.isSwitching.not(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(tag = currentWorkspaceReloadButtonTag)
+                        ) {
+                            Text(stringResource(R.string.settings_reload))
+                        }
+                    }
+                }
 
-                            else -> {
-                                // The live smoke verifies structural workspace changes by
-                                // counting linked workspace rows instead of relying on
-                                // transient snackbar copy.
-                                uiState.workspaces.forEach { workspace ->
-                                    OutlinedButton(
-                                        onClick = {
-                                            if (workspace.isCreateNew) {
-                                                onCreateWorkspace()
-                                            } else {
-                                                onSwitchToExistingWorkspace(workspace.workspaceId)
-                                            }
-                                        },
-                                        enabled = uiState.isSwitching.not(),
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .then(
-                                                if (workspace.isCreateNew) {
-                                                    Modifier
-                                                } else {
-                                                    Modifier.testTag(tag = currentWorkspaceExistingRowTag)
-                                                }
-                                            )
-                                            .then(
-                                                if (workspace.isCreateNew) {
-                                                    Modifier.testTag(tag = currentWorkspaceCreateButtonTag)
-                                                } else {
-                                                    Modifier.testTag(
-                                                        tag = currentWorkspaceExistingButtonTag(
-                                                            workspaceId = workspace.workspaceId
-                                                        )
-                                                    )
-                                                }
-                                            )
+                else -> {
+                    val existingWorkspaces = uiState.workspaces.filterNot { workspace ->
+                        workspace.isCreateNew
+                    }
+                    if (existingWorkspaces.isNotEmpty()) {
+                        item(key = "existing-workspaces") {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .selectableGroup()
+                            ) {
+                                existingWorkspaces.forEach { workspace ->
+                                    val isSelectionEnabled = workspace.isSelected.not() &&
+                                        uiState.isSwitching.not()
+                                    Column(
+                                        modifier = Modifier.testTag(
+                                            tag = currentWorkspaceExistingRowTag
+                                        )
                                     ) {
-                                        Column(
-                                            verticalArrangement = Arrangement.spacedBy(4.dp),
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .then(
-                                                    if (workspace.isSelected) {
-                                                        Modifier.testTag(tag = currentWorkspaceSelectedSummaryTag)
+                                        ListItem(
+                                            headlineContent = {
+                                                Text(
+                                                    text = if (workspace.isSelected) {
+                                                        stringResource(
+                                                            R.string.settings_post_auth_current_workspace_suffix,
+                                                            workspace.title
+                                                        )
+                                                    } else {
+                                                        workspace.title
+                                                    },
+                                                    modifier = if (workspace.isSelected) {
+                                                        Modifier.testTag(
+                                                            tag = currentWorkspaceSelectedSummaryTag
+                                                        )
                                                     } else {
                                                         Modifier
                                                     }
                                                 )
-                                        ) {
-                                            Text(
-                                                text = if (workspace.isSelected) {
-                                                    stringResource(
-                                                        R.string.settings_post_auth_current_workspace_suffix,
-                                                        workspace.title
+                                            },
+                                            supportingContent = {
+                                                Text(text = workspace.subtitle)
+                                            },
+                                            leadingContent = {
+                                                RadioButton(
+                                                    selected = workspace.isSelected,
+                                                    onClick = null,
+                                                    modifier = if (workspace.isSelected) {
+                                                        Modifier.testTag(
+                                                            tag = currentWorkspaceSelectedIndicatorTag(
+                                                                workspaceId = workspace.workspaceId
+                                                            )
+                                                        )
+                                                    } else {
+                                                        Modifier
+                                                    }
+                                                )
+                                            },
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .testTag(
+                                                    tag = currentWorkspaceExistingButtonTag(
+                                                        workspaceId = workspace.workspaceId
                                                     )
-                                                } else {
-                                                    workspace.title
-                                                },
-                                                modifier = if (workspace.isCreateNew) {
-                                                    Modifier
-                                                } else if (workspace.isSelected) {
-                                                    Modifier.testTag(tag = currentWorkspaceExistingRowTag)
-                                                } else {
-                                                    Modifier.testTag(tag = currentWorkspaceExistingRowTag)
-                                                }
-                                            )
-                                            Text(
-                                                text = workspace.subtitle,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        }
+                                                )
+                                                .selectable(
+                                                    selected = workspace.isSelected,
+                                                    enabled = isSelectionEnabled,
+                                                    role = Role.RadioButton,
+                                                    onClick = {
+                                                        onSwitchToExistingWorkspace(
+                                                            workspace.workspaceId
+                                                        )
+                                                    }
+                                                )
+                                        )
                                     }
                                 }
-                                if (uiState.canRetryLastWorkspaceAction && uiState.errorMessage.isNotEmpty()) {
-                                    OutlinedButton(
-                                        onClick = onRetryLastWorkspaceAction,
-                                        modifier = Modifier.fillMaxWidth()
-                                    ) {
-                                        Text(stringResource(R.string.settings_retry))
-                                    }
+                            }
+                        }
+                    }
+                    val createWorkspace = uiState.workspaces.firstOrNull { workspace ->
+                        workspace.isCreateNew
+                    }
+                    if (createWorkspace != null) {
+                        item(key = createWorkspace.workspaceId) {
+                            OutlinedButton(
+                                onClick = onCreateWorkspace,
+                                enabled = uiState.isSwitching.not(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag(tag = currentWorkspaceCreateButtonTag)
+                            ) {
+                                Column(
+                                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text(text = createWorkspace.title)
+                                    Text(
+                                        text = createWorkspace.subtitle,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
                                 }
+                            }
+                        }
+                    }
+                    if (uiState.errorMessage.isNotEmpty()) {
+                        item {
+                            WorkspaceErrorMessage(
+                                errorMessage = uiState.errorMessage,
+                                modifier = Modifier
+                            )
+                        }
+                    }
+                    if (uiState.canRetryLastWorkspaceAction && uiState.errorMessage.isNotEmpty()) {
+                        item {
+                            OutlinedButton(
+                                onClick = onRetryLastWorkspaceAction,
+                                enabled = uiState.isSwitching.not(),
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(stringResource(R.string.settings_retry))
                             }
                         }
                     }
@@ -342,4 +587,68 @@ fun CurrentWorkspaceRoute(
             }
         }
     }
+}
+
+@Composable
+private fun CurrentWorkspaceRenameDialog(
+    uiState: CurrentWorkspaceUiState,
+    onWorkspaceNameChange: (String) -> Unit,
+    onSaveWorkspaceName: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = onSaveWorkspaceName,
+                enabled = uiState.isSavingName.not() &&
+                    uiState.isSwitching.not() &&
+                    uiState.workspaceNameDraft.trim().isNotEmpty() &&
+                    uiState.workspaceNameDraft.trim() != uiState.currentWorkspaceName,
+                modifier = Modifier.testTag(tag = currentWorkspaceSaveNameButtonTag)
+            ) {
+                Text(
+                    if (uiState.isSavingName) {
+                        stringResource(R.string.settings_saving)
+                    } else {
+                        stringResource(R.string.settings_workspace_save_name_button)
+                    }
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = uiState.isSavingName.not()
+            ) {
+                Text(stringResource(R.string.settings_cancel))
+            }
+        },
+        title = {
+            Text(stringResource(R.string.settings_current_workspace_rename_dialog_title))
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = uiState.workspaceNameDraft,
+                    onValueChange = onWorkspaceNameChange,
+                    enabled = uiState.isSavingName.not() && uiState.isSwitching.not(),
+                    label = {
+                        Text(stringResource(R.string.settings_workspace_name_label))
+                    },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(tag = currentWorkspaceNameFieldTag)
+                )
+                if (uiState.errorMessage.isNotEmpty()) {
+                    WorkspaceErrorMessage(
+                        errorMessage = uiState.errorMessage,
+                        modifier = Modifier
+                    )
+                }
+            }
+        },
+        modifier = Modifier.testTag(tag = currentWorkspaceRenameDialogTag)
+    )
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/current/CurrentWorkspaceUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/current/CurrentWorkspaceUiState.kt
@@ -13,7 +13,18 @@ enum class CurrentWorkspaceOperation {
     SYNCING
 }
 
+enum class CurrentWorkspaceRenameResult {
+    SUCCEEDED,
+    FAILED
+}
+
+data class CurrentWorkspaceRenameCompletion(
+    val submissionId: String,
+    val result: CurrentWorkspaceRenameResult
+)
+
 data class CurrentWorkspaceUiState(
+    val isInitialized: Boolean,
     val cloudStatusTitle: String,
     val currentWorkspaceName: String,
     val linkedEmail: String?,
@@ -29,6 +40,7 @@ data class CurrentWorkspaceUiState(
     val successMessage: String,
     val workspaceNameDraft: String,
     val isSavingName: Boolean,
+    val renameCompletion: CurrentWorkspaceRenameCompletion?,
     val workspaces: List<CurrentWorkspaceItemUiState>
 )
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/current/CurrentWorkspaceViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/current/CurrentWorkspaceViewModel.kt
@@ -33,6 +33,7 @@ import com.flashcardsopensourceapp.feature.settings.cloud.workspaceSelectionTitl
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
 import com.flashcardsopensourceapp.feature.settings.resolveWorkspaceName
 import com.flashcardsopensourceapp.feature.settings.workspace.shared.workspaceUpdatedOnAnotherDeviceMessage
+import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -59,6 +60,7 @@ private data class CurrentWorkspaceDraftState(
     val workspaceNameDraft: String,
     val hasUserEditedName: Boolean,
     val isSavingName: Boolean,
+    val renameCompletion: CurrentWorkspaceRenameCompletion?,
     val workspaces: List<CloudWorkspaceSummary>
 )
 
@@ -82,6 +84,7 @@ class CurrentWorkspaceViewModel(
             workspaceNameDraft = "",
             hasUserEditedName = false,
             isSavingName = false,
+            renameCompletion = null,
             workspaces = emptyList()
         )
     )
@@ -93,6 +96,7 @@ class CurrentWorkspaceViewModel(
     private var pendingAutoSyncRequestId: String? = null
     private var currentWorkspaceSignatureAtAutoSyncStart: CurrentWorkspaceVisibleSignature? = null
     private var lastVisibleAutoSyncChangeSignature: CurrentWorkspaceVisibleSignature? = null
+    private var activeRenameSubmissionId: String? = null
 
     val uiState: StateFlow<CurrentWorkspaceUiState> = combine(
         workspaceRepository.observeAppMetadata(),
@@ -133,6 +137,7 @@ class CurrentWorkspaceViewModel(
             currentWorkspaceName
         }
         CurrentWorkspaceUiState(
+            isInitialized = true,
             cloudStatusTitle = displayCloudAccountStateTitle(
                 cloudState = cloudSettings.cloudState,
                 strings = strings
@@ -156,6 +161,7 @@ class CurrentWorkspaceViewModel(
             successMessage = draft.successMessage,
             workspaceNameDraft = workspaceNameDraft,
             isSavingName = draft.isSavingName,
+            renameCompletion = draft.renameCompletion,
             workspaces = buildCurrentWorkspaceItems(
                 activeWorkspaceId = cloudSettings.activeWorkspaceId,
                 workspaces = draft.workspaces,
@@ -166,6 +172,7 @@ class CurrentWorkspaceViewModel(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
         initialValue = CurrentWorkspaceUiState(
+            isInitialized = false,
             cloudStatusTitle = strings.get(R.string.settings_loading),
             currentWorkspaceName = strings.get(R.string.settings_loading),
             linkedEmail = null,
@@ -181,6 +188,7 @@ class CurrentWorkspaceViewModel(
             successMessage = "",
             workspaceNameDraft = "",
             isSavingName = false,
+            renameCompletion = null,
             workspaces = emptyList()
         )
     )
@@ -191,7 +199,10 @@ class CurrentWorkspaceViewModel(
 
     suspend fun loadWorkspaces() {
         val cloudSettings = cloudAccountRepository.observeCloudSettings().first()
-        if (cloudSettings.cloudState != CloudAccountState.LINKED) {
+        if (
+            cloudSettings.cloudState != CloudAccountState.LINKED
+            && cloudSettings.cloudState != CloudAccountState.LINKING_READY
+        ) {
             messageController.showMessage(
                 message = if (cloudSettings.cloudState == CloudAccountState.GUEST) {
                     strings.get(R.string.settings_current_workspace_load_guest_message)
@@ -446,6 +457,9 @@ class CurrentWorkspaceViewModel(
             }
             true
         } catch (error: CancellationException) {
+            draftState.update { state ->
+                state.copy(isSavingName = false)
+            }
             throw error
         } catch (error: Exception) {
             val errorMessage = strings.get(R.string.settings_workspace_name_save_failed)
@@ -470,10 +484,34 @@ class CurrentWorkspaceViewModel(
         }
     }
 
-    fun saveWorkspaceNameAsync() {
-        viewModelScope.launch {
-            saveWorkspaceName()
+    fun saveWorkspaceNameAsync(): String {
+        val activeSubmissionId = activeRenameSubmissionId
+        if (activeSubmissionId != null) {
+            return activeSubmissionId
         }
+
+        val submissionId = UUID.randomUUID().toString()
+        activeRenameSubmissionId = submissionId
+        viewModelScope.launch {
+            try {
+                val result = if (saveWorkspaceName()) {
+                    CurrentWorkspaceRenameResult.SUCCEEDED
+                } else {
+                    CurrentWorkspaceRenameResult.FAILED
+                }
+                draftState.update { state ->
+                    state.copy(
+                        renameCompletion = CurrentWorkspaceRenameCompletion(
+                            submissionId = submissionId,
+                            result = result
+                        )
+                    )
+                }
+            } finally {
+                activeRenameSubmissionId = null
+            }
+        }
+        return submissionId
     }
 
     private fun observeAutoSyncDrivenWorkspaceChanges() {

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -262,6 +262,11 @@
     <string name="settings_current_workspace_manage_sign_in_message">Sign in to manage linked workspaces.</string>
     <string name="settings_current_workspace_switching">Switching to %1$s...</string>
     <string name="settings_current_workspace_syncing">Syncing %1$s...</string>
+    <string name="settings_current_workspace_current_title">Current workspace</string>
+    <string name="settings_current_workspace_change_action">Change workspace</string>
+    <string name="settings_current_workspace_rename_action">Rename workspace</string>
+    <string name="settings_current_workspace_change_sheet_title">Change workspace</string>
+    <string name="settings_current_workspace_rename_dialog_title">Rename workspace</string>
 
     <string name="settings_account_status_title">Account status</string>
     <string name="settings_account_legal_title">Legal</string>


### PR DESCRIPTION
## Summary
- simplify the Android Workspace screen to read-only current state and explicit actions
- present workspace selection in a lifecycle-safe Material 3 bottom sheet
- present workspace rename in a typed, ViewModel-owned Material 3 dialog flow
- update tag-based instrumentation readiness, diagnostics, and dependent assertions

## Validation
- `git diff --check`
- settings strings XML parsing
- static state-path, constructor, lifecycle, sheet-state, radio semantics, tag, overlay-back, readiness, diagnostics, and stale-assertion checks
- final fresh empty-history review: no P0-P4 findings

Gradle and emulator validation were not run because they were not authorized for this task.