### PR TITLE
Add durable generated media lifecycle

### DIFF
--- a/apps/backend/src/chat/cardImages/openaiAdapter.test.ts
+++ b/apps/backend/src/chat/cardImages/openaiAdapter.test.ts
@@ -29,6 +29,7 @@ import {
 import type {
   OpenAIImageGenerationInput,
 } from "./providerTypes";
+import { GeneratedCardImageDeadlineExceededError } from "./providerTypes";
 
 type CapturedProviderRequest = Readonly<{
   method: string | null;
@@ -282,6 +283,11 @@ function createProvider(baseURL: string): OpenAIGeneratedCardImageProvider {
   return new OpenAIGeneratedCardImageProvider(client);
 }
 
+function createProviderWithFetch(fetch: typeof globalThis.fetch): OpenAIGeneratedCardImageProvider {
+  return new OpenAIGeneratedCardImageProvider(
+    new OpenAI({ apiKey: "test-openai-api-key", maxRetries: 4, fetch }),
+  );
+}
 function createProviderInput(
   imagePrompt: string,
   signal: AbortSignal,
@@ -307,6 +313,7 @@ function createProviderInput(
       rootObservation,
     },
     signal,
+    operationDeadlineMs: Date.now() + 120_000,
   };
 }
 
@@ -431,7 +438,7 @@ function getErrorField(error: Error, fieldName: string): unknown {
 
 function countLangfuseResults(
   telemetry: RecordedLangfuseTelemetry,
-  expectedResult: "success" | "error" | "aborted",
+  expectedResult: "success" | "error" | "aborted" | "deadline",
 ): number {
   return telemetry.updates.filter((update) => {
     const output = toRecord(update).output;
@@ -773,6 +780,26 @@ test("provider makes exactly three attempts for transient 5xx failures", async (
   );
 });
 
+test("native SDK connection timeout retries and preserves terminal timeout classification", async () => {
+  const successBytes = Buffer.from("native timeout retry success"); let successFetchCalls = 0;
+  const result = await createProviderWithFetch(async () => {
+    if (++successFetchCalls === 1) throw new DOMException("socket timed out", "TimeoutError");
+    return new Response(JSON.stringify({ data: [{ b64_json: successBytes.toString("base64") }] }),
+      { status: 200, headers: { "content-type": "application/json",
+        "x-request-id": "req_native_timeout_success" } });
+  }).generate(createProviderInput("Draw a native timeout retry diagram.",
+    new AbortController().signal, null));
+  assert.deepEqual(result.bytes, successBytes); assert.equal(successFetchCalls, 2);
+  let exhaustedFetchCalls = 0;
+  const exhaustedError = await captureThrownError(createProviderWithFetch(async () => {
+    exhaustedFetchCalls += 1;
+    throw new DOMException("socket timed out", "TimeoutError");
+  }).generate(createProviderInput("Draw an exhausted native timeout diagram.",
+    new AbortController().signal, null)));
+  assert.equal(exhaustedFetchCalls, 3); assert.equal(exhaustedError.name, "OpenAIImageGenerationError");
+  assert.equal(getErrorField(exhaustedError, "status"), null);
+  assert.equal(exhaustedError instanceof GeneratedCardImageDeadlineExceededError, false);
+});
 test("provider does not retry invalid, authentication, permission, conflict, or moderation failures", async () => {
   const failureCases = [
     {
@@ -922,6 +949,39 @@ test("provider aborts the in-flight SDK request without retrying", async () => {
       assert.equal(capture.cloudWatchLogs.length, 0);
       assert.equal(countLangfuseResults(langfuse, "aborted"), 1);
       assert.equal(langfuse.getEndCount(), 1);
+    },
+  );
+});
+
+test("provider preserves a known 429 when the remaining budget cannot fit a retry", async () => {
+  await withProviderTestServer(
+    (_request, _requestNumber, response) => writeJsonResponse(response, 429,
+      "req_insufficient_retry_budget",
+      { error: { message: "Rate limited.", type: "rate_limit_error", code: "rate_limit_exceeded" } }),
+    async (server) => {
+      const input = createProviderInput("Draw a bounded retry diagram.",
+        new AbortController().signal, null);
+      const error = await captureThrownError(createProvider(server.baseURL).generate(
+        { ...input, operationDeadlineMs: Date.now() + 35_000 }));
+      assert.equal(server.requests.length, 1); assert.equal(error.name, "OpenAIImageGenerationError");
+      assert.equal(getErrorField(error, "status"), 429);
+      assert.equal(getErrorField(error, "requestID"), "req_insufficient_retry_budget");
+    },
+  );
+});
+
+test("provider reports a true request deadline distinctly", async () => {
+  await withProviderTestServer(
+    (_request, _requestNumber, _response) => {
+      // Keep the response open until the bounded provider timeout aborts it.
+    },
+    async (server) => {
+      const input = createProviderInput("Draw a provider deadline diagram.",
+        new AbortController().signal, null);
+      const error = await captureThrownError(createProvider(server.baseURL).generate(
+        { ...input, operationDeadlineMs: Date.now() + 30_500 }));
+      assert.equal(error instanceof GeneratedCardImageDeadlineExceededError, true);
+      assert.equal(server.requests.length, 1);
     },
   );
 });

--- a/apps/backend/src/chat/cardImages/openaiAdapter.ts
+++ b/apps/backend/src/chat/cardImages/openaiAdapter.ts
@@ -7,9 +7,10 @@ import {
   type GeneratedCardImageProviderDetails,
 } from "../../observability/sentry";
 import { maximumImageIngestionOriginalBytes } from "../../mediaAssets/validators";
-import type {
-  GeneratedProviderImage,
-  OpenAIImageGenerationInput,
+import {
+  GeneratedCardImageDeadlineExceededError,
+  type GeneratedProviderImage,
+  type OpenAIImageGenerationInput,
 } from "./providerTypes";
 
 export const generatedCardImageModel = "gpt-image-2";
@@ -20,6 +21,8 @@ export const generatedCardImageOutputFormat = "jpeg";
 const generatedCardImageMaximumProviderAttempts = 3;
 const generatedCardImageInitialRetryDelayMs = 500;
 const generatedCardImageMaximumRetryDelayMs = 30_000;
+const generatedCardImagePersistenceReserveMs = 30_000;
+const generatedCardImageMinimumRetryRequestMs = 10_000;
 const maximumEncodedImageCharacters = Math.ceil(maximumImageIngestionOriginalBytes / 3) * 4;
 
 type OpenAIImageFailureMetadata = Readonly<{
@@ -100,8 +103,12 @@ function getOpenAIImageFailureMetadata(error: unknown): OpenAIImageFailureMetada
   };
 }
 
-function isTransientProviderFailure(metadata: OpenAIImageFailureMetadata): boolean {
-  return metadata.status === 429
+function isTransientProviderFailure(
+  error: unknown,
+  metadata: OpenAIImageFailureMetadata,
+): boolean {
+  return error instanceof OpenAI.APIConnectionTimeoutError
+    || metadata.status === 429
     || (metadata.status !== null && metadata.status >= 500 && metadata.status <= 599);
 }
 
@@ -179,6 +186,8 @@ function createProviderDetails(
   attempt: number,
   retryDelay: number | null,
   metadata: OpenAIImageFailureMetadata,
+  requestTimeoutMs: number,
+  retrySkippedForBudget: boolean,
 ): GeneratedCardImageProviderDetails {
   return {
     model: generatedCardImageModel,
@@ -189,6 +198,8 @@ function createProviderDetails(
     attempt,
     maximumAttempts: generatedCardImageMaximumProviderAttempts,
     retryDelayMs: retryDelay,
+    requestTimeoutMs,
+    retrySkippedForBudget,
     providerStatus: metadata.status,
     providerRequestId: metadata.requestId,
     providerErrorType: metadata.errorType,
@@ -204,6 +215,7 @@ function createSuccessProviderDetails(
   imagePrompt: string,
   attempt: number,
   providerRequestId: string | null,
+  requestTimeoutMs: number,
 ): GeneratedCardImageProviderDetails {
   return {
     model: generatedCardImageModel,
@@ -214,6 +226,8 @@ function createSuccessProviderDetails(
     attempt,
     maximumAttempts: generatedCardImageMaximumProviderAttempts,
     retryDelayMs: null,
+    requestTimeoutMs,
+    retrySkippedForBudget: false,
     providerStatus: 200,
     providerRequestId,
     providerErrorType: null,
@@ -239,12 +253,16 @@ function describeSafeProviderFailure(metadata: OpenAIImageFailureMetadata): stri
 }
 
 function providerFailureHint(metadata: OpenAIImageFailureMetadata): string {
+  if (metadata.errorClass === "APIConnectionTimeoutError") {
+    return "The OpenAI image connection timed out within the bounded retry budget.";
+  }
+
   if (metadata.status === 401 || metadata.status === 403) {
     return "Check the OpenAI API key, project permissions, and image-model access.";
   }
 
   if (metadata.status === 429) {
-    return "The OpenAI image rate limit remained unavailable after bounded retries.";
+    return "The OpenAI image rate limit prevented generation within the bounded retry budget.";
   }
 
   if (metadata.errorCode === "moderation_blocked") {
@@ -256,7 +274,7 @@ function providerFailureHint(metadata: OpenAIImageFailureMetadata): string {
     && metadata.status >= 500
     && metadata.status <= 599
   ) {
-    return "OpenAI image generation remained unavailable after bounded retries.";
+    return "OpenAI image generation remained unavailable within the bounded retry budget.";
   }
 
   return "Review the safe provider fields and correct the image request before retrying.";
@@ -301,6 +319,49 @@ function createInvalidProviderResponseError(
       code: "invalid_image_response",
     },
   );
+}
+
+function remainingOperationTimeMs(operationDeadlineMs: number): number {
+  return Math.max(0, operationDeadlineMs - Date.now());
+}
+
+function providerRequestTimeoutMs(operationDeadlineMs: number): number {
+  const requestBudgetMs = remainingOperationTimeMs(operationDeadlineMs)
+    - generatedCardImagePersistenceReserveMs;
+  if (requestBudgetMs <= 0) {
+    throw new GeneratedCardImageDeadlineExceededError(null);
+  }
+
+  return Math.max(1, Math.floor(requestBudgetMs));
+}
+
+class GeneratedCardImageProviderDeadlineSignalError extends Error {
+  constructor() {
+    super("The generated card image provider request reached its bounded deadline.");
+    this.name = "GeneratedCardImageProviderDeadlineSignalError";
+  }
+}
+
+function createProviderDeadlineController(requestTimeoutMs: number): Readonly<{
+  controller: AbortController;
+  timer: ReturnType<typeof setTimeout>;
+}> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new GeneratedCardImageProviderDeadlineSignalError()),
+    requestTimeoutMs,
+  );
+  return { controller, timer };
+}
+
+function hasProviderRetryBudget(
+  operationDeadlineMs: number,
+  retryDelay: number,
+): boolean {
+  return remainingOperationTimeMs(operationDeadlineMs)
+    >= retryDelay
+      + generatedCardImageMinimumRetryRequestMs
+      + generatedCardImagePersistenceReserveMs;
 }
 
 function extractGeneratedImageBase64(response: unknown): string {
@@ -412,6 +473,12 @@ export class OpenAIGeneratedCardImageProvider {
     try {
       for (let attempt = 1; attempt <= generatedCardImageMaximumProviderAttempts; attempt += 1) {
         input.signal.throwIfAborted();
+        const requestTimeoutMs = providerRequestTimeoutMs(input.operationDeadlineMs);
+        const providerDeadline = createProviderDeadlineController(requestTimeoutMs);
+        const requestSignal = AbortSignal.any([
+          input.signal,
+          providerDeadline.controller.signal,
+        ]);
 
         try {
           const providerRequest = this.#client.images.generate(
@@ -426,7 +493,7 @@ export class OpenAIGeneratedCardImageProvider {
             },
             {
               maxRetries: 0,
-              signal: input.signal,
+              signal: requestSignal,
             },
           );
           const rawProviderResponse = await providerRequest.asResponse();
@@ -450,6 +517,7 @@ export class OpenAIGeneratedCardImageProvider {
             input.imagePrompt,
             attempt,
             providerRequestId,
+            requestTimeoutMs,
           );
           addBackendBreadcrumb({
             action: "generated_card_image_provider_complete",
@@ -473,26 +541,86 @@ export class OpenAIGeneratedCardImageProvider {
           }
 
           const metadata = getOpenAIImageFailureMetadata(error);
-          if (
-            attempt < generatedCardImageMaximumProviderAttempts
-            && isTransientProviderFailure(metadata)
-          ) {
-            const delayMs = retryDelayForFailureMs(error, attempt);
-            const details = createProviderDetails(input.imagePrompt, attempt, delayMs, metadata);
+          if (providerDeadline.controller.signal.aborted) {
+            const details = createProviderDetails(
+              input.imagePrompt,
+              attempt,
+              null,
+              metadata,
+              requestTimeoutMs,
+              false,
+            );
             captureBackendWarning({
-              action: "generated_card_image_provider_retry",
-              message: "OpenAI image generation will retry after a transient provider failure.",
+              action: "generated_card_image_provider_failed",
+              message: "OpenAI image generation reached its bounded request deadline.",
               scope: input.observationContext.scope,
               details,
             });
             providerObservation?.updateOtelSpanAttributes({
+              output: { result: "deadline" },
               metadata: details,
             });
-            await waitForRetry(delayMs, input.signal);
-            continue;
+            providerResultRecorded = true;
+            throw new GeneratedCardImageDeadlineExceededError(error);
           }
 
-          const details = createProviderDetails(input.imagePrompt, attempt, null, metadata);
+          if (
+            attempt < generatedCardImageMaximumProviderAttempts
+            && isTransientProviderFailure(error, metadata)
+          ) {
+            const delayMs = retryDelayForFailureMs(error, attempt);
+            if (hasProviderRetryBudget(input.operationDeadlineMs, delayMs)) {
+              const details = createProviderDetails(
+                input.imagePrompt,
+                attempt,
+                delayMs,
+                metadata,
+                requestTimeoutMs,
+                false,
+              );
+              captureBackendWarning({
+                action: "generated_card_image_provider_retry",
+                message: "OpenAI image generation will retry after a transient provider failure.",
+                scope: input.observationContext.scope,
+                details,
+              });
+              providerObservation?.updateOtelSpanAttributes({
+                metadata: details,
+              });
+              await waitForRetry(delayMs, input.signal);
+              continue;
+            }
+
+            const details = createProviderDetails(
+              input.imagePrompt,
+              attempt,
+              delayMs,
+              metadata,
+              requestTimeoutMs,
+              true,
+            );
+            captureBackendWarning({
+              action: "generated_card_image_provider_failed",
+              message: "OpenAI image generation could not retry within the remaining operation budget.",
+              scope: input.observationContext.scope,
+              details,
+            });
+            providerObservation?.updateOtelSpanAttributes({
+              output: { result: "error" },
+              metadata: details,
+            });
+            providerResultRecorded = true;
+            throw createMappedProviderError(error, metadata);
+          }
+
+          const details = createProviderDetails(
+            input.imagePrompt,
+            attempt,
+            null,
+            metadata,
+            requestTimeoutMs,
+            false,
+          );
           captureBackendWarning({
             action: "generated_card_image_provider_failed",
             message: "OpenAI image generation failed.",
@@ -507,15 +635,22 @@ export class OpenAIGeneratedCardImageProvider {
           });
           providerResultRecorded = true;
           throw createMappedProviderError(error, metadata);
+        } finally {
+          clearTimeout(providerDeadline.timer);
         }
       }
 
       throw new Error("OpenAI image generation exhausted its attempt loop without a result.");
     } catch (error) {
-      if (input.signal.aborted && providerResultRecorded === false) {
+      if (
+        (input.signal.aborted || error instanceof GeneratedCardImageDeadlineExceededError)
+        && providerResultRecorded === false
+      ) {
         providerObservation?.updateOtelSpanAttributes({
           output: {
-            result: "aborted",
+            result: error instanceof GeneratedCardImageDeadlineExceededError
+              ? "deadline"
+              : "aborted",
           },
         });
         providerResultRecorded = true;

--- a/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
@@ -9,26 +9,33 @@ import {
   closeSessionAdvisoryLockPoolForTests, readSessionAdvisoryLockWaitingCountForTests,
   SessionAdvisoryLockCapacityError, toSessionAdvisoryLockConnectionBoundaryError,
 } from "../../database/sessionAdvisoryLock";
-import { TransientDatabaseHttpError } from "../../database/transient";
+import {
+  DatabaseCommitOutcomeUnknownError, TransientDatabaseHttpError,
+} from "../../database/transient";
+import type { GeneratedMediaStagingObject } from "../../mediaAssets/storage";
 import { imageJpegCardMediaBlobMimeType } from "../../mediaAssets/types";
 import { createBackendObservationScope } from "../../observability/sentry";
 import { HttpError } from "../../shared/errors";
 import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
+import { claimChatRun, InactiveChatRunClaimError, prepareChatRun, type ClaimedChatRun } from "../runs";
 import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
 import { createGeneratedCardImageOperationDependencies, generateCardImageWithDependencies } from "./operation";
 import {
   GeneratedCardImageOperationLockAbortedError,
   withGeneratedCardImageOperationLock, type GeneratedCardImageOperationLockInput,
 } from "./operationLock";
+import { enqueueGeneratedMediaPromotionJob } from "./promotionJobs";
 import type { GeneratedCardImageInput } from "./types";
 const normalizedBytes = Buffer.from("deterministic-local-normalized-image");
 const normalizedSha256 = "8349792a6784cfdc5061b34e1184c85bcdb13719e86ac4be576e52e5e8c5f603";
 const lockSessionApplicationName = "backend-session-advisory-lock";
 type CountRow = Readonly<{ count: string }>;
 type TransactionStateRow = Readonly<{ session_count: string; no_open_transaction: boolean }>;
-type PersistedAssetRow = Readonly<{ source_url: string | null; sha256: string; normalization_version: string }>;
 type PersistedCardRow = Readonly<{ back_text: string }>;
-type HotChangeCountRow = Readonly<{ entity_type: string; count: string }>;
+type PromotionJobRow = Readonly<{
+  user_id: string; operation_id: string; card_id: string; replica_id: string;
+  sha256: string; state: string;
+}>;
 type AdvisoryLockRow = Readonly<{ acquired: boolean }>;
 type AdvisoryUnlockRow = Readonly<{ unlocked: boolean }>;
 type BackendPidRow = Readonly<{ pid: number }>;
@@ -60,10 +67,12 @@ async function holdLock<Input>(runner: LockRunner<Input>, input: Input): Promise
   return { completion, release: release.resolve };
 }
 function createInput(
-  fixture: PostgresIntegrationFixture, runId: string, targetSide: "front" | "back", signal: AbortSignal,
+  fixture: PostgresIntegrationFixture, run: ClaimedChatRun,
+  targetSide: "front" | "back", signal: AbortSignal,
 ): GeneratedCardImageInput {
   return {
-    runId, userId: fixture.userId, workspaceId: fixture.workspaceId,
+    runId: run.runId, sessionId: run.sessionId, claimToken: run.claimToken,
+    userId: fixture.userId, workspaceId: fixture.workspaceId,
     cardId: fixture.cardId, targetSide,
     imagePrompt: "Draw a deterministic integration diagram.",
     altText: "Generated integration diagram",
@@ -71,13 +80,25 @@ function createInput(
     observationContext: {
       scope: createBackendObservationScope(
         "chat-worker", "generated-image-postgres-integration", null, null, fixture.userId,
-        fixture.workspaceId, "generated-image-postgres-chat-request", runId,
-        "55555555-5555-4555-8555-555555555555", null, null,
+        fixture.workspaceId, "generated-image-postgres-chat-request", run.runId,
+        run.sessionId, null, null,
       ),
       rootObservation: null,
     },
-    signal,
+    signal, operationDeadlineMs: Date.now() + 120_000,
   };
+}
+async function createClaimedImageRun(fixture: PostgresIntegrationFixture): Promise<ClaimedChatRun> {
+  const prepared = await prepareChatRun(
+    fixture.userId, fixture.workspaceId, undefined,
+    [{ type: "text", text: "Generate an image for this card." }],
+    randomUUID(), "Europe/Madrid", null,
+  );
+  const claimed = await claimChatRun(fixture.userId, fixture.workspaceId, prepared.runId);
+  if (claimed === null) {
+    throw new Error(`Failed to claim generated image integration run. runId=${prepared.runId}`);
+  }
+  return claimed;
 }
 async function waitForLockAttemptCount(fixture: PostgresIntegrationFixture, expectedCount: number): Promise<void> {
   await waitForValue(async () => {
@@ -168,15 +189,17 @@ function sessionLockInput(lockKey: string, timeoutMs: number): SessionAdvisoryLo
     signal: new AbortController().signal,
   };
 }
-test("generated image operation coordinates real sessions and persists atomically", async () => {
+test("generated image operation reconciles ambiguous enqueue without early card visibility", async () => {
   try {
     await withPostgresIntegrationFixture(async (fixture) => {
-      const runId = randomUUID();
-      const operationMetadata = deriveGeneratedCardImageOperationMetadata(runId, fixture.cardId, "back");
+      const run = await createClaimedImageRun(fixture);
+      const operationMetadata = deriveGeneratedCardImageOperationMetadata(run.runId, fixture.cardId, "back");
       const providerStarted = createDeferred();
       const releaseProvider = createDeferred();
       let providerCalls = 0;
       let storageCalls = 0;
+      let enqueueCalls = 0;
+      let stagedObject: GeneratedMediaStagingObject | null = null;
       const dependencies = createGeneratedCardImageOperationDependencies({
         generateProviderImageFn: async () => {
           providerCalls += 1;
@@ -188,25 +211,43 @@ test("generated image operation coordinates real sessions and persists atomicall
           bytes: normalizedBytes, mimeType: imageJpegCardMediaBlobMimeType,
           sizeBytes: normalizedBytes.byteLength,
         }),
-        storeMediaAssetBlobBytesIfAbsentFn: async (input) => {
+        loadGeneratedMediaStagingObjectFn: async () => stagedObject,
+        storeGeneratedMediaStagingObjectFn: async (input) => {
           storageCalls += 1;
           assert.equal(input.sha256, normalizedSha256);
+          assert.match(input.stagingStorageKey, /^media\/uploads\//u);
           assert.equal(await countMediaAsset(fixture, input.mediaAssetId), 0);
           await assertNoExternalWorkTransaction(fixture);
+          stagedObject = {
+            stagingStorageKey: input.stagingStorageKey,
+            mimeType: input.mimeType,
+            sizeBytes: input.sizeBytes,
+            sha256: input.sha256,
+          };
+          return stagedObject;
         },
-        currentTimestampFn: () => fixture.createdAt,
+        enqueueGeneratedMediaPromotionJobFn: async (input) => {
+          enqueueCalls += 1;
+          const result = await enqueueGeneratedMediaPromotionJob(input);
+          if (enqueueCalls === 1) {
+            throw new DatabaseCommitOutcomeUnknownError(
+              new Error("Simulated lost COMMIT response after durable enqueue."),
+            );
+          }
+          return result;
+        },
       });
       const operations: Array<Promise<unknown>> = [];
       try {
         const first = generateCardImageWithDependencies(
-          createInput(fixture, runId, "back", new AbortController().signal), dependencies,
+          createInput(fixture, run, "back", new AbortController().signal), dependencies,
         );
         operations.push(first);
         void first.catch(() => undefined);
         await providerStarted.promise;
         await assertNoExternalWorkTransaction(fixture);
         const second = generateCardImageWithDependencies(
-          createInput(fixture, runId, "back", new AbortController().signal), dependencies,
+          createInput(fixture, run, "back", new AbortController().signal), dependencies,
         );
         operations.push(second);
         void second.catch(() => undefined);
@@ -215,61 +256,30 @@ test("generated image operation coordinates real sessions and persists atomicall
         const results = await Promise.all([first, second]);
         assert.equal(providerCalls, 1);
         assert.equal(storageCalls, 1);
-        assert.deepEqual(results.map((result) => result.reused).sort(), [false, true]);
-        assert.deepEqual(results.map((result) => result.cardAppendApplied).sort(), [false, true]);
-        assert.equal(results.every((result) => result.sourceUrl === null), true);
-        const asset = await fixture.ownerPool.query<PersistedAssetRow>(
-          `SELECT media_assets.source_url, media_blobs.sha256, media_blobs.normalization_version
-             FROM content.media_assets AS media_assets
-             INNER JOIN content.media_blobs AS media_blobs
-               ON media_blobs.media_blob_id = media_assets.media_blob_id
-             WHERE media_assets.workspace_id = $1 AND media_assets.media_asset_id = $2`,
-          [fixture.workspaceId, operationMetadata.mediaAssetId],
-        );
-        assert.deepEqual(asset.rows[0], {
-          source_url: null, sha256: normalizedSha256, normalization_version: "image-jpeg-card-v1",
-        });
+        assert.deepEqual(results.map((result) => result.reused).sort(), [true, true]);
+        assert.equal(results.every((result) => result.cardAppendApplied === false), true);
+        assert.deepEqual(results.map((result) => result.status), ["already_queued", "already_queued"]);
+        assert.equal(enqueueCalls, 3);
+        assert.equal(await countMediaAsset(fixture, operationMetadata.mediaAssetId), 0);
         const card = await fixture.ownerPool.query<PersistedCardRow>(
           "SELECT back_text FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
           [fixture.workspaceId, fixture.cardId],
         );
-        const assetReference = new RegExp(`fcasset:${operationMetadata.mediaAssetId}`, "gu");
-        assert.equal(card.rows[0]?.back_text.match(assetReference)?.length, 1);
-        const hotChanges = await fixture.ownerPool.query<HotChangeCountRow>(
-          [
-            "SELECT entity_type, count(*)::text AS count FROM sync.hot_changes",
-            "WHERE workspace_id = $1 GROUP BY entity_type ORDER BY entity_type",
-          ].join(" "),
-          [fixture.workspaceId],
+        assert.equal(card.rows[0]?.back_text, "Original answer");
+        const job = await fixture.ownerPool.query<PromotionJobRow>(
+          `SELECT user_id, operation_id, card_id, replica_id, sha256, state
+           FROM content.generated_media_promotion_jobs
+           WHERE operation_id = $1`,
+          [operationMetadata.operationId],
         );
-        assert.deepEqual(hotChanges.rows, [
-          { entity_type: "card", count: "1" },
-          { entity_type: "media_asset", count: "1" },
-        ]);
-        const failedRunId = randomUUID();
-        const failedMetadata = deriveGeneratedCardImageOperationMetadata(failedRunId, fixture.cardId, "front");
-        await fixture.ownerPool.query(
-          "UPDATE content.cards SET front_text = $1 WHERE workspace_id = $2 AND card_id = $3",
-          ["```markdown\nUnclosed", fixture.workspaceId, fixture.cardId],
-        );
-        await assert.rejects(
-          generateCardImageWithDependencies(
-            createInput(fixture, failedRunId, "front", new AbortController().signal),
-            dependencies,
-          ),
-          (error: unknown) => error instanceof HttpError
-            && error.code === "CARD_IMAGE_APPEND_MARKDOWN_BLOCK_UNCLOSED",
-        );
-        assert.equal(await countMediaAsset(fixture, failedMetadata.mediaAssetId), 0);
-        const hotChangeCount = await fixture.ownerPool.query<CountRow>(
-          "SELECT count(*)::text AS count FROM sync.hot_changes WHERE workspace_id = $1",
-          [fixture.workspaceId],
-        );
-        assert.equal(hotChangeCount.rows[0]?.count, "2");
-        await fixture.ownerPool.query(
-          "UPDATE content.cards SET front_text = $1 WHERE workspace_id = $2 AND card_id = $3",
-          ["Original question", fixture.workspaceId, fixture.cardId],
-        );
+        assert.deepEqual(job.rows[0], {
+          user_id: fixture.userId,
+          operation_id: operationMetadata.operationId,
+          card_id: fixture.cardId,
+          replica_id: fixture.replicaId,
+          sha256: normalizedSha256,
+          state: "pending",
+        });
         await closeSessionAdvisoryLockPoolForTests();
         const operationLockKey = `chat.generated_card_image:${fixture.workspaceId}:${operationMetadata.mediaAssetId}`;
         const holder = await holdLock(
@@ -296,11 +306,12 @@ test("generated image operation coordinates real sessions and persists atomicall
         await assertAdvisoryLockReleased(fixture, operationLockKey);
         await closeSessionAdvisoryLockPoolForTests();
         const completedRetry = await generateCardImageWithDependencies(
-          createInput(fixture, runId, "back", new AbortController().signal), dependencies,
+          createInput(fixture, run, "back", new AbortController().signal), dependencies,
         );
         assert.equal(completedRetry.reused, true);
         assert.equal(completedRetry.cardAppendApplied, false);
-        assert.equal(providerCalls, 2);
+        assert.equal(completedRetry.status, "already_queued");
+        assert.equal(providerCalls, 1);
         await closeSessionAdvisoryLockPoolForTests();
         const timeoutKey = `generated-image-timeout:${randomUUID()}`;
         const timeoutHolder = await holdLock(withSessionAdvisoryLock, sessionLockInput(timeoutKey, 1_000));
@@ -321,14 +332,21 @@ test("generated image operation coordinates real sessions and persists atomicall
           await withSessionAdvisoryLock(sessionLockInput(timeoutKey, 1_000), async (_signal) => "reacquired"),
           "reacquired",
         );
+        await assert.rejects(
+          generateCardImageWithDependencies(
+            { ...createInput(fixture, run, "back", new AbortController().signal),
+              claimToken: "stale-claim-token" },
+            dependencies,
+          ),
+          (error: unknown) => error instanceof InactiveChatRunClaimError,
+        );
+        assert.equal(providerCalls, 1);
       } finally {
         releaseProvider.resolve();
         await Promise.allSettled(operations);
         await fixture.ownerPool.query(
-          "DELETE FROM content.media_assets WHERE workspace_id = $1", [fixture.workspaceId],
-        );
-        await fixture.ownerPool.query(
-          "DELETE FROM content.media_blobs WHERE sha256 = $1", [normalizedSha256],
+          "DELETE FROM content.generated_media_promotion_jobs WHERE workspace_id = $1",
+          [fixture.workspaceId],
         );
       }
     });

--- a/apps/backend/src/chat/cardImages/operation.test.ts
+++ b/apps/backend/src/chat/cardImages/operation.test.ts
@@ -10,24 +10,22 @@ const runId = "11111111-1111-4111-8111-111111111111";
 const workspaceId = "22222222-2222-4222-8222-222222222222";
 const cardId = "33333333-3333-4333-8333-333333333333";
 const replicaId = "44444444-4444-4444-8444-444444444444";
-const timestamp = "2026-07-24T10:00:00.000Z";
+const sessionId = "55555555-5555-4555-8555-555555555555";
 function createInput(signal: AbortSignal): GeneratedCardImageInput {
   return {
-    runId, userId: "operation-test-user", workspaceId, cardId, targetSide: "back",
-    imagePrompt: "Draw a labeled plant cell.",
-    altText: "Plant cell diagram",
-    replicaId,
+    runId, sessionId, claimToken: "2026-07-24 10:11:12.123456+00",
+    userId: "operation-test-user", workspaceId, cardId, targetSide: "back",
+    imagePrompt: "Draw a labeled plant cell.", altText: "Plant cell diagram", replicaId,
     observationContext: {
       scope: createBackendObservationScope(
         "chat-worker", "operation-test-request", null, null, "operation-test-user",
-        workspaceId, "operation-test-chat-request", runId,
-        "55555555-5555-4555-8555-555555555555", null, null,
+        workspaceId, "operation-test-chat-request", runId, sessionId, null, null,
       ), rootObservation: null,
     },
-    signal,
+    signal, operationDeadlineMs: Date.now() + 120_000,
   };
 }
-test("generated image orchestration prepares before persistence", async () => {
+test("generated image orchestration stages before durable enqueue", async () => {
   const calls: Array<string> = [];
   const metadata = deriveGeneratedCardImageOperationMetadata(runId, cardId, "back");
   const lockSignal = new AbortController().signal;
@@ -38,30 +36,28 @@ test("generated image orchestration prepares before persistence", async () => {
       assert.notEqual(lockInput.signal, lockSignal);
       return callback(lockSignal);
     },
-    findMediaAssetFn: async () => { calls.push("find-media"); return null; },
-    prepareGeneratedImageFn: async (input) => {
-      calls.push("prepare");
+    prepareStagedImageFn: async (input) => {
+      calls.push("stage");
       assert.equal(input.signal, lockSignal);
       return {
-        mediaAssetId: metadata.mediaAssetId, sourceUrl: null,
-        createdAt: timestamp, clientUpdatedAt: timestamp,
-        lastModifiedByReplicaId: replicaId, lastOperationId: metadata.mediaLastOperationId,
-        sizeBytes: 10, sha256: "a".repeat(64),
+        stagingStorageKey: "media/uploads/test", mimeType: "image/jpeg",
+        sizeBytes: 10, sha256: "a".repeat(64), reused: false,
       };
     },
-    persistGeneratedImageFn: async (input, _metadata, preparedImage) => {
-      calls.push("persist");
-      assert.equal(input.signal, lockSignal);
-      assert.notEqual(preparedImage, null);
-      return { mediaRegistrationApplied: true, cardAppendApplied: true, reused: false };
+    enqueuePromotionJobFn: async (input, operationMetadata, preparedImage) => {
+      calls.push("enqueue");
+      assert.equal(input.signal.aborted, false);
+      assert.deepEqual(operationMetadata, metadata);
+      assert.equal(preparedImage.stagingStorageKey, "media/uploads/test");
+      return { outcome: "created", jobId: metadata.operationId };
     },
   };
   const result = await generateCardImageWithDependencies(
     createInput(new AbortController().signal), dependencies,
   );
-  assert.deepEqual(calls, ["preconditions", "lock", "find-media", "prepare", "persist"]);
+  assert.deepEqual(calls, ["preconditions", "lock", "stage", "enqueue"]);
   assert.deepEqual(result, {
-    cardId, mediaAssetId: metadata.mediaAssetId, targetSide: "back",
-    mediaRegistrationApplied: true, cardAppendApplied: true, reused: false, sourceUrl: null,
+    status: "queued", cardId, mediaAssetId: metadata.mediaAssetId, targetSide: "back",
+    mediaRegistrationApplied: false, cardAppendApplied: false, reused: false, sourceUrl: null,
   });
 });

--- a/apps/backend/src/chat/cardImages/operation.ts
+++ b/apps/backend/src/chat/cardImages/operation.ts
@@ -1,59 +1,60 @@
 import { createHash } from "node:crypto";
-import { appendManagedImageToCardSideInExecutor, getCard, type CardTextSide } from "../../cards";
-import {
-  queryWithWorkspaceScopeReadOnly, transactionWithWorkspaceScope, transactionWithWorkspaceScopeReadOnly,
-} from "../../database";
-import {
-  MEDIA_ASSET_COLUMNS, MEDIA_ASSET_JOIN_CLAUSE, loadReusableImageMediaBlobForWorkspace, mapMediaAssetRow,
-} from "../../mediaAssets";
+import type { CardTextSide } from "../../cards";
+import { transactionWithWorkspaceScopeDeadline } from "../../database";
+import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
 import { normalizeImageBytesForCard } from "../../mediaAssets/ingestion/imageNormalization";
 import {
-  findMediaAssetRowForUpdateInExecutor, upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
-} from "../../mediaAssets/persistence";
-import { storeMediaAssetBlobBytesIfAbsent } from "../../mediaAssets/storage";
-import { buildMediaBlobStorageKey } from "../../mediaAssets/storageKeys";
+  loadGeneratedMediaStagingObject,
+  storeGeneratedMediaStagingObject,
+  type GeneratedMediaStagingObject,
+} from "../../mediaAssets/storage";
 import {
-  imageJpegCardMediaBlobMimeType, imageJpegCardMediaBlobNormalizationVersion, type MediaAsset,
-  type MediaAssetRow, type NormalizedImageMediaAssetInput,
-} from "../../mediaAssets/types";
+  buildMediaBlobStorageKey,
+  buildMediaUploadStagingStorageKey,
+} from "../../mediaAssets/storageKeys";
 import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
 import { expectNonEmptyString, expectUuidString } from "../../server/requestParsing";
 import { HttpError } from "../../shared/errors";
-import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../sync/replication/changes";
+import { assertActiveChatRunClaimWithExecutor } from "../runs/claimFence";
 import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
 import { createOpenAIGeneratedCardImageProvider } from "./openaiAdapter";
 import { withGeneratedCardImageOperationLock } from "./operationLock";
-import type { GeneratedProviderImage, OpenAIImageGenerationInput } from "./providerTypes";
-import type { GeneratedCardImageInput, GeneratedCardImageOperationMetadata, GeneratedCardImageResult } from "./types";
+import { enqueueGeneratedMediaPromotionJob, type EnqueueGeneratedMediaPromotionJobResult } from "./promotionJobs";
+import {
+  GeneratedCardImageDeadlineExceededError,
+  type GeneratedProviderImage,
+  type OpenAIImageGenerationInput,
+} from "./providerTypes";
+import type {
+  GeneratedCardImageInput,
+  GeneratedCardImageOperationMetadata,
+  GeneratedCardImageResult,
+} from "./types";
 
 const maximumGeneratedCardImagePromptCharacters = 32_000;
+const maximumGeneratedCardImageAltTextCharacters = 2_000;
+const controlCharacterPattern = /[\u0000-\u001f\u007f-\u009f]/u;
+const maximumTimerDelayMs = 2_147_483_647;
 
-export type PreparedGeneratedCardImage = NormalizedImageMediaAssetInput;
-
-type PersistedGeneratedCardImage =
-  Pick<GeneratedCardImageResult, "mediaRegistrationApplied" | "cardAppendApplied" | "reused">;
+export type PreparedGeneratedCardImage = GeneratedMediaStagingObject & Readonly<{ reused: boolean }>;
 
 export type GeneratedCardImageOperationDependencies = Readonly<{
   assertPreconditionsFn: (input: GeneratedCardImageInput) => Promise<void>;
   withOperationLockFn: typeof withGeneratedCardImageOperationLock;
-  findMediaAssetFn: (userId: string, workspaceId: string, mediaAssetId: string) => Promise<MediaAsset | null>;
-  prepareGeneratedImageFn: (
-    input: GeneratedCardImageInput,
-    operationMetadata: GeneratedCardImageOperationMetadata,
-  ) => Promise<PreparedGeneratedCardImage>;
-  persistGeneratedImageFn: (
-    input: GeneratedCardImageInput,
-    operationMetadata: GeneratedCardImageOperationMetadata,
-    preparedImage: PreparedGeneratedCardImage | null,
-    cardClientUpdatedAt: string,
-  ) => Promise<PersistedGeneratedCardImage>;
+  prepareStagedImageFn: (input: GeneratedCardImageInput,
+    operationMetadata: GeneratedCardImageOperationMetadata) => Promise<PreparedGeneratedCardImage>;
+  enqueuePromotionJobFn: (
+    input: GeneratedCardImageInput, operationMetadata: GeneratedCardImageOperationMetadata,
+    preparedImage: PreparedGeneratedCardImage,
+  ) => Promise<EnqueueGeneratedMediaPromotionJobResult>;
 }>;
 
 export type GeneratedCardImageExternalDependencies = Readonly<{
   generateProviderImageFn: (input: OpenAIImageGenerationInput) => Promise<GeneratedProviderImage>;
   normalizeImageBytesForCardFn: typeof normalizeImageBytesForCard;
-  storeMediaAssetBlobBytesIfAbsentFn: typeof storeMediaAssetBlobBytesIfAbsent;
-  currentTimestampFn: () => string;
+  loadGeneratedMediaStagingObjectFn: typeof loadGeneratedMediaStagingObject;
+  storeGeneratedMediaStagingObjectFn: typeof storeGeneratedMediaStagingObject;
+  enqueueGeneratedMediaPromotionJobFn: typeof enqueueGeneratedMediaPromotionJob;
 }>;
 
 function normalizeTargetSide(targetSide: CardTextSide): CardTextSide {
@@ -66,183 +67,159 @@ function normalizeTargetSide(targetSide: CardTextSide): CardTextSide {
 function normalizeGeneratedCardImageInput(input: GeneratedCardImageInput): GeneratedCardImageInput {
   const imagePrompt = expectNonEmptyString(input.imagePrompt, "imagePrompt");
   if (imagePrompt.length > maximumGeneratedCardImagePromptCharacters) {
-    throw new HttpError(400, `imagePrompt must be at most ${maximumGeneratedCardImagePromptCharacters} characters`);
+    throw new HttpError(400,
+      `imagePrompt must be at most ${maximumGeneratedCardImagePromptCharacters} characters`);
   }
-
+  const altText = expectNonEmptyString(input.altText, "altText");
+  if (
+    altText.length > maximumGeneratedCardImageAltTextCharacters
+    || controlCharacterPattern.test(altText)
+  ) {
+    throw new HttpError(400,
+      `altText must be at most ${maximumGeneratedCardImageAltTextCharacters} characters without control characters`);
+  }
   return {
     runId: expectUuidString(input.runId, "runId"),
+    sessionId: expectUuidString(input.sessionId, "sessionId"),
+    claimToken: expectNonEmptyString(input.claimToken, "claimToken"),
     userId: expectNonEmptyString(input.userId, "userId"),
     workspaceId: expectUuidString(input.workspaceId, "workspaceId"),
     cardId: expectUuidString(input.cardId, "cardId"),
     targetSide: normalizeTargetSide(input.targetSide),
     imagePrompt,
-    altText: expectNonEmptyString(input.altText, "altText"),
+    altText,
     replicaId: expectUuidString(input.replicaId, "replicaId"),
     observationContext: input.observationContext,
     signal: input.signal,
+    operationDeadlineMs: input.operationDeadlineMs,
   };
 }
 
-async function assertGeneratedCardImagePreconditions(input: GeneratedCardImageInput): Promise<void> {
-  await Promise.all([
-    getCard(input.userId, input.workspaceId, input.cardId),
-    transactionWithWorkspaceScopeReadOnly(
-      { userId: input.userId, workspaceId: input.workspaceId },
-      async (executor) => assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId),
-    ),
-  ]);
+function assertGeneratedCardImageOperationActive(input: GeneratedCardImageInput): void {
+  input.signal.throwIfAborted();
+  if (!Number.isSafeInteger(input.operationDeadlineMs) || input.operationDeadlineMs < 1) {
+    throw new RangeError(
+      "Generated card image operation deadline must be a positive absolute epoch-millisecond safe integer.",
+    );
+  }
+  if (input.operationDeadlineMs <= Date.now()) {
+    throw new GeneratedCardImageDeadlineExceededError(null);
+  }
 }
 
-async function findGeneratedCardImageMediaAsset(
-  userId: string, workspaceId: string, mediaAssetId: string,
-): Promise<MediaAsset | null> {
-  const result = await queryWithWorkspaceScopeReadOnly<MediaAssetRow>(
-    { userId, workspaceId },
-    `SELECT ${MEDIA_ASSET_COLUMNS}
-       FROM ${MEDIA_ASSET_JOIN_CLAUSE}
-       WHERE media_assets.workspace_id = $1 AND media_assets.media_asset_id = $2
-       LIMIT 1`,
-    [workspaceId, mediaAssetId],
+async function withGeneratedCardImageDeadline<Result>(
+  input: GeneratedCardImageInput,
+  run: (deadlineInput: GeneratedCardImageInput) => Promise<Result>,
+): Promise<Result> {
+  assertGeneratedCardImageOperationActive(input);
+  const deadlineController = new AbortController();
+  const deadlineError = new GeneratedCardImageDeadlineExceededError(null);
+  const deadlineTimer = setTimeout(
+    () => deadlineController.abort(deadlineError),
+    Math.min(input.operationDeadlineMs - Date.now(), maximumTimerDelayMs),
   );
-  const row = result.rows[0];
-  return row === undefined ? null : mapMediaAssetRow(row);
-}
-
-function assertReusableGeneratedMediaAsset(
-  mediaAsset: MediaAsset, operationMetadata: GeneratedCardImageOperationMetadata,
-): void {
-  if (mediaAsset.lastOperationId !== operationMetadata.mediaLastOperationId
-      || mediaAsset.sourceUrl !== null) {
-    throw new HttpError(409,
-      `The deterministic generated media asset id belongs to another operation. mediaAssetId=${operationMetadata.mediaAssetId}`,
-      "GENERATED_CARD_IMAGE_MEDIA_ID_CONFLICT");
-  }
-  if (mediaAsset.deletedAt !== null) {
-    throw new HttpError(409, `The generated media asset was deleted. mediaAssetId=${operationMetadata.mediaAssetId}`,
-      "GENERATED_CARD_IMAGE_MEDIA_DELETED");
+  const deadlineInput = {
+    ...input, signal: AbortSignal.any([input.signal, deadlineController.signal]),
+  };
+  try {
+    return await run(deadlineInput);
+  } catch (error) {
+    if (deadlineController.signal.aborted) throw deadlineError;
+    throw error;
+  } finally {
+    clearTimeout(deadlineTimer);
   }
 }
 
-async function prepareGeneratedCardImage(
+async function assertGeneratedCardImagePreconditions(input: GeneratedCardImageInput): Promise<void> {
+  await transactionWithWorkspaceScopeDeadline(
+    { userId: input.userId, workspaceId: input.workspaceId },
+    input.operationDeadlineMs,
+    async (executor) => {
+      await assertActiveChatRunClaimWithExecutor(executor, input);
+      const cardResult = await executor.query<{ card_id: string }>(
+        `SELECT card_id FROM content.cards
+         WHERE workspace_id = $1 AND card_id = $2 AND deleted_at IS NULL
+         LIMIT 1`,
+        [input.workspaceId, input.cardId],
+      );
+      if (cardResult.rows[0] === undefined) {
+        throw new HttpError(404, "Card not found");
+      }
+      await assertReplicaBelongsToWorkspaceInExecutor(
+        executor, input.workspaceId, input.replicaId,
+      );
+    },
+  );
+}
+
+async function prepareStagedGeneratedCardImage(
   input: GeneratedCardImageInput,
   operationMetadata: GeneratedCardImageOperationMetadata,
   dependencies: GeneratedCardImageExternalDependencies,
 ): Promise<PreparedGeneratedCardImage> {
+  const stagingStorageKey = buildMediaUploadStagingStorageKey(
+    input.workspaceId, operationMetadata.mediaAssetId, operationMetadata.operationId);
+  const stagingInput = {
+    workspaceId: input.workspaceId, mediaAssetId: operationMetadata.mediaAssetId,
+    operationId: operationMetadata.operationId, stagingStorageKey,
+    observationScope: input.observationContext.scope, signal: input.signal,
+  };
+  const existing = await dependencies.loadGeneratedMediaStagingObjectFn(stagingInput);
+  if (existing !== null) return { ...existing, reused: true };
   const generatedImage = await dependencies.generateProviderImageFn({
-    userId: input.userId,
-    imagePrompt: input.imagePrompt,
+    userId: input.userId, imagePrompt: input.imagePrompt,
     observationContext: input.observationContext,
-    signal: input.signal,
+    signal: input.signal, operationDeadlineMs: input.operationDeadlineMs,
   });
   input.signal.throwIfAborted();
-
   const normalizedImage = await dependencies.normalizeImageBytesForCardFn(generatedImage.bytes);
   input.signal.throwIfAborted();
-
-  const timestamp = dependencies.currentTimestampFn();
-  const mediaAssetInput: NormalizedImageMediaAssetInput = {
-    mediaAssetId: operationMetadata.mediaAssetId,
-    sourceUrl: null,
-    createdAt: timestamp,
-    clientUpdatedAt: timestamp,
-    lastModifiedByReplicaId: input.replicaId,
-    lastOperationId: operationMetadata.mediaLastOperationId,
+  const staged = await dependencies.storeGeneratedMediaStagingObjectFn({
+    ...stagingInput,
+    mimeType: normalizedImage.mimeType,
     sizeBytes: normalizedImage.sizeBytes,
     sha256: createHash("sha256").update(normalizedImage.bytes).digest("hex"),
-  };
-  const reusableBlob = await loadReusableImageMediaBlobForWorkspace(
-    input.userId, input.workspaceId, mediaAssetInput,
-  );
+    bytes: normalizedImage.bytes,
+  });
   input.signal.throwIfAborted();
-
-  if (reusableBlob === null) {
-    await dependencies.storeMediaAssetBlobBytesIfAbsentFn({
-      workspaceId: input.workspaceId,
-      mediaAssetId: operationMetadata.mediaAssetId,
-      storageKey: buildMediaBlobStorageKey(mediaAssetInput.sha256),
-      mimeType: normalizedImage.mimeType,
-      sha256: mediaAssetInput.sha256,
-      lastOperationId: operationMetadata.mediaLastOperationId,
-      bytes: normalizedImage.bytes,
-      observationScope: input.observationContext.scope,
-    });
-  }
-  input.signal.throwIfAborted();
-  return mediaAssetInput;
+  return { ...staged, reused: false };
 }
 
-async function persistGeneratedCardImage(
+async function enqueueGeneratedCardImagePromotion(
   input: GeneratedCardImageInput,
   operationMetadata: GeneratedCardImageOperationMetadata,
-  preparedImage: PreparedGeneratedCardImage | null,
-  cardClientUpdatedAt: string,
-): Promise<PersistedGeneratedCardImage> {
+  preparedImage: PreparedGeneratedCardImage,
+  dependencies: GeneratedCardImageExternalDependencies,
+): Promise<EnqueueGeneratedMediaPromotionJobResult> {
   input.signal.throwIfAborted();
+  return dependencies.enqueueGeneratedMediaPromotionJobFn({
+    userId: input.userId, workspaceId: input.workspaceId,
+    sessionId: input.sessionId, runId: input.runId, claimToken: input.claimToken,
+    deadlineAtMs: input.operationDeadlineMs,
+    jobId: operationMetadata.operationId, operationId: operationMetadata.operationId,
+    cardId: input.cardId, targetSide: input.targetSide, altText: input.altText,
+    mediaAssetId: operationMetadata.mediaAssetId, replicaId: input.replicaId,
+    stagingStorageKey: preparedImage.stagingStorageKey,
+    blobStorageKey: buildMediaBlobStorageKey(preparedImage.sha256),
+    sha256: preparedImage.sha256, mimeType: preparedImage.mimeType,
+    sizeBytes: preparedImage.sizeBytes,
+  });
+}
 
-  return transactionWithWorkspaceScope(
-    { userId: input.userId, workspaceId: input.workspaceId },
-    async (executor) => {
-      await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, input.workspaceId);
-      await assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId);
-      input.signal.throwIfAborted();
-
-      const existingRow = await findMediaAssetRowForUpdateInExecutor(
-        executor, input.workspaceId, operationMetadata.mediaAssetId,
-      );
-      let mediaRegistrationApplied = false;
-      let reused = preparedImage === null || existingRow !== null;
-      if (existingRow === null) {
-        if (preparedImage === null) {
-          throw new HttpError(409,
-            `The generated media asset disappeared. mediaAssetId=${operationMetadata.mediaAssetId}`,
-            "GENERATED_CARD_IMAGE_MEDIA_MISSING");
-        }
-        const mediaResult = await upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
-          executor,
-          input.workspaceId,
-          {
-            mediaAssetId: preparedImage.mediaAssetId,
-            mimeType: imageJpegCardMediaBlobMimeType,
-            sizeBytes: preparedImage.sizeBytes,
-            sha256: preparedImage.sha256,
-            sourceUrl: null,
-            createdAt: preparedImage.createdAt,
-            deletedAt: null,
-          },
-          {
-            clientUpdatedAt: preparedImage.clientUpdatedAt,
-            lastModifiedByReplicaId: input.replicaId,
-            lastOperationId: operationMetadata.mediaLastOperationId,
-          },
-          imageJpegCardMediaBlobNormalizationVersion,
-        );
-        assertReusableGeneratedMediaAsset(mediaResult.mediaAsset, operationMetadata);
-        mediaRegistrationApplied = true;
-        reused = false;
-      } else {
-        assertReusableGeneratedMediaAsset(mapMediaAssetRow(existingRow), operationMetadata);
-      }
-
-      input.signal.throwIfAborted();
-      const cardResult = await appendManagedImageToCardSideInExecutor(
-        executor,
-        input.workspaceId,
-        {
-          cardId: input.cardId,
-          targetSide: input.targetSide,
-          mediaAssetId: operationMetadata.mediaAssetId,
-          altText: input.altText,
-        },
-        {
-          clientUpdatedAt: cardClientUpdatedAt,
-          lastModifiedByReplicaId: input.replicaId,
-          lastOperationId: operationMetadata.cardLastOperationId,
-        },
-      );
-      input.signal.throwIfAborted();
-      return { mediaRegistrationApplied, cardAppendApplied: cardResult.applied, reused };
-    },
-  );
+async function enqueueGeneratedCardImagePromotionWithCommitReconciliation(
+  input: GeneratedCardImageInput,
+  operationMetadata: GeneratedCardImageOperationMetadata,
+  preparedImage: PreparedGeneratedCardImage,
+  enqueuePromotionJobFn: GeneratedCardImageOperationDependencies["enqueuePromotionJobFn"],
+): Promise<EnqueueGeneratedMediaPromotionJobResult> {
+  try {
+    return await enqueuePromotionJobFn(input, operationMetadata, preparedImage);
+  } catch (error) {
+    if (!(error instanceof DatabaseCommitOutcomeUnknownError)) throw error;
+    assertGeneratedCardImageOperationActive(input);
+    return enqueuePromotionJobFn(input, operationMetadata, preparedImage);
+  }
 }
 
 export function createGeneratedCardImageOperationDependencies(
@@ -251,26 +228,11 @@ export function createGeneratedCardImageOperationDependencies(
   return {
     assertPreconditionsFn: assertGeneratedCardImagePreconditions,
     withOperationLockFn: withGeneratedCardImageOperationLock,
-    findMediaAssetFn: findGeneratedCardImageMediaAsset,
-    prepareGeneratedImageFn: async (input, metadata) => prepareGeneratedCardImage(
+    prepareStagedImageFn: async (input, metadata) => prepareStagedGeneratedCardImage(
       input, metadata, externalDependencies,
     ),
-    persistGeneratedImageFn: persistGeneratedCardImage,
-  };
-}
-
-function toGeneratedCardImageResult(
-  input: GeneratedCardImageInput, operationMetadata: GeneratedCardImageOperationMetadata,
-  persisted: PersistedGeneratedCardImage,
-): GeneratedCardImageResult {
-  return {
-    cardId: input.cardId,
-    mediaAssetId: operationMetadata.mediaAssetId,
-    targetSide: input.targetSide,
-    mediaRegistrationApplied: persisted.mediaRegistrationApplied,
-    cardAppendApplied: persisted.cardAppendApplied,
-    reused: persisted.reused,
-    sourceUrl: null,
+    enqueuePromotionJobFn: async (input, metadata, preparedImage) =>
+      enqueueGeneratedCardImagePromotion(input, metadata, preparedImage, externalDependencies),
   };
 }
 
@@ -279,51 +241,54 @@ export async function generateCardImageWithDependencies(
   dependencies: GeneratedCardImageOperationDependencies,
 ): Promise<GeneratedCardImageResult> {
   const normalizedInput = normalizeGeneratedCardImageInput(input);
-  normalizedInput.signal.throwIfAborted();
+  assertGeneratedCardImageOperationActive(normalizedInput);
   const operationMetadata = deriveGeneratedCardImageOperationMetadata(
     normalizedInput.runId, normalizedInput.cardId, normalizedInput.targetSide,
   );
-
   await dependencies.assertPreconditionsFn(normalizedInput);
-  normalizedInput.signal.throwIfAborted();
-  return dependencies.withOperationLockFn(
-    {
-      workspaceId: normalizedInput.workspaceId, mediaAssetId: operationMetadata.mediaAssetId,
-      signal: normalizedInput.signal,
-    },
-    async (lockSignal) => {
-      const lockedInput: GeneratedCardImageInput = { ...normalizedInput, signal: lockSignal };
-      lockedInput.signal.throwIfAborted();
-      const existingMediaAsset = await dependencies.findMediaAssetFn(
-        lockedInput.userId, lockedInput.workspaceId, operationMetadata.mediaAssetId,
-      );
-      lockedInput.signal.throwIfAborted();
-
-      if (existingMediaAsset !== null) {
-        assertReusableGeneratedMediaAsset(existingMediaAsset, operationMetadata);
-        const persisted = await dependencies.persistGeneratedImageFn(
-          lockedInput, operationMetadata, null, new Date().toISOString(),
+  assertGeneratedCardImageOperationActive(normalizedInput);
+  return withGeneratedCardImageDeadline(
+    normalizedInput,
+    async (deadlineInput) => dependencies.withOperationLockFn(
+      {
+        workspaceId: deadlineInput.workspaceId, mediaAssetId: operationMetadata.mediaAssetId,
+        signal: deadlineInput.signal,
+      },
+      async (lockSignal) => {
+        const lockedInput = { ...deadlineInput, signal: lockSignal };
+        const preparedImage = await dependencies.prepareStagedImageFn(
+          lockedInput, operationMetadata,
         );
-        return toGeneratedCardImageResult(lockedInput, operationMetadata, persisted);
-      }
-
-      const preparedImage = await dependencies.prepareGeneratedImageFn(lockedInput, operationMetadata);
-      const persisted = await dependencies.persistGeneratedImageFn(
-        lockedInput, operationMetadata, preparedImage, preparedImage.clientUpdatedAt,
-      );
-      return toGeneratedCardImageResult(lockedInput, operationMetadata, persisted);
-    },
+        assertGeneratedCardImageOperationActive(lockedInput);
+        const enqueueResult = await enqueueGeneratedCardImagePromotionWithCommitReconciliation(
+          lockedInput, operationMetadata, preparedImage, dependencies.enqueuePromotionJobFn,
+        );
+        return {
+          status: enqueueResult.outcome === "created" ? "queued" : "already_queued",
+          cardId: lockedInput.cardId,
+          mediaAssetId: operationMetadata.mediaAssetId,
+          targetSide: lockedInput.targetSide,
+          mediaRegistrationApplied: false,
+          cardAppendApplied: false,
+          reused: preparedImage.reused || enqueueResult.outcome === "existing",
+          sourceUrl: null,
+        };
+      },
+    ),
   );
 }
 
 const defaultExternalDependencies: GeneratedCardImageExternalDependencies = {
   generateProviderImageFn: async (input) => createOpenAIGeneratedCardImageProvider().generate(input),
   normalizeImageBytesForCardFn: normalizeImageBytesForCard,
-  storeMediaAssetBlobBytesIfAbsentFn: storeMediaAssetBlobBytesIfAbsent,
-  currentTimestampFn: () => new Date().toISOString(),
+  loadGeneratedMediaStagingObjectFn: loadGeneratedMediaStagingObject,
+  storeGeneratedMediaStagingObjectFn: storeGeneratedMediaStagingObject,
+  enqueueGeneratedMediaPromotionJobFn: enqueueGeneratedMediaPromotionJob,
 };
 
 export async function generateCardImage(input: GeneratedCardImageInput): Promise<GeneratedCardImageResult> {
-  return generateCardImageWithDependencies(input,
-    createGeneratedCardImageOperationDependencies(defaultExternalDependencies));
+  return generateCardImageWithDependencies(
+    input,
+    createGeneratedCardImageOperationDependencies(defaultExternalDependencies),
+  );
 }

--- a/apps/backend/src/chat/cardImages/providerTypes.ts
+++ b/apps/backend/src/chat/cardImages/providerTypes.ts
@@ -16,4 +16,15 @@ export type OpenAIImageGenerationInput = Readonly<{
   imagePrompt: string;
   observationContext: GeneratedCardImageObservationContext;
   signal: AbortSignal;
+  operationDeadlineMs: number;
 }>;
+
+export class GeneratedCardImageDeadlineExceededError extends Error {
+  readonly code = "GENERATED_CARD_IMAGE_DEADLINE_EXCEEDED";
+
+  constructor(cause: unknown | null) {
+    super("The generated card image operation exceeded its safe execution deadline.",
+      cause === null ? undefined : { cause });
+    this.name = "GeneratedCardImageDeadlineExceededError";
+  }
+}

--- a/apps/backend/src/chat/cardImages/types.ts
+++ b/apps/backend/src/chat/cardImages/types.ts
@@ -1,8 +1,11 @@
 import type { CardTextSide } from "../../cards";
+import type { ChatRunClaimToken } from "../runs";
 import type { GeneratedCardImageObservationContext } from "./providerTypes";
 
 export type GeneratedCardImageInput = Readonly<{
   runId: string;
+  sessionId: string;
+  claimToken: ChatRunClaimToken;
   userId: string;
   workspaceId: string;
   cardId: string;
@@ -12,9 +15,11 @@ export type GeneratedCardImageInput = Readonly<{
   replicaId: string;
   observationContext: GeneratedCardImageObservationContext;
   signal: AbortSignal;
+  operationDeadlineMs: number;
 }>;
 
 export type GeneratedCardImageResult = Readonly<{
+  status: "queued" | "already_queued";
   cardId: string;
   mediaAssetId: string;
   targetSide: CardTextSide;

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
-import { CopyObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { CopyObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../storageKeys";
 import {
   GeneratedMediaPromotionStorageTerminalError,
   GeneratedMediaPromotionStorageTransientError,
+  loadGeneratedMediaStagingObjectWithDependencies,
   promoteGeneratedMediaObjectWithDependencies,
+  storeGeneratedMediaStagingObjectWithDependencies,
   type GeneratedMediaObjectPromotionInput,
+  type StoreGeneratedMediaStagingObjectInput,
 } from "./generatedPromotion";
 import { createUploadProofMetadata } from "./proof";
 import {
@@ -64,6 +68,48 @@ async function promote(
     s3Client: client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
   });
 }
+function stagingInput(bytes: Buffer): StoreGeneratedMediaStagingObjectInput {
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  return {
+    workspaceId: testWorkspaceId, mediaAssetId: testMediaAssetId, operationId,
+    stagingStorageKey: buildMediaUploadStagingStorageKey(testWorkspaceId, testMediaAssetId, operationId),
+    mimeType, sizeBytes: bytes.byteLength, sha256, bytes, observationScope: testObservationScope,
+    signal: new AbortController().signal,
+  };
+}
+test("generated staging is reusable, conditional, and cannot be poisoned by different bytes", async () => {
+  const firstInput = stagingInput(Buffer.from("first normalized generated image"));
+  let storedInput: StoreGeneratedMediaStagingObjectInput | null = null;
+  const client = createTestS3Client();
+  client.send = (async (command: unknown, options?: Readonly<{ abortSignal?: AbortSignal }>) => {
+    assert.ok(options?.abortSignal instanceof AbortSignal);
+    if (command instanceof PutObjectCommand) {
+      assert.equal(command.input.IfNoneMatch, "*");
+      if (storedInput !== null) throw createS3Error(412, "PreconditionFailed", "exists");
+      storedInput = firstInput; return {};
+    }
+    assert.ok(command instanceof HeadObjectCommand); const stored = storedInput;
+    if (stored === null) throw createS3Error(404, "NotFound", "missing");
+    return headResponse(
+      { ...input(stored.signal), sizeBytes: stored.sizeBytes, sha256: stored.sha256 },
+      createUploadProofMetadata({
+        workspaceId: stored.workspaceId, mediaAssetId: stored.mediaAssetId,
+        lastOperationId: stored.operationId, sha256: stored.sha256,
+      }),
+      stored.sha256,
+    );
+  }) as S3Client["send"];
+  const dependencies = { s3Client: client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig };
+  const stored = await storeGeneratedMediaStagingObjectWithDependencies(firstInput, dependencies);
+  assert.deepEqual(await loadGeneratedMediaStagingObjectWithDependencies(firstInput, dependencies), stored);
+  await assert.rejects(
+    storeGeneratedMediaStagingObjectWithDependencies(
+      stagingInput(Buffer.from("different normalized generated image")), dependencies),
+    (error: unknown) => error instanceof GeneratedMediaPromotionStorageTerminalError
+      && error.code === "STAGING_CONTENT_INVALID",
+  );
+  storedInput = null; assert.equal(await loadGeneratedMediaStagingObjectWithDependencies(firstInput, dependencies), null);
+});
 test("generated promotion handles 409/412 and cross-workspace reuses a tenant-neutral blob", async () => {
   for (const copyStatuses of [[], [409, 409], [412]] as const) {
     const promotionInput = input(new AbortController().signal);

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
@@ -1,20 +1,31 @@
-import { CopyObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
+import { CopyObjectCommand, HeadObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { createHash } from "node:crypto";
 import { addBackendBreadcrumb, type BackendObservationScope } from "../../observability/sentry";
-import type { MediaAssetObjectMetadata } from "../types";
+import { imageJpegCardMediaBlobMimeType, type MediaAssetObjectMetadata } from "../types";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../storageKeys";
 import { getMediaAssetsS3Client, getMediaAssetsStorageConfig } from "./config";
 import type { MediaAssetStorageDependencies } from "./contracts";
 import { getS3ErrorStatusCode } from "./errors";
 import {
-  createUploadProofMetadata, toHexSha256Digest, uploadProofLastOperationIdSha256Key,
+  createUploadProofMetadata, toBase64Sha256Digest, toHexSha256Digest,
+  uploadProofLastOperationIdSha256Key,
   uploadProofMediaAssetIdKey, uploadProofSha256Key, uploadProofWorkspaceIdKey,
 } from "./proof";
 const maximumS3Attempts = 3;
-export type GeneratedMediaObjectPromotionInput = Readonly<{
-  workspaceId: string; mediaAssetId: string; operationId: string;
-  stagingStorageKey: string; blobStorageKey: string;
-  mimeType: string; sizeBytes: number; sha256: string;
-  observationScope: BackendObservationScope; signal: AbortSignal;
+type GeneratedMediaStorageRequestInput = Readonly<{
+  workspaceId: string; mediaAssetId: string; operationId: string; signal: AbortSignal;
+  observationScope: BackendObservationScope;
+}>;
+export type GeneratedMediaStagingObjectInput = GeneratedMediaStorageRequestInput
+  & Readonly<{ stagingStorageKey: string }>;
+export type GeneratedMediaStagingObject = Readonly<{
+  stagingStorageKey: string; mimeType: typeof imageJpegCardMediaBlobMimeType; sizeBytes: number; sha256: string;
+}>;
+export type StoreGeneratedMediaStagingObjectInput = GeneratedMediaStagingObjectInput & Readonly<{
+  bytes: Buffer; mimeType: typeof imageJpegCardMediaBlobMimeType; sizeBytes: number; sha256: string;
+}>;
+export type GeneratedMediaObjectPromotionInput = GeneratedMediaStagingObjectInput & Readonly<{
+  blobStorageKey: string; mimeType: string; sizeBytes: number; sha256: string;
 }>;
 type GeneratedMediaObjectMetadata = MediaAssetObjectMetadata & Readonly<{ customMetadata: Readonly<Record<string, string>> }>;
 export class GeneratedMediaPromotionStorageTerminalError extends Error {
@@ -56,8 +67,8 @@ async function waitForRetry(signal: AbortSignal): Promise<void> {
   });
 }
 async function runS3<Result>(
-  input: GeneratedMediaObjectPromotionInput,
-  operation: "head_object" | "copy_object",
+  input: GeneratedMediaStorageRequestInput,
+  operation: "head_object" | "copy_object" | "put_object",
   run: () => Promise<Result>,
 ): Promise<Result> {
   let lastStatusCode: number | null = null;
@@ -76,8 +87,7 @@ async function runS3<Result>(
         details: {
           operation, attempt, maxAttempts: maximumS3Attempts,
           workspaceId: input.workspaceId, mediaAssetId: input.mediaAssetId,
-          statusCode: lastStatusCode,
-          errorClass: error instanceof Error ? error.name : "UnknownError",
+          statusCode: lastStatusCode, errorClass: error instanceof Error ? error.name : "UnknownError",
         },
       });
       await waitForRetry(input.signal);
@@ -107,23 +117,29 @@ function toMetadata(response: Readonly<{
 function terminal(code: string, safeMessage: string, statusCode: number | null): never {
   throw new GeneratedMediaPromotionStorageTerminalError(code, safeMessage, statusCode);
 }
-function validateInput(input: GeneratedMediaObjectPromotionInput): void {
-  const keysMatch = input.stagingStorageKey === buildMediaUploadStagingStorageKey(
+function validateStagingIdentity(input: GeneratedMediaStagingObjectInput): void {
+  if (input.stagingStorageKey !== buildMediaUploadStagingStorageKey(
     input.workspaceId, input.mediaAssetId, input.operationId,
-  ) && input.blobStorageKey === buildMediaBlobStorageKey(input.sha256);
+  )) terminal("INVALID_STORAGE_KEY", "Generated-media staging storage key is not deterministic.", null);
+}
+function validateContent(input: Readonly<{
+  mimeType: string; sizeBytes: number; sha256: string;
+}>): void {
   const proofFieldsValid = input.mimeType === input.mimeType.trim().toLowerCase()
     && /^[a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*$/u.test(input.mimeType)
     && /^[0-9a-f]{64}$/u.test(input.sha256)
     && Number.isSafeInteger(input.sizeBytes) && input.sizeBytes > 0;
-  if (!keysMatch) terminal(
-    "INVALID_STORAGE_KEY", "Generated-media promotion storage keys are not deterministic.", null,
-  );
-  if (!proofFieldsValid) terminal(
-    "INVALID_MEDIA_PROOF", "Generated-media promotion proof fields are not normalized.", null,
-  );
+  if (!proofFieldsValid) terminal("INVALID_MEDIA_PROOF", "Generated-media promotion proof fields are not normalized.", null);
+}
+function validatePromotionInput(input: GeneratedMediaObjectPromotionInput): void {
+  validateStagingIdentity(input);
+  validateContent(input);
+  if (input.blobStorageKey !== buildMediaBlobStorageKey(input.sha256)) {
+    terminal("INVALID_STORAGE_KEY", "Generated-media blob storage key is not deterministic.", null);
+  }
 }
 async function headObject(
-  input: GeneratedMediaObjectPromotionInput,
+  input: GeneratedMediaStorageRequestInput,
   key: string,
   dependencies: MediaAssetStorageDependencies,
 ): Promise<GeneratedMediaObjectMetadata | null> {
@@ -151,36 +167,66 @@ function contentMatches(input: GeneratedMediaObjectPromotionInput, metadata: Med
     && metadata.checksumSha256 === input.sha256
     && metadata.checksumType === "FULL_OBJECT";
 }
-function assertStaging(input: GeneratedMediaObjectPromotionInput, metadata: GeneratedMediaObjectMetadata): void {
+function readStagingObject(
+  input: GeneratedMediaStagingObjectInput,
+  metadata: GeneratedMediaObjectMetadata,
+): GeneratedMediaStagingObject {
+  const sha256 = metadata.checksumSha256;
+  const sizeBytes = metadata.sizeBytes;
+  const metadataKeys = Object.keys(metadata.customMetadata).sort();
+  const expectedMetadataKeys = [
+    uploadProofLastOperationIdSha256Key,
+    uploadProofMediaAssetIdKey,
+    uploadProofSha256Key,
+    uploadProofWorkspaceIdKey,
+  ].sort();
+  if (metadata.mimeType !== imageJpegCardMediaBlobMimeType
+    || typeof sizeBytes !== "number"
+    || !Number.isSafeInteger(sizeBytes)
+    || sizeBytes < 1
+    || sha256 === null
+    || !/^[0-9a-f]{64}$/u.test(sha256)
+    || metadata.checksumType !== "FULL_OBJECT") {
+    terminal("STAGING_CONTENT_INVALID", "Staged generated-media MIME type, byte size, or SHA-256 checksum is invalid.", null);
+  }
+  if (metadata.uploadProof.sha256 !== sha256) {
+    terminal("STAGING_CONTENT_INVALID", "Staged generated-media checksum does not match its immutable content proof.", null);
+  }
   const proof = createUploadProofMetadata({
     workspaceId: input.workspaceId, mediaAssetId: input.mediaAssetId,
-    lastOperationId: input.operationId, sha256: input.sha256,
+    lastOperationId: input.operationId, sha256,
   });
-  if (!contentMatches(input, metadata)) terminal(
-    "STAGING_CONTENT_INVALID",
-    "Staged generated-media MIME type, byte size, or SHA-256 does not match the job.",
-    null,
-  );
-  if (
-    metadata.uploadProof.workspaceId !== proof[uploadProofWorkspaceIdKey]
+  if (metadataKeys.length !== expectedMetadataKeys.length
+    || metadataKeys.some((key, index) => key !== expectedMetadataKeys[index])
+    || metadata.uploadProof.workspaceId !== proof[uploadProofWorkspaceIdKey]
     || metadata.uploadProof.mediaAssetId !== proof[uploadProofMediaAssetIdKey]
-    || metadata.uploadProof.lastOperationIdSha256
-      !== proof[uploadProofLastOperationIdSha256Key]
-    || metadata.uploadProof.sha256 !== proof[uploadProofSha256Key]
-  ) terminal(
-    "STAGING_PROOF_INVALID",
-    "Staged generated-media ownership proof does not match the durable job.",
-    null,
-  );
+    || metadata.uploadProof.lastOperationIdSha256 !== proof[uploadProofLastOperationIdSha256Key]) {
+    terminal("STAGING_PROOF_INVALID", "Staged generated-media ownership proof does not match the durable job.", null);
+  }
+  return {
+    stagingStorageKey: input.stagingStorageKey,
+    mimeType: imageJpegCardMediaBlobMimeType,
+    sizeBytes,
+    sha256,
+  };
+}
+function assertStaging(
+  input: GeneratedMediaObjectPromotionInput,
+  metadata: GeneratedMediaObjectMetadata,
+): void {
+  const staging = readStagingObject(input, metadata);
+  if (staging.sizeBytes !== input.sizeBytes
+    || staging.mimeType !== input.mimeType
+    || staging.sha256 !== input.sha256) {
+    terminal("STAGING_CONTENT_INVALID", "Staged generated-media MIME type, byte size, or SHA-256 does not match the job.", null);
+  }
 }
 function assertPermanent(input: GeneratedMediaObjectPromotionInput, metadata: GeneratedMediaObjectMetadata): void {
   const tenantNeutral = Object.keys(metadata.customMetadata).length === 1
     && metadata.customMetadata[uploadProofSha256Key] === input.sha256;
-  if (!contentMatches(input, metadata) || !tenantNeutral) terminal(
-    "PERMANENT_BLOB_CONFLICT",
-    "The permanent object conflicts with the job or contains tenant metadata.",
-    null,
-  );
+  if (!contentMatches(input, metadata) || !tenantNeutral) {
+    terminal("PERMANENT_BLOB_CONFLICT", "The permanent object conflicts with the job or contains tenant metadata.", null);
+  }
 }
 async function copyObject(
   input: GeneratedMediaObjectPromotionInput,
@@ -210,11 +256,68 @@ async function copyObject(
     terminal("S3_REQUEST_REJECTED", "Object storage rejected the promotion request.", statusCode);
   }
 }
+async function putStagingObject(
+  input: StoreGeneratedMediaStagingObjectInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  const bucketName = dependencies.getMediaAssetsStorageConfigFn().bucketName;
+  try {
+    await runS3(input, "put_object", async () => dependencies.s3Client.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: input.stagingStorageKey,
+        Body: input.bytes,
+        ContentType: input.mimeType,
+        ChecksumSHA256: toBase64Sha256Digest(input.sha256),
+        IfNoneMatch: "*",
+        Metadata: createUploadProofMetadata({
+          workspaceId: input.workspaceId, mediaAssetId: input.mediaAssetId,
+          lastOperationId: input.operationId, sha256: input.sha256,
+        }),
+      }),
+      { abortSignal: input.signal },
+    ));
+  } catch (error) {
+    input.signal.throwIfAborted();
+    const statusCode = getS3ErrorStatusCode(error);
+    if (statusCode === 412) return;
+    if (error instanceof GeneratedMediaPromotionStorageTransientError) throw error;
+    if (statusCode === null) throw error;
+    terminal("S3_REQUEST_REJECTED", "Object storage rejected the staging request.", statusCode);
+  }
+}
+export async function loadGeneratedMediaStagingObjectWithDependencies(
+  input: GeneratedMediaStagingObjectInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<GeneratedMediaStagingObject | null> {
+  validateStagingIdentity(input);
+  const metadata = await headObject(input, input.stagingStorageKey, dependencies);
+  return metadata === null ? null : readStagingObject(input, metadata);
+}
+export async function storeGeneratedMediaStagingObjectWithDependencies(
+  input: StoreGeneratedMediaStagingObjectInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<GeneratedMediaStagingObject> {
+  validateStagingIdentity(input);
+  validateContent(input);
+  if (input.mimeType !== imageJpegCardMediaBlobMimeType
+    || input.bytes.byteLength !== input.sizeBytes
+    || createHash("sha256").update(input.bytes).digest("hex") !== input.sha256) {
+    terminal("INVALID_MEDIA_PROOF", "Generated-media staging bytes do not match normalized metadata.", null);
+  }
+  await putStagingObject(input, dependencies);
+  const stored = await loadGeneratedMediaStagingObjectWithDependencies(input, dependencies);
+  if (stored === null) throw new GeneratedMediaPromotionStorageTransientError(404);
+  if (stored.sizeBytes !== input.sizeBytes || stored.sha256 !== input.sha256) {
+    terminal("STAGING_CONTENT_INVALID", "The deterministic staging key already contains different generated-media bytes.", null);
+  }
+  return stored;
+}
 export async function promoteGeneratedMediaObjectWithDependencies(
   input: GeneratedMediaObjectPromotionInput,
   dependencies: MediaAssetStorageDependencies,
 ): Promise<void> {
-  validateInput(input);
+  validatePromotionInput(input);
   const staging = await headObject(input, input.stagingStorageKey, dependencies);
   if (staging === null) terminal("STAGING_NOT_FOUND", "The staged object is missing.", 404);
   assertStaging(input, staging);
@@ -232,6 +335,22 @@ export async function promoteGeneratedMediaObject(
   input: GeneratedMediaObjectPromotionInput,
 ): Promise<void> {
   return promoteGeneratedMediaObjectWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+export async function loadGeneratedMediaStagingObject(
+  input: GeneratedMediaStagingObjectInput,
+): Promise<GeneratedMediaStagingObject | null> {
+  return loadGeneratedMediaStagingObjectWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+export async function storeGeneratedMediaStagingObject(
+  input: StoreGeneratedMediaStagingObjectInput,
+): Promise<GeneratedMediaStagingObject> {
+  return storeGeneratedMediaStagingObjectWithDependencies(input, {
     s3Client: getMediaAssetsS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });

--- a/apps/backend/src/mediaAssets/storage/index.ts
+++ b/apps/backend/src/mediaAssets/storage/index.ts
@@ -43,10 +43,19 @@ import {
 export {
   GeneratedMediaPromotionStorageTerminalError,
   GeneratedMediaPromotionStorageTransientError,
+  loadGeneratedMediaStagingObject,
+  loadGeneratedMediaStagingObjectWithDependencies,
   promoteGeneratedMediaObject,
   promoteGeneratedMediaObjectWithDependencies,
+  storeGeneratedMediaStagingObject,
+  storeGeneratedMediaStagingObjectWithDependencies,
 } from "./generatedPromotion";
-export type { GeneratedMediaObjectPromotionInput } from "./generatedPromotion";
+export type {
+  GeneratedMediaObjectPromotionInput,
+  GeneratedMediaStagingObject,
+  GeneratedMediaStagingObjectInput,
+  StoreGeneratedMediaStagingObjectInput,
+} from "./generatedPromotion";
 
 export { getMediaAssetsStorageConfig } from "./config";
 export type { MediaAssetsStorageConfig } from "./config";

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -529,6 +529,8 @@ export type GeneratedCardImageProviderDetails = Readonly<{
   attempt: number;
   maximumAttempts: number;
   retryDelayMs: number | null;
+  requestTimeoutMs: number;
+  retrySkippedForBudget: boolean;
   providerStatus: number | null;
   providerRequestId: string | null;
   providerErrorType: string | null;


### PR DESCRIPTION
## Summary
- stage generated images under deterministic lifecycle-managed upload keys and reuse valid staged objects
- enqueue the merged durable promotion job with claim, replica, deadline, and ambiguous-commit reconciliation
- keep permanent blob metadata tenant-neutral and distinguish provider connection timeouts from operation deadlines

## Validation
- focused generated-image tests
- real PostgreSQL integration tests
- full backend test suite: 827 passed
- backend lint and build
- git diff --check

No OpenAI image request or local AWS/CDK build/deploy was performed.