### PR TITLE
Stabilize iOS card photo picker

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
@@ -235,6 +235,7 @@ private struct CardTextEditorScreen: View {
     @Binding var editorSessionId: UUID
     @Binding var mediaAssetIdsReadyForUpload: Set<String>
     @FocusState private var isTextEditorFocused: Bool
+    @State private var isPhotoPickerPresented: Bool = false
     @State private var selectedPhotoItem: PhotosPickerItem?
     @State private var textSelection: TextSelection?
     @State private var isImportingImage: Bool = false
@@ -288,6 +289,13 @@ private struct CardTextEditorScreen: View {
                 self.addImageToolbarItem
             }
         }
+        .photosPicker(
+            isPresented: self.$isPhotoPickerPresented,
+            selection: self.$selectedPhotoItem,
+            matching: .images,
+            preferredItemEncoding: .current,
+            photoLibrary: .shared()
+        )
         .alert(
             String(localized: "Image couldn't be inserted", table: reviewCardsStringsTableName),
             isPresented: self.$isImageImportErrorPresented
@@ -305,32 +313,34 @@ private struct CardTextEditorScreen: View {
         }
         .onChange(of: self.editorSessionId) { _, _ in
             self.cancelImageImport()
+            self.clearSelectedPhotoItem()
         }
         .onAppear {
             self.isTextEditorFocused = true
         }
         .onDisappear {
             self.cancelImageImport()
+            self.clearSelectedPhotoItem()
         }
     }
 
-    @ViewBuilder
     private var addImageToolbarItem: some View {
-        if self.isImportingImage {
-            ProgressView()
-                .controlSize(.small)
-                .accessibilityLabel(String(localized: "Processing image...", table: reviewCardsStringsTableName))
-        } else {
-            PhotosPicker(
-                selection: self.$selectedPhotoItem,
-                matching: .images,
-                preferredItemEncoding: .current,
-                photoLibrary: .shared()
-            ) {
+        Button {
+            self.isPhotoPickerPresented = true
+        } label: {
+            if self.isImportingImage {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
                 Image(systemName: "photo.badge.plus")
             }
-            .accessibilityLabel(String(localized: "Add image", table: reviewCardsStringsTableName))
         }
+        .disabled(self.isImportingImage)
+        .accessibilityLabel(
+            self.isImportingImage
+                ? String(localized: "Processing image...", table: reviewCardsStringsTableName)
+                : String(localized: "Add image", table: reviewCardsStringsTableName)
+        )
     }
 
     private func startImageImport(item: PhotosPickerItem) {
@@ -339,7 +349,6 @@ private struct CardTextEditorScreen: View {
         let editorSessionId = self.editorSessionId
         self.activeImageImportId = importId
         self.isImportingImage = true
-        self.selectedPhotoItem = nil
         self.imageImportTask = Task { @MainActor in
             await self.handleSelectedPhotoItem(
                 item,
@@ -354,6 +363,9 @@ private struct CardTextEditorScreen: View {
         self.imageImportTask = nil
         self.activeImageImportId = nil
         self.isImportingImage = false
+    }
+
+    private func clearSelectedPhotoItem() {
         self.selectedPhotoItem = nil
     }
 
@@ -422,7 +434,7 @@ private struct CardTextEditorScreen: View {
         self.imageImportTask = nil
         self.activeImageImportId = nil
         self.isImportingImage = false
-        self.selectedPhotoItem = nil
+        self.clearSelectedPhotoItem()
     }
 
     private func isCurrentImageImport(editorSessionId: UUID, importId: UUID) -> Bool {

--- a/docs/managed-media-cross-client-smoke.md
+++ b/docs/managed-media-cross-client-smoke.md
@@ -35,6 +35,31 @@ Expected behavior for every path:
 - Destination clients must not remain permanently stuck on unavailable media
   after the source upload has completed and sync has run.
 
+## iOS Card Photo Picker Regression
+
+Run this flow on a real iPhone:
+
+1. Open Cards, tap Add card, and open Front.
+2. Enter ordinary text, tap Add image, and select a recognizable photo.
+3. Confirm the Front editor remains visible after the system photo picker closes,
+   the original text remains present, and the selected image appears in the
+   preview strip.
+4. Use Back to return to the card form; this must not save or dismiss the card.
+   Open Back, enter ordinary answer text, return to the card form, and tap Save.
+5. Confirm the new card is visible in Cards, reopen it, open Front, and confirm
+   the text and image are still present.
+
+Repeat the picker portion with each of these conditions:
+
+- Tap Cancel in the system photo picker. The Front editor and enclosing card
+  editor must remain open and unchanged.
+- Select an animated GIF. The actionable rejection alert must appear, and
+  closing it must leave the Front editor and enclosing card editor open with
+  the existing text unchanged.
+- Select JPEG- and HEIC-origin photos, including once while the iPhone is
+  offline. Each supported photo must be inserted locally while the Front editor
+  and enclosing card editor remain open; upload may wait for connectivity.
+
 ## Failure Evidence
 
 If any path fails, capture:


### PR DESCRIPTION
## Summary
- keep the card text editor photo-picker presenter mounted for the screen lifetime
- separate image-import cancellation from picker-selection cleanup
- document the real-iPhone managed-media regression flow

## Validation
- `git --no-pager diff --check`
- `xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift`
- required picker/state `rg` scan; no `saveCard` or `editorPresentation` path in `CardTextEditorScreen`
- fresh empty-history review: no P0-P4 findings and no split recommendation

## Residual risk
The system photo-picker lifecycle has not been exercised on a real iPhone. Simulator-backed tests were not run by instruction. The documented manual check remains required, including picker Cancel, animated-GIF rejection, JPEG/HEIC-origin photos, and offline selection.