### PR TITLE
Reserve generated image attempts durably

### DIFF
--- a/apps/backend/src/chat/openai/tools/generatedImageAttemptBudget.ts
+++ b/apps/backend/src/chat/openai/tools/generatedImageAttemptBudget.ts
@@ -1,0 +1,51 @@
+import {
+  transactionWithWorkspaceScope,
+  type DatabaseExecutor,
+} from "../../../database";
+import {
+  assertActiveChatRunClaimWithExecutor,
+  InactiveChatRunClaimError,
+  type ChatRunClaimFenceParams,
+} from "../../runs/claimFence";
+import {
+  reserveGeneratedCardImageAttemptForActiveRunWithExecutor,
+} from "../../runs/repository";
+
+export const maximumGeneratedCardImageAttemptsPerRun = 3 as const;
+
+export type GeneratedCardImageAttemptReservation =
+  | Readonly<{ status: "reserved"; attempt: 1 | 2 | 3 }>
+  | Readonly<{ status: "limit_reached" }>
+  | Readonly<{ status: "run_inactive" }>;
+
+export async function reserveGeneratedCardImageAttemptWithExecutor(
+  executor: DatabaseExecutor,
+  params: ChatRunClaimFenceParams,
+): Promise<GeneratedCardImageAttemptReservation> {
+  try {
+    await assertActiveChatRunClaimWithExecutor(executor, params);
+  } catch (error) {
+    if (error instanceof InactiveChatRunClaimError) {
+      return { status: "run_inactive" };
+    }
+    throw error;
+  }
+
+  return reserveGeneratedCardImageAttemptForActiveRunWithExecutor(
+    executor,
+    params,
+    maximumGeneratedCardImageAttemptsPerRun,
+  );
+}
+
+export async function reserveGeneratedCardImageAttempt(
+  params: ChatRunClaimFenceParams,
+): Promise<GeneratedCardImageAttemptReservation> {
+  return transactionWithWorkspaceScope(
+    {
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+    },
+    async (executor) => reserveGeneratedCardImageAttemptWithExecutor(executor, params),
+  );
+}

--- a/apps/backend/src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts
+++ b/apps/backend/src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import {
+  reserveGeneratedCardImageAttempt,
+  reserveGeneratedCardImageAttemptWithExecutor,
+  type GeneratedCardImageAttemptReservation,
+} from "../openai/tools/generatedImageAttemptBudget";
+import { HttpError } from "../../shared/errors";
+import {
+  updateAssistantMessageItem,
+  updateAssistantMessageItemAndInvalidateMainContent,
+} from "../store/messageService";
+import {
+  type PostgresIntegrationFixture,
+  withPostgresIntegrationFixture,
+} from "../../testSupport/postgresIntegration";
+import { claimChatRun } from "./lifecycleService";
+import type { ChatRunClaimFenceParams } from "./claimFence";
+
+type ChatRunFixture = Readonly<{
+  sessionId: string;
+  runId: string;
+  assistantItemId: string;
+  claimToken: string;
+}>;
+
+type ClaimTokenRow = Readonly<{ claim_token: string }>;
+type AssistantPayloadRow = Readonly<{
+  payload: Readonly<{
+    content?: unknown;
+    generatedCardImageAttemptCount?: unknown;
+    reservationSentinel?: unknown;
+  }>;
+}>;
+
+async function createChatRunFixture(
+  fixture: PostgresIntegrationFixture,
+): Promise<ChatRunFixture> {
+  const sessionId = randomUUID();
+  const runId = randomUUID();
+  const assistantItemId = randomUUID();
+  const claimTimestamp = new Date(Date.now() - 60_000).toISOString();
+  const client = await fixture.ownerPool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO ai.chat_sessions (
+         session_id, user_id, workspace_id, status, active_run_id, active_run_heartbeat_at
+       ) VALUES ($1, $2, $3, 'running', NULL, $4)`,
+      [sessionId, fixture.userId, fixture.workspaceId, claimTimestamp],
+    );
+    await client.query(
+      `INSERT INTO ai.chat_items (
+         item_id, session_id, item_kind, state, payload
+       ) VALUES ($1, $2, 'message', 'in_progress', $3::jsonb)`,
+      [
+        assistantItemId,
+        sessionId,
+        JSON.stringify({
+          role: "assistant",
+          content: [{ type: "text", text: "Initial assistant content" }],
+          reservationSentinel: { preserved: true },
+        }),
+      ],
+    );
+    const insertedRun = await client.query<ClaimTokenRow>(
+      `INSERT INTO ai.chat_runs (
+         run_id, session_id, assistant_item_id, status, request_id, model_id,
+         reasoning_effort, timezone, turn_input, worker_claimed_at,
+         worker_heartbeat_at, started_at
+       ) VALUES (
+         $1, $2, $3, 'running', $4, 'gpt-5.4', 'medium', 'Europe/Madrid',
+         '[]'::jsonb, $5, $5, $5
+       )
+       RETURNING worker_claimed_at::text AS claim_token`,
+      [runId, sessionId, assistantItemId, `request-${runId}`, claimTimestamp],
+    );
+    await client.query(
+      `UPDATE ai.chat_sessions
+       SET active_run_id = $2
+       WHERE session_id = $1`,
+      [sessionId, runId],
+    );
+    await client.query("COMMIT");
+
+    const claimToken = insertedRun.rows[0]?.claim_token;
+    if (claimToken === undefined) {
+      throw new Error(`Chat run fixture did not return a claim token. runId=${runId}`);
+    }
+    return { sessionId, runId, assistantItemId, claimToken };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function createReservationParams(
+  fixture: PostgresIntegrationFixture,
+  run: ChatRunFixture,
+  claimToken: string,
+): ChatRunClaimFenceParams {
+  return {
+    userId: fixture.userId,
+    workspaceId: fixture.workspaceId,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    claimToken,
+  };
+}
+
+async function loadAssistantPayload(
+  fixture: PostgresIntegrationFixture,
+  assistantItemId: string,
+): Promise<AssistantPayloadRow["payload"]> {
+  const result = await fixture.ownerPool.query<AssistantPayloadRow>(
+    "SELECT payload FROM ai.chat_items WHERE item_id = $1",
+    [assistantItemId],
+  );
+  const payload = result.rows[0]?.payload;
+  if (payload === undefined) {
+    throw new Error(`Assistant payload was not found. assistantItemId=${assistantItemId}`);
+  }
+  return payload;
+}
+
+async function reserveThenRunSentinel(
+  params: ChatRunClaimFenceParams,
+  onReserved: () => void,
+): Promise<GeneratedCardImageAttemptReservation> {
+  const reservation = await reserveGeneratedCardImageAttempt(params);
+  if (reservation.status === "reserved") {
+    onReserved();
+  }
+  return reservation;
+}
+
+function hasErrorCode(error: unknown, expectedCode: string): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === expectedCode;
+}
+
+test("generated image attempt reservations are durable, fenced, and concurrency-safe", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const sequentialRun = await createChatRunFixture(fixture);
+    const sequentialParams = createReservationParams(
+      fixture,
+      sequentialRun,
+      sequentialRun.claimToken,
+    );
+    let postReservationCallCount = 0;
+    const sequentialResults: Array<GeneratedCardImageAttemptReservation> = [];
+    for (let workerIndex = 0; workerIndex < 2; workerIndex += 1) {
+      for (let attemptIndex = 0; attemptIndex < 2; attemptIndex += 1) {
+        sequentialResults.push(await reserveThenRunSentinel(
+          sequentialParams,
+          (): void => {
+            postReservationCallCount += 1;
+          },
+        ));
+      }
+    }
+    assert.deepEqual(sequentialResults, [
+      { status: "reserved", attempt: 1 },
+      { status: "reserved", attempt: 2 },
+      { status: "reserved", attempt: 3 },
+      { status: "limit_reached" },
+    ]);
+    assert.equal(postReservationCallCount, 3);
+    const sequentialPayload = await loadAssistantPayload(
+      fixture,
+      sequentialRun.assistantItemId,
+    );
+    assert.equal(sequentialPayload.generatedCardImageAttemptCount, 3);
+    assert.deepEqual(sequentialPayload.reservationSentinel, { preserved: true });
+
+    const concurrentRun = await createChatRunFixture(fixture);
+    const concurrentParams = createReservationParams(
+      fixture,
+      concurrentRun,
+      concurrentRun.claimToken,
+    );
+    const concurrentResults = await Promise.all(
+      Array.from(
+        { length: 4 },
+        async () => reserveGeneratedCardImageAttempt(concurrentParams),
+      ),
+    );
+    const concurrentAttempts = concurrentResults.flatMap((result) =>
+      result.status === "reserved" ? [result.attempt] : []).sort();
+    assert.deepEqual(concurrentAttempts, [1, 2, 3]);
+    assert.equal(
+      concurrentResults.filter((result) => result.status === "limit_reached").length,
+      1,
+    );
+    assert.equal(
+      (await loadAssistantPayload(fixture, concurrentRun.assistantItemId))
+        .generatedCardImageAttemptCount,
+      3,
+    );
+
+    const inactiveRun = await createChatRunFixture(fixture);
+    const inactiveParams = createReservationParams(
+      fixture,
+      inactiveRun,
+      inactiveRun.claimToken,
+    );
+    assert.deepEqual(await reserveGeneratedCardImageAttempt(inactiveParams), {
+      status: "reserved",
+      attempt: 1,
+    });
+    await fixture.ownerPool.query(
+      "UPDATE ai.chat_runs SET cancel_requested_at = now() WHERE run_id = $1",
+      [inactiveRun.runId],
+    );
+    assert.deepEqual(
+      await reserveGeneratedCardImageAttempt(inactiveParams),
+      { status: "run_inactive" },
+    );
+    await fixture.ownerPool.query(
+      "UPDATE ai.chat_runs SET cancel_requested_at = NULL WHERE run_id = $1",
+      [inactiveRun.runId],
+    );
+    await fixture.ownerPool.query(
+      "UPDATE ai.chat_sessions SET status = 'idle', active_run_id = NULL WHERE session_id = $1",
+      [inactiveRun.sessionId],
+    );
+    assert.deepEqual(
+      await reserveGeneratedCardImageAttempt(inactiveParams),
+      { status: "run_inactive" },
+    );
+    assert.equal(
+      (await loadAssistantPayload(fixture, inactiveRun.assistantItemId))
+        .generatedCardImageAttemptCount,
+      1,
+    );
+
+    const reclaimedRun = await createChatRunFixture(fixture);
+    const firstClaimParams = createReservationParams(
+      fixture,
+      reclaimedRun,
+      reclaimedRun.claimToken,
+    );
+    assert.deepEqual(await reserveGeneratedCardImageAttempt(firstClaimParams), {
+      status: "reserved",
+      attempt: 1,
+    });
+    const reclaimedClaim = await claimChatRun(
+      fixture.userId,
+      fixture.workspaceId,
+      reclaimedRun.runId,
+    );
+    assert.ok(reclaimedClaim);
+    assert.notEqual(reclaimedClaim.claimToken, reclaimedRun.claimToken);
+    assert.deepEqual(
+      await reserveGeneratedCardImageAttempt(firstClaimParams),
+      { status: "run_inactive" },
+    );
+    assert.deepEqual(
+      await reserveGeneratedCardImageAttempt(createReservationParams(
+        fixture,
+        reclaimedRun,
+        reclaimedClaim.claimToken,
+      )),
+      { status: "reserved", attempt: 2 },
+    );
+
+    const rewriteRun = await createChatRunFixture(fixture);
+    const rewriteParams = createReservationParams(
+      fixture,
+      rewriteRun,
+      rewriteRun.claimToken,
+    );
+    assert.equal(
+      (await reserveGeneratedCardImageAttempt(rewriteParams)).status,
+      "reserved",
+    );
+    const updatedItem = await updateAssistantMessageItem(
+      fixture.userId,
+      fixture.workspaceId,
+      {
+        itemId: rewriteRun.assistantItemId,
+        content: [{ type: "text", text: "Streaming update" }],
+        state: "in_progress",
+      },
+    );
+    assert.equal("generatedCardImageAttemptCount" in updatedItem, false);
+    assert.equal(
+      (await loadAssistantPayload(fixture, rewriteRun.assistantItemId))
+        .generatedCardImageAttemptCount,
+      1,
+    );
+    await updateAssistantMessageItemAndInvalidateMainContent(
+      fixture.userId,
+      fixture.workspaceId,
+      {
+        itemId: rewriteRun.assistantItemId,
+        content: [{ type: "text", text: "Mutating tool update" }],
+        state: "in_progress",
+      },
+    );
+    const rewrittenPayload = await loadAssistantPayload(
+      fixture,
+      rewriteRun.assistantItemId,
+    );
+    assert.equal(rewrittenPayload.generatedCardImageAttemptCount, 1);
+    assert.deepEqual(rewrittenPayload.content, [
+      { type: "text", text: "Mutating tool update" },
+    ]);
+
+    await assert.rejects(
+      reserveGeneratedCardImageAttempt({
+        ...rewriteParams,
+        runId: "not-a-uuid",
+      }),
+      (error: unknown) => hasErrorCode(error, "22P02"),
+    );
+
+    const databaseBoundaryError = new HttpError(503, "Database boundary sentinel", "DATABASE_BOUNDARY_SENTINEL");
+    await assert.rejects(
+      reserveGeneratedCardImageAttemptWithExecutor(
+        { query: async () => { throw databaseBoundaryError; } },
+        rewriteParams,
+      ),
+      (error: unknown) => error === databaseBoundaryError
+        && databaseBoundaryError.code === "DATABASE_BOUNDARY_SENTINEL",
+    );
+  });
+});

--- a/apps/backend/src/chat/runs/repository.ts
+++ b/apps/backend/src/chat/runs/repository.ts
@@ -12,9 +12,11 @@ import {
 } from "../config";
 import type { ChatCostPolicyMode } from "../costPolicy";
 import type { ChatComposerSuggestionsLocale } from "../composerSuggestions";
-import type { ChatSessionRunState } from "../store";
+import type { ChatItemState, ChatSessionRunState } from "../store";
 import type { ChatSessionRow } from "../store/repository";
+import type { GeneratedCardImageAttemptReservation } from "../openai/tools/generatedImageAttemptBudget";
 import type { ContentPart } from "../types";
+import type { ChatRunClaimFenceParams } from "./claimFence";
 import type { ChatRunClaimToken, ChatRunStatus } from "./types";
 
 export type ChatRunRow = Readonly<{
@@ -76,6 +78,18 @@ type CreateChatRunStatusUpdateFromRowParams = Readonly<{
   startedAt?: Date | null;
   finishedAt?: Date | null;
   lastErrorMessage: string | null;
+}>;
+
+type GeneratedCardImageAttemptStateRow = Readonly<{
+  item_id: string;
+  state: ChatItemState;
+  role: string | null;
+  attempt_count_type: string | null;
+  attempt_count_text: string | null;
+}>;
+
+type ReservedGeneratedCardImageAttemptRow = Readonly<{
+  attempt_count_text: string;
 }>;
 
 const CHAT_RUN_COLUMNS_SQL = `
@@ -219,6 +233,33 @@ ${CHAT_RUN_COLUMNS_SQL}
   LIMIT 1
 `;
 
+const SELECT_GENERATED_CARD_IMAGE_ATTEMPT_STATE_FOR_UPDATE_SQL = `
+  SELECT
+    chat_items.item_id,
+    chat_items.state,
+    chat_items.payload->>'role' AS role,
+    jsonb_typeof(chat_items.payload->'generatedCardImageAttemptCount') AS attempt_count_type,
+    chat_items.payload->>'generatedCardImageAttemptCount' AS attempt_count_text
+  FROM ai.chat_runs AS chat_runs
+  INNER JOIN ai.chat_items AS chat_items
+    ON chat_items.item_id = chat_runs.assistant_item_id
+  WHERE chat_runs.run_id = $1
+    AND chat_items.item_kind = 'message'
+  FOR UPDATE OF chat_items
+`;
+
+const RESERVE_GENERATED_CARD_IMAGE_ATTEMPT_SQL = `
+  UPDATE ai.chat_items
+  SET payload = jsonb_set(
+    payload,
+    '{generatedCardImageAttemptCount}',
+    to_jsonb($2::integer),
+    true
+  )
+  WHERE item_id = $1
+  RETURNING payload->>'generatedCardImageAttemptCount' AS attempt_count_text
+`;
+
 async function executeQuery<Row extends QueryResultRow>(
   executor: DatabaseExecutor,
   text: string,
@@ -243,6 +284,51 @@ function toDateOrNull(value: string | null): Date | null {
   }
 
   return new Date(value);
+}
+
+function parseGeneratedCardImageAttemptCount(
+  row: GeneratedCardImageAttemptStateRow,
+  maximumAttempts: 3,
+): number {
+  if (row.attempt_count_type === null && row.attempt_count_text === null) {
+    return 0;
+  }
+  if (row.attempt_count_type !== "number" || row.attempt_count_text === null) {
+    throw new Error(
+      `Generated card image attempt count must be a JSON number. itemId=${row.item_id}`,
+    );
+  }
+
+  const attemptCount = Number(row.attempt_count_text);
+  if (
+    !Number.isSafeInteger(attemptCount)
+    || attemptCount < 0
+    || attemptCount > maximumAttempts
+  ) {
+    throw new Error(
+      `Generated card image attempt count must be an integer between 0 and ${maximumAttempts}. itemId=${row.item_id}`,
+    );
+  }
+  return attemptCount;
+}
+
+function requireReservedGeneratedCardImageAttempt(
+  value: string,
+  expectedAttempt: number,
+  maximumAttempts: 3,
+): 1 | 2 | 3 {
+  const attempt = Number(value);
+  if (
+    !Number.isSafeInteger(attempt)
+    || attempt < 1
+    || attempt > maximumAttempts
+    || attempt !== expectedAttempt
+  ) {
+    throw new Error(
+      `Generated card image attempt reservation returned an invalid attempt. attempt=${value}; expectedAttempt=${expectedAttempt}`,
+    );
+  }
+  return attempt as 1 | 2 | 3;
 }
 
 export function requireSessionRow(row: ChatSessionRow | undefined, operation: string): ChatSessionRow {
@@ -341,6 +427,55 @@ export async function selectSessionForUpdateWithExecutor(
   return withScopedExecutor(executor, scope, async () => {
     const rows = await executeQuery<ChatSessionRow>(executor, SELECT_SESSION_FOR_UPDATE_SQL, [sessionId]);
     return requireSessionRow(rows[0], "lock");
+  });
+}
+
+export async function reserveGeneratedCardImageAttemptForActiveRunWithExecutor(
+  executor: DatabaseExecutor,
+  params: ChatRunClaimFenceParams,
+  maximumAttempts: 3,
+): Promise<GeneratedCardImageAttemptReservation> {
+  return withScopedExecutor(executor, params, async () => {
+    const stateRows = await executeQuery<GeneratedCardImageAttemptStateRow>(
+      executor,
+      SELECT_GENERATED_CARD_IMAGE_ATTEMPT_STATE_FOR_UPDATE_SQL,
+      [params.runId],
+    );
+    const state = stateRows[0];
+    if (
+      state === undefined
+      || state.state !== "in_progress"
+      || state.role !== "assistant"
+    ) {
+      return { status: "run_inactive" };
+    }
+
+    const attemptCount = parseGeneratedCardImageAttemptCount(state, maximumAttempts);
+    if (attemptCount === maximumAttempts) {
+      return { status: "limit_reached" };
+    }
+
+    const reservedAttempt = attemptCount + 1;
+    const reservedRows = await executeQuery<ReservedGeneratedCardImageAttemptRow>(
+      executor,
+      RESERVE_GENERATED_CARD_IMAGE_ATTEMPT_SQL,
+      [state.item_id, reservedAttempt],
+    );
+    const reservedRow = reservedRows[0];
+    if (reservedRow === undefined) {
+      throw new Error(
+        `Generated card image attempt target disappeared while locked. itemId=${state.item_id}`,
+      );
+    }
+
+    return {
+      status: "reserved",
+      attempt: requireReservedGeneratedCardImageAttempt(
+        reservedRow.attempt_count_text,
+        reservedAttempt,
+        maximumAttempts,
+      ),
+    };
   });
 }
 

--- a/apps/backend/src/chat/store/repository.ts
+++ b/apps/backend/src/chat/store/repository.ts
@@ -50,6 +50,8 @@ export type ChatItemPayload = Readonly<{
   role: "user" | "assistant";
   content: ReadonlyArray<ContentPart>;
   openaiItems?: ReadonlyArray<StoredOpenAIReplayItem>;
+  /** Internal durable state; normal chat-item mappers intentionally omit it. */
+  generatedCardImageAttemptCount?: 0 | 1 | 2 | 3;
 }>;
 
 export type ChatItemRow = Readonly<{
@@ -243,7 +245,16 @@ const INSERT_CHAT_ITEM_SQL = `
 const UPDATE_CHAT_ITEM_SQL = `
   WITH updated_item AS (
     UPDATE ai.chat_items
-    SET payload = $2::jsonb,
+    SET payload = CASE
+          WHEN payload ? 'generatedCardImageAttemptCount'
+          THEN jsonb_set(
+            $2::jsonb,
+            '{generatedCardImageAttemptCount}',
+            payload->'generatedCardImageAttemptCount',
+            true
+          )
+          ELSE $2::jsonb
+        END,
         state = $3,
         updated_at = now()
     WHERE item_id = $1
@@ -354,7 +365,16 @@ const UPDATE_CHAT_SESSION_ACTIVE_COMPOSER_SUGGESTION_GENERATION_SQL = `
 const UPDATE_CHAT_ITEM_AND_INVALIDATE_MAIN_CONTENT_SQL = `
   WITH updated_item AS (
     UPDATE ai.chat_items
-    SET payload = $2::jsonb,
+    SET payload = CASE
+          WHEN payload ? 'generatedCardImageAttemptCount'
+          THEN jsonb_set(
+            $2::jsonb,
+            '{generatedCardImageAttemptCount}',
+            payload->'generatedCardImageAttemptCount',
+            true
+          )
+          ELSE $2::jsonb
+        END,
         state = $3,
         updated_at = now()
     WHERE item_id = $1


### PR DESCRIPTION
## Summary
- reserve generated-card image attempts durably in assistant-item JSONB
- fence reservations to the active run claim and serialize concurrent reservations
- preserve the internal counter across assistant payload rewrites
- cover sequential, concurrent, inactive, reclaim, preservation, and database-error behavior with real PostgreSQL integration tests

## Validation
- focused real-PostgreSQL and lifecycle checks
- full backend test suite
- backend lint
- backend build/typecheck
- git diff --check