### PR TITLE
Pause iOS review animations in Low Power Mode

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -394,6 +394,7 @@ struct FlashcardsApp: App {
     @State private var uiTestAIHandoffCard: FlashcardsUITestAIHandoffCard?
     @State private var hasRunInitialStartup: Bool
     @State private var isStartupReadyForBackgroundWork: Bool
+    @State private var isLowPowerModeEnabled: Bool
 
     @MainActor
     init() {
@@ -524,6 +525,7 @@ struct FlashcardsApp: App {
         _uiTestAIHandoffCard = State(initialValue: aiHandoffCard)
         _hasRunInitialStartup = State(initialValue: false)
         _isStartupReadyForBackgroundWork = State(initialValue: false)
+        _isLowPowerModeEnabled = State(initialValue: processInfo.isLowPowerModeEnabled)
     }
 
     var body: some Scene {
@@ -531,10 +533,14 @@ struct FlashcardsApp: App {
             RootTabView()
                 .environment(store)
                 .environment(navigation)
+                .environment(\.isLowPowerModeEnabled, self.isLowPowerModeEnabled)
                 .task(id: self.isCloudCredentialRecoveryGateActive) {
                     await self.runInitialAppStartupIfNeeded()
                 }
                 .onChange(of: scenePhase) { _, nextPhase in
+                    if nextPhase == .active {
+                        self.refreshLowPowerModeState()
+                    }
                     logAppLifecycleBreadcrumb(
                         action: .scenePhaseChanged,
                         store: store,
@@ -577,6 +583,9 @@ struct FlashcardsApp: App {
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
                     self.handleProgressContextSystemChange()
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .NSProcessInfoPowerStateDidChange)) { _ in
+                    self.refreshLowPowerModeState()
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.significantTimeChangeNotification)) { _ in
                     self.handleProgressContextSystemChange()
@@ -630,6 +639,11 @@ struct FlashcardsApp: App {
 
     private var isCloudCredentialRecoveryGateActive: Bool {
         self.store.cloudCredentialRecoveryState != nil
+    }
+
+    @MainActor
+    private func refreshLowPowerModeState() {
+        self.isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
     }
 
     @MainActor

--- a/apps/ios/Flashcards/Flashcards/App/LowPowerModeEnvironment.swift
+++ b/apps/ios/Flashcards/Flashcards/App/LowPowerModeEnvironment.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct LowPowerModeEnabledEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var isLowPowerModeEnabled: Bool {
+        get { self[LowPowerModeEnabledEnvironmentKey.self] }
+        set { self[LowPowerModeEnabledEnvironmentKey.self] = newValue }
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLottieAssetStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLottieAssetStore.swift
@@ -44,6 +44,7 @@ enum ReviewReactionLottieAssetLoadResult: @unchecked Sendable {
 }
 
 typealias ReviewReactionLottieAssetLoadHandler = @MainActor @Sendable (ReviewReactionLottieAssetLoadResult) -> Void
+typealias ReviewReactionLottieAssetPrewarmCompletionHandler = @MainActor @Sendable () -> Void
 
 struct ReviewReactionLottieAssetStore {
     let readyAnimations: [ReviewReactionVariant: LottieAnimation]
@@ -413,16 +414,35 @@ func reviewReactionLottiePrewarmAssetConfigurations() -> [ReviewReactionLottieAs
 }
 
 func startReviewReactionLottieAssetPrewarm(
-    onLoadResult: @escaping ReviewReactionLottieAssetLoadHandler
-) {
-    Task.detached(priority: .utility) {
-        for assetConfiguration in reviewReactionLottiePrewarmAssetConfigurations() {
+    pendingVariants: Set<ReviewReactionVariant>,
+    onLoadResult: @escaping ReviewReactionLottieAssetLoadHandler,
+    onCompletion: @escaping ReviewReactionLottieAssetPrewarmCompletionHandler
+) -> Task<Void, Never> {
+    let pendingAssetConfigurations: [ReviewReactionLottieAssetConfiguration] = reviewReactionLottiePrewarmAssetConfigurations()
+        .filter { assetConfiguration in
+            pendingVariants.contains(assetConfiguration.variant)
+        }
+
+    return Task.detached(priority: .utility) {
+        for assetConfiguration in pendingAssetConfigurations {
+            guard Task.isCancelled == false else {
+                break
+            }
             let loadResult: ReviewReactionLottieAssetLoadResult = loadReviewReactionLottieAsset(
                 assetConfiguration: assetConfiguration
             )
+            guard Task.isCancelled == false else {
+                break
+            }
             await MainActor.run {
+                guard Task.isCancelled == false else {
+                    return
+                }
                 onLoadResult(loadResult)
             }
+        }
+        await MainActor.run {
+            onCompletion()
         }
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
@@ -2,16 +2,45 @@ import SwiftUI
 
 extension ReviewView {
     func prewarmReviewReactionLottieAssets() {
-        if self.hasStartedReviewReactionLottiePrewarm {
+        guard self.areReviewReactionAnimationsEnabled else {
+            return
+        }
+        guard self.reviewReactionLottiePrewarmTask == nil else {
+            return
+        }
+        let pendingVariants: Set<ReviewReactionVariant> = self.reviewReactionLottieAssetStore.pendingVariants
+        guard pendingVariants.isEmpty == false else {
             return
         }
 
-        self.hasStartedReviewReactionLottiePrewarm = true
-        startReviewReactionLottieAssetPrewarm { loadResult in
-            self.reviewReactionLottieAssetStore = self.reviewReactionLottieAssetStore.recordingLoadResult(
-                loadResult: loadResult
-            )
+        let prewarmId = UUID()
+        self.reviewReactionLottiePrewarmId = prewarmId
+        self.reviewReactionLottiePrewarmTask = startReviewReactionLottieAssetPrewarm(
+            pendingVariants: pendingVariants,
+            onLoadResult: { loadResult in
+                self.reviewReactionLottieAssetStore = self.reviewReactionLottieAssetStore.recordingLoadResult(
+                    loadResult: loadResult
+                )
+            },
+            onCompletion: {
+                self.finishReviewReactionLottiePrewarm(prewarmId: prewarmId)
+            }
+        )
+    }
+
+    func cancelReviewReactionLottiePrewarm() {
+        self.reviewReactionLottiePrewarmTask?.cancel()
+        self.reviewReactionLottiePrewarmTask = nil
+        self.reviewReactionLottiePrewarmId = nil
+    }
+
+    private func finishReviewReactionLottiePrewarm(prewarmId: UUID) {
+        guard self.reviewReactionLottiePrewarmId == prewarmId else {
+            return
         }
+
+        self.reviewReactionLottiePrewarmTask = nil
+        self.reviewReactionLottiePrewarmId = nil
     }
 
     func emitReviewReaction(rating: ReviewRating) {

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -14,6 +14,7 @@ private let reviewQueuePreviewPageSize: Int = 50
 
 struct ReviewView: View {
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.isLowPowerModeEnabled) var isLowPowerModeEnabled: Bool
     @Environment(FlashcardsStore.self) var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
 
@@ -22,7 +23,8 @@ struct ReviewView: View {
     @State var preparedRevealState: PreparedReviewRevealState? = nil
     // Keep the next review card warm so the next front can appear immediately after rating.
     @State var preparedNextRevealState: PreparedReviewRevealState? = nil
-    @State var hasStartedReviewReactionLottiePrewarm: Bool = false
+    @State var reviewReactionLottiePrewarmTask: Task<Void, Never>?
+    @State var reviewReactionLottiePrewarmId: UUID?
     @State var reviewReactionLottieAssetStore: ReviewReactionLottieAssetStore = makePendingReviewReactionLottieAssetStore()
     @State var activeReviewReactionEvents: [ReviewReactionEvent] = []
     @State var isQueuePreviewPresented: Bool = false
@@ -60,6 +62,10 @@ struct ReviewView: View {
         case .tag(let tag):
             return tag
         }
+    }
+
+    var areReviewReactionAnimationsEnabled: Bool {
+        store.accountPreferences.reviewReactionAnimationsEnabled && self.isLowPowerModeEnabled == false
     }
 
     private func reviewFilterMenuItemLabel(reviewFilter: ReviewFilter) -> String {
@@ -132,14 +138,15 @@ struct ReviewView: View {
         .accessibilityIdentifier(UITestIdentifier.reviewScreen)
         .navigationTitle(String(localized: "Review", table: reviewCardsStringsTableName))
         .onAppear {
-            if store.accountPreferences.reviewReactionAnimationsEnabled {
+            if self.areReviewReactionAnimationsEnabled {
                 self.prewarmReviewReactionLottieAssets()
             }
         }
-        .onChange(of: store.accountPreferences.reviewReactionAnimationsEnabled) { _, isEnabled in
+        .onChange(of: self.areReviewReactionAnimationsEnabled) { _, isEnabled in
             if isEnabled {
                 self.prewarmReviewReactionLottieAssets()
             } else {
+                self.cancelReviewReactionLottiePrewarm()
                 self.dismissActiveReviewReactions()
             }
         }
@@ -149,6 +156,7 @@ struct ReviewView: View {
         }
         .onDisappear {
             self.reviewSpeechController.stopSpeech()
+            self.cancelReviewReactionLottiePrewarm()
         }
         .task(id: preparedRevealStatesTaskId) {
             await self.refreshPreparedRevealStates(reviewQueue: store.effectiveReviewQueue)
@@ -704,7 +712,7 @@ struct ReviewView: View {
 
     private func reviewAnswerButton(cardId: String, option: ReviewAnswerOption) -> some View {
         Button {
-            if store.accountPreferences.reviewReactionAnimationsEnabled {
+            if self.areReviewReactionAnimationsEnabled {
                 self.emitReviewReaction(rating: option.rating)
             }
             self.submitReview(cardId: cardId, rating: option.rating)

--- a/apps/ios/Flashcards/Flashcards/Settings/ReviewAnimationsSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/ReviewAnimationsSettingsView.swift
@@ -30,6 +30,13 @@ struct ReviewAnimationsSettingsView: View {
                 )
                 .disabled(self.isSaving || store.canPersistAccountPreferences == false)
                 .accessibilityIdentifier(UITestIdentifier.reviewAnimationsSettingsToggle)
+            } footer: {
+                Text(
+                    aiSettingsLocalized(
+                        "settings.reviewAnimations.lowPowerMode.footer",
+                        "Low Power Mode temporarily disables review animations without changing this setting."
+                    )
+                )
             }
         }
         .listStyle(.insetGrouped)

--- a/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
@@ -85,7 +85,10 @@ struct TestSettingsView: View {
 }
 
 struct TestAnimationsView: View {
-    @State private var hasStartedReviewReactionLottiePrewarm: Bool = false
+    @Environment(\.isLowPowerModeEnabled) private var isLowPowerModeEnabled: Bool
+
+    @State private var reviewReactionLottiePrewarmTask: Task<Void, Never>?
+    @State private var reviewReactionLottiePrewarmId: UUID?
     @State private var reviewReactionLottieAssetStore: ReviewReactionLottieAssetStore = makePendingReviewReactionLottieAssetStore()
     @State private var activeReviewReactionEvents: [ReviewReactionEvent] = []
 
@@ -106,13 +109,25 @@ struct TestAnimationsView: View {
 
                                     Spacer(minLength: 0)
 
-                                    Text(testAnimationDetailText(entry: entry, assetStatus: assetStatus))
+                                    Text(
+                                        testAnimationDetailText(
+                                            entry: entry,
+                                            assetStatus: assetStatus,
+                                            isLowPowerModeEnabled: self.isLowPowerModeEnabled
+                                        )
+                                    )
                                         .font(.subheadline.monospacedDigit())
                                         .foregroundStyle(.secondary)
                                 }
                             }
-                            .disabled(assetStatus == .pending)
-                            .accessibilityLabel(testAnimationAccessibilityLabel(entry: entry, assetStatus: assetStatus))
+                            .disabled(self.isLowPowerModeEnabled || assetStatus == .pending)
+                            .accessibilityLabel(
+                                testAnimationAccessibilityLabel(
+                                    entry: entry,
+                                    assetStatus: assetStatus,
+                                    isLowPowerModeEnabled: self.isLowPowerModeEnabled
+                                )
+                            )
                         }
                     }
                 }
@@ -130,22 +145,65 @@ struct TestAnimationsView: View {
         .onAppear {
             self.prewarmReviewReactionLottieAssets()
         }
+        .onChange(of: self.isLowPowerModeEnabled) { _, isEnabled in
+            if isEnabled {
+                self.cancelReviewReactionLottiePrewarm()
+                self.activeReviewReactionEvents = []
+            } else {
+                self.prewarmReviewReactionLottieAssets()
+            }
+        }
+        .onDisappear {
+            self.cancelReviewReactionLottiePrewarm()
+        }
     }
 
     private func prewarmReviewReactionLottieAssets() {
-        if self.hasStartedReviewReactionLottiePrewarm {
+        guard self.isLowPowerModeEnabled == false else {
+            return
+        }
+        guard self.reviewReactionLottiePrewarmTask == nil else {
+            return
+        }
+        let pendingVariants: Set<ReviewReactionVariant> = self.reviewReactionLottieAssetStore.pendingVariants
+        guard pendingVariants.isEmpty == false else {
             return
         }
 
-        self.hasStartedReviewReactionLottiePrewarm = true
-        startReviewReactionLottieAssetPrewarm { loadResult in
-            self.reviewReactionLottieAssetStore = self.reviewReactionLottieAssetStore.recordingLoadResult(
-                loadResult: loadResult
-            )
+        let prewarmId = UUID()
+        self.reviewReactionLottiePrewarmId = prewarmId
+        self.reviewReactionLottiePrewarmTask = startReviewReactionLottieAssetPrewarm(
+            pendingVariants: pendingVariants,
+            onLoadResult: { loadResult in
+                self.reviewReactionLottieAssetStore = self.reviewReactionLottieAssetStore.recordingLoadResult(
+                    loadResult: loadResult
+                )
+            },
+            onCompletion: {
+                self.finishReviewReactionLottiePrewarm(prewarmId: prewarmId)
+            }
+        )
+    }
+
+    private func cancelReviewReactionLottiePrewarm() {
+        self.reviewReactionLottiePrewarmTask?.cancel()
+        self.reviewReactionLottiePrewarmTask = nil
+        self.reviewReactionLottiePrewarmId = nil
+    }
+
+    private func finishReviewReactionLottiePrewarm(prewarmId: UUID) {
+        guard self.reviewReactionLottiePrewarmId == prewarmId else {
+            return
         }
+
+        self.reviewReactionLottiePrewarmTask = nil
+        self.reviewReactionLottiePrewarmId = nil
     }
 
     private func playAnimation(entry: ReviewReactionVariantDistributionEntry) {
+        guard self.isLowPowerModeEnabled == false else {
+            return
+        }
         guard self.assetStatus(entry: entry) != .pending else {
             return
         }
@@ -200,8 +258,16 @@ private func testAnimationProbabilityText(entry: ReviewReactionVariantDistributi
 
 private func testAnimationDetailText(
     entry: ReviewReactionVariantDistributionEntry,
-    assetStatus: ReviewReactionLottieAssetStatus
+    assetStatus: ReviewReactionLottieAssetStatus,
+    isLowPowerModeEnabled: Bool
 ) -> String {
+    if isLowPowerModeEnabled {
+        return aiSettingsLocalized(
+            "settings.reviewAnimations.lowPowerMode.paused",
+            "Paused by Low Power Mode"
+        )
+    }
+
     switch assetStatus {
     case .pending:
         return aiSettingsLocalized("common.loading", "Loading...")
@@ -212,13 +278,18 @@ private func testAnimationDetailText(
 
 private func testAnimationAccessibilityLabel(
     entry: ReviewReactionVariantDistributionEntry,
-    assetStatus: ReviewReactionLottieAssetStatus
+    assetStatus: ReviewReactionLottieAssetStatus,
+    isLowPowerModeEnabled: Bool
 ) -> String {
     aiSettingsLocalizedFormat(
         "settings.test.animations.playAccessibility",
         "Play %@ animation, %@",
         entry.variant.debugIdentifier,
-        testAnimationDetailText(entry: entry, assetStatus: assetStatus)
+        testAnimationDetailText(
+            entry: entry,
+            assetStatus: assetStatus,
+            isLowPowerModeEnabled: isLowPowerModeEnabled
+        )
     )
 }
 

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "إعادة تسمية مساحة العمل متاحة فقط لمساحات العمل السحابية المرتبطة.";
 "settings.reviewAnimations.title" = "رسوم المراجعة المتحركة";
 "settings.reviewAnimations.toggle" = "إظهار الرسوم المتحركة بعد تقييم بطاقة";
+"settings.reviewAnimations.lowPowerMode.footer" = "يعطّل نمط الطاقة المنخفضة رسوم المراجعة المتحركة مؤقتًا دون تغيير هذا الإعداد.";
+"settings.reviewAnimations.lowPowerMode.paused" = "متوقفة مؤقتًا بسبب نمط الطاقة المنخفضة";
 "settings.aiChatSuggestions.title" = "اقتراحات دردشة الذكاء الاصطناعي";
 "settings.aiChatSuggestions.toggle" = "إظهار اقتراحات محرر الرسائل";
 "settings.aiChatSuggestions.description" = "عند إيقاف هذا الخيار، لن تعرض دردشة الذكاء الاصطناعي اقتراحات فوق محرر الرسائل.";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "Das Umbenennen von Arbeitsbereichen ist nur fur verknupfte Cloud-Arbeitsbereiche verfugbar.";
 "settings.reviewAnimations.title" = "Wiederholungsanimationen";
 "settings.reviewAnimations.toggle" = "Animationen nach dem Bewerten einer Karte anzeigen";
+"settings.reviewAnimations.lowPowerMode.footer" = "Der Stromsparmodus deaktiviert Wiederholungsanimationen vorübergehend, ohne diese Einstellung zu ändern.";
+"settings.reviewAnimations.lowPowerMode.paused" = "Durch Stromsparmodus pausiert";
 "settings.aiChatSuggestions.title" = "KI-Chat-Vorschläge";
 "settings.aiChatSuggestions.toggle" = "Vorschläge im Texteingabefeld anzeigen";
 "settings.aiChatSuggestions.description" = "Wenn diese Einstellung aus ist, zeigt der KI-Chat keine vorgeschlagenen Prompts über dem Texteingabefeld.";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "El cambio de nombre del espacio de trabajo solo esta disponible para espacios de trabajo en la nube vinculados.";
 "settings.reviewAnimations.title" = "Animaciones de repaso";
 "settings.reviewAnimations.toggle" = "Mostrar animaciones despues de valorar una tarjeta";
+"settings.reviewAnimations.lowPowerMode.footer" = "El modo de bajo consumo desactiva temporalmente las animaciones de repaso sin cambiar este ajuste.";
+"settings.reviewAnimations.lowPowerMode.paused" = "En pausa por el modo de bajo consumo";
 "settings.aiChatSuggestions.title" = "Sugerencias del chat con IA";
 "settings.aiChatSuggestions.toggle" = "Mostrar sugerencias en el redactor";
 "settings.aiChatSuggestions.description" = "Cuando está desactivado, el chat con IA no muestra sugerencias de mensajes encima del redactor.";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "El cambio de nombre del espacio de trabajo solo esta disponible para espacios de trabajo en la nube vinculados.";
 "settings.reviewAnimations.title" = "Animaciones de repaso";
 "settings.reviewAnimations.toggle" = "Mostrar animaciones despues de valorar una tarjeta";
+"settings.reviewAnimations.lowPowerMode.footer" = "El modo de bajo consumo desactiva temporalmente las animaciones de repaso sin cambiar esta configuración.";
+"settings.reviewAnimations.lowPowerMode.paused" = "En pausa por el modo de bajo consumo";
 "settings.aiChatSuggestions.title" = "Sugerencias del chat con IA";
 "settings.aiChatSuggestions.toggle" = "Mostrar sugerencias en el redactor";
 "settings.aiChatSuggestions.description" = "Cuando está desactivado, el chat con IA no muestra sugerencias de mensajes encima del redactor.";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "कार्यस्थान का नाम बदलना केवल लिंक किए गए क्लाउड कार्यस्थानों के लिए उपलब्ध है।";
 "settings.reviewAnimations.title" = "समीक्षा एनिमेशन";
 "settings.reviewAnimations.toggle" = "कार्ड को रेट करने के बाद एनिमेशन दिखाएं";
+"settings.reviewAnimations.lowPowerMode.footer" = "लो पावर मोड इस सेटिंग को बदले बिना समीक्षा एनिमेशन को अस्थायी रूप से बंद कर देता है।";
+"settings.reviewAnimations.lowPowerMode.paused" = "लो पावर मोड के कारण रुका हुआ";
 "settings.aiChatSuggestions.title" = "AI चैट सुझाव";
 "settings.aiChatSuggestions.toggle" = "कंपोज़र सुझाव दिखाएँ";
 "settings.aiChatSuggestions.description" = "यह बंद होने पर, AI चैट कंपोज़र के ऊपर सुझाए गए प्रॉम्प्ट नहीं दिखाता.";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "ワークスペース名の変更は、リンク済みのクラウドワークスペースでのみ利用できます。";
 "settings.reviewAnimations.title" = "復習アニメーション";
 "settings.reviewAnimations.toggle" = "カード評価後にアニメーションを表示";
+"settings.reviewAnimations.lowPowerMode.footer" = "低電力モードでは、この設定を変更せずに復習アニメーションが一時的に無効になります。";
+"settings.reviewAnimations.lowPowerMode.paused" = "低電力モードにより一時停止中";
 "settings.aiChatSuggestions.title" = "AIチャットの候補";
 "settings.aiChatSuggestions.toggle" = "入力欄の候補を表示";
 "settings.aiChatSuggestions.description" = "オフにすると、AIチャットは入力欄の上に候補プロンプトを表示しません。";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "Переименование рабочей области доступно только для связанных облачных рабочих областей.";
 "settings.reviewAnimations.title" = "Анимации повторения";
 "settings.reviewAnimations.toggle" = "Показывать анимации после оценки карточки";
+"settings.reviewAnimations.lowPowerMode.footer" = "Режим энергосбережения временно отключает анимации повторения, не изменяя эту настройку.";
+"settings.reviewAnimations.lowPowerMode.paused" = "Приостановлено режимом энергосбережения";
 "settings.aiChatSuggestions.title" = "Подсказки AI-чата";
 "settings.aiChatSuggestions.toggle" = "Показывать подсказки в поле ввода";
 "settings.aiChatSuggestions.description" = "Когда настройка выключена, AI-чат не показывает предложенные запросы над полем ввода.";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -171,6 +171,8 @@
 "settings.currentWorkspace.renameLinkedOnly" = "只有已关联的云端工作空间可以重命名。";
 "settings.reviewAnimations.title" = "复习动画";
 "settings.reviewAnimations.toggle" = "给卡片评分后显示动画";
+"settings.reviewAnimations.lowPowerMode.footer" = "低电量模式会暂时停用复习动画，但不会更改此设置。";
+"settings.reviewAnimations.lowPowerMode.paused" = "已因低电量模式暂停";
 "settings.aiChatSuggestions.title" = "AI 聊天建议";
 "settings.aiChatSuggestions.toggle" = "显示输入框建议";
 "settings.aiChatSuggestions.description" = "关闭后，AI 聊天不会在输入框上方显示建议提示。";


### PR DESCRIPTION
## Summary
- expose device-local Low Power Mode state to SwiftUI
- pause review reactions and cancellable Lottie prewarm while Low Power Mode is active
- resume pending assets without discarding decoded animations
- explain the behavior in Settings and all supported iOS localizations

## Validation
- `git diff --check`
- localization key audit
- `plutil -lint` for all eight locale files
- `swiftc -parse` for changed Swift files
- independent review: no P0-P4 findings

Full `xcodebuild` validation could not start because iOS 26.5 is not installed in the worker environment.