### PR TITLE
Publish agent invalid-email contract

### DIFF
--- a/api/src/paths/api_agent_send-code.yaml
+++ b/api/src/paths/api_agent_send-code.yaml
@@ -87,6 +87,43 @@ post:
                   openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
                   docsUrl: https://flashcards-open-source-app.com/docs/
                   swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
+    '400':
+      description: The request body or email address is invalid and must be corrected before retrying.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/AgentErrorEnvelope.yaml
+          examples:
+            invalidRequest:
+              summary: Invalid request body
+              value:
+                ok: false
+                data: {}
+                actions: []
+                instructions: Provide an email string and call this endpoint again.
+                docs:
+                  openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
+                  swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
+                error:
+                  code: INVALID_REQUEST
+                  message: Invalid request.
+            invalidEmail:
+              summary: Invalid email address
+              value:
+                ok: false
+                data: {}
+                actions: []
+                instructions: >-
+                  Provide a valid email address, then call POST
+                  /api/agent/send-code again.
+                docs:
+                  openapiUrl: https://api.flashcards-open-source-app.com/v1/agent/openapi.json
+                  docsUrl: https://flashcards-open-source-app.com/docs/
+                  swaggerUrl: https://api.flashcards-open-source-app.com/v1/agent/swagger.json
+                error:
+                  code: INVALID_EMAIL
+                  message: Enter a valid email address.
     '503':
       description: >-
         Service temporarily unavailable. Follow the response envelope

--- a/scripts/checks/check-agent-api-smoke.sh
+++ b/scripts/checks/check-agent-api-smoke.sh
@@ -230,6 +230,8 @@ missing_paths = sorted(required_paths.difference(payload["paths"].keys()))
 unexpected_paths = sorted(set(payload["paths"].keys()).difference(required_paths))
 assert missing_paths == [], missing_paths
 assert unexpected_paths == [], unexpected_paths
+send_code_400 = payload["paths"]["/api/agent/send-code"]["post"]["responses"]["400"]
+assert send_code_400["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/AgentErrorEnvelope"
 PY
 
 request_json "GET" "${API_BASE_URL%/}/openapi.json" "" ""
@@ -252,6 +254,21 @@ agent_swagger = json.load(open(sys.argv[4], encoding="utf-8"))
 assert canonical == root_openapi
 assert canonical == root_swagger
 assert canonical == agent_swagger
+PY
+
+request_json "POST" "${AUTH_BASE_URL%/}/api/agent/send-code" '{"email":"invalid"}' ""
+assert_status "400" "POST /api/agent/send-code with invalid email"
+INVALID_EMAIL_BODY="${LAST_BODY_FILE}"
+python3 - <<'PY' "${INVALID_EMAIL_BODY}"
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["ok"] is False
+assert payload["data"] == {}
+assert payload["actions"] == []
+assert payload["error"]["code"] == "INVALID_EMAIL"
+assert isinstance(payload["instructions"], str) and payload["instructions"].strip() != ""
 PY
 
 request_json "POST" "${AUTH_BASE_URL%/}/api/agent/send-code" "{\"email\":\"${DEMO_EMAIL}\"}" ""


### PR DESCRIPTION
## Summary

- publish INVALID_REQUEST and INVALID_EMAIL 400 AgentErrorEnvelope examples for agent send-code
- verify the deployed OpenAPI 400 schema and malformed-email response before the demo auth flow

## Validation

- npm run lint --prefix api
- npm run bundle --prefix api
- bash -n scripts/checks/check-agent-api-smoke.sh
- bundled JSON contract assertions
- git --no-pager diff --check