### PR TITLE
Add atomic multipart completion resolution

### DIFF
--- a/apps/backend/src/mediaAssets/multipartCompletionResolution.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipartCompletionResolution.postgres.integration.ts
@@ -1,0 +1,364 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+import { beginMediaAssetUploadSessionCompletionWithOwner, fenceMediaAssetUploadSessionCompletionApplyWithOwner,
+  fenceMediaAssetUploadSessionCompletionApplyWithOwnerInExecutor, resolveMediaAssetUploadSessionCompletionAfterAccessRevocation,
+  resolveMediaAssetUploadSessionCompletionAfterAccessRevocationInExecutor, resolveMediaAssetUploadSessionCompletionFailureWithOwner,
+  type MediaAssetUploadSessionCompletionResolutionInput, type MediaAssetUploadSessionCompletionRevocationInput, type MediaAssetUploadSessionCompletionWithOwnerInput } from "./uploadSessions";
+import { compareLwwMetadata } from "../sync/conflicts/lww";
+import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "./types";
+const migration0096 = readFileSync(resolve(__dirname, "../../../../db/migrations/0096_atomic_multipart_completion_resolution.sql"), "utf8");
+const signatures = {
+  apply: "content.fence_media_upload_session_completion_apply_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,uuid,text,integer)",
+  failure: "content.resolve_media_upload_session_completion_failure_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,uuid,text,integer)",
+  revocation: "content.resolve_media_upload_session_completion_after_access_revocation(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,integer)",
+  helper: "content.classify_media_upload_session_completion_asset_internal(uuid,uuid,text,text,text,bigint,text,text,timestamp with time zone,timestamp with time zone,uuid,text)",
+  begin: "content.begin_media_upload_session_completion_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,text)",
+  close: "content.close_media_upload_session_blob_writer(text,uuid,uuid,uuid,uuid,text,text,text,text,bigint,timestamp with time zone,integer)",
+  reference: "content.fence_media_blob_reference(uuid)",
+  workspaceDelete: "content.terminalize_media_blob_writers_before_workspace_delete()",
+} as const;
+function digest(): string { return createHash("sha256").update(randomUUID()).digest("hex"); }
+function session(fixture: PostgresIntegrationFixture): MediaAssetUploadSessionCompletionWithOwnerInput {
+  const sessionId = randomUUID(), mediaAssetId = randomUUID(), sha256 = digest();
+  return {
+    userId: fixture.userId, workspaceId: fixture.workspaceId, sessionId, mediaAssetId,
+    lastModifiedByReplicaId: fixture.replicaId, lastOperationId: randomUUID(), sha256,
+    stagingStorageKey: `media/uploads/workspaces/${fixture.workspaceId}/assets/${mediaAssetId}/sessions/${sessionId}`,
+    blobStorageKey: buildMediaBlobStorageKey(sha256), s3UploadId: `upload-${randomUUID()}`,
+    mimeType: "application/octet-stream", sizeBytes: 42, partSizeBytes: 42, partCount: 1,
+    sourceUrl: null, assetCreatedAt: fixture.createdAt, clientUpdatedAt: fixture.createdAt,
+    expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    normalizationVersion: passthroughMediaBlobNormalizationVersion,
+  };
+}
+async function insertSession(
+  fixture: PostgresIntegrationFixture, input: MediaAssetUploadSessionCompletionWithOwnerInput,
+  state: "active" | "completing",
+): Promise<void> {
+  await fixture.ownerPool.query(
+    `INSERT INTO content.media_upload_sessions (media_upload_session_id,workspace_id,media_asset_id,
+       media_blob_sha256,staging_storage_key,blob_storage_key,s3_upload_id,mime_type,size_bytes,
+       part_size_bytes,part_count,state,source_url,asset_created_at,client_updated_at,last_modified_by_replica_id,last_operation_id,expires_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+    [input.sessionId, input.workspaceId, input.mediaAssetId, input.sha256,
+      input.stagingStorageKey, input.blobStorageKey, input.s3UploadId, input.mimeType,
+      input.sizeBytes, input.partSizeBytes, input.partCount, state, input.sourceUrl,
+      input.assetCreatedAt, input.clientUpdatedAt, input.lastModifiedByReplicaId,
+      input.lastOperationId, input.expiresAt]);
+}
+async function start(fixture: PostgresIntegrationFixture, input: MediaAssetUploadSessionCompletionWithOwnerInput,
+): Promise<MediaAssetUploadSessionCompletionResolutionInput> {
+  await insertSession(fixture, input, "active");
+  const result = await beginMediaAssetUploadSessionCompletionWithOwner(input);
+  assert.equal(result.status, "started");
+  assert.ok("reservation" in result);
+  return { ...input, reservationToken: result.reservation.reservationToken,
+    normalizationVersion: result.reservation.normalizationVersion };
+}
+function toRevocationInput(input: MediaAssetUploadSessionCompletionRevocationInput & Readonly<{
+  normalizationVersion: MediaAssetUploadSessionCompletionResolutionInput["normalizationVersion"];
+  reservationToken?: string;
+}>): MediaAssetUploadSessionCompletionRevocationInput {
+  const { normalizationVersion: _normalizationVersion,
+    reservationToken: _reservationToken, ...revocationInput } = input;
+  return revocationInput;
+}
+async function insertAsset(fixture: PostgresIntegrationFixture,
+  input: MediaAssetUploadSessionCompletionResolutionInput, exact: boolean,
+): Promise<void> {
+  const clientUpdatedAt = exact ? input.clientUpdatedAt
+    : new Date(new Date(input.clientUpdatedAt).getTime() + 60_000).toISOString();
+  await fixture.ownerPool.query(
+    `WITH blob AS (INSERT INTO content.media_blobs
+         (media_blob_id,sha256,mime_type,size_bytes,storage_key,normalization_version)
+       VALUES ($1,$2,$3,$4,$5,$6) RETURNING media_blob_id
+     ) INSERT INTO content.media_assets (media_asset_id,workspace_id,media_blob_id,source_url,
+       created_at,client_updated_at,last_modified_by_replica_id,last_operation_id)
+     SELECT $7,$8,media_blob_id,$9,$10,$11,$12,$13 FROM blob`,
+    [randomUUID(), input.sha256, input.mimeType, input.sizeBytes, input.blobStorageKey,
+      input.normalizationVersion, input.mediaAssetId, input.workspaceId, input.sourceUrl,
+      input.assetCreatedAt, clientUpdatedAt, input.lastModifiedByReplicaId,
+      exact ? input.lastOperationId : randomUUID()]);
+}
+async function setMembership(fixture: PostgresIntegrationFixture, present: boolean): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1::text||':'||$2::text,0::bigint))",
+      [fixture.userId, fixture.workspaceId]);
+    if (present) {
+      await client.query(`INSERT INTO org.workspace_memberships(workspace_id,user_id,role)
+        VALUES ($1,$2,'owner') ON CONFLICT DO NOTHING`, [fixture.workspaceId, fixture.userId]);
+    } else {
+      await client.query("DELETE FROM org.workspace_memberships WHERE workspace_id=$1 AND user_id=$2",
+        [fixture.workspaceId, fixture.userId]);
+    }
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally { client.release(); }
+}
+async function state(
+  fixture: PostgresIntegrationFixture, sessionId: string,
+): Promise<Readonly<{ session_state: string; writer_state: string | null }>> {
+  return (await fixture.ownerPool.query(
+    `SELECT sessions.state AS session_state, reservations.state AS writer_state
+     FROM content.media_upload_sessions AS sessions LEFT JOIN content.media_blob_writer_reservations AS reservations
+       ON reservations.operation_id=sessions.media_upload_session_id::text WHERE sessions.media_upload_session_id=$1`,
+    [sessionId])).rows[0];
+}
+async function absentState(fixture: PostgresIntegrationFixture, input: MediaAssetUploadSessionCompletionWithOwnerInput
+): Promise<Readonly<{ state: string; lifecycle: boolean; asset: boolean }>> {
+  return (await fixture.ownerPool.query(
+    `SELECT sessions.state, EXISTS(SELECT 1 FROM content.media_blob_lifecycles WHERE sha256=$2) AS lifecycle,
+       EXISTS(SELECT 1 FROM content.media_assets WHERE media_asset_id=$3) AS asset FROM content.media_upload_sessions AS sessions
+     WHERE media_upload_session_id=$1`,
+    [input.sessionId, input.sha256, input.mediaAssetId])).rows[0];
+}
+type SqlExecutor = Readonly<{ query: PostgresIntegrationFixture["ownerPool"]["query"] }>;
+async function waitForLock(observer: SqlExecutor, pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const waiting = (await observer.query<{ waiting: boolean }>("SELECT wait_event_type='Lock' AS waiting FROM pg_stat_activity WHERE pid=$1", [pid])).rows[0]?.waiting;
+    if (waiting === true) return;
+    await observer.query("SELECT pg_sleep(0.01)");
+  }
+  assert.fail(`backend ${pid} did not enter a lock wait`);
+}
+async function assertLifecycleRace(
+  fixture: PostgresIntegrationFixture, input: MediaAssetUploadSessionCompletionResolutionInput,
+  expected: "already_applied" | "peer_conflict",
+  startConcurrent: (worker: SqlExecutor) => Promise<unknown>,
+): Promise<void> {
+  const holder = await fixture.ownerPool.connect(), worker = await fixture.ownerPool.connect();
+  const workerPid = (await worker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+  let work: Promise<unknown> | undefined;
+  try {
+    await holder.query("BEGIN");
+    await holder.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]);
+    await holder.query("SELECT 1 FROM content.media_blob_lifecycles WHERE sha256=$1 FOR UPDATE", [input.sha256]);
+    work = startConcurrent(worker);
+    await waitForLock(holder, workerPid);
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwnerInExecutor(holder, input), expected);
+    await holder.query("COMMIT");
+    await work;
+  } catch (error) { await holder.query("ROLLBACK");
+    if (work !== undefined) await Promise.allSettled([work]);
+    throw error; } finally { worker.release(); holder.release(); }
+}
+async function assertUpgradeSecurity(fixture: PostgresIntegrationFixture): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  try {
+    const before = (await client.query(
+      `SELECT to_regprocedure($1) IS NULL AS no_apply, to_regprocedure($2) IS NULL AS no_failure,
+        to_regprocedure($3) IS NULL AS no_revocation, to_regprocedure($4) IS NULL AS no_helper,
+        to_regprocedure($5) IS NOT NULL AS old_begin, to_regprocedure($6) IS NOT NULL AS old_close,
+        to_regprocedure($7) IS NOT NULL AS old_reference, to_regprocedure($8) IS NOT NULL AS old_workspace_delete`,
+      [signatures.apply, signatures.failure, signatures.revocation, signatures.helper,
+        signatures.begin, signatures.close, signatures.reference, signatures.workspaceDelete])).rows[0];
+    assert.deepEqual(before, {
+      no_apply: true, no_failure: true, no_revocation: true, no_helper: true, old_begin: true,
+      old_close: true, old_reference: true, old_workspace_delete: true,
+    });
+    await client.query("BEGIN");
+    await client.query(migration0096);
+    await client.query("COMMIT");
+    const row = (await client.query(
+      `SELECT bool_and(prosecdef AND proconfig=ARRAY['search_path=pg_catalog']) AS hardened,
+        bool_and(has_function_privilege('backend_app',oid,'EXECUTE')) FILTER
+          (WHERE oid=ANY(ARRAY[$1::regprocedure,$2::regprocedure,$3::regprocedure])) AS backend_execute,
+        bool_or(has_function_privilege('backend_app',oid,'EXECUTE')) FILTER
+          (WHERE oid=ANY(ARRAY[$4::regprocedure,$5::regprocedure,$6::regprocedure])) AS internal_execute,
+        bool_or(has_function_privilege('auth_app',oid,'EXECUTE')) AS auth_execute,
+        bool_or(has_function_privilege('reporting_readonly',oid,'EXECUTE')) AS reporting_execute
+       FROM pg_proc WHERE oid=ANY(ARRAY[$1::regprocedure,$2::regprocedure,
+         $3::regprocedure,$4::regprocedure,$5::regprocedure,$6::regprocedure])`,
+      [signatures.apply, signatures.failure, signatures.revocation, signatures.helper,
+        signatures.reference, signatures.workspaceDelete])).rows[0];
+    assert.deepEqual(row, { hardened: true, backend_execute: true, internal_execute: false,
+      auth_execute: false, reporting_execute: false });
+    const compatibility = (await client.query(
+      `SELECT to_regprocedure($1) IS NOT NULL AS old_begin, to_regprocedure($2) IS NOT NULL AS old_close,
+        to_regprocedure($3) IS NOT NULL AS old_reference, to_regprocedure($4) IS NOT NULL AS old_workspace_delete,
+        has_table_privilege('backend_app','content.media_blob_writer_reservations','SELECT') AS writer_table,
+        has_table_privilege('backend_app','content.media_blob_writer_owner_snapshots','SELECT') AS owner_table`,
+      [signatures.begin, signatures.close, signatures.reference, signatures.workspaceDelete])).rows[0];
+    assert.deepEqual(compatibility, {
+      old_begin: true, old_close: true, old_reference: true, old_workspace_delete: true,
+      writer_table: false, owner_table: false });
+  } catch (error) { await client.query("ROLLBACK"); throw error;
+  } finally { client.release(); }
+}
+test("multipart completion resolution is atomic, replayable, revocation-safe, and deadlock-free", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    await assertUpgradeSecurity(fixture);
+    for (const [storedOperationId, incomingOperationId] of
+      [["lww-tie-", "lww-tie_"], [`lww-tie-\uE000`, "lww-tie-😀"]]) {
+      const lww = await start(fixture, { ...session(fixture), lastOperationId: incomingOperationId });
+      const metadata = (lastOperationId: string) => ({
+        clientUpdatedAt: lww.clientUpdatedAt, lastModifiedByReplicaId: lww.lastModifiedByReplicaId,
+        lastOperationId });
+      assert.ok(compareLwwMetadata(metadata(incomingOperationId), metadata(storedOperationId)) > 0);
+      await insertAsset(fixture, { ...lww, lastOperationId: storedOperationId }, true);
+      assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(lww), "ready");
+    }
+    const failure = await start(fixture, session(fixture));
+    assert.equal(await resolveMediaAssetUploadSessionCompletionFailureWithOwner(failure), "unreferenced_restored");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionFailureWithOwner(failure), "unreferenced_restored");
+    assert.deepEqual(await state(fixture, failure.sessionId), { session_state: "active", writer_state: "unreferenced" });
+    const exact = await start(fixture, session(fixture));
+    await insertAsset(fixture, exact, true);
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(exact), "already_applied");
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(exact), "already_applied");
+    assert.deepEqual(await state(fixture, exact.sessionId), { session_state: "completed", writer_state: "finalized" });
+    const peer = await start(fixture, session(fixture));
+    await insertAsset(fixture, peer, false);
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(peer), "peer_conflict");
+    assert.deepEqual(await state(fixture, peer.sessionId), { session_state: "aborted", writer_state: "finalized" });
+    const fenced = await start(fixture, session(fixture));
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(
+      { ...fenced, reservationToken: randomUUID() }), "stale");
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(
+      { ...fenced, normalizationVersion: imageJpegCardMediaBlobNormalizationVersion }), "stale");
+    await fixture.ownerPool.query(`UPDATE content.media_blob_writer_owner_snapshots SET session_source_url=$1
+      WHERE reservation_token=$2`, ["owner-mismatch", fenced.reservationToken]);
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(fenced), "stale");
+    await fixture.ownerPool.query(`UPDATE content.media_blob_writer_owner_snapshots SET session_source_url=$1
+      WHERE reservation_token=$2`, [fenced.sourceUrl, fenced.reservationToken]);
+    await fixture.ownerPool.query(`UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=now(),
+      cleanup_lease_token=$1,cleanup_lease_expires_at=now()+interval '1 hour' WHERE sha256=$2`,
+    [randomUUID(), fenced.sha256]);
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(fenced), "stale");
+    await fixture.ownerPool.query(`UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=NULL,
+      cleanup_lease_token=NULL,cleanup_lease_expires_at=NULL WHERE sha256=$1`, [fenced.sha256]);
+    const restored = await start(fixture, session(fixture));
+    await setMembership(fixture, false);
+    const reassignedUserId = `multipart-resolution-${randomUUID()}`;
+    await fixture.ownerPool.query(
+      `WITH inserted AS (INSERT INTO org.user_settings(user_id) VALUES ($1) RETURNING 1)
+       UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2`,
+      [reassignedUserId, fixture.replicaId]);
+    assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(restored), "access_denied");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionFailureWithOwner(restored), "access_denied");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation({ ...toRevocationInput(restored), userId: `wrong-${randomUUID()}` }), "stale");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation({ ...toRevocationInput(restored), s3UploadId: `${restored.s3UploadId}-wrong` }), "stale");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation({ ...toRevocationInput(restored), sessionId: randomUUID() }), "stale");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation({ ...toRevocationInput(restored), lastModifiedByReplicaId: randomUUID() }), "stale");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation({ ...toRevocationInput(restored), sizeBytes: restored.sizeBytes + 1 }), "stale");
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation(toRevocationInput(restored)),
+      "unreferenced_closed");
+    assert.deepEqual(await state(fixture, restored.sessionId), { session_state: "aborted", writer_state: "unreferenced" });
+    const absent = session(fixture);
+    await insertSession(fixture, absent, "completing");
+    const absentBefore = await absentState(fixture, absent);
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation({ ...toRevocationInput(absent), userId: `wrong-${randomUUID()}` }), "stale");
+    assert.deepEqual(await absentState(fixture, absent), absentBefore);
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation(toRevocationInput(absent)), "stale");
+    assert.deepEqual(await absentState(fixture, absent), absentBefore);
+    const holder = await fixture.ownerPool.connect(), worker = await fixture.ownerPool.connect();
+    const workerPid = (await worker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+    let recovery: Promise<string> | undefined;
+    try {
+      await holder.query("BEGIN");
+      await holder.query("SELECT 1 FROM sync.workspace_sync_metadata WHERE workspace_id=$1 FOR UPDATE", [fixture.workspaceId]);
+      await holder.query(
+        `WITH blob AS (INSERT INTO content.media_blobs (media_blob_id,sha256,mime_type,size_bytes,
+           storage_key,normalization_version) VALUES ($1,$2,$3,$4,$5,$6) RETURNING media_blob_id)
+         INSERT INTO content.media_assets (media_asset_id,workspace_id,media_blob_id,source_url,created_at,
+           client_updated_at,last_modified_by_replica_id,last_operation_id)
+         SELECT $7,$8,media_blob_id,NULL,$9,$9,$10,$11 FROM blob`,
+        [randomUUID(), absent.sha256, absent.mimeType, absent.sizeBytes, absent.blobStorageKey,
+          passthroughMediaBlobNormalizationVersion, randomUUID(), fixture.workspaceId,
+          fixture.createdAt, fixture.replicaId, randomUUID()]);
+      recovery = resolveMediaAssetUploadSessionCompletionAfterAccessRevocationInExecutor(worker, toRevocationInput(absent));
+      await waitForLock(holder, workerPid);
+      await holder.query("UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2", [fixture.userId, fixture.replicaId]);
+      await holder.query("COMMIT");
+      assert.equal(await recovery, "absent_closed");
+      await fixture.ownerPool.query("DELETE FROM org.user_settings WHERE user_id=$1", [reassignedUserId]);
+    } catch (error) { await holder.query("ROLLBACK");
+      if (recovery !== undefined) await Promise.allSettled([recovery]);
+      throw error; } finally { worker.release(); holder.release(); }
+    await setMembership(fixture, true);
+    const activeAgain = await start(fixture, session(fixture));
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation(toRevocationInput(activeAgain)),
+      "access_active");
+    assert.deepEqual(await state(fixture, activeAgain.sessionId), { session_state: "completing", writer_state: "active" });
+    const referenced = await start(fixture, session(fixture));
+    await insertAsset(fixture, referenced, true);
+    await setMembership(fixture, false);
+    assert.equal(await resolveMediaAssetUploadSessionCompletionAfterAccessRevocation(toRevocationInput(referenced)),
+      "referenced");
+    assert.deepEqual(await state(fixture, referenced.sessionId), { session_state: "completed", writer_state: "finalized" });
+    await setMembership(fixture, true);
+    const referenceRace = await start(fixture, session(fixture));
+    await insertAsset(fixture, referenceRace, true);
+    await assertLifecycleRace(fixture, referenceRace, "already_applied",
+      (worker) => worker.query(
+        `INSERT INTO content.media_assets (media_asset_id,workspace_id,media_blob_id,source_url,
+           created_at,client_updated_at,last_modified_by_replica_id,last_operation_id)
+         SELECT $2,$3,media_blob_id,NULL,$4,$4,$5,$6 FROM content.media_blobs WHERE sha256=$1`,
+        [referenceRace.sha256, randomUUID(), fixture.workspaceId, fixture.createdAt,
+          fixture.replicaId, randomUUID()]));
+    const deleteRace = await start(fixture, session(fixture));
+    const deletingReplicaId = randomUUID(), deletingOperationId = randomUUID(), deletingReservationToken = randomUUID();
+    await fixture.ownerPool.query(
+      `WITH workspace AS (
+         INSERT INTO org.workspaces
+           (workspace_id,name,fsrs_client_updated_at,fsrs_last_modified_by_replica_id,fsrs_last_operation_id)
+         VALUES ($1,'Deletion race',$2,$3,$4) RETURNING workspace_id
+       ), replica AS (
+         INSERT INTO sync.workspace_replicas
+           (replica_id,workspace_id,user_id,actor_kind,actor_key,platform,app_version)
+         SELECT $3,workspace_id,$5,'ai_chat',$6,'system','postgres-integration'
+         FROM workspace RETURNING workspace_id
+       ) INSERT INTO org.workspace_memberships(workspace_id,user_id,role)
+         SELECT workspace_id,$5,'owner' FROM replica`,
+      [fixture.outOfScopeWorkspaceId, fixture.createdAt, deletingReplicaId,
+        deletingOperationId, fixture.userId, `deletion-race-${deletingReplicaId}`],
+    );
+    await insertAsset(fixture, { ...deleteRace, workspaceId: fixture.outOfScopeWorkspaceId,
+      lastModifiedByReplicaId: deletingReplicaId, lastOperationId: deletingOperationId }, true);
+    await fixture.ownerPool.query(
+      `WITH reservation AS (
+         INSERT INTO content.media_blob_writer_reservations
+           (reservation_token,sha256,writer_kind,workspace_id,media_asset_id,operation_id,state)
+         VALUES ($1,$2,'direct_ingestion',$3,$4,$5,'finalized') RETURNING *
+       ) INSERT INTO content.media_blob_writer_owner_snapshots
+         (reservation_token,writer_kind,workspace_id,media_asset_id,operation_id,
+          sha256,user_id,replica_id)
+         SELECT reservation_token,writer_kind,workspace_id,media_asset_id,operation_id,
+           sha256,$6,$7 FROM reservation`,
+      [deletingReservationToken, deleteRace.sha256, fixture.outOfScopeWorkspaceId,
+        deleteRace.mediaAssetId, deletingOperationId, fixture.userId, deletingReplicaId],
+    );
+    try {
+      await assertLifecycleRace(fixture, deleteRace, "peer_conflict",
+        (worker) => worker.query("DELETE FROM org.workspaces WHERE workspace_id=$1",
+          [fixture.outOfScopeWorkspaceId]));
+    } finally { await fixture.ownerPool.query("DELETE FROM org.workspaces WHERE workspace_id=$1",
+      [fixture.outOfScopeWorkspaceId]); }
+    const concurrent = await start(fixture, session(fixture));
+    assert.deepEqual((await Promise.all([fenceMediaAssetUploadSessionCompletionApplyWithOwner(concurrent),
+      fenceMediaAssetUploadSessionCompletionApplyWithOwner(concurrent)])).sort(), ["ready", "ready"]);
+    const blocker = await fixture.ownerPool.connect();
+    try {
+      await blocker.query("BEGIN");
+      await blocker.query("SELECT 1 FROM content.media_upload_sessions WHERE media_upload_session_id=$1 FOR UPDATE",
+        [concurrent.sessionId]);
+      const completion = fenceMediaAssetUploadSessionCompletionApplyWithOwner(concurrent);
+      await blocker.query("UPDATE content.media_upload_sessions SET state='aborting' WHERE media_upload_session_id=$1",
+        [concurrent.sessionId]);
+      await blocker.query("COMMIT");
+      assert.equal(await completion, "aborting");
+      assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(
+        { ...concurrent, reservationToken: randomUUID() }), "stale");
+      assert.equal(await fenceMediaAssetUploadSessionCompletionApplyWithOwner(concurrent), "aborting");
+    } finally { await blocker.query("ROLLBACK"); blocker.release(); }
+  });
+});

--- a/apps/backend/src/mediaAssets/uploadSessions/index.ts
+++ b/apps/backend/src/mediaAssets/uploadSessions/index.ts
@@ -36,6 +36,7 @@ import type {
   MediaAssetUploadSessionCreateResult,
   MediaAssetUploadSessionRow,
   MediaAssetUploadSessionState,
+  MediaBlobNormalizationVersion,
   MediaBlobRow,
 } from "../types";
 import {
@@ -88,9 +89,26 @@ export type MediaAssetUploadSessionCompletionWithOwnerResult =
     reservation: MediaBlobWriterReservation;
   }>
   | Readonly<{ status: MediaAssetUploadSessionCompletionWithOwnerRejection }>;
+export type MediaAssetUploadSessionCompletionResolutionInput =
+  Omit<MediaAssetUploadSessionCompletionWithOwnerInput, "normalizationVersion">
+  & Readonly<{ normalizationVersion: MediaBlobNormalizationVersion; reservationToken: string }>;
+export type MediaAssetUploadSessionCompletionApplyFence =
+  | "ready" | "already_applied" | "peer_conflict" | "access_denied"
+  | "aborting" | "aborted" | "stale";
+export type MediaAssetUploadSessionCompletionFailureResolution =
+  | "referenced" | "unreferenced_restored" | "peer_conflict"
+  | "already_closed" | "access_denied" | "stale";
+export type MediaAssetUploadSessionCompletionRevocationInput =
+  Omit<MediaAssetUploadSessionCompletionWithOwnerInput, "normalizationVersion">;
+export type MediaAssetUploadSessionCompletionRevocationResolution =
+  | "referenced" | "unreferenced_closed" | "absent_closed" | "peer_conflict"
+  | "already_closed" | "access_active" | "stale";
 type MediaAssetUploadSessionCompletionWithOwnerRow = Readonly<{
   completion_status: string; reservation_token: string | null;
   reservation_state: string | null; normalization_version: string | null;
+}>;
+type MediaAssetUploadSessionCompletionResolutionRow = Readonly<{
+  resolution_status: string;
 }>;
 type OwnedMultipartReservationRow = Readonly<{
   reservation_token: string | null; reservation_state: string | null;
@@ -862,6 +880,110 @@ export async function beginMediaAssetUploadSessionCompletionWithOwner(
   return transactionWithWorkspaceScope(
     { userId: input.userId, workspaceId: input.workspaceId },
     (executor) => beginMediaAssetUploadSessionCompletionWithOwnerInExecutor(executor, input),
+  );
+}
+
+function toMediaAssetUploadSessionCompletionResolutionParams(
+  input: MediaAssetUploadSessionCompletionRevocationInput,
+): ReadonlyArray<string | number | null> {
+  return [
+    input.userId, input.workspaceId, input.sessionId, input.mediaAssetId,
+    input.lastModifiedByReplicaId, input.lastOperationId, input.sha256,
+    input.stagingStorageKey, input.blobStorageKey, input.s3UploadId, input.mimeType,
+    input.sizeBytes, input.partSizeBytes, input.partCount, input.sourceUrl,
+    input.assetCreatedAt, input.clientUpdatedAt, input.expiresAt,
+  ];
+}
+
+export async function fenceMediaAssetUploadSessionCompletionApplyWithOwnerInExecutor(
+  executor: DatabaseExecutor,
+  input: MediaAssetUploadSessionCompletionResolutionInput,
+): Promise<MediaAssetUploadSessionCompletionApplyFence> {
+  assertMediaBlobWriterReservationToken(input.reservationToken);
+  const result = await executor.query<MediaAssetUploadSessionCompletionResolutionRow>(
+    `SELECT content.fence_media_upload_session_completion_apply_with_owner(
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21
+     ) AS resolution_status`,
+    [
+      ...toMediaAssetUploadSessionCompletionResolutionParams(input),
+      input.reservationToken, input.normalizationVersion, mediaBlobCleanupDelayMs,
+    ],
+  );
+  const status = result.rows[0]?.resolution_status;
+  if (status === "ready" || status === "already_applied" || status === "peer_conflict"
+    || status === "access_denied" || status === "aborting" || status === "aborted"
+    || status === "stale") return status;
+  throw new TypeError("PostgreSQL returned an invalid multipart completion apply fence.");
+}
+
+export async function fenceMediaAssetUploadSessionCompletionApplyWithOwner(
+  input: MediaAssetUploadSessionCompletionResolutionInput,
+): Promise<MediaAssetUploadSessionCompletionApplyFence> {
+  return transactionWithWorkspaceScope(
+    { userId: input.userId, workspaceId: input.workspaceId },
+    (executor) => fenceMediaAssetUploadSessionCompletionApplyWithOwnerInExecutor(executor, input),
+  );
+}
+
+export async function resolveMediaAssetUploadSessionCompletionFailureWithOwnerInExecutor(
+  executor: DatabaseExecutor,
+  input: MediaAssetUploadSessionCompletionResolutionInput,
+): Promise<MediaAssetUploadSessionCompletionFailureResolution> {
+  assertMediaBlobWriterReservationToken(input.reservationToken);
+  const result = await executor.query<MediaAssetUploadSessionCompletionResolutionRow>(
+    `SELECT content.resolve_media_upload_session_completion_failure_with_owner(
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21
+     ) AS resolution_status`,
+    [
+      ...toMediaAssetUploadSessionCompletionResolutionParams(input),
+      input.reservationToken, input.normalizationVersion, mediaBlobCleanupDelayMs,
+    ],
+  );
+  const status = result.rows[0]?.resolution_status;
+  if (status === "referenced" || status === "unreferenced_restored"
+    || status === "peer_conflict" || status === "already_closed"
+    || status === "access_denied" || status === "stale") return status;
+  throw new TypeError("PostgreSQL returned an invalid multipart completion failure resolution.");
+}
+
+export async function resolveMediaAssetUploadSessionCompletionFailureWithOwner(
+  input: MediaAssetUploadSessionCompletionResolutionInput,
+): Promise<MediaAssetUploadSessionCompletionFailureResolution> {
+  return transactionWithWorkspaceScope(
+    { userId: input.userId, workspaceId: input.workspaceId },
+    (executor) => resolveMediaAssetUploadSessionCompletionFailureWithOwnerInExecutor(executor, input),
+  );
+}
+
+export async function resolveMediaAssetUploadSessionCompletionAfterAccessRevocationInExecutor(
+  executor: DatabaseExecutor,
+  input: MediaAssetUploadSessionCompletionRevocationInput,
+): Promise<MediaAssetUploadSessionCompletionRevocationResolution> {
+  const result = await executor.query<MediaAssetUploadSessionCompletionResolutionRow>(
+    `SELECT content.resolve_media_upload_session_completion_after_access_revocation(
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19
+     ) AS resolution_status`,
+    [
+      ...toMediaAssetUploadSessionCompletionResolutionParams(input),
+      mediaBlobCleanupDelayMs,
+    ],
+  );
+  const status = result.rows[0]?.resolution_status;
+  if (status === "referenced" || status === "unreferenced_closed"
+    || status === "absent_closed" || status === "peer_conflict"
+    || status === "already_closed" || status === "access_active"
+    || status === "stale") return status;
+  throw new TypeError("PostgreSQL returned an invalid multipart completion revocation resolution.");
+}
+
+export async function resolveMediaAssetUploadSessionCompletionAfterAccessRevocation(
+  input: MediaAssetUploadSessionCompletionRevocationInput,
+): Promise<MediaAssetUploadSessionCompletionRevocationResolution> {
+  return unsafeTransaction(
+    (executor) => resolveMediaAssetUploadSessionCompletionAfterAccessRevocationInExecutor(
+      executor,
+      input,
+    ),
   );
 }
 

--- a/apps/backend/src/sync/conflicts/lww.ts
+++ b/apps/backend/src/sync/conflicts/lww.ts
@@ -21,12 +21,14 @@ export function compareLwwMetadata(left: LwwMetadata, right: LwwMetadata): numbe
     return timestampDifference;
   }
 
-  const deviceComparison = left.lastModifiedByReplicaId.localeCompare(right.lastModifiedByReplicaId);
+  const deviceComparison = Buffer.compare(
+    Buffer.from(left.lastModifiedByReplicaId, "utf8"), Buffer.from(right.lastModifiedByReplicaId, "utf8"),
+  );
   if (deviceComparison !== 0) {
     return deviceComparison;
   }
 
-  return left.lastOperationId.localeCompare(right.lastOperationId);
+  return Buffer.compare(Buffer.from(left.lastOperationId, "utf8"), Buffer.from(right.lastOperationId, "utf8"));
 }
 
 export function incomingLwwMetadataWins(

--- a/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
@@ -348,6 +348,11 @@ struct SyncApplier {
     }
 }
 
+private func compareUtf8Strings(left: String, right: String) -> ComparisonResult {
+    left.utf8.elementsEqual(right.utf8) ? .orderedSame
+        : (left.utf8.lexicographicallyPrecedes(right.utf8) ? .orderedAscending : .orderedDescending)
+}
+
 private func compareLwwTuple(
     leftClientUpdatedAt: String,
     leftDeviceId: String,
@@ -356,17 +361,17 @@ private func compareLwwTuple(
     rightDeviceId: String,
     rightOperationId: String
 ) -> Int {
-    let timestampComparison = leftClientUpdatedAt.compare(rightClientUpdatedAt)
+    let timestampComparison = compareUtf8Strings(left: leftClientUpdatedAt, right: rightClientUpdatedAt)
     if timestampComparison != .orderedSame {
         return timestampComparison == .orderedAscending ? -1 : 1
     }
 
-    let deviceComparison = leftDeviceId.compare(rightDeviceId)
+    let deviceComparison = compareUtf8Strings(left: leftDeviceId, right: rightDeviceId)
     if deviceComparison != .orderedSame {
         return deviceComparison == .orderedAscending ? -1 : 1
     }
 
-    let operationComparison = leftOperationId.compare(rightOperationId)
+    let operationComparison = compareUtf8Strings(left: leftOperationId, right: rightOperationId)
     if operationComparison == .orderedAscending {
         return -1
     }

--- a/apps/web/src/appData/domain/index.test.ts
+++ b/apps/web/src/appData/domain/index.test.ts
@@ -9,6 +9,7 @@ import {
   buildUpdatedCard,
   cardsMatchingReviewFilter,
   compareCardsForReviewOrder,
+  compareLww,
   doesCardMutationAffectReviewSchedule,
   matchesCardFilter,
   matchesDeckFilterDefinition,
@@ -327,5 +328,13 @@ describe("review tag matching domain", () => {
     expect(matchesCardFilter({
       tags: ["éclair"],
     }, card)).toBe(true);
+  });
+
+  it("orders LWW metadata by UTF-8 bytes", () => {
+    const metadata = (lastOperationId: string) => ({
+      clientUpdatedAt: "2026-03-10T09:00:00.000Z", lastModifiedByReplicaId: "replica", lastOperationId,
+    });
+    expect(compareLww(metadata("lww-tie_"), metadata("lww-tie-"))).toBeGreaterThan(0);
+    expect(compareLww(metadata("lww-tie-😀"), metadata(`lww-tie-\uE000`))).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/appData/domain/index.ts
+++ b/apps/web/src/appData/domain/index.ts
@@ -418,18 +418,28 @@ export function currentReviewCard(reviewQueue: ReadonlyArray<Card>): Card | null
   return reviewQueue[0] ?? null;
 }
 
+function compareUtf8Strings(left: string, right: string): number {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  for (let index = 0; index < Math.max(leftBytes.length, rightBytes.length); index += 1) {
+    const difference = (leftBytes[index] ?? -1) - (rightBytes[index] ?? -1);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
 export function compareLww(left: LastWriteWinsRecord, right: LastWriteWinsRecord): number {
-  const timestampDifference = left.clientUpdatedAt.localeCompare(right.clientUpdatedAt);
+  const timestampDifference = compareUtf8Strings(left.clientUpdatedAt, right.clientUpdatedAt);
   if (timestampDifference !== 0) {
     return timestampDifference;
   }
 
-  const deviceDifference = left.lastModifiedByReplicaId.localeCompare(right.lastModifiedByReplicaId);
+  const deviceDifference = compareUtf8Strings(left.lastModifiedByReplicaId, right.lastModifiedByReplicaId);
   if (deviceDifference !== 0) {
     return deviceDifference;
   }
 
-  return left.lastOperationId.localeCompare(right.lastOperationId);
+  return compareUtf8Strings(left.lastOperationId, right.lastOperationId);
 }
 
 export function upsertCard(cards: ReadonlyArray<Card>, nextCard: Card): Array<Card> {

--- a/db/migrations/0096_atomic_multipart_completion_resolution.sql
+++ b/db/migrations/0096_atomic_multipart_completion_resolution.sql
@@ -1,0 +1,720 @@
+-- Current additive migration for atomic multipart completion apply and recovery fencing.
+-- Schemas touched/read explicitly: content, org, security, sync, pg_catalog.
+CREATE OR REPLACE FUNCTION content.fence_media_blob_reference(p_media_blob_id UUID)
+RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  media_blob content.media_blobs%ROWTYPE; lifecycle content.media_blob_lifecycles%ROWTYPE;
+BEGIN
+  SELECT blobs.* INTO media_blob FROM content.media_blobs AS blobs WHERE blobs.media_blob_id = p_media_blob_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Media blob reference targets a missing media blob'
+    USING ERRCODE = '23503'; END IF;
+  INSERT INTO content.media_blob_lifecycles
+    (sha256, storage_key, mime_type, size_bytes, normalization_version, created_at, updated_at)
+  VALUES (media_blob.sha256, media_blob.storage_key, media_blob.mime_type, media_blob.size_bytes,
+    media_blob.normalization_version, media_blob.created_at, media_blob.updated_at)
+  ON CONFLICT (sha256) DO NOTHING;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = media_blob.sha256 FOR UPDATE;
+  SELECT blobs.* INTO media_blob FROM content.media_blobs AS blobs WHERE blobs.media_blob_id = p_media_blob_id FOR SHARE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Media blob reference targets a missing media blob'
+    USING ERRCODE = '23503'; END IF;
+  IF lifecycle.sha256 IS DISTINCT FROM media_blob.sha256
+    OR lifecycle.storage_key IS DISTINCT FROM media_blob.storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM media_blob.mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM media_blob.size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM media_blob.normalization_version
+  THEN RAISE EXCEPTION 'Media blob reference conflicts with immutable lifecycle metadata' USING ERRCODE = '23514'; END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > clock_timestamp()
+  THEN RAISE EXCEPTION 'Media blob reference conflicts with an active cleanup claim' USING ERRCODE = '55P03'; END IF;
+  UPDATE content.media_blob_lifecycles AS lifecycles SET cleanup_eligible_at = NULL,
+    cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = clock_timestamp()
+  WHERE lifecycles.sha256 = media_blob.sha256;
+END;
+$$;
+CREATE OR REPLACE FUNCTION content.terminalize_media_blob_writers_before_workspace_delete()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  owner_user_id TEXT; affected_sha256s TEXT[]; affected_sha256 TEXT; terminalized_at TIMESTAMPTZ;
+BEGIN
+  FOR owner_user_id IN
+    SELECT user_ids.user_id FROM (
+      SELECT memberships.user_id FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = OLD.workspace_id
+      UNION SELECT snapshots.user_id FROM content.media_blob_writer_owner_snapshots AS snapshots
+      WHERE snapshots.workspace_id = OLD.workspace_id
+    ) AS user_ids ORDER BY user_ids.user_id
+  LOOP PERFORM pg_advisory_xact_lock(hashtextextended(
+    owner_user_id || ':' || OLD.workspace_id::TEXT, 0::BIGINT)); END LOOP;
+  SELECT array_agg(DISTINCT reservations.sha256 ORDER BY reservations.sha256) INTO affected_sha256s
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion');
+  IF affected_sha256s IS NULL THEN RETURN OLD; END IF;
+  PERFORM 1 FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = OLD.workspace_id ORDER BY sessions.media_upload_session_id FOR UPDATE;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata WHERE metadata.workspace_id = OLD.workspace_id FOR UPDATE;
+  FOREACH affected_sha256 IN ARRAY affected_sha256s LOOP
+    PERFORM 1 FROM content.media_blob_lifecycles AS lifecycles
+    WHERE lifecycles.sha256 = affected_sha256 FOR UPDATE; END LOOP;
+  PERFORM 1 FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion')
+  ORDER BY reservations.sha256, reservations.writer_kind, reservations.media_asset_id,
+    reservations.operation_id FOR UPDATE;
+  PERFORM 1 FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.workspace_id = OLD.workspace_id ORDER BY snapshots.reservation_token FOR UPDATE;
+  DELETE FROM content.media_upload_sessions AS sessions WHERE sessions.workspace_id = OLD.workspace_id;
+  DELETE FROM content.media_assets AS assets WHERE assets.workspace_id = OLD.workspace_id;
+  UPDATE content.media_blob_writer_reservations AS reservations SET state = 'unreferenced'
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion')
+    AND reservations.state <> 'unreferenced';
+  terminalized_at := clock_timestamp();
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_eligible_at = GREATEST(COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ),
+      terminalized_at + interval '1 hour'),
+    cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = terminalized_at
+  WHERE lifecycles.sha256 = ANY(affected_sha256s)
+    AND NOT EXISTS (
+      SELECT 1 FROM content.media_assets AS assets INNER JOIN content.media_blobs AS blobs
+        ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256 AND assets.deleted_at IS NULL)
+    AND NOT EXISTS (
+      SELECT 1 FROM catalog.package_media_assets AS assets INNER JOIN content.media_blobs AS blobs
+        ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256)
+    AND NOT EXISTS (
+      SELECT 1 FROM content.media_blob_writer_reservations AS reservations
+      WHERE reservations.sha256 = lifecycles.sha256 AND reservations.state NOT IN ('finalized', 'unreferenced'));
+  RETURN OLD;
+END;
+$$;
+CREATE FUNCTION content.classify_media_upload_session_completion_asset_internal(
+  p_workspace_id UUID, p_media_asset_id UUID, p_sha256 TEXT,
+  p_blob_storage_key TEXT, p_mime_type TEXT, p_size_bytes BIGINT,
+  p_normalization_version TEXT, p_source_url TEXT,
+  p_asset_created_at TIMESTAMPTZ, p_client_updated_at TIMESTAMPTZ,
+  p_last_modified_by_replica_id UUID, p_last_operation_id TEXT
+)
+RETURNS TABLE (asset_status TEXT, writer_referenced BOOLEAN)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  asset RECORD;
+  immutable_match BOOLEAN;
+  incoming_wins BOOLEAN;
+BEGIN
+  SELECT
+    assets.workspace_id, assets.source_url, assets.created_at,
+    assets.client_updated_at, assets.last_modified_by_replica_id,
+    assets.last_operation_id, assets.deleted_at, blobs.sha256,
+    blobs.storage_key, blobs.mime_type, blobs.size_bytes,
+    blobs.normalization_version
+  INTO asset
+  FROM content.media_assets AS assets
+  INNER JOIN content.media_blobs AS blobs
+    ON blobs.media_blob_id = assets.media_blob_id
+  WHERE assets.media_asset_id = p_media_asset_id
+  FOR UPDATE OF assets, blobs;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'absent'::TEXT, false;
+    RETURN;
+  END IF;
+  immutable_match :=
+    asset.workspace_id IS NOT DISTINCT FROM p_workspace_id
+    AND asset.sha256 IS NOT DISTINCT FROM p_sha256
+    AND asset.storage_key IS NOT DISTINCT FROM p_blob_storage_key
+    AND asset.mime_type IS NOT DISTINCT FROM p_mime_type
+    AND asset.size_bytes IS NOT DISTINCT FROM p_size_bytes
+    AND asset.normalization_version IS NOT DISTINCT FROM p_normalization_version;
+  writer_referenced :=
+    asset.deleted_at IS NULL
+    AND asset.workspace_id IS NOT DISTINCT FROM p_workspace_id
+    AND asset.sha256 IS NOT DISTINCT FROM p_sha256;
+  IF immutable_match
+    AND asset.deleted_at IS NULL
+    AND asset.source_url IS NOT DISTINCT FROM p_source_url
+    AND asset.created_at IS NOT DISTINCT FROM p_asset_created_at
+    AND asset.client_updated_at IS NOT DISTINCT FROM p_client_updated_at
+    AND asset.last_modified_by_replica_id IS NOT DISTINCT FROM p_last_modified_by_replica_id
+    AND asset.last_operation_id IS NOT DISTINCT FROM p_last_operation_id
+  THEN
+    RETURN QUERY SELECT 'exact'::TEXT, writer_referenced;
+    RETURN;
+  END IF;
+  incoming_wins :=
+    asset.client_updated_at < p_client_updated_at
+    OR (
+      asset.client_updated_at = p_client_updated_at
+      AND asset.last_modified_by_replica_id::TEXT COLLATE "C"
+        < p_last_modified_by_replica_id::TEXT COLLATE "C"
+    )
+    OR (
+      asset.client_updated_at = p_client_updated_at
+      AND asset.last_modified_by_replica_id = p_last_modified_by_replica_id
+      AND asset.last_operation_id COLLATE "C" < p_last_operation_id COLLATE "C"
+    );
+  IF immutable_match AND incoming_wins THEN
+    RETURN QUERY SELECT 'ready'::TEXT, writer_referenced;
+    RETURN;
+  END IF;
+  RETURN QUERY SELECT 'peer_conflict'::TEXT, writer_referenced;
+END;
+$$;
+CREATE FUNCTION content.fence_media_upload_session_completion_apply_with_owner(
+  p_user_id TEXT, p_workspace_id UUID, p_media_upload_session_id UUID, p_media_asset_id UUID,
+  p_last_modified_by_replica_id UUID, p_last_operation_id TEXT, p_sha256 TEXT, p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT, p_s3_upload_id TEXT, p_mime_type TEXT, p_size_bytes BIGINT,
+  p_part_size_bytes BIGINT, p_part_count INTEGER, p_source_url TEXT, p_asset_created_at TIMESTAMPTZ,
+  p_client_updated_at TIMESTAMPTZ, p_expires_at TIMESTAMPTZ, p_reservation_token UUID, p_normalization_version TEXT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  asset RECORD;
+  terminalization_status TEXT;
+BEGIN
+  IF p_user_id IS NULL OR p_user_id IS DISTINCT FROM btrim(p_user_id) OR p_user_id = ''
+    OR p_workspace_id IS NULL OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL OR p_last_modified_by_replica_id IS NULL
+    OR p_last_operation_id IS NULL OR p_sha256 IS NULL
+    OR p_staging_storage_key IS NULL OR p_blob_storage_key IS NULL
+    OR p_s3_upload_id IS NULL OR p_mime_type IS NULL OR p_size_bytes IS NULL
+    OR p_part_size_bytes IS NULL OR p_part_count IS NULL
+    OR p_asset_created_at IS NULL OR p_client_updated_at IS NULL
+    OR p_expires_at IS NULL OR p_reservation_token IS NULL
+    OR p_normalization_version IS NULL OR p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN RETURN 'access_denied'; END IF;
+  SELECT sessions.* INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+  FOR UPDATE;
+  IF NOT FOUND OR session.workspace_id IS DISTINCT FROM p_workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+    OR session.staging_storage_key IS DISTINCT FROM p_staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_mime_type
+    OR session.size_bytes IS DISTINCT FROM p_size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_part_count
+    OR session.source_url IS DISTINCT FROM p_source_url
+    OR session.asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM p_client_updated_at
+    OR session.expires_at IS DISTINCT FROM p_expires_at
+  THEN RETURN 'stale'; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN RETURN 'access_denied'; END IF;
+  IF session.state NOT IN ('completing', 'completed', 'aborting', 'aborted') THEN
+    RETURN 'stale';
+  END IF;
+  INSERT INTO sync.workspace_sync_metadata (
+    workspace_id, min_available_hot_change_id, updated_at
+  ) VALUES (p_workspace_id, 0, statement_timestamp())
+  ON CONFLICT (workspace_id) DO NOTHING;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_workspace_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT lifecycles.* INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT reservations.* INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT snapshots.* INTO owner_snapshot
+  FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.reservation_token = p_reservation_token FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT * INTO asset
+  FROM content.classify_media_upload_session_completion_asset_internal(
+    p_workspace_id, p_media_asset_id, p_sha256, p_blob_storage_key, p_mime_type,
+    p_size_bytes, p_normalization_version, p_source_url, p_asset_created_at,
+    p_client_updated_at, p_last_modified_by_replica_id, p_last_operation_id);
+  IF reservation.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR reservation.workspace_id IS DISTINCT FROM p_workspace_id
+    OR reservation.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR reservation.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR (
+      reservation.state NOT IN ('active', 'ambiguous', 'finalized')
+      AND NOT (
+        session.state IN ('aborting', 'aborted')
+        AND reservation.state = 'unreferenced'
+      )
+    )
+    OR lifecycle.storage_key IS DISTINCT FROM p_blob_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM p_normalization_version
+    OR (reservation.state <> 'unreferenced' AND lifecycle.cleanup_eligible_at IS NOT NULL)
+    OR lifecycle.cleanup_lease_token IS NOT NULL
+    OR lifecycle.cleanup_lease_expires_at IS NOT NULL
+    OR owner_snapshot.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR owner_snapshot.workspace_id IS DISTINCT FROM p_workspace_id
+    OR owner_snapshot.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR owner_snapshot.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR owner_snapshot.sha256 IS DISTINCT FROM p_sha256
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+    OR owner_snapshot.session_source_url IS DISTINCT FROM p_source_url
+    OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_client_updated_at
+    OR (reservation.state = 'finalized' AND asset.writer_referenced IS DISTINCT FROM true)
+    OR (reservation.state = 'unreferenced' AND asset.writer_referenced IS DISTINCT FROM false)
+  THEN RETURN 'stale'; END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+    OR NOT EXISTS (
+      SELECT 1 FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = p_workspace_id
+        AND memberships.user_id = p_user_id
+    )
+  THEN RETURN 'access_denied'; END IF;
+  IF session.state = 'aborting' THEN RETURN 'aborting';
+  ELSIF session.state = 'aborted' THEN RETURN 'aborted';
+  END IF;
+  IF asset.asset_status = 'exact' THEN
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+      p_size_bytes, p_normalization_version, 'multipart_completion',
+      p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+      p_cleanup_delay_ms);
+    IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'completed', completed_at = COALESCE(sessions.completed_at, clock_timestamp()),
+      aborted_at = NULL
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'already_applied';
+  END IF;
+  IF asset.asset_status = 'peer_conflict' THEN
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+      p_size_bytes, p_normalization_version, 'multipart_completion',
+      p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+      p_cleanup_delay_ms);
+    IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'aborted', completed_at = NULL,
+      aborted_at = COALESCE(sessions.aborted_at, clock_timestamp())
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'peer_conflict';
+  END IF;
+  IF session.state = 'completed' THEN RETURN 'stale'; END IF;
+  RETURN 'ready';
+END;
+$$;
+CREATE FUNCTION content.resolve_media_upload_session_completion_failure_with_owner(
+  p_user_id TEXT, p_workspace_id UUID, p_media_upload_session_id UUID, p_media_asset_id UUID,
+  p_last_modified_by_replica_id UUID, p_last_operation_id TEXT, p_sha256 TEXT, p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT, p_s3_upload_id TEXT, p_mime_type TEXT, p_size_bytes BIGINT,
+  p_part_size_bytes BIGINT, p_part_count INTEGER, p_source_url TEXT, p_asset_created_at TIMESTAMPTZ,
+  p_client_updated_at TIMESTAMPTZ, p_expires_at TIMESTAMPTZ, p_reservation_token UUID, p_normalization_version TEXT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  asset RECORD;
+  terminalization_status TEXT;
+BEGIN
+  IF p_user_id IS NULL OR p_user_id IS DISTINCT FROM btrim(p_user_id) OR p_user_id = ''
+    OR p_workspace_id IS NULL OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL OR p_last_modified_by_replica_id IS NULL
+    OR p_last_operation_id IS NULL OR p_sha256 IS NULL
+    OR p_staging_storage_key IS NULL OR p_blob_storage_key IS NULL
+    OR p_s3_upload_id IS NULL OR p_mime_type IS NULL OR p_size_bytes IS NULL
+    OR p_part_size_bytes IS NULL OR p_part_count IS NULL
+    OR p_asset_created_at IS NULL OR p_client_updated_at IS NULL
+    OR p_expires_at IS NULL OR p_reservation_token IS NULL
+    OR p_normalization_version IS NULL OR p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN RETURN 'access_denied'; END IF;
+  SELECT sessions.* INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+  FOR UPDATE;
+  IF NOT FOUND OR session.workspace_id IS DISTINCT FROM p_workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+    OR session.staging_storage_key IS DISTINCT FROM p_staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_mime_type
+    OR session.size_bytes IS DISTINCT FROM p_size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_part_count
+    OR session.source_url IS DISTINCT FROM p_source_url
+    OR session.asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM p_client_updated_at
+    OR session.expires_at IS DISTINCT FROM p_expires_at
+  THEN RETURN 'stale'; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN RETURN 'access_denied'; END IF;
+  INSERT INTO sync.workspace_sync_metadata (
+    workspace_id, min_available_hot_change_id, updated_at
+  ) VALUES (p_workspace_id, 0, statement_timestamp())
+  ON CONFLICT (workspace_id) DO NOTHING;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_workspace_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT lifecycles.* INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT reservations.* INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT snapshots.* INTO owner_snapshot
+  FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.reservation_token = p_reservation_token FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT * INTO asset
+  FROM content.classify_media_upload_session_completion_asset_internal(
+    p_workspace_id, p_media_asset_id, p_sha256, p_blob_storage_key, p_mime_type,
+    p_size_bytes, p_normalization_version, p_source_url, p_asset_created_at,
+    p_client_updated_at, p_last_modified_by_replica_id, p_last_operation_id);
+  IF reservation.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR reservation.workspace_id IS DISTINCT FROM p_workspace_id
+    OR reservation.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR reservation.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR reservation.state NOT IN ('active', 'ambiguous', 'finalized', 'unreferenced')
+    OR lifecycle.storage_key IS DISTINCT FROM p_blob_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM p_normalization_version
+    OR (reservation.state <> 'unreferenced' AND lifecycle.cleanup_eligible_at IS NOT NULL)
+    OR lifecycle.cleanup_lease_token IS NOT NULL
+    OR lifecycle.cleanup_lease_expires_at IS NOT NULL
+    OR owner_snapshot.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR owner_snapshot.workspace_id IS DISTINCT FROM p_workspace_id
+    OR owner_snapshot.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR owner_snapshot.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR owner_snapshot.sha256 IS DISTINCT FROM p_sha256
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+    OR owner_snapshot.session_source_url IS DISTINCT FROM p_source_url
+    OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_client_updated_at
+    OR (reservation.state = 'finalized' AND asset.writer_referenced IS DISTINCT FROM true)
+    OR (reservation.state = 'unreferenced' AND asset.writer_referenced IS DISTINCT FROM false)
+  THEN RETURN 'stale'; END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+    OR NOT EXISTS (
+      SELECT 1 FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = p_workspace_id
+        AND memberships.user_id = p_user_id
+    )
+  THEN RETURN 'access_denied'; END IF;
+  IF asset.asset_status = 'peer_conflict' THEN
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+      p_size_bytes, p_normalization_version, 'multipart_completion',
+      p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+      p_cleanup_delay_ms);
+    IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'aborted', completed_at = NULL,
+      aborted_at = COALESCE(sessions.aborted_at, clock_timestamp())
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'peer_conflict';
+  END IF;
+  IF asset.asset_status = 'exact' THEN
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+      p_size_bytes, p_normalization_version, 'multipart_completion',
+      p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+      p_cleanup_delay_ms);
+    IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'completed', completed_at = COALESCE(sessions.completed_at, clock_timestamp()),
+      aborted_at = NULL
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'referenced';
+  END IF;
+  IF session.state = 'completed' THEN RETURN 'stale'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    p_reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+    p_size_bytes, p_normalization_version, 'multipart_completion',
+    p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+    p_cleanup_delay_ms);
+  IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+  IF session.state IN ('aborting', 'aborted') THEN
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'aborted', completed_at = NULL,
+      aborted_at = COALESCE(sessions.aborted_at, clock_timestamp())
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'already_closed';
+  END IF;
+  UPDATE content.media_upload_sessions AS sessions
+  SET state = 'active', completed_at = NULL, aborted_at = NULL
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+  IF terminalization_status = 'referenced' THEN RETURN 'referenced'; END IF;
+  RETURN 'unreferenced_restored';
+END;
+$$;
+CREATE FUNCTION content.resolve_media_upload_session_completion_after_access_revocation(
+  p_user_id TEXT, p_workspace_id UUID, p_media_upload_session_id UUID, p_media_asset_id UUID,
+  p_last_modified_by_replica_id UUID, p_last_operation_id TEXT, p_sha256 TEXT, p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT, p_s3_upload_id TEXT, p_mime_type TEXT, p_size_bytes BIGINT,
+  p_part_size_bytes BIGINT, p_part_count INTEGER, p_source_url TEXT, p_asset_created_at TIMESTAMPTZ,
+  p_client_updated_at TIMESTAMPTZ, p_expires_at TIMESTAMPTZ,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  lifecycle_found BOOLEAN;
+  reservation_found BOOLEAN;
+  asset RECORD;
+  terminalization_status TEXT;
+BEGIN
+  IF p_user_id IS NULL OR p_user_id IS DISTINCT FROM btrim(p_user_id) OR p_user_id = ''
+    OR p_workspace_id IS NULL OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL OR p_last_modified_by_replica_id IS NULL
+    OR p_last_operation_id IS NULL OR p_sha256 IS NULL
+    OR p_staging_storage_key IS NULL OR p_blob_storage_key IS NULL
+    OR p_s3_upload_id IS NULL OR p_mime_type IS NULL OR p_size_bytes IS NULL
+    OR p_part_size_bytes IS NULL OR p_part_count IS NULL
+    OR p_asset_created_at IS NULL OR p_client_updated_at IS NULL
+    OR p_expires_at IS NULL OR p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT));
+  SELECT sessions.* INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+  FOR UPDATE;
+  IF NOT FOUND OR session.workspace_id IS DISTINCT FROM p_workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+    OR session.staging_storage_key IS DISTINCT FROM p_staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_mime_type
+    OR session.size_bytes IS DISTINCT FROM p_size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_part_count
+    OR session.source_url IS DISTINCT FROM p_source_url
+    OR session.asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM p_client_updated_at
+    OR session.expires_at IS DISTINCT FROM p_expires_at
+  THEN RETURN 'stale'; END IF;
+  INSERT INTO sync.workspace_sync_metadata (
+    workspace_id, min_available_hot_change_id, updated_at
+  ) VALUES (p_workspace_id, 0, statement_timestamp())
+  ON CONFLICT (workspace_id) DO NOTHING;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_workspace_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN 'stale'; END IF;
+  SELECT lifecycles.* INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  lifecycle_found := FOUND;
+  SELECT reservations.* INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion'
+    AND reservations.workspace_id = p_workspace_id
+    AND reservations.media_asset_id = p_media_asset_id
+    AND reservations.operation_id = p_media_upload_session_id::TEXT
+  FOR UPDATE;
+  reservation_found := FOUND;
+  IF reservation_found THEN
+    SELECT snapshots.* INTO owner_snapshot
+    FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+    IF NOT FOUND THEN RETURN 'stale'; END IF;
+  ELSE
+    PERFORM 1 FROM content.media_blob_writer_reservations AS conflicts
+    WHERE conflicts.writer_kind = 'multipart_completion'
+      AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ORDER BY conflicts.reservation_token FOR UPDATE;
+    IF FOUND THEN RETURN 'stale'; END IF;
+    PERFORM 1 FROM content.media_blob_writer_owner_snapshots AS conflicts
+    WHERE conflicts.writer_kind = 'multipart_completion'
+      AND conflicts.operation_id = p_media_upload_session_id::TEXT
+    ORDER BY conflicts.reservation_token FOR UPDATE;
+    IF FOUND THEN RETURN 'stale'; END IF;
+  END IF;
+  SELECT * INTO asset
+  FROM content.classify_media_upload_session_completion_asset_internal(
+    p_workspace_id, p_media_asset_id, p_sha256, p_blob_storage_key, p_mime_type,
+    p_size_bytes, lifecycle.normalization_version, p_source_url,
+    p_asset_created_at, p_client_updated_at, p_last_modified_by_replica_id,
+    p_last_operation_id);
+  IF lifecycle_found AND (
+    lifecycle.storage_key IS DISTINCT FROM p_blob_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version NOT IN ('passthrough-v1', 'image-jpeg-card-v1')
+    OR lifecycle.cleanup_lease_token IS NOT NULL
+    OR lifecycle.cleanup_lease_expires_at IS NOT NULL
+  ) THEN RETURN 'stale'; END IF;
+  IF reservation_found AND (
+    NOT lifecycle_found OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR reservation.state NOT IN ('active', 'ambiguous', 'finalized', 'unreferenced')
+    OR (reservation.state <> 'unreferenced' AND lifecycle.cleanup_eligible_at IS NOT NULL)
+    OR owner_snapshot.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR owner_snapshot.workspace_id IS DISTINCT FROM p_workspace_id
+    OR owner_snapshot.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR owner_snapshot.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR owner_snapshot.sha256 IS DISTINCT FROM p_sha256
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+    OR owner_snapshot.session_source_url IS DISTINCT FROM p_source_url
+    OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_asset_created_at
+    OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_client_updated_at
+    OR (reservation.state = 'finalized' AND asset.writer_referenced IS DISTINCT FROM true)
+    OR (reservation.state = 'unreferenced' AND asset.writer_referenced IS DISTINCT FROM false)
+  ) THEN RETURN 'stale'; END IF;
+  IF NOT reservation_found THEN
+    PERFORM 1 FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_last_modified_by_replica_id
+      AND replicas.workspace_id = p_workspace_id
+      AND replicas.user_id = p_user_id
+    FOR NO KEY UPDATE;
+    IF NOT FOUND THEN RETURN 'stale'; END IF;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN RETURN 'access_active'; END IF;
+  IF asset.asset_status = 'peer_conflict' THEN
+    IF reservation_found THEN
+      terminalization_status := content.terminalize_media_blob_writer_failure(
+        reservation.reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+        p_size_bytes, lifecycle.normalization_version, 'multipart_completion',
+        p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+        p_cleanup_delay_ms);
+      IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+    END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'aborted', completed_at = NULL,
+      aborted_at = COALESCE(sessions.aborted_at, clock_timestamp())
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'peer_conflict';
+  END IF;
+  IF asset.asset_status = 'exact' THEN
+    IF reservation_found THEN
+      terminalization_status := content.terminalize_media_blob_writer_failure(
+        reservation.reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+        p_size_bytes, lifecycle.normalization_version, 'multipart_completion',
+        p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+        p_cleanup_delay_ms);
+      IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF;
+    END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'completed', completed_at = COALESCE(sessions.completed_at, clock_timestamp()),
+      aborted_at = NULL
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'referenced';
+  END IF;
+  IF reservation_found AND reservation.state = 'unreferenced'
+    AND session.state = 'aborted'
+  THEN RETURN 'unreferenced_closed'; END IF;
+  IF session.state IN ('completed', 'aborted') THEN RETURN 'already_closed'; END IF;
+  IF NOT reservation_found THEN
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'aborted', completed_at = NULL,
+      aborted_at = COALESCE(sessions.aborted_at, clock_timestamp())
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    RETURN 'absent_closed';
+  END IF;
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    reservation.reservation_token, p_sha256, p_blob_storage_key, p_mime_type,
+    p_size_bytes, lifecycle.normalization_version, 'multipart_completion',
+    p_workspace_id, p_media_asset_id, p_media_upload_session_id::TEXT,
+    p_cleanup_delay_ms);
+  IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+  UPDATE content.media_upload_sessions AS sessions
+  SET state = 'aborted', completed_at = NULL,
+    aborted_at = COALESCE(sessions.aborted_at, clock_timestamp())
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+  IF terminalization_status = 'referenced' THEN RETURN 'referenced'; END IF;
+  RETURN 'unreferenced_closed';
+END;
+$$;
+COMMENT ON FUNCTION content.fence_media_upload_session_completion_apply_with_owner(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,UUID,TEXT,INTEGER)
+IS 'Fences one exact active owner-bound multipart writer before final media-asset application.';
+COMMENT ON FUNCTION content.resolve_media_upload_session_completion_failure_with_owner(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,UUID,TEXT,INTEGER) IS 'Atomically terminalizes one exact active multipart writer and restores or closes its session after definite failure.';
+COMMENT ON FUNCTION content.resolve_media_upload_session_completion_after_access_revocation(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,INTEGER) IS 'Resolves one exact historical-owner multipart completion only while workspace membership is absent.';
+REVOKE ALL ON FUNCTION content.classify_media_upload_session_completion_asset_internal(
+  UUID,UUID,TEXT,TEXT,TEXT,BIGINT,TEXT,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,UUID,TEXT) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.fence_media_upload_session_completion_apply_with_owner(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,UUID,TEXT,INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.resolve_media_upload_session_completion_failure_with_owner(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,UUID,TEXT,INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.resolve_media_upload_session_completion_after_access_revocation(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+GRANT EXECUTE ON FUNCTION content.fence_media_upload_session_completion_apply_with_owner(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,UUID,TEXT,INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.resolve_media_upload_session_completion_failure_with_owner(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,UUID,TEXT,INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.resolve_media_upload_session_completion_after_access_revocation(
+  TEXT,UUID,UUID,UUID,UUID,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,BIGINT,BIGINT,INTEGER,TEXT,TIMESTAMPTZ,TIMESTAMPTZ,TIMESTAMPTZ,INTEGER) TO backend_app;


### PR DESCRIPTION
## Summary
- add migration 0096 with atomic multipart completion pre-apply, definite-failure, and post-revocation resolution boundaries
- preserve deployed 0091–0095 signatures while aligning reference and workspace-deletion locks to the canonical order
- use immutable owner snapshots for historical recovery and a late current-replica lock only for absent writers
- standardize shared LWW ordering on locale-independent UTF-8 byte order across PostgreSQL, backend, web, and iOS
- add typed backend database boundaries and focused real PostgreSQL evidence; no production 0096 caller is enabled

## Validation
- genuine PostgreSQL 18.4 0095→0096 upgrade and separate fresh 98-migration chain plus views
- focused multipart completion suite: 1/1; adjacent media lifecycle/writer suites: 3/3
- backend lint/build and tests: 827/827
- web build and tests: 608/608
- Swift UTF-8 comparator harness
- signature, grant, direct-table, caller, lock-order, diff, and scope audits
