### PR TITLE
Add generated writer revocation schema boundary

### DIFF
--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import test from "node:test";
 import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../database";
-import { reserveMediaBlobWriterInExecutor } from "../../mediaAssets/blobLifecycle";
+import {
+  reserveMediaBlobWriterInExecutor,
+  type MediaBlobWriterReservation,
+} from "../../mediaAssets/blobLifecycle";
 import { testObservationScope } from "../../mediaAssets/storage/testHelpers";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
 import { imageJpegCardMediaBlobNormalizationVersion } from "../../mediaAssets/types";
@@ -11,6 +16,7 @@ import { InactiveChatRunClaimError } from "../runs/claimFence";
 import {
   claimGeneratedMediaPromotionJobs,
   enqueueGeneratedMediaPromotionJob,
+  failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor,
   failGeneratedMediaPromotionJobWithExecutor,
   failGeneratedMediaPromotionJobWithBlobWriterInExecutor,
   GeneratedMediaPromotionJobConflictError,
@@ -33,6 +39,22 @@ type JobStateRow = Readonly<{ state: string; retry_count: number;
   last_error_code: string | null }>;
 type SecurityRow = Readonly<{ rls_enabled: boolean; policy_count: string;
   backend_can_update: boolean; backend_can_delete: boolean; auth_can_select: boolean }>;
+type RevocationStateRow = Readonly<{
+  job_state: string; job_error_code: string | null; reservation_state: string | null;
+  cleanup_scheduled: boolean | null;
+}>;
+type AccessNoOpStateRow = Readonly<{
+  job_state: string; job_error_code: string | null; reservation_state: string;
+}>;
+type RevocationUpgradeRow = Readonly<{
+  function_exists: boolean; security_definer: boolean; exact_search_path: boolean;
+  backend_execute: boolean; auth_execute: boolean; reporting_execute: boolean;
+  backend_reservation_select: boolean; backend_job_update: boolean;
+  writer_support_function_exists: boolean;
+}>;
+const revocationMigrationSql = readFileSync(resolve(
+  __dirname, "../../../../../db/migrations/0093_generated_media_writer_revocation.sql",
+), "utf8");
 async function createRun(fixture: PostgresIntegrationFixture): Promise<RunFixture> {
   const sessionId = randomUUID();
   const runId = randomUUID();
@@ -112,6 +134,140 @@ Promise<ReadonlyArray<ClaimedGeneratedMediaPromotionJob>> {
 }
 function hasPostgresCode(error: unknown, code: string): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+function uniqueSha256(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+function withSha256(
+  input: EnqueueGeneratedMediaPromotionJobInput,
+  sha256: string,
+): EnqueueGeneratedMediaPromotionJobInput {
+  return { ...input, sha256, blobStorageKey: buildMediaBlobStorageKey(sha256) };
+}
+async function reserveGeneratedWriter(
+  fixture: PostgresIntegrationFixture,
+  job: ClaimedGeneratedMediaPromotionJob,
+  sha256: string,
+): Promise<MediaBlobWriterReservation> {
+  return transition(fixture, (executor) => reserveMediaBlobWriterInExecutor(executor, {
+    writerKind: "generated_promotion",
+    workspaceId: job.workspaceId,
+    mediaAssetId: job.mediaAssetId,
+    operationId: job.operationId,
+    sha256,
+    storageKey: buildMediaBlobStorageKey(sha256),
+    mimeType: job.mimeType,
+    sizeBytes: job.sizeBytes,
+    normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+  }));
+}
+function revocationParams(job: ClaimedGeneratedMediaPromotionJob): Array<string | number> {
+  return [
+    job.jobId, job.leaseToken, job.operationId, job.userId, job.workspaceId,
+    job.cardId, job.targetSide, job.altText, job.mediaAssetId, job.replicaId,
+    job.stagingStorageKey, job.blobStorageKey, job.sha256, job.mimeType,
+    job.sizeBytes, 3_600_000,
+  ];
+}
+async function rawRevocationStatus(
+  fixture: PostgresIntegrationFixture,
+  params: ReadonlyArray<string | number>,
+): Promise<string> {
+  const result = await fixture.runtimePool.query<{ revocation_status: string }>(
+    `SELECT content.fail_generated_media_promotion_job_after_access_revocation(
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16
+     ) AS revocation_status`,
+    [...params],
+  );
+  const status = result.rows[0]?.revocation_status;
+  if (status === undefined) throw new Error("PostgreSQL returned no revocation status.");
+  return status;
+}
+async function loadAccessNoOpState(
+  fixture: PostgresIntegrationFixture,
+  jobId: string,
+  reservationToken: string,
+): Promise<AccessNoOpStateRow | undefined> {
+  const result = await fixture.ownerPool.query<AccessNoOpStateRow>(
+    `SELECT
+       jobs.state AS job_state,
+       jobs.last_error_code AS job_error_code,
+       reservations.state AS reservation_state
+     FROM content.generated_media_promotion_jobs AS jobs
+     INNER JOIN content.media_blob_writer_reservations AS reservations
+       ON reservations.reservation_token = $2
+     WHERE jobs.job_id = $1`,
+    [jobId, reservationToken],
+  );
+  return result.rows[0];
+}
+async function assertRevocationMigrationUpgrade(
+  fixture: PostgresIntegrationFixture,
+): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(`
+      DROP FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+        UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+        TEXT, TEXT, BIGINT, INTEGER
+      )
+    `);
+    await client.query(revocationMigrationSql);
+    const upgrade = await client.query<RevocationUpgradeRow>(
+      `SELECT
+         to_regprocedure(
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)'
+         ) IS NOT NULL AS function_exists,
+         procedures.prosecdef AS security_definer,
+         procedures.proconfig = ARRAY['search_path=pg_catalog'] AS exact_search_path,
+         has_function_privilege(
+           'backend_app',
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)',
+           'EXECUTE'
+         ) AS backend_execute,
+         has_function_privilege(
+           'auth_app',
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)',
+           'EXECUTE'
+         ) AS auth_execute,
+         has_function_privilege(
+           'reporting_readonly',
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)',
+           'EXECUTE'
+         ) AS reporting_execute,
+         has_table_privilege(
+           'backend_app', 'content.media_blob_writer_reservations', 'SELECT'
+         ) AS backend_reservation_select,
+         has_table_privilege(
+           'backend_app', 'content.generated_media_promotion_jobs', 'UPDATE'
+         ) AS backend_job_update,
+         to_regprocedure(
+           'content.fail_generated_media_promotion_job_with_blob_writer(uuid,uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)'
+         ) IS NOT NULL AS writer_support_function_exists
+       FROM pg_proc AS procedures
+       WHERE procedures.oid = to_regprocedure(
+         'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)'
+       )`,
+    );
+    assert.deepEqual(upgrade.rows[0], {
+      function_exists: true,
+      security_definer: true,
+      exact_search_path: true,
+      backend_execute: true,
+      auth_execute: false,
+      reporting_execute: false,
+      backend_reservation_select: false,
+      backend_job_update: false,
+      writer_support_function_exists: true,
+    });
+    await client.query("ROLLBACK");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS", async () => {
   await withPostgresIntegrationFixture(async (fixture) => {
@@ -382,6 +538,261 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
         [applied.jobId],
       ),
       (error: unknown) => hasPostgresCode(error, "23514"),
+    );
+  });
+});
+test("access revocation resolves an exact generated writer and fences stale leases", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    await assertRevocationMigrationUpgrade(fixture);
+    const run = await createRun(fixture);
+    const inputs = Array.from(
+      { length: 6 },
+      () => withSha256(createInput(fixture, run), uniqueSha256()),
+    );
+    for (const input of inputs) {
+      assert.equal((await enqueueGeneratedMediaPromotionJob(input)).outcome, "created");
+    }
+    const initiallyClaimed = await claim("revocation-integration-initial", inputs.length);
+    const rescheduled = byJobId(initiallyClaimed, inputs[0]?.jobId ?? "");
+    const ambiguous = byJobId(initiallyClaimed, inputs[1]?.jobId ?? "");
+    const absent = byJobId(initiallyClaimed, inputs[2]?.jobId ?? "");
+    const expired = byJobId(initiallyClaimed, inputs[3]?.jobId ?? "");
+    const applied = byJobId(initiallyClaimed, inputs[4]?.jobId ?? "");
+    const metadataConflict = byJobId(initiallyClaimed, inputs[5]?.jobId ?? "");
+    const rescheduledWriter = await reserveGeneratedWriter(
+      fixture, rescheduled, rescheduled.sha256,
+    );
+    const ambiguousWriter = await reserveGeneratedWriter(
+      fixture, ambiguous, ambiguous.sha256,
+    );
+    const expiredWriter = await reserveGeneratedWriter(
+      fixture, expired, expired.sha256,
+    );
+    const conflictingSha256 = uniqueSha256();
+    const metadataConflictWriter = await reserveGeneratedWriter(
+      fixture, metadataConflict, conflictingSha256,
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, rescheduled,
+      ),
+      "access_active",
+    );
+    assert.deepEqual(
+      await loadAccessNoOpState(
+        fixture, rescheduled.jobId, rescheduledWriter.reservationToken,
+      ),
+      {
+        job_state: "leased",
+        job_error_code: null,
+        reservation_state: "active",
+      },
+    );
+    await transition(fixture, (executor) =>
+      markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor(executor, {
+        ...ambiguous,
+        reservationToken: ambiguousWriter.reservationToken,
+        normalizationVersion: ambiguousWriter.normalizationVersion,
+      }));
+    await transition(fixture, (executor) =>
+      markGeneratedMediaPromotionJobAppliedWithExecutor(executor, applied));
+    await transition(fixture, (executor) =>
+      rescheduleGeneratedMediaPromotionJobWithExecutor(executor, {
+        ...rescheduled,
+        nextAttemptAt: new Date(),
+        error: {
+          code: "DATABASE_TRANSIENT",
+          message: "Reservation commit outcome requires deterministic replay.",
+        },
+      }));
+    await fixture.ownerPool.query(
+      `UPDATE content.generated_media_promotion_jobs
+       SET updated_at = created_at,
+           lease_expires_at = created_at + interval '1 millisecond'
+       WHERE job_id = $1`,
+      [expired.jobId],
+    );
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
+      [fixture.workspaceId, fixture.userId],
+    );
+    await fixture.ownerPool.query(
+      "INSERT INTO org.workspace_memberships (workspace_id, user_id, role) VALUES ($1, $2, 'owner')",
+      [fixture.workspaceId, fixture.userId],
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, ambiguous,
+      ),
+      "access_active",
+    );
+    assert.deepEqual(
+      await loadAccessNoOpState(
+        fixture, ambiguous.jobId, ambiguousWriter.reservationToken,
+      ),
+      {
+        job_state: "leased",
+        job_error_code: "DATABASE_COMMIT_OUTCOME_UNKNOWN",
+        reservation_state: "ambiguous",
+      },
+    );
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
+      [fixture.workspaceId, fixture.userId],
+    );
+    await assert.rejects(
+      failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, expired,
+      ),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
+    const reclaimed = await claim("revocation-integration-reclaimer", 2);
+    const reclaimedRescheduled = byJobId(reclaimed, rescheduled.jobId);
+    const replacement = byJobId(reclaimed, expired.jobId);
+    assert.notEqual(replacement.leaseToken, expired.leaseToken);
+    await assert.rejects(
+      failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, expired,
+      ),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
+    const mismatchedPayloadParams = revocationParams(reclaimedRescheduled);
+    mismatchedPayloadParams[6] = reclaimedRescheduled.targetSide === "front" ? "back" : "front";
+    assert.equal(
+      await rawRevocationStatus(fixture, mismatchedPayloadParams),
+      "stale",
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, reclaimedRescheduled,
+      ),
+      "failed",
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, ambiguous,
+      ),
+      "failed",
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, absent,
+      ),
+      "failed",
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, replacement,
+      ),
+      "failed",
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, applied,
+      ),
+      "applied",
+    );
+    const wrongIdentityParams = revocationParams(metadataConflict);
+    const wrongMediaAssetId = randomUUID();
+    wrongIdentityParams[8] = wrongMediaAssetId;
+    wrongIdentityParams[10] = buildMediaUploadStagingStorageKey(
+      metadataConflict.workspaceId,
+      wrongMediaAssetId,
+      metadataConflict.operationId,
+    );
+    assert.equal(await rawRevocationStatus(fixture, wrongIdentityParams), "stale");
+    await assert.rejects(
+      failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+        fixture.runtimePool, metadataConflict,
+      ),
+      GeneratedMediaPromotionJobLeaseLostError,
+    );
+    for (const [job, reservation] of [
+      [reclaimedRescheduled, rescheduledWriter],
+      [ambiguous, ambiguousWriter],
+      [replacement, expiredWriter],
+    ] as const) {
+      const state = await fixture.ownerPool.query<RevocationStateRow>(
+        `SELECT
+           jobs.state AS job_state,
+           jobs.last_error_code AS job_error_code,
+           reservations.state AS reservation_state,
+           lifecycles.cleanup_eligible_at IS NOT NULL AS cleanup_scheduled
+         FROM content.generated_media_promotion_jobs AS jobs
+         INNER JOIN content.media_blob_writer_reservations AS reservations
+           ON reservations.reservation_token = $2
+         INNER JOIN content.media_blob_lifecycles AS lifecycles
+           ON lifecycles.sha256 = reservations.sha256
+         WHERE jobs.job_id = $1`,
+        [job.jobId, reservation.reservationToken],
+      );
+      assert.deepEqual(state.rows[0], {
+        job_state: "failed",
+        job_error_code: "WORKSPACE_ACCESS_REVOKED",
+        reservation_state: "unreferenced",
+        cleanup_scheduled: true,
+      });
+    }
+    assert.deepEqual((await fixture.ownerPool.query<RevocationStateRow>(
+      `SELECT
+         jobs.state AS job_state,
+         jobs.last_error_code AS job_error_code,
+         NULL::TEXT AS reservation_state,
+         NULL::BOOLEAN AS cleanup_scheduled
+       FROM content.generated_media_promotion_jobs AS jobs
+       WHERE jobs.job_id = $1
+         AND NOT EXISTS (
+           SELECT 1
+           FROM content.media_blob_writer_reservations AS reservations
+           WHERE reservations.writer_kind = 'generated_promotion'
+             AND reservations.workspace_id = jobs.workspace_id
+             AND reservations.media_asset_id = jobs.media_asset_id
+             AND reservations.operation_id = jobs.operation_id::TEXT
+         )`,
+      [absent.jobId],
+    )).rows[0], {
+      job_state: "failed",
+      job_error_code: "WORKSPACE_ACCESS_REVOKED",
+      reservation_state: null,
+      cleanup_scheduled: null,
+    });
+    assert.deepEqual((await fixture.ownerPool.query<{
+      state: string; last_error_code: string | null;
+    }>(
+      `SELECT state, last_error_code
+       FROM content.generated_media_promotion_jobs
+       WHERE job_id = $1`,
+      [applied.jobId],
+    )).rows[0], { state: "applied", last_error_code: null });
+    assert.deepEqual((await fixture.ownerPool.query<{
+      job_state: string; reservation_state: string; reservation_sha256: string;
+    }>(
+      `SELECT
+         jobs.state AS job_state,
+         reservations.state AS reservation_state,
+         reservations.sha256 AS reservation_sha256
+       FROM content.generated_media_promotion_jobs AS jobs
+       INNER JOIN content.media_blob_writer_reservations AS reservations
+         ON reservations.reservation_token = $2
+       WHERE jobs.job_id = $1`,
+      [metadataConflict.jobId, metadataConflictWriter.reservationToken],
+    )).rows[0], {
+      job_state: "leased",
+      reservation_state: "active",
+      reservation_sha256: conflictingSha256,
+    });
+    await assert.rejects(
+      fixture.runtimePool.query(
+        "SELECT reservation_token FROM content.media_blob_writer_reservations LIMIT 1",
+      ),
+      (error: unknown) => hasPostgresCode(error, "42501"),
+    );
+    await assert.rejects(
+      fixture.runtimePool.query(
+        "UPDATE content.generated_media_promotion_jobs SET retry_count = retry_count WHERE job_id = $1",
+        [metadataConflict.jobId],
+      ),
+      (error: unknown) => hasPostgresCode(error, "42501"),
     );
   });
 });

--- a/apps/backend/src/chat/cardImages/promotionJobs.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.ts
@@ -65,6 +65,8 @@ export type GeneratedMediaPromotionBlobWriterInput =
   }>;
 export type FailGeneratedMediaPromotionJobWithBlobWriterInput =
   GeneratedMediaPromotionBlobWriterInput & Readonly<{ error: SafeGeneratedMediaPromotionJobError }>;
+export type GeneratedMediaPromotionAccessRevocationOutcome =
+  "access_active" | "applied" | "failed";
 type StoredPayloadRow = Readonly<{
   job_id: string;
   operation_id: string;
@@ -96,6 +98,7 @@ type ClaimedJobRow = StoredPayloadRow & Readonly<{
 type TransitionRow = Readonly<{ transitioned: boolean }>;
 type AppliedScopeRow = Readonly<{ scope_status: string }>;
 type OperationAppliedRow = Readonly<{ applied: boolean }>;
+type AccessRevocationRow = Readonly<{ revocation_status: string }>;
 type InsertedRow = Readonly<{ job_id: string }>;
 export class GeneratedMediaPromotionJobConflictError extends Error {
   readonly code = "GENERATED_MEDIA_PROMOTION_JOB_CONFLICT";
@@ -409,6 +412,33 @@ export async function failGeneratedMediaPromotionJobWithBlobWriterInExecutor(
       3_600_000,
     ],
     input.jobId,
+  );
+}
+export async function failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+  executor: DatabaseExecutor,
+  input: ClaimedGeneratedMediaPromotionJob,
+): Promise<GeneratedMediaPromotionAccessRevocationOutcome> {
+  requirePayload(input);
+  requireUuid(input.leaseToken, "leaseToken");
+  const result = await executor.query<AccessRevocationRow>(
+    `SELECT content.fail_generated_media_promotion_job_after_access_revocation(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+     ) AS revocation_status`,
+    [
+      input.jobId, input.leaseToken, input.operationId, input.userId,
+      input.workspaceId, input.cardId, input.targetSide, input.altText,
+      input.mediaAssetId, input.replicaId, input.stagingStorageKey,
+      input.blobStorageKey, input.sha256, input.mimeType, input.sizeBytes,
+      3_600_000,
+    ],
+  );
+  const status = result.rows[0]?.revocation_status;
+  if (status === "access_active" || status === "applied" || status === "failed") return status;
+  if (status === "stale") {
+    throw new GeneratedMediaPromotionJobLeaseLostError(input.jobId);
+  }
+  throw new TypeError(
+    `PostgreSQL returned an invalid promotion access-revocation status. jobId=${input.jobId}`,
   );
 }
 export async function applyGeneratedMediaPromotionJobScopeWithExecutor(

--- a/db/migrations/0093_generated_media_writer_revocation.sql
+++ b/db/migrations/0093_generated_media_writer_revocation.sql
@@ -1,0 +1,193 @@
+-- Migration status: Current / additive.
+-- Introduces: exact generated-writer resolution and terminalization after workspace access revocation.
+-- Schemas touched/read explicitly: content, org, pg_catalog.
+
+CREATE FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  p_job_id UUID,
+  p_lease_token UUID,
+  p_operation_id UUID,
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_card_id UUID,
+  p_target_side TEXT,
+  p_alt_text TEXT,
+  p_media_asset_id UUID,
+  p_replica_id UUID,
+  p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT,
+  p_sha256 TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  job_snapshot content.generated_media_promotion_jobs%ROWTYPE;
+  job content.generated_media_promotion_jobs%ROWTYPE;
+  reservation_found BOOLEAN;
+  reservation_token UUID;
+  reservation_sha256 TEXT;
+  reservation_state TEXT;
+  lifecycle_storage_key TEXT;
+  lifecycle_mime_type TEXT;
+  lifecycle_size_bytes BIGINT;
+  lifecycle_normalization_version TEXT;
+  terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000 THEN
+    RAISE EXCEPTION 'p_cleanup_delay_ms must be between 1 and 604800000'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT jobs.*
+  INTO job_snapshot
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id;
+
+  IF NOT FOUND THEN
+    RETURN 'stale';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(
+      job_snapshot.user_id || ':' || job_snapshot.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  SELECT
+    reservations.reservation_token,
+    reservations.sha256,
+    reservations.state,
+    lifecycles.storage_key,
+    lifecycles.mime_type,
+    lifecycles.size_bytes,
+    lifecycles.normalization_version
+  INTO
+    reservation_token,
+    reservation_sha256,
+    reservation_state,
+    lifecycle_storage_key,
+    lifecycle_mime_type,
+    lifecycle_size_bytes,
+    lifecycle_normalization_version
+  FROM content.media_blob_writer_reservations AS reservations
+  INNER JOIN content.media_blob_lifecycles AS lifecycles
+    ON lifecycles.sha256 = reservations.sha256
+  WHERE reservations.writer_kind = 'generated_promotion'
+    AND reservations.workspace_id = job_snapshot.workspace_id
+    AND reservations.media_asset_id = job_snapshot.media_asset_id
+    AND reservations.operation_id = job_snapshot.operation_id::TEXT
+  FOR UPDATE OF lifecycles, reservations;
+  reservation_found := FOUND;
+
+  SELECT jobs.*
+  INTO job
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR job.operation_id IS DISTINCT FROM p_operation_id
+    OR job.user_id IS DISTINCT FROM p_user_id
+    OR job.workspace_id IS DISTINCT FROM p_workspace_id
+    OR job.card_id IS DISTINCT FROM p_card_id
+    OR job.target_side IS DISTINCT FROM p_target_side
+    OR job.alt_text IS DISTINCT FROM p_alt_text
+    OR job.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR job.replica_id IS DISTINCT FROM p_replica_id
+    OR job.staging_storage_key IS DISTINCT FROM p_staging_storage_key
+    OR job.blob_storage_key IS DISTINCT FROM p_blob_storage_key
+    OR job.sha256 IS DISTINCT FROM p_sha256
+    OR job.mime_type IS DISTINCT FROM p_mime_type
+    OR job.size_bytes IS DISTINCT FROM p_size_bytes
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  IF job.state = 'applied' THEN
+    RETURN 'applied';
+  END IF;
+
+  IF job.state IS DISTINCT FROM 'leased'
+    OR job.lease_token IS DISTINCT FROM p_lease_token
+    OR job.lease_expires_at <= clock_timestamp()
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = job.workspace_id
+      AND memberships.user_id = job.user_id
+  ) THEN
+    RETURN 'access_active';
+  END IF;
+
+  IF reservation_found THEN
+    IF reservation_sha256 IS DISTINCT FROM job.sha256
+      OR reservation_state NOT IN ('active', 'ambiguous', 'finalized', 'unreferenced')
+      OR lifecycle_storage_key IS DISTINCT FROM job.blob_storage_key
+      OR lifecycle_mime_type IS DISTINCT FROM job.mime_type
+      OR lifecycle_size_bytes IS DISTINCT FROM job.size_bytes
+      OR lifecycle_normalization_version NOT IN ('passthrough-v1', 'image-jpeg-card-v1')
+    THEN
+      RETURN 'stale';
+    END IF;
+
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      reservation_token,
+      reservation_sha256,
+      lifecycle_storage_key,
+      lifecycle_mime_type,
+      lifecycle_size_bytes,
+      lifecycle_normalization_version,
+      'generated_promotion',
+      job.workspace_id,
+      job.media_asset_id,
+      job.operation_id::TEXT,
+      p_cleanup_delay_ms
+    );
+
+    IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN
+      RETURN 'stale';
+    END IF;
+  END IF;
+
+  UPDATE content.generated_media_promotion_jobs AS jobs
+  SET
+    state = 'failed',
+    next_attempt_at = NULL,
+    lease_token = NULL,
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_error_code = 'WORKSPACE_ACCESS_REVOKED',
+    last_error_message =
+      'Workspace access was revoked before generated-media promotion completed.',
+    updated_at = statement_timestamp()
+  WHERE jobs.job_id = job.job_id;
+
+  RETURN 'failed';
+END;
+$$;
+
+COMMENT ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, INTEGER
+) IS
+  'Atomically resolves and terminalizes one exact generated writer before failing its current job lease after workspace access revocation.';
+
+REVOKE ALL ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, INTEGER
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, INTEGER
+) TO backend_app;


### PR DESCRIPTION
## Summary
- add the explicit-schema generated-writer revocation operation
- expose the typed backend database boundary without a production caller
- cover exact lease, reservation, membership, recovery, grant, and upgrade behavior in real PostgreSQL

## Validation
- complete migration chain through 0092 plus 0093 upgrade
- focused generated-media and blob-lifecycle PostgreSQL integration suites
- full backend tests (827/827)
- backend lint and build
- MCP tests
- exact privilege, caller, scope, and diff audits