### PR TITLE
Add generated media promotion reconciler

### DIFF
--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import test from "node:test";
 import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../database";
+import { testObservationScope } from "../../mediaAssets/storage/testHelpers";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
 import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
 import { InactiveChatRunClaimError } from "../runs/claimFence";
@@ -16,6 +17,11 @@ import {
   type ClaimedGeneratedMediaPromotionJob,
   type EnqueueGeneratedMediaPromotionJobInput,
 } from "./promotionJobs";
+import {
+  applyGeneratedMediaPromotionJob, failGeneratedMediaPromotionJob,
+  processClaimedGeneratedMediaPromotionJobWithDependencies,
+  rescheduleGeneratedMediaPromotionJob,
+} from "./promotionProcessor";
 type RunFixture = Readonly<{ sessionId: string; runId: string; claimToken: string }>;
 type ClaimTokenRow = Readonly<{ claim_token: string }>;
 type JobStateRow = Readonly<{ state: string; retry_count: number;
@@ -58,7 +64,7 @@ EnqueueGeneratedMediaPromotionJobInput {
   const jobId = randomUUID();
   const operationId = randomUUID();
   const mediaAssetId = randomUUID();
-  const sha256 = "8349792a6784cfdc5061b34e1184c85bcdb13719e86ac4be576e52e5e8c5f603";
+  const sha256 = "e4514fb8fbc32fb38d301d03c556edbf81e27aebbe7039b9eb40e3352ac2147f";
   return {
     userId: fixture.userId,
     workspaceId: fixture.workspaceId,
@@ -105,7 +111,7 @@ function hasPostgresCode(error: unknown, code: string): boolean {
 test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS", async () => {
   await withPostgresIntegrationFixture(async (fixture) => {
     const run = await createRun(fixture);
-    const concurrentInput = createInput(fixture, run);
+    const concurrentInput = { ...createInput(fixture, run), targetSide: "front" as const };
     await assert.rejects(
       enqueueGeneratedMediaPromotionJob({ ...concurrentInput, claimToken: new Date(0).toISOString() }),
       InactiveChatRunClaimError,
@@ -122,6 +128,14 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
       "UPDATE ai.chat_runs SET cancel_requested_at = NULL WHERE run_id = $1",
       [run.runId],
     );
+    await fixture.ownerPool.query(
+      "UPDATE sync.workspace_replicas SET user_id = 'unowned-replica-user' WHERE replica_id = $1", [fixture.replicaId]);
+    await assert.rejects(
+      enqueueGeneratedMediaPromotionJob(concurrentInput), (error: unknown) =>
+        hasPostgresCode(error, "MEDIA_ASSET_REPLICA_INVALID"),
+    );
+    await fixture.ownerPool.query(
+      "UPDATE sync.workspace_replicas SET user_id = $1 WHERE replica_id = $2", [fixture.userId, fixture.replicaId]);
     const concurrentEnqueue = await Promise.all([
       enqueueGeneratedMediaPromotionJob(concurrentInput),
       enqueueGeneratedMediaPromotionJob(concurrentInput),
@@ -166,6 +180,11 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     assert.equal(new Set(claimed.map((job) => job.jobId)).size, 4);
     assert.equal(new Set(claimed.map((job) => job.leaseToken)).size, 4);
     const applied = byJobId(claimed, inputs[0]?.jobId ?? "");
+    assert.equal(applied.userId, fixture.userId);
+    await fixture.ownerPool.query(
+      "UPDATE sync.workspace_replicas SET user_id = 'reassigned-user' WHERE replica_id = $1",
+      [fixture.replicaId],
+    );
     await assert.rejects(
       transition(fixture, async (executor) =>
         markGeneratedMediaPromotionJobAppliedWithExecutor(executor, {
@@ -174,8 +193,24 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
         })),
       GeneratedMediaPromotionJobLeaseLostError,
     );
-    await transition(fixture, async (executor) =>
-      markGeneratedMediaPromotionJobAppliedWithExecutor(executor, applied));
+    await applyGeneratedMediaPromotionJob(applied, Date.now() + 10_000);
+    const appliedCard = await fixture.ownerPool.query<{ front_text: string; back_text: string }>(
+      "SELECT front_text, back_text FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
+      [fixture.workspaceId, fixture.cardId],
+    );
+    assert.equal(appliedCard.rows[0]?.back_text, "Original answer");
+    assert.equal(
+      appliedCard.rows[0]?.front_text.match(new RegExp(`fcasset:${applied.mediaAssetId}`, "gu"))?.length,
+      1,
+    );
+    assert.ok(appliedCard.rows[0]?.front_text.startsWith("Original question\n\n![Generated integration image]"));
+    assert.equal(
+      (await fixture.ownerPool.query<{ count: string }>(
+        "SELECT count(*)::text AS count FROM content.media_assets WHERE media_asset_id = $1",
+        [applied.mediaAssetId],
+      )).rows[0]?.count,
+      "1",
+    );
     const rescheduled = byJobId(claimed, inputs[1]?.jobId ?? "");
     const nextAttemptAt = new Date(Date.now() + 60_000);
     const retryError = { code: "S3_TRANSIENT", message: "Temporary object-store failure." };
@@ -239,11 +274,28 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     const terminalInput = inputs[3];
     if (terminalInput === undefined) throw new Error("Missing terminal input.");
     const terminal = byJobId(claimed, terminalInput.jobId);
-    await transition(fixture, async (executor) =>
-      failGeneratedMediaPromotionJobWithExecutor(executor, {
-        ...terminal,
-        error: { code: "IMMUTABLE_CONFLICT", message: "Immutable payload conflict." },
-      }));
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
+      [fixture.workspaceId, fixture.userId],
+    );
+    const revokedResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+      terminal,
+      {
+        leaseOwner: "integration-revoked", leaseDurationMs: 60_000,
+        maximumJobs: 1, deadlineAtMs: Date.now() + 10_000,
+        observationScope: testObservationScope, signal: new AbortController().signal,
+      },
+      {
+        claimJobsFn: claimGeneratedMediaPromotionJobs,
+        promoteObjectFn: async () => {},
+        applyJobFn: applyGeneratedMediaPromotionJob,
+        rescheduleJobFn: rescheduleGeneratedMediaPromotionJob,
+        failJobFn: failGeneratedMediaPromotionJob,
+        nowFn: Date.now,
+      },
+    );
+    assert.equal(revokedResult.outcome, "failed");
+    assert.equal(revokedResult.errorCode, "WORKSPACE_ACCESS_REVOKED");
     await assert.rejects(
       transition(fixture, async (executor) =>
         failGeneratedMediaPromotionJobWithExecutor(executor, {

--- a/apps/backend/src/chat/cardImages/promotionJobs.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.ts
@@ -1,6 +1,7 @@
 import { transactionWithWorkspaceScopeDeadline, type DatabaseExecutor } from "../../database";
 import { unsafeQueryWithDeadline } from "../../database/unsafe";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
 import { assertActiveChatRunClaimWithExecutor, type ChatRunClaimFenceParams } from "../runs/claimFence";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const sha256Pattern = /^[0-9a-f]{64}$/u;
@@ -10,6 +11,7 @@ const controlCharacterPattern = /[\u0000-\u001f\u007f-\u009f]/u;
 export type GeneratedMediaPromotionJobPayload = Readonly<{
   jobId: string;
   operationId: string;
+  userId: string;
   workspaceId: string;
   cardId: string;
   targetSide: "front" | "back";
@@ -51,6 +53,7 @@ export type FailGeneratedMediaPromotionJobInput =
 type StoredPayloadRow = Readonly<{
   job_id: string;
   operation_id: string;
+  user_id: string;
   workspace_id: string;
   card_id: string;
   target_side: "front" | "back";
@@ -76,6 +79,7 @@ type ClaimedJobRow = StoredPayloadRow & Readonly<{
   updated_at: Date;
 }>;
 type TransitionRow = Readonly<{ transitioned: boolean }>;
+type AppliedScopeRow = Readonly<{ scope_status: string }>;
 type InsertedRow = Readonly<{ job_id: string }>;
 export class GeneratedMediaPromotionJobConflictError extends Error {
   readonly code = "GENERATED_MEDIA_PROMOTION_JOB_CONFLICT";
@@ -93,6 +97,13 @@ export class GeneratedMediaPromotionJobLeaseLostError extends Error {
     this.name = "GeneratedMediaPromotionJobLeaseLostError";
   }
 }
+export class GeneratedMediaPromotionJobAccessRevokedError extends Error {
+  readonly code = "WORKSPACE_ACCESS_REVOKED";
+  constructor(jobId: string) {
+    super(`Generated-media promotion job workspace access was revoked. jobId=${jobId}`);
+    this.name = "GeneratedMediaPromotionJobAccessRevokedError";
+  }
+}
 function requireUuid(value: string, fieldName: string): void {
   if (!uuidPattern.test(value)) {
     throw new TypeError(`${fieldName} must be a lowercase UUID.`);
@@ -105,6 +116,10 @@ function requirePayload(payload: GeneratedMediaPromotionJobPayload): void {
   requireUuid(payload.cardId, "cardId");
   requireUuid(payload.mediaAssetId, "mediaAssetId");
   requireUuid(payload.replicaId, "replicaId");
+  if (payload.userId !== payload.userId.trim() || payload.userId === ""
+    || controlCharacterPattern.test(payload.userId)) {
+    throw new TypeError("userId must be non-empty, trimmed, and contain no control characters.");
+  }
   if (
     payload.altText !== payload.altText.trim()
     || payload.altText.length < 1
@@ -153,6 +168,7 @@ function toPayload(row: StoredPayloadRow): GeneratedMediaPromotionJobPayload {
   const payload: GeneratedMediaPromotionJobPayload = {
     jobId: row.job_id,
     operationId: row.operation_id,
+    userId: row.user_id,
     workspaceId: row.workspace_id,
     cardId: row.card_id,
     targetSide: row.target_side,
@@ -213,7 +229,7 @@ function toClaimedJob(row: ClaimedJobRow): ClaimedGeneratedMediaPromotionJob {
   };
 }
 const storedPayloadColumns = `
-  job_id, operation_id, workspace_id, card_id, target_side, alt_text,
+  job_id, operation_id, user_id, workspace_id, card_id, target_side, alt_text,
   media_asset_id, replica_id, staging_storage_key, blob_storage_key,
   sha256, mime_type, size_bytes
 `;
@@ -226,17 +242,18 @@ export async function enqueueGeneratedMediaPromotionJob(
     input.deadlineAtMs,
     async (executor) => {
       await assertActiveChatRunClaimWithExecutor(executor, input);
+      await assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId);
       const inserted = await executor.query<InsertedRow>(
         `INSERT INTO content.generated_media_promotion_jobs (
-           job_id, operation_id, workspace_id, card_id, target_side, alt_text,
+           job_id, operation_id, user_id, workspace_id, card_id, target_side, alt_text,
            media_asset_id, replica_id, staging_storage_key, blob_storage_key,
            sha256, mime_type, size_bytes
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
          ON CONFLICT DO NOTHING
          RETURNING job_id`,
         [
-          input.jobId, input.operationId, input.workspaceId, input.cardId,
-          input.targetSide, input.altText, input.mediaAssetId, input.replicaId,
+          input.jobId, input.operationId, input.userId, input.workspaceId,
+          input.cardId, input.targetSide, input.altText, input.mediaAssetId, input.replicaId,
           input.stagingStorageKey, input.blobStorageKey, input.sha256,
           input.mimeType, input.sizeBytes,
         ],
@@ -312,6 +329,26 @@ export async function markGeneratedMediaPromotionJobAppliedWithExecutor(
     [input.jobId, input.leaseToken],
     input.jobId,
   );
+}
+export async function applyGeneratedMediaPromotionJobScopeWithExecutor(
+  executor: DatabaseExecutor,
+  input: GeneratedMediaPromotionJobLeaseInput,
+): Promise<void> {
+  requireUuid(input.jobId, "jobId");
+  requireUuid(input.leaseToken, "leaseToken");
+  const result = await executor.query<AppliedScopeRow>(
+    "SELECT content.apply_generated_media_promotion_job_scope($1, $2) AS scope_status",
+    [input.jobId, input.leaseToken],
+  );
+  const status = result.rows[0]?.scope_status;
+  if (status === "scoped") return;
+  if (status === "access_revoked") {
+    throw new GeneratedMediaPromotionJobAccessRevokedError(input.jobId);
+  }
+  if (status === "lease_lost") {
+    throw new GeneratedMediaPromotionJobLeaseLostError(input.jobId);
+  }
+  throw new TypeError(`PostgreSQL returned an invalid promotion scope status. jobId=${input.jobId}`);
 }
 export async function rescheduleGeneratedMediaPromotionJobWithExecutor(
   executor: DatabaseExecutor,

--- a/apps/backend/src/chat/cardImages/promotionProcessor.test.ts
+++ b/apps/backend/src/chat/cardImages/promotionProcessor.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { TransientDatabaseHttpError } from "../../database/transient";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+import {
+  testMediaAssetId, testObservationScope, testSha256, testWorkspaceId,
+} from "../../mediaAssets/storage/testHelpers";
+import type { ClaimedGeneratedMediaPromotionJob } from "./promotionJobs";
+import { processClaimedGeneratedMediaPromotionJobWithDependencies } from "./promotionProcessor";
+const jobId = "33333333-3333-4333-8333-333333333333";
+const operationId = "44444444-4444-4444-8444-444444444444";
+const timestamp = "2026-07-25T00:00:00.000Z";
+const nowMs = Date.parse(timestamp);
+const job: ClaimedGeneratedMediaPromotionJob = {
+  jobId, operationId, userId: "user-1", workspaceId: testWorkspaceId,
+  cardId: "55555555-5555-4555-8555-555555555555",
+  targetSide: "back", altText: "Generated image", mediaAssetId: testMediaAssetId,
+  replicaId: "66666666-6666-4666-8666-666666666666",
+  stagingStorageKey: buildMediaUploadStagingStorageKey(testWorkspaceId, testMediaAssetId, operationId),
+  blobStorageKey: buildMediaBlobStorageKey(testSha256),
+  sha256: testSha256, mimeType: "image/jpeg", sizeBytes: 42,
+  state: "leased", retryCount: 0, nextAttemptAt: timestamp,
+  leaseToken: "77777777-7777-4777-8777-777777777777",
+  leaseOwner: "test-worker", leaseExpiresAt: "2026-07-25T00:03:00.000Z",
+  lastError: null, createdAt: timestamp, updatedAt: timestamp,
+};
+test("processor reschedules transient database boundary errors", async () => {
+  const result = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+    job,
+    {
+      leaseOwner: "test-worker", leaseDurationMs: 180_000,
+      maximumJobs: 1, deadlineAtMs: nowMs + 60_000,
+      observationScope: testObservationScope, signal: new AbortController().signal,
+    },
+    {
+      claimJobsFn: async () => [],
+      promoteObjectFn: async () => {},
+      applyJobFn: async () => {
+        throw new TransientDatabaseHttpError(
+          Object.assign(new Error("deadlock detected"), { code: "40P01" }),
+        );
+      },
+      rescheduleJobFn: async (_job, _deadlineAtMs, nextAttemptAt, error) => {
+        assert.equal(nextAttemptAt.getTime(), nowMs + 30_000);
+        assert.equal(error.code, "DATABASE_TRANSIENT");
+      },
+      failJobFn: async () => { assert.fail("Transient database errors must not fail the job."); },
+      nowFn: () => nowMs,
+    },
+  );
+  assert.equal(result.outcome, "rescheduled");
+  assert.equal(result.errorCode, "DATABASE_TRANSIENT");
+});

--- a/apps/backend/src/chat/cardImages/promotionProcessor.ts
+++ b/apps/backend/src/chat/cardImages/promotionProcessor.ts
@@ -1,0 +1,326 @@
+import { appendManagedImageToCardSideInExecutor } from "../../cards";
+import { DatabaseDeadlineExceededError, type DatabaseExecutor } from "../../database";
+import { unsafeTransactionWithDeadline } from "../../database/unsafe";
+import {
+  DatabaseCommitOutcomeUnknownError, isTransientDatabaseError, TransientDatabaseHttpError,
+} from "../../database/transient";
+import {
+  findMediaAssetRowForUpdateInExecutor, mapMediaAssetRow,
+  upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
+} from "../../mediaAssets/persistence";
+import {
+  GeneratedMediaPromotionStorageTerminalError, GeneratedMediaPromotionStorageTransientError,
+  promoteGeneratedMediaObject,
+} from "../../mediaAssets/storage";
+import {
+  imageJpegCardMediaBlobMimeType, imageJpegCardMediaBlobNormalizationVersion,
+  passthroughMediaBlobNormalizationVersion, type MediaAsset,
+} from "../../mediaAssets/types";
+import type { BackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
+import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../sync/replication/changes";
+import {
+  applyGeneratedMediaPromotionJobScopeWithExecutor, claimGeneratedMediaPromotionJobs,
+  failGeneratedMediaPromotionJobWithExecutor, GeneratedMediaPromotionJobAccessRevokedError,
+  GeneratedMediaPromotionJobLeaseLostError,
+  markGeneratedMediaPromotionJobAppliedWithExecutor, rescheduleGeneratedMediaPromotionJobWithExecutor,
+  type ClaimedGeneratedMediaPromotionJob, type SafeGeneratedMediaPromotionJobError,
+} from "./promotionJobs";
+const maximumJobAttempts = 5;
+const retryBaseDelayMs = 30_000;
+const retryMaximumDelayMs = 15 * 60_000;
+const minimumNewJobBudgetMs = 1_000;
+export type GeneratedMediaPromotionJobOutcome =
+  | "applied"
+  | "ambiguous"
+  | "failed"
+  | "interrupted"
+  | "lease_lost"
+  | "rescheduled";
+export type GeneratedMediaPromotionJobResult = Readonly<{
+  jobId: string; workspaceId: string; outcome: GeneratedMediaPromotionJobOutcome;
+  retryCount: number; errorCode: string | null;
+}>;
+export type GeneratedMediaPromotionBatchInput = Readonly<{
+  leaseOwner: string; leaseDurationMs: number; maximumJobs: number; deadlineAtMs: number;
+  observationScope: BackendObservationScope; signal: AbortSignal;
+}>;
+export type GeneratedMediaPromotionBatchResult = Readonly<{
+  claimed: number; applied: number; ambiguous: number; failed: number;
+  interrupted: number; leaseLost: number; rescheduled: number;
+  results: ReadonlyArray<GeneratedMediaPromotionJobResult>;
+}>;
+export type GeneratedMediaPromotionProcessorDependencies = Readonly<{
+  claimJobsFn: typeof claimGeneratedMediaPromotionJobs; promoteObjectFn: typeof promoteGeneratedMediaObject;
+  applyJobFn: typeof applyGeneratedMediaPromotionJob;
+  rescheduleJobFn: typeof rescheduleGeneratedMediaPromotionJob;
+  failJobFn: typeof failGeneratedMediaPromotionJob; nowFn: () => number;
+}>;
+function assertPersistedMediaIdentity(
+  mediaAsset: MediaAsset,
+  job: ClaimedGeneratedMediaPromotionJob,
+): void {
+  if (
+    mediaAsset.mediaAssetId !== job.mediaAssetId
+    || mediaAsset.workspaceId !== job.workspaceId
+    || mediaAsset.mimeType !== job.mimeType
+    || mediaAsset.sizeBytes !== job.sizeBytes
+    || mediaAsset.sha256 !== job.sha256
+    || mediaAsset.sourceUrl !== null
+    || mediaAsset.deletedAt !== null
+    || mediaAsset.lastModifiedByReplicaId !== job.replicaId
+    || mediaAsset.lastOperationId !== job.operationId
+  ) {
+    throw new HttpError(
+      409,
+      "The generated media asset identity conflicts with the durable promotion job.",
+      "GENERATED_MEDIA_ASSET_IMMUTABLE_CONFLICT",
+    );
+  }
+}
+async function applyGeneratedMediaPromotionJobInExecutor(
+  executor: DatabaseExecutor,
+  job: ClaimedGeneratedMediaPromotionJob,
+): Promise<void> {
+  await applyGeneratedMediaPromotionJobScopeWithExecutor(executor, job);
+  await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, job.workspaceId);
+  const existingRow = await findMediaAssetRowForUpdateInExecutor(
+    executor, job.workspaceId, job.mediaAssetId,
+  );
+  if (existingRow !== null) {
+    assertPersistedMediaIdentity(mapMediaAssetRow(existingRow), job);
+  }
+  const mediaResult = await upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
+    executor,
+    job.workspaceId,
+    {
+      mediaAssetId: job.mediaAssetId, mimeType: job.mimeType,
+      sizeBytes: job.sizeBytes, sha256: job.sha256,
+      sourceUrl: null, createdAt: job.createdAt, deletedAt: null,
+    },
+    {
+      clientUpdatedAt: job.createdAt, lastModifiedByReplicaId: job.replicaId,
+      lastOperationId: job.operationId,
+    },
+    job.mimeType === imageJpegCardMediaBlobMimeType
+      ? imageJpegCardMediaBlobNormalizationVersion
+      : passthroughMediaBlobNormalizationVersion,
+  );
+  assertPersistedMediaIdentity(mediaResult.mediaAsset, job);
+  await appendManagedImageToCardSideInExecutor(
+    executor, job.workspaceId,
+    {
+      cardId: job.cardId, targetSide: job.targetSide,
+      mediaAssetId: job.mediaAssetId, altText: job.altText,
+    },
+    {
+      clientUpdatedAt: job.createdAt, lastModifiedByReplicaId: job.replicaId,
+      lastOperationId: job.operationId,
+    },
+  );
+  await markGeneratedMediaPromotionJobAppliedWithExecutor(executor, job);
+}
+export async function applyGeneratedMediaPromotionJob(
+  job: ClaimedGeneratedMediaPromotionJob,
+  deadlineAtMs: number,
+): Promise<void> {
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => (
+    applyGeneratedMediaPromotionJobInExecutor(executor, job)
+  ));
+}
+export async function rescheduleGeneratedMediaPromotionJob(
+  job: ClaimedGeneratedMediaPromotionJob,
+  deadlineAtMs: number,
+  nextAttemptAt: Date,
+  error: SafeGeneratedMediaPromotionJobError,
+): Promise<void> {
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
+    await rescheduleGeneratedMediaPromotionJobWithExecutor(executor, { ...job, nextAttemptAt, error });
+  });
+}
+export async function failGeneratedMediaPromotionJob(
+  job: ClaimedGeneratedMediaPromotionJob,
+  deadlineAtMs: number,
+  error: SafeGeneratedMediaPromotionJobError,
+): Promise<void> {
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
+    await failGeneratedMediaPromotionJobWithExecutor(executor, { ...job, error });
+  });
+}
+function terminalError(error: unknown): SafeGeneratedMediaPromotionJobError | null {
+  if (error instanceof GeneratedMediaPromotionStorageTerminalError) {
+    return { code: error.code, message: error.safeMessage };
+  }
+  if (error instanceof GeneratedMediaPromotionJobAccessRevokedError) {
+    return {
+      code: error.code,
+      message: "Workspace access was revoked before generated-media promotion completed.",
+    };
+  }
+  if (error instanceof HttpError) {
+    return {
+      code: "IMMUTABLE_CONFLICT",
+      message: "The durable generated-media job conflicts with current card or media state.",
+    };
+  }
+  if (error instanceof TypeError || error instanceof RangeError) {
+    return {
+      code: "INVALID_JOB_PAYLOAD",
+      message: "The durable generated-media job payload is invalid.",
+    };
+  }
+  return null;
+}
+function isTransientFailure(error: unknown): boolean {
+  return error instanceof GeneratedMediaPromotionStorageTransientError
+    || error instanceof TransientDatabaseHttpError
+    || isTransientDatabaseError(error);
+}
+function retryError(error: unknown): SafeGeneratedMediaPromotionJobError {
+  return error instanceof GeneratedMediaPromotionStorageTransientError
+    ? { code: error.code, message: error.safeMessage }
+    : { code: "DATABASE_TRANSIENT", message: "PostgreSQL is temporarily unavailable." };
+}
+function calculateRetryAt(job: ClaimedGeneratedMediaPromotionJob, nowMs: number): Date {
+  const delayMs = Math.min(retryBaseDelayMs * (2 ** job.retryCount), retryMaximumDelayMs);
+  return new Date(nowMs + delayMs);
+}
+function result(
+  job: ClaimedGeneratedMediaPromotionJob,
+  outcome: GeneratedMediaPromotionJobOutcome,
+  errorCode: string | null,
+): GeneratedMediaPromotionJobResult {
+  return {
+    jobId: job.jobId, workspaceId: job.workspaceId, outcome,
+    retryCount: job.retryCount, errorCode,
+  };
+}
+async function settleKnownFailure(
+  job: ClaimedGeneratedMediaPromotionJob,
+  input: GeneratedMediaPromotionBatchInput,
+  dependencies: GeneratedMediaPromotionProcessorDependencies,
+  error: SafeGeneratedMediaPromotionJobError,
+  retryable: boolean,
+): Promise<GeneratedMediaPromotionJobResult> {
+  try {
+    if (retryable && job.retryCount < maximumJobAttempts - 1) {
+      await dependencies.rescheduleJobFn(
+        job, input.deadlineAtMs, calculateRetryAt(job, dependencies.nowFn()), error,
+      );
+      return result(job, "rescheduled", error.code);
+    }
+    const terminalErrorValue = retryable
+      ? {
+        code: "RETRY_EXHAUSTED",
+        message: "Generated-media promotion exhausted its bounded transient retry budget.",
+      }
+      : error;
+    await dependencies.failJobFn(job, input.deadlineAtMs, terminalErrorValue);
+    return result(job, "failed", terminalErrorValue.code);
+  } catch (transitionError) {
+    if (transitionError instanceof GeneratedMediaPromotionJobLeaseLostError) {
+      return result(job, "lease_lost", null);
+    }
+    if (transitionError instanceof DatabaseCommitOutcomeUnknownError) {
+      return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+    }
+    if (
+      input.signal.aborted
+      || transitionError instanceof DatabaseDeadlineExceededError
+    ) {
+      return result(job, "interrupted", "WORKER_DEADLINE");
+    }
+    throw transitionError;
+  }
+}
+export async function processClaimedGeneratedMediaPromotionJobWithDependencies(
+  job: ClaimedGeneratedMediaPromotionJob,
+  input: GeneratedMediaPromotionBatchInput,
+  dependencies: GeneratedMediaPromotionProcessorDependencies,
+): Promise<GeneratedMediaPromotionJobResult> {
+  try {
+    input.signal.throwIfAborted();
+    await dependencies.promoteObjectFn({
+      workspaceId: job.workspaceId, mediaAssetId: job.mediaAssetId,
+      operationId: job.operationId, stagingStorageKey: job.stagingStorageKey,
+      blobStorageKey: job.blobStorageKey, mimeType: job.mimeType,
+      sizeBytes: job.sizeBytes, sha256: job.sha256,
+      observationScope: input.observationScope, signal: input.signal,
+    });
+    input.signal.throwIfAborted();
+    await dependencies.applyJobFn(job, input.deadlineAtMs);
+    return result(job, "applied", null);
+  } catch (error) {
+    if (error instanceof GeneratedMediaPromotionJobLeaseLostError) {
+      return result(job, "lease_lost", null);
+    }
+    if (error instanceof DatabaseCommitOutcomeUnknownError) {
+      return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+    }
+    if (input.signal.aborted || error instanceof DatabaseDeadlineExceededError) {
+      return result(job, "interrupted", "WORKER_DEADLINE");
+    }
+    if (isTransientFailure(error)) {
+      return settleKnownFailure(job, input, dependencies, retryError(error), true);
+    }
+    const knownTerminalError = terminalError(error);
+    if (knownTerminalError !== null) {
+      return settleKnownFailure(job, input, dependencies, knownTerminalError, false);
+    }
+    throw error;
+  }
+}
+function countOutcome(
+  results: ReadonlyArray<GeneratedMediaPromotionJobResult>,
+  outcome: GeneratedMediaPromotionJobOutcome,
+): number {
+  return results.filter((item) => item.outcome === outcome).length;
+}
+export async function runGeneratedMediaPromotionBatchWithDependencies(
+  input: GeneratedMediaPromotionBatchInput,
+  dependencies: GeneratedMediaPromotionProcessorDependencies,
+): Promise<GeneratedMediaPromotionBatchResult> {
+  const results: Array<GeneratedMediaPromotionJobResult> = [];
+  while (
+    results.length < input.maximumJobs
+    && !input.signal.aborted
+    && dependencies.nowFn() + minimumNewJobBudgetMs < input.deadlineAtMs
+  ) {
+    const claimed = await dependencies.claimJobsFn({
+      leaseOwner: input.leaseOwner,
+      leaseDurationMs: input.leaseDurationMs,
+      limit: 1,
+      deadlineAtMs: input.deadlineAtMs,
+    });
+    const job = claimed[0];
+    if (job === undefined) break;
+    const jobResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+      job, input, dependencies,
+    );
+    results.push(jobResult);
+    if (jobResult.outcome === "interrupted") break;
+  }
+  return {
+    claimed: results.length,
+    applied: countOutcome(results, "applied"),
+    ambiguous: countOutcome(results, "ambiguous"),
+    failed: countOutcome(results, "failed"),
+    interrupted: countOutcome(results, "interrupted"),
+    leaseLost: countOutcome(results, "lease_lost"),
+    rescheduled: countOutcome(results, "rescheduled"),
+    results,
+  };
+}
+const defaultDependencies: GeneratedMediaPromotionProcessorDependencies = {
+  claimJobsFn: claimGeneratedMediaPromotionJobs,
+  promoteObjectFn: promoteGeneratedMediaObject,
+  applyJobFn: applyGeneratedMediaPromotionJob,
+  rescheduleJobFn: rescheduleGeneratedMediaPromotionJob,
+  failJobFn: failGeneratedMediaPromotionJob,
+  nowFn: Date.now,
+};
+export async function runGeneratedMediaPromotionBatch(
+  input: GeneratedMediaPromotionBatchInput,
+): Promise<GeneratedMediaPromotionBatchResult> {
+  return runGeneratedMediaPromotionBatchWithDependencies(input, defaultDependencies);
+}

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
@@ -1,0 +1,82 @@
+import type { Handler } from "aws-lambda";
+import {
+  runGeneratedMediaPromotionBatch,
+  type GeneratedMediaPromotionBatchResult,
+} from "../../chat/cardImages/promotionProcessor";
+import {
+  addBackendBreadcrumb, captureBackendException, createBackendObservationScope,
+  initializeBackendSentry, normalizeCaughtError, type GeneratedMediaPromotionBatchDetails,
+  wrapBackendHandler,
+} from "../../observability/sentry";
+initializeBackendSentry("generated-media-promotion");
+export const generatedMediaPromotionMaximumJobs = 5;
+export const generatedMediaPromotionLeaseDurationMs = 180_000;
+export const generatedMediaPromotionFinalizationReserveMs = 10_000;
+type GeneratedMediaPromotionResponse = Omit<GeneratedMediaPromotionBatchResult, "results"> & Readonly<{
+  ok: true;
+}>;
+function emptyDetails(): GeneratedMediaPromotionBatchDetails {
+  return {
+    maximumJobs: generatedMediaPromotionMaximumJobs,
+    claimed: 0, applied: 0, ambiguous: 0, failed: 0,
+    interrupted: 0, leaseLost: 0, rescheduled: 0, results: [],
+  };
+}
+function toDetails(result: GeneratedMediaPromotionBatchResult): GeneratedMediaPromotionBatchDetails {
+  return {
+    maximumJobs: generatedMediaPromotionMaximumJobs,
+    claimed: result.claimed, applied: result.applied, ambiguous: result.ambiguous,
+    failed: result.failed, interrupted: result.interrupted,
+    leaseLost: result.leaseLost, rescheduled: result.rescheduled,
+    results: result.results.map((item) => ({
+      jobId: item.jobId, outcome: item.outcome,
+      retryCount: item.retryCount, errorCode: item.errorCode,
+    })),
+  };
+}
+const generatedMediaPromotionHandler: Handler<unknown, GeneratedMediaPromotionResponse> =
+async (_event, context) => {
+  const observationScope = createBackendObservationScope(
+    "generated-media-promotion", context.awsRequestId ?? null,
+    null, null, null, null, null, null, null, null, null,
+  );
+  const deadlineAtMs = Date.now()
+    + Math.max(0, context.getRemainingTimeInMillis() - generatedMediaPromotionFinalizationReserveMs);
+  const abortController = new AbortController();
+  const deadlineTimer = setTimeout(
+    () => abortController.abort(new Error("Generated-media promotion worker deadline reached.")),
+    Math.max(0, deadlineAtMs - Date.now()),
+  );
+  try {
+    const result = await runGeneratedMediaPromotionBatch({
+      leaseOwner: `generated-media-promotion:${context.awsRequestId}`,
+      leaseDurationMs: generatedMediaPromotionLeaseDurationMs,
+      maximumJobs: generatedMediaPromotionMaximumJobs,
+      deadlineAtMs,
+      observationScope,
+      signal: abortController.signal,
+    });
+    addBackendBreadcrumb({
+      action: "generated_media_promotion_batch_completed",
+      scope: observationScope,
+      details: toDetails(result),
+    });
+    return {
+      ok: true,
+      claimed: result.claimed, applied: result.applied, ambiguous: result.ambiguous,
+      failed: result.failed, interrupted: result.interrupted,
+      leaseLost: result.leaseLost, rescheduled: result.rescheduled,
+    };
+  } catch (error) {
+    captureBackendException({
+      action: "generated_media_promotion_batch_failed",
+      error: normalizeCaughtError(error),
+      scope: observationScope,
+      details: emptyDetails(),
+    });
+    throw error;
+  } finally {
+    clearTimeout(deadlineTimer);
+  }
+};
+export const handler = wrapBackendHandler(generatedMediaPromotionHandler);

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CopyObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../storageKeys";
+import {
+  GeneratedMediaPromotionStorageTerminalError,
+  GeneratedMediaPromotionStorageTransientError,
+  promoteGeneratedMediaObjectWithDependencies,
+  type GeneratedMediaObjectPromotionInput,
+} from "./generatedPromotion";
+import { createUploadProofMetadata } from "./proof";
+import {
+  createS3Error, createTestS3Client, getTestMediaAssetsStorageConfig,
+  testMediaAssetId, testObservationScope, testSha256, testWorkspaceId,
+} from "./testHelpers";
+const operationId = "33333333-3333-4333-8333-333333333333";
+const mimeType = "image/jpeg";
+const sizeBytes = 42;
+function input(signal: AbortSignal): GeneratedMediaObjectPromotionInput {
+  return {
+    workspaceId: testWorkspaceId, mediaAssetId: testMediaAssetId, operationId,
+    stagingStorageKey: buildMediaUploadStagingStorageKey(testWorkspaceId, testMediaAssetId, operationId),
+    blobStorageKey: buildMediaBlobStorageKey(testSha256),
+    mimeType, sizeBytes, sha256: testSha256,
+    observationScope: testObservationScope, signal,
+  };
+}
+function headResponse(
+  promotionInput: GeneratedMediaObjectPromotionInput,
+  metadata: Readonly<Record<string, string>>,
+  checksumSha256: string,
+): Readonly<{
+  ContentLength: number; ContentType: string; ChecksumSHA256: string;
+  ChecksumType: "FULL_OBJECT"; Metadata: Readonly<Record<string, string>>;
+}> {
+  return {
+    ContentLength: promotionInput.sizeBytes,
+    ContentType: promotionInput.mimeType,
+    ChecksumSHA256: Buffer.from(checksumSha256, "hex").toString("base64"),
+    ChecksumType: "FULL_OBJECT",
+    Metadata: metadata,
+  };
+}
+function stagingResponse(promotionInput: GeneratedMediaObjectPromotionInput) {
+  return headResponse(promotionInput, createUploadProofMetadata({
+    workspaceId: promotionInput.workspaceId, mediaAssetId: promotionInput.mediaAssetId,
+    lastOperationId: promotionInput.operationId, sha256: promotionInput.sha256,
+  }), promotionInput.sha256);
+}
+function permanentResponse(promotionInput: GeneratedMediaObjectPromotionInput) {
+  return headResponse(
+    promotionInput,
+    { "flashcards-sha256": promotionInput.sha256 },
+    promotionInput.sha256,
+  );
+}
+async function promote(
+  promotionInput: GeneratedMediaObjectPromotionInput,
+  send: S3Client["send"],
+): Promise<void> {
+  const client = createTestS3Client();
+  client.send = send;
+  await promoteGeneratedMediaObjectWithDependencies(promotionInput, {
+    s3Client: client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+  });
+}
+test("generated promotion handles 409/412 and cross-workspace reuses a tenant-neutral blob", async () => {
+  for (const copyStatuses of [[], [409, 409], [412]] as const) {
+    const promotionInput = input(new AbortController().signal);
+    const commands: Array<string> = [];
+    let blobHeads = 0;
+    let copyAttempts = 0;
+    await promote(promotionInput, (async (command: unknown) => {
+      if (command instanceof HeadObjectCommand) {
+        commands.push(`head:${String(command.input.Key)}`);
+        if (command.input.Key === promotionInput.stagingStorageKey) return stagingResponse(promotionInput);
+        blobHeads += 1;
+        if (blobHeads === 1) throw createS3Error(404, "NotFound", "missing");
+        return permanentResponse(promotionInput);
+      }
+      assert.ok(command instanceof CopyObjectCommand);
+      commands.push("copy");
+      assert.deepEqual(command.input.Metadata, { "flashcards-sha256": promotionInput.sha256 });
+      assert.equal(command.input.IfNoneMatch, "*");
+      copyAttempts += 1;
+      const status = copyStatuses[copyAttempts - 1];
+      if (status !== undefined) throw createS3Error(status, "ConditionalRequestConflict", "winner");
+      return {};
+    }) as S3Client["send"]);
+    assert.equal(commands[0], `head:${promotionInput.stagingStorageKey}`);
+    assert.equal(commands.at(-1), `head:${promotionInput.blobStorageKey}`);
+    assert.equal(copyAttempts, copyStatuses[0] === 412 ? 1 : copyStatuses.length + 1);
+  }
+  const reusedIdentity = {
+    workspaceId: "44444444-4444-4444-8444-444444444444",
+    mediaAssetId: "55555555-5555-4555-8555-555555555555",
+    operationId: "66666666-6666-4666-8666-666666666666",
+  };
+  const reusedInput: GeneratedMediaObjectPromotionInput = {
+    ...input(new AbortController().signal), ...reusedIdentity,
+    stagingStorageKey: buildMediaUploadStagingStorageKey(
+      reusedIdentity.workspaceId, reusedIdentity.mediaAssetId, reusedIdentity.operationId,
+    ),
+  };
+  let copied = false;
+  await promote(reusedInput, (async (command: unknown) => {
+    if (command instanceof CopyObjectCommand) copied = true;
+    if (command instanceof HeadObjectCommand && command.input.Key === reusedInput.stagingStorageKey) {
+      return stagingResponse(reusedInput);
+    }
+    return permanentResponse(reusedInput);
+  }) as S3Client["send"]);
+  assert.equal(copied, false);
+  await assert.rejects(
+    promote(reusedInput, (async (command: unknown) => {
+      if (command instanceof HeadObjectCommand && command.input.Key === reusedInput.stagingStorageKey) {
+        return stagingResponse(reusedInput);
+      }
+      return headResponse(reusedInput, {
+        "flashcards-sha256": reusedInput.sha256, "tenant-user-id": "private-user",
+      }, reusedInput.sha256);
+    }) as S3Client["send"]),
+    (error: unknown) => error instanceof GeneratedMediaPromotionStorageTerminalError
+      && error.code === "PERMANENT_BLOB_CONFLICT",
+  );
+});
+test("generated promotion terminates corrupt objects, bounds retry, and obeys its deadline", async () => {
+  const missingInput = input(new AbortController().signal);
+  await assert.rejects(
+    promote(missingInput, (async () => {
+      throw createS3Error(404, "NotFound", "missing");
+    }) as S3Client["send"]),
+    (error: unknown) => error instanceof GeneratedMediaPromotionStorageTerminalError
+      && error.code === "STAGING_NOT_FOUND",
+  );
+  const unexpectedError = new Error("storage configuration missing");
+  let unexpectedCalls = 0;
+  await assert.rejects(
+    promote(missingInput, (async () => {
+      unexpectedCalls += 1;
+      throw unexpectedError;
+    }) as S3Client["send"]),
+    (error: unknown) => error === unexpectedError,
+  );
+  assert.equal(unexpectedCalls, 1);
+  const corruptInput = input(new AbortController().signal);
+  await assert.rejects(
+    promote(corruptInput, (async () => headResponse(
+      corruptInput,
+      createUploadProofMetadata({
+        workspaceId: corruptInput.workspaceId, mediaAssetId: corruptInput.mediaAssetId,
+        lastOperationId: corruptInput.operationId, sha256: corruptInput.sha256,
+      }),
+      "0".repeat(64),
+    )) as S3Client["send"]),
+    (error: unknown) => error instanceof GeneratedMediaPromotionStorageTerminalError
+      && error.code === "STAGING_CONTENT_INVALID",
+  );
+  const mismatchedInput = input(new AbortController().signal);
+  await assert.rejects(
+    promote(mismatchedInput, (async () => headResponse(
+      mismatchedInput,
+      createUploadProofMetadata({
+        workspaceId: "77777777-7777-4777-8777-777777777777",
+        mediaAssetId: mismatchedInput.mediaAssetId,
+        lastOperationId: mismatchedInput.operationId,
+        sha256: mismatchedInput.sha256,
+      }),
+      mismatchedInput.sha256,
+    )) as S3Client["send"]),
+    (error: unknown) => error instanceof GeneratedMediaPromotionStorageTerminalError
+      && error.code === "STAGING_PROOF_INVALID",
+  );
+  const retryInput = input(new AbortController().signal);
+  let copyAttempts = 0;
+  let blobHeads = 0;
+  await assert.rejects(
+    promote(retryInput, (async (command: unknown) => {
+      if (command instanceof HeadObjectCommand) {
+        if (command.input.Key === retryInput.stagingStorageKey) return stagingResponse(retryInput);
+        blobHeads += 1;
+        throw createS3Error(404, "NotFound", "missing");
+      }
+      copyAttempts += 1;
+      throw createS3Error(400, "RequestTimeout", "timeout");
+    }) as S3Client["send"]),
+    GeneratedMediaPromotionStorageTransientError,
+  );
+  assert.equal(blobHeads, 1);
+  assert.equal(copyAttempts, 3);
+  const abortController = new AbortController();
+  const deadlineInput = input(abortController.signal);
+  let deadlineCopyAttempts = 0;
+  const deadlineReason = new Error("worker deadline");
+  const operation = promote(deadlineInput, (async (
+    command: unknown,
+    options: Readonly<{ abortSignal?: AbortSignal }>,
+  ) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === deadlineInput.stagingStorageKey) return stagingResponse(deadlineInput);
+      throw createS3Error(404, "NotFound", "missing");
+    }
+    deadlineCopyAttempts += 1;
+    return new Promise((_resolve, reject) => {
+      options.abortSignal?.addEventListener("abort", () => reject(options.abortSignal?.reason), { once: true });
+    });
+  }) as S3Client["send"]);
+  setTimeout(() => abortController.abort(deadlineReason), 10);
+  await assert.rejects(operation, (error: unknown) => error === deadlineReason);
+  assert.equal(deadlineCopyAttempts, 1);
+});

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
@@ -1,0 +1,238 @@
+import { CopyObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
+import { addBackendBreadcrumb, type BackendObservationScope } from "../../observability/sentry";
+import type { MediaAssetObjectMetadata } from "../types";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../storageKeys";
+import { getMediaAssetsS3Client, getMediaAssetsStorageConfig } from "./config";
+import type { MediaAssetStorageDependencies } from "./contracts";
+import { getS3ErrorStatusCode } from "./errors";
+import {
+  createUploadProofMetadata, toHexSha256Digest, uploadProofLastOperationIdSha256Key,
+  uploadProofMediaAssetIdKey, uploadProofSha256Key, uploadProofWorkspaceIdKey,
+} from "./proof";
+const maximumS3Attempts = 3;
+export type GeneratedMediaObjectPromotionInput = Readonly<{
+  workspaceId: string; mediaAssetId: string; operationId: string;
+  stagingStorageKey: string; blobStorageKey: string;
+  mimeType: string; sizeBytes: number; sha256: string;
+  observationScope: BackendObservationScope; signal: AbortSignal;
+}>;
+type GeneratedMediaObjectMetadata = MediaAssetObjectMetadata & Readonly<{ customMetadata: Readonly<Record<string, string>> }>;
+export class GeneratedMediaPromotionStorageTerminalError extends Error {
+  constructor(readonly code: string, readonly safeMessage: string, readonly statusCode: number | null) {
+    super(safeMessage);
+    this.name = "GeneratedMediaPromotionStorageTerminalError";
+  }
+}
+export class GeneratedMediaPromotionStorageTransientError extends Error {
+  readonly code = "S3_TRANSIENT";
+  readonly safeMessage = "Object storage remained temporarily unavailable after bounded retries.";
+  constructor(readonly statusCode: number | null) {
+    super("Object storage remained temporarily unavailable after bounded retries.");
+    this.name = "GeneratedMediaPromotionStorageTransientError";
+  }
+}
+function isTransientS3Error(error: unknown, statusCode: number | null): boolean {
+  const fields = typeof error === "object" && error !== null ? error as Readonly<{ $retryable?: unknown; code?: unknown; name?: unknown }> : null;
+  return fields?.$retryable !== undefined
+    || (typeof fields?.name === "string"
+      && ["TimeoutError", "RequestTimeout", "RequestTimeoutException"].includes(fields.name))
+    || (typeof fields?.code === "string"
+      && ["ECONNRESET", "ECONNREFUSED", "EPIPE", "ETIMEDOUT", "EHOSTUNREACH",
+        "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN"].includes(fields.code))
+    || (statusCode !== null && ([408, 409, 425, 429].includes(statusCode) || statusCode >= 500));
+}
+async function waitForRetry(signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted();
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, 50);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+async function runS3<Result>(
+  input: GeneratedMediaObjectPromotionInput,
+  operation: "head_object" | "copy_object",
+  run: () => Promise<Result>,
+): Promise<Result> {
+  let lastStatusCode: number | null = null;
+  for (let attempt = 1; attempt <= maximumS3Attempts; attempt += 1) {
+    input.signal.throwIfAborted();
+    try {
+      return await run();
+    } catch (error) {
+      input.signal.throwIfAborted();
+      lastStatusCode = getS3ErrorStatusCode(error);
+      if (!isTransientS3Error(error, lastStatusCode)) throw error;
+      if (attempt === maximumS3Attempts) break;
+      addBackendBreadcrumb({
+        action: "media_asset_storage_retry",
+        scope: input.observationScope,
+        details: {
+          operation, attempt, maxAttempts: maximumS3Attempts,
+          workspaceId: input.workspaceId, mediaAssetId: input.mediaAssetId,
+          statusCode: lastStatusCode,
+          errorClass: error instanceof Error ? error.name : "UnknownError",
+        },
+      });
+      await waitForRetry(input.signal);
+    }
+  }
+  throw new GeneratedMediaPromotionStorageTransientError(lastStatusCode);
+}
+function toMetadata(response: Readonly<{
+  ContentLength?: number; ContentType?: string; ChecksumSHA256?: string;
+  ChecksumType?: "COMPOSITE" | "FULL_OBJECT";
+  Metadata?: Readonly<Record<string, string>>;
+}>): GeneratedMediaObjectMetadata {
+  return {
+    sizeBytes: response.ContentLength ?? null,
+    mimeType: response.ContentType ?? null,
+    checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
+    checksumType: response.ChecksumType ?? null,
+    customMetadata: response.Metadata ?? {},
+    uploadProof: {
+      workspaceId: response.Metadata?.[uploadProofWorkspaceIdKey] ?? null,
+      mediaAssetId: response.Metadata?.[uploadProofMediaAssetIdKey] ?? null,
+      lastOperationIdSha256: response.Metadata?.[uploadProofLastOperationIdSha256Key] ?? null,
+      sha256: response.Metadata?.[uploadProofSha256Key] ?? null,
+    },
+  };
+}
+function terminal(code: string, safeMessage: string, statusCode: number | null): never {
+  throw new GeneratedMediaPromotionStorageTerminalError(code, safeMessage, statusCode);
+}
+function validateInput(input: GeneratedMediaObjectPromotionInput): void {
+  const keysMatch = input.stagingStorageKey === buildMediaUploadStagingStorageKey(
+    input.workspaceId, input.mediaAssetId, input.operationId,
+  ) && input.blobStorageKey === buildMediaBlobStorageKey(input.sha256);
+  const proofFieldsValid = input.mimeType === input.mimeType.trim().toLowerCase()
+    && /^[a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*$/u.test(input.mimeType)
+    && /^[0-9a-f]{64}$/u.test(input.sha256)
+    && Number.isSafeInteger(input.sizeBytes) && input.sizeBytes > 0;
+  if (!keysMatch) terminal(
+    "INVALID_STORAGE_KEY", "Generated-media promotion storage keys are not deterministic.", null,
+  );
+  if (!proofFieldsValid) terminal(
+    "INVALID_MEDIA_PROOF", "Generated-media promotion proof fields are not normalized.", null,
+  );
+}
+async function headObject(
+  input: GeneratedMediaObjectPromotionInput,
+  key: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<GeneratedMediaObjectMetadata | null> {
+  try {
+    return toMetadata(await runS3(input, "head_object", async () => dependencies.s3Client.send(
+      new HeadObjectCommand({
+        Bucket: dependencies.getMediaAssetsStorageConfigFn().bucketName,
+        Key: key,
+        ChecksumMode: "ENABLED",
+      }),
+      { abortSignal: input.signal },
+    )));
+  } catch (error) {
+    input.signal.throwIfAborted();
+    const statusCode = getS3ErrorStatusCode(error);
+    if (statusCode === 403 || statusCode === 404) return null;
+    if (error instanceof GeneratedMediaPromotionStorageTransientError) throw error;
+    if (statusCode === null) throw error;
+    terminal("S3_REQUEST_REJECTED", "Object storage rejected the promotion request.", statusCode);
+  }
+}
+function contentMatches(input: GeneratedMediaObjectPromotionInput, metadata: MediaAssetObjectMetadata): boolean {
+  return metadata.sizeBytes === input.sizeBytes
+    && metadata.mimeType === input.mimeType
+    && metadata.checksumSha256 === input.sha256
+    && metadata.checksumType === "FULL_OBJECT";
+}
+function assertStaging(input: GeneratedMediaObjectPromotionInput, metadata: GeneratedMediaObjectMetadata): void {
+  const proof = createUploadProofMetadata({
+    workspaceId: input.workspaceId, mediaAssetId: input.mediaAssetId,
+    lastOperationId: input.operationId, sha256: input.sha256,
+  });
+  if (!contentMatches(input, metadata)) terminal(
+    "STAGING_CONTENT_INVALID",
+    "Staged generated-media MIME type, byte size, or SHA-256 does not match the job.",
+    null,
+  );
+  if (
+    metadata.uploadProof.workspaceId !== proof[uploadProofWorkspaceIdKey]
+    || metadata.uploadProof.mediaAssetId !== proof[uploadProofMediaAssetIdKey]
+    || metadata.uploadProof.lastOperationIdSha256
+      !== proof[uploadProofLastOperationIdSha256Key]
+    || metadata.uploadProof.sha256 !== proof[uploadProofSha256Key]
+  ) terminal(
+    "STAGING_PROOF_INVALID",
+    "Staged generated-media ownership proof does not match the durable job.",
+    null,
+  );
+}
+function assertPermanent(input: GeneratedMediaObjectPromotionInput, metadata: GeneratedMediaObjectMetadata): void {
+  const tenantNeutral = Object.keys(metadata.customMetadata).length === 1
+    && metadata.customMetadata[uploadProofSha256Key] === input.sha256;
+  if (!contentMatches(input, metadata) || !tenantNeutral) terminal(
+    "PERMANENT_BLOB_CONFLICT",
+    "The permanent object conflicts with the job or contains tenant metadata.",
+    null,
+  );
+}
+async function copyObject(
+  input: GeneratedMediaObjectPromotionInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  const bucketName = dependencies.getMediaAssetsStorageConfigFn().bucketName;
+  try {
+    await runS3(input, "copy_object", async () => dependencies.s3Client.send(
+      new CopyObjectCommand({
+        Bucket: bucketName,
+        Key: input.blobStorageKey,
+        CopySource: `${bucketName}/${input.stagingStorageKey.split("/").map(encodeURIComponent).join("/")}`,
+        ContentType: input.mimeType,
+        ChecksumAlgorithm: "SHA256",
+        IfNoneMatch: "*",
+        MetadataDirective: "REPLACE",
+        Metadata: { [uploadProofSha256Key]: input.sha256 },
+      }),
+      { abortSignal: input.signal },
+    ));
+  } catch (error) {
+    input.signal.throwIfAborted();
+    const statusCode = getS3ErrorStatusCode(error);
+    if (statusCode === 412) return;
+    if (error instanceof GeneratedMediaPromotionStorageTransientError) throw error;
+    if (statusCode === null) throw error;
+    terminal("S3_REQUEST_REJECTED", "Object storage rejected the promotion request.", statusCode);
+  }
+}
+export async function promoteGeneratedMediaObjectWithDependencies(
+  input: GeneratedMediaObjectPromotionInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  validateInput(input);
+  const staging = await headObject(input, input.stagingStorageKey, dependencies);
+  if (staging === null) terminal("STAGING_NOT_FOUND", "The staged object is missing.", 404);
+  assertStaging(input, staging);
+  const existing = await headObject(input, input.blobStorageKey, dependencies);
+  if (existing !== null) {
+    assertPermanent(input, existing);
+    return;
+  }
+  await copyObject(input, dependencies);
+  const promoted = await headObject(input, input.blobStorageKey, dependencies);
+  if (promoted === null) throw new GeneratedMediaPromotionStorageTransientError(404);
+  assertPermanent(input, promoted);
+}
+export async function promoteGeneratedMediaObject(
+  input: GeneratedMediaObjectPromotionInput,
+): Promise<void> {
+  return promoteGeneratedMediaObjectWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}

--- a/apps/backend/src/mediaAssets/storage/index.ts
+++ b/apps/backend/src/mediaAssets/storage/index.ts
@@ -40,6 +40,13 @@ import {
   promoteMediaAssetUploadToBlobWithDependencies,
   storeMediaAssetBlobBytesIfAbsentWithDependencies,
 } from "./promotion";
+export {
+  GeneratedMediaPromotionStorageTerminalError,
+  GeneratedMediaPromotionStorageTransientError,
+  promoteGeneratedMediaObject,
+  promoteGeneratedMediaObjectWithDependencies,
+} from "./generatedPromotion";
+export type { GeneratedMediaObjectPromotionInput } from "./generatedPromotion";
 
 export { getMediaAssetsStorageConfig } from "./config";
 export type { MediaAssetsStorageConfig } from "./config";

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -8,6 +8,7 @@ export type BackendService =
   | "community-leaderboard-snapshot"
   | "streak-leaderboard-snapshot"
   | "progress-active-days-backfill"
+  | "generated-media-promotion"
   | "migration";
 
 export type BackendObservationScope = Readonly<{
@@ -674,6 +675,14 @@ export type ProgressActiveDaysBackfillFailureDetails = Readonly<{
   message: string;
 }>;
 
+export type GeneratedMediaPromotionBatchDetails = Readonly<{
+  maximumJobs: number; claimed: number; applied: number; ambiguous: number;
+  failed: number; interrupted: number; leaseLost: number; rescheduled: number;
+  results: ReadonlyArray<Readonly<{
+    jobId: string; outcome: string; retryCount: number; errorCode: string | null;
+  }>>;
+}>;
+
 export type DatabaseTransientRetryDetails = Readonly<{
   attempt: number;
   maxAttempts: number;
@@ -773,6 +782,7 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"community_leaderboard_snapshot_generated", CommunityLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"streak_leaderboard_snapshot_generated", StreakLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>
+  | EventByAction<"generated_media_promotion_batch_completed", GeneratedMediaPromotionBatchDetails>
   | EventByAction<"database_transient_retry", DatabaseTransientRetryDetails>
   | EventByAction<"global_metrics_s3_retry", GlobalMetricsS3RetryDetails>
   | EventByAction<"media_asset_storage_retry", MediaAssetStorageRetryDetails>
@@ -1032,6 +1042,9 @@ export type BackendExceptionEvent =
     error: Error;
   }>)
   | (EventByAction<"progress_active_days_backfill_failed", ProgressActiveDaysBackfillFailureDetails> & Readonly<{
+    error: Error;
+  }>)
+  | (EventByAction<"generated_media_promotion_batch_failed", GeneratedMediaPromotionBatchDetails> & Readonly<{
     error: Error;
   }>)
   | (EventByAction<"migration_failed", MigrationFailureDetails> & Readonly<{ error: Error }>)

--- a/apps/backend/src/testSupport/postgresIntegration.ts
+++ b/apps/backend/src/testSupport/postgresIntegration.ts
@@ -17,6 +17,7 @@ export type PostgresIntegrationFixture = Readonly<{
 }>;
 
 type RemainingFixtureRows = Readonly<{ remaining: boolean }>;
+type MediaBlobIdRow = Readonly<{ media_blob_id: string }>;
 
 function requireDatabaseUrl(environmentVariable: "DATABASE_URL" | "TEST_DATABASE_ADMIN_URL"): string {
   const databaseUrl = process.env[environmentVariable]?.trim();
@@ -114,16 +115,40 @@ async function deleteAndVerifyFixtureRows(fixture: PostgresIntegrationFixture): 
   const ownerClient = await fixture.ownerPool.connect();
   try {
     await ownerClient.query("BEGIN");
+    const mediaBlobRows = await ownerClient.query<MediaBlobIdRow>(
+      "SELECT DISTINCT media_blob_id FROM content.media_assets WHERE workspace_id = $1",
+      [fixture.workspaceId],
+    );
     await ownerClient.query("DELETE FROM org.workspaces WHERE workspace_id = $1", [fixture.workspaceId]);
+    await ownerClient.query(
+      `DELETE FROM content.media_blobs AS blobs
+       WHERE blobs.media_blob_id = ANY($1::uuid[])
+         AND NOT EXISTS (
+           SELECT 1 FROM content.media_assets AS assets
+           WHERE assets.media_blob_id = blobs.media_blob_id
+         )
+         AND NOT EXISTS (SELECT 1 FROM catalog.package_media_assets AS package_assets
+                         WHERE package_assets.media_blob_id = blobs.media_blob_id)`,
+      [mediaBlobRows.rows.map((row) => row.media_blob_id)],
+    );
     await ownerClient.query("DELETE FROM org.user_settings WHERE user_id = $1", [fixture.userId]);
     const verification = await ownerClient.query<RemainingFixtureRows>([
       "SELECT EXISTS (SELECT 1 FROM org.workspaces WHERE workspace_id = $1)",
       "OR EXISTS (SELECT 1 FROM org.user_settings WHERE user_id = $2)",
       "OR EXISTS (SELECT 1 FROM sync.workspace_replicas WHERE replica_id = $3)",
       "OR EXISTS (SELECT 1 FROM content.cards WHERE card_id = $4)",
-      "OR EXISTS (SELECT 1 FROM sync.hot_changes WHERE workspace_id = $1) AS remaining",
+      "OR EXISTS (SELECT 1 FROM sync.hot_changes WHERE workspace_id = $1)",
+      "OR EXISTS (SELECT 1 FROM content.media_blobs AS blobs",
+      "WHERE blobs.media_blob_id = ANY($5::uuid[])",
+      "AND NOT EXISTS (SELECT 1 FROM content.media_assets AS assets",
+      "WHERE assets.media_blob_id = blobs.media_blob_id)",
+      "AND NOT EXISTS (SELECT 1 FROM catalog.package_media_assets AS package_assets",
+      "WHERE package_assets.media_blob_id = blobs.media_blob_id)) AS remaining",
     ].join(" "),
-      [fixture.workspaceId, fixture.userId, fixture.replicaId, fixture.cardId],
+      [
+        fixture.workspaceId, fixture.userId, fixture.replicaId, fixture.cardId,
+        mediaBlobRows.rows.map((row) => row.media_blob_id),
+      ],
     );
     if (verification.rows[0]?.remaining !== false) {
       throw new Error(

--- a/db/migrations/0090_generated_media_promotion_job_scope.sql
+++ b/db/migrations/0090_generated_media_promotion_job_scope.sql
@@ -1,0 +1,65 @@
+-- Migration status: Current / additive.
+-- Introduces: exact-lease-fenced workspace scope initialization for the internal promotion worker.
+-- Schemas touched/read explicitly: content, org, pg_catalog.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM content.generated_media_promotion_jobs) THEN
+    RAISE EXCEPTION 'generated_media_promotion_jobs must be empty before adding enqueueing principals';
+  END IF;
+END
+$$;
+ALTER TABLE content.generated_media_promotion_jobs ADD COLUMN user_id TEXT NOT NULL;
+COMMENT ON COLUMN content.generated_media_promotion_jobs.user_id IS
+  'Immutable enqueueing principal used to authorize the deferred promotion transaction.';
+GRANT SELECT (user_id), INSERT (user_id) ON content.generated_media_promotion_jobs TO backend_app;
+CREATE FUNCTION content.apply_generated_media_promotion_job_scope(
+  p_job_id UUID, p_lease_token UUID
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  scoped_user_id TEXT;
+  scoped_workspace_id UUID;
+BEGIN
+  SELECT jobs.user_id, jobs.workspace_id
+  INTO scoped_user_id, scoped_workspace_id
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id
+    AND jobs.state = 'leased'
+    AND jobs.lease_token = p_lease_token
+    AND jobs.lease_expires_at > statement_timestamp();
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(scoped_user_id || ':' || scoped_workspace_id::TEXT, 0::BIGINT));
+  PERFORM 1
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id
+    AND jobs.user_id = scoped_user_id
+    AND jobs.workspace_id = scoped_workspace_id
+    AND jobs.state = 'leased'
+    AND jobs.lease_token = p_lease_token
+    AND jobs.lease_expires_at > clock_timestamp();
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+  PERFORM 1 FROM org.workspace_memberships AS memberships
+  WHERE memberships.workspace_id = scoped_workspace_id
+    AND memberships.user_id = scoped_user_id
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RETURN 'access_revoked';
+  END IF;
+  PERFORM set_config('app.user_id', scoped_user_id, true);
+  PERFORM set_config('app.workspace_id', scoped_workspace_id::TEXT, true);
+  RETURN 'scoped';
+END;
+$$;
+COMMENT ON FUNCTION content.apply_generated_media_promotion_job_scope(UUID, UUID) IS
+  'Reports lease/access status and applies an active generated-media job enqueueing principal scope to the current transaction.';
+REVOKE ALL ON FUNCTION content.apply_generated_media_promotion_job_scope(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION content.apply_generated_media_promotion_job_scope(UUID, UUID) TO backend_app;

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -41,6 +41,7 @@ export interface MonitoringProps {
   communityLeaderboardSnapshotFn: lambda.IFunction;
   streakLeaderboardSnapshotFn: lambda.IFunction;
   progressActiveDaysBackfillFn: lambda.IFunction;
+  generatedMediaPromotionFn: lambda.IFunction;
 }
 
 export interface MonitoringResult {
@@ -322,6 +323,24 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     alarmDescription:
       "Progress active review days backfill Lambda has not run for two consecutive hours, " +
       "so known-timezone users may keep missing active-day materialization",
+    treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+  }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "GeneratedMediaPromotionLambdaErrorAlarm", {
+    metric: props.generatedMediaPromotionFn.metricErrors(
+      { period: cdk.Duration.minutes(5), statistic: "Sum" },
+    ),
+    threshold: 1, evaluationPeriods: 1, alarmDescription: "Generated-media promotion Lambda had errors",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "GeneratedMediaPromotionStaleAlarm", {
+    metric: props.generatedMediaPromotionFn.metricInvocations(
+      { period: cdk.Duration.minutes(5), statistic: "Sum" },
+    ),
+    threshold: 1, comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+    evaluationPeriods: 2, datapointsToAlarm: 2,
+    alarmDescription: "Generated-media promotion Lambda has not run for ten minutes",
     treatMissingData: cloudwatch.TreatMissingData.BREACHING,
   }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
 

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.ts
@@ -1,0 +1,79 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as scheduler from "aws-cdk-lib/aws-scheduler";
+import { Construct } from "constructs";
+import { backendNodejsProjectPaths, resolveFromRepoRoot } from "../nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "../sentry-source-maps";
+export interface GeneratedMediaPromotionProps {
+  vpc: ec2.Vpc; lambdaSg: ec2.SecurityGroup; db: rds.DatabaseInstance;
+  backendDbSecret: cdk.aws_secretsmanager.Secret; mediaAssetsBucket: s3.IBucket;
+  sentryDsnSecretArn: string; sentryEnvironment: string; sentryRelease: string; sentryTracesSampleRate: string;
+}
+export interface GeneratedMediaPromotionResult { promotionFunction: lambdaNodejs.NodejsFunction }
+export const generatedMediaPromotionScheduleExpression = "rate(1 minute)";
+export function generatedMediaPromotion(
+  scope: Construct, props: GeneratedMediaPromotionProps): GeneratedMediaPromotionResult {
+  const promotionFunction = new lambdaNodejs.NodejsFunction(
+    scope, "GeneratedMediaPromotionHandler", {
+      entry: resolveFromRepoRoot(
+        "apps", "backend", "src", "entrypoints", "scheduledJobs", "lambda-generated-media-promotion.ts",
+      ),
+      handler: "handler", runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.minutes(2), memorySize: 512,
+      vpc: props.vpc, vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      securityGroups: [props.lambdaSg],
+      ...backendNodejsProjectPaths,
+      bundling: {
+        minify: true, sourceMap: true,
+        commandHooks: {
+          beforeBundling: () => [], beforeInstall: () => [],
+          afterBundling: (_inputDir: string, outputDir: string) => [
+            `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+            createSentrySourceMapUploadCommand(outputDir),
+          ],
+        },
+      },
+      environment: {
+        NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
+        DB_SECRET_ARN: props.backendDbSecret.secretArn, DB_HOST: props.db.dbInstanceEndpointAddress,
+        DB_NAME: "flashcards", MEDIA_ASSETS_S3_BUCKET_NAME: props.mediaAssetsBucket.bucketName,
+        SENTRY_ENVIRONMENT: props.sentryEnvironment, SENTRY_RELEASE: props.sentryRelease,
+        SENTRY_TRACES_SAMPLE_RATE: props.sentryTracesSampleRate,
+      },
+    },
+  );
+  props.backendDbSecret.grantRead(promotionFunction);
+  const sentryDsnSecret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+    scope, "GeneratedMediaPromotionSentryDsnSecret", props.sentryDsnSecretArn);
+  sentryDsnSecret.grantRead(promotionFunction);
+  promotionFunction.addEnvironment("SENTRY_DSN", sentryDsnSecret.secretValue.unsafeUnwrap());
+  promotionFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:GetObject"],
+    resources: [props.mediaAssetsBucket.arnForObjects("media/uploads/*"),
+      props.mediaAssetsBucket.arnForObjects("media/blobs/*")],
+  }));
+  promotionFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:PutObject"],
+    resources: [props.mediaAssetsBucket.arnForObjects("media/blobs/*")],
+  }));
+  const schedulerRole = new iam.Role(scope, "GeneratedMediaPromotionSchedulerRole",
+    { assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com") });
+  schedulerRole.addToPolicy(new iam.PolicyStatement({
+    actions: ["lambda:InvokeFunction"],
+    resources: [promotionFunction.functionArn],
+  }));
+  new scheduler.CfnSchedule(scope, "GeneratedMediaPromotionSchedule", {
+    description: "Reconcile durable generated-media promotion jobs", flexibleTimeWindow: { mode: "OFF" },
+    scheduleExpression: generatedMediaPromotionScheduleExpression,
+    scheduleExpressionTimezone: "UTC",
+    state: "ENABLED", target: {
+      arn: promotionFunction.functionArn, input: "{}", roleArn: schedulerRole.roleArn,
+    },
+  });
+  return { promotionFunction };
+}

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -19,6 +19,7 @@ import { globalMetrics } from "./scheduled-jobs/global-metrics";
 import { communityLeaderboard } from "./scheduled-jobs/community-leaderboard";
 import { streakLeaderboard } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfill } from "./scheduled-jobs/progress-active-days-backfill";
+import { generatedMediaPromotion } from "./scheduled-jobs/generated-media-promotion";
 import { mediaAssets } from "./media-assets";
 
 function getOptionalContextValue(stack: cdk.Stack, key: string): string | undefined {
@@ -195,6 +196,14 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const mediaAssetsResult = mediaAssets(this, {
       baseDomain,
     });
+    const generatedMediaPromotionResult = generatedMediaPromotion(this, {
+      vpc: net.vpc,
+      lambdaSg: net.lambdaSg,
+      db: dbResult.db,
+      backendDbSecret: dbResult.backendDbSecret,
+      mediaAssetsBucket: mediaAssetsResult.bucket,
+      ...sentryContext,
+    });
     let analyticsAccessResult: AnalyticsAccessResult | undefined;
     if (analyticsAccessRequested) {
       if (analyticsSshPublicKeysValue === undefined) {
@@ -319,6 +328,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       communityLeaderboardSnapshotFn: communityLeaderboardResult.snapshotFunction,
       streakLeaderboardSnapshotFn: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
+      generatedMediaPromotionFn: generatedMediaPromotionResult.promotionFunction,
     });
 
     ciCd(this, {


### PR DESCRIPTION
## Summary

- reconcile durable generated-media promotion jobs into verified tenant-neutral content-addressed S3 blobs
- apply media persistence, canonical card references, and job completion atomically behind exact lease and workspace fencing
- run bounded batches from an internal EventBridge Scheduler Lambda with safe telemetry, least-privilege storage access, and CloudWatch error/staleness alarms

## Validation

- backend tests: 823 passed
- focused real PostgreSQL integration: 6 passed
- backend TypeScript lint and build
- infrastructure TypeScript static check
- tracked and untracked whitespace checks