### PR TITLE
Decouple backend runtime observability

### DIFF
--- a/apps/backend/src/agent/apiKeys.ts
+++ b/apps/backend/src/agent/apiKeys.ts
@@ -8,7 +8,7 @@ import {
   type CursorPageInput,
 } from "../shared/pagination";
 import { createCrockfordToken, normalizeCrockfordToken } from "./crockford";
-import { ensureApiKeyWorkspaceSelection } from "../workspaces";
+import { ensureApiKeyWorkspaceSelection } from "../workspaces/selection";
 
 const AGENT_API_KEY_PREFIX = "fca";
 const AGENT_API_KEY_ID_LENGTH = 8;

--- a/apps/backend/src/auth/ensureUser.ts
+++ b/apps/backend/src/auth/ensureUser.ts
@@ -8,7 +8,7 @@ import {
   type DatabaseExecutor,
 } from "../database";
 import { unsafeTransaction } from "../database/unsafe";
-import { ensureUserSelectedWorkspaceInExecutor } from "../workspaces";
+import { ensureUserSelectedWorkspaceInExecutor } from "../workspaces/selection";
 import { assertSubjectIsNotDeletedInExecutor } from "./deletedSubjects";
 import {
   bindCognitoIdentityMappingInExecutor,

--- a/apps/backend/src/auth/index.ts
+++ b/apps/backend/src/auth/index.ts
@@ -13,7 +13,8 @@ import {
 import { authenticateAgentApiKey } from "../agent/apiKeys";
 import { getAuthConfig } from "./config";
 import { HttpError } from "../shared/errors";
-import { authenticateGuestSession, type GuestSessionPlatform } from "../guestAuth";
+import { authenticateGuestSession } from "../guestAuth/session";
+import type { GuestSessionPlatform } from "../guestAuth/types";
 import { loadCognitoIdentityMapping } from "./userIdentities";
 
 export type AuthTransport = "none" | "bearer" | "session" | "api_key" | "guest";

--- a/apps/backend/src/auth/mcpTokens.ts
+++ b/apps/backend/src/auth/mcpTokens.ts
@@ -3,7 +3,7 @@ import { unsafeQuery } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import { normalizeCrockfordToken } from "../agent/crockford";
 import { authenticateAgentApiKey } from "../agent/apiKeys";
-import { ensureMcpConnectionWorkspaceSelection } from "../workspaces";
+import { ensureMcpConnectionWorkspaceSelection } from "../workspaces/selection";
 
 const AGENT_API_KEY_PREFIX = "FCA_";
 

--- a/apps/backend/src/database/core.ts
+++ b/apps/backend/src/database/core.ts
@@ -10,9 +10,9 @@ import {
   toDatabaseCommitBoundaryError,
 } from "./transient";
 import {
-  captureBackendWarning,
+  captureBackendRuntimeWarning,
   createBackendRuntimeObservationScope,
-} from "../observability/sentry";
+} from "../observability/runtime";
 import {
   queryWithPostgresDeadline,
   resolvePostgresPoolUntilDeadline,
@@ -145,7 +145,7 @@ function toClientReleaseError(error: unknown): Error {
 function logUnsafeTransactionRollbackFailure(originalError: unknown, rollbackError: unknown): void {
   const originalFields = getDatabaseErrorFields(originalError);
   const rollbackFields = getDatabaseErrorFields(rollbackError);
-  captureBackendWarning({
+  captureBackendRuntimeWarning({
     action: "unsafe_transaction_rollback_failed",
     scope: createBackendRuntimeObservationScope(),
     details: {

--- a/apps/backend/src/database/transient.ts
+++ b/apps/backend/src/database/transient.ts
@@ -1,10 +1,10 @@
 import { HttpError } from "../shared/errors";
 import {
-  addBackendBreadcrumb,
-  captureBackendWarning,
+  addBackendRuntimeBreadcrumb,
+  captureBackendRuntimeWarning,
   createBackendRuntimeObservationScope,
-  type BackendObservationScope,
-} from "../observability/sentry";
+} from "../observability/runtime";
+import type { BackendObservationScope } from "../observability/sentry/events";
 
 const transientDatabaseSqlStates: ReadonlySet<string> = new Set([
   "40001",
@@ -141,7 +141,7 @@ function logDatabaseTransientRetry(
   delayMs: number,
   error: unknown,
 ): void {
-  addBackendBreadcrumb({
+  addBackendRuntimeBreadcrumb({
     action: "database_transient_retry",
     scope: getObservationScope(),
     details: {
@@ -255,7 +255,7 @@ export function toDatabaseCommitBoundaryError(error: unknown): unknown {
 
 export function logDatabasePoolError(poolName: string, error: unknown): void {
   try {
-    captureBackendWarning({
+    captureBackendRuntimeWarning({
       action: "database_pool_error",
       scope: createBackendRuntimeObservationScope(),
       details: {

--- a/apps/backend/src/guestAuth/session/index.ts
+++ b/apps/backend/src/guestAuth/session/index.ts
@@ -6,8 +6,8 @@ import { unsafeQuery } from "../../database/unsafe";
 import { HttpError } from "../../shared/errors";
 import {
   AUTO_CREATED_WORKSPACE_NAME,
-  createWorkspaceInExecutor,
-} from "../../workspaces";
+} from "../../workspaces/types";
+import { createWorkspaceInExecutor } from "../../workspaces/create";
 import { guestSessionPlatformColumnExistsInExecutor } from "../platformColumn";
 import { hashGuestToken } from "../shared";
 import type { GuestSessionPlatform, GuestSessionSnapshot } from "../types";

--- a/apps/backend/src/mediaAssets/storage/contracts.ts
+++ b/apps/backend/src/mediaAssets/storage/contracts.ts
@@ -1,5 +1,5 @@
 import type { S3Client } from "@aws-sdk/client-s3";
-import type { BackendObservationScope } from "../../observability/sentry";
+import type { BackendObservationScope } from "../../observability/sentry/events";
 import type {
   CompleteMediaAssetUploadPartInput,
   MediaAssetUploadSessionPartRequest,

--- a/apps/backend/src/mediaAssets/storage/errors.ts
+++ b/apps/backend/src/mediaAssets/storage/errors.ts
@@ -1,6 +1,6 @@
 import {
-  addBackendBreadcrumb,
-} from "../../observability/sentry";
+  addBackendRuntimeBreadcrumb,
+} from "../../observability/runtime";
 import { HttpError, type MediaAssetStorageErrorDetails } from "../../shared/errors";
 import type {
   MediaAssetStorageContext,
@@ -55,7 +55,7 @@ export async function runMediaAssetStorageOperationWithRetries<Result>(
         break;
       }
 
-      addBackendBreadcrumb({
+      addBackendRuntimeBreadcrumb({
         action: "media_asset_storage_retry",
         scope: context.observationScope,
         details: {

--- a/apps/backend/src/mediaAssets/storage/promotion.ts
+++ b/apps/backend/src/mediaAssets/storage/promotion.ts
@@ -2,7 +2,7 @@ import {
   CopyObjectCommand,
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
-import type { BackendObservationScope } from "../../observability/sentry";
+import type { BackendObservationScope } from "../../observability/sentry/events";
 import { HttpError } from "../../shared/errors";
 import type {
   AssertMediaAssetObjectInput,

--- a/apps/backend/src/observability/reportedErrors.ts
+++ b/apps/backend/src/observability/reportedErrors.ts
@@ -1,0 +1,26 @@
+import {
+  hasCapturedBackendException,
+  markCapturedBackendException,
+  normalizeCaughtError,
+} from "./sentry/errorNormalization";
+
+const reportedBackendExceptionWrappers = new WeakSet<Error>();
+
+export function markBackendExceptionWrapperAsReported(error: Error): Error {
+  reportedBackendExceptionWrappers.add(error);
+  return error;
+}
+
+export function hasReportedBackendExceptionWrapper(error: Error): boolean {
+  return reportedBackendExceptionWrappers.has(error);
+}
+
+export function hasReportedBackendException(error: Error): boolean {
+  return hasCapturedBackendException(error)
+    || hasReportedBackendExceptionWrapper(error);
+}
+
+export {
+  markCapturedBackendException,
+  normalizeCaughtError,
+};

--- a/apps/backend/src/observability/reporting.test.ts
+++ b/apps/backend/src/observability/reporting.test.ts
@@ -3,14 +3,38 @@ import test from "node:test";
 import { AuthError, authVerificationTemporarilyUnavailableCode } from "../auth";
 import { HttpError } from "../shared/errors";
 import { createBackendFailureDetails } from "../server/logging";
-import { captureBackendException } from "./sentry/capture";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  captureBackendWarning,
+} from "./sentry/capture";
 import { normalizeCaughtError } from "./sentry/errorNormalization";
 import { createBackendObservationScope } from "./sentry/scope";
-import { hasReportedBackendException, reportBackendExceptionOrBreadcrumb } from "./reporting";
+import {
+  hasReportedBackendException,
+  markBackendExceptionWrapperAsReported,
+  reportBackendExceptionOrBreadcrumb,
+} from "./reporting";
+import {
+  configureBackendRuntimeObservability,
+  resetBackendRuntimeObservability,
+} from "./runtime";
 import {
   sentryModule,
   withCapturedConsole,
 } from "./sentry/testHelpers";
+
+test.beforeEach(() => {
+  configureBackendRuntimeObservability("backend-api", {
+    addBreadcrumb: addBackendBreadcrumb,
+    captureWarning: captureBackendWarning,
+    captureException: captureBackendException,
+  });
+});
+
+test.afterEach(() => {
+  resetBackendRuntimeObservability();
+});
 
 test("normalizeCaughtError preserves Error and converts non-Error throws", () => {
   const error = new TypeError("bad input");
@@ -249,6 +273,47 @@ test("backend reporting recognizes repeated normalized non-Error throws", () => 
 
     assert.equal(appDetectedPreviousReport, true);
     assert.equal(captureExceptionCount, 1);
+  } finally {
+    sentryModule.captureException = originalCaptureException;
+  }
+});
+
+test("backend reporting does not recapture explicitly reported wrapper errors", () => {
+  const originalCaptureException = sentryModule.captureException;
+  let captureExceptionCount = 0;
+  sentryModule.captureException = () => {
+    captureExceptionCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const error = markBackendExceptionWrapperAsReported(
+      new HttpError(500, "Workspace creation failed", "WORKSPACE_CREATE_FAILED"),
+    );
+    const scope = createBackendObservationScope(
+      "backend-api",
+      "request-wrapper",
+      "/workspaces",
+      "POST",
+      "user-wrapper",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+    const details = createBackendFailureDetails(error);
+    const breadcrumbMessages = withCapturedConsole("log", () => {
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_create_error", error, scope, details },
+        { action: "workspace_create_error", scope, details },
+      );
+    });
+
+    assert.equal(captureExceptionCount, 0);
+    assert.equal(JSON.parse(breadcrumbMessages[0] ?? "").action, "workspace_create_error");
   } finally {
     sentryModule.captureException = originalCaptureException;
   }

--- a/apps/backend/src/observability/reporting.ts
+++ b/apps/backend/src/observability/reporting.ts
@@ -1,16 +1,16 @@
 import { AuthError, authVerificationTemporarilyUnavailableCode } from "../auth";
 import { HttpError } from "../shared/errors";
 import {
-  addBackendBreadcrumb,
-  captureBackendException,
-} from "./sentry/capture";
-import { hasCapturedBackendException } from "./sentry/errorNormalization";
+  addBackendRuntimeBreadcrumb,
+  captureBackendRuntimeException,
+} from "./runtime";
 import type {
   BackendBreadcrumbEvent,
   BackendExceptionEvent,
 } from "./sentry/events";
-
-const reportedBackendExceptionWrappers = new WeakSet<Error>();
+import {
+  hasReportedBackendException,
+} from "./reportedErrors";
 
 function isExpectedRequestError(error: unknown): boolean {
   if (error instanceof AuthError) {
@@ -21,14 +21,10 @@ function isExpectedRequestError(error: unknown): boolean {
     && (error.statusCode < 500 || error.code === authVerificationTemporarilyUnavailableCode);
 }
 
-export function markBackendExceptionWrapperAsReported(error: Error): Error {
-  reportedBackendExceptionWrappers.add(error);
-  return error;
-}
-
-export function hasReportedBackendException(error: Error): boolean {
-  return hasCapturedBackendException(error) || reportedBackendExceptionWrappers.has(error);
-}
+export {
+  hasReportedBackendException,
+  markBackendExceptionWrapperAsReported,
+} from "./reportedErrors";
 
 export function reportBackendExceptionOrBreadcrumb(
   error: unknown,
@@ -36,14 +32,14 @@ export function reportBackendExceptionOrBreadcrumb(
   breadcrumbEvent: BackendBreadcrumbEvent,
 ): void {
   if (isExpectedRequestError(error)) {
-    addBackendBreadcrumb(breadcrumbEvent);
+    addBackendRuntimeBreadcrumb(breadcrumbEvent);
     return;
   }
 
   if (hasReportedBackendException(exceptionEvent.error)) {
-    addBackendBreadcrumb(breadcrumbEvent);
+    addBackendRuntimeBreadcrumb(breadcrumbEvent);
     return;
   }
 
-  captureBackendException(exceptionEvent);
+  captureBackendRuntimeException(exceptionEvent);
 }

--- a/apps/backend/src/observability/runtime.test.ts
+++ b/apps/backend/src/observability/runtime.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  addBackendRuntimeBreadcrumb,
+  captureBackendRuntimeException,
+  captureBackendRuntimeWarning,
+  configureBackendRuntimeObservability,
+  createBackendObservationScope,
+  createBackendRuntimeObservationScope,
+  resetBackendRuntimeObservability,
+  type BackendRuntimeObservabilitySink,
+} from "./runtime";
+import { hasCapturedBackendException } from "./sentry/errorNormalization";
+import type {
+  BackendBreadcrumbEvent,
+  BackendExceptionEvent,
+  BackendObservationScope,
+  BackendWarningEvent,
+} from "./sentry/events";
+
+type ConsoleMethod = "log" | "warn" | "error";
+
+function withCapturedConsole(
+  method: ConsoleMethod,
+  callback: () => void,
+): ReadonlyArray<string> {
+  const originalMethod = console[method];
+  const messages: Array<string> = [];
+  console[method] = (message?: unknown): void => {
+    messages.push(typeof message === "string" ? message : String(message));
+  };
+
+  try {
+    callback();
+    return messages;
+  } finally {
+    console[method] = originalMethod;
+  }
+}
+
+function parseRecord(message: string): Readonly<Record<string, unknown>> {
+  const parsedValue: unknown = JSON.parse(message);
+  if (
+    typeof parsedValue !== "object"
+    || parsedValue === null
+    || Array.isArray(parsedValue)
+  ) {
+    throw new Error("Expected a structured CloudWatch record.");
+  }
+
+  return parsedValue as Readonly<Record<string, unknown>>;
+}
+
+function createScope(service: "backend-api" | "chat-worker", requestId: string): BackendObservationScope {
+  return createBackendObservationScope(
+    service,
+    requestId,
+    "/v1/runtime-test",
+    "POST",
+    `user-${requestId}`,
+    `workspace-${requestId}`,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+}
+
+function createBreadcrumbEvent(scope: BackendObservationScope): BackendBreadcrumbEvent {
+  return {
+    action: "database_transient_retry",
+    scope,
+    details: {
+      attempt: 1,
+      maxAttempts: 3,
+      delayMs: 50,
+      sqlState: null,
+      errorCode: "ECONNRESET",
+      errorClass: "Error",
+      errorMessage: "retry failed for user@example.com",
+    },
+  };
+}
+
+function createWarningEvent(scope: BackendObservationScope): BackendWarningEvent {
+  return {
+    action: "database_pool_error",
+    scope,
+    details: {
+      poolName: "main",
+      sqlState: null,
+      errorCode: "ECONNRESET",
+      errorClass: "Error",
+      errorMessage: "pool rejected sk_12345678901234567890",
+    },
+  };
+}
+
+function createExceptionEvent(
+  scope: BackendObservationScope,
+  error: Error,
+): BackendExceptionEvent {
+  return {
+    action: "request_failed",
+    error,
+    scope,
+    details: {
+      statusCode: 500,
+      code: "INTERNAL_ERROR",
+      message: "private request body",
+      validationIssues: [],
+    },
+  };
+}
+
+test("runtime observability emits redacted structured CloudWatch records without a sink", () => {
+  resetBackendRuntimeObservability();
+  const scope = createScope("backend-api", "fallback");
+  const error = new Error("request failed for user@example.com");
+  error.stack = "Error: request failed for user@example.com\n    at handler (/var/task/src/handler.ts:12:34)";
+
+  const breadcrumbMessages = withCapturedConsole("log", () => {
+    addBackendRuntimeBreadcrumb(createBreadcrumbEvent(scope));
+  });
+  const warningMessages = withCapturedConsole("warn", () => {
+    captureBackendRuntimeWarning(createWarningEvent(scope));
+  });
+  const exceptionMessages = withCapturedConsole("error", () => {
+    captureBackendRuntimeException(createExceptionEvent(scope, error));
+  });
+
+  assert.equal(breadcrumbMessages.length, 1);
+  assert.equal(warningMessages.length, 1);
+  assert.equal(exceptionMessages.length, 1);
+  const breadcrumbRecord = parseRecord(breadcrumbMessages[0] ?? "");
+  assert.deepEqual(breadcrumbRecord, {
+    domain: "backend",
+    action: "database_transient_retry",
+    ...scope,
+    attempt: 1,
+    maxAttempts: 3,
+    delayMs: 50,
+    sqlState: null,
+    errorCode: "ECONNRESET",
+    errorClass: "Error",
+    errorMessage: "retry failed for <masked-email>",
+  });
+  const warningRecord = parseRecord(warningMessages[0] ?? "");
+  assert.equal(warningRecord.errorMessage, "pool rejected <masked-api-key>");
+  const exceptionRecord = parseRecord(exceptionMessages[0] ?? "");
+  assert.equal(exceptionRecord.message, "<redacted-content>");
+  assert.equal(exceptionRecord.errorMessage, "request failed for <masked-email>");
+  assert.equal(typeof exceptionRecord.errorStack, "string");
+  assert.equal(
+    typeof exceptionRecord.errorStack === "string"
+      && exceptionRecord.errorStack.includes("user@example.com"),
+    false,
+  );
+  assert.equal(hasCapturedBackendException(error), true);
+});
+
+test("runtime observability dispatches each classification to the configured sink", () => {
+  resetBackendRuntimeObservability();
+  const breadcrumbs: Array<BackendBreadcrumbEvent> = [];
+  const warnings: Array<BackendWarningEvent> = [];
+  const exceptions: Array<BackendExceptionEvent> = [];
+  const sink: BackendRuntimeObservabilitySink = {
+    addBreadcrumb: (event) => {
+      breadcrumbs.push(event);
+    },
+    captureWarning: (event) => {
+      warnings.push(event);
+    },
+    captureException: (event) => {
+      exceptions.push(event);
+    },
+  };
+  const scope = createScope("chat-worker", "sink");
+  const breadcrumb = createBreadcrumbEvent(scope);
+  const warning = createWarningEvent(scope);
+  const exception = createExceptionEvent(scope, new Error("sink failure"));
+
+  configureBackendRuntimeObservability("chat-worker", sink);
+  addBackendRuntimeBreadcrumb(breadcrumb);
+  captureBackendRuntimeWarning(warning);
+  captureBackendRuntimeException(exception);
+
+  assert.deepEqual(breadcrumbs, [breadcrumb]);
+  assert.deepEqual(warnings, [warning]);
+  assert.deepEqual(exceptions, [exception]);
+  assert.equal(createBackendRuntimeObservationScope().service, "chat-worker");
+
+  resetBackendRuntimeObservability();
+  assert.equal(createBackendRuntimeObservationScope().service, "backend-api");
+});
+
+test("runtime observability keeps concurrent request scopes isolated", async () => {
+  resetBackendRuntimeObservability();
+  const breadcrumbs: Array<BackendBreadcrumbEvent> = [];
+  configureBackendRuntimeObservability("backend-api", {
+    addBreadcrumb: (event) => {
+      breadcrumbs.push(event);
+    },
+    captureWarning: () => {},
+    captureException: () => {},
+  });
+  const requestIds = Array.from({ length: 20 }, (_value, index) => `concurrent-${index}`);
+
+  await Promise.all(requestIds.map(async (requestId) => {
+    await Promise.resolve();
+    addBackendRuntimeBreadcrumb(createBreadcrumbEvent(createScope("backend-api", requestId)));
+  }));
+
+  assert.deepEqual(
+    breadcrumbs.map((event) => event.scope.requestId).sort(),
+    [...requestIds].sort(),
+  );
+  assert.deepEqual(
+    breadcrumbs.map((event) => event.scope.userId).sort(),
+    requestIds.map((requestId) => `user-${requestId}`).sort(),
+  );
+  resetBackendRuntimeObservability();
+});

--- a/apps/backend/src/observability/runtime.ts
+++ b/apps/backend/src/observability/runtime.ts
@@ -1,0 +1,126 @@
+import { writeCloudWatchRecord } from "./cloudWatch";
+import {
+  markCapturedBackendException,
+  normalizeCaughtError,
+} from "./reportedErrors";
+import type {
+  BackendBreadcrumbEvent,
+  BackendExceptionEvent,
+  BackendObservationScope,
+  BackendService,
+  BackendWarningEvent,
+} from "./sentry/events";
+
+export type BackendRuntimeObservabilitySink = Readonly<{
+  addBreadcrumb: (event: BackendBreadcrumbEvent) => void;
+  captureWarning: (event: BackendWarningEvent) => void;
+  captureException: (event: BackendExceptionEvent) => void;
+}>;
+
+type BackendRuntimeObservabilityConfiguration = Readonly<{
+  service: BackendService;
+  sink: BackendRuntimeObservabilitySink;
+}>;
+
+let runtimeObservabilityConfiguration: BackendRuntimeObservabilityConfiguration | null = null;
+
+export function configureBackendRuntimeObservability(
+  service: BackendService,
+  sink: BackendRuntimeObservabilitySink,
+): void {
+  runtimeObservabilityConfiguration = {
+    service,
+    sink: {
+      addBreadcrumb: sink.addBreadcrumb,
+      captureWarning: sink.captureWarning,
+      captureException: sink.captureException,
+    },
+  };
+}
+
+export function resetBackendRuntimeObservability(): void {
+  runtimeObservabilityConfiguration = null;
+}
+
+export function addBackendRuntimeBreadcrumb(
+  event: BackendBreadcrumbEvent,
+): void {
+  const sink = runtimeObservabilityConfiguration?.sink;
+  if (sink !== undefined) {
+    sink.addBreadcrumb(event);
+    return;
+  }
+
+  writeCloudWatchRecord(event, "breadcrumb");
+}
+
+export function captureBackendRuntimeWarning(
+  event: BackendWarningEvent,
+): void {
+  const sink = runtimeObservabilityConfiguration?.sink;
+  if (sink !== undefined) {
+    sink.captureWarning(event);
+    return;
+  }
+
+  writeCloudWatchRecord(event, "warning");
+}
+
+export function captureBackendRuntimeException(
+  event: BackendExceptionEvent,
+): void {
+  markCapturedBackendException(event.error);
+  const sink = runtimeObservabilityConfiguration?.sink;
+  if (sink !== undefined) {
+    sink.captureException(event);
+    return;
+  }
+
+  writeCloudWatchRecord(event, "exception");
+}
+
+export function createBackendRuntimeObservationScope(): BackendObservationScope {
+  return createBackendObservationScope(
+    runtimeObservabilityConfiguration?.service ?? "backend-api",
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+}
+
+export function createBackendObservationScope(
+  service: BackendService,
+  requestId: string | null,
+  route: string | null,
+  method: string | null,
+  userId: string | null,
+  workspaceId: string | null,
+  chatRequestId: string | null,
+  runId: string | null,
+  sessionId: string | null,
+  clientAppVersion: string | null,
+  clientPlatform: string | null,
+): BackendObservationScope {
+  return {
+    service,
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    chatRequestId,
+    runId,
+    sessionId,
+    clientAppVersion,
+    clientPlatform,
+  };
+}
+
+export { normalizeCaughtError };

--- a/apps/backend/src/observability/sentry/index.test.ts
+++ b/apps/backend/src/observability/sentry/index.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  captureBackendRuntimeWarning,
+} from "../runtime";
+import {
   addBackendBreadcrumb,
   addBackendSentryBreadcrumb,
   type BackendBreadcrumbEvent,
@@ -30,6 +33,10 @@ import {
   wrapBackendHandler,
   wrapBackendStreamHandler,
 } from ".";
+import {
+  sentryModule,
+  withCapturedConsole,
+} from "./testHelpers";
 
 type FacadeTypeSample = Readonly<{
   service: BackendService;
@@ -145,4 +152,84 @@ test("backend Sentry facade exports the public observability API", () => {
   assert.equal(typeSample.breadcrumb.action, "request_error");
   assert.equal(typeSample.warning.action, "database_pool_error");
   assert.equal(typeSample.exception.error, normalizedError);
+});
+
+test("backend Sentry initialization configures the runtime sink idempotently and reset removes it", () => {
+  resetBackendSentryForTests();
+  const originalCaptureMessage = sentryModule.captureMessage;
+  const originalEnvironment = {
+    sentryDsn: process.env.SENTRY_DSN,
+    awsExecutionEnvironment: process.env.AWS_EXECUTION_ENV,
+    awsLambdaFunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
+  };
+  let captureMessageCount = 0;
+  sentryModule.captureMessage = () => {
+    captureMessageCount += 1;
+    return "event-id";
+  };
+  delete process.env.SENTRY_DSN;
+  delete process.env.AWS_EXECUTION_ENV;
+  delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+
+  const event: BackendWarningEvent = {
+    action: "database_pool_error",
+    scope: createBackendObservationScope(
+      "backend-api",
+      "request-runtime-sink",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ),
+    details: {
+      poolName: "main",
+      sqlState: null,
+      errorCode: "ECONNRESET",
+      errorClass: "Error",
+      errorMessage: "pool failed",
+    },
+  };
+
+  try {
+    initializeBackendSentry("backend-api");
+    initializeBackendSentry("backend-api");
+    const configuredMessages = withCapturedConsole("warn", () => {
+      captureBackendRuntimeWarning(event);
+    });
+
+    assert.equal(configuredMessages.length, 1);
+    assert.equal(captureMessageCount, 1);
+    assert.equal(createBackendRuntimeObservationScope().service, "backend-api");
+
+    resetBackendSentryForTests();
+    const fallbackMessages = withCapturedConsole("warn", () => {
+      captureBackendRuntimeWarning(event);
+    });
+
+    assert.equal(fallbackMessages.length, 1);
+    assert.equal(captureMessageCount, 1);
+  } finally {
+    sentryModule.captureMessage = originalCaptureMessage;
+    if (originalEnvironment.sentryDsn === undefined) {
+      delete process.env.SENTRY_DSN;
+    } else {
+      process.env.SENTRY_DSN = originalEnvironment.sentryDsn;
+    }
+    if (originalEnvironment.awsExecutionEnvironment === undefined) {
+      delete process.env.AWS_EXECUTION_ENV;
+    } else {
+      process.env.AWS_EXECUTION_ENV = originalEnvironment.awsExecutionEnvironment;
+    }
+    if (originalEnvironment.awsLambdaFunctionName === undefined) {
+      delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+    } else {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = originalEnvironment.awsLambdaFunctionName;
+    }
+    resetBackendSentryForTests();
+  }
 });

--- a/apps/backend/src/observability/sentry/index.ts
+++ b/apps/backend/src/observability/sentry/index.ts
@@ -1,3 +1,18 @@
+import {
+  configureBackendRuntimeObservability,
+  resetBackendRuntimeObservability,
+} from "../runtime";
+import {
+  addBackendBreadcrumb as addBackendBreadcrumbImpl,
+  captureBackendException as captureBackendExceptionImpl,
+  captureBackendWarning as captureBackendWarningImpl,
+} from "./capture";
+import {
+  initializeBackendSentry as initializeBackendSentryImpl,
+  resetBackendSentryForTests as resetBackendSentryForTestsImpl,
+} from "./config";
+import type { BackendService } from "./events";
+
 export { getBackendErrorLogDetails } from "../cloudWatch";
 export {
   addBackendBreadcrumb,
@@ -8,10 +23,8 @@ export {
 } from "./capture";
 export {
   getBackendSentryConfig,
-  initializeBackendSentry,
   initializeBackendSentryWithDeps,
   isBackendSentryInitializedForOpenTelemetry,
-  resetBackendSentryForTests,
 } from "./config";
 export {
   hasCapturedBackendException,
@@ -31,3 +44,17 @@ export {
   wrapBackendHandler,
   wrapBackendStreamHandler,
 } from "./tracing";
+
+export function initializeBackendSentry(service: BackendService): void {
+  initializeBackendSentryImpl(service);
+  configureBackendRuntimeObservability(service, {
+    addBreadcrumb: addBackendBreadcrumbImpl,
+    captureWarning: captureBackendWarningImpl,
+    captureException: captureBackendExceptionImpl,
+  });
+}
+
+export function resetBackendSentryForTests(): void {
+  resetBackendSentryForTestsImpl();
+  resetBackendRuntimeObservability();
+}

--- a/apps/backend/src/observability/sentry/redaction.ts
+++ b/apps/backend/src/observability/sentry/redaction.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/aws-serverless";
+import type * as Sentry from "@sentry/aws-serverless";
 import {
   sanitizeBackendTelemetryValue,
   type SanitizedTelemetryValue,

--- a/apps/backend/src/workspaces/create.ts
+++ b/apps/backend/src/workspaces/create.ts
@@ -7,13 +7,15 @@ import {
 } from "../database";
 import { HttpError } from "../shared/errors";
 import {
-  addBackendBreadcrumb,
-  captureBackendException,
+  addBackendRuntimeBreadcrumb,
+  captureBackendRuntimeException,
   normalizeCaughtError,
-  type BackendObservationScope,
-  type WorkspaceTransactionDetails,
-} from "../observability/sentry";
-import { markBackendExceptionWrapperAsReported } from "../observability/reporting";
+} from "../observability/runtime";
+import type {
+  BackendObservationScope,
+  WorkspaceTransactionDetails,
+} from "../observability/sentry/events";
+import { markBackendExceptionWrapperAsReported } from "../observability/reportedErrors";
 import {
   buildSystemWorkspaceReplicaId,
   ensureBootstrapSystemWorkspaceReplicaInExecutor,
@@ -92,7 +94,11 @@ function handleWorkspaceCreateFailure(
       table: null,
       detail: null,
     };
-    addBackendBreadcrumb({ action: "workspace_create_transaction_error", scope, details });
+    addBackendRuntimeBreadcrumb({
+      action: "workspace_create_transaction_error",
+      scope,
+      details,
+    });
     throw error;
   }
 
@@ -109,7 +115,7 @@ function handleWorkspaceCreateFailure(
     selectedWorkspaceIdAfterPreparation: null,
     deletedCardsCount: null,
   };
-  captureBackendException({
+  captureBackendRuntimeException({
     action: "workspace_create_transaction_error",
     error: normalizeCaughtError(error),
     scope,

--- a/apps/backend/src/workspaces/shared.ts
+++ b/apps/backend/src/workspaces/shared.ts
@@ -1,8 +1,8 @@
 import { HttpError } from "../shared/errors";
 import {
   createBackendObservationScope,
-  type BackendObservationScope,
-} from "../observability/sentry";
+} from "../observability/runtime";
+import type { BackendObservationScope } from "../observability/sentry/events";
 import { decodeOpaqueCursor } from "../shared/pagination";
 import {
   deleteWorkspaceConfirmationText,


### PR DESCRIPTION
## Summary
- add a runtime-neutral observability sink with structured redacted CloudWatch fallback
- preserve shared-Lambda Sentry behavior, error marking, duplicate suppression, scopes, fingerprints, and reset semantics
- decouple auth, workspace, database, and media-storage callers needed by the direct-ingestion rollout

## Validation
- focused backend tests: 48/48
- full backend tests: 832/832
- backend lint
- backend build
- git diff --check
- runtime/reporting bundle import audit under Node 24.18.0