### PR TITLE
Add generated media promotion job contract

### DIFF
--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../database";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
+import { InactiveChatRunClaimError } from "../runs/claimFence";
+import {
+  claimGeneratedMediaPromotionJobs,
+  enqueueGeneratedMediaPromotionJob,
+  failGeneratedMediaPromotionJobWithExecutor,
+  GeneratedMediaPromotionJobConflictError,
+  GeneratedMediaPromotionJobLeaseLostError,
+  markGeneratedMediaPromotionJobAppliedWithExecutor,
+  rescheduleGeneratedMediaPromotionJobWithExecutor,
+  type ClaimedGeneratedMediaPromotionJob,
+  type EnqueueGeneratedMediaPromotionJobInput,
+} from "./promotionJobs";
+type RunFixture = Readonly<{ sessionId: string; runId: string; claimToken: string }>;
+type ClaimTokenRow = Readonly<{ claim_token: string }>;
+type JobStateRow = Readonly<{ state: string; retry_count: number;
+  last_error_code: string | null }>;
+type SecurityRow = Readonly<{ rls_enabled: boolean; policy_count: string;
+  backend_can_update: boolean; backend_can_delete: boolean; auth_can_select: boolean }>;
+async function createRun(fixture: PostgresIntegrationFixture): Promise<RunFixture> {
+  const sessionId = randomUUID();
+  const runId = randomUUID();
+  const assistantItemId = randomUUID();
+  const result = await fixture.ownerPool.query<ClaimTokenRow>(
+    `WITH inserted_session AS (
+       INSERT INTO ai.chat_sessions (
+         session_id, user_id, workspace_id, status, active_run_id
+       ) VALUES ($1, $2, $3, 'running', $4)
+     ), inserted_item AS (
+       INSERT INTO ai.chat_items (item_id, session_id, item_kind, state, payload)
+       VALUES ($5, $1, 'message', 'in_progress', '{"role":"assistant","content":[]}'::jsonb)
+     )
+     INSERT INTO ai.chat_runs (
+       run_id, session_id, assistant_item_id, status, request_id, model_id,
+       reasoning_effort, timezone, turn_input, worker_claimed_at,
+       worker_heartbeat_at, started_at
+     ) VALUES (
+       $4, $1, $5, 'running', $6, 'gpt-5.4', 'medium', 'Europe/Madrid',
+       '[]'::jsonb, statement_timestamp(), statement_timestamp(), statement_timestamp()
+     )
+     RETURNING worker_claimed_at::text AS claim_token`,
+    [
+      sessionId, fixture.userId, fixture.workspaceId, runId,
+      assistantItemId, `promotion-job-${runId}`,
+    ],
+  );
+  const claimToken = result.rows[0]?.claim_token;
+  if (claimToken === undefined) throw new Error(`Run fixture has no claim token. runId=${runId}`);
+  return { sessionId, runId, claimToken };
+}
+function createInput(fixture: PostgresIntegrationFixture, run: RunFixture):
+EnqueueGeneratedMediaPromotionJobInput {
+  const jobId = randomUUID();
+  const operationId = randomUUID();
+  const mediaAssetId = randomUUID();
+  const sha256 = "8349792a6784cfdc5061b34e1184c85bcdb13719e86ac4be576e52e5e8c5f603";
+  return {
+    userId: fixture.userId,
+    workspaceId: fixture.workspaceId,
+    sessionId: run.sessionId,
+    runId: run.runId,
+    claimToken: run.claimToken,
+    deadlineAtMs: Date.now() + 10_000,
+    jobId,
+    operationId,
+    cardId: fixture.cardId,
+    targetSide: "back",
+    altText: "Generated integration image",
+    mediaAssetId,
+    replicaId: fixture.replicaId,
+    stagingStorageKey: buildMediaUploadStagingStorageKey(fixture.workspaceId, mediaAssetId, operationId),
+    blobStorageKey: buildMediaBlobStorageKey(sha256),
+    sha256,
+    mimeType: "image/jpeg",
+    sizeBytes: 4096,
+  };
+}
+async function transition(fixture: PostgresIntegrationFixture,
+  callback: (executor: DatabaseExecutor) => Promise<void>): Promise<void> {
+  await transactionWithWorkspaceScope(
+    { userId: fixture.userId, workspaceId: fixture.workspaceId },
+    callback,
+  );
+}
+function byJobId(jobs: ReadonlyArray<ClaimedGeneratedMediaPromotionJob>,
+  jobId: string): ClaimedGeneratedMediaPromotionJob {
+  const job = jobs.find((candidate) => candidate.jobId === jobId);
+  if (job === undefined) throw new Error(`Claimed job was not found. jobId=${jobId}`);
+  return job;
+}
+function claim(leaseOwner: string, limit: number):
+Promise<ReadonlyArray<ClaimedGeneratedMediaPromotionJob>> {
+  return claimGeneratedMediaPromotionJobs({
+    leaseOwner, leaseDurationMs: 60_000, limit, deadlineAtMs: Date.now() + 10_000,
+  });
+}
+function hasPostgresCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const run = await createRun(fixture);
+    const concurrentInput = createInput(fixture, run);
+    await assert.rejects(
+      enqueueGeneratedMediaPromotionJob({ ...concurrentInput, claimToken: new Date(0).toISOString() }),
+      InactiveChatRunClaimError,
+    );
+    await fixture.ownerPool.query(
+      "UPDATE ai.chat_runs SET cancel_requested_at = now() WHERE run_id = $1",
+      [run.runId],
+    );
+    await assert.rejects(
+      enqueueGeneratedMediaPromotionJob(concurrentInput),
+      InactiveChatRunClaimError,
+    );
+    await fixture.ownerPool.query(
+      "UPDATE ai.chat_runs SET cancel_requested_at = NULL WHERE run_id = $1",
+      [run.runId],
+    );
+    const concurrentEnqueue = await Promise.all([
+      enqueueGeneratedMediaPromotionJob(concurrentInput),
+      enqueueGeneratedMediaPromotionJob(concurrentInput),
+    ]);
+    assert.deepEqual(concurrentEnqueue.map((result) => result.outcome).sort(), [
+      "created", "existing",
+    ]);
+    assert.deepEqual(
+      await enqueueGeneratedMediaPromotionJob(concurrentInput),
+      { outcome: "existing", jobId: concurrentInput.jobId },
+    );
+    await assert.rejects(
+      enqueueGeneratedMediaPromotionJob({
+        ...concurrentInput,
+        altText: "Different immutable alt text",
+      }),
+      GeneratedMediaPromotionJobConflictError,
+    );
+    const inputs = [
+      concurrentInput,
+      createInput(fixture, run),
+      createInput(fixture, run),
+      createInput(fixture, run),
+    ];
+    for (const input of inputs.slice(1)) {
+      assert.equal((await enqueueGeneratedMediaPromotionJob(input)).outcome, "created");
+    }
+    const wrongScopeCount = await transactionWithWorkspaceScope(
+      { userId: fixture.userId, workspaceId: randomUUID() },
+      async (executor) => executor.query<{ count: string }>(
+        "SELECT count(*)::text AS count FROM content.generated_media_promotion_jobs",
+        [],
+      ),
+    );
+    assert.equal(wrongScopeCount.rows[0]?.count, "0");
+    const claims = await Promise.all([
+      claim("integration-worker-a", 2),
+      claim("integration-worker-b", 2),
+    ]);
+    const claimed = claims.flat();
+    assert.equal(claimed.length, 4);
+    assert.equal(new Set(claimed.map((job) => job.jobId)).size, 4);
+    assert.equal(new Set(claimed.map((job) => job.leaseToken)).size, 4);
+    const applied = byJobId(claimed, inputs[0]?.jobId ?? "");
+    await assert.rejects(
+      transition(fixture, async (executor) =>
+        markGeneratedMediaPromotionJobAppliedWithExecutor(executor, {
+          jobId: applied.jobId,
+          leaseToken: randomUUID(),
+        })),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
+    await transition(fixture, async (executor) =>
+      markGeneratedMediaPromotionJobAppliedWithExecutor(executor, applied));
+    const rescheduled = byJobId(claimed, inputs[1]?.jobId ?? "");
+    const nextAttemptAt = new Date(Date.now() + 60_000);
+    const retryError = { code: "S3_TRANSIENT", message: "Temporary object-store failure." };
+    await assert.rejects(
+      transition(fixture, async (executor) =>
+        rescheduleGeneratedMediaPromotionJobWithExecutor(executor, {
+          ...rescheduled, leaseToken: randomUUID(), nextAttemptAt, error: retryError,
+        })),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
+    await assert.rejects(
+      fixture.ownerPool.query(
+        `SELECT content.reschedule_generated_media_promotion_job(
+           $1, $2, statement_timestamp(), 'S3_TRANSIENT', NULL)`,
+        [rescheduled.jobId, rescheduled.leaseToken],
+      ),
+      (error: unknown) => hasPostgresCode(error, "23514"),
+    );
+    await transition(fixture, async (executor) =>
+      rescheduleGeneratedMediaPromotionJobWithExecutor(executor, {
+        ...rescheduled, nextAttemptAt, error: retryError,
+      }));
+    const reclaimedInput = inputs[2];
+    if (reclaimedInput === undefined) throw new Error("Missing reclaim input.");
+    const expired = byJobId(claimed, reclaimedInput.jobId);
+    await fixture.ownerPool.query(
+      `UPDATE content.generated_media_promotion_jobs
+       SET updated_at = created_at,
+           lease_expires_at = created_at + interval '1 millisecond'
+       WHERE job_id = $1`,
+      [expired.jobId],
+    );
+    const reclaimed = byJobId(
+      await claim("integration-reclaimer", 1),
+      expired.jobId,
+    );
+    assert.notEqual(reclaimed.leaseToken, expired.leaseToken);
+    const rescheduledState = await fixture.ownerPool.query<JobStateRow>(
+      `SELECT state, retry_count, last_error_code
+       FROM content.generated_media_promotion_jobs WHERE job_id = $1`,
+      [rescheduled.jobId],
+    );
+    assert.deepEqual(rescheduledState.rows[0], {
+      state: "pending",
+      retry_count: 1,
+      last_error_code: "S3_TRANSIENT",
+    });
+    await assert.rejects(
+      transition(fixture, async (executor) =>
+        failGeneratedMediaPromotionJobWithExecutor(executor, {
+          ...expired,
+          error: { code: "STALE_WORKER", message: "Stale worker must be fenced." },
+        })),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
+    await transition(fixture, async (executor) =>
+      failGeneratedMediaPromotionJobWithExecutor(executor, {
+        ...reclaimed,
+        error: { code: "CORRUPT_STAGING", message: "Staged object proof is invalid." },
+      }));
+    const terminalInput = inputs[3];
+    if (terminalInput === undefined) throw new Error("Missing terminal input.");
+    const terminal = byJobId(claimed, terminalInput.jobId);
+    await transition(fixture, async (executor) =>
+      failGeneratedMediaPromotionJobWithExecutor(executor, {
+        ...terminal,
+        error: { code: "IMMUTABLE_CONFLICT", message: "Immutable payload conflict." },
+      }));
+    await assert.rejects(
+      transition(fixture, async (executor) =>
+        failGeneratedMediaPromotionJobWithExecutor(executor, {
+          ...terminal,
+          error: { code: "UNSAFE\nCODE", message: "Unsafe error." },
+        })),
+      TypeError,
+    );
+    const security = await fixture.ownerPool.query<SecurityRow>(
+      `SELECT
+         relrowsecurity AS rls_enabled,
+         (SELECT count(*)::text FROM pg_policies
+          WHERE schemaname = 'content'
+            AND tablename = 'generated_media_promotion_jobs') AS policy_count,
+         has_table_privilege('backend_app', 'content.generated_media_promotion_jobs', 'UPDATE')
+           AS backend_can_update,
+         has_table_privilege('backend_app', 'content.generated_media_promotion_jobs', 'DELETE')
+           AS backend_can_delete,
+         has_table_privilege('auth_app', 'content.generated_media_promotion_jobs', 'SELECT')
+           AS auth_can_select
+       FROM pg_class
+       WHERE oid = 'content.generated_media_promotion_jobs'::regclass`,
+    );
+    assert.deepEqual(security.rows[0], {
+      rls_enabled: true,
+      policy_count: "2",
+      backend_can_update: false,
+      backend_can_delete: false,
+      auth_can_select: false,
+    });
+    await assert.rejects(
+      fixture.ownerPool.query(
+        "UPDATE content.generated_media_promotion_jobs SET alt_text = 'Changed' WHERE job_id = $1",
+        [applied.jobId],
+      ),
+      (error: unknown) => hasPostgresCode(error, "23514"),
+    );
+  });
+});

--- a/apps/backend/src/chat/cardImages/promotionJobs.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.ts
@@ -1,0 +1,351 @@
+import { transactionWithWorkspaceScopeDeadline, type DatabaseExecutor } from "../../database";
+import { unsafeQueryWithDeadline } from "../../database/unsafe";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+import { assertActiveChatRunClaimWithExecutor, type ChatRunClaimFenceParams } from "../runs/claimFence";
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+const mimeTypePattern = /^[a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*$/u;
+const safeErrorCodePattern = /^[A-Z][A-Z0-9_]{0,63}$/u;
+const controlCharacterPattern = /[\u0000-\u001f\u007f-\u009f]/u;
+export type GeneratedMediaPromotionJobPayload = Readonly<{
+  jobId: string;
+  operationId: string;
+  workspaceId: string;
+  cardId: string;
+  targetSide: "front" | "back";
+  altText: string;
+  mediaAssetId: string;
+  replicaId: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  sha256: string;
+  mimeType: string;
+  sizeBytes: number;
+}>;
+export type EnqueueGeneratedMediaPromotionJobInput = ChatRunClaimFenceParams
+  & GeneratedMediaPromotionJobPayload & Readonly<{ deadlineAtMs: number }>;
+export type EnqueueGeneratedMediaPromotionJobResult =
+  Readonly<{ outcome: "created" | "existing"; jobId: string }>;
+export type ClaimedGeneratedMediaPromotionJob =
+  GeneratedMediaPromotionJobPayload
+  & Readonly<{
+    state: "leased";
+    retryCount: number; nextAttemptAt: string;
+    leaseToken: string; leaseOwner: string; leaseExpiresAt: string;
+    lastError: SafeGeneratedMediaPromotionJobError | null;
+    createdAt: string; updatedAt: string;
+  }>;
+export type ClaimGeneratedMediaPromotionJobsInput = Readonly<{
+  leaseOwner: string; leaseDurationMs: number;
+  limit: number; deadlineAtMs: number;
+}>;
+export type GeneratedMediaPromotionJobLeaseInput =
+  Readonly<{ jobId: string; leaseToken: string }>;
+export type SafeGeneratedMediaPromotionJobError =
+  Readonly<{ code: string; message: string }>;
+export type RescheduleGeneratedMediaPromotionJobInput =
+  GeneratedMediaPromotionJobLeaseInput
+  & Readonly<{ nextAttemptAt: Date; error: SafeGeneratedMediaPromotionJobError }>;
+export type FailGeneratedMediaPromotionJobInput =
+  GeneratedMediaPromotionJobLeaseInput & Readonly<{ error: SafeGeneratedMediaPromotionJobError }>;
+type StoredPayloadRow = Readonly<{
+  job_id: string;
+  operation_id: string;
+  workspace_id: string;
+  card_id: string;
+  target_side: "front" | "back";
+  alt_text: string;
+  media_asset_id: string;
+  replica_id: string;
+  staging_storage_key: string;
+  blob_storage_key: string;
+  sha256: string;
+  mime_type: string;
+  size_bytes: string;
+}>;
+type ClaimedJobRow = StoredPayloadRow & Readonly<{
+  state: string;
+  retry_count: number;
+  next_attempt_at: Date;
+  lease_token: string | null;
+  lease_owner: string | null;
+  lease_expires_at: Date | null;
+  last_error_code: string | null;
+  last_error_message: string | null;
+  created_at: Date;
+  updated_at: Date;
+}>;
+type TransitionRow = Readonly<{ transitioned: boolean }>;
+type InsertedRow = Readonly<{ job_id: string }>;
+export class GeneratedMediaPromotionJobConflictError extends Error {
+  readonly code = "GENERATED_MEDIA_PROMOTION_JOB_CONFLICT";
+  constructor(jobId: string, operationId: string, fieldName: string) {
+    super(
+      `Generated-media promotion job identity already has a different immutable payload. jobId=${jobId}; operationId=${operationId}; field=${fieldName}`,
+    );
+    this.name = "GeneratedMediaPromotionJobConflictError";
+  }
+}
+export class GeneratedMediaPromotionJobLeaseLostError extends Error {
+  readonly code = "GENERATED_MEDIA_PROMOTION_JOB_LEASE_LOST";
+  constructor(jobId: string) {
+    super(`Generated-media promotion job lease is no longer active. jobId=${jobId}`);
+    this.name = "GeneratedMediaPromotionJobLeaseLostError";
+  }
+}
+function requireUuid(value: string, fieldName: string): void {
+  if (!uuidPattern.test(value)) {
+    throw new TypeError(`${fieldName} must be a lowercase UUID.`);
+  }
+}
+function requirePayload(payload: GeneratedMediaPromotionJobPayload): void {
+  requireUuid(payload.jobId, "jobId");
+  requireUuid(payload.operationId, "operationId");
+  requireUuid(payload.workspaceId, "workspaceId");
+  requireUuid(payload.cardId, "cardId");
+  requireUuid(payload.mediaAssetId, "mediaAssetId");
+  requireUuid(payload.replicaId, "replicaId");
+  if (
+    payload.altText !== payload.altText.trim()
+    || payload.altText.length < 1
+    || payload.altText.length > 2000
+    || controlCharacterPattern.test(payload.altText)
+  ) {
+    throw new TypeError("altText must be 1 to 2000 trimmed characters without control characters.");
+  }
+  if (!sha256Pattern.test(payload.sha256)) {
+    throw new TypeError("sha256 must be a normalized lowercase SHA-256 digest.");
+  }
+  if (!mimeTypePattern.test(payload.mimeType)) {
+    throw new TypeError("mimeType must be a normalized lowercase MIME type.");
+  }
+  if (!Number.isSafeInteger(payload.sizeBytes) || payload.sizeBytes < 1) {
+    throw new RangeError("sizeBytes must be a positive safe integer.");
+  }
+  if (
+    payload.stagingStorageKey !== buildMediaUploadStagingStorageKey(
+      payload.workspaceId,
+      payload.mediaAssetId,
+      payload.operationId,
+    )
+  ) {
+    throw new TypeError("stagingStorageKey does not match the deterministic promotion payload.");
+  }
+  if (payload.blobStorageKey !== buildMediaBlobStorageKey(payload.sha256)) {
+    throw new TypeError("blobStorageKey does not match sha256.");
+  }
+}
+function requireSafeError(error: SafeGeneratedMediaPromotionJobError): void {
+  if (!safeErrorCodePattern.test(error.code)) {
+    throw new TypeError("error.code must be a safe uppercase identifier of at most 64 characters.");
+  }
+  if (
+    error.message !== error.message.trim()
+    || error.message.length < 1
+    || error.message.length > 500
+    || controlCharacterPattern.test(error.message)
+  ) {
+    throw new TypeError("error.message must be 1 to 500 trimmed characters without control characters.");
+  }
+}
+function toPayload(row: StoredPayloadRow): GeneratedMediaPromotionJobPayload {
+  const sizeBytes = Number(row.size_bytes);
+  const payload: GeneratedMediaPromotionJobPayload = {
+    jobId: row.job_id,
+    operationId: row.operation_id,
+    workspaceId: row.workspace_id,
+    cardId: row.card_id,
+    targetSide: row.target_side,
+    altText: row.alt_text,
+    mediaAssetId: row.media_asset_id,
+    replicaId: row.replica_id,
+    stagingStorageKey: row.staging_storage_key,
+    blobStorageKey: row.blob_storage_key,
+    sha256: row.sha256,
+    mimeType: row.mime_type,
+    sizeBytes,
+  };
+  requirePayload(payload);
+  return payload;
+}
+function findPayloadMismatch(
+  left: GeneratedMediaPromotionJobPayload,
+  right: GeneratedMediaPromotionJobPayload,
+): keyof GeneratedMediaPromotionJobPayload | null {
+  for (const key of Object.keys(left) as Array<keyof GeneratedMediaPromotionJobPayload>) {
+    if (left[key] !== right[key]) return key;
+  }
+  return null;
+}
+function toIsoString(value: Date, fieldName: string): string {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new TypeError(`PostgreSQL returned an invalid ${fieldName}.`);
+  }
+  return value.toISOString();
+}
+function toClaimedJob(row: ClaimedJobRow): ClaimedGeneratedMediaPromotionJob {
+  if (
+    row.state !== "leased"
+    || row.lease_token === null
+    || row.lease_owner === null
+    || row.lease_expires_at === null
+  ) {
+    throw new TypeError(`PostgreSQL returned an invalid claimed job state. jobId=${row.job_id}`);
+  }
+  const lastError = row.last_error_code === null && row.last_error_message === null
+    ? null
+    : { code: row.last_error_code ?? "", message: row.last_error_message ?? "" };
+  if (lastError !== null) requireSafeError(lastError);
+  if (!Number.isSafeInteger(row.retry_count) || row.retry_count < 0) {
+    throw new TypeError(`PostgreSQL returned an invalid retry count. jobId=${row.job_id}`);
+  }
+  return {
+    ...toPayload(row),
+    state: "leased",
+    retryCount: row.retry_count,
+    nextAttemptAt: toIsoString(row.next_attempt_at, "next_attempt_at"),
+    leaseToken: row.lease_token,
+    leaseOwner: row.lease_owner,
+    leaseExpiresAt: toIsoString(row.lease_expires_at, "lease_expires_at"),
+    lastError,
+    createdAt: toIsoString(row.created_at, "created_at"),
+    updatedAt: toIsoString(row.updated_at, "updated_at"),
+  };
+}
+const storedPayloadColumns = `
+  job_id, operation_id, workspace_id, card_id, target_side, alt_text,
+  media_asset_id, replica_id, staging_storage_key, blob_storage_key,
+  sha256, mime_type, size_bytes
+`;
+export async function enqueueGeneratedMediaPromotionJob(
+  input: EnqueueGeneratedMediaPromotionJobInput,
+): Promise<EnqueueGeneratedMediaPromotionJobResult> {
+  requirePayload(input);
+  return transactionWithWorkspaceScopeDeadline(
+    { userId: input.userId, workspaceId: input.workspaceId },
+    input.deadlineAtMs,
+    async (executor) => {
+      await assertActiveChatRunClaimWithExecutor(executor, input);
+      const inserted = await executor.query<InsertedRow>(
+        `INSERT INTO content.generated_media_promotion_jobs (
+           job_id, operation_id, workspace_id, card_id, target_side, alt_text,
+           media_asset_id, replica_id, staging_storage_key, blob_storage_key,
+           sha256, mime_type, size_bytes
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+         ON CONFLICT DO NOTHING
+         RETURNING job_id`,
+        [
+          input.jobId, input.operationId, input.workspaceId, input.cardId,
+          input.targetSide, input.altText, input.mediaAssetId, input.replicaId,
+          input.stagingStorageKey, input.blobStorageKey, input.sha256,
+          input.mimeType, input.sizeBytes,
+        ],
+      );
+      if (inserted.rows[0]?.job_id === input.jobId) {
+        return { outcome: "created", jobId: input.jobId };
+      }
+      const existing = await executor.query<StoredPayloadRow>(
+        `SELECT ${storedPayloadColumns}
+         FROM content.generated_media_promotion_jobs
+         WHERE job_id = $1 OR operation_id = $2`,
+        [input.jobId, input.operationId],
+      );
+      const mismatch = existing.rows.length === 1
+        ? findPayloadMismatch(toPayload(existing.rows[0] as StoredPayloadRow), input)
+        : "jobId";
+      if (mismatch !== null) {
+        throw new GeneratedMediaPromotionJobConflictError(
+          input.jobId,
+          input.operationId,
+          mismatch,
+        );
+      }
+      return { outcome: "existing", jobId: input.jobId };
+    },
+  );
+}
+export async function claimGeneratedMediaPromotionJobs(
+  input: ClaimGeneratedMediaPromotionJobsInput,
+): Promise<ReadonlyArray<ClaimedGeneratedMediaPromotionJob>> {
+  if (
+    input.leaseOwner !== input.leaseOwner.trim()
+    || input.leaseOwner.length < 1
+    || input.leaseOwner.length > 200
+    || controlCharacterPattern.test(input.leaseOwner)
+  ) {
+    throw new TypeError("leaseOwner must be 1 to 200 trimmed characters without control characters.");
+  }
+  if (!Number.isSafeInteger(input.leaseDurationMs) || input.leaseDurationMs < 1
+    || input.leaseDurationMs > 3_600_000) {
+    throw new RangeError("leaseDurationMs must be between 1 and 3600000.");
+  }
+  if (!Number.isSafeInteger(input.limit) || input.limit < 1 || input.limit > 100) {
+    throw new RangeError("limit must be between 1 and 100.");
+  }
+  const result = await unsafeQueryWithDeadline<ClaimedJobRow>(
+    input.deadlineAtMs,
+    "SELECT * FROM content.claim_generated_media_promotion_jobs($1, $2, $3)",
+    [input.leaseOwner, input.leaseDurationMs, input.limit],
+  );
+  return result.rows.map(toClaimedJob);
+}
+async function requireTransition(
+  executor: DatabaseExecutor,
+  text: string,
+  params: ReadonlyArray<string | Date>,
+  jobId: string,
+): Promise<void> {
+  const result = await executor.query<TransitionRow>(text, params);
+  if (result.rows[0]?.transitioned !== true) {
+    throw new GeneratedMediaPromotionJobLeaseLostError(jobId);
+  }
+}
+export async function markGeneratedMediaPromotionJobAppliedWithExecutor(
+  executor: DatabaseExecutor,
+  input: GeneratedMediaPromotionJobLeaseInput,
+): Promise<void> {
+  requireUuid(input.jobId, "jobId");
+  requireUuid(input.leaseToken, "leaseToken");
+  await requireTransition(
+    executor,
+    "SELECT content.mark_generated_media_promotion_job_applied($1, $2) AS transitioned",
+    [input.jobId, input.leaseToken],
+    input.jobId,
+  );
+}
+export async function rescheduleGeneratedMediaPromotionJobWithExecutor(
+  executor: DatabaseExecutor,
+  input: RescheduleGeneratedMediaPromotionJobInput,
+): Promise<void> {
+  requireUuid(input.jobId, "jobId");
+  requireUuid(input.leaseToken, "leaseToken");
+  requireSafeError(input.error);
+  if (!(input.nextAttemptAt instanceof Date) || !Number.isFinite(input.nextAttemptAt.getTime())) {
+    throw new TypeError("nextAttemptAt must be a valid Date.");
+  }
+  await requireTransition(
+    executor,
+    `SELECT content.reschedule_generated_media_promotion_job(
+       $1, $2, $3, $4, $5
+     ) AS transitioned`,
+    [
+      input.jobId, input.leaseToken, input.nextAttemptAt,
+      input.error.code, input.error.message,
+    ],
+    input.jobId,
+  );
+}
+export async function failGeneratedMediaPromotionJobWithExecutor(
+  executor: DatabaseExecutor,
+  input: FailGeneratedMediaPromotionJobInput,
+): Promise<void> {
+  requireUuid(input.jobId, "jobId");
+  requireUuid(input.leaseToken, "leaseToken");
+  requireSafeError(input.error);
+  await requireTransition(
+    executor,
+    "SELECT content.fail_generated_media_promotion_job($1, $2, $3, $4) AS transitioned",
+    [input.jobId, input.leaseToken, input.error.code, input.error.message],
+    input.jobId,
+  );
+}

--- a/db/migrations/0089_generated_media_promotion_jobs.sql
+++ b/db/migrations/0089_generated_media_promotion_jobs.sql
@@ -1,0 +1,314 @@
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cards_workspace_card_id ON content.cards(workspace_id, card_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_replicas_workspace_replica_id ON sync.workspace_replicas(workspace_id, replica_id);
+CREATE TABLE content.generated_media_promotion_jobs (
+  job_id               UUID        PRIMARY KEY,
+  operation_id         UUID        NOT NULL UNIQUE,
+  workspace_id         UUID        NOT NULL,
+  card_id              UUID        NOT NULL,
+  target_side          TEXT        NOT NULL CHECK (target_side IN ('front', 'back')),
+  alt_text             TEXT        NOT NULL,
+  media_asset_id       UUID        NOT NULL,
+  replica_id           UUID        NOT NULL,
+  staging_storage_key  TEXT        NOT NULL,
+  blob_storage_key     TEXT        NOT NULL,
+  sha256               TEXT        NOT NULL,
+  mime_type            TEXT        NOT NULL,
+  size_bytes           BIGINT      NOT NULL CHECK (size_bytes > 0),
+  state                TEXT        NOT NULL DEFAULT 'pending'
+    CHECK (state IN ('pending', 'leased', 'applied', 'failed')),
+  retry_count          INTEGER     NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+  next_attempt_at      TIMESTAMPTZ DEFAULT statement_timestamp(),
+  lease_token          UUID,
+  lease_owner          TEXT,
+  lease_expires_at     TIMESTAMPTZ,
+  last_error_code      TEXT,
+  last_error_message   TEXT,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+  applied_at           TIMESTAMPTZ,
+  CONSTRAINT generated_media_promotion_jobs_workspace_fk
+    FOREIGN KEY (workspace_id) REFERENCES org.workspaces(workspace_id) ON DELETE CASCADE,
+  CONSTRAINT generated_media_promotion_jobs_card_workspace_fk
+    FOREIGN KEY (workspace_id, card_id) REFERENCES content.cards(workspace_id, card_id)
+    ON DELETE CASCADE,
+  CONSTRAINT generated_media_promotion_jobs_replica_workspace_fk
+    FOREIGN KEY (workspace_id, replica_id) REFERENCES sync.workspace_replicas(workspace_id, replica_id)
+    ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED,
+  CONSTRAINT generated_media_promotion_jobs_alt_text_safe
+    CHECK (
+      alt_text = btrim(alt_text)
+      AND char_length(alt_text) BETWEEN 1 AND 2000
+      AND alt_text !~ '[[:cntrl:]]'
+    ),
+  CONSTRAINT generated_media_promotion_jobs_sha256_normalized
+    CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT generated_media_promotion_jobs_mime_type_normalized
+    CHECK (
+      mime_type = lower(btrim(mime_type))
+      AND mime_type ~ '^[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*$'
+    ),
+  CONSTRAINT generated_media_promotion_jobs_staging_key_deterministic
+    CHECK (
+      staging_storage_key =
+        'media/uploads/workspaces/' || lower(workspace_id::text)
+        || '/assets/' || lower(media_asset_id::text)
+        || '/operations/' || encode(public.digest(operation_id::text, 'sha256'), 'hex')
+    ),
+  CONSTRAINT generated_media_promotion_jobs_blob_key_deterministic
+    CHECK (
+      blob_storage_key =
+        'media/blobs/sha256/' || substring(sha256 from 1 for 2)
+        || '/' || substring(sha256 from 3 for 2) || '/' || sha256
+    ),
+  CONSTRAINT generated_media_promotion_jobs_error_safe
+    CHECK (
+      (last_error_code IS NULL AND last_error_message IS NULL)
+      OR (
+        last_error_code IS NOT NULL AND last_error_message IS NOT NULL
+        AND last_error_code ~ '^[A-Z][A-Z0-9_]{0,63}$'
+        AND last_error_message = btrim(last_error_message)
+        AND char_length(last_error_message) BETWEEN 1 AND 500
+        AND last_error_message !~ '[[:cntrl:]]'
+      )
+    ),
+  CONSTRAINT generated_media_promotion_jobs_timestamps_ordered
+    CHECK (
+      updated_at >= created_at
+      AND (next_attempt_at IS NULL OR next_attempt_at >= created_at)
+      AND (lease_expires_at IS NULL OR lease_expires_at > updated_at)
+      AND (applied_at IS NULL OR applied_at >= created_at)
+    ),
+  CONSTRAINT generated_media_promotion_jobs_state_shape
+    CHECK (
+      (
+        state = 'pending'
+        AND next_attempt_at IS NOT NULL
+        AND lease_token IS NULL
+        AND lease_owner IS NULL
+        AND lease_expires_at IS NULL
+        AND applied_at IS NULL
+      )
+      OR (
+        state = 'leased'
+        AND next_attempt_at IS NOT NULL
+        AND lease_token IS NOT NULL
+        AND lease_owner IS NOT NULL
+        AND lease_owner = btrim(lease_owner)
+        AND btrim(lease_owner) <> ''
+        AND char_length(lease_owner) <= 200
+        AND lease_owner !~ '[[:cntrl:]]'
+        AND lease_expires_at IS NOT NULL
+        AND applied_at IS NULL
+      )
+      OR (
+        state = 'applied'
+        AND next_attempt_at IS NULL
+        AND lease_token IS NULL
+        AND lease_owner IS NULL
+        AND lease_expires_at IS NULL
+        AND last_error_code IS NULL
+        AND applied_at IS NOT NULL
+      )
+      OR (
+        state = 'failed'
+        AND next_attempt_at IS NULL
+        AND lease_token IS NULL
+        AND lease_owner IS NULL
+        AND lease_expires_at IS NULL
+        AND last_error_code IS NOT NULL
+        AND applied_at IS NULL
+      )
+    )
+);
+CREATE INDEX idx_generated_media_promotion_jobs_due
+  ON content.generated_media_promotion_jobs(next_attempt_at, created_at, job_id) WHERE state = 'pending';
+CREATE INDEX idx_generated_media_promotion_jobs_reclaim
+  ON content.generated_media_promotion_jobs(lease_expires_at, created_at, job_id) WHERE state = 'leased';
+CREATE FUNCTION content.prevent_generated_media_promotion_job_payload_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF to_jsonb(NEW) - ARRAY[
+    'state', 'retry_count', 'next_attempt_at', 'lease_token', 'lease_owner',
+    'lease_expires_at', 'last_error_code', 'last_error_message', 'updated_at', 'applied_at'
+  ] IS DISTINCT FROM to_jsonb(OLD) - ARRAY[
+    'state', 'retry_count', 'next_attempt_at', 'lease_token', 'lease_owner',
+    'lease_expires_at', 'last_error_code', 'last_error_message', 'updated_at', 'applied_at'
+  ] THEN
+    RAISE EXCEPTION 'Generated-media promotion job payload is immutable'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER generated_media_promotion_jobs_payload_immutable
+  BEFORE UPDATE ON content.generated_media_promotion_jobs
+  FOR EACH ROW
+  EXECUTE FUNCTION content.prevent_generated_media_promotion_job_payload_update();
+REVOKE ALL ON FUNCTION content.prevent_generated_media_promotion_job_payload_update() FROM PUBLIC;
+CREATE FUNCTION content.claim_generated_media_promotion_jobs(
+  p_lease_owner TEXT, p_lease_duration_ms INTEGER, p_limit INTEGER)
+RETURNS SETOF content.generated_media_promotion_jobs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF p_lease_owner IS NULL OR btrim(p_lease_owner) = ''
+    OR p_lease_owner IS DISTINCT FROM btrim(p_lease_owner)
+    OR char_length(p_lease_owner) > 200
+    OR p_lease_owner ~ '[[:cntrl:]]'
+  THEN
+    RAISE EXCEPTION 'p_lease_owner must be 1 to 200 trimmed characters'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_lease_duration_ms IS NULL OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000 THEN
+    RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_limit IS NULL OR p_limit NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'p_limit must be between 1 and 100'
+      USING ERRCODE = '22023';
+  END IF;
+  RETURN QUERY
+  WITH claimable AS (
+    SELECT jobs.job_id
+    FROM content.generated_media_promotion_jobs AS jobs
+    WHERE (
+      jobs.state = 'pending'
+      AND jobs.next_attempt_at <= statement_timestamp()
+    ) OR (
+      jobs.state = 'leased'
+      AND jobs.lease_expires_at <= statement_timestamp()
+    )
+    ORDER BY
+      CASE WHEN jobs.state = 'leased' THEN jobs.lease_expires_at
+        ELSE jobs.next_attempt_at END,
+      jobs.created_at,
+      jobs.job_id
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit
+  )
+  UPDATE content.generated_media_promotion_jobs AS jobs
+  SET
+    state = 'leased',
+    lease_token = gen_random_uuid(),
+    lease_owner = p_lease_owner,
+    lease_expires_at =
+      statement_timestamp() + (p_lease_duration_ms * interval '1 millisecond'),
+    updated_at = statement_timestamp()
+  FROM claimable
+  WHERE jobs.job_id = claimable.job_id
+  RETURNING jobs.*;
+END;
+$$;
+CREATE FUNCTION content.mark_generated_media_promotion_job_applied(
+  p_job_id UUID, p_lease_token UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  WITH transitioned AS (
+    UPDATE content.generated_media_promotion_jobs
+    SET
+      state = 'applied',
+      next_attempt_at = NULL,
+      lease_token = NULL,
+      lease_owner = NULL,
+      lease_expires_at = NULL,
+      last_error_code = NULL,
+      last_error_message = NULL,
+      updated_at = statement_timestamp(),
+      applied_at = statement_timestamp()
+    WHERE job_id = p_job_id
+      AND state = 'leased'
+      AND lease_token = p_lease_token
+      AND lease_expires_at > statement_timestamp()
+    RETURNING 1
+  )
+  SELECT EXISTS (SELECT 1 FROM transitioned);
+$$;
+CREATE FUNCTION content.reschedule_generated_media_promotion_job(
+  p_job_id UUID, p_lease_token UUID, p_next_attempt_at TIMESTAMPTZ,
+  p_error_code TEXT, p_error_message TEXT)
+RETURNS BOOLEAN
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  WITH transitioned AS (
+    UPDATE content.generated_media_promotion_jobs
+    SET
+      state = 'pending',
+      retry_count = retry_count + 1,
+      next_attempt_at = p_next_attempt_at,
+      lease_token = NULL,
+      lease_owner = NULL,
+      lease_expires_at = NULL,
+      last_error_code = p_error_code,
+      last_error_message = p_error_message,
+      updated_at = statement_timestamp()
+    WHERE job_id = p_job_id
+      AND state = 'leased'
+      AND lease_token = p_lease_token
+      AND lease_expires_at > statement_timestamp()
+    RETURNING 1
+  )
+  SELECT EXISTS (SELECT 1 FROM transitioned);
+$$;
+CREATE FUNCTION content.fail_generated_media_promotion_job(
+  p_job_id UUID, p_lease_token UUID, p_error_code TEXT, p_error_message TEXT)
+RETURNS BOOLEAN
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  WITH transitioned AS (
+    UPDATE content.generated_media_promotion_jobs
+    SET
+      state = 'failed',
+      next_attempt_at = NULL,
+      lease_token = NULL,
+      lease_owner = NULL,
+      lease_expires_at = NULL,
+      last_error_code = p_error_code,
+      last_error_message = p_error_message,
+      updated_at = statement_timestamp()
+    WHERE job_id = p_job_id
+      AND state = 'leased'
+      AND lease_token = p_lease_token
+      AND lease_expires_at > statement_timestamp()
+    RETURNING 1
+  )
+  SELECT EXISTS (SELECT 1 FROM transitioned);
+$$;
+ALTER TABLE content.generated_media_promotion_jobs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY generated_media_promotion_jobs_scoped_select_runtime
+  ON content.generated_media_promotion_jobs FOR SELECT TO backend_app
+  USING (security.current_workspace_access_allowed(workspace_id));
+CREATE POLICY generated_media_promotion_jobs_scoped_insert_runtime
+  ON content.generated_media_promotion_jobs FOR INSERT TO backend_app
+  WITH CHECK (security.current_workspace_access_allowed(workspace_id));
+REVOKE ALL ON content.generated_media_promotion_jobs
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+GRANT SELECT (
+  job_id, operation_id, workspace_id, card_id, target_side, alt_text,
+  media_asset_id, replica_id, staging_storage_key, blob_storage_key,
+  sha256, mime_type, size_bytes
+) ON content.generated_media_promotion_jobs TO backend_app;
+GRANT INSERT (
+  job_id, operation_id, workspace_id, card_id, target_side, alt_text,
+  media_asset_id, replica_id, staging_storage_key, blob_storage_key,
+  sha256, mime_type, size_bytes
+) ON content.generated_media_promotion_jobs TO backend_app;
+REVOKE ALL ON FUNCTION content.claim_generated_media_promotion_jobs(TEXT, INTEGER, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.mark_generated_media_promotion_job_applied(UUID, UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.reschedule_generated_media_promotion_job(UUID, UUID, TIMESTAMPTZ, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.fail_generated_media_promotion_job(UUID, UUID, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION content.claim_generated_media_promotion_jobs(TEXT, INTEGER, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.mark_generated_media_promotion_job_applied(UUID, UUID) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.reschedule_generated_media_promotion_job(UUID, UUID, TIMESTAMPTZ, TEXT, TEXT) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.fail_generated_media_promotion_job(UUID, UUID, TEXT, TEXT) TO backend_app;


### PR DESCRIPTION
## Summary
- add the durable generated-media promotion job schema and lifecycle functions
- add claim-fenced idempotent enqueue and globally fenced claim/reclaim contracts
- add real PostgreSQL coverage for concurrency, fencing, reclaim, RLS, grants, and constraints

## Validation
- fresh PostgreSQL migration chain through 0089 plus views
- focused real-PostgreSQL integration test
- backend test suite: 820 passed
- backend lint and build