### PR TITLE
Fix flaky iOS live smoke tests

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
@@ -649,11 +649,6 @@ extension FlashcardsStore {
             try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.manualReviewCard, context: context)
         case .guestManualReviewCardWithReminderAttention:
             try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.manualReviewCard, context: context)
-            self.markReviewReminderAttention(
-                workspaceId: context.workspaceId,
-                requestId: "ui-test-review-reminder-attention",
-                deliveredAtMillis: epochMillis(date: Date())
-            )
         case .guestAIReviewCard:
             try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.aiReviewCard, context: context)
         case .marketingScreenshots:
@@ -662,6 +657,19 @@ extension FlashcardsStore {
         case .marketingGuestSessionCleanup:
             return
         }
+    }
+
+    func markUITestReviewReminderAttentionAfterNotificationCleanup() async throws {
+        while let task = self.activeReviewNotificationsRescheduleTask {
+            await task.value
+        }
+
+        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        self.markReviewReminderAttention(
+            workspaceId: context.workspaceId,
+            requestId: "ui-test-review-reminder-attention",
+            deliveredAtMillis: epochMillis(date: Date())
+        )
     }
 
     private func createUITestMarketingScreenshotsData(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsUITestLaunchCoordinator.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsUITestLaunchCoordinator.swift
@@ -84,6 +84,9 @@ private struct FlashcardsUITestLaunchCoordinator {
                 processInfo: self.processInfo
             )
             try store.reload(now: Date(), refreshVisibleProgress: false)
+            if self.launchScenario == .guestManualReviewCardWithReminderAttention {
+                try await store.markUITestReviewReminderAttentionAfterNotificationCleanup()
+            }
             return
         }
 

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Interactions/LiveSmokeTextInput.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Interactions/LiveSmokeTextInput.swift
@@ -1,5 +1,7 @@
 import XCTest
 
+private let liveSmokeTextInputCharacterIntervalSeconds: TimeInterval = 0.05
+
 extension LiveSmokeTestCase {
     @MainActor
     func typeTextSafely(
@@ -15,7 +17,7 @@ extension LiveSmokeTestCase {
                 timeout: timeout
             )
             self.logActionStart(action: "type_text", identifier: identifier)
-            element.typeText(text)
+            self.typeTextReliably(text, intoElement: element)
             if try self.waitForElementValueContaining(
                 element,
                 identifier: identifier,
@@ -69,9 +71,9 @@ extension LiveSmokeTestCase {
             let existingValue = self.elementValue(element: element)
             if existingValue.isEmpty == false && existingValue != placeholderValue {
                 let deleteSequence = String(repeating: XCUIKeyboardKey.delete.rawValue, count: existingValue.count)
-                element.typeText(deleteSequence)
+                self.typeTextReliably(deleteSequence, intoElement: element)
             }
-            element.typeText(text)
+            self.typeTextReliably(text, intoElement: element)
 
             if try self.waitForElementValueContaining(
                 element,
@@ -107,6 +109,19 @@ extension LiveSmokeTestCase {
             placeholderValue: element.placeholderValue ?? "",
             timeout: timeout
         )
+    }
+
+    @MainActor
+    private func typeTextReliably(
+        _ text: String,
+        intoElement element: XCUIElement
+    ) {
+        for character in text {
+            element.typeText(String(character))
+            RunLoop.current.run(
+                until: Date(timeIntervalSinceNow: liveSmokeTextInputCharacterIntervalSeconds)
+            )
+        }
     }
 
     // Raw XCUIElement.typeText can hang until XCTest's global execution allowance


### PR DESCRIPTION
## Summary
- throttle XCUITest text entry to prevent dropped and reordered characters in Xcode Cloud
- wait for review-notification cleanup before creating the reminder badge fixture

## Validation
- `xcrun swiftc -parse` for all changed Swift files
- `git diff --check`
- local `xcodebuild build-for-testing` could not start because the iOS 26.5 platform is not installed
- simulator-backed tests were not run locally