### PR TITLE
Harden iOS card editor sheet lifecycle

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
@@ -51,7 +51,6 @@ extension FlashcardsStore {
             preparedImage: preparedImage,
             altText: altText
         )
-        self.localReadVersion += 1
         return result
     }
 

--- a/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
@@ -232,6 +232,7 @@ struct CardsScreen: View {
             }
             .technicalErrorSheet(store: self.store)
             .accessibilityIdentifier(UITestIdentifier.cardEditorScreen)
+            .interactiveDismissDisabled()
         }
         .sheet(isPresented: $isFilterSheetPresented) {
             NavigationStack {

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -240,6 +240,7 @@ struct ReviewView: View {
                 )
             }
             .technicalErrorSheet(store: self.store)
+            .interactiveDismissDisabled()
         }
         .alert(
             String(localized: "Review wasn't saved", table: reviewCardsStringsTableName),

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeCardsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeCardsTests.swift
@@ -12,6 +12,16 @@ final class LiveSmokeCardsTests: LiveSmokeTestCase {
     }
 
     @MainActor
+    func testLiveSmokeUnsavedCardDraftSurvivesInteractiveDismissal() throws {
+        let frontText = "Unsaved card draft \(UUID().uuidString)"
+        try self.launchApplication(launchScenario: .guestEmptyWorkspace, selectedTab: .cards)
+
+        try self.step("keep an unsaved card draft after interactive dismissal") {
+            try self.assertUnsavedCardDraftSurvivesInteractiveDismissal(frontText: frontText)
+        }
+    }
+
+    @MainActor
     func testLiveSmokeCardsEditorAiHandoffFlow() throws {
         try self.launchApplication(launchScenario: .guestManualReviewCard, selectedTab: .cards)
 

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Flows/LiveSmokeCardsReviewFlows.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Flows/LiveSmokeCardsReviewFlows.swift
@@ -2,6 +2,53 @@ import XCTest
 
 extension LiveSmokeTestCase {
     @MainActor
+    func assertUnsavedCardDraftSurvivesInteractiveDismissal(frontText: String) throws {
+        try self.assertScreenVisible(screen: .cards, timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        try self.tapButton(identifier: LiveSmokeIdentifier.cardsAddButton, timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.cardEditorScreen,
+            timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
+        )
+        try self.tapButton(identifier: LiveSmokeIdentifier.cardEditorFrontRow, timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
+        try self.typeTextSafely(
+            frontText,
+            intoElementWithIdentifier: LiveSmokeIdentifier.cardEditorFrontTextEditor,
+            timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
+        )
+        try self.tapFirstNavigationBackButton()
+
+        let cardEditorSheet = self.app.descendants(matching: .any)
+            .matching(identifier: LiveSmokeIdentifier.cardEditorScreen)
+            .firstMatch
+        cardEditorSheet.swipeDown()
+
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.cardEditorScreen,
+            timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+        )
+        try self.tapButton(identifier: LiveSmokeIdentifier.cardEditorFrontRow, timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
+
+        let frontTextEditor = self.app.descendants(matching: .any)
+            .matching(identifier: LiveSmokeIdentifier.cardEditorFrontTextEditor)
+            .firstMatch
+        if try self.waitForElementValue(
+            frontTextEditor,
+            identifier: LiveSmokeIdentifier.cardEditorFrontTextEditor,
+            expectedValue: frontText,
+            timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
+        ) == false {
+            throw LiveSmokeFailure.unexpectedElementValue(
+                identifier: LiveSmokeIdentifier.cardEditorFrontTextEditor,
+                expectedValue: frontText,
+                actualValue: self.elementValue(element: frontTextEditor),
+                timeoutSeconds: LiveSmokeConfiguration.longUiTimeoutSeconds,
+                screen: self.currentScreenSummary(),
+                step: self.currentStepTitle
+            )
+        }
+    }
+
+    @MainActor
     func createManualCard(frontText: String, backText: String) throws {
         try self.assertScreenVisible(screen: .cards, timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
         try self.tapButton(identifier: LiveSmokeIdentifier.cardsAddButton, timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)


### PR DESCRIPTION
## Summary
- prevent draft media authoring from invalidating Cards and Review read presenters
- disable interactive dismissal for card editor sheets opened from Cards and Review
- add a stable-ID live smoke for preserving an unsaved draft after a swipe-down attempt

## Validation
- git diff --check
- xcrun swiftc -parse for all five changed Swift files
- lifecycle and localReadVersion reference scan
- fresh worker-owned review: no P0-P4 findings

## Not run
- simulator-backed XCUITest, per task instruction