### PR TITLE
Add atomic multipart writer schema boundary

### DIFF
--- a/apps/backend/src/mediaAssets/atomicMultipartWriter.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/atomicMultipartWriter.postgres.integration.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import { unsafeTransaction } from "../database/unsafe";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+import {
+  beginMediaAssetUploadSessionCompletionWithOwner,
+  beginMediaAssetUploadSessionCompletionWithOwnerInExecutor,
+  closeMediaAssetUploadSessionBlobWriter,
+  type MediaAssetUploadSessionCompletionWithOwnerInput,
+} from "./uploadSessions";
+import { passthroughMediaBlobNormalizationVersion } from "./types";
+
+const migration0094 = readFileSync(resolve(
+  __dirname, "../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql",
+), "utf8");
+const migration0095 = readFileSync(resolve(
+  __dirname, "../../../../db/migrations/0095_atomic_multipart_writer_completion.sql",
+), "utf8");
+const closerStart = migration0094.indexOf(
+  "CREATE FUNCTION content.close_media_upload_session_blob_writer(",
+);
+const closerEnd = migration0094.indexOf(
+  "CREATE FUNCTION content.terminalize_media_blob_writers_before_workspace_delete()",
+  closerStart,
+);
+const previousCloserSql = migration0094.slice(closerStart, closerEnd);
+const beginSignature = "content.begin_media_upload_session_completion_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,text)";
+const closeSignature = "content.close_media_upload_session_blob_writer(text,uuid,uuid,uuid,uuid,text,text,text,text,bigint,timestamp with time zone,integer)";
+
+function digest(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+
+function session(
+  fixture: PostgresIntegrationFixture,
+  state: "active" | "completing" | "aborting",
+  expiresAt: string,
+): MediaAssetUploadSessionCompletionWithOwnerInput {
+  const sessionId = randomUUID();
+  const mediaAssetId = randomUUID();
+  const sha256 = digest();
+  return {
+    userId: fixture.userId, workspaceId: fixture.workspaceId, sessionId, mediaAssetId,
+    lastModifiedByReplicaId: fixture.replicaId, lastOperationId: randomUUID(), sha256,
+    stagingStorageKey: `media/uploads/workspaces/${fixture.workspaceId}/assets/${mediaAssetId}/sessions/${sessionId}`,
+    blobStorageKey: buildMediaBlobStorageKey(sha256), s3UploadId: `upload-${randomUUID()}`,
+    mimeType: "application/octet-stream", sizeBytes: 42, partSizeBytes: 42, partCount: 1,
+    sourceUrl: null, assetCreatedAt: fixture.createdAt, clientUpdatedAt: fixture.createdAt,
+    expiresAt, normalizationVersion: passthroughMediaBlobNormalizationVersion,
+  };
+}
+
+async function insertSession(
+  fixture: PostgresIntegrationFixture,
+  input: MediaAssetUploadSessionCompletionWithOwnerInput,
+  state: "active" | "completing" | "aborting",
+): Promise<void> {
+  await fixture.ownerPool.query(
+    `INSERT INTO content.media_upload_sessions
+       (media_upload_session_id,workspace_id,media_asset_id,media_blob_sha256,
+        staging_storage_key,blob_storage_key,s3_upload_id,mime_type,size_bytes,
+        part_size_bytes,part_count,state,source_url,asset_created_at,client_updated_at,
+        last_modified_by_replica_id,last_operation_id,expires_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+    [input.sessionId, input.workspaceId, input.mediaAssetId, input.sha256,
+      input.stagingStorageKey, input.blobStorageKey, input.s3UploadId, input.mimeType,
+      input.sizeBytes, input.partSizeBytes, input.partCount, state, input.sourceUrl,
+      input.assetCreatedAt, input.clientUpdatedAt, input.lastModifiedByReplicaId,
+      input.lastOperationId, input.expiresAt],
+  );
+}
+
+async function close(
+  input: MediaAssetUploadSessionCompletionWithOwnerInput,
+  sizeBytes: number,
+): Promise<string> {
+  return closeMediaAssetUploadSessionBlobWriter({
+    userId: input.userId, workspaceId: input.workspaceId, sessionId: input.sessionId,
+    mediaAssetId: input.mediaAssetId, lastModifiedByReplicaId: input.lastModifiedByReplicaId,
+    lastOperationId: input.lastOperationId, sha256: input.sha256,
+    storageKey: input.blobStorageKey, mimeType: input.mimeType, sizeBytes,
+    expiresAt: input.expiresAt,
+  });
+}
+
+async function assertUpgradeAndSecurity(fixture: PostgresIntegrationFixture): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(`DROP FUNCTION ${beginSignature}; DROP FUNCTION ${closeSignature}`);
+    await client.query(previousCloserSql);
+    await client.query(migration0095);
+    const row = (await client.query(
+      `SELECT has_function_privilege('backend_app',$1,'EXECUTE') AS backend_begin,
+        has_function_privilege('auth_app',$1,'EXECUTE') AS auth_begin,
+        has_function_privilege('reporting_readonly',$2,'EXECUTE') AS reporting_close,
+        has_table_privilege('backend_app','content.media_blob_writer_reservations','SELECT') AS direct_table,
+        bool_and(prosecdef AND proconfig = ARRAY['search_path=pg_catalog']) AS hardened
+       FROM pg_proc WHERE oid IN ($1::regprocedure,$2::regprocedure)`,
+      [beginSignature, closeSignature],
+    )).rows[0];
+    assert.deepEqual(row, {
+      backend_begin: true, auth_begin: false, reporting_close: false,
+      direct_table: false, hardened: true,
+    });
+    await client.query("ROLLBACK");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+test("atomic multipart writer start and no-writer closure are exact, replayable, and fenced", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    await assertUpgradeAndSecurity(fixture);
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const expired = new Date(Date.now() - 3_600_000).toISOString();
+    const aborting = session(fixture, "aborting", future);
+    const expiredSession = session(fixture, "active", expired);
+    const live = session(fixture, "active", future);
+    await insertSession(fixture, aborting, "aborting");
+    await insertSession(fixture, expiredSession, "active");
+    await insertSession(fixture, live, "active");
+    assert.equal(await close(aborting, aborting.sizeBytes), "no_writer_closed");
+    assert.equal(await close(aborting, aborting.sizeBytes), "already_closed");
+    assert.equal(await close(expiredSession, expiredSession.sizeBytes), "no_writer_closed");
+    assert.equal(await close(live, live.sizeBytes), "stale");
+    const noWriter = (await fixture.ownerPool.query(
+      `SELECT count(*) FILTER (WHERE source='lifecycle')::int AS lifecycles,
+        count(*) FILTER (WHERE source='reservation')::int AS reservations,
+        count(*) FILTER (WHERE source='snapshot')::int AS snapshots,
+        count(*) FILTER (WHERE source='blob')::int AS blobs
+       FROM (
+         SELECT 'lifecycle' AS source FROM content.media_blob_lifecycles WHERE sha256=ANY($1)
+         UNION ALL SELECT 'reservation' FROM content.media_blob_writer_reservations WHERE sha256=ANY($1)
+         UNION ALL SELECT 'snapshot' FROM content.media_blob_writer_owner_snapshots WHERE sha256=ANY($1)
+         UNION ALL SELECT 'blob' FROM content.media_blobs WHERE sha256=ANY($1)
+       ) AS rows`,
+      [[aborting.sha256, expiredSession.sha256]],
+    )).rows[0];
+    assert.deepEqual(noWriter, { lifecycles: 0, reservations: 0, snapshots: 0, blobs: 0 });
+    assert.deepEqual((await fixture.ownerPool.query(
+      "SELECT state FROM content.media_upload_sessions WHERE media_upload_session_id=ANY($1) ORDER BY state",
+      [[aborting.sessionId, expiredSession.sessionId, live.sessionId]],
+    )).rows, [{ state: "aborted" }, { state: "aborted" }, { state: "active" }]);
+
+    const exact = session(fixture, "active", future);
+    await insertSession(fixture, exact, "active");
+    const started = await beginMediaAssetUploadSessionCompletionWithOwner(exact);
+    assert.equal(started.status, "started");
+    assert.ok("reservation" in started);
+    const replayed = await beginMediaAssetUploadSessionCompletionWithOwner(exact);
+    assert.equal(replayed.status, "replayed");
+    assert.ok("reservation" in replayed);
+    assert.equal(replayed.reservation.reservationToken, started.reservation.reservationToken);
+    assert.equal(replayed.reservation.normalizationVersion, started.reservation.normalizationVersion);
+
+    const expiringReplay = session(
+      fixture, "active", new Date(Date.now() + 1_000).toISOString(),
+    );
+    await insertSession(fixture, expiringReplay, "active");
+    const expiringStarted = await beginMediaAssetUploadSessionCompletionWithOwner(expiringReplay);
+    assert.equal(expiringStarted.status, "started");
+    assert.ok("reservation" in expiringStarted);
+    await fixture.ownerPool.query(
+      "SELECT pg_sleep(GREATEST(EXTRACT(EPOCH FROM $1::timestamptz - clock_timestamp()) + 0.05, 0.05))",
+      [expiringReplay.expiresAt],
+    );
+    const afterExpiry = await beginMediaAssetUploadSessionCompletionWithOwner(expiringReplay);
+    assert.equal(afterExpiry.status, "replayed");
+    assert.ok("reservation" in afterExpiry);
+    assert.deepEqual(afterExpiry.reservation, expiringStarted.reservation);
+    assert.equal((await beginMediaAssetUploadSessionCompletionWithOwner({
+      ...expiringReplay, sizeBytes: expiringReplay.sizeBytes + 1,
+    })).status, "payload_mismatch");
+
+    await fixture.ownerPool.query(
+      "UPDATE content.media_upload_sessions SET state='aborting' WHERE media_upload_session_id=$1",
+      [exact.sessionId],
+    );
+    assert.equal(await close(exact, exact.sizeBytes + 1), "stale");
+    assert.deepEqual((await fixture.ownerPool.query(
+      `SELECT sessions.state, reservations.state AS reservation_state
+       FROM content.media_upload_sessions AS sessions
+       INNER JOIN content.media_blob_writer_reservations AS reservations
+         ON reservations.operation_id=sessions.media_upload_session_id::text
+       WHERE sessions.media_upload_session_id=$1`,
+      [exact.sessionId],
+    )).rows[0], { state: "aborting", reservation_state: "active" });
+
+    const concurrent = session(fixture, "active", future);
+    await insertSession(fixture, concurrent, "active");
+    const concurrentResults = await Promise.all([
+      beginMediaAssetUploadSessionCompletionWithOwner(concurrent),
+      beginMediaAssetUploadSessionCompletionWithOwner(concurrent),
+    ]);
+    assert.deepEqual(concurrentResults.map((result) => result.status).sort(), ["replayed", "started"]);
+    const concurrentTokens = concurrentResults.flatMap((result) =>
+      "reservation" in result ? [result.reservation.reservationToken] : []);
+    assert.equal(concurrentTokens.length, 2);
+    assert.equal(concurrentTokens[0], concurrentTokens[1]);
+
+    const legacy = session(fixture, "completing", future);
+    const rejectedAbort = session(fixture, "aborting", future);
+    const rejectedExpiry = session(fixture, "active", expired);
+    await insertSession(fixture, legacy, "completing");
+    await insertSession(fixture, rejectedAbort, "aborting");
+    await insertSession(fixture, rejectedExpiry, "active");
+    assert.equal((await beginMediaAssetUploadSessionCompletionWithOwner(legacy)).status, "legacy_unbound");
+    assert.equal((await beginMediaAssetUploadSessionCompletionWithOwner(rejectedAbort)).status, "aborting");
+    assert.equal((await beginMediaAssetUploadSessionCompletionWithOwner(rejectedExpiry)).status, "expired");
+    assert.equal((await unsafeTransaction(
+      (executor) => beginMediaAssetUploadSessionCompletionWithOwnerInExecutor(executor, live),
+    )).status, "access_denied");
+    assert.equal((await beginMediaAssetUploadSessionCompletionWithOwner({
+      ...live, sizeBytes: live.sizeBytes + 1,
+    })).status, "payload_mismatch");
+    const otherUserId = `multipart-owner-${randomUUID()}`;
+    await fixture.ownerPool.query(
+      `WITH inserted AS (INSERT INTO org.user_settings(user_id) VALUES ($1) RETURNING 1)
+       UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2`,
+      [otherUserId, fixture.replicaId],
+    );
+    assert.equal((await beginMediaAssetUploadSessionCompletionWithOwner(live)).status, "replica_mismatch");
+    await fixture.ownerPool.query(
+      `WITH restored AS (UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2 RETURNING 1)
+       DELETE FROM org.user_settings WHERE user_id=$3`, [fixture.userId, fixture.replicaId, otherUserId]);
+
+    const peer = session(fixture, "active", future);
+    await insertSession(fixture, peer, "active");
+    const peerStart = await beginMediaAssetUploadSessionCompletionWithOwner(peer);
+    assert.ok("reservation" in peerStart);
+    const blobId = randomUUID();
+    await fixture.ownerPool.query(
+      `WITH inserted_blob AS (
+         INSERT INTO content.media_blobs
+         (media_blob_id,sha256,mime_type,size_bytes,storage_key,normalization_version)
+         VALUES ($1,$2,$3,$4,$5,$6) RETURNING media_blob_id
+       ), inserted_asset AS (
+         INSERT INTO content.media_assets
+         (media_asset_id,workspace_id,media_blob_id,source_url,created_at,client_updated_at,
+          last_modified_by_replica_id,last_operation_id)
+         SELECT $7,$8,media_blob_id,$9,$10,$10,$11,$12 FROM inserted_blob RETURNING 1
+       ), finalized AS (
+         UPDATE content.media_blob_writer_reservations SET state='finalized'
+         WHERE reservation_token=$13 RETURNING 1
+       )
+       UPDATE content.media_upload_sessions SET state='completed',completed_at=now()
+       WHERE media_upload_session_id=$14
+         AND EXISTS (SELECT 1 FROM inserted_asset) AND EXISTS (SELECT 1 FROM finalized)`,
+      [blobId, peer.sha256, peer.mimeType, peer.sizeBytes, peer.blobStorageKey,
+        peerStart.reservation.normalizationVersion, peer.mediaAssetId, peer.workspaceId,
+        peer.sourceUrl, peer.assetCreatedAt, peer.lastModifiedByReplicaId,
+        peer.lastOperationId, peerStart.reservation.reservationToken, peer.sessionId],
+    );
+    const completed = await beginMediaAssetUploadSessionCompletionWithOwner(peer);
+    assert.equal(completed.status, "already_completed");
+    await fixture.ownerPool.query(
+      "UPDATE content.media_assets SET last_operation_id=$1 WHERE media_asset_id=$2",
+      [randomUUID(), peer.mediaAssetId],
+    );
+    assert.equal((await beginMediaAssetUploadSessionCompletionWithOwner(peer)).status, "completed_mismatch");
+
+    const abortRace = session(fixture, "active", future);
+    await insertSession(fixture, abortRace, "active");
+    const blocker = await fixture.ownerPool.connect();
+    try {
+      await blocker.query("BEGIN");
+      await blocker.query(
+        "SELECT 1 FROM content.media_upload_sessions WHERE media_upload_session_id=$1 FOR UPDATE",
+        [abortRace.sessionId],
+      );
+      const startPromise = beginMediaAssetUploadSessionCompletionWithOwner(abortRace);
+      await blocker.query(
+        "UPDATE content.media_upload_sessions SET state='aborting' WHERE media_upload_session_id=$1",
+        [abortRace.sessionId],
+      );
+      await blocker.query("COMMIT");
+      assert.equal((await startPromise).status, "aborting");
+    } finally {
+      await blocker.query("ROLLBACK");
+      blocker.release();
+    }
+
+    const deleteRace = session(fixture, "active", future);
+    await insertSession(fixture, deleteRace, "active");
+    const deletion = await fixture.ownerPool.connect();
+    try {
+      await deletion.query("BEGIN");
+      await deletion.query(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1||':'||$2::text,0::bigint))",
+        [fixture.userId, fixture.workspaceId],
+      );
+      const startPromise = beginMediaAssetUploadSessionCompletionWithOwner(deleteRace);
+      await deletion.query("DELETE FROM org.workspaces WHERE workspace_id=$1", [fixture.workspaceId]);
+      await deletion.query("COMMIT");
+      assert.equal((await startPromise).status, "access_denied");
+    } finally {
+      await deletion.query("ROLLBACK");
+      deletion.release();
+    }
+  });
+});

--- a/apps/backend/src/mediaAssets/uploadSessions/index.ts
+++ b/apps/backend/src/mediaAssets/uploadSessions/index.ts
@@ -48,6 +48,7 @@ export type MediaAssetUploadSessionWriterClosure =
   | "absent"
   | "referenced"
   | "unreferenced"
+  | "no_writer_closed"
   | "access_active"
   | "already_closed"
   | "stale";
@@ -59,6 +60,38 @@ export type MediaAssetUploadSessionWriterClosureInput = Readonly<{
 }>;
 
 type MediaAssetUploadSessionWriterClosureRow = Readonly<{ closure_status: string }>;
+export type MediaAssetUploadSessionCompletionWithOwnerInput = Readonly<{
+  userId: string; workspaceId: string; sessionId: string; mediaAssetId: string;
+  lastModifiedByReplicaId: string; lastOperationId: string; sha256: string;
+  stagingStorageKey: string; blobStorageKey: string; s3UploadId: string;
+  mimeType: string; sizeBytes: number; partSizeBytes: number; partCount: number;
+  sourceUrl: string | null; assetCreatedAt: string; clientUpdatedAt: string;
+  expiresAt: string; normalizationVersion: typeof passthroughMediaBlobNormalizationVersion;
+}>;
+export type MediaAssetUploadSessionCompletionWithOwnerRejection =
+  | "access_denied"
+  | "session_not_found"
+  | "payload_mismatch"
+  | "replica_mismatch"
+  | "expired"
+  | "aborting"
+  | "aborted"
+  | "state_conflict"
+  | "legacy_unbound"
+  | "ownership_mismatch"
+  | "writer_conflict"
+  | "cleanup_claimed"
+  | "completed_mismatch";
+export type MediaAssetUploadSessionCompletionWithOwnerResult =
+  | Readonly<{
+    status: "started" | "replayed" | "already_completed";
+    reservation: MediaBlobWriterReservation;
+  }>
+  | Readonly<{ status: MediaAssetUploadSessionCompletionWithOwnerRejection }>;
+type MediaAssetUploadSessionCompletionWithOwnerRow = Readonly<{
+  completion_status: string; reservation_token: string | null;
+  reservation_state: string | null; normalization_version: string | null;
+}>;
 type OwnedMultipartReservationRow = Readonly<{
   reservation_token: string | null; reservation_state: string | null;
   reservation_status: string; normalization_version: string;
@@ -756,6 +789,7 @@ export async function closeMediaAssetUploadSessionBlobWriterInExecutor(
   const status = result.rows[0]?.closure_status;
   if (
     status === "absent" || status === "referenced" || status === "unreferenced"
+    || status === "no_writer_closed"
     || status === "access_active" || status === "already_closed" || status === "stale"
   ) return status;
   throw new TypeError("PostgreSQL returned an invalid media upload session writer closure.");
@@ -766,6 +800,68 @@ export async function closeMediaAssetUploadSessionBlobWriter(
 ): Promise<MediaAssetUploadSessionWriterClosure> {
   return unsafeTransaction(
     (executor) => closeMediaAssetUploadSessionBlobWriterInExecutor(executor, input),
+  );
+}
+
+export async function beginMediaAssetUploadSessionCompletionWithOwnerInExecutor(
+  executor: DatabaseExecutor,
+  input: MediaAssetUploadSessionCompletionWithOwnerInput,
+): Promise<MediaAssetUploadSessionCompletionWithOwnerResult> {
+  const result = await executor.query<MediaAssetUploadSessionCompletionWithOwnerRow>(
+    `SELECT completion_status, reservation_token, reservation_state, normalization_version
+     FROM content.begin_media_upload_session_completion_with_owner(
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19
+     )`,
+    [
+      input.userId, input.workspaceId, input.sessionId, input.mediaAssetId,
+      input.lastModifiedByReplicaId, input.lastOperationId, input.sha256,
+      input.stagingStorageKey, input.blobStorageKey, input.s3UploadId, input.mimeType,
+      input.sizeBytes, input.partSizeBytes, input.partCount, input.sourceUrl,
+      input.assetCreatedAt, input.clientUpdatedAt, input.expiresAt,
+      input.normalizationVersion,
+    ],
+  );
+  const row = result.rows[0];
+  if (
+    row?.completion_status === "started" || row?.completion_status === "replayed"
+    || row?.completion_status === "already_completed"
+  ) {
+    const normalizationVersion = mediaBlobNormalizationVersions.find(
+      (candidate) => candidate === row.normalization_version,
+    );
+    if (row.reservation_token === null || normalizationVersion === undefined
+      || (row.reservation_state !== "active" && row.reservation_state !== "ambiguous"
+        && row.reservation_state !== "finalized")
+    ) throw new TypeError("PostgreSQL returned an invalid atomic multipart completion start.");
+    assertMediaBlobWriterReservationToken(row.reservation_token);
+    return {
+      status: row.completion_status,
+      reservation: {
+        reservationToken: row.reservation_token,
+        state: row.reservation_state,
+        normalizationVersion,
+      },
+    };
+  }
+  const rejectionStatuses: ReadonlyArray<MediaAssetUploadSessionCompletionWithOwnerRejection> = [
+    "access_denied", "session_not_found", "payload_mismatch", "replica_mismatch",
+    "expired", "aborting", "aborted", "state_conflict", "legacy_unbound",
+    "ownership_mismatch", "writer_conflict", "cleanup_claimed", "completed_mismatch",
+  ];
+  const rejection = rejectionStatuses.find(
+    (candidate) => candidate === row?.completion_status,
+  );
+  if (rejection !== undefined && row?.reservation_token === null
+    && row.reservation_state === null) return { status: rejection };
+  throw new TypeError("PostgreSQL returned an invalid atomic multipart completion rejection.");
+}
+
+export async function beginMediaAssetUploadSessionCompletionWithOwner(
+  input: MediaAssetUploadSessionCompletionWithOwnerInput,
+): Promise<MediaAssetUploadSessionCompletionWithOwnerResult> {
+  return transactionWithWorkspaceScope(
+    { userId: input.userId, workspaceId: input.workspaceId },
+    (executor) => beginMediaAssetUploadSessionCompletionWithOwnerInExecutor(executor, input),
   );
 }
 

--- a/db/migrations/0095_atomic_multipart_writer_completion.sql
+++ b/db/migrations/0095_atomic_multipart_writer_completion.sql
@@ -1,0 +1,362 @@
+-- Current additive migration for no-writer multipart closure and atomic owner-bound completion start.
+CREATE OR REPLACE FUNCTION content.close_media_upload_session_blob_writer(
+  p_user_id TEXT, p_workspace_id UUID, p_media_upload_session_id UUID, p_media_asset_id UUID,
+  p_last_modified_by_replica_id UUID, p_last_operation_id TEXT, p_sha256 TEXT,
+  p_storage_key TEXT, p_mime_type TEXT, p_size_bytes BIGINT, p_expires_at TIMESTAMPTZ,
+  p_cleanup_delay_ms INTEGER)
+RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE; lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  session_found BOOLEAN; lifecycle_found BOOLEAN; reservation_found BOOLEAN;
+  reference RECORD; reference_found BOOLEAN; abort_proven BOOLEAN; expiry_proven BOOLEAN;
+  terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+    OR p_user_id IS NULL OR p_workspace_id IS NULL OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL OR p_last_modified_by_replica_id IS NULL
+    OR p_last_operation_id IS NULL OR p_sha256 IS NULL OR p_storage_key IS NULL
+    OR p_mime_type IS NULL OR p_size_bytes IS NULL OR p_expires_at IS NULL
+  THEN RETURN 'stale'; END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  SELECT sessions.* INTO session FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id FOR UPDATE;
+  session_found := FOUND;
+  IF session_found AND (
+    session.workspace_id IS DISTINCT FROM p_workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+    OR session.blob_storage_key IS DISTINCT FROM p_storage_key
+    OR session.mime_type IS DISTINCT FROM p_mime_type
+    OR session.size_bytes IS DISTINCT FROM p_size_bytes
+    OR session.expires_at IS DISTINCT FROM p_expires_at
+  ) THEN RETURN 'stale'; END IF;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  lifecycle_found := FOUND;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion'
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_media_upload_session_id::TEXT FOR UPDATE;
+  reservation_found := FOUND;
+  IF NOT reservation_found THEN
+    PERFORM 1 FROM content.media_blob_writer_reservations AS conflicts
+    WHERE conflicts.writer_kind = 'multipart_completion'
+      AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ORDER BY conflicts.reservation_token FOR UPDATE;
+    IF FOUND THEN RETURN 'stale'; END IF;
+    PERFORM 1 FROM content.media_blob_writer_owner_snapshots AS conflicts
+    WHERE conflicts.writer_kind = 'multipart_completion'
+      AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ORDER BY conflicts.reservation_token FOR UPDATE;
+    IF FOUND THEN RETURN 'stale'; END IF;
+    IF NOT session_found THEN RETURN 'absent'; END IF;
+    IF session.state = 'aborted' THEN RETURN 'already_closed'; END IF;
+    IF session.state = 'completed'
+      OR (session.state IS DISTINCT FROM 'aborting' AND session.expires_at > clock_timestamp())
+    THEN RETURN 'stale'; END IF;
+    PERFORM 1 FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_last_modified_by_replica_id
+      AND replicas.workspace_id = p_workspace_id AND replicas.user_id = p_user_id
+    FOR KEY SHARE;
+    IF NOT FOUND THEN RETURN 'stale'; END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'aborted', completed_at = NULL, aborted_at = clock_timestamp()
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id
+      AND sessions.state IN ('active', 'completing', 'aborting');
+    IF NOT FOUND THEN RETURN 'stale'; END IF;
+    RETURN 'no_writer_closed';
+  END IF;
+  IF NOT lifecycle_found THEN RETURN 'stale'; END IF;
+  SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+  IF NOT FOUND
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+    OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version NOT IN ('passthrough-v1', 'image-jpeg-card-v1')
+    OR reservation.state NOT IN ('active', 'ambiguous', 'finalized', 'unreferenced')
+  THEN RETURN 'stale'; END IF;
+  IF session_found AND (
+    owner_snapshot.session_source_url IS DISTINCT FROM session.source_url
+    OR owner_snapshot.session_asset_created_at IS DISTINCT FROM session.asset_created_at
+    OR owner_snapshot.session_client_updated_at IS DISTINCT FROM session.client_updated_at
+  ) THEN RETURN 'stale'; END IF;
+  IF NOT session_found AND reservation.state = 'unreferenced' THEN RETURN 'already_closed'; END IF;
+  IF session_found AND session.state IN ('completed', 'aborted') THEN RETURN 'already_closed'; END IF;
+  abort_proven := session_found AND session.state = 'aborting';
+  expiry_proven := owner_snapshot.session_expires_at <= clock_timestamp();
+  IF NOT abort_proven AND NOT expiry_proven AND EXISTS (
+    SELECT 1 FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id AND memberships.user_id = p_user_id
+  ) THEN RETURN 'access_active'; END IF;
+  SELECT assets.workspace_id, assets.source_url, assets.created_at, assets.client_updated_at,
+    assets.last_modified_by_replica_id, assets.last_operation_id, blobs.sha256,
+    blobs.storage_key, blobs.mime_type, blobs.size_bytes, blobs.normalization_version
+  INTO reference FROM content.media_assets AS assets
+  INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id
+  WHERE assets.media_asset_id = p_media_asset_id AND assets.deleted_at IS NULL;
+  reference_found := FOUND;
+  IF reference_found AND (
+    reference.workspace_id IS DISTINCT FROM p_workspace_id
+    OR reference.source_url IS DISTINCT FROM owner_snapshot.session_source_url
+    OR reference.created_at IS DISTINCT FROM owner_snapshot.session_asset_created_at
+    OR reference.client_updated_at IS DISTINCT FROM owner_snapshot.session_client_updated_at
+    OR reference.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR reference.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR reference.sha256 IS DISTINCT FROM p_sha256
+    OR reference.storage_key IS DISTINCT FROM p_storage_key
+    OR reference.mime_type IS DISTINCT FROM p_mime_type
+    OR reference.size_bytes IS DISTINCT FROM p_size_bytes
+    OR reference.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+  ) THEN RETURN 'stale'; END IF;
+  IF reference_found THEN
+    IF reservation.state = 'unreferenced' THEN RETURN 'stale'; END IF;
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      reservation.reservation_token, p_sha256, p_storage_key, p_mime_type, p_size_bytes,
+      lifecycle.normalization_version, 'multipart_completion', p_workspace_id,
+      p_media_asset_id, p_media_upload_session_id::TEXT, p_cleanup_delay_ms);
+    IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF;
+    IF session_found THEN UPDATE content.media_upload_sessions
+      SET state = 'completed', completed_at = clock_timestamp(), aborted_at = NULL
+      WHERE media_upload_session_id = p_media_upload_session_id; END IF;
+    RETURN 'referenced';
+  END IF;
+  IF NOT abort_proven AND NOT expiry_proven THEN RETURN 'stale'; END IF;
+  IF reservation.state = 'finalized' THEN RETURN 'stale'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    reservation.reservation_token, p_sha256, p_storage_key, p_mime_type, p_size_bytes,
+    lifecycle.normalization_version, 'multipart_completion', p_workspace_id,
+    p_media_asset_id, p_media_upload_session_id::TEXT, p_cleanup_delay_ms);
+  IF terminalization_status <> 'unreferenced' THEN RETURN 'stale'; END IF;
+  IF session_found THEN UPDATE content.media_upload_sessions
+    SET state = 'aborted', completed_at = NULL, aborted_at = clock_timestamp()
+    WHERE media_upload_session_id = p_media_upload_session_id; END IF;
+  RETURN 'unreferenced';
+END;
+$$;
+
+CREATE FUNCTION content.begin_media_upload_session_completion_with_owner(
+  p_user_id TEXT, p_workspace_id UUID, p_media_upload_session_id UUID,
+  p_media_asset_id UUID, p_last_modified_by_replica_id UUID, p_last_operation_id TEXT,
+  p_sha256 TEXT, p_staging_storage_key TEXT, p_blob_storage_key TEXT, p_s3_upload_id TEXT,
+  p_mime_type TEXT, p_size_bytes BIGINT, p_part_size_bytes BIGINT, p_part_count INTEGER,
+  p_source_url TEXT, p_asset_created_at TIMESTAMPTZ, p_client_updated_at TIMESTAMPTZ,
+  p_expires_at TIMESTAMPTZ, p_normalization_version TEXT)
+RETURNS TABLE (completion_status TEXT, reservation_token UUID, reservation_state TEXT,
+  normalization_version TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE; lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  lifecycle_found BOOLEAN; reservation_found BOOLEAN; owner_snapshot_found BOOLEAN;
+  reservation_result RECORD; reference RECORD;
+BEGIN
+  IF p_user_id IS NULL OR p_user_id IS DISTINCT FROM btrim(p_user_id) OR p_user_id = ''
+    OR p_workspace_id IS NULL OR p_media_upload_session_id IS NULL OR p_media_asset_id IS NULL
+    OR p_last_modified_by_replica_id IS NULL OR p_last_operation_id IS NULL OR p_sha256 IS NULL
+    OR p_staging_storage_key IS NULL OR p_blob_storage_key IS NULL OR p_s3_upload_id IS NULL
+    OR p_mime_type IS NULL OR p_size_bytes IS NULL OR p_part_size_bytes IS NULL
+    OR p_part_count IS NULL OR p_asset_created_at IS NULL OR p_client_updated_at IS NULL
+    OR p_expires_at IS NULL OR p_normalization_version IS NULL
+  THEN RAISE EXCEPTION 'Atomic multipart completion identity is invalid' USING ERRCODE = '22023';
+  END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  PERFORM 1 FROM org.workspace_memberships AS memberships
+  WHERE memberships.workspace_id = p_workspace_id AND memberships.user_id = p_user_id FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  SELECT sessions.* INTO session FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'session_not_found'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF session.workspace_id IS DISTINCT FROM p_workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+    OR session.staging_storage_key IS DISTINCT FROM p_staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_mime_type
+    OR session.size_bytes IS DISTINCT FROM p_size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_part_count
+    OR session.source_url IS DISTINCT FROM p_source_url
+    OR session.asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM p_client_updated_at
+    OR session.expires_at IS DISTINCT FROM p_expires_at
+  THEN RETURN QUERY SELECT 'payload_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  PERFORM 1 FROM sync.workspace_replicas AS replicas
+  WHERE replicas.replica_id = p_last_modified_by_replica_id
+    AND replicas.workspace_id = p_workspace_id AND replicas.user_id = p_user_id FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF session.state = 'aborting' THEN
+    RETURN QUERY SELECT 'aborting'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  ELSIF session.state = 'aborted' THEN
+    RETURN QUERY SELECT 'aborted'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  ELSIF session.state NOT IN ('active', 'completing', 'completed') THEN
+    RETURN QUERY SELECT 'state_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  ELSIF session.state = 'active' AND session.expires_at <= clock_timestamp() THEN
+    RETURN QUERY SELECT 'expired'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  lifecycle_found := FOUND;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion'
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_media_upload_session_id::TEXT FOR UPDATE;
+  reservation_found := FOUND;
+  IF reservation_found THEN
+    SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+    owner_snapshot_found := FOUND;
+  ELSE
+    owner_snapshot_found := false;
+    PERFORM 1 FROM content.media_blob_writer_reservations AS conflicts
+    WHERE conflicts.writer_kind = 'multipart_completion'
+      AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ORDER BY conflicts.reservation_token FOR UPDATE;
+    IF FOUND THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+    END IF;
+    PERFORM 1 FROM content.media_blob_writer_owner_snapshots AS conflicts
+    WHERE conflicts.writer_kind = 'multipart_completion'
+      AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ORDER BY conflicts.reservation_token FOR UPDATE;
+    IF FOUND THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+    END IF;
+  END IF;
+  IF reservation_found AND NOT owner_snapshot_found THEN
+    RETURN QUERY SELECT 'legacy_unbound'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF reservation_found AND (
+    NOT lifecycle_found OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR lifecycle.storage_key IS DISTINCT FROM p_blob_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version NOT IN ('passthrough-v1', 'image-jpeg-card-v1')
+  ) THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF owner_snapshot_found AND (
+    owner_snapshot.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+    OR owner_snapshot.session_source_url IS DISTINCT FROM p_source_url
+    OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_client_updated_at
+  ) THEN RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF lifecycle_found AND (
+    lifecycle.storage_key IS DISTINCT FROM p_blob_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+  ) THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF session.state = 'completed' THEN
+    IF NOT reservation_found OR reservation.state IS DISTINCT FROM 'finalized' THEN
+      RETURN QUERY SELECT 'completed_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+    END IF;
+    SELECT assets.workspace_id, assets.source_url, assets.created_at, assets.client_updated_at,
+      assets.last_modified_by_replica_id, assets.last_operation_id, blobs.sha256,
+      blobs.storage_key, blobs.mime_type, blobs.size_bytes, blobs.normalization_version
+    INTO reference FROM content.media_assets AS assets
+    INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id
+    WHERE assets.media_asset_id = p_media_asset_id AND assets.deleted_at IS NULL
+    FOR KEY SHARE OF assets, blobs;
+    IF NOT FOUND OR reference.workspace_id IS DISTINCT FROM p_workspace_id
+      OR reference.source_url IS DISTINCT FROM p_source_url
+      OR reference.created_at IS DISTINCT FROM p_asset_created_at
+      OR reference.client_updated_at IS DISTINCT FROM p_client_updated_at
+      OR reference.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+      OR reference.last_operation_id IS DISTINCT FROM p_last_operation_id
+      OR reference.sha256 IS DISTINCT FROM p_sha256
+      OR reference.storage_key IS DISTINCT FROM p_blob_storage_key
+      OR reference.mime_type IS DISTINCT FROM p_mime_type
+      OR reference.size_bytes IS DISTINCT FROM p_size_bytes
+      OR reference.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+    THEN RETURN QUERY SELECT 'completed_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+    END IF;
+    RETURN QUERY SELECT 'already_completed'::TEXT, reservation.reservation_token,
+      reservation.state, lifecycle.normalization_version; RETURN;
+  END IF;
+  IF session.state = 'completing' THEN
+    IF NOT reservation_found OR reservation.state NOT IN ('active', 'ambiguous', 'finalized') THEN
+      RETURN QUERY SELECT 'legacy_unbound'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+    END IF;
+    RETURN QUERY SELECT 'replayed'::TEXT, reservation.reservation_token,
+      reservation.state, lifecycle.normalization_version; RETURN;
+  END IF;
+  SELECT * INTO reservation_result FROM content.reserve_owned_media_blob_writer_internal(
+    p_user_id, p_last_modified_by_replica_id, p_sha256, p_blob_storage_key,
+    p_mime_type, p_size_bytes, p_normalization_version, 'multipart_completion',
+    p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+    p_last_operation_id, p_expires_at, p_source_url, p_asset_created_at, p_client_updated_at);
+  IF reservation_result.reservation_status = 'cleanup_claimed' THEN
+    RETURN QUERY SELECT 'cleanup_claimed'::TEXT, NULL::UUID, NULL::TEXT,
+      reservation_result.normalization_version; RETURN;
+  END IF;
+  IF reservation_result.reservation_status <> 'reserved'
+    OR reservation_result.reservation_token IS NULL
+    OR reservation_result.reservation_state NOT IN ('active', 'ambiguous', 'finalized')
+  THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  UPDATE content.media_upload_sessions AS sessions SET state = 'completing'
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id AND sessions.state = 'active';
+  IF NOT FOUND THEN RAISE EXCEPTION 'Atomic multipart completion lost the locked active session'
+    USING ERRCODE = '40001'; END IF;
+  RETURN QUERY SELECT 'started'::TEXT, reservation_result.reservation_token,
+    reservation_result.reservation_state, reservation_result.normalization_version;
+END;
+$$;
+
+COMMENT ON FUNCTION content.close_media_upload_session_blob_writer(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER) IS
+  'Closes one exact multipart writer or atomically aborts an exact aborting/expired session proven to have no writer.';
+COMMENT ON FUNCTION content.begin_media_upload_session_completion_with_owner(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, BIGINT,
+  BIGINT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, TEXT) IS
+  'Atomically starts or replays one exact owner-bound multipart completion without object-storage or final media-asset mutation.';
+REVOKE ALL ON TABLE content.media_blob_lifecycles, content.media_blob_writer_reservations,
+  content.media_blob_writer_owner_snapshots FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.close_media_upload_session_blob_writer(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.begin_media_upload_session_completion_with_owner(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, BIGINT,
+  BIGINT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, TEXT
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+GRANT EXECUTE ON FUNCTION content.close_media_upload_session_blob_writer(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.begin_media_upload_session_completion_with_owner(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, BIGINT,
+  BIGINT, INTEGER, TEXT, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ, TEXT
+) TO backend_app;


### PR DESCRIPTION
## Summary
- close exact aborting or expired multipart sessions without manufacturing a writer
- atomically begin and replay owner-bound multipart completion
- add focused PostgreSQL integration coverage for concurrency, expiry replay, upgrade, and security

## Validation
- full transactional migration chain through 0095
- focused and related PostgreSQL integrations
- 827 backend tests
- backend lint and build
- ACL, signature, caller, scope, and diff audits