### PR TITLE
Web refresh reconciliation

### DIFF
--- a/apps/web/src/api/transport/transport.test.ts
+++ b/apps/web/src/api/transport/transport.test.ts
@@ -208,6 +208,112 @@ describe("session transport auth recovery", () => {
     expectLocalBrowserStatePreserved();
   });
 
+  it("reconciles a session when every refresh response is lost after server-side success", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-2",
+      }))
+      .mockResolvedValueOnce(createNewChatSessionResponse("session-1"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createTransportBackedChatSession("session-1")).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(fetchMock.mock.calls.slice(1, 4).map((call) => call[0])).toEqual([
+      "http://localhost:8081/api/refresh-session",
+      "http://localhost:8081/api/refresh-session",
+      "http://localhost:8081/api/refresh-session",
+    ]);
+    expect(fetchMock.mock.calls[4]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[5]?.[0]).toBe("http://localhost:8080/v1/chat/new");
+
+    const retriedRequestInit = fetchMock.mock.calls[5]?.[1] as RequestInit | undefined;
+    expect(new Headers(retriedRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-2");
+  });
+
+  it("preserves the original refresh network error when reconciliation remains unauthorized", async () => {
+    seedLocalBrowserState();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    let redirectedUrl = "";
+    setNavigationHandlerForTests((url: string) => {
+      redirectedUrl = url;
+    });
+
+    await expect(getSession()).rejects.toMatchObject({
+      statusCode: 0,
+      message: "The auth service is unavailable. Try again. (/api/refresh-session; Load failed)",
+      code: null,
+      requestId: null,
+      endpoint: "POST /api/refresh-session",
+      responseBodyKind: "empty",
+    } satisfies Partial<ApiError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(fetchMock.mock.calls.slice(4).map((call) => call[0])).toEqual([
+      "http://localhost:8080/v1/me",
+      "http://localhost:8080/v1/me",
+      "http://localhost:8080/v1/me",
+    ]);
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
+    expect(redirectedUrl).toBe("");
+    expectLocalBrowserStatePreserved();
+    expect(isBrowserReauthRequired()).toBe(false);
+  });
+
+  it("shares refresh reconciliation across concurrent callers", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-2",
+      }))
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-2",
+      }))
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-2",
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sessions = await Promise.all([getSession(), getSession()]);
+
+    expect(sessions).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(fetchMock.mock.calls.slice(2, 5).map((call) => call[0])).toEqual([
+      "http://localhost:8081/api/refresh-session",
+      "http://localhost:8081/api/refresh-session",
+      "http://localhost:8081/api/refresh-session",
+    ]);
+    expect(fetchMock.mock.calls[5]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls.slice(6).map((call) => call[0])).toEqual([
+      "http://localhost:8080/v1/me",
+      "http://localhost:8080/v1/me",
+    ]);
+  });
+
   it("keeps request metadata on API errors with header requestId priority", async () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(new Response(JSON.stringify({

--- a/apps/web/src/api/transport/transport.ts
+++ b/apps/web/src/api/transport/transport.ts
@@ -14,6 +14,7 @@ import {
 } from "./response";
 
 type SessionCsrfState = "unknown" | "session" | "non-session";
+type RefreshBrowserSessionResult = "refreshed" | "reconciled" | "unauthorized";
 export type AuthRecoveryMode = "allow" | "skip";
 export type NetworkRetryMode = "none" | "transient";
 type NavigateToUrl = (url: string) => void;
@@ -33,6 +34,8 @@ const refreshSessionEndpoint = "POST /api/refresh-session";
 const refreshSessionMaximumAttemptCount = 3;
 const refreshSessionBaseRetryDelayMs = 100;
 const refreshSessionMaximumRetryDelayMs = 500;
+const refreshSessionReconciliationMaximumAttemptCount = 3;
+const refreshSessionReconciliationDelayMs = 200;
 const apiNetworkRetryMaximumAttemptCount = 4;
 const apiNetworkRetryBaseDelayMs = 250;
 const apiNetworkRetryMaximumDelayMs = 2000;
@@ -392,13 +395,48 @@ function waitForRefreshSessionRetry(attemptIndex: number): Promise<void> {
   });
 }
 
+function waitForRefreshSessionReconciliation(): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, refreshSessionReconciliationDelayMs);
+  });
+}
+
+async function reconcileRefreshSession(
+  networkRetryMode: NetworkRetryMode,
+  refreshNetworkError: ApiError,
+): Promise<void> {
+  for (
+    let attemptCount = 1;
+    attemptCount <= refreshSessionReconciliationMaximumAttemptCount;
+    attemptCount += 1
+  ) {
+    await waitForRefreshSessionReconciliation();
+
+    try {
+      await loadSessionInfoWithoutRecovery(networkRetryMode);
+      return;
+    } catch (error) {
+      if (error instanceof ApiError === false || error.statusCode !== 401) {
+        throw error;
+      }
+
+      if (attemptCount === refreshSessionReconciliationMaximumAttemptCount) {
+        throw refreshNetworkError;
+      }
+    }
+  }
+
+  throw new Error("Refresh session reconciliation loop exited without a result");
+}
+
 /**
- * Calls the auth service refresh endpoint with shared cookies and returns
- * `false` only when the refresh token is no longer valid.
+ * Calls the auth service refresh endpoint with shared cookies and distinguishes
+ * a normal refresh from a session verified after ambiguous network failures.
  */
-async function refreshBrowserSession(): Promise<boolean> {
+async function refreshBrowserSession(networkRetryMode: NetworkRetryMode): Promise<RefreshBrowserSessionResult> {
   const config = getAppConfig();
   let lastNetworkError: ApiError | null = null;
+  let networkRejectionCount = 0;
 
   for (let attemptIndex = 0; attemptIndex < refreshSessionMaximumAttemptCount; attemptIndex += 1) {
     let response: Response;
@@ -410,21 +448,27 @@ async function refreshBrowserSession(): Promise<boolean> {
       });
     } catch (error) {
       lastNetworkError = createRefreshSessionNetworkError(error);
+      networkRejectionCount += 1;
       if (hasRemainingRefreshAttempt(attemptIndex)) {
         await waitForRefreshSessionRetry(attemptIndex);
         continue;
+      }
+
+      if (networkRejectionCount === refreshSessionMaximumAttemptCount) {
+        await reconcileRefreshSession(networkRetryMode, lastNetworkError);
+        return "reconciled";
       }
 
       throw lastNetworkError;
     }
 
     if (response.ok) {
-      return true;
+      return "refreshed";
     }
 
     if (response.status === 401) {
       resetSessionState();
-      return false;
+      return "unauthorized";
     }
 
     if (isTransientRefreshSessionStatus(response.status) && hasRemainingRefreshAttempt(attemptIndex)) {
@@ -452,9 +496,13 @@ function shouldRetryAfterWeakerSessionRecovery(error: unknown, options: RequestO
 
 function startSessionRecovery(options: RequestOptions): Promise<void> {
   const recoveryTask = (async (): Promise<void> => {
-    const refreshed = await refreshBrowserSession();
-    if (refreshed === false) {
+    const refreshResult = await refreshBrowserSession(options.networkRetryMode);
+    if (refreshResult === "unauthorized") {
       await redirectToLogin(options.prepareForAuthRedirect);
+    }
+
+    if (refreshResult === "reconciled") {
+      return;
     }
 
     try {


### PR DESCRIPTION
## Summary
- reconcile ambiguous refresh-session network failures through bounded delayed /me reads
- reuse verified session and CSRF state without recursive auth recovery
- cover late success, persistent 401, and concurrent recovery at the transport boundary

## Validation
- npm exec -- vitest run src/api/transport/transport.test.ts (31/31 passed)
- npm run build
- git diff --check

## Review
- fresh worker-owned review: no P0-P4 findings; green light for commit