### PR TITLE
Atomic card image append

### DIFF
--- a/apps/backend/src/cards/generatedImageAppend.postgres.integration.ts
+++ b/apps/backend/src/cards/generatedImageAppend.postgres.integration.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import { HttpError } from "../shared/errors";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import { appendManagedImageToCardSideInExecutor } from "./index";
+import type { AppendManagedImageToCardSideInput, AppendManagedImageToCardSideResult } from "./types";
+
+const futureClientUpdatedAt = "2099-01-01T00:00:00.000Z";
+const expectedGeneratedClientUpdatedAt = "2099-01-01T00:00:00.001Z";
+
+type BackendPidRow = Readonly<{ backend_pid: number }>;
+type BlockingPidsRow = Readonly<{ blocking_pids: ReadonlyArray<number> }>;
+type CountRow = Readonly<{ count: string }>;
+type PersistedCardRow = Readonly<{
+  front_text: string;
+  back_text: string;
+  client_updated_at: Date;
+  last_modified_by_replica_id: string;
+  last_operation_id: string;
+  updated_at: Date;
+  row_version: string;
+}>;
+type PersistedHotChangeRow = Readonly<{
+  entity_type: string;
+  entity_id: string;
+  replica_id: string;
+  operation_id: string;
+  client_updated_at: Date;
+}>;
+
+function createClientExecutor(client: pg.PoolClient): DatabaseExecutor {
+  return {
+    query<Row extends pg.QueryResultRow>(text: string, params: ReadonlyArray<SqlValue>): Promise<pg.QueryResult<Row>> {
+      return client.query<Row>(text, [...params]);
+    },
+  };
+}
+
+async function beginWorkspaceTransaction(
+  client: pg.PoolClient,
+  userId: string,
+  workspaceId: string,
+): Promise<void> {
+  await client.query("BEGIN");
+  await client.query(
+    "SELECT set_config('app.user_id', $1, true), set_config('app.workspace_id', $2, true)",
+    [userId, workspaceId],
+  );
+}
+
+async function withRuntimeTransaction<Result>(
+  fixture: PostgresIntegrationFixture,
+  workspaceId: string,
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+): Promise<Result> {
+  const client = await fixture.runtimePool.connect();
+  try {
+    await beginWorkspaceTransaction(client, fixture.userId, workspaceId);
+    const result = await callback(createClientExecutor(client));
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function loadBackendPid(client: pg.PoolClient): Promise<number> {
+  const result = await client.query<BackendPidRow>("SELECT pg_backend_pid() AS backend_pid");
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error("PostgreSQL did not return a backend pid for the integration client.");
+  }
+  return row.backend_pid;
+}
+
+async function waitForCardLockBlock(
+  fixture: PostgresIntegrationFixture,
+  blockedPid: number,
+  blockingPid: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const result = await fixture.ownerPool.query<BlockingPidsRow>(
+      "SELECT pg_blocking_pids($1) AS blocking_pids",
+      [blockedPid],
+    );
+    if (result.rows[0]?.blocking_pids.includes(blockingPid) === true) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(
+    `Card append backend ${blockedPid} did not block behind editor backend ${blockingPid}.`,
+  );
+}
+
+async function loadPersistedCard(fixture: PostgresIntegrationFixture): Promise<PersistedCardRow> {
+  const result = await fixture.ownerPool.query<PersistedCardRow>(
+    [
+      "SELECT front_text, back_text, client_updated_at, last_modified_by_replica_id,",
+      "last_operation_id, updated_at, xmin::text AS row_version",
+      "FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
+    ].join(" "),
+    [fixture.workspaceId, fixture.cardId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Fixture card was not found. cardId=${fixture.cardId}`);
+  }
+  return row;
+}
+
+async function countCardHotChanges(fixture: PostgresIntegrationFixture): Promise<number> {
+  const result = await fixture.ownerPool.query<CountRow>(
+    [
+      "SELECT count(*)::text AS count FROM sync.hot_changes",
+      "WHERE workspace_id = $1 AND entity_type = 'card' AND entity_id = $2",
+    ].join(" "),
+    [fixture.workspaceId, fixture.cardId],
+  );
+  return Number.parseInt(result.rows[0]?.count ?? "", 10);
+}
+
+test("card image append is atomic, lock-safe, RLS-scoped, and duplicate-free", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    await withRuntimeTransaction(fixture, fixture.outOfScopeWorkspaceId, async (executor) => {
+      const result = await executor.query<{ card_id: string }>(
+        "SELECT card_id FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
+        [fixture.workspaceId, fixture.cardId],
+      );
+      assert.equal(result.rows.length, 0);
+    });
+
+    const validInput: AppendManagedImageToCardSideInput = {
+      cardId: fixture.cardId,
+      targetSide: "back",
+      mediaAssetId: fixture.mediaAssetId,
+      altText: "Generated image",
+    };
+    const appendMetadata = {
+      clientUpdatedAt: fixture.createdAt,
+      lastModifiedByReplicaId: fixture.replicaId,
+      lastOperationId: fixture.operationId,
+    };
+    for (const [input, expectedMessage] of [
+      [{ ...validInput, cardId: "invalid-card-id" }, "cardId must be a UUID"],
+      [{ ...validInput, mediaAssetId: "invalid-media-id" }, "mediaAssetId must be a UUID"],
+    ] as const) {
+      await withRuntimeTransaction(fixture, fixture.workspaceId, async (executor) => {
+        let primitiveQueryCount = 0;
+        const countedExecutor: DatabaseExecutor = {
+          query<Row extends pg.QueryResultRow>(text: string, params: ReadonlyArray<SqlValue>): Promise<pg.QueryResult<Row>> {
+            primitiveQueryCount += 1;
+            return executor.query<Row>(text, params);
+          },
+        };
+        await assert.rejects(
+          appendManagedImageToCardSideInExecutor(countedExecutor, fixture.workspaceId, input, appendMetadata),
+          (error: unknown) => error instanceof HttpError
+            && error.statusCode === 400
+            && error.message === expectedMessage,
+        );
+        assert.equal(primitiveQueryCount, 0);
+      });
+    }
+    assert.equal(await countCardHotChanges(fixture), 0);
+
+    const editorClient = await fixture.runtimePool.connect();
+    const appendClient = await fixture.runtimePool.connect();
+    let editorTransactionOpen = false;
+    let appendTransactionOpen = false;
+    let appendPromise: Promise<AppendManagedImageToCardSideResult> | null = null;
+    let appendResult: AppendManagedImageToCardSideResult;
+    try {
+      await beginWorkspaceTransaction(editorClient, fixture.userId, fixture.workspaceId);
+      editorTransactionOpen = true;
+      await beginWorkspaceTransaction(appendClient, fixture.userId, fixture.workspaceId);
+      appendTransactionOpen = true;
+      const editorPid = await loadBackendPid(editorClient);
+      const appendPid = await loadBackendPid(appendClient);
+
+      await editorClient.query(
+        "SELECT card_id FROM content.cards WHERE workspace_id = $1 AND card_id = $2 FOR UPDATE",
+        [fixture.workspaceId, fixture.cardId],
+      );
+      await editorClient.query(
+        [
+          "UPDATE content.cards SET back_text = $1, client_updated_at = $2,",
+          "last_modified_by_replica_id = $3, last_operation_id = $4, updated_at = now()",
+          "WHERE workspace_id = $5 AND card_id = $6",
+        ].join(" "),
+        [
+          "Concurrent answer edit", futureClientUpdatedAt, fixture.replicaId,
+          fixture.concurrentOperationId, fixture.workspaceId, fixture.cardId,
+        ],
+      );
+
+      appendPromise = appendManagedImageToCardSideInExecutor(
+        createClientExecutor(appendClient),
+        fixture.workspaceId,
+        validInput,
+        appendMetadata,
+      );
+
+      await waitForCardLockBlock(fixture, appendPid, editorPid);
+      await editorClient.query("COMMIT");
+      editorTransactionOpen = false;
+      appendResult = await appendPromise;
+      await appendClient.query("COMMIT");
+      appendTransactionOpen = false;
+    } finally {
+      if (editorTransactionOpen) await editorClient.query("ROLLBACK");
+      if (appendPromise !== null && appendTransactionOpen) {
+        await Promise.allSettled([appendPromise]);
+      }
+      if (appendTransactionOpen) await appendClient.query("ROLLBACK");
+      editorClient.release();
+      appendClient.release();
+    }
+
+    const expectedBackText = [
+      "Concurrent answer edit", "", `![Generated image](fcasset:${fixture.mediaAssetId})`,
+    ].join("\n");
+    assert.equal(appendResult.applied, true);
+    assert.equal(appendResult.card.frontText, "Original question");
+    assert.equal(appendResult.card.backText, expectedBackText);
+    assert.equal(appendResult.card.clientUpdatedAt, expectedGeneratedClientUpdatedAt);
+    assert.equal(appendResult.card.lastModifiedByReplicaId, fixture.replicaId);
+    assert.equal(appendResult.card.lastOperationId, fixture.operationId);
+
+    const persistedCard = await loadPersistedCard(fixture);
+    assert.equal(persistedCard.front_text, "Original question");
+    assert.equal(persistedCard.back_text, expectedBackText);
+    assert.equal(persistedCard.client_updated_at.toISOString(), expectedGeneratedClientUpdatedAt);
+    assert.equal(persistedCard.last_modified_by_replica_id, fixture.replicaId);
+    assert.equal(persistedCard.last_operation_id, fixture.operationId);
+
+    const hotChanges = await fixture.ownerPool.query<PersistedHotChangeRow>(
+      [
+        "SELECT entity_type, entity_id, replica_id, operation_id, client_updated_at",
+        "FROM sync.hot_changes",
+        "WHERE workspace_id = $1 AND entity_type = 'card' AND entity_id = $2",
+      ].join(" "),
+      [fixture.workspaceId, fixture.cardId],
+    );
+    assert.equal(hotChanges.rows.length, 1);
+    const hotChange = hotChanges.rows[0];
+    assert.ok(hotChange);
+    assert.equal(hotChange.entity_type, "card");
+    assert.equal(hotChange.entity_id, fixture.cardId);
+    assert.equal(hotChange.replica_id, fixture.replicaId);
+    assert.equal(hotChange.operation_id, fixture.operationId);
+    assert.equal(hotChange.client_updated_at.toISOString(), expectedGeneratedClientUpdatedAt);
+
+    const duplicateResult = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      async (executor) => appendManagedImageToCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        { ...validInput, altText: "Retry image" },
+        {
+          ...appendMetadata,
+          lastOperationId: fixture.retryOperationId,
+        },
+      ),
+    );
+    assert.equal(duplicateResult.applied, false);
+    assert.equal(duplicateResult.card.backText, expectedBackText);
+    assert.equal(duplicateResult.card.lastOperationId, fixture.operationId);
+    assert.deepEqual(await loadPersistedCard(fixture), persistedCard);
+    assert.equal(await countCardHotChanges(fixture), 1);
+
+    for (const blockedText of ["```markdown\nAnswer", "~~~markdown\nAnswer", "<script>\nAnswer"]) {
+      await fixture.ownerPool.query(
+        "UPDATE content.cards SET back_text = $1 WHERE workspace_id = $2 AND card_id = $3",
+        [blockedText, fixture.workspaceId, fixture.cardId],
+      );
+      const unchangedCard = await loadPersistedCard(fixture);
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const primitiveQueries: Array<string> = [];
+        await assert.rejects(
+          withRuntimeTransaction(fixture, fixture.workspaceId, async (executor) => {
+            const recordingExecutor: DatabaseExecutor = {
+              query<Row extends pg.QueryResultRow>(text: string, params: ReadonlyArray<SqlValue>): Promise<pg.QueryResult<Row>> {
+                primitiveQueries.push(text);
+                return executor.query<Row>(text, params);
+              },
+            };
+            return appendManagedImageToCardSideInExecutor(
+              recordingExecutor, fixture.workspaceId, validInput, appendMetadata,
+            );
+          }),
+          (error: unknown) => error instanceof HttpError
+            && error.statusCode === 409
+            && error.code === "CARD_IMAGE_APPEND_MARKDOWN_BLOCK_UNCLOSED",
+        );
+        assert.equal(primitiveQueries.length, 3);
+        assert.match(primitiveQueries[1] ?? "", /FROM sync\.workspace_sync_metadata.*FOR UPDATE/su);
+        assert.match(primitiveQueries[2] ?? "", /FROM content\.cards.*FOR UPDATE/su);
+        assert.deepEqual(await loadPersistedCard(fixture), unchangedCard);
+        assert.equal(await countCardHotChanges(fixture), 1);
+      }
+    }
+  });
+});

--- a/apps/backend/src/cards/generatedImageAppend.test.ts
+++ b/apps/backend/src/cards/generatedImageAppend.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  appendManagedImageToCardSideInExecutor,
+  appendManagedImageToCardText,
+  buildManagedImageMarkdownReference,
+} from "./index";
+import type { AppendManagedImageToCardSideInput, CardMutationMetadata, CardRow, CardTextSide } from "./types";
+
+const testWorkspaceId = "22222222-2222-4222-8222-222222222222";
+const testCardId = "33333333-3333-4333-8333-333333333333";
+const testReplicaId = "44444444-4444-4444-8444-444444444444";
+const testMediaAssetId = "66666666-6666-4666-8666-666666666666";
+const testTimestamp = "2026-07-23T10:00:00.000Z";
+
+const testMetadata: CardMutationMetadata = {
+  clientUpdatedAt: testTimestamp,
+  lastModifiedByReplicaId: testReplicaId,
+  lastOperationId: "generated-image-card-append",
+};
+
+type QueryRecord = Readonly<{ text: string; params: ReadonlyArray<SqlValue> }>;
+
+function classifyAppendQuery(text: string): string {
+  if (text.includes("INSERT INTO sync.workspace_sync_metadata")) return "ensure-hot-metadata";
+  if (text.includes("FROM sync.workspace_sync_metadata")) return "lock-hot-metadata";
+  if (text.includes("FROM content.cards")) return "lock-card";
+  if (text.includes("UPDATE content.cards")) return "update-card";
+  if (text.includes("INSERT INTO sync.hot_changes")) return "record-hot-change";
+  return "unexpected";
+}
+
+function createQueryResult<Row extends pg.QueryResultRow>(command: string, rows: Array<Row>): pg.QueryResult<Row> {
+  return { command, rowCount: rows.length, oid: 0, fields: [], rows };
+}
+
+function createCardRow(clientUpdatedAt: string): CardRow {
+  return {
+    card_id: testCardId,
+    front_text: "Question",
+    back_text: "Answer",
+    card_type: "basic",
+    metadata: { version: 1, source: null },
+    tags: [],
+    effort_level: "fast",
+    due_at: null,
+    created_at: testTimestamp,
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: clientUpdatedAt,
+    last_modified_by_replica_id: "55555555-5555-4555-8555-555555555555",
+    last_operation_id: "previous-operation",
+    updated_at: clientUpdatedAt,
+    deleted_at: null,
+  };
+}
+
+test("managed image Markdown is canonical and parser-safe", () => {
+  assert.equal(
+    buildManagedImageMarkdownReference(
+      testMediaAssetId.toUpperCase(),
+      "  Diagram [labeled]\r\n path\\\t detail  ",
+    ),
+    `![Diagram (labeled) path＼ detail](fcasset:${testMediaAssetId})`,
+  );
+
+  assert.throws(
+    () => buildManagedImageMarkdownReference("asset-1", "Diagram"),
+    (error: unknown) => error instanceof HttpError
+      && error.statusCode === 400
+      && error.message === "mediaAssetId must be a UUID",
+  );
+  assert.throws(
+    () => buildManagedImageMarkdownReference(testMediaAssetId, " \n "),
+    (error: unknown) => error instanceof HttpError
+      && error.statusCode === 400
+      && error.message === "altText must not be empty",
+  );
+});
+
+test("managed image append uses one canonical Markdown block boundary", () => {
+  const reference = `![Generated image](fcasset:${testMediaAssetId})`;
+  const cases: ReadonlyArray<readonly [string, string]> = [
+    ["", reference],
+    ["Answer", `Answer\n\n${reference}`],
+    ["Answer\n", `Answer\n\n${reference}`],
+    ["Answer\n\n", `Answer\n\n${reference}`],
+  ];
+
+  for (const [text, expectedText] of cases) {
+    assert.deepEqual(
+      appendManagedImageToCardText(text, testMediaAssetId, "Generated image"),
+      { text: expectedText, applied: true },
+    );
+  }
+});
+
+test("managed image duplicate detection uses only exact active image destinations", () => {
+  const duplicateTexts = [
+    `![Canonical](fcasset:${testMediaAssetId})`,
+    `![Titled](fcasset:${testMediaAssetId} "Generated image")`,
+    String.raw`![Escaped \] label](fcasset:${testMediaAssetId})`,
+  ];
+  for (const text of duplicateTexts) {
+    assert.deepEqual(
+      appendManagedImageToCardText(text, testMediaAssetId, "Generated image"),
+      { text, applied: false },
+    );
+  }
+
+  const nonDuplicateTexts = [
+    `Mention fcasset:${testMediaAssetId} in prose.`,
+    `[Link](fcasset:${testMediaAssetId})`,
+    `\`![Code](fcasset:${testMediaAssetId})\``,
+    ["```markdown", `![Code](fcasset:${testMediaAssetId})`, "```"].join("\n"),
+    `![Malformed](fcasset:${testMediaAssetId}`,
+    `![Longer](fcasset:${testMediaAssetId}-suffix)`,
+  ];
+  for (const text of nonDuplicateTexts) {
+    const result = appendManagedImageToCardText(text, testMediaAssetId, "Generated image");
+    assert.equal(result.applied, true);
+    assert.equal(result.text.endsWith(`![Generated image](fcasset:${testMediaAssetId})`), true);
+  }
+});
+
+test("card-side append rejects invalid inputs before executing a query", async () => {
+  let queryCount = 0;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(text: string, params: ReadonlyArray<SqlValue>): Promise<pg.QueryResult<Row>> {
+      queryCount += 1;
+      throw new Error(`Invalid append input executed a query: ${text}; params=${JSON.stringify(params)}`);
+    },
+  };
+  const validInput: AppendManagedImageToCardSideInput = {
+    cardId: testCardId,
+    targetSide: "back",
+    mediaAssetId: testMediaAssetId,
+    altText: "Generated image",
+  };
+  const cases: ReadonlyArray<readonly [AppendManagedImageToCardSideInput, string]> = [
+    [{ ...validInput, cardId: "not-a-card-uuid" }, "cardId must be a UUID"],
+    [{ ...validInput, mediaAssetId: "not-a-media-uuid" }, "mediaAssetId must be a UUID"],
+    [{ ...validInput, targetSide: "middle" as CardTextSide }, "targetSide must be either front or back"],
+  ];
+
+  for (const [input, expectedMessage] of cases) {
+    await assert.rejects(
+      appendManagedImageToCardSideInExecutor(executor, testWorkspaceId, input, testMetadata),
+      (error: unknown) => error instanceof HttpError
+        && error.statusCode === 400
+        && error.message === expectedMessage,
+    );
+  }
+  assert.equal(queryCount, 0);
+});
+
+test("card-side append updates atomically and rejects inactive image placement without writes", async () => {
+  const storedClientUpdatedAt = "2099-01-01T00:00:00.000Z";
+  const expectedClientUpdatedAt = "2099-01-01T00:00:00.001Z";
+  let currentRow = createCardRow(storedClientUpdatedAt);
+  const queries: Array<QueryRecord> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(text: string, params: ReadonlyArray<SqlValue>): Promise<pg.QueryResult<Row>> {
+      queries.push({ text, params });
+
+      if (text.includes("INSERT INTO sync.workspace_sync_metadata")) {
+        return createQueryResult<Row>("INSERT", []);
+      }
+      if (text.includes("FROM sync.workspace_sync_metadata") && text.includes("FOR UPDATE")) {
+        return createQueryResult<Row>("SELECT", [{ workspace_id: testWorkspaceId } as unknown as Row]);
+      }
+      if (text.includes("FROM content.cards") && text.includes("FOR UPDATE")) {
+        return createQueryResult<Row>("SELECT", [currentRow as unknown as Row]);
+      }
+      if (text.includes("UPDATE content.cards")) {
+        currentRow = {
+          ...currentRow,
+          front_text: String(params[0]),
+          client_updated_at: String(params[1]),
+          last_modified_by_replica_id: String(params[2]),
+          last_operation_id: String(params[3]),
+          updated_at: expectedClientUpdatedAt,
+        };
+        return createQueryResult<Row>("UPDATE", [currentRow as unknown as Row]);
+      }
+      if (text.includes("INSERT INTO sync.hot_changes")) {
+        return createQueryResult<Row>("INSERT", [{ change_id: 1 } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected generated image append query: ${text}`);
+    },
+  };
+
+  const appendInput: AppendManagedImageToCardSideInput = {
+    cardId: testCardId,
+    targetSide: "front",
+    mediaAssetId: testMediaAssetId,
+    altText: "Generated image",
+  };
+  const result = await appendManagedImageToCardSideInExecutor(
+    executor,
+    testWorkspaceId,
+    {
+      ...appendInput,
+      cardId: appendInput.cardId.toUpperCase(),
+      mediaAssetId: appendInput.mediaAssetId.toUpperCase(),
+    },
+    testMetadata,
+  );
+
+  assert.equal(result.applied, true);
+  assert.equal(result.card.frontText, `Question\n\n![Generated image](fcasset:${testMediaAssetId})`);
+  assert.equal(result.card.backText, "Answer");
+  assert.equal(result.card.clientUpdatedAt, expectedClientUpdatedAt);
+  assert.deepEqual(
+    queries.map((query) => classifyAppendQuery(query.text)),
+    ["ensure-hot-metadata", "lock-hot-metadata", "lock-card", "update-card", "record-hot-change"],
+  );
+  assert.deepEqual(queries[2]?.params, [testWorkspaceId, testCardId]);
+  assert.match(queries[3]?.text ?? "", /SET front_text = \$1/u);
+  assert.doesNotMatch(queries[3]?.text ?? "", /back_text =/u);
+  assert.equal(queries[3]?.params[1], expectedClientUpdatedAt);
+  assert.deepEqual(queries[4]?.params, [
+    testWorkspaceId, "card", testCardId, "upsert", testReplicaId,
+    testMetadata.lastOperationId, expectedClientUpdatedAt,
+  ]);
+  const duplicateResult = await appendManagedImageToCardSideInExecutor(
+    executor,
+    testWorkspaceId,
+    {
+      ...appendInput,
+      altText: "Retry image",
+    },
+    testMetadata,
+  );
+  assert.equal(duplicateResult.applied, false);
+  assert.equal(duplicateResult.card.frontText, currentRow.front_text);
+  assert.equal(duplicateResult.card.lastOperationId, testMetadata.lastOperationId);
+  assert.deepEqual(
+    queries.slice(5).map((query) => classifyAppendQuery(query.text)),
+    ["ensure-hot-metadata", "lock-hot-metadata", "lock-card"],
+  );
+
+  for (const blockedText of ["```markdown\nAnswer", "~~~markdown\nAnswer", "<script>\nAnswer"]) {
+    const unchangedRow = { ...currentRow, front_text: blockedText };
+    currentRow = unchangedRow;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const firstQueryIndex = queries.length;
+      await assert.rejects(
+        appendManagedImageToCardSideInExecutor(
+          executor,
+          testWorkspaceId,
+          appendInput,
+          testMetadata,
+        ),
+        (error: unknown) => error instanceof HttpError
+          && error.statusCode === 409
+          && error.code === "CARD_IMAGE_APPEND_MARKDOWN_BLOCK_UNCLOSED",
+      );
+      assert.deepEqual(currentRow, unchangedRow);
+      assert.deepEqual(
+        queries.slice(firstQueryIndex).map((query) => classifyAppendQuery(query.text)),
+        ["ensure-hot-metadata", "lock-hot-metadata", "lock-card"],
+      );
+    }
+  }
+});

--- a/apps/backend/src/cards/index.ts
+++ b/apps/backend/src/cards/index.ts
@@ -4,6 +4,8 @@
  * described in docs/fsrs-scheduling-logic.md.
  */
 export type {
+  AppendManagedImageToCardSideInput,
+  AppendManagedImageToCardSideResult,
   BulkCreateCardItem,
   BulkDeleteCardItem,
   BulkDeleteCardsResult,
@@ -19,6 +21,7 @@ export type {
   CardQuerySortDirection,
   CardQuerySortKey,
   CardSnapshotInput,
+  CardTextSide,
   CreateCardInput,
   DeckSummary,
   QueryCardsInput,
@@ -45,6 +48,9 @@ export {
 } from "./fsrs";
 
 export {
+  appendManagedImageToCardSideInExecutor,
+  appendManagedImageToCardText,
+  buildManagedImageMarkdownReference,
   createCard,
   createCards,
   createCardInExecutor,

--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -3,12 +3,14 @@ import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../database";
+import { expectUuidString } from "../server/requestParsing";
 import { HttpError } from "../shared/errors";
 import {
   incomingLwwMetadataWins,
   normalizeIsoTimestamp,
 } from "../sync/conflicts/lww";
 import { findLatestSyncChangeId, lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../sync/replication/changes";
+import { extractMarkdownImageFcAssetIds } from "../workspacePackages/markdownMedia";
 import {
   createSyncConflictHttpError,
   findSyncConflictWorkspaceIdInExecutor,
@@ -26,6 +28,8 @@ import {
   toCardLwwMetadata,
 } from "./shared";
 import type {
+  AppendManagedImageToCardSideInput,
+  AppendManagedImageToCardSideResult,
   BulkCreateCardItem,
   BulkDeleteCardItem,
   BulkDeleteCardsResult,
@@ -35,12 +39,108 @@ import type {
   CardMutationResult,
   CardRow,
   CardSnapshotInput,
+  CardTextSide,
   CreateCardInput,
   UpdateCardInput,
   UpdateQueryParts,
 } from "./types";
 
 const MAX_CARD_BATCH_SIZE = 100;
+
+type AppendedManagedImageCardText = Readonly<{ text: string; applied: boolean }>;
+
+const cardTextColumnBySide: Readonly<Record<CardTextSide, "front_text" | "back_text">> = {
+  front: "front_text",
+  back: "back_text",
+};
+
+function normalizeCardTextSide(targetSide: CardTextSide): CardTextSide {
+  if (targetSide !== "front" && targetSide !== "back") {
+    throw new HttpError(400, "targetSide must be either front or back");
+  }
+
+  return targetSide;
+}
+
+function normalizeManagedImageAltText(altText: string): string {
+  const normalizedAltText = altText
+    .trim()
+    .replace(/\r\n|\r|\n/gu, " ")
+    .replace(/\s+/gu, " ")
+    .replace(/\\/gu, "＼")
+    .replace(/\[/gu, "(")
+    .replace(/\]/gu, ")");
+  if (normalizedAltText === "") {
+    throw new HttpError(400, "altText must not be empty");
+  }
+
+  return normalizedAltText;
+}
+
+function buildNormalizedManagedImageMarkdownReference(mediaAssetId: string, altText: string): string {
+  return `![${altText}](fcasset:${mediaAssetId})`;
+}
+
+function hasExactManagedImageMarkdownReference(text: string, mediaAssetId: string): boolean {
+  return extractMarkdownImageFcAssetIds(text)
+    .some((referencedMediaAssetId) => referencedMediaAssetId.toLowerCase() === mediaAssetId);
+}
+
+function appendMarkdownBlock(text: string, markdownBlock: string): string {
+  const separator = text === "" || text.endsWith("\n\n")
+    ? ""
+    : text.endsWith("\n") ? "\n" : "\n\n";
+  return `${text}${separator}${markdownBlock}`;
+}
+
+function appendNormalizedManagedImageToCardText(
+  text: string,
+  mediaAssetId: string,
+  markdownReference: string,
+): AppendedManagedImageCardText {
+  if (hasExactManagedImageMarkdownReference(text, mediaAssetId)) {
+    return { text, applied: false };
+  }
+
+  const appendedText = appendMarkdownBlock(text, markdownReference);
+  if (!hasExactManagedImageMarkdownReference(appendedText, mediaAssetId)) {
+    throw new HttpError(
+      409,
+      "Close the selected card side's unterminated Markdown fence or HTML block before appending an image.",
+      "CARD_IMAGE_APPEND_MARKDOWN_BLOCK_UNCLOSED",
+    );
+  }
+  return { text: appendedText, applied: true };
+}
+
+function deriveGeneratedCardMutationTimestamp(
+  currentTime: Date,
+  storedClientUpdatedAt: string | Date,
+): string {
+  return new Date(Math.max(
+    currentTime.getTime(), new Date(storedClientUpdatedAt).getTime() + 1,
+  )).toISOString();
+}
+
+export function buildManagedImageMarkdownReference(mediaAssetId: string, altText: string): string {
+  return buildNormalizedManagedImageMarkdownReference(
+    expectUuidString(mediaAssetId, "mediaAssetId"),
+    normalizeManagedImageAltText(altText),
+  );
+}
+
+export function appendManagedImageToCardText(
+  text: string,
+  mediaAssetId: string,
+  altText: string,
+): AppendedManagedImageCardText {
+  const normalizedMediaAssetId = expectUuidString(mediaAssetId, "mediaAssetId");
+  const markdownReference = buildNormalizedManagedImageMarkdownReference(
+    normalizedMediaAssetId,
+    normalizeManagedImageAltText(altText),
+  );
+  return appendNormalizedManagedImageToCardText(text, normalizedMediaAssetId, markdownReference);
+}
 
 function normalizeRequiredCardText(value: string, fieldName: string): string {
   const normalizedValue = value.trim();
@@ -195,6 +295,88 @@ async function loadCardRowForMutation(
   );
 
   return result.rows[0];
+}
+
+async function loadActiveCardRowForMutation(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  cardId: string,
+): Promise<CardRow | undefined> {
+  const result = await executor.query<CardRow>(
+    [
+      CARD_SELECT,
+      "WHERE workspace_id = $1 AND card_id = $2 AND deleted_at IS NULL",
+      "FOR UPDATE",
+    ].join(" "),
+    [workspaceId, cardId],
+  );
+
+  return result.rows[0];
+}
+
+export async function appendManagedImageToCardSideInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: AppendManagedImageToCardSideInput,
+  metadata: CardMutationMetadata,
+): Promise<AppendManagedImageToCardSideResult> {
+  const targetSide = normalizeCardTextSide(input.targetSide);
+  const cardId = expectUuidString(input.cardId, "cardId");
+  const mediaAssetId = expectUuidString(input.mediaAssetId, "mediaAssetId");
+  const markdownReference = buildNormalizedManagedImageMarkdownReference(
+    mediaAssetId,
+    normalizeManagedImageAltText(input.altText),
+  );
+  const normalizedMetadata = normalizeCardMutationMetadata(metadata);
+
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(
+    executor,
+    workspaceId,
+  );
+  const row = await loadActiveCardRowForMutation(executor, workspaceId, cardId);
+  if (row === undefined) {
+    throw new HttpError(404, "Card not found");
+  }
+
+  const currentText = targetSide === "front" ? row.front_text : row.back_text;
+  const appendedText = appendNormalizedManagedImageToCardText(
+    currentText,
+    mediaAssetId,
+    markdownReference,
+  );
+  if (appendedText.applied === false) {
+    return { card: mapCard(row), applied: false };
+  }
+
+  const generatedClientUpdatedAt = deriveGeneratedCardMutationTimestamp(new Date(), row.client_updated_at);
+  const targetColumn = cardTextColumnBySide[targetSide];
+  const updateResult = await executor.query<CardRow>(
+    [
+      "UPDATE content.cards",
+      `SET ${targetColumn} = $1, client_updated_at = $2,`,
+      "last_modified_by_replica_id = $3, last_operation_id = $4, updated_at = now()",
+      "WHERE workspace_id = $5 AND card_id = $6 AND deleted_at IS NULL",
+      "RETURNING",
+      CARD_COLUMNS,
+    ].join(" "),
+    [
+      appendedText.text,
+      generatedClientUpdatedAt,
+      normalizedMetadata.lastModifiedByReplicaId,
+      normalizedMetadata.lastOperationId,
+      workspaceId,
+      cardId,
+    ],
+  );
+
+  const updatedRow = updateResult.rows[0];
+  if (updatedRow === undefined) {
+    throw new HttpError(404, "Card not found");
+  }
+
+  const card = mapCard(updatedRow);
+  await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, card);
+  return { card, applied: true };
 }
 
 async function insertCardRowForSnapshotInExecutor(

--- a/apps/backend/src/cards/types.ts
+++ b/apps/backend/src/cards/types.ts
@@ -158,6 +158,20 @@ export type CardListPage = Readonly<{
 
 export type CardMutationMetadata = LwwMetadata;
 
+export type CardTextSide = "front" | "back";
+
+export type AppendManagedImageToCardSideInput = Readonly<{
+  cardId: string;
+  targetSide: CardTextSide;
+  mediaAssetId: string;
+  altText: string;
+}>;
+
+export type AppendManagedImageToCardSideResult = Readonly<{
+  card: Card;
+  applied: boolean;
+}>;
+
 export type CreateCardInput = Readonly<{
   frontText: string;
   backText: string;

--- a/apps/backend/src/testSupport/postgresIntegration.ts
+++ b/apps/backend/src/testSupport/postgresIntegration.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+
+export type PostgresIntegrationFixture = Readonly<{
+  runtimePool: pg.Pool;
+  ownerPool: pg.Pool;
+  userId: string;
+  workspaceId: string;
+  outOfScopeWorkspaceId: string;
+  replicaId: string;
+  cardId: string;
+  mediaAssetId: string;
+  operationId: string;
+  retryOperationId: string;
+  concurrentOperationId: string;
+  createdAt: string;
+}>;
+
+type RemainingFixtureRows = Readonly<{ remaining: boolean }>;
+
+function requireDatabaseUrl(environmentVariable: "DATABASE_URL" | "TEST_DATABASE_ADMIN_URL"): string {
+  const databaseUrl = process.env[environmentVariable]?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error(
+      `${environmentVariable} is required for the PostgreSQL integration test and must be a PostgreSQL connection URL.`,
+    );
+  }
+
+  return databaseUrl;
+}
+
+function createFixtureIds(): Omit<PostgresIntegrationFixture, "runtimePool" | "ownerPool" | "createdAt"> {
+  const operationNamespace = randomUUID();
+  return {
+    userId: `postgres-integration-${randomUUID()}`,
+    workspaceId: randomUUID(),
+    outOfScopeWorkspaceId: randomUUID(),
+    replicaId: randomUUID(),
+    cardId: randomUUID(),
+    mediaAssetId: randomUUID(),
+    operationId: `postgres-integration-append-${operationNamespace}`,
+    retryOperationId: `postgres-integration-append-retry-${operationNamespace}`,
+    concurrentOperationId: `postgres-integration-concurrent-edit-${operationNamespace}`,
+  };
+}
+
+async function createFixtureRows(fixture: PostgresIntegrationFixture): Promise<void> {
+  const ownerClient = await fixture.ownerPool.connect();
+  try {
+    await ownerClient.query("BEGIN");
+    await ownerClient.query("INSERT INTO org.user_settings (user_id) VALUES ($1)", [fixture.userId]);
+    await ownerClient.query(
+      [
+        "INSERT INTO org.workspaces (",
+        "workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_replica_id, fsrs_last_operation_id",
+        ") VALUES ($1, $2, $3, $4, $5)",
+      ].join(" "),
+      [
+        fixture.workspaceId,
+        "Generated image append integration",
+        fixture.createdAt,
+        fixture.replicaId,
+        `postgres-integration-workspace-${fixture.workspaceId}`,
+      ],
+    );
+    await ownerClient.query(
+      "INSERT INTO org.workspace_memberships (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+      [fixture.workspaceId, fixture.userId],
+    );
+    await ownerClient.query(
+      [
+        "INSERT INTO sync.workspace_replicas (",
+        "replica_id, workspace_id, user_id, actor_kind, installation_id, actor_key, platform, app_version",
+        ") VALUES ($1, $2, $3, 'ai_chat', NULL, $4, 'system', $5)",
+      ].join(" "),
+      [
+        fixture.replicaId,
+        fixture.workspaceId,
+        fixture.userId,
+        `postgres-integration-${fixture.replicaId}`,
+        "postgres-integration",
+      ],
+    );
+    await ownerClient.query(
+      [
+        "INSERT INTO content.cards (",
+        "card_id, workspace_id, front_text, back_text, card_type, metadata, tags, effort_level, due_at, created_at,",
+        "reps, lapses, fsrs_card_state, fsrs_step_index, fsrs_stability, fsrs_difficulty, fsrs_last_reviewed_at, fsrs_scheduled_days,",
+        "client_updated_at, last_modified_by_replica_id, last_operation_id",
+        ") VALUES ($1, $2, $3, $4, 'basic', $5::jsonb, '{}', 'fast', NULL, $6, 0, 0, 'new', NULL, NULL, NULL, NULL, NULL, $7, $8, $9)",
+      ].join(" "),
+      [
+        fixture.cardId,
+        fixture.workspaceId,
+        "Original question",
+        "Original answer",
+        JSON.stringify({ version: 1, source: null }),
+        fixture.createdAt,
+        fixture.createdAt,
+        fixture.replicaId,
+        `postgres-integration-card-${fixture.cardId}`,
+      ],
+    );
+    await ownerClient.query("COMMIT");
+  } catch (error) {
+    await ownerClient.query("ROLLBACK");
+    throw error;
+  } finally {
+    ownerClient.release();
+  }
+}
+
+async function deleteAndVerifyFixtureRows(fixture: PostgresIntegrationFixture): Promise<void> {
+  const ownerClient = await fixture.ownerPool.connect();
+  try {
+    await ownerClient.query("BEGIN");
+    await ownerClient.query("DELETE FROM org.workspaces WHERE workspace_id = $1", [fixture.workspaceId]);
+    await ownerClient.query("DELETE FROM org.user_settings WHERE user_id = $1", [fixture.userId]);
+    const verification = await ownerClient.query<RemainingFixtureRows>([
+      "SELECT EXISTS (SELECT 1 FROM org.workspaces WHERE workspace_id = $1)",
+      "OR EXISTS (SELECT 1 FROM org.user_settings WHERE user_id = $2)",
+      "OR EXISTS (SELECT 1 FROM sync.workspace_replicas WHERE replica_id = $3)",
+      "OR EXISTS (SELECT 1 FROM content.cards WHERE card_id = $4)",
+      "OR EXISTS (SELECT 1 FROM sync.hot_changes WHERE workspace_id = $1) AS remaining",
+    ].join(" "),
+      [fixture.workspaceId, fixture.userId, fixture.replicaId, fixture.cardId],
+    );
+    if (verification.rows[0]?.remaining !== false) {
+      throw new Error(
+        `PostgreSQL integration cleanup left fixture rows. workspaceId=${fixture.workspaceId}; cardId=${fixture.cardId}`,
+      );
+    }
+    await ownerClient.query("COMMIT");
+  } catch (error) {
+    await ownerClient.query("ROLLBACK");
+    throw error;
+  } finally {
+    ownerClient.release();
+  }
+}
+
+async function closeFixturePools(fixture: PostgresIntegrationFixture): Promise<void> {
+  const closeResults = await Promise.allSettled([fixture.runtimePool.end(), fixture.ownerPool.end()]);
+  const closeErrors = closeResults.flatMap((result) => (
+    result.status === "rejected" ? [result.reason as unknown] : []
+  ));
+  if (closeErrors.length > 0) {
+    throw new AggregateError(closeErrors, "Failed to close PostgreSQL integration pools.");
+  }
+}
+
+export async function withPostgresIntegrationFixture<Result>(
+  callback: (fixture: PostgresIntegrationFixture) => Promise<Result>,
+): Promise<Result> {
+  const fixtureIds = createFixtureIds();
+  const fixture: PostgresIntegrationFixture = {
+    runtimePool: new pg.Pool({
+      connectionString: requireDatabaseUrl("DATABASE_URL"),
+      application_name: "generated-image-append-integration-runtime",
+    }),
+    ownerPool: new pg.Pool({
+      connectionString: requireDatabaseUrl("TEST_DATABASE_ADMIN_URL"),
+      application_name: "generated-image-append-integration-owner",
+    }),
+    ...fixtureIds,
+    createdAt: new Date().toISOString(),
+  };
+
+  let result!: Result;
+  const errors: Array<unknown> = [];
+  try {
+    await createFixtureRows(fixture);
+    result = await callback(fixture);
+  } catch (error) {
+    errors.push(error);
+  } finally {
+    try {
+      await deleteAndVerifyFixtureRows(fixture);
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await closeFixturePools(fixture);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "PostgreSQL integration or fixture cleanup failed.");
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- add a lock-safe backend primitive for canonical managed-image Markdown appends
- preserve concurrent card edits, advance LWW metadata, and emit exactly one hot change
- reject inactive Markdown placement and make exact active-image retries write-free
- add focused executor coverage and isolated real-PostgreSQL integration coverage

## Validation
- Node 24 focused tests: 5 passed
- real PostgreSQL integration: 1 passed with backend_app and owner URLs
- full backend tests: 803 passed
- backend lint and build passed
- module dependency-boundary check passed
- git diff --check passed