### PR TITLE
feat(android): add app-level notifications UI

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -127,7 +127,7 @@ internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
     listOf(
         settingsAccountStatusRowTag to "Account status",
         settingsCurrentWorkspaceRowTag to "Workspace",
-        settingsReviewRemindersRowTag to "Reminders",
+        settingsReviewRemindersRowTag to "Notifications",
         settingsLeaderboardParticipationRowTag to "Leaderboard participation",
         settingsLanguageRowTag to "Language",
         settingsAccessRowTag to "Access",
@@ -171,7 +171,7 @@ internal fun LiveSmokeContext.openSettingsInformationArchitectureDetails() {
         ),
         SettingsDetailProbe(
             rowTag = settingsReviewRemindersRowTag,
-            rowLabel = "Reminders",
+            rowLabel = "Notifications",
             destinationTag = reviewNotificationsScreenTag
         ),
         SettingsDetailProbe(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
@@ -72,7 +72,7 @@ data object SettingsWorkspaceSchedulerDestination {
     const val route: String = "settings/scheduling"
 }
 
-data object SettingsWorkspaceNotificationsDestination {
+data object SettingsNotificationsDestination {
     const val route: String = "settings/review-reminders"
 }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNavGraph.kt
@@ -27,6 +27,11 @@ internal fun NavGraphBuilder.registerSettingsNavGraph(
             coroutineScope = coroutineScope,
             reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore
         )
+        registerSettingsNotificationsDestination(
+            appGraph = appGraph,
+            navController = navController,
+            coroutineScope = coroutineScope
+        )
         registerSettingsWorkspaceNavGraph(
             appGraph = appGraph,
             navController = navController,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNotificationsNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNotificationsNavGraph.kt
@@ -1,0 +1,109 @@
+package com.flashcardsopensourceapp.app.navigation.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
+import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
+import com.flashcardsopensourceapp.feature.settings.review.ReviewNotificationsRoute
+import com.flashcardsopensourceapp.feature.settings.review.createReviewNotificationsViewModelFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal fun NavGraphBuilder.registerSettingsNotificationsDestination(
+    appGraph: AppGraph,
+    navController: NavHostController,
+    coroutineScope: CoroutineScope
+) {
+    composable(route = SettingsNotificationsDestination.route) {
+        val notificationSchedulingMutex = remember { Mutex() }
+        val reviewNotificationsViewModel = viewModel<com.flashcardsopensourceapp.feature.settings.review.ReviewNotificationsViewModel>(
+            factory = createReviewNotificationsViewModelFactory(
+                workspaceRepository = appGraph.workspaceRepository,
+                reviewNotificationsStore = appGraph.reviewNotificationsStore,
+                strictRemindersStore = appGraph.strictRemindersStore,
+                onReviewSettingsChanged = {
+                    coroutineScope.launch {
+                        notificationSchedulingMutex.withLock {
+                            val nowMillis = System.currentTimeMillis()
+                            appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
+                                trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
+                                nowMillis = nowMillis
+                            )
+                            appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
+                                trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
+                                nowMillis = nowMillis
+                            )
+                        }
+                    }
+                },
+                onStrictRemindersSettingsChanged = { isEnabled ->
+                    coroutineScope.launch {
+                        notificationSchedulingMutex.withLock {
+                            val nowMillis = System.currentTimeMillis()
+                            if (isEnabled) {
+                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
+                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
+                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                            } else {
+                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
+                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
+                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                            }
+                        }
+                    }
+                },
+                onAppIconBadgeDisabled = {
+                    coroutineScope.launch {
+                        appGraph.reviewNotificationsManager.clearDeliveredReviewReminderNotifications()
+                    }
+                }
+            )
+        )
+        val uiState by reviewNotificationsViewModel.uiState.collectAsStateWithLifecycle()
+
+        ReviewNotificationsRoute(
+            uiState = uiState,
+            onUpdateEnabled = reviewNotificationsViewModel::updateEnabled,
+            onUpdateMode = reviewNotificationsViewModel::updateMode,
+            onUpdateDailyTime = reviewNotificationsViewModel::updateDailyTime,
+            onUpdateInactivityWindowStart = reviewNotificationsViewModel::updateInactivityWindowStart,
+            onUpdateInactivityWindowEnd = reviewNotificationsViewModel::updateInactivityWindowEnd,
+            onUpdateIdleMinutes = reviewNotificationsViewModel::updateIdleMinutes,
+            onUpdateShowAppIconBadge = reviewNotificationsViewModel::updateShowAppIconBadge,
+            onUpdateStrictRemindersEnabled = reviewNotificationsViewModel::updateStrictRemindersEnabled,
+            onMarkSystemPermissionRequested = reviewNotificationsViewModel::markSystemPermissionRequested,
+            onPermissionGranted = {
+                val nowMillis = System.currentTimeMillis()
+                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
+                    trigger = ReviewNotificationsReconcileTrigger.PERMISSION_CHANGED,
+                    nowMillis = nowMillis
+                )
+                appGraph.strictRemindersManager.reconcileStrictReminders(
+                    trigger = StrictRemindersReconcileTrigger.PERMISSION_CHANGED,
+                    nowMillis = nowMillis
+                )
+            },
+            onBack = {
+                navController.popBackStack()
+            }
+        )
+    }
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
@@ -145,7 +145,7 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
                 navController.navigate(route = SettingsCurrentWorkspaceDestination.route)
             },
             onOpenReviewReminders = {
-                navController.navigate(route = SettingsWorkspaceNotificationsDestination.route)
+                navController.navigate(route = SettingsNotificationsDestination.route)
             },
             onOpenReviewAnimations = {
                 navController.navigate(route = SettingsReviewAnimationsDestination.route)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -1,7 +1,6 @@
 package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -12,8 +11,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
-import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
-import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
 import com.flashcardsopensourceapp.feature.settings.deck.DeckDetailRoute
 import com.flashcardsopensourceapp.feature.settings.deck.DeckEditorSaveResult
 import com.flashcardsopensourceapp.feature.settings.deck.DeckEditorRoute
@@ -23,8 +20,6 @@ import com.flashcardsopensourceapp.feature.settings.deck.createAllCardsDeckDetai
 import com.flashcardsopensourceapp.feature.settings.deck.createDeckDetailViewModelFactory
 import com.flashcardsopensourceapp.feature.settings.deck.createDeckEditorViewModelFactory
 import com.flashcardsopensourceapp.feature.settings.deck.createDecksViewModelFactory
-import com.flashcardsopensourceapp.feature.settings.review.ReviewNotificationsRoute
-import com.flashcardsopensourceapp.feature.settings.review.createReviewNotificationsViewModelFactory
 import com.flashcardsopensourceapp.feature.settings.scheduler.SchedulerSettingsRoute
 import com.flashcardsopensourceapp.feature.settings.scheduler.createSchedulerSettingsViewModelFactory
 import com.flashcardsopensourceapp.feature.settings.workspace.delete.DeleteCurrentWorkspaceRoute
@@ -40,8 +35,6 @@ import com.flashcardsopensourceapp.feature.settings.workspace.tags.createWorkspa
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
@@ -55,7 +48,6 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
             factory = createWorkspaceSettingsViewModelFactory(
                 workspaceRepository = appGraph.workspaceRepository,
                 cloudAccountRepository = appGraph.cloudAccountRepository,
-                reviewNotificationsStore = appGraph.reviewNotificationsStore,
                 technicalErrorController = appGraph.appMessageBus,
                 applicationContext = context.applicationContext
             )
@@ -70,111 +62,6 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
             onRequestResetProgress = workspaceSettingsViewModel::requestResetProgressAsync,
             onDismissResetPreviewAlert = workspaceSettingsViewModel::dismissResetPreviewAlert,
             onResetProgress = workspaceSettingsViewModel::resetProgressAsync,
-            onBack = {
-                navController.popBackStack()
-            }
-        )
-    }
-
-    composable(route = SettingsWorkspaceNotificationsDestination.route) {
-        val notificationSchedulingMutex = remember { Mutex() }
-        val reviewNotificationsViewModel = viewModel<com.flashcardsopensourceapp.feature.settings.review.ReviewNotificationsViewModel>(
-            factory = createReviewNotificationsViewModelFactory(
-                workspaceRepository = appGraph.workspaceRepository,
-                reviewNotificationsStore = appGraph.reviewNotificationsStore,
-                strictRemindersStore = appGraph.strictRemindersStore,
-                onNotificationsMasterChanged = { isEnabled ->
-                    coroutineScope.launch {
-                        notificationSchedulingMutex.withLock {
-                            val nowMillis = System.currentTimeMillis()
-                            if (isEnabled) {
-                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
-                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
-                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                            } else {
-                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
-                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
-                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                            }
-                        }
-                    }
-                },
-                onReviewSettingsChanged = {
-                    coroutineScope.launch {
-                        notificationSchedulingMutex.withLock {
-                            appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
-                                trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
-                                nowMillis = System.currentTimeMillis()
-                            )
-                        }
-                    }
-                },
-                onStrictRemindersSettingsChanged = { isEnabled ->
-                    coroutineScope.launch {
-                        notificationSchedulingMutex.withLock {
-                            val nowMillis = System.currentTimeMillis()
-                            if (isEnabled) {
-                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
-                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
-                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                            } else {
-                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
-                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
-                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
-                                    nowMillis = nowMillis
-                                )
-                            }
-                        }
-                    }
-                },
-                onAppIconBadgeDisabled = {
-                    coroutineScope.launch {
-                        appGraph.reviewNotificationsManager.clearDeliveredReviewReminderNotifications()
-                    }
-                }
-            )
-        )
-        val uiState by reviewNotificationsViewModel.uiState.collectAsStateWithLifecycle()
-
-        ReviewNotificationsRoute(
-            uiState = uiState,
-            onUpdateEnabled = reviewNotificationsViewModel::updateEnabled,
-            onUpdateMode = reviewNotificationsViewModel::updateMode,
-            onUpdateDailyTime = reviewNotificationsViewModel::updateDailyTime,
-            onUpdateInactivityWindowStart = reviewNotificationsViewModel::updateInactivityWindowStart,
-            onUpdateInactivityWindowEnd = reviewNotificationsViewModel::updateInactivityWindowEnd,
-            onUpdateIdleMinutes = reviewNotificationsViewModel::updateIdleMinutes,
-            onUpdateShowAppIconBadge = reviewNotificationsViewModel::updateShowAppIconBadge,
-            onUpdateStrictRemindersEnabled = reviewNotificationsViewModel::updateStrictRemindersEnabled,
-            onMarkSystemPermissionRequested = reviewNotificationsViewModel::markSystemPermissionRequested,
-            onPermissionGranted = {
-                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
-                    trigger = ReviewNotificationsReconcileTrigger.PERMISSION_CHANGED,
-                    nowMillis = System.currentTimeMillis()
-                )
-                appGraph.strictRemindersManager.reconcileStrictReminders(
-                    trigger = StrictRemindersReconcileTrigger.PERMISSION_CHANGED,
-                    nowMillis = System.currentTimeMillis()
-                )
-            },
             onBack = {
                 navController.popBackStack()
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/notifications/NotificationDiagnosticsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/notifications/NotificationDiagnosticsRoute.kt
@@ -337,6 +337,10 @@ private fun NotificationDiagnosticsReviewPayloadCard(
         title = stringResource(R.string.settings_notification_diagnostics_payload_title, index + 1),
         rows = listOfNotNull(
             NotificationDiagnosticsInfoRow(
+                label = stringResource(R.string.settings_device_workspace_id_label),
+                value = payload.workspaceId
+            ),
+            NotificationDiagnosticsInfoRow(
                 label = stringResource(R.string.settings_notification_diagnostics_request_id_label),
                 value = payload.requestId
             ),
@@ -380,6 +384,10 @@ private fun NotificationDiagnosticsStrictReminderPayloadCard(
     NotificationDiagnosticsInfoCard(
         title = stringResource(R.string.settings_notification_diagnostics_payload_title, index + 1),
         rows = listOf(
+            NotificationDiagnosticsInfoRow(
+                label = stringResource(R.string.settings_device_workspace_id_label),
+                value = payload.workspaceId
+            ),
             NotificationDiagnosticsInfoRow(
                 label = stringResource(R.string.settings_notification_diagnostics_request_id_label),
                 value = payload.requestId

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
@@ -8,12 +8,16 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -28,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -102,6 +107,25 @@ fun ReviewNotificationsRoute(
         }
     }
 
+    if (uiState.isLoaded.not()) {
+        SettingsScreenScaffold(
+            title = stringResource(R.string.settings_notifications_title),
+            onBack = onBack,
+            isBackEnabled = true
+        ) { innerPadding ->
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .testTag(tag = reviewNotificationsScreenTag)
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        return
+    }
+
     SettingsScreenScaffold(
         title = stringResource(R.string.settings_notifications_title),
         onBack = onBack,
@@ -170,7 +194,10 @@ fun ReviewNotificationsRoute(
                                 }
                             )
 
-                            if (uiState.settings.selectedMode == ReviewNotificationMode.DAILY) {
+                            if (
+                                uiState.settings.isEnabled &&
+                                uiState.settings.selectedMode == ReviewNotificationMode.DAILY
+                            ) {
                                 ReviewNotificationModeSelector(
                                     selectedMode = uiState.settings.selectedMode,
                                     onUpdateMode = onUpdateMode
@@ -191,7 +218,7 @@ fun ReviewNotificationsRoute(
                                         )
                                     }
                                 )
-                            } else {
+                            } else if (uiState.settings.isEnabled) {
                                 ReviewNotificationModeSelector(
                                     selectedMode = uiState.settings.selectedMode,
                                     onUpdateMode = onUpdateMode
@@ -237,23 +264,10 @@ fun ReviewNotificationsRoute(
                                         Text(stringResource(R.string.settings_notifications_remind_after_title))
                                     },
                                     trailingContent = {
-                                        SingleChoiceSegmentedButtonRow {
-                                            listOf(60, 120, 180).forEachIndexed { index, value ->
-                                                SegmentedButton(
-                                                    selected = uiState.settings.inactivity.idleMinutes == value,
-                                                    onClick = {
-                                                        onUpdateIdleMinutes(value)
-                                                    },
-                                                    shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
-                                                        index = index,
-                                                        count = 3
-                                                    ),
-                                                    label = {
-                                                        Text(idleMinutesLabel(minutes = value))
-                                                    }
-                                                )
-                                            }
-                                        }
+                                        IdleMinutesDropdown(
+                                            selectedMinutes = uiState.settings.inactivity.idleMinutes,
+                                            onUpdateIdleMinutes = onUpdateIdleMinutes
+                                        )
                                     }
                                 )
                             }
@@ -261,56 +275,87 @@ fun ReviewNotificationsRoute(
                     }
                 }
 
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_show_app_icon_badge_title))
-                            },
-                            supportingContent = {
-                                Text(stringResource(R.string.settings_notifications_show_app_icon_badge_body))
-                            },
-                            trailingContent = {
-                                Switch(
-                                    checked = uiState.settings.showAppIconBadge,
-                                    onCheckedChange = onUpdateShowAppIconBadge
-                                )
-                            }
-                        )
+                if (uiState.settings.isEnabled) {
+                    item {
+                        Card(modifier = Modifier.fillMaxWidth()) {
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_show_app_icon_badge_title))
+                                },
+                                supportingContent = {
+                                    Text(stringResource(R.string.settings_notifications_show_app_icon_badge_body))
+                                },
+                                trailingContent = {
+                                    Switch(
+                                        checked = uiState.settings.showAppIconBadge,
+                                        onCheckedChange = onUpdateShowAppIconBadge
+                                    )
+                                }
+                            )
+                        }
                     }
-                }
 
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_strict_reminders_title))
-                            },
-                            supportingContent = {
-                                Text(stringResource(R.string.settings_notifications_strict_reminders_body))
-                            },
-                            trailingContent = {
-                                Switch(
-                                    checked = uiState.strictRemindersSettings.isEnabled,
-                                    onCheckedChange = onUpdateStrictRemindersEnabled
-                                )
-                            }
-                        )
+                    item {
+                        Card(modifier = Modifier.fillMaxWidth()) {
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_strict_reminders_title))
+                                },
+                                supportingContent = {
+                                    Text(stringResource(R.string.settings_notifications_strict_reminders_body))
+                                },
+                                trailingContent = {
+                                    Switch(
+                                        checked = uiState.strictRemindersSettings.isEnabled,
+                                        onCheckedChange = onUpdateStrictRemindersEnabled
+                                    )
+                                }
+                            )
+                        }
                     }
-                }
 
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_this_device_title))
-                            },
-                            supportingContent = {
-                                Text(stringResource(R.string.settings_notifications_this_device_body))
-                            }
-                        )
+                    item {
+                        Card(modifier = Modifier.fillMaxWidth()) {
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_this_device_title))
+                                },
+                                supportingContent = {
+                                    Text(stringResource(R.string.settings_notifications_this_device_body))
+                                }
+                            )
+                        }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IdleMinutesDropdown(
+    selectedMinutes: Int,
+    onUpdateIdleMinutes: (Int) -> Unit
+) {
+    var isExpanded by remember { mutableStateOf(value = false) }
+    val intervalMinutes = listOf(30, 60, 90, 120, 180, 240)
+
+    Box {
+        TextButton(onClick = { isExpanded = true }) {
+            Text(idleMinutesLabel(minutes = selectedMinutes))
+        }
+        DropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false }
+        ) {
+            intervalMinutes.forEach { minutes ->
+                DropdownMenuItem(
+                    text = { Text(idleMinutesLabel(minutes = minutes)) },
+                    onClick = {
+                        isExpanded = false
+                        onUpdateIdleMinutes(minutes)
+                    }
+                )
             }
         }
     }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsUiState.kt
@@ -12,8 +12,7 @@ enum class ReviewNotificationPermissionUiStatus {
 }
 
 data class ReviewNotificationsUiState(
-    val workspaceId: String?,
-    val workspaceName: String,
+    val isLoaded: Boolean,
     val settings: ReviewNotificationsSettings,
     val strictRemindersSettings: StrictRemindersSettings,
     val hasRequestedSystemPermission: Boolean
@@ -21,8 +20,7 @@ data class ReviewNotificationsUiState(
 
 fun initialReviewNotificationsUiState(): ReviewNotificationsUiState {
     return ReviewNotificationsUiState(
-        workspaceId = null,
-        workspaceName = "",
+        isLoaded = false,
         settings = defaultReviewNotificationsSettings(),
         strictRemindersSettings = defaultStrictRemindersSettings(),
         hasRequestedSystemPermission = false

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsViewModel.kt
@@ -23,7 +23,6 @@ class ReviewNotificationsViewModel(
     private val workspaceRepository: WorkspaceRepository,
     private val reviewNotificationsStore: ReviewNotificationsStore,
     private val strictRemindersStore: StrictRemindersStore,
-    private val onNotificationsMasterChanged: (Boolean) -> Unit,
     private val onReviewSettingsChanged: () -> Unit,
     private val onStrictRemindersSettingsChanged: (Boolean) -> Unit,
     private val onAppIconBadgeDisabled: () -> Unit
@@ -41,8 +40,7 @@ class ReviewNotificationsViewModel(
         reviewNotificationsStore.migrateLegacySettings(currentWorkspaceId = workspace.workspaceId)
         val promptState = reviewNotificationsStore.loadPromptState()
         ReviewNotificationsUiState(
-            workspaceId = workspace.workspaceId,
-            workspaceName = workspace.name,
+            isLoaded = true,
             settings = reviewNotificationsStore.loadSettings(),
             strictRemindersSettings = strictRemindersStore.loadStrictRemindersSettings(),
             hasRequestedSystemPermission = promptState.hasRequestedSystemPermission
@@ -54,13 +52,9 @@ class ReviewNotificationsViewModel(
     )
 
     fun updateEnabled(isEnabled: Boolean) {
-        if (uiState.value.workspaceId == null) {
-            return
+        updateSettings { settings ->
+            settings.copy(isEnabled = isEnabled)
         }
-        val nextSettings = uiState.value.settings.copy(isEnabled = isEnabled)
-        reviewNotificationsStore.saveSettings(settings = nextSettings)
-        refreshVersion.update { version -> version + 1 }
-        onNotificationsMasterChanged(isEnabled)
     }
 
     fun updateMode(mode: ReviewNotificationMode) {
@@ -111,21 +105,18 @@ class ReviewNotificationsViewModel(
     }
 
     fun updateShowAppIconBadge(value: Boolean) {
-        if (uiState.value.workspaceId == null) {
-            return
-        }
-        updateSettings { settings ->
+        val didUpdate = updateSettings { settings ->
             settings.copy(showAppIconBadge = value)
         }
         // When the toggle is turned off, drop any badge currently shown so the
         // user gets immediate feedback rather than waiting for a future event.
-        if (value.not()) {
+        if (didUpdate && value.not()) {
             onAppIconBadgeDisabled()
         }
     }
 
     fun updateStrictRemindersEnabled(isEnabled: Boolean) {
-        if (uiState.value.workspaceId == null) {
+        if (uiState.value.isLoaded.not()) {
             return
         }
         val nextSettings = StrictRemindersSettings(isEnabled = isEnabled)
@@ -135,7 +126,7 @@ class ReviewNotificationsViewModel(
     }
 
     fun markSystemPermissionRequested() {
-        if (uiState.value.workspaceId == null) {
+        if (uiState.value.isLoaded.not()) {
             return
         }
         val promptState = reviewNotificationsStore.loadPromptState()
@@ -149,14 +140,17 @@ class ReviewNotificationsViewModel(
         refreshVersion.update { version -> version + 1 }
     }
 
-    private fun updateSettings(transform: (ReviewNotificationsSettings) -> ReviewNotificationsSettings) {
-        if (uiState.value.workspaceId == null) {
-            return
+    private fun updateSettings(
+        transform: (ReviewNotificationsSettings) -> ReviewNotificationsSettings
+    ): Boolean {
+        if (uiState.value.isLoaded.not()) {
+            return false
         }
         val nextSettings = transform(uiState.value.settings)
         reviewNotificationsStore.saveSettings(settings = nextSettings)
         refreshVersion.update { version -> version + 1 }
         onReviewSettingsChanged()
+        return true
     }
 }
 
@@ -164,7 +158,6 @@ fun createReviewNotificationsViewModelFactory(
     workspaceRepository: WorkspaceRepository,
     reviewNotificationsStore: ReviewNotificationsStore,
     strictRemindersStore: StrictRemindersStore,
-    onNotificationsMasterChanged: (Boolean) -> Unit,
     onReviewSettingsChanged: () -> Unit,
     onStrictRemindersSettingsChanged: (Boolean) -> Unit,
     onAppIconBadgeDisabled: () -> Unit
@@ -175,7 +168,6 @@ fun createReviewNotificationsViewModelFactory(
                 workspaceRepository = workspaceRepository,
                 reviewNotificationsStore = reviewNotificationsStore,
                 strictRemindersStore = strictRemindersStore,
-                onNotificationsMasterChanged = onNotificationsMasterChanged,
                 onReviewSettingsChanged = onReviewSettingsChanged,
                 onStrictRemindersSettingsChanged = onStrictRemindersSettingsChanged,
                 onAppIconBadgeDisabled = onAppIconBadgeDisabled

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsUiState.kt
@@ -8,7 +8,6 @@ data class WorkspaceSettingsUiState(
     val deckCount: Int,
     val totalCards: Int,
     val tagCount: Int,
-    val notificationsSummary: String,
     val schedulerSummary: String,
     val exportSummary: String,
     val isLinked: Boolean,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsViewModel.kt
@@ -10,7 +10,6 @@ import com.flashcardsopensourceapp.core.ui.AppTechnicalErrorController
 import com.flashcardsopensourceapp.core.ui.makeAppTechnicalError
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceResetProgressPreview
-import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncBlockedException
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
@@ -44,7 +43,6 @@ private data class WorkspaceSettingsDraftState(
 class WorkspaceSettingsViewModel(
     workspaceRepository: WorkspaceRepository,
     private val cloudAccountRepository: CloudAccountRepository,
-    reviewNotificationsStore: ReviewNotificationsStore,
     private val technicalErrorController: AppTechnicalErrorController,
     private val strings: SettingsStringResolver
 ) : ViewModel() {
@@ -64,22 +62,14 @@ class WorkspaceSettingsViewModel(
     val uiState: StateFlow<WorkspaceSettingsUiState> = combine(
         workspaceRepository.observeWorkspaceOverview(),
         workspaceRepository.observeWorkspaceSchedulerSettings(),
-        workspaceRepository.observeWorkspace(),
         cloudAccountRepository.observeCloudSettings(),
         draftState
-    ) { overview, schedulerSettings, workspace, cloudSettings, draft ->
+    ) { overview, schedulerSettings, cloudSettings, draft ->
         WorkspaceSettingsUiState(
             workspaceName = overview?.workspaceName ?: strings.get(R.string.settings_unavailable),
             deckCount = overview?.deckCount ?: 0,
             totalCards = overview?.totalCards ?: 0,
             tagCount = overview?.tagsCount ?: 0,
-            notificationsSummary = workspace?.let {
-                if (reviewNotificationsStore.loadSettings().isEnabled) {
-                    strings.get(R.string.settings_on)
-                } else {
-                    strings.get(R.string.settings_off)
-                }
-            } ?: strings.get(R.string.settings_unavailable),
             schedulerSummary = schedulerSettings?.let { settings ->
                 formatWorkspaceSchedulerSummary(settings = settings, strings = strings)
             } ?: strings.get(R.string.settings_unavailable),
@@ -102,7 +92,6 @@ class WorkspaceSettingsViewModel(
             deckCount = 0,
             totalCards = 0,
             tagCount = 0,
-            notificationsSummary = strings.get(R.string.settings_loading),
             schedulerSummary = strings.get(R.string.settings_loading),
             exportSummary = strings.get(R.string.settings_export_package_summary),
             isLinked = false,
@@ -337,7 +326,6 @@ class WorkspaceSettingsViewModel(
 fun createWorkspaceSettingsViewModelFactory(
     workspaceRepository: WorkspaceRepository,
     cloudAccountRepository: CloudAccountRepository,
-    reviewNotificationsStore: ReviewNotificationsStore,
     technicalErrorController: AppTechnicalErrorController,
     applicationContext: Context
 ): ViewModelProvider.Factory {
@@ -346,7 +334,6 @@ fun createWorkspaceSettingsViewModelFactory(
             WorkspaceSettingsViewModel(
                 workspaceRepository = workspaceRepository,
                 cloudAccountRepository = cloudAccountRepository,
-                reviewNotificationsStore = reviewNotificationsStore,
                 technicalErrorController = technicalErrorController,
                 strings = createSettingsStringResolver(context = applicationContext)
             )

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -90,8 +90,8 @@
     <string name="settings_share_app_text">Study with Flashcards. Your cards stay available across iOS, Android, and the web.</string>
     <string name="settings_root_test_title">Test</string>
     <string name="settings_root_test_summary">3 items</string>
-    <string name="settings_review_reminders_title">Reminders</string>
-    <string name="settings_review_reminders_summary">Workspace reminders and streak reminders</string>
+    <string name="settings_review_reminders_title">Notifications</string>
+    <string name="settings_review_reminders_summary">Study notifications on this device</string>
     <string name="settings_review_animations_title">Review Animations</string>
     <string name="settings_review_animations_summary">Show animations after rating a card</string>
     <string name="settings_review_animations_toggle_title">Show animations after rating a card</string>
@@ -216,7 +216,7 @@
     <string name="settings_notification_diagnostics_delivered_other_label">Other review-channel notifications</string>
     <string name="settings_notification_diagnostics_enabled_label">Enabled</string>
     <string name="settings_notification_diagnostics_mode_label">Mode</string>
-    <string name="settings_notification_diagnostics_inactivity_window_label">Cards reminder window</string>
+    <string name="settings_notification_diagnostics_inactivity_window_label">Break time window</string>
     <string name="settings_notification_diagnostics_window_format">%1$s to %2$s</string>
     <string name="settings_notification_diagnostics_idle_minutes_label">Idle minutes</string>
     <string name="settings_notification_diagnostics_work_limit_label">Work limit</string>
@@ -368,9 +368,9 @@
     <string name="settings_access_photos_guidance">Android 14+ uses the system photo picker here, so broad storage access is not required.</string>
     <string name="settings_access_files_guidance">Android uses the system document picker here, so broad storage access is not required.</string>
 
-    <string name="settings_notifications_title">Reminders</string>
+    <string name="settings_notifications_title">Notifications</string>
     <string name="settings_notifications_this_device_title">This device only</string>
-    <string name="settings_notifications_this_device_body">Study reminders stay on this device and contain cards only, never marketing.</string>
+    <string name="settings_notifications_this_device_body">These settings stay on this device. Notifications use the currently selected workspace and never contain marketing.</string>
     <string name="settings_notifications_permission_title">Permission</string>
     <string name="settings_notifications_allow_button">Allow notifications</string>
     <string name="settings_notifications_permission_guidance_allowed">Android can deliver enabled study reminders.</string>
@@ -378,19 +378,19 @@
     <string name="settings_notifications_permission_guidance_blocked">Android is blocking study reminders. Open app settings to allow notifications again.</string>
     <string name="settings_notifications_strict_reminders_title">Streak reminders</string>
     <string name="settings_notifications_strict_reminders_body">If you have not reviewed today, Flashcards reminds you 4, 3, and 2 hours before midnight so you can keep your streak.</string>
-    <string name="settings_notifications_reminders_title">Workspace reminders</string>
-    <string name="settings_notifications_reminders_body">Send cards from the current workspace.</string>
+    <string name="settings_notifications_reminders_title">Enable notifications</string>
+    <string name="settings_notifications_reminders_body">Turn all study notifications on or off.</string>
     <string name="settings_notifications_show_app_icon_badge_title">Show app icon badge</string>
     <string name="settings_notifications_show_app_icon_badge_body">Supported launchers may show a red 1 or dot while a review reminder notification is active. Opening the app or completing a review clears delivered review reminders.</string>
-    <string name="settings_notifications_mode_daily">Daily</string>
-    <string name="settings_notifications_mode_inactivity">Cards</string>
-    <string name="settings_notifications_daily_title">Daily reminder</string>
-    <string name="settings_notifications_daily_example">Send one card every day at the selected time.</string>
-    <string name="settings_notifications_inactivity_title">Cards reminder</string>
-    <string name="settings_notifications_inactivity_example">Send a card after you have been away for a while, during the time window you choose.</string>
+    <string name="settings_notifications_mode_daily">Once daily</string>
+    <string name="settings_notifications_mode_inactivity">After a break</string>
+    <string name="settings_notifications_daily_title">Time</string>
+    <string name="settings_notifications_daily_example">Send one card once per day at the selected time.</string>
+    <string name="settings_notifications_inactivity_title">Time window</string>
+    <string name="settings_notifications_inactivity_example">After you have been inactive, send a card during this window and repeat at the selected interval.</string>
     <string name="settings_notifications_from_title">From</string>
     <string name="settings_notifications_to_title">To</string>
-    <string name="settings_notifications_remind_after_title">Remind me after</string>
+    <string name="settings_notifications_remind_after_title">Repeat every</string>
 
     <string name="settings_workspace_decks_title">Decks</string>
     <string name="settings_workspace_tags_title">Tags</string>


### PR DESCRIPTION
## Summary

- move Notifications into app-level Settings navigation while preserving the stable route and test identifiers
- implement permission and app-master visibility states with native Material 3 controls
- align base English copy, diagnostics, workspace presentation, and live smoke expectations

## Validation

- verified exact 13-path source patch inventory and checksum
- passed diff/whitespace, XML, legacy copy/API, route/test-ID, visibility-state, label, interval, and path-boundary checks
- mandatory fresh review found no P0-P4 issues and no split recommendation
- Gradle, emulator, instrumentation, and device checks were not run because explicit permission was not provided