### PR TITLE
Group AWS scheduled job constructs

### DIFF
--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -15,10 +15,10 @@ import {
   globalMetricsSnapshotFreshnessMetricName,
   globalMetricsSnapshotFreshnessMetricNamespace,
   globalMetricsSnapshotFreshnessMetricStackDimensionName,
-} from "./global-metrics";
-import { communityLeaderboardSnapshotScheduleHours } from "./community-leaderboard";
-import { streakLeaderboardSnapshotScheduleHours } from "./streak-leaderboard";
-import { progressActiveDaysBackfillScheduleHours } from "./progress-active-days-backfill";
+} from "./scheduled-jobs/global-metrics";
+import { communityLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/community-leaderboard";
+import { streakLeaderboardSnapshotScheduleHours } from "./scheduled-jobs/streak-leaderboard";
+import { progressActiveDaysBackfillScheduleHours } from "./scheduled-jobs/progress-active-days-backfill";
 
 const communityLeaderboardSnapshotStaleEvaluationPeriods = 2;
 const streakLeaderboardSnapshotStaleEvaluationPeriods = 2;

--- a/infra/aws/lib/scheduled-jobs/community-leaderboard.test.ts
+++ b/infra/aws/lib/scheduled-jobs/community-leaderboard.test.ts
@@ -17,7 +17,7 @@ test("community leaderboard snapshot is scheduled hourly", () => {
 });
 
 test("community leaderboard construct creates the hourly schedule and snapshot Lambda", () => {
-  const source = readLibSource("lib/community-leaderboard.ts");
+  const source = readLibSource("lib/scheduled-jobs/community-leaderboard.ts");
 
   // A NodejsFunction whose entry is the leaderboard snapshot Lambda handler.
   assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "CommunityLeaderboardSnapshotHandler"/);

--- a/infra/aws/lib/scheduled-jobs/community-leaderboard.ts
+++ b/infra/aws/lib/scheduled-jobs/community-leaderboard.ts
@@ -6,10 +6,10 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as rds from "aws-cdk-lib/aws-rds";
 import * as scheduler from "aws-cdk-lib/aws-scheduler";
 import { Construct } from "constructs";
-import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
-import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
+import { backendNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "../sentry-source-maps";
 
-export interface StreakLeaderboardProps {
+export interface CommunityLeaderboardProps {
   vpc: ec2.Vpc;
   lambdaSg: ec2.SecurityGroup;
   db: rds.DatabaseInstance;
@@ -20,12 +20,12 @@ export interface StreakLeaderboardProps {
   sentryTracesSampleRate: string | undefined;
 }
 
-export interface StreakLeaderboardResult {
+export interface CommunityLeaderboardResult {
   snapshotFunction: lambdaNodejs.NodejsFunction;
 }
 
-export const streakLeaderboardSnapshotScheduleHours = 24;
-export const streakLeaderboardSnapshotScheduleExpression = "cron(0 12 * * ? *)";
+export const communityLeaderboardSnapshotScheduleHours = 1;
+export const communityLeaderboardSnapshotScheduleExpression = "cron(0 * * * ? *)";
 
 const lambdaBundling: lambdaNodejs.BundlingOptions = {
   minify: true,
@@ -47,7 +47,7 @@ function hasConfiguredValue(value: string | undefined): value is string {
 function addOptionalSentryEnvironment(
   scope: Construct,
   fn: lambdaNodejs.NodejsFunction,
-  props: StreakLeaderboardProps,
+  props: CommunityLeaderboardProps,
 ): void {
   if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
     return;
@@ -67,7 +67,7 @@ function addOptionalSentryEnvironment(
 
   const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
     scope,
-    "StreakLeaderboardSnapshotSentryDsnSecret",
+    "CommunityLeaderboardSnapshotSentryDsnSecret",
     props.sentryDsnSecretArn,
   );
   secret.grantRead(fn);
@@ -77,9 +77,15 @@ function addOptionalSentryEnvironment(
   fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
 }
 
-export function streakLeaderboard(scope: Construct, props: StreakLeaderboardProps): StreakLeaderboardResult {
-  const snapshotFunction = new lambdaNodejs.NodejsFunction(scope, "StreakLeaderboardSnapshotHandler", {
-    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-streak-leaderboard-snapshot.ts"),
+/**
+ * Hourly community leaderboard snapshot generation. The Lambda connects to Postgres as
+ * the backend_app runtime role (read-write) and calls the SECURITY DEFINER snapshot
+ * function, so it needs the backend database secret rather than the read-only reporting
+ * secret used by the global metrics snapshot.
+ */
+export function communityLeaderboard(scope: Construct, props: CommunityLeaderboardProps): CommunityLeaderboardResult {
+  const snapshotFunction = new lambdaNodejs.NodejsFunction(scope, "CommunityLeaderboardSnapshotHandler", {
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-community-leaderboard-snapshot.ts"),
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),
@@ -100,7 +106,7 @@ export function streakLeaderboard(scope: Construct, props: StreakLeaderboardProp
   props.backendDbSecret.grantRead(snapshotFunction);
   addOptionalSentryEnvironment(scope, snapshotFunction, props);
 
-  const schedulerInvokeRole = new iam.Role(scope, "StreakLeaderboardSnapshotSchedulerRole", {
+  const schedulerInvokeRole = new iam.Role(scope, "CommunityLeaderboardSnapshotSchedulerRole", {
     assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com"),
   });
   schedulerInvokeRole.addToPolicy(new iam.PolicyStatement({
@@ -108,10 +114,10 @@ export function streakLeaderboard(scope: Construct, props: StreakLeaderboardProp
     resources: [snapshotFunction.functionArn],
   }));
 
-  new scheduler.CfnSchedule(scope, "StreakLeaderboardSnapshotDailySchedule", {
-    description: "Generate the streak leaderboard snapshot daily at 12:00 UTC",
+  new scheduler.CfnSchedule(scope, "CommunityLeaderboardSnapshotHourlySchedule", {
+    description: "Generate the community leaderboard snapshots every hour",
     flexibleTimeWindow: { mode: "OFF" },
-    scheduleExpression: streakLeaderboardSnapshotScheduleExpression,
+    scheduleExpression: communityLeaderboardSnapshotScheduleExpression,
     scheduleExpressionTimezone: "UTC",
     state: "ENABLED",
     target: {

--- a/infra/aws/lib/scheduled-jobs/global-metrics.ts
+++ b/infra/aws/lib/scheduled-jobs/global-metrics.ts
@@ -8,8 +8,8 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import * as scheduler from "aws-cdk-lib/aws-scheduler";
 import { Construct } from "constructs";
 import * as path from "path";
-import { backendNodejsProjectPaths, infraAwsNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
-import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
+import { backendNodejsProjectPaths, infraAwsNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "../sentry-source-maps";
 
 export interface GlobalMetricsProps {
   vpc: ec2.Vpc;
@@ -153,7 +153,7 @@ export function globalMetrics(scope: Construct, props: GlobalMetricsProps): Glob
     scope,
     "GlobalMetricsSnapshotFreshnessCheckerHandler",
     {
-      entry: path.join(__dirname, "../lambda/global-metrics-snapshot-freshness/index.ts"),
+      entry: path.join(__dirname, "../../lambda/global-metrics-snapshot-freshness/index.ts"),
       handler: "handler",
       runtime: lambda.Runtime.NODEJS_24_X,
       timeout: cdk.Duration.seconds(30),

--- a/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.test.ts
+++ b/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.test.ts
@@ -17,7 +17,7 @@ test("progress active days backfill is scheduled hourly", () => {
 });
 
 test("progress active days backfill construct creates the hourly schedule and Lambda", () => {
-  const source = readLibSource("lib/progress-active-days-backfill.ts");
+  const source = readLibSource("lib/scheduled-jobs/progress-active-days-backfill.ts");
 
   assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "ProgressActiveDaysBackfillHandler"/);
   assert.match(

--- a/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.ts
+++ b/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.ts
@@ -6,26 +6,27 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as rds from "aws-cdk-lib/aws-rds";
 import * as scheduler from "aws-cdk-lib/aws-scheduler";
 import { Construct } from "constructs";
-import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
-import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
+import { backendNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "../sentry-source-maps";
 
-export interface CommunityLeaderboardProps {
+export interface ProgressActiveDaysBackfillProps {
   vpc: ec2.Vpc;
   lambdaSg: ec2.SecurityGroup;
   db: rds.DatabaseInstance;
   backendDbSecret: cdk.aws_secretsmanager.Secret;
+  reportingDbSecret: cdk.aws_secretsmanager.ISecret;
   sentryDsnSecretArn: string | undefined;
   sentryEnvironment: string | undefined;
   sentryRelease: string | undefined;
   sentryTracesSampleRate: string | undefined;
 }
 
-export interface CommunityLeaderboardResult {
-  snapshotFunction: lambdaNodejs.NodejsFunction;
+export interface ProgressActiveDaysBackfillResult {
+  backfillFunction: lambdaNodejs.NodejsFunction;
 }
 
-export const communityLeaderboardSnapshotScheduleHours = 1;
-export const communityLeaderboardSnapshotScheduleExpression = "cron(0 * * * ? *)";
+export const progressActiveDaysBackfillScheduleHours = 1;
+export const progressActiveDaysBackfillScheduleExpression = "cron(15 * * * ? *)";
 
 const lambdaBundling: lambdaNodejs.BundlingOptions = {
   minify: true,
@@ -47,7 +48,7 @@ function hasConfiguredValue(value: string | undefined): value is string {
 function addOptionalSentryEnvironment(
   scope: Construct,
   fn: lambdaNodejs.NodejsFunction,
-  props: CommunityLeaderboardProps,
+  props: ProgressActiveDaysBackfillProps,
 ): void {
   if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
     return;
@@ -67,7 +68,7 @@ function addOptionalSentryEnvironment(
 
   const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
     scope,
-    "CommunityLeaderboardSnapshotSentryDsnSecret",
+    "ProgressActiveDaysBackfillSentryDsnSecret",
     props.sentryDsnSecretArn,
   );
   secret.grantRead(fn);
@@ -77,15 +78,12 @@ function addOptionalSentryEnvironment(
   fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
 }
 
-/**
- * Hourly community leaderboard snapshot generation. The Lambda connects to Postgres as
- * the backend_app runtime role (read-write) and calls the SECURITY DEFINER snapshot
- * function, so it needs the backend database secret rather than the read-only reporting
- * secret used by the global metrics snapshot.
- */
-export function communityLeaderboard(scope: Construct, props: CommunityLeaderboardProps): CommunityLeaderboardResult {
-  const snapshotFunction = new lambdaNodejs.NodejsFunction(scope, "CommunityLeaderboardSnapshotHandler", {
-    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-community-leaderboard-snapshot.ts"),
+export function progressActiveDaysBackfill(
+  scope: Construct,
+  props: ProgressActiveDaysBackfillProps,
+): ProgressActiveDaysBackfillResult {
+  const backfillFunction = new lambdaNodejs.NodejsFunction(scope, "ProgressActiveDaysBackfillHandler", {
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-progress-active-days-backfill.ts"),
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),
@@ -98,36 +96,38 @@ export function communityLeaderboard(scope: Construct, props: CommunityLeaderboa
     environment: {
       NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
       DB_SECRET_ARN: props.backendDbSecret.secretArn,
+      REPORTING_DB_SECRET_ARN: props.reportingDbSecret.secretArn,
       DB_HOST: props.db.dbInstanceEndpointAddress,
       DB_NAME: "flashcards",
     },
   });
 
-  props.backendDbSecret.grantRead(snapshotFunction);
-  addOptionalSentryEnvironment(scope, snapshotFunction, props);
+  props.backendDbSecret.grantRead(backfillFunction);
+  props.reportingDbSecret.grantRead(backfillFunction);
+  addOptionalSentryEnvironment(scope, backfillFunction, props);
 
-  const schedulerInvokeRole = new iam.Role(scope, "CommunityLeaderboardSnapshotSchedulerRole", {
+  const schedulerInvokeRole = new iam.Role(scope, "ProgressActiveDaysBackfillSchedulerRole", {
     assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com"),
   });
   schedulerInvokeRole.addToPolicy(new iam.PolicyStatement({
     actions: ["lambda:InvokeFunction"],
-    resources: [snapshotFunction.functionArn],
+    resources: [backfillFunction.functionArn],
   }));
 
-  new scheduler.CfnSchedule(scope, "CommunityLeaderboardSnapshotHourlySchedule", {
-    description: "Generate the community leaderboard snapshots every hour",
+  new scheduler.CfnSchedule(scope, "ProgressActiveDaysBackfillHourlySchedule", {
+    description: "Materialize missing Progress active review days every hour",
     flexibleTimeWindow: { mode: "OFF" },
-    scheduleExpression: communityLeaderboardSnapshotScheduleExpression,
+    scheduleExpression: progressActiveDaysBackfillScheduleExpression,
     scheduleExpressionTimezone: "UTC",
     state: "ENABLED",
     target: {
-      arn: snapshotFunction.functionArn,
+      arn: backfillFunction.functionArn,
       input: "{}",
       roleArn: schedulerInvokeRole.roleArn,
     },
   });
 
   return {
-    snapshotFunction,
+    backfillFunction,
   };
 }

--- a/infra/aws/lib/scheduled-jobs/streak-leaderboard.test.ts
+++ b/infra/aws/lib/scheduled-jobs/streak-leaderboard.test.ts
@@ -17,7 +17,7 @@ test("streak leaderboard snapshot is scheduled daily at 12:00 UTC", () => {
 });
 
 test("streak leaderboard construct creates the daily schedule and snapshot Lambda", () => {
-  const source = readLibSource("lib/streak-leaderboard.ts");
+  const source = readLibSource("lib/scheduled-jobs/streak-leaderboard.ts");
 
   assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "StreakLeaderboardSnapshotHandler"/);
   assert.match(

--- a/infra/aws/lib/scheduled-jobs/streak-leaderboard.ts
+++ b/infra/aws/lib/scheduled-jobs/streak-leaderboard.ts
@@ -6,27 +6,26 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as rds from "aws-cdk-lib/aws-rds";
 import * as scheduler from "aws-cdk-lib/aws-scheduler";
 import { Construct } from "constructs";
-import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
-import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
+import { backendNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "../sentry-source-maps";
 
-export interface ProgressActiveDaysBackfillProps {
+export interface StreakLeaderboardProps {
   vpc: ec2.Vpc;
   lambdaSg: ec2.SecurityGroup;
   db: rds.DatabaseInstance;
   backendDbSecret: cdk.aws_secretsmanager.Secret;
-  reportingDbSecret: cdk.aws_secretsmanager.ISecret;
   sentryDsnSecretArn: string | undefined;
   sentryEnvironment: string | undefined;
   sentryRelease: string | undefined;
   sentryTracesSampleRate: string | undefined;
 }
 
-export interface ProgressActiveDaysBackfillResult {
-  backfillFunction: lambdaNodejs.NodejsFunction;
+export interface StreakLeaderboardResult {
+  snapshotFunction: lambdaNodejs.NodejsFunction;
 }
 
-export const progressActiveDaysBackfillScheduleHours = 1;
-export const progressActiveDaysBackfillScheduleExpression = "cron(15 * * * ? *)";
+export const streakLeaderboardSnapshotScheduleHours = 24;
+export const streakLeaderboardSnapshotScheduleExpression = "cron(0 12 * * ? *)";
 
 const lambdaBundling: lambdaNodejs.BundlingOptions = {
   minify: true,
@@ -48,7 +47,7 @@ function hasConfiguredValue(value: string | undefined): value is string {
 function addOptionalSentryEnvironment(
   scope: Construct,
   fn: lambdaNodejs.NodejsFunction,
-  props: ProgressActiveDaysBackfillProps,
+  props: StreakLeaderboardProps,
 ): void {
   if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
     return;
@@ -68,7 +67,7 @@ function addOptionalSentryEnvironment(
 
   const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
     scope,
-    "ProgressActiveDaysBackfillSentryDsnSecret",
+    "StreakLeaderboardSnapshotSentryDsnSecret",
     props.sentryDsnSecretArn,
   );
   secret.grantRead(fn);
@@ -78,12 +77,9 @@ function addOptionalSentryEnvironment(
   fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
 }
 
-export function progressActiveDaysBackfill(
-  scope: Construct,
-  props: ProgressActiveDaysBackfillProps,
-): ProgressActiveDaysBackfillResult {
-  const backfillFunction = new lambdaNodejs.NodejsFunction(scope, "ProgressActiveDaysBackfillHandler", {
-    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-progress-active-days-backfill.ts"),
+export function streakLeaderboard(scope: Construct, props: StreakLeaderboardProps): StreakLeaderboardResult {
+  const snapshotFunction = new lambdaNodejs.NodejsFunction(scope, "StreakLeaderboardSnapshotHandler", {
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-streak-leaderboard-snapshot.ts"),
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),
@@ -96,38 +92,36 @@ export function progressActiveDaysBackfill(
     environment: {
       NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
       DB_SECRET_ARN: props.backendDbSecret.secretArn,
-      REPORTING_DB_SECRET_ARN: props.reportingDbSecret.secretArn,
       DB_HOST: props.db.dbInstanceEndpointAddress,
       DB_NAME: "flashcards",
     },
   });
 
-  props.backendDbSecret.grantRead(backfillFunction);
-  props.reportingDbSecret.grantRead(backfillFunction);
-  addOptionalSentryEnvironment(scope, backfillFunction, props);
+  props.backendDbSecret.grantRead(snapshotFunction);
+  addOptionalSentryEnvironment(scope, snapshotFunction, props);
 
-  const schedulerInvokeRole = new iam.Role(scope, "ProgressActiveDaysBackfillSchedulerRole", {
+  const schedulerInvokeRole = new iam.Role(scope, "StreakLeaderboardSnapshotSchedulerRole", {
     assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com"),
   });
   schedulerInvokeRole.addToPolicy(new iam.PolicyStatement({
     actions: ["lambda:InvokeFunction"],
-    resources: [backfillFunction.functionArn],
+    resources: [snapshotFunction.functionArn],
   }));
 
-  new scheduler.CfnSchedule(scope, "ProgressActiveDaysBackfillHourlySchedule", {
-    description: "Materialize missing Progress active review days every hour",
+  new scheduler.CfnSchedule(scope, "StreakLeaderboardSnapshotDailySchedule", {
+    description: "Generate the streak leaderboard snapshot daily at 12:00 UTC",
     flexibleTimeWindow: { mode: "OFF" },
-    scheduleExpression: progressActiveDaysBackfillScheduleExpression,
+    scheduleExpression: streakLeaderboardSnapshotScheduleExpression,
     scheduleExpressionTimezone: "UTC",
     state: "ENABLED",
     target: {
-      arn: backfillFunction.functionArn,
+      arn: snapshotFunction.functionArn,
       input: "{}",
       roleArn: schedulerInvokeRole.roleArn,
     },
   });
 
   return {
-    backfillFunction,
+    snapshotFunction,
   };
 }

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -15,10 +15,10 @@ import { migrationRunner } from "./migration-runner";
 import { authGateway } from "./gateways/auth-gateway";
 import { mcpGateway } from "./gateways/mcp-gateway";
 import { analyticsAccess, type AnalyticsAccessResult } from "./analytics-access";
-import { globalMetrics } from "./global-metrics";
-import { communityLeaderboard } from "./community-leaderboard";
-import { streakLeaderboard } from "./streak-leaderboard";
-import { progressActiveDaysBackfill } from "./progress-active-days-backfill";
+import { globalMetrics } from "./scheduled-jobs/global-metrics";
+import { communityLeaderboard } from "./scheduled-jobs/community-leaderboard";
+import { streakLeaderboard } from "./scheduled-jobs/streak-leaderboard";
+import { progressActiveDaysBackfill } from "./scheduled-jobs/progress-active-days-backfill";
 import { mediaAssets } from "./media-assets";
 
 function getOptionalContextValue(stack: cdk.Stack, key: string): string | undefined {


### PR DESCRIPTION
## Summary

- group four scheduled AWS product jobs under one `lib/scheduled-jobs` boundary
- keep stack composition and monitoring at the library root
- preserve construct behavior while updating relative imports and source-reading test paths

## Validation

- `git diff --check`
- TypeScript no-emit check
- `npm --prefix infra/aws test` (32 tests passed)
- fresh worker-owned review: no P0-P4 findings

CDK synth and deployment were intentionally not run under repository policy.