### PR TITLE
Fence chat worker claims and replica writes

### DIFF
--- a/apps/backend/src/agent/syncIdentity.ts
+++ b/apps/backend/src/agent/syncIdentity.ts
@@ -17,5 +17,6 @@ export async function ensureAgentSyncReplica(
     actorKey: connectionId,
     platform: "web",
     appVersion: `agent:${connectionId}`,
+    signal: null,
   });
 }

--- a/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
@@ -65,12 +65,16 @@ test("startOpenAILoopWithDeps stops after a completed tool call before the next 
   let stopBeforeNextStep = false;
   let streamCallCount = 0;
   let toolCallCount = 0;
+  let observedClaimToken: string | null = null;
+  let observedSignal: AbortSignal | null = null;
+  const abortController = new AbortController();
   const startedFunctionCallItem = createFunctionCallItem("in_progress");
   const completedFunctionCallItem = createFunctionCallItem("completed");
   const { sink, events } = collectEvents();
 
   const result = await startOpenAILoopWithDeps(
     createParams({
+      signal: abortController.signal,
       shouldStopBeforeNextStep: (): boolean => stopBeforeNextStep,
     }),
     sink,
@@ -82,8 +86,10 @@ test("startOpenAILoopWithDeps stops after a completed tool call before the next 
           createResponse([completedFunctionCallItem], ""),
         );
       },
-      async () => {
+      async (params) => {
         toolCallCount += 1;
+        observedClaimToken = params.claimToken;
+        observedSignal = params.signal;
         stopBeforeNextStep = true;
         return {
           output: "{\"ok\":true}",
@@ -96,6 +102,8 @@ test("startOpenAILoopWithDeps stops after a completed tool call before the next 
 
   assert.equal(streamCallCount, 1);
   assert.equal(toolCallCount, 1);
+  assert.equal(observedClaimToken, createParams({}).claimToken);
+  assert.equal(observedSignal, abortController.signal);
   assert.equal(result.terminationReason, "stopped_before_next_step");
   assert.deepEqual(result.openaiItems, [
     {

--- a/apps/backend/src/chat/openai/loop/loop.testSupport.ts
+++ b/apps/backend/src/chat/openai/loop/loop.testSupport.ts
@@ -15,6 +15,7 @@ export function createParams(
 ): StartOpenAILoopParams {
   return {
     requestId: "request-1",
+    claimToken: "2026-07-24 10:11:12.123456+00",
     userId: "user-1",
     workspaceId: "workspace-1",
     sessionId: "session-1",

--- a/apps/backend/src/chat/openai/loop/loop.ts
+++ b/apps/backend/src/chat/openai/loop/loop.ts
@@ -43,6 +43,7 @@ import {
   type ChatRuntimeModelId,
   type ChatRuntimeReasoningEffort,
 } from "../../config";
+import type { ChatRunClaimToken } from "../../runs";
 
 export const CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS = 30;
 const MAX_REASONING_ITEMS = 8;
@@ -76,8 +77,10 @@ type OpenAILoopDependencies = Readonly<{
   getObservedOpenAIClient: typeof getObservedOpenAIClient;
   runOneToolCall: (params: Readonly<{
     item: OpenAI.Responses.ResponseFunctionToolCall;
+    claimToken: ChatRunClaimToken;
     userId: string;
     workspaceId: string;
+    signal: AbortSignal | null;
     rootObservation: LangfuseObservation | null;
   }>) => Promise<ExecutedChatToolCall>;
 }>;
@@ -127,6 +130,7 @@ type BuildOpenAIResponsesRequestParams = Readonly<{
 
 export type StartOpenAILoopParams = Readonly<{
   requestId: string;
+  claimToken: ChatRunClaimToken;
   userId: string;
   workspaceId: string;
   sessionId: string;
@@ -277,8 +281,10 @@ async function getFinalResponseFromStream(
 async function runOneToolCall(
   params: Readonly<{
     item: OpenAI.Responses.ResponseFunctionToolCall;
+    claimToken: ChatRunClaimToken;
     userId: string;
     workspaceId: string;
+    signal: AbortSignal | null;
     rootObservation: LangfuseObservation | null;
   }>,
 ): Promise<ExecutedChatToolCall> {
@@ -875,8 +881,10 @@ async function runLoopWithDeps(
       try {
         const output = await dependencies.runOneToolCall({
           item: functionCall,
+          claimToken: params.claimToken,
           userId: params.userId,
           workspaceId: params.workspaceId,
+          signal: params.signal ?? null,
           rootObservation: params.rootObservation,
         });
         const update = applyToolCallOutput(

--- a/apps/backend/src/chat/openai/tools/toolExecutor.ts
+++ b/apps/backend/src/chat/openai/tools/toolExecutor.ts
@@ -4,6 +4,7 @@ import {
   executeChatToolCall,
   type ExecutedChatToolCall,
 } from "./tools";
+import type { ChatRunClaimToken } from "../../runs";
 
 type ToolTelemetryMetadata = Readonly<{
   toolName: string;
@@ -72,8 +73,10 @@ function buildToolTelemetryMetadata(
 export async function runOneToolCall(
   params: Readonly<{
     item: OpenAI.Responses.ResponseFunctionToolCall;
+    claimToken: ChatRunClaimToken;
     userId: string;
     workspaceId: string;
+    signal: AbortSignal | null;
     rootObservation: LangfuseObservation | null;
   }>,
 ): Promise<ExecutedChatToolCall> {
@@ -109,6 +112,8 @@ export async function runOneToolCall(
       {
         userId: params.userId,
         workspaceId: params.workspaceId,
+        claimToken: params.claimToken,
+        signal: params.signal,
       },
     );
 

--- a/apps/backend/src/chat/openai/tools/tools.ts
+++ b/apps/backend/src/chat/openai/tools/tools.ts
@@ -17,10 +17,13 @@ import {
   SQL_TOOL_ARGUMENT_VALIDATOR,
   SQL_TOOL_NAME,
 } from "../../../aiTools/toolContract/sqlToolContract";
+import type { ChatRunClaimToken } from "../../runs";
 
 export type OpenAIToolContext = Readonly<{
   userId: string;
   workspaceId: string;
+  claimToken: ChatRunClaimToken;
+  signal: AbortSignal | null;
 }>;
 
 export type ExecutedChatToolCall = Readonly<{
@@ -31,7 +34,7 @@ export type ExecutedChatToolCall = Readonly<{
 
 type OpenAIToolDependencies = Readonly<{
   executeAgentSql: typeof executeAgentSql;
-  createToolDependencies: () => AgentToolOperationDependencies;
+  createToolDependencies: (context: OpenAIToolContext) => AgentToolOperationDependencies;
 }>;
 
 type ToolErrorPayload = Readonly<{
@@ -52,11 +55,11 @@ type ToolErrorPayload = Readonly<{
  */
 const MAX_TOOL_OUTPUT_CHARS = 24_000 as const;
 
-function createToolDependencies(): AgentToolOperationDependencies {
+function createToolDependencies(context: OpenAIToolContext): AgentToolOperationDependencies {
   return {
     ...DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
     ensureAgentSyncReplica: async (workspaceId: string, userId: string): Promise<string> =>
-      ensureAIChatSyncReplica(workspaceId, userId, "web"),
+      ensureAIChatSyncReplica(workspaceId, userId, "web", context.signal),
   };
 }
 
@@ -194,7 +197,7 @@ export async function executeChatToolCallWithDependencies(
         connectionId: "chat-v2",
       },
       parsed.sql,
-      dependencies.createToolDependencies(),
+      dependencies.createToolDependencies(context),
     );
 
     return {

--- a/apps/backend/src/chat/runs.ts
+++ b/apps/backend/src/chat/runs.ts
@@ -3,6 +3,7 @@
  * Internal implementation is split across focused modules under `./runs/`.
  */
 export type {
+  ChatRunClaimToken,
   ChatRunHeartbeatState,
   ChatRunSnapshot,
   ChatRunStatus,
@@ -11,6 +12,12 @@ export type {
   PreparedChatRun,
   RecoveredPaginatedSession,
 } from "./runs/types";
+
+export {
+  assertActiveChatRunClaimWithExecutor,
+  InactiveChatRunClaimError,
+} from "./runs/claimFence";
+export type { ChatRunClaimFenceParams } from "./runs/claimFence";
 
 export {
   getChatRunSnapshot,

--- a/apps/backend/src/chat/runs/claimFence.ts
+++ b/apps/backend/src/chat/runs/claimFence.ts
@@ -1,0 +1,51 @@
+import type {
+  DatabaseExecutor,
+  WorkspaceDatabaseScope,
+} from "../../database";
+import {
+  selectChatRunForUpdateWithExecutor,
+  selectSessionForUpdateWithExecutor,
+} from "./repository";
+import type { ChatRunClaimToken } from "./types";
+
+export type ChatRunClaimFenceParams = WorkspaceDatabaseScope & Readonly<{
+  runId: string;
+  sessionId: string;
+  claimToken: ChatRunClaimToken;
+}>;
+
+export class InactiveChatRunClaimError extends Error {
+  public constructor(runId: string) {
+    super(`Chat run claim is no longer active: ${runId}`);
+    this.name = "InactiveChatRunClaimError";
+  }
+}
+
+/**
+ * Locks and verifies a worker claim inside the caller's existing transaction.
+ */
+export async function assertActiveChatRunClaimWithExecutor(
+  executor: DatabaseExecutor,
+  params: ChatRunClaimFenceParams,
+): Promise<void> {
+  const scope = {
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+  };
+  const run = await selectChatRunForUpdateWithExecutor(executor, scope, params.runId);
+  if (run === null) {
+    throw new InactiveChatRunClaimError(params.runId);
+  }
+
+  const session = await selectSessionForUpdateWithExecutor(executor, scope, run.session_id);
+  if (
+    run.session_id !== params.sessionId
+    || run.status !== "running"
+    || run.cancel_requested_at !== null
+    || run.worker_claimed_at !== params.claimToken
+    || session.status !== "running"
+    || session.active_run_id !== run.run_id
+  ) {
+    throw new InactiveChatRunClaimError(params.runId);
+  }
+}

--- a/apps/backend/src/chat/runs/lifecycleService.test.ts
+++ b/apps/backend/src/chat/runs/lifecycleService.test.ts
@@ -4,9 +4,21 @@ import type pg from "pg";
 import type { DatabaseExecutor, SqlValue, WorkspaceDatabaseScope } from "../../database";
 import { ChatRunRowNotFoundError } from "../errors";
 import type { ChatSessionRow } from "../store/repository";
+import {
+  assertActiveChatRunClaimWithExecutor,
+  InactiveChatRunClaimError,
+} from "./claimFence";
 import { finalizeInterruptedRunWithExecutor } from "./finalization";
-import { assertClaimedRunStillActive, requestChatRunCancellationWithExecutor } from "./lifecycleService";
-import type { ChatRunRow } from "./repository";
+import {
+  assertClaimedRunStillActive,
+  requestChatRunCancellationWithExecutor,
+} from "./lifecycleService";
+import {
+  claimChatRunWithExecutor,
+  createChatRunStatusUpdateFromRow,
+  updateClaimedChatRunStatusWithExecutor,
+  type ChatRunRow,
+} from "./repository";
 
 type RecordedQuery = Readonly<{
   text: string;
@@ -17,6 +29,8 @@ const scope: WorkspaceDatabaseScope = {
   userId: "user-1",
   workspaceId: "workspace-1",
 };
+const firstClaimToken = "2026-07-24 10:11:12.123456+00";
+const secondClaimToken = "2026-07-24 10:12:13.654321+00";
 
 function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
   return {
@@ -45,7 +59,7 @@ function createRunRow(
     timezone: "Europe/Madrid",
     ui_locale: "es",
     turn_input: [],
-    worker_claimed_at: null,
+    worker_claimed_at: firstClaimToken,
     worker_heartbeat_at: null,
     cancel_requested_at: null,
     started_at: null,
@@ -77,6 +91,7 @@ test("assertClaimedRunStillActive accepts the active running owner", () => {
     assertClaimedRunStillActive(
       createRunRow(),
       createSessionRow(),
+      firstClaimToken,
       "complete",
     );
   });
@@ -89,6 +104,7 @@ test("assertClaimedRunStillActive rejects a session that no longer owns the run"
       createSessionRow({
         active_run_id: "run-2",
       }),
+      firstClaimToken,
       "complete",
     );
   }, ChatRunRowNotFoundError);
@@ -103,9 +119,218 @@ test("assertClaimedRunStillActive rejects non-running terminal state", () => {
       createSessionRow({
         status: "idle",
       }),
+      firstClaimToken,
       "fail",
     );
   }, ChatRunRowNotFoundError);
+});
+
+test("assertClaimedRunStillActive rejects a reclaimed run for the first claim token", () => {
+  assert.throws(() => {
+    assertClaimedRunStillActive(
+      createRunRow({
+        worker_claimed_at: secondClaimToken,
+      }),
+      createSessionRow(),
+      firstClaimToken,
+      "complete",
+    );
+  }, ChatRunRowNotFoundError);
+});
+
+test("claimChatRunWithExecutor returns the exact persisted worker claim token", async () => {
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("set_config('app.user_id'")) {
+        return createQueryResult<Row>([]);
+      }
+      if (text.includes("UPDATE ai.chat_runs")) {
+        assert.match(text, /worker_claimed_at = statement_timestamp\(\)/);
+        assert.deepEqual(params, ["run-1"]);
+        return createQueryResult<Row>([
+          createRunRow({
+            worker_claimed_at: firstClaimToken,
+            worker_heartbeat_at: firstClaimToken,
+          }) as unknown as Row,
+        ]);
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const claimedRun = await claimChatRunWithExecutor(executor, scope, "run-1");
+  assert.equal(claimedRun?.worker_claimed_at, firstClaimToken);
+});
+
+test("claimed heartbeat and terminal updates reject stale ownership in the update predicate", async () => {
+  const run = createRunRow();
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("set_config('app.user_id'")) {
+        return createQueryResult<Row>([]);
+      }
+      if (text.includes("UPDATE ai.chat_runs")) {
+        assert.match(text, /status = 'running'/);
+        assert.match(text, /worker_claimed_at = \$2::timestamptz/);
+        assert.doesNotMatch(
+          text.slice(text.indexOf("SET"), text.indexOf("WHERE")),
+          /worker_claimed_at/,
+        );
+        return createQueryResult<Row>(
+          params[1] === firstClaimToken
+            ? [createRunRow({
+              status: params[2] === "running" ? "running" : "completed",
+              worker_heartbeat_at: typeof params[3] === "string" ? params[3] : null,
+            }) as unknown as Row]
+            : [],
+        );
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+  const heartbeatAt = new Date("2026-07-24T10:13:14.000Z");
+  const heartbeatUpdate = createChatRunStatusUpdateFromRow(run, {
+    status: "running",
+    workerHeartbeatAt: heartbeatAt,
+    finishedAt: null,
+    lastErrorMessage: null,
+  });
+  const terminalUpdate = createChatRunStatusUpdateFromRow(run, {
+    status: "completed",
+    finishedAt: new Date("2026-07-24T10:14:15.000Z"),
+    lastErrorMessage: null,
+  });
+
+  const currentHeartbeat = await updateClaimedChatRunStatusWithExecutor(
+    executor,
+    scope,
+    firstClaimToken,
+    heartbeatUpdate,
+  );
+  const staleHeartbeat = await updateClaimedChatRunStatusWithExecutor(
+    executor,
+    scope,
+    secondClaimToken,
+    heartbeatUpdate,
+  );
+  const currentResult = await updateClaimedChatRunStatusWithExecutor(
+    executor,
+    scope,
+    firstClaimToken,
+    terminalUpdate,
+  );
+  const staleResult = await updateClaimedChatRunStatusWithExecutor(
+    executor,
+    scope,
+    secondClaimToken,
+    terminalUpdate,
+  );
+
+  assert.equal(currentHeartbeat?.worker_heartbeat_at, heartbeatAt.toISOString());
+  assert.equal(staleHeartbeat, null);
+  assert.equal(currentResult?.status, "completed");
+  assert.equal(staleResult, null);
+});
+
+test("assertActiveChatRunClaimWithExecutor locks run then session and accepts the active claim", async () => {
+  const lockOrder: Array<string> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("set_config('app.user_id'")) {
+        return createQueryResult<Row>([]);
+      }
+      if (text.includes("FROM ai.chat_runs") && text.includes("FOR UPDATE")) {
+        lockOrder.push("run");
+        return createQueryResult<Row>([createRunRow() as unknown as Row]);
+      }
+      if (text.includes("FROM ai.chat_sessions") && text.includes("FOR UPDATE")) {
+        lockOrder.push("session");
+        return createQueryResult<Row>([createSessionRow() as unknown as Row]);
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  await assertActiveChatRunClaimWithExecutor(executor, {
+    ...scope,
+    runId: "run-1",
+    sessionId: "session-1",
+    claimToken: firstClaimToken,
+  });
+
+  assert.deepEqual(lockOrder, ["run", "session"]);
+});
+
+test("assertActiveChatRunClaimWithExecutor rejects every inactive claim state", async () => {
+  const cases: ReadonlyArray<Readonly<{
+    name: string;
+    run: ChatRunRow;
+    session: ChatSessionRow;
+  }>> = [
+    {
+      name: "claim token mismatch",
+      run: createRunRow({ worker_claimed_at: secondClaimToken }),
+      session: createSessionRow(),
+    },
+    {
+      name: "cancel requested",
+      run: createRunRow({ cancel_requested_at: "2026-07-24T10:12:00.000Z" }),
+      session: createSessionRow(),
+    },
+    {
+      name: "non-running run",
+      run: createRunRow({ status: "completed" }),
+      session: createSessionRow(),
+    },
+    {
+      name: "inactive session",
+      run: createRunRow(),
+      session: createSessionRow({ status: "idle" }),
+    },
+    {
+      name: "mismatched active run",
+      run: createRunRow(),
+      session: createSessionRow({ active_run_id: "run-2" }),
+    },
+  ];
+
+  for (const testCase of cases) {
+    const executor: DatabaseExecutor = {
+      async query<Row extends pg.QueryResultRow>(
+        text: string,
+      ): Promise<pg.QueryResult<Row>> {
+        if (text.includes("set_config('app.user_id'")) {
+          return createQueryResult<Row>([]);
+        }
+        if (text.includes("FROM ai.chat_runs") && text.includes("FOR UPDATE")) {
+          return createQueryResult<Row>([testCase.run as unknown as Row]);
+        }
+        if (text.includes("FROM ai.chat_sessions") && text.includes("FOR UPDATE")) {
+          return createQueryResult<Row>([testCase.session as unknown as Row]);
+        }
+        throw new Error(`Unexpected query: ${text}`);
+      },
+    };
+
+    await assert.rejects(
+      assertActiveChatRunClaimWithExecutor(executor, {
+        ...scope,
+        runId: "run-1",
+        sessionId: "session-1",
+        claimToken: firstClaimToken,
+      }),
+      InactiveChatRunClaimError,
+      testCase.name,
+    );
+  }
 });
 
 test("requestChatRunCancellationWithExecutor no-ops when the expected run is no longer active", async () => {

--- a/apps/backend/src/chat/runs/lifecycleService.ts
+++ b/apps/backend/src/chat/runs/lifecycleService.ts
@@ -46,6 +46,7 @@ import {
   recoverStaleRunWithExecutor,
 } from "./finalization";
 import {
+  claimChatRunWithExecutor as claimChatRunRowWithExecutor,
   createChatRunStatusUpdateFromRow,
   insertChatRunWithExecutor,
   mapChatRunStatusToSessionRunState,
@@ -54,10 +55,12 @@ import {
   selectChatRunForUpdateWithExecutor,
   selectSessionForUpdateWithExecutor,
   updateChatRunPolicySnapshotWithExecutor,
+  updateClaimedChatRunStatusWithExecutor,
   updateChatRunStatusWithExecutor,
   type ChatRunRow,
 } from "./repository";
 import type {
+  ChatRunClaimToken,
   ChatRunHeartbeatState,
   ChatRunStopState,
   ClaimedChatRun,
@@ -203,19 +206,15 @@ export async function claimChatRun(
       return null;
     }
 
-    const now = new Date();
-    const claimedRun = await updateChatRunStatusWithExecutor(
-      executor,
-      scope,
-      createChatRunStatusUpdateFromRow(run, {
-        status: "running",
-        workerClaimedAt: now,
-        workerHeartbeatAt: now,
-        startedAt: run.started_at === null ? now : undefined,
-        finishedAt: null,
-        lastErrorMessage: null,
-      }),
+    const claimedRun = requireRunRow(
+      await claimChatRunRowWithExecutor(executor, scope, run.run_id) ?? undefined,
+      "claim",
     );
+    if (claimedRun.worker_claimed_at === null) {
+      throw new Error(`Claimed chat run is missing worker_claimed_at: ${claimedRun.run_id}`);
+    }
+    const claimToken = claimedRun.worker_claimed_at;
+    const claimedAt = new Date(claimToken);
 
     await updateChatSessionRunStateWithExecutor(
       executor,
@@ -223,7 +222,7 @@ export async function claimChatRun(
       session.session_id,
       "running",
       claimedRun.run_id,
-      now,
+      claimedAt,
     );
 
     const messages = await buildLocalMessagesForClaimedRun(executor, scope, claimedRun.session_id, claimedRun.assistant_item_id);
@@ -232,6 +231,7 @@ export async function claimChatRun(
 
     return {
       runId: claimedRun.run_id,
+      claimToken,
       sessionId: claimedRun.session_id,
       requestId: claimedRun.request_id,
       userId,
@@ -268,10 +268,12 @@ async function buildLocalMessagesForClaimedRun(
 export function assertClaimedRunStillActive(
   run: ChatRunRow,
   session: ChatSessionRow,
+  claimToken: ChatRunClaimToken,
   operation: string,
 ): void {
   if (
     run.status !== "running"
+    || run.worker_claimed_at !== claimToken
     || session.status !== "running"
     || session.active_run_id !== run.run_id
   ) {
@@ -289,12 +291,17 @@ export async function touchClaimedChatRunHeartbeat(
   userId: string,
   workspaceId: string,
   runId: string,
+  claimToken: ChatRunClaimToken,
   heartbeatAt: Date,
 ): Promise<ChatRunHeartbeatState> {
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
     const scope = { userId, workspaceId };
     const run = await selectChatRunForUpdateWithExecutor(executor, scope, runId);
-    if (run === null || run.status !== "running") {
+    if (
+      run === null
+      || run.status !== "running"
+      || run.worker_claimed_at !== claimToken
+    ) {
       return {
         cancellationRequested: false,
         ownershipLost: true,
@@ -309,18 +316,24 @@ export async function touchClaimedChatRunHeartbeat(
       };
     }
 
-    await updateChatRunStatusWithExecutor(
+    const updatedRun = await updateClaimedChatRunStatusWithExecutor(
       executor,
       scope,
+      claimToken,
       createChatRunStatusUpdateFromRow(run, {
         status: "running",
-        workerClaimedAt: run.worker_claimed_at === null ? heartbeatAt : undefined,
         workerHeartbeatAt: heartbeatAt,
         startedAt: run.started_at === null ? heartbeatAt : undefined,
         finishedAt: null,
         lastErrorMessage: null,
       }),
     );
+    if (updatedRun === null) {
+      return {
+        cancellationRequested: false,
+        ownershipLost: true,
+      };
+    }
 
     await updateChatSessionRunStateWithExecutor(
       executor,
@@ -352,6 +365,7 @@ export async function completeClaimedChatRun(
     assistantOpenAIItems?: ReadonlyArray<StoredOpenAIReplayItem>;
     composerSuggestions: ReadonlyArray<ChatComposerSuggestion>;
   }>,
+  claimToken: ChatRunClaimToken,
 ): Promise<void> {
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
     const scope = { userId, workspaceId };
@@ -360,7 +374,7 @@ export async function completeClaimedChatRun(
       "complete",
     );
     const session = await selectSessionForUpdateWithExecutor(executor, scope, run.session_id);
-    assertClaimedRunStillActive(run, session, "complete");
+    assertClaimedRunStillActive(run, session, claimToken, "complete");
 
     await updateChatItemWithExecutor(executor, scope, {
       itemId: params.assistantItemId,
@@ -369,14 +383,18 @@ export async function completeClaimedChatRun(
       assistantOpenAIItems: params.assistantOpenAIItems,
     });
 
-    await updateChatRunStatusWithExecutor(
-      executor,
-      scope,
-      createChatRunStatusUpdateFromRow(run, {
-        status: "completed",
-        finishedAt: new Date(),
-        lastErrorMessage: null,
-      }),
+    requireRunRow(
+      await updateClaimedChatRunStatusWithExecutor(
+        executor,
+        scope,
+        claimToken,
+        createChatRunStatusUpdateFromRow(run, {
+          status: "completed",
+          finishedAt: new Date(),
+          lastErrorMessage: null,
+        }),
+      ) ?? undefined,
+      "complete",
     );
 
     await updateChatSessionRunStateWithExecutor(executor, scope, params.sessionId, "idle", null, null);
@@ -405,6 +423,7 @@ export async function persistClaimedChatRunTerminalError(
     errorMessage: string;
     sessionState: ChatSessionRunState;
   }>,
+  claimToken: ChatRunClaimToken,
 ): Promise<void> {
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
     const scope = { userId, workspaceId };
@@ -413,7 +432,7 @@ export async function persistClaimedChatRunTerminalError(
       "fail",
     );
     const session = await selectSessionForUpdateWithExecutor(executor, scope, run.session_id);
-    assertClaimedRunStillActive(run, session, "fail");
+    assertClaimedRunStillActive(run, session, claimToken, "fail");
     const finalizedAssistantContent = finalizePendingToolCallContent(
       params.assistantContent,
       "incomplete",
@@ -444,14 +463,18 @@ export async function persistClaimedChatRunTerminalError(
       });
     }
 
-    await updateChatRunStatusWithExecutor(
-      executor,
-      scope,
-      createChatRunStatusUpdateFromRow(run, {
-        status: params.sessionState === "interrupted" ? "interrupted" : "failed",
-        finishedAt: new Date(),
-        lastErrorMessage: params.errorMessage,
-      }),
+    requireRunRow(
+      await updateClaimedChatRunStatusWithExecutor(
+        executor,
+        scope,
+        claimToken,
+        createChatRunStatusUpdateFromRow(run, {
+          status: params.sessionState === "interrupted" ? "interrupted" : "failed",
+          finishedAt: new Date(),
+          lastErrorMessage: params.errorMessage,
+        }),
+      ) ?? undefined,
+      "fail",
     );
 
     await updateChatSessionRunStateWithExecutor(
@@ -484,6 +507,7 @@ export async function persistClaimedChatRunCancelled(
     assistantContent: ReadonlyArray<ContentPart>;
     assistantOpenAIItems?: ReadonlyArray<StoredOpenAIReplayItem>;
   }>,
+  claimToken: ChatRunClaimToken,
 ): Promise<void> {
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
     const scope = { userId, workspaceId };
@@ -492,7 +516,7 @@ export async function persistClaimedChatRunCancelled(
       "cancel",
     );
     const session = await selectSessionForUpdateWithExecutor(executor, scope, run.session_id);
-    assertClaimedRunStillActive(run, session, "cancel");
+    assertClaimedRunStillActive(run, session, claimToken, "cancel");
 
     await updateChatItemWithExecutor(executor, scope, {
       itemId: params.assistantItemId,
@@ -501,15 +525,19 @@ export async function persistClaimedChatRunCancelled(
       assistantOpenAIItems: params.assistantOpenAIItems,
     });
 
-    await updateChatRunStatusWithExecutor(
-      executor,
-      scope,
-      createChatRunStatusUpdateFromRow(run, {
-        status: "cancelled",
-        cancelRequestedAt: run.cancel_requested_at === null ? new Date() : undefined,
-        finishedAt: new Date(),
-        lastErrorMessage: STOPPED_BY_USER_TOOL_OUTPUT,
-      }),
+    requireRunRow(
+      await updateClaimedChatRunStatusWithExecutor(
+        executor,
+        scope,
+        claimToken,
+        createChatRunStatusUpdateFromRow(run, {
+          status: "cancelled",
+          cancelRequestedAt: run.cancel_requested_at === null ? new Date() : undefined,
+          finishedAt: new Date(),
+          lastErrorMessage: STOPPED_BY_USER_TOOL_OUTPUT,
+        }),
+      ) ?? undefined,
+      "cancel",
     );
 
     await updateChatSessionRunStateWithExecutor(executor, scope, params.sessionId, "idle", null, null);

--- a/apps/backend/src/chat/runs/repository.ts
+++ b/apps/backend/src/chat/runs/repository.ts
@@ -15,7 +15,7 @@ import type { ChatComposerSuggestionsLocale } from "../composerSuggestions";
 import type { ChatSessionRunState } from "../store";
 import type { ChatSessionRow } from "../store/repository";
 import type { ContentPart } from "../types";
-import type { ChatRunStatus } from "./types";
+import type { ChatRunClaimToken, ChatRunStatus } from "./types";
 
 export type ChatRunRow = Readonly<{
   run_id: string;
@@ -62,7 +62,6 @@ export type UpdateChatRunPolicySnapshotParams = Readonly<{
 export type UpdateChatRunStatusParams = Readonly<{
   runId: string;
   status: ChatRunStatus;
-  workerClaimedAt: Date | null;
   workerHeartbeatAt: Date | null;
   cancelRequestedAt: Date | null;
   startedAt: Date | null;
@@ -72,7 +71,6 @@ export type UpdateChatRunStatusParams = Readonly<{
 
 type CreateChatRunStatusUpdateFromRowParams = Readonly<{
   status: ChatRunStatus;
-  workerClaimedAt?: Date | null;
   workerHeartbeatAt?: Date | null;
   cancelRequestedAt?: Date | null;
   startedAt?: Date | null;
@@ -94,7 +92,7 @@ const CHAT_RUN_COLUMNS_SQL = `
     timezone,
     ui_locale,
     turn_input,
-    worker_claimed_at,
+    worker_claimed_at::text AS worker_claimed_at,
     worker_heartbeat_at,
     cancel_requested_at,
     started_at,
@@ -138,7 +136,35 @@ ${CHAT_RUN_COLUMNS_SQL}
 const UPDATE_CHAT_RUN_STATUS_SQL = `
   UPDATE ai.chat_runs
   SET status = $2,
-      worker_claimed_at = $3,
+      worker_heartbeat_at = $3,
+      cancel_requested_at = $4,
+      started_at = $5,
+      finished_at = $6,
+      last_error_message = $7,
+      updated_at = now()
+  WHERE run_id = $1
+  RETURNING
+${CHAT_RUN_COLUMNS_SQL}
+`;
+
+const CLAIM_CHAT_RUN_SQL = `
+  UPDATE ai.chat_runs
+  SET status = 'running',
+      worker_claimed_at = statement_timestamp(),
+      worker_heartbeat_at = statement_timestamp(),
+      started_at = COALESCE(started_at, statement_timestamp()),
+      finished_at = NULL,
+      last_error_message = NULL,
+      updated_at = now()
+  WHERE run_id = $1
+    AND status IN ('queued', 'running')
+  RETURNING
+${CHAT_RUN_COLUMNS_SQL}
+`;
+
+const UPDATE_CLAIMED_CHAT_RUN_STATUS_SQL = `
+  UPDATE ai.chat_runs
+  SET status = $3,
       worker_heartbeat_at = $4,
       cancel_requested_at = $5,
       started_at = $6,
@@ -146,6 +172,8 @@ const UPDATE_CHAT_RUN_STATUS_SQL = `
       last_error_message = $8,
       updated_at = now()
   WHERE run_id = $1
+    AND status = 'running'
+    AND worker_claimed_at = $2::timestamptz
   RETURNING
 ${CHAT_RUN_COLUMNS_SQL}
 `;
@@ -252,9 +280,6 @@ export function createChatRunStatusUpdateFromRow(
   return {
     runId: run.run_id,
     status: params.status,
-    workerClaimedAt: params.workerClaimedAt === undefined
-      ? toDateOrNull(run.worker_claimed_at)
-      : params.workerClaimedAt,
     workerHeartbeatAt: params.workerHeartbeatAt === undefined
       ? toDateOrNull(run.worker_heartbeat_at)
       : params.workerHeartbeatAt,
@@ -366,7 +391,6 @@ export async function updateChatRunStatusWithExecutor(
     const rows = await executeQuery<ChatRunRow>(executor, UPDATE_CHAT_RUN_STATUS_SQL, [
       params.runId,
       params.status,
-      params.workerClaimedAt?.toISOString() ?? null,
       params.workerHeartbeatAt?.toISOString() ?? null,
       params.cancelRequestedAt?.toISOString() ?? null,
       params.startedAt?.toISOString() ?? null,
@@ -374,5 +398,37 @@ export async function updateChatRunStatusWithExecutor(
       params.lastErrorMessage,
     ]);
     return requireRunRow(rows[0], "update");
+  });
+}
+
+export async function claimChatRunWithExecutor(
+  executor: DatabaseExecutor,
+  scope: WorkspaceDatabaseScope,
+  runId: string,
+): Promise<ChatRunRow | null> {
+  return withScopedExecutor(executor, scope, async () => {
+    const rows = await executeQuery<ChatRunRow>(executor, CLAIM_CHAT_RUN_SQL, [runId]);
+    return rows[0] ?? null;
+  });
+}
+
+export async function updateClaimedChatRunStatusWithExecutor(
+  executor: DatabaseExecutor,
+  scope: WorkspaceDatabaseScope,
+  claimToken: ChatRunClaimToken,
+  params: UpdateChatRunStatusParams,
+): Promise<ChatRunRow | null> {
+  return withScopedExecutor(executor, scope, async () => {
+    const rows = await executeQuery<ChatRunRow>(executor, UPDATE_CLAIMED_CHAT_RUN_STATUS_SQL, [
+      params.runId,
+      claimToken,
+      params.status,
+      params.workerHeartbeatAt?.toISOString() ?? null,
+      params.cancelRequestedAt?.toISOString() ?? null,
+      params.startedAt?.toISOString() ?? null,
+      params.finishedAt?.toISOString() ?? null,
+      params.lastErrorMessage,
+    ]);
+    return rows[0] ?? null;
   });
 }

--- a/apps/backend/src/chat/runs/types.ts
+++ b/apps/backend/src/chat/runs/types.ts
@@ -20,6 +20,8 @@ export type ChatRunStatus =
   | "failed"
   | "interrupted";
 
+export type ChatRunClaimToken = string;
+
 export type PreparedChatRun = Readonly<{
   sessionId: string;
   runId: string;
@@ -45,6 +47,7 @@ export type ChatRunDiagnostics = Readonly<{
 
 export type ClaimedChatRun = Readonly<{
   runId: string;
+  claimToken: ChatRunClaimToken;
   sessionId: string;
   requestId: string;
   userId: string;

--- a/apps/backend/src/chat/runtime/control.ts
+++ b/apps/backend/src/chat/runtime/control.ts
@@ -143,6 +143,7 @@ export function createChatRuntimeControl(
           params.userId,
           params.workspaceId,
           params.runId,
+          params.claimToken,
           heartbeatAt,
         ).then((state) => {
           handleHeartbeatState(heartbeatAt, state);
@@ -155,6 +156,7 @@ export function createChatRuntimeControl(
         params.userId,
         params.workspaceId,
         params.runId,
+        params.claimToken,
         initialHeartbeatAt,
       );
       if (initialHeartbeatState.ownershipLost) {

--- a/apps/backend/src/chat/runtime/executor.ts
+++ b/apps/backend/src/chat/runtime/executor.ts
@@ -55,6 +55,23 @@ type RuntimeFinalizationResult = Readonly<{
   result: ChatWorkerRunResult;
 }>;
 
+class TerminalPersistenceError extends Error {
+  public readonly originalError: unknown;
+
+  public constructor(originalError: unknown) {
+    super("Terminal chat persistence failed");
+    this.name = "TerminalPersistenceError";
+    this.originalError = originalError;
+  }
+}
+
+function rethrowTerminalPersistenceError(error: unknown): never {
+  if (error instanceof TerminalPersistenceError) {
+    throw error.originalError;
+  }
+  throw error;
+}
+
 /**
  * Runs one persisted chat session using a single awaited provider-control flow.
  * User cancellation is terminal and persists exactly once.
@@ -107,10 +124,28 @@ export async function runPersistedChatSessionWithDeps(
     return finalizationResult.result;
   };
 
+  const persistTerminalResult = async (
+    persist: () => Promise<RuntimeFinalizationResult>,
+  ): Promise<ChatWorkerRunResult> => {
+    try {
+      return applyFinalizationResult(await persist());
+    } catch (error) {
+      if (isChatStorageEntityNotFoundError(error)) {
+        return {
+          outcome: "ownership_lost",
+          abortReason: "ownership_lost",
+          runStatus: null,
+          sessionState: null,
+        };
+      }
+      throw new TerminalPersistenceError(error);
+    }
+  };
+
   const persistCancelled = async (
     reason: ChatWorkerAbortReason,
-  ): Promise<ChatWorkerRunResult> => applyFinalizationResult(
-    await persistCancelledChatRun({
+  ): Promise<ChatWorkerRunResult> => persistTerminalResult(
+    () => persistCancelledChatRun({
       ...createFinalizationBaseParams(),
       reason,
     }),
@@ -118,8 +153,8 @@ export async function runPersistedChatSessionWithDeps(
 
   const persistFailed = async (
     error: unknown,
-  ): Promise<ChatWorkerRunResult> => applyFinalizationResult(
-    await persistFailedChatRun({
+  ): Promise<ChatWorkerRunResult> => persistTerminalResult(
+    () => persistFailedChatRun({
       ...createFinalizationBaseParams(),
       error,
     }),
@@ -128,8 +163,8 @@ export async function runPersistedChatSessionWithDeps(
   const persistInterrupted = async (
     errorMessage: string,
     assistantOpenAIItems: ReadonlyArray<StoredOpenAIReplayItem> | undefined,
-  ): Promise<ChatWorkerRunResult> => applyFinalizationResult(
-    await persistInterruptedChatRun({
+  ): Promise<ChatWorkerRunResult> => persistTerminalResult(
+    () => persistInterruptedChatRun({
       ...createFinalizationBaseParams(),
       errorMessage,
       assistantOpenAIItems,
@@ -138,8 +173,8 @@ export async function runPersistedChatSessionWithDeps(
 
   const persistCompleted = async (
     assistantOpenAIItems: ReadonlyArray<StoredOpenAIReplayItem>,
-  ): Promise<ChatWorkerRunResult> => applyFinalizationResult(
-    await persistCompletedChatRun({
+  ): Promise<ChatWorkerRunResult> => persistTerminalResult(
+    () => persistCompletedChatRun({
       ...createFinalizationBaseParams(),
       assistantOpenAIItems,
     }),
@@ -165,7 +200,7 @@ export async function runPersistedChatSessionWithDeps(
       };
     }
     if (initialHeartbeat.outcome === "initial_cancelled") {
-      return persistCancelled("initial_cancel_state");
+      return persistCancelled("initial_cancel_state").catch(rethrowTerminalPersistenceError);
     }
 
     control.scheduleSoftDeadlineTimer();
@@ -205,6 +240,7 @@ export async function runPersistedChatSessionWithDeps(
           "ai.openai",
           async () => dependencies.startOpenAILoop({
             requestId: params.requestId,
+            claimToken: params.claimToken,
             userId: params.userId,
             workspaceId: params.workspaceId,
             sessionId: params.sessionId,
@@ -325,6 +361,10 @@ export async function runPersistedChatSessionWithDeps(
       sessionState: "idle",
     };
   } catch (error) {
+    if (error instanceof TerminalPersistenceError) {
+      throw error.originalError;
+    }
+
     const abortReason = control.getAbortReason();
     if (abortReason !== null && isUserAbortError(error)) {
       logProviderCallAborted(
@@ -346,10 +386,13 @@ export async function runPersistedChatSessionWithDeps(
       }
 
       if (abortReason === "deadline_reached") {
-        return persistInterrupted(DEADLINE_REACHED_MESSAGE, undefined);
+        return persistInterrupted(
+          DEADLINE_REACHED_MESSAGE,
+          undefined,
+        ).catch(rethrowTerminalPersistenceError);
       }
 
-      return persistCancelled(abortReason);
+      return persistCancelled(abortReason).catch(rethrowTerminalPersistenceError);
     }
 
     if (control.getOwnershipLost() || error instanceof ChatRunOwnershipLostError) {
@@ -370,7 +413,7 @@ export async function runPersistedChatSessionWithDeps(
       };
     }
 
-    return persistFailed(error);
+    return persistFailed(error).catch(rethrowTerminalPersistenceError);
   } finally {
     control.clearTimers();
     await dependencies.endTaskProtection();

--- a/apps/backend/src/chat/runtime/terminalFinalization.ts
+++ b/apps/backend/src/chat/runtime/terminalFinalization.ts
@@ -96,7 +96,7 @@ export async function persistCancelledChatRun(
     sessionId: input.params.sessionId,
     assistantItemId: input.params.assistantItemId,
     assistantContent,
-  });
+  }, input.params.claimToken);
   const lifecycleState = input.readLifecycleState();
   logTerminalStatePersisted(
     input.logContext,
@@ -135,7 +135,7 @@ export async function persistFailedChatRun(
     assistantContent,
     errorMessage: createPublicTerminalErrorMessage(input.error),
     sessionState: "idle",
-  });
+  }, input.params.claimToken);
   const lifecycleState = input.readLifecycleState();
   logTerminalStatePersisted(
     input.logContext,
@@ -176,7 +176,7 @@ export async function persistInterruptedChatRun(
     assistantOpenAIItems: input.assistantOpenAIItems,
     errorMessage: input.errorMessage,
     sessionState: "interrupted",
-  });
+  }, input.params.claimToken);
   const lifecycleState = input.readLifecycleState();
   logTerminalStatePersisted(
     input.logContext,
@@ -221,7 +221,7 @@ export async function persistCompletedChatRun(
     assistantContent,
     assistantOpenAIItems: input.assistantOpenAIItems,
     composerSuggestions,
-  });
+  }, input.params.claimToken);
   const lifecycleState = input.readLifecycleState();
   logTerminalStatePersisted(
     input.logContext,

--- a/apps/backend/src/chat/runtime/types.ts
+++ b/apps/backend/src/chat/runtime/types.ts
@@ -12,6 +12,7 @@ import type {
 import type {
   ContentPart,
 } from "../types";
+import type { ChatRunClaimToken } from "../runs";
 
 type ChatRunDiagnostics = Readonly<{
   requestId: string;
@@ -30,6 +31,7 @@ type ChatRunDiagnostics = Readonly<{
 export type StartPersistedChatRunParams = Readonly<{
   lambdaRequestId: string | null;
   runId: string;
+  claimToken: ChatRunClaimToken;
   requestId: string;
   userId: string;
   workspaceId: string;

--- a/apps/backend/src/chat/tests/runtime/finalization.test.ts
+++ b/apps/backend/src/chat/tests/runtime/finalization.test.ts
@@ -69,19 +69,92 @@ test("runPersistedChatSessionWithDeps exits without failing when the claimed run
   assert.equal(findLog(logs, "chat_worker_terminal_state_persisted"), undefined);
 });
 
+test("runPersistedChatSessionWithDeps maps stale failed, cancelled, and interrupted persistence to ownership loss", async () => {
+  const staleTerminalPersistence = async (): Promise<never> => {
+    throw new ChatRunRowNotFoundError("terminal");
+  };
+  const results = await Promise.all([
+    runPersistedChatSessionWithDeps(createParams(), createDependencies({
+      startOpenAILoop: async () => { throw new Error("Provider failed"); },
+      persistAssistantTerminalError: staleTerminalPersistence,
+    })),
+    runPersistedChatSessionWithDeps(createParams(), createDependencies({
+      touchChatRunHeartbeat: async () => ({ cancellationRequested: true, ownershipLost: false }),
+      persistAssistantCancelled: staleTerminalPersistence,
+    })),
+    runPersistedChatSessionWithDeps(
+      { ...createParams(), getRemainingTimeInMillis: (): number => 0 },
+      createDependencies({ persistAssistantTerminalError: staleTerminalPersistence }),
+    ),
+  ]);
+  assert.deepEqual(results.map((result) => result.outcome), [
+    "ownership_lost",
+    "ownership_lost",
+    "ownership_lost",
+  ]);
+});
+
+test("runPersistedChatSessionWithDeps preserves every terminal persistence infrastructure error", async () => {
+  const assertInfrastructureErrorPropagates = async (
+    operation: string,
+    params: ReturnType<typeof createParams>,
+    overrides: Parameters<typeof createDependencies>[0],
+  ): Promise<void> => {
+    const databaseError = new Error(`Database unavailable during ${operation}`);
+    let terminalPersistCount = 0;
+    const persistTerminal = async (): Promise<never> => {
+      terminalPersistCount += 1;
+      throw databaseError;
+    };
+    const execution = runPersistedChatSessionWithDeps(params, createDependencies({
+      ...overrides,
+      completeChatRun: persistTerminal,
+      persistAssistantCancelled: persistTerminal,
+      persistAssistantTerminalError: persistTerminal,
+    }));
+
+    await assert.rejects(execution, (error: unknown): boolean => error === databaseError);
+    assert.equal(terminalPersistCount, 1);
+  };
+
+  await assertInfrastructureErrorPropagates("completion", createParams(), {});
+  await assertInfrastructureErrorPropagates("failure", createParams(), {
+    startOpenAILoop: async (
+      _params: StartOpenAILoopParams,
+      onEvent: OpenAILoopEventSink,
+    ): Promise<OpenAILoopCompletion> => {
+      await onEvent({ type: "error", message: "Provider failed" });
+      return { openaiItems: [], terminationReason: "completed" };
+    },
+  });
+  await assertInfrastructureErrorPropagates("cancellation", createParams(), {
+    touchChatRunHeartbeat: async () => ({
+      cancellationRequested: true,
+      ownershipLost: false,
+    }),
+  });
+  await assertInfrastructureErrorPropagates(
+    "interruption",
+    { ...createParams(), getRemainingTimeInMillis: (): number => 0 },
+    {},
+  );
+});
+
 test("runPersistedChatSessionWithDeps completes a successful run and persists completion once", async () => {
   let completedPersistCount = 0;
   let composerSuggestionUserId: string | null = null;
   let composerSuggestionUiLocale: string | null | undefined = undefined;
+  const observedClaimTokens: Array<string> = [];
 
   const logs = await withCapturedLogs(async () => {
     const result = await runPersistedChatSessionWithDeps(
       createParams(),
       createDependencies({
         startOpenAILoop: async (
-          _params: StartOpenAILoopParams,
+          params: StartOpenAILoopParams,
           onEvent: OpenAILoopEventSink,
         ): Promise<OpenAILoopCompletion> => {
+          observedClaimTokens.push(params.claimToken);
           await onEvent({
             type: "delta",
             text: "done",
@@ -106,8 +179,21 @@ test("runPersistedChatSessionWithDeps completes a successful run and persists co
           composerSuggestionUiLocale = uiLocale;
           return [];
         },
-        completeChatRun: async () => {
+        completeChatRun: async (_userId, _workspaceId, _params, claimToken) => {
           completedPersistCount += 1;
+          observedClaimTokens.push(claimToken);
+        },
+        touchChatRunHeartbeat: async (
+          _userId,
+          _workspaceId,
+          _runId,
+          claimToken,
+        ) => {
+          observedClaimTokens.push(claimToken);
+          return {
+            cancellationRequested: false,
+            ownershipLost: false,
+          };
         },
       }),
     );
@@ -123,6 +209,7 @@ test("runPersistedChatSessionWithDeps completes a successful run and persists co
   assert.equal(completedPersistCount, 1);
   assert.equal(composerSuggestionUserId, "user-1");
   assert.equal(composerSuggestionUiLocale, "es-MX");
+  assert.deepEqual(observedClaimTokens, Array.from({ length: 3 }, () => createParams().claimToken));
   assert.equal(findLog(logs, "chat_worker_terminal_state_persisted")?.runStatus, "completed");
 });
 

--- a/apps/backend/src/chat/tests/runtime/testSupport.ts
+++ b/apps/backend/src/chat/tests/runtime/testSupport.ts
@@ -79,6 +79,7 @@ export function createParams(): StartPersistedChatRunParams {
   return {
     lambdaRequestId: "lambda-request-1",
     runId: "run-1",
+    claimToken: "2026-07-24 10:11:12.123456+00",
     requestId: "chat-request-1",
     userId: "user-1",
     workspaceId: "workspace-1",

--- a/apps/backend/src/chat/worker/index.ts
+++ b/apps/backend/src/chat/worker/index.ts
@@ -88,6 +88,7 @@ export async function handleChatWorkerEvent(
   const result: ChatWorkerRunResult = await runPersistedChatSession({
     lambdaRequestId: executionContext.lambdaRequestId,
     runId: claimedRun.runId,
+    claimToken: claimedRun.claimToken,
     requestId: claimedRun.requestId,
     userId: claimedRun.userId,
     workspaceId: claimedRun.workspaceId,

--- a/apps/backend/src/guestAuth/merge/index.ts
+++ b/apps/backend/src/guestAuth/merge/index.ts
@@ -507,6 +507,7 @@ async function recreateGuestReplicasInExecutor(
         actorKey: replica.actorKey,
         platform: replica.platform,
         appVersion: replica.appVersion,
+        signal: null,
       });
     }
 

--- a/apps/backend/src/sync/identity/aiChatIdentity.ts
+++ b/apps/backend/src/sync/identity/aiChatIdentity.ts
@@ -10,7 +10,9 @@ export async function ensureAIChatSyncReplica(
   workspaceId: string,
   userId: string,
   devicePlatform: SyncClientPlatform,
+  signal: AbortSignal | null,
 ): Promise<string> {
+  signal?.throwIfAborted();
   return ensureSystemWorkspaceReplica({
     workspaceId,
     userId,
@@ -18,5 +20,6 @@ export async function ensureAIChatSyncReplica(
     actorKey: `${devicePlatform}:chat`,
     platform: devicePlatform,
     appVersion: `ai-chat:${devicePlatform}:chat`,
+    signal,
   });
 }

--- a/apps/backend/src/sync/identity/replica.test.ts
+++ b/apps/backend/src/sync/identity/replica.test.ts
@@ -271,6 +271,7 @@ test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", asyn
     actorKey: "chat-session-1",
     platform: "web",
     appVersion: "1.2.3",
+    signal: null,
   });
 
   assert.equal(replicaId, buildSystemWorkspaceReplicaId("workspace-1", "ai_chat", "chat-session-1"));
@@ -279,6 +280,90 @@ test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", asyn
   assert.ok(isWorkspaceAccessLifecycleLockQuery(recordedQueries[1]!.text));
   assert.ok(isWorkspaceAccessLockQuery(recordedQueries[2]!.text));
   assert.match(recordedQueries[3]!.text, /INSERT INTO sync\.workspace_replicas/);
+});
+
+test("ensureSystemWorkspaceReplicaInExecutor performs no queries when already aborted", async () => {
+  const abortController = new AbortController();
+  const abortError = new Error("Chat run ownership was lost.");
+  let queryCount = 0;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(): Promise<pg.QueryResult<Row>> {
+      queryCount += 1;
+      throw new Error("Database query was not expected.");
+    },
+  };
+  abortController.abort(abortError);
+
+  await assert.rejects(
+    ensureSystemWorkspaceReplicaInExecutor(executor, {
+      workspaceId: "workspace-1",
+      userId: "user-b",
+      actorKind: "ai_chat",
+      actorKey: "web:chat",
+      platform: "web",
+      appVersion: "ai-chat:web:chat",
+      signal: abortController.signal,
+    }),
+    (error: unknown): boolean => error === abortError,
+  );
+
+  assert.equal(queryCount, 0);
+});
+
+test("ensureSystemWorkspaceReplicaInExecutor stops before replica writes after lookup abort", async () => {
+  const abortController = new AbortController();
+  const abortError = new Error("Chat run ownership was lost.");
+  const recordedQueries: Array<RecordedQuery> = [];
+  let replicaWriteCount = 0;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<string | number | boolean | Date | null | ReadonlyArray<string>>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+
+      if (text.includes("set_config('app.user_id'")) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (isWorkspaceAccessLifecycleLockQuery(text)) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (isWorkspaceAccessLockQuery(text)) {
+        abortController.abort(abortError);
+        return createQueryResult<Row>([{
+          workspace_id: "workspace-1",
+        } as unknown as Row]);
+      }
+
+      if (
+        text.includes("INSERT INTO sync.workspace_replicas")
+        || text.includes("UPDATE sync.workspace_replicas")
+      ) {
+        replicaWriteCount += 1;
+        throw new Error("Workspace replica write was not expected.");
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  await assert.rejects(
+    ensureSystemWorkspaceReplicaInExecutor(executor, {
+      workspaceId: "workspace-1",
+      userId: "user-b",
+      actorKind: "ai_chat",
+      actorKey: "web:chat",
+      platform: "web",
+      appVersion: "ai-chat:web:chat",
+      signal: abortController.signal,
+    }),
+    (error: unknown): boolean => error === abortError,
+  );
+
+  assert.equal(replicaWriteCount, 0);
+  assert.equal(recordedQueries.length, 3);
 });
 
 test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", async () => {
@@ -340,6 +425,7 @@ test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", as
     actorKey: "reset-progress",
     platform: "system",
     appVersion: null,
+    signal: null,
   });
 
   assert.equal(replicaId, buildSystemWorkspaceReplicaId("workspace-1", "workspace_reset", "reset-progress"));
@@ -375,6 +461,7 @@ test("ensureSystemWorkspaceReplicaInExecutor raises workspace not found before r
       actorKey: "chat-session-1",
       platform: "web",
       appVersion: "1.2.3",
+      signal: null,
     }),
     (error: unknown): boolean => {
       assert.ok(error instanceof HttpError);
@@ -444,6 +531,7 @@ test("ensureBootstrapSystemWorkspaceReplicaInExecutor uses provided bootstrap re
     actorKey: "workspace-seed",
     platform: "system",
     appVersion: "server-bootstrap",
+    signal: null,
   }, replicaId);
 
   assert.equal(returnedReplicaId, replicaId);

--- a/apps/backend/src/sync/identity/replica.ts
+++ b/apps/backend/src/sync/identity/replica.ts
@@ -54,6 +54,7 @@ type EnsureSystemWorkspaceReplicaParams = Readonly<{
   actorKey: string;
   platform: WorkspaceReplicaPlatform;
   appVersion: string | null;
+  signal: AbortSignal | null;
 }>;
 
 function toUuidFromSeed(seed: string): string {
@@ -137,7 +138,9 @@ async function upsertWorkspaceReplicaInExecutor(
   actorKey: string | null,
   platform: WorkspaceReplicaPlatform,
   appVersion: string | null,
+  signal: AbortSignal | null,
 ): Promise<string> {
+  signal?.throwIfAborted();
   const insertResult = await executor.query<WorkspaceReplicaRow>(
     [
       "INSERT INTO sync.workspace_replicas",
@@ -150,11 +153,13 @@ async function upsertWorkspaceReplicaInExecutor(
     ].join(" "),
     [replicaId, workspaceId, userId, actorKind, installationId, actorKey, platform, appVersion],
   );
+  signal?.throwIfAborted();
 
   if (insertResult.rows.length === 1) {
     return replicaId;
   }
 
+  signal?.throwIfAborted();
   const updateResult = await executor.query<WorkspaceReplicaRow>(
     [
       "UPDATE sync.workspace_replicas",
@@ -169,6 +174,7 @@ async function upsertWorkspaceReplicaInExecutor(
     ].join(" "),
     [replicaId, workspaceId, userId, actorKind, installationId, actorKey, platform, appVersion],
   );
+  signal?.throwIfAborted();
 
   if (updateResult.rows.length === 1) {
     return replicaId;
@@ -185,8 +191,11 @@ async function lockWorkspaceAccessInExecutor(
   executor: DatabaseExecutor,
   userId: string,
   workspaceId: string,
+  signal: AbortSignal | null,
 ): Promise<void> {
+  signal?.throwIfAborted();
   await lockWorkspaceAccessLifecycleInExecutor(executor, userId, workspaceId);
+  signal?.throwIfAborted();
 
   const result = await executor.query<WorkspaceAccessLockRow>(
     [
@@ -199,6 +208,7 @@ async function lockWorkspaceAccessInExecutor(
     ].join(" "),
     [userId, workspaceId],
   );
+  signal?.throwIfAborted();
 
   if (result.rows[0] === undefined) {
     throw new HttpError(404, "Workspace not found", "WORKSPACE_NOT_FOUND");
@@ -218,7 +228,7 @@ export async function ensureWorkspaceReplicaInExecutor(
     userId: params.userId,
     workspaceId: params.workspaceId,
   });
-  await lockWorkspaceAccessInExecutor(executor, params.userId, params.workspaceId);
+  await lockWorkspaceAccessInExecutor(executor, params.userId, params.workspaceId, null);
   await ensureInstallationInExecutor(
     executor,
     params.userId,
@@ -238,6 +248,7 @@ export async function ensureWorkspaceReplicaInExecutor(
     null,
     params.platform,
     params.appVersion,
+    null,
   );
 }
 
@@ -257,21 +268,32 @@ export async function ensureWorkspaceReplica(
 export async function ensureSystemWorkspaceReplica(
   params: EnsureSystemWorkspaceReplicaParams,
 ): Promise<string> {
-  return transactionWithWorkspaceScope(
+  params.signal?.throwIfAborted();
+  const replicaId = await transactionWithWorkspaceScope(
     { userId: params.userId, workspaceId: params.workspaceId },
     async (executor) => ensureSystemWorkspaceReplicaInExecutor(executor, params),
   );
+  params.signal?.throwIfAborted();
+  return replicaId;
 }
 
 export async function ensureSystemWorkspaceReplicaInExecutor(
   executor: DatabaseExecutor,
   params: EnsureSystemWorkspaceReplicaParams,
 ): Promise<string> {
+  params.signal?.throwIfAborted();
   await applyWorkspaceDatabaseScopeInExecutor(executor, {
     userId: params.userId,
     workspaceId: params.workspaceId,
   });
-  await lockWorkspaceAccessInExecutor(executor, params.userId, params.workspaceId);
+  params.signal?.throwIfAborted();
+  await lockWorkspaceAccessInExecutor(
+    executor,
+    params.userId,
+    params.workspaceId,
+    params.signal,
+  );
+  params.signal?.throwIfAborted();
 
   const replicaId = buildSystemWorkspaceReplicaId(
     params.workspaceId,
@@ -289,6 +311,7 @@ export async function ensureSystemWorkspaceReplicaInExecutor(
     params.actorKey,
     params.platform,
     params.appVersion,
+    params.signal,
   );
 }
 
@@ -297,10 +320,12 @@ export async function ensureBootstrapSystemWorkspaceReplicaInExecutor(
   params: EnsureSystemWorkspaceReplicaParams,
   replicaId: string,
 ): Promise<string> {
+  params.signal?.throwIfAborted();
   await applyWorkspaceDatabaseScopeInExecutor(executor, {
     userId: params.userId,
     workspaceId: params.workspaceId,
   });
+  params.signal?.throwIfAborted();
 
   return upsertWorkspaceReplicaInExecutor(
     executor,
@@ -312,5 +337,6 @@ export async function ensureBootstrapSystemWorkspaceReplicaInExecutor(
     params.actorKey,
     params.platform,
     params.appVersion,
+    params.signal,
   );
 }

--- a/apps/backend/src/workspaces/create.ts
+++ b/apps/backend/src/workspaces/create.ts
@@ -176,6 +176,7 @@ export async function createWorkspaceInExecutorWithObservationScope(
       actorKey: "workspace-seed",
       platform: "system",
       appVersion: "server-bootstrap",
+      signal: null,
     }, bootstrapReplicaId);
 
     stage = "load_scheduler_settings";

--- a/apps/backend/src/workspaces/management.ts
+++ b/apps/backend/src/workspaces/management.ts
@@ -453,6 +453,7 @@ async function resetWorkspaceProgressInExecutor(
       actorKey: "reset-progress",
       platform: "system",
       appVersion: null,
+      signal: null,
     });
 
     for (const resettableCard of resettableCards) {


### PR DESCRIPTION
## Summary
- propagate exact database chat-run claim tokens through worker, runtime, loop, and terminal persistence
- reject stale heartbeat/finalization writes and expose the executor-scoped active-claim fence
- make system and AI-chat replica setup abort-aware with focused lifecycle and runtime coverage

## Validation
- focused backend lifecycle/runtime/replica/loop tests
- full backend test suite
- backend lint and build/typecheck
- git diff --check

No generated-image tool exposure or provider call is included.