### PR TITLE
Group Android settings route tests

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/AccountDangerZoneRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/AccountDangerZoneRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.routes
+package com.flashcardsopensourceapp.app.routes.settings
 
 import androidx.activity.ComponentActivity
 import androidx.annotation.StringRes

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/AccountStatusRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/AccountStatusRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.routes
+package com.flashcardsopensourceapp.app.routes.settings
 
 import androidx.activity.ComponentActivity
 import androidx.annotation.StringRes

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/AgentConnectionsRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/AgentConnectionsRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.routes
+package com.flashcardsopensourceapp.app.routes.settings
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/CloudPostAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/CloudPostAuthRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.routes
+package com.flashcardsopensourceapp.app.routes.settings
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/SettingsAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/SettingsAuthRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.routes
+package com.flashcardsopensourceapp.app.routes.settings
 
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.getValue

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/SettingsRootRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.routes
+package com.flashcardsopensourceapp.app.routes.settings
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertCountEquals

--- a/apps/android/docs/add-language-checklist.md
+++ b/apps/android/docs/add-language-checklist.md
@@ -165,8 +165,8 @@ rg -n 'onNodeWithText\\(|assertTextEquals\\(|assertTextContains\\(' \
 Current examples worth checking:
 
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt`
-- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsAuthRouteTest.kt`
-- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/CloudPostAuthRouteTest.kt`
+- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/SettingsAuthRouteTest.kt`
+- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/CloudPostAuthRouteTest.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDeletionBlockingSurfaceTest.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioAiHelpers.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioCardHelpers.kt`


### PR DESCRIPTION
## Summary
- group six settings-owned Android instrumentation route suites under `routes/settings/`
- update their package declarations without changing test behavior
- update the two affected add-language checklist paths

## Validation
- `git --no-pager diff --check`
- structural path, package, and stale-reference validation
- fresh read-only review: no P0-P4 findings
- Gradle not run per repository policy