### PR TITLE
Add durable media blob lifecycle schema

### DIFF
--- a/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
@@ -1,0 +1,532 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
+import { unsafeTransaction } from "../database/unsafe";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import {
+  claimMediaBlobCleanupInExecutor, failMediaBlobWriterInExecutor,
+  finalizeMediaBlobWriterInExecutor, markMediaBlobWriterAmbiguousInExecutor,
+  MediaBlobLifecycleBusyError, MediaBlobLifecycleConflictError, MediaBlobWriterFenceError,
+  reconcileMediaBlobWriterInExecutor, reserveMediaBlobWriterInExecutor,
+  type MediaBlobWriterReservationInput,
+} from "./blobLifecycle";
+import { createImageNormalizedMediaAssetForWorkspace } from ".";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "./types";
+type LifecycleUpgradeRow = Readonly<{
+  storage_key: string; mime_type: string; size_bytes: string; normalization_version: string;
+  created_at_matches: boolean; updated_at_matches: boolean; workspace_fence: boolean; catalog_fence: boolean;
+  backend_table_access: boolean; auth_table_access: boolean;
+  backend_reserve_access: boolean; backend_fence_access: boolean;
+}>;
+function createUniqueSha256(): string { return createHash("sha256").update(randomUUID()).digest("hex"); }
+const lifecycleMigrationSql = readFileSync(resolve(
+  __dirname, "../../../../db/migrations/0091_durable_media_blob_lifecycle.sql",
+), "utf8");
+function input(workspaceId: string, mediaAssetId: string, operationId: string, sha256: string): MediaBlobWriterReservationInput {
+  return {
+    writerKind: "direct_ingestion", workspaceId, mediaAssetId, operationId,
+    sha256, storageKey: buildMediaBlobStorageKey(sha256), mimeType: "image/jpeg",
+    sizeBytes: 42, normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+  };
+}
+function hasSqlState(error: unknown, sqlState: string): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === sqlState; }
+async function createCleanupCandidate(
+  fixture: PostgresIntegrationFixture, sha256: string,
+): Promise<Readonly<{ blobId: string; lifecycleInput: MediaBlobWriterReservationInput }>> {
+  const lifecycleInput = input(fixture.workspaceId, randomUUID(), `cleanup-${randomUUID()}`, sha256);
+  const reservation = await transactionWithWorkspaceScope(
+    { userId: fixture.userId, workspaceId: fixture.workspaceId },
+    (executor) => reserveMediaBlobWriterInExecutor(executor, lifecycleInput),
+  );
+  const blobId = randomUUID();
+  await fixture.ownerPool.query(
+    `INSERT INTO content.media_blobs
+       (media_blob_id, sha256, mime_type, size_bytes, storage_key, normalization_version)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [blobId, sha256, lifecycleInput.mimeType, lifecycleInput.sizeBytes,
+      lifecycleInput.storageKey, lifecycleInput.normalizationVersion],
+  );
+  await transactionWithWorkspaceScope(
+    { userId: fixture.userId, workspaceId: fixture.workspaceId },
+    (executor) => failMediaBlobWriterInExecutor(executor, reservation.reservationToken),
+  );
+  await fixture.ownerPool.query("UPDATE content.media_blob_lifecycles SET cleanup_eligible_at = now() - interval '1 second' WHERE sha256 = $1", [sha256]);
+  return { blobId, lifecycleInput };
+}
+async function assertCleanupLeaseStartsAfterLockWait(
+  fixture: PostgresIntegrationFixture, sha256: string,
+): Promise<void> {
+  await createCleanupCandidate(fixture, sha256);
+  const blocker = await fixture.ownerPool.connect();
+  try {
+    await blocker.query("BEGIN");
+    await blocker.query(
+      "SELECT 1 FROM content.media_blob_lifecycles WHERE sha256 = $1 FOR UPDATE",
+      [sha256],
+    );
+    const claim = claimMediaBlobCleanupInExecutor(fixture.runtimePool, sha256, 1_000);
+    await blocker.query("SELECT pg_sleep(1.1)");
+    await blocker.query("UPDATE content.media_blob_lifecycles SET cleanup_eligible_at = clock_timestamp() WHERE sha256 = $1", [sha256]);
+    await blocker.query("COMMIT");
+    assert.notEqual(await claim, null);
+    assert.equal((await fixture.ownerPool.query<{ lease_started_after_lock: boolean }>(
+      "SELECT cleanup_lease_expires_at >= cleanup_eligible_at + interval '1 second' AS lease_started_after_lock FROM content.media_blob_lifecycles WHERE sha256 = $1",
+      [sha256],
+    )).rows[0]?.lease_started_after_lock, true);
+  } catch (error) {
+    await blocker.query("ROLLBACK");
+    throw error;
+  } finally {
+    blocker.release();
+  }
+}
+async function assertExpiredCleanupLeaseAllowsOperation(
+  fixture: PostgresIntegrationFixture, sha256: string, operation: () => Promise<unknown>,
+): Promise<void> {
+  assert.notEqual(await unsafeTransaction(
+    (executor) => claimMediaBlobCleanupInExecutor(executor, sha256, 1_000),
+  ), null);
+  const blocker = await fixture.ownerPool.connect();
+  try {
+    await blocker.query("BEGIN");
+    await blocker.query(
+      "SELECT 1 FROM content.media_blob_lifecycles WHERE sha256 = $1 FOR UPDATE", [sha256],
+    );
+    const outcome = operation();
+    await blocker.query("SELECT pg_sleep(1.1)");
+    await blocker.query("COMMIT");
+    await outcome;
+  } catch (error) {
+    await blocker.query("ROLLBACK");
+    throw error;
+  } finally {
+    blocker.release();
+  }
+}
+async function assertReferenceWinsCleanupClaim(
+  fixture: PostgresIntegrationFixture, sha256: string, query: string, values: ReadonlyArray<string>,
+): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  try {
+    const blockerPid = (await client.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0]?.pid;
+    if (blockerPid === undefined) throw new Error("PostgreSQL did not return the reference blocker pid.");
+    await client.query("BEGIN");
+    await client.query(query, [...values]);
+    const claim = fixture.runtimePool.query<{ lease_token: string | null }>(
+      "SELECT content.claim_media_blob_cleanup($1, $2) AS lease_token", [sha256, 60_000],
+    );
+    let claimBlocked = false;
+    for (let attempt = 0; attempt < 80 && !claimBlocked; attempt += 1) {
+      const wait = await fixture.ownerPool.query<{ blocked: boolean }>(
+        `SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE usename = 'backend_app'
+         AND query LIKE 'SELECT content.claim_media_blob_cleanup%'
+         AND $1 = ANY(pg_blocking_pids(pid))) AS blocked`, [blockerPid],
+      );
+      claimBlocked = wait.rows[0]?.blocked === true;
+      if (!claimBlocked) await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 25));
+    }
+    assert.equal(claimBlocked, true);
+    await client.query("COMMIT");
+    assert.equal((await claim).rows[0]?.lease_token, null);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixture, sha256: string): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  const blobId = randomUUID();
+  const storageKey = buildMediaBlobStorageKey(sha256);
+  try {
+    await client.query("BEGIN");
+    await client.query(`
+      DROP TRIGGER media_assets_blob_reference_fence ON content.media_assets; DROP TRIGGER package_media_assets_blob_reference_fence ON catalog.package_media_assets;
+      DROP FUNCTION content.fence_workspace_media_asset_reference(), content.fence_catalog_media_asset_reference(), content.fence_media_blob_reference(UUID);
+      DROP FUNCTION content.reserve_media_blob_writer(TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT), content.finalize_media_blob_writer(UUID, TEXT, UUID, UUID);
+      DROP FUNCTION content.mark_media_blob_writer_ambiguous(UUID), content.reconcile_media_blob_writer(UUID, TEXT, UUID, UUID, INTEGER);
+      DROP FUNCTION content.fail_media_blob_writer(UUID, INTEGER), content.claim_media_blob_cleanup(TEXT, INTEGER), content.generated_media_promotion_operation_applied(UUID, UUID);
+      DROP TABLE content.media_blob_writer_reservations, content.media_blob_lifecycles
+    `);
+    await client.query(
+      `INSERT INTO content.media_blobs (media_blob_id, sha256, mime_type, size_bytes, storage_key,
+         normalization_version, created_at, updated_at)
+       VALUES ($1, $2, 'application/octet-stream', 0, $3, 'passthrough-v1', $4, $4)`,
+      [blobId, sha256, storageKey, fixture.createdAt],
+    );
+    await client.query(lifecycleMigrationSql);
+    assert.deepEqual((await client.query<LifecycleUpgradeRow>(
+      `SELECT lifecycles.storage_key, lifecycles.mime_type, lifecycles.size_bytes::text, lifecycles.normalization_version,
+              lifecycles.created_at = $2::timestamptz AS created_at_matches, lifecycles.updated_at = $2::timestamptz AS updated_at_matches,
+              EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'media_assets_blob_reference_fence') AS workspace_fence,
+              EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'package_media_assets_blob_reference_fence') AS catalog_fence,
+              has_table_privilege('backend_app', 'content.media_blob_lifecycles', 'SELECT') AS backend_table_access,
+              has_table_privilege('auth_app', 'content.media_blob_writer_reservations', 'SELECT') AS auth_table_access,
+              has_function_privilege('backend_app', 'content.reserve_media_blob_writer(text,text,text,bigint,text,text,uuid,uuid,text)', 'EXECUTE') AS backend_reserve_access,
+              has_function_privilege('backend_app', 'content.fence_media_blob_reference(uuid)', 'EXECUTE') AS backend_fence_access
+       FROM content.media_blob_lifecycles AS lifecycles WHERE lifecycles.sha256 = $1`,
+      [sha256, fixture.createdAt],
+    )).rows[0], {
+      storage_key: storageKey, mime_type: "application/octet-stream", size_bytes: "0", normalization_version: passthroughMediaBlobNormalizationVersion,
+      created_at_matches: true, updated_at_matches: true, workspace_fence: true, catalog_fence: true,
+      backend_table_access: false, auth_table_access: false,
+      backend_reserve_access: true, backend_fence_access: false,
+    });
+    await client.query("ROLLBACK");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and global grants", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const referencedSha = createUniqueSha256();
+    const cleanupSha = createUniqueSha256();
+    const mediaRaceSha = createUniqueSha256();
+    const catalogRaceSha = createUniqueSha256();
+    const legacySha = createUniqueSha256();
+    const backfillSha = createUniqueSha256();
+    const leaseWaitSha = createUniqueSha256();
+    const referenceLeaseSha = createUniqueSha256();
+    const reservationLeaseSha = createUniqueSha256();
+    const fixtureSha256s = [
+      referencedSha, cleanupSha, mediaRaceSha, catalogRaceSha, legacySha, backfillSha, leaseWaitSha,
+      referenceLeaseSha, reservationLeaseSha,
+    ];
+    const cleanupBlobId = randomUUID();
+    const concurrentWorkspaceId = randomUUID();
+    const authorId = randomUUID();
+    const packageId = randomUUID();
+    const catalogSlug = `lifecycle-${randomUUID()}`;
+    const referencedInput = input(
+      fixture.workspaceId, randomUUID(), `lifecycle-reference-${randomUUID()}`, referencedSha,
+    );
+    const concurrentInput = input(
+      concurrentWorkspaceId, randomUUID(), `lifecycle-concurrent-${randomUUID()}`, referencedSha,
+    );
+    const cleanupInput = {
+      ...input(fixture.workspaceId, randomUUID(), "o".repeat(1_024), cleanupSha),
+      mimeType: "application/vnd.flashcards_test+json",
+      sizeBytes: 0,
+    };
+    try {
+      await fixture.ownerPool.query(
+        `WITH inserted_workspace AS (
+           INSERT INTO org.workspaces
+             (workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_replica_id, fsrs_last_operation_id)
+           VALUES ($1, 'Lifecycle concurrent', $2, $3, $4)
+           RETURNING workspace_id
+         )
+         INSERT INTO org.workspace_memberships (workspace_id, user_id, role)
+         SELECT workspace_id, $5, 'owner' FROM inserted_workspace`,
+        [concurrentWorkspaceId, fixture.createdAt, fixture.replicaId,
+          `lifecycle-workspace-${concurrentWorkspaceId}`, fixture.userId],
+      );
+      await assertLifecycleMigrationUpgrade(fixture, backfillSha);
+      await assertCleanupLeaseStartsAfterLockWait(fixture, leaseWaitSha);
+      const expiredReference = await createCleanupCandidate(fixture, referenceLeaseSha);
+      await assertExpiredCleanupLeaseAllowsOperation(
+        fixture, referenceLeaseSha,
+        () => fixture.ownerPool.query(
+          "SELECT content.fence_media_blob_reference($1)", [expiredReference.blobId],
+        ),
+      );
+      const expiredReservation = await createCleanupCandidate(fixture, reservationLeaseSha);
+      await assertExpiredCleanupLeaseAllowsOperation(
+        fixture, reservationLeaseSha,
+        () => transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, expiredReservation.lifecycleInput),
+        ),
+      );
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.outOfScopeWorkspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, {
+            ...referencedInput, workspaceId: fixture.outOfScopeWorkspaceId,
+          }),
+        ),
+        (error: unknown) => hasSqlState(error, "42501"),
+      );
+      const [first, concurrent] = await Promise.all([
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, referencedInput),
+        ),
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: concurrentWorkspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, concurrentInput),
+        ),
+      ]);
+      assert.notEqual(first.reservationToken, concurrent.reservationToken);
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, {
+            ...referencedInput, operationId: `${referencedInput.operationId}-conflict`, sizeBytes: 43,
+          }),
+        ),
+        MediaBlobLifecycleConflictError,
+      );
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, {
+            ...referencedInput, operationId: `${referencedInput.operationId}-normalization`,
+            normalizationVersion: passthroughMediaBlobNormalizationVersion,
+          }),
+        ),
+        MediaBlobLifecycleConflictError,
+      );
+      const deniedOperations: ReadonlyArray<(executor: DatabaseExecutor) => Promise<unknown>> = [
+        (executor) => finalizeMediaBlobWriterInExecutor(executor, {
+          reservationToken: first.reservationToken, sha256: referencedSha,
+          workspaceId: fixture.workspaceId, mediaAssetId: referencedInput.mediaAssetId,
+        }),
+        (executor) => markMediaBlobWriterAmbiguousInExecutor(executor, first.reservationToken),
+        (executor) => reconcileMediaBlobWriterInExecutor(executor, {
+          reservationToken: first.reservationToken, sha256: referencedSha,
+          workspaceId: fixture.workspaceId, mediaAssetId: referencedInput.mediaAssetId,
+        }),
+        (executor) => failMediaBlobWriterInExecutor(executor, first.reservationToken),
+      ];
+      for (const deniedOperation of deniedOperations) {
+        await assert.rejects(
+          transactionWithWorkspaceScope(
+            { userId: fixture.userId, workspaceId: fixture.outOfScopeWorkspaceId },
+            deniedOperation,
+          ),
+          (error: unknown) => hasSqlState(error, "42501"),
+        );
+      }
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => finalizeMediaBlobWriterInExecutor(executor, {
+            reservationToken: randomUUID(), sha256: referencedSha,
+            workspaceId: fixture.workspaceId, mediaAssetId: referencedInput.mediaAssetId,
+          }),
+        ),
+        MediaBlobWriterFenceError,
+      );
+      await createImageNormalizedMediaAssetForWorkspace(
+        fixture.userId,
+        fixture.workspaceId,
+        {
+          mediaAssetId: referencedInput.mediaAssetId, sourceUrl: null,
+          createdAt: fixture.createdAt, clientUpdatedAt: fixture.createdAt,
+          lastModifiedByReplicaId: fixture.replicaId,
+          lastOperationId: referencedInput.operationId,
+          sizeBytes: referencedInput.sizeBytes, sha256: referencedSha,
+        },
+      );
+      await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => finalizeMediaBlobWriterInExecutor(executor, {
+          reservationToken: first.reservationToken, sha256: referencedSha,
+          workspaceId: fixture.workspaceId, mediaAssetId: referencedInput.mediaAssetId,
+        }),
+      );
+      await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: concurrentWorkspaceId },
+        (executor) => failMediaBlobWriterInExecutor(executor, concurrent.reservationToken),
+      );
+      await createImageNormalizedMediaAssetForWorkspace(
+        fixture.userId, fixture.workspaceId, {
+          mediaAssetId: randomUUID(), sourceUrl: null,
+          createdAt: fixture.createdAt, clientUpdatedAt: fixture.createdAt,
+          lastModifiedByReplicaId: fixture.replicaId,
+          lastOperationId: `legacy-${randomUUID()}`, sizeBytes: 42, sha256: legacySha,
+        },
+      );
+      assert.equal((await fixture.ownerPool.query(
+        "SELECT normalization_version FROM content.media_blob_lifecycles WHERE sha256 = $1",
+        [legacySha],
+      )).rows[0]?.normalization_version, imageJpegCardMediaBlobNormalizationVersion);
+      const cleanupWriter = await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => reserveMediaBlobWriterInExecutor(executor, cleanupInput),
+      );
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_blobs
+           (media_blob_id, sha256, mime_type, size_bytes, storage_key, normalization_version)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [cleanupBlobId, cleanupSha, cleanupInput.mimeType, cleanupInput.sizeBytes,
+          cleanupInput.storageKey, cleanupInput.normalizationVersion],
+      );
+      await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        async (executor) => {
+        await markMediaBlobWriterAmbiguousInExecutor(
+          executor, cleanupWriter.reservationToken,
+        );
+        assert.equal(await claimMediaBlobCleanupInExecutor(executor, cleanupSha, 60_000), null);
+        assert.equal(
+          await reconcileMediaBlobWriterInExecutor(executor, {
+            reservationToken: cleanupWriter.reservationToken, sha256: cleanupSha,
+            workspaceId: cleanupInput.workspaceId, mediaAssetId: cleanupInput.mediaAssetId,
+          }),
+          "unreferenced",
+        );
+        },
+      );
+      assert.equal(
+        await transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reconcileMediaBlobWriterInExecutor(executor, {
+            reservationToken: cleanupWriter.reservationToken, sha256: cleanupSha,
+            workspaceId: cleanupInput.workspaceId, mediaAssetId: cleanupInput.mediaAssetId,
+          }),
+        ),
+        "unreferenced",
+      );
+      const retriedCleanupWriter = await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => reserveMediaBlobWriterInExecutor(executor, cleanupInput),
+      );
+      assert.equal(retriedCleanupWriter.state, "active");
+      assert.notEqual(retriedCleanupWriter.reservationToken, cleanupWriter.reservationToken);
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reconcileMediaBlobWriterInExecutor(executor, {
+            reservationToken: cleanupWriter.reservationToken, sha256: cleanupSha,
+            workspaceId: cleanupInput.workspaceId, mediaAssetId: cleanupInput.mediaAssetId,
+          }),
+        ),
+        MediaBlobWriterFenceError,
+      );
+      await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => failMediaBlobWriterInExecutor(executor, retriedCleanupWriter.reservationToken),
+      );
+      await fixture.ownerPool.query(
+        "UPDATE content.media_blob_lifecycles SET cleanup_eligible_at = now() - interval '1 second' WHERE sha256 = $1",
+        [cleanupSha],
+      );
+      const cleanupLease = await unsafeTransaction(
+        (executor) => claimMediaBlobCleanupInExecutor(executor, cleanupSha, 60_000),
+      );
+      assert.notEqual(cleanupLease, null);
+      assert.equal(
+        await unsafeTransaction(
+          (executor) => claimMediaBlobCleanupInExecutor(executor, cleanupSha, 60_000),
+        ),
+        null,
+      );
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, cleanupInput),
+        ),
+        MediaBlobLifecycleBusyError,
+      );
+      await fixture.ownerPool.query(
+        `WITH inserted_author AS (
+           INSERT INTO catalog.authors (author_id, slug, display_name) VALUES ($1, $3, 'Lifecycle integration')
+           RETURNING author_id
+         )
+         INSERT INTO catalog.packages (package_id, author_id, slug, title, summary, description,
+                                       language_tags, topic_tags, license)
+         SELECT $2, author_id, $3 || '-package', 'Lifecycle', 'Lifecycle', 'Lifecycle',
+                ARRAY['en'], ARRAY[]::text[], 'CC0-1.0'
+         FROM inserted_author`,
+        [authorId, packageId, catalogSlug],
+      );
+      const tombstonedAssetId = randomUUID();
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_assets
+           (media_asset_id, workspace_id, media_blob_id, source_url, created_at,
+            client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at)
+         VALUES ($1, $2, $3, NULL, $4, $4, $5, $6, $4)`,
+        [tombstonedAssetId, fixture.workspaceId, cleanupBlobId, fixture.createdAt,
+          fixture.replicaId, `tombstone-${randomUUID()}`],
+      );
+      await assert.rejects(
+        fixture.ownerPool.query(
+          "UPDATE content.media_assets SET deleted_at = NULL WHERE media_asset_id = $1",
+          [tombstonedAssetId],
+        ),
+        (error: unknown) => hasSqlState(error, "55P03"),
+      );
+      await assert.rejects(
+        fixture.ownerPool.query(
+          "UPDATE content.media_assets SET media_blob_id = $1 WHERE media_asset_id = $2",
+          [cleanupBlobId, referencedInput.mediaAssetId],
+        ),
+        (error: unknown) => hasSqlState(error, "55P03"),
+      );
+      await assert.rejects(
+        fixture.ownerPool.query(
+          `INSERT INTO catalog.package_media_assets
+             (package_media_asset_id, package_id, package_media_key, media_blob_id)
+           VALUES ($1, $2, 'claimed', $3)`,
+          [randomUUID(), packageId, cleanupBlobId],
+        ),
+        (error: unknown) => hasSqlState(error, "55P03"),
+      );
+      const mediaRace = await createCleanupCandidate(fixture, mediaRaceSha);
+      await assertReferenceWinsCleanupClaim(
+        fixture, mediaRaceSha,
+        `INSERT INTO content.media_assets
+           (media_asset_id, workspace_id, media_blob_id, source_url, created_at,
+            client_updated_at, last_modified_by_replica_id, last_operation_id)
+         VALUES ($1, $2, $3, NULL, $4, $4, $5, $6)`,
+        [mediaRace.lifecycleInput.mediaAssetId, fixture.workspaceId, mediaRace.blobId,
+          fixture.createdAt, fixture.replicaId, mediaRace.lifecycleInput.operationId],
+      );
+      const catalogRace = await createCleanupCandidate(fixture, catalogRaceSha);
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_assets
+           (media_asset_id, workspace_id, media_blob_id, source_url, created_at,
+            client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at)
+         VALUES ($1, $2, $3, NULL, $4, $4, $5, $6, $4)`,
+        [catalogRace.lifecycleInput.mediaAssetId, fixture.workspaceId, catalogRace.blobId,
+          fixture.createdAt, fixture.replicaId, catalogRace.lifecycleInput.operationId],
+      );
+      await assertReferenceWinsCleanupClaim(
+        fixture, catalogRaceSha,
+        `INSERT INTO catalog.package_media_assets
+           (package_media_asset_id, package_id, package_media_key, media_blob_id)
+         VALUES ($1, $2, $3, $4)`,
+        [randomUUID(), packageId, `race-${randomUUID()}`, catalogRace.blobId],
+      );
+    } finally {
+      await fixture.ownerPool.query("DELETE FROM catalog.packages WHERE package_id = $1", [packageId]);
+      await fixture.ownerPool.query("DELETE FROM catalog.authors WHERE author_id = $1", [authorId]);
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blob_writer_reservations WHERE sha256 = ANY($1::text[])",
+        [fixtureSha256s],
+      );
+      await fixture.ownerPool.query(
+        `DELETE FROM content.media_blobs AS blobs
+         WHERE blobs.sha256 = ANY($1::text[])
+           AND NOT EXISTS (SELECT 1 FROM content.media_assets AS assets
+                           WHERE assets.media_blob_id = blobs.media_blob_id)
+           AND NOT EXISTS (SELECT 1 FROM catalog.package_media_assets AS package_assets
+                           WHERE package_assets.media_blob_id = blobs.media_blob_id)`,
+        [fixtureSha256s],
+      );
+      await fixture.ownerPool.query(
+        `DELETE FROM content.media_blob_lifecycles AS lifecycles
+         WHERE lifecycles.sha256 = ANY($1::text[])
+           AND NOT EXISTS (SELECT 1 FROM content.media_blobs AS blobs
+                           WHERE blobs.sha256 = lifecycles.sha256)
+           AND NOT EXISTS (SELECT 1 FROM content.media_blob_writer_reservations AS reservations
+                           WHERE reservations.sha256 = lifecycles.sha256)`,
+        [fixtureSha256s],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM org.workspaces WHERE workspace_id = $1",
+        [concurrentWorkspaceId],
+      );
+    }
+  });
+});

--- a/apps/backend/src/mediaAssets/blobLifecycle.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.ts
@@ -1,0 +1,157 @@
+import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
+import { HttpError } from "../shared/errors";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+import type { MediaBlobNormalizationVersion } from "./types";
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+const mimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/u;
+const maximumOperationIdLength = 1_024;
+export const mediaBlobCleanupDelayMs = 3_600_000;
+export const mediaBlobWriterKinds = ["direct_ingestion", "multipart_completion", "generated_promotion"] as const;
+export type MediaBlobWriterKind = typeof mediaBlobWriterKinds[number];
+export type MediaBlobWriterIdentity = Readonly<{
+  writerKind: MediaBlobWriterKind; workspaceId: string; mediaAssetId: string; operationId: string;
+}>;
+export type MediaBlobWriterReservationInput = MediaBlobWriterIdentity & Readonly<{
+  sha256: string; storageKey: string; mimeType: string; sizeBytes: number;
+  normalizationVersion: MediaBlobNormalizationVersion;
+}>;
+export type MediaBlobWriterReservation = Readonly<{
+  reservationToken: string; state: "active" | "ambiguous" | "finalized";
+}>;
+export type MediaBlobWriterReconciliation = "referenced" | "unreferenced";
+type ReservationRow = Readonly<{ reservation_token: string | null; reservation_state: string | null; reservation_status: string }>;
+type BooleanRow = Readonly<{ transitioned: boolean }>;
+type ReconciliationRow = Readonly<{ reconciliation_status: string }>;
+type CleanupClaimRow = Readonly<{ lease_token: string | null }>;
+export class MediaBlobLifecycleBusyError extends HttpError {
+  constructor() { super( 503, "Media bytes are temporarily fenced by cleanup. Retry shortly.", "MEDIA_BLOB_LIFECYCLE_BUSY", ); this.name = "MediaBlobLifecycleBusyError";
+  }
+}
+export class MediaBlobLifecycleConflictError extends HttpError {
+  constructor() { super(409, "Media bytes conflict with immutable content-hash metadata.", "MEDIA_BLOB_METADATA_CONFLICT"); this.name = "MediaBlobLifecycleConflictError";
+  }
+}
+export class MediaBlobWriterFenceError extends Error {
+  constructor(action: string) { super(`Permanent media blob writer reservation rejected a stale exact token. action=${action}`); this.name = "MediaBlobWriterFenceError";
+  }
+}
+export function assertMediaBlobWriterReservationToken(reservationToken: string): void {
+  if (!uuidPattern.test(reservationToken)) { throw new TypeError("mediaBlobWriterReservationToken must be a lowercase UUID.");
+  }
+}
+function assertReservationInput(input: MediaBlobWriterReservationInput): void {
+  if (!mediaBlobWriterKinds.includes(input.writerKind)) { throw new TypeError("writerKind is unsupported.");
+  }
+  if (!uuidPattern.test(input.workspaceId) || !uuidPattern.test(input.mediaAssetId)) { throw new TypeError("workspaceId and mediaAssetId must be lowercase UUIDs.");
+  }
+  if ( input.operationId !== input.operationId.trim() || input.operationId.length < 1 || input.operationId.length > maximumOperationIdLength
+  ) { throw new TypeError(`operationId must be 1 to ${maximumOperationIdLength} trimmed characters.`);
+  }
+  if (!sha256Pattern.test(input.sha256)) { throw new TypeError("sha256 must be a normalized lowercase SHA-256 digest.");
+  }
+  if (input.storageKey !== buildMediaBlobStorageKey(input.sha256)) { throw new TypeError("storageKey does not match sha256.");
+  }
+  if (!mimeTypePattern.test(input.mimeType)) { throw new TypeError("mimeType must be a normalized lowercase MIME type.");
+  }
+  if (!Number.isSafeInteger(input.sizeBytes) || input.sizeBytes < 0) { throw new RangeError("sizeBytes must be a non-negative safe integer.");
+  }
+}
+export async function reserveMediaBlobWriterInExecutor(
+  executor: DatabaseExecutor, input: MediaBlobWriterReservationInput,
+): Promise<MediaBlobWriterReservation> {
+  assertReservationInput(input);
+  const result = await executor.query<ReservationRow>( `SELECT reservation_token, reservation_state, reservation_status FROM content.reserve_media_blob_writer($1, $2, $3, $4, $5, $6, $7, $8, $9)`, [ input.sha256, input.storageKey, input.mimeType, input.sizeBytes, input.normalizationVersion, input.writerKind, input.workspaceId, input.mediaAssetId, input.operationId, ],
+  ).catch((error: unknown) => {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "23514") throw new MediaBlobLifecycleConflictError();
+    throw error;
+  });
+  const row = result.rows[0];
+  if (row?.reservation_status === "cleanup_claimed") { throw new MediaBlobLifecycleBusyError();
+  }
+  if ( row?.reservation_status !== "reserved" || row.reservation_token === null || (row.reservation_state !== "active" && row.reservation_state !== "ambiguous" && row.reservation_state !== "finalized")
+  ) { throw new TypeError("PostgreSQL returned an invalid media blob writer reservation.");
+  }
+  assertMediaBlobWriterReservationToken(row.reservation_token);
+  return { reservationToken: row.reservation_token, state: row.reservation_state,
+  };
+}
+export async function reserveMediaBlobWriterForWorkspace(
+  userId: string, input: MediaBlobWriterReservationInput,
+): Promise<MediaBlobWriterReservation> {
+  return transactionWithWorkspaceScope( { userId, workspaceId: input.workspaceId }, async (executor) => reserveMediaBlobWriterInExecutor(executor, input),
+  );
+}
+export async function finalizeMediaBlobWriterInExecutor(
+  executor: DatabaseExecutor,
+  input: Readonly<{ reservationToken: string; sha256: string; workspaceId: string; mediaAssetId: string;
+  }>,
+): Promise<void> {
+  assertMediaBlobWriterReservationToken(input.reservationToken);
+  const result = await executor.query<BooleanRow>( `SELECT content.finalize_media_blob_writer($1, $2, $3, $4) AS transitioned`, [input.reservationToken, input.sha256, input.workspaceId, input.mediaAssetId],
+  );
+  if (result.rows[0]?.transitioned !== true) { throw new MediaBlobWriterFenceError("finalize");
+  }
+}
+export async function markMediaBlobWriterAmbiguousInExecutor(
+  executor: DatabaseExecutor, reservationToken: string,
+): Promise<boolean> {
+  assertMediaBlobWriterReservationToken(reservationToken);
+  const result = await executor.query<BooleanRow>( "SELECT content.mark_media_blob_writer_ambiguous($1) AS transitioned", [reservationToken],
+  );
+  return result.rows[0]?.transitioned === true;
+}
+export async function reconcileMediaBlobWriterInExecutor(
+  executor: DatabaseExecutor,
+  input: Readonly<{ reservationToken: string; sha256: string; workspaceId: string; mediaAssetId: string;
+  }>,
+): Promise<MediaBlobWriterReconciliation> {
+  assertMediaBlobWriterReservationToken(input.reservationToken);
+  const result = await executor.query<ReconciliationRow>( `SELECT content.reconcile_media_blob_writer($1, $2, $3, $4, $5) AS reconciliation_status`, [ input.reservationToken, input.sha256, input.workspaceId, input.mediaAssetId, mediaBlobCleanupDelayMs, ],
+  );
+  const status = result.rows[0]?.reconciliation_status;
+  if (status === "referenced" || status === "unreferenced") { return status;
+  }
+  throw new MediaBlobWriterFenceError("reconcile");
+}
+export async function failMediaBlobWriterInExecutor(
+  executor: DatabaseExecutor, reservationToken: string,
+): Promise<void> {
+  assertMediaBlobWriterReservationToken(reservationToken);
+  const result = await executor.query<BooleanRow>( "SELECT content.fail_media_blob_writer($1, $2) AS transitioned", [reservationToken, mediaBlobCleanupDelayMs],
+  );
+  if (result.rows[0]?.transitioned !== true) { throw new MediaBlobWriterFenceError("fail");
+  }
+}
+export async function markMediaBlobWriterAmbiguousForWorkspace(
+  userId: string, workspaceId: string, reservationToken: string,
+): Promise<boolean> {
+  return transactionWithWorkspaceScope( { userId, workspaceId }, async (executor) => markMediaBlobWriterAmbiguousInExecutor(executor, reservationToken),
+  );
+}
+export async function reconcileMediaBlobWriterForWorkspace(
+  userId: string,
+  input: Readonly<{ reservationToken: string; sha256: string; workspaceId: string; mediaAssetId: string;
+  }>,
+): Promise<MediaBlobWriterReconciliation> {
+  return transactionWithWorkspaceScope( { userId, workspaceId: input.workspaceId }, async (executor) => reconcileMediaBlobWriterInExecutor(executor, input),
+  );
+}
+export async function failMediaBlobWriterForWorkspace(
+  userId: string, workspaceId: string, reservationToken: string,
+): Promise<void> {
+  return transactionWithWorkspaceScope( { userId, workspaceId }, async (executor) => failMediaBlobWriterInExecutor(executor, reservationToken),
+  );
+}
+export async function claimMediaBlobCleanupInExecutor(
+  executor: DatabaseExecutor, sha256: string, leaseDurationMs: number,
+): Promise<string | null> {
+  if (!sha256Pattern.test(sha256)) throw new TypeError("sha256 must be normalized.");
+  if (!Number.isSafeInteger(leaseDurationMs) || leaseDurationMs < 1 || leaseDurationMs > 3_600_000) { throw new RangeError("leaseDurationMs must be between 1 and 3600000.");
+  }
+  const result = await executor.query<CleanupClaimRow>( "SELECT content.claim_media_blob_cleanup($1, $2) AS lease_token", [sha256, leaseDurationMs],
+  );
+  const token = result.rows[0]?.lease_token ?? null;
+  if (token !== null) assertMediaBlobWriterReservationToken(token);
+  return token;
+}

--- a/apps/backend/src/testSupport/postgresIntegration.ts
+++ b/apps/backend/src/testSupport/postgresIntegration.ts
@@ -17,7 +17,8 @@ export type PostgresIntegrationFixture = Readonly<{
 }>;
 
 type RemainingFixtureRows = Readonly<{ remaining: boolean }>;
-type MediaBlobIdRow = Readonly<{ media_blob_id: string }>;
+type MediaBlobFixtureRow = Readonly<{ media_blob_id: string; sha256: string }>;
+type Sha256Row = Readonly<{ sha256: string }>;
 
 function requireDatabaseUrl(environmentVariable: "DATABASE_URL" | "TEST_DATABASE_ADMIN_URL"): string {
   const databaseUrl = process.env[environmentVariable]?.trim();
@@ -115,11 +116,30 @@ async function deleteAndVerifyFixtureRows(fixture: PostgresIntegrationFixture): 
   const ownerClient = await fixture.ownerPool.connect();
   try {
     await ownerClient.query("BEGIN");
-    const mediaBlobRows = await ownerClient.query<MediaBlobIdRow>(
-      "SELECT DISTINCT media_blob_id FROM content.media_assets WHERE workspace_id = $1",
+    const mediaBlobRows = await ownerClient.query<MediaBlobFixtureRow>(
+      `SELECT DISTINCT media_blobs.media_blob_id, media_blobs.sha256
+       FROM content.media_assets AS media_assets
+       INNER JOIN content.media_blobs AS media_blobs
+         ON media_blobs.media_blob_id = media_assets.media_blob_id
+       WHERE media_assets.workspace_id = $1`,
       [fixture.workspaceId],
     );
+    const fixtureWorkspaceIds = [fixture.workspaceId, fixture.outOfScopeWorkspaceId];
+    const reservationRows = await ownerClient.query<Sha256Row>(
+      `SELECT DISTINCT sha256
+       FROM content.media_blob_writer_reservations
+       WHERE workspace_id = ANY($1::uuid[])`,
+      [fixtureWorkspaceIds],
+    );
+    const fixtureSha256s = [...new Set([
+      ...mediaBlobRows.rows.map((row) => row.sha256),
+      ...reservationRows.rows.map((row) => row.sha256),
+    ])];
     await ownerClient.query("DELETE FROM org.workspaces WHERE workspace_id = $1", [fixture.workspaceId]);
+    await ownerClient.query(
+      "DELETE FROM content.media_blob_writer_reservations WHERE workspace_id = ANY($1::uuid[])",
+      [fixtureWorkspaceIds],
+    );
     await ownerClient.query(
       `DELETE FROM content.media_blobs AS blobs
        WHERE blobs.media_blob_id = ANY($1::uuid[])
@@ -130,6 +150,19 @@ async function deleteAndVerifyFixtureRows(fixture: PostgresIntegrationFixture): 
          AND NOT EXISTS (SELECT 1 FROM catalog.package_media_assets AS package_assets
                          WHERE package_assets.media_blob_id = blobs.media_blob_id)`,
       [mediaBlobRows.rows.map((row) => row.media_blob_id)],
+    );
+    await ownerClient.query(
+      `DELETE FROM content.media_blob_lifecycles AS lifecycles
+       WHERE lifecycles.sha256 = ANY($1::text[])
+         AND NOT EXISTS (
+           SELECT 1 FROM content.media_blobs AS blobs
+           WHERE blobs.sha256 = lifecycles.sha256
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM content.media_blob_writer_reservations AS reservations
+           WHERE reservations.sha256 = lifecycles.sha256
+         )`,
+      [fixtureSha256s],
     );
     await ownerClient.query("DELETE FROM org.user_settings WHERE user_id = $1", [fixture.userId]);
     const verification = await ownerClient.query<RemainingFixtureRows>([
@@ -143,11 +176,20 @@ async function deleteAndVerifyFixtureRows(fixture: PostgresIntegrationFixture): 
       "AND NOT EXISTS (SELECT 1 FROM content.media_assets AS assets",
       "WHERE assets.media_blob_id = blobs.media_blob_id)",
       "AND NOT EXISTS (SELECT 1 FROM catalog.package_media_assets AS package_assets",
-      "WHERE package_assets.media_blob_id = blobs.media_blob_id)) AS remaining",
+      "WHERE package_assets.media_blob_id = blobs.media_blob_id))",
+      "OR EXISTS (SELECT 1 FROM content.media_blob_writer_reservations",
+      "WHERE workspace_id = ANY($6::uuid[]))",
+      "OR EXISTS (SELECT 1 FROM content.media_blob_lifecycles AS lifecycles",
+      "WHERE lifecycles.sha256 = ANY($7::text[])",
+      "AND NOT EXISTS (SELECT 1 FROM content.media_blobs AS blobs",
+      "WHERE blobs.sha256 = lifecycles.sha256)",
+      "AND NOT EXISTS (SELECT 1 FROM content.media_blob_writer_reservations AS reservations",
+      "WHERE reservations.sha256 = lifecycles.sha256)) AS remaining",
     ].join(" "),
       [
         fixture.workspaceId, fixture.userId, fixture.replicaId, fixture.cardId,
         mediaBlobRows.rows.map((row) => row.media_blob_id),
+        fixtureWorkspaceIds, fixtureSha256s,
       ],
     );
     if (verification.rows[0]?.remaining !== false) {

--- a/db/migrations/0091_durable_media_blob_lifecycle.sql
+++ b/db/migrations/0091_durable_media_blob_lifecycle.sql
@@ -1,0 +1,359 @@
+-- Migration status: Current / additive.
+-- Introduces: exact-token writer reservations and cleanup claims for permanent media blobs.
+-- Schemas touched/read explicitly: content, catalog, pg_catalog, public.
+CREATE TABLE content.media_blob_lifecycles (
+  sha256                    TEXT        PRIMARY KEY,
+  storage_key               TEXT        NOT NULL UNIQUE,
+  mime_type                 TEXT        NOT NULL,
+  size_bytes                BIGINT      NOT NULL CHECK (size_bytes >= 0),
+  normalization_version     TEXT        NOT NULL,
+  cleanup_eligible_at       TIMESTAMPTZ,
+  cleanup_lease_token       UUID,
+  cleanup_lease_expires_at  TIMESTAMPTZ,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+  CONSTRAINT media_blob_lifecycles_sha256_normalized CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT media_blob_lifecycles_storage_key_deterministic CHECK ( storage_key = 'media/blobs/sha256/' || substring(sha256 from 1 for 2) || '/' || substring(sha256 from 3 for 2) || '/' || sha256 ),
+  CONSTRAINT media_blob_lifecycles_mime_type_normalized CHECK ( mime_type = lower(btrim(mime_type)) AND mime_type ~ '^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$' ),
+  CONSTRAINT media_blob_lifecycles_normalization_version_supported CHECK (normalization_version IN ('passthrough-v1', 'image-jpeg-card-v1')),
+  CONSTRAINT media_blob_lifecycles_cleanup_lease_shape CHECK ( ( cleanup_lease_token IS NULL AND cleanup_lease_expires_at IS NULL ) OR ( cleanup_eligible_at IS NOT NULL AND cleanup_lease_token IS NOT NULL AND cleanup_lease_expires_at IS NOT NULL ) )
+);
+COMMENT ON TABLE content.media_blob_lifecycles IS 'Global immutable content-hash identity plus delayed cleanup eligibility and exact cleanup lease for one permanent media blob.';
+COMMENT ON COLUMN content.media_blob_lifecycles.cleanup_eligible_at IS 'Earliest time an unreferenced permanent object may be claimed for cleanup.';
+COMMENT ON COLUMN content.media_blob_lifecycles.cleanup_lease_token IS 'Exact token fencing the current cleanup claimant from writers and stale cleanup workers.';
+CREATE FUNCTION content.fence_media_blob_reference(p_media_blob_id UUID) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  media_blob content.media_blobs%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+BEGIN
+  SELECT media_blobs.* INTO media_blob
+  FROM content.media_blobs AS media_blobs
+  WHERE media_blobs.media_blob_id = p_media_blob_id
+  FOR SHARE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Media blob reference targets a missing media blob' USING ERRCODE = '23503';
+  END IF;
+  INSERT INTO content.media_blob_lifecycles
+    (sha256, storage_key, mime_type, size_bytes, normalization_version, created_at, updated_at)
+  VALUES (
+    media_blob.sha256, media_blob.storage_key, media_blob.mime_type,
+    media_blob.size_bytes, media_blob.normalization_version, media_blob.created_at, media_blob.updated_at
+  )
+  ON CONFLICT (sha256) DO NOTHING;
+  SELECT lifecycles.* INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = media_blob.sha256
+  FOR UPDATE;
+  IF NOT FOUND OR lifecycle.storage_key IS DISTINCT FROM media_blob.storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM media_blob.mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM media_blob.size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM media_blob.normalization_version
+  THEN
+    RAISE EXCEPTION 'Media blob reference conflicts with immutable lifecycle metadata' USING ERRCODE = '23514';
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL AND lifecycle.cleanup_lease_expires_at > clock_timestamp()
+  THEN
+    RAISE EXCEPTION 'Media blob reference conflicts with an active cleanup claim' USING ERRCODE = '55P03';
+  END IF;
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_eligible_at = NULL, cleanup_lease_token = NULL,
+      cleanup_lease_expires_at = NULL, updated_at = clock_timestamp()
+  WHERE lifecycles.sha256 = media_blob.sha256;
+END;
+$$;
+CREATE FUNCTION content.fence_workspace_media_asset_reference() RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.deleted_at IS NULL THEN PERFORM content.fence_media_blob_reference(NEW.media_blob_id);
+    END IF;
+  ELSIF NEW.deleted_at IS NULL AND (OLD.deleted_at IS NOT NULL OR NEW.media_blob_id IS DISTINCT FROM OLD.media_blob_id)
+  THEN
+    PERFORM content.fence_media_blob_reference(NEW.media_blob_id);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE FUNCTION content.fence_catalog_media_asset_reference() RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' OR NEW.media_blob_id IS DISTINCT FROM OLD.media_blob_id THEN
+    PERFORM content.fence_media_blob_reference(NEW.media_blob_id);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+-- Install both reference fences before backfill so their table locks close the rolling-writer snapshot gap.
+CREATE TRIGGER media_assets_blob_reference_fence BEFORE INSERT OR UPDATE ON content.media_assets
+  FOR EACH ROW EXECUTE FUNCTION content.fence_workspace_media_asset_reference();
+CREATE TRIGGER package_media_assets_blob_reference_fence BEFORE INSERT OR UPDATE ON catalog.package_media_assets
+  FOR EACH ROW EXECUTE FUNCTION content.fence_catalog_media_asset_reference();
+INSERT INTO content.media_blob_lifecycles (
+  sha256, storage_key, mime_type, size_bytes, normalization_version, created_at, updated_at
+)
+SELECT
+  media_blobs.sha256, media_blobs.storage_key, media_blobs.mime_type,
+  media_blobs.size_bytes, media_blobs.normalization_version,
+  media_blobs.created_at, media_blobs.updated_at
+FROM content.media_blobs AS media_blobs
+ON CONFLICT (sha256) DO NOTHING;
+CREATE TABLE content.media_blob_writer_reservations (
+  reservation_token   UUID        PRIMARY KEY DEFAULT public.gen_random_uuid(),
+  sha256              TEXT        NOT NULL REFERENCES content.media_blob_lifecycles(sha256) ON DELETE RESTRICT,
+  writer_kind         TEXT        NOT NULL CHECK (writer_kind IN ('direct_ingestion', 'multipart_completion', 'generated_promotion')),
+  workspace_id        UUID        NOT NULL,
+  media_asset_id      UUID        NOT NULL,
+  operation_id        TEXT        NOT NULL,
+  state               TEXT        NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'ambiguous', 'finalized', 'unreferenced')),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+  ambiguous_at        TIMESTAMPTZ,
+  CONSTRAINT media_blob_writer_reservations_identity_unique UNIQUE (writer_kind, workspace_id, media_asset_id, operation_id),
+  CONSTRAINT media_blob_writer_reservations_operation_id_safe CHECK ( operation_id = btrim(operation_id) AND char_length(operation_id) BETWEEN 1 AND 1024 ),
+  CONSTRAINT media_blob_writer_reservations_state_shape CHECK ( (state = 'active' AND ambiguous_at IS NULL) OR (state = 'ambiguous' AND ambiguous_at IS NOT NULL) OR state IN ('finalized', 'unreferenced') )
+);
+CREATE INDEX idx_media_blob_writer_reservations_sha256 ON content.media_blob_writer_reservations(sha256, reservation_token);
+CREATE INDEX idx_media_blob_lifecycles_cleanup_due ON content.media_blob_lifecycles(cleanup_eligible_at, sha256)
+  WHERE cleanup_eligible_at IS NOT NULL;
+COMMENT ON TABLE content.media_blob_writer_reservations IS 'Durable exact-token fences held from before a permanent object write until a definite database reference or reconciled terminal outcome.';
+COMMENT ON COLUMN content.media_blob_writer_reservations.ambiguous_at IS 'Timestamp when a database commit outcome became unknown. Ambiguous reservations never become cleanup-eligible by time alone.';
+CREATE FUNCTION content.reserve_media_blob_writer(p_sha256 TEXT, p_storage_key TEXT, p_mime_type TEXT, p_size_bytes BIGINT, p_normalization_version TEXT, p_writer_kind TEXT, p_workspace_id UUID, p_media_asset_id UUID, p_operation_id TEXT) RETURNS TABLE (
+  reservation_token UUID,
+  reservation_state TEXT,
+  reservation_status TEXT
+) LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+BEGIN
+  IF security.current_workspace_access_allowed(p_workspace_id) IS DISTINCT FROM true
+  THEN RAISE EXCEPTION 'Permanent media blob writer requires the active workspace scope' USING ERRCODE = '42501';
+  END IF;
+  INSERT INTO content.media_blob_lifecycles (sha256, storage_key, mime_type, size_bytes, normalization_version)
+  VALUES (p_sha256, p_storage_key, p_mime_type, p_size_bytes, p_normalization_version)
+  ON CONFLICT DO NOTHING;
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256
+  FOR UPDATE;
+  IF NOT FOUND OR lifecycle.storage_key IS DISTINCT FROM p_storage_key OR lifecycle.mime_type IS DISTINCT FROM p_mime_type OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes OR lifecycle.normalization_version IS DISTINCT FROM p_normalization_version
+  THEN RAISE EXCEPTION 'Permanent media blob immutable metadata conflicts with its content hash' USING ERRCODE = '23514';
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL AND lifecycle.cleanup_lease_expires_at > clock_timestamp()
+  THEN RETURN QUERY SELECT NULL::UUID, NULL::TEXT, 'cleanup_claimed'::TEXT; RETURN;
+  END IF;
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_eligible_at = NULL, cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = clock_timestamp()
+  WHERE lifecycles.sha256 = p_sha256;
+  INSERT INTO content.media_blob_writer_reservations ( sha256, writer_kind, workspace_id, media_asset_id, operation_id
+  )
+  VALUES ( p_sha256, p_writer_kind, p_workspace_id, p_media_asset_id, p_operation_id
+  )
+  ON CONFLICT (writer_kind, workspace_id, media_asset_id, operation_id) DO NOTHING;
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = p_writer_kind AND reservations.workspace_id = p_workspace_id AND reservations.media_asset_id = p_media_asset_id AND reservations.operation_id = p_operation_id
+  FOR UPDATE;
+  IF NOT FOUND OR reservation.sha256 IS DISTINCT FROM p_sha256 THEN RAISE EXCEPTION 'Permanent media blob writer identity conflicts with a different content hash' USING ERRCODE = '23514';
+  END IF;
+  IF reservation.state = 'unreferenced' THEN
+    UPDATE content.media_blob_writer_reservations AS reservations
+    SET reservation_token = public.gen_random_uuid(), state = 'active', ambiguous_at = NULL WHERE reservations.reservation_token = reservation.reservation_token RETURNING reservations.* INTO reservation;
+  END IF;
+  RETURN QUERY
+  SELECT reservation.reservation_token, reservation.state, 'reserved'::TEXT;
+END;
+$$;
+CREATE FUNCTION content.finalize_media_blob_writer(p_reservation_token UUID,
+  p_sha256 TEXT, p_workspace_id UUID, p_media_asset_id UUID) RETURNS BOOLEAN LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+BEGIN
+  IF security.current_workspace_access_allowed(p_workspace_id) IS DISTINCT FROM true
+  THEN RAISE EXCEPTION 'Permanent media blob finalization requires the active workspace scope' USING ERRCODE = '42501';
+  END IF;
+  PERFORM 1
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256
+  FOR UPDATE;
+  IF NOT FOUND THEN RETURN false;
+  END IF;
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token
+  FOR UPDATE;
+  IF NOT FOUND OR reservation.sha256 IS DISTINCT FROM p_sha256 OR reservation.workspace_id IS DISTINCT FROM p_workspace_id OR reservation.media_asset_id IS DISTINCT FROM p_media_asset_id
+  THEN RETURN false;
+  END IF;
+  IF reservation.state = 'finalized' THEN RETURN true;
+  ELSIF reservation.state = 'unreferenced' THEN RETURN false;
+  END IF;
+  PERFORM 1
+  FROM content.media_assets AS media_assets
+  INNER JOIN content.media_blobs AS media_blobs ON media_blobs.media_blob_id = media_assets.media_blob_id
+  WHERE media_assets.workspace_id = p_workspace_id AND media_assets.media_asset_id = p_media_asset_id AND media_assets.deleted_at IS NULL AND media_blobs.sha256 = p_sha256;
+  IF NOT FOUND THEN RETURN false;
+  END IF;
+  UPDATE content.media_blob_writer_reservations AS reservations
+  SET state = 'finalized'
+  WHERE reservations.reservation_token = p_reservation_token;
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_eligible_at = NULL, cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = clock_timestamp()
+  WHERE lifecycles.sha256 = p_sha256;
+  RETURN true;
+END;
+$$;
+CREATE FUNCTION content.mark_media_blob_writer_ambiguous(p_reservation_token UUID) RETURNS BOOLEAN LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  reservation_workspace_id UUID;
+BEGIN
+  SELECT reservations.workspace_id INTO reservation_workspace_id
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token;
+  IF NOT FOUND THEN RETURN false;
+  END IF;
+  IF security.current_workspace_access_allowed(reservation_workspace_id) IS DISTINCT FROM true
+  THEN RAISE EXCEPTION 'Permanent media blob ambiguity requires the reservation workspace scope' USING ERRCODE = '42501';
+  END IF;
+  UPDATE content.media_blob_writer_reservations
+  SET state = 'ambiguous', ambiguous_at = COALESCE(ambiguous_at, statement_timestamp())
+  WHERE reservation_token = p_reservation_token AND state NOT IN ('finalized', 'unreferenced');
+  RETURN FOUND;
+END;
+$$;
+CREATE FUNCTION content.reconcile_media_blob_writer(p_reservation_token UUID,
+  p_sha256 TEXT, p_workspace_id UUID, p_media_asset_id UUID, p_cleanup_delay_ms INTEGER) RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  reservation_found BOOLEAN;
+  exact_reference_exists BOOLEAN;
+  any_reference_exists BOOLEAN;
+  reconciled_at TIMESTAMPTZ;
+BEGIN
+  IF security.current_workspace_access_allowed(p_workspace_id) IS DISTINCT FROM true
+  THEN RAISE EXCEPTION 'Permanent media blob reconciliation requires the active workspace scope' USING ERRCODE = '42501';
+  END IF;
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000 THEN RAISE EXCEPTION 'p_cleanup_delay_ms must be between 1 and 604800000' USING ERRCODE = '22023';
+  END IF;
+  PERFORM 1
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256
+  FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale';
+  END IF;
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token
+  FOR UPDATE;
+  reservation_found := FOUND;
+  SELECT EXISTS ( SELECT 1 FROM content.media_assets AS media_assets INNER JOIN content.media_blobs AS media_blobs ON media_blobs.media_blob_id = media_assets.media_blob_id WHERE media_assets.workspace_id = p_workspace_id AND media_assets.media_asset_id = p_media_asset_id AND media_assets.deleted_at IS NULL AND media_blobs.sha256 = p_sha256
+  )
+  INTO exact_reference_exists;
+  IF NOT reservation_found THEN RETURN 'stale';
+  END IF;
+  IF reservation.sha256 IS DISTINCT FROM p_sha256 OR reservation.workspace_id IS DISTINCT FROM p_workspace_id OR reservation.media_asset_id IS DISTINCT FROM p_media_asset_id
+  THEN RETURN 'stale';
+  END IF;
+  IF reservation.state = 'finalized' THEN RETURN 'referenced';
+  ELSIF reservation.state = 'unreferenced' THEN RETURN 'unreferenced';
+  END IF;
+  IF exact_reference_exists THEN UPDATE content.media_blob_writer_reservations AS reservations SET state = 'finalized' WHERE reservations.reservation_token = p_reservation_token; UPDATE content.media_blob_lifecycles AS lifecycles SET cleanup_eligible_at = NULL, cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = clock_timestamp() WHERE lifecycles.sha256 = p_sha256; RETURN 'referenced';
+  END IF;
+  UPDATE content.media_blob_writer_reservations AS reservations SET state = 'unreferenced'
+  WHERE reservations.reservation_token = p_reservation_token;
+  SELECT EXISTS ( SELECT 1 FROM content.media_assets AS media_assets INNER JOIN content.media_blobs AS media_blobs ON media_blobs.media_blob_id = media_assets.media_blob_id WHERE media_blobs.sha256 = p_sha256 AND media_assets.deleted_at IS NULL ) OR EXISTS ( SELECT 1 FROM catalog.package_media_assets AS package_media_assets INNER JOIN content.media_blobs AS media_blobs ON media_blobs.media_blob_id = package_media_assets.media_blob_id WHERE media_blobs.sha256 = p_sha256 )
+  INTO any_reference_exists;
+  IF NOT any_reference_exists AND NOT EXISTS ( SELECT 1 FROM content.media_blob_writer_reservations AS reservations WHERE reservations.sha256 = p_sha256 AND reservations.state NOT IN ('finalized', 'unreferenced') )
+  THEN
+    reconciled_at := clock_timestamp();
+    UPDATE content.media_blob_lifecycles AS lifecycles SET cleanup_eligible_at = GREATEST( COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ), reconciled_at + (p_cleanup_delay_ms * interval '1 millisecond') ), cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = reconciled_at WHERE lifecycles.sha256 = p_sha256;
+  END IF;
+  RETURN 'unreferenced';
+END;
+$$;
+CREATE FUNCTION content.fail_media_blob_writer(p_reservation_token UUID, p_cleanup_delay_ms INTEGER) RETURNS BOOLEAN LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  reconciliation_status TEXT;
+BEGIN
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token;
+  IF NOT FOUND THEN RETURN false;
+  END IF;
+  IF security.current_workspace_access_allowed(reservation.workspace_id) IS DISTINCT FROM true
+  THEN RAISE EXCEPTION 'Permanent media blob failure requires the reservation workspace scope' USING ERRCODE = '42501';
+  END IF;
+  reconciliation_status := content.reconcile_media_blob_writer( p_reservation_token, reservation.sha256, reservation.workspace_id, reservation.media_asset_id, p_cleanup_delay_ms
+  );
+  RETURN reconciliation_status IN ('referenced', 'unreferenced');
+END;
+$$;
+CREATE FUNCTION content.claim_media_blob_cleanup(p_sha256 TEXT, p_lease_duration_ms INTEGER) RETURNS UUID LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  claimed_token UUID;
+  claim_time TIMESTAMPTZ;
+BEGIN
+  IF p_lease_duration_ms IS NULL OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000 THEN RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000' USING ERRCODE = '22023';
+  END IF;
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256
+  FOR UPDATE;
+  IF NOT FOUND THEN RETURN NULL;
+  END IF;
+  claim_time := clock_timestamp();
+  IF lifecycle.cleanup_eligible_at IS NULL OR lifecycle.cleanup_eligible_at > claim_time OR ( lifecycle.cleanup_lease_token IS NOT NULL AND lifecycle.cleanup_lease_expires_at > claim_time ) OR EXISTS ( SELECT 1 FROM content.media_blob_writer_reservations AS reservations WHERE reservations.sha256 = p_sha256 AND reservations.state NOT IN ('finalized', 'unreferenced') ) OR EXISTS ( SELECT 1 FROM content.media_assets AS media_assets INNER JOIN content.media_blobs AS media_blobs ON media_blobs.media_blob_id = media_assets.media_blob_id WHERE media_blobs.sha256 = p_sha256 AND media_assets.deleted_at IS NULL ) OR EXISTS ( SELECT 1 FROM catalog.package_media_assets AS package_media_assets INNER JOIN content.media_blobs AS media_blobs ON media_blobs.media_blob_id = package_media_assets.media_blob_id WHERE media_blobs.sha256 = p_sha256 )
+  THEN RETURN NULL;
+  END IF;
+  claimed_token := public.gen_random_uuid();
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_lease_token = claimed_token, cleanup_lease_expires_at = claim_time + (p_lease_duration_ms * interval '1 millisecond'), updated_at = claim_time
+  WHERE lifecycles.sha256 = p_sha256;
+  RETURN claimed_token;
+END;
+$$;
+CREATE FUNCTION content.generated_media_promotion_operation_applied(p_job_id UUID, p_operation_id UUID)
+RETURNS BOOLEAN LANGUAGE SQL STABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM content.generated_media_promotion_jobs AS jobs
+    WHERE jobs.job_id = p_job_id AND jobs.operation_id = p_operation_id AND jobs.state = 'applied'
+  );
+$$;
+REVOKE ALL ON TABLE
+  content.media_blob_lifecycles,
+  content.media_blob_writer_reservations
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.fence_media_blob_reference(UUID) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.fence_workspace_media_asset_reference() FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.fence_catalog_media_asset_reference() FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.reserve_media_blob_writer(TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.finalize_media_blob_writer(UUID, TEXT, UUID, UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.mark_media_blob_writer_ambiguous(UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.reconcile_media_blob_writer(UUID, TEXT, UUID, UUID, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.fail_media_blob_writer(UUID, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.claim_media_blob_cleanup(TEXT, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.generated_media_promotion_operation_applied(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION content.reserve_media_blob_writer(TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.finalize_media_blob_writer(UUID, TEXT, UUID, UUID) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.mark_media_blob_writer_ambiguous(UUID) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.reconcile_media_blob_writer(UUID, TEXT, UUID, UUID, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.fail_media_blob_writer(UUID, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.claim_media_blob_cleanup(TEXT, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.generated_media_promotion_operation_applied(UUID, UUID) TO backend_app;


### PR DESCRIPTION
## Summary

- add the durable content-hash lifecycle and exact-token writer reservation schema
- fence every current workspace and catalog media reference path against cleanup claims
- add the unused typed lifecycle boundary plus real PostgreSQL migration, concurrency, and security coverage
- clean lifecycle fixture rows in shared PostgreSQL integration teardown

## Rollout

This is the schema-first prerequisite. No production writer path calls the new migration functions yet; writer integration follows only after migration 0091 is deployed and verified.

## Validation

- fresh PostgreSQL 16: all 93 migrations transactionally applied plus the repository view
- focused lifecycle PostgreSQL integration: 1/1
- all PostgreSQL integrations: 8/8
- full backend tests: 827/827
- backend lint and build
- git diff --check and exact caller/schema/security/scope audits

Complete patch size: 1,098 changed lines.