### PR TITLE
Add direct writer lifecycle boundary

### DIFF
--- a/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.postgres.integration.ts
@@ -3,15 +3,29 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
-import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
+import {
+  DatabaseDeadlineExceededError, transactionWithWorkspaceScope, transactionWithWorkspaceScopeDeadline, type DatabaseExecutor,
+} from "../database";
 import { unsafeTransaction } from "../database/unsafe";
 import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
 import {
+  assertDirectMediaBlobStorageCapabilityForMutation,
+  beginDirectMediaBlobWriterAttemptWithOwner,
   claimMediaBlobCleanupInExecutor, failMediaBlobWriterInExecutor,
+  fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor,
+  finishDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor,
   finalizeMediaBlobWriterInExecutor, markMediaBlobWriterAmbiguousInExecutor,
+  mediaBlobCleanupDelayMs,
   MediaBlobLifecycleBusyError, MediaBlobLifecycleConflictError, MediaBlobWriterFenceError,
   reconcileMediaBlobWriterInExecutor, reserveMediaBlobWriterInExecutor,
+  resolveDirectMediaBlobWriterAttemptAfterAccessRevocation,
+  resolveDirectMediaBlobWriterAttemptFailureWithOwner,
   terminalizeMediaBlobWriterFailureInExecutor,
+  transactionWithDirectMediaBlobWriterApplyDeadline,
+  type DirectMediaBlobWriterAttemptInput,
+  type DirectMediaBlobWriterAttemptLease,
+  type DirectMediaBlobWriterApplyExecutor,
+  type DirectMediaBlobStorageCapability,
   type MediaBlobWriterReservationInput,
 } from "./blobLifecycle";
 import { createImageNormalizedMediaAssetForWorkspace } from ".";
@@ -38,6 +52,35 @@ function input(workspaceId: string, mediaAssetId: string, operationId: string, s
     sha256, storageKey: buildMediaBlobStorageKey(sha256), mimeType: "image/jpeg",
     sizeBytes: 42, normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
   };
+}
+function directAttemptInput(
+  fixture: Pick<PostgresIntegrationFixture, "userId" | "workspaceId" | "replicaId" | "createdAt">,
+  sha256: string,
+): DirectMediaBlobWriterAttemptInput {
+  return {
+    attemptToken: randomUUID(), userId: fixture.userId, workspaceId: fixture.workspaceId,
+    mediaAssetId: randomUUID(), operationId: randomUUID(),
+    lastModifiedByReplicaId: fixture.replicaId, sha256,
+    storageKey: buildMediaBlobStorageKey(sha256), mimeType: "image/jpeg", sizeBytes: 42,
+    normalizationVersion: imageJpegCardMediaBlobNormalizationVersion, sourceUrl: null,
+    assetCreatedAt: fixture.createdAt, clientUpdatedAt: fixture.createdAt,
+  };
+}
+function createDirectAttemptDeadline(): string {
+  return new Date(Date.now() + 30_000).toISOString();
+}
+function createDirectAttemptLease(): DirectMediaBlobWriterAttemptLease {
+  return { leaseDurationMs: 60_000, operationDeadlineAt: createDirectAttemptDeadline() };
+}
+async function insertDirectAttemptAsset(
+  executor: DatabaseExecutor, input: DirectMediaBlobWriterAttemptInput,
+): Promise<void> {
+  await executor.query(
+    `WITH blob AS (INSERT INTO content.media_blobs (media_blob_id,sha256,mime_type,size_bytes,storage_key,normalization_version) VALUES ($1,$2,$3,$4,$5,$6) RETURNING media_blob_id) INSERT INTO content.media_assets (media_asset_id,workspace_id,media_blob_id,source_url,created_at,client_updated_at,last_modified_by_replica_id,last_operation_id) SELECT $7,$8,media_blob_id,$9,$10,$11,$12,$13 FROM blob`,
+    [randomUUID(), input.sha256, input.mimeType, input.sizeBytes, input.storageKey,
+      input.normalizationVersion, input.mediaAssetId, input.workspaceId, input.sourceUrl,
+      input.assetCreatedAt, input.clientUpdatedAt, input.lastModifiedByReplicaId, input.operationId],
+  );
 }
 function hasSqlState(error: unknown, sqlState: string): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === sqlState; }
 async function createCleanupCandidate(
@@ -203,7 +246,7 @@ async function assertLifecycleMigrationUpgrade(fixture: PostgresIntegrationFixtu
     client.release();
   }
 }
-test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and global grants", async () => {
+test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and global grants", async (testContext) => {
   await withPostgresIntegrationFixture(async (fixture) => {
     const referencedSha = createUniqueSha256();
     const cleanupSha = createUniqueSha256();
@@ -215,12 +258,26 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
     const referenceLeaseSha = createUniqueSha256();
     const reservationLeaseSha = createUniqueSha256();
     const revokedSha = createUniqueSha256();
+    const attemptSha = createUniqueSha256();
+    const failedAttemptSha = createUniqueSha256();
+    const takeoverAttemptSha = createUniqueSha256();
+    const revokedAttemptSha = createUniqueSha256();
+    const abortedAttemptSha = createUniqueSha256();
+    const snapshotAttemptSha = createUniqueSha256();
+    const deadlineAttemptSha = createUniqueSha256();
+    const deniedAttemptSha = createUniqueSha256();
+    const attemptFixtureSha256s = [
+      attemptSha, failedAttemptSha, takeoverAttemptSha, revokedAttemptSha, abortedAttemptSha,
+      snapshotAttemptSha, deadlineAttemptSha, deniedAttemptSha,
+    ];
     const fixtureSha256s = [
       referencedSha, cleanupSha, mediaRaceSha, catalogRaceSha, legacySha, backfillSha, leaseWaitSha,
-      referenceLeaseSha, reservationLeaseSha, revokedSha,
+      referenceLeaseSha, reservationLeaseSha, revokedSha, ...attemptFixtureSha256s,
     ];
     const cleanupBlobId = randomUUID();
     const concurrentWorkspaceId = randomUUID();
+    const abortedWorkspaceId = randomUUID();
+    const abortedReplicaId = randomUUID();
     const authorId = randomUUID();
     const packageId = randomUUID();
     const catalogSlug = `lifecycle-${randomUUID()}`;
@@ -236,6 +293,302 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
       sizeBytes: 0,
     };
     try {
+      const attemptInput = directAttemptInput(fixture, attemptSha);
+      const initialLease = createDirectAttemptLease();
+      const attempt = await beginDirectMediaBlobWriterAttemptWithOwner(attemptInput, initialLease);
+      assert.equal(attempt.status, "acquired");
+      if (!("reservationToken" in attempt)) throw new Error("Direct attempt did not return a token.");
+      assert.equal((await fixture.ownerPool.query<{ committed: boolean }>(
+        "SELECT EXISTS (SELECT 1 FROM content.media_blob_writer_attempts WHERE attempt_token=$1 AND reservation_token=$2) AS committed",
+        [attemptInput.attemptToken, attempt.reservationToken],
+      )).rows[0]?.committed, true);
+      const exactAttempt = { ...attemptInput, reservationToken: attempt.reservationToken,
+        normalizationVersion: attempt.normalizationVersion };
+      assert.doesNotThrow(() => assertDirectMediaBlobStorageCapabilityForMutation(
+        attempt.storageCapability, exactAttempt,
+      ));
+      for (const mismatch of [
+        { ...exactAttempt, attemptToken: randomUUID() },
+        { ...exactAttempt, reservationToken: randomUUID() },
+        { ...exactAttempt, sourceUrl: "https://mismatch.invalid/" },
+      ]) assert.throws(
+        () => assertDirectMediaBlobStorageCapabilityForMutation(
+          attempt.storageCapability, mismatch,
+        ),
+        MediaBlobWriterFenceError,
+      );
+      assert.throws(() => assertDirectMediaBlobStorageCapabilityForMutation(
+        Object.freeze({}) as DirectMediaBlobStorageCapability, exactAttempt,
+      ), MediaBlobWriterFenceError);
+      for (const copy of [
+        Object.freeze({ ...attempt.storageCapability }),
+        Object.freeze(Object.create(attempt.storageCapability)),
+        Object.freeze(structuredClone(attempt.storageCapability)),
+      ] as ReadonlyArray<DirectMediaBlobStorageCapability>) {
+        assert.throws(() => assertDirectMediaBlobStorageCapabilityForMutation(
+          copy, exactAttempt,
+        ), MediaBlobWriterFenceError);
+      }
+      const dateNowMock = testContext.mock.method(
+        Date, "now", () => Date.parse(initialLease.operationDeadlineAt),
+      );
+      try {
+        assert.throws(() => assertDirectMediaBlobStorageCapabilityForMutation(
+          attempt.storageCapability, exactAttempt,
+        ), MediaBlobWriterFenceError);
+      } finally {
+        dateNowMock.mock.restore();
+      }
+      const snapshotBase = directAttemptInput(fixture, snapshotAttemptSha);
+      let sourceUrlReads = 0;
+      const getterInput = Object.defineProperty({ ...snapshotBase }, "sourceUrl", {
+        enumerable: true,
+        get: () => (sourceUrlReads += 1) === 1 ? null : "https://mutated.invalid/",
+      }) as DirectMediaBlobWriterAttemptInput;
+      const snapshotAttempt = await beginDirectMediaBlobWriterAttemptWithOwner(
+        getterInput, createDirectAttemptLease(),
+      );
+      assert.equal(sourceUrlReads, 1);
+      if (!("reservationToken" in snapshotAttempt)) throw new Error("Snapshot attempt did not acquire.");
+      const exactSnapshot = { ...snapshotBase, reservationToken: snapshotAttempt.reservationToken,
+        normalizationVersion: snapshotAttempt.normalizationVersion };
+      assert.doesNotThrow(() => assertDirectMediaBlobStorageCapabilityForMutation(
+        snapshotAttempt.storageCapability, exactSnapshot,
+      ));
+      assert.equal(await resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+        exactSnapshot, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "unreferenced");
+      assert.equal((await beginDirectMediaBlobWriterAttemptWithOwner(
+        snapshotBase, createDirectAttemptLease(),
+      )).status, "unreferenced");
+      const invalidSourceInput = directAttemptInput(fixture, createUniqueSha256());
+      Object.defineProperty(invalidSourceInput, "sourceUrl", { value: 42 });
+      assert.throws(() => beginDirectMediaBlobWriterAttemptWithOwner(
+        invalidSourceInput, createDirectAttemptLease()), TypeError);
+      const deadlineHolder = await fixture.ownerPool.connect();
+      try {
+        await deadlineHolder.query("BEGIN");
+        await deadlineHolder.query(
+          "SELECT pg_advisory_xact_lock(hashtextextended($1||':'||$2::text,0))",
+          [fixture.userId, fixture.workspaceId],
+        );
+        const deadlineFailure = (error: unknown): boolean =>
+          error instanceof DatabaseDeadlineExceededError || hasSqlState(error, "55P03") || hasSqlState(error, "57014");
+        await assert.rejects(beginDirectMediaBlobWriterAttemptWithOwner(
+          directAttemptInput(fixture, deadlineAttemptSha), { leaseDurationMs: 2_000,
+            operationDeadlineAt: new Date(Date.now() + 500).toISOString() }), deadlineFailure);
+        await assert.rejects(resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+          exactAttempt, mediaBlobCleanupDelayMs,
+          new Date(Date.now() + 500).toISOString()), deadlineFailure);
+        await assert.rejects(resolveDirectMediaBlobWriterAttemptAfterAccessRevocation(
+          exactAttempt, mediaBlobCleanupDelayMs,
+          new Date(Date.now() + 500).toISOString()), deadlineFailure);
+        const applyLockDeadline = new Date(Date.now() + 500).toISOString();
+        await assert.rejects(transactionWithDirectMediaBlobWriterApplyDeadline(
+          exactAttempt,
+          applyLockDeadline,
+          (executor, snapshot, exactDeadline) =>
+            fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+              executor, snapshot, mediaBlobCleanupDelayMs, exactDeadline,
+            ),
+        ), deadlineFailure);
+      } finally {
+        await deadlineHolder.query("ROLLBACK");
+        deadlineHolder.release();
+      }
+      const renewed = await beginDirectMediaBlobWriterAttemptWithOwner(
+        attemptInput, createDirectAttemptLease(),
+      );
+      assert.equal(renewed.status, "replayed");
+      if (!("reservationToken" in renewed)) throw new Error("Renewal did not return a token.");
+      assert.equal(renewed.reservationToken, attempt.reservationToken);
+      assert.doesNotThrow(() => assertDirectMediaBlobStorageCapabilityForMutation(
+        renewed.storageCapability, exactAttempt,
+      ));
+      assert.equal(
+        (await beginDirectMediaBlobWriterAttemptWithOwner(
+          { ...attemptInput, attemptToken: randomUUID() }, createDirectAttemptLease(),
+        )).status,
+        "busy",
+      );
+      assert.equal((await beginDirectMediaBlobWriterAttemptWithOwner(
+        { ...directAttemptInput(fixture, createUniqueSha256()),
+          lastModifiedByReplicaId: randomUUID() }, createDirectAttemptLease(),
+      )).status, "replica_mismatch");
+      assert.equal(
+        await resolveDirectMediaBlobWriterAttemptAfterAccessRevocation(
+          exactAttempt, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+        ),
+        "access_active",
+      );
+      const ordinaryExecutorDeadline = createDirectAttemptDeadline();
+      await assert.rejects(transactionWithWorkspaceScopeDeadline(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        Date.parse(ordinaryExecutorDeadline),
+        (executor) => fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+          executor as DirectMediaBlobWriterApplyExecutor,
+          exactAttempt, mediaBlobCleanupDelayMs, ordinaryExecutorDeadline,
+        ),
+      ), TypeError);
+      const rollbackDeadline = createDirectAttemptDeadline();
+      let rolledBackExecutor: DirectMediaBlobWriterApplyExecutor | null = null;
+      await assert.rejects(transactionWithDirectMediaBlobWriterApplyDeadline(
+        exactAttempt,
+        rollbackDeadline,
+        async (executor, snapshot, exactDeadline) => {
+          rolledBackExecutor = executor;
+          const copiedExecutor: DatabaseExecutor = Object.freeze({ ...executor });
+          const wrappedExecutor: DatabaseExecutor = Object.freeze({ query: executor.query });
+          for (const lookalike of [
+            copiedExecutor as DirectMediaBlobWriterApplyExecutor,
+            wrappedExecutor as DirectMediaBlobWriterApplyExecutor,
+          ]) {
+            assert.throws(() => fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+              lookalike, snapshot, mediaBlobCleanupDelayMs, exactDeadline,
+            ), TypeError);
+          }
+          const mismatchedDeadline = new Date(Date.parse(exactDeadline) + 1).toISOString();
+          assert.throws(() => fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+            executor, snapshot, mediaBlobCleanupDelayMs, mismatchedDeadline,
+          ), TypeError);
+          assert.throws(() => finishDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+            executor, snapshot, mediaBlobCleanupDelayMs, mismatchedDeadline,
+          ), TypeError);
+          for (const mismatchedAttempt of [
+            exactSnapshot,
+            { ...snapshot, attemptToken: exactSnapshot.attemptToken },
+            { ...snapshot, reservationToken: exactSnapshot.reservationToken },
+            { ...snapshot, sourceUrl: "https://mismatched-payload.invalid/" },
+          ]) {
+            assert.throws(() => fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+              executor, mismatchedAttempt, mediaBlobCleanupDelayMs, exactDeadline,
+            ), TypeError);
+            assert.throws(() => finishDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+              executor, mismatchedAttempt, mediaBlobCleanupDelayMs, exactDeadline,
+            ), TypeError);
+          }
+          assert.equal(await fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+            executor, snapshot, mediaBlobCleanupDelayMs, exactDeadline,
+          ), "ready");
+          throw new Error("Direct writer apply rollback evidence.");
+        },
+      ), /Direct writer apply rollback evidence/u);
+      const exactRolledBackExecutor = rolledBackExecutor;
+      if (exactRolledBackExecutor === null) {
+        throw new Error("Apply executor did not enter rollback evidence.");
+      }
+      assert.throws(() => fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+        exactRolledBackExecutor, exactAttempt, mediaBlobCleanupDelayMs, rollbackDeadline,
+      ), TypeError);
+      const applyDeadline = createDirectAttemptDeadline();
+      await transactionWithDirectMediaBlobWriterApplyDeadline(
+        exactAttempt,
+        applyDeadline,
+        async (executor, snapshot, exactDeadline) => {
+          assert.equal(await fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+            executor, snapshot, mediaBlobCleanupDelayMs, exactDeadline,
+          ), "ready");
+          await insertDirectAttemptAsset(executor, snapshot);
+          assert.equal(await finishDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+            executor, snapshot, mediaBlobCleanupDelayMs, exactDeadline,
+          ), "live_applied");
+        },
+      );
+      assert.equal((await beginDirectMediaBlobWriterAttemptWithOwner(
+        attemptInput, createDirectAttemptLease(),
+      )).status, "live_applied");
+      assert.equal(await resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+        exactAttempt, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "live_applied");
+      const failedInput = directAttemptInput(fixture, failedAttemptSha);
+      const failed = await beginDirectMediaBlobWriterAttemptWithOwner(
+        failedInput, createDirectAttemptLease(),
+      );
+      if (!("reservationToken" in failed)) throw new Error("Failed attempt did not acquire.");
+      const exactFailed = { ...failedInput, reservationToken: failed.reservationToken,
+        normalizationVersion: failed.normalizationVersion };
+      assert.equal(await resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+        { ...exactFailed, reservationToken: randomUUID() },
+        mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "writer_conflict");
+      assert.equal(await resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+        exactFailed, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "unreferenced");
+      assert.equal(await resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+        exactFailed, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "unreferenced");
+      const terminalReplayDeadline = createDirectAttemptDeadline();
+      assert.equal(await transactionWithDirectMediaBlobWriterApplyDeadline(
+        exactFailed,
+        terminalReplayDeadline,
+        (executor, snapshot, exactDeadline) =>
+          finishDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+            executor, snapshot, mediaBlobCleanupDelayMs, exactDeadline),
+      ), "unreferenced");
+      const takeoverInput = directAttemptInput(fixture, takeoverAttemptSha);
+      const expiring = await beginDirectMediaBlobWriterAttemptWithOwner(
+        takeoverInput, createDirectAttemptLease(),
+      );
+      if (!("reservationToken" in expiring)) throw new Error("Expiring attempt did not acquire.");
+      await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [takeoverInput.attemptToken]);
+      const takeoverInputNext = { ...takeoverInput, attemptToken: randomUUID() };
+      const takeover = await beginDirectMediaBlobWriterAttemptWithOwner(
+        takeoverInputNext, createDirectAttemptLease(),
+      );
+      assert.equal(takeover.status, "expired_takeover");
+      assert.equal(await resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+        { ...takeoverInput, reservationToken: expiring.reservationToken,
+          normalizationVersion: expiring.normalizationVersion }, mediaBlobCleanupDelayMs,
+        createDirectAttemptDeadline(),
+      ), "stale_attempt");
+      const revokedAttemptInput = directAttemptInput(fixture, revokedAttemptSha);
+      const revoked = await beginDirectMediaBlobWriterAttemptWithOwner(
+        revokedAttemptInput, createDirectAttemptLease(),
+      );
+      if (!("reservationToken" in revoked)) throw new Error("Revoked attempt did not acquire.");
+      const exactRevoked = { ...revokedAttemptInput, reservationToken: revoked.reservationToken,
+        normalizationVersion: revoked.normalizationVersion };
+      await fixture.ownerPool.query("DELETE FROM org.workspace_memberships WHERE workspace_id=$1 AND user_id=$2", [fixture.workspaceId, fixture.userId]);
+      assert.equal((await beginDirectMediaBlobWriterAttemptWithOwner(
+        directAttemptInput(fixture, deniedAttemptSha), createDirectAttemptLease(),
+      )).status, "access_denied");
+      assert.equal(await resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+        exactRevoked, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "access_denied");
+      assert.equal(await resolveDirectMediaBlobWriterAttemptAfterAccessRevocation(
+        exactRevoked, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "busy");
+      await fixture.ownerPool.query("UPDATE content.media_blob_writer_attempts SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE attempt_token=$1", [revokedAttemptInput.attemptToken]);
+      assert.equal(await resolveDirectMediaBlobWriterAttemptAfterAccessRevocation(
+        exactRevoked, mediaBlobCleanupDelayMs, createDirectAttemptDeadline()), "unreferenced");
+      assert.equal(await resolveDirectMediaBlobWriterAttemptAfterAccessRevocation(
+        exactRevoked, mediaBlobCleanupDelayMs, createDirectAttemptDeadline(),
+      ), "unreferenced");
+      await fixture.ownerPool.query("INSERT INTO org.workspace_memberships(workspace_id,user_id,role) VALUES($1,$2,'owner')", [fixture.workspaceId, fixture.userId]);
+      await fixture.ownerPool.query(
+        `WITH workspace AS (
+           INSERT INTO org.workspaces (workspace_id,name,fsrs_client_updated_at,
+             fsrs_last_modified_by_replica_id,fsrs_last_operation_id)
+           VALUES ($1,'Aborted wrapper evidence',$2,$3,$4) RETURNING workspace_id),
+         membership AS (
+           INSERT INTO org.workspace_memberships(workspace_id,user_id,role) SELECT workspace_id,$5,'owner' FROM workspace)
+         INSERT INTO sync.workspace_replicas (replica_id,workspace_id,user_id,actor_kind,actor_key,platform,app_version)
+         VALUES ($3,$1,$5,'ai_chat',$6,'system','postgres-integration')`,
+        [abortedWorkspaceId, fixture.createdAt, abortedReplicaId, randomUUID(), fixture.userId,
+          `postgres-integration-${abortedReplicaId}`],
+      );
+      const abortedInput = directAttemptInput({
+        userId: fixture.userId, workspaceId: abortedWorkspaceId,
+        replicaId: abortedReplicaId, createdAt: fixture.createdAt,
+      }, abortedAttemptSha);
+      const aborted = await beginDirectMediaBlobWriterAttemptWithOwner(
+        abortedInput, createDirectAttemptLease(),
+      );
+      if (!("reservationToken" in aborted)) throw new Error("Aborted attempt did not acquire.");
+      await fixture.ownerPool.query("DELETE FROM org.workspaces WHERE workspace_id=$1", [abortedWorkspaceId]);
+      assert.equal((await beginDirectMediaBlobWriterAttemptWithOwner(
+        abortedInput, createDirectAttemptLease(),
+      )).status, "aborted");
       await fixture.ownerPool.query(
         `WITH inserted_workspace AS (
            INSERT INTO org.workspaces
@@ -565,8 +918,13 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
         }),
       ), "unreferenced");
     } finally {
+      await fixture.ownerPool.query(
+        "DELETE FROM org.workspaces WHERE workspace_id = $1", [abortedWorkspaceId],
+      );
       await fixture.ownerPool.query("DELETE FROM catalog.packages WHERE package_id = $1", [packageId]);
       await fixture.ownerPool.query("DELETE FROM catalog.authors WHERE author_id = $1", [authorId]);
+      await fixture.ownerPool.query("DELETE FROM content.media_assets WHERE media_blob_id IN (SELECT media_blob_id FROM content.media_blobs WHERE sha256=ANY($1::text[]))", [attemptFixtureSha256s]);
+      await fixture.ownerPool.query("DELETE FROM content.media_blob_writer_attempts WHERE sha256=ANY($1::text[])", [attemptFixtureSha256s]);
       await fixture.ownerPool.query(
         "DELETE FROM content.media_blob_writer_reservations WHERE sha256 = ANY($1::text[])",
         [fixtureSha256s],
@@ -585,10 +943,12 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
          WHERE lifecycles.sha256 = ANY($1::text[])
            AND NOT EXISTS (SELECT 1 FROM content.media_blobs AS blobs
                            WHERE blobs.sha256 = lifecycles.sha256)
-           AND NOT EXISTS (SELECT 1 FROM content.media_blob_writer_reservations AS reservations
+          AND NOT EXISTS (SELECT 1 FROM content.media_blob_writer_reservations AS reservations
                            WHERE reservations.sha256 = lifecycles.sha256)`,
         [fixtureSha256s],
       );
+      const attemptResidue = (await fixture.ownerPool.query(`SELECT (SELECT count(*)::int FROM content.media_blob_writer_attempts WHERE sha256=ANY($1::text[])) AS attempts,(SELECT count(*)::int FROM content.media_blob_writer_reservations WHERE sha256=ANY($1::text[])) AS reservations,(SELECT count(*)::int FROM content.media_blob_lifecycles WHERE sha256=ANY($1::text[])) AS lifecycles,(SELECT count(*)::int FROM content.media_blobs WHERE sha256=ANY($1::text[])) AS blobs`, [attemptFixtureSha256s])).rows[0];
+      assert.deepEqual(attemptResidue, { attempts: 0, reservations: 0, lifecycles: 0, blobs: 0 });
       await fixture.ownerPool.query(
         "DELETE FROM org.workspaces WHERE workspace_id = $1",
         [concurrentWorkspaceId],

--- a/apps/backend/src/mediaAssets/blobLifecycle.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle.ts
@@ -1,16 +1,25 @@
-import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
-import { unsafeTransaction } from "../database/unsafe";
+import {
+  applyWorkspaceDatabaseScopeInExecutor,
+  transactionWithWorkspaceScope,
+  transactionWithWorkspaceScopeDeadline,
+  type DatabaseExecutor,
+} from "../database";
+import { unsafeTransaction, unsafeTransactionWithDeadline } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import { buildMediaBlobStorageKey } from "./storageKeys";
 import {
   mediaBlobNormalizationVersions,
   passthroughMediaBlobNormalizationVersion,
   type MediaBlobNormalizationVersion,
+  type TimestampValue,
 } from "./types";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const sha256Pattern = /^[0-9a-f]{64}$/u;
 const mimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/u;
 const maximumOperationIdLength = 1_024;
+const maximumMediaBlobWriterAttemptLeaseDurationMs = 3_600_000;
+const maximumMediaBlobWriterOperationDeadlineMs = 3_600_000;
+const maximumMediaBlobCleanupDelayMs = 604_800_000;
 export const mediaBlobCleanupDelayMs = 3_600_000;
 export const mediaBlobWriterKinds = ["direct_ingestion", "multipart_completion", "generated_promotion"] as const;
 export type MediaBlobWriterKind = typeof mediaBlobWriterKinds[number];
@@ -41,6 +50,60 @@ export type DirectMediaBlobWriterResolutionInput = Readonly<{
 }>;
 export type DirectMediaBlobWriterReservationInput =
   DirectMediaBlobWriterResolutionInput & Readonly<{ normalizationVersion: MediaBlobNormalizationVersion }>;
+export type DirectMediaBlobWriterAttemptInput = DirectMediaBlobWriterReservationInput & Readonly<{
+  attemptToken: string; sourceUrl: string | null; assetCreatedAt: string; clientUpdatedAt: string;
+}>;
+export type DirectMediaBlobWriterAttemptExactInput =
+  DirectMediaBlobWriterAttemptInput & Readonly<{ reservationToken: string }>;
+export type DirectMediaBlobWriterAttemptLease = Readonly<{
+  leaseDurationMs: number; operationDeadlineAt: string;
+}>;
+declare const directMediaBlobStorageCapabilityType: unique symbol;
+declare const directMediaBlobWriterApplyExecutorType: unique symbol;
+type DirectMediaBlobStorageCapabilityPayload = Readonly<{
+  writerKind: "direct_ingestion"; attemptToken: string; reservationToken: string;
+  leaseExpiresAt: string; operationDeadlineAt: string; userId: string;
+  workspaceId: string; mediaAssetId: string; operationId: string;
+  lastModifiedByReplicaId: string; sha256: string; storageKey: string;
+  mimeType: string; sizeBytes: number; normalizationVersion: MediaBlobNormalizationVersion;
+  sourceUrl: string | null; assetCreatedAt: string; clientUpdatedAt: string;
+}>;
+type DirectMediaBlobWriterApplyExecutorClaim = Readonly<{
+  input: DirectMediaBlobWriterAttemptExactInput;
+  operationDeadlineAt: string;
+  operationDeadlineAtMs: number;
+}>;
+export type DirectMediaBlobStorageCapability = Readonly<{
+  readonly [directMediaBlobStorageCapabilityType]: true;
+}>;
+export type DirectMediaBlobWriterApplyExecutor = DatabaseExecutor & Readonly<{
+  readonly [directMediaBlobWriterApplyExecutorType]: true;
+}>;
+const directAttemptTerminalStatuses = ["already_applied", "live_applied", "peer_conflict",
+  "referenced", "unreferenced", "aborted", "stale_attempt"] as const;
+const directAttemptRejectionStatuses = ["access_denied", "replica_mismatch",
+  "ownership_mismatch", "writer_conflict", "cleanup_claimed", "stale"] as const;
+const directAttemptBeginStatuses = [...directAttemptTerminalStatuses,
+  ...directAttemptRejectionStatuses, "busy"] as const;
+const directAttemptFenceStatuses = [...directAttemptTerminalStatuses,
+  ...directAttemptRejectionStatuses, "ready"] as const;
+const directAttemptFinishStatuses = [...directAttemptTerminalStatuses,
+  ...directAttemptRejectionStatuses] as const;
+const directAttemptFailureStatuses = [...directAttemptFinishStatuses] as const;
+const directAttemptRevocationStatuses =
+  [...directAttemptFinishStatuses, "access_active", "busy"] as const;
+export type DirectMediaBlobWriterAttemptFenceStatus = typeof directAttemptFenceStatuses[number];
+export type DirectMediaBlobWriterAttemptFinishStatus = typeof directAttemptFinishStatuses[number];
+export type DirectMediaBlobWriterAttemptFailureStatus = typeof directAttemptFailureStatuses[number];
+export type DirectMediaBlobWriterAttemptRevocationStatus = typeof directAttemptRevocationStatuses[number];
+export type DirectMediaBlobWriterAttemptResult =
+  | Readonly<{
+    status: "acquired" | "replayed" | "expired_takeover";
+    reservationToken: string; normalizationVersion: MediaBlobNormalizationVersion;
+    leaseExpiresAt: string; storageCapability: DirectMediaBlobStorageCapability;
+  }>
+  | Readonly<{ status: "busy"; leaseExpiresAt: string }>
+  | Readonly<{ status: Exclude<typeof directAttemptBeginStatuses[number], "busy"> }>;
 type ReservationRow = Readonly<{
   reservation_token: string | null; reservation_state: string | null;
   reservation_status: string; normalization_version: string;
@@ -48,7 +111,16 @@ type ReservationRow = Readonly<{
 type BooleanRow = Readonly<{ transitioned: boolean }>;
 type ReconciliationRow = Readonly<{ reconciliation_status: string }>;
 type DirectResolutionRow = Readonly<{ resolution_status: string }>;
+type AttemptBeginRow = Readonly<{
+  attempt_status: string; reservation_token: string | null;
+  normalization_version: string | null; lease_expires_at: TimestampValue | null;
+}>;
+type AttemptStatusRow = Readonly<{ attempt_status: string }>;
 type CleanupClaimRow = Readonly<{ lease_token: string | null }>;
+const directMediaBlobStorageCapabilityClaims =
+  new WeakMap<DirectMediaBlobStorageCapability, DirectMediaBlobStorageCapabilityPayload>();
+const directMediaBlobWriterApplyExecutorClaims =
+  new WeakMap<DirectMediaBlobWriterApplyExecutor, DirectMediaBlobWriterApplyExecutorClaim>();
 export class MediaBlobLifecycleBusyError extends HttpError {
   constructor() { super( 503, "Media bytes are temporarily fenced by cleanup. Retry shortly.", "MEDIA_BLOB_LIFECYCLE_BUSY", ); this.name = "MediaBlobLifecycleBusyError";
   }
@@ -63,6 +135,11 @@ export class MediaBlobWriterFenceError extends Error {
 }
 export function assertMediaBlobWriterReservationToken(reservationToken: string): void {
   if (!uuidPattern.test(reservationToken)) { throw new TypeError("mediaBlobWriterReservationToken must be a lowercase UUID.");
+  }
+}
+export function assertMediaBlobWriterAttemptToken(attemptToken: string): void {
+  if (!uuidPattern.test(attemptToken)) {
+    throw new TypeError("mediaBlobWriterAttemptToken must be a lowercase UUID.");
   }
 }
 function assertReservationInput(input: MediaBlobWriterReservationInput): void {
@@ -95,6 +172,191 @@ function requireNormalizationVersion(value: string): MediaBlobNormalizationVersi
 function assertHistoricalWriterOwner(userId: string, replicaId: string): void {
   if (userId !== userId.trim() || userId.length === 0) throw new TypeError("userId must be non-empty and trimmed.");
   if (!uuidPattern.test(replicaId)) throw new TypeError("lastModifiedByReplicaId must be a lowercase UUID.");
+}
+function requireIsoTimestamp(value: TimestampValue, fieldName: string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) throw new TypeError(`${fieldName} must be a valid timestamp.`);
+  return date.toISOString();
+}
+function assertPositiveBoundedDuration(value: number, fieldName: string, maximumMs: number): void {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximumMs) {
+    throw new RangeError(`${fieldName} must be an integer between 1 and ${maximumMs}.`);
+  }
+}
+type DirectMediaBlobWriterOperationDeadline = Readonly<{
+  operationDeadlineAt: string;
+  operationDeadlineAtMs: number;
+}>;
+function snapshotDirectAttemptOperationDeadline(
+  rawOperationDeadlineAt: string,
+): DirectMediaBlobWriterOperationDeadline {
+  if (typeof rawOperationDeadlineAt !== "string") {
+    throw new TypeError("operationDeadlineAt must be an ISO timestamp string.");
+  }
+  const operationDeadlineAt = requireIsoTimestamp(rawOperationDeadlineAt, "operationDeadlineAt");
+  const operationDeadlineAtMs = Date.parse(operationDeadlineAt);
+  const remainingMs = operationDeadlineAtMs - Date.now();
+  if (remainingMs <= 0 || remainingMs > maximumMediaBlobWriterOperationDeadlineMs) {
+    throw new RangeError(
+      `operationDeadlineAt must be within the next ${maximumMediaBlobWriterOperationDeadlineMs} milliseconds.`,
+    );
+  }
+  return Object.freeze({ operationDeadlineAt, operationDeadlineAtMs });
+}
+type DirectMediaBlobWriterAttemptLeaseSnapshot =
+  DirectMediaBlobWriterAttemptLease & DirectMediaBlobWriterOperationDeadline;
+function snapshotDirectAttemptLease(
+  lease: DirectMediaBlobWriterAttemptLease,
+): DirectMediaBlobWriterAttemptLeaseSnapshot {
+  if (typeof lease !== "object" || lease === null) {
+    throw new TypeError("Direct writer attempt lease must be an object.");
+  }
+  const leaseDurationMs = lease.leaseDurationMs;
+  const deadline = snapshotDirectAttemptOperationDeadline(lease.operationDeadlineAt);
+  assertPositiveBoundedDuration(
+    leaseDurationMs,
+    "leaseDurationMs",
+    maximumMediaBlobWriterAttemptLeaseDurationMs,
+  );
+  const remainingMs = deadline.operationDeadlineAtMs - Date.now();
+  if (remainingMs >= leaseDurationMs) {
+    throw new RangeError("operationDeadlineAt must expire strictly before the writer attempt lease.");
+  }
+  return Object.freeze({ leaseDurationMs, ...deadline });
+}
+function snapshotDirectAttemptInput(
+  input: DirectMediaBlobWriterAttemptInput,
+): DirectMediaBlobWriterAttemptInput {
+  if (typeof input !== "object" || input === null) {
+    throw new TypeError("Direct writer attempt input must be an object.");
+  }
+  const snapshot = {
+    attemptToken: input.attemptToken, userId: input.userId, workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId, operationId: input.operationId,
+    lastModifiedByReplicaId: input.lastModifiedByReplicaId, sha256: input.sha256,
+    storageKey: input.storageKey, mimeType: input.mimeType, sizeBytes: input.sizeBytes,
+    normalizationVersion: input.normalizationVersion, sourceUrl: input.sourceUrl,
+    assetCreatedAt: input.assetCreatedAt, clientUpdatedAt: input.clientUpdatedAt,
+  };
+  if ([
+    snapshot.attemptToken, snapshot.userId, snapshot.workspaceId, snapshot.mediaAssetId,
+    snapshot.operationId, snapshot.lastModifiedByReplicaId, snapshot.sha256,
+    snapshot.storageKey, snapshot.mimeType, snapshot.assetCreatedAt, snapshot.clientUpdatedAt,
+  ].some((value) => typeof value !== "string")) {
+    throw new TypeError("Direct writer attempt string fields must be strings.");
+  }
+  if (snapshot.sourceUrl !== null && typeof snapshot.sourceUrl !== "string") {
+    throw new TypeError("sourceUrl must be a string or null.");
+  }
+  const canonical = Object.freeze({
+    ...snapshot,
+    assetCreatedAt: requireIsoTimestamp(snapshot.assetCreatedAt, "assetCreatedAt"),
+    clientUpdatedAt: requireIsoTimestamp(snapshot.clientUpdatedAt, "clientUpdatedAt"),
+  });
+  assertMediaBlobWriterAttemptToken(canonical.attemptToken);
+  assertReservationInput({ ...canonical, writerKind: "direct_ingestion" });
+  assertHistoricalWriterOwner(canonical.userId, canonical.lastModifiedByReplicaId);
+  return canonical;
+}
+function snapshotDirectAttemptExactInput(
+  input: DirectMediaBlobWriterAttemptExactInput,
+): DirectMediaBlobWriterAttemptExactInput {
+  const reservationToken = input.reservationToken;
+  const snapshot = snapshotDirectAttemptInput(input);
+  if (typeof reservationToken !== "string") {
+    throw new TypeError("reservationToken must be a string.");
+  }
+  assertMediaBlobWriterReservationToken(reservationToken);
+  return Object.freeze({ ...snapshot, reservationToken });
+}
+function toDirectAttemptParams(
+  input: DirectMediaBlobWriterAttemptInput,
+): ReadonlyArray<string | number | null> {
+  return [
+    input.userId, input.workspaceId, input.mediaAssetId, input.operationId,
+    input.lastModifiedByReplicaId, input.sha256, input.storageKey, input.mimeType,
+    input.sizeBytes, input.normalizationVersion, input.sourceUrl,
+    input.assetCreatedAt, input.clientUpdatedAt,
+  ];
+}
+function requireDirectAttemptStatus<Status extends string>(
+  value: string | undefined,
+  statuses: ReadonlyArray<Status>,
+  operation: string,
+): Status {
+  const status = statuses.find((candidate) => candidate === value);
+  if (status === undefined) {
+    throw new TypeError(`PostgreSQL returned an invalid direct writer attempt status. operation=${operation}`);
+  }
+  return status;
+}
+function createDirectMediaBlobStorageCapability(
+  input: DirectMediaBlobWriterAttemptExactInput,
+  leaseExpiresAt: string,
+  operationDeadlineAt: string,
+): DirectMediaBlobStorageCapability {
+  const payload: DirectMediaBlobStorageCapabilityPayload = Object.freeze({
+    writerKind: "direct_ingestion", attemptToken: input.attemptToken,
+    reservationToken: input.reservationToken, leaseExpiresAt, operationDeadlineAt,
+    userId: input.userId, workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId, operationId: input.operationId,
+    lastModifiedByReplicaId: input.lastModifiedByReplicaId, sha256: input.sha256,
+    storageKey: input.storageKey, mimeType: input.mimeType, sizeBytes: input.sizeBytes,
+    normalizationVersion: input.normalizationVersion, sourceUrl: input.sourceUrl,
+    assetCreatedAt: requireIsoTimestamp(input.assetCreatedAt, "assetCreatedAt"),
+    clientUpdatedAt: requireIsoTimestamp(input.clientUpdatedAt, "clientUpdatedAt"),
+  });
+  const capability = Object.freeze({}) as DirectMediaBlobStorageCapability;
+  directMediaBlobStorageCapabilityClaims.set(capability, payload);
+  return capability;
+}
+function hasExactDirectMediaBlobWriterAttemptInput(
+  expected: DirectMediaBlobWriterAttemptExactInput,
+  actual: DirectMediaBlobWriterAttemptExactInput,
+): boolean {
+  return expected.attemptToken === actual.attemptToken
+    && expected.reservationToken === actual.reservationToken
+    && expected.userId === actual.userId
+    && expected.workspaceId === actual.workspaceId
+    && expected.mediaAssetId === actual.mediaAssetId
+    && expected.operationId === actual.operationId
+    && expected.lastModifiedByReplicaId === actual.lastModifiedByReplicaId
+    && expected.sha256 === actual.sha256
+    && expected.storageKey === actual.storageKey
+    && expected.mimeType === actual.mimeType
+    && expected.sizeBytes === actual.sizeBytes
+    && expected.normalizationVersion === actual.normalizationVersion
+    && expected.sourceUrl === actual.sourceUrl
+    && expected.assetCreatedAt === actual.assetCreatedAt
+    && expected.clientUpdatedAt === actual.clientUpdatedAt;
+}
+function assertDirectMediaBlobStorageCapabilityForMutationAtTime(
+  capability: DirectMediaBlobStorageCapability,
+  input: DirectMediaBlobWriterAttemptExactInput,
+  observedAtMs: number,
+): void {
+  const exactInput = snapshotDirectAttemptExactInput(input);
+  const payload = typeof capability === "object" && capability !== null
+    ? directMediaBlobStorageCapabilityClaims.get(capability)
+    : undefined;
+  const exactMatch = payload !== undefined
+    && Object.isFrozen(capability)
+    && Object.isFrozen(payload)
+    && payload.writerKind === "direct_ingestion"
+    && hasExactDirectMediaBlobWriterAttemptInput(payload, exactInput);
+  if (!exactMatch) throw new MediaBlobWriterFenceError("verify_direct_storage_capability");
+  if (
+    Date.parse(payload.leaseExpiresAt) <= observedAtMs
+    || Date.parse(payload.operationDeadlineAt) <= observedAtMs
+  ) {
+    throw new MediaBlobWriterFenceError("verify_direct_storage_capability_expired");
+  }
+}
+export function assertDirectMediaBlobStorageCapabilityForMutation(
+  capability: DirectMediaBlobStorageCapability,
+  input: DirectMediaBlobWriterAttemptExactInput,
+): void {
+  assertDirectMediaBlobStorageCapabilityForMutationAtTime(capability, input, Date.now());
 }
 export async function reserveMediaBlobWriterInExecutor(
   executor: DatabaseExecutor, input: MediaBlobWriterReservationInput,
@@ -151,6 +413,250 @@ export async function reserveDirectMediaBlobWriterWithOwner(
 ): Promise<MediaBlobWriterReservation> {
   return transactionWithWorkspaceScope( { userId: input.userId, workspaceId: input.workspaceId },
     (executor) => reserveDirectMediaBlobWriterWithOwnerInExecutor(executor, input));
+}
+async function beginDirectMediaBlobWriterAttemptSnapshotInExecutor(
+  executor: DatabaseExecutor,
+  input: DirectMediaBlobWriterAttemptInput,
+  lease: DirectMediaBlobWriterAttemptLeaseSnapshot,
+): Promise<DirectMediaBlobWriterAttemptResult> {
+  const result = await executor.query<AttemptBeginRow>(
+    `SELECT attempt_status, reservation_token, normalization_version, lease_expires_at
+     FROM content.begin_direct_media_blob_writer_attempt_with_owner(
+       $1,$2,ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+       ::content.direct_media_blob_writer_attempt_payload
+     )`,
+    [input.attemptToken, lease.leaseDurationMs, ...toDirectAttemptParams(input)],
+  );
+  if (result.rows.length !== 1) {
+    throw new TypeError("PostgreSQL returned an invalid direct writer attempt row count.");
+  }
+  const row = result.rows[0];
+  if (row?.attempt_status === "acquired" || row?.attempt_status === "replayed"
+    || row?.attempt_status === "expired_takeover") {
+    if (row.reservation_token === null || row.normalization_version === null
+      || row.lease_expires_at === null) {
+      throw new TypeError("PostgreSQL returned an incomplete direct writer attempt acquisition.");
+    }
+    assertMediaBlobWriterReservationToken(row.reservation_token);
+    const normalizationVersion = requireNormalizationVersion(row.normalization_version);
+    const leaseExpiresAt = requireIsoTimestamp(row.lease_expires_at, "leaseExpiresAt");
+    if (Date.parse(leaseExpiresAt) <= lease.operationDeadlineAtMs) {
+      throw new TypeError("PostgreSQL returned a writer lease that does not cover the operation deadline.");
+    }
+    const exactInput = Object.freeze({
+      ...input,
+      reservationToken: row.reservation_token,
+      normalizationVersion,
+    });
+    return {
+      status: row.attempt_status,
+      reservationToken: row.reservation_token,
+      normalizationVersion,
+      leaseExpiresAt,
+      storageCapability: createDirectMediaBlobStorageCapability(
+        exactInput,
+        leaseExpiresAt,
+        lease.operationDeadlineAt,
+      ),
+    };
+  }
+  const status = requireDirectAttemptStatus(
+    row?.attempt_status, directAttemptBeginStatuses, "begin_direct_writer_attempt",
+  );
+  if (row.reservation_token !== null) {
+    throw new TypeError("PostgreSQL returned an invalid direct writer attempt acquisition result.");
+  }
+  if (status === "cleanup_claimed") {
+    if (row.normalization_version === null || row.lease_expires_at !== null) {
+      throw new TypeError("PostgreSQL returned an invalid cleanup-claimed writer result.");
+    }
+    requireNormalizationVersion(row.normalization_version);
+    return { status };
+  }
+  if (row.normalization_version !== null) {
+    throw new TypeError("PostgreSQL returned an unexpected direct writer normalization version.");
+  }
+  if (status === "busy") {
+    if (row.lease_expires_at === null) {
+      throw new TypeError("PostgreSQL returned a busy direct writer attempt without its lease expiry.");
+    }
+    return { status, leaseExpiresAt: requireIsoTimestamp(row.lease_expires_at, "leaseExpiresAt") };
+  }
+  if (row.lease_expires_at !== null) {
+    throw new TypeError("PostgreSQL returned an unexpected direct writer attempt lease.");
+  }
+  return { status };
+}
+export function beginDirectMediaBlobWriterAttemptWithOwner(
+  input: DirectMediaBlobWriterAttemptInput,
+  lease: DirectMediaBlobWriterAttemptLease,
+): Promise<DirectMediaBlobWriterAttemptResult> {
+  const snapshot = snapshotDirectAttemptInput(input);
+  const leaseSnapshot = snapshotDirectAttemptLease(lease);
+  return transactionWithWorkspaceScopeDeadline(
+    { userId: snapshot.userId, workspaceId: snapshot.workspaceId },
+    leaseSnapshot.operationDeadlineAtMs,
+    (executor) => beginDirectMediaBlobWriterAttemptSnapshotInExecutor(
+      executor, snapshot, leaseSnapshot,
+    ),
+  );
+}
+async function queryDirectAttemptStatus<Status extends string>(
+  executor: DatabaseExecutor,
+  sql: string,
+  input: DirectMediaBlobWriterAttemptExactInput,
+  cleanupDelayMs: number,
+  statuses: ReadonlyArray<Status>,
+  operation: string,
+): Promise<Status> {
+  assertPositiveBoundedDuration(
+    cleanupDelayMs,
+    "cleanupDelayMs",
+    maximumMediaBlobCleanupDelayMs,
+  );
+  const result = await executor.query<AttemptStatusRow>(sql, [
+    input.attemptToken, input.reservationToken, ...toDirectAttemptParams(input),
+    cleanupDelayMs,
+  ]);
+  if (result.rows.length !== 1) {
+    throw new TypeError(`PostgreSQL returned an invalid direct writer status row count. operation=${operation}`);
+  }
+  return requireDirectAttemptStatus(result.rows[0]?.attempt_status, statuses, operation);
+}
+function createDirectMediaBlobWriterApplyExecutor(
+  executor: DatabaseExecutor,
+  input: DirectMediaBlobWriterAttemptExactInput,
+  deadline: DirectMediaBlobWriterOperationDeadline,
+): DirectMediaBlobWriterApplyExecutor {
+  const applyExecutor = Object.freeze(executor) as DirectMediaBlobWriterApplyExecutor;
+  directMediaBlobWriterApplyExecutorClaims.set(applyExecutor, Object.freeze({
+    input,
+    operationDeadlineAt: deadline.operationDeadlineAt,
+    operationDeadlineAtMs: deadline.operationDeadlineAtMs,
+  }));
+  return applyExecutor;
+}
+function assertDirectMediaBlobWriterApplyExecutor(
+  executor: DirectMediaBlobWriterApplyExecutor,
+  input: DirectMediaBlobWriterAttemptExactInput,
+  deadline: DirectMediaBlobWriterOperationDeadline,
+): void {
+  const claim = typeof executor === "object" && executor !== null
+    ? directMediaBlobWriterApplyExecutorClaims.get(executor)
+    : undefined;
+  if (
+    claim === undefined
+    || claim.operationDeadlineAt !== deadline.operationDeadlineAt
+    || claim.operationDeadlineAtMs !== deadline.operationDeadlineAtMs
+    || !hasExactDirectMediaBlobWriterAttemptInput(claim.input, input)
+  ) {
+    throw new TypeError("Direct writer apply executor does not match its exact attempt and deadline.");
+  }
+}
+export function transactionWithDirectMediaBlobWriterApplyDeadline<Result>(
+  input: DirectMediaBlobWriterAttemptExactInput,
+  operationDeadlineAt: string,
+  callback: (
+    executor: DirectMediaBlobWriterApplyExecutor,
+    snapshot: DirectMediaBlobWriterAttemptExactInput,
+    exactOperationDeadlineAt: string,
+  ) => Promise<Result>,
+): Promise<Result> {
+  const snapshot = snapshotDirectAttemptExactInput(input);
+  const deadline = snapshotDirectAttemptOperationDeadline(operationDeadlineAt);
+  return transactionWithWorkspaceScopeDeadline(
+    { userId: snapshot.userId, workspaceId: snapshot.workspaceId },
+    deadline.operationDeadlineAtMs,
+    async (executor) => {
+      const applyExecutor = createDirectMediaBlobWriterApplyExecutor(
+        executor, snapshot, deadline,
+      );
+      try {
+        return await callback(applyExecutor, snapshot, deadline.operationDeadlineAt);
+      } finally {
+        directMediaBlobWriterApplyExecutorClaims.delete(applyExecutor);
+      }
+    },
+  );
+}
+export function fenceDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+  executor: DirectMediaBlobWriterApplyExecutor,
+  input: DirectMediaBlobWriterAttemptExactInput,
+  cleanupDelayMs: number,
+  operationDeadlineAt: string,
+): Promise<DirectMediaBlobWriterAttemptFenceStatus> {
+  const snapshot = snapshotDirectAttemptExactInput(input);
+  const deadline = snapshotDirectAttemptOperationDeadline(operationDeadlineAt);
+  assertDirectMediaBlobWriterApplyExecutor(executor, snapshot, deadline);
+  return queryDirectAttemptStatus(
+    executor,
+    `SELECT content.fence_direct_media_blob_writer_attempt_apply_with_owner(
+       $1,$2,ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+       ::content.direct_media_blob_writer_attempt_payload,$16
+    ) AS attempt_status`,
+    snapshot, cleanupDelayMs, directAttemptFenceStatuses, "fence_direct_writer_attempt_apply",
+  );
+}
+export function finishDirectMediaBlobWriterAttemptApplyWithOwnerInExecutor(
+  executor: DirectMediaBlobWriterApplyExecutor,
+  input: DirectMediaBlobWriterAttemptExactInput,
+  cleanupDelayMs: number,
+  operationDeadlineAt: string,
+): Promise<DirectMediaBlobWriterAttemptFinishStatus> {
+  const snapshot = snapshotDirectAttemptExactInput(input);
+  const deadline = snapshotDirectAttemptOperationDeadline(operationDeadlineAt);
+  assertDirectMediaBlobWriterApplyExecutor(executor, snapshot, deadline);
+  return queryDirectAttemptStatus(
+    executor,
+    `SELECT content.finish_direct_media_blob_writer_attempt_apply_with_owner(
+       $1,$2,ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+       ::content.direct_media_blob_writer_attempt_payload,$16
+    ) AS attempt_status`,
+    snapshot, cleanupDelayMs, directAttemptFinishStatuses, "finish_direct_writer_attempt_apply",
+  );
+}
+export function resolveDirectMediaBlobWriterAttemptFailureWithOwner(
+  input: DirectMediaBlobWriterAttemptExactInput,
+  cleanupDelayMs: number,
+  operationDeadlineAt: string,
+): Promise<DirectMediaBlobWriterAttemptFailureStatus> {
+  const snapshot = snapshotDirectAttemptExactInput(input);
+  const deadline = snapshotDirectAttemptOperationDeadline(operationDeadlineAt);
+  return transactionWithWorkspaceScopeDeadline(
+    { userId: snapshot.userId, workspaceId: snapshot.workspaceId },
+    deadline.operationDeadlineAtMs,
+    (executor) => queryDirectAttemptStatus(
+      executor,
+      `SELECT content.resolve_direct_media_blob_writer_attempt_failure_with_owner(
+         $1,$2,ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+         ::content.direct_media_blob_writer_attempt_payload,$16
+       ) AS attempt_status`,
+      snapshot, cleanupDelayMs, directAttemptFailureStatuses, "resolve_direct_writer_attempt_failure",
+    ),
+  );
+}
+export function resolveDirectMediaBlobWriterAttemptAfterAccessRevocation(
+  input: DirectMediaBlobWriterAttemptExactInput,
+  cleanupDelayMs: number,
+  operationDeadlineAt: string,
+): Promise<DirectMediaBlobWriterAttemptRevocationStatus> {
+  const snapshot = snapshotDirectAttemptExactInput(input);
+  const deadline = snapshotDirectAttemptOperationDeadline(operationDeadlineAt);
+  return unsafeTransactionWithDeadline(deadline.operationDeadlineAtMs, async (executor) => {
+    await applyWorkspaceDatabaseScopeInExecutor(
+      executor,
+      { userId: snapshot.userId, workspaceId: snapshot.workspaceId },
+    );
+    return queryDirectAttemptStatus(
+      executor,
+      `SELECT content.resolve_direct_media_blob_writer_attempt_after_access_revocation(
+         $1,$2,ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+         ::content.direct_media_blob_writer_attempt_payload,$16
+       ) AS attempt_status`,
+      snapshot, cleanupDelayMs, directAttemptRevocationStatuses,
+      "resolve_direct_writer_attempt_after_access_revocation",
+    );
+  });
 }
 export async function finalizeMediaBlobWriterInExecutor(
   executor: DatabaseExecutor,


### PR DESCRIPTION
## Summary
- add strict migration-0097 direct writer lifecycle wrappers with canonical immutable snapshots and operation-specific status parsing
- add exact-identity storage capabilities and deadline-bound apply executor claims
- add real PostgreSQL evidence for deadlines, access revocation, takeover, deletion, transaction rollback, and zero residue

## Validation
- PostgreSQL 18 full 99-migration chain
- focused wrapper integration twice serially
- deadline/lock 1/1; 0096 resolution 1/1; 0097 upgrade 2/2
- backend tests 827/827
- lint, build, git diff --check
- clean fresh review: no P0-P4 findings