### PR TITLE
Add media writer attempt fencing

### DIFF
--- a/apps/backend/src/mediaAssets/mediaBlobWriterAttempts.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/mediaBlobWriterAttempts.postgres.integration.ts
@@ -1,0 +1,538 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import type pg from "pg";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+type DirectPayload = Readonly<{
+  userId: string; workspaceId: string; mediaAssetId: string; operationId: string;
+  replicaId: string; sha256: string; storageKey: string; mimeType: string;
+  sizeBytes: number; normalizationVersion: string; sourceUrl: string | null;
+  assetCreatedAt: string; clientUpdatedAt: string;
+}>;
+type MultipartPayload = Readonly<{
+  userId: string; workspaceId: string; sessionId: string; mediaAssetId: string;
+  replicaId: string; lastOperationId: string; sha256: string;
+  stagingStorageKey: string; blobStorageKey: string; s3UploadId: string;
+  mimeType: string; sizeBytes: number; partSizeBytes: number; partCount: number;
+  sourceUrl: string | null; assetCreatedAt: string; clientUpdatedAt: string;
+  sessionExpiresAt: string; normalizationVersion: string; partsFingerprint: string;
+}>;
+type BeginRow = Readonly<{
+  attempt_status: string; reservation_token: string | null;
+  normalization_version: string | null; lease_expires_at: string | Date | null;
+}>;
+type StatusRow = Readonly<{ status: string }>;
+type LegacyBeginRow = Readonly<{ completion_status: string; reservation_token: string; normalization_version: string }>;
+type OwnedMedia = Readonly<{ blob_ids: ReadonlyArray<string>; sha256s: ReadonlyArray<string> }>;
+type SqlValue = string | number | null;
+type QueryExecutor = Pick<pg.PoolClient, "query">;
+const cleanupDelayMs = 3_600_000;
+const migration0097 = readFileSync(resolve(
+  __dirname, "../../../../db/migrations/0097_direct_multipart_writer_attempt_fencing.sql",
+), "utf8");
+const directRow = `ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+  ::content.direct_media_blob_writer_attempt_payload`;
+const multipartRow = `ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
+  ::content.multipart_media_blob_writer_attempt_payload`;
+function digest(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+function direct(fixture: PostgresIntegrationFixture, overrides: Partial<DirectPayload>): DirectPayload {
+  const sha256 = overrides.sha256 ?? digest();
+  return {
+    userId: fixture.userId, workspaceId: fixture.workspaceId,
+    mediaAssetId: randomUUID(), operationId: randomUUID(), replicaId: fixture.replicaId,
+    sha256, storageKey: buildMediaBlobStorageKey(sha256), mimeType: "image/jpeg",
+    sizeBytes: 42, normalizationVersion: "image-jpeg-card-v1", sourceUrl: null,
+    assetCreatedAt: fixture.createdAt, clientUpdatedAt: fixture.createdAt, ...overrides,
+  };
+}
+function multipart(
+  fixture: PostgresIntegrationFixture,
+  overrides: Partial<MultipartPayload>,
+): MultipartPayload {
+  const sessionId = overrides.sessionId ?? randomUUID();
+  const mediaAssetId = overrides.mediaAssetId ?? randomUUID();
+  const sha256 = overrides.sha256 ?? digest();
+  return {
+    userId: fixture.userId, workspaceId: fixture.workspaceId, sessionId, mediaAssetId,
+    replicaId: fixture.replicaId, lastOperationId: randomUUID(), sha256,
+    stagingStorageKey: `media/uploads/workspaces/${fixture.workspaceId}/assets/${mediaAssetId}/sessions/${sessionId}`,
+    blobStorageKey: buildMediaBlobStorageKey(sha256), s3UploadId: `upload-${randomUUID()}`,
+    mimeType: "application/octet-stream", sizeBytes: 42, partSizeBytes: 42,
+    partCount: 1, sourceUrl: null, assetCreatedAt: fixture.createdAt,
+    clientUpdatedAt: fixture.createdAt,
+    sessionExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    normalizationVersion: "passthrough-v1", partsFingerprint: digest(), ...overrides,
+  };
+}
+function directValues(payload: DirectPayload): ReadonlyArray<SqlValue> {
+  return [payload.userId, payload.workspaceId, payload.mediaAssetId, payload.operationId,
+    payload.replicaId, payload.sha256, payload.storageKey, payload.mimeType,
+    payload.sizeBytes, payload.normalizationVersion, payload.sourceUrl,
+    payload.assetCreatedAt, payload.clientUpdatedAt];
+}
+function multipartValues(payload: MultipartPayload): ReadonlyArray<SqlValue> {
+  return [payload.userId, payload.workspaceId, payload.sessionId, payload.mediaAssetId,
+    payload.replicaId, payload.lastOperationId, payload.sha256,
+    payload.stagingStorageKey, payload.blobStorageKey, payload.s3UploadId,
+    payload.mimeType, payload.sizeBytes, payload.partSizeBytes, payload.partCount,
+    payload.sourceUrl, payload.assetCreatedAt, payload.clientUpdatedAt,
+    payload.sessionExpiresAt, payload.normalizationVersion, payload.partsFingerprint];
+}
+async function scoped<Result>(
+  fixture: PostgresIntegrationFixture,
+  callback: (client: pg.PoolClient) => Promise<Result>,
+): Promise<Result> {
+  const client = await fixture.runtimePool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query( "SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId],
+    );
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+async function beginDirect(
+  fixture: PostgresIntegrationFixture, attemptToken: string,
+  payload: DirectPayload, leaseMs: number,
+): Promise<BeginRow> {
+  return scoped(fixture, async (client) => (await client.query<BeginRow>(
+    `SELECT * FROM content.begin_direct_media_blob_writer_attempt_with_owner($1,$2,${directRow})`,
+    [attemptToken, leaseMs, ...directValues(payload)],
+  )).rows[0]);
+}
+async function directStatus(
+  fixture: PostgresIntegrationFixture, functionName: string, attemptToken: string,
+  reservationToken: string, payload: DirectPayload,
+): Promise<string> {
+  return scoped(fixture, async (client) => (await client.query<StatusRow>(
+    `SELECT content.${functionName}($1,$2,${directRow},$16) AS status`,
+    [attemptToken, reservationToken, ...directValues(payload), cleanupDelayMs],
+  )).rows[0].status);
+}
+async function insertSession(
+  executor: QueryExecutor, payload: MultipartPayload, state: "active" | "completing",
+): Promise<void> {
+  await executor.query(
+    `INSERT INTO content.media_upload_sessions (media_upload_session_id,workspace_id,media_asset_id,media_blob_sha256, staging_storage_key,blob_storage_key,s3_upload_id,mime_type,size_bytes, part_size_bytes,part_count,state,source_url,asset_created_at,client_updated_at, last_modified_by_replica_id,last_operation_id,expires_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+    [payload.sessionId, payload.workspaceId, payload.mediaAssetId, payload.sha256, payload.stagingStorageKey, payload.blobStorageKey, payload.s3UploadId, payload.mimeType, payload.sizeBytes, payload.partSizeBytes, payload.partCount, state, payload.sourceUrl, payload.assetCreatedAt, payload.clientUpdatedAt, payload.replicaId, payload.lastOperationId, payload.sessionExpiresAt],
+  );
+}
+async function beginMultipart(
+  fixture: PostgresIntegrationFixture, attemptToken: string,
+  payload: MultipartPayload, leaseMs: number,
+): Promise<BeginRow> {
+  return scoped(fixture, async (client) => (await client.query<BeginRow>(
+    `SELECT * FROM content.begin_media_upload_session_completion_attempt_with_owner( $1,$2,${multipartRow})`,
+    [attemptToken, leaseMs, ...multipartValues(payload)],
+  )).rows[0]);
+}
+async function multipartStatus(
+  fixture: PostgresIntegrationFixture, functionName: string, attemptToken: string,
+  reservationToken: string, payload: MultipartPayload,
+): Promise<string> {
+  return scoped(fixture, async (client) => (await client.query<StatusRow>(
+    `SELECT content.${functionName}($1,$2,${multipartRow},$23) AS status`,
+    [attemptToken, reservationToken, ...multipartValues(payload), cleanupDelayMs],
+  )).rows[0].status);
+}
+async function insertAsset(
+  executor: QueryExecutor, payload: DirectPayload | MultipartPayload,
+  operationId: string, clientUpdatedAt: string, deletedAt: string | null,
+): Promise<string> {
+  const storageKey = "storageKey" in payload ? payload.storageKey : payload.blobStorageKey;
+  const normalizationVersion = payload.normalizationVersion;
+  const mediaBlobId = randomUUID();
+  await executor.query(
+    `WITH blob AS ( INSERT INTO content.media_blobs (media_blob_id,sha256,mime_type,size_bytes,storage_key,normalization_version) VALUES ($1,$2,$3,$4,$5,$6) RETURNING media_blob_id
+     )
+     INSERT INTO content.media_assets (media_asset_id,workspace_id,media_blob_id,source_url,created_at, client_updated_at,last_modified_by_replica_id,last_operation_id,deleted_at)
+     SELECT $7,$8,media_blob_id,$9,$10,$11,$12,$13,$14 FROM blob`,
+    [mediaBlobId, payload.sha256, payload.mimeType, payload.sizeBytes, storageKey, normalizationVersion, payload.mediaAssetId, payload.workspaceId, payload.sourceUrl, payload.assetCreatedAt, clientUpdatedAt, payload.replicaId, operationId, deletedAt],
+  );
+  return mediaBlobId;
+}
+async function apply0097UpgradeAndAssertSecurity(fixture: PostgresIntegrationFixture): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  const legacyStates = ["active", "finalized", "unreferenced"] as const;
+  const signatureSql = `SELECT array_agg(format('%I.%I(%s)',namespaces.nspname,functions.proname,pg_get_function_identity_arguments(functions.oid)) ORDER BY namespaces.nspname,functions.proname,pg_get_function_identity_arguments(functions.oid)) AS signatures FROM pg_proc AS functions INNER JOIN pg_namespace AS namespaces ON namespaces.oid=functions.pronamespace WHERE namespaces.nspname=ANY('{content,org,security,sync,catalog}'::text[])`;
+  const legacyMultipart = multipart(fixture, {});
+  try {
+    const baseline = (await client.query(`SELECT current_setting('server_version_num')::int / 10000 AS major, count(*)::int AS migrations, max(filename) AS latest, to_regclass('content.media_blob_writer_attempts') IS NULL AS attempts_absent, to_regtype('content.direct_media_blob_writer_attempt_payload') IS NULL AS payload_absent, to_regprocedure('content.fence_media_upload_session_completion_apply_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamptz,timestamptz,timestamptz,uuid,text,integer)') IS NOT NULL AS migration_0096_present FROM public.schema_migrations`)).rows[0];
+    assert.deepEqual(baseline, { major: 18, migrations: 98, latest: "0096_atomic_multipart_completion_resolution.sql", attempts_absent: true, payload_absent: true, migration_0096_present: true });
+    const signaturesBefore = (await client.query<{ signatures: string[] }>(signatureSql)).rows[0].signatures; assert.equal(signaturesBefore.length, 47);
+    for (const state of legacyStates) { const sha256 = digest(); await client.query( `WITH lifecycle AS ( INSERT INTO content.media_blob_lifecycles (sha256,storage_key,mime_type,size_bytes,normalization_version) VALUES ($1,$2,'image/jpeg',42,'image-jpeg-card-v1') RETURNING sha256 ) INSERT INTO content.media_blob_writer_reservations (sha256,writer_kind,workspace_id,media_asset_id,operation_id,state) SELECT sha256,'direct_ingestion',$3,$4,$5,$6 FROM lifecycle`, [sha256, buildMediaBlobStorageKey(sha256), fixture.workspaceId, randomUUID(), randomUUID(), state], );
+    }
+    await insertSession(client, legacyMultipart, "active"); await client.query("BEGIN"); await client.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); const legacyMultipartBegin = (await client.query<LegacyBeginRow>(`SELECT * FROM content.begin_media_upload_session_completion_with_owner(${Array.from({ length: 19 }, (_, index) => `$${index + 1}`).join(",")})`, multipartValues(legacyMultipart).slice(0, 19))).rows[0]; await client.query("COMMIT"); assert.equal(legacyMultipartBegin.completion_status, "started");
+    await client.query("BEGIN"); await client.query(migration0097); await client.query("INSERT INTO public.schema_migrations(filename) VALUES ('0097_direct_multipart_writer_attempt_fencing.sql')"); await client.query("COMMIT");
+    const signaturesAfter = (await client.query<{ signatures: string[] }>(signatureSql)).rows[0].signatures; assert.deepEqual(signaturesAfter.filter((signature) => signaturesBefore.includes(signature)), signaturesBefore);
+    await client.query("BEGIN"); await client.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); const releasedDirect = (await client.query<{ statuses: string[] }>(`SELECT array_agg(result.reservation_status ORDER BY reservations.state) AS statuses FROM content.media_blob_writer_reservations AS reservations INNER JOIN content.media_blob_lifecycles AS lifecycles USING (sha256) CROSS JOIN LATERAL content.reserve_direct_media_blob_writer_with_owner($1,reservations.workspace_id,reservations.media_asset_id,reservations.operation_id,$2,reservations.sha256,lifecycles.storage_key,lifecycles.mime_type,lifecycles.size_bytes,lifecycles.normalization_version) AS result WHERE reservations.workspace_id=$3 AND reservations.writer_kind='direct_ingestion'`, [fixture.userId, fixture.replicaId, fixture.workspaceId])).rows[0].statuses; const releasedMultipart = (await client.query<LegacyBeginRow>(`SELECT * FROM content.begin_media_upload_session_completion_with_owner(${Array.from({ length: 19 }, (_, index) => `$${index + 1}`).join(",")})`, multipartValues(legacyMultipart).slice(0, 19))).rows[0]; const releasedFence = (await client.query<StatusRow>(`SELECT content.fence_media_upload_session_completion_apply_with_owner(${Array.from({ length: 21 }, (_, index) => `$${index + 1}`).join(",")}) AS status`, [...multipartValues(legacyMultipart).slice(0, 18), legacyMultipartBegin.reservation_token, legacyMultipartBegin.normalization_version, cleanupDelayMs])).rows[0].status; await client.query("COMMIT"); assert.deepEqual(releasedDirect, ["ownership_unbound", "ownership_unbound", "ownership_unbound"]); assert.deepEqual([releasedMultipart.completion_status, releasedFence], ["replayed", "ready"]);
+    const upgrade = (await client.query(
+      `SELECT array_agg(state ORDER BY state) AS states,
+        (SELECT count(*)::int FROM content.media_blob_writer_attempts) AS attempts,
+        to_regprocedure('content.finalize_media_blob_writer(uuid,text,uuid,uuid)') IS NOT NULL AS old_signature,
+        (SELECT count(*)::int FROM public.schema_migrations) AS migrations
+       FROM content.media_blob_writer_reservations WHERE workspace_id=$1`,
+      [fixture.workspaceId],
+    )).rows[0];
+    assert.deepEqual(upgrade, { states: ["active", "active", "finalized", "unreferenced"], attempts: 0, old_signature: true, migrations: 99,
+    });
+    const acl = (await client.query( `SELECT has_table_privilege('backend_app','content.media_blob_writer_attempts','SELECT') AS backend_table, has_table_privilege('auth_app','content.media_blob_writer_attempts','SELECT') AS auth_table, has_table_privilege('reporting_readonly','content.media_blob_writer_attempts','SELECT') AS reporting_table, has_function_privilege('backend_app', 'content.begin_direct_media_blob_writer_attempt_with_owner(uuid,integer,content.direct_media_blob_writer_attempt_payload)','EXECUTE') AS backend_begin, has_function_privilege('auth_app', 'content.begin_direct_media_blob_writer_attempt_with_owner(uuid,integer,content.direct_media_blob_writer_attempt_payload)','EXECUTE') AS auth_begin, has_function_privilege('reporting_readonly', 'content.begin_direct_media_blob_writer_attempt_with_owner(uuid,integer,content.direct_media_blob_writer_attempt_payload)','EXECUTE') AS reporting_begin, has_function_privilege('backend_app', 'content.terminalize_media_blob_writer_attempt_internal(uuid,uuid,integer)','EXECUTE') AS backend_internal, NOT EXISTS (SELECT 1 FROM pg_class AS classes CROSS JOIN LATERAL aclexplode(COALESCE(classes.relacl,acldefault('r',classes.relowner))) AS privileges WHERE classes.oid='content.media_blob_writer_attempts'::regclass AND privileges.grantee=0) AS no_public_table, NOT EXISTS (SELECT 1 FROM pg_proc AS functions CROSS JOIN LATERAL aclexplode(COALESCE(functions.proacl,acldefault('f',functions.proowner))) AS privileges WHERE functions.oid='content.begin_direct_media_blob_writer_attempt_with_owner(uuid,integer,content.direct_media_blob_writer_attempt_payload)'::regprocedure AND privileges.grantee=0) AS no_public_begin, bool_and(prosecdef AND proconfig=ARRAY['search_path=pg_catalog']) AS hardened FROM pg_proc WHERE pronamespace='content'::regnamespace AND proname LIKE '%attempt%'`,
+    )).rows[0];
+    assert.deepEqual(acl, { backend_table: false, auth_table: false, reporting_table: false, backend_begin: true, auth_begin: false, reporting_begin: false, backend_internal: false, no_public_table: true, no_public_begin: true, hardened: true,
+    });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+async function waitForLock(fixture: PostgresIntegrationFixture, pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const waiting = (await fixture.ownerPool.query<{ waiting: boolean }>( "SELECT wait_event_type='Lock' AS waiting FROM pg_stat_activity WHERE pid=$1", [pid],
+    )).rows[0]?.waiting;
+    if (waiting === true) return;
+    await fixture.ownerPool.query("SELECT pg_sleep(0.01)");
+  }
+  assert.fail(`PostgreSQL worker did not enter a bounded lock wait. pid=${pid}`);
+}
+async function raceBegins(
+  fixture: PostgresIntegrationFixture, sql: string,
+  firstValues: Array<SqlValue>, secondValues: Array<SqlValue>,
+): Promise<ReadonlyArray<BeginRow>> {
+  const holder = await fixture.ownerPool.connect();
+  const workers = await Promise.all([fixture.runtimePool.connect(), fixture.runtimePool.connect()]);
+  try {
+    await holder.query("BEGIN");
+    await holder.query("SELECT pg_advisory_xact_lock(hashtextextended($1||':'||$2::text,0))", [fixture.userId, fixture.workspaceId]);
+    for (const worker of workers) { await worker.query("BEGIN"); await worker.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); await worker.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); }
+    const pids = await Promise.all(workers.map(async (worker) => (await worker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid));
+    const pending = workers.map((worker, index) => worker.query<BeginRow>(sql, index === 0 ? firstValues : secondValues).then(async (result) => { await worker.query("COMMIT"); return result.rows[0]; }));
+    await Promise.all(pids.map(async (pid) => waitForLock(fixture, pid)));
+    await holder.query("COMMIT");
+    return await Promise.all(pending);
+  } finally {
+    await Promise.allSettled([holder.query("ROLLBACK"), ...workers.map((worker) => worker.query("ROLLBACK"))]);
+    holder.release(); workers.forEach((worker) => worker.release());
+  }
+}
+async function raceAfterAsset<Result extends pg.QueryResultRow>(
+  fixture: PostgresIntegrationFixture, winnerPayload: MultipartPayload,
+  deletedAt: string | null, sql: string, values: Array<SqlValue>,
+): Promise<Result> {
+  await fixture.ownerPool.query("INSERT INTO content.media_blob_lifecycles(sha256,storage_key,mime_type,size_bytes,normalization_version) VALUES($1,$2,$3,$4,$5) ON CONFLICT DO NOTHING", [winnerPayload.sha256, winnerPayload.blobStorageKey, winnerPayload.mimeType, winnerPayload.sizeBytes, winnerPayload.normalizationVersion]);
+  const holder = await fixture.ownerPool.connect(); const winner = await fixture.ownerPool.connect(); const loser = await fixture.runtimePool.connect();
+  try {
+    await holder.query("BEGIN"); await holder.query("SELECT pg_advisory_xact_lock(hashtextextended($1||':'||$2::text,0))", [fixture.userId, fixture.workspaceId]); await holder.query("SELECT 1 FROM content.media_blob_lifecycles WHERE sha256=$1 FOR UPDATE", [winnerPayload.sha256]);
+    await winner.query("BEGIN"); await winner.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); const winnerPid = (await winner.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+    const pendingWinner = winner.query("SELECT pg_advisory_xact_lock(hashtextextended($1||':'||$2::text,0))", [fixture.userId, fixture.workspaceId]).then(async () => { await insertAsset(winner, winnerPayload, winnerPayload.lastOperationId, winnerPayload.clientUpdatedAt, deletedAt); await winner.query("COMMIT"); }); await waitForLock(fixture, winnerPid);
+    await loser.query("BEGIN"); await loser.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); await loser.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); const loserPid = (await loser.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+    const pendingLoser = loser.query<Result>(sql, values); await waitForLock(fixture, loserPid); await holder.query("COMMIT"); await pendingWinner; const result = (await pendingLoser).rows[0]; await loser.query("COMMIT"); return result;
+  } finally {
+    await Promise.allSettled([holder.query("ROLLBACK"), winner.query("ROLLBACK"), loser.query("ROLLBACK")]); holder.release(); winner.release(); loser.release();
+  }
+}
+async function takeoverAfterLockedExpiry(
+  fixture: PostgresIntegrationFixture, expiredAttempt: string,
+  sql: string, values: Array<SqlValue>, staleSql: readonly [string, string],
+  staleValues: Array<SqlValue>,
+): Promise<Readonly<{ takeover: BeginRow; stale: ReadonlyArray<string> }>> {
+  const holder = await fixture.ownerPool.connect();
+  const worker = await fixture.runtimePool.connect(); const stale = await fixture.runtimePool.connect();
+  try {
+    await holder.query("BEGIN"); await holder.query("SELECT 1 FROM content.media_blob_writer_attempts WHERE attempt_token=$1 FOR UPDATE", [expiredAttempt]);
+    for (const client of [worker, stale]) { await client.query("BEGIN"); await client.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); await client.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); }
+    const pid = (await worker.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+    const pending = worker.query<BeginRow>(sql, values); await waitForLock(fixture, pid); const stalePid = (await stale.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+    const pendingStale = stale.query<StatusRow>(staleSql[0], staleValues); await waitForLock(fixture, stalePid);
+    await holder.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [expiredAttempt]); await holder.query("COMMIT");
+    const takeover = (await pending).rows[0]; await worker.query("COMMIT"); const staleStatuses = [(await pendingStale).rows[0].status, (await stale.query<StatusRow>(staleSql[1], staleValues)).rows[0].status]; await stale.query("COMMIT"); return { takeover, stale: staleStatuses };
+  } finally {
+    await Promise.allSettled([holder.query("ROLLBACK"), worker.query("ROLLBACK"), stale.query("ROLLBACK")]);
+    holder.release(); worker.release(); stale.release();
+  }
+}
+async function writerState(fixture: PostgresIntegrationFixture, attemptToken: string, reservationToken: string, sha256: string): Promise<string> {
+  return (await fixture.ownerPool.query<{ snapshot: string }>(`SELECT jsonb_build_object('attempt',(SELECT to_jsonb(attempts) FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token=$1),'reservation',(SELECT to_jsonb(reservations) FROM content.media_blob_writer_reservations AS reservations WHERE reservations.reservation_token=$2),'lifecycle',(SELECT to_jsonb(lifecycles) FROM content.media_blob_lifecycles AS lifecycles WHERE lifecycles.sha256=$3),'blobs',(SELECT COALESCE(jsonb_agg(to_jsonb(blobs) ORDER BY blobs.media_blob_id),'[]'::jsonb) FROM content.media_blobs AS blobs WHERE blobs.sha256=$3))::text AS snapshot`, [attemptToken, reservationToken, sha256])).rows[0].snapshot;
+}
+async function captureOwnedMedia(fixture: PostgresIntegrationFixture): Promise<OwnedMedia> {
+  return (await fixture.ownerPool.query<OwnedMedia>(`WITH owned AS MATERIALIZED (SELECT sha256 FROM content.media_blob_writer_attempts WHERE workspace_id=ANY($1::uuid[]) UNION SELECT sha256 FROM content.media_blob_writer_reservations WHERE workspace_id=ANY($1::uuid[]) UNION SELECT blobs.sha256 FROM content.media_assets AS assets INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id=assets.media_blob_id WHERE assets.workspace_id=ANY($1::uuid[])) SELECT ARRAY(SELECT DISTINCT blobs.media_blob_id FROM content.media_blobs AS blobs WHERE blobs.sha256 IN (SELECT sha256 FROM owned)) AS blob_ids, ARRAY(SELECT sha256 FROM owned) AS sha256s`, [[fixture.workspaceId, fixture.outOfScopeWorkspaceId]])).rows[0];
+}
+async function removeOwnedMedia(fixture: PostgresIntegrationFixture, captured: OwnedMedia): Promise<void> {
+  const current = await captureOwnedMedia(fixture); const owned = { blob_ids: [...new Set([...captured.blob_ids, ...current.blob_ids])], sha256s: [...new Set([...captured.sha256s, ...current.sha256s])] };
+  const workspaceIds = [fixture.workspaceId, fixture.outOfScopeWorkspaceId]; await fixture.ownerPool.query("DELETE FROM org.workspaces WHERE workspace_id=$1", [fixture.outOfScopeWorkspaceId]);
+  await fixture.ownerPool.query("DELETE FROM content.media_assets WHERE workspace_id=ANY($1::uuid[])", [workspaceIds]);
+  await fixture.ownerPool.query("DELETE FROM content.media_blob_writer_attempts WHERE workspace_id=ANY($1::uuid[])", [workspaceIds]);
+  await fixture.ownerPool.query("DELETE FROM content.media_blob_writer_reservations WHERE workspace_id=ANY($1::uuid[])", [workspaceIds]);
+  await fixture.ownerPool.query("DELETE FROM content.media_blobs AS blobs WHERE media_blob_id=ANY($1::uuid[]) AND NOT EXISTS (SELECT 1 FROM content.media_assets WHERE media_blob_id=blobs.media_blob_id) AND NOT EXISTS (SELECT 1 FROM catalog.package_media_assets WHERE media_blob_id=blobs.media_blob_id)", [owned.blob_ids]);
+  await fixture.ownerPool.query("DELETE FROM content.media_blob_lifecycles AS lifecycles WHERE sha256=ANY($1::text[]) AND NOT EXISTS (SELECT 1 FROM content.media_blobs WHERE sha256=lifecycles.sha256) AND NOT EXISTS (SELECT 1 FROM content.media_blob_writer_reservations WHERE sha256=lifecycles.sha256)", [owned.sha256s]);
+  const remaining = (await fixture.ownerPool.query("SELECT (SELECT count(*)::int FROM content.media_blob_writer_attempts WHERE workspace_id=ANY($1::uuid[])) AS attempts,(SELECT count(*)::int FROM content.media_blob_writer_reservations WHERE workspace_id=ANY($1::uuid[])) AS reservations,(SELECT count(*)::int FROM content.media_blobs WHERE media_blob_id=ANY($2::uuid[])) AS blobs,(SELECT count(*)::int FROM content.media_blob_lifecycles WHERE sha256=ANY($3::text[])) AS lifecycles", [workspaceIds, owned.blob_ids, owned.sha256s])).rows[0];
+  assert.deepEqual(remaining, { attempts: 0, reservations: 0, blobs: 0, lifecycles: 0 });
+}
+test("writer attempts fence direct and multipart work with durable replay and canonical locks", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    await apply0097UpgradeAndAssertSecurity(fixture);
+    let captured: OwnedMedia = { blob_ids: [], sha256s: [] };
+    try {
+    const directBeginSql = `SELECT * FROM content.begin_direct_media_blob_writer_attempt_with_owner($1,$2,${directRow})`;
+    const sameDirectPayload = direct(fixture, {}); const sameDirectToken = randomUUID();
+    const sameDirect = await raceBegins(fixture, directBeginSql, [sameDirectToken, 60_000, ...directValues(sameDirectPayload)], [sameDirectToken, 60_000, ...directValues(sameDirectPayload)]);
+    assert.deepEqual(sameDirect.map((row) => row.attempt_status).sort(), ["acquired", "replayed"]);
+    const competingDirectPayload = direct(fixture, {}); const competingDirectTokens = [randomUUID(), randomUUID()];
+    const competingDirect = await raceBegins(fixture, directBeginSql, [competingDirectTokens[0], 60_000, ...directValues(competingDirectPayload)], [competingDirectTokens[1], 60_000, ...directValues(competingDirectPayload)]);
+    assert.deepEqual(competingDirect.map((row) => row.attempt_status).sort(), ["acquired", "busy"]);
+    const otherReplica = randomUUID(); await fixture.ownerPool.query(`WITH workspace AS (INSERT INTO org.workspaces(workspace_id,name,fsrs_client_updated_at,fsrs_last_modified_by_replica_id,fsrs_last_operation_id) VALUES($1,'Attempt token race',$2,$3,$4) RETURNING workspace_id),membership AS (INSERT INTO org.workspace_memberships(workspace_id,user_id,role) SELECT workspace_id,$5,'owner' FROM workspace) INSERT INTO sync.workspace_replicas(replica_id,workspace_id,user_id,actor_kind,actor_key,platform,app_version) VALUES($3,$1,$5,'ai_chat',$6,'system','postgres-integration')`, [fixture.outOfScopeWorkspaceId, fixture.createdAt, otherReplica, randomUUID(), fixture.userId, `postgres-integration-${otherReplica}`]);
+    const globalToken = randomUUID(); const globalOwnerPayload = direct(fixture, {}); const globalPeerPayload = direct(fixture, { workspaceId: fixture.outOfScopeWorkspaceId, replicaId: otherReplica }); const globalOwner = await fixture.runtimePool.connect(); const globalPeer = await fixture.runtimePool.connect();
+    try { for (const [client, workspaceId] of [[globalOwner, fixture.workspaceId], [globalPeer, fixture.outOfScopeWorkspaceId]] as const) { await client.query("BEGIN"); await client.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, workspaceId]); await client.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); } await globalOwner.query("SELECT pg_advisory_xact_lock(hashtextextended('attempt:'||$1::text,3))", [globalToken]); const ownerPid = (await globalOwner.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid; const peerPid = (await globalPeer.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid; const pendingPeer = globalPeer.query<BeginRow>(directBeginSql, [globalToken, 60_000, ...directValues(globalPeerPayload)]); await waitForLock(fixture, peerPid); assert.equal((await fixture.ownerPool.query<{ waiting: boolean }>("SELECT EXISTS(SELECT 1 FROM pg_locks AS waiting INNER JOIN pg_locks AS granted USING(locktype,database,classid,objid,objsubid) WHERE waiting.pid=$1 AND granted.pid=$2 AND waiting.locktype='advisory' AND NOT waiting.granted AND granted.granted) AS waiting", [peerPid, ownerPid])).rows[0].waiting, true); const acquired = (await globalOwner.query<BeginRow>(directBeginSql, [globalToken, 60_000, ...directValues(globalOwnerPayload)])).rows[0]; await globalOwner.query("COMMIT"); const beforeDenial = (await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [globalToken])).rows[0]; const denied = (await pendingPeer).rows[0]; await globalPeer.query("COMMIT"); assert.deepEqual([acquired.attempt_status, denied.attempt_status, denied.reservation_token], ["acquired", "access_denied", null]); assert.deepEqual((await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [globalToken])).rows[0], beforeDenial);
+    } finally { await Promise.allSettled([globalOwner.query("ROLLBACK"), globalPeer.query("ROLLBACK")]); globalOwner.release(); globalPeer.release(); }
+    const guardedDirectPayload = direct(fixture, {}); const guardedDirectAttempt = randomUUID(); const guardedDirect = await beginDirect(fixture, guardedDirectAttempt, guardedDirectPayload, 60_000); assert.equal(guardedDirect.attempt_status, "acquired");
+    const guardedDirectBefore = (await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [guardedDirectAttempt])).rows[0]; const wrongDirectPeer = await beginDirect(fixture, randomUUID(), { ...guardedDirectPayload, sourceUrl: "https://wrong.invalid/" }, 60_000);
+    assert.deepEqual([wrongDirectPeer.attempt_status, wrongDirectPeer.lease_expires_at, (await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [guardedDirectAttempt])).rows[0]], ["stale_attempt", null, guardedDirectBefore]);
+    const firstPayload = direct(fixture, {});
+    const firstAttempt = randomUUID();
+    const first = await beginDirect(fixture, firstAttempt, firstPayload, 60_000);
+    assert.equal(first.attempt_status, "acquired");
+    assert.equal((await beginDirect(fixture, firstAttempt, firstPayload, 60_000)).attempt_status, "replayed");
+    const busyDirectAttempt = randomUUID();
+    assert.equal((await beginDirect(fixture, busyDirectAttempt, firstPayload, 60_000)).attempt_status, "busy");
+    assert.equal(await directStatus(fixture, "resolve_direct_media_blob_writer_attempt_failure_with_owner", busyDirectAttempt, first.reservation_token!, firstPayload), "stale_attempt");
+    assert.equal(await directStatus(fixture, "resolve_direct_media_blob_writer_attempt_failure_with_owner", firstAttempt, first.reservation_token!, firstPayload), "unreferenced");
+    assert.equal(await directStatus(fixture, "resolve_direct_media_blob_writer_attempt_failure_with_owner", firstAttempt, first.reservation_token!, firstPayload), "unreferenced");
+    const rotated = await beginDirect(fixture, randomUUID(), firstPayload, 60_000);
+    assert.equal(rotated.attempt_status, "acquired");
+    assert.notEqual(rotated.reservation_token, first.reservation_token);
+    assert.equal((await beginDirect(fixture, firstAttempt, firstPayload, 60_000)).attempt_status, "unreferenced");
+    const expiringPayload = direct(fixture, {});
+    const expiredAttempt = randomUUID();
+    const expired = await beginDirect(fixture, expiredAttempt, expiringPayload, 10);
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [expiredAttempt]); assert.equal((await beginDirect(fixture, randomUUID(), { ...expiringPayload, sourceUrl: "https://wrong.invalid/" }, 60_000)).attempt_status, "stale_attempt"); assert.equal((await fixture.ownerPool.query("SELECT state FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [expiredAttempt])).rows[0].state, "leased");
+    const directTakeoverRace = await takeoverAfterLockedExpiry(fixture, expiredAttempt, `SELECT * FROM content.begin_direct_media_blob_writer_attempt_with_owner($1,$2,${directRow})`, [randomUUID(), 60_000, ...directValues(expiringPayload)], [`SELECT content.fence_direct_media_blob_writer_attempt_apply_with_owner($1,$2,${directRow},$16) AS status`, `SELECT content.resolve_direct_media_blob_writer_attempt_failure_with_owner($1,$2,${directRow},$16) AS status`], [expiredAttempt, expired.reservation_token!, ...directValues({ ...expiringPayload, normalizationVersion: expired.normalization_version! }), cleanupDelayMs]);
+    const takeover = directTakeoverRace.takeover; assert.deepEqual(directTakeoverRace.stale, ["stale_attempt", "stale_attempt"]);
+    assert.equal(takeover.attempt_status, "expired_takeover");
+    const livePayload = direct(fixture, {});
+    const liveAttempt = randomUUID();
+    const live = await beginDirect(fixture, liveAttempt, livePayload, 60_000);
+    const canonicalLive = { ...livePayload, normalizationVersion: live.normalization_version! };
+    await scoped(fixture, async (client) => { assert.equal((await client.query<StatusRow>( `SELECT content.fence_direct_media_blob_writer_attempt_apply_with_owner( $1,$2,${directRow},$16) AS status`, [liveAttempt, live.reservation_token, ...directValues(canonicalLive), cleanupDelayMs], )).rows[0].status, "ready"); await insertAsset(client, canonicalLive, canonicalLive.operationId, canonicalLive.clientUpdatedAt, null); assert.equal((await client.query<StatusRow>( `SELECT content.finish_direct_media_blob_writer_attempt_apply_with_owner( $1,$2,${directRow},$16) AS status`, [liveAttempt, live.reservation_token, ...directValues(canonicalLive), cleanupDelayMs], )).rows[0].status, "live_applied");
+    });
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", liveAttempt, live.reservation_token!, canonicalLive), "live_applied");
+    const exactPayload = direct(fixture, {});
+    await insertAsset(fixture.ownerPool, exactPayload, exactPayload.operationId, exactPayload.clientUpdatedAt, null);
+    const exactAttempt = randomUUID();
+    const exactRace = await raceBegins(fixture, directBeginSql, [exactAttempt, 60_000, ...directValues(exactPayload)], [exactAttempt, 60_000, ...directValues(exactPayload)]);
+    assert.deepEqual(exactRace.map((row) => [row.attempt_status, row.reservation_token]), [["already_applied", null], ["already_applied", null]]);
+    const peerPayload = direct(fixture, {});
+    const peerAttempt = randomUUID();
+    const peer = await beginDirect(fixture, peerAttempt, peerPayload, 60_000);
+    const peerWinner = direct(fixture, { mediaAssetId: peerPayload.mediaAssetId, clientUpdatedAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    await insertAsset(fixture.ownerPool, peerWinner, peerWinner.operationId, peerWinner.clientUpdatedAt, null);
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", peerAttempt, peer.reservation_token!, { ...peerPayload, normalizationVersion: peer.normalization_version!, }), "peer_conflict");
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", peerAttempt, peer.reservation_token!, { ...peerPayload, normalizationVersion: peer.normalization_version!, }), "peer_conflict");
+    const tombstonePayload = direct(fixture, {});
+    const tombstoneWinner = { ...tombstonePayload, clientUpdatedAt: new Date(Date.now() + 60_000).toISOString() };
+    await insertAsset(fixture.ownerPool, tombstoneWinner, tombstoneWinner.operationId, tombstoneWinner.clientUpdatedAt, tombstoneWinner.clientUpdatedAt);
+    assert.equal((await beginDirect(fixture, randomUUID(), tombstonePayload, 60_000)).attempt_status, "peer_conflict");
+    const statusPayload = direct(fixture, {});
+    const statusAttempt = randomUUID();
+    const statusBegin = await beginDirect(fixture, statusAttempt, statusPayload, 60_000);
+    const canonicalStatus = { ...statusPayload, normalizationVersion: statusBegin.normalization_version!,
+    };
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", statusAttempt, randomUUID(), canonicalStatus), "writer_conflict");
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", statusAttempt, statusBegin.reservation_token!, { ...canonicalStatus, replicaId: randomUUID() }), "replica_mismatch");
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_owner_snapshots SET replica_id=$1 WHERE reservation_token=$2", [randomUUID(), statusBegin.reservation_token]);
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", statusAttempt, statusBegin.reservation_token!, canonicalStatus), "ownership_mismatch");
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_owner_snapshots SET replica_id=$1 WHERE reservation_token=$2", [fixture.replicaId, statusBegin.reservation_token]);
+    const scopeFenceBefore = (await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [statusAttempt])).rows[0]; assert.equal(await scoped(fixture, async (client) => { await client.query("SELECT set_config('app.workspace_id',$1,true)", [fixture.outOfScopeWorkspaceId]); return (await client.query<StatusRow>( `SELECT content.fence_direct_media_blob_writer_attempt_apply_with_owner( $1,$2,${directRow},$16) AS status`, [statusAttempt, statusBegin.reservation_token, ...directValues(canonicalStatus), cleanupDelayMs], )).rows[0].status;
+    }), "access_denied");
+    assert.deepEqual((await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [statusAttempt])).rows[0], scopeFenceBefore);
+    assert.equal((await beginDirect(fixture, randomUUID(), direct(fixture, { replicaId: randomUUID() }), 60_000)).attempt_status, "replica_mismatch");
+    await fixture.ownerPool.query( `UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=now(), cleanup_lease_token=$1,cleanup_lease_expires_at=now()+interval '1 minute' WHERE sha256=$2`, [randomUUID(), statusPayload.sha256]);
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", statusAttempt, statusBegin.reservation_token!, canonicalStatus), "cleanup_claimed");
+    await fixture.ownerPool.query( `UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=NULL, cleanup_lease_token=NULL,cleanup_lease_expires_at=NULL WHERE sha256=$1`, [statusPayload.sha256]);
+    const directRevocationPayload = direct(fixture, {});
+    const directRevocationAttempt = randomUUID();
+    const directRevocationBegin = await beginDirect(fixture, directRevocationAttempt, directRevocationPayload, 60_000);
+    const canonicalDirectRevocation = { ...directRevocationPayload, normalizationVersion: directRevocationBegin.normalization_version!,
+    };
+    const directRevocationSql = `SELECT content.resolve_direct_media_blob_writer_attempt_after_access_revocation( $1,$2,${directRow},$16) AS status`;
+    assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(directRevocationSql, [directRevocationAttempt, directRevocationBegin.reservation_token, ...directValues(canonicalDirectRevocation), cleanupDelayMs])).rows[0].status), "access_active");
+    await fixture.ownerPool.query( "DELETE FROM org.workspace_memberships WHERE workspace_id=$1 AND user_id=$2", [fixture.workspaceId, fixture.userId]);
+    const directRevokedState = await writerState(fixture, directRevocationAttempt, directRevocationBegin.reservation_token!, directRevocationPayload.sha256); assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(directRevocationSql, [directRevocationAttempt, directRevocationBegin.reservation_token, ...directValues(canonicalDirectRevocation), cleanupDelayMs])).rows[0].status), "busy"); assert.equal(await writerState(fixture, directRevocationAttempt, directRevocationBegin.reservation_token!, directRevocationPayload.sha256), directRevokedState);
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [directRevocationAttempt]);
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", directRevocationAttempt, directRevocationBegin.reservation_token!, { ...canonicalDirectRevocation, operationId: randomUUID() }), "access_denied");
+    assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(directRevocationSql, [directRevocationAttempt, directRevocationBegin.reservation_token, ...directValues(canonicalDirectRevocation), cleanupDelayMs])).rows[0].status), "unreferenced");
+    assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(directRevocationSql, [directRevocationAttempt, directRevocationBegin.reservation_token, ...directValues(canonicalDirectRevocation), cleanupDelayMs])).rows[0].status), "unreferenced");
+    await fixture.ownerPool.query( "INSERT INTO org.workspace_memberships(workspace_id,user_id,role) VALUES ($1,$2,'owner')", [fixture.workspaceId, fixture.userId]);
+    const utf8Payload = direct(fixture, { operationId: "lww-tie-😀" });
+    const utf8Begin = await beginDirect(fixture, randomUUID(), utf8Payload, 60_000);
+    await insertAsset(fixture.ownerPool, utf8Payload, "lww-tie-\uE000", utf8Payload.clientUpdatedAt, null);
+    assert.equal(await directStatus(fixture, "fence_direct_media_blob_writer_attempt_apply_with_owner", (await fixture.ownerPool.query<{ attempt_token: string }>( "SELECT attempt_token FROM content.media_blob_writer_attempts WHERE workspace_id=$1 AND operation_id=$2", [fixture.workspaceId, utf8Payload.operationId], )).rows[0].attempt_token, utf8Begin.reservation_token!, { ...utf8Payload, normalizationVersion: utf8Begin.normalization_version!, }), "ready");
+    const multipartBeginSql = `SELECT * FROM content.begin_media_upload_session_completion_attempt_with_owner($1,$2,${multipartRow})`;
+    const sameMultipartPayload = multipart(fixture, {}); await insertSession(fixture.ownerPool, sameMultipartPayload, "active"); const sameMultipartToken = randomUUID();
+    const sameMultipart = await raceBegins(fixture, multipartBeginSql, [sameMultipartToken, 60_000, ...multipartValues(sameMultipartPayload)], [sameMultipartToken, 60_000, ...multipartValues(sameMultipartPayload)]);
+    assert.deepEqual(sameMultipart.map((row) => row.attempt_status).sort(), ["acquired", "replayed"]);
+    const competingMultipartPayload = multipart(fixture, {}); await insertSession(fixture.ownerPool, competingMultipartPayload, "active"); const competingMultipartTokens = [randomUUID(), randomUUID()];
+    const competingMultipart = await raceBegins(fixture, multipartBeginSql, [competingMultipartTokens[0], 60_000, ...multipartValues(competingMultipartPayload)], [competingMultipartTokens[1], 60_000, ...multipartValues(competingMultipartPayload)]);
+    assert.deepEqual(competingMultipart.map((row) => row.attempt_status).sort(), ["acquired", "busy"]);
+    const guardedMultipartPayload = multipart(fixture, {}); await insertSession(fixture.ownerPool, guardedMultipartPayload, "active"); const guardedMultipartAttempt = randomUUID(); const guardedMultipart = await beginMultipart(fixture, guardedMultipartAttempt, guardedMultipartPayload, 60_000); assert.equal(guardedMultipart.attempt_status, "acquired");
+    const guardedMultipartBefore = (await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [guardedMultipartAttempt])).rows[0]; const wrongMultipartPeer = await beginMultipart(fixture, randomUUID(), { ...guardedMultipartPayload, partsFingerprint: digest() }, 60_000);
+    assert.deepEqual([wrongMultipartPeer.attempt_status, wrongMultipartPeer.lease_expires_at, (await fixture.ownerPool.query("SELECT state,lease_expires_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [guardedMultipartAttempt])).rows[0]], ["stale_attempt", null, guardedMultipartBefore]);
+    const multipartPayload = multipart(fixture, {});
+    await insertSession(fixture.ownerPool, multipartPayload, "active");
+    const multipartAttempt = randomUUID();
+    const multipartBegin = await beginMultipart(fixture, multipartAttempt, multipartPayload, 60_000);
+    assert.equal(multipartBegin.attempt_status, "acquired");
+    assert.equal((await beginMultipart( fixture, multipartAttempt, multipartPayload, 60_000)).attempt_status, "replayed");
+    const busyMultipartAttempt = randomUUID();
+    assert.equal((await beginMultipart( fixture, busyMultipartAttempt, multipartPayload, 60_000)).attempt_status, "busy");
+    assert.equal(await multipartStatus(fixture, "resolve_media_upload_session_completion_attempt_failure_with_owner", busyMultipartAttempt, multipartBegin.reservation_token!, { ...multipartPayload, normalizationVersion: multipartBegin.normalization_version!,
+    }), "stale_attempt");
+    assert.equal((await beginMultipart(fixture, multipartAttempt, { ...multipartPayload, partsFingerprint: digest(),
+    }, 60_000)).attempt_status, "stale_attempt");
+    assert.equal((await beginMultipart(fixture, multipartAttempt, { ...multipartPayload, lastOperationId: randomUUID() }, 60_000)).attempt_status, "stale_attempt");
+    const differentSessionId = randomUUID();
+    assert.equal((await beginMultipart(fixture, multipartAttempt, { ...multipartPayload, sessionId: differentSessionId, stagingStorageKey: `media/uploads/workspaces/${fixture.workspaceId}/assets/${multipartPayload.mediaAssetId}/sessions/${differentSessionId}`,
+    }, 60_000)).attempt_status, "stale_attempt");
+    const differentHash = digest();
+    assert.equal((await beginMultipart(fixture, multipartAttempt, { ...multipartPayload, sha256: differentHash, blobStorageKey: buildMediaBlobStorageKey(differentHash),
+    }, 60_000)).attempt_status, "stale_attempt");
+    assert.equal((await beginMultipart(fixture, multipartAttempt, { ...multipartPayload, normalizationVersion: "image-jpeg-card-v1",
+    }, 60_000)).attempt_status, "stale_attempt");
+    assert.equal((await beginMultipart(fixture, multipartAttempt, { ...multipartPayload, partCount: 2,
+    }, 60_000)).attempt_status, "stale_attempt");
+    const canonicalMultipart = { ...multipartPayload, normalizationVersion: multipartBegin.normalization_version!,
+    };
+    await fixture.ownerPool.query( "UPDATE content.media_upload_sessions SET s3_upload_id='changed-upload' WHERE media_upload_session_id=$1", [multipartPayload.sessionId]);
+    assert.equal(await multipartStatus(fixture, "fence_media_upload_session_completion_attempt_apply_with_owner", multipartAttempt, multipartBegin.reservation_token!, canonicalMultipart), "stale");
+    await fixture.ownerPool.query( "UPDATE content.media_upload_sessions SET s3_upload_id=$2 WHERE media_upload_session_id=$1", [multipartPayload.sessionId, multipartPayload.s3UploadId]);
+    await scoped(fixture, async (client) => { assert.equal((await client.query<StatusRow>( `SELECT content.fence_media_upload_session_completion_attempt_apply_with_owner( $1,$2,${multipartRow},$23) AS status`, [multipartAttempt, multipartBegin.reservation_token, ...multipartValues(canonicalMultipart), cleanupDelayMs], )).rows[0].status, "ready"); await insertAsset(client, canonicalMultipart, canonicalMultipart.lastOperationId, canonicalMultipart.clientUpdatedAt, null); assert.equal((await client.query<StatusRow>( `SELECT content.finish_media_upload_session_completion_attempt_apply_with_owner( $1,$2,${multipartRow},$23) AS status`, [multipartAttempt, multipartBegin.reservation_token, ...multipartValues(canonicalMultipart), cleanupDelayMs], )).rows[0].status, "live_applied");
+    });
+    assert.equal(await multipartStatus(fixture, "finish_media_upload_session_completion_attempt_apply_with_owner", multipartAttempt, multipartBegin.reservation_token!, canonicalMultipart), "live_applied");
+    const multipartPeerPayload = multipart(fixture, {}); await insertSession(fixture.ownerPool, multipartPeerPayload, "active");
+    const multipartPeerAttempt = randomUUID(); const multipartPeer = await beginMultipart(fixture, multipartPeerAttempt, multipartPeerPayload, 60_000);
+    const multipartPeerWinner = { ...multipartPeerPayload, lastOperationId: randomUUID(), clientUpdatedAt: new Date(Date.now() + 60_000).toISOString() };
+    const multipartPeerRace = await raceAfterAsset<StatusRow>(fixture, multipartPeerWinner, null, `SELECT content.fence_media_upload_session_completion_attempt_apply_with_owner($1,$2,${multipartRow},$23) AS status`, [multipartPeerAttempt, multipartPeer.reservation_token!, ...multipartValues({ ...multipartPeerPayload, normalizationVersion: multipartPeer.normalization_version! }), cleanupDelayMs]);
+    assert.equal(multipartPeerRace.status, "peer_conflict");
+    const multipartPeerState = (await fixture.ownerPool.query("SELECT state,outcome,terminal_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [multipartPeerAttempt])).rows[0]; assert.equal(await multipartStatus(fixture, "fence_media_upload_session_completion_attempt_apply_with_owner", multipartPeerAttempt, multipartPeer.reservation_token!, { ...multipartPeerPayload, normalizationVersion: multipartPeer.normalization_version! }), "peer_conflict"); assert.deepEqual((await fixture.ownerPool.query("SELECT state,outcome,terminal_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [multipartPeerAttempt])).rows[0], multipartPeerState);
+    const multipartTombstone = multipart(fixture, {}); await insertSession(fixture.ownerPool, multipartTombstone, "active");
+    const multipartTombstoneWinner = { ...multipartTombstone, clientUpdatedAt: new Date(Date.now() + 60_000).toISOString() };
+    const multipartTombstoneAttempt = randomUUID(); const multipartTombstoneRace = await raceAfterAsset<BeginRow>(fixture, multipartTombstoneWinner, multipartTombstoneWinner.clientUpdatedAt, `SELECT * FROM content.begin_media_upload_session_completion_attempt_with_owner($1,$2,${multipartRow})`, [multipartTombstoneAttempt, 60_000, ...multipartValues(multipartTombstone)]);
+    assert.equal(multipartTombstoneRace.attempt_status, "peer_conflict");
+    const multipartTombstoneState = (await fixture.ownerPool.query("SELECT state,outcome,terminal_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [multipartTombstoneAttempt])).rows[0]; assert.equal((await beginMultipart(fixture, multipartTombstoneAttempt, multipartTombstone, 60_000)).attempt_status, "peer_conflict"); assert.deepEqual((await fixture.ownerPool.query("SELECT state,outcome,terminal_at FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [multipartTombstoneAttempt])).rows[0], multipartTombstoneState);
+    const expiringMultipartPayload = multipart(fixture, {});
+    await insertSession(fixture.ownerPool, expiringMultipartPayload, "active");
+    const expiredMultipartAttempt = randomUUID();
+    const expiredMultipart = await beginMultipart(fixture, expiredMultipartAttempt, expiringMultipartPayload, 10);
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [expiredMultipartAttempt]); assert.equal((await beginMultipart(fixture, randomUUID(), { ...expiringMultipartPayload, partsFingerprint: digest() }, 60_000)).attempt_status, "stale_attempt"); assert.equal((await fixture.ownerPool.query("SELECT state FROM content.media_blob_writer_attempts WHERE attempt_token=$1", [expiredMultipartAttempt])).rows[0].state, "leased");
+    const multipartTakeoverAttempt = randomUUID();
+    const multipartTakeoverRace = await takeoverAfterLockedExpiry(fixture, expiredMultipartAttempt, `SELECT * FROM content.begin_media_upload_session_completion_attempt_with_owner($1,$2,${multipartRow})`, [multipartTakeoverAttempt, 60_000, ...multipartValues(expiringMultipartPayload)], [`SELECT content.fence_media_upload_session_completion_attempt_apply_with_owner($1,$2,${multipartRow},$23) AS status`, `SELECT content.resolve_media_upload_session_completion_attempt_failure_with_owner($1,$2,${multipartRow},$23) AS status`], [expiredMultipartAttempt, expiredMultipart.reservation_token!, ...multipartValues({ ...expiringMultipartPayload, normalizationVersion: expiredMultipart.normalization_version! }), cleanupDelayMs]);
+    const multipartTakeover = multipartTakeoverRace.takeover; assert.deepEqual(multipartTakeoverRace.stale, ["stale_attempt", "stale_attempt"]);
+    assert.equal(multipartTakeover.attempt_status, "expired_takeover");
+    const canonicalTakeover = { ...expiringMultipartPayload, normalizationVersion: multipartTakeover.normalization_version!,
+    };
+    assert.equal(await multipartStatus(fixture, "resolve_media_upload_session_completion_attempt_failure_with_owner", multipartTakeoverAttempt, multipartTakeover.reservation_token!, canonicalTakeover), "unreferenced_restored");
+    assert.equal(await multipartStatus(fixture, "resolve_media_upload_session_completion_attempt_failure_with_owner", multipartTakeoverAttempt, multipartTakeover.reservation_token!, canonicalTakeover), "unreferenced_restored");
+    const abortPayload = multipart(fixture, {});
+    await insertSession(fixture.ownerPool, abortPayload, "active");
+    const abortAttempt = randomUUID();
+    const abortBegin = await beginMultipart(fixture, abortAttempt, abortPayload, 60_000);
+    const canonicalAbort = { ...abortPayload, normalizationVersion: abortBegin.normalization_version!,
+    };
+    const completing = await fixture.runtimePool.connect(); const aborting = await fixture.runtimePool.connect();
+    try {
+      for (const client of [completing, aborting]) { await client.query("BEGIN"); await client.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); await client.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); }
+      assert.equal((await completing.query<StatusRow>(`SELECT content.fence_media_upload_session_completion_attempt_apply_with_owner($1,$2,${multipartRow},$23) AS status`, [abortAttempt, abortBegin.reservation_token!, ...multipartValues(canonicalAbort), cleanupDelayMs])).rows[0].status, "ready"); await insertAsset(completing, canonicalAbort, canonicalAbort.lastOperationId, canonicalAbort.clientUpdatedAt, null);
+      const abortPid = (await aborting.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid; const pendingAbort = aborting.query("UPDATE content.media_upload_sessions SET state='aborting',completed_at=NULL,aborted_at=NULL WHERE media_upload_session_id=$1", [abortPayload.sessionId]).then(async () => (await aborting.query<StatusRow>(`SELECT content.close_media_upload_session_blob_writer_attempts($1,$2,${multipartRow},$23) AS status`, [abortAttempt, abortBegin.reservation_token!, ...multipartValues(canonicalAbort), cleanupDelayMs])).rows[0].status); await waitForLock(fixture, abortPid);
+      assert.equal((await completing.query<StatusRow>(`SELECT content.finish_media_upload_session_completion_attempt_apply_with_owner($1,$2,${multipartRow},$23) AS status`, [abortAttempt, abortBegin.reservation_token!, ...multipartValues(canonicalAbort), cleanupDelayMs])).rows[0].status, "live_applied"); await completing.query("COMMIT"); assert.equal(await pendingAbort, "live_applied"); await aborting.query("ROLLBACK");
+    } finally { await Promise.allSettled([completing.query("ROLLBACK"), aborting.query("ROLLBACK")]); completing.release(); aborting.release(); }
+    const expiredClosePayload = multipart(fixture, {}); await insertSession(fixture.ownerPool, expiredClosePayload, "active"); const expiredCloseAttempt = randomUUID(); const expiredCloseBegin = await beginMultipart(fixture, expiredCloseAttempt, expiredClosePayload, 60_000); const canonicalExpiredClose = { ...expiredClosePayload, normalizationVersion: expiredCloseBegin.normalization_version! };
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [expiredCloseAttempt]); await fixture.ownerPool.query("UPDATE content.media_upload_sessions SET state='aborting' WHERE media_upload_session_id=$1", [expiredClosePayload.sessionId]); assert.equal(await multipartStatus(fixture, "close_media_upload_session_blob_writer_attempts", expiredCloseAttempt, expiredCloseBegin.reservation_token!, canonicalExpiredClose), "aborted");
+    const revokedPayload = multipart(fixture, {});
+    await insertSession(fixture.ownerPool, revokedPayload, "active");
+    const revokedAttempt = randomUUID();
+    const revokedBegin = await beginMultipart(fixture, revokedAttempt, revokedPayload, 60_000);
+    const canonicalRevoked = { ...revokedPayload, normalizationVersion: revokedBegin.normalization_version!,
+    };
+    const revocationSql = `SELECT content.resolve_media_upload_session_completion_attempt_after_access_revocation( $1,$2,${multipartRow},$23) AS status`;
+    assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(revocationSql, [revokedAttempt, revokedBegin.reservation_token, ...multipartValues(canonicalRevoked), cleanupDelayMs])).rows[0].status), "access_active");
+    await fixture.ownerPool.query( "DELETE FROM org.workspace_memberships WHERE workspace_id=$1 AND user_id=$2", [fixture.workspaceId, fixture.userId]);
+    const multipartRevokedState = await writerState(fixture, revokedAttempt, revokedBegin.reservation_token!, revokedPayload.sha256); assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(revocationSql, [revokedAttempt, revokedBegin.reservation_token, ...multipartValues(canonicalRevoked), cleanupDelayMs])).rows[0].status), "busy"); assert.equal(await writerState(fixture, revokedAttempt, revokedBegin.reservation_token!, revokedPayload.sha256), multipartRevokedState);
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [revokedAttempt]);
+    assert.equal(await multipartStatus(fixture, "fence_media_upload_session_completion_attempt_apply_with_owner", revokedAttempt, revokedBegin.reservation_token!, { ...canonicalRevoked, lastOperationId: randomUUID() }), "access_denied");
+    assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(revocationSql, [revokedAttempt, revokedBegin.reservation_token, ...multipartValues(canonicalRevoked), cleanupDelayMs])).rows[0].status), "unreferenced");
+    assert.equal(await scoped(fixture, async (client) => (await client.query<StatusRow>(revocationSql, [revokedAttempt, revokedBegin.reservation_token, ...multipartValues(canonicalRevoked), cleanupDelayMs])).rows[0].status), "unreferenced");
+    await fixture.ownerPool.query( "INSERT INTO org.workspace_memberships(workspace_id,user_id,role) VALUES ($1,$2,'owner')", [fixture.workspaceId, fixture.userId]);
+    const sessionExpiryPayload = multipart(fixture, { sessionExpiresAt: new Date(Date.now() + 250).toISOString() }); await insertSession(fixture.ownerPool, sessionExpiryPayload, "active"); const sessionExpiryAttempt = randomUUID(); const sessionExpiryBegin = await beginMultipart(fixture, sessionExpiryAttempt, sessionExpiryPayload, 60_000); const canonicalSessionExpiry = { ...sessionExpiryPayload, normalizationVersion: sessionExpiryBegin.normalization_version! };
+    await fixture.ownerPool.query("SELECT pg_sleep(GREATEST(0,EXTRACT(EPOCH FROM ($1::timestamptz-pg_catalog.clock_timestamp()))+0.05))", [sessionExpiryPayload.sessionExpiresAt]); const sessionExpiredState = await writerState(fixture, sessionExpiryAttempt, sessionExpiryBegin.reservation_token!, sessionExpiryPayload.sha256);
+    assert.equal(await multipartStatus(fixture, "close_media_upload_session_blob_writer_attempts", sessionExpiryAttempt, sessionExpiryBegin.reservation_token!, canonicalSessionExpiry), "busy"); assert.equal(await writerState(fixture, sessionExpiryAttempt, sessionExpiryBegin.reservation_token!, sessionExpiryPayload.sha256), sessionExpiredState);
+    await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [sessionExpiryAttempt]); assert.equal(await multipartStatus(fixture, "close_media_upload_session_blob_writer_attempts", sessionExpiryAttempt, sessionExpiryBegin.reservation_token!, canonicalSessionExpiry), "aborted"); assert.equal(await multipartStatus(fixture, "close_media_upload_session_blob_writer_attempts", sessionExpiryAttempt, sessionExpiryBegin.reservation_token!, canonicalSessionExpiry), "aborted");
+    const racePayload = multipart(fixture, {});
+    await insertSession(fixture.ownerPool, racePayload, "active");
+    const raceAttempt = randomUUID();
+    const raceBegin = await beginMultipart(fixture, raceAttempt, racePayload, 60_000);
+    const canonicalRace = { ...racePayload, normalizationVersion: raceBegin.normalization_version! };
+    captured = await captureOwnedMedia(fixture);
+    const worker = await fixture.runtimePool.connect(); const deleter = await fixture.ownerPool.connect();
+    try {
+      await worker.query("BEGIN"); await worker.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); await worker.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'");
+      assert.equal((await worker.query<StatusRow>(`SELECT content.fence_media_upload_session_completion_attempt_apply_with_owner($1,$2,${multipartRow},$23) AS status`, [raceAttempt, raceBegin.reservation_token, ...multipartValues(canonicalRace), cleanupDelayMs])).rows[0].status, "ready");
+      await worker.query("UPDATE content.media_upload_sessions SET state='aborting' WHERE media_upload_session_id=$1", [racePayload.sessionId]);
+      assert.equal((await worker.query<StatusRow>(`SELECT content.close_media_upload_session_blob_writer_attempts($1,$2,${multipartRow},$23) AS status`, [raceAttempt, raceBegin.reservation_token, ...multipartValues(canonicalRace), cleanupDelayMs])).rows[0].status, "aborted");
+      await deleter.query("BEGIN"); await deleter.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); const deletePid = (await deleter.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+      const pendingDelete = deleter.query("DELETE FROM org.workspaces WHERE workspace_id=$1", [fixture.workspaceId]); await waitForLock(fixture, deletePid);
+      await worker.query("COMMIT"); await pendingDelete; await deleter.query("COMMIT");
+    } finally { await Promise.allSettled([worker.query("ROLLBACK"), deleter.query("ROLLBACK")]); worker.release(); deleter.release();
+    }
+    const deletion = (await fixture.ownerPool.query( `SELECT count(*) FILTER (WHERE state='leased')::int AS live, count(*) FILTER (WHERE outcome='aborted')::int AS aborted, bool_and(lifecycles.cleanup_eligible_at IS NOT NULL) AS cleanup FROM content.media_blob_writer_attempts AS attempts INNER JOIN content.media_blob_lifecycles AS lifecycles ON lifecycles.sha256=attempts.sha256 WHERE attempts.workspace_id=$1`, [fixture.workspaceId],
+    )).rows[0];
+    assert.equal(deletion.live, 0);
+    assert.equal(deletion.aborted > 0, true);
+    assert.equal(deletion.cleanup, true);
+    assert.equal(await multipartStatus(fixture, "close_media_upload_session_blob_writer_attempts", raceAttempt, raceBegin.reservation_token!, canonicalRace), "aborted");
+    const replayedDirect = await beginDirect(fixture, liveAttempt, livePayload, 60_000); assert.deepEqual([replayedDirect.attempt_status, replayedDirect.reservation_token], ["live_applied", null]);
+    const replayedMultipart = await beginMultipart(fixture, multipartAttempt, multipartPayload, 60_000); assert.deepEqual([replayedMultipart.attempt_status, replayedMultipart.reservation_token], ["live_applied", null]);
+    assert.equal((await beginMultipart(fixture, multipartAttempt, { ...multipartPayload, lastOperationId: randomUUID() }, 60_000)).attempt_status, "stale_attempt");
+    assert.equal(await directStatus(fixture, "finish_direct_media_blob_writer_attempt_apply_with_owner", randomUUID(), live.reservation_token!, canonicalLive), "access_denied");
+    assert.equal(await directStatus(fixture, "finish_direct_media_blob_writer_attempt_apply_with_owner", liveAttempt, live.reservation_token!, { ...canonicalLive, operationId: randomUUID() }), "stale_attempt");
+    assert.equal(await multipartStatus(fixture, "finish_media_upload_session_completion_attempt_apply_with_owner", multipartAttempt, multipartBegin.reservation_token!, canonicalMultipart), "live_applied");
+    const deniedReplay = await scoped(fixture, async (client) => { await client.query("SELECT set_config('app.workspace_id',$1,true)", [fixture.outOfScopeWorkspaceId]); return (await client.query<BeginRow>(directBeginSql, [liveAttempt, 60_000, ...directValues(livePayload)])).rows[0]; }); assert.deepEqual([deniedReplay.attempt_status, deniedReplay.reservation_token], ["access_denied", null]);
+    const deniedTerminal = await scoped(fixture, async (client) => { await client.query("SELECT set_config('app.workspace_id',$1,true)", [fixture.outOfScopeWorkspaceId]); const directResult = (await client.query<StatusRow>(`SELECT content.finish_direct_media_blob_writer_attempt_apply_with_owner($1,$2,${directRow},$16) AS status`, [liveAttempt, live.reservation_token!, ...directValues(canonicalLive), cleanupDelayMs])).rows[0].status; const multipartResult = (await client.query<StatusRow>(`SELECT content.finish_media_upload_session_completion_attempt_apply_with_owner($1,$2,${multipartRow},$23) AS status`, [multipartAttempt, multipartBegin.reservation_token!, ...multipartValues(canonicalMultipart), cleanupDelayMs])).rows[0].status; return [directResult, multipartResult]; }); assert.deepEqual(deniedTerminal, ["access_denied", "access_denied"]);
+    assert.equal((await fixture.ownerPool.query<{ count: number }>("SELECT count(*)::int AS count FROM sync.workspace_sync_metadata WHERE workspace_id=$1", [fixture.workspaceId])).rows[0].count, 0);
+    await assert.rejects( fixture.runtimePool.query("SELECT attempt_token FROM content.media_blob_writer_attempts"), (error: unknown) => typeof error === "object" && error !== null && "code" in error && error.code === "42501",
+    );
+    } finally { await removeOwnedMedia(fixture, captured); }
+  });
+});
+test("direct apply serializes with workspace deletion and replays after deletion", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    try {
+    const payload = direct(fixture, {}); const attempt = randomUUID(); const begun = await beginDirect(fixture, attempt, payload, 60_000);
+    const canonical = { ...payload, normalizationVersion: begun.normalization_version! };
+    const worker = await fixture.runtimePool.connect(); const deleter = await fixture.ownerPool.connect();
+    try {
+      await worker.query("BEGIN"); await worker.query("SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)", [fixture.userId, fixture.workspaceId]); await worker.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'");
+      assert.equal((await worker.query<StatusRow>(`SELECT content.fence_direct_media_blob_writer_attempt_apply_with_owner($1,$2,${directRow},$16) AS status`, [attempt, begun.reservation_token, ...directValues(canonical), cleanupDelayMs])).rows[0].status, "ready");
+      await insertAsset(worker, canonical, canonical.operationId, canonical.clientUpdatedAt, null);
+      await deleter.query("BEGIN"); await deleter.query("SET LOCAL statement_timeout='4s'; SET LOCAL lock_timeout='4s'"); const pid = (await deleter.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0].pid;
+      const pendingDelete = deleter.query("DELETE FROM org.workspaces WHERE workspace_id=$1", [fixture.workspaceId]); await waitForLock(fixture, pid);
+      assert.equal((await worker.query<StatusRow>(`SELECT content.finish_direct_media_blob_writer_attempt_apply_with_owner($1,$2,${directRow},$16) AS status`, [attempt, begun.reservation_token, ...directValues(canonical), cleanupDelayMs])).rows[0].status, "live_applied");
+      await worker.query("COMMIT"); await pendingDelete; await deleter.query("COMMIT");
+    } finally { await Promise.allSettled([worker.query("ROLLBACK"), deleter.query("ROLLBACK")]); worker.release(); deleter.release(); }
+    const replay = await beginDirect(fixture, attempt, payload, 60_000); assert.deepEqual([replay.attempt_status, replay.reservation_token, replay.lease_expires_at], ["live_applied", null, null]);
+    assert.equal((await beginDirect(fixture, attempt, { ...payload, sourceUrl: "https://wrong.invalid/" }, 60_000)).attempt_status, "stale_attempt");
+    } finally { await removeOwnedMedia(fixture, { blob_ids: [], sha256s: [] }); }
+  });
+});

--- a/db/migrations/0097_direct_multipart_writer_attempt_fencing.sql
+++ b/db/migrations/0097_direct_multipart_writer_attempt_fencing.sql
@@ -1,0 +1,942 @@
+-- Current additive migration for durable direct and multipart writer-attempt leases.
+-- Schemas touched/read explicitly: content, org, security, sync, catalog, pg_catalog.
+CREATE TYPE content.direct_media_blob_writer_attempt_payload AS (
+  user_id TEXT,
+  workspace_id UUID,
+  media_asset_id UUID,
+  operation_id TEXT,
+  replica_id UUID,
+  sha256 TEXT,
+  storage_key TEXT,
+  mime_type TEXT,
+  size_bytes BIGINT,
+  normalization_version TEXT,
+  source_url TEXT,
+  asset_created_at TIMESTAMPTZ,
+  client_updated_at TIMESTAMPTZ
+);
+CREATE TYPE content.multipart_media_blob_writer_attempt_payload AS (
+  user_id TEXT,
+  workspace_id UUID,
+  media_upload_session_id UUID,
+  media_asset_id UUID,
+  replica_id UUID,
+  last_operation_id TEXT,
+  sha256 TEXT,
+  staging_storage_key TEXT,
+  blob_storage_key TEXT,
+  s3_upload_id TEXT,
+  mime_type TEXT,
+  size_bytes BIGINT,
+  part_size_bytes BIGINT,
+  part_count INTEGER,
+  source_url TEXT,
+  asset_created_at TIMESTAMPTZ,
+  client_updated_at TIMESTAMPTZ,
+  session_expires_at TIMESTAMPTZ,
+  normalization_version TEXT,
+  completed_parts_fingerprint TEXT
+);
+CREATE TABLE content.media_blob_writer_attempts (
+  attempt_token UUID PRIMARY KEY,
+  reservation_token UUID NOT NULL,
+  writer_kind TEXT NOT NULL CHECK (writer_kind IN ('direct_ingestion', 'multipart_completion')),
+  user_id TEXT NOT NULL CHECK (user_id = pg_catalog.btrim(user_id) AND user_id <> ''),
+  workspace_id UUID NOT NULL,
+  media_asset_id UUID NOT NULL,
+  operation_id TEXT NOT NULL,
+  last_operation_id TEXT,
+  replica_id UUID NOT NULL,
+  sha256 TEXT NOT NULL,
+  blob_storage_key TEXT NOT NULL,
+  mime_type TEXT NOT NULL,
+  size_bytes BIGINT NOT NULL,
+  requested_normalization_version TEXT NOT NULL,
+  normalization_version TEXT NOT NULL,
+  source_url TEXT,
+  asset_created_at TIMESTAMPTZ NOT NULL,
+  client_updated_at TIMESTAMPTZ NOT NULL,
+  media_upload_session_id UUID,
+  staging_storage_key TEXT,
+  s3_upload_id TEXT,
+  part_size_bytes BIGINT,
+  part_count INTEGER,
+  session_expires_at TIMESTAMPTZ,
+  completed_parts_fingerprint TEXT,
+  state TEXT NOT NULL CHECK ( state IN ('leased', 'applied', 'peer_conflict', 'referenced', 'unreferenced', 'cancelled', 'expired')
+  ),
+  outcome TEXT CHECK ( outcome IS NULL OR outcome IN ( 'already_applied', 'peer_conflict', 'live_applied', 'referenced', 'unreferenced', 'unreferenced_restored', 'already_closed', 'aborted', 'stale_attempt' )
+  ),
+  lease_expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT pg_catalog.statement_timestamp(),
+  terminal_at TIMESTAMPTZ,
+  CONSTRAINT media_blob_writer_attempts_operation_safe CHECK ( operation_id = pg_catalog.btrim(operation_id) AND pg_catalog.char_length(operation_id) BETWEEN 1 AND 1024
+    AND (last_operation_id IS NULL OR (last_operation_id = pg_catalog.btrim(last_operation_id) AND pg_catalog.char_length(last_operation_id) BETWEEN 1 AND 1024))
+  ),
+  CONSTRAINT media_blob_writer_attempts_sha256_normalized CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT media_blob_writer_attempts_storage_key_deterministic CHECK ( blob_storage_key = 'media/blobs/sha256/' || pg_catalog.substring(sha256, 1, 2) || '/' || pg_catalog.substring(sha256, 3, 2) || '/' || sha256
+  ),
+  CONSTRAINT media_blob_writer_attempts_mime_type_normalized CHECK ( mime_type = pg_catalog.lower(pg_catalog.btrim(mime_type)) AND mime_type ~ '^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$'
+  ),
+  CONSTRAINT media_blob_writer_attempts_normalization_supported CHECK ( requested_normalization_version IN ('passthrough-v1', 'image-jpeg-card-v1') AND normalization_version IN ('passthrough-v1', 'image-jpeg-card-v1')
+  ),
+  CONSTRAINT media_blob_writer_attempts_state_shape CHECK ( (state = 'leased' AND outcome IS NULL AND terminal_at IS NULL) OR (state = 'applied' AND outcome IN ('already_applied', 'live_applied') AND terminal_at IS NOT NULL) OR (state = 'peer_conflict' AND outcome = 'peer_conflict' AND terminal_at IS NOT NULL) OR (state = 'referenced' AND outcome = 'referenced' AND terminal_at IS NOT NULL) OR (state = 'unreferenced' AND outcome IN ('unreferenced', 'unreferenced_restored') AND terminal_at IS NOT NULL) OR (state = 'cancelled' AND outcome IN ('already_closed', 'aborted') AND terminal_at IS NOT NULL) OR (state = 'expired' AND outcome = 'stale_attempt' AND terminal_at IS NOT NULL)
+  ),
+  CONSTRAINT media_blob_writer_attempts_kind_shape CHECK ( ( writer_kind = 'direct_ingestion' AND last_operation_id IS NULL AND media_upload_session_id IS NULL AND staging_storage_key IS NULL AND s3_upload_id IS NULL AND part_size_bytes IS NULL AND part_count IS NULL AND session_expires_at IS NULL AND completed_parts_fingerprint IS NULL ) OR ( writer_kind = 'multipart_completion' AND last_operation_id IS NOT NULL AND media_upload_session_id IS NOT NULL AND operation_id = media_upload_session_id::TEXT AND staging_storage_key IS NOT NULL AND s3_upload_id IS NOT NULL AND part_size_bytes > 0 AND part_count BETWEEN 1 AND 10000 AND session_expires_at IS NOT NULL AND completed_parts_fingerprint ~ '^[0-9a-f]{64}$' )
+  )
+);
+CREATE UNIQUE INDEX media_blob_writer_attempts_one_live_writer
+  ON content.media_blob_writer_attempts(writer_kind, workspace_id, media_asset_id, operation_id)
+  WHERE state = 'leased';
+CREATE INDEX media_blob_writer_attempts_workspace_history
+  ON content.media_blob_writer_attempts(workspace_id, writer_kind, media_asset_id, operation_id, created_at);
+CREATE INDEX media_blob_writer_attempts_sha256_history
+  ON content.media_blob_writer_attempts(sha256, state, attempt_token);
+COMMENT ON TABLE content.media_blob_writer_attempts IS
+  'Private durable attempt leases and terminal replay history for direct and multipart permanent-blob writers.';
+COMMENT ON COLUMN content.media_blob_writer_attempts.reservation_token IS
+  'Immutable reservation-token snapshot. It intentionally has no cascading foreign key so attempt history survives logical reservation-token rotation.';
+COMMENT ON COLUMN content.media_blob_writer_attempts.completed_parts_fingerprint IS
+  'Lowercase SHA-256 of the canonical ordered multipart completion parts payload.';
+CREATE FUNCTION content.direct_media_blob_writer_attempt_payload_valid_internal(
+  p_payload content.direct_media_blob_writer_attempt_payload
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT p_payload.user_id IS NOT NULL AND p_payload.user_id = pg_catalog.btrim(p_payload.user_id) AND p_payload.user_id <> '' AND p_payload.workspace_id IS NOT NULL AND p_payload.media_asset_id IS NOT NULL AND p_payload.operation_id IS NOT NULL AND p_payload.operation_id = pg_catalog.btrim(p_payload.operation_id) AND pg_catalog.char_length(p_payload.operation_id) BETWEEN 1 AND 1024 AND p_payload.replica_id IS NOT NULL AND p_payload.sha256 ~ '^[0-9a-f]{64}$' AND p_payload.storage_key = 'media/blobs/sha256/' || pg_catalog.substring(p_payload.sha256, 1, 2) || '/' || pg_catalog.substring(p_payload.sha256, 3, 2) || '/' || p_payload.sha256 AND p_payload.mime_type = pg_catalog.lower(pg_catalog.btrim(p_payload.mime_type)) AND p_payload.mime_type ~ '^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$' AND p_payload.size_bytes >= 0 AND p_payload.normalization_version IN ('passthrough-v1', 'image-jpeg-card-v1') AND p_payload.asset_created_at IS NOT NULL AND p_payload.client_updated_at IS NOT NULL;
+$$;
+CREATE FUNCTION content.multipart_media_blob_writer_attempt_payload_valid_internal(
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT p_payload.user_id IS NOT NULL AND p_payload.user_id = pg_catalog.btrim(p_payload.user_id) AND p_payload.user_id <> '' AND p_payload.workspace_id IS NOT NULL AND p_payload.media_upload_session_id IS NOT NULL AND p_payload.media_asset_id IS NOT NULL AND p_payload.replica_id IS NOT NULL AND p_payload.last_operation_id IS NOT NULL AND p_payload.last_operation_id = pg_catalog.btrim(p_payload.last_operation_id) AND pg_catalog.char_length(p_payload.last_operation_id) BETWEEN 1 AND 1024 AND p_payload.sha256 ~ '^[0-9a-f]{64}$' AND p_payload.staging_storage_key = 'media/uploads/workspaces/' || pg_catalog.lower(p_payload.workspace_id::TEXT) || '/assets/' || pg_catalog.lower(p_payload.media_asset_id::TEXT) || '/sessions/' || pg_catalog.lower(p_payload.media_upload_session_id::TEXT) AND p_payload.blob_storage_key = 'media/blobs/sha256/' || pg_catalog.substring(p_payload.sha256, 1, 2) || '/' || pg_catalog.substring(p_payload.sha256, 3, 2) || '/' || p_payload.sha256 AND p_payload.s3_upload_id IS NOT NULL AND p_payload.s3_upload_id = pg_catalog.btrim(p_payload.s3_upload_id) AND p_payload.s3_upload_id <> '' AND p_payload.mime_type = pg_catalog.lower(pg_catalog.btrim(p_payload.mime_type)) AND p_payload.mime_type ~ '^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$' AND p_payload.size_bytes > 0 AND p_payload.part_size_bytes > 0 AND p_payload.part_count BETWEEN 1 AND 10000 AND p_payload.asset_created_at IS NOT NULL AND p_payload.client_updated_at IS NOT NULL AND p_payload.session_expires_at IS NOT NULL AND p_payload.normalization_version IN ('passthrough-v1', 'image-jpeg-card-v1') AND p_payload.completed_parts_fingerprint ~ '^[0-9a-f]{64}$';
+$$;
+CREATE FUNCTION content.direct_media_blob_writer_attempt_identity_status_internal(
+  p_attempt content.media_blob_writer_attempts, p_reservation_token UUID,
+  p_payload content.direct_media_blob_writer_attempt_payload)
+RETURNS TEXT LANGUAGE SQL IMMUTABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+  SELECT CASE WHEN (p_attempt).attempt_token IS NULL THEN 'stale_attempt' WHEN (p_attempt).user_id IS DISTINCT FROM p_payload.user_id OR (p_attempt).replica_id IS DISTINCT FROM p_payload.replica_id THEN 'ownership_mismatch' WHEN (p_attempt).reservation_token IS DISTINCT FROM p_reservation_token THEN 'writer_conflict' WHEN (p_attempt).writer_kind IS DISTINCT FROM 'direct_ingestion' OR (p_attempt).workspace_id IS DISTINCT FROM p_payload.workspace_id OR (p_attempt).media_asset_id IS DISTINCT FROM p_payload.media_asset_id OR (p_attempt).operation_id IS DISTINCT FROM p_payload.operation_id OR (p_attempt).sha256 IS DISTINCT FROM p_payload.sha256 OR (p_attempt).blob_storage_key IS DISTINCT FROM p_payload.storage_key OR (p_attempt).mime_type IS DISTINCT FROM p_payload.mime_type OR (p_attempt).size_bytes IS DISTINCT FROM p_payload.size_bytes OR (p_attempt).normalization_version IS DISTINCT FROM p_payload.normalization_version OR (p_attempt).source_url IS DISTINCT FROM p_payload.source_url OR (p_attempt).asset_created_at IS DISTINCT FROM p_payload.asset_created_at OR (p_attempt).client_updated_at IS DISTINCT FROM p_payload.client_updated_at THEN 'stale_attempt' ELSE 'ready' END;
+$$;
+CREATE FUNCTION content.multipart_media_blob_writer_attempt_identity_status_internal(
+  p_attempt content.media_blob_writer_attempts, p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload)
+RETURNS TEXT LANGUAGE SQL IMMUTABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+  SELECT CASE WHEN (p_attempt).attempt_token IS NULL THEN 'stale_attempt' WHEN (p_attempt).user_id IS DISTINCT FROM p_payload.user_id OR (p_attempt).replica_id IS DISTINCT FROM p_payload.replica_id THEN 'ownership_mismatch' WHEN (p_attempt).reservation_token IS DISTINCT FROM p_reservation_token THEN 'writer_conflict' WHEN (p_attempt).writer_kind IS DISTINCT FROM 'multipart_completion' OR (p_attempt).workspace_id IS DISTINCT FROM p_payload.workspace_id OR (p_attempt).media_asset_id IS DISTINCT FROM p_payload.media_asset_id OR (p_attempt).operation_id IS DISTINCT FROM p_payload.media_upload_session_id::TEXT OR (p_attempt).last_operation_id IS DISTINCT FROM p_payload.last_operation_id OR (p_attempt).sha256 IS DISTINCT FROM p_payload.sha256 OR (p_attempt).blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key OR (p_attempt).mime_type IS DISTINCT FROM p_payload.mime_type OR (p_attempt).size_bytes IS DISTINCT FROM p_payload.size_bytes OR (p_attempt).normalization_version IS DISTINCT FROM p_payload.normalization_version OR (p_attempt).source_url IS DISTINCT FROM p_payload.source_url OR (p_attempt).asset_created_at IS DISTINCT FROM p_payload.asset_created_at OR (p_attempt).client_updated_at IS DISTINCT FROM p_payload.client_updated_at OR (p_attempt).media_upload_session_id IS DISTINCT FROM p_payload.media_upload_session_id OR (p_attempt).staging_storage_key IS DISTINCT FROM p_payload.staging_storage_key OR (p_attempt).s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id OR (p_attempt).part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes OR (p_attempt).part_count IS DISTINCT FROM p_payload.part_count OR (p_attempt).session_expires_at IS DISTINCT FROM p_payload.session_expires_at OR (p_attempt).completed_parts_fingerprint IS DISTINCT FROM p_payload.completed_parts_fingerprint THEN 'stale_attempt' ELSE 'ready' END;
+$$;
+CREATE FUNCTION content.lock_direct_media_blob_writer_attempt_revoked_internal(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.direct_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  validation_status TEXT,
+  scope_matches BOOLEAN,
+  access_present BOOLEAN,
+  replica_matches BOOLEAN,
+  asset_status TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  asset RECORD;
+  identity_status TEXT;
+BEGIN
+  IF p_attempt_token IS NULL OR p_reservation_token IS NULL OR content.direct_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true
+  THEN RETURN QUERY SELECT 'stale_attempt'::TEXT, false, false, false, NULL::TEXT; RETURN;
+  END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT; RETURN;
+  END IF;
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token AND attempts.state <> 'leased';
+  IF FOUND THEN IF attempt.user_id IS DISTINCT FROM security.current_user_id() OR attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT; RETURN; END IF; identity_status := content.direct_media_blob_writer_attempt_identity_status_internal(attempt, p_reservation_token, p_payload); IF identity_status <> 'ready' THEN RETURN QUERY SELECT identity_status, false, false, false, NULL::TEXT; RETURN; END IF; RETURN QUERY SELECT attempt.outcome, true, false, false, NULL::TEXT; RETURN; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( p_payload.user_id || ':' || p_payload.workspace_id::TEXT, 0::BIGINT));
+  scope_matches := security.current_user_id() IS NOT DISTINCT FROM p_payload.user_id AND security.current_workspace_id() IS NOT DISTINCT FROM p_payload.workspace_id;
+  SELECT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id) INTO access_present;
+  SELECT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id) INTO replica_matches;
+  IF scope_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT; RETURN;
+  ELSIF replica_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT CASE WHEN access_present THEN 'replica_mismatch' ELSE 'access_denied' END, true, access_present, false, NULL::TEXT; RETURN; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( 'direct:' || p_payload.workspace_id::TEXT || ':' || p_payload.media_asset_id::TEXT || ':' || p_payload.operation_id, 2::BIGINT));
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token;
+  identity_status := content.direct_media_blob_writer_attempt_identity_status_internal(attempt, p_reservation_token, p_payload);
+  IF access_present IS DISTINCT FROM true AND identity_status <> 'ready' THEN RETURN QUERY SELECT 'access_denied'::TEXT, true, false, replica_matches, NULL::TEXT; RETURN; END IF;
+  IF identity_status <> 'ready' THEN RETURN QUERY SELECT identity_status, false, false, false, NULL::TEXT; RETURN; END IF;
+  IF attempt.state <> 'leased' THEN RETURN QUERY SELECT attempt.outcome, true, false, false, NULL::TEXT; RETURN; END IF;
+  IF NOT EXISTS (SELECT 1 FROM org.workspaces AS workspaces WHERE workspaces.workspace_id = p_payload.workspace_id)
+  THEN RETURN QUERY SELECT 'stale_attempt'::TEXT, false, false, false, NULL::TEXT; RETURN; END IF;
+  IF access_present THEN INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES (p_payload.workspace_id, 0, pg_catalog.statement_timestamp()) ON CONFLICT (workspace_id) DO NOTHING; END IF;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_payload.workspace_id FOR UPDATE;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_payload.sha256 FOR UPDATE;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'direct_ingestion' AND reservations.workspace_id = p_payload.workspace_id AND reservations.media_asset_id = p_payload.media_asset_id AND reservations.operation_id = p_payload.operation_id FOR UPDATE;
+  IF FOUND THEN SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+  END IF;
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token FOR UPDATE;
+  identity_status := content.direct_media_blob_writer_attempt_identity_status_internal(attempt, p_reservation_token, p_payload);
+  IF identity_status <> 'ready' THEN RETURN QUERY SELECT identity_status, false, false, false, NULL::TEXT; RETURN; END IF;
+  IF attempt.state <> 'leased' THEN RETURN QUERY SELECT attempt.outcome, true, false, false, NULL::TEXT; RETURN;
+  END IF;
+  IF reservation.reservation_token IS DISTINCT FROM p_reservation_token OR reservation.sha256 IS DISTINCT FROM p_payload.sha256 OR reservation.state NOT IN ('active', 'ambiguous', 'finalized') OR lifecycle.sha256 IS DISTINCT FROM p_payload.sha256 OR lifecycle.storage_key IS DISTINCT FROM p_payload.storage_key OR lifecycle.mime_type IS DISTINCT FROM p_payload.mime_type OR lifecycle.size_bytes IS DISTINCT FROM p_payload.size_bytes OR lifecycle.normalization_version IS DISTINCT FROM p_payload.normalization_version
+  THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, false, false, false, NULL::TEXT; RETURN;
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN RETURN QUERY SELECT 'cleanup_claimed'::TEXT, false, false, false, NULL::TEXT; RETURN;
+  END IF;
+  IF owner_snapshot.reservation_token IS NULL OR owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id
+  THEN RETURN QUERY SELECT 'ownership_mismatch'::TEXT, false, false, false, NULL::TEXT; RETURN;
+  END IF;
+  SELECT * INTO asset FROM content.classify_media_upload_session_completion_asset_internal( p_payload.workspace_id, p_payload.media_asset_id, p_payload.sha256, p_payload.storage_key, p_payload.mime_type, p_payload.size_bytes, p_payload.normalization_version, p_payload.source_url, p_payload.asset_created_at, p_payload.client_updated_at, p_payload.replica_id, p_payload.operation_id);
+  scope_matches := security.current_user_id() IS NOT DISTINCT FROM p_payload.user_id AND security.current_workspace_id() IS NOT DISTINCT FROM p_payload.workspace_id;
+  SELECT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id
+  ) INTO access_present;
+  SELECT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id
+  ) INTO replica_matches;
+  IF scope_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT; RETURN;
+  ELSIF replica_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT CASE WHEN access_present THEN 'replica_mismatch' ELSE 'access_denied' END, true, access_present, false, NULL::TEXT; RETURN;
+  ELSIF EXISTS (SELECT 1 FROM content.media_blob_writer_attempts AS successor WHERE successor.writer_kind = 'direct_ingestion' AND successor.workspace_id = p_payload.workspace_id AND successor.media_asset_id = p_payload.media_asset_id AND successor.operation_id = p_payload.operation_id AND successor.state = 'leased' AND successor.attempt_token <> p_attempt_token) THEN RETURN QUERY SELECT 'stale_attempt'::TEXT, true, access_present, true, NULL::TEXT; RETURN; END IF;
+  RETURN QUERY SELECT 'ready'::TEXT, scope_matches, access_present, replica_matches, asset.asset_status;
+END;
+$$;
+CREATE FUNCTION content.lock_multipart_media_blob_writer_attempt_revoked_internal(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  validation_status TEXT,
+  scope_matches BOOLEAN,
+  access_present BOOLEAN,
+  replica_matches BOOLEAN,
+  asset_status TEXT,
+  session_state TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  asset RECORD;
+  identity_status TEXT;
+BEGIN
+  IF p_attempt_token IS NULL OR p_reservation_token IS NULL OR content.multipart_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true
+  THEN RETURN QUERY SELECT 'stale_attempt'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token AND attempts.state <> 'leased';
+  IF FOUND THEN IF attempt.user_id IS DISTINCT FROM security.current_user_id() OR attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN; END IF; identity_status := content.multipart_media_blob_writer_attempt_identity_status_internal(attempt, p_reservation_token, p_payload); IF identity_status <> 'ready' THEN RETURN QUERY SELECT identity_status, false, false, false, NULL::TEXT, NULL::TEXT; RETURN; END IF; RETURN QUERY SELECT attempt.outcome, true, false, false, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( p_payload.user_id || ':' || p_payload.workspace_id::TEXT, 0::BIGINT));
+  scope_matches := security.current_user_id() IS NOT DISTINCT FROM p_payload.user_id AND security.current_workspace_id() IS NOT DISTINCT FROM p_payload.workspace_id;
+  SELECT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id) INTO access_present;
+  SELECT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id) INTO replica_matches;
+  IF scope_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  ELSIF replica_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT CASE WHEN access_present THEN 'replica_mismatch' ELSE 'access_denied' END, true, access_present, false, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  SELECT sessions.* INTO session FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id FOR UPDATE;
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token;
+  identity_status := content.multipart_media_blob_writer_attempt_identity_status_internal(attempt, p_reservation_token, p_payload);
+  IF access_present IS DISTINCT FROM true AND identity_status <> 'ready' THEN RETURN QUERY SELECT 'access_denied'::TEXT, true, false, replica_matches, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  IF identity_status <> 'ready' THEN RETURN QUERY SELECT identity_status, false, false, false, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  IF attempt.state <> 'leased' THEN RETURN QUERY SELECT attempt.outcome, true, false, false, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  IF NOT EXISTS (SELECT 1 FROM org.workspaces AS workspaces WHERE workspaces.workspace_id = p_payload.workspace_id)
+  THEN RETURN QUERY SELECT 'stale_attempt'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  IF access_present THEN INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES (p_payload.workspace_id, 0, pg_catalog.statement_timestamp()) ON CONFLICT (workspace_id) DO NOTHING; END IF;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_payload.workspace_id FOR UPDATE;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_payload.sha256 FOR UPDATE;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion' AND reservations.workspace_id = p_payload.workspace_id AND reservations.media_asset_id = p_payload.media_asset_id AND reservations.operation_id = p_payload.media_upload_session_id::TEXT FOR UPDATE;
+  IF FOUND THEN SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+  END IF;
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token FOR UPDATE;
+  identity_status := content.multipart_media_blob_writer_attempt_identity_status_internal(attempt, p_reservation_token, p_payload);
+  IF identity_status <> 'ready' THEN RETURN QUERY SELECT identity_status, false, false, false, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  IF attempt.state <> 'leased' THEN RETURN QUERY SELECT attempt.outcome, true, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF reservation.reservation_token IS DISTINCT FROM p_reservation_token OR reservation.sha256 IS DISTINCT FROM p_payload.sha256 OR reservation.state NOT IN ('active', 'ambiguous', 'finalized') OR lifecycle.sha256 IS DISTINCT FROM p_payload.sha256 OR lifecycle.storage_key IS DISTINCT FROM p_payload.blob_storage_key OR lifecycle.mime_type IS DISTINCT FROM p_payload.mime_type OR lifecycle.size_bytes IS DISTINCT FROM p_payload.size_bytes OR lifecycle.normalization_version IS DISTINCT FROM p_payload.normalization_version
+  THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN RETURN QUERY SELECT 'cleanup_claimed'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF owner_snapshot.reservation_token IS NULL OR owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_payload.last_operation_id OR owner_snapshot.session_expires_at IS DISTINCT FROM p_payload.session_expires_at OR owner_snapshot.session_source_url IS DISTINCT FROM p_payload.source_url OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_payload.asset_created_at OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+  THEN RETURN QUERY SELECT 'ownership_mismatch'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  IF session.media_upload_session_id IS NULL OR session.workspace_id IS DISTINCT FROM p_payload.workspace_id OR session.media_asset_id IS DISTINCT FROM p_payload.media_asset_id OR session.last_modified_by_replica_id IS DISTINCT FROM p_payload.replica_id OR session.last_operation_id IS DISTINCT FROM p_payload.last_operation_id OR session.media_blob_sha256 IS DISTINCT FROM p_payload.sha256 OR session.staging_storage_key IS DISTINCT FROM p_payload.staging_storage_key OR session.blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key OR session.s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id OR session.mime_type IS DISTINCT FROM p_payload.mime_type OR session.size_bytes IS DISTINCT FROM p_payload.size_bytes OR session.part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes OR session.part_count IS DISTINCT FROM p_payload.part_count OR session.source_url IS DISTINCT FROM p_payload.source_url OR session.asset_created_at IS DISTINCT FROM p_payload.asset_created_at OR session.client_updated_at IS DISTINCT FROM p_payload.client_updated_at OR session.expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN RETURN QUERY SELECT 'stale'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  END IF;
+  SELECT * INTO asset FROM content.classify_media_upload_session_completion_asset_internal( p_payload.workspace_id, p_payload.media_asset_id, p_payload.sha256, p_payload.blob_storage_key, p_payload.mime_type, p_payload.size_bytes, p_payload.normalization_version, p_payload.source_url, p_payload.asset_created_at, p_payload.client_updated_at, p_payload.replica_id, p_payload.last_operation_id);
+  scope_matches := security.current_user_id() IS NOT DISTINCT FROM p_payload.user_id AND security.current_workspace_id() IS NOT DISTINCT FROM p_payload.workspace_id;
+  SELECT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id
+  ) INTO access_present;
+  SELECT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id
+  ) INTO replica_matches;
+  IF scope_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT 'access_denied'::TEXT, false, false, false, NULL::TEXT, NULL::TEXT; RETURN;
+  ELSIF replica_matches IS DISTINCT FROM true THEN RETURN QUERY SELECT CASE WHEN access_present THEN 'replica_mismatch' ELSE 'access_denied' END, true, access_present, false, NULL::TEXT, NULL::TEXT; RETURN;
+  ELSIF EXISTS (SELECT 1 FROM content.media_blob_writer_attempts AS successor WHERE successor.writer_kind = 'multipart_completion' AND successor.media_upload_session_id = p_payload.media_upload_session_id AND successor.state = 'leased' AND successor.attempt_token <> p_attempt_token) THEN RETURN QUERY SELECT 'stale_attempt'::TEXT, true, access_present, true, NULL::TEXT, NULL::TEXT; RETURN; END IF;
+  RETURN QUERY SELECT 'ready'::TEXT, scope_matches, access_present, replica_matches, asset.asset_status, session.state;
+END;
+$$;
+CREATE FUNCTION content.lock_direct_media_blob_writer_attempt_internal(
+  p_attempt_token UUID, p_reservation_token UUID, p_payload content.direct_media_blob_writer_attempt_payload)
+RETURNS TABLE (validation_status TEXT, scope_matches BOOLEAN, access_present BOOLEAN, replica_matches BOOLEAN, asset_status TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE attempt content.media_blob_writer_attempts%ROWTYPE; locked RECORD; identity_status TEXT;
+BEGIN
+  IF p_attempt_token IS NULL OR p_reservation_token IS NULL OR content.direct_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true THEN RETURN QUERY SELECT 'stale_attempt'::TEXT,false,false,false,NULL::TEXT; RETURN; END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id THEN RETURN QUERY SELECT 'access_denied'::TEXT,false,false,false,NULL::TEXT; RETURN; END IF;
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token=p_attempt_token AND attempts.state<>'leased';
+  IF FOUND THEN identity_status:=content.direct_media_blob_writer_attempt_identity_status_internal(attempt,p_reservation_token,p_payload); IF attempt.user_id IS DISTINCT FROM security.current_user_id() OR attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN identity_status:='access_denied'; END IF; RETURN QUERY SELECT CASE WHEN identity_status='ready' THEN attempt.outcome ELSE identity_status END,true,false,false,NULL::TEXT; RETURN; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(p_payload.user_id||':'||p_payload.workspace_id::TEXT,0::BIGINT));
+  IF NOT EXISTS (SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id=p_payload.workspace_id AND memberships.user_id=p_payload.user_id) THEN RETURN QUERY SELECT 'access_denied'::TEXT,true,false,false,NULL::TEXT; RETURN;
+  ELSIF NOT EXISTS (SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id=p_payload.replica_id AND replicas.workspace_id=p_payload.workspace_id AND replicas.user_id=p_payload.user_id) THEN RETURN QUERY SELECT 'replica_mismatch'::TEXT,true,true,false,NULL::TEXT; RETURN; END IF;
+  SELECT * INTO locked FROM content.lock_direct_media_blob_writer_attempt_revoked_internal(p_attempt_token,p_reservation_token,p_payload);
+  IF locked.validation_status='ready' AND EXISTS (SELECT 1 FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token=p_attempt_token AND attempts.state='leased' AND attempts.lease_expires_at<=pg_catalog.clock_timestamp()) THEN locked.validation_status:='stale_attempt'; END IF;
+  RETURN QUERY SELECT locked.validation_status,locked.scope_matches,locked.access_present,locked.replica_matches,locked.asset_status;
+END;
+$$;
+CREATE FUNCTION content.lock_multipart_media_blob_writer_attempt_internal(
+  p_attempt_token UUID, p_reservation_token UUID, p_payload content.multipart_media_blob_writer_attempt_payload)
+RETURNS TABLE (validation_status TEXT, scope_matches BOOLEAN, access_present BOOLEAN, replica_matches BOOLEAN, asset_status TEXT, session_state TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE attempt content.media_blob_writer_attempts%ROWTYPE; locked RECORD; identity_status TEXT;
+BEGIN
+  IF p_attempt_token IS NULL OR p_reservation_token IS NULL OR content.multipart_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true THEN RETURN QUERY SELECT 'stale_attempt'::TEXT,false,false,false,NULL::TEXT,NULL::TEXT; RETURN; END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id THEN RETURN QUERY SELECT 'access_denied'::TEXT,false,false,false,NULL::TEXT,NULL::TEXT; RETURN; END IF;
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token=p_attempt_token AND attempts.state<>'leased';
+  IF FOUND THEN identity_status:=content.multipart_media_blob_writer_attempt_identity_status_internal(attempt,p_reservation_token,p_payload); IF attempt.user_id IS DISTINCT FROM security.current_user_id() OR attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN identity_status:='access_denied'; END IF; RETURN QUERY SELECT CASE WHEN identity_status='ready' THEN attempt.outcome ELSE identity_status END,true,false,false,NULL::TEXT,NULL::TEXT; RETURN; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(p_payload.user_id||':'||p_payload.workspace_id::TEXT,0::BIGINT));
+  IF NOT EXISTS (SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id=p_payload.workspace_id AND memberships.user_id=p_payload.user_id) THEN RETURN QUERY SELECT 'access_denied'::TEXT,true,false,false,NULL::TEXT,NULL::TEXT; RETURN;
+  ELSIF NOT EXISTS (SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id=p_payload.replica_id AND replicas.workspace_id=p_payload.workspace_id AND replicas.user_id=p_payload.user_id) THEN RETURN QUERY SELECT 'replica_mismatch'::TEXT,true,true,false,NULL::TEXT,NULL::TEXT; RETURN; END IF;
+  SELECT * INTO locked FROM content.lock_multipart_media_blob_writer_attempt_revoked_internal(p_attempt_token,p_reservation_token,p_payload);
+  IF locked.validation_status='ready' AND EXISTS (SELECT 1 FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token=p_attempt_token AND attempts.state='leased' AND attempts.lease_expires_at<=pg_catalog.clock_timestamp()) THEN locked.validation_status:='stale_attempt'; END IF;
+  RETURN QUERY SELECT locked.validation_status,locked.scope_matches,locked.access_present,locked.replica_matches,locked.asset_status,locked.session_state;
+END;
+$$;
+CREATE FUNCTION content.terminalize_media_blob_writer_attempt_internal(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+BEGIN
+  SELECT attempts.* INTO attempt FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.reservation_token = p_reservation_token AND attempts.state = 'leased';
+  IF NOT FOUND THEN RETURN 'stale_attempt'; END IF;
+  RETURN content.terminalize_media_blob_writer_failure( p_reservation_token, attempt.sha256, attempt.blob_storage_key, attempt.mime_type, attempt.size_bytes, attempt.normalization_version, attempt.writer_kind, attempt.workspace_id, attempt.media_asset_id, attempt.operation_id, p_cleanup_delay_ms);
+END;
+$$;
+CREATE FUNCTION content.fence_direct_media_blob_writer_attempt_apply_with_owner(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.direct_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  locked RECORD;
+  terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_direct_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.scope_matches IS DISTINCT FROM true OR locked.access_present IS DISTINCT FROM true
+  THEN RETURN 'access_denied'; END IF;
+  IF locked.replica_matches IS DISTINCT FROM true THEN RETURN 'replica_mismatch'; END IF;
+  IF locked.asset_status = 'exact' THEN terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms); IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'applied', outcome = 'already_applied', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'already_applied';
+  ELSIF locked.asset_status = 'peer_conflict' THEN terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms); IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'peer_conflict', outcome = 'peer_conflict', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'peer_conflict';
+  END IF;
+  RETURN 'ready';
+END;
+$$;
+CREATE FUNCTION content.begin_direct_media_blob_writer_attempt_with_owner(
+  p_attempt_token UUID,
+  p_lease_duration_ms INTEGER,
+  p_payload content.direct_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing_attempt content.media_blob_writer_attempts%ROWTYPE;
+  peer_attempt content.media_blob_writer_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reservation_result RECORD;
+  apply_payload content.direct_media_blob_writer_attempt_payload;
+  fence_status TEXT;
+  takeover BOOLEAN := false;
+  leased_until TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL OR p_lease_duration_ms IS NULL OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000 OR content.direct_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true
+  THEN RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  SELECT attempts.* INTO existing_attempt FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state <> 'leased';
+  IF FOUND THEN IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id() OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; apply_payload := p_payload; apply_payload.normalization_version := existing_attempt.normalization_version; fence_status := content.direct_media_blob_writer_attempt_identity_status_internal(existing_attempt, existing_attempt.reservation_token, apply_payload); IF existing_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version THEN fence_status := 'stale_attempt'; END IF; IF fence_status <> 'ready' THEN RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; RETURN QUERY SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( p_payload.user_id || ':' || p_payload.workspace_id::TEXT, 0::BIGINT));
+  IF NOT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id)
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF NOT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id)
+  THEN RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( 'direct:' || p_payload.workspace_id::TEXT || ':' || p_payload.media_asset_id::TEXT || ':' || p_payload.operation_id, 2::BIGINT));
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( 'attempt:' || p_attempt_token::TEXT, 3::BIGINT));
+  SELECT attempts.* INTO existing_attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token;
+  IF FOUND THEN IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id() OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; apply_payload := p_payload; apply_payload.normalization_version := existing_attempt.normalization_version; fence_status := content.direct_media_blob_writer_attempt_identity_status_internal(existing_attempt, existing_attempt.reservation_token, apply_payload); IF existing_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version THEN fence_status := 'stale_attempt'; END IF; IF fence_status <> 'ready' THEN RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; IF existing_attempt.state <> 'leased' THEN RETURN QUERY SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; fence_status := content.fence_direct_media_blob_writer_attempt_apply_with_owner( p_attempt_token, existing_attempt.reservation_token, apply_payload, 3600000); IF fence_status = 'ready' THEN leased_until := pg_catalog.clock_timestamp() + (p_lease_duration_ms * interval '1 millisecond'); UPDATE content.media_blob_writer_attempts AS attempts SET lease_expires_at = leased_until WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased' AND attempts.lease_expires_at > pg_catalog.clock_timestamp(); IF NOT FOUND THEN fence_status := 'stale_attempt'; ELSE fence_status := 'replayed'; END IF; END IF; IF fence_status = 'replayed' THEN RETURN QUERY SELECT fence_status, existing_attempt.reservation_token, existing_attempt.normalization_version, leased_until; ELSE RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; END IF; RETURN;
+  END IF;
+  INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at)
+  VALUES (p_payload.workspace_id, 0, pg_catalog.statement_timestamp()) ON CONFLICT (workspace_id) DO NOTHING;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_payload.workspace_id FOR UPDATE;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_payload.sha256 FOR UPDATE;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'direct_ingestion' AND reservations.workspace_id = p_payload.workspace_id AND reservations.media_asset_id = p_payload.media_asset_id AND reservations.operation_id = p_payload.operation_id FOR UPDATE;
+  IF FOUND THEN SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+  END IF;
+  SELECT attempts.* INTO peer_attempt FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'direct_ingestion' AND attempts.workspace_id = p_payload.workspace_id AND attempts.media_asset_id = p_payload.media_asset_id AND attempts.operation_id = p_payload.operation_id AND attempts.state = 'leased' FOR UPDATE;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id OR NOT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id)
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF NOT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id
+  ) THEN RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF lifecycle.sha256 IS NOT NULL AND ( lifecycle.storage_key IS DISTINCT FROM p_payload.storage_key OR lifecycle.mime_type IS DISTINCT FROM p_payload.mime_type OR lifecycle.size_bytes IS DISTINCT FROM p_payload.size_bytes
+  ) THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN RETURN QUERY SELECT 'cleanup_claimed'::TEXT, NULL::UUID, lifecycle.normalization_version, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF reservation.reservation_token IS NOT NULL AND ( reservation.sha256 IS DISTINCT FROM p_payload.sha256 OR owner_snapshot.reservation_token IS NULL
+  ) THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF owner_snapshot.reservation_token IS NOT NULL AND ( owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id
+  ) THEN RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF peer_attempt.attempt_token IS NOT NULL THEN apply_payload := p_payload; apply_payload.normalization_version := peer_attempt.normalization_version; fence_status := content.direct_media_blob_writer_attempt_identity_status_internal(peer_attempt, peer_attempt.reservation_token, apply_payload); IF fence_status <> 'ready' OR peer_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version THEN RETURN QUERY SELECT CASE WHEN fence_status = 'ready' THEN 'stale_attempt' ELSE fence_status END, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; ELSIF peer_attempt.reservation_token IS DISTINCT FROM reservation.reservation_token OR peer_attempt.normalization_version IS DISTINCT FROM lifecycle.normalization_version OR reservation.state NOT IN ('active', 'ambiguous', 'finalized') THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; ELSIF peer_attempt.lease_expires_at > pg_catalog.clock_timestamp() THEN RETURN QUERY SELECT 'busy'::TEXT, NULL::UUID, NULL::TEXT, peer_attempt.lease_expires_at; RETURN; END IF; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'expired', outcome = 'stale_attempt', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = peer_attempt.attempt_token AND attempts.state = 'leased'; takeover := true; END IF;
+  SELECT * INTO reservation_result FROM content.reserve_owned_media_blob_writer_internal( p_payload.user_id, p_payload.replica_id, p_payload.sha256, p_payload.storage_key, p_payload.mime_type, p_payload.size_bytes, p_payload.normalization_version, 'direct_ingestion', p_payload.workspace_id, p_payload.media_asset_id, p_payload.operation_id, NULL, NULL, NULL, NULL, NULL);
+  IF reservation_result.reservation_status = 'cleanup_claimed' THEN RETURN QUERY SELECT 'cleanup_claimed'::TEXT, NULL::UUID, reservation_result.normalization_version, NULL::TIMESTAMPTZ; RETURN;
+  ELSIF reservation_result.reservation_status = 'ownership_mismatch' THEN RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  ELSIF reservation_result.reservation_status <> 'reserved' OR reservation_result.reservation_token IS NULL
+  THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  leased_until := pg_catalog.clock_timestamp() + (p_lease_duration_ms * interval '1 millisecond');
+  INSERT INTO content.media_blob_writer_attempts ( attempt_token, reservation_token, writer_kind, user_id, workspace_id, media_asset_id, operation_id, replica_id, sha256, blob_storage_key, mime_type, size_bytes, requested_normalization_version, normalization_version, source_url, asset_created_at, client_updated_at, state, lease_expires_at
+  ) VALUES ( p_attempt_token, reservation_result.reservation_token, 'direct_ingestion', p_payload.user_id, p_payload.workspace_id, p_payload.media_asset_id, p_payload.operation_id, p_payload.replica_id, p_payload.sha256, p_payload.storage_key, p_payload.mime_type, p_payload.size_bytes, p_payload.normalization_version, reservation_result.normalization_version, p_payload.source_url, p_payload.asset_created_at, p_payload.client_updated_at, 'leased', leased_until
+  );
+  apply_payload := p_payload;
+  apply_payload.normalization_version := reservation_result.normalization_version;
+  fence_status := content.fence_direct_media_blob_writer_attempt_apply_with_owner( p_attempt_token, reservation_result.reservation_token, apply_payload, 3600000);
+  IF fence_status = 'ready' THEN fence_status := CASE WHEN takeover THEN 'expired_takeover' ELSE 'acquired' END;
+  END IF;
+  IF fence_status IN ('acquired', 'expired_takeover') THEN RETURN QUERY SELECT fence_status, reservation_result.reservation_token, reservation_result.normalization_version, leased_until; ELSE RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; END IF;
+END;
+$$;
+CREATE FUNCTION content.finish_direct_media_blob_writer_attempt_apply_with_owner(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.direct_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_direct_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.scope_matches IS DISTINCT FROM true OR locked.access_present IS DISTINCT FROM true
+  THEN RETURN 'access_denied'; END IF;
+  IF locked.replica_matches IS DISTINCT FROM true THEN RETURN 'replica_mismatch'; END IF;
+  IF locked.asset_status <> 'exact' THEN RETURN 'stale'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms);
+  IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF;
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = 'applied', outcome = 'live_applied', terminal_at = pg_catalog.clock_timestamp()
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased';
+  RETURN 'live_applied';
+END;
+$$;
+CREATE FUNCTION content.resolve_direct_media_blob_writer_attempt_failure_with_owner(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.direct_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_direct_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.scope_matches IS DISTINCT FROM true OR locked.access_present IS DISTINCT FROM true
+  THEN RETURN 'access_denied'; END IF;
+  IF locked.replica_matches IS DISTINCT FROM true THEN RETURN 'replica_mismatch'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms);
+  IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+  IF locked.asset_status = 'peer_conflict' THEN UPDATE content.media_blob_writer_attempts AS attempts SET state = 'peer_conflict', outcome = 'peer_conflict', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'peer_conflict';
+  END IF;
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = terminalization_status, outcome = terminalization_status, terminal_at = pg_catalog.clock_timestamp()
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased';
+  RETURN terminalization_status;
+END;
+$$;
+CREATE FUNCTION content.resolve_direct_media_blob_writer_attempt_after_access_revocation(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.direct_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_direct_media_blob_writer_attempt_revoked_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.access_present IS DISTINCT FROM false THEN RETURN 'access_active'; END IF;
+  IF EXISTS (SELECT 1 FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased' AND attempts.lease_expires_at > pg_catalog.clock_timestamp()) THEN RETURN 'busy'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms);
+  IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+  IF locked.asset_status = 'peer_conflict' THEN UPDATE content.media_blob_writer_attempts AS attempts SET state = 'peer_conflict', outcome = 'peer_conflict', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'peer_conflict';
+  END IF;
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = terminalization_status, outcome = terminalization_status, terminal_at = pg_catalog.clock_timestamp()
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased';
+  RETURN terminalization_status;
+END;
+$$;
+CREATE FUNCTION content.fence_media_upload_session_completion_attempt_apply_with_owner(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_multipart_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.scope_matches IS DISTINCT FROM true OR locked.access_present IS DISTINCT FROM true
+  THEN RETURN 'access_denied'; END IF;
+  IF locked.replica_matches IS DISTINCT FROM true THEN RETURN 'replica_mismatch'; END IF;
+  IF locked.session_state = 'aborting' THEN RETURN 'aborting';
+  ELSIF locked.session_state = 'aborted' THEN RETURN 'aborted';
+  END IF;
+  IF locked.asset_status = 'exact' THEN terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms); IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF; UPDATE content.media_upload_sessions AS sessions SET state = 'completed', completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()), aborted_at = NULL WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'applied', outcome = 'already_applied', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'already_applied';
+  ELSIF locked.asset_status = 'peer_conflict' THEN terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms); IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF; UPDATE content.media_upload_sessions AS sessions SET state = 'aborted', completed_at = NULL, aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp()) WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'peer_conflict', outcome = 'peer_conflict', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'peer_conflict';
+  END IF;
+  IF locked.session_state = 'completed' THEN RETURN 'stale'; END IF;
+  RETURN 'ready';
+END;
+$$;
+CREATE FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  p_attempt_token UUID,
+  p_lease_duration_ms INTEGER,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing_attempt content.media_blob_writer_attempts%ROWTYPE;
+  peer_attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reservation_result RECORD;
+  apply_payload content.multipart_media_blob_writer_attempt_payload;
+  fence_status TEXT;
+  takeover BOOLEAN := false;
+  leased_until TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL OR p_lease_duration_ms IS NULL OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000 OR content.multipart_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true
+  THEN RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  SELECT attempts.* INTO existing_attempt FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state <> 'leased';
+  IF FOUND THEN IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id() OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; apply_payload := p_payload; apply_payload.normalization_version := existing_attempt.normalization_version; fence_status := content.multipart_media_blob_writer_attempt_identity_status_internal(existing_attempt, existing_attempt.reservation_token, apply_payload); IF existing_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version THEN fence_status := 'stale_attempt'; END IF; IF fence_status <> 'ready' THEN RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; RETURN QUERY SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( p_payload.user_id || ':' || p_payload.workspace_id::TEXT, 0::BIGINT));
+  IF NOT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id)
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF NOT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id)
+  THEN RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  SELECT sessions.* INTO session FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id FOR UPDATE;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( 'attempt:' || p_attempt_token::TEXT, 3::BIGINT));
+  SELECT attempts.* INTO existing_attempt FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token;
+  IF FOUND THEN IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id() OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id() THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; apply_payload := p_payload; apply_payload.normalization_version := existing_attempt.normalization_version; fence_status := content.multipart_media_blob_writer_attempt_identity_status_internal(existing_attempt, existing_attempt.reservation_token, apply_payload); IF existing_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version THEN fence_status := 'stale_attempt'; END IF; IF fence_status <> 'ready' THEN RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; IF existing_attempt.state <> 'leased' THEN RETURN QUERY SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; END IF; fence_status := content.fence_media_upload_session_completion_attempt_apply_with_owner( p_attempt_token, existing_attempt.reservation_token, apply_payload, 3600000); IF fence_status = 'ready' THEN leased_until := pg_catalog.clock_timestamp() + (p_lease_duration_ms * interval '1 millisecond'); UPDATE content.media_blob_writer_attempts AS attempts SET lease_expires_at = leased_until WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased' AND attempts.lease_expires_at > pg_catalog.clock_timestamp(); IF NOT FOUND THEN fence_status := 'stale_attempt'; ELSE fence_status := 'replayed'; END IF; END IF; IF fence_status = 'replayed' THEN RETURN QUERY SELECT fence_status, existing_attempt.reservation_token, existing_attempt.normalization_version, leased_until; ELSE RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; END IF; RETURN;
+  END IF;
+  INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at)
+  VALUES (p_payload.workspace_id, 0, pg_catalog.statement_timestamp()) ON CONFLICT (workspace_id) DO NOTHING;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_payload.workspace_id FOR UPDATE;
+  SELECT lifecycles.* INTO lifecycle FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_payload.sha256 FOR UPDATE;
+  SELECT reservations.* INTO reservation FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion' AND reservations.workspace_id = p_payload.workspace_id AND reservations.media_asset_id = p_payload.media_asset_id AND reservations.operation_id = p_payload.media_upload_session_id::TEXT FOR UPDATE;
+  IF FOUND THEN SELECT snapshots.* INTO owner_snapshot FROM content.media_blob_writer_owner_snapshots AS snapshots WHERE snapshots.reservation_token = reservation.reservation_token FOR UPDATE;
+  END IF;
+  SELECT attempts.* INTO peer_attempt FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion' AND attempts.workspace_id = p_payload.workspace_id AND attempts.media_asset_id = p_payload.media_asset_id AND attempts.operation_id = p_payload.media_upload_session_id::TEXT AND attempts.state = 'leased' FOR UPDATE;
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id OR NOT EXISTS ( SELECT 1 FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = p_payload.workspace_id AND memberships.user_id = p_payload.user_id)
+  THEN RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF NOT EXISTS ( SELECT 1 FROM sync.workspace_replicas AS replicas WHERE replicas.replica_id = p_payload.replica_id AND replicas.workspace_id = p_payload.workspace_id AND replicas.user_id = p_payload.user_id
+  ) THEN RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF session.media_upload_session_id IS NULL OR session.workspace_id IS DISTINCT FROM p_payload.workspace_id OR session.media_asset_id IS DISTINCT FROM p_payload.media_asset_id OR session.last_modified_by_replica_id IS DISTINCT FROM p_payload.replica_id OR session.last_operation_id IS DISTINCT FROM p_payload.last_operation_id OR session.media_blob_sha256 IS DISTINCT FROM p_payload.sha256 OR session.staging_storage_key IS DISTINCT FROM p_payload.staging_storage_key OR session.blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key OR session.s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id OR session.mime_type IS DISTINCT FROM p_payload.mime_type OR session.size_bytes IS DISTINCT FROM p_payload.size_bytes OR session.part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes OR session.part_count IS DISTINCT FROM p_payload.part_count OR session.source_url IS DISTINCT FROM p_payload.source_url OR session.asset_created_at IS DISTINCT FROM p_payload.asset_created_at OR session.client_updated_at IS DISTINCT FROM p_payload.client_updated_at OR session.expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF session.state = 'aborting' THEN RETURN QUERY SELECT 'aborting'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  ELSIF session.state = 'aborted' THEN RETURN QUERY SELECT 'aborted'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  ELSIF session.state = 'active' AND session.expires_at <= pg_catalog.clock_timestamp() THEN RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  ELSIF session.state NOT IN ('active', 'completing', 'completed') THEN RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF lifecycle.sha256 IS NOT NULL AND ( lifecycle.storage_key IS DISTINCT FROM p_payload.blob_storage_key OR lifecycle.mime_type IS DISTINCT FROM p_payload.mime_type OR lifecycle.size_bytes IS DISTINCT FROM p_payload.size_bytes
+  ) THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN RETURN QUERY SELECT 'cleanup_claimed'::TEXT, NULL::UUID, lifecycle.normalization_version, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF reservation.reservation_token IS NOT NULL AND ( reservation.sha256 IS DISTINCT FROM p_payload.sha256 OR owner_snapshot.reservation_token IS NULL
+  ) THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF owner_snapshot.reservation_token IS NOT NULL AND ( owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_payload.last_operation_id OR owner_snapshot.session_expires_at IS DISTINCT FROM p_payload.session_expires_at OR owner_snapshot.session_source_url IS DISTINCT FROM p_payload.source_url OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_payload.asset_created_at OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+  ) THEN RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF session.state = 'completed' AND (reservation.reservation_token IS NULL OR reservation.state <> 'finalized')
+  THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF peer_attempt.attempt_token IS NOT NULL THEN apply_payload := p_payload; apply_payload.normalization_version := peer_attempt.normalization_version; fence_status := content.multipart_media_blob_writer_attempt_identity_status_internal(peer_attempt, peer_attempt.reservation_token, apply_payload); IF fence_status <> 'ready' OR peer_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version THEN RETURN QUERY SELECT CASE WHEN fence_status = 'ready' THEN 'stale_attempt' ELSE fence_status END, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; ELSIF peer_attempt.reservation_token IS DISTINCT FROM reservation.reservation_token OR peer_attempt.normalization_version IS DISTINCT FROM lifecycle.normalization_version OR reservation.state NOT IN ('active', 'ambiguous', 'finalized') THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN; ELSIF peer_attempt.lease_expires_at > pg_catalog.clock_timestamp() THEN RETURN QUERY SELECT 'busy'::TEXT, NULL::UUID, NULL::TEXT, peer_attempt.lease_expires_at; RETURN; END IF; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'expired', outcome = 'stale_attempt', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = peer_attempt.attempt_token AND attempts.state = 'leased'; takeover := true; END IF;
+  SELECT * INTO reservation_result FROM content.reserve_owned_media_blob_writer_internal( p_payload.user_id, p_payload.replica_id, p_payload.sha256, p_payload.blob_storage_key, p_payload.mime_type, p_payload.size_bytes, p_payload.normalization_version, 'multipart_completion', p_payload.workspace_id, p_payload.media_asset_id, p_payload.media_upload_session_id::TEXT, p_payload.last_operation_id, p_payload.session_expires_at, p_payload.source_url, p_payload.asset_created_at, p_payload.client_updated_at);
+  IF reservation_result.reservation_status = 'cleanup_claimed' THEN RETURN QUERY SELECT 'cleanup_claimed'::TEXT, NULL::UUID, reservation_result.normalization_version, NULL::TIMESTAMPTZ; RETURN;
+  ELSIF reservation_result.reservation_status = 'ownership_mismatch' THEN RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  ELSIF reservation_result.reservation_status <> 'reserved' OR reservation_result.reservation_token IS NULL
+  THEN RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; RETURN;
+  END IF;
+  IF session.state = 'active' THEN UPDATE content.media_upload_sessions AS sessions SET state = 'completing' WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id AND sessions.state = 'active';
+  END IF;
+  leased_until := pg_catalog.clock_timestamp() + (p_lease_duration_ms * interval '1 millisecond');
+  INSERT INTO content.media_blob_writer_attempts ( attempt_token, reservation_token, writer_kind, user_id, workspace_id, media_asset_id, operation_id, last_operation_id, replica_id, sha256, blob_storage_key, mime_type, size_bytes, requested_normalization_version, normalization_version, source_url, asset_created_at, client_updated_at, media_upload_session_id, staging_storage_key, s3_upload_id, part_size_bytes, part_count, session_expires_at, completed_parts_fingerprint, state, lease_expires_at
+  ) VALUES ( p_attempt_token, reservation_result.reservation_token, 'multipart_completion', p_payload.user_id, p_payload.workspace_id, p_payload.media_asset_id, p_payload.media_upload_session_id::TEXT, p_payload.last_operation_id, p_payload.replica_id, p_payload.sha256, p_payload.blob_storage_key, p_payload.mime_type, p_payload.size_bytes, p_payload.normalization_version, reservation_result.normalization_version, p_payload.source_url, p_payload.asset_created_at, p_payload.client_updated_at, p_payload.media_upload_session_id, p_payload.staging_storage_key, p_payload.s3_upload_id, p_payload.part_size_bytes, p_payload.part_count, p_payload.session_expires_at, p_payload.completed_parts_fingerprint, 'leased', leased_until
+  );
+  apply_payload := p_payload;
+  apply_payload.normalization_version := reservation_result.normalization_version;
+  fence_status := content.fence_media_upload_session_completion_attempt_apply_with_owner( p_attempt_token, reservation_result.reservation_token, apply_payload, 3600000);
+  IF fence_status = 'ready' THEN fence_status := CASE WHEN takeover THEN 'expired_takeover' ELSE 'acquired' END;
+  END IF;
+  IF fence_status IN ('acquired', 'expired_takeover') THEN RETURN QUERY SELECT fence_status, reservation_result.reservation_token, reservation_result.normalization_version, leased_until; ELSE RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ; END IF;
+END;
+$$;
+CREATE FUNCTION content.finish_media_upload_session_completion_attempt_apply_with_owner(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_multipart_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.scope_matches IS DISTINCT FROM true OR locked.access_present IS DISTINCT FROM true
+  THEN RETURN 'access_denied'; END IF;
+  IF locked.replica_matches IS DISTINCT FROM true THEN RETURN 'replica_mismatch'; END IF;
+  IF locked.session_state = 'aborting' THEN RETURN 'aborting';
+  ELSIF locked.session_state = 'aborted' THEN RETURN 'aborted';
+  ELSIF locked.session_state <> 'completing' OR locked.asset_status <> 'exact' THEN RETURN 'stale';
+  END IF;
+  terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms);
+  IF terminalization_status <> 'referenced' THEN RETURN 'stale'; END IF;
+  UPDATE content.media_upload_sessions AS sessions
+  SET state = 'completed', completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()), aborted_at = NULL
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id;
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = 'applied', outcome = 'live_applied', terminal_at = pg_catalog.clock_timestamp()
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased';
+  RETURN 'live_applied';
+END;
+$$;
+CREATE FUNCTION content.resolve_media_upload_session_completion_attempt_failure_with_owner(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_multipart_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.scope_matches IS DISTINCT FROM true OR locked.access_present IS DISTINCT FROM true
+  THEN RETURN 'access_denied'; END IF;
+  IF locked.replica_matches IS DISTINCT FROM true THEN RETURN 'replica_mismatch'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms);
+  IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+  IF locked.asset_status = 'peer_conflict' THEN UPDATE content.media_upload_sessions AS sessions SET state = 'aborted', completed_at = NULL, aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp()) WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'peer_conflict', outcome = 'peer_conflict', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'peer_conflict';
+  ELSIF locked.asset_status = 'exact' OR terminalization_status = 'referenced' THEN UPDATE content.media_upload_sessions AS sessions SET state = 'completed', completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()), aborted_at = NULL WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'referenced', outcome = 'referenced', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'referenced';
+  ELSIF locked.session_state IN ('aborting', 'aborted') THEN UPDATE content.media_upload_sessions AS sessions SET state = 'aborted', completed_at = NULL, aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp()) WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'cancelled', outcome = 'already_closed', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'already_closed';
+  END IF;
+  UPDATE content.media_upload_sessions AS sessions
+  SET state = 'active', completed_at = NULL, aborted_at = NULL
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id;
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = 'unreferenced', outcome = 'unreferenced_restored', terminal_at = pg_catalog.clock_timestamp()
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased';
+  RETURN 'unreferenced_restored';
+END;
+$$;
+CREATE FUNCTION content.resolve_media_upload_session_completion_attempt_after_access_revocation(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_multipart_media_blob_writer_attempt_revoked_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.access_present IS DISTINCT FROM false THEN RETURN 'access_active'; END IF;
+  IF EXISTS (SELECT 1 FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased' AND attempts.lease_expires_at > pg_catalog.clock_timestamp()) THEN RETURN 'busy'; END IF;
+  IF locked.session_state = 'aborting' THEN RETURN 'aborting'; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms);
+  IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+  IF locked.asset_status = 'peer_conflict' THEN UPDATE content.media_upload_sessions AS sessions SET state = 'aborted', completed_at = NULL, aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp()) WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'peer_conflict', outcome = 'peer_conflict', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'peer_conflict';
+  ELSIF locked.asset_status = 'exact' OR terminalization_status = 'referenced' THEN UPDATE content.media_upload_sessions AS sessions SET state = 'completed', completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()), aborted_at = NULL WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'referenced', outcome = 'referenced', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'referenced';
+  END IF;
+  UPDATE content.media_upload_sessions AS sessions
+  SET state = 'aborted', completed_at = NULL, aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp())
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id;
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = 'unreferenced', outcome = 'unreferenced', terminal_at = pg_catalog.clock_timestamp()
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased';
+  RETURN 'unreferenced';
+END;
+$$;
+CREATE FUNCTION content.close_media_upload_session_blob_writer_attempts(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE locked RECORD; terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN RETURN 'stale'; END IF;
+  SELECT * INTO locked FROM content.lock_multipart_media_blob_writer_attempt_revoked_internal( p_attempt_token, p_reservation_token, p_payload);
+  IF locked.validation_status <> 'ready' THEN RETURN locked.validation_status; END IF;
+  IF locked.session_state NOT IN ('aborting', 'aborted') AND EXISTS (SELECT 1 FROM content.media_blob_writer_attempts AS attempts WHERE attempts.attempt_token=p_attempt_token AND attempts.state='leased' AND attempts.lease_expires_at>pg_catalog.clock_timestamp())
+  THEN RETURN CASE WHEN locked.access_present IS DISTINCT FROM false AND p_payload.session_expires_at > pg_catalog.clock_timestamp() THEN 'access_active' ELSE 'busy' END; END IF;
+  terminalization_status := content.terminalize_media_blob_writer_attempt_internal( p_attempt_token, p_reservation_token, p_cleanup_delay_ms);
+  IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN RETURN 'stale'; END IF;
+  IF locked.asset_status = 'exact' OR terminalization_status = 'referenced' THEN UPDATE content.media_upload_sessions AS sessions SET state = 'completed', completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()), aborted_at = NULL WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id; UPDATE content.media_blob_writer_attempts AS attempts SET state = 'referenced', outcome = 'referenced', terminal_at = pg_catalog.clock_timestamp() WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased'; RETURN 'referenced';
+  END IF;
+  UPDATE content.media_upload_sessions AS sessions
+  SET state = 'aborted', completed_at = NULL, aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp())
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id;
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = 'cancelled', outcome = 'aborted', terminal_at = pg_catalog.clock_timestamp()
+  WHERE attempts.attempt_token = p_attempt_token AND attempts.state = 'leased';
+  RETURN 'aborted';
+END;
+$$;
+CREATE OR REPLACE FUNCTION content.terminalize_media_blob_writers_before_workspace_delete()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  owner_user_id TEXT;
+  affected_sha256s TEXT[];
+  affected_sha256 TEXT;
+  terminalized_at TIMESTAMPTZ;
+BEGIN
+  FOR owner_user_id IN SELECT owners.user_id FROM ( SELECT memberships.user_id FROM org.workspace_memberships AS memberships WHERE memberships.workspace_id = OLD.workspace_id UNION SELECT snapshots.user_id FROM content.media_blob_writer_owner_snapshots AS snapshots WHERE snapshots.workspace_id = OLD.workspace_id UNION SELECT attempts.user_id FROM content.media_blob_writer_attempts AS attempts WHERE attempts.workspace_id = OLD.workspace_id ) AS owners ORDER BY owners.user_id
+  LOOP PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended( owner_user_id || ':' || OLD.workspace_id::TEXT, 0::BIGINT));
+  END LOOP;
+  PERFORM 1 FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = OLD.workspace_id
+  ORDER BY sessions.media_upload_session_id FOR UPDATE;
+  PERFORM 1 FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = OLD.workspace_id FOR UPDATE;
+  SELECT pg_catalog.array_agg(DISTINCT writers.sha256 ORDER BY writers.sha256)
+  INTO affected_sha256s FROM ( SELECT reservations.sha256 FROM content.media_blob_writer_reservations AS reservations WHERE reservations.workspace_id = OLD.workspace_id AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion') UNION SELECT attempts.sha256 FROM content.media_blob_writer_attempts AS attempts WHERE attempts.workspace_id = OLD.workspace_id
+  ) AS writers;
+  IF affected_sha256s IS NULL THEN RETURN OLD; END IF;
+  FOREACH affected_sha256 IN ARRAY affected_sha256s LOOP PERFORM 1 FROM content.media_blob_lifecycles AS lifecycles WHERE lifecycles.sha256 = affected_sha256 FOR UPDATE;
+  END LOOP;
+  PERFORM 1 FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.workspace_id = OLD.workspace_id AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion')
+  ORDER BY reservations.sha256, reservations.writer_kind, reservations.media_asset_id, reservations.operation_id FOR UPDATE;
+  PERFORM 1 FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.workspace_id = OLD.workspace_id
+  ORDER BY snapshots.reservation_token FOR UPDATE;
+  PERFORM 1 FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.workspace_id = OLD.workspace_id
+  ORDER BY attempts.writer_kind, attempts.media_asset_id, attempts.operation_id, attempts.attempt_token FOR UPDATE;
+  PERFORM 1 FROM content.media_assets AS assets
+  WHERE assets.workspace_id = OLD.workspace_id ORDER BY assets.media_asset_id FOR UPDATE;
+  PERFORM 1 FROM content.media_blobs AS blobs
+  WHERE blobs.sha256 = ANY(affected_sha256s) ORDER BY blobs.sha256 FOR SHARE;
+  DELETE FROM content.media_upload_sessions AS sessions WHERE sessions.workspace_id = OLD.workspace_id;
+  DELETE FROM content.media_assets AS assets WHERE assets.workspace_id = OLD.workspace_id;
+  UPDATE content.media_blob_writer_reservations AS reservations SET state = 'unreferenced'
+  WHERE reservations.workspace_id = OLD.workspace_id AND reservations.writer_kind IN ('direct_ingestion', 'multipart_completion') AND reservations.state <> 'unreferenced';
+  terminalized_at := pg_catalog.clock_timestamp();
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET state = 'cancelled', outcome = 'aborted', terminal_at = terminalized_at
+  WHERE attempts.workspace_id = OLD.workspace_id AND attempts.state = 'leased';
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET cleanup_eligible_at = GREATEST( COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ), terminalized_at + interval '1 hour'), cleanup_lease_token = NULL, cleanup_lease_expires_at = NULL, updated_at = terminalized_at
+  WHERE lifecycles.sha256 = ANY(affected_sha256s) AND NOT EXISTS ( SELECT 1 FROM content.media_assets AS assets INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id WHERE blobs.sha256 = lifecycles.sha256 AND assets.deleted_at IS NULL) AND NOT EXISTS ( SELECT 1 FROM catalog.package_media_assets AS assets INNER JOIN content.media_blobs AS blobs ON blobs.media_blob_id = assets.media_blob_id WHERE blobs.sha256 = lifecycles.sha256) AND NOT EXISTS ( SELECT 1 FROM content.media_blob_writer_reservations AS reservations WHERE reservations.sha256 = lifecycles.sha256 AND reservations.state NOT IN ('finalized', 'unreferenced')) AND NOT EXISTS ( SELECT 1 FROM content.media_blob_writer_attempts AS attempts WHERE attempts.sha256 = lifecycles.sha256 AND attempts.state = 'leased');
+  RETURN OLD;
+END;
+$$;
+REVOKE ALL ON TABLE content.media_blob_writer_attempts FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.direct_media_blob_writer_attempt_payload_valid_internal(content.direct_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.multipart_media_blob_writer_attempt_payload_valid_internal(content.multipart_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.direct_media_blob_writer_attempt_identity_status_internal(content.media_blob_writer_attempts, UUID, content.direct_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.multipart_media_blob_writer_attempt_identity_status_internal(content.media_blob_writer_attempts, UUID, content.multipart_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.lock_direct_media_blob_writer_attempt_revoked_internal(UUID, UUID, content.direct_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.lock_multipart_media_blob_writer_attempt_revoked_internal(UUID, UUID, content.multipart_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.lock_direct_media_blob_writer_attempt_internal(UUID, UUID, content.direct_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.lock_multipart_media_blob_writer_attempt_internal(UUID, UUID, content.multipart_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.terminalize_media_blob_writer_attempt_internal(UUID, UUID, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.begin_direct_media_blob_writer_attempt_with_owner(UUID, INTEGER, content.direct_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.fence_direct_media_blob_writer_attempt_apply_with_owner(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.finish_direct_media_blob_writer_attempt_apply_with_owner(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.resolve_direct_media_blob_writer_attempt_failure_with_owner(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.resolve_direct_media_blob_writer_attempt_after_access_revocation(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(UUID, INTEGER, content.multipart_media_blob_writer_attempt_payload) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.fence_media_upload_session_completion_attempt_apply_with_owner(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.finish_media_upload_session_completion_attempt_apply_with_owner(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.resolve_media_upload_session_completion_attempt_failure_with_owner(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.resolve_media_upload_session_completion_attempt_after_access_revocation(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.close_media_upload_session_blob_writer_attempts(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.terminalize_media_blob_writers_before_workspace_delete() FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+GRANT EXECUTE ON FUNCTION content.begin_direct_media_blob_writer_attempt_with_owner(UUID, INTEGER, content.direct_media_blob_writer_attempt_payload) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.fence_direct_media_blob_writer_attempt_apply_with_owner(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.finish_direct_media_blob_writer_attempt_apply_with_owner(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.resolve_direct_media_blob_writer_attempt_failure_with_owner(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.resolve_direct_media_blob_writer_attempt_after_access_revocation(UUID, UUID, content.direct_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(UUID, INTEGER, content.multipart_media_blob_writer_attempt_payload) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.fence_media_upload_session_completion_attempt_apply_with_owner(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.finish_media_upload_session_completion_attempt_apply_with_owner(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.resolve_media_upload_session_completion_attempt_failure_with_owner(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.resolve_media_upload_session_completion_attempt_after_access_revocation(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.close_media_upload_session_blob_writer_attempts(UUID, UUID, content.multipart_media_blob_writer_attempt_payload, INTEGER) TO backend_app;


### PR DESCRIPTION
## Summary
- add durable direct and multipart writer-attempt leases and terminal replay history
- add attempt-aware security-definer fencing boundaries without changing released signatures
- add real PostgreSQL upgrade, concurrency, cleanup, ACL, and replay evidence

## Validation
- focused PostgreSQL integration suite passed twice from genuine 0096 baselines
- fresh full 99-migration chain passed
- adjacent PostgreSQL suites, full backend tests, lint, and build passed
- git diff and caller/security/scope audits passed