### PR TITLE
fix(ios): bound large AI response rendering

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatLongTextView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatLongTextView.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import UIKit
+
+private let aiChatLongTextPreviewCharacterLimit: Int = 4_000
+private let aiChatLongTextChunkCharacterLimit: Int = 2_000
+
+struct AIChatLongTextPreview {
+    let text: String
+    let isTruncated: Bool
+}
+
+func buildAIChatLongTextPreview(
+    text: String,
+    characterLimit: Int
+) -> AIChatLongTextPreview {
+    precondition(
+        characterLimit > 0,
+        "AI chat long text preview character limit must be greater than zero."
+    )
+
+    let previewEndIndex = text.index(
+        text.startIndex,
+        offsetBy: characterLimit,
+        limitedBy: text.endIndex
+    ) ?? text.endIndex
+
+    guard previewEndIndex != text.endIndex else {
+        return AIChatLongTextPreview(text: text, isTruncated: false)
+    }
+
+    return AIChatLongTextPreview(
+        text: String(text[..<previewEndIndex]),
+        isTruncated: true
+    )
+}
+
+func segmentAIChatLongText(
+    text: String,
+    chunkCharacterLimit: Int,
+    cancellationRequested: @Sendable () -> Bool
+) -> [String]? {
+    precondition(
+        chunkCharacterLimit > 0,
+        "AI chat long text chunk character limit must be greater than zero."
+    )
+
+    var fullTextChunks: [String] = []
+    var chunkStartIndex: String.Index = text.startIndex
+
+    while chunkStartIndex != text.endIndex {
+        guard cancellationRequested() == false else {
+            return nil
+        }
+
+        let chunkEndIndex = text.index(
+            chunkStartIndex,
+            offsetBy: chunkCharacterLimit,
+            limitedBy: text.endIndex
+        ) ?? text.endIndex
+        fullTextChunks.append(String(text[chunkStartIndex..<chunkEndIndex]))
+        chunkStartIndex = chunkEndIndex
+    }
+
+    return fullTextChunks
+}
+
+func buildAIChatLongTextChunks(
+    text: String,
+    chunkCharacterLimit: Int
+) async -> [String]? {
+    let segmentationTask = Task.detached(priority: .userInitiated) {
+        segmentAIChatLongText(
+            text: text,
+            chunkCharacterLimit: chunkCharacterLimit,
+            cancellationRequested: {
+                Task.isCancelled
+            }
+        )
+    }
+
+    return await withTaskCancellationHandler {
+        await segmentationTask.value
+    } onCancel: {
+        segmentationTask.cancel()
+    }
+}
+
+struct AIChatLongTextView: View {
+    let text: String
+
+    @State private var isFullResponsePresented: Bool = false
+
+    private let preview: AIChatLongTextPreview
+
+    init(text: String) {
+        self.text = text
+        self.preview = buildAIChatLongTextPreview(
+            text: text,
+            characterLimit: aiChatLongTextPreviewCharacterLimit
+        )
+    }
+
+    @ViewBuilder
+    var body: some View {
+        if self.preview.isTruncated {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(verbatim: self.preview.text)
+                Button(aiSettingsLocalized("ai.message.fullResponse.show", "Show full response")) {
+                    self.isFullResponsePresented = true
+                }
+                .font(.subheadline.weight(.semibold))
+            }
+            .sheet(isPresented: self.$isFullResponsePresented) {
+                AIChatFullResponseView(text: self.text)
+            }
+        } else {
+            Text(verbatim: self.preview.text)
+        }
+    }
+}
+
+private struct AIChatFullResponseView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var chunks: [String]?
+
+    let text: String
+
+    init(text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if let chunks = self.chunks {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(chunks.indices, id: \.self) { index in
+                            Text(verbatim: chunks[index])
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    .padding()
+                } else {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                }
+            }
+            .task(id: self.text) {
+                let text = self.text
+                self.chunks = nil
+
+                guard let chunks = await buildAIChatLongTextChunks(
+                    text: text,
+                    chunkCharacterLimit: aiChatLongTextChunkCharacterLimit
+                ) else {
+                    return
+                }
+                guard Task.isCancelled == false else {
+                    return
+                }
+
+                self.chunks = chunks
+            }
+            .navigationTitle(aiSettingsLocalized("ai.message.fullResponse.title", "Full response"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(aiSettingsLocalized("common.close", "Close")) {
+                        self.dismiss()
+                    }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button(
+                        aiSettingsLocalized("common.copy", "Copy"),
+                        systemImage: "doc.on.doc"
+                    ) {
+                        UIPasteboard.general.string = self.text
+                    }
+                    .accessibilityLabel(aiSettingsLocalized("ai.tool.copy.response", "Copy response"))
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatMessageViews.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatMessageViews.swift
@@ -147,7 +147,7 @@ extension AIChatView {
 
         if message.role == .assistant, message.isError {
             row
-                .accessibilityElement(children: .ignore)
+                .accessibilityElement(children: .contain)
                 .accessibilityLabel(self.messageRowAccessibilityLabel(message: message))
                 .accessibilityIdentifier(UITestIdentifier.aiAssistantErrorMessage)
         } else if message.role == .assistant {
@@ -216,11 +216,11 @@ extension AIChatView {
         switch part {
         case .text(let text):
             if message.role == .assistant {
-                Text(text)
+                AIChatLongTextView(text: text)
                     .textSelection(.enabled)
                     .accessibilityIdentifier(UITestIdentifier.aiAssistantVisibleText)
             } else {
-                Text(text)
+                AIChatLongTextView(text: text)
             }
         case .image:
             Label(aiSettingsLocalized("ai.message.imageAttached", "Image attached"), systemImage: "photo")
@@ -340,8 +340,8 @@ extension AIChatView {
                     self.detachAutoFollowForExpandedContent()
                 }
             ) {
-                Text(
-                    reasoningSummary.summary.isEmpty
+                AIChatLongTextView(
+                    text: reasoningSummary.summary.isEmpty
                         ? aiSettingsLocalized("ai.message.reasoning.thinking", "Thinking...")
                         : reasoningSummary.summary
                 )

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "قيد التقدم";
 "ai.message.reasoning.status.done" = "تم";
 "ai.message.reasoning.thinking" = "أفكر...";
+"ai.message.fullResponse.show" = "عرض الرد الكامل";
+"ai.message.fullResponse.title" = "الرد الكامل";
 "ai.tool.label.codeExecution" = "تنفيذ التعليمات البرمجية";
 "ai.tool.label.webSearch" = "بحث الويب";
 "ai.tool.section.request" = "التطبيق";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "IN BEARBEITUNG";
 "ai.message.reasoning.status.done" = "FERTIG";
 "ai.message.reasoning.thinking" = "Denken...";
+"ai.message.fullResponse.show" = "Vollständige Antwort anzeigen";
+"ai.message.fullResponse.title" = "Vollständige Antwort";
 "ai.tool.label.codeExecution" = "Codeausführung";
 "ai.tool.label.webSearch" = "Websuche";
 "ai.tool.section.request" = "Anwendung";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "EN CURSO";
 "ai.message.reasoning.status.done" = "HECHO";
 "ai.message.reasoning.thinking" = "Pensando...";
+"ai.message.fullResponse.show" = "Mostrar respuesta completa";
+"ai.message.fullResponse.title" = "Respuesta completa";
 "ai.tool.label.codeExecution" = "Ejecucion de codigo";
 "ai.tool.label.webSearch" = "Busqueda web";
 "ai.tool.section.request" = "Solicitud";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "EN CURSO";
 "ai.message.reasoning.status.done" = "HECHO";
 "ai.message.reasoning.thinking" = "Pensando...";
+"ai.message.fullResponse.show" = "Mostrar respuesta completa";
+"ai.message.fullResponse.title" = "Respuesta completa";
 "ai.tool.label.codeExecution" = "Ejecucion de codigo";
 "ai.tool.label.webSearch" = "Busqueda web";
 "ai.tool.section.request" = "Solicitud";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "प्रगति पर";
 "ai.message.reasoning.status.done" = "हो गया";
 "ai.message.reasoning.thinking" = "सोच रहा हूँ...";
+"ai.message.fullResponse.show" = "पूरा जवाब दिखाएँ";
+"ai.message.fullResponse.title" = "पूरा जवाब";
 "ai.tool.label.codeExecution" = "कोड निष्पादन";
 "ai.tool.label.webSearch" = "वेब खोज";
 "ai.tool.section.request" = "एप्लीकेशन";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "進行中";
 "ai.message.reasoning.status.done" = "完了";
 "ai.message.reasoning.thinking" = "考え中...";
+"ai.message.fullResponse.show" = "回答をすべて表示";
+"ai.message.fullResponse.title" = "回答全文";
 "ai.tool.label.codeExecution" = "コードの実行";
 "ai.tool.label.webSearch" = "ウェブ検索";
 "ai.tool.section.request" = "アプリケーション";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "В ПРОГРЕССЕ";
 "ai.message.reasoning.status.done" = "СОВЕРШЕНО";
 "ai.message.reasoning.thinking" = "Думая...";
+"ai.message.fullResponse.show" = "Показать ответ полностью";
+"ai.message.fullResponse.title" = "Полный ответ";
 "ai.tool.label.codeExecution" = "Выполнение кода";
 "ai.tool.label.webSearch" = "Веб-поиск";
 "ai.tool.section.request" = "Приложение";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -83,6 +83,8 @@
 "ai.message.reasoning.status.running" = "进行中";
 "ai.message.reasoning.status.done" = "完成";
 "ai.message.reasoning.thinking" = "思考...";
+"ai.message.fullResponse.show" = "显示完整回复";
+"ai.message.fullResponse.title" = "完整回复";
 "ai.tool.label.codeExecution" = "代码执行";
 "ai.tool.label.webSearch" = "网页搜索";
 "ai.tool.section.request" = "应用";


### PR DESCRIPTION
## Summary
- bound long AI transcript text to a 4,000-grapheme preview
- render full text as cancellation-aware, off-main 2,000-grapheme chunks in a native sheet
- keep streaming sheet content current and preserve exact copy, selection, accessibility, and localization behavior

## Validation
- git diff --check
- plutil lint for all eight modified AISettings.strings tables
- Swift parser checks
- standalone iOS Swift 6 strict-concurrency type-check
- static task, cancellation, current-copy, and accessibility inspection

Full project build and simulator maximum-size UI testing were not run because the required iOS platform/runtime is unavailable in this environment.