### PR TITLE
Harden chat send button DOM stability

### DIFF
--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -505,14 +505,13 @@ export function ChatPanel(props: Props): ReactElement {
                 disabled={!canSendPendingMessage}
                 data-testid="chat-send-button"
               >
-                {isSendButtonBusy ? (
-                  <span
-                    className="chat-send-btn-spinner"
-                    aria-hidden="true"
-                    data-testid="chat-send-button-busy-indicator"
-                  />
-                ) : null}
-                {t("chatPanel.actions.send")}
+                <span
+                  className="chat-send-btn-spinner"
+                  aria-hidden="true"
+                  data-testid="chat-send-button-busy-indicator"
+                  hidden={!isSendButtonBusy}
+                />
+                <span>{t("chatPanel.actions.send")}</span>
               </button>
             )}
           </div>

--- a/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
@@ -296,7 +296,7 @@ describe("ChatPanel composer controls", () => {
     expect(sendButton).not.toBeNull();
     expect(sendButton?.disabled).toBe(true);
     expect(sendButton?.getAttribute("aria-busy")).toBe("true");
-    expect(queryChatSendButtonBusyIndicator(getContainer())).not.toBeNull();
+    expect(queryChatSendButtonBusyIndicator(getContainer())?.hidden).toBe(false);
 
     await dispatchChatPanelDragEvent(getContainer(), createDropEvent(new File(["pending"], "pending.txt", { type: "text/plain" })));
     await flushAsync();
@@ -341,7 +341,7 @@ describe("ChatPanel composer controls", () => {
     expect(composerState?.getAttribute("data-send-phase")).toBe("preparingSend");
     expect(sendButton).not.toBeNull();
     expect(sendButton?.getAttribute("aria-busy")).toBe("true");
-    expect(queryChatSendButtonBusyIndicator(getContainer())).not.toBeNull();
+    expect(queryChatSendButtonBusyIndicator(getContainer())?.hidden).toBe(false);
     expect(resolveDelayedAttachment).not.toBeNull();
 
     await act(async () => {

--- a/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx
@@ -314,7 +314,7 @@ describe("ChatPanel send recovered drafts", () => {
     expect(textareaAfterReopen?.value).toBe("keep this draft after closing panel");
     expect(sendButtonAfterReopen?.disabled).toBe(true);
     expect(sendButtonAfterReopen?.getAttribute("aria-busy")).toBe("true");
-    expect(queryChatSendButtonBusyIndicator(getContainer())).not.toBeNull();
+    expect(queryChatSendButtonBusyIndicator(getContainer())?.hidden).toBe(false);
     expect(readStoredDraftInputText("workspace-1", staleSessionId as string)).toBeNull();
     expect(readStoredDraftInputText("workspace-1", recoveredSessionId as string)).toBe("keep this draft after closing panel");
 
@@ -327,7 +327,7 @@ describe("ChatPanel send recovered drafts", () => {
     expect(composerStateAfterRetryFailure?.getAttribute("data-send-phase")).toBe("idle");
     expect(sendButtonAfterRetryFailure?.disabled).toBe(false);
     expect(sendButtonAfterRetryFailure?.getAttribute("aria-busy")).toBe("false");
-    expect(queryChatSendButtonBusyIndicator(getContainer())).toBeNull();
+    expect(queryChatSendButtonBusyIndicator(getContainer())?.hidden).toBe(true);
     expect(readStoredDraftInputText("workspace-1", recoveredSessionId as string)).toBe("keep this draft after closing panel");
   });
 


### PR DESCRIPTION
## Summary
- keep the chat send spinner mounted and toggle its native hidden state
- wrap the localized Send text in a stable label element
- align existing busy and idle assertions with persistent spinner visibility

## Validation
- targeted Vitest: 2 files, 18 tests passed under Node 24.18.0
- npm run build passed under Node 24.18.0
- git diff --check passed
- read-only review found no P0-P4 issues

## Residual validation gap
- optional authenticated manual translated-DOM mutation check was not run because the local web, backend, and auth ports were unavailable