### PR TITLE
fix(infra): increase backend Lambda memory

### DIFF
--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -635,7 +635,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       snapshotObjectKey: props.globalMetricsSnapshotObjectKey,
     },
     mediaAssetsBucket: props.mediaAssetsBucket,
-    memorySize: 256,
+    memorySize: 1024,
     architecture: lambda.Architecture.ARM_64,
     bundling: createLambdaBundling({
       nodeModules: ["sharp"],


### PR DESCRIPTION
## Summary

- increase the main BackendHandler Lambda memory from 256 MB to 1024 MB
- preserve the existing ARM64 architecture and all other function settings

## Validation

- npm test --prefix infra/aws (32/32 passed)
- git diff --check
- fresh read-only review: no P0-P4 findings