### PR TITLE
Enable managed media for chat worker

### DIFF
--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -21,6 +21,16 @@ function loadApiGatewaySource(): string {
   return readFileSync(apiGatewayPath, "utf8");
 }
 
+function getBackendFunctionConfiguration(apiGatewaySource: string, constructId: string): string {
+  const configurationStart = apiGatewaySource.indexOf(`constructId: "${constructId}"`);
+  assert.notEqual(configurationStart, -1, `Missing ${constructId} configuration`);
+
+  const configurationEnd = apiGatewaySource.indexOf("\n  });", configurationStart);
+  assert.notEqual(configurationEnd, -1, `Missing ${constructId} configuration end`);
+
+  return apiGatewaySource.slice(configurationStart, configurationEnd);
+}
+
 function assertApiGatewayUsesBackendProxy(apiGatewaySource: string): void {
   assert.match(
     apiGatewaySource,
@@ -55,13 +65,19 @@ test("API Gateway proxy accepts browser-safe binary bodies", () => {
   );
 });
 
-test("Backend API Lambda packages sharp with ARM64 Docker bundling only on the API handler", () => {
-  const apiGatewayPath = resolve(process.cwd(), "lib/gateways/api-gateway.ts");
-  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+test("backend API and chat worker package sharp with ARM64 Docker bundling and managed media access", () => {
+  const apiGatewaySource = loadApiGatewaySource();
+  const backendConfiguration = getBackendFunctionConfiguration(apiGatewaySource, "BackendHandler");
+  const chatWorkerConfiguration = getBackendFunctionConfiguration(apiGatewaySource, "ChatRunWorkerHandler");
+  const chatLiveConfiguration = getBackendFunctionConfiguration(apiGatewaySource, "ChatLiveHandler");
 
   assert.match(
-    apiGatewaySource,
-    /constructId: "BackendHandler"[\s\S]*architecture: lambda\.Architecture\.ARM_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
+    backendConfiguration,
+    /mediaAssetsBucket: props\.mediaAssetsBucket[\s\S]*memorySize: 1024[\s\S]*architecture: lambda\.Architecture\.ARM_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
+  );
+  assert.match(
+    chatWorkerConfiguration,
+    /mediaAssetsBucket: props\.mediaAssetsBucket[\s\S]*memorySize: 1024[\s\S]*architecture: lambda\.Architecture\.ARM_64[\s\S]*nodeModules: \["sharp"\][\s\S]*forceDockerBundling: true/,
   );
   assert.match(
     apiGatewaySource,
@@ -71,13 +87,15 @@ test("Backend API Lambda packages sharp with ARM64 Docker bundling only on the A
     apiGatewaySource,
     /SENTRY_BACKEND_CLI_PATH: `\$\{dockerBundlingRepoRootPath\}\/apps\/backend\/node_modules\/\.bin\/sentry-cli`/,
   );
+  assert.equal(apiGatewaySource.match(/mediaAssetsBucket: props\.mediaAssetsBucket/g)?.length, 2);
+  assert.equal(apiGatewaySource.match(/nodeModules: \["sharp"\]/g)?.length, 2);
   assert.doesNotMatch(
-    apiGatewaySource,
-    /constructId: "ChatRunWorkerHandler"[\s\S]*nodeModules: \["sharp"\]/,
+    chatLiveConfiguration,
+    /mediaAssetsBucket: props\.mediaAssetsBucket/,
   );
   assert.doesNotMatch(
-    apiGatewaySource,
-    /constructId: "ChatLiveHandler"[\s\S]*nodeModules: \["sharp"\]/,
+    chatLiveConfiguration,
+    /nodeModules: \["sharp"\]/,
   );
 });
 

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -673,12 +673,12 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
-    mediaAssetsBucket: undefined,
-    memorySize: 512,
-    architecture: lambda.Architecture.X86_64,
+    mediaAssetsBucket: props.mediaAssetsBucket,
+    memorySize: 1024,
+    architecture: lambda.Architecture.ARM_64,
     bundling: createLambdaBundling({
-      nodeModules: [],
-      forceDockerBundling: false,
+      nodeModules: ["sharp"],
+      forceDockerBundling: true,
     }),
   });
   const chatLiveFn = createBackendFunction(scope, {


### PR DESCRIPTION
## Summary
- grant the detached chat worker the existing managed-media bucket capability
- use the proven ARM64, 1024 MB, Docker-bundled Sharp runtime
- keep the live chat handler isolated from Sharp and media permissions

## Validation
- git diff --check
- npm run build --prefix infra/aws
- npm test --prefix infra/aws (32/32 passed)

No local CDK synth, diff, or deploy was run.