### PR TITLE
Add durable direct and multipart writer abandonment recovery

### DIFF
--- a/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
@@ -162,6 +162,7 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
       DROP FUNCTION content.reserve_media_blob_writer(TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT), content.finalize_media_blob_writer(UUID, TEXT, UUID, UUID);
       DROP FUNCTION content.mark_media_blob_writer_ambiguous(UUID), content.reconcile_media_blob_writer(UUID, TEXT, UUID, UUID, INTEGER);
       DROP FUNCTION content.fail_media_blob_writer(UUID, INTEGER), content.claim_media_blob_cleanup(TEXT, INTEGER), content.generated_media_promotion_operation_applied(UUID, UUID);
+      DROP TABLE content.media_blob_writer_owner_snapshots;
       DROP TABLE content.media_blob_writer_reservations, content.media_blob_lifecycles
     `);
     await client.query(

--- a/apps/backend/src/mediaAssets/blobLifecycle.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.ts
@@ -1,8 +1,10 @@
 import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
+import { unsafeTransaction } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import { buildMediaBlobStorageKey } from "./storageKeys";
 import {
   mediaBlobNormalizationVersions,
+  passthroughMediaBlobNormalizationVersion,
   type MediaBlobNormalizationVersion,
 } from "./types";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -27,12 +29,25 @@ export type MediaBlobWriterExactInput = MediaBlobWriterReservationInput & Readon
   reservationToken: string;
 }>;
 export type MediaBlobWriterReconciliation = "referenced" | "unreferenced";
+export type DirectMediaBlobWriterResolution =
+  | MediaBlobWriterReconciliation
+  | "absent"
+  | "access_active"
+  | "stale";
+export type DirectMediaBlobWriterResolutionInput = Readonly<{
+  userId: string; workspaceId: string; mediaAssetId: string; operationId: string;
+  lastModifiedByReplicaId: string; sha256: string; storageKey: string;
+  mimeType: string; sizeBytes: number;
+}>;
+export type DirectMediaBlobWriterReservationInput =
+  DirectMediaBlobWriterResolutionInput & Readonly<{ normalizationVersion: MediaBlobNormalizationVersion }>;
 type ReservationRow = Readonly<{
   reservation_token: string | null; reservation_state: string | null;
   reservation_status: string; normalization_version: string;
 }>;
 type BooleanRow = Readonly<{ transitioned: boolean }>;
 type ReconciliationRow = Readonly<{ reconciliation_status: string }>;
+type DirectResolutionRow = Readonly<{ resolution_status: string }>;
 type CleanupClaimRow = Readonly<{ lease_token: string | null }>;
 export class MediaBlobLifecycleBusyError extends HttpError {
   constructor() { super( 503, "Media bytes are temporarily fenced by cleanup. Retry shortly.", "MEDIA_BLOB_LIFECYCLE_BUSY", ); this.name = "MediaBlobLifecycleBusyError";
@@ -77,6 +92,10 @@ function requireNormalizationVersion(value: string): MediaBlobNormalizationVersi
   }
   return version;
 }
+function assertHistoricalWriterOwner(userId: string, replicaId: string): void {
+  if (userId !== userId.trim() || userId.length === 0) throw new TypeError("userId must be non-empty and trimmed.");
+  if (!uuidPattern.test(replicaId)) throw new TypeError("lastModifiedByReplicaId must be a lowercase UUID.");
+}
 export async function reserveMediaBlobWriterInExecutor(
   executor: DatabaseExecutor, input: MediaBlobWriterReservationInput,
 ): Promise<MediaBlobWriterReservation> {
@@ -102,6 +121,36 @@ export async function reserveMediaBlobWriterForWorkspace(
 ): Promise<MediaBlobWriterReservation> {
   return transactionWithWorkspaceScope( { userId, workspaceId: input.workspaceId }, async (executor) => reserveMediaBlobWriterInExecutor(executor, input),
   );
+}
+export async function reserveDirectMediaBlobWriterWithOwnerInExecutor(
+  executor: DatabaseExecutor,
+  input: DirectMediaBlobWriterReservationInput,
+): Promise<MediaBlobWriterReservation> {
+  assertReservationInput({ ...input, writerKind: "direct_ingestion" });
+  assertHistoricalWriterOwner(input.userId, input.lastModifiedByReplicaId);
+  const result = await executor.query<ReservationRow>(
+    `SELECT reservation_token, reservation_state, reservation_status, normalization_version FROM content.reserve_direct_media_blob_writer_with_owner($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+    [
+      input.userId, input.workspaceId, input.mediaAssetId, input.operationId,
+      input.lastModifiedByReplicaId, input.sha256, input.storageKey, input.mimeType,
+      input.sizeBytes, input.normalizationVersion,
+    ],
+  );
+  const row = result.rows[0];
+  if (row?.reservation_status === "cleanup_claimed") throw new MediaBlobLifecycleBusyError();
+  if (row?.reservation_status !== "reserved" || row.reservation_token === null
+    || (row.reservation_state !== "active" && row.reservation_state !== "ambiguous"
+      && row.reservation_state !== "finalized")
+  ) throw new MediaBlobWriterFenceError("reserve_direct_owner");
+  assertMediaBlobWriterReservationToken(row.reservation_token);
+  return { reservationToken: row.reservation_token, state: row.reservation_state,
+    normalizationVersion: requireNormalizationVersion(row.normalization_version) };
+}
+export async function reserveDirectMediaBlobWriterWithOwner(
+  input: DirectMediaBlobWriterReservationInput,
+): Promise<MediaBlobWriterReservation> {
+  return transactionWithWorkspaceScope( { userId: input.userId, workspaceId: input.workspaceId },
+    (executor) => reserveDirectMediaBlobWriterWithOwnerInExecutor(executor, input));
 }
 export async function finalizeMediaBlobWriterInExecutor(
   executor: DatabaseExecutor,
@@ -162,6 +211,40 @@ export async function terminalizeMediaBlobWriterFailureInExecutor(
   const status = result.rows[0]?.reconciliation_status;
   if (status === "referenced" || status === "unreferenced") return status;
   throw new MediaBlobWriterFenceError("terminalize_failure");
+}
+export async function resolveDirectMediaBlobWriterAfterAccessRevocationInExecutor(
+  executor: DatabaseExecutor,
+  input: DirectMediaBlobWriterResolutionInput,
+): Promise<DirectMediaBlobWriterResolution> {
+  assertReservationInput({
+    ...input,
+    writerKind: "direct_ingestion",
+    normalizationVersion: passthroughMediaBlobNormalizationVersion,
+  });
+  assertHistoricalWriterOwner(input.userId, input.lastModifiedByReplicaId);
+  const result = await executor.query<DirectResolutionRow>(
+    `SELECT content.resolve_direct_media_blob_writer_after_access_revocation(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+     ) AS resolution_status`,
+    [
+      input.userId, input.workspaceId, input.mediaAssetId, input.operationId,
+      input.lastModifiedByReplicaId, input.sha256, input.storageKey, input.mimeType,
+      input.sizeBytes, mediaBlobCleanupDelayMs,
+    ],
+  );
+  const status = result.rows[0]?.resolution_status;
+  if (
+    status === "absent" || status === "referenced" || status === "unreferenced"
+    || status === "access_active" || status === "stale"
+  ) return status;
+  throw new TypeError("PostgreSQL returned an invalid direct media blob writer resolution.");
+}
+export async function resolveDirectMediaBlobWriterAfterAccessRevocation(
+  input: DirectMediaBlobWriterResolutionInput,
+): Promise<DirectMediaBlobWriterResolution> {
+  return unsafeTransaction(
+    (executor) => resolveDirectMediaBlobWriterAfterAccessRevocationInExecutor(executor, input),
+  );
 }
 export async function markMediaBlobWriterAmbiguousForWorkspace(
   userId: string, workspaceId: string, reservationToken: string,

--- a/apps/backend/src/mediaAssets/uploadSessions/index.ts
+++ b/apps/backend/src/mediaAssets/uploadSessions/index.ts
@@ -3,7 +3,15 @@ import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../../database";
+import { unsafeTransaction } from "../../database/unsafe";
 import { HttpError } from "../../shared/errors";
+import {
+  assertMediaBlobWriterReservationToken,
+  mediaBlobCleanupDelayMs,
+  MediaBlobLifecycleBusyError,
+  MediaBlobWriterFenceError,
+  type MediaBlobWriterReservation,
+} from "../blobLifecycle";
 import {
   assertMediaBlobMatchesInput,
   findMediaAssetRowForUpdateInExecutor,
@@ -30,7 +38,31 @@ import type {
   MediaAssetUploadSessionState,
   MediaBlobRow,
 } from "../types";
+import {
+  mediaBlobNormalizationVersions,
+  passthroughMediaBlobNormalizationVersion,
+} from "../types";
 import { assertReplicaBelongsToWorkspaceInExecutor } from "../workspaceReplicas";
+
+export type MediaAssetUploadSessionWriterClosure =
+  | "absent"
+  | "referenced"
+  | "unreferenced"
+  | "access_active"
+  | "already_closed"
+  | "stale";
+
+export type MediaAssetUploadSessionWriterClosureInput = Readonly<{
+  userId: string; workspaceId: string; sessionId: string; mediaAssetId: string;
+  lastModifiedByReplicaId: string; lastOperationId: string; sha256: string;
+  storageKey: string; mimeType: string; sizeBytes: number; expiresAt: string;
+}>;
+
+type MediaAssetUploadSessionWriterClosureRow = Readonly<{ closure_status: string }>;
+type OwnedMultipartReservationRow = Readonly<{
+  reservation_token: string | null; reservation_state: string | null;
+  reservation_status: string; normalization_version: string;
+}>;
 
 const MEDIA_UPLOAD_SESSION_COLUMNS = [
   "media_upload_session_id",
@@ -703,5 +735,59 @@ export async function markMediaAssetUploadSessionAbortedForWorkspace(
     }
 
     return mapMediaAssetUploadSessionRow(updatedRow);
+  });
+}
+
+export async function closeMediaAssetUploadSessionBlobWriterInExecutor(
+  executor: DatabaseExecutor,
+  input: MediaAssetUploadSessionWriterClosureInput,
+): Promise<MediaAssetUploadSessionWriterClosure> {
+  const result = await executor.query<MediaAssetUploadSessionWriterClosureRow>(
+    `SELECT content.close_media_upload_session_blob_writer(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+     ) AS closure_status`,
+    [
+      input.userId, input.workspaceId, input.sessionId, input.mediaAssetId,
+      input.lastModifiedByReplicaId, input.lastOperationId, input.sha256,
+      input.storageKey, input.mimeType, input.sizeBytes, input.expiresAt,
+      mediaBlobCleanupDelayMs,
+    ],
+  );
+  const status = result.rows[0]?.closure_status;
+  if (
+    status === "absent" || status === "referenced" || status === "unreferenced"
+    || status === "access_active" || status === "already_closed" || status === "stale"
+  ) return status;
+  throw new TypeError("PostgreSQL returned an invalid media upload session writer closure.");
+}
+
+export async function closeMediaAssetUploadSessionBlobWriter(
+  input: MediaAssetUploadSessionWriterClosureInput,
+): Promise<MediaAssetUploadSessionWriterClosure> {
+  return unsafeTransaction(
+    (executor) => closeMediaAssetUploadSessionBlobWriterInExecutor(executor, input),
+  );
+}
+
+export async function reserveMediaAssetUploadSessionBlobWriterWithOwner(
+  userId: string, workspaceId: string, sessionId: string,
+): Promise<MediaBlobWriterReservation> {
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    const result = await executor.query<OwnedMultipartReservationRow>(
+      `SELECT reservation_token, reservation_state, reservation_status, normalization_version FROM content.reserve_media_upload_session_blob_writer_with_owner($1,$2,$3,$4)`,
+      [userId, workspaceId, sessionId, passthroughMediaBlobNormalizationVersion],
+    );
+    const row = result.rows[0];
+    if (row?.reservation_status === "cleanup_claimed") throw new MediaBlobLifecycleBusyError();
+    const normalizationVersion = mediaBlobNormalizationVersions.find(
+      (candidate) => candidate === row?.normalization_version,
+    );
+    if (row?.reservation_status !== "reserved" || row.reservation_token === null
+      || (row.reservation_state !== "active" && row.reservation_state !== "ambiguous"
+        && row.reservation_state !== "finalized") || normalizationVersion === undefined
+    ) throw new MediaBlobWriterFenceError("reserve_multipart_owner");
+    assertMediaBlobWriterReservationToken(row.reservation_token);
+    return { reservationToken: row.reservation_token, state: row.reservation_state,
+      normalizationVersion };
   });
 }

--- a/apps/backend/src/mediaAssets/writerAbandonment.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/writerAbandonment.postgres.integration.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import { transactionWithWorkspaceScope } from "../database";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import { resolveDirectMediaBlobWriterAfterAccessRevocation, reserveDirectMediaBlobWriterWithOwner,
+  reserveMediaBlobWriterInExecutor,
+  type DirectMediaBlobWriterReservationInput,
+  type DirectMediaBlobWriterResolutionInput,
+  type MediaBlobWriterReservationInput } from "./blobLifecycle";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+import { closeMediaAssetUploadSessionBlobWriter,
+  reserveMediaAssetUploadSessionBlobWriterWithOwner,
+  type MediaAssetUploadSessionWriterClosureInput } from "./uploadSessions";
+import { passthroughMediaBlobNormalizationVersion } from "./types";
+const migrationSql = readFileSync(resolve(__dirname, "../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql"), "utf8");
+const signatures = {
+  directReserve: "content.reserve_direct_media_blob_writer_with_owner(text,uuid,uuid,text,uuid,text,text,text,bigint,text)",
+  multipartReserve: "content.reserve_media_upload_session_blob_writer_with_owner(text,uuid,uuid,text)",
+  directClose: "content.resolve_direct_media_blob_writer_after_access_revocation(text,uuid,uuid,text,uuid,text,text,text,bigint,integer)",
+  multipartClose: "content.close_media_upload_session_blob_writer(text,uuid,uuid,uuid,uuid,text,text,text,text,bigint,timestamp with time zone,integer)",
+  internal: "content.reserve_owned_media_blob_writer_internal(text,uuid,text,text,text,bigint,text,text,uuid,uuid,text,text,timestamp with time zone,text,timestamp with time zone,timestamp with time zone)",
+};
+function digest(): string { return createHash("sha256").update(randomUUID()).digest("hex"); }
+function writer(fixture: PostgresIntegrationFixture, kind: "direct_ingestion" | "multipart_completion",
+  mediaAssetId: string, operationId: string): MediaBlobWriterReservationInput {
+  const sha256 = digest();
+  return { writerKind: kind, workspaceId: fixture.workspaceId, mediaAssetId, operationId,
+    sha256, storageKey: buildMediaBlobStorageKey(sha256), mimeType: "application/octet-stream",
+    sizeBytes: 42, normalizationVersion: passthroughMediaBlobNormalizationVersion };
+}
+function directOwned(fixture: PostgresIntegrationFixture, input: MediaBlobWriterReservationInput):
+DirectMediaBlobWriterReservationInput {
+  return { userId: fixture.userId, workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId, operationId: input.operationId,
+    lastModifiedByReplicaId: fixture.replicaId, sha256: input.sha256,
+    storageKey: input.storageKey, mimeType: input.mimeType, sizeBytes: input.sizeBytes,
+    normalizationVersion: input.normalizationVersion };
+}
+function directClose(input: DirectMediaBlobWriterReservationInput): DirectMediaBlobWriterResolutionInput {
+  const { normalizationVersion: _normalizationVersion, ...resolution } = input;
+  return resolution;
+}
+function sessionInput(fixture: PostgresIntegrationFixture, input: MediaBlobWriterReservationInput,
+  sessionId: string, expiresAt: string): MediaAssetUploadSessionWriterClosureInput {
+  return { userId: fixture.userId, workspaceId: fixture.workspaceId, sessionId,
+    mediaAssetId: input.mediaAssetId, lastModifiedByReplicaId: fixture.replicaId,
+    lastOperationId: input.operationId, sha256: input.sha256, storageKey: input.storageKey,
+    mimeType: input.mimeType, sizeBytes: input.sizeBytes, expiresAt };
+}
+async function insertSession(fixture: PostgresIntegrationFixture, input: MediaAssetUploadSessionWriterClosureInput): Promise<void> {
+  await fixture.ownerPool.query(
+    `INSERT INTO content.media_upload_sessions
+       (media_upload_session_id,workspace_id,media_asset_id,media_blob_sha256,
+        staging_storage_key,blob_storage_key,s3_upload_id,mime_type,size_bytes,part_size_bytes,
+        part_count,state,asset_created_at,client_updated_at,last_modified_by_replica_id,
+        last_operation_id,expires_at)
+     VALUES ($1,$2,$3,$4,'media/uploads/workspaces/'||lower($2::uuid::text)||
+       '/assets/'||lower($3::uuid::text)||'/sessions/'||lower($1::uuid::text),
+       $5,'upload-id',$6,$7,42,1,'completing',$8,$8,$9,$10,$11)`,
+    [input.sessionId, input.workspaceId, input.mediaAssetId, input.sha256,
+      input.storageKey, input.mimeType, input.sizeBytes, fixture.createdAt,
+      input.lastModifiedByReplicaId, input.lastOperationId, input.expiresAt],
+  );
+}
+async function legacyReserve(fixture: PostgresIntegrationFixture, input: MediaBlobWriterReservationInput): Promise<void> {
+  await transactionWithWorkspaceScope({ userId: fixture.userId, workspaceId: fixture.workspaceId },
+    (executor) => reserveMediaBlobWriterInExecutor(executor, input));
+}
+async function insertReference(fixture: PostgresIntegrationFixture, input: MediaBlobWriterReservationInput,
+  replicaId: string, lastOperationId: string): Promise<string> {
+  const blobId = randomUUID();
+  await fixture.ownerPool.query(
+    `INSERT INTO content.media_blobs (media_blob_id,sha256,mime_type,size_bytes,
+       storage_key,normalization_version) VALUES ($1,$2,$3,$4,$5,$6)`,
+    [blobId, input.sha256, input.mimeType, input.sizeBytes, input.storageKey,
+      input.normalizationVersion],
+  );
+  await fixture.ownerPool.query(
+    `INSERT INTO content.media_assets (media_asset_id,workspace_id,media_blob_id,
+       source_url,created_at,client_updated_at,last_modified_by_replica_id,last_operation_id)
+     VALUES ($1,$2,$3,NULL,$4,$4,$5,$6)`,
+    [input.mediaAssetId, fixture.workspaceId, blobId, fixture.createdAt,
+      replicaId, lastOperationId],
+  );
+  return blobId;
+}
+async function assertUpgradeAndAcl(fixture: PostgresIntegrationFixture): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(`
+      DROP TRIGGER media_blob_writers_before_workspace_delete ON org.workspaces;
+      DROP FUNCTION ${signatures.directClose}; DROP FUNCTION ${signatures.multipartClose};
+      DROP FUNCTION ${signatures.directReserve}; DROP FUNCTION ${signatures.multipartReserve};
+      DROP FUNCTION ${signatures.internal};
+      DROP FUNCTION content.terminalize_media_blob_writers_before_workspace_delete();
+      DROP TABLE content.media_blob_writer_owner_snapshots;
+      ALTER TABLE content.media_blob_writer_reservations
+        DROP CONSTRAINT media_blob_writer_reservations_owner_reference_unique`);
+    await client.query(migrationSql);
+    const acl = (await client.query(
+      `SELECT has_function_privilege('backend_app',$1,'EXECUTE') AS direct_reserve,
+        has_function_privilege('backend_app',$2,'EXECUTE') AS multipart_reserve,
+        has_function_privilege('backend_app',$3,'EXECUTE') AS direct_close,
+        has_function_privilege('backend_app',$4,'EXECUTE') AS multipart_close,
+        has_function_privilege('backend_app',$5,'EXECUTE') AS internal_access,
+        has_function_privilege('auth_app',$1,'EXECUTE') AS auth_access,
+        has_function_privilege('reporting_readonly',$4,'EXECUTE') AS reporting_access,
+        has_table_privilege('backend_app','content.media_blob_writer_owner_snapshots','SELECT') AS owner_table,
+        has_table_privilege('backend_app','content.media_blob_writer_reservations','SELECT') AS reservation_table`,
+      [signatures.directReserve, signatures.multipartReserve, signatures.directClose,
+        signatures.multipartClose, signatures.internal],
+    )).rows[0];
+    assert.deepEqual(acl, { direct_reserve: true, multipart_reserve: true,
+      direct_close: true, multipart_close: true, internal_access: false,
+      auth_access: false, reporting_access: false, owner_table: false,
+      reservation_table: false });
+    await client.query("ROLLBACK");
+  } catch (error) { await client.query("ROLLBACK"); throw error;
+  } finally { client.release(); }
+}
+async function waitForAdvisoryLock(fixture: PostgresIntegrationFixture, backendPid: number): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const wait = await fixture.ownerPool.query(
+      "SELECT wait_event FROM pg_stat_activity WHERE pid = $1", [backendPid]);
+    if (wait.rows[0]?.wait_event === "advisory") return;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+  }
+  throw new Error(`Multipart closure did not wait for the access lock. backendPid=${backendPid}`);
+}
+test("owned writer abandonment binds history and closes writers during workspace deletion", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    await assertUpgradeAndAcl(fixture);
+    const otherUserId = `writer-owner-${randomUUID()}`;
+    const otherReplicaId = randomUUID();
+    await fixture.ownerPool.query("INSERT INTO org.user_settings (user_id) VALUES ($1)", [otherUserId]);
+    await fixture.ownerPool.query(
+      "INSERT INTO org.workspace_memberships (workspace_id,user_id,role) VALUES ($1,$2,'member')",
+      [fixture.workspaceId, otherUserId]);
+    await fixture.ownerPool.query(
+      `INSERT INTO sync.workspace_replicas (replica_id,workspace_id,user_id,
+         actor_kind,actor_key,platform)
+       VALUES ($1,$2,$3,'agent_connection',$4,'system')`,
+      [otherReplicaId, fixture.workspaceId, otherUserId, `writer-owner-${otherReplicaId}`]);
+    const ownedDirect = writer(fixture, "direct_ingestion", randomUUID(), randomUUID());
+    const ownedDirectInput = directOwned(fixture, ownedDirect);
+    const firstDirect = await reserveDirectMediaBlobWriterWithOwner(ownedDirectInput);
+    assert.equal((await reserveDirectMediaBlobWriterWithOwner(ownedDirectInput)).reservationToken,
+      firstDirect.reservationToken);
+    await assert.rejects(reserveDirectMediaBlobWriterWithOwner({
+      ...ownedDirectInput, lastModifiedByReplicaId: otherReplicaId }));
+    await assert.rejects(reserveDirectMediaBlobWriterWithOwner({
+      ...ownedDirectInput, userId: otherUserId, lastModifiedByReplicaId: otherReplicaId,
+    }));
+    assert.equal(await resolveDirectMediaBlobWriterAfterAccessRevocation(
+      directClose(ownedDirectInput)), "access_active");
+    const referencedDirect = writer(fixture, "direct_ingestion", randomUUID(), randomUUID());
+    const referencedDirectInput = directOwned(fixture, referencedDirect);
+    await reserveDirectMediaBlobWriterWithOwner(referencedDirectInput);
+    const referencedDirectBlobId = await insertReference(fixture, referencedDirect, fixture.replicaId, referencedDirect.operationId);
+    const legacyDirect = writer(fixture, "direct_ingestion", randomUUID(), randomUUID());
+    await legacyReserve(fixture, legacyDirect);
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const expired = new Date(Date.now() - 3_600_000).toISOString();
+    const ownedMultipartWriter = writer(fixture, "multipart_completion", randomUUID(), randomUUID());
+    const ownedSession = sessionInput(fixture, ownedMultipartWriter, randomUUID(), expired);
+    await insertSession(fixture, ownedSession);
+    await fixture.ownerPool.query("UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2",
+      [otherUserId, fixture.replicaId]);
+    await assert.rejects(reserveMediaAssetUploadSessionBlobWriterWithOwner(
+      fixture.userId, fixture.workspaceId, ownedSession.sessionId));
+    await fixture.ownerPool.query("UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2",
+      [fixture.userId, fixture.replicaId]);
+    await reserveMediaAssetUploadSessionBlobWriterWithOwner(fixture.userId,
+      fixture.workspaceId, ownedSession.sessionId);
+    const referencedMultipart = writer(fixture, "multipart_completion", randomUUID(), randomUUID());
+    const referencedSession = sessionInput(fixture, referencedMultipart, randomUUID(), future);
+    await insertSession(fixture, referencedSession);
+    await reserveMediaAssetUploadSessionBlobWriterWithOwner(fixture.userId,
+      fixture.workspaceId, referencedSession.sessionId);
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter(referencedSession), "access_active");
+    const referencedMultipartBlobId = await insertReference(fixture, referencedMultipart, fixture.replicaId, referencedSession.lastOperationId);
+    const legacyMultipartWriter = writer(fixture, "multipart_completion", randomUUID(), randomUUID());
+    const legacySession = sessionInput(fixture, legacyMultipartWriter, randomUUID(), future);
+    await insertSession(fixture, legacySession);
+    await legacyReserve(fixture, { ...legacyMultipartWriter, operationId: legacySession.sessionId });
+    const abortWriter = writer(fixture, "multipart_completion", randomUUID(), randomUUID());
+    const abortSession = sessionInput(fixture, abortWriter, randomUUID(), future);
+    await insertSession(fixture, abortSession);
+    await reserveMediaAssetUploadSessionBlobWriterWithOwner(fixture.userId, fixture.workspaceId, abortSession.sessionId);
+    await fixture.ownerPool.query("UPDATE content.media_upload_sessions SET state='aborting' WHERE media_upload_session_id=$1", [abortSession.sessionId]);
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter(abortSession), "unreferenced");
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter(abortSession), "already_closed");
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspace_memberships WHERE workspace_id=$1 AND user_id=$2",
+      [fixture.workspaceId, fixture.userId]);
+    await fixture.ownerPool.query("UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2",
+      [otherUserId, fixture.replicaId]);
+    assert.equal(await resolveDirectMediaBlobWriterAfterAccessRevocation({ ...directClose(ownedDirectInput),
+      userId: otherUserId, lastModifiedByReplicaId: otherReplicaId }), "stale");
+    assert.equal(await resolveDirectMediaBlobWriterAfterAccessRevocation(
+      directClose(ownedDirectInput)), "unreferenced");
+    assert.equal(await resolveDirectMediaBlobWriterAfterAccessRevocation(
+      directClose(referencedDirectInput)), "referenced");
+    assert.equal(await resolveDirectMediaBlobWriterAfterAccessRevocation(directClose(
+      directOwned(fixture, legacyDirect))), "stale");
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter({ ...ownedSession,
+      userId: otherUserId }), "stale");
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter({
+      ...ownedSession, sizeBytes: ownedSession.sizeBytes + 1 }), "stale");
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter(ownedSession), "unreferenced");
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter(referencedSession), "referenced");
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter(legacySession), "stale");
+    const absentWriter = writer(fixture, "direct_ingestion", randomUUID(), randomUUID());
+    assert.equal(await resolveDirectMediaBlobWriterAfterAccessRevocation(directClose(
+      directOwned(fixture, absentWriter))), "absent");
+    assert.equal(await closeMediaAssetUploadSessionBlobWriter(sessionInput(
+      fixture, absentWriter, randomUUID(), expired)), "absent");
+    const deleteDirect = writer(fixture, "direct_ingestion", randomUUID(), randomUUID());
+    const deleteDirectReservation = await reserveDirectMediaBlobWriterWithOwner({
+      ...directOwned(fixture, deleteDirect), userId: otherUserId,
+      lastModifiedByReplicaId: otherReplicaId });
+    const deleteDirectBlobId = await insertReference(fixture, deleteDirect, otherReplicaId, deleteDirect.operationId);
+    await fixture.ownerPool.query(
+      "UPDATE content.media_blob_writer_reservations SET state='finalized' WHERE reservation_token=$1",
+      [deleteDirectReservation.reservationToken]);
+    const deleteMultipartWriter = writer(fixture, "multipart_completion", randomUUID(), randomUUID());
+    const deleteSession = { ...sessionInput(fixture, deleteMultipartWriter, randomUUID(), future),
+      userId: otherUserId, lastModifiedByReplicaId: otherReplicaId };
+    await insertSession(fixture, deleteSession);
+    await transactionWithWorkspaceScope({ userId: otherUserId, workspaceId: fixture.workspaceId },
+      async (executor) => executor.query(
+        "SELECT * FROM content.reserve_media_upload_session_blob_writer_with_owner($1,$2,$3,$4)",
+        [otherUserId, fixture.workspaceId, deleteSession.sessionId,
+          passthroughMediaBlobNormalizationVersion]));
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_reservations SET state='ambiguous', ambiguous_at=now()
+       WHERE writer_kind='multipart_completion' AND operation_id=$1`,
+      [deleteSession.sessionId]);
+    const deletionClient = await fixture.ownerPool.connect();
+    const closureClient = await fixture.runtimePool.connect();
+    try {
+      await deletionClient.query("BEGIN");
+      await deletionClient.query(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1::text||':'||$2::text,0::bigint))",
+        [otherUserId, fixture.workspaceId]);
+      await closureClient.query("BEGIN");
+      const backendPid = Number((await closureClient.query("SELECT pg_backend_pid() AS pid"))
+        .rows[0]?.pid);
+      const closurePromise = closureClient.query<{ status: string }>(
+        `SELECT content.close_media_upload_session_blob_writer(
+           $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,3600000) AS status`,
+        [otherUserId, fixture.workspaceId, deleteSession.sessionId,
+          deleteSession.mediaAssetId, otherReplicaId, deleteSession.lastOperationId,
+          deleteSession.sha256, deleteSession.storageKey, deleteSession.mimeType,
+          deleteSession.sizeBytes, deleteSession.expiresAt]);
+      await waitForAdvisoryLock(fixture, backendPid);
+      await deletionClient.query("DELETE FROM org.workspaces WHERE workspace_id=$1", [fixture.workspaceId]);
+      await deletionClient.query("COMMIT");
+      assert.equal((await closurePromise).rows[0]?.status, "already_closed");
+      await closureClient.query("COMMIT");
+    } catch (error) {
+      await Promise.allSettled([deletionClient.query("ROLLBACK"), closureClient.query("ROLLBACK")]);
+      throw error;
+    } finally {
+      deletionClient.release();
+      closureClient.release();
+      await fixture.ownerPool.query(
+        `DELETE FROM content.media_blobs AS blobs WHERE blobs.media_blob_id=ANY($1::uuid[])
+         AND NOT EXISTS (SELECT 1 FROM content.media_assets AS assets WHERE assets.media_blob_id=blobs.media_blob_id)
+         AND NOT EXISTS (SELECT 1 FROM catalog.package_media_assets AS assets WHERE assets.media_blob_id=blobs.media_blob_id)`,
+        [[referencedDirectBlobId, referencedMultipartBlobId, deleteDirectBlobId]],
+      );
+    }
+    const closed = await fixture.ownerPool.query(
+      `SELECT reservations.state, lifecycles.cleanup_eligible_at IS NOT NULL AS cleanup
+       FROM content.media_blob_writer_reservations AS reservations
+       INNER JOIN content.media_blob_lifecycles AS lifecycles ON lifecycles.sha256=reservations.sha256
+       WHERE reservations.sha256=ANY($1::text[]) ORDER BY reservations.sha256`,
+      [[deleteDirect.sha256, deleteMultipartWriter.sha256]]);
+    assert.deepEqual(closed.rows, [{ state: "unreferenced", cleanup: true },
+      { state: "unreferenced", cleanup: true }]);
+    assert.equal((await fixture.ownerPool.query(
+      "SELECT count(*)::int AS count FROM content.media_blob_writer_owner_snapshots WHERE workspace_id=$1",
+      [fixture.workspaceId])).rows[0]?.count >= 2, true);
+    await fixture.ownerPool.query("DELETE FROM org.user_settings WHERE user_id=$1", [otherUserId]);
+  });
+});

--- a/db/migrations/0094_direct_multipart_writer_abandonment.sql
+++ b/db/migrations/0094_direct_multipart_writer_abandonment.sql
@@ -1,0 +1,487 @@
+-- Current additive migration for immutable direct/multipart writer ownership and exact abandonment.
+ALTER TABLE content.media_blob_writer_reservations ADD CONSTRAINT media_blob_writer_reservations_owner_reference_unique UNIQUE (reservation_token, writer_kind, workspace_id, media_asset_id, operation_id, sha256);
+CREATE TABLE content.media_blob_writer_owner_snapshots (
+  reservation_token UUID PRIMARY KEY, writer_kind TEXT NOT NULL
+    CHECK (writer_kind IN ('direct_ingestion', 'multipart_completion')),
+  workspace_id UUID NOT NULL, media_asset_id UUID NOT NULL, operation_id TEXT NOT NULL,
+  sha256 TEXT NOT NULL, user_id TEXT NOT NULL
+    CHECK (user_id = btrim(user_id) AND user_id <> ''), replica_id UUID NOT NULL,
+  session_last_operation_id TEXT, session_expires_at TIMESTAMPTZ,
+  session_source_url TEXT, session_asset_created_at TIMESTAMPTZ, session_client_updated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+  CONSTRAINT media_blob_writer_owner_snapshots_reservation_fk FOREIGN KEY
+    (reservation_token, writer_kind, workspace_id, media_asset_id, operation_id, sha256)
+    REFERENCES content.media_blob_writer_reservations (reservation_token, writer_kind, workspace_id, media_asset_id, operation_id, sha256)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT media_blob_writer_owner_snapshots_shape CHECK (
+    (writer_kind = 'direct_ingestion' AND session_last_operation_id IS NULL AND session_expires_at IS NULL
+      AND session_source_url IS NULL AND session_asset_created_at IS NULL AND session_client_updated_at IS NULL)
+    OR (writer_kind = 'multipart_completion' AND session_last_operation_id IS NOT NULL AND session_expires_at IS NOT NULL
+      AND session_asset_created_at IS NOT NULL AND session_client_updated_at IS NOT NULL)
+  )
+);
+COMMENT ON TABLE content.media_blob_writer_owner_snapshots IS 'Non-cascading immutable historical user, replica, workspace, and multipart payload evidence for exact writer recovery.';
+CREATE FUNCTION content.reserve_owned_media_blob_writer_internal(
+  p_user_id TEXT, p_replica_id UUID, p_sha256 TEXT, p_storage_key TEXT,
+  p_mime_type TEXT, p_size_bytes BIGINT, p_normalization_version TEXT,
+  p_writer_kind TEXT, p_workspace_id UUID, p_media_asset_id UUID, p_operation_id TEXT,
+  p_session_last_operation_id TEXT, p_session_expires_at TIMESTAMPTZ,
+  p_session_source_url TEXT, p_session_asset_created_at TIMESTAMPTZ,
+  p_session_client_updated_at TIMESTAMPTZ)
+RETURNS TABLE (reservation_token UUID, reservation_state TEXT, reservation_status TEXT, normalization_version TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE; reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE; inserted_count INTEGER;
+BEGIN
+  IF p_writer_kind NOT IN ('direct_ingestion', 'multipart_completion')
+    OR p_user_id IS NULL OR p_user_id <> btrim(p_user_id) OR p_user_id = ''
+    OR p_replica_id IS NULL OR p_workspace_id IS NULL OR p_media_asset_id IS NULL
+    OR p_operation_id IS NULL OR p_operation_id <> btrim(p_operation_id) OR char_length(p_operation_id) NOT BETWEEN 1 AND 1024
+    OR p_sha256 IS NULL OR p_storage_key IS NULL OR p_mime_type IS NULL OR p_size_bytes IS NULL
+    OR p_normalization_version IS NULL THEN
+    RAISE EXCEPTION 'Owned media blob writer identity is invalid' USING ERRCODE = '22023';
+  END IF;
+  INSERT INTO content.media_blob_lifecycles (sha256, storage_key, mime_type, size_bytes, normalization_version)
+  VALUES (p_sha256, p_storage_key, p_mime_type, p_size_bytes, p_normalization_version) ON CONFLICT DO NOTHING;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  IF NOT FOUND
+    OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes THEN
+    RAISE EXCEPTION 'Permanent media blob immutable metadata conflicts with its content hash'
+      USING ERRCODE = '23514';
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > clock_timestamp() THEN
+    RETURN QUERY SELECT NULL::UUID, NULL::TEXT, 'cleanup_claimed'::TEXT, lifecycle.normalization_version;
+    RETURN;
+  END IF;
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_eligible_at = NULL, cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = clock_timestamp()
+  WHERE lifecycles.sha256 = p_sha256;
+  INSERT INTO content.media_blob_writer_reservations (sha256, writer_kind, workspace_id, media_asset_id, operation_id)
+  VALUES (p_sha256, p_writer_kind, p_workspace_id, p_media_asset_id, p_operation_id)
+  ON CONFLICT (writer_kind, workspace_id, media_asset_id, operation_id) DO NOTHING;
+  GET DIAGNOSTICS inserted_count = ROW_COUNT;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = p_writer_kind
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_operation_id FOR UPDATE;
+  IF NOT FOUND OR reservation.sha256 IS DISTINCT FROM p_sha256 THEN
+    RAISE EXCEPTION 'Permanent media blob writer identity conflicts with a different content hash'
+      USING ERRCODE = '23514';
+  END IF;
+  IF inserted_count = 1 THEN
+    INSERT INTO content.media_blob_writer_owner_snapshots (
+      reservation_token, writer_kind, workspace_id, media_asset_id, operation_id,
+      sha256, user_id, replica_id, session_last_operation_id, session_expires_at,
+      session_source_url, session_asset_created_at, session_client_updated_at) VALUES (
+      reservation.reservation_token, p_writer_kind, p_workspace_id, p_media_asset_id,
+      p_operation_id, p_sha256, p_user_id, p_replica_id, p_session_last_operation_id,
+      p_session_expires_at, p_session_source_url, p_session_asset_created_at,
+      p_session_client_updated_at);
+  ELSE
+    SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN QUERY SELECT NULL::UUID, NULL::TEXT, 'ownership_unbound'::TEXT, lifecycle.normalization_version;
+      RETURN;
+    END IF;
+    IF owner_snapshot.user_id IS DISTINCT FROM p_user_id OR owner_snapshot.replica_id IS DISTINCT FROM p_replica_id
+      OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_session_last_operation_id
+      OR owner_snapshot.session_expires_at IS DISTINCT FROM p_session_expires_at
+      OR owner_snapshot.session_source_url IS DISTINCT FROM p_session_source_url
+      OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_session_asset_created_at
+      OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_session_client_updated_at THEN
+      RETURN QUERY SELECT NULL::UUID, NULL::TEXT, 'ownership_mismatch'::TEXT, lifecycle.normalization_version;
+      RETURN;
+    END IF;
+  END IF;
+  IF reservation.state = 'unreferenced' THEN
+    UPDATE content.media_blob_writer_reservations AS reservations
+    SET reservation_token = public.gen_random_uuid(), state = 'active', ambiguous_at = NULL
+    WHERE reservations.reservation_token = reservation.reservation_token
+    RETURNING reservations.* INTO reservation;
+  END IF;
+  RETURN QUERY SELECT reservation.reservation_token, reservation.state, 'reserved'::TEXT, lifecycle.normalization_version;
+END;
+$$;
+CREATE FUNCTION content.reserve_direct_media_blob_writer_with_owner(
+  p_user_id TEXT, p_workspace_id UUID, p_media_asset_id UUID, p_operation_id TEXT,
+  p_replica_id UUID, p_sha256 TEXT, p_storage_key TEXT, p_mime_type TEXT, p_size_bytes BIGINT,
+  p_normalization_version TEXT)
+RETURNS TABLE (reservation_token UUID, reservation_state TEXT, reservation_status TEXT, normalization_version TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_access_allowed(p_workspace_id) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Owned direct writer requires the active historical user workspace scope'
+      USING ERRCODE = '42501';
+  END IF;
+  PERFORM 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_replica_id
+    AND replicas.workspace_id = p_workspace_id
+    AND replicas.user_id = p_user_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Owned direct writer replica does not belong to the active user and workspace'
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN QUERY SELECT * FROM content.reserve_owned_media_blob_writer_internal(
+    p_user_id, p_replica_id, p_sha256, p_storage_key, p_mime_type, p_size_bytes,
+    p_normalization_version, 'direct_ingestion', p_workspace_id, p_media_asset_id, p_operation_id, NULL, NULL, NULL, NULL, NULL);
+END;
+$$;
+CREATE FUNCTION content.reserve_media_upload_session_blob_writer_with_owner(
+  p_user_id TEXT, p_workspace_id UUID, p_media_upload_session_id UUID, p_normalization_version TEXT)
+RETURNS TABLE (reservation_token UUID, reservation_state TEXT, reservation_status TEXT, normalization_version TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_access_allowed(p_workspace_id) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Owned multipart writer requires the active historical user workspace scope'
+      USING ERRCODE = '42501';
+  END IF;
+  SELECT sessions.* INTO session FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+    AND sessions.workspace_id = p_workspace_id FOR UPDATE;
+  IF NOT FOUND OR session.state IS DISTINCT FROM 'completing' THEN
+    RAISE EXCEPTION 'Owned multipart writer requires the exact completing upload session'
+      USING ERRCODE = '23514';
+  END IF;
+  PERFORM 1 FROM sync.workspace_replicas AS replicas
+  WHERE replicas.replica_id = session.last_modified_by_replica_id
+    AND replicas.workspace_id = p_workspace_id
+    AND replicas.user_id = p_user_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Owned multipart writer replica does not belong to the active user and workspace'
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN QUERY SELECT * FROM content.reserve_owned_media_blob_writer_internal(
+    p_user_id, session.last_modified_by_replica_id, session.media_blob_sha256,
+    session.blob_storage_key, session.mime_type, session.size_bytes,
+    p_normalization_version, 'multipart_completion', p_workspace_id,
+    session.media_asset_id, p_media_upload_session_id::TEXT,
+    session.last_operation_id, session.expires_at, session.source_url,
+    session.asset_created_at, session.client_updated_at
+  );
+END;
+$$;
+CREATE FUNCTION content.resolve_direct_media_blob_writer_after_access_revocation(
+  p_user_id TEXT, p_workspace_id UUID, p_media_asset_id UUID, p_operation_id TEXT,
+  p_replica_id UUID, p_sha256 TEXT, p_storage_key TEXT, p_mime_type TEXT,
+  p_size_bytes BIGINT, p_cleanup_delay_ms INTEGER)
+RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE; reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reference RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000 OR p_user_id IS NULL
+    OR p_workspace_id IS NULL OR p_media_asset_id IS NULL OR p_operation_id IS NULL
+    OR p_replica_id IS NULL OR p_sha256 IS NULL OR p_storage_key IS NULL
+    OR p_mime_type IS NULL OR p_size_bytes IS NULL
+  THEN RETURN 'stale'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  IF NOT FOUND THEN
+    IF EXISTS (
+      SELECT 1 FROM content.media_blob_writer_reservations AS conflicts
+      WHERE conflicts.writer_kind = 'direct_ingestion'
+        AND conflicts.workspace_id = p_workspace_id
+        AND conflicts.media_asset_id = p_media_asset_id
+        AND conflicts.operation_id = p_operation_id
+    ) THEN RETURN 'stale'; END IF;
+    RETURN 'absent';
+  END IF;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'direct_ingestion'
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_operation_id FOR UPDATE;
+  IF NOT FOUND THEN
+    IF EXISTS (
+      SELECT 1 FROM content.media_blob_writer_reservations AS conflicts
+      WHERE conflicts.workspace_id = p_workspace_id
+        AND conflicts.media_asset_id = p_media_asset_id
+        AND (conflicts.writer_kind = 'direct_ingestion'
+          OR conflicts.operation_id = p_operation_id)
+    ) THEN RETURN 'stale'; END IF;
+    RETURN 'absent';
+  END IF;
+  SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+  IF NOT FOUND
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_replica_id
+    OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version NOT IN ('passthrough-v1', 'image-jpeg-card-v1')
+    OR reservation.state NOT IN ('active', 'ambiguous', 'finalized', 'unreferenced')
+  THEN RETURN 'stale'; END IF;
+  IF EXISTS (
+    SELECT 1 FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN RETURN 'access_active'; END IF;
+  SELECT assets.workspace_id, assets.last_modified_by_replica_id,
+    assets.last_operation_id, blobs.sha256, blobs.storage_key, blobs.mime_type,
+    blobs.size_bytes, blobs.normalization_version
+  INTO reference FROM content.media_assets AS assets
+  INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id
+  WHERE assets.media_asset_id = p_media_asset_id AND assets.deleted_at IS NULL;
+  IF FOUND AND (
+    reference.workspace_id IS DISTINCT FROM p_workspace_id
+    OR reference.last_modified_by_replica_id IS DISTINCT FROM p_replica_id
+    OR reference.last_operation_id IS DISTINCT FROM p_operation_id
+    OR reference.sha256 IS DISTINCT FROM p_sha256
+    OR reference.storage_key IS DISTINCT FROM p_storage_key
+    OR reference.mime_type IS DISTINCT FROM p_mime_type
+    OR reference.size_bytes IS DISTINCT FROM p_size_bytes
+    OR reference.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+  ) THEN RETURN 'stale'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    reservation.reservation_token, p_sha256, p_storage_key, p_mime_type,
+    p_size_bytes, lifecycle.normalization_version, 'direct_ingestion',
+    p_workspace_id, p_media_asset_id, p_operation_id, p_cleanup_delay_ms);
+  IF terminalization_status IN ('referenced', 'unreferenced') THEN RETURN terminalization_status; END IF;
+  RETURN 'stale';
+END;
+$$;
+CREATE FUNCTION content.close_media_upload_session_blob_writer(
+  p_user_id TEXT, p_workspace_id UUID, p_media_upload_session_id UUID, p_media_asset_id UUID,
+  p_last_modified_by_replica_id UUID, p_last_operation_id TEXT,
+  p_sha256 TEXT, p_storage_key TEXT, p_mime_type TEXT, p_size_bytes BIGINT,
+  p_expires_at TIMESTAMPTZ, p_cleanup_delay_ms INTEGER)
+RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE; lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE; owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  session_found BOOLEAN; reference RECORD; reference_found BOOLEAN;
+  abort_proven BOOLEAN; expiry_proven BOOLEAN; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000 OR p_user_id IS NULL
+    OR p_workspace_id IS NULL OR p_media_upload_session_id IS NULL OR p_media_asset_id IS NULL
+    OR p_last_modified_by_replica_id IS NULL OR p_last_operation_id IS NULL OR p_sha256 IS NULL
+    OR p_storage_key IS NULL OR p_mime_type IS NULL OR p_size_bytes IS NULL OR p_expires_at IS NULL
+  THEN RETURN 'stale'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  SELECT sessions.* INTO session FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+  FOR UPDATE;
+  session_found := FOUND;
+  IF session_found AND (
+    session.workspace_id IS DISTINCT FROM p_workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+    OR session.blob_storage_key IS DISTINCT FROM p_storage_key
+    OR session.mime_type IS DISTINCT FROM p_mime_type
+    OR session.size_bytes IS DISTINCT FROM p_size_bytes
+    OR session.expires_at IS DISTINCT FROM p_expires_at
+  ) THEN RETURN 'stale'; END IF;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  IF NOT FOUND THEN
+    IF session_found OR EXISTS (
+      SELECT 1 FROM content.media_blob_writer_reservations AS conflicts
+      WHERE conflicts.writer_kind = 'multipart_completion'
+        AND conflicts.workspace_id = p_workspace_id
+        AND conflicts.media_asset_id = p_media_asset_id
+        AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ) THEN RETURN 'stale'; END IF;
+    RETURN 'absent';
+  END IF;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion'
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_media_upload_session_id::TEXT FOR UPDATE;
+  IF NOT FOUND THEN
+    IF session_found OR EXISTS (
+      SELECT 1 FROM content.media_blob_writer_reservations AS conflicts
+      WHERE conflicts.workspace_id = p_workspace_id
+        AND conflicts.media_asset_id = p_media_asset_id
+        AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ) THEN RETURN 'stale'; END IF;
+    RETURN 'absent';
+  END IF;
+  SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+  IF NOT FOUND
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+    OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version NOT IN ('passthrough-v1', 'image-jpeg-card-v1')
+    OR reservation.state NOT IN ('active', 'ambiguous', 'finalized', 'unreferenced')
+  THEN RETURN 'stale'; END IF;
+  IF session_found AND (
+    owner_snapshot.session_source_url IS DISTINCT FROM session.source_url
+    OR owner_snapshot.session_asset_created_at IS DISTINCT FROM session.asset_created_at
+    OR owner_snapshot.session_client_updated_at IS DISTINCT FROM session.client_updated_at
+  ) THEN RETURN 'stale'; END IF;
+  IF NOT session_found AND reservation.state = 'unreferenced' THEN
+    RETURN 'already_closed'; END IF;
+  IF session_found AND session.state IN ('completed', 'aborted') THEN
+    RETURN 'already_closed'; END IF;
+  abort_proven := session_found AND session.state = 'aborting';
+  expiry_proven := owner_snapshot.session_expires_at <= clock_timestamp();
+  IF NOT abort_proven AND NOT expiry_proven AND EXISTS (
+    SELECT 1 FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN RETURN 'access_active'; END IF;
+  SELECT assets.workspace_id, assets.source_url, assets.created_at,
+    assets.client_updated_at, assets.last_modified_by_replica_id,
+    assets.last_operation_id, blobs.sha256, blobs.storage_key, blobs.mime_type,
+    blobs.size_bytes, blobs.normalization_version
+  INTO reference FROM content.media_assets AS assets
+  INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id
+  WHERE assets.media_asset_id = p_media_asset_id AND assets.deleted_at IS NULL;
+  reference_found := FOUND;
+  IF reference_found AND (
+    reference.workspace_id IS DISTINCT FROM p_workspace_id
+    OR reference.source_url IS DISTINCT FROM owner_snapshot.session_source_url
+    OR reference.created_at IS DISTINCT FROM owner_snapshot.session_asset_created_at
+    OR reference.client_updated_at IS DISTINCT FROM owner_snapshot.session_client_updated_at
+    OR reference.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR reference.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR reference.sha256 IS DISTINCT FROM p_sha256
+    OR reference.storage_key IS DISTINCT FROM p_storage_key
+    OR reference.mime_type IS DISTINCT FROM p_mime_type
+    OR reference.size_bytes IS DISTINCT FROM p_size_bytes
+    OR reference.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+  ) THEN RETURN 'stale'; END IF;
+  IF reference_found THEN
+    IF reservation.state = 'unreferenced' THEN RETURN 'stale'; END IF;
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      reservation.reservation_token, p_sha256, p_storage_key, p_mime_type,
+      p_size_bytes, lifecycle.normalization_version, 'multipart_completion',
+      p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+      p_cleanup_delay_ms);
+    IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF;
+    IF session_found THEN UPDATE content.media_upload_sessions
+      SET state = 'completed', completed_at = clock_timestamp(), aborted_at = NULL
+      WHERE media_upload_session_id = p_media_upload_session_id; END IF;
+    RETURN 'referenced';
+  END IF;
+  IF NOT abort_proven AND NOT expiry_proven THEN RETURN 'stale'; END IF;
+  IF reservation.state = 'finalized' THEN RETURN 'stale'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    reservation.reservation_token, p_sha256, p_storage_key, p_mime_type,
+    p_size_bytes, lifecycle.normalization_version, 'multipart_completion',
+    p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+    p_cleanup_delay_ms);
+  IF terminalization_status <> 'unreferenced' THEN RETURN 'stale'; END IF;
+  IF session_found THEN UPDATE content.media_upload_sessions
+    SET state = 'aborted', completed_at = NULL, aborted_at = clock_timestamp()
+    WHERE media_upload_session_id = p_media_upload_session_id; END IF;
+  RETURN 'unreferenced';
+END;
+$$;
+CREATE FUNCTION content.terminalize_media_blob_writers_before_workspace_delete()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  owner_user_id TEXT; affected_sha256s TEXT[]; affected_sha256 TEXT; terminalized_at TIMESTAMPTZ;
+BEGIN
+  FOR owner_user_id IN
+    SELECT user_ids.user_id
+    FROM (
+      SELECT memberships.user_id FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = OLD.workspace_id
+      UNION
+      SELECT snapshots.user_id FROM content.media_blob_writer_owner_snapshots AS snapshots
+      WHERE snapshots.workspace_id = OLD.workspace_id
+    ) AS user_ids
+    ORDER BY user_ids.user_id
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(owner_user_id || ':' || OLD.workspace_id::TEXT, 0::BIGINT));
+  END LOOP;
+  SELECT array_agg(DISTINCT reservations.sha256 ORDER BY reservations.sha256)
+  INTO affected_sha256s FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion');
+  IF affected_sha256s IS NULL THEN RETURN OLD; END IF;
+  PERFORM 1 FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = OLD.workspace_id
+  ORDER BY sessions.media_upload_session_id FOR UPDATE;
+  DELETE FROM content.media_upload_sessions AS sessions WHERE sessions.workspace_id = OLD.workspace_id;
+  DELETE FROM content.media_assets AS assets WHERE assets.workspace_id = OLD.workspace_id;
+  FOREACH affected_sha256 IN ARRAY affected_sha256s LOOP
+    PERFORM 1 FROM content.media_blob_lifecycles AS lifecycles
+    WHERE lifecycles.sha256 = affected_sha256 FOR UPDATE;
+  END LOOP;
+  PERFORM 1 FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion')
+  ORDER BY reservations.sha256, reservations.writer_kind,
+    reservations.media_asset_id, reservations.operation_id
+  FOR UPDATE;
+  PERFORM 1 FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.workspace_id = OLD.workspace_id ORDER BY snapshots.reservation_token FOR UPDATE;
+  UPDATE content.media_blob_writer_reservations AS reservations
+  SET state = 'unreferenced'
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion')
+    AND reservations.state <> 'unreferenced';
+  terminalized_at := clock_timestamp();
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_eligible_at = GREATEST(
+      COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ),
+      terminalized_at + interval '1 hour'
+    ),
+    cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL,
+    updated_at = terminalized_at
+  WHERE lifecycles.sha256 = ANY(affected_sha256s)
+    AND NOT EXISTS (
+      SELECT 1 FROM content.media_assets AS assets
+      INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256 AND assets.deleted_at IS NULL
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM catalog.package_media_assets AS assets
+      INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM content.media_blob_writer_reservations AS reservations
+      WHERE reservations.sha256 = lifecycles.sha256
+        AND reservations.state NOT IN ('finalized', 'unreferenced')
+    );
+  RETURN OLD;
+END;
+$$;
+CREATE TRIGGER media_blob_writers_before_workspace_delete BEFORE DELETE ON org.workspaces FOR EACH ROW EXECUTE FUNCTION content.terminalize_media_blob_writers_before_workspace_delete();
+REVOKE ALL ON TABLE content.media_blob_lifecycles, content.media_blob_writer_reservations, content.media_blob_writer_owner_snapshots FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.reserve_owned_media_blob_writer_internal(TEXT, UUID, TEXT, TEXT, TEXT, BIGINT, TEXT, TEXT, UUID, UUID, TEXT, TEXT, TIMESTAMPTZ, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.reserve_direct_media_blob_writer_with_owner(TEXT, UUID, UUID, TEXT, UUID, TEXT, TEXT, TEXT, BIGINT, TEXT) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.reserve_media_upload_session_blob_writer_with_owner(TEXT, UUID, UUID, TEXT) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.resolve_direct_media_blob_writer_after_access_revocation(TEXT, UUID, UUID, TEXT, UUID, TEXT, TEXT, TEXT, BIGINT, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.close_media_upload_session_blob_writer(TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.terminalize_media_blob_writers_before_workspace_delete() FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+GRANT EXECUTE ON FUNCTION content.reserve_direct_media_blob_writer_with_owner(TEXT, UUID, UUID, TEXT, UUID, TEXT, TEXT, TEXT, BIGINT, TEXT) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.reserve_media_upload_session_blob_writer_with_owner(TEXT, UUID, UUID, TEXT) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.resolve_direct_media_blob_writer_after_access_revocation(TEXT, UUID, UUID, TEXT, UUID, TEXT, TEXT, TEXT, BIGINT, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.close_media_upload_session_blob_writer(TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER) TO backend_app;


### PR DESCRIPTION
## Summary
- persist immutable historical ownership for direct and multipart writer reservations
- add exact revocation, abort, expiry, and workspace-deletion terminalization operations
- enforce the global advisory/session/lifecycle/reservation lock order and narrow backend-only grants
- add focused real PostgreSQL identity, deletion, concurrency, security, and migration-upgrade evidence

## Validation
- complete 96-migration PostgreSQL chain through 0094
- focused writer-abandonment PostgreSQL test
- combined lifecycle/generated/abandonment PostgreSQL regressions (4/4)
- full backend tests (827/827)
- backend lint and build
- git diff --check and exact ACL/signature/caller audits

No production caller is enabled by this schema-first change.