### PR TITLE
Stabilize Android workspace sheet cleanup

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
@@ -2,12 +2,16 @@
 
 package com.flashcardsopensourceapp.app.livesmoke.support
 
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performSemanticsAction
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.nodeSummary
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.nodeSummaryIncludingDescendants
@@ -76,7 +80,11 @@ internal fun LiveSmokeContext.dismissCurrentWorkspaceChangeSheet(timeoutMillis: 
     ) {
         return
     }
-    device.pressBack()
+    composeRule.onNode(
+        matcher = SemanticsMatcher.keyIsDefined(SemanticsActions.Dismiss) and
+            hasAnyAncestor(hasTestTag(currentWorkspaceChangeSheetTag)),
+        useUnmergedTree = true
+    ).performSemanticsAction(SemanticsActions.Dismiss)
     waitUntilWithMitigation(
         timeoutMillis = timeoutMillis,
         context = "while dismissing the Change workspace sheet"


### PR DESCRIPTION
## Summary
- dismiss the tagged workspace change sheet through its Compose accessibility action
- avoid the Android 16 system Back path that left the Material 3 sheet open in Firebase Test Lab
- keep the existing wait that verifies the sheet actually disappears

## Firebase Test Lab evidence
- matrix: `matrix-3axe2ypivbc2t`
- only failing test: `linkedWorkspaceAccountStatusAndWorkspaceStateAreVisible`
- failure occurred during cleanup in `dismissCurrentWorkspaceChangeSheet` after the test scenario itself passed
- video and raw hierarchy showed the sheet remained visible and exposed the standard dismiss action

## Validation
- `git diff --check`
- Gradle/instrumentation not run locally because repository policy requires explicit approval for Android Gradle runs; the merged release pipeline will run the managed-device smoke suite