### PR TITLE
Add media blob writer support schema

### DIFF
--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -2,16 +2,21 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import test from "node:test";
 import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../database";
+import { reserveMediaBlobWriterInExecutor } from "../../mediaAssets/blobLifecycle";
 import { testObservationScope } from "../../mediaAssets/storage/testHelpers";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+import { imageJpegCardMediaBlobNormalizationVersion } from "../../mediaAssets/types";
 import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
 import { InactiveChatRunClaimError } from "../runs/claimFence";
 import {
   claimGeneratedMediaPromotionJobs,
   enqueueGeneratedMediaPromotionJob,
   failGeneratedMediaPromotionJobWithExecutor,
+  failGeneratedMediaPromotionJobWithBlobWriterInExecutor,
   GeneratedMediaPromotionJobConflictError,
   GeneratedMediaPromotionJobLeaseLostError,
+  isGeneratedMediaPromotionOperationAppliedWithExecutor,
+  markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor,
   markGeneratedMediaPromotionJobAppliedWithExecutor,
   rescheduleGeneratedMediaPromotionJobWithExecutor,
   type ClaimedGeneratedMediaPromotionJob,
@@ -86,9 +91,9 @@ EnqueueGeneratedMediaPromotionJobInput {
     sizeBytes: 4096,
   };
 }
-async function transition(fixture: PostgresIntegrationFixture,
-  callback: (executor: DatabaseExecutor) => Promise<void>): Promise<void> {
-  await transactionWithWorkspaceScope(
+async function transition<Result>(fixture: PostgresIntegrationFixture,
+  callback: (executor: DatabaseExecutor) => Promise<Result>): Promise<Result> {
+  return transactionWithWorkspaceScope(
     { userId: fixture.userId, workspaceId: fixture.workspaceId },
     callback,
   );
@@ -194,6 +199,14 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
       GeneratedMediaPromotionJobLeaseLostError,
     );
     await applyGeneratedMediaPromotionJob(applied, Date.now() + 10_000);
+    await transition(fixture, async (executor) => {
+      assert.equal(await isGeneratedMediaPromotionOperationAppliedWithExecutor(
+        executor, applied.jobId, applied.operationId,
+      ), true);
+      assert.equal(await isGeneratedMediaPromotionOperationAppliedWithExecutor(
+        executor, applied.jobId, randomUUID(),
+      ), false);
+    });
     const appliedCard = await fixture.ownerPool.query<{ front_text: string; back_text: string }>(
       "SELECT front_text, back_text FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
       [fixture.workspaceId, fixture.cardId],
@@ -236,6 +249,27 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     const reclaimedInput = inputs[2];
     if (reclaimedInput === undefined) throw new Error("Missing reclaim input.");
     const expired = byJobId(claimed, reclaimedInput.jobId);
+    const writer = await transition(fixture, async (executor) =>
+      reserveMediaBlobWriterInExecutor(executor, {
+        writerKind: "generated_promotion", workspaceId: expired.workspaceId,
+        mediaAssetId: expired.mediaAssetId, operationId: expired.operationId,
+        sha256: expired.sha256, storageKey: expired.blobStorageKey,
+        mimeType: expired.mimeType, sizeBytes: expired.sizeBytes,
+        normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+      }));
+    const writerInput = {
+      ...expired, reservationToken: writer.reservationToken,
+      normalizationVersion: writer.normalizationVersion,
+    };
+    await assert.rejects(
+      transition(fixture, (executor) =>
+        markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor(executor, {
+          ...writerInput, leaseToken: randomUUID(),
+        })),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
+    await transition(fixture, (executor) =>
+      markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor(executor, writerInput));
     await fixture.ownerPool.query(
       `UPDATE content.generated_media_promotion_jobs
        SET updated_at = created_at,
@@ -248,6 +282,11 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
       expired.jobId,
     );
     assert.notEqual(reclaimed.leaseToken, expired.leaseToken);
+    await assert.rejects(
+      transition(fixture, (executor) =>
+        markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor(executor, writerInput)),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
     const rescheduledState = await fixture.ownerPool.query<JobStateRow>(
       `SELECT state, retry_count, last_error_code
        FROM content.generated_media_promotion_jobs WHERE job_id = $1`,
@@ -260,17 +299,28 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     });
     await assert.rejects(
       transition(fixture, async (executor) =>
-        failGeneratedMediaPromotionJobWithExecutor(executor, {
-          ...expired,
+        failGeneratedMediaPromotionJobWithBlobWriterInExecutor(executor, {
+          ...writerInput,
           error: { code: "STALE_WORKER", message: "Stale worker must be fenced." },
         })),
       GeneratedMediaPromotionJobLeaseLostError,
     );
     await transition(fixture, async (executor) =>
-      failGeneratedMediaPromotionJobWithExecutor(executor, {
-        ...reclaimed,
+      failGeneratedMediaPromotionJobWithBlobWriterInExecutor(executor, {
+        ...reclaimed, reservationToken: writer.reservationToken,
+        normalizationVersion: writer.normalizationVersion,
         error: { code: "CORRUPT_STAGING", message: "Staged object proof is invalid." },
       }));
+    assert.deepEqual((await fixture.ownerPool.query<{
+      job_state: string; reservation_state: string;
+    }>(
+      `SELECT jobs.state AS job_state, reservations.state AS reservation_state
+       FROM content.generated_media_promotion_jobs AS jobs
+       INNER JOIN content.media_blob_writer_reservations AS reservations
+         ON reservations.reservation_token = $2
+       WHERE jobs.job_id = $1`,
+      [reclaimed.jobId, writer.reservationToken],
+    )).rows[0], { job_state: "failed", reservation_state: "unreferenced" });
     const terminalInput = inputs[3];
     if (terminalInput === undefined) throw new Error("Missing terminal input.");
     const terminal = byJobId(claimed, terminalInput.jobId);

--- a/apps/backend/src/chat/cardImages/promotionJobs.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.ts
@@ -1,6 +1,14 @@
-import { transactionWithWorkspaceScopeDeadline, type DatabaseExecutor } from "../../database";
+import {
+  transactionWithWorkspaceScopeDeadline,
+  type DatabaseExecutor,
+  type SqlValue,
+} from "../../database";
 import { unsafeQueryWithDeadline } from "../../database/unsafe";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+import {
+  mediaBlobNormalizationVersions,
+  type MediaBlobNormalizationVersion,
+} from "../../mediaAssets/types";
 import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
 import { assertActiveChatRunClaimWithExecutor, type ChatRunClaimFenceParams } from "../runs/claimFence";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -50,6 +58,13 @@ export type RescheduleGeneratedMediaPromotionJobInput =
   & Readonly<{ nextAttemptAt: Date; error: SafeGeneratedMediaPromotionJobError }>;
 export type FailGeneratedMediaPromotionJobInput =
   GeneratedMediaPromotionJobLeaseInput & Readonly<{ error: SafeGeneratedMediaPromotionJobError }>;
+export type GeneratedMediaPromotionBlobWriterInput =
+  ClaimedGeneratedMediaPromotionJob & Readonly<{
+    reservationToken: string;
+    normalizationVersion: MediaBlobNormalizationVersion;
+  }>;
+export type FailGeneratedMediaPromotionJobWithBlobWriterInput =
+  GeneratedMediaPromotionBlobWriterInput & Readonly<{ error: SafeGeneratedMediaPromotionJobError }>;
 type StoredPayloadRow = Readonly<{
   job_id: string;
   operation_id: string;
@@ -80,6 +95,7 @@ type ClaimedJobRow = StoredPayloadRow & Readonly<{
 }>;
 type TransitionRow = Readonly<{ transitioned: boolean }>;
 type AppliedScopeRow = Readonly<{ scope_status: string }>;
+type OperationAppliedRow = Readonly<{ applied: boolean }>;
 type InsertedRow = Readonly<{ job_id: string }>;
 export class GeneratedMediaPromotionJobConflictError extends Error {
   readonly code = "GENERATED_MEDIA_PROMOTION_JOB_CONFLICT";
@@ -162,6 +178,24 @@ function requireSafeError(error: SafeGeneratedMediaPromotionJobError): void {
   ) {
     throw new TypeError("error.message must be 1 to 500 trimmed characters without control characters.");
   }
+}
+function requireBlobWriterInput(input: GeneratedMediaPromotionBlobWriterInput): void {
+  requirePayload(input);
+  requireUuid(input.leaseToken, "leaseToken");
+  requireUuid(input.reservationToken, "reservationToken");
+  if (!mediaBlobNormalizationVersions.some((version) => version === input.normalizationVersion)) {
+    throw new TypeError("normalizationVersion is unsupported.");
+  }
+}
+function blobWriterTransitionParams(
+  input: GeneratedMediaPromotionBlobWriterInput,
+): ReadonlyArray<SqlValue> {
+  return [
+    input.jobId, input.leaseToken, input.reservationToken, input.operationId,
+    input.userId, input.workspaceId, input.cardId, input.targetSide, input.altText,
+    input.mediaAssetId, input.replicaId, input.stagingStorageKey, input.blobStorageKey,
+    input.sha256, input.mimeType, input.sizeBytes, input.normalizationVersion,
+  ];
 }
 function toPayload(row: StoredPayloadRow): GeneratedMediaPromotionJobPayload {
   const sizeBytes = Number(row.size_bytes);
@@ -309,7 +343,7 @@ export async function claimGeneratedMediaPromotionJobs(
 async function requireTransition(
   executor: DatabaseExecutor,
   text: string,
-  params: ReadonlyArray<string | Date>,
+  params: ReadonlyArray<SqlValue>,
   jobId: string,
 ): Promise<void> {
   const result = await executor.query<TransitionRow>(text, params);
@@ -327,6 +361,53 @@ export async function markGeneratedMediaPromotionJobAppliedWithExecutor(
     executor,
     "SELECT content.mark_generated_media_promotion_job_applied($1, $2) AS transitioned",
     [input.jobId, input.leaseToken],
+    input.jobId,
+  );
+}
+export async function isGeneratedMediaPromotionOperationAppliedWithExecutor(
+  executor: DatabaseExecutor, jobId: string, operationId: string,
+): Promise<boolean> {
+  requireUuid(jobId, "jobId");
+  requireUuid(operationId, "operationId");
+  const result = await executor.query<OperationAppliedRow>(
+    "SELECT content.generated_media_promotion_operation_applied($1, $2) AS applied",
+    [jobId, operationId],
+  );
+  const applied = result.rows[0]?.applied;
+  if (typeof applied !== "boolean") {
+    throw new TypeError(`PostgreSQL returned an invalid promotion operation status. jobId=${jobId}`);
+  }
+  return applied;
+}
+export async function markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor(
+  executor: DatabaseExecutor, input: GeneratedMediaPromotionBlobWriterInput,
+): Promise<void> {
+  requireBlobWriterInput(input);
+  await requireTransition(
+    executor,
+    `SELECT content.mark_generated_media_promotion_blob_writer_ambiguous(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+       $16, $17
+     ) AS transitioned`,
+    blobWriterTransitionParams(input),
+    input.jobId,
+  );
+}
+export async function failGeneratedMediaPromotionJobWithBlobWriterInExecutor(
+  executor: DatabaseExecutor, input: FailGeneratedMediaPromotionJobWithBlobWriterInput,
+): Promise<void> {
+  requireBlobWriterInput(input);
+  requireSafeError(input.error);
+  await requireTransition(
+    executor,
+    `SELECT content.fail_generated_media_promotion_job_with_blob_writer(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+       $16, $17, $18, $19, $20
+     ) AS transitioned`,
+    [
+      ...blobWriterTransitionParams(input), input.error.code, input.error.message,
+      3_600_000,
+    ],
     input.jobId,
   );
 }

--- a/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
@@ -11,6 +11,7 @@ import {
   finalizeMediaBlobWriterInExecutor, markMediaBlobWriterAmbiguousInExecutor,
   MediaBlobLifecycleBusyError, MediaBlobLifecycleConflictError, MediaBlobWriterFenceError,
   reconcileMediaBlobWriterInExecutor, reserveMediaBlobWriterInExecutor,
+  terminalizeMediaBlobWriterFailureInExecutor,
   type MediaBlobWriterReservationInput,
 } from "./blobLifecycle";
 import { createImageNormalizedMediaAssetForWorkspace } from ".";
@@ -21,10 +22,15 @@ type LifecycleUpgradeRow = Readonly<{
   created_at_matches: boolean; updated_at_matches: boolean; workspace_fence: boolean; catalog_fence: boolean;
   backend_table_access: boolean; auth_table_access: boolean;
   backend_reserve_access: boolean; backend_fence_access: boolean;
+  backend_terminalize_access: boolean; auth_terminalize_access: boolean;
+  backend_generated_failure_access: boolean;
 }>;
 function createUniqueSha256(): string { return createHash("sha256").update(randomUUID()).digest("hex"); }
 const lifecycleMigrationSql = readFileSync(resolve(
   __dirname, "../../../../db/migrations/0091_durable_media_blob_lifecycle.sql",
+), "utf8");
+const writerSupportMigrationSql = readFileSync(resolve(
+  __dirname, "../../../../db/migrations/0092_media_blob_writer_support.sql",
 ), "utf8");
 function input(workspaceId: string, mediaAssetId: string, operationId: string, sha256: string): MediaBlobWriterReservationInput {
   return {
@@ -147,6 +153,11 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
     await client.query("BEGIN");
     await client.query(`
       DROP TRIGGER media_assets_blob_reference_fence ON content.media_assets; DROP TRIGGER package_media_assets_blob_reference_fence ON catalog.package_media_assets;
+      DROP FUNCTION content.mark_generated_media_promotion_blob_writer_ambiguous(UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TEXT);
+      DROP FUNCTION content.fail_generated_media_promotion_job_with_blob_writer(UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, TEXT, INTEGER);
+      DROP FUNCTION content.generated_media_promotion_blob_writer_lease_matches(UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT);
+      DROP FUNCTION content.terminalize_media_blob_writer_failure(UUID, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT, INTEGER);
+      DROP FUNCTION content.media_blob_writer_exact_match(UUID, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT);
       DROP FUNCTION content.fence_workspace_media_asset_reference(), content.fence_catalog_media_asset_reference(), content.fence_media_blob_reference(UUID);
       DROP FUNCTION content.reserve_media_blob_writer(TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT), content.finalize_media_blob_writer(UUID, TEXT, UUID, UUID);
       DROP FUNCTION content.mark_media_blob_writer_ambiguous(UUID), content.reconcile_media_blob_writer(UUID, TEXT, UUID, UUID, INTEGER);
@@ -160,6 +171,7 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
       [blobId, sha256, storageKey, fixture.createdAt],
     );
     await client.query(lifecycleMigrationSql);
+    await client.query(writerSupportMigrationSql);
     assert.deepEqual((await client.query<LifecycleUpgradeRow>(
       `SELECT lifecycles.storage_key, lifecycles.mime_type, lifecycles.size_bytes::text, lifecycles.normalization_version,
               lifecycles.created_at = $2::timestamptz AS created_at_matches, lifecycles.updated_at = $2::timestamptz AS updated_at_matches,
@@ -168,7 +180,10 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
               has_table_privilege('backend_app', 'content.media_blob_lifecycles', 'SELECT') AS backend_table_access,
               has_table_privilege('auth_app', 'content.media_blob_writer_reservations', 'SELECT') AS auth_table_access,
               has_function_privilege('backend_app', 'content.reserve_media_blob_writer(text,text,text,bigint,text,text,uuid,uuid,text)', 'EXECUTE') AS backend_reserve_access,
-              has_function_privilege('backend_app', 'content.fence_media_blob_reference(uuid)', 'EXECUTE') AS backend_fence_access
+              has_function_privilege('backend_app', 'content.fence_media_blob_reference(uuid)', 'EXECUTE') AS backend_fence_access,
+              has_function_privilege('backend_app', 'content.terminalize_media_blob_writer_failure(uuid,text,text,text,bigint,text,text,uuid,uuid,text,integer)', 'EXECUTE') AS backend_terminalize_access,
+              has_function_privilege('auth_app', 'content.terminalize_media_blob_writer_failure(uuid,text,text,text,bigint,text,text,uuid,uuid,text,integer)', 'EXECUTE') AS auth_terminalize_access,
+              has_function_privilege('backend_app', 'content.fail_generated_media_promotion_job_with_blob_writer(uuid,uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)', 'EXECUTE') AS backend_generated_failure_access
        FROM content.media_blob_lifecycles AS lifecycles WHERE lifecycles.sha256 = $1`,
       [sha256, fixture.createdAt],
     )).rows[0], {
@@ -176,6 +191,8 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
       created_at_matches: true, updated_at_matches: true, workspace_fence: true, catalog_fence: true,
       backend_table_access: false, auth_table_access: false,
       backend_reserve_access: true, backend_fence_access: false,
+      backend_terminalize_access: true, auth_terminalize_access: false,
+      backend_generated_failure_access: true,
     });
     await client.query("ROLLBACK");
   } catch (error) {
@@ -196,9 +213,10 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
     const leaseWaitSha = createUniqueSha256();
     const referenceLeaseSha = createUniqueSha256();
     const reservationLeaseSha = createUniqueSha256();
+    const revokedSha = createUniqueSha256();
     const fixtureSha256s = [
       referencedSha, cleanupSha, mediaRaceSha, catalogRaceSha, legacySha, backfillSha, leaseWaitSha,
-      referenceLeaseSha, reservationLeaseSha,
+      referenceLeaseSha, reservationLeaseSha, revokedSha,
     ];
     const cleanupBlobId = randomUUID();
     const concurrentWorkspaceId = randomUUID();
@@ -275,15 +293,26 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
         ),
         MediaBlobLifecycleConflictError,
       );
-      await assert.rejects(
-        transactionWithWorkspaceScope(
-          { userId: fixture.userId, workspaceId: fixture.workspaceId },
-          (executor) => reserveMediaBlobWriterInExecutor(executor, {
-            ...referencedInput, operationId: `${referencedInput.operationId}-normalization`,
-            normalizationVersion: passthroughMediaBlobNormalizationVersion,
-          }),
-        ),
-        MediaBlobLifecycleConflictError,
+      const adopted = await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => reserveMediaBlobWriterInExecutor(executor, {
+          ...referencedInput, writerKind: "multipart_completion",
+          operationId: `${referencedInput.operationId}-normalization`,
+          normalizationVersion: passthroughMediaBlobNormalizationVersion,
+        }),
+      );
+      assert.equal(adopted.normalizationVersion, imageJpegCardMediaBlobNormalizationVersion);
+      const generatedAdopted = await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        (executor) => reserveMediaBlobWriterInExecutor(executor, {
+          ...referencedInput, writerKind: "generated_promotion",
+          mediaAssetId: randomUUID(), operationId: randomUUID(),
+          normalizationVersion: passthroughMediaBlobNormalizationVersion,
+        }),
+      );
+      assert.equal(
+        generatedAdopted.normalizationVersion,
+        imageJpegCardMediaBlobNormalizationVersion,
       );
       const deniedOperations: ReadonlyArray<(executor: DatabaseExecutor) => Promise<unknown>> = [
         (executor) => finalizeMediaBlobWriterInExecutor(executor, {
@@ -498,6 +527,42 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
          VALUES ($1, $2, $3, $4)`,
         [randomUUID(), packageId, `race-${randomUUID()}`, catalogRace.blobId],
       );
+      const revokedInput = input(
+        concurrentWorkspaceId, randomUUID(), `revoked-${randomUUID()}`, revokedSha,
+      );
+      const revokedReservation = await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: concurrentWorkspaceId },
+        (executor) => reserveMediaBlobWriterInExecutor(executor, revokedInput),
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
+        [concurrentWorkspaceId, fixture.userId],
+      );
+      const exactParams: Array<string | number> = [
+        revokedReservation.reservationToken, revokedInput.sha256, revokedInput.storageKey,
+        revokedInput.mimeType, revokedInput.sizeBytes, revokedReservation.normalizationVersion,
+        revokedInput.writerKind, revokedInput.workspaceId, revokedInput.mediaAssetId,
+        revokedInput.operationId, 3_600_000,
+      ];
+      for (const [index, value] of [
+        [0, randomUUID()], [1, createUniqueSha256()],
+        [2, buildMediaBlobStorageKey(createUniqueSha256())], [3, "image/png"], [4, 43],
+        [5, passthroughMediaBlobNormalizationVersion], [7, randomUUID()],
+        [8, randomUUID()], [9, `wrong-${randomUUID()}`],
+      ] as const) {
+        const rejectedParams = [...exactParams];
+        rejectedParams[index] = value;
+        assert.equal((await fixture.runtimePool.query<{ reconciliation_status: string }>(
+          "SELECT content.terminalize_media_blob_writer_failure($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) AS reconciliation_status",
+          rejectedParams,
+        )).rows[0]?.reconciliation_status, "stale");
+      }
+      assert.equal(await unsafeTransaction(
+        (executor) => terminalizeMediaBlobWriterFailureInExecutor(executor, {
+          ...revokedInput, reservationToken: revokedReservation.reservationToken,
+          normalizationVersion: revokedReservation.normalizationVersion,
+        }),
+      ), "unreferenced");
     } finally {
       await fixture.ownerPool.query("DELETE FROM catalog.packages WHERE package_id = $1", [packageId]);
       await fixture.ownerPool.query("DELETE FROM catalog.authors WHERE author_id = $1", [authorId]);

--- a/apps/backend/src/mediaAssets/blobLifecycle.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.ts
@@ -1,7 +1,10 @@
 import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
 import { HttpError } from "../shared/errors";
 import { buildMediaBlobStorageKey } from "./storageKeys";
-import type { MediaBlobNormalizationVersion } from "./types";
+import {
+  mediaBlobNormalizationVersions,
+  type MediaBlobNormalizationVersion,
+} from "./types";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const sha256Pattern = /^[0-9a-f]{64}$/u;
 const mimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/u;
@@ -18,9 +21,16 @@ export type MediaBlobWriterReservationInput = MediaBlobWriterIdentity & Readonly
 }>;
 export type MediaBlobWriterReservation = Readonly<{
   reservationToken: string; state: "active" | "ambiguous" | "finalized";
+  normalizationVersion: MediaBlobNormalizationVersion;
+}>;
+export type MediaBlobWriterExactInput = MediaBlobWriterReservationInput & Readonly<{
+  reservationToken: string;
 }>;
 export type MediaBlobWriterReconciliation = "referenced" | "unreferenced";
-type ReservationRow = Readonly<{ reservation_token: string | null; reservation_state: string | null; reservation_status: string }>;
+type ReservationRow = Readonly<{
+  reservation_token: string | null; reservation_state: string | null;
+  reservation_status: string; normalization_version: string;
+}>;
 type BooleanRow = Readonly<{ transitioned: boolean }>;
 type ReconciliationRow = Readonly<{ reconciliation_status: string }>;
 type CleanupClaimRow = Readonly<{ lease_token: string | null }>;
@@ -56,12 +66,22 @@ function assertReservationInput(input: MediaBlobWriterReservationInput): void {
   }
   if (!Number.isSafeInteger(input.sizeBytes) || input.sizeBytes < 0) { throw new RangeError("sizeBytes must be a non-negative safe integer.");
   }
+  if (!mediaBlobNormalizationVersions.some((version) => version === input.normalizationVersion)) {
+    throw new TypeError("normalizationVersion is unsupported.");
+  }
+}
+function requireNormalizationVersion(value: string): MediaBlobNormalizationVersion {
+  const version = mediaBlobNormalizationVersions.find((candidate) => candidate === value);
+  if (version === undefined) {
+    throw new TypeError("PostgreSQL returned an invalid media blob normalization version.");
+  }
+  return version;
 }
 export async function reserveMediaBlobWriterInExecutor(
   executor: DatabaseExecutor, input: MediaBlobWriterReservationInput,
 ): Promise<MediaBlobWriterReservation> {
   assertReservationInput(input);
-  const result = await executor.query<ReservationRow>( `SELECT reservation_token, reservation_state, reservation_status FROM content.reserve_media_blob_writer($1, $2, $3, $4, $5, $6, $7, $8, $9)`, [ input.sha256, input.storageKey, input.mimeType, input.sizeBytes, input.normalizationVersion, input.writerKind, input.workspaceId, input.mediaAssetId, input.operationId, ],
+  const result = await executor.query<ReservationRow>( `SELECT reservation_token, reservation_state, reservation_status, normalization_version FROM content.reserve_media_blob_writer($1, $2, $3, $4, $5, $6, $7, $8, $9)`, [ input.sha256, input.storageKey, input.mimeType, input.sizeBytes, input.normalizationVersion, input.writerKind, input.workspaceId, input.mediaAssetId, input.operationId, ],
   ).catch((error: unknown) => {
     if (typeof error === "object" && error !== null && "code" in error && error.code === "23514") throw new MediaBlobLifecycleConflictError();
     throw error;
@@ -74,6 +94,7 @@ export async function reserveMediaBlobWriterInExecutor(
   }
   assertMediaBlobWriterReservationToken(row.reservation_token);
   return { reservationToken: row.reservation_token, state: row.reservation_state,
+    normalizationVersion: requireNormalizationVersion(row.normalization_version),
   };
 }
 export async function reserveMediaBlobWriterForWorkspace(
@@ -122,6 +143,25 @@ export async function failMediaBlobWriterInExecutor(
   );
   if (result.rows[0]?.transitioned !== true) { throw new MediaBlobWriterFenceError("fail");
   }
+}
+export async function terminalizeMediaBlobWriterFailureInExecutor(
+  executor: DatabaseExecutor, input: MediaBlobWriterExactInput,
+): Promise<MediaBlobWriterReconciliation> {
+  assertReservationInput(input);
+  assertMediaBlobWriterReservationToken(input.reservationToken);
+  const result = await executor.query<ReconciliationRow>(
+    `SELECT content.terminalize_media_blob_writer_failure(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+     ) AS reconciliation_status`,
+    [
+      input.reservationToken, input.sha256, input.storageKey, input.mimeType, input.sizeBytes,
+      input.normalizationVersion, input.writerKind, input.workspaceId, input.mediaAssetId,
+      input.operationId, mediaBlobCleanupDelayMs,
+    ],
+  );
+  const status = result.rows[0]?.reconciliation_status;
+  if (status === "referenced" || status === "unreferenced") return status;
+  throw new MediaBlobWriterFenceError("terminalize_failure");
 }
 export async function markMediaBlobWriterAmbiguousForWorkspace(
   userId: string, workspaceId: string, reservationToken: string,

--- a/db/migrations/0092_media_blob_writer_support.sql
+++ b/db/migrations/0092_media_blob_writer_support.sql
@@ -1,0 +1,510 @@
+-- Migration status: Current / additive.
+-- Introduces: canonical normalization adoption and exact generated-writer lifecycle transitions.
+-- Schemas touched/read explicitly: content, catalog, security, pg_catalog, public.
+
+DROP FUNCTION content.reserve_media_blob_writer(
+  TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT
+);
+
+CREATE FUNCTION content.reserve_media_blob_writer(
+  p_sha256 TEXT,
+  p_storage_key TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_normalization_version TEXT,
+  p_writer_kind TEXT,
+  p_workspace_id UUID,
+  p_media_asset_id UUID,
+  p_operation_id TEXT
+)
+RETURNS TABLE (
+  reservation_token UUID,
+  reservation_state TEXT,
+  reservation_status TEXT,
+  normalization_version TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+BEGIN
+  IF security.current_workspace_access_allowed(p_workspace_id) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Permanent media blob writer requires the active workspace scope'
+      USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO content.media_blob_lifecycles (
+    sha256, storage_key, mime_type, size_bytes, normalization_version
+  )
+  VALUES (
+    p_sha256, p_storage_key, p_mime_type, p_size_bytes, p_normalization_version
+  )
+  ON CONFLICT DO NOTHING;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+  THEN
+    RAISE EXCEPTION 'Permanent media blob immutable metadata conflicts with its content hash'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > clock_timestamp()
+  THEN
+    RETURN QUERY
+    SELECT NULL::UUID, NULL::TEXT, 'cleanup_claimed'::TEXT, lifecycle.normalization_version;
+    RETURN;
+  END IF;
+
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET
+    cleanup_eligible_at = NULL,
+    cleanup_lease_token = NULL,
+    cleanup_lease_expires_at = NULL,
+    updated_at = clock_timestamp()
+  WHERE lifecycles.sha256 = p_sha256;
+
+  INSERT INTO content.media_blob_writer_reservations (
+    sha256, writer_kind, workspace_id, media_asset_id, operation_id
+  )
+  VALUES (
+    p_sha256, p_writer_kind, p_workspace_id, p_media_asset_id, p_operation_id
+  )
+  ON CONFLICT (writer_kind, workspace_id, media_asset_id, operation_id) DO NOTHING;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = p_writer_kind
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_operation_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR reservation.sha256 IS DISTINCT FROM p_sha256 THEN
+    RAISE EXCEPTION 'Permanent media blob writer identity conflicts with a different content hash'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF reservation.state = 'unreferenced' THEN
+    UPDATE content.media_blob_writer_reservations AS reservations
+    SET
+      reservation_token = public.gen_random_uuid(),
+      state = 'active',
+      ambiguous_at = NULL
+    WHERE reservations.reservation_token = reservation.reservation_token
+    RETURNING reservations.* INTO reservation;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    reservation.reservation_token,
+    reservation.state,
+    'reserved'::TEXT,
+    lifecycle.normalization_version;
+END;
+$$;
+
+CREATE FUNCTION content.media_blob_writer_exact_match(
+  p_reservation_token UUID,
+  p_sha256 TEXT,
+  p_storage_key TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_normalization_version TEXT,
+  p_writer_kind TEXT,
+  p_workspace_id UUID,
+  p_media_asset_id UUID,
+  p_operation_id TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  PERFORM 1
+  FROM content.media_blob_lifecycles AS lifecycles
+  INNER JOIN content.media_blob_writer_reservations AS reservations
+    ON reservations.sha256 = lifecycles.sha256
+  WHERE reservations.reservation_token = p_reservation_token
+    AND reservations.sha256 = p_sha256
+    AND reservations.writer_kind = p_writer_kind
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_operation_id
+    AND lifecycles.storage_key = p_storage_key
+    AND lifecycles.mime_type = p_mime_type
+    AND lifecycles.size_bytes = p_size_bytes
+    AND lifecycles.normalization_version = p_normalization_version
+  FOR UPDATE OF lifecycles, reservations;
+
+  RETURN FOUND;
+END;
+$$;
+
+CREATE FUNCTION content.terminalize_media_blob_writer_failure(
+  p_reservation_token UUID,
+  p_sha256 TEXT,
+  p_storage_key TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_normalization_version TEXT,
+  p_writer_kind TEXT,
+  p_workspace_id UUID,
+  p_media_asset_id UUID,
+  p_operation_id TEXT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  reservation_state TEXT;
+  exact_reference_exists BOOLEAN;
+  any_reference_exists BOOLEAN;
+  terminalized_at TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000 THEN
+    RAISE EXCEPTION 'p_cleanup_delay_ms must be between 1 and 604800000'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF content.media_blob_writer_exact_match(
+    p_reservation_token, p_sha256, p_storage_key, p_mime_type, p_size_bytes,
+    p_normalization_version, p_writer_kind, p_workspace_id, p_media_asset_id,
+    p_operation_id
+  ) IS DISTINCT FROM true THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT reservations.state
+  INTO reservation_state
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token;
+
+  IF reservation_state = 'finalized' THEN
+    RETURN 'referenced';
+  ELSIF reservation_state = 'unreferenced' THEN
+    RETURN 'unreferenced';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM content.media_assets AS media_assets
+    INNER JOIN content.media_blobs AS media_blobs
+      ON media_blobs.media_blob_id = media_assets.media_blob_id
+    WHERE media_assets.workspace_id = p_workspace_id
+      AND media_assets.media_asset_id = p_media_asset_id
+      AND media_assets.deleted_at IS NULL
+      AND media_blobs.sha256 = p_sha256
+  )
+  INTO exact_reference_exists;
+
+  IF exact_reference_exists THEN
+    UPDATE content.media_blob_writer_reservations AS reservations
+    SET state = 'finalized'
+    WHERE reservations.reservation_token = p_reservation_token;
+
+    UPDATE content.media_blob_lifecycles AS lifecycles
+    SET
+      cleanup_eligible_at = NULL,
+      cleanup_lease_token = NULL,
+      cleanup_lease_expires_at = NULL,
+      updated_at = clock_timestamp()
+    WHERE lifecycles.sha256 = p_sha256;
+
+    RETURN 'referenced';
+  END IF;
+
+  UPDATE content.media_blob_writer_reservations AS reservations
+  SET state = 'unreferenced'
+  WHERE reservations.reservation_token = p_reservation_token;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM content.media_assets AS media_assets
+    INNER JOIN content.media_blobs AS media_blobs
+      ON media_blobs.media_blob_id = media_assets.media_blob_id
+    WHERE media_blobs.sha256 = p_sha256
+      AND media_assets.deleted_at IS NULL
+  ) OR EXISTS (
+    SELECT 1
+    FROM catalog.package_media_assets AS package_media_assets
+    INNER JOIN content.media_blobs AS media_blobs
+      ON media_blobs.media_blob_id = package_media_assets.media_blob_id
+    WHERE media_blobs.sha256 = p_sha256
+  )
+  INTO any_reference_exists;
+
+  IF NOT any_reference_exists
+    AND NOT EXISTS (
+      SELECT 1
+      FROM content.media_blob_writer_reservations AS reservations
+      WHERE reservations.sha256 = p_sha256
+        AND reservations.state NOT IN ('finalized', 'unreferenced')
+    )
+  THEN
+    terminalized_at := clock_timestamp();
+    UPDATE content.media_blob_lifecycles AS lifecycles
+    SET
+      cleanup_eligible_at = GREATEST(
+        COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ),
+        terminalized_at + (p_cleanup_delay_ms * interval '1 millisecond')
+      ),
+      cleanup_lease_token = NULL,
+      cleanup_lease_expires_at = NULL,
+      updated_at = terminalized_at
+    WHERE lifecycles.sha256 = p_sha256;
+  END IF;
+
+  RETURN 'unreferenced';
+END;
+$$;
+
+CREATE FUNCTION content.generated_media_promotion_blob_writer_lease_matches(
+  p_job_id UUID,
+  p_lease_token UUID,
+  p_operation_id UUID,
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_card_id UUID,
+  p_target_side TEXT,
+  p_alt_text TEXT,
+  p_media_asset_id UUID,
+  p_replica_id UUID,
+  p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT,
+  p_sha256 TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  PERFORM 1
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id
+    AND jobs.state = 'leased'
+    AND jobs.lease_token = p_lease_token
+    AND jobs.lease_expires_at > clock_timestamp()
+    AND jobs.operation_id = p_operation_id
+    AND jobs.user_id = p_user_id
+    AND jobs.workspace_id = p_workspace_id
+    AND jobs.card_id = p_card_id
+    AND jobs.target_side = p_target_side
+    AND jobs.alt_text = p_alt_text
+    AND jobs.media_asset_id = p_media_asset_id
+    AND jobs.replica_id = p_replica_id
+    AND jobs.staging_storage_key = p_staging_storage_key
+    AND jobs.blob_storage_key = p_blob_storage_key
+    AND jobs.sha256 = p_sha256
+    AND jobs.mime_type = p_mime_type
+    AND jobs.size_bytes = p_size_bytes
+  FOR UPDATE;
+
+  RETURN FOUND;
+END;
+$$;
+
+CREATE FUNCTION content.mark_generated_media_promotion_blob_writer_ambiguous(
+  p_job_id UUID,
+  p_lease_token UUID,
+  p_reservation_token UUID,
+  p_operation_id UUID,
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_card_id UUID,
+  p_target_side TEXT,
+  p_alt_text TEXT,
+  p_media_asset_id UUID,
+  p_replica_id UUID,
+  p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT,
+  p_sha256 TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_normalization_version TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF content.media_blob_writer_exact_match(
+    p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type, p_size_bytes,
+    p_normalization_version, 'generated_promotion', p_workspace_id, p_media_asset_id,
+    p_operation_id::TEXT
+  ) IS DISTINCT FROM true THEN
+    RETURN false;
+  END IF;
+
+  IF content.generated_media_promotion_blob_writer_lease_matches(
+    p_job_id, p_lease_token, p_operation_id, p_user_id, p_workspace_id, p_card_id,
+    p_target_side, p_alt_text, p_media_asset_id, p_replica_id, p_staging_storage_key,
+    p_blob_storage_key, p_sha256, p_mime_type, p_size_bytes
+  ) IS DISTINCT FROM true THEN
+    RETURN false;
+  END IF;
+
+  UPDATE content.media_blob_writer_reservations AS reservations
+  SET
+    state = 'ambiguous',
+    ambiguous_at = COALESCE(reservations.ambiguous_at, statement_timestamp())
+  WHERE reservations.reservation_token = p_reservation_token
+    AND reservations.state IN ('active', 'ambiguous');
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  UPDATE content.generated_media_promotion_jobs AS jobs
+  SET
+    last_error_code = 'DATABASE_COMMIT_OUTCOME_UNKNOWN',
+    last_error_message = 'PostgreSQL commit outcome requires durable writer reconciliation.',
+    updated_at = statement_timestamp()
+  WHERE jobs.job_id = p_job_id;
+
+  RETURN true;
+END;
+$$;
+
+CREATE FUNCTION content.fail_generated_media_promotion_job_with_blob_writer(
+  p_job_id UUID,
+  p_lease_token UUID,
+  p_reservation_token UUID,
+  p_operation_id UUID,
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_card_id UUID,
+  p_target_side TEXT,
+  p_alt_text TEXT,
+  p_media_asset_id UUID,
+  p_replica_id UUID,
+  p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT,
+  p_sha256 TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_normalization_version TEXT,
+  p_error_code TEXT,
+  p_error_message TEXT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  terminalization_status TEXT;
+BEGIN
+  IF content.media_blob_writer_exact_match(
+    p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type, p_size_bytes,
+    p_normalization_version, 'generated_promotion', p_workspace_id, p_media_asset_id,
+    p_operation_id::TEXT
+  ) IS DISTINCT FROM true THEN
+    RETURN false;
+  END IF;
+
+  IF content.generated_media_promotion_blob_writer_lease_matches(
+    p_job_id, p_lease_token, p_operation_id, p_user_id, p_workspace_id, p_card_id,
+    p_target_side, p_alt_text, p_media_asset_id, p_replica_id, p_staging_storage_key,
+    p_blob_storage_key, p_sha256, p_mime_type, p_size_bytes
+  ) IS DISTINCT FROM true THEN
+    RETURN false;
+  END IF;
+
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type, p_size_bytes,
+    p_normalization_version, 'generated_promotion', p_workspace_id, p_media_asset_id,
+    p_operation_id::TEXT, p_cleanup_delay_ms
+  );
+  IF terminalization_status = 'stale' THEN
+    RETURN false;
+  END IF;
+
+  UPDATE content.generated_media_promotion_jobs AS jobs
+  SET
+    state = 'failed',
+    next_attempt_at = NULL,
+    lease_token = NULL,
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_error_code = p_error_code,
+    last_error_message = p_error_message,
+    updated_at = statement_timestamp()
+  WHERE jobs.job_id = p_job_id;
+
+  RETURN true;
+END;
+$$;
+
+COMMENT ON FUNCTION content.terminalize_media_blob_writer_failure(
+  UUID, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT, INTEGER
+) IS
+  'Terminalizes one exact permanent-blob writer identity without depending on current workspace access.';
+COMMENT ON FUNCTION content.mark_generated_media_promotion_blob_writer_ambiguous(
+  UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT,
+  TEXT, TEXT, TEXT, BIGINT, TEXT
+) IS
+  'Marks one exact generated-media job lease and its exact blob reservation as commit-ambiguous.';
+COMMENT ON FUNCTION content.fail_generated_media_promotion_job_with_blob_writer(
+  UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT,
+  TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, TEXT, INTEGER
+) IS
+  'Atomically fails one exact active generated-media job lease and terminalizes its exact blob reservation.';
+
+REVOKE ALL ON FUNCTION content.reserve_media_blob_writer(
+  TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.media_blob_writer_exact_match(
+  UUID, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.generated_media_promotion_blob_writer_lease_matches(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.terminalize_media_blob_writer_failure(
+  UUID, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT, INTEGER
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.mark_generated_media_promotion_blob_writer_ambiguous(
+  UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT,
+  TEXT, TEXT, TEXT, BIGINT, TEXT
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION content.fail_generated_media_promotion_job_with_blob_writer(
+  UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT,
+  TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, TEXT, INTEGER
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION content.reserve_media_blob_writer(
+  TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.terminalize_media_blob_writer_failure(
+  UUID, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT, INTEGER
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.mark_generated_media_promotion_blob_writer_ambiguous(
+  UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT,
+  TEXT, TEXT, TEXT, BIGINT, TEXT
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.fail_generated_media_promotion_job_with_blob_writer(
+  UUID, UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT,
+  TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, TEXT, INTEGER
+) TO backend_app;


### PR DESCRIPTION
## Summary

- adopt and return the canonical media-blob normalization version during reservation
- add exact-token failure terminalization and generated-job lease-fenced ambiguity/failure transitions
- expose typed backend boundaries without enabling production writer callers
- cover the 0091 to 0092 upgrade, PostgreSQL fencing, recovery, grants, and runtime table denial

## Validation

- focused real PostgreSQL integrations
- full backend test suite
- backend lint and build
- complete migration validation through 0092
- git diff --check and caller/security/scope audits