### PR TITLE
Fix Android Firebase Test Lab smoke failures

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
@@ -38,7 +38,6 @@ import com.flashcardsopensourceapp.app.livesmoke.support.waitForCurrentWorkspace
 import com.flashcardsopensourceapp.app.livesmoke.support.waitForCurrentWorkspaceName
 import com.flashcardsopensourceapp.app.livesmoke.support.waitForCurrentWorkspaceScreenToSettle
 import com.flashcardsopensourceapp.app.livesmoke.support.waitForSelectedWorkspaceSummary
-import com.flashcardsopensourceapp.app.livesmoke.support.waitForSelectedWorkspaceSummaryToChange
 import com.flashcardsopensourceapp.app.livesmoke.support.deleteCurrentWorkspaceErrorMessageOrNull
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.feature.settings.settingsCurrentWorkspaceRowTag
@@ -91,9 +90,6 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
         context = "before creating a linked workspace",
         timeoutMillis = internalUiTimeoutMillis
     )
-    val selectedWorkspaceSummaryBeforeCreate: String = selectedWorkspaceSummary(
-        context = "before creating a linked workspace"
-    )
     val selectedWorkspaceIdBeforeCreate: String = currentWorkspaceIdOrThrow(
         context = "before creating a linked workspace"
     )
@@ -110,8 +106,7 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
         timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
     waitForCurrentWorkspaceChangeSheetToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
-    waitForSelectedWorkspaceSummaryToChange(
-        beforeSummary = selectedWorkspaceSummaryBeforeCreate,
+    waitForSelectedWorkspaceSummary(
         context = "after creating a linked workspace",
         timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
@@ -117,32 +117,6 @@ internal fun LiveSmokeContext.waitForCurrentWorkspaceChangeSheetToSettle(timeout
     }
 }
 
-internal fun LiveSmokeContext.waitForSelectedWorkspaceSummaryToChange(
-    beforeSummary: String,
-    context: String,
-    timeoutMillis: Long
-) {
-    try {
-        waitUntilWithMitigation(
-            timeoutMillis = timeoutMillis,
-            context = "while waiting for current workspace selection to change $context"
-        ) {
-            runCatching {
-                scrollCurrentWorkspaceListToSelectedWorkspace()
-                selectedWorkspaceSummary(context = context) != beforeSummary
-            }.getOrDefault(false)
-        }
-    } catch (error: Throwable) {
-        throw AssertionError(
-            "Workspace selection did not change $context. " +
-                "Before=$beforeSummary After=${selectedWorkspaceSummaryOrNull()} " +
-                "WorkspaceName=${currentWorkspaceNameOrNull()} " +
-                "Error=${currentWorkspaceErrorMessageOrNull()}",
-            error
-        )
-    }
-}
-
 internal fun LiveSmokeContext.waitForCurrentWorkspaceScreenToSettle(timeoutMillis: Long) {
     try {
         waitUntilWithMitigation(

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
@@ -29,6 +29,7 @@ import com.flashcardsopensourceapp.feature.review.reviewCurrentCardTag
 import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag
 import java.io.BufferedReader
 import java.io.InputStreamReader
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
 private const val notificationPermissionUserFixedFlag: String = "user-fixed"
@@ -225,8 +226,8 @@ private fun activeNotificationIds(context: Context): Set<Int> {
 }
 
 private suspend fun LiveSmokeContext.requireCurrentWorkspaceIdForNotificationSmoke(): String {
-    return requireNotNull(appGraph().database.workspaceDao().loadAnyWorkspace()?.workspaceId) {
-        "Expected a current workspace before posting a review reminder notification."
+    return requireNotNull(appGraph().workspaceRepository.observeWorkspace().first()?.workspaceId) {
+        "Expected an active current workspace before posting a review reminder notification."
     }
 }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationsManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationsManager.kt
@@ -321,7 +321,7 @@ class ReviewNotificationsManager(
         clearReviewScheduling()
         var deliveredCleanupCompleted = false
         if (shouldClearDeliveredReviewNotifications) {
-            clearDeliveredReviewReminderState()
+            clearDeliveredReviewReminderNotifications()
             onDeliveredCleanupCompleted()
             deliveredCleanupCompleted = true
         }
@@ -348,8 +348,8 @@ class ReviewNotificationsManager(
 
         val settings = reviewNotificationsStore.loadSettings()
         if (settings.isEnabled.not()) {
+            clearDeliveredReviewReminderState()
             if (deliveredCleanupCompleted.not()) {
-                clearDeliveredReviewReminderState()
                 onDeliveredCleanupCompleted()
             }
             saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsReconcileTrigger.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsReconcileTrigger.kt
@@ -4,8 +4,9 @@ package com.flashcardsopensourceapp.data.local.notifications
  * Identifies why review reminders are being reconciled.
  *
  * [APP_ACTIVE], [REVIEW_RECORDED], and [WORKSPACE_CHANGED] clear delivered
- * reminders because their previous attention scope is no longer relevant. The
- * remaining triggers only reconcile pending work and scheduled payloads.
+ * system notifications. In-app review attention is managed separately so it
+ * can remain visible after the app opens and clear only when its review scope
+ * is no longer relevant.
  */
 enum class ReviewNotificationsReconcileTrigger(
     val shouldClearDeliveredReviewNotifications: Boolean


### PR DESCRIPTION
## Summary

- wait for linked workspace creation using the stable workspace ID instead of the unchanged default `Personal (Current)` label
- preserve in-app review reminder attention when foreground cleanup removes delivered system notifications
- associate notification smoke attention with the active workspace instead of an arbitrary database row

## Evidence

Firebase Test Lab matrix `matrix-2gkl4vyr4pql0` failed 3 of 75 tests. The two workspace failures shared the unchanged-label wait, while the review reminder badge disappeared during `APP_ACTIVE` reconciliation. Matrix XML, per-test logcat, and videos confirmed both causes.

## Validation

- `git diff --check`
- inspected Firebase Test Lab XML, per-test logcat, and videos for test cases 0025, 0027, and 0033
- local Gradle/emulator run not performed because repository policy requires explicit approval for resource-heavy Android runs; the next Firebase Test Lab matrix is the production-equivalent validation