### PR TITLE
Fix Android AI UI locale resolution

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotAppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotAppStateResetRule.kt
@@ -79,15 +79,16 @@ class MarketingScreenshotAppStateResetRule : AppStateResetRule() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val localeManager = context.getSystemService(LocaleManager::class.java)
             ?: throw IllegalStateException("LocaleManager was unavailable while applying screenshot locale.")
-        val localeList = LocaleList.forLanguageTags(localeConfig.appLocaleTag)
+        val applicationLocales: LocaleList = LocaleList.forLanguageTags(localeConfig.appLocaleTag)
+        val supportedLocales: LocaleList = LocaleList.forLanguageTags("${localeConfig.appLocaleTag},en")
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            localeManager.overrideLocaleConfig = LocaleConfig(localeList)
-            localeManager.applicationLocales = localeList
+            localeManager.overrideLocaleConfig = LocaleConfig(supportedLocales)
+            localeManager.applicationLocales = applicationLocales
         }
         waitForOverrideLocaleConfigState(
             localeManager = localeManager,
-            expectedLanguageTags = localeConfig.appLocaleTag,
+            expectedLanguageTags = supportedLocales.toLanguageTags(),
             phase = "applying marketing screenshot override locale config '${localeConfig.localePrefix}'"
         )
         waitForLocaleState(

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiUiLocale.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiUiLocale.kt
@@ -1,0 +1,53 @@
+package com.flashcardsopensourceapp.feature.ai
+
+import android.app.LocaleConfig
+import android.content.Context
+import android.os.LocaleList
+import java.util.Locale
+
+internal fun currentAiUiLocaleTag(context: Context): String {
+    val localeConfig: LocaleConfig = LocaleConfig(context)
+    check(localeConfig.status == LocaleConfig.STATUS_SUCCESS) {
+        "Android LocaleConfig must load successfully for AI UI locale resolution, " +
+            "but returned status ${localeConfig.status}."
+    }
+    val supportedLocales: LocaleList = checkNotNull(localeConfig.supportedLocales) {
+        "Android LocaleConfig returned no supported locales for AI UI locale resolution."
+    }
+    return resolveAiUiLocaleTag(
+        preferredLocales = context.resources.configuration.locales,
+        supportedLocales = supportedLocales,
+        baseLocale = Locale.ENGLISH
+    )
+}
+
+internal fun resolveAiUiLocaleTag(
+    preferredLocales: LocaleList,
+    supportedLocales: LocaleList,
+    baseLocale: Locale
+): String {
+    check(supportedLocales.isEmpty.not()) {
+        "Android LocaleConfig must declare at least one supported locale for AI UI locale resolution."
+    }
+    check(supportedLocales.indexOf(baseLocale) >= 0) {
+        "Android LocaleConfig must declare the base AI UI locale '${baseLocale.toLanguageTag()}'. " +
+            "Supported locales: ${supportedLocales.toLanguageTags()}."
+    }
+
+    for (preferredIndex: Int in 0 until preferredLocales.size()) {
+        val preferredLocale: Locale = preferredLocales[preferredIndex]
+        val exactSupportedIndex: Int = supportedLocales.indexOf(preferredLocale)
+        if (exactSupportedIndex >= 0) {
+            return supportedLocales[exactSupportedIndex].toLanguageTag()
+        }
+
+        for (supportedIndex: Int in 0 until supportedLocales.size()) {
+            val supportedLocale: Locale = supportedLocales[supportedIndex]
+            if (LocaleList.matchesLanguageAndScript(supportedLocale, preferredLocale)) {
+                return supportedLocale.toLanguageTag()
+            }
+        }
+    }
+
+    return baseLocale.toLanguageTag()
+}

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiViewModel.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.core.observability.AppObservability
-import com.flashcardsopensourceapp.core.ui.currentResourceLocale
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatComposerSuggestion
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
@@ -300,7 +299,7 @@ fun createAiViewModelFactory(
                 observability = observability,
                 textProvider = aiTextProvider(context = application),
                 currentUiLocaleTag = {
-                    currentResourceLocale(resources = application.resources).toLanguageTag()
+                    currentAiUiLocaleTag(context = application)
                 }
             )
         }


### PR DESCRIPTION
## Summary

- Fix FLASHCARDS-ANDROID-Y, where Android forwarded the first configuration locale and an unsupported Traditional Chinese locale such as zh-TW caused POST /v1/chat/new to return 400.
- Resolve the AI uiLocale against Android LocaleConfig-supported locales using exact matching, then language-and-script matching, then the explicit base en locale.
- Keep the marketing screenshot runtime override compatible by supporting the selected locale plus en while applicationLocales remains selected-locale-only.

## Validation

- git diff --check passed.
- Two fresh review gates completed; the corrected full patch had no P0-P4 findings or split recommendation.
- Gradle and emulator checks were not run because explicit permission was not granted; Android CI provides build and lint validation.