### PR TITLE
Group Android review reaction drawing files

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionOverlay.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionOverlay.kt
@@ -21,6 +21,11 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.Dp
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.compose.LottieAnimation
+import com.flashcardsopensourceapp.feature.review.reaction.drawing.drawReviewReaction
+import com.flashcardsopensourceapp.feature.review.reaction.drawing.reviewReactionCenterX
+import com.flashcardsopensourceapp.feature.review.reaction.drawing.reviewReactionCenterY
+import com.flashcardsopensourceapp.feature.review.reaction.drawing.reviewReactionClampedProgress
+import com.flashcardsopensourceapp.feature.review.reaction.drawing.reviewReactionOpacity
 import kotlinx.coroutines.delay
 
 private const val reviewReactionAnimationMinimumProgress: Float = 0f

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionDrawingPrimitives.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionDrawingPrimitives.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.review.reaction
+package com.flashcardsopensourceapp.feature.review.reaction.drawing
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionEasyRenderers.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionEasyRenderers.kt
@@ -1,7 +1,9 @@
-package com.flashcardsopensourceapp.feature.review.reaction
+package com.flashcardsopensourceapp.feature.review.reaction.drawing
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionMotionMode
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionVariant
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.min

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionGeometry.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionGeometry.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.review.reaction
+package com.flashcardsopensourceapp.feature.review.reaction.drawing
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Path

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionMotion.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionMotion.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.review.reaction
+package com.flashcardsopensourceapp.feature.review.reaction.drawing
 
 import kotlin.math.PI
 import kotlin.math.max

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionPalette.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionPalette.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.review.reaction
+package com.flashcardsopensourceapp.feature.review.reaction.drawing
 
 import androidx.compose.ui.graphics.Color
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionRenderer.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/drawing/ReviewReactionRenderer.kt
@@ -1,6 +1,9 @@
-package com.flashcardsopensourceapp.feature.review.reaction
+package com.flashcardsopensourceapp.feature.review.reaction.drawing
 
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionEvent
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionMotionMode
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionVariant
 
 internal fun DrawScope.drawReviewReaction(
     event: ReviewReactionEvent,


### PR DESCRIPTION
## Summary

- group native Compose review reaction drawing implementation under `reaction/drawing`
- keep state, Lottie readiness, overlay orchestration, and the developer route at the reaction root
- update package and cross-package imports without changing renderer behavior

## Validation

- freshness, diff, package/import, old-path, content-preservation, and rename checks passed
- fresh review found no P0-P4 issues and no split recommendation
- Gradle compile was not run because repository policy requires explicit authorization