### PR TITLE
Present generated image tool across clients

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/strings/AiStrings.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/strings/AiStrings.kt
@@ -66,6 +66,7 @@ data class AiTextProvider(
     val filesSettingsMessage: String,
     val toolSql: String,
     val toolCodeExecution: String,
+    val toolGeneratedCardImage: String,
     val toolWebSearch: String,
     val toolRunning: String,
     val toolDone: String,
@@ -149,6 +150,7 @@ data class AiTextProvider(
         return when (name) {
             "sql" -> toolSql
             "code_execution", "code_interpreter" -> toolCodeExecution
+            "add_generated_image_to_card" -> toolGeneratedCardImage
             "web_search" -> toolWebSearch
             else -> name
         }
@@ -247,6 +249,7 @@ fun aiTextProvider(context: Context): AiTextProvider {
         filesSettingsMessage = context.getString(R.string.ai_alert_files_message),
         toolSql = context.getString(R.string.ai_tool_sql),
         toolCodeExecution = context.getString(R.string.ai_tool_code_execution),
+        toolGeneratedCardImage = context.getString(R.string.ai_tool_generated_card_image),
         toolWebSearch = context.getString(R.string.ai_tool_web_search),
         toolRunning = context.getString(R.string.ai_tool_running),
         toolDone = context.getString(R.string.ai_tool_done),
@@ -315,6 +318,7 @@ fun testAiTextProvider(): AiTextProvider {
         filesSettingsMessage = "File access is turned off for Flashcards Open Source App. Open Settings to allow it.",
         toolSql = "SQL",
         toolCodeExecution = "Code execution",
+        toolGeneratedCardImage = "Generate card image",
         toolWebSearch = "Web search",
         toolRunning = "Running",
         toolDone = "Done",

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/toolcall/AiToolCallPresentation.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/toolcall/AiToolCallPresentation.kt
@@ -13,12 +13,17 @@ fun formatAiToolLabel(name: String, textProvider: AiTextProvider): String {
     return when (name) {
         "sql" -> textProvider.toolSql
         "code_execution", "code_interpreter" -> textProvider.toolCodeExecution
+        "add_generated_image_to_card" -> textProvider.toolGeneratedCardImage
         "web_search" -> textProvider.toolWebSearch
         else -> name
     }
 }
 
 fun formatAiToolCallPreview(name: String, input: String?): String? {
+    if (name == "add_generated_image_to_card") {
+        return null
+    }
+
     if (input == null || input.trim().isEmpty()) {
         return null
     }

--- a/apps/android/feature/ai/src/main/res/values/strings.xml
+++ b/apps/android/feature/ai/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="ai_tool_label">Tool: %1$s</string>
     <string name="ai_tool_sql">SQL</string>
     <string name="ai_tool_code_execution">Code execution</string>
+    <string name="ai_tool_generated_card_image">Generate card image</string>
     <string name="ai_tool_web_search">Web search</string>
     <string name="ai_tool_running">Running</string>
     <string name="ai_tool_done">Done</string>

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatToolPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatToolPresentation.swift
@@ -23,6 +23,8 @@ func aiChatToolLabel(name: String) -> String {
         return "SQL"
     case "code_execution", "code_interpreter":
         return aiSettingsLocalized("ai.tool.label.codeExecution", "Code execution")
+    case "add_generated_image_to_card":
+        return aiSettingsLocalized("ai.tool.label.generatedCardImage", "Generate card image")
     case "web_search":
         return aiSettingsLocalized("ai.tool.label.webSearch", "Web search")
     default:
@@ -31,6 +33,10 @@ func aiChatToolLabel(name: String) -> String {
 }
 
 func aiChatToolPreview(name: String, input: String?) -> String? {
+    if name == "add_generated_image_to_card" {
+        return nil
+    }
+
     guard let input, input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
         return nil
     }

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "عرض الرد الكامل";
 "ai.message.fullResponse.title" = "الرد الكامل";
 "ai.tool.label.codeExecution" = "تنفيذ التعليمات البرمجية";
+"ai.tool.label.generatedCardImage" = "إنشاء صورة للبطاقة";
 "ai.tool.label.webSearch" = "بحث الويب";
 "ai.tool.section.request" = "التطبيق";
 "ai.tool.section.response" = "الإجابة";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "Vollständige Antwort anzeigen";
 "ai.message.fullResponse.title" = "Vollständige Antwort";
 "ai.tool.label.codeExecution" = "Codeausführung";
+"ai.tool.label.generatedCardImage" = "Kartenbild erstellen";
 "ai.tool.label.webSearch" = "Websuche";
 "ai.tool.section.request" = "Anwendung";
 "ai.tool.section.response" = "Antwort";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "Mostrar respuesta completa";
 "ai.message.fullResponse.title" = "Respuesta completa";
 "ai.tool.label.codeExecution" = "Ejecucion de codigo";
+"ai.tool.label.generatedCardImage" = "Generar imagen de tarjeta";
 "ai.tool.label.webSearch" = "Busqueda web";
 "ai.tool.section.request" = "Solicitud";
 "ai.tool.section.response" = "Respuesta";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "Mostrar respuesta completa";
 "ai.message.fullResponse.title" = "Respuesta completa";
 "ai.tool.label.codeExecution" = "Ejecucion de codigo";
+"ai.tool.label.generatedCardImage" = "Generar imagen de tarjeta";
 "ai.tool.label.webSearch" = "Busqueda web";
 "ai.tool.section.request" = "Solicitud";
 "ai.tool.section.response" = "Respuesta";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "पूरा जवाब दिखाएँ";
 "ai.message.fullResponse.title" = "पूरा जवाब";
 "ai.tool.label.codeExecution" = "कोड निष्पादन";
+"ai.tool.label.generatedCardImage" = "कार्ड की छवि बनाएँ";
 "ai.tool.label.webSearch" = "वेब खोज";
 "ai.tool.section.request" = "एप्लीकेशन";
 "ai.tool.section.response" = "उत्तर";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "回答をすべて表示";
 "ai.message.fullResponse.title" = "回答全文";
 "ai.tool.label.codeExecution" = "コードの実行";
+"ai.tool.label.generatedCardImage" = "カード画像を生成";
 "ai.tool.label.webSearch" = "ウェブ検索";
 "ai.tool.section.request" = "アプリケーション";
 "ai.tool.section.response" = "答え";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "Показать ответ полностью";
 "ai.message.fullResponse.title" = "Полный ответ";
 "ai.tool.label.codeExecution" = "Выполнение кода";
+"ai.tool.label.generatedCardImage" = "Создать изображение карточки";
 "ai.tool.label.webSearch" = "Веб-поиск";
 "ai.tool.section.request" = "Приложение";
 "ai.tool.section.response" = "Ответ";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -86,6 +86,7 @@
 "ai.message.fullResponse.show" = "显示完整回复";
 "ai.message.fullResponse.title" = "完整回复";
 "ai.tool.label.codeExecution" = "代码执行";
+"ai.tool.label.generatedCardImage" = "生成卡片图片";
 "ai.tool.label.webSearch" = "网页搜索";
 "ai.tool.section.request" = "应用";
 "ai.tool.section.response" = "答案";

--- a/apps/web/src/chat/history/chatMessageContent.tsx
+++ b/apps/web/src/chat/history/chatMessageContent.tsx
@@ -19,6 +19,7 @@ type ChatMessageTechnicalErrorHandler = (error: unknown) => boolean;
 export function formatToolLabel(name: string, t: Translate): string {
   if (name === "sql") return t("chatMessageContent.toolLabels.sql");
   if (name === "code_execution" || name === "code_interpreter") return t("chatMessageContent.toolLabels.codeExecution");
+  if (name === "add_generated_image_to_card") return t("chatMessageContent.toolLabels.generatedCardImage");
   if (name === "web_search") return t("chatMessageContent.toolLabels.webSearch");
   return name;
 }
@@ -29,6 +30,10 @@ export function formatToolLabel(name: string, t: Translate): string {
  * - `apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/toolcall/AiToolCallPresentation.kt::formatAiToolCallPreview`
  */
 function extractToolCallPreview(name: string, input: string | null): string | null {
+  if (name === "add_generated_image_to_card") {
+    return null;
+  }
+
   if (input === null || input.trim() === "") {
     return null;
   }

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -1182,6 +1182,7 @@ const arCatalog: TranslationCatalog = {
     thinking: "جارٍ التفكير...",
     toolLabels: {
       codeExecution: "تنفيذ الكود",
+      generatedCardImage: "إنشاء صورة للبطاقة",
       sql: "SQL",
       webSearch: "بحث الويب",
     },

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -1182,6 +1182,7 @@ const deCatalog: TranslationCatalog = {
     thinking: "Denkt nach...",
     toolLabels: {
       codeExecution: "Codeausführung",
+      generatedCardImage: "Kartenbild erstellen",
       sql: "SQL",
       webSearch: "Websuche",
     },

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -1180,6 +1180,7 @@ const enCatalog = {
     thinking: "Thinking...",
     toolLabels: {
       codeExecution: "Code execution",
+      generatedCardImage: "Generate card image",
       sql: "SQL",
       webSearch: "Web search",
     },

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -1182,6 +1182,7 @@ const esEsCatalog: TranslationCatalog = {
     thinking: "Pensando...",
     toolLabels: {
       codeExecution: "Ejecución de código",
+      generatedCardImage: "Generar imagen de tarjeta",
       sql: "SQL",
       webSearch: "Búsqueda web",
     },

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -1182,6 +1182,7 @@ const esMxCatalog: TranslationCatalog = {
     thinking: "Pensando...",
     toolLabels: {
       codeExecution: "Ejecución de código",
+      generatedCardImage: "Generar imagen de tarjeta",
       sql: "SQL",
       webSearch: "Búsqueda web",
     },

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -1182,6 +1182,7 @@ const hiCatalog: TranslationCatalog = {
     thinking: "सोच रहा है...",
     toolLabels: {
       codeExecution: "कोड निष्पादन",
+      generatedCardImage: "कार्ड की छवि बनाएँ",
       sql: "SQL",
       webSearch: "वेब खोज",
     },

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -1182,6 +1182,7 @@ export const jaCatalog = {
     thinking: "考え中...",
     toolLabels: {
       codeExecution: "コード実行",
+      generatedCardImage: "カード画像を生成",
       sql: "SQL",
       webSearch: "Web 検索",
     },

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -1182,6 +1182,7 @@ export const ruCatalog = {
     thinking: "Думает...",
     toolLabels: {
       codeExecution: "Выполнение кода",
+      generatedCardImage: "Создать изображение карточки",
       sql: "SQL",
       webSearch: "Веб-поиск",
     },

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -1182,6 +1182,7 @@ export const zhHansCatalog = {
     thinking: "思考中...",
     toolLabels: {
       codeExecution: "代码执行",
+      generatedCardImage: "生成卡片图片",
       sql: "SQL",
       webSearch: "网页搜索",
     },


### PR DESCRIPTION
## Summary

- map add_generated_image_to_card to a localized label on web, iOS, and Android
- suppress raw generated-image tool input from collapsed transcript summaries
- preserve expanded request/response details and unknown-tool fallbacks

## Validation

- git diff --check
- plutil -lint for all 8 changed iOS AISettings.strings files
- npm run build --prefix apps/web
- npm test --prefix apps/web (77 files, 607 tests)
- localization completeness: web 9/9, iOS 8/8

Gradle and iOS simulator-backed tests were intentionally not run per repository policy; Android CI and Xcode Cloud provide native compilation checks.