### PR TITLE
Correlate auth refresh traces

### DIFF
--- a/apps/auth/src/app.ts
+++ b/apps/auth/src/app.ts
@@ -25,11 +25,18 @@ import oauthRegister from "./routes/oauth/register.js";
 import oauthToken from "./routes/oauth/token.js";
 import oauthAuthorize from "./routes/oauth/authorize.js";
 import robots from "./routes/robots.js";
-import { type AuthAppEnv, getRequestId, jsonAuthError } from "./server/apiErrors.js";
+import {
+  type AuthAppEnv,
+  getRequestLogger,
+  getRequestId,
+  getTraceId,
+  jsonAuthError,
+} from "./server/apiErrors.js";
 import { getDemoEmailAccessConfig } from "./server/demoEmailAccess.js";
 import { createAgentErrorEnvelope } from "./server/agent/agentEnvelope.js";
 import { isTransientDatabaseError } from "./server/databaseErrors.js";
 import { log } from "./server/logger.js";
+import { continueAuthTrace } from "./server/sentry.js";
 
 const apiCorsAllowHeaders = [
   "content-type",
@@ -127,6 +134,89 @@ function isOAuthPublicPath(path: string): boolean {
   return oauthPublicPaths.includes(stripApiStagePrefix(path));
 }
 
+export function registerAuthErrorHandler(app: Hono<AuthAppEnv>): void {
+  app.onError((error, c) => {
+    const requestId = getRequestId(c);
+    const traceId = getTraceId(c);
+    const logger = getRequestLogger(c);
+    const routeKind = getApiRouteKind(c.req.path);
+    if (isTransientDatabaseError(error)) {
+      const statusCode = 503;
+      const code = "SERVICE_UNAVAILABLE";
+      const message = "Service is temporarily unavailable. Retry shortly.";
+      logger({
+        domain: "auth",
+        action: "request_error",
+        requestId,
+        traceId,
+        route: c.req.path,
+        statusCode,
+        code,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      c.header("Retry-After", "1");
+      c.header("Access-Control-Expose-Headers", apiCorsExposeHeaders.join(", "));
+
+      if (routeKind === "agent") {
+        return c.json(
+          createAgentErrorEnvelope(
+            c.req.url,
+            code,
+            message,
+            "Retry the same action shortly.",
+          ),
+          statusCode,
+        );
+      }
+
+      if (routeKind === "api") {
+        return c.json({
+          error: message,
+          requestId,
+          code,
+        }, statusCode);
+      }
+
+      return c.text(`Request failed. Reference: ${requestId}`, statusCode);
+    }
+
+    logger({
+      domain: "auth",
+      action: "request_error",
+      requestId,
+      traceId,
+      route: c.req.path,
+      statusCode: 500,
+      code: "INTERNAL_ERROR",
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    // Hono's onError swallows the error (returns a 500 response), so
+    // Sentry.wrapHandler never sees it. Capture explicitly here.
+    Sentry.captureException(error, {
+      tags: { service: "auth", route: c.req.path, code: "INTERNAL_ERROR" },
+      extra: { requestId },
+    });
+
+    if (routeKind === "agent" || routeKind === "api") {
+      if (routeKind === "agent") {
+        return c.json(
+          createAgentErrorEnvelope(
+            c.req.url,
+            "INTERNAL_ERROR",
+            "Agent authentication request failed. Try again.",
+            "Retry the same action. If the issue persists, restart from GET /v1/agent on the API host and follow the returned actions.",
+          ),
+          500,
+        );
+      }
+      return jsonAuthError(c, 500, "INTERNAL_ERROR", "Authentication failed. Try again.");
+    }
+
+    return c.text(`Request failed. Reference: ${requestId}`, 500);
+  });
+}
+
 function createMountedApp(basePath: string): Hono<AuthAppEnv> {
   getDemoEmailAccessConfig();
   const app = new Hono<AuthAppEnv>().basePath(basePath);
@@ -135,9 +225,19 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
   app.use("*", async (c, next) => {
     const requestId = randomUUID();
     c.set("requestId", requestId);
+    c.set("logger", log);
     c.header("X-Request-Id", requestId);
     await next();
     c.header("X-Robots-Tag", "noindex, nofollow, noarchive");
+  });
+
+  app.use("*", async (c, next) => {
+    const sentryTrace = c.req.header("sentry-trace") ?? null;
+    const baggage = c.req.header("baggage") ?? null;
+    await continueAuthTrace(sentryTrace, baggage, async (traceId) => {
+      c.set("traceId", traceId);
+      await next();
+    });
   });
 
   // Public, credential-free CORS for the OAuth Authorization Server endpoints so
@@ -192,82 +292,7 @@ function createMountedApp(basePath: string): Hono<AuthAppEnv> {
   // outside /api/*, so it gets the same cross-origin guard explicitly.
   app.use("/authorize/consent", denyCrossOrigin);
 
-  app.onError((error, c) => {
-    const requestId = getRequestId(c);
-    const routeKind = getApiRouteKind(c.req.path);
-    if (isTransientDatabaseError(error)) {
-      const statusCode = 503;
-      const code = "SERVICE_UNAVAILABLE";
-      const message = "Service is temporarily unavailable. Retry shortly.";
-      log({
-        domain: "auth",
-        action: "request_error",
-        requestId,
-        route: c.req.path,
-        statusCode,
-        code,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      c.header("Retry-After", "1");
-      c.header("Access-Control-Expose-Headers", apiCorsExposeHeaders.join(", "));
-
-      if (routeKind === "agent") {
-        return c.json(
-          createAgentErrorEnvelope(
-            c.req.url,
-            code,
-            message,
-            "Retry the same action shortly.",
-          ),
-          statusCode,
-        );
-      }
-
-      if (routeKind === "api") {
-        return c.json({
-          error: message,
-          requestId,
-          code,
-        }, statusCode);
-      }
-
-      return c.text(`Request failed. Reference: ${requestId}`, statusCode);
-    }
-
-    log({
-      domain: "auth",
-      action: "request_error",
-      requestId,
-      route: c.req.path,
-      statusCode: 500,
-      code: "INTERNAL_ERROR",
-      error: error instanceof Error ? error.message : String(error),
-    });
-
-    // Hono's onError swallows the error (returns a 500 response), so
-    // Sentry.wrapHandler never sees it. Capture explicitly here.
-    Sentry.captureException(error, {
-      tags: { service: "auth", route: c.req.path, code: "INTERNAL_ERROR" },
-      extra: { requestId },
-    });
-
-    if (routeKind === "agent" || routeKind === "api") {
-      if (routeKind === "agent") {
-        return c.json(
-          createAgentErrorEnvelope(
-            c.req.url,
-            "INTERNAL_ERROR",
-            "Agent authentication request failed. Try again.",
-            "Retry the same action. If the issue persists, restart from GET /v1/agent on the API host and follow the returned actions.",
-          ),
-          500,
-        );
-      }
-      return jsonAuthError(c, 500, "INTERNAL_ERROR", "Authentication failed. Try again.");
-    }
-
-    return c.text(`Request failed. Reference: ${requestId}`, 500);
-  });
+  registerAuthErrorHandler(app);
 
   app.route("/", health);
   app.route("/", robots);

--- a/apps/auth/src/otpRouteTransientErrors.test.ts
+++ b/apps/auth/src/otpRouteTransientErrors.test.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { createSendCodeApp } from "./routes/browser/sendCode.js";
 import { createVerifyCodeApp } from "./routes/browser/verifyCode.js";
 import type { AuthAppEnv } from "./server/apiErrors.js";
+import { log } from "./server/logger.js";
 import type { OtpVerifyAttemptState } from "./server/otp/otpVerifyAttempts.js";
 
 type ServiceUnavailableResponse = Readonly<{
@@ -29,6 +30,8 @@ function createTestApp(routeApp: Hono<AuthAppEnv>): Hono<AuthAppEnv> {
   const app = new Hono<AuthAppEnv>();
   app.use("*", async (context, next) => {
     context.set("requestId", "request-1");
+    context.set("logger", log);
+    context.set("traceId", null);
     await next();
   });
   app.route("/", routeApp);

--- a/apps/auth/src/refreshRoutes.test.ts
+++ b/apps/auth/src/refreshRoutes.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
+import { registerAuthErrorHandler } from "./app.js";
 import { createRefreshSessionApp } from "./routes/browser/refreshSession.js";
 import { createRefreshTokenApp } from "./routes/browser/refreshToken.js";
 import type { AuthAppEnv } from "./server/apiErrors.js";
 import { createCognitoTypedError, type CognitoTypedError } from "./server/cognito/cognitoErrors.js";
+import { type AuthLogEvent, type AuthLogger, log } from "./server/logger.js";
+import { continueAuthTrace } from "./server/sentry.js";
 
 type RefreshResult = Readonly<{
   idToken: string;
@@ -20,11 +23,17 @@ function createRefreshResult(): RefreshResult {
   };
 }
 
-function createTestApp(routeApp: Hono<AuthAppEnv>): Hono<AuthAppEnv> {
+function createTestApp(routeApp: Hono<AuthAppEnv>, logger: AuthLogger): Hono<AuthAppEnv> {
   const app = new Hono<AuthAppEnv>();
   app.use("*", async (context, next) => {
     context.set("requestId", "request-1");
-    await next();
+    context.set("logger", logger);
+    const sentryTrace = context.req.header("sentry-trace") ?? null;
+    const baggage = context.req.header("baggage") ?? null;
+    await continueAuthTrace(sentryTrace, baggage, async (traceId) => {
+      context.set("traceId", traceId);
+      await next();
+    });
   });
   app.route("/", routeApp);
   return app;
@@ -46,6 +55,8 @@ function getSetCookieValues(response: Response): ReadonlyArray<string> {
 
 test("refresh-session returns 401 and clears cookies when refresh cookie is missing", async () => {
   let clearCookieCallCount = 0;
+  const events: Array<AuthLogEvent> = [];
+  const logger: AuthLogger = (event) => events.push(event);
   const app = createTestApp(createRefreshSessionApp({
     refreshTokens: async () => createRefreshResult(),
     setBrowserSessionCookies: () => {
@@ -57,7 +68,7 @@ test("refresh-session returns 401 and clears cookies when refresh cookie is miss
       context.header("Set-Cookie", "refresh=; Max-Age=0", { append: true });
       context.header("Set-Cookie", "logged_in=; Max-Age=0", { append: true });
     },
-  }));
+  }), logger);
 
   const response = await app.request("http://localhost/api/refresh-session", { method: "POST" });
   const payload = await response.json() as Readonly<{ code: string }>;
@@ -66,10 +77,85 @@ test("refresh-session returns 401 and clears cookies when refresh cookie is miss
   assert.equal(payload.code, "REFRESH_TOKEN_MISSING");
   assert.equal(clearCookieCallCount, 1);
   assert.equal(getSetCookieValues(response).length, 3);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].action, "refresh_session_missing_cookie");
+  assert.equal(events[0].traceId, null);
+  assert.equal(events[1].action, "request_error");
+  assert.equal(events[1].traceId, null);
+});
+
+test("refresh-session logs the incoming Sentry trace ID on success", async () => {
+  const traceId = "4c79f60c11214eb38604f4ae0781bfb2";
+  const events: Array<AuthLogEvent> = [];
+  const logger: AuthLogger = (event) => events.push(event);
+  const app = createTestApp(createRefreshSessionApp({
+    refreshTokens: async () => createRefreshResult(),
+    setBrowserSessionCookies: () => undefined,
+    clearBrowserSessionCookies: () => {
+      throw new Error("clearBrowserSessionCookies must not be called");
+    },
+  }), logger);
+
+  const response = await app.request("http://localhost/api/refresh-session", {
+    method: "POST",
+    headers: {
+      cookie: "refresh=refresh-token",
+      "sentry-trace": `${traceId}-0123456789abcdef-1`,
+      baggage: "sentry-release=%E0%A4%A-secret-release-value",
+    },
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(events, [{
+    domain: "auth",
+    action: "refresh_session",
+    requestId: "request-1",
+    traceId,
+    route: "/api/refresh-session",
+    statusCode: 200,
+  }]);
+  assert.equal(JSON.stringify(events).includes("secret-release-value"), false);
+});
+
+test("refresh-session ignores invalid Sentry traces on success", async () => {
+  const invalidSentryTraces = [
+    "malformed-trace-value",
+    `${"0".repeat(32)}-0123456789abcdef-1`,
+    `4c79f60c11214eb38604f4ae0781bfb2-${"0".repeat(16)}-1`,
+  ] as const;
+
+  for (const sentryTrace of invalidSentryTraces) {
+    const events: Array<AuthLogEvent> = [];
+    const logger: AuthLogger = (event) => events.push(event);
+    const app = createTestApp(createRefreshSessionApp({
+      refreshTokens: async () => createRefreshResult(),
+      setBrowserSessionCookies: () => undefined,
+      clearBrowserSessionCookies: () => {
+        throw new Error("clearBrowserSessionCookies must not be called");
+      },
+    }), logger);
+
+    const response = await app.request("http://localhost/api/refresh-session", {
+      method: "POST",
+      headers: {
+        cookie: "refresh=refresh-token",
+        "sentry-trace": sentryTrace,
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].action, "refresh_session");
+    assert.equal(events[0].traceId, null);
+    assert.equal(JSON.stringify(events).includes(sentryTrace), false);
+  }
 });
 
 test("refresh-session returns 401 and clears cookies for terminal refresh failures", async () => {
   let clearCookieCallCount = 0;
+  const traceId = "4c79f60c11214eb38604f4ae0781bfb2";
+  const events: Array<AuthLogEvent> = [];
+  const logger: AuthLogger = (event) => events.push(event);
   const app = createTestApp(createRefreshSessionApp({
     refreshTokens: async () => Promise.reject(createTerminalRefreshFailure()),
     setBrowserSessionCookies: () => {
@@ -81,12 +167,14 @@ test("refresh-session returns 401 and clears cookies for terminal refresh failur
       context.header("Set-Cookie", "refresh=; Max-Age=0", { append: true });
       context.header("Set-Cookie", "logged_in=; Max-Age=0", { append: true });
     },
-  }));
+  }), logger);
 
   const response = await app.request("http://localhost/api/refresh-session", {
     method: "POST",
     headers: {
       cookie: "refresh=refresh-token",
+      "sentry-trace": `${traceId}-0123456789abcdef-1`,
+      baggage: "sentry-release=secret-release-value",
     },
   });
   const payload = await response.json() as Readonly<{ code: string }>;
@@ -95,10 +183,20 @@ test("refresh-session returns 401 and clears cookies for terminal refresh failur
   assert.equal(payload.code, "REFRESH_TOKEN_FAILED");
   assert.equal(clearCookieCallCount, 1);
   assert.equal(getSetCookieValues(response).length, 3);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].action, "refresh_session_error");
+  assert.equal(events[0].traceId, traceId);
+  assert.equal(events[1].action, "request_error");
+  assert.equal(events[1].traceId, traceId);
+  assert.equal(JSON.stringify(events).includes(`${traceId}-0123456789abcdef-1`), false);
+  assert.equal(JSON.stringify(events).includes("secret-release-value"), false);
 });
 
 test("refresh-session bubbles non-terminal refresh failures as 500 without clearing cookies", async () => {
   let clearCookieCallCount = 0;
+  const traceId = "4c79f60c11214eb38604f4ae0781bfb2";
+  const events: Array<AuthLogEvent> = [];
+  const logger: AuthLogger = (event) => events.push(event);
   const app = createTestApp(createRefreshSessionApp({
     refreshTokens: async () => Promise.reject(createNonTerminalRefreshFailure()),
     setBrowserSessionCookies: () => {
@@ -107,24 +205,49 @@ test("refresh-session bubbles non-terminal refresh failures as 500 without clear
     clearBrowserSessionCookies: () => {
       clearCookieCallCount += 1;
     },
-  }));
+  }), logger);
+  registerAuthErrorHandler(app);
 
   const response = await app.request("http://localhost/api/refresh-session", {
     method: "POST",
     headers: {
       cookie: "refresh=refresh-token",
+      "sentry-trace": `${traceId}-0123456789abcdef-1`,
+      baggage: "sentry-release=secret-release-value",
     },
   });
 
   assert.equal(response.status, 500);
   assert.equal(clearCookieCallCount, 0);
   assert.equal(getSetCookieValues(response).length, 0);
+  assert.equal(events.length, 2);
+  assert.deepEqual(events[0], {
+    domain: "auth",
+    action: "request_error",
+    requestId: "request-1",
+    traceId,
+    route: "/api/refresh-session",
+    statusCode: 500,
+    code: "INTERNAL_ERROR",
+    error: "Cognito internal error",
+  });
+  assert.deepEqual(events[1], {
+    domain: "auth",
+    action: "request_error",
+    requestId: "request-1",
+    traceId,
+    route: "/api/refresh-session",
+    statusCode: 500,
+    code: "INTERNAL_ERROR",
+  });
+  assert.equal(JSON.stringify(events).includes(`${traceId}-0123456789abcdef-1`), false);
+  assert.equal(JSON.stringify(events).includes("secret-release-value"), false);
 });
 
 test("refresh-token returns 401 for terminal refresh failures", async () => {
   const app = createTestApp(createRefreshTokenApp({
     refreshTokens: async () => Promise.reject(createTerminalRefreshFailure()),
-  }));
+  }), log);
 
   const response = await app.request("http://localhost/api/refresh-token", {
     method: "POST",
@@ -144,7 +267,7 @@ test("refresh-token returns 401 for terminal refresh failures", async () => {
 test("refresh-token returns 500 for non-terminal refresh failures", async () => {
   const app = createTestApp(createRefreshTokenApp({
     refreshTokens: async () => Promise.reject(createNonTerminalRefreshFailure()),
-  }));
+  }), log);
 
   const response = await app.request("http://localhost/api/refresh-token", {
     method: "POST",

--- a/apps/auth/src/routes/browser/refreshSession.ts
+++ b/apps/auth/src/routes/browser/refreshSession.ts
@@ -1,9 +1,14 @@
 import { Hono } from "hono";
 import { getCookie } from "hono/cookie";
-import { type AuthAppEnv, getRequestId, jsonAuthError } from "../../server/apiErrors.js";
+import {
+  type AuthAppEnv,
+  getRequestLogger,
+  getRequestId,
+  getTraceId,
+  jsonAuthError,
+} from "../../server/apiErrors.js";
 import { clearBrowserSessionCookies, setBrowserSessionCookies } from "../../server/browserSession.js";
 import { isTerminalRefreshFailure, refreshTokens } from "../../server/cognito/cognitoAuth.js";
-import { log } from "../../server/logger.js";
 
 type RefreshSessionDependencies = Readonly<{
   refreshTokens: (refreshToken: string) => Promise<Awaited<ReturnType<typeof refreshTokens>>>;
@@ -16,12 +21,15 @@ export function createRefreshSessionApp(dependencies: RefreshSessionDependencies
 
   app.post("/api/refresh-session", async (c) => {
     const requestId = getRequestId(c);
+    const traceId = getTraceId(c);
+    const logger = getRequestLogger(c);
     const refreshToken = getCookie(c, "refresh") ?? "";
     if (refreshToken === "") {
-      log({
+      logger({
         domain: "auth",
         action: "refresh_session_missing_cookie",
         requestId,
+        traceId,
         route: c.req.path,
         statusCode: 401,
         code: "REFRESH_TOKEN_MISSING",
@@ -34,10 +42,11 @@ export function createRefreshSessionApp(dependencies: RefreshSessionDependencies
     try {
       const tokens = await dependencies.refreshTokens(refreshToken);
       dependencies.setBrowserSessionCookies(c, tokens.idToken, refreshToken);
-      log({
+      logger({
         domain: "auth",
         action: "refresh_session",
         requestId,
+        traceId,
         route: c.req.path,
         statusCode: 200,
       });
@@ -45,10 +54,11 @@ export function createRefreshSessionApp(dependencies: RefreshSessionDependencies
     } catch (error) {
       if (isTerminalRefreshFailure(error)) {
         const message = error instanceof Error ? error.message : String(error);
-        log({
+        logger({
           domain: "auth",
           action: "refresh_session_error",
           requestId,
+          traceId,
           route: c.req.path,
           statusCode: 401,
           code: "REFRESH_TOKEN_FAILED",

--- a/apps/auth/src/server/apiErrors.ts
+++ b/apps/auth/src/server/apiErrors.ts
@@ -1,10 +1,13 @@
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { log } from "./logger.js";
+import type { AuthLogger } from "./logger.js";
+import type { AuthTraceId } from "./sentry.js";
 
 export type AuthAppEnv = {
   Variables: {
     requestId: string;
+    traceId: AuthTraceId | null;
+    logger: AuthLogger;
   };
 };
 
@@ -30,6 +33,14 @@ export function getRequestId(context: Context<AuthAppEnv>): string {
   return context.get("requestId");
 }
 
+export function getTraceId(context: Context<AuthAppEnv>): AuthTraceId | null {
+  return context.get("traceId");
+}
+
+export function getRequestLogger(context: Context<AuthAppEnv>): AuthLogger {
+  return context.get("logger");
+}
+
 export function jsonAuthError(
   context: Context<AuthAppEnv>,
   statusCode: ContentfulStatusCode,
@@ -37,11 +48,14 @@ export function jsonAuthError(
   error: string,
 ): Response {
   const requestId = getRequestId(context);
+  const traceId = getTraceId(context);
+  const logger = getRequestLogger(context);
 
-  log({
+  logger({
     domain: "auth",
     action: "request_error",
     requestId,
+    traceId,
     route: context.req.path,
     statusCode,
     code,

--- a/apps/auth/src/server/logger.ts
+++ b/apps/auth/src/server/logger.ts
@@ -1,6 +1,8 @@
 /**
  * Structured logger for auth service.
  */
+import type { AuthTraceId } from "./sentry.js";
+
 type AuthAction =
   | "send_code"
   | "send_code_error"
@@ -26,10 +28,11 @@ type AuthAction =
   | "request_error"
   | "error";
 
-type LogEvent = Readonly<{
+export type AuthLogEvent = Readonly<{
   domain: "auth";
   action: AuthAction;
   requestId?: string;
+  traceId?: AuthTraceId | null;
   route?: string;
   statusCode?: number;
   code?: string;
@@ -44,16 +47,18 @@ type LogEvent = Readonly<{
   error?: string;
 }>;
 
+export type AuthLogger = (event: AuthLogEvent) => void;
+
 export const maskEmail = (email: string): string => {
   const [local, domain] = email.split("@");
   if (!local || !domain) return "***";
   return `${local[0]}***@${domain}`;
 };
 
-export const log = (event: LogEvent): void => {
+export const log: AuthLogger = (event) => {
   console.log(JSON.stringify(event));
 };
 
-export const logWarning = (event: LogEvent): void => {
+export const logWarning: AuthLogger = (event) => {
   console.warn(JSON.stringify(event));
 };

--- a/apps/auth/src/server/sentry.ts
+++ b/apps/auth/src/server/sentry.ts
@@ -8,6 +8,12 @@
  */
 import * as Sentry from "@sentry/aws-serverless";
 
+declare const authTraceIdBrand: unique symbol;
+
+export type AuthTraceId = string & Readonly<{
+  [authTraceIdBrand]: true;
+}>;
+
 type AuthSentryInitOptions = NonNullable<Parameters<typeof Sentry.init>[0]>;
 type AuthSentryEvent = Parameters<NonNullable<AuthSentryInitOptions["beforeSend"]>>[0];
 
@@ -24,6 +30,39 @@ const redactedSecretValue = "<redacted>";
 const maskedEmailValue = "<masked-email>";
 
 let authSentryInitialized = false;
+
+const sentryTracePattern = /^([0-9a-f]{32})-([0-9a-f]{16})(?:-[01])?$/;
+const zeroTraceId = "0".repeat(32);
+const zeroSpanId = "0".repeat(16);
+
+function parseAuthTraceId(sentryTrace: string | null): AuthTraceId | null {
+  if (sentryTrace === null) {
+    return null;
+  }
+
+  const match = sentryTracePattern.exec(sentryTrace);
+  if (match === null || match[1] === zeroTraceId || match[2] === zeroSpanId) {
+    return null;
+  }
+
+  return match[1] as AuthTraceId;
+}
+
+export function continueAuthTrace<Result>(
+  sentryTrace: string | null,
+  baggage: string | null,
+  callback: (traceId: AuthTraceId | null) => Result,
+): Result {
+  const traceId = parseAuthTraceId(sentryTrace);
+  if (traceId === null) {
+    return callback(null);
+  }
+
+  return Sentry.continueTrace({
+    sentryTrace: sentryTrace ?? undefined,
+    baggage: baggage ?? undefined,
+  }, () => callback(traceId));
+}
 
 function isAwsLambdaRuntime(env: NodeJS.ProcessEnv): boolean {
   return (env.AWS_EXECUTION_ENV ?? "").startsWith("AWS_Lambda_")


### PR DESCRIPTION
Summary:
- Reuses validated Sentry trace IDs across auth refresh logs.
- Carries typed logger and trace context through refresh, jsonAuthError, and onError paths.
- Treats malformed telemetry as non-fatal without logging raw header values.

Validation:
- Focused refresh suite: 7/7 passed
- Focused OTP transient-error suite: 2/2 passed
- Full auth suite: 35/35 passed
- TypeScript build: passed
- git diff --check: passed
- Final worker-owned review: no split recommendation and no P0-P4 findings