### PR TITLE
Guard shared direct image ingestion route

### DIFF
--- a/apps/backend/src/entrypoints/lambda.test.ts
+++ b/apps/backend/src/entrypoints/lambda.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import type { Context } from "aws-lambda";
+import type { APIGatewayProxyResult, LambdaEvent } from "hono/aws-lambda";
+import { handler } from "./lambda";
+
+const allowedOrigin = "https://app.flashcards-open-source-app.com";
+const directPath =
+  "/v1/v1/workspaces/11111111-1111-4111-8111-111111111111/media-assets/images/";
+
+function createLambdaContext(): Context {
+  return {
+    awsRequestId: "lambda-request-1",
+    callbackWaitsForEmptyEventLoop: true,
+    getRemainingTimeInMillis: () => 900_000,
+  } as Context;
+}
+
+function createDirectImageRestEvent(
+  headers: Readonly<Record<string, string>>,
+  bodyRead: () => void,
+): LambdaEvent {
+  const event: Record<string, unknown> = {
+    version: "1.0",
+    httpMethod: "POST",
+    path: directPath,
+    headers,
+    requestContext: {
+      requestId: "api-gateway-request-1",
+      httpMethod: "POST",
+      path: `/v1${directPath}`,
+      stage: "v1",
+    },
+  };
+  Object.defineProperty(event, "body", {
+    enumerable: true,
+    get: () => {
+      bodyRead();
+      throw new Error("Shared direct-image guard read the request body.");
+    },
+  });
+  return event as unknown as LambdaEvent;
+}
+
+async function invokeHandler(event: LambdaEvent): Promise<APIGatewayProxyResult> {
+  const result = await handler(event, createLambdaContext(), () => {});
+  if (result === undefined) {
+    throw new Error("Shared backend Lambda handler returned no result.");
+  }
+  return result;
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+test("shared Lambda rejects direct-image POST before app bootstrap or body work with browser CORS", async () => {
+  const originalAllowedOrigins = process.env.BACKEND_ALLOWED_ORIGINS;
+  const originalAuthMode = process.env.AUTH_MODE;
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  process.env.BACKEND_ALLOWED_ORIGINS = allowedOrigin;
+  process.env.AUTH_MODE = "guard-must-not-bootstrap";
+  delete process.env.DATABASE_URL;
+  let bodyReads = 0;
+
+  try {
+    const result = await invokeHandler(createDirectImageRestEvent(
+      {
+        Origin: allowedOrigin,
+        "X-Request-Id": "client-forged-request-id",
+      },
+      () => {
+        bodyReads += 1;
+      },
+    ));
+    const body = JSON.parse(result.body) as Readonly<{
+      error: string;
+      requestId: string;
+      code: string;
+    }>;
+
+    assert.equal(result.statusCode, 404);
+    assert.equal(result.isBase64Encoded, false);
+    assert.equal(
+      result.headers?.["content-type"],
+      "application/json; charset=UTF-8",
+    );
+    assert.equal(
+      result.headers?.["x-request-id"],
+      "api-gateway-request-1",
+    );
+    assert.equal(
+      result.headers?.["access-control-allow-origin"],
+      allowedOrigin,
+    );
+    assert.equal(
+      result.headers?.["access-control-allow-credentials"],
+      "true",
+    );
+    assert.equal(
+      body.error,
+      "Direct image ingestion is available only through its bounded API route.",
+    );
+    assert.equal(body.requestId, "api-gateway-request-1");
+    assert.equal(
+      body.code,
+      "DIRECT_IMAGE_INGESTION_ROUTE_UNAVAILABLE",
+    );
+    assert.equal(bodyReads, 0);
+  } finally {
+    restoreEnv("BACKEND_ALLOWED_ORIGINS", originalAllowedOrigins);
+    restoreEnv("AUTH_MODE", originalAuthMode);
+    restoreEnv("DATABASE_URL", originalDatabaseUrl);
+  }
+});
+
+test("shared Lambda returns the published agent envelope to API-key callers", async () => {
+  const originalPublicApiBaseUrl = process.env.PUBLIC_API_BASE_URL;
+  process.env.PUBLIC_API_BASE_URL =
+    "https://api.flashcards-open-source-app.com/v1";
+
+  try {
+    const result = await invokeHandler(createDirectImageRestEvent(
+      { Authorization: "ApiKey invalid" },
+      () => {},
+    ));
+    const body = JSON.parse(result.body) as Readonly<{
+      ok: boolean;
+      data: Readonly<Record<string, never>>;
+      instructions: string;
+      docs: Readonly<{ openapiUrl: string }>;
+      error: Readonly<{ code: string; message: string }>;
+      requestId: string;
+    }>;
+
+    assert.equal(result.statusCode, 404);
+    assert.equal(body.ok, false);
+    assert.deepEqual(body.data, {});
+    assert.equal(
+      body.error.code,
+      "DIRECT_IMAGE_INGESTION_ROUTE_UNAVAILABLE",
+    );
+    assert.equal(
+      body.error.message,
+      "Direct image ingestion is available only through its bounded API route.",
+    );
+    assert.equal(
+      body.instructions,
+      "Verify that the referenced resource id exists in the selected workspace, then retry only after correcting the id.",
+    );
+    assert.equal(
+      body.docs.openapiUrl,
+      "https://api.flashcards-open-source-app.com/v1/agent/openapi.json",
+    );
+    assert.equal(body.requestId, "api-gateway-request-1");
+  } finally {
+    restoreEnv("PUBLIC_API_BASE_URL", originalPublicApiBaseUrl);
+  }
+});
+
+test("shared direct-image guard remains before lazy runtime initialization", () => {
+  const source = readFileSync(resolve(__dirname, "lambda.ts"), "utf8");
+  const handlerStart = source.indexOf(
+    "const backendApiBootstrapHandler: BackendApiHandler",
+  );
+  const guardStart = source.indexOf(
+    "isDirectImageIngestionPostTarget(readApiGatewayRequestTarget(event))",
+    handlerStart,
+  );
+  const runtimeStart = source.indexOf(
+    "runtime = await getBackendApiRuntime()",
+    handlerStart,
+  );
+
+  assert.notEqual(handlerStart, -1);
+  assert.notEqual(guardStart, -1);
+  assert.notEqual(runtimeStart, -1);
+  assert.ok(guardStart < runtimeStart);
+});

--- a/apps/backend/src/entrypoints/lambda.ts
+++ b/apps/backend/src/entrypoints/lambda.ts
@@ -7,6 +7,18 @@ import {
   normalizeCaughtError,
   wrapBackendHandler,
 } from "../observability/sentry";
+import {
+  createAgentApiKeyErrorEnvelope,
+  isAgentApiKeyAuthorizationHeader,
+} from "../agent/envelope";
+import {
+  createCredentialedBrowserCorsResponseHeaders,
+  getAllowedBrowserOrigins,
+} from "../server/browserCors";
+import {
+  isDirectImageIngestionPostTarget,
+  readApiGatewayRequestTarget,
+} from "../server/directImageIngestionRouting";
 
 initializeBackendSentry("backend-api");
 
@@ -82,6 +94,16 @@ function getBackendApiRequestContext(event: LambdaEvent, context: Context): Back
   };
 }
 
+function requirePublicApiBaseUrl(): string {
+  const publicApiBaseUrl = process.env.PUBLIC_API_BASE_URL?.trim();
+  if (publicApiBaseUrl === undefined || publicApiBaseUrl === "") {
+    throw new Error(
+      "PUBLIC_API_BASE_URL is required for shared direct image ingestion guard API-key error envelopes.",
+    );
+  }
+  return publicApiBaseUrl;
+}
+
 const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => {
   const requestContext = getBackendApiRequestContext(event, context);
   const observationScope = createBackendObservationScope(
@@ -97,6 +119,47 @@ const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => 
     null,
     null,
   );
+  if (isDirectImageIngestionPostTarget(readApiGatewayRequestTarget(event))) {
+    const requestId = requestContext.requestId ?? context.awsRequestId;
+    const requestHeaders = Object.entries(event.headers ?? {});
+    const readRequestHeader = (headerName: string): string | null =>
+      requestHeaders.find(
+        ([name, value]) =>
+          name.toLowerCase() === headerName && typeof value === "string",
+      )?.[1] ?? null;
+    const code = "DIRECT_IMAGE_INGESTION_ROUTE_UNAVAILABLE";
+    const message =
+      "Direct image ingestion is available only through its bounded API route.";
+    const body = isAgentApiKeyAuthorizationHeader(
+      readRequestHeader("authorization"),
+    )
+      ? createAgentApiKeyErrorEnvelope(
+        requirePublicApiBaseUrl(),
+        code,
+        message,
+        404,
+        requestId,
+        undefined,
+      )
+      : {
+        error: message,
+        requestId,
+        code,
+      };
+    return {
+      statusCode: 404,
+      isBase64Encoded: false,
+      headers: {
+        "content-type": "application/json; charset=UTF-8",
+        "x-request-id": requestId,
+        ...createCredentialedBrowserCorsResponseHeaders(
+          readRequestHeader("origin"),
+          getAllowedBrowserOrigins(),
+        ),
+      },
+      body: JSON.stringify(body),
+    };
+  }
   let runtime: BackendApiRuntime | null = null;
   try {
     runtime = await getBackendApiRuntime();

--- a/apps/backend/src/server/directImageIngestionRouting.test.ts
+++ b/apps/backend/src/server/directImageIngestionRouting.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isDirectImageIngestionPostTarget,
+  readApiGatewayRequestTarget,
+} from "./directImageIngestionRouting";
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+const directPath = `/workspaces/${workspaceId}/media-assets/images`;
+
+function createRestApiEvent(path: string, method: string): unknown {
+  return {
+    path,
+    httpMethod: method,
+    headers: {},
+    requestContext: {
+      httpMethod: method,
+      path: `/v1${path}`,
+      stage: "v1",
+    },
+  };
+}
+
+function createHttpApiEvent(path: string, method: string): unknown {
+  return {
+    version: "2.0",
+    rawPath: path,
+    headers: {},
+    requestContext: {
+      http: {
+        method,
+        path,
+      },
+      stage: "$default",
+    },
+  };
+}
+
+function matchesDirectImagePost(event: unknown): boolean {
+  return isDirectImageIngestionPostTarget(
+    readApiGatewayRequestTarget(event),
+  );
+}
+
+test("shared Lambda matches every direct-image POST path across REST v1 and HTTP v2 events", () => {
+  const directPostPaths = [
+    ["custom-domain stripped", directPath],
+    ["custom-domain stripped trailing slash", `${directPath}/`],
+    ["single v1 prefix", `/v1${directPath}`],
+    ["single v1 prefix trailing slash", `/v1${directPath}/`],
+    ["execute-api double-v1 spelling", `/v1/v1${directPath}`],
+    ["repeated v1 prefixes", `/v1/v1/v1${directPath}`],
+  ] as const;
+  const eventFactories = [
+    ["REST v1", createRestApiEvent],
+    ["HTTP v2", createHttpApiEvent],
+  ] as const;
+
+  for (const [eventLabel, createEvent] of eventFactories) {
+    for (const [pathLabel, path] of directPostPaths) {
+      assert.equal(
+        matchesDirectImagePost(createEvent(path, "POST")),
+        true,
+        `${eventLabel}: ${pathLabel}`,
+      );
+    }
+  }
+});
+
+test("shared Lambda preserves other methods and unrelated shared routes", () => {
+  const preservedTargets = [
+    ["direct GET", directPath, "GET"],
+    ["direct PATCH", directPath, "PATCH"],
+    ["direct PUT", directPath, "PUT"],
+    ["direct DELETE", directPath, "DELETE"],
+    ["direct OPTIONS", directPath, "OPTIONS"],
+    ["direct HEAD", directPath, "HEAD"],
+    [
+      "multipart upload",
+      `/workspaces/${workspaceId}/media-assets/upload-sessions`,
+      "POST",
+    ],
+    ["media collection", `/v1/workspaces/${workspaceId}/media-assets`, "POST"],
+    ["direct child path", `${directPath}/unexpected`, "POST"],
+    ["double trailing slash", `${directPath}//`, "POST"],
+    ["missing workspace id", "/workspaces//media-assets/images", "POST"],
+    ["discovery", "/v1/agent", "POST"],
+  ] as const;
+  const eventFactories = [createRestApiEvent, createHttpApiEvent] as const;
+
+  for (const createEvent of eventFactories) {
+    for (const [label, path, method] of preservedTargets) {
+      assert.equal(
+        matchesDirectImagePost(createEvent(path, method)),
+        false,
+        label,
+      );
+    }
+  }
+});
+
+test("route selection ignores client headers and uses REST v1 method and path fields", () => {
+  const event = {
+    ...createRestApiEvent("/health", "GET") as Readonly<Record<string, unknown>>,
+    headers: {
+      "x-http-method-override": "POST",
+      "x-original-uri": directPath,
+      "x-forwarded-uri": directPath,
+    },
+    requestContext: {
+      http: {
+        method: "POST",
+        path: directPath,
+      },
+    },
+  };
+
+  assert.equal(matchesDirectImagePost(event), false);
+});
+
+test("route selection ignores client headers and uses HTTP v2 method and raw path fields", () => {
+  const event = {
+    ...createHttpApiEvent("/health", "GET") as Readonly<Record<string, unknown>>,
+    httpMethod: "POST",
+    path: directPath,
+    headers: {
+      "x-http-method-override": "POST",
+      "x-original-uri": directPath,
+      "x-forwarded-uri": directPath,
+    },
+  };
+
+  assert.equal(matchesDirectImagePost(event), false);
+});
+
+test("malformed and unsupported events do not match the guarded route", () => {
+  const malformedEvents = [
+    null,
+    [],
+    {},
+    { version: "2.0", rawPath: directPath },
+    {
+      version: "2.0",
+      rawPath: directPath,
+      requestContext: { http: { method: 1 } },
+    },
+    { version: "1.0", path: directPath },
+    { version: "1.0", httpMethod: "POST" },
+  ];
+
+  for (const event of malformedEvents) {
+    assert.equal(matchesDirectImagePost(event), false);
+  }
+});

--- a/apps/backend/src/server/directImageIngestionRouting.ts
+++ b/apps/backend/src/server/directImageIngestionRouting.ts
@@ -1,0 +1,40 @@
+const directImageIngestionPathPattern =
+  /^\/(?:v1\/)*workspaces\/[^/]+\/media-assets\/images\/?$/u;
+
+type RequestTarget = Readonly<{
+  method: string;
+  path: string;
+}>;
+
+function toRecord(value: unknown): Readonly<Record<string, unknown>> | null {
+  return typeof value === "object" && value !== null
+    ? value as Readonly<Record<string, unknown>>
+    : null;
+}
+
+export function readApiGatewayRequestTarget(event: unknown): RequestTarget | null {
+  const eventRecord = toRecord(event);
+  if (eventRecord === null) return null;
+
+  if (eventRecord.version === "2.0") {
+    const requestContext = toRecord(eventRecord.requestContext);
+    const http = toRecord(requestContext?.http);
+    return typeof eventRecord.rawPath === "string"
+      && typeof http?.method === "string"
+      ? { method: http.method, path: eventRecord.rawPath }
+      : null;
+  }
+
+  return typeof eventRecord.httpMethod === "string"
+    && typeof eventRecord.path === "string"
+    ? { method: eventRecord.httpMethod, path: eventRecord.path }
+    : null;
+}
+
+export function isDirectImageIngestionPostTarget(
+  target: RequestTarget | null,
+): boolean {
+  return target !== null
+    && target.method === "POST"
+    && directImageIngestionPathPattern.test(target.path);
+}


### PR DESCRIPTION
Summary:
- reject direct image ingestion POST bypass spellings before shared runtime bootstrap
- preserve published API-key errors and credentialed browser CORS
- cover REST v1 and HTTP v2 target matrices plus the early Lambda boundary

Validation:
- focused routing/Lambda tests: 8 passed
- full backend tests: 891 passed
- backend lint and build passed
- git diff --check passed