### PR TITLE
Replace Android review Markdown renderer

### DIFF
--- a/apps/android/feature/review/build.gradle.kts
+++ b/apps/android/feature/review/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     implementation(libs.lottie.compose)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+    implementation(libs.markdown.renderer)
+    implementation(libs.markdown.renderer.m3)
+    implementation(libs.markdown.renderer.coil3)
 
     testImplementation(libs.junit4)
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
@@ -19,44 +19,24 @@ sealed interface ReviewRenderedContent {
         val text: String
     ) : ReviewRenderedContent
 
-    data class Rich(
-        val blocks: List<ReviewRichBlock>
+    data class Markdown(
+        val markdown: String
+    ) : ReviewRenderedContent
+
+    data class ManagedMarkdown(
+        val blocks: List<ReviewManagedMarkdownBlock>
     ) : ReviewRenderedContent
 }
 
-sealed interface ReviewRichBlock {
-    data class Paragraph(
-        val segments: List<ReviewInlineSegment>
-    ) : ReviewRichBlock
-
-    data class Heading(
-        val level: Int,
-        val segments: List<ReviewInlineSegment>
-    ) : ReviewRichBlock
-
-    data class BulletList(
-        val ordered: Boolean,
-        val items: List<List<ReviewInlineSegment>>
-    ) : ReviewRichBlock
-
-    data class Quote(
-        val segments: List<ReviewInlineSegment>
-    ) : ReviewRichBlock
-
-    data class CodeBlock(
-        val languageLabel: String?,
-        val code: String
-    ) : ReviewRichBlock
+sealed interface ReviewManagedMarkdownBlock {
+    data class Markdown(
+        val markdown: String
+    ) : ReviewManagedMarkdownBlock
 
     data class ManagedMedia(
         val reference: ReviewManagedMediaReference
-    ) : ReviewRichBlock
+    ) : ReviewManagedMarkdownBlock
 }
-
-data class ReviewInlineSegment(
-    val text: String,
-    val isCode: Boolean
-)
 
 data class ReviewManagedMediaReference(
     val mediaAssetId: String,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
@@ -4,7 +4,7 @@ import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 
 /*
  Keep review content presentation heuristics aligned with:
- - apps/web/src/screens/reviewContentPresentation.ts
+ - apps/web/src/screens/review/components/card/reviewContentPresentation.ts
  - apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
  */
 
@@ -15,7 +15,6 @@ internal val reviewHeadingRegex: Regex = Regex(pattern = """^\s{0,3}(#{1,6})\s+(
 internal val reviewQuoteRegex: Regex = Regex(pattern = """^\s{0,3}>\s?(.*)$""")
 internal val reviewBulletRegex: Regex = Regex(pattern = """^\s{0,3}[-*+]\s+(.+?)\s*$""")
 internal val reviewOrderedListRegex: Regex = Regex(pattern = """^\s{0,3}\d+\.\s+(.+?)\s*$""")
-internal val reviewFenceRegex: Regex = Regex(pattern = """^\s{0,3}(```|~~~)\s*([\w+-]+)?\s*$""")
 internal val reviewHorizontalRuleRegex: Regex = Regex(pattern = """^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$""")
 internal val reviewTableDelimiterRegex: Regex = Regex(
     pattern = """^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$"""
@@ -23,7 +22,17 @@ internal val reviewTableDelimiterRegex: Regex = Regex(
 internal val reviewManagedMediaReferenceRegex: Regex = Regex(
     pattern = """(!)?\[([^\]]*)]\(([^)\s]+)(?:\s+"[^"]*")?\)"""
 )
+private val reviewMarkdownLinkOrImageRegex: Regex = Regex(
+    pattern = """!?\[[^\]]*]\([^)]+\)"""
+)
+private val reviewFenceOpeningRegex: Regex = Regex(pattern = """^\s{0,3}(`{3,}|~{3,})(.*)$""")
+private val reviewFenceClosingRegex: Regex = Regex(pattern = """^\s{0,3}(`{3,}|~{3,})\s*$""")
 private const val reviewManagedMediaSchemePrefix: String = "fcasset:"
+
+private data class ReviewManagedMediaMatch(
+    val range: IntRange,
+    val reference: ReviewManagedMediaReference
+)
 
 fun classifyReviewContentPresentation(text: String): ReviewContentPresentationMode {
     val trimmedText: String = text.trim()
@@ -56,15 +65,18 @@ fun makeReviewRenderedContent(
     text: String,
     mediaAssetsById: Map<String, MediaAsset>
 ): ReviewRenderedContent {
+    val managedMarkdown: ReviewRenderedContent.ManagedMarkdown? = makeReviewManagedMarkdownContent(
+        text = text,
+        mediaAssetsById = mediaAssetsById
+    )
+    if (managedMarkdown != null) {
+        return managedMarkdown
+    }
+
     return when (classifyReviewContentPresentation(text = text)) {
         ReviewContentPresentationMode.SHORT_PLAIN -> ReviewRenderedContent.ShortPlain(text = text)
         ReviewContentPresentationMode.PARAGRAPH_PLAIN -> ReviewRenderedContent.ParagraphPlain(text = text)
-        ReviewContentPresentationMode.RICH -> ReviewRenderedContent.Rich(
-            blocks = parseReviewRichBlocks(
-                text = text,
-                mediaAssetsById = mediaAssetsById
-            )
-        )
+        ReviewContentPresentationMode.RICH -> ReviewRenderedContent.Markdown(markdown = text)
     }
 }
 
@@ -72,7 +84,7 @@ private fun hasStrongRichCue(text: String): Boolean {
     if (text.isBlank()) {
         return false
     }
-    if (containsReviewManagedMediaReference(text = text)) {
+    if (reviewMarkdownLinkOrImageRegex.containsMatchIn(input = text)) {
         return true
     }
 
@@ -81,17 +93,31 @@ private fun hasStrongRichCue(text: String): Boolean {
             || reviewQuoteRegex.matches(line)
             || reviewBulletRegex.matches(line)
             || reviewOrderedListRegex.matches(line)
-            || reviewFenceRegex.matches(line)
+            || reviewFenceMarker(line = line) != null
             || reviewHorizontalRuleRegex.matches(line)
             || reviewTableDelimiterRegex.matches(line)
     }
 }
 
-private fun containsReviewManagedMediaReference(text: String): Boolean {
-    return reviewManagedMediaReferenceRegex.findAll(input = text).any { match ->
-        val reference: String = match.groups[3]?.value ?: return@any false
-        parseReviewManagedMediaAssetId(reference = reference) != null
+internal fun reviewFenceMarker(line: String): String? {
+    val match: MatchResult = reviewFenceOpeningRegex.matchEntire(input = line) ?: return null
+    val marker: String = match.groupValues[1]
+    val info: String = match.groupValues[2]
+    if (marker.first() == '`' && info.contains('`')) {
+        return null
     }
+
+    return marker
+}
+
+internal fun isReviewFenceClosingLine(
+    line: String,
+    openingMarker: String
+): Boolean {
+    val match: MatchResult = reviewFenceClosingRegex.matchEntire(input = line) ?: return false
+    val closingMarker: String = match.groupValues[1]
+    return closingMarker.first() == openingMarker.first() &&
+        closingMarker.length >= openingMarker.length
 }
 
 internal fun parseReviewManagedMediaAssetId(reference: String): String? {
@@ -115,271 +141,97 @@ internal fun parseReviewManagedMediaAssetId(reference: String): String? {
     return mediaAssetId.ifEmpty { null }
 }
 
-private fun parseReviewRichBlocks(
+private fun makeReviewManagedMarkdownContent(
     text: String,
     mediaAssetsById: Map<String, MediaAsset>
-): List<ReviewRichBlock> {
-    val normalizedText: String = text.replace("\r\n", "\n").replace('\r', '\n')
-    val lines: List<String> = normalizedText.lines()
-    var index: Int = 0
-    val blocks: MutableList<ReviewRichBlock> = mutableListOf()
-
-    while (index < lines.size) {
-        val line: String = lines[index]
-
-        if (line.isBlank()) {
-            index += 1
-            continue
-        }
-
-        val fenceMatch: MatchResult? = reviewFenceRegex.matchEntire(line)
-        if (fenceMatch != null) {
-            val fence: String = fenceMatch.groupValues[1]
-            val languageLabel: String? = fenceMatch.groupValues[2].ifBlank { null }
-            val codeLines: MutableList<String> = mutableListOf()
-            index += 1
-
-            while (index < lines.size && reviewFenceRegex.matchEntire(lines[index])?.groupValues?.get(1) != fence) {
-                codeLines += lines[index]
-                index += 1
-            }
-
-            if (index < lines.size) {
-                index += 1
-            }
-
-            blocks += ReviewRichBlock.CodeBlock(
-                languageLabel = languageLabel,
-                code = codeLines.joinToString(separator = "\n")
-            )
-            continue
-        }
-
-        val managedMediaBlocks: List<ReviewRichBlock>? = splitReviewManagedMediaLine(
-            line = line,
-            mediaAssetsById = mediaAssetsById
-        )
-        if (managedMediaBlocks != null) {
-            blocks += managedMediaBlocks
-            index += 1
-            continue
-        }
-
-        val headingMatch: MatchResult? = reviewHeadingRegex.matchEntire(line)
-        if (headingMatch != null) {
-            blocks += ReviewRichBlock.Heading(
-                level = headingMatch.groupValues[1].length,
-                segments = parseInlineSegments(text = headingMatch.groupValues[2])
-            )
-            index += 1
-            continue
-        }
-
-        if (reviewQuoteRegex.matches(line)) {
-            val quoteLines: MutableList<String> = mutableListOf()
-
-            while (index < lines.size) {
-                val quoteMatch: MatchResult = reviewQuoteRegex.matchEntire(lines[index]) ?: break
-                quoteLines += quoteMatch.groupValues[1]
-                index += 1
-            }
-
-            blocks += ReviewRichBlock.Quote(
-                segments = parseInlineSegments(text = quoteLines.joinToString(separator = "\n"))
-            )
-            continue
-        }
-
-        val bulletMatch: MatchResult? = reviewBulletRegex.matchEntire(line)
-        val orderedMatch: MatchResult? = reviewOrderedListRegex.matchEntire(line)
-        if (bulletMatch != null || orderedMatch != null) {
-            val ordered: Boolean = orderedMatch != null
-            val items: MutableList<List<ReviewInlineSegment>> = mutableListOf()
-
-            while (index < lines.size) {
-                val itemMatch: MatchResult = if (ordered) {
-                    reviewOrderedListRegex.matchEntire(lines[index])
-                } else {
-                    reviewBulletRegex.matchEntire(lines[index])
-                } ?: break
-
-                items += parseInlineSegments(text = itemMatch.groupValues[1])
-                index += 1
-            }
-
-            blocks += ReviewRichBlock.BulletList(
-                ordered = ordered,
-                items = items
-            )
-            continue
-        }
-
-        val paragraphLines: MutableList<String> = mutableListOf()
-        while (index < lines.size && shouldContinueParagraph(line = lines[index])) {
-            paragraphLines += lines[index]
-            index += 1
-        }
-
-        blocks += ReviewRichBlock.Paragraph(
-            segments = parseInlineSegments(text = paragraphLines.joinToString(separator = "\n"))
-        )
-    }
-
-    return if (blocks.isEmpty()) {
-        listOf(
-            ReviewRichBlock.Paragraph(
-                segments = parseInlineSegments(text = text)
-            )
-        )
-    } else {
-        blocks
-    }
-}
-
-private fun shouldContinueParagraph(line: String): Boolean {
-    if (line.isBlank()) {
-        return false
-    }
-
-    return reviewFenceRegex.matches(line).not()
-        && containsReviewManagedMediaReference(text = line).not()
-        && reviewHeadingRegex.matches(line).not()
-        && reviewQuoteRegex.matches(line).not()
-        && reviewBulletRegex.matches(line).not()
-        && reviewOrderedListRegex.matches(line).not()
-}
-
-private fun splitReviewManagedMediaLine(
-    line: String,
-    mediaAssetsById: Map<String, MediaAsset>
-): List<ReviewRichBlock>? {
-    val matches: List<MatchResult> = reviewManagedMediaReferenceRegex.findAll(input = line).toList()
+): ReviewRenderedContent.ManagedMarkdown? {
+    val matches: List<ReviewManagedMediaMatch> = findReviewManagedMediaMatches(
+        text = text,
+        mediaAssetsById = mediaAssetsById
+    )
     if (matches.isEmpty()) {
         return null
     }
 
-    val blocks: MutableList<ReviewRichBlock> = mutableListOf()
     var currentIndex: Int = 0
-    var didFindManagedMedia: Boolean = false
-
-    matches.forEach { match ->
-        val reference: String = match.groups[3]?.value ?: return@forEach
-        val mediaAssetId: String = parseReviewManagedMediaAssetId(reference = reference) ?: return@forEach
-        val matchStart: Int = match.range.first
-        val matchEndExclusive: Int = match.range.last + 1
-
-        appendReviewManagedMediaTextBlock(
-            text = line.substring(startIndex = currentIndex, endIndex = matchStart),
-            blocks = blocks
-        )
-        blocks += ReviewRichBlock.ManagedMedia(
-            reference = ReviewManagedMediaReference(
-                mediaAssetId = mediaAssetId,
-                label = match.groups[2]?.value?.trim()?.ifEmpty { null },
-                isImageSyntax = match.groups[1] != null,
-                mediaAsset = mediaAssetsById[mediaAssetId]
+    val blocks: List<ReviewManagedMarkdownBlock> = buildList {
+        matches.forEach { match ->
+            val precedingMarkdown: String = text.substring(
+                startIndex = currentIndex,
+                endIndex = match.range.first
             )
-        )
-        currentIndex = matchEndExclusive
-        didFindManagedMedia = true
+            if (precedingMarkdown.isNotBlank()) {
+                add(ReviewManagedMarkdownBlock.Markdown(markdown = precedingMarkdown))
+            }
+            add(ReviewManagedMarkdownBlock.ManagedMedia(reference = match.reference))
+            currentIndex = match.range.last + 1
+        }
+
+        val trailingMarkdown: String = text.substring(startIndex = currentIndex)
+        if (trailingMarkdown.isNotBlank()) {
+            add(ReviewManagedMarkdownBlock.Markdown(markdown = trailingMarkdown))
+        }
     }
 
-    if (didFindManagedMedia.not()) {
-        return null
-    }
-
-    appendReviewManagedMediaTextBlock(
-        text = line.substring(startIndex = currentIndex),
-        blocks = blocks
-    )
-    return blocks
+    return ReviewRenderedContent.ManagedMarkdown(blocks = blocks)
 }
 
-private fun appendReviewManagedMediaTextBlock(
+private fun findReviewManagedMediaMatches(
     text: String,
-    blocks: MutableList<ReviewRichBlock>
-) {
-    if (text.trim().isEmpty()) {
-        return
-    }
+    mediaAssetsById: Map<String, MediaAsset>
+): List<ReviewManagedMediaMatch> {
+    return buildList {
+        var activeFenceMarker: String? = null
+        var lineStart: Int = 0
 
-    blocks += ReviewRichBlock.Paragraph(
-        segments = parseInlineSegments(text = text)
-    )
-}
-
-private fun parseInlineSegments(text: String): List<ReviewInlineSegment> {
-    if (text.contains('`').not()) {
-        return listOf(
-            ReviewInlineSegment(
-                text = text,
-                isCode = false
-            )
-        )
-    }
-
-    val segments: MutableList<ReviewInlineSegment> = mutableListOf()
-    val currentText: StringBuilder = StringBuilder()
-    var isInsideCode: Boolean = false
-
-    text.forEach { character ->
-        if (character == '`') {
-            if (currentText.isNotEmpty()) {
-                segments += ReviewInlineSegment(
-                    text = currentText.toString(),
-                    isCode = isInsideCode
-                )
-                currentText.clear()
+        while (lineStart <= text.length) {
+            val lineEnd: Int = text.indexOfAny(
+                chars = charArrayOf('\r', '\n'),
+                startIndex = lineStart
+            ).let { index ->
+                if (index < 0) text.length else index
             }
-            isInsideCode = isInsideCode.not()
-        } else {
-            currentText.append(character)
-        }
-    }
+            val line: String = text.substring(startIndex = lineStart, endIndex = lineEnd)
+            val fenceMarker: String? = reviewFenceMarker(line = line)
+            val currentFenceMarker: String? = activeFenceMarker
 
-    if (currentText.isNotEmpty()) {
-        segments += ReviewInlineSegment(
-            text = currentText.toString(),
-            isCode = isInsideCode
-        )
-    }
-
-    return if (segments.isEmpty()) {
-        listOf(
-            ReviewInlineSegment(
-                text = text,
-                isCode = false
-            )
-        )
-    } else {
-        segments
-    }
-}
-
-fun reviewRenderedContentDebugText(content: ReviewRenderedContent): String {
-    return when (content) {
-        is ReviewRenderedContent.ShortPlain -> content.text
-        is ReviewRenderedContent.ParagraphPlain -> content.text
-        is ReviewRenderedContent.Rich -> content.blocks.joinToString(separator = "\n") { block ->
-            when (block) {
-                is ReviewRichBlock.Paragraph -> inlineSegmentsDebugText(segments = block.segments)
-                is ReviewRichBlock.Heading -> inlineSegmentsDebugText(segments = block.segments)
-                is ReviewRichBlock.BulletList -> block.items.joinToString(separator = "\n") { item ->
-                    inlineSegmentsDebugText(segments = item)
+            if (currentFenceMarker != null) {
+                if (isReviewFenceClosingLine(line = line, openingMarker = currentFenceMarker)) {
+                    activeFenceMarker = null
                 }
-
-                is ReviewRichBlock.Quote -> inlineSegmentsDebugText(segments = block.segments)
-                is ReviewRichBlock.CodeBlock -> block.code
-                is ReviewRichBlock.ManagedMedia -> block.reference.label.orEmpty()
+            } else if (fenceMarker != null) {
+                activeFenceMarker = fenceMarker
+            } else {
+                reviewManagedMediaReferenceRegex.findAll(input = line).forEach { match ->
+                    val rawReference: String = match.groups[3]?.value ?: return@forEach
+                    val mediaAssetId: String = parseReviewManagedMediaAssetId(
+                        reference = rawReference
+                    ) ?: return@forEach
+                    add(
+                        ReviewManagedMediaMatch(
+                            range = (lineStart + match.range.first)..(lineStart + match.range.last),
+                            reference = ReviewManagedMediaReference(
+                                mediaAssetId = mediaAssetId,
+                                label = match.groups[2]?.value?.trim()?.ifEmpty { null },
+                                isImageSyntax = match.groups[1] != null,
+                                mediaAsset = mediaAssetsById[mediaAssetId]
+                            )
+                        )
+                    )
+                }
             }
-        }
-    }
-}
 
-private fun inlineSegmentsDebugText(segments: List<ReviewInlineSegment>): String {
-    return buildString {
-        segments.forEach { segment ->
-            append(segment.text)
+            if (lineEnd == text.length) {
+                break
+            }
+            lineStart = if (text[lineEnd] == '\r' &&
+                lineEnd + 1 < text.length &&
+                text[lineEnd + 1] == '\n'
+            ) {
+                lineEnd + 2
+            } else {
+                lineEnd + 1
+            }
         }
     }
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMarkdownText.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMarkdownText.kt
@@ -1,0 +1,165 @@
+package com.flashcardsopensourceapp.feature.review
+
+import android.net.Uri
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
+import com.mikepenz.markdown.m3.Markdown
+import com.mikepenz.markdown.m3.markdownColor
+import com.mikepenz.markdown.m3.markdownTypography
+import com.mikepenz.markdown.model.ImageData
+import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownPadding
+
+private val reviewMarkdownLoadingIndicatorSize = 24.dp
+private val reviewMarkdownLoadingMinimumHeight = 48.dp
+
+private object ReviewNetworkImageTransformer : ImageTransformer {
+    @Composable
+    override fun transform(link: String): ImageData? {
+        if (isSupportedReviewMarkdownExternalUrl(url = link).not()) {
+            return null
+        }
+
+        return Coil3ImageTransformerImpl.transform(link = link)
+    }
+
+    @Composable
+    override fun intrinsicSize(painter: Painter): Size {
+        return Coil3ImageTransformerImpl.intrinsicSize(painter = painter)
+    }
+}
+
+@Composable
+internal fun ReviewMarkdownText(
+    markdown: String,
+    modifier: Modifier
+) {
+    val platformUriHandler: UriHandler = LocalUriHandler.current
+    val reviewUriHandler: UriHandler = remember(platformUriHandler) {
+        makeReviewMarkdownUriHandler(platformUriHandler = platformUriHandler)
+    }
+
+    CompositionLocalProvider(LocalUriHandler provides reviewUriHandler) {
+        key(markdown) {
+            Markdown(
+                content = markdown,
+                colors = markdownColor(
+                    text = MaterialTheme.colorScheme.onSurface,
+                    codeBackground = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    inlineCodeBackground = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    dividerColor = MaterialTheme.colorScheme.outlineVariant,
+                    tableBackground = MaterialTheme.colorScheme.surfaceContainer
+                ),
+                typography = markdownTypography(
+                    h1 = MaterialTheme.typography.headlineSmall,
+                    h2 = MaterialTheme.typography.titleLarge,
+                    h3 = MaterialTheme.typography.titleMedium,
+                    h4 = MaterialTheme.typography.titleMedium,
+                    h5 = MaterialTheme.typography.titleMedium,
+                    h6 = MaterialTheme.typography.titleMedium,
+                    text = MaterialTheme.typography.bodyLarge,
+                    code = MaterialTheme.typography.bodyMedium.copy(
+                        fontFamily = FontFamily.Monospace
+                    ),
+                    inlineCode = MaterialTheme.typography.bodyLarge.copy(
+                        fontFamily = FontFamily.Monospace
+                    ),
+                    quote = MaterialTheme.typography.bodyLarge,
+                    paragraph = MaterialTheme.typography.bodyLarge,
+                    ordered = MaterialTheme.typography.bodyLarge,
+                    bullet = MaterialTheme.typography.bodyLarge,
+                    list = MaterialTheme.typography.bodyLarge,
+                    textLink = TextLinkStyles(
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.SemiBold,
+                            textDecoration = TextDecoration.Underline
+                        ).toSpanStyle()
+                    ),
+                    table = MaterialTheme.typography.bodyMedium
+                ),
+                modifier = modifier.fillMaxWidth(),
+                padding = markdownPadding(
+                    block = 8.dp,
+                    list = 4.dp,
+                    listItemTop = 4.dp,
+                    listItemBottom = 4.dp,
+                    listIndent = 20.dp,
+                    codeBlock = PaddingValues(12.dp),
+                    blockQuote = PaddingValues(horizontal = 16.dp),
+                    blockQuoteText = PaddingValues(vertical = 4.dp),
+                    blockQuoteBar = PaddingValues.Absolute(
+                        left = 4.dp,
+                        top = 2.dp,
+                        right = 4.dp,
+                        bottom = 2.dp
+                    )
+                ),
+                dimens = markdownDimens(
+                    dividerThickness = 1.dp,
+                    codeBackgroundCornerSize = 12.dp,
+                    blockQuoteThickness = 4.dp,
+                    tableMaxWidth = Dp.Unspecified,
+                    tableCellWidth = 140.dp,
+                    tableCellPadding = 12.dp,
+                    tableCornerSize = 12.dp
+                ),
+                imageTransformer = ReviewNetworkImageTransformer,
+                loading = { loadingModifier ->
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = loadingModifier
+                            .fillMaxWidth()
+                            .heightIn(min = reviewMarkdownLoadingMinimumHeight)
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(reviewMarkdownLoadingIndicatorSize)
+                        )
+                    }
+                }
+            )
+        }
+    }
+}
+
+private fun makeReviewMarkdownUriHandler(
+    platformUriHandler: UriHandler
+): UriHandler {
+    return object : UriHandler {
+        override fun openUri(uri: String) {
+            require(isSupportedReviewMarkdownExternalUrl(url = uri)) {
+                "Review Markdown links must use an absolute HTTPS URL: $uri"
+            }
+            platformUriHandler.openUri(uri = uri)
+        }
+    }
+}
+
+private fun isSupportedReviewMarkdownExternalUrl(url: String): Boolean {
+    val uri: Uri = Uri.parse(url)
+    return uri.scheme.equals(other = "https", ignoreCase = true) &&
+        uri.host.isNullOrBlank().not()
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
@@ -1,24 +1,13 @@
 package com.flashcardsopensourceapp.feature.review
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
@@ -47,141 +36,35 @@ fun ReviewRenderedContentView(
             )
         }
 
-        is ReviewRenderedContent.Rich -> {
-            val contentColor: Color = MaterialTheme.colorScheme.onSurface
+        is ReviewRenderedContent.Markdown -> {
+            ReviewMarkdownText(
+                markdown = content.markdown,
+                modifier = modifier.fillMaxWidth()
+            )
+        }
 
+        is ReviewRenderedContent.ManagedMarkdown -> {
             Column(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = modifier.fillMaxWidth()
             ) {
-                content.blocks.forEach { block ->
-                    when (block) {
-                        is ReviewRichBlock.Paragraph -> InlineSegmentsText(
-                            segments = block.segments,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = contentColor,
-                            modifier = Modifier
-                        )
-
-                        is ReviewRichBlock.Heading -> InlineSegmentsText(
-                            segments = block.segments,
-                            style = when (block.level) {
-                                1 -> MaterialTheme.typography.headlineSmall
-                                2 -> MaterialTheme.typography.titleLarge
-                                else -> MaterialTheme.typography.titleMedium
-                            },
-                            color = contentColor,
-                            modifier = Modifier
-                        )
-
-                        is ReviewRichBlock.BulletList -> Column(
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            block.items.forEachIndexed { index, item ->
-                                Row(
-                                    modifier = Modifier.fillMaxWidth()
-                                ) {
-                                    Text(
-                                        text = if (block.ordered) "${index + 1}." else "•",
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = contentColor,
-                                        modifier = Modifier.padding(end = 8.dp)
-                                    )
-                                    InlineSegmentsText(
-                                        segments = item,
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = contentColor,
-                                        modifier = Modifier.weight(weight = 1f)
-                                    )
-                                }
-                            }
-                        }
-
-                        is ReviewRichBlock.Quote -> Row(
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .padding(end = 12.dp)
-                                    .background(
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                    .padding(horizontal = 2.dp, vertical = 24.dp)
+                content.blocks.forEachIndexed { index, block ->
+                    key(index) {
+                        when (block) {
+                            is ReviewManagedMarkdownBlock.Markdown -> ReviewMarkdownText(
+                                markdown = block.markdown,
+                                modifier = Modifier.fillMaxWidth()
                             )
-                            InlineSegmentsText(
-                                segments = block.segments,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = contentColor,
-                                modifier = Modifier.weight(weight = 1f)
+
+                            is ReviewManagedMarkdownBlock.ManagedMedia -> ReviewManagedMediaContent(
+                                reference = block.reference,
+                                onLoadManagedMediaFile = onLoadManagedMediaFile,
+                                onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
                             )
                         }
-
-                        is ReviewRichBlock.CodeBlock -> Column(
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(
-                                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                                    shape = MaterialTheme.shapes.medium
-                                )
-                                .padding(12.dp)
-                        ) {
-                            if (block.languageLabel != null) {
-                                Text(
-                                    text = block.languageLabel,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                            }
-                            Text(
-                                text = block.code,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontFamily = FontFamily.Monospace,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .horizontalScroll(state = rememberScrollState())
-                            )
-                        }
-
-                        is ReviewRichBlock.ManagedMedia -> ReviewManagedMediaContent(
-                            reference = block.reference,
-                            onLoadManagedMediaFile = onLoadManagedMediaFile,
-                            onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
-                        )
                     }
                 }
             }
         }
     }
-}
-
-@Composable
-private fun InlineSegmentsText(
-    segments: List<ReviewInlineSegment>,
-    style: TextStyle,
-    color: Color,
-    modifier: Modifier
-) {
-    val codeStyle = SpanStyle(
-        fontFamily = FontFamily.Monospace,
-        background = MaterialTheme.colorScheme.surfaceContainerHighest
-    )
-
-    Text(
-        text = buildAnnotatedString {
-            segments.forEach { segment ->
-                if (segment.isCode) {
-                    pushStyle(codeStyle)
-                    append(segment.text)
-                    pop()
-                } else {
-                    append(segment.text)
-                }
-            }
-        },
-        style = style,
-        color = color,
-        modifier = modifier
-    )
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewSpeakableText.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewSpeakableText.kt
@@ -14,9 +14,10 @@ fun makeReviewSpeakableText(text: String): String {
 
         text.lines().forEach { line ->
             val fenceMarker: String? = reviewFenceMarker(line = line)
+            val currentFenceMarker: String? = activeFenceMarker
 
-            if (activeFenceMarker != null) {
-                if (fenceMarker == activeFenceMarker) {
+            if (currentFenceMarker != null) {
+                if (isReviewFenceClosingLine(line = line, openingMarker = currentFenceMarker)) {
                     activeFenceMarker = null
                 }
                 return@forEach
@@ -35,11 +36,6 @@ fun makeReviewSpeakableText(text: String): String {
     }
 
     return normalizeReviewSpeakableText(lines = speakableLines)
-}
-
-private fun reviewFenceMarker(line: String): String? {
-    val match: MatchResult? = reviewFenceRegex.matchEntire(line.trim())
-    return match?.groups?.get(index = 1)?.value
 }
 
 private fun normalizeReviewSpeakableMarkdownLine(line: String): String {

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ navigationCompose = "2.9.8"
 composeBom = "2026.06.01"
 lottieCompose = "6.7.1"
 coil = "3.5.0"
+markdownRenderer = "0.43.0"
 room = "2.8.4"
 work = "2.11.2"
 adaptive = "1.2.0"
@@ -55,6 +56,9 @@ androidx-compose-adaptive-navigation-suite = { group = "androidx.compose.materia
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottieCompose" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+markdown-renderer = { group = "com.mikepenz", name = "multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
+markdown-renderer-m3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
+markdown-renderer-coil3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-coil3", version.ref = "markdownRenderer" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary
- replace the handwritten Android review Markdown parser/renderer with the pinned multiplatform Markdown renderer
- keep managed `fcasset:` media on the existing offline media path
- add Material 3 styling, HTTPS-only external links/images, and asynchronous loading feedback

## Validation
- `git diff --check`
- confirmed old handwritten renderer symbols have no remaining references
- confirmed all pinned 0.43.0 Maven artifacts are available
- inspected the pinned public API/source
- fresh review found no P0-P4 findings
- local Gradle and API 36 emulator validation intentionally not run per user direction; rely on Android CI and later device validation