### PR TITLE
Fix async XCTest assertion compilation

### DIFF
--- a/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/StrictReminderCompletionTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/StrictReminderCompletionTests.swift
@@ -143,13 +143,14 @@ final class StrictReminderCompletionTests: ReviewNotificationsTestCase {
         )
         XCTAssertTrue(resolution.shouldPersistImportedCompletion)
         XCTAssertFalse(resolution.shouldClearPersistedCompletion)
+        let unrelatedWorkspaceCompletedDayStartMillis: Set<Int64> = try await loadStrictReminderImportedCompletedDayStartMillis(
+            databaseURL: databaseURL,
+            workspaceId: "workspace-without-review",
+            now: now,
+            calendar: calendar
+        )
         XCTAssertEqual(
-            try await loadStrictReminderImportedCompletedDayStartMillis(
-                databaseURL: databaseURL,
-                workspaceId: "workspace-without-review",
-                now: now,
-                calendar: calendar
-            ),
+            unrelatedWorkspaceCompletedDayStartMillis,
             []
         )
     }


### PR DESCRIPTION
## Summary
- resolve the imported completion query before calling `XCTAssertEqual`
- keep the strict reminder empty-set expectation unchanged

## Validation
- `git diff --check`
- focused scan found no other `await` directly inside an XCTest assertion in this file
- independent review found no P0-P4 issues

## Residual validation
- generic `build-for-testing` could not reach compilation because the local Xcode installation reported no eligible iOS Simulator destination; no simulator was booted or downloaded