### PR TITLE
Move Android AI input UI

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/input/AiAttachmentSheet.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/input/AiAttachmentSheet.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.ai.ui
+package com.flashcardsopensourceapp.feature.ai.input
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/input/AiComposerContent.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/input/AiComposerContent.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.ai.ui
+package com.flashcardsopensourceapp.feature.ai.input
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -59,6 +59,7 @@ import com.flashcardsopensourceapp.core.ui.currentResourceLocale
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatAttachment
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatDictationState
 import com.flashcardsopensourceapp.feature.ai.strings.aiTextProvider
+import com.flashcardsopensourceapp.feature.ai.ui.RepairStatusCard
 
 private val aiComposerActionSize = 40.dp
 private val aiComposerPrimaryActionSize = 36.dp

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
@@ -63,7 +63,10 @@ import com.flashcardsopensourceapp.feature.ai.R
 import com.flashcardsopensourceapp.feature.ai.aiConversationLoadingTag
 import com.flashcardsopensourceapp.feature.ai.aiNewChatButtonTag
 import com.flashcardsopensourceapp.feature.ai.input.AiCapabilityPresentationResult
+import com.flashcardsopensourceapp.feature.ai.input.AiComposer
 import com.flashcardsopensourceapp.feature.ai.input.AndroidAiChatDictationRecorder
+import com.flashcardsopensourceapp.feature.ai.input.AttachmentAction
+import com.flashcardsopensourceapp.feature.ai.input.AttachmentSheet
 import com.flashcardsopensourceapp.feature.ai.input.aiAttachmentImportAlert
 import com.flashcardsopensourceapp.feature.ai.input.aiCapabilityPresentationResult
 import com.flashcardsopensourceapp.feature.ai.input.aiChatDocumentPickerMimeTypes


### PR DESCRIPTION
## Summary
- move the AI composer and attachment sheet into the Android AI input package
- update AiScreen imports for the relocated input UI
- preserve existing Material 3 behavior and callbacks

## Validation
- diff, rename, package/import, old-path, stale-reference, and duplicate-definition checks passed
- independent review found no P0-P4 issues
- Gradle was not run because explicit authorization was not provided