### PR TITLE
Add deadline-aware PostgreSQL boundary

### DIFF
--- a/apps/backend/src/aws/secrets.ts
+++ b/apps/backend/src/aws/secrets.ts
@@ -9,8 +9,16 @@ const secretsClient = new SecretsManagerClient({});
 let resolvedBackendCsrfSecret: string | undefined;
 let resolvedBackendChatLiveAuthSecret: string | undefined;
 
-export async function getDatabaseCredentialsSecret(secretArn: string): Promise<DatabaseCredentialsSecret> {
-  const response = await secretsClient.send(new GetSecretValueCommand({ SecretId: secretArn }));
+async function loadDatabaseCredentialsSecret(
+  secretArn: string,
+  abortSignal: AbortSignal | null,
+): Promise<DatabaseCredentialsSecret> {
+  abortSignal?.throwIfAborted();
+  const command = new GetSecretValueCommand({ SecretId: secretArn });
+  const response = abortSignal === null
+    ? await secretsClient.send(command)
+    : await secretsClient.send(command, { abortSignal });
+  abortSignal?.throwIfAborted();
   if (!response.SecretString) {
     throw new Error(`Secret ${secretArn} does not contain SecretString`);
   }
@@ -28,6 +36,17 @@ export async function getDatabaseCredentialsSecret(secretArn: string): Promise<D
     username: value.username,
     password: value.password,
   };
+}
+
+export async function getDatabaseCredentialsSecret(secretArn: string): Promise<DatabaseCredentialsSecret> {
+  return loadDatabaseCredentialsSecret(secretArn, null);
+}
+
+export async function getDatabaseCredentialsSecretWithAbortSignal(
+  secretArn: string,
+  abortSignal: AbortSignal,
+): Promise<DatabaseCredentialsSecret> {
+  return loadDatabaseCredentialsSecret(secretArn, abortSignal);
 }
 
 export async function getBackendCsrfSecret(secretArn: string): Promise<string> {

--- a/apps/backend/src/database/config.ts
+++ b/apps/backend/src/database/config.ts
@@ -1,22 +1,44 @@
-import { getDatabaseCredentialsSecret } from "../aws/secrets";
+import {
+  getDatabaseCredentialsSecret,
+  getDatabaseCredentialsSecretWithAbortSignal,
+} from "../aws/secrets";
 
 let resolvedDatabaseUrl: string | undefined;
 
-export async function getDatabaseUrl(): Promise<string> {
+function validateDatabaseUrlResolution(
+  abortSignal: AbortSignal | null,
+  deadlineAtMs: number | null,
+): void {
+  abortSignal?.throwIfAborted();
+  if (deadlineAtMs !== null && Date.now() >= deadlineAtMs) {
+    throw new Error("Database URL resolution exceeded its absolute deadline.");
+  }
+}
+
+async function resolveDatabaseUrl(
+  abortSignal: AbortSignal | null,
+  deadlineAtMs: number | null,
+): Promise<string> {
+  validateDatabaseUrlResolution(abortSignal, deadlineAtMs);
   if (resolvedDatabaseUrl) {
     return resolvedDatabaseUrl;
   }
 
   const secretArn = process.env.DB_SECRET_ARN;
   if (secretArn) {
-    const secret = await getDatabaseCredentialsSecret(secretArn);
+    const secret = abortSignal === null
+      ? await getDatabaseCredentialsSecret(secretArn)
+      : await getDatabaseCredentialsSecretWithAbortSignal(secretArn, abortSignal);
+    validateDatabaseUrlResolution(abortSignal, deadlineAtMs);
     const host = process.env.DB_HOST;
     const dbName = process.env.DB_NAME;
     if (!host || !dbName) {
       throw new Error("DB_HOST and DB_NAME are required when DB_SECRET_ARN is set");
     }
 
-    resolvedDatabaseUrl = `postgresql://${secret.username}:${encodeURIComponent(secret.password)}@${host}:5432/${dbName}`;
+    const databaseUrl = `postgresql://${secret.username}:${encodeURIComponent(secret.password)}@${host}:5432/${dbName}`;
+    validateDatabaseUrlResolution(abortSignal, deadlineAtMs);
+    resolvedDatabaseUrl = databaseUrl;
     return resolvedDatabaseUrl;
   }
 
@@ -24,6 +46,18 @@ export async function getDatabaseUrl(): Promise<string> {
     throw new Error("DATABASE_URL is required when DB_SECRET_ARN is not set");
   }
 
+  validateDatabaseUrlResolution(abortSignal, deadlineAtMs);
   resolvedDatabaseUrl = process.env.DATABASE_URL;
   return resolvedDatabaseUrl;
+}
+
+export async function getDatabaseUrl(): Promise<string> {
+  return resolveDatabaseUrl(null, null);
+}
+
+export async function getDatabaseUrlWithAbortSignal(
+  abortSignal: AbortSignal,
+  deadlineAtMs: number,
+): Promise<string> {
+  return resolveDatabaseUrl(abortSignal, deadlineAtMs);
 }

--- a/apps/backend/src/database/core.deadline.test.ts
+++ b/apps/backend/src/database/core.deadline.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SecretsManagerClient,
+  type GetSecretValueCommandOutput,
+} from "@aws-sdk/client-secrets-manager";
+import pg from "pg";
+import { DatabaseDeadlineExceededError } from "./deadline";
+
+type Deferred<Value> = Readonly<{
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+  reject: (error: Error) => void;
+}>;
+
+type SecretSendOptions = Readonly<{
+  abortSignal?: AbortSignal;
+}>;
+
+type SecretSend = (
+  command: object,
+  options?: SecretSendOptions,
+) => Promise<GetSecretValueCommandOutput>;
+
+function createDeferred<Value>(): Deferred<Value> {
+  let resolve!: (value: Value) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<Value>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function settleBeforeTestWatchdog<Value>(
+  operation: Promise<Value>,
+  timeoutMessage: string,
+): Promise<Value> {
+  return new Promise<Value>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(timeoutMessage)), 1_000);
+    void operation.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+test("deadline wrappers abort cold initialization without publishing late pool state", async () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  const originalDbSecretArn = process.env.DB_SECRET_ARN;
+  const originalDbHost = process.env.DB_HOST;
+  const originalDbName = process.env.DB_NAME;
+  const originalPool = pg.Pool;
+  const secretsPrototype = SecretsManagerClient.prototype as unknown as {
+    send: SecretSend;
+  };
+  const originalSecretSend = secretsPrototype.send;
+  const observedAbortSignals: Array<AbortSignal | null> = [];
+  let pendingSecret = createDeferred<GetSecretValueCommandOutput>();
+  let poolConstructionCount = 0;
+
+  class FakePool {
+    constructor(_config: pg.PoolConfig) {
+      poolConstructionCount += 1;
+    }
+
+    on(_event: string, _listener: (error: Error) => void): void {}
+
+    async connect(): Promise<pg.PoolClient> {
+      throw new Error("Deadline initialization test must not connect.");
+    }
+
+    async end(): Promise<void> {}
+  }
+
+  delete process.env.DATABASE_URL;
+  process.env.DB_SECRET_ARN = "deadline-test-secret";
+  process.env.DB_HOST = "deadline-test-host";
+  process.env.DB_NAME = "deadline-test-database";
+  (pg as unknown as { Pool: typeof pg.Pool }).Pool = FakePool as unknown as typeof pg.Pool;
+  secretsPrototype.send = (_command, options) => {
+    observedAbortSignals.push(options?.abortSignal ?? null);
+    return pendingSecret.promise;
+  };
+
+  try {
+    const dbCore = await import("./core");
+    const queryOperation = dbCore.unsafeQueryWithDeadline(
+      Date.now() + 100,
+      "SELECT 1",
+      [],
+    );
+    await assert.rejects(
+      settleBeforeTestWatchdog(
+        queryOperation,
+        "Query wrapper did not reject expired pool initialization.",
+      ),
+      (error: unknown) => error instanceof DatabaseDeadlineExceededError
+        && error.phase === "pool_checkout",
+    );
+    assert.equal(observedAbortSignals[0]?.aborted, true);
+    assert.equal(poolConstructionCount, 0);
+
+    pendingSecret.resolve({
+      $metadata: {},
+      SecretString: JSON.stringify({ username: "late-user", password: "late-password" }),
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(poolConstructionCount, 0);
+
+    pendingSecret = createDeferred<GetSecretValueCommandOutput>();
+    let callbackCalled = false;
+    const transactionOperation = dbCore.unsafeTransactionWithDeadline(
+      Date.now() + 100,
+      async () => {
+        callbackCalled = true;
+        return "unreachable";
+      },
+    );
+    await assert.rejects(
+      settleBeforeTestWatchdog(
+        transactionOperation,
+        "Transaction wrapper did not reject expired pool initialization.",
+      ),
+      (error: unknown) => error instanceof DatabaseDeadlineExceededError
+        && error.phase === "pool_checkout",
+    );
+    assert.equal(observedAbortSignals[1]?.aborted, true);
+    assert.equal(callbackCalled, false);
+    assert.equal(poolConstructionCount, 0);
+
+    pendingSecret.reject(new Error("late secret rejection"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(poolConstructionCount, 0);
+  } finally {
+    secretsPrototype.send = originalSecretSend;
+    (pg as unknown as { Pool: typeof pg.Pool }).Pool = originalPool;
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
+    if (originalDbSecretArn === undefined) {
+      delete process.env.DB_SECRET_ARN;
+    } else {
+      process.env.DB_SECRET_ARN = originalDbSecretArn;
+    }
+    if (originalDbHost === undefined) {
+      delete process.env.DB_HOST;
+    } else {
+      process.env.DB_HOST = originalDbHost;
+    }
+    if (originalDbName === undefined) {
+      delete process.env.DB_NAME;
+    } else {
+      process.env.DB_NAME = originalDbName;
+    }
+  }
+});

--- a/apps/backend/src/database/core.test.ts
+++ b/apps/backend/src/database/core.test.ts
@@ -20,6 +20,10 @@ function createCodedError(code: string, message: string): CodedError {
   return error;
 }
 
+function hasCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
 test("unsafeTransaction classifies transaction failures and discards clients when needed", async () => {
   const originalDatabaseUrl = process.env.DATABASE_URL;
   const originalDbSecretArn = process.env.DB_SECRET_ARN;
@@ -33,6 +37,7 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
   let beginError: CodedError | null = transientBeginError;
   let commitError: CodedError | null = transientCommitError;
   let rollbackError: CodedError | null = null;
+  let poolConstructionCount = 0;
 
   const fakeClient = {
     async query(text: string, params?: ReadonlyArray<unknown>): Promise<pg.QueryResult<pg.QueryResultRow>> {
@@ -66,7 +71,9 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
   };
 
   class FakePool {
-    constructor(_config: pg.PoolConfig) {}
+    constructor(_config: pg.PoolConfig) {
+      poolConstructionCount += 1;
+    }
 
     on(_event: string, _listener: (error: Error) => void): void {}
 
@@ -91,6 +98,16 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
     const dbCore = await import("./core");
 
     await assert.rejects(
+      dbCore.unsafeQueryWithDeadline(Date.now() - 1, "SELECT 1", []),
+      (error: unknown) => hasCode(error, "DATABASE_DEADLINE_EXCEEDED"),
+    );
+    await assert.rejects(
+      dbCore.unsafeTransactionWithDeadline(Date.now() - 1, async () => "unreachable"),
+      (error: unknown) => hasCode(error, "DATABASE_DEADLINE_EXCEEDED"),
+    );
+    assert.equal(poolConstructionCount, 0);
+
+    await assert.rejects(
       dbCore.unsafeTransaction(async () => {
         throw new Error("Callback should not run when BEGIN fails.");
       }),
@@ -105,6 +122,7 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
     assert.deepEqual(queries, [
       { text: "BEGIN", params: null },
     ]);
+    assert.equal(poolConstructionCount, 1);
     assert.equal(releaseArguments.length, 1);
     assert.equal(releaseArguments[0], transientBeginError);
 

--- a/apps/backend/src/database/core.ts
+++ b/apps/backend/src/database/core.ts
@@ -1,5 +1,8 @@
 import pg from "pg";
-import { getDatabaseUrl } from "./config";
+import {
+  getDatabaseUrl,
+  getDatabaseUrlWithAbortSignal,
+} from "./config";
 import {
   getDatabaseErrorFields,
   logDatabasePoolError,
@@ -10,6 +13,12 @@ import {
   captureBackendWarning,
   createBackendRuntimeObservationScope,
 } from "../observability/sentry";
+import {
+  queryWithPostgresDeadline,
+  resolvePostgresPoolUntilDeadline,
+  transactionWithPostgresDeadline,
+  validateDatabaseDeadline,
+} from "./deadline";
 
 let pool: pg.Pool | undefined;
 
@@ -31,16 +40,53 @@ export type DatabaseExecutor = Readonly<{
   ): Promise<pg.QueryResult<Row>>;
 }>;
 
+function createDatabasePool(connectionString: string): pg.Pool {
+  const ssl = process.env.DB_SECRET_ARN ? true : false;
+  const databasePool = new pg.Pool({ connectionString, ssl });
+  databasePool.on("error", (error: Error): void => {
+    logDatabasePoolError("main", error);
+  });
+  return databasePool;
+}
+
 async function getPool(): Promise<pg.Pool> {
-  if (!pool) {
-    const connectionString = await getDatabaseUrl();
-    const ssl = process.env.DB_SECRET_ARN ? true : false;
-    pool = new pg.Pool({ connectionString, ssl });
-    pool.on("error", (error: Error): void => {
-      logDatabasePoolError("main", error);
-    });
-  }
+  if (pool) return pool;
+  const connectionString = await getDatabaseUrl();
+  if (pool) return pool;
+  pool = createDatabasePool(connectionString);
   return pool;
+}
+
+async function initializePoolUntilDeadline(
+  deadlineAtMs: number,
+  abortSignal: AbortSignal,
+): Promise<pg.Pool> {
+  if (pool) return pool;
+  const connectionString = await getDatabaseUrlWithAbortSignal(
+    abortSignal,
+    deadlineAtMs,
+  );
+  abortSignal.throwIfAborted();
+  validateDatabaseDeadline(deadlineAtMs);
+  if (pool) return pool;
+
+  const databasePool = createDatabasePool(connectionString);
+  try {
+    abortSignal.throwIfAborted();
+    validateDatabaseDeadline(deadlineAtMs);
+  } catch (error) {
+    await databasePool.end();
+    throw error;
+  }
+  pool = databasePool;
+  return pool;
+}
+
+async function getPoolUntilDeadline(deadlineAtMs: number): Promise<pg.Pool> {
+  return resolvePostgresPoolUntilDeadline(
+    deadlineAtMs,
+    async (abortSignal) => initializePoolUntilDeadline(deadlineAtMs, abortSignal),
+  );
 }
 
 async function executeQuery<Row extends pg.QueryResultRow>(
@@ -148,6 +194,20 @@ export async function unsafeQuery<Row extends pg.QueryResultRow>(
   return executeQuery<Row>(await getPool(), text, params);
 }
 
+export async function unsafeQueryWithDeadline<Row extends pg.QueryResultRow>(
+  deadlineAtMs: number,
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+): Promise<pg.QueryResult<Row>> {
+  validateDatabaseDeadline(deadlineAtMs);
+  return queryWithPostgresDeadline<Row>(
+    await getPoolUntilDeadline(deadlineAtMs),
+    deadlineAtMs,
+    text,
+    params,
+  );
+}
+
 /**
  * Opens one privileged transaction without applying any request scope.
  * Callers must set any needed user/workspace scope explicitly.
@@ -156,6 +216,18 @@ export async function unsafeTransaction<Result>(
   callback: (executor: DatabaseExecutor) => Promise<Result>,
 ): Promise<Result> {
   return unsafeTransactionWithBeginStatement("BEGIN", callback);
+}
+
+export async function unsafeTransactionWithDeadline<Result>(
+  deadlineAtMs: number,
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+): Promise<Result> {
+  validateDatabaseDeadline(deadlineAtMs);
+  return transactionWithPostgresDeadline(
+    await getPoolUntilDeadline(deadlineAtMs),
+    deadlineAtMs,
+    callback,
+  );
 }
 
 export async function unsafeRepeatableReadTransaction<Result>(

--- a/apps/backend/src/database/deadline.postgres.integration.ts
+++ b/apps/backend/src/database/deadline.postgres.integration.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import pg from "pg";
+import {
+  DatabaseDeadlineExceededError,
+  DatabaseTransactionRolledBackError,
+  queryWithPostgresDeadline,
+  transactionWithPostgresDeadline,
+} from "./deadline";
+import { DatabaseCommitOutcomeUnknownError } from "./transient";
+
+type CountRow = Readonly<{ count: number }>;
+
+function requireTestDatabaseUrl(): string {
+  const databaseUrl = process.env.TEST_DATABASE_ADMIN_URL?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error("TEST_DATABASE_ADMIN_URL is required for the PostgreSQL deadline integration test.");
+  }
+  return databaseUrl;
+}
+
+function createPool(maximumClients: number): pg.Pool {
+  return new pg.Pool({
+    connectionString: requireTestDatabaseUrl(),
+    application_name: "database-deadline-integration",
+    max: maximumClients,
+  });
+}
+
+async function waitForLateCheckoutRelease(pool: pg.Pool): Promise<void> {
+  const waitDeadlineAtMs = Date.now() + 5_000;
+  while (pool.waitingCount !== 0 || pool.idleCount !== 1) {
+    if (Date.now() >= waitDeadlineAtMs) {
+      throw new Error(
+        `Timed-out checkout was not released. waitingCount=${pool.waitingCount}; idleCount=${pool.idleCount}`,
+      );
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function hasCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
+test("PostgreSQL deadline boundary bounds checkout, statements, locks, rollback, and commit", async () => {
+  const expiredPool = createPool(1);
+  try {
+    await assert.rejects(
+      transactionWithPostgresDeadline(expiredPool, Date.now() - 1, async () => "unreachable"),
+      (error: unknown) => error instanceof DatabaseDeadlineExceededError
+        && error.phase === "pool_checkout",
+    );
+    assert.equal(expiredPool.totalCount, 0);
+  } finally {
+    await expiredPool.end();
+  }
+
+  const saturatedPool = createPool(1);
+  const heldClient = await saturatedPool.connect();
+  let heldClientReleased = false;
+  try {
+    await assert.rejects(
+      transactionWithPostgresDeadline(
+        saturatedPool,
+        Date.now() + 1_000,
+        async () => "unreachable",
+      ),
+      (error: unknown) => error instanceof DatabaseDeadlineExceededError
+        && error.phase === "pool_checkout",
+    );
+    assert.equal(saturatedPool.waitingCount, 1);
+    heldClient.release();
+    heldClientReleased = true;
+    await waitForLateCheckoutRelease(saturatedPool);
+    assert.equal((await saturatedPool.query("SELECT 1 AS value")).rows[0]?.value, 1);
+  } finally {
+    if (!heldClientReleased) heldClient.release();
+    await saturatedPool.end();
+  }
+
+  const transactionPool = createPool(1);
+  try {
+    const success = await transactionWithPostgresDeadline(
+      transactionPool,
+      Date.now() + 5_000,
+      async (executor) => (await executor.query<{ value: number }>("SELECT 42 AS value", [])).rows[0]?.value,
+    );
+    assert.equal(success, 42);
+    assert.equal(
+      (await queryWithPostgresDeadline<{ value: number }>(
+        transactionPool, Date.now() + 5_000, "SELECT 7 AS value", [],
+      )).rows[0]?.value,
+      7,
+    );
+
+    await transactionPool.query("CREATE TEMP TABLE deadline_rollback_probe (value integer)");
+    await assert.rejects(
+      transactionWithPostgresDeadline(transactionPool, Date.now() + 1_500, async (executor) => {
+        await executor.query("INSERT INTO deadline_rollback_probe (value) VALUES (1)", []);
+        await executor.query("SELECT pg_sleep(5)", []);
+      }),
+      (error: unknown) => hasCode(error, "57014"),
+    );
+    const rollbackResult = await transactionPool.query<CountRow>(
+      "SELECT count(*)::int AS count FROM deadline_rollback_probe",
+    );
+    assert.equal(rollbackResult.rows[0]?.count, 0);
+
+    await assert.rejects(
+      transactionWithPostgresDeadline(transactionPool, Date.now() + 1_500, async (executor) => {
+        await executor.query("INSERT INTO deadline_rollback_probe (value) VALUES (2)", []);
+        try {
+          await executor.query("SELECT pg_sleep(5)", []);
+        } catch (error) {
+          assert.ok(hasCode(error, "57014"));
+        }
+      }),
+      (error: unknown) => error instanceof DatabaseTransactionRolledBackError
+        && error.sqlState === "57014"
+        && error.errorCode === "57014",
+    );
+    const swallowedStatementResult = await transactionPool.query<CountRow>(
+      "SELECT count(*)::int AS count FROM deadline_rollback_probe",
+    );
+    assert.equal(swallowedStatementResult.rows[0]?.count, 0);
+  } finally {
+    await transactionPool.end();
+  }
+
+  const lockPool = createPool(2);
+  const blocker = await lockPool.connect();
+  const lockKey = Date.now();
+  try {
+    await blocker.query("SELECT pg_advisory_lock($1)", [lockKey]);
+    await assert.rejects(
+      transactionWithPostgresDeadline(lockPool, Date.now() + 1_500, async (executor) => {
+        try {
+          await executor.query("SELECT pg_advisory_xact_lock($1)", [lockKey]);
+        } catch (error) {
+          assert.ok(hasCode(error, "55P03"));
+        }
+      }),
+      (error: unknown) => error instanceof DatabaseTransactionRolledBackError
+        && error.sqlState === "55P03"
+        && error.errorCode === "55P03",
+    );
+  } finally {
+    await blocker.query("SELECT pg_advisory_unlock($1)", [lockKey]);
+    blocker.release();
+    await lockPool.end();
+  }
+
+  const commitPool = createPool(1);
+  const commitProbeSuffix = randomUUID().replaceAll("-", "");
+  const commitProbeTable = `deadline_commit_probe_${commitProbeSuffix}`;
+  const commitFailureFunction = `fail_deadline_commit_${commitProbeSuffix}`;
+  const commitFailureTrigger = `deadline_commit_failure_${commitProbeSuffix}`;
+  try {
+    await commitPool.query(`CREATE TABLE public.${commitProbeTable} (value integer)`);
+    await commitPool.query(
+      `CREATE FUNCTION public.${commitFailureFunction}() RETURNS trigger LANGUAGE plpgsql AS 'BEGIN RAISE EXCEPTION USING ERRCODE = ''57014'', MESSAGE = ''deadline commit probe''; RETURN NEW; END'`,
+    );
+    await commitPool.query(
+      `CREATE CONSTRAINT TRIGGER ${commitFailureTrigger} AFTER INSERT ON public.${commitProbeTable} DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.${commitFailureFunction}()`,
+    );
+
+    await assert.rejects(
+      transactionWithPostgresDeadline(commitPool, Date.now() + 5_000, async (executor) => {
+        await executor.query(`INSERT INTO public.${commitProbeTable} (value) VALUES (1)`, []);
+      }),
+      (error: unknown) => hasCode(error, "57014")
+        && !(error instanceof DatabaseCommitOutcomeUnknownError),
+    );
+    const commitFailureResult = await commitPool.query<CountRow>(
+      `SELECT count(*)::int AS count FROM public.${commitProbeTable}`,
+    );
+    assert.equal(commitFailureResult.rows[0]?.count, 0);
+  } finally {
+    await commitPool.query(`DROP TABLE IF EXISTS public.${commitProbeTable}`);
+    await commitPool.query(`DROP FUNCTION IF EXISTS public.${commitFailureFunction}()`);
+    await commitPool.end();
+  }
+});

--- a/apps/backend/src/database/deadline.test.ts
+++ b/apps/backend/src/database/deadline.test.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+import {
+  DatabaseDeadlineExceededError,
+  transactionWithPostgresDeadline,
+} from "./deadline";
+import { DatabaseCommitOutcomeUnknownError } from "./transient";
+
+type Deferred<Value> = Readonly<{
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+  reject: (error: Error) => void;
+}>;
+
+type FakeDatabase = Readonly<{
+  pool: pg.Pool;
+  queryTexts: Array<string>;
+  releaseArguments: Array<Error | boolean | undefined>;
+}>;
+
+type QueryResponder = (
+  text: string,
+) => Promise<pg.QueryResult<pg.QueryResultRow>>;
+
+function createDeferred<Value>(): Deferred<Value> {
+  let resolve!: (value: Value) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<Value>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function settleBeforeTestWatchdog<Value>(
+  operation: Promise<Value>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<Value> {
+  return new Promise<Value>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+    void operation.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function readQueryText(query: string | pg.QueryConfig): string {
+  return typeof query === "string" ? query : query.text;
+}
+
+function createQueryResult(command: string): pg.QueryResult<pg.QueryResultRow> {
+  return {
+    command,
+    rowCount: 0,
+    oid: 0,
+    fields: [],
+    rows: [],
+  };
+}
+
+async function respondWithSuccessfulQuery(
+  text: string,
+): Promise<pg.QueryResult<pg.QueryResultRow>> {
+  return createQueryResult(text);
+}
+
+function createFakeDatabase(respondToQuery: QueryResponder): FakeDatabase {
+  const queryTexts: Array<string> = [];
+  const releaseArguments: Array<Error | boolean | undefined> = [];
+  const client = {
+    async query(query: string | pg.QueryConfig): Promise<pg.QueryResult<pg.QueryResultRow>> {
+      const text = readQueryText(query);
+      queryTexts.push(text);
+      return respondToQuery(text);
+    },
+    release(error?: Error | boolean): void {
+      releaseArguments.push(error);
+    },
+  };
+  const pool = {
+    async connect(): Promise<pg.PoolClient> {
+      return client as unknown as pg.PoolClient;
+    },
+  } as pg.Pool;
+  return { pool, queryTexts, releaseArguments };
+}
+
+test("checkout at the deadline releases its client and rejects without a pending branch", async () => {
+  const database = createFakeDatabase(respondWithSuccessfulQuery);
+  const originalDateNow = Date.now;
+  const nowMs = originalDateNow();
+  const deadlineAtMs = nowMs + 1_000;
+  let dateReadCount = 0;
+  Date.now = (): number => {
+    dateReadCount += 1;
+    return dateReadCount < 3 ? nowMs : deadlineAtMs;
+  };
+
+  try {
+    const operation = transactionWithPostgresDeadline(
+      database.pool,
+      deadlineAtMs,
+      async () => "unreachable",
+    );
+
+    await assert.rejects(
+      settleBeforeTestWatchdog(
+        operation,
+        100,
+        "Deadline checkout promise remained pending.",
+      ),
+      (error: unknown) => error instanceof DatabaseDeadlineExceededError
+        && error.phase === "pool_checkout",
+    );
+    assert.equal(database.releaseArguments.length, 1);
+    assert.equal(database.releaseArguments[0], undefined);
+    assert.deepEqual(database.queryTexts, []);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
+test("transaction waits for every started executor operation before commit and release", async () => {
+  const configurationGate = createDeferred<pg.QueryResult<pg.QueryResultRow>>();
+  const callerSqlGate = createDeferred<pg.QueryResult<pg.QueryResultRow>>();
+  const database = createFakeDatabase(async (text) => {
+    if (text.includes("set_config")) return configurationGate.promise;
+    if (text === "INSERT") return callerSqlGate.promise;
+    return createQueryResult(text);
+  });
+
+  const operation = transactionWithPostgresDeadline(
+    database.pool,
+    Date.now() + 5_000,
+    async (executor) => {
+      void executor.query("INSERT", []);
+      return "callback result";
+    },
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(database.queryTexts[0], "BEGIN");
+  assert.equal(database.queryTexts[1]?.includes("set_config"), true);
+  assert.equal(database.queryTexts.includes("COMMIT"), false);
+  assert.equal(database.releaseArguments.length, 0);
+
+  configurationGate.resolve(createQueryResult("SELECT"));
+  for (let attempt = 0; attempt < 20 && !database.queryTexts.includes("INSERT"); attempt += 1) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  assert.equal(database.queryTexts.includes("INSERT"), true);
+  assert.equal(database.queryTexts.includes("COMMIT"), false);
+  assert.equal(database.releaseArguments.length, 0);
+
+  callerSqlGate.resolve(createQueryResult("INSERT"));
+  assert.equal(await operation, "callback result");
+  assert.deepEqual(
+    database.queryTexts.map((text) => text.includes("set_config") ? "CONFIGURE" : text),
+    ["BEGIN", "CONFIGURE", "INSERT", "COMMIT"],
+  );
+  assert.deepEqual(database.releaseArguments, [undefined]);
+
+  const expiringConfigurationGate = createDeferred<pg.QueryResult<pg.QueryResultRow>>();
+  const expiringDatabase = createFakeDatabase(async (text) => {
+    if (text.includes("set_config")) return expiringConfigurationGate.promise;
+    return createQueryResult(text);
+  });
+  const expiringOperation = transactionWithPostgresDeadline(
+    expiringDatabase.pool,
+    Date.now() + 100,
+    async (executor) => {
+      void executor.query("LATE INSERT", []);
+      return "expired operation";
+    },
+  );
+  await assert.rejects(
+    settleBeforeTestWatchdog(
+      expiringOperation,
+      1_000,
+      "Started executor operation did not expire.",
+    ),
+    (error: unknown) => error instanceof DatabaseDeadlineExceededError
+      && error.phase === "executor_operations",
+  );
+  assert.ok(expiringDatabase.releaseArguments[0] instanceof DatabaseDeadlineExceededError);
+
+  expiringConfigurationGate.resolve(createQueryResult("SELECT"));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(expiringDatabase.queryTexts.includes("LATE INSERT"), false);
+  assert.equal(expiringDatabase.queryTexts.includes("COMMIT"), false);
+});
+
+test("callback expiry discards the client and observes late callback settlement", async () => {
+  const resolvingDatabase = createFakeDatabase(respondWithSuccessfulQuery);
+  const callbackGate = createDeferred<void>();
+  const callbackFinished = createDeferred<void>();
+  let lateQueryError: unknown = null;
+
+  const resolvingOperation = transactionWithPostgresDeadline(
+    resolvingDatabase.pool,
+    Date.now() + 100,
+    async (executor) => {
+      await callbackGate.promise;
+      try {
+        await executor.query("SELECT 1", []);
+      } catch (error) {
+        lateQueryError = error;
+      }
+      callbackFinished.resolve();
+      return "late result";
+    },
+  );
+
+  await assert.rejects(
+    settleBeforeTestWatchdog(
+      resolvingOperation,
+      1_000,
+      "Deadline callback promise did not reject promptly.",
+    ),
+    (error: unknown) => error instanceof DatabaseDeadlineExceededError
+      && error.phase === "transaction_callback",
+  );
+  assert.equal(resolvingDatabase.releaseArguments.length, 1);
+  assert.ok(resolvingDatabase.releaseArguments[0] instanceof DatabaseDeadlineExceededError);
+
+  callbackGate.resolve();
+  await callbackFinished.promise;
+  assert.ok(lateQueryError instanceof DatabaseDeadlineExceededError);
+  assert.equal(lateQueryError.phase, "transaction_callback");
+  assert.deepEqual(resolvingDatabase.queryTexts, ["BEGIN"]);
+
+  const rejectingDatabase = createFakeDatabase(respondWithSuccessfulQuery);
+  const lateCallback = createDeferred<string>();
+  const rejectingOperation = transactionWithPostgresDeadline(
+    rejectingDatabase.pool,
+    Date.now() + 100,
+    async () => lateCallback.promise,
+  );
+
+  await assert.rejects(
+    settleBeforeTestWatchdog(
+      rejectingOperation,
+      1_000,
+      "Deadline callback promise did not reject promptly.",
+    ),
+    (error: unknown) => error instanceof DatabaseDeadlineExceededError
+      && error.phase === "transaction_callback",
+  );
+  lateCallback.reject(new Error("late callback rejection"));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(rejectingDatabase.releaseArguments.length, 1);
+  assert.deepEqual(rejectingDatabase.queryTexts, ["BEGIN"]);
+});
+
+test("commit distinguishes explicit server errors from response loss", async () => {
+  const serverError = new pg.DatabaseError("terminating connection due to administrator command", 0, "error");
+  serverError.code = "57P01";
+  const serverErrorDatabase = createFakeDatabase(async (text) => {
+    if (text === "COMMIT") throw serverError;
+    return createQueryResult(text);
+  });
+
+  await assert.rejects(
+    transactionWithPostgresDeadline(
+      serverErrorDatabase.pool,
+      Date.now() + 5_000,
+      async () => "server error",
+    ),
+    (error: unknown) => error === serverError,
+  );
+  assert.deepEqual(serverErrorDatabase.releaseArguments, [serverError]);
+
+  const responseLossDatabase = createFakeDatabase(async (text) => {
+    if (text === "COMMIT") throw new Error("Query read timeout");
+    return createQueryResult(text);
+  });
+  await assert.rejects(
+    transactionWithPostgresDeadline(
+      responseLossDatabase.pool,
+      Date.now() + 5_000,
+      async () => "unknown outcome",
+    ),
+    (error: unknown) => error instanceof DatabaseCommitOutcomeUnknownError
+      && error.code === "DATABASE_COMMIT_OUTCOME_UNKNOWN",
+  );
+  assert.ok(
+    responseLossDatabase.releaseArguments[0] instanceof DatabaseCommitOutcomeUnknownError,
+  );
+});

--- a/apps/backend/src/database/deadline.ts
+++ b/apps/backend/src/database/deadline.ts
@@ -1,0 +1,517 @@
+import pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "./core";
+import {
+  getDatabaseErrorFields,
+  logDatabasePoolError,
+  toDatabaseBoundaryError,
+  toDatabaseCommitBoundaryError,
+  toDatabaseCommitOutcomeUnknownError,
+  type DatabaseBoundaryErrorFields,
+} from "./transient";
+
+const maximumTimerDelayMs = 2_147_483_647;
+const rollbackReserveMs = 250;
+const queryReadTimeoutMessage = "Query read timeout";
+const timeoutConfigurationSql = [
+  "SELECT",
+  "set_config('statement_timeout', $1, true),",
+  "set_config('lock_timeout', $2, true)",
+].join(" ");
+
+export type DatabaseDeadlinePhase =
+  | "pool_checkout"
+  | "transaction_begin"
+  | "transaction_callback"
+  | "executor_operations"
+  | "statement"
+  | "before_commit"
+  | "rollback";
+
+type DeadlineQueryConfig = pg.QueryConfig<Array<SqlValue>> & Readonly<{
+  query_timeout: number;
+}>;
+
+export class DatabaseDeadlineExceededError extends Error {
+  readonly code = "DATABASE_DEADLINE_EXCEEDED";
+
+  constructor(
+    readonly phase: DatabaseDeadlinePhase,
+    readonly deadlineAtMs: number,
+    cause: unknown | null,
+  ) {
+    super(
+      `Database deadline exceeded. phase=${phase}; deadlineAtMs=${deadlineAtMs}`,
+      cause === null ? undefined : { cause },
+    );
+    this.name = "DatabaseDeadlineExceededError";
+  }
+}
+
+export class DatabaseTransactionRolledBackError extends Error implements DatabaseBoundaryErrorFields {
+  readonly code = "DATABASE_TRANSACTION_ROLLED_BACK";
+  readonly sqlState: string | null;
+  readonly errorCode: string | null;
+  readonly databaseErrorClass: string;
+  readonly databaseErrorMessage: string;
+
+  constructor(sourceError: unknown | null) {
+    super("PostgreSQL rolled back the transaction instead of committing it.");
+    this.name = "DatabaseTransactionRolledBackError";
+    if (sourceError === null) {
+      this.sqlState = null;
+      this.errorCode = null;
+      this.databaseErrorClass = "UnknownDatabaseError";
+      this.databaseErrorMessage = "PostgreSQL did not provide the original transaction error.";
+    } else {
+      const fields = getDatabaseErrorFields(sourceError);
+      this.sqlState = fields.sqlState;
+      this.errorCode = fields.errorCode;
+      this.databaseErrorClass = fields.errorClass;
+      this.databaseErrorMessage = fields.errorMessage;
+    }
+  }
+}
+
+export function validateDatabaseDeadline(deadlineAtMs: number): void {
+  if (!Number.isSafeInteger(deadlineAtMs) || deadlineAtMs < 1) {
+    throw new RangeError("Database deadline must be a positive absolute epoch-millisecond safe integer.");
+  }
+  if (deadlineAtMs <= Date.now()) {
+    throw new DatabaseDeadlineExceededError("pool_checkout", deadlineAtMs, null);
+  }
+}
+
+function remainingTimeMs(deadlineAtMs: number, phase: DatabaseDeadlinePhase): number {
+  const remainingMs = deadlineAtMs - Date.now();
+  if (remainingMs <= 0) {
+    throw new DatabaseDeadlineExceededError(phase, deadlineAtMs, null);
+  }
+  return Math.min(remainingMs, maximumTimerDelayMs);
+}
+
+function toReleaseError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function isQueryReadTimeout(error: unknown): boolean {
+  return error instanceof Error && error.message === queryReadTimeoutMessage;
+}
+
+function createQueryConfig(
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+  queryTimeoutMs: number,
+): DeadlineQueryConfig {
+  return {
+    text,
+    values: [...params],
+    query_timeout: queryTimeoutMs,
+  };
+}
+
+function executePromiseUntilDeadline<Result>(
+  operation: () => Promise<Result>,
+  deadlineAtMs: number,
+  phase: DatabaseDeadlinePhase,
+  onDeadline: (error: DatabaseDeadlineExceededError) => void,
+): Promise<Result> {
+  const remainingMs = remainingTimeMs(deadlineAtMs, phase);
+  const operationPromise = Promise.resolve().then(operation);
+
+  return new Promise<Result>((resolve, reject) => {
+    let settled = false;
+
+    const rejectWithDeadline = (): void => {
+      if (settled) return;
+      settled = true;
+      const error = new DatabaseDeadlineExceededError(phase, deadlineAtMs, null);
+      onDeadline(error);
+      reject(error);
+    };
+
+    const timer = setTimeout(rejectWithDeadline, remainingMs);
+    void operationPromise.then(
+      (result) => {
+        if (settled) return;
+        if (Date.now() >= deadlineAtMs) {
+          clearTimeout(timer);
+          rejectWithDeadline();
+          return;
+        }
+        clearTimeout(timer);
+        settled = true;
+        resolve(result);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        if (Date.now() >= deadlineAtMs) {
+          clearTimeout(timer);
+          rejectWithDeadline();
+          return;
+        }
+        clearTimeout(timer);
+        settled = true;
+        reject(error);
+      },
+    );
+  });
+}
+
+export function resolvePostgresPoolUntilDeadline(
+  deadlineAtMs: number,
+  provider: (abortSignal: AbortSignal) => Promise<pg.Pool>,
+): Promise<pg.Pool> {
+  validateDatabaseDeadline(deadlineAtMs);
+  const abortController = new AbortController();
+  return executePromiseUntilDeadline(
+    async () => provider(abortController.signal),
+    deadlineAtMs,
+    "pool_checkout",
+    (error) => abortController.abort(error),
+  );
+}
+
+async function connectUntilDeadline(pool: pg.Pool, deadlineAtMs: number): Promise<pg.PoolClient> {
+  const remainingMs = remainingTimeMs(deadlineAtMs, "pool_checkout");
+  let connectPromise: Promise<pg.PoolClient>;
+  try {
+    connectPromise = pool.connect();
+  } catch (error) {
+    throw toDatabaseBoundaryError(error);
+  }
+
+  return new Promise<pg.PoolClient>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new DatabaseDeadlineExceededError("pool_checkout", deadlineAtMs, null));
+    }, remainingMs);
+
+    void connectPromise.then(
+      (client) => {
+        if (settled) {
+          client.release();
+          return;
+        }
+        if (Date.now() >= deadlineAtMs) {
+          clearTimeout(timer);
+          settled = true;
+          reject(new DatabaseDeadlineExceededError("pool_checkout", deadlineAtMs, null));
+          client.release();
+          return;
+        }
+        clearTimeout(timer);
+        settled = true;
+        resolve(client);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        clearTimeout(timer);
+        settled = true;
+        reject(toDatabaseBoundaryError(error));
+      },
+    ).catch((error: unknown) => {
+      logDatabasePoolError("deadline-late-checkout-release", error);
+    });
+  });
+}
+
+async function executeClientQuery<Row extends pg.QueryResultRow>(
+  client: pg.PoolClient,
+  deadlineAtMs: number,
+  phase: Exclude<DatabaseDeadlinePhase, "pool_checkout" | "before_commit">,
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+): Promise<pg.QueryResult<Row>> {
+  const queryTimeoutMs = remainingTimeMs(deadlineAtMs, phase);
+  try {
+    const result = await client.query<Row, Array<SqlValue>>(
+      createQueryConfig(text, params, queryTimeoutMs),
+    );
+    if (Date.now() >= deadlineAtMs) {
+      throw new DatabaseDeadlineExceededError(phase, deadlineAtMs, null);
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof DatabaseDeadlineExceededError) throw error;
+    if (isQueryReadTimeout(error)) {
+      throw new DatabaseDeadlineExceededError(phase, deadlineAtMs, error);
+    }
+    throw toDatabaseBoundaryError(error);
+  }
+}
+
+async function configureTransactionTimeouts(
+  client: pg.PoolClient,
+  deadlineAtMs: number,
+): Promise<void> {
+  const remainingMs = remainingTimeMs(deadlineAtMs, "statement");
+  const statementTimeoutMs = Math.max(1, remainingMs - rollbackReserveMs);
+  const lockTimeoutMs = Math.max(1, statementTimeoutMs - 1);
+  await executeClientQuery(
+    client,
+    deadlineAtMs,
+    "statement",
+    timeoutConfigurationSql,
+    [`${statementTimeoutMs}ms`, `${lockTimeoutMs}ms`],
+  );
+}
+
+async function rollbackTransaction(
+  client: pg.PoolClient,
+  deadlineAtMs: number,
+): Promise<unknown | null> {
+  try {
+    await executeClientQuery(client, deadlineAtMs, "rollback", "ROLLBACK", []);
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+async function executeCommit(
+  client: pg.PoolClient,
+  deadlineAtMs: number,
+  statementError: unknown | null,
+): Promise<void> {
+  const queryTimeoutMs = remainingTimeMs(deadlineAtMs, "before_commit");
+  let commitPromise: Promise<pg.QueryResult<pg.QueryResultRow>>;
+  try {
+    commitPromise = client.query(createQueryConfig("COMMIT", [], queryTimeoutMs));
+  } catch (error) {
+    throw toDatabaseBoundaryError(error);
+  }
+
+  let result: pg.QueryResult<pg.QueryResultRow>;
+  try {
+    result = await commitPromise;
+  } catch (error) {
+    if (error instanceof pg.DatabaseError) {
+      throw error;
+    }
+    if (isQueryReadTimeout(error)) {
+      throw toDatabaseCommitOutcomeUnknownError(error);
+    }
+    throw toDatabaseCommitBoundaryError(error);
+  }
+
+  if (result.command === "ROLLBACK") {
+    throw new DatabaseTransactionRolledBackError(statementError);
+  }
+  if (result.command !== "COMMIT") {
+    throw new Error(`PostgreSQL returned an unexpected transaction result. command=${result.command}`);
+  }
+}
+
+function executeCallbackUntilDeadline<Result>(
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+  executor: DatabaseExecutor,
+  deadlineAtMs: number,
+  closeExecutor: () => void,
+  onDeadline: (error: DatabaseDeadlineExceededError) => void,
+): Promise<Result> {
+  return executePromiseUntilDeadline(
+    async () => {
+      try {
+        const result = await callback(executor);
+        closeExecutor();
+        return result;
+      } catch (error) {
+        closeExecutor();
+        throw error;
+      }
+    },
+    deadlineAtMs,
+    "transaction_callback",
+    onDeadline,
+  );
+}
+
+async function settleStartedExecutorOperations(
+  pendingOperations: ReadonlySet<Promise<unknown>>,
+  deadlineAtMs: number,
+  onDeadline: (error: DatabaseDeadlineExceededError) => void,
+): Promise<void> {
+  const operations = [...pendingOperations];
+  if (operations.length === 0) return;
+
+  let firstError: unknown = null;
+  let hasError = false;
+  const settlementPromise = Promise.all(operations.map(async (operation) => {
+    try {
+      await operation;
+    } catch (error) {
+      if (!hasError) {
+        firstError = error;
+        hasError = true;
+      }
+    }
+  }));
+
+  await executePromiseUntilDeadline(
+    async () => settlementPromise,
+    deadlineAtMs,
+    "executor_operations",
+    onDeadline,
+  );
+  if (hasError) throw firstError;
+}
+
+export async function transactionWithPostgresDeadline<Result>(
+  pool: pg.Pool,
+  deadlineAtMs: number,
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+): Promise<Result> {
+  validateDatabaseDeadline(deadlineAtMs);
+  const client = await connectUntilDeadline(pool, deadlineAtMs);
+  let releaseError: Error | undefined;
+  let statementError: unknown | null = null;
+  let executorAcceptingOperations = true;
+  let executorFailureError: Error | null = null;
+  const pendingExecutorOperations = new Set<Promise<unknown>>();
+  const executorClosedError = new Error(
+    "Database transaction executor cannot be used after its callback completes.",
+  );
+  const closeExecutor = (): void => {
+    executorAcceptingOperations = false;
+  };
+  const failExecutor = (error: Error): void => {
+    executorAcceptingOperations = false;
+    executorFailureError = error;
+  };
+  try {
+    try {
+      await executeClientQuery(client, deadlineAtMs, "transaction_begin", "BEGIN", []);
+    } catch (error) {
+      releaseError = toReleaseError(error);
+      throw error;
+    }
+
+    const executor: DatabaseExecutor = {
+      query<Row extends pg.QueryResultRow>(
+        text: string,
+        params: ReadonlyArray<SqlValue>,
+      ): Promise<pg.QueryResult<Row>> {
+        if (!executorAcceptingOperations) {
+          const rejection = Promise.reject(executorFailureError ?? executorClosedError);
+          void rejection.catch(() => {});
+          return rejection;
+        }
+
+        const operation = (async (): Promise<pg.QueryResult<Row>> => {
+          try {
+            await configureTransactionTimeouts(client, deadlineAtMs);
+            if (executorFailureError !== null) throw executorFailureError;
+            return await executeClientQuery(client, deadlineAtMs, "statement", text, params);
+          } catch (error) {
+            statementError ??= error;
+            throw error;
+          }
+        })();
+        pendingExecutorOperations.add(operation);
+        void operation.then(
+          () => pendingExecutorOperations.delete(operation),
+          () => pendingExecutorOperations.delete(operation),
+        );
+        return operation;
+      },
+    };
+
+    let result!: Result;
+    try {
+      let callbackError: unknown = null;
+      let hasCallbackError = false;
+      try {
+        result = await executeCallbackUntilDeadline(
+          callback,
+          executor,
+          deadlineAtMs,
+          closeExecutor,
+          failExecutor,
+        );
+      } catch (error) {
+        if (
+          error instanceof DatabaseDeadlineExceededError
+          && error.phase === "transaction_callback"
+        ) {
+          throw error;
+        }
+        callbackError = error;
+        hasCallbackError = true;
+      }
+
+      let operationError: unknown = null;
+      let hasOperationError = false;
+      try {
+        await settleStartedExecutorOperations(
+          pendingExecutorOperations,
+          deadlineAtMs,
+          failExecutor,
+        );
+      } catch (error) {
+        if (
+          error instanceof DatabaseDeadlineExceededError
+          && error.phase === "executor_operations"
+        ) {
+          throw error;
+        }
+        operationError = error;
+        hasOperationError = true;
+      }
+
+      if (hasCallbackError) throw callbackError;
+      if (hasOperationError) throw operationError;
+      remainingTimeMs(deadlineAtMs, "before_commit");
+    } catch (error) {
+      closeExecutor();
+      if (
+        error instanceof DatabaseDeadlineExceededError
+        && (
+          error.phase === "transaction_callback"
+          || error.phase === "executor_operations"
+        )
+      ) {
+        failExecutor(error);
+        releaseError = error;
+        throw error;
+      }
+      if (Date.now() >= deadlineAtMs) {
+        releaseError = toReleaseError(error);
+        failExecutor(releaseError);
+        throw error;
+      }
+      const rollbackError = await rollbackTransaction(client, deadlineAtMs);
+      if (rollbackError !== null) {
+        releaseError = toReleaseError(rollbackError);
+        logDatabasePoolError("deadline-transaction-rollback", rollbackError);
+      }
+      throw error;
+    }
+
+    try {
+      await executeCommit(client, deadlineAtMs, statementError);
+    } catch (error) {
+      if (!(error instanceof DatabaseTransactionRolledBackError)) {
+        releaseError = toReleaseError(error);
+      }
+      throw error;
+    }
+    return result;
+  } finally {
+    client.release(releaseError);
+  }
+}
+
+export async function queryWithPostgresDeadline<Row extends pg.QueryResultRow>(
+  pool: pg.Pool,
+  deadlineAtMs: number,
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+): Promise<pg.QueryResult<Row>> {
+  return transactionWithPostgresDeadline(
+    pool,
+    deadlineAtMs,
+    async (executor) => executor.query<Row>(text, params),
+  );
+}

--- a/apps/backend/src/database/index.ts
+++ b/apps/backend/src/database/index.ts
@@ -4,6 +4,7 @@ import {
   applyWorkspaceDatabaseScopeInExecutor,
   unsafeRepeatableReadReadOnlyTransaction,
   unsafeTransaction,
+  unsafeTransactionWithDeadline,
   type DatabaseExecutor,
   type SqlValue,
   type UserDatabaseScope,
@@ -23,6 +24,11 @@ export {
   SessionAdvisoryLockAbortedError, SessionAdvisoryLockTimeoutError, withSessionAdvisoryLock,
 } from "./sessionAdvisoryLock";
 export type { SessionAdvisoryLockInput } from "./sessionAdvisoryLock";
+export {
+  DatabaseDeadlineExceededError,
+  DatabaseTransactionRolledBackError,
+} from "./deadline";
+export type { DatabaseDeadlinePhase } from "./deadline";
 
 export async function transactionWithUserScope<Result>(
   scope: UserDatabaseScope,
@@ -39,6 +45,17 @@ export async function transactionWithWorkspaceScope<Result>(
   callback: (executor: DatabaseExecutor) => Promise<Result>,
 ): Promise<Result> {
   return unsafeTransaction(async (executor) => {
+    await applyWorkspaceDatabaseScopeInExecutor(executor, scope);
+    return callback(executor);
+  });
+}
+
+export async function transactionWithWorkspaceScopeDeadline<Result>(
+  scope: WorkspaceDatabaseScope,
+  deadlineAtMs: number,
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+): Promise<Result> {
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
     await applyWorkspaceDatabaseScopeInExecutor(executor, scope);
     return callback(executor);
   });

--- a/apps/backend/src/database/unsafe.ts
+++ b/apps/backend/src/database/unsafe.ts
@@ -1,5 +1,7 @@
 export {
   unsafeQuery,
+  unsafeQueryWithDeadline,
   unsafeRepeatableReadTransaction,
   unsafeTransaction,
+  unsafeTransactionWithDeadline,
 } from "./core";


### PR DESCRIPTION
## Summary
- add an absolute-deadline PostgreSQL query and transaction boundary
- bound cold secret/pool initialization, checkout, executor work, rollback, and commit handling
- preserve definitive PostgreSQL commit errors while classifying response-loss ambiguity
- add deterministic and real-PostgreSQL coverage

## Validation
- focused deadline/module tests: 6 passed
- real PostgreSQL deadline integration: passed
- full backend test suite: 820 passed
- backend lint: passed
- backend build: passed
- git diff checks: passed