### PR TITLE
Classify Cognito invalid email failures

### DIFF
--- a/apps/auth/src/refreshRoutes.test.ts
+++ b/apps/auth/src/refreshRoutes.test.ts
@@ -40,11 +40,23 @@ function createTestApp(routeApp: Hono<AuthAppEnv>, logger: AuthLogger): Hono<Aut
 }
 
 function createTerminalRefreshFailure(): CognitoTypedError {
-  return createCognitoTypedError("Refresh token is invalid", "NotAuthorizedException");
+  return createCognitoTypedError({
+    operation: "InitiateAuth",
+    providerStatusCode: 400,
+    cognitoType: "NotAuthorizedException",
+    reasonCode: null,
+    message: "Refresh token is invalid",
+  });
 }
 
 function createNonTerminalRefreshFailure(): CognitoTypedError {
-  return createCognitoTypedError("Cognito internal error", "InternalErrorException");
+  return createCognitoTypedError({
+    operation: "InitiateAuth",
+    providerStatusCode: 500,
+    cognitoType: "InternalErrorException",
+    reasonCode: null,
+    message: "Cognito internal error",
+  });
 }
 
 function getSetCookieValues(response: Response): ReadonlyArray<string> {

--- a/apps/auth/src/routes/agent/agentSendCode.ts
+++ b/apps/auth/src/routes/agent/agentSendCode.ts
@@ -27,6 +27,7 @@ import {
 import { log, maskEmail } from "../../server/logger.js";
 import { getPublicAuthBaseUrl, getPublicApiBaseUrl } from "../../server/publicUrls.js";
 import { isTransientDatabaseError } from "../../server/databaseErrors.js";
+import { isCognitoInvalidEmailError } from "../../server/cognito/cognitoErrors.js";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const POST_EMAIL_DELIVERY_DB_FAILURE_INSTRUCTIONS = "A verification email may already be in the user's inbox, but this response could not create a usable agent verification handle. Do not retry this same send-code request immediately because it may send another email. Ask the user to wait briefly and check their email, including spam or junk. If sign-in is still needed, start a fresh flow with POST /api/agent/send-code and use only the latest email code and latest otpSessionToken.";
@@ -188,6 +189,30 @@ export function createAgentSendCodeApp(dependencies: AgentSendCodeDependencies):
       try {
         session = (await dependencies.initiateEmailOtp(email)).session;
       } catch (error) {
+        if (isCognitoInvalidEmailError(error)) {
+          log({
+            domain: "auth",
+            action: "agent_send_code_error",
+            requestId,
+            route: c.req.path,
+            statusCode: 400,
+            code: "INVALID_EMAIL",
+            reasonCategory: "provider_invalid_email",
+            errorClass: error.cognitoType,
+            errorCode: error.reasonCode,
+            errorMessage: error.message,
+          });
+          return c.json(
+            createAgentErrorEnvelope(
+              c.req.url,
+              "INVALID_EMAIL",
+              "Enter a valid email address.",
+              "Do not retry with the same email address. Correct it before calling POST /api/agent/send-code again.",
+            ),
+            400,
+          );
+        }
+
         log({
           domain: "auth",
           action: "agent_send_code_error",

--- a/apps/auth/src/routes/browser/sendCode.ts
+++ b/apps/auth/src/routes/browser/sendCode.ts
@@ -26,6 +26,7 @@ import {
 import { log, maskEmail } from "../../server/logger.js";
 import { isTransientDatabaseError } from "../../server/databaseErrors.js";
 import { isRejectedPasswordSignIn } from "../../server/cognito/passwordSignInErrors.js";
+import { isCognitoInvalidEmailError } from "../../server/cognito/cognitoErrors.js";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const POST_EMAIL_DB_FAILURE_MESSAGE = "A verification email may have been sent, but sign-in could not be prepared.";
@@ -181,6 +182,22 @@ export function createSendCodeApp(dependencies: SendCodeDependencies): Hono<Auth
         const [result] = await Promise.all([dependencies.initiateEmailOtp(email), dependencies.jitterDelay()]);
         session = result.session;
       } catch (err) {
+        if (isCognitoInvalidEmailError(err)) {
+          log({
+            domain: "auth",
+            action: "send_code_error",
+            requestId,
+            route: c.req.path,
+            statusCode: 400,
+            code: "INVALID_EMAIL",
+            reasonCategory: "provider_invalid_email",
+            errorClass: err.cognitoType,
+            errorCode: err.reasonCode,
+            errorMessage: err.message,
+          });
+          return jsonAuthError(c, 400, "INVALID_EMAIL", "Enter a valid email address.");
+        }
+
         log({
           domain: "auth",
           action: "send_code_error",

--- a/apps/auth/src/server/cognito/cognitoAuth.ts
+++ b/apps/auth/src/server/cognito/cognitoAuth.ts
@@ -9,12 +9,14 @@ import {
   createCognitoTypedError,
   getCognitoErrorType,
   getNormalizedCognitoErrorType,
+  type CognitoOperation,
 } from "./cognitoErrors.js";
 import { log, maskEmail } from "../logger.js";
 
 type CognitoErrorResponse = Readonly<{
-  __type?: string;
-  message?: string;
+  cognitoType: string;
+  message: string;
+  reasonCode: string | null;
 }>;
 
 type InitiateAuthResult = Readonly<{
@@ -51,8 +53,57 @@ const getClientId = (): string => {
   return clientId;
 };
 
+function getCognitoErrorResponseContext(
+  operation: CognitoOperation,
+  providerStatusCode: number,
+): string {
+  return `Cognito ${operation} error response (HTTP ${providerStatusCode})`;
+}
+
+function parseRequiredCognitoErrorString(
+  value: unknown,
+  fieldName: "__type" | "message",
+  context: string,
+): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new TypeError(`${context} must include a non-empty string ${fieldName} field`);
+  }
+
+  return value;
+}
+
+function parseCognitoReasonCode(value: unknown, context: string): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new TypeError(`${context} reasonCode field must be a non-empty string when present`);
+  }
+
+  return value;
+}
+
+function parseCognitoErrorResponse(
+  value: unknown,
+  operation: CognitoOperation,
+  providerStatusCode: number,
+): CognitoErrorResponse {
+  const context = getCognitoErrorResponseContext(operation, providerStatusCode);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${context} must be a JSON object`);
+  }
+
+  const fields = value as Record<string, unknown>;
+  return {
+    cognitoType: parseRequiredCognitoErrorString(fields.__type, "__type", context),
+    message: parseRequiredCognitoErrorString(fields.message, "message", context),
+    reasonCode: parseCognitoReasonCode(fields.reasonCode, context),
+  };
+}
+
 const cognitoFetch = async (
-  target: string,
+  target: CognitoOperation,
   body: Record<string, unknown>,
 ): Promise<Record<string, unknown>> => {
   const endpoint = `https://cognito-idp.${getRegion()}.amazonaws.com/`;
@@ -67,17 +118,31 @@ const cognitoFetch = async (
   });
 
   if (!response.ok) {
-    const error = await response.json() as CognitoErrorResponse;
-    const errorType = error.__type ?? "";
-    const errorMessage = error.message ?? `Cognito ${target} failed: ${response.status}`;
-    throw createCognitoTypedError(errorMessage, errorType);
+    let errorResponseValue: unknown;
+    try {
+      errorResponseValue = await response.json();
+    } catch (error) {
+      throw new TypeError(
+        `${getCognitoErrorResponseContext(target, response.status)} was not valid JSON`,
+        { cause: error },
+      );
+    }
+
+    const errorResponse = parseCognitoErrorResponse(errorResponseValue, target, response.status);
+    throw createCognitoTypedError({
+      operation: target,
+      providerStatusCode: response.status,
+      cognitoType: errorResponse.cognitoType,
+      reasonCode: errorResponse.reasonCode,
+      message: errorResponse.message,
+    });
   }
 
   return response.json() as Promise<Record<string, unknown>>;
 };
 
 type CognitoFetchFunction = (
-  target: string,
+  target: CognitoOperation,
   body: Record<string, unknown>,
 ) => Promise<Record<string, unknown>>;
 

--- a/apps/auth/src/server/cognito/cognitoErrors.ts
+++ b/apps/auth/src/server/cognito/cognitoErrors.ts
@@ -1,18 +1,57 @@
-export type CognitoTypedError = Error & Readonly<{
+export type CognitoOperation =
+  | "InitiateAuth"
+  | "RespondToAuthChallenge"
+  | "RevokeToken"
+  | "SignUp";
+
+export type CognitoErrorMetadata = Readonly<{
+  operation: CognitoOperation;
+  providerStatusCode: number;
   cognitoType: string;
+  reasonCode: string | null;
+  message: string;
 }>;
 
-export function createCognitoTypedError(
-  message: string,
-  cognitoType: string,
-): CognitoTypedError {
-  return Object.assign(new Error(message), { cognitoType });
+export type CognitoTypedError = Readonly<Error & {
+  operation: CognitoOperation;
+  providerStatusCode: number;
+  cognitoType: string;
+  reasonCode: string | null;
+}>;
+
+export function createCognitoTypedError(metadata: CognitoErrorMetadata): CognitoTypedError {
+  return Object.assign(new Error(metadata.message), {
+    operation: metadata.operation,
+    providerStatusCode: metadata.providerStatusCode,
+    cognitoType: metadata.cognitoType,
+    reasonCode: metadata.reasonCode,
+  });
+}
+
+function isCognitoOperation(value: unknown): value is CognitoOperation {
+  return value === "InitiateAuth"
+    || value === "RespondToAuthChallenge"
+    || value === "RevokeToken"
+    || value === "SignUp";
 }
 
 export function isCognitoTypedError(error: unknown): error is CognitoTypedError {
   return error instanceof Error
+    && "operation" in error
+    && isCognitoOperation(error.operation)
+    && "providerStatusCode" in error
+    && typeof error.providerStatusCode === "number"
+    && Number.isInteger(error.providerStatusCode)
+    && error.providerStatusCode >= 100
+    && error.providerStatusCode <= 599
     && "cognitoType" in error
-    && typeof error.cognitoType === "string";
+    && typeof error.cognitoType === "string"
+    && error.cognitoType.trim() !== ""
+    && "reasonCode" in error
+    && (
+      error.reasonCode === null
+      || (typeof error.reasonCode === "string" && error.reasonCode.trim() !== "")
+    );
 }
 
 export function getCognitoErrorType(error: unknown): string | null {
@@ -22,4 +61,11 @@ export function getCognitoErrorType(error: unknown): string | null {
 export function getNormalizedCognitoErrorType(error: unknown): string {
   const cognitoType = getCognitoErrorType(error);
   return cognitoType === null ? "" : cognitoType.toLowerCase();
+}
+
+export function isCognitoInvalidEmailError(error: unknown): error is CognitoTypedError {
+  return isCognitoTypedError(error)
+    && error.operation === "SignUp"
+    && error.cognitoType === "InvalidParameterException"
+    && error.message.trim().toLowerCase() === "invalid email address format.";
 }


### PR DESCRIPTION
## Summary

- retain validated Cognito operation, status, exception type, reason code, and message metadata
- classify only the exact SignUp invalid-email provider failure
- return the existing INVALID_EMAIL contract from browser and agent send-code routes while preserving generic 5xx handling

## Validation

- npm run build --prefix apps/auth
- npm run test --prefix apps/auth (35/35 passed)
- focused browser and agent send-code smoke
- git --no-pager diff --check
- worker-owned review: no P0-P4 findings