### PR TITLE
Group Android progress leaderboard files

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -24,12 +24,12 @@ import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationShareEff
 import com.flashcardsopensourceapp.feature.friendinvite.FriendInvitationUiState
 import com.flashcardsopensourceapp.feature.progress.sections.ErrorCard
 import com.flashcardsopensourceapp.feature.progress.sections.GuidanceCard
-import com.flashcardsopensourceapp.feature.progress.sections.LeaderboardSectionCard
+import com.flashcardsopensourceapp.feature.progress.sections.leaderboard.LeaderboardSectionCard
 import com.flashcardsopensourceapp.feature.progress.sections.LoadingCard
-import com.flashcardsopensourceapp.feature.progress.sections.ProgressLeaderboardProfileSheet
+import com.flashcardsopensourceapp.feature.progress.sections.leaderboard.ProgressLeaderboardProfileSheet
 import com.flashcardsopensourceapp.feature.progress.sections.ReviewScheduleSectionCard
 import com.flashcardsopensourceapp.feature.progress.sections.ReviewsSectionCard
-import com.flashcardsopensourceapp.feature.progress.sections.StreakLeaderboardSectionCard
+import com.flashcardsopensourceapp.feature.progress.sections.leaderboard.StreakLeaderboardSectionCard
 import com.flashcardsopensourceapp.feature.progress.sections.StreakSectionCard
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/leaderboard/ProgressLeaderboardProfileSheet.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/leaderboard/ProgressLeaderboardProfileSheet.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress.sections
+package com.flashcardsopensourceapp.feature.progress.sections.leaderboard
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -42,6 +42,9 @@ import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardProfileRe
 import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardProfileReviewActivityDayUiState
 import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardProfileSheetUiState
 import com.flashcardsopensourceapp.feature.progress.R
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardProfileActivityChartTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardProfileRetryButtonTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardProfileSheetTag
 import java.text.NumberFormat
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/leaderboard/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/leaderboard/ProgressLeaderboardSection.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress.sections
+package com.flashcardsopensourceapp.feature.progress.sections.leaderboard
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -53,6 +53,15 @@ import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardProfileId
 import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardRowUiState
 import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardSectionUiState
 import com.flashcardsopensourceapp.feature.progress.R
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardGapRowTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardInfoButtonTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardInviteButtonTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardInviteDisplayNameFieldTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardParticipantRowTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardPeriodSelectorTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardResolvedContentTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardSectionTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressSectionShape
 import com.flashcardsopensourceapp.feature.friendinvite.R as FriendInviteR
 import java.text.NumberFormat
 import java.util.Locale

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/leaderboard/ProgressStreakLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/leaderboard/ProgressStreakLeaderboardSection.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress.sections
+package com.flashcardsopensourceapp.feature.progress.sections.leaderboard
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -37,6 +37,12 @@ import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardProfileId
 import com.flashcardsopensourceapp.feature.progress.ProgressStreakLeaderboardRowUiState
 import com.flashcardsopensourceapp.feature.progress.ProgressStreakLeaderboardSectionUiState
 import com.flashcardsopensourceapp.feature.progress.R
+import com.flashcardsopensourceapp.feature.progress.sections.progressSectionShape
+import com.flashcardsopensourceapp.feature.progress.sections.progressStreakLeaderboardGapRowTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressStreakLeaderboardInfoButtonTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressStreakLeaderboardParticipantRowTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressStreakLeaderboardResolvedContentTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressStreakLeaderboardSectionTag
 import java.text.NumberFormat
 import java.util.Locale
 


### PR DESCRIPTION
## Summary
- move the rating leaderboard, streak leaderboard, and profile sheet into sections/leaderboard
- update package declarations, shared-default imports, and ProgressRoute imports without changing behavior

## Validation
- git diff --check
- package declaration and import checks
- stale old-package reference check
- rename detection at 94–97% similarity
- independent review: no P0–P4 findings

Gradle was not run because it was not authorized for this task.