### PR TITLE
Group backend scheduled job entrypoints

### DIFF
--- a/apps/backend/src/community/leaderboard/progress/leaderboardSnapshots.test.ts
+++ b/apps/backend/src/community/leaderboard/progress/leaderboardSnapshots.test.ts
@@ -568,11 +568,11 @@ test("production leaderboard snapshot generation uses one repeatable-read transa
 test("community leaderboard snapshot Lambda retries transient database failures", () => {
   const sourcePath = resolve(
     process.cwd(),
-    "src/entrypoints/lambda-community-leaderboard-snapshot.ts",
+    "src/entrypoints/scheduledJobs/lambda-community-leaderboard-snapshot.ts",
   );
   const source = readFileSync(sourcePath, "utf8").replace(/\s+/g, " ");
 
-  assert.match(source, /import \{ withTransientDatabaseRetry \} from "\.\.\/database\/transient"/);
+  assert.match(source, /import \{ withTransientDatabaseRetry \} from "\.\.\/\.\.\/database\/transient"/);
   assert.match(source, /const result = await withTransientDatabaseRetry\( \(\) => runtime\.generateLeaderboardSnapshots\(\), \(\) => observationScope, \)/);
 });
 

--- a/apps/backend/src/community/leaderboard/streak/streakLeaderboardSnapshots.test.ts
+++ b/apps/backend/src/community/leaderboard/streak/streakLeaderboardSnapshots.test.ts
@@ -260,12 +260,12 @@ test("production streak leaderboard snapshot generation uses one repeatable-read
 test("streak leaderboard snapshot Lambda retries transient database failures", () => {
   const sourcePath = resolve(
     process.cwd(),
-    "src/entrypoints/lambda-streak-leaderboard-snapshot.ts",
+    "src/entrypoints/scheduledJobs/lambda-streak-leaderboard-snapshot.ts",
   );
   const source = readFileSync(sourcePath, "utf8").replace(/\s+/g, " ");
 
   assert.match(source, /initializeBackendSentry\("streak-leaderboard-snapshot"\)/);
-  assert.match(source, /import \{ withTransientDatabaseRetry \} from "\.\.\/database\/transient"/);
+  assert.match(source, /import \{ withTransientDatabaseRetry \} from "\.\.\/\.\.\/database\/transient"/);
   assert.match(source, /const result = await withTransientDatabaseRetry\( \(\) => runtime\.generateStreakLeaderboardSnapshots\(\), \(\) => observationScope, \)/);
 });
 

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-community-leaderboard-snapshot.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-community-leaderboard-snapshot.ts
@@ -6,9 +6,9 @@ import {
   initializeBackendSentry,
   normalizeCaughtError,
   wrapBackendHandler,
-} from "../observability/sentry";
-import { LEADERBOARD_SNAPSHOT_METRIC_VERSION } from "../community/leaderboard/progress/leaderboardWindows";
-import { withTransientDatabaseRetry } from "../database/transient";
+} from "../../observability/sentry";
+import { LEADERBOARD_SNAPSHOT_METRIC_VERSION } from "../../community/leaderboard/progress/leaderboardWindows";
+import { withTransientDatabaseRetry } from "../../database/transient";
 
 initializeBackendSentry("community-leaderboard-snapshot");
 
@@ -21,13 +21,13 @@ type CommunityLeaderboardSnapshotResponse = Readonly<{
 }>;
 
 type CommunityLeaderboardSnapshotRuntime = Readonly<{
-  generateLeaderboardSnapshots: typeof import("../community/leaderboard/progress/leaderboardSnapshots").generateLeaderboardSnapshots;
+  generateLeaderboardSnapshots: typeof import("../../community/leaderboard/progress/leaderboardSnapshots").generateLeaderboardSnapshots;
 }>;
 
 let communityLeaderboardSnapshotRuntimePromise: Promise<CommunityLeaderboardSnapshotRuntime> | null = null;
 
 async function createCommunityLeaderboardSnapshotRuntime(): Promise<CommunityLeaderboardSnapshotRuntime> {
-  const { generateLeaderboardSnapshots } = await import("../community/leaderboard/progress/leaderboardSnapshots");
+  const { generateLeaderboardSnapshots } = await import("../../community/leaderboard/progress/leaderboardSnapshots");
   return {
     generateLeaderboardSnapshots,
   };

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-global-metrics-snapshot.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-global-metrics-snapshot.ts
@@ -7,7 +7,7 @@ import {
   normalizeCaughtError,
   type GlobalMetricsSnapshotFailureDetails,
   wrapBackendHandler,
-} from "../observability/sentry";
+} from "../../observability/sentry";
 
 initializeBackendSentry("global-metrics-snapshot");
 
@@ -22,7 +22,7 @@ type GlobalMetricsSnapshotResponse = Readonly<{
 }>;
 
 type GlobalMetricsSnapshotRuntime = Readonly<{
-  generateAndWriteGlobalMetricsSnapshot: typeof import("../globalMetrics/generation").generateAndWriteGlobalMetricsSnapshot;
+  generateAndWriteGlobalMetricsSnapshot: typeof import("../../globalMetrics/generation").generateAndWriteGlobalMetricsSnapshot;
 }>;
 
 let globalMetricsSnapshotRuntimePromise: Promise<GlobalMetricsSnapshotRuntime> | null = null;
@@ -32,8 +32,8 @@ async function createGlobalMetricsSnapshotRuntime(): Promise<GlobalMetricsSnapsh
     { initializeLangfuseTelemetry },
     { generateAndWriteGlobalMetricsSnapshot },
   ] = await Promise.all([
-    import("../telemetry/langfuse"),
-    import("../globalMetrics/generation"),
+    import("../../telemetry/langfuse"),
+    import("../../globalMetrics/generation"),
   ]);
   initializeLangfuseTelemetry();
   return {

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-progress-active-days-backfill.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-progress-active-days-backfill.ts
@@ -6,7 +6,7 @@ import {
   initializeBackendSentry,
   normalizeCaughtError,
   wrapBackendHandler,
-} from "../observability/sentry";
+} from "../../observability/sentry";
 
 initializeBackendSentry("progress-active-days-backfill");
 
@@ -30,7 +30,7 @@ type ProgressActiveDaysBackfillResponse = Readonly<{
 }>;
 
 type ProgressActiveDaysBackfillRuntime = Readonly<{
-  backfillActiveReviewDays: typeof import("../progress/activeReviewDays/activeReviewDaysBackfill").backfillActiveReviewDays;
+  backfillActiveReviewDays: typeof import("../../progress/activeReviewDays/activeReviewDaysBackfill").backfillActiveReviewDays;
 }>;
 
 const scheduledBatchSize = 25;
@@ -41,7 +41,7 @@ const maximumMaxPages = 100;
 let progressActiveDaysBackfillRuntimePromise: Promise<ProgressActiveDaysBackfillRuntime> | null = null;
 
 async function createProgressActiveDaysBackfillRuntime(): Promise<ProgressActiveDaysBackfillRuntime> {
-  const { backfillActiveReviewDays } = await import("../progress/activeReviewDays/activeReviewDaysBackfill");
+  const { backfillActiveReviewDays } = await import("../../progress/activeReviewDays/activeReviewDaysBackfill");
   return {
     backfillActiveReviewDays,
   };

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-streak-leaderboard-snapshot.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-streak-leaderboard-snapshot.ts
@@ -6,9 +6,9 @@ import {
   initializeBackendSentry,
   normalizeCaughtError,
   wrapBackendHandler,
-} from "../observability/sentry";
-import { STREAK_LEADERBOARD_SNAPSHOT_METRIC_VERSION } from "../community/leaderboard/streak/streakLeaderboardSnapshots";
-import { withTransientDatabaseRetry } from "../database/transient";
+} from "../../observability/sentry";
+import { STREAK_LEADERBOARD_SNAPSHOT_METRIC_VERSION } from "../../community/leaderboard/streak/streakLeaderboardSnapshots";
+import { withTransientDatabaseRetry } from "../../database/transient";
 
 initializeBackendSentry("streak-leaderboard-snapshot");
 
@@ -24,13 +24,13 @@ type StreakLeaderboardSnapshotResponse = Readonly<{
 }>;
 
 type StreakLeaderboardSnapshotRuntime = Readonly<{
-  generateStreakLeaderboardSnapshots: typeof import("../community/leaderboard/streak/streakLeaderboardSnapshots").generateStreakLeaderboardSnapshots;
+  generateStreakLeaderboardSnapshots: typeof import("../../community/leaderboard/streak/streakLeaderboardSnapshots").generateStreakLeaderboardSnapshots;
 }>;
 
 let streakLeaderboardSnapshotRuntimePromise: Promise<StreakLeaderboardSnapshotRuntime> | null = null;
 
 async function createStreakLeaderboardSnapshotRuntime(): Promise<StreakLeaderboardSnapshotRuntime> {
-  const { generateStreakLeaderboardSnapshots } = await import("../community/leaderboard/streak/streakLeaderboardSnapshots");
+  const { generateStreakLeaderboardSnapshots } = await import("../../community/leaderboard/streak/streakLeaderboardSnapshots");
   return {
     generateStreakLeaderboardSnapshots,
   };

--- a/apps/backend/src/globalMetrics/reporting.ts
+++ b/apps/backend/src/globalMetrics/reporting.ts
@@ -11,7 +11,7 @@ import {
 
 // The three SQL builders below back the public anonymized endpoint
 // (`apps/backend/src/routes/globalSnapshot.ts`) and the scheduled snapshot Lambda
-// (`apps/backend/src/entrypoints/lambda-global-metrics-snapshot.ts`).
+// (`apps/backend/src/entrypoints/scheduledJobs/lambda-global-metrics-snapshot.ts`).
 //
 // The two fragment constants below are the canonical encoding of the user-identity
 // filters shared by those three queries. The same rules are restated in the admin

--- a/infra/aws/lib/scheduled-jobs/community-leaderboard.test.ts
+++ b/infra/aws/lib/scheduled-jobs/community-leaderboard.test.ts
@@ -23,7 +23,7 @@ test("community leaderboard construct creates the hourly schedule and snapshot L
   assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "CommunityLeaderboardSnapshotHandler"/);
   assert.match(
     source,
-    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "lambda-community-leaderboard-snapshot\.ts"\)/,
+    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-community-leaderboard-snapshot\.ts"\)/,
   );
 
   // The job writes to Postgres as backend_app, so it uses the backend (read-write) secret,

--- a/infra/aws/lib/scheduled-jobs/community-leaderboard.ts
+++ b/infra/aws/lib/scheduled-jobs/community-leaderboard.ts
@@ -85,7 +85,7 @@ function addOptionalSentryEnvironment(
  */
 export function communityLeaderboard(scope: Construct, props: CommunityLeaderboardProps): CommunityLeaderboardResult {
   const snapshotFunction = new lambdaNodejs.NodejsFunction(scope, "CommunityLeaderboardSnapshotHandler", {
-    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-community-leaderboard-snapshot.ts"),
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-community-leaderboard-snapshot.ts"),
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),

--- a/infra/aws/lib/scheduled-jobs/global-metrics.ts
+++ b/infra/aws/lib/scheduled-jobs/global-metrics.ts
@@ -101,7 +101,7 @@ export function globalMetrics(scope: Construct, props: GlobalMetricsProps): Glob
   });
 
   const snapshotFunction = new lambdaNodejs.NodejsFunction(scope, "GlobalMetricsSnapshotHandler", {
-    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-global-metrics-snapshot.ts"),
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-global-metrics-snapshot.ts"),
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),

--- a/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.test.ts
+++ b/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.test.ts
@@ -22,7 +22,7 @@ test("progress active days backfill construct creates the hourly schedule and La
   assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "ProgressActiveDaysBackfillHandler"/);
   assert.match(
     source,
-    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "lambda-progress-active-days-backfill\.ts"\)/,
+    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-progress-active-days-backfill\.ts"\)/,
   );
   assert.match(source, /DB_SECRET_ARN: props\.backendDbSecret\.secretArn/);
   assert.match(source, /REPORTING_DB_SECRET_ARN: props\.reportingDbSecret\.secretArn/);

--- a/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.ts
+++ b/infra/aws/lib/scheduled-jobs/progress-active-days-backfill.ts
@@ -83,7 +83,7 @@ export function progressActiveDaysBackfill(
   props: ProgressActiveDaysBackfillProps,
 ): ProgressActiveDaysBackfillResult {
   const backfillFunction = new lambdaNodejs.NodejsFunction(scope, "ProgressActiveDaysBackfillHandler", {
-    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-progress-active-days-backfill.ts"),
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-progress-active-days-backfill.ts"),
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),

--- a/infra/aws/lib/scheduled-jobs/streak-leaderboard.test.ts
+++ b/infra/aws/lib/scheduled-jobs/streak-leaderboard.test.ts
@@ -22,7 +22,7 @@ test("streak leaderboard construct creates the daily schedule and snapshot Lambd
   assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "StreakLeaderboardSnapshotHandler"/);
   assert.match(
     source,
-    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "lambda-streak-leaderboard-snapshot\.ts"\)/,
+    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-streak-leaderboard-snapshot\.ts"\)/,
   );
   assert.match(source, /DB_SECRET_ARN: props\.backendDbSecret\.secretArn/);
   assert.equal(source.includes("REPORTING_DB_SECRET_ARN"), false);

--- a/infra/aws/lib/scheduled-jobs/streak-leaderboard.ts
+++ b/infra/aws/lib/scheduled-jobs/streak-leaderboard.ts
@@ -79,7 +79,7 @@ function addOptionalSentryEnvironment(
 
 export function streakLeaderboard(scope: Construct, props: StreakLeaderboardProps): StreakLeaderboardResult {
   const snapshotFunction = new lambdaNodejs.NodejsFunction(scope, "StreakLeaderboardSnapshotHandler", {
-    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-streak-leaderboard-snapshot.ts"),
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-streak-leaderboard-snapshot.ts"),
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(5),


### PR DESCRIPTION
## Summary
- group the four backend scheduled Lambda handlers under `entrypoints/scheduledJobs/`
- update handler import depths and CDK entry paths
- update path-sensitive tests and source documentation

## Validation
- `npm run lint --prefix apps/backend`
- `npm run build --prefix apps/backend`
- `npm run test --prefix apps/backend` (772/772)
- `npm run test --prefix infra/aws` (32/32)
- old scheduled-job entrypoint path search returned no matches
- `git diff HEAD --check`