### PR TITLE
Add generated card image orchestration

### DIFF
--- a/apps/backend/src/chat/cardImages/index.ts
+++ b/apps/backend/src/chat/cardImages/index.ts
@@ -1,0 +1,7 @@
+export { generateCardImage } from "./operation";
+export {
+  generatedCardImageModel, generatedCardImageOutputFormat,
+  generatedCardImageQuality, generatedCardImageSize,
+} from "./openaiAdapter";
+export type { GeneratedCardImageInput, GeneratedCardImageResult } from "./types";
+export type { GeneratedCardImageObservationContext } from "./providerTypes";

--- a/apps/backend/src/chat/cardImages/metadata.test.ts
+++ b/apps/backend/src/chat/cardImages/metadata.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
+const runId = "11111111-1111-4111-8111-111111111111";
+const cardId = "22222222-2222-4222-8222-222222222222";
+test("generated image metadata matches its stable contract vector", () => {
+  const front = deriveGeneratedCardImageOperationMetadata(runId, cardId, "front");
+  const retry = deriveGeneratedCardImageOperationMetadata(
+    runId.toUpperCase(), cardId.toUpperCase(), "front",
+  );
+  assert.equal(front.operationId, "0e6e709f-ca5b-5992-9f23-46917d55e9f9");
+  assert.equal(front.mediaAssetId, "1a7ca68f-9a72-564e-98b2-17f97f6ac54e");
+  assert.deepEqual(retry, front);
+});
+test("generated image metadata separates card sides", () => {
+  const back = deriveGeneratedCardImageOperationMetadata(runId, cardId, "back");
+  assert.equal(back.operationId, "39f32f10-3901-55ee-b9b4-e9966cff86e1");
+  assert.equal(back.mediaAssetId, "2c574654-675a-5ade-a6f2-1c32f0f57353");
+});

--- a/apps/backend/src/chat/cardImages/metadata.ts
+++ b/apps/backend/src/chat/cardImages/metadata.ts
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto";
+import type { CardTextSide } from "../../cards";
+import type { GeneratedCardImageOperationMetadata } from "./types";
+
+const generatedCardImageOperationNamespace = "flashcards-open-source-app:generated-card-image:v1";
+
+function deterministicUuidFromOperationIdentity(
+  purpose: "operation" | "media-asset",
+  runId: string,
+  cardId: string,
+  targetSide: CardTextSide,
+): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify(
+      [generatedCardImageOperationNamespace, purpose, runId.toLowerCase(), cardId.toLowerCase(), targetSide],
+    ))
+    .digest();
+  const uuidBytes = Buffer.from(digest.subarray(0, 16));
+  uuidBytes[6] = (uuidBytes[6] & 0x0f) | 0x50;
+  uuidBytes[8] = (uuidBytes[8] & 0x3f) | 0x80;
+
+  const hex = uuidBytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}
+
+export function deriveGeneratedCardImageOperationMetadata(
+  runId: string,
+  cardId: string,
+  targetSide: CardTextSide,
+): GeneratedCardImageOperationMetadata {
+  const operationId = deterministicUuidFromOperationIdentity("operation", runId, cardId, targetSide);
+  return {
+    operationId,
+    mediaAssetId: deterministicUuidFromOperationIdentity("media-asset", runId, cardId, targetSide),
+    mediaLastOperationId: `generated-card-image:${operationId}:media`,
+    cardLastOperationId: `generated-card-image:${operationId}:card`,
+  };
+}

--- a/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
@@ -1,0 +1,495 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import {
+  SessionAdvisoryLockAbortedError, SessionAdvisoryLockTimeoutError,
+  withSessionAdvisoryLock, type SessionAdvisoryLockInput,
+} from "../../database";
+import {
+  closeSessionAdvisoryLockPoolForTests, readSessionAdvisoryLockWaitingCountForTests,
+  SessionAdvisoryLockCapacityError, toSessionAdvisoryLockConnectionBoundaryError,
+} from "../../database/sessionAdvisoryLock";
+import { TransientDatabaseHttpError } from "../../database/transient";
+import { imageJpegCardMediaBlobMimeType } from "../../mediaAssets/types";
+import { createBackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
+import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
+import { createGeneratedCardImageOperationDependencies, generateCardImageWithDependencies } from "./operation";
+import {
+  GeneratedCardImageOperationLockAbortedError,
+  withGeneratedCardImageOperationLock, type GeneratedCardImageOperationLockInput,
+} from "./operationLock";
+import type { GeneratedCardImageInput } from "./types";
+const normalizedBytes = Buffer.from("deterministic-local-normalized-image");
+const normalizedSha256 = "8349792a6784cfdc5061b34e1184c85bcdb13719e86ac4be576e52e5e8c5f603";
+const lockSessionApplicationName = "backend-session-advisory-lock";
+type CountRow = Readonly<{ count: string }>;
+type TransactionStateRow = Readonly<{ session_count: string; no_open_transaction: boolean }>;
+type PersistedAssetRow = Readonly<{ source_url: string | null; sha256: string; normalization_version: string }>;
+type PersistedCardRow = Readonly<{ back_text: string }>;
+type HotChangeCountRow = Readonly<{ entity_type: string; count: string }>;
+type AdvisoryLockRow = Readonly<{ acquired: boolean }>;
+type AdvisoryUnlockRow = Readonly<{ unlocked: boolean }>;
+type BackendPidRow = Readonly<{ pid: number }>;
+type TerminateBackendRow = Readonly<{ terminated: boolean }>;
+type Deferred = Readonly<{ promise: Promise<void>; resolve: () => void }>;
+type HeldLock = Readonly<{ completion: Promise<void>; release: () => void }>;
+type LockRunner<Input> = (input: Input, callback: (signal: AbortSignal) => Promise<void>) => Promise<void>;
+function createDeferred(): Deferred {
+  let resolvePromise = (): void => { throw new Error("Deferred resolver was not initialized."); };
+  const promise = new Promise<void>((resolve) => { resolvePromise = resolve; });
+  return { promise, resolve: resolvePromise };
+}
+async function waitForValue<Value>(loadValue: () => Promise<Value | null>, failureMessage: string): Promise<Value> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const value = await loadValue();
+    if (value !== null) return value;
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(failureMessage);
+}
+async function holdLock<Input>(runner: LockRunner<Input>, input: Input): Promise<HeldLock> {
+  const started = createDeferred();
+  const release = createDeferred();
+  const completion = runner(input, async (_signal) => {
+    started.resolve();
+    await release.promise;
+  });
+  await started.promise;
+  return { completion, release: release.resolve };
+}
+function createInput(
+  fixture: PostgresIntegrationFixture, runId: string, targetSide: "front" | "back", signal: AbortSignal,
+): GeneratedCardImageInput {
+  return {
+    runId, userId: fixture.userId, workspaceId: fixture.workspaceId,
+    cardId: fixture.cardId, targetSide,
+    imagePrompt: "Draw a deterministic integration diagram.",
+    altText: "Generated integration diagram",
+    replicaId: fixture.replicaId,
+    observationContext: {
+      scope: createBackendObservationScope(
+        "chat-worker", "generated-image-postgres-integration", null, null, fixture.userId,
+        fixture.workspaceId, "generated-image-postgres-chat-request", runId,
+        "55555555-5555-4555-8555-555555555555", null, null,
+      ),
+      rootObservation: null,
+    },
+    signal,
+  };
+}
+async function waitForLockAttemptCount(fixture: PostgresIntegrationFixture, expectedCount: number): Promise<void> {
+  await waitForValue(async () => {
+    const result = await fixture.ownerPool.query<CountRow>(
+      `SELECT count(DISTINCT pid)::text AS count FROM pg_stat_activity
+       WHERE application_name = $1 AND query LIKE 'SELECT pg_try_advisory_lock(%'`,
+      [lockSessionApplicationName],
+    );
+    return Number.parseInt(result.rows[0]?.count ?? "0", 10) >= expectedCount ? true : null;
+  }, `Expected ${expectedCount} sessions to execute pg_try_advisory_lock.`);
+}
+async function waitForSingleLockSessionPid(fixture: PostgresIntegrationFixture): Promise<number> {
+  return waitForValue(async () => {
+    const result = await fixture.ownerPool.query<BackendPidRow>(
+      `SELECT pid FROM pg_stat_activity
+       WHERE application_name = $1 AND query LIKE 'SELECT pg_try_advisory_lock(%'`,
+      [lockSessionApplicationName],
+    );
+    return result.rows.length === 1 ? result.rows[0]?.pid ?? null : null;
+  }, "Expected exactly one checked-out session advisory lock connection.");
+}
+async function waitForLockPoolWaitingCount(expectedCount: number): Promise<void> {
+  await waitForValue(async () => readSessionAdvisoryLockWaitingCountForTests() === expectedCount ? true : null,
+    `Expected the session advisory lock admission queue to have ${expectedCount} waiting requests.`);
+}
+async function waitForBackendExit(fixture: PostgresIntegrationFixture, backendPid: number): Promise<void> {
+  await waitForValue(async () => {
+    const result = await fixture.ownerPool.query<CountRow>(
+      "SELECT count(*)::text AS count FROM pg_stat_activity WHERE pid = $1",
+      [backendPid],
+    );
+    return result.rows[0]?.count === "0" ? true : null;
+  }, `Terminated advisory lock backend remained active. backendPid=${backendPid}`);
+}
+async function assertAdvisoryLockReleased(fixture: PostgresIntegrationFixture, lockKey: string): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  let releaseError: Error | undefined;
+  try {
+    const acquired = await client.query<AdvisoryLockRow>(
+      "SELECT pg_try_advisory_lock(hashtextextended($1, 3::bigint)) AS acquired", [lockKey],
+    );
+    assert.equal(acquired.rows[0]?.acquired, true);
+    const unlocked = await client.query<AdvisoryUnlockRow>(
+      "SELECT pg_advisory_unlock(hashtextextended($1, 3::bigint)) AS unlocked", [lockKey],
+    );
+    assert.equal(unlocked.rows[0]?.unlocked, true);
+  } catch (error) {
+    releaseError = error instanceof Error ? error : new Error(String(error));
+    throw error;
+  } finally {
+    try {
+      await client.query("SELECT pg_advisory_unlock_all()");
+    } catch (error) {
+      releaseError ??= error instanceof Error ? error : new Error(String(error));
+    }
+    client.release(releaseError);
+  }
+  if (releaseError !== undefined) throw releaseError;
+}
+async function countMediaAsset(fixture: PostgresIntegrationFixture, mediaAssetId: string): Promise<number> {
+  const result = await fixture.ownerPool.query<CountRow>(
+    "SELECT count(*)::text AS count FROM content.media_assets WHERE workspace_id = $1 AND media_asset_id = $2",
+    [fixture.workspaceId, mediaAssetId],
+  );
+  return Number.parseInt(result.rows[0]?.count ?? "0", 10);
+}
+async function assertNoExternalWorkTransaction(fixture: PostgresIntegrationFixture): Promise<void> {
+  const result = await fixture.ownerPool.query<TransactionStateRow>(
+    `SELECT
+       count(*)::text AS session_count,
+       COALESCE(bool_and(xact_start IS NULL), false) AS no_open_transaction
+     FROM pg_stat_activity
+     WHERE datname = current_database()
+       AND usename = 'backend_app'
+       AND application_name = ''`,
+  );
+  assert.notEqual(result.rows[0]?.session_count, "0");
+  assert.equal(result.rows[0]?.no_open_transaction, true);
+}
+function operationLockInput(
+  fixture: PostgresIntegrationFixture, mediaAssetId: string, signal: AbortSignal,
+): GeneratedCardImageOperationLockInput {
+  return { workspaceId: fixture.workspaceId, mediaAssetId, signal };
+}
+function sessionLockInput(lockKey: string, timeoutMs: number): SessionAdvisoryLockInput {
+  return {
+    lockName: "generated-image-timeout-integration", lockKey, timeoutMs, pollIntervalMs: 10,
+    signal: new AbortController().signal,
+  };
+}
+test("generated image operation coordinates real sessions and persists atomically", async () => {
+  try {
+    await withPostgresIntegrationFixture(async (fixture) => {
+      const runId = randomUUID();
+      const operationMetadata = deriveGeneratedCardImageOperationMetadata(runId, fixture.cardId, "back");
+      const providerStarted = createDeferred();
+      const releaseProvider = createDeferred();
+      let providerCalls = 0;
+      let storageCalls = 0;
+      const dependencies = createGeneratedCardImageOperationDependencies({
+        generateProviderImageFn: async () => {
+          providerCalls += 1;
+          providerStarted.resolve();
+          await releaseProvider.promise;
+          return { bytes: Buffer.from("deterministic-provider-image"), providerRequestId: null };
+        },
+        normalizeImageBytesForCardFn: async () => ({
+          bytes: normalizedBytes, mimeType: imageJpegCardMediaBlobMimeType,
+          sizeBytes: normalizedBytes.byteLength,
+        }),
+        storeMediaAssetBlobBytesIfAbsentFn: async (input) => {
+          storageCalls += 1;
+          assert.equal(input.sha256, normalizedSha256);
+          assert.equal(await countMediaAsset(fixture, input.mediaAssetId), 0);
+          await assertNoExternalWorkTransaction(fixture);
+        },
+        currentTimestampFn: () => fixture.createdAt,
+      });
+      const operations: Array<Promise<unknown>> = [];
+      try {
+        const first = generateCardImageWithDependencies(
+          createInput(fixture, runId, "back", new AbortController().signal), dependencies,
+        );
+        operations.push(first);
+        void first.catch(() => undefined);
+        await providerStarted.promise;
+        await assertNoExternalWorkTransaction(fixture);
+        const second = generateCardImageWithDependencies(
+          createInput(fixture, runId, "back", new AbortController().signal), dependencies,
+        );
+        operations.push(second);
+        void second.catch(() => undefined);
+        await waitForLockAttemptCount(fixture, 2);
+        releaseProvider.resolve();
+        const results = await Promise.all([first, second]);
+        assert.equal(providerCalls, 1);
+        assert.equal(storageCalls, 1);
+        assert.deepEqual(results.map((result) => result.reused).sort(), [false, true]);
+        assert.deepEqual(results.map((result) => result.cardAppendApplied).sort(), [false, true]);
+        assert.equal(results.every((result) => result.sourceUrl === null), true);
+        const asset = await fixture.ownerPool.query<PersistedAssetRow>(
+          `SELECT media_assets.source_url, media_blobs.sha256, media_blobs.normalization_version
+             FROM content.media_assets AS media_assets
+             INNER JOIN content.media_blobs AS media_blobs
+               ON media_blobs.media_blob_id = media_assets.media_blob_id
+             WHERE media_assets.workspace_id = $1 AND media_assets.media_asset_id = $2`,
+          [fixture.workspaceId, operationMetadata.mediaAssetId],
+        );
+        assert.deepEqual(asset.rows[0], {
+          source_url: null, sha256: normalizedSha256, normalization_version: "image-jpeg-card-v1",
+        });
+        const card = await fixture.ownerPool.query<PersistedCardRow>(
+          "SELECT back_text FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
+          [fixture.workspaceId, fixture.cardId],
+        );
+        const assetReference = new RegExp(`fcasset:${operationMetadata.mediaAssetId}`, "gu");
+        assert.equal(card.rows[0]?.back_text.match(assetReference)?.length, 1);
+        const hotChanges = await fixture.ownerPool.query<HotChangeCountRow>(
+          [
+            "SELECT entity_type, count(*)::text AS count FROM sync.hot_changes",
+            "WHERE workspace_id = $1 GROUP BY entity_type ORDER BY entity_type",
+          ].join(" "),
+          [fixture.workspaceId],
+        );
+        assert.deepEqual(hotChanges.rows, [
+          { entity_type: "card", count: "1" },
+          { entity_type: "media_asset", count: "1" },
+        ]);
+        const failedRunId = randomUUID();
+        const failedMetadata = deriveGeneratedCardImageOperationMetadata(failedRunId, fixture.cardId, "front");
+        await fixture.ownerPool.query(
+          "UPDATE content.cards SET front_text = $1 WHERE workspace_id = $2 AND card_id = $3",
+          ["```markdown\nUnclosed", fixture.workspaceId, fixture.cardId],
+        );
+        await assert.rejects(
+          generateCardImageWithDependencies(
+            createInput(fixture, failedRunId, "front", new AbortController().signal),
+            dependencies,
+          ),
+          (error: unknown) => error instanceof HttpError
+            && error.code === "CARD_IMAGE_APPEND_MARKDOWN_BLOCK_UNCLOSED",
+        );
+        assert.equal(await countMediaAsset(fixture, failedMetadata.mediaAssetId), 0);
+        const hotChangeCount = await fixture.ownerPool.query<CountRow>(
+          "SELECT count(*)::text AS count FROM sync.hot_changes WHERE workspace_id = $1",
+          [fixture.workspaceId],
+        );
+        assert.equal(hotChangeCount.rows[0]?.count, "2");
+        await fixture.ownerPool.query(
+          "UPDATE content.cards SET front_text = $1 WHERE workspace_id = $2 AND card_id = $3",
+          ["Original question", fixture.workspaceId, fixture.cardId],
+        );
+        await closeSessionAdvisoryLockPoolForTests();
+        const operationLockKey = `chat.generated_card_image:${fixture.workspaceId}:${operationMetadata.mediaAssetId}`;
+        const holder = await holdLock(
+          withGeneratedCardImageOperationLock,
+          operationLockInput(fixture, operationMetadata.mediaAssetId, new AbortController().signal),
+        );
+        try {
+          const abortController = new AbortController();
+          const abortedRetry = withGeneratedCardImageOperationLock(
+            operationLockInput(fixture, operationMetadata.mediaAssetId, abortController.signal),
+            async (_signal) => { throw new Error("Aborted lock contender unexpectedly acquired the lock."); },
+          );
+          const abortedResult = assert.rejects(
+            abortedRetry,
+            (error: unknown) => error instanceof GeneratedCardImageOperationLockAbortedError,
+          );
+          await waitForLockAttemptCount(fixture, 2);
+          abortController.abort(new Error("Stop generated image retry."));
+          await abortedResult;
+        } finally {
+          holder.release();
+          await holder.completion;
+        }
+        await assertAdvisoryLockReleased(fixture, operationLockKey);
+        await closeSessionAdvisoryLockPoolForTests();
+        const completedRetry = await generateCardImageWithDependencies(
+          createInput(fixture, runId, "back", new AbortController().signal), dependencies,
+        );
+        assert.equal(completedRetry.reused, true);
+        assert.equal(completedRetry.cardAppendApplied, false);
+        assert.equal(providerCalls, 2);
+        await closeSessionAdvisoryLockPoolForTests();
+        const timeoutKey = `generated-image-timeout:${randomUUID()}`;
+        const timeoutHolder = await holdLock(withSessionAdvisoryLock, sessionLockInput(timeoutKey, 1_000));
+        try {
+          const timeoutResult = assert.rejects(
+            withSessionAdvisoryLock(sessionLockInput(timeoutKey, 75), async (_signal) => "unexpected"),
+            (error: unknown) => error instanceof SessionAdvisoryLockTimeoutError,
+          );
+          await waitForLockAttemptCount(fixture, 2);
+          await timeoutResult;
+        } finally {
+          timeoutHolder.release();
+          await timeoutHolder.completion;
+        }
+        await assertAdvisoryLockReleased(fixture, timeoutKey);
+        await closeSessionAdvisoryLockPoolForTests();
+        assert.equal(
+          await withSessionAdvisoryLock(sessionLockInput(timeoutKey, 1_000), async (_signal) => "reacquired"),
+          "reacquired",
+        );
+      } finally {
+        releaseProvider.resolve();
+        await Promise.allSettled(operations);
+        await fixture.ownerPool.query(
+          "DELETE FROM content.media_assets WHERE workspace_id = $1", [fixture.workspaceId],
+        );
+        await fixture.ownerPool.query(
+          "DELETE FROM content.media_blobs WHERE sha256 = $1", [normalizedSha256],
+        );
+      }
+    });
+  } finally {
+    await closeSessionAdvisoryLockPoolForTests();
+  }
+});
+test("session advisory lock cancels work when its PostgreSQL backend is terminated", async () => {
+  try {
+    await withPostgresIntegrationFixture(async (fixture) => {
+      await closeSessionAdvisoryLockPoolForTests();
+      const lockKey = `generated-image-lock-loss:${randomUUID()}`;
+      const callerAbort = new AbortController();
+      const callbackStarted = createDeferred();
+      let callbackObservedAbort = false;
+      const operation = withSessionAdvisoryLock(
+        { ...sessionLockInput(lockKey, 1_000), signal: callerAbort.signal },
+        async (signal) => {
+          callbackStarted.resolve();
+          await new Promise<void>((_resolve, reject) => {
+            const onAbort = (): void => {
+              callbackObservedAbort = true;
+              reject(signal.reason);
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            if (signal.aborted) onAbort();
+          });
+        },
+      );
+      const failedOperation = assert.rejects(
+        operation,
+        (error: unknown) => error instanceof HttpError && error.code === "SERVICE_UNAVAILABLE",
+      );
+      try {
+        await callbackStarted.promise;
+        const terminatedPid = await waitForSingleLockSessionPid(fixture);
+        const termination = await fixture.ownerPool.query<TerminateBackendRow>(
+          "SELECT pg_terminate_backend($1) AS terminated", [terminatedPid],
+        );
+        assert.equal(termination.rows[0]?.terminated, true);
+        await failedOperation;
+        assert.equal(callbackObservedAbort, true);
+        await waitForBackendExit(fixture, terminatedPid);
+        const replacement = await holdLock(withSessionAdvisoryLock, sessionLockInput(lockKey, 1_000));
+        try {
+          const replacementPid = await waitForSingleLockSessionPid(fixture);
+          assert.notEqual(replacementPid, terminatedPid);
+        } finally {
+          replacement.release();
+          await replacement.completion;
+        }
+        await assertAdvisoryLockReleased(fixture, lockKey);
+      } finally {
+        callerAbort.abort(new Error("Clean up terminated advisory lock integration."));
+        await Promise.allSettled([operation, failedOperation]);
+      }
+    });
+  } finally {
+    await closeSessionAdvisoryLockPoolForTests();
+  }
+});
+test("session advisory lock bounds admission and promptly removes cancelled waiters", async () => {
+  try {
+    await withPostgresIntegrationFixture(async (fixture) => {
+      await closeSessionAdvisoryLockPoolForTests();
+      const firstKey = `generated-image-pool-first:${randomUUID()}`;
+      const secondKey = `generated-image-pool-second:${randomUUID()}`;
+      const timedOutKey = `generated-image-pool-timed-out:${randomUUID()}`;
+      const abortedKey = `generated-image-pool-aborted:${randomUUID()}`;
+      const thirdKey = `generated-image-pool-third:${randomUUID()}`;
+      const first = await holdLock(withSessionAdvisoryLock, sessionLockInput(firstKey, 1_000));
+      const second = await holdLock(withSessionAdvisoryLock, sessionLockInput(secondKey, 1_000));
+      let firstReleased = false;
+      let secondReleased = false;
+      let thirdAcquired = false;
+      let thirdError: unknown;
+      const excessControllers: Array<AbortController> = [];
+      const excessWaiters: Array<Promise<void>> = [];
+      const timedOutWaiter = withSessionAdvisoryLock(
+        sessionLockInput(timedOutKey, 75),
+        async (_signal) => { throw new Error("Timed-out pool waiter unexpectedly acquired the lock."); },
+      );
+      const timedOutResult = assert.rejects(
+        timedOutWaiter,
+        (error: unknown) => error instanceof SessionAdvisoryLockTimeoutError,
+      );
+      const abortController = new AbortController();
+      const abortedWaiter = withSessionAdvisoryLock(
+        { ...sessionLockInput(abortedKey, 10_000), signal: abortController.signal },
+        async (_signal) => { throw new Error("Aborted pool waiter unexpectedly acquired the lock."); },
+      );
+      const abortedResult = assert.rejects(
+        abortedWaiter,
+        (error: unknown) => error instanceof SessionAdvisoryLockAbortedError,
+      );
+      const thirdCompletion = withSessionAdvisoryLock(sessionLockInput(thirdKey, 10_000),
+        async (_signal) => { thirdAcquired = true; }).catch((error: unknown) => { thirdError = error; });
+      try {
+        await waitForLockPoolWaitingCount(3);
+        abortController.abort(new Error("Remove cancelled pool waiter."));
+        await Promise.all([timedOutResult, abortedResult]);
+        await waitForLockPoolWaitingCount(1);
+        assert.equal(thirdAcquired, false);
+        assert.equal(thirdError, undefined);
+        for (let index = 0; index < 7; index += 1) {
+          const controller = new AbortController();
+          excessControllers.push(controller);
+          const waiter = withSessionAdvisoryLock(
+            { ...sessionLockInput(`generated-image-pool-excess-${index}:${randomUUID()}`, 10_000),
+              signal: controller.signal },
+            async (signal) => new Promise<void>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+            }),
+          );
+          excessWaiters.push(waiter);
+          void waiter.catch(() => undefined);
+        }
+        await waitForLockPoolWaitingCount(8);
+        const capacityKey = `generated-image-pool-capacity:${randomUUID()}`;
+        await assert.rejects(
+          withSessionAdvisoryLock(
+            sessionLockInput(capacityKey, 10_000),
+            async (_signal) => { throw new Error("Excess waiter unexpectedly acquired the lock."); },
+          ),
+          (error: unknown) => error instanceof SessionAdvisoryLockCapacityError
+            && error.maximumPendingCount === 8,
+        );
+        first.release();
+        firstReleased = true;
+        await first.completion;
+        await thirdCompletion;
+        assert.equal(thirdError, undefined);
+        assert.equal(thirdAcquired, true);
+        excessControllers.forEach((controller) => controller.abort(new Error("Clean up excess waiter.")));
+        const excessResults = await Promise.allSettled(excessWaiters);
+        assert.equal(excessResults.every((result) => result.status === "rejected"), true);
+        await waitForLockPoolWaitingCount(0);
+      } finally {
+        abortController.abort(new Error("Clean up cancelled pool waiter."));
+        excessControllers.forEach((controller) => controller.abort(new Error("Clean up excess waiter.")));
+        if (!firstReleased) {
+          first.release();
+          await first.completion;
+        }
+        if (!secondReleased) {
+          second.release();
+          secondReleased = true;
+          await second.completion;
+        }
+        await Promise.allSettled([timedOutWaiter, abortedWaiter, thirdCompletion, ...excessWaiters]);
+      }
+      await Promise.all([firstKey, secondKey, timedOutKey, abortedKey, thirdKey]
+        .map((lockKey) => assertAdvisoryLockReleased(fixture, lockKey)));
+      const mappedError = toSessionAdvisoryLockConnectionBoundaryError(new Error("timeout expired"));
+      assert.ok(mappedError instanceof TransientDatabaseHttpError);
+      assert.equal(mappedError.code, "SERVICE_UNAVAILABLE");
+      assert.equal(mappedError.errorCode, "ETIMEDOUT");
+      assert.equal(mappedError.databaseErrorClass, "SessionAdvisoryLockConnectionTimeoutError");
+      assert.equal(mappedError.databaseErrorMessage, "PostgreSQL session advisory lock connection timed out. timeoutMs=5000");
+    });
+  } finally {
+    await closeSessionAdvisoryLockPoolForTests();
+  }
+});

--- a/apps/backend/src/chat/cardImages/operation.test.ts
+++ b/apps/backend/src/chat/cardImages/operation.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBackendObservationScope } from "../../observability/sentry";
+import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
+import {
+  generateCardImageWithDependencies, type GeneratedCardImageOperationDependencies,
+} from "./operation";
+import type { GeneratedCardImageInput } from "./types";
+const runId = "11111111-1111-4111-8111-111111111111";
+const workspaceId = "22222222-2222-4222-8222-222222222222";
+const cardId = "33333333-3333-4333-8333-333333333333";
+const replicaId = "44444444-4444-4444-8444-444444444444";
+const timestamp = "2026-07-24T10:00:00.000Z";
+function createInput(signal: AbortSignal): GeneratedCardImageInput {
+  return {
+    runId, userId: "operation-test-user", workspaceId, cardId, targetSide: "back",
+    imagePrompt: "Draw a labeled plant cell.",
+    altText: "Plant cell diagram",
+    replicaId,
+    observationContext: {
+      scope: createBackendObservationScope(
+        "chat-worker", "operation-test-request", null, null, "operation-test-user",
+        workspaceId, "operation-test-chat-request", runId,
+        "55555555-5555-4555-8555-555555555555", null, null,
+      ), rootObservation: null,
+    },
+    signal,
+  };
+}
+test("generated image orchestration prepares before persistence", async () => {
+  const calls: Array<string> = [];
+  const metadata = deriveGeneratedCardImageOperationMetadata(runId, cardId, "back");
+  const lockSignal = new AbortController().signal;
+  const dependencies: GeneratedCardImageOperationDependencies = {
+    assertPreconditionsFn: async () => { calls.push("preconditions"); },
+    withOperationLockFn: async (lockInput, callback) => {
+      calls.push("lock");
+      assert.notEqual(lockInput.signal, lockSignal);
+      return callback(lockSignal);
+    },
+    findMediaAssetFn: async () => { calls.push("find-media"); return null; },
+    prepareGeneratedImageFn: async (input) => {
+      calls.push("prepare");
+      assert.equal(input.signal, lockSignal);
+      return {
+        mediaAssetId: metadata.mediaAssetId, sourceUrl: null,
+        createdAt: timestamp, clientUpdatedAt: timestamp,
+        lastModifiedByReplicaId: replicaId, lastOperationId: metadata.mediaLastOperationId,
+        sizeBytes: 10, sha256: "a".repeat(64),
+      };
+    },
+    persistGeneratedImageFn: async (input, _metadata, preparedImage) => {
+      calls.push("persist");
+      assert.equal(input.signal, lockSignal);
+      assert.notEqual(preparedImage, null);
+      return { mediaRegistrationApplied: true, cardAppendApplied: true, reused: false };
+    },
+  };
+  const result = await generateCardImageWithDependencies(
+    createInput(new AbortController().signal), dependencies,
+  );
+  assert.deepEqual(calls, ["preconditions", "lock", "find-media", "prepare", "persist"]);
+  assert.deepEqual(result, {
+    cardId, mediaAssetId: metadata.mediaAssetId, targetSide: "back",
+    mediaRegistrationApplied: true, cardAppendApplied: true, reused: false, sourceUrl: null,
+  });
+});

--- a/apps/backend/src/chat/cardImages/operation.ts
+++ b/apps/backend/src/chat/cardImages/operation.ts
@@ -1,0 +1,329 @@
+import { createHash } from "node:crypto";
+import { appendManagedImageToCardSideInExecutor, getCard, type CardTextSide } from "../../cards";
+import {
+  queryWithWorkspaceScopeReadOnly, transactionWithWorkspaceScope, transactionWithWorkspaceScopeReadOnly,
+} from "../../database";
+import {
+  MEDIA_ASSET_COLUMNS, MEDIA_ASSET_JOIN_CLAUSE, loadReusableImageMediaBlobForWorkspace, mapMediaAssetRow,
+} from "../../mediaAssets";
+import { normalizeImageBytesForCard } from "../../mediaAssets/ingestion/imageNormalization";
+import {
+  findMediaAssetRowForUpdateInExecutor, upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
+} from "../../mediaAssets/persistence";
+import { storeMediaAssetBlobBytesIfAbsent } from "../../mediaAssets/storage";
+import { buildMediaBlobStorageKey } from "../../mediaAssets/storageKeys";
+import {
+  imageJpegCardMediaBlobMimeType, imageJpegCardMediaBlobNormalizationVersion, type MediaAsset,
+  type MediaAssetRow, type NormalizedImageMediaAssetInput,
+} from "../../mediaAssets/types";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
+import { expectNonEmptyString, expectUuidString } from "../../server/requestParsing";
+import { HttpError } from "../../shared/errors";
+import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../sync/replication/changes";
+import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
+import { createOpenAIGeneratedCardImageProvider } from "./openaiAdapter";
+import { withGeneratedCardImageOperationLock } from "./operationLock";
+import type { GeneratedProviderImage, OpenAIImageGenerationInput } from "./providerTypes";
+import type { GeneratedCardImageInput, GeneratedCardImageOperationMetadata, GeneratedCardImageResult } from "./types";
+
+const maximumGeneratedCardImagePromptCharacters = 32_000;
+
+export type PreparedGeneratedCardImage = NormalizedImageMediaAssetInput;
+
+type PersistedGeneratedCardImage =
+  Pick<GeneratedCardImageResult, "mediaRegistrationApplied" | "cardAppendApplied" | "reused">;
+
+export type GeneratedCardImageOperationDependencies = Readonly<{
+  assertPreconditionsFn: (input: GeneratedCardImageInput) => Promise<void>;
+  withOperationLockFn: typeof withGeneratedCardImageOperationLock;
+  findMediaAssetFn: (userId: string, workspaceId: string, mediaAssetId: string) => Promise<MediaAsset | null>;
+  prepareGeneratedImageFn: (
+    input: GeneratedCardImageInput,
+    operationMetadata: GeneratedCardImageOperationMetadata,
+  ) => Promise<PreparedGeneratedCardImage>;
+  persistGeneratedImageFn: (
+    input: GeneratedCardImageInput,
+    operationMetadata: GeneratedCardImageOperationMetadata,
+    preparedImage: PreparedGeneratedCardImage | null,
+    cardClientUpdatedAt: string,
+  ) => Promise<PersistedGeneratedCardImage>;
+}>;
+
+export type GeneratedCardImageExternalDependencies = Readonly<{
+  generateProviderImageFn: (input: OpenAIImageGenerationInput) => Promise<GeneratedProviderImage>;
+  normalizeImageBytesForCardFn: typeof normalizeImageBytesForCard;
+  storeMediaAssetBlobBytesIfAbsentFn: typeof storeMediaAssetBlobBytesIfAbsent;
+  currentTimestampFn: () => string;
+}>;
+
+function normalizeTargetSide(targetSide: CardTextSide): CardTextSide {
+  if (targetSide !== "front" && targetSide !== "back") {
+    throw new HttpError(400, "targetSide must be either front or back");
+  }
+  return targetSide;
+}
+
+function normalizeGeneratedCardImageInput(input: GeneratedCardImageInput): GeneratedCardImageInput {
+  const imagePrompt = expectNonEmptyString(input.imagePrompt, "imagePrompt");
+  if (imagePrompt.length > maximumGeneratedCardImagePromptCharacters) {
+    throw new HttpError(400, `imagePrompt must be at most ${maximumGeneratedCardImagePromptCharacters} characters`);
+  }
+
+  return {
+    runId: expectUuidString(input.runId, "runId"),
+    userId: expectNonEmptyString(input.userId, "userId"),
+    workspaceId: expectUuidString(input.workspaceId, "workspaceId"),
+    cardId: expectUuidString(input.cardId, "cardId"),
+    targetSide: normalizeTargetSide(input.targetSide),
+    imagePrompt,
+    altText: expectNonEmptyString(input.altText, "altText"),
+    replicaId: expectUuidString(input.replicaId, "replicaId"),
+    observationContext: input.observationContext,
+    signal: input.signal,
+  };
+}
+
+async function assertGeneratedCardImagePreconditions(input: GeneratedCardImageInput): Promise<void> {
+  await Promise.all([
+    getCard(input.userId, input.workspaceId, input.cardId),
+    transactionWithWorkspaceScopeReadOnly(
+      { userId: input.userId, workspaceId: input.workspaceId },
+      async (executor) => assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId),
+    ),
+  ]);
+}
+
+async function findGeneratedCardImageMediaAsset(
+  userId: string, workspaceId: string, mediaAssetId: string,
+): Promise<MediaAsset | null> {
+  const result = await queryWithWorkspaceScopeReadOnly<MediaAssetRow>(
+    { userId, workspaceId },
+    `SELECT ${MEDIA_ASSET_COLUMNS}
+       FROM ${MEDIA_ASSET_JOIN_CLAUSE}
+       WHERE media_assets.workspace_id = $1 AND media_assets.media_asset_id = $2
+       LIMIT 1`,
+    [workspaceId, mediaAssetId],
+  );
+  const row = result.rows[0];
+  return row === undefined ? null : mapMediaAssetRow(row);
+}
+
+function assertReusableGeneratedMediaAsset(
+  mediaAsset: MediaAsset, operationMetadata: GeneratedCardImageOperationMetadata,
+): void {
+  if (mediaAsset.lastOperationId !== operationMetadata.mediaLastOperationId
+      || mediaAsset.sourceUrl !== null) {
+    throw new HttpError(409,
+      `The deterministic generated media asset id belongs to another operation. mediaAssetId=${operationMetadata.mediaAssetId}`,
+      "GENERATED_CARD_IMAGE_MEDIA_ID_CONFLICT");
+  }
+  if (mediaAsset.deletedAt !== null) {
+    throw new HttpError(409, `The generated media asset was deleted. mediaAssetId=${operationMetadata.mediaAssetId}`,
+      "GENERATED_CARD_IMAGE_MEDIA_DELETED");
+  }
+}
+
+async function prepareGeneratedCardImage(
+  input: GeneratedCardImageInput,
+  operationMetadata: GeneratedCardImageOperationMetadata,
+  dependencies: GeneratedCardImageExternalDependencies,
+): Promise<PreparedGeneratedCardImage> {
+  const generatedImage = await dependencies.generateProviderImageFn({
+    userId: input.userId,
+    imagePrompt: input.imagePrompt,
+    observationContext: input.observationContext,
+    signal: input.signal,
+  });
+  input.signal.throwIfAborted();
+
+  const normalizedImage = await dependencies.normalizeImageBytesForCardFn(generatedImage.bytes);
+  input.signal.throwIfAborted();
+
+  const timestamp = dependencies.currentTimestampFn();
+  const mediaAssetInput: NormalizedImageMediaAssetInput = {
+    mediaAssetId: operationMetadata.mediaAssetId,
+    sourceUrl: null,
+    createdAt: timestamp,
+    clientUpdatedAt: timestamp,
+    lastModifiedByReplicaId: input.replicaId,
+    lastOperationId: operationMetadata.mediaLastOperationId,
+    sizeBytes: normalizedImage.sizeBytes,
+    sha256: createHash("sha256").update(normalizedImage.bytes).digest("hex"),
+  };
+  const reusableBlob = await loadReusableImageMediaBlobForWorkspace(
+    input.userId, input.workspaceId, mediaAssetInput,
+  );
+  input.signal.throwIfAborted();
+
+  if (reusableBlob === null) {
+    await dependencies.storeMediaAssetBlobBytesIfAbsentFn({
+      workspaceId: input.workspaceId,
+      mediaAssetId: operationMetadata.mediaAssetId,
+      storageKey: buildMediaBlobStorageKey(mediaAssetInput.sha256),
+      mimeType: normalizedImage.mimeType,
+      sha256: mediaAssetInput.sha256,
+      lastOperationId: operationMetadata.mediaLastOperationId,
+      bytes: normalizedImage.bytes,
+      observationScope: input.observationContext.scope,
+    });
+  }
+  input.signal.throwIfAborted();
+  return mediaAssetInput;
+}
+
+async function persistGeneratedCardImage(
+  input: GeneratedCardImageInput,
+  operationMetadata: GeneratedCardImageOperationMetadata,
+  preparedImage: PreparedGeneratedCardImage | null,
+  cardClientUpdatedAt: string,
+): Promise<PersistedGeneratedCardImage> {
+  input.signal.throwIfAborted();
+
+  return transactionWithWorkspaceScope(
+    { userId: input.userId, workspaceId: input.workspaceId },
+    async (executor) => {
+      await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, input.workspaceId);
+      await assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId);
+      input.signal.throwIfAborted();
+
+      const existingRow = await findMediaAssetRowForUpdateInExecutor(
+        executor, input.workspaceId, operationMetadata.mediaAssetId,
+      );
+      let mediaRegistrationApplied = false;
+      let reused = preparedImage === null || existingRow !== null;
+      if (existingRow === null) {
+        if (preparedImage === null) {
+          throw new HttpError(409,
+            `The generated media asset disappeared. mediaAssetId=${operationMetadata.mediaAssetId}`,
+            "GENERATED_CARD_IMAGE_MEDIA_MISSING");
+        }
+        const mediaResult = await upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
+          executor,
+          input.workspaceId,
+          {
+            mediaAssetId: preparedImage.mediaAssetId,
+            mimeType: imageJpegCardMediaBlobMimeType,
+            sizeBytes: preparedImage.sizeBytes,
+            sha256: preparedImage.sha256,
+            sourceUrl: null,
+            createdAt: preparedImage.createdAt,
+            deletedAt: null,
+          },
+          {
+            clientUpdatedAt: preparedImage.clientUpdatedAt,
+            lastModifiedByReplicaId: input.replicaId,
+            lastOperationId: operationMetadata.mediaLastOperationId,
+          },
+          imageJpegCardMediaBlobNormalizationVersion,
+        );
+        assertReusableGeneratedMediaAsset(mediaResult.mediaAsset, operationMetadata);
+        mediaRegistrationApplied = true;
+        reused = false;
+      } else {
+        assertReusableGeneratedMediaAsset(mapMediaAssetRow(existingRow), operationMetadata);
+      }
+
+      input.signal.throwIfAborted();
+      const cardResult = await appendManagedImageToCardSideInExecutor(
+        executor,
+        input.workspaceId,
+        {
+          cardId: input.cardId,
+          targetSide: input.targetSide,
+          mediaAssetId: operationMetadata.mediaAssetId,
+          altText: input.altText,
+        },
+        {
+          clientUpdatedAt: cardClientUpdatedAt,
+          lastModifiedByReplicaId: input.replicaId,
+          lastOperationId: operationMetadata.cardLastOperationId,
+        },
+      );
+      input.signal.throwIfAborted();
+      return { mediaRegistrationApplied, cardAppendApplied: cardResult.applied, reused };
+    },
+  );
+}
+
+export function createGeneratedCardImageOperationDependencies(
+  externalDependencies: GeneratedCardImageExternalDependencies,
+): GeneratedCardImageOperationDependencies {
+  return {
+    assertPreconditionsFn: assertGeneratedCardImagePreconditions,
+    withOperationLockFn: withGeneratedCardImageOperationLock,
+    findMediaAssetFn: findGeneratedCardImageMediaAsset,
+    prepareGeneratedImageFn: async (input, metadata) => prepareGeneratedCardImage(
+      input, metadata, externalDependencies,
+    ),
+    persistGeneratedImageFn: persistGeneratedCardImage,
+  };
+}
+
+function toGeneratedCardImageResult(
+  input: GeneratedCardImageInput, operationMetadata: GeneratedCardImageOperationMetadata,
+  persisted: PersistedGeneratedCardImage,
+): GeneratedCardImageResult {
+  return {
+    cardId: input.cardId,
+    mediaAssetId: operationMetadata.mediaAssetId,
+    targetSide: input.targetSide,
+    mediaRegistrationApplied: persisted.mediaRegistrationApplied,
+    cardAppendApplied: persisted.cardAppendApplied,
+    reused: persisted.reused,
+    sourceUrl: null,
+  };
+}
+
+export async function generateCardImageWithDependencies(
+  input: GeneratedCardImageInput,
+  dependencies: GeneratedCardImageOperationDependencies,
+): Promise<GeneratedCardImageResult> {
+  const normalizedInput = normalizeGeneratedCardImageInput(input);
+  normalizedInput.signal.throwIfAborted();
+  const operationMetadata = deriveGeneratedCardImageOperationMetadata(
+    normalizedInput.runId, normalizedInput.cardId, normalizedInput.targetSide,
+  );
+
+  await dependencies.assertPreconditionsFn(normalizedInput);
+  normalizedInput.signal.throwIfAborted();
+  return dependencies.withOperationLockFn(
+    {
+      workspaceId: normalizedInput.workspaceId, mediaAssetId: operationMetadata.mediaAssetId,
+      signal: normalizedInput.signal,
+    },
+    async (lockSignal) => {
+      const lockedInput: GeneratedCardImageInput = { ...normalizedInput, signal: lockSignal };
+      lockedInput.signal.throwIfAborted();
+      const existingMediaAsset = await dependencies.findMediaAssetFn(
+        lockedInput.userId, lockedInput.workspaceId, operationMetadata.mediaAssetId,
+      );
+      lockedInput.signal.throwIfAborted();
+
+      if (existingMediaAsset !== null) {
+        assertReusableGeneratedMediaAsset(existingMediaAsset, operationMetadata);
+        const persisted = await dependencies.persistGeneratedImageFn(
+          lockedInput, operationMetadata, null, new Date().toISOString(),
+        );
+        return toGeneratedCardImageResult(lockedInput, operationMetadata, persisted);
+      }
+
+      const preparedImage = await dependencies.prepareGeneratedImageFn(lockedInput, operationMetadata);
+      const persisted = await dependencies.persistGeneratedImageFn(
+        lockedInput, operationMetadata, preparedImage, preparedImage.clientUpdatedAt,
+      );
+      return toGeneratedCardImageResult(lockedInput, operationMetadata, persisted);
+    },
+  );
+}
+
+const defaultExternalDependencies: GeneratedCardImageExternalDependencies = {
+  generateProviderImageFn: async (input) => createOpenAIGeneratedCardImageProvider().generate(input),
+  normalizeImageBytesForCardFn: normalizeImageBytesForCard,
+  storeMediaAssetBlobBytesIfAbsentFn: storeMediaAssetBlobBytesIfAbsent,
+  currentTimestampFn: () => new Date().toISOString(),
+};
+
+export async function generateCardImage(input: GeneratedCardImageInput): Promise<GeneratedCardImageResult> {
+  return generateCardImageWithDependencies(input,
+    createGeneratedCardImageOperationDependencies(defaultExternalDependencies));
+}

--- a/apps/backend/src/chat/cardImages/operationLock.ts
+++ b/apps/backend/src/chat/cardImages/operationLock.ts
@@ -1,0 +1,56 @@
+import {
+  SessionAdvisoryLockAbortedError, SessionAdvisoryLockTimeoutError, withSessionAdvisoryLock,
+} from "../../database";
+
+const generatedCardImageOperationLockTimeoutMs = 120_000;
+const generatedCardImageOperationLockPollIntervalMs = 50;
+const generatedCardImageOperationLockName = "generated-card-image-operation";
+
+export type GeneratedCardImageOperationLockInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  signal: AbortSignal;
+}>;
+
+export class GeneratedCardImageOperationLockAbortedError extends Error {
+  constructor(cause: unknown) {
+    super("Generated card image operation lock acquisition was aborted.", { cause });
+    this.name = "GeneratedCardImageOperationLockAbortedError";
+  }
+}
+
+export class GeneratedCardImageOperationLockTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number, cause: unknown) {
+    super(`Generated card image operation lock timed out after ${timeoutMs}ms.`, { cause });
+    this.name = "GeneratedCardImageOperationLockTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export async function withGeneratedCardImageOperationLock<Result>(
+  input: GeneratedCardImageOperationLockInput,
+  callback: (signal: AbortSignal) => Promise<Result>,
+): Promise<Result> {
+  try {
+    return await withSessionAdvisoryLock(
+      {
+        lockName: generatedCardImageOperationLockName,
+        lockKey: `chat.generated_card_image:${input.workspaceId.toLowerCase()}:${input.mediaAssetId.toLowerCase()}`,
+        timeoutMs: generatedCardImageOperationLockTimeoutMs,
+        pollIntervalMs: generatedCardImageOperationLockPollIntervalMs,
+        signal: input.signal,
+      },
+      callback,
+    );
+  } catch (error) {
+    if (error instanceof SessionAdvisoryLockAbortedError) {
+      throw new GeneratedCardImageOperationLockAbortedError(error);
+    }
+    if (error instanceof SessionAdvisoryLockTimeoutError) {
+      throw new GeneratedCardImageOperationLockTimeoutError(error.timeoutMs, error);
+    }
+    throw error;
+  }
+}

--- a/apps/backend/src/chat/cardImages/types.ts
+++ b/apps/backend/src/chat/cardImages/types.ts
@@ -1,0 +1,32 @@
+import type { CardTextSide } from "../../cards";
+import type { GeneratedCardImageObservationContext } from "./providerTypes";
+
+export type GeneratedCardImageInput = Readonly<{
+  runId: string;
+  userId: string;
+  workspaceId: string;
+  cardId: string;
+  targetSide: CardTextSide;
+  imagePrompt: string;
+  altText: string;
+  replicaId: string;
+  observationContext: GeneratedCardImageObservationContext;
+  signal: AbortSignal;
+}>;
+
+export type GeneratedCardImageResult = Readonly<{
+  cardId: string;
+  mediaAssetId: string;
+  targetSide: CardTextSide;
+  mediaRegistrationApplied: boolean;
+  cardAppendApplied: boolean;
+  reused: boolean;
+  sourceUrl: null;
+}>;
+
+export type GeneratedCardImageOperationMetadata = Readonly<{
+  operationId: string;
+  mediaAssetId: string;
+  mediaLastOperationId: string;
+  cardLastOperationId: string;
+}>;

--- a/apps/backend/src/database/index.ts
+++ b/apps/backend/src/database/index.ts
@@ -19,6 +19,10 @@ export type {
   UserDatabaseScope,
   WorkspaceDatabaseScope,
 } from "./core";
+export {
+  SessionAdvisoryLockAbortedError, SessionAdvisoryLockTimeoutError, withSessionAdvisoryLock,
+} from "./sessionAdvisoryLock";
+export type { SessionAdvisoryLockInput } from "./sessionAdvisoryLock";
 
 export async function transactionWithUserScope<Result>(
   scope: UserDatabaseScope,

--- a/apps/backend/src/database/sessionAdvisoryLock.ts
+++ b/apps/backend/src/database/sessionAdvisoryLock.ts
@@ -1,0 +1,445 @@
+import pg from "pg";
+import { getDatabaseUrl } from "./config";
+import { logDatabasePoolError, toDatabaseBoundaryError } from "./transient";
+
+const lockPoolName = "session-advisory-lock";
+const lockPoolMaximumClients = 2;
+const lockAdmissionMaximumPendingCount = 8;
+const lockClientConnectionTimeoutMs = 5_000;
+const lockPoolCheckoutAttemptTimeoutMs = 5_500;
+const unlockQueryTimeoutMs = 5_000;
+const poolCheckoutTimeoutMessage = "timeout exceeded when trying to connect";
+const connectionTimeoutMessages = new Set(["timeout expired", "Connection terminated due to connection timeout"]);
+let lockPoolPromise: Promise<pg.Pool> | undefined;
+let activeLockAdmissionCount = 0;
+const pendingLockAdmissions: Array<() => void> = [];
+export type SessionAdvisoryLockInput = Readonly<{
+  lockName: string; lockKey: string; timeoutMs: number; pollIntervalMs: number;
+  signal: AbortSignal;
+}>;
+type LockRow = Readonly<{ acquired: boolean }>;
+type UnlockRow = Readonly<{ unlocked: boolean }>;
+type LockClientLease = Readonly<{ client: pg.PoolClient; releaseAdmission: () => void }>;
+class SessionAdvisoryLockClient extends pg.Client {
+  constructor(config?: pg.ClientConfig) {
+    super({ ...config, connectionTimeoutMillis: lockClientConnectionTimeoutMs });
+  }
+}
+class SessionAdvisoryLockConnectionTimeoutError extends Error {
+  readonly code = "ETIMEDOUT";
+  constructor(cause: Error) {
+    super(
+      `PostgreSQL session advisory lock connection timed out. timeoutMs=${lockClientConnectionTimeoutMs}`,
+      { cause },
+    );
+    this.name = "SessionAdvisoryLockConnectionTimeoutError";
+  }
+}
+class SessionAdvisoryLockQueryUncertainError extends Error {
+  constructor(readonly operationError: unknown) {
+    super("Session advisory lock query completion could not be confirmed.", { cause: operationError });
+    this.name = "SessionAdvisoryLockQueryUncertainError";
+  }
+}
+export class SessionAdvisoryLockAbortedError extends Error {
+  constructor(readonly lockName: string, cause: unknown) {
+    super(`Session advisory lock acquisition was aborted. lockName=${lockName}`, { cause });
+    this.name = "SessionAdvisoryLockAbortedError";
+  }
+}
+export class SessionAdvisoryLockTimeoutError extends Error {
+  constructor(readonly lockName: string, readonly timeoutMs: number) {
+    super(`Session advisory lock acquisition timed out. lockName=${lockName}; timeoutMs=${timeoutMs}`);
+    this.name = "SessionAdvisoryLockTimeoutError";
+  }
+}
+export class SessionAdvisoryLockCapacityError extends Error {
+  constructor(readonly lockName: string, readonly maximumPendingCount: number) {
+    super(`Session advisory lock admission queue is full. lockName=${lockName}; maximumPendingCount=${maximumPendingCount}`);
+    this.name = "SessionAdvisoryLockCapacityError";
+  }
+}
+async function createLockPool(): Promise<pg.Pool> {
+  const pool = new pg.Pool({
+    connectionString: await getDatabaseUrl(),
+    ssl: process.env.DB_SECRET_ARN ? true : false,
+    max: lockPoolMaximumClients,
+    Client: SessionAdvisoryLockClient,
+    connectionTimeoutMillis: lockPoolCheckoutAttemptTimeoutMs,
+    application_name: "backend-session-advisory-lock",
+  });
+  pool.on("error", (error: Error): void => logDatabasePoolError(lockPoolName, error));
+  return pool;
+}
+function getLockPool(): Promise<pg.Pool> {
+  if (lockPoolPromise === undefined) {
+    let retryablePromise: Promise<pg.Pool>;
+    retryablePromise = createLockPool().catch((error: unknown) => {
+      if (lockPoolPromise === retryablePromise) lockPoolPromise = undefined;
+      throw error;
+    });
+    lockPoolPromise = retryablePromise;
+  }
+  return lockPoolPromise;
+}
+function abortError(input: SessionAdvisoryLockInput): SessionAdvisoryLockAbortedError {
+  return new SessionAdvisoryLockAbortedError(input.lockName, input.signal.reason);
+}
+function timeoutError(input: SessionAdvisoryLockInput): SessionAdvisoryLockTimeoutError {
+  return new SessionAdvisoryLockTimeoutError(input.lockName, input.timeoutMs);
+}
+function isPoolCheckoutTimeout(error: unknown): boolean {
+  return error instanceof Error && error.message === poolCheckoutTimeoutMessage;
+}
+export function toSessionAdvisoryLockConnectionBoundaryError(error: unknown): unknown {
+  const normalizedError = error instanceof Error && connectionTimeoutMessages.has(error.message)
+    ? new SessionAdvisoryLockConnectionTimeoutError(error)
+    : error;
+  return toDatabaseBoundaryError(normalizedError);
+}
+function releaseLockAdmission(): void {
+  const nextAdmission = pendingLockAdmissions.shift();
+  if (nextAdmission === undefined) {
+    activeLockAdmissionCount -= 1;
+    return;
+  }
+  nextAdmission();
+}
+function createLockAdmissionRelease(): () => void {
+  let released = false;
+  return () => {
+    if (released) throw new Error("Session advisory lock admission was released more than once.");
+    released = true;
+    releaseLockAdmission();
+  };
+}
+async function acquireLockAdmission(input: SessionAdvisoryLockInput, deadlineMs: number): Promise<() => void> {
+  if (input.signal.aborted) throw abortError(input);
+  const remainingMs = deadlineMs - Date.now();
+  if (remainingMs <= 0) throw timeoutError(input);
+  if (activeLockAdmissionCount < lockPoolMaximumClients) {
+    activeLockAdmissionCount += 1;
+    return createLockAdmissionRelease();
+  }
+  if (pendingLockAdmissions.length >= lockAdmissionMaximumPendingCount) {
+    throw new SessionAdvisoryLockCapacityError(input.lockName, lockAdmissionMaximumPendingCount);
+  }
+  return new Promise<() => void>((resolve, reject) => {
+    let queued = true;
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      input.signal.removeEventListener("abort", onAbort);
+    };
+    const remove = (error: Error): void => {
+      if (!queued) return;
+      queued = false;
+      cleanup();
+      const index = pendingLockAdmissions.indexOf(grant);
+      if (index >= 0) pendingLockAdmissions.splice(index, 1);
+      reject(error);
+    };
+    const grant = (): void => {
+      if (!queued) return;
+      queued = false;
+      cleanup();
+      if (input.signal.aborted) {
+        reject(abortError(input));
+        releaseLockAdmission();
+      } else if (Date.now() >= deadlineMs) {
+        reject(timeoutError(input));
+        releaseLockAdmission();
+      } else {
+        resolve(createLockAdmissionRelease());
+      }
+    };
+    const onAbort = (): void => remove(abortError(input));
+    const timer = setTimeout(() => remove(timeoutError(input)), remainingMs);
+    pendingLockAdmissions.push(grant);
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    if (input.signal.aborted) onAbort();
+  });
+}
+function validateInput(input: SessionAdvisoryLockInput): void {
+  if (input.lockName.trim() === "" || input.lockKey.trim() === "") {
+    throw new Error("Session advisory lock name and key must not be empty.");
+  }
+  if (Number.isSafeInteger(input.timeoutMs) === false || input.timeoutMs < 1
+      || Number.isSafeInteger(input.pollIntervalMs) === false || input.pollIntervalMs < 1) {
+    throw new RangeError("Session advisory lock timeout and poll interval must be positive safe integers.");
+  }
+}
+
+async function connectLockClientAttempt(
+  input: SessionAdvisoryLockInput,
+  deadlineMs: number,
+  onClientError: (error: Error) => void,
+  releaseAdmission: () => void,
+): Promise<LockClientLease> {
+  if (input.signal.aborted) {
+    releaseAdmission();
+    throw abortError(input);
+  }
+  if (Date.now() >= deadlineMs) {
+    releaseAdmission();
+    throw timeoutError(input);
+  }
+  const connectPromise = getLockPool().then((pool) => pool.connect());
+  return new Promise<LockClientLease>((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      input.signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = (): void => settle(() => reject(abortError(input)));
+    const timer = setTimeout(() => settle(() => reject(timeoutError(input))),
+      Math.max(0, deadlineMs - Date.now()));
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    if (input.signal.aborted) onAbort();
+    void connectPromise.then(
+      (client) => {
+        if (settled) {
+          client.release();
+          releaseAdmission();
+          return;
+        }
+        client.on("error", onClientError);
+        settle(() => resolve({ client, releaseAdmission }));
+      },
+      (error: unknown) => {
+        releaseAdmission();
+        settle(() => reject(error));
+      },
+    ).catch((error: unknown) => logDatabasePoolError(lockPoolName, error));
+  });
+}
+
+async function connectLockClient(
+  input: SessionAdvisoryLockInput,
+  deadlineMs: number,
+  onClientError: (error: Error) => void,
+): Promise<LockClientLease> {
+  while (true) {
+    const releaseAdmission = await acquireLockAdmission(input, deadlineMs);
+    try {
+      return await connectLockClientAttempt(input, deadlineMs, onClientError, releaseAdmission);
+    } catch (error) {
+      if (error instanceof SessionAdvisoryLockAbortedError
+          || error instanceof SessionAdvisoryLockTimeoutError) {
+        throw error;
+      }
+      if (isPoolCheckoutTimeout(error) === false) {
+        throw toSessionAdvisoryLockConnectionBoundaryError(error);
+      }
+      if (input.signal.aborted) throw abortError(input);
+      if (Date.now() >= deadlineMs) throw timeoutError(input);
+    }
+  }
+}
+
+async function queryLockAttempt(
+  client: pg.PoolClient,
+  input: SessionAdvisoryLockInput,
+  deadlineMs: number,
+): Promise<pg.QueryResult<LockRow>> {
+  if (input.signal.aborted) throw abortError(input);
+  const remainingMs = deadlineMs - Date.now();
+  if (remainingMs <= 0) throw timeoutError(input);
+
+  let queryPromise: Promise<pg.QueryResult<LockRow>>;
+  try {
+    queryPromise = client.query<LockRow>(
+      "SELECT pg_try_advisory_lock(hashtextextended($1, 3::bigint)) AS acquired", [input.lockKey],
+    );
+  } catch (error) {
+    throw new SessionAdvisoryLockQueryUncertainError(toDatabaseBoundaryError(error));
+  }
+
+  return new Promise<pg.QueryResult<LockRow>>((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      input.signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const rejectUncertain = (error: unknown): void => settle(
+      () => reject(new SessionAdvisoryLockQueryUncertainError(error)),
+    );
+    const onAbort = (): void => rejectUncertain(abortError(input));
+    const timer = setTimeout(() => rejectUncertain(timeoutError(input)), remainingMs);
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    if (input.signal.aborted) onAbort();
+    void queryPromise.then(
+      (result) => settle(() => resolve(result)),
+      (error: unknown) => rejectUncertain(toDatabaseBoundaryError(error)),
+    );
+  });
+}
+
+async function waitToPoll(input: SessionAdvisoryLockInput, deadlineMs: number): Promise<void> {
+  if (input.signal.aborted) throw abortError(input);
+  const remainingMs = deadlineMs - Date.now();
+  if (remainingMs <= 0) throw timeoutError(input);
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => { clearTimeout(timer); reject(abortError(input)); };
+    const timer = setTimeout(() => {
+      input.signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, Math.min(input.pollIntervalMs, remainingMs));
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    if (input.signal.aborted) onAbort();
+  });
+}
+
+async function acquireLock(
+  client: pg.PoolClient, input: SessionAdvisoryLockInput, deadlineMs: number,
+): Promise<void> {
+  while (Date.now() < deadlineMs) {
+    const result = await queryLockAttempt(client, input, deadlineMs);
+    if (result.rows[0]?.acquired === true) return;
+    if (result.rows[0]?.acquired !== false) {
+      throw new Error(`PostgreSQL returned an invalid advisory lock result. lockName=${input.lockName}`);
+    }
+    await waitToPoll(input, deadlineMs);
+  }
+  throw timeoutError(input);
+}
+
+async function queryUnlock(client: pg.PoolClient, input: SessionAdvisoryLockInput): Promise<pg.QueryResult<UnlockRow>> {
+  const queryPromise = client.query<UnlockRow>(
+    "SELECT pg_advisory_unlock(hashtextextended($1, 3::bigint)) AS unlocked", [input.lockKey],
+  );
+
+  return new Promise<pg.QueryResult<UnlockRow>>((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+    const timer = setTimeout(() => settle(() => reject(new Error(
+        `Session advisory unlock query timed out. lockName=${input.lockName}; timeoutMs=${unlockQueryTimeoutMs}`,
+      ))), unlockQueryTimeoutMs);
+    void queryPromise.then(
+      (result) => settle(() => resolve(result)),
+      (error: unknown) => settle(() => reject(error)),
+    );
+  });
+}
+
+async function unlock(client: pg.PoolClient, input: SessionAdvisoryLockInput): Promise<void> {
+  try {
+    const result = await queryUnlock(client, input);
+    if (result.rows[0]?.unlocked !== true) {
+      throw new Error("PostgreSQL reported that the session did not own the advisory lock.");
+    }
+  } catch (error) {
+    throw Object.assign(
+      new Error(`Session advisory lock could not be confirmed as unlocked. lockName=${input.lockName}`, { cause: error }),
+      { name: "SessionAdvisoryLockUnlockError" },
+    );
+  }
+}
+
+async function cleanupLockClient(
+  client: pg.PoolClient,
+  input: SessionAdvisoryLockInput,
+  acquired: boolean,
+  readConnectionError: () => Error | undefined,
+  onClientError: (error: Error) => void,
+): Promise<Error | undefined> {
+  let cleanupError: Error | undefined;
+  try {
+    if (acquired && readConnectionError() === undefined) await unlock(client, input);
+  } catch (error) {
+    cleanupError = error instanceof Error ? error : new Error(String(error));
+  }
+  try {
+    client.release(readConnectionError() ?? cleanupError);
+  } catch (error) {
+    const releaseError = Object.assign(new Error(
+      `Session advisory lock connection could not be released. lockName=${input.lockName}`, { cause: error },
+    ), { name: "SessionAdvisoryLockReleaseError" });
+    if (cleanupError === undefined) cleanupError = releaseError;
+    else logDatabasePoolError(`${lockPoolName}-cleanup`, releaseError);
+  } finally {
+    client.removeListener("error", onClientError);
+  }
+  return cleanupError;
+}
+
+export async function withSessionAdvisoryLock<Result>(
+  input: SessionAdvisoryLockInput,
+  callback: (signal: AbortSignal) => Promise<Result>,
+): Promise<Result> {
+  validateInput(input);
+  const deadlineMs = Date.now() + input.timeoutMs;
+  const lockLossController = new AbortController();
+  let clientError: Error | undefined;
+  const onClientError = (error: Error): void => {
+    if (clientError !== undefined) return;
+    clientError = error;
+    lockLossController.abort(error);
+  };
+  const { client, releaseAdmission } = await connectLockClient(input, deadlineMs, onClientError);
+  const callbackSignal = AbortSignal.any([input.signal, lockLossController.signal]);
+  const activeInput: SessionAdvisoryLockInput = { ...input, signal: callbackSignal };
+  let acquired = false;
+  let succeeded = false;
+  let primaryError: unknown;
+  let connectionError: Error | undefined;
+  let result!: Result;
+  try {
+    if (clientError !== undefined) throw clientError;
+    await acquireLock(client, activeInput, deadlineMs);
+    acquired = true;
+    if (callbackSignal.aborted) throw abortError(activeInput);
+    if (Date.now() >= deadlineMs) throw timeoutError(activeInput);
+    result = await callback(callbackSignal);
+    if (clientError !== undefined) throw clientError;
+    succeeded = true;
+  } catch (error) {
+    if (clientError !== undefined) {
+      connectionError = clientError;
+      primaryError = toDatabaseBoundaryError(clientError);
+    } else if (error instanceof SessionAdvisoryLockQueryUncertainError) {
+      connectionError = error;
+      primaryError = error.operationError;
+    } else {
+      primaryError = error;
+    }
+  }
+  let cleanupError: Error | undefined;
+  try {
+    cleanupError = await cleanupLockClient(
+      client, activeInput, acquired, () => clientError ?? connectionError, onClientError,
+    );
+  } finally {
+    releaseAdmission();
+  }
+  if (succeeded === false) {
+    if (cleanupError !== undefined) logDatabasePoolError(`${lockPoolName}-cleanup`, cleanupError);
+    throw primaryError;
+  }
+  if (clientError !== undefined) {
+    if (cleanupError !== undefined) logDatabasePoolError(`${lockPoolName}-cleanup`, cleanupError);
+    throw toDatabaseBoundaryError(clientError);
+  }
+  if (cleanupError !== undefined) throw cleanupError;
+  return result;
+}
+
+export async function closeSessionAdvisoryLockPoolForTests(): Promise<void> {
+  const poolPromise = lockPoolPromise;
+  lockPoolPromise = undefined;
+  if (poolPromise !== undefined) await (await poolPromise).end();
+}
+
+export function readSessionAdvisoryLockWaitingCountForTests(): number {
+  return pendingLockAdmissions.length;
+}


### PR DESCRIPTION
## Summary
- add deterministic generated-image operation metadata and result contracts
- add bounded PostgreSQL session advisory-lock coordination with cancellation and lock-loss handling
- orchestrate provider, normalization, S3 storage, and atomic media/card persistence
- add focused and real PostgreSQL integration coverage

## Validation
- focused card image tests: 3 passed
- PostgreSQL integration tests: 3 passed
- backend test suite: 806 passed
- backend lint passed
- backend build passed