### PR TITLE
Virtualize the iOS AI transcript

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView+Scrolling.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView+Scrolling.swift
@@ -10,7 +10,12 @@ func aiChatScrollState(
     scrollGeometry: ScrollGeometry,
     bottomThreshold: CGFloat
 ) -> AIChatScrollState {
-    let distanceToBottom = max(scrollGeometry.contentSize.height - scrollGeometry.visibleRect.maxY, 0)
+    let distanceToBottom = max(
+        scrollGeometry.contentSize.height
+            + scrollGeometry.contentInsets.bottom
+            - scrollGeometry.visibleRect.maxY,
+        0
+    )
     let isUserInitiatedScroll: Bool
     switch scrollPhase {
     case .tracking, .interacting, .decelerating:

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -447,9 +447,7 @@ struct AIChatView: View {
     }
 
     var chatScrollSurface: some View {
-        ScrollView {
-            self.chatScrollContent
-        }
+        self.chatScrollContent
         .accessibilityIdentifier(UITestIdentifier.aiConversationScrollSurface)
         .defaultScrollAnchor(.bottom, for: .initialOffset)
         .defaultScrollAnchor(.bottom, for: .alignment)
@@ -461,6 +459,7 @@ struct AIChatView: View {
         // until the user nudged the scroll view manually.
         .scrollPosition(self.$scrollPosition, anchor: .bottom)
         .contentMargins(.horizontal, aiChatMessageListHorizontalPadding, for: .scrollContent)
+        .contentMargins(.vertical, 12, for: .scrollContent)
         .contentMargins(.horizontal, 0, for: .scrollIndicators)
         .contentShape(Rectangle())
         .onTapGesture {
@@ -550,35 +549,39 @@ struct AIChatView: View {
 
     @ViewBuilder
     var chatScrollContent: some View {
-        if self.chatStore.messages.isEmpty {
-            VStack {
+        // The transcript must use a native virtualized container and stable row IDs.
+        List {
+            if self.chatStore.messages.isEmpty {
                 self.emptyChatState
-            }
-            .scrollTargetLayout()
-            .frame(maxWidth: .infinity)
-            .containerRelativeFrame(.vertical, alignment: .center)
-            .padding(.vertical, 12)
-        } else {
-            // Keep this as VStack: LazyVStack caused blank chat history during keyboard-driven relayout here, and stability matters more than lazy virtualization on this screen.
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(Array(self.chatStore.messages.enumerated()), id: \.element.id) { index, message in
+                    .frame(maxWidth: .infinity)
+                    .containerRelativeFrame(.vertical, alignment: .center)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+            } else {
+                let tailMessageId: String? = self.chatStore.messages.last?.id
+
+                ForEach(self.chatStore.messages) { message in
                     self.messageRow(
                         message: message,
                         repairStatus: self.repairStatus(for: message),
                         showsTypingIndicator: aiChatShouldShowTypingIndicator(
                             message: message,
-                            isLastMessage: index == self.chatStore.messages.indices.last,
+                            isLastMessage: message.id == tailMessageId,
                             isStreaming: self.chatStore.isStreaming,
                             optimisticAssistantMessageId: self.chatStore.optimisticOutgoingTurnState?.assistantMessageId
                         )
                     )
                     .id(message.id)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
                 }
             }
-            .scrollTargetLayout()
-            .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .listStyle(.plain)
+        .listRowSpacing(12)
+        .scrollContentBackground(.hidden)
     }
 
     func acceptExternalAIConsent() {


### PR DESCRIPTION
## Summary
- replace the eager AI transcript stack with a native plain List
- preserve stable message identity, empty-state layout, and bottom-follow behavior
- account for List content insets when detecting manual scroll-away

## Validation
- git diff --check
- Swift parser checks for both changed files
- isolated SwiftUI List, ScrollPosition, and ScrollGeometry.contentInsets API type-checks
- two fresh worker review rounds; final review found no P0-P4 issues

Full Xcode build and simulator runtime validation were not run because the required iOS 26.5 runtime/platform is unavailable in this environment.