### PR TITLE
Pause Android review animations in Battery Saver

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -71,7 +71,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.setContent {
             FlashcardsTheme {
                 val reviewReactionLottieConfigurationStore =
-                    rememberReviewReactionLottieConfigurationStore()
+                    rememberReviewReactionLottieConfigurationStore(loadLottieCompositions = true)
                 ReviewRoute(
                     uiState = ReviewUiState(
                         isLoading = false,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -80,6 +80,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackTrigger
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.sync.AccountPreferences
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
@@ -96,6 +97,8 @@ import com.flashcardsopensourceapp.feature.settings.SettingsAttentionSummary
 import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionIssues
 import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionSummary
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 private const val startupLoadingTag: String = "app.startupLoading"
@@ -160,7 +163,23 @@ fun FlashcardsApp(
         }
 
         val snackbarHostState = remember { SnackbarHostState() }
-        val reviewReactionLottieConfigurationStore = rememberReviewReactionLottieConfigurationStore()
+        val isPowerSaveMode: Boolean = rememberIsPowerSaveMode()
+        val accountPreferencesFlow: Flow<AccountPreferences?> =
+            remember(appGraph.cloudAccountRepository) {
+                appGraph.cloudAccountRepository
+                    .observeAccountPreferences()
+                    .map<AccountPreferences, AccountPreferences?> { accountPreferences ->
+                        accountPreferences
+                    }
+            }
+        val accountPreferences: AccountPreferences? by accountPreferencesFlow.collectAsStateWithLifecycle(
+            initialValue = null
+        )
+        val effectiveReviewReactionAnimationsEnabled: Boolean =
+            accountPreferences?.reviewReactionAnimationsEnabled == true && isPowerSaveMode.not()
+        val reviewReactionLottieConfigurationStore = rememberReviewReactionLottieConfigurationStore(
+            loadLottieCompositions = effectiveReviewReactionAnimationsEnabled
+        )
         LaunchedEffect(appGraph.appMessageBus, snackbarHostState) {
             appGraph.appMessageBus.messages.collect { message ->
                 snackbarHostState.showSnackbar(message = message)
@@ -578,6 +597,8 @@ fun FlashcardsApp(
                     appGraph = appGraph,
                     navController = navController,
                     reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
+                    reviewReactionAnimationsEnabled = effectiveReviewReactionAnimationsEnabled,
+                    isPowerSaveMode = isPowerSaveMode,
                     appNotificationTapRequest = appNotificationTapRequest,
                     consumeAppNotificationTap = consumeAppNotificationTap
                 )

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/PowerSaveModeState.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/PowerSaveModeState.kt
@@ -1,0 +1,65 @@
+package com.flashcardsopensourceapp.app
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.PowerManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+internal fun rememberIsPowerSaveMode(): Boolean {
+    val applicationContext: Context = LocalContext.current.applicationContext
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val powerManager: PowerManager = remember(applicationContext) {
+        applicationContext.getSystemService(PowerManager::class.java)
+            ?: error(
+                "Android PowerManager service is unavailable; " +
+                    "Battery Saver state cannot be observed."
+            )
+    }
+    var isPowerSaveMode: Boolean by remember(powerManager) {
+        mutableStateOf(value = powerManager.isPowerSaveMode)
+    }
+
+    DisposableEffect(applicationContext, lifecycleOwner, powerManager) {
+        fun refreshPowerSaveMode(): Unit {
+            isPowerSaveMode = powerManager.isPowerSaveMode
+        }
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                refreshPowerSaveMode()
+            }
+        }
+        val lifecycleObserver = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                refreshPowerSaveMode()
+            }
+        }
+
+        applicationContext.registerReceiver(
+            receiver,
+            IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED),
+            Context.RECEIVER_NOT_EXPORTED
+        )
+        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+        refreshPowerSaveMode()
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
+            applicationContext.unregisterReceiver(receiver)
+        }
+    }
+
+    return isPowerSaveMode
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
@@ -2,8 +2,10 @@ package com.flashcardsopensourceapp.app.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -27,10 +29,16 @@ fun AppNavHost(
     appGraph: AppGraph,
     navController: NavHostController,
     reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
+    reviewReactionAnimationsEnabled: Boolean,
+    isPowerSaveMode: Boolean,
     appNotificationTapRequest: AppNotificationTapHandoffRequest?,
     consumeAppNotificationTap: (Long) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val reviewReactionAnimationsEnabledState: State<Boolean> = rememberUpdatedState(
+        newValue = reviewReactionAnimationsEnabled
+    )
+    val isPowerSaveModeState: State<Boolean> = rememberUpdatedState(newValue = isPowerSaveMode)
     val cardEditorRequest by appGraph.appHandoffCoordinator.observeCardEditor().collectAsStateWithLifecycle()
     val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
     val settingsNavigationRequest by appGraph.appHandoffCoordinator.observeSettingsNavigation().collectAsStateWithLifecycle()
@@ -91,7 +99,8 @@ fun AppNavHost(
         registerReviewNavGraph(
             appGraph = appGraph,
             navController = navController,
-            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
+            reviewReactionAnimationsEnabledState = reviewReactionAnimationsEnabledState
         )
         registerCardsNavGraph(
             appGraph = appGraph,
@@ -111,7 +120,7 @@ fun AppNavHost(
             navController = navController,
             packageInfo = packageInfo,
             coroutineScope = coroutineScope,
-            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore
+            isPowerSaveModeState = isPowerSaveModeState
         )
     }
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -25,7 +26,6 @@ import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
 import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
 import com.flashcardsopensourceapp.data.local.ai.diagnostics.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
-import com.flashcardsopensourceapp.data.local.model.sync.defaultAccountPreferences
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
 import com.flashcardsopensourceapp.feature.review.ReviewPreviewRoute
@@ -36,7 +36,8 @@ import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieC
 internal fun NavGraphBuilder.registerReviewNavGraph(
     appGraph: AppGraph,
     navController: NavHostController,
-    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore
+    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
+    reviewReactionAnimationsEnabledState: State<Boolean>
 ) {
     fun handleNotificationPermissionGranted() {
         appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
@@ -114,9 +115,6 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 )
             )
             val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
-            val accountPreferences by appGraph.cloudAccountRepository.observeAccountPreferences().collectAsStateWithLifecycle(
-                initialValue = defaultAccountPreferences()
-            )
             val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
 
             LaunchedEffect(reviewFilterRequest?.requestId, uiState) {
@@ -130,7 +128,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
             ReviewRoute(
                 uiState = uiState,
                 reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
-                reviewReactionAnimationsEnabled = accountPreferences.reviewReactionAnimationsEnabled,
+                reviewReactionAnimationsEnabled = reviewReactionAnimationsEnabledState.value,
                 onSelectFilter = reviewViewModel::selectFilter,
                 onOpenPreview = {
                     reviewViewModel.refreshPreview()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNavGraph.kt
@@ -1,12 +1,12 @@
 package com.flashcardsopensourceapp.app.navigation.settings
 
+import androidx.compose.runtime.State
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.navigation
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.AppPackageInfo
 import com.flashcardsopensourceapp.app.navigation.SettingsDestination
-import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 import kotlinx.coroutines.CoroutineScope
 
 internal fun NavGraphBuilder.registerSettingsNavGraph(
@@ -14,7 +14,7 @@ internal fun NavGraphBuilder.registerSettingsNavGraph(
     navController: NavHostController,
     packageInfo: AppPackageInfo,
     coroutineScope: CoroutineScope,
-    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore
+    isPowerSaveModeState: State<Boolean>
 ) {
     navigation(
         startDestination = SettingsDestination.route,
@@ -25,7 +25,7 @@ internal fun NavGraphBuilder.registerSettingsNavGraph(
             navController = navController,
             packageInfo = packageInfo,
             coroutineScope = coroutineScope,
-            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore
+            isPowerSaveModeState = isPowerSaveModeState
         )
         registerSettingsNotificationsDestination(
             appGraph = appGraph,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
@@ -7,6 +7,7 @@ import android.os.SystemClock
 import android.provider.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -32,7 +33,6 @@ import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationDialog
 import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationShareEffect
 import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationViewModel
 import com.flashcardsopensourceapp.feature.friendinvite.createFriendInvitationViewModelFactory
-import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 import com.flashcardsopensourceapp.feature.review.reaction.TestAnimationsRoute
 import com.flashcardsopensourceapp.feature.settings.SettingsFriendInviteAvailability
 import com.flashcardsopensourceapp.feature.settings.SettingsRoute
@@ -65,7 +65,7 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
     navController: NavHostController,
     packageInfo: AppPackageInfo,
     coroutineScope: CoroutineScope,
-    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore
+    isPowerSaveModeState: State<Boolean>
 ) {
     composable(route = SettingsDestination.route) { backStackEntry ->
         val context = LocalContext.current
@@ -446,7 +446,7 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
 
     composable(route = SettingsTestAnimationsDestination.route) {
         TestAnimationsRoute(
-            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
+            isPowerSaveMode = isPowerSaveModeState.value,
             onBack = {
                 navController.popBackStack()
             }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionLottieState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionLottieState.kt
@@ -294,19 +294,23 @@ private val reviewReactionLottieAssetConfigurations: List<ReviewReactionLottieAs
 )
 
 @Composable
-fun rememberReviewReactionLottieConfigurationStore(): ReviewReactionLottieConfigurationStore {
+fun rememberReviewReactionLottieConfigurationStore(
+    loadLottieCompositions: Boolean
+): ReviewReactionLottieConfigurationStore {
     val configurationStore: ReviewReactionLottieConfigurationStore =
         remember { createReviewReactionLottieConfigurationStore() }
 
-    reviewReactionLottieAssetConfigurations.forEach { assetConfiguration: ReviewReactionLottieAssetConfiguration ->
-        val readiness: ReviewReactionLottieReadiness = rememberReviewReactionLottieReadiness(
-            assetConfiguration = assetConfiguration
-        )
-        SideEffect {
-            configurationStore.updateReadiness(
-                variant = assetConfiguration.variant,
-                readiness = readiness
+    if (loadLottieCompositions) {
+        reviewReactionLottieAssetConfigurations.forEach { assetConfiguration: ReviewReactionLottieAssetConfiguration ->
+            val readiness: ReviewReactionLottieReadiness = rememberReviewReactionLottieReadiness(
+                assetConfiguration = assetConfiguration
             )
+            SideEffect {
+                configurationStore.updateReadiness(
+                    variant = assetConfiguration.variant,
+                    readiness = readiness
+                )
+            }
         }
     }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/TestAnimationsRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/TestAnimationsRoute.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,18 +45,41 @@ private val testAnimationRatingOrder: List<ReviewRating> = listOf(
     ReviewRating.EASY
 )
 
+private data class TestAnimationEntryUiState(
+    val entry: ReviewReactionVariantDistributionEntry,
+    val availability: TestAnimationAvailability
+)
+
+private enum class TestAnimationAvailability {
+    PLAYABLE,
+    LOADING,
+    PAUSED_BY_BATTERY_SAVER
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TestAnimationsRoute(
-    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
+    isPowerSaveMode: Boolean,
     onBack: () -> Unit
 ) {
     var activeReviewReactionEvents by remember {
         mutableStateOf<List<ReviewReactionEvent>>(value = emptyList())
     }
     val reviewReactionMotionMode: ReviewReactionMotionMode = reviewReactionMotionModeFromAnimatorSettings()
+    val reviewReactionLottieConfigurationStore = rememberReviewReactionLottieConfigurationStore(
+        loadLottieCompositions = isPowerSaveMode.not()
+    )
 
     fun playAnimation(entry: ReviewReactionVariantDistributionEntry) {
+        val availability: TestAnimationAvailability = testAnimationAvailability(
+            entry = entry,
+            isPowerSaveMode = isPowerSaveMode,
+            configurationStore = reviewReactionLottieConfigurationStore
+        )
+        if (availability != TestAnimationAvailability.PLAYABLE) {
+            return
+        }
+
         val event = ReviewReactionEvent(
             id = UUID.randomUUID().toString(),
             rating = entry.rating,
@@ -66,6 +90,12 @@ fun TestAnimationsRoute(
             event = event,
             maximumActiveEvents = reviewReactionMaximumActiveEvents
         )
+    }
+
+    LaunchedEffect(isPowerSaveMode) {
+        if (isPowerSaveMode) {
+            activeReviewReactionEvents = emptyList()
+        }
     }
 
     Scaffold(
@@ -104,8 +134,20 @@ fun TestAnimationsRoute(
                     }
 
                     item {
+                        val entryUiStates: List<TestAnimationEntryUiState> =
+                            reviewReactionVariantDistributionEntries(rating = rating)
+                                .map { entry: ReviewReactionVariantDistributionEntry ->
+                                    TestAnimationEntryUiState(
+                                        entry = entry,
+                                        availability = testAnimationAvailability(
+                                            entry = entry,
+                                            isPowerSaveMode = isPowerSaveMode,
+                                            configurationStore = reviewReactionLottieConfigurationStore
+                                        )
+                                    )
+                                }
                         TestAnimationRatingCard(
-                            entries = reviewReactionVariantDistributionEntries(rating = rating),
+                            entryUiStates = entryUiStates,
                             onPlayAnimation = { entry: ReviewReactionVariantDistributionEntry ->
                                 playAnimation(entry = entry)
                             }
@@ -131,15 +173,22 @@ fun TestAnimationsRoute(
 
 @Composable
 private fun TestAnimationRatingCard(
-    entries: List<ReviewReactionVariantDistributionEntry>,
+    entryUiStates: List<TestAnimationEntryUiState>,
     onPlayAnimation: (ReviewReactionVariantDistributionEntry) -> Unit
 ) {
     Card(modifier = Modifier.fillMaxWidth()) {
-        entries.forEach { entry: ReviewReactionVariantDistributionEntry ->
+        entryUiStates.forEach { uiState: TestAnimationEntryUiState ->
+            val entry: ReviewReactionVariantDistributionEntry = uiState.entry
+            val isPlayable: Boolean = uiState.availability == TestAnimationAvailability.PLAYABLE
             val probabilityText: String = testAnimationProbabilityText(entry = entry)
-            val playContentDescription: String = testAnimationPlayContentDescription(
-                entry = entry,
+            val supportingText: String = testAnimationSupportingText(
+                availability = uiState.availability,
                 probabilityText = probabilityText
+            )
+            val rowContentDescription: String = testAnimationContentDescription(
+                entry = entry,
+                availability = uiState.availability,
+                supportingText = supportingText
             )
             ListItem(
                 headlineContent = {
@@ -149,18 +198,45 @@ private fun TestAnimationRatingCard(
                     )
                 },
                 supportingContent = {
-                    Text(probabilityText)
+                    Text(supportingText)
                 },
                 modifier = Modifier
                     .fillMaxWidth()
                     .semantics {
-                        contentDescription = playContentDescription
+                        contentDescription = rowContentDescription
                     }
-                    .clickable {
-                        onPlayAnimation(entry)
-                    }
+                    .clickable(
+                        enabled = isPlayable,
+                        onClick = {
+                            onPlayAnimation(entry)
+                        }
+                    )
             )
         }
+    }
+}
+
+private fun testAnimationAvailability(
+    entry: ReviewReactionVariantDistributionEntry,
+    isPowerSaveMode: Boolean,
+    configurationStore: ReviewReactionLottieConfigurationStore
+): TestAnimationAvailability {
+    if (isPowerSaveMode) {
+        return TestAnimationAvailability.PAUSED_BY_BATTERY_SAVER
+    }
+
+    val configuration: ReviewReactionLottieConfiguration = reviewReactionLottieConfiguration(
+        variant = entry.variant,
+        configurationStore = configurationStore
+    ) ?: error(
+        "Test animation Lottie configuration is missing. " +
+            "variant=${entry.variant.debugIdentifier}"
+    )
+
+    return when (configuration.readiness) {
+        is ReviewReactionLottieReadiness.Ready -> TestAnimationAvailability.PLAYABLE
+        ReviewReactionLottieReadiness.Pending -> TestAnimationAvailability.LOADING
+        is ReviewReactionLottieReadiness.Failed -> TestAnimationAvailability.PLAYABLE
     }
 }
 
@@ -183,13 +259,36 @@ private fun testAnimationProbabilityText(entry: ReviewReactionVariantDistributio
 }
 
 @Composable
-private fun testAnimationPlayContentDescription(
-    entry: ReviewReactionVariantDistributionEntry,
+private fun testAnimationSupportingText(
+    availability: TestAnimationAvailability,
     probabilityText: String
 ): String {
-    return stringResource(
-        R.string.review_test_animations_play_content_description,
-        entry.variant.debugIdentifier,
-        probabilityText
-    )
+    return when (availability) {
+        TestAnimationAvailability.PLAYABLE -> probabilityText
+        TestAnimationAvailability.LOADING -> stringResource(R.string.review_test_animations_loading)
+        TestAnimationAvailability.PAUSED_BY_BATTERY_SAVER ->
+            stringResource(R.string.review_test_animations_battery_saver_paused)
+    }
+}
+
+@Composable
+private fun testAnimationContentDescription(
+    entry: ReviewReactionVariantDistributionEntry,
+    availability: TestAnimationAvailability,
+    supportingText: String
+): String {
+    return when (availability) {
+        TestAnimationAvailability.PLAYABLE -> stringResource(
+            R.string.review_test_animations_play_content_description,
+            entry.variant.debugIdentifier,
+            supportingText
+        )
+
+        TestAnimationAvailability.LOADING,
+        TestAnimationAvailability.PAUSED_BY_BATTERY_SAVER -> stringResource(
+            R.string.review_test_animations_status_content_description,
+            entry.variant.debugIdentifier,
+            supportingText
+        )
+    }
 }

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -45,6 +45,9 @@
     <string name="review_test_animations_title">Animations</string>
     <string name="review_test_animations_probability">%1$d%% probability</string>
     <string name="review_test_animations_play_content_description">Play %1$s animation, %2$s</string>
+    <string name="review_test_animations_status_content_description">%1$s animation, %2$s</string>
+    <string name="review_test_animations_loading">Loading animation...</string>
+    <string name="review_test_animations_battery_saver_paused">Paused while Battery Saver is on</string>
     <string name="review_scope_title">Review scope</string>
     <string name="review_scope_subtitle_all_cards">Review the full local queue</string>
     <string name="review_decks_title">Decks</string>

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
     <string name="settings_review_animations_title">Review Animations</string>
     <string name="settings_review_animations_summary">Show animations after rating a card</string>
     <string name="settings_review_animations_toggle_title">Show animations after rating a card</string>
-    <string name="settings_review_animations_toggle_body">Review reaction animations appear briefly after Again, Hard, Good, and Easy.</string>
+    <string name="settings_review_animations_toggle_body">Review reaction animations appear briefly after Again, Hard, Good, and Easy. They are automatically paused while Battery Saver is on.</string>
     <string name="settings_review_animations_update_failed">Could not update review animations.</string>
     <string name="settings_ai_chat_suggestions_title">AI Chat Suggestions</string>
     <string name="settings_ai_chat_suggestions_toggle_title">Show composer suggestions</string>


### PR DESCRIPTION
## Summary
- observe Android Battery Saver reactively at startup, broadcasts, and resume
- apply the saved-preference and Battery Saver policy to production review reactions and Lottie loading
- keep Test Animations preference-independent with disabled loading/paused states
- explain Battery Saver behavior in Settings

## Validation
- git diff --check, including the new helper
- xmllint for both changed strings.xml files
- Lottie-store and changed call-site source audits
- independent review: no P0-P4 findings

## Residual risk
- Gradle, instrumentation, and Android 16 device checks were not run because explicit permission was not provided