### PR TITLE
Handle expected workspace package validation

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -693,6 +693,8 @@ const arCatalog: TranslationCatalog = {
     packageImportButton: "اختيار flashcards.zip",
     packageConfirmButton: "استيراد الحزمة بعد المعاينة",
     packagePreviewRequired: "اختر حزمة وانتظر المعاينة قبل الاستيراد.",
+    packageInvalid: "هذا الملف ليس حزمة flashcards.zip صالحة. اختر حزمة تم تصديرها من تطبيق Flashcards Open Source App.",
+    packageTooLarge: "الحزمة المحددة كبيرة جدًا. اختر ملف flashcards.zip أصغر.",
     packageImportSuccess: "تم استيراد {{count}} بطاقة.",
     packageImportSuccessWithTag: "تم استيراد {{count}} بطاقة مع الوسم {{tag}}.",
     importTagLabel: "وسم البطاقات المستوردة",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -693,6 +693,8 @@ const deCatalog: TranslationCatalog = {
     packageImportButton: "flashcards.zip wählen",
     packageConfirmButton: "Paket aus Vorschau importieren",
     packagePreviewRequired: "Wähle ein Paket und warte auf die Vorschau, bevor du importierst.",
+    packageInvalid: "Diese Datei ist keine gültige flashcards.zip-Datei. Wähle ein Paket, das aus der Flashcards Open Source App exportiert wurde.",
+    packageTooLarge: "Das ausgewählte Paket ist zu groß. Wähle eine kleinere flashcards.zip-Datei.",
     packageImportSuccess: "{{count}} Karten importiert.",
     packageImportSuccessWithTag: "{{count}} Karten mit Tag {{tag}} importiert.",
     importTagLabel: "Importierte Karten taggen",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -691,6 +691,8 @@ const enCatalog = {
     packageImportButton: "Choose flashcards.zip",
     packageConfirmButton: "Import previewed package",
     packagePreviewRequired: "Choose a package and wait for the preview before importing.",
+    packageInvalid: "This file is not a valid flashcards.zip. Choose a package exported from Flashcards Open Source App.",
+    packageTooLarge: "The selected package is too large. Choose a smaller flashcards.zip.",
     packageImportSuccess: "Imported {{count}} cards.",
     packageImportSuccessWithTag: "Imported {{count}} cards with tag {{tag}}.",
     importTagLabel: "Tag imported cards",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -693,6 +693,8 @@ const esEsCatalog: TranslationCatalog = {
     packageImportButton: "Elegir flashcards.zip",
     packageConfirmButton: "Importar paquete previsualizado",
     packagePreviewRequired: "Elige un paquete y espera la previsualización antes de importar.",
+    packageInvalid: "Este archivo no es un flashcards.zip válido. Elige un paquete exportado desde Flashcards Open Source App.",
+    packageTooLarge: "El paquete seleccionado es demasiado grande. Elige un flashcards.zip más pequeño.",
     packageImportSuccess: "{{count}} tarjetas importadas.",
     packageImportSuccessWithTag: "{{count}} tarjetas importadas con la etiqueta {{tag}}.",
     importTagLabel: "Etiquetar tarjetas importadas",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -693,6 +693,8 @@ const esMxCatalog: TranslationCatalog = {
     packageImportButton: "Elegir flashcards.zip",
     packageConfirmButton: "Importar paquete previsualizado",
     packagePreviewRequired: "Elige un paquete y espera la previsualización antes de importar.",
+    packageInvalid: "Este archivo no es un flashcards.zip válido. Elige un paquete exportado desde Flashcards Open Source App.",
+    packageTooLarge: "El paquete seleccionado es demasiado grande. Elige un flashcards.zip más pequeño.",
     packageImportSuccess: "{{count}} tarjetas importadas.",
     packageImportSuccessWithTag: "{{count}} tarjetas importadas con la etiqueta {{tag}}.",
     importTagLabel: "Etiquetar tarjetas importadas",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -693,6 +693,8 @@ const hiCatalog: TranslationCatalog = {
     packageImportButton: "flashcards.zip चुनें",
     packageConfirmButton: "प्रीव्यू किया पैकेज इम्पोर्ट करें",
     packagePreviewRequired: "इम्पोर्ट से पहले पैकेज चुनें और प्रीव्यू पूरा होने दें।",
+    packageInvalid: "यह फ़ाइल मान्य flashcards.zip नहीं है। Flashcards Open Source App से एक्सपोर्ट किया गया पैकेज चुनें।",
+    packageTooLarge: "चुना गया पैकेज बहुत बड़ा है। छोटा flashcards.zip चुनें।",
     packageImportSuccess: "{{count}} कार्ड इम्पोर्ट किए गए।",
     packageImportSuccessWithTag: "{{tag}} टैग के साथ {{count}} कार्ड इम्पोर्ट किए गए।",
     importTagLabel: "इम्पोर्ट किए गए कार्ड टैग करें",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -693,6 +693,8 @@ export const jaCatalog = {
     packageImportButton: "flashcards.zip を選択",
     packageConfirmButton: "プレビュー済みパッケージをインポート",
     packagePreviewRequired: "インポートする前にパッケージを選択し、プレビューを待ってください。",
+    packageInvalid: "このファイルは有効な flashcards.zip ではありません。Flashcards Open Source App からエクスポートしたパッケージを選択してください。",
+    packageTooLarge: "選択したパッケージが大きすぎます。より小さい flashcards.zip を選択してください。",
     packageImportSuccess: "{{count}}件のカードをインポートしました。",
     packageImportSuccessWithTag: "{{tag}} タグ付きで {{count}}件のカードをインポートしました。",
     importTagLabel: "インポートしたカードにタグを付ける",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -693,6 +693,8 @@ export const ruCatalog = {
     packageImportButton: "Выбрать flashcards.zip",
     packageConfirmButton: "Импортировать пакет из предпросмотра",
     packagePreviewRequired: "Выберите пакет и дождитесь предпросмотра перед импортом.",
+    packageInvalid: "Этот файл не является допустимым flashcards.zip. Выберите пакет, экспортированный из Flashcards Open Source App.",
+    packageTooLarge: "Выбранный пакет слишком велик. Выберите файл flashcards.zip меньшего размера.",
     packageImportSuccess: "Импортировано карточек: {{count}}.",
     packageImportSuccessWithTag: "Импортировано карточек: {{count}} с тегом {{tag}}.",
     importTagLabel: "Добавить тег к импортированным карточкам",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -693,6 +693,8 @@ export const zhHansCatalog = {
     packageImportButton: "选择 flashcards.zip",
     packageConfirmButton: "导入已预览的包",
     packagePreviewRequired: "请先选择包并等待预览完成再导入。",
+    packageInvalid: "此文件不是有效的 flashcards.zip。请选择从 Flashcards Open Source App 导出的包。",
+    packageTooLarge: "所选包太大。请选择较小的 flashcards.zip。",
     packageImportSuccess: "已导入 {{count}} 张卡片。",
     packageImportSuccessWithTag: "已导入 {{count}} 张带有标签 {{tag}} 的卡片。",
     importTagLabel: "标记导入的卡片",

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.package.test.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.package.test.tsx
@@ -2,6 +2,7 @@
 import { act } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../../../api";
 import type { AppDataContextValue } from "../../../../appData";
 import { AppErrorDialogProvider } from "../../../../appError/AppErrorContext";
 import { I18nProvider } from "../../../../i18n";
@@ -607,6 +608,32 @@ describe("WorkspaceImportScreen package import", () => {
     ));
 
     expect(requireElement("[data-testid='workspace-import-error']", HTMLParagraphElement).textContent).toContain("A technical error occurred.");
+    expect(document.body.querySelector("[data-testid='app-error-dialog']")).not.toBeNull();
+    expect(confirmWorkspacePackageImportMock).not.toHaveBeenCalled();
+  });
+
+  it("shows inline guidance for invalid packages without a technical error dialog", async () => {
+    const file = createZipFile("flashcards.zip");
+    previewWorkspacePackageImportMock.mockRejectedValueOnce(new ApiError({
+      statusCode: 400,
+      message: "ZIP entry is not supported: gemini-code-1784560458635.txt",
+      code: "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID",
+      requestId: "7684327b-64e3-41b2-a4f0-7bf428d4e225",
+      endpoint: "POST /workspaces/workspace-1/packages/import/preview",
+      responseBodyKind: "json",
+    }));
+
+    await renderScreen();
+    await choosePackageFile(file);
+    await waitForCondition("Invalid package guidance was not shown", () => (
+      getContainer().querySelector("[data-testid='workspace-import-error']") !== null
+    ));
+
+    expect(requireElement("[data-testid='workspace-import-error']", HTMLParagraphElement).textContent).toContain(
+      "This file is not a valid flashcards.zip. Choose a package exported from Flashcards Open Source App.",
+    );
+    expect(getContainer().querySelector("[data-testid='workspace-package-import-preview']")).toBeNull();
+    expect(document.body.querySelector("[data-testid='app-error-dialog']")).toBeNull();
     expect(confirmWorkspacePackageImportMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import {
+  ApiError,
   confirmWorkspacePackageImport,
   previewWorkspacePackageImport,
 } from "../../../../api";
 import { useAppData } from "../../../../appData";
 import { requireCloudInstallationId } from "../../../../appData/sync/local/syncCloudSettings";
 import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
-import { useI18n } from "../../../../i18n";
+import { type TranslationKey, useI18n } from "../../../../i18n";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type {
   WorkspacePackageImportConfirmOptions,
@@ -24,6 +25,28 @@ type PackageImportPreviewIdentity = Readonly<{
   workspaceId: string;
   installationId: string;
 }>;
+
+function getWorkspacePackageValidationErrorMessage(
+  error: unknown,
+  t: (key: TranslationKey) => string,
+): string | null {
+  if (!(error instanceof ApiError) || error.statusCode < 400 || error.statusCode >= 500) {
+    return null;
+  }
+
+  switch (error.code) {
+    case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_EMPTY":
+    case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_ZIP_INVALID":
+    case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_MALFORMED":
+    case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_CARDS_JSON_INVALID":
+      return t("workspaceImport.packageInvalid");
+    case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_BODY_TOO_LARGE":
+    case "WORKSPACE_PACKAGE_IMPORT_PREVIEW_TOO_LARGE":
+      return t("workspaceImport.packageTooLarge");
+  }
+
+  return null;
+}
 
 function buildSafeMetadataHttpUrl(value: string): string | null {
   try {
@@ -161,12 +184,17 @@ export function WorkspaceImportScreen(): ReactElement {
       setPackageImportTag(preview.defaultOptions.suggestedImportTag);
       setPackageImportRemoveTags([...preview.defaultOptions.removedTags]);
     } catch (error) {
-      const wasCaptured = captureWorkspaceImportError(error);
-      if (wasCaptured) {
-        showCapturedTechnicalError(error);
-        setErrorMessage(technicalErrorMessage);
+      const validationErrorMessage = getWorkspacePackageValidationErrorMessage(error, t);
+      if (validationErrorMessage !== null) {
+        setErrorMessage(validationErrorMessage);
       } else {
-        setErrorMessage(error instanceof Error ? error.message : String(error));
+        const wasCaptured = captureWorkspaceImportError(error);
+        if (wasCaptured) {
+          showCapturedTechnicalError(error);
+          setErrorMessage(technicalErrorMessage);
+        } else {
+          setErrorMessage(error instanceof Error ? error.message : String(error));
+        }
       }
     } finally {
       setIsPackagePreviewing(false);
@@ -226,12 +254,17 @@ export function WorkspaceImportScreen(): ReactElement {
           tag: result.summary.importTag,
         }));
     } catch (error) {
-      const wasCaptured = captureWorkspaceImportError(error);
-      if (wasCaptured) {
-        showCapturedTechnicalError(error);
-        setErrorMessage(technicalErrorMessage);
+      const validationErrorMessage = getWorkspacePackageValidationErrorMessage(error, t);
+      if (validationErrorMessage !== null) {
+        setErrorMessage(validationErrorMessage);
       } else {
-        setErrorMessage(error instanceof Error ? error.message : String(error));
+        const wasCaptured = captureWorkspaceImportError(error);
+        if (wasCaptured) {
+          showCapturedTechnicalError(error);
+          setErrorMessage(technicalErrorMessage);
+        } else {
+          setErrorMessage(error instanceof Error ? error.message : String(error));
+        }
       }
     } finally {
       setIsPackageImporting(false);


### PR DESCRIPTION
## Summary
- show localized inline guidance for invalid or oversized workspace packages
- preserve technical error capture for unexpected import failures
- cover the production ZIP_INVALID behavior and all supported web locales

## Validation
- focused WorkspaceImportScreen package Vitest: 14/14 passed
- web production build passed
- git diff --check passed
- fresh review: no P0-P4 findings

Manual browser validation was not run because the local auth/backend stack was not prepared.