### PR TITLE
Revalidate web session before periodic sync

### DIFF
--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -42,7 +42,6 @@ import type { SessionInfo } from "../../../types";
 type UseWorkspaceLifecycleParams =
   & Readonly<{
     t: (key: TranslationKey) => string;
-    runSync: () => Promise<void>;
     runSyncSilently: () => Promise<void>;
     resolveInitialWorkspace: (currentSession: SessionInfo) => Promise<void>;
     clearConfirmedUserScopedState: (reason: LocalBrowserDataCleanupReason) => Promise<void>;
@@ -90,7 +89,6 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     setErrorMessage,
     setTechnicalError,
     setCloudSettings,
-    runSync,
     runSyncSilently,
     resolveInitialWorkspace,
     clearConfirmedUserScopedState,
@@ -362,7 +360,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
 
     const intervalId = window.setInterval(() => {
       if (document.visibilityState === "visible") {
-        runLifecycleTaskInBackground(runSync());
+        runLifecycleTaskInBackground(resumeInBackground());
       }
     }, 60_000);
 
@@ -387,7 +385,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [resumeInBackground, runSync, session, sessionLoadState, sessionVerificationState]);
+  }, [resumeInBackground, session, sessionLoadState, sessionVerificationState]);
 
   return {
     initialize,

--- a/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
@@ -317,7 +317,7 @@ describe("useWorkspaceSession bootstrap", () => {
     expect(latestState?.technicalError).toBeNull();
   });
 
-  it("catches rejecting visible interval sync tasks", async () => {
+  it("revalidates the same user before a visible interval sync", async () => {
     seedBrowserStorage();
     await seedIndexedDbState();
 
@@ -337,13 +337,12 @@ describe("useWorkspaceSession bootstrap", () => {
 
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
-      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]));
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]))
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-interval"));
     vi.stubGlobal("fetch", fetchMock);
 
-    const intervalSyncError = new Error("Interval sync failed");
-    const runSyncMock = vi.fn(async (): Promise<void> => {
-      throw intervalSyncError;
-    });
+    const runSyncMock = vi.fn(async (): Promise<void> => {});
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {});
 
     await act(async () => {
       root?.render(
@@ -358,7 +357,7 @@ describe("useWorkspaceSession bootstrap", () => {
           }}
           refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
           runSyncMock={runSyncMock}
-          runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
+          runSyncSilentlyMock={runSyncSilentlyMock}
           runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
           discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
           discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
@@ -385,7 +384,13 @@ describe("useWorkspaceSession bootstrap", () => {
       await Promise.resolve();
     });
 
-    expect(runSyncMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(runSyncMock).not.toHaveBeenCalled();
+    expect(runSyncSilentlyMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.invocationCallOrder[2]).toBeLessThan(
+      runSyncSilentlyMock.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(latestState?.session?.csrfToken).toBe("csrf-interval");
     expect(latestState?.sessionLoadState).toBe("ready");
     expect(latestState?.sessionVerificationState).toBe("verified");
   });

--- a/apps/web/src/appData/session/useWorkspaceSession.reauthResume.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.reauthResume.test.tsx
@@ -51,6 +51,7 @@ describe("useWorkspaceSession reauth resume", () => {
         root?.unmount();
       });
     }
+    globalThis.IS_REACT_ACT_ENVIRONMENT = undefined;
 
     container?.remove();
     root = null;
@@ -274,6 +275,112 @@ describe("useWorkspaceSession reauth resume", () => {
       linkedUserId: "user-2",
       linkedWorkspaceId: "workspace-2",
     }));
+  });
+
+  it("revalidates an account change before each visible interval sync", async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    seedBrowserStorage();
+    await seedIndexedDbState();
+    vi.useFakeTimers({
+      toFake: ["setInterval", "clearInterval"],
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: (): DocumentVisibilityState => "visible",
+    });
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
+    const syncDiscardDeferred = createDeferredVoidPromise();
+    const replacementWorkspaceSyncStarted = createDeferredVoidPromise();
+    const discardAllSyncWorkMock = vi.fn(async (
+      runWhileDiscarding: () => Promise<void>,
+    ): Promise<void> => {
+      await syncDiscardDeferred.promise;
+      await runWhileDiscarding();
+    });
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]))
+      .mockResolvedValueOnce(buildSessionResponseForUser("user-2", "workspace-2", "csrf-user-2"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([replacementWorkspace]))
+      .mockResolvedValueOnce(buildSessionResponseForUser("user-2", "workspace-2", "csrf-user-2-next"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const runSyncMock = vi.fn(async (): Promise<void> => {});
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {});
+    const runSyncForWorkspaceMock = vi.fn(async (workspace: WorkspaceSummary): Promise<void> => {
+      if (workspace.workspaceId === replacementWorkspace.workspaceId) {
+        replacementWorkspaceSyncStarted.resolve();
+      }
+    });
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={runSyncMock}
+          runSyncSilentlyMock={runSyncSilentlyMock}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={discardAllSyncWorkMock}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
+          onActionsChange={null}
+        />,
+      );
+    });
+
+    for (let attempt = 0; attempt < 10 && runSyncForWorkspaceMock.mock.calls.length === 0; attempt += 1) {
+      await act(async () => {
+        await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+      });
+    }
+    expect(latestState?.session?.userId).toBe("user-1");
+    expect(latestState?.sessionVerificationState).toBe("verified");
+    expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    runSyncForWorkspaceMock.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(discardAllSyncWorkMock).toHaveBeenCalledTimes(1);
+    expect(runSyncMock).not.toHaveBeenCalled();
+    expect(runSyncSilentlyMock).not.toHaveBeenCalled();
+    expect(runSyncForWorkspaceMock).not.toHaveBeenCalled();
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      syncDiscardDeferred.resolve();
+      await replacementWorkspaceSyncStarted.promise;
+      await Promise.resolve();
+    });
+
+    expect(latestState?.session?.userId).toBe("user-2");
+    expect(latestState?.activeWorkspace?.workspaceId).toBe("workspace-2");
+    expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+
+    expect(discardAllSyncWorkMock.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteDatabaseSpy.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(runSyncForWorkspaceMock).toHaveBeenCalledWith(replacementWorkspace);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(runSyncSilentlyMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    expect(latestState?.session?.userId).toBe("user-2");
+    expect(latestState?.session?.csrfToken).toBe("csrf-user-2-next");
   });
 
   it("shows an error when resume account switch bootstrap fails", async () => {


### PR DESCRIPTION
## Summary
- route visible-tab periodic sync through the existing deduplicated session resume flow
- revalidate the authenticated user before syncing and reuse existing account-switch cleanup
- cover same-user and account-change interval behavior

## Validation
- `npm exec vitest -- run src/appData/session/useWorkspaceSession.reauthResume.test.tsx src/appData/session/useWorkspaceSession.bootstrap.test.tsx` (18/18 passed)
- `npm run build`
- `git diff --check`