### PR TITLE
Add multipart abort and terminal replay database contract

### DIFF
--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -85,12 +85,20 @@ const createdRolesByMigration = new Map([
 ]);
 const boundaryDefinitions = Object.freeze([
   Object.freeze({
-    migrationFileName: "0097_direct_multipart_writer_attempt_fencing.sql",
-    expectedMigrationCount: 99,
+    migrationFileName: "0098_multipart_writer_abort_and_terminal_replay.sql",
+    expectedMigrationCount: 100,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle.postgres.integration.ts",
       "src/mediaAssets/directIngestionApply.postgres.integration.ts",
+      "src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
+    migrationFileName: "0097_direct_multipart_writer_attempt_fencing.sql",
+    expectedMigrationCount: 99,
+    testFiles: Object.freeze([
+      "src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts",
     ]),
   }),
   Object.freeze({

--- a/apps/backend/src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts
@@ -1,0 +1,1165 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import type pg from "pg";
+import {
+  type PostgresIntegrationFixture,
+  withPostgresIntegrationFixture,
+} from "../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+
+type MultipartPayload = Readonly<{
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  mediaAssetId: string;
+  replicaId: string;
+  lastOperationId: string;
+  sha256: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  s3UploadId: string;
+  mimeType: string;
+  sizeBytes: number;
+  partSizeBytes: number;
+  partCount: number;
+  sourceUrl: string | null;
+  assetCreatedAt: string;
+  clientUpdatedAt: string;
+  sessionExpiresAt: string;
+  normalizationVersion: string;
+  partsFingerprint: string;
+}>;
+
+type BeginRow = Readonly<{
+  attempt_status: string;
+  reservation_token: string | null;
+  normalization_version: string | null;
+  lease_expires_at: string | Date | null;
+}>;
+
+type StatusRow = Readonly<{ status: string }>;
+type StateRow = Readonly<{
+  session_state: string;
+  attempt_state: string;
+  attempt_outcome: string;
+  reservation_state: string;
+}>;
+type OwnedMedia = Readonly<{
+  blobIds: ReadonlyArray<string>;
+  sha256s: ReadonlyArray<string>;
+}>;
+type UpgradeHistory = Readonly<{
+  original: MultipartPayload;
+  conflicting: MultipartPayload;
+}>;
+type SqlValue = string | number | null;
+type QueryExecutor = Pick<pg.PoolClient | pg.Pool, "query">;
+
+const cleanupDelayMs = 3_600_000;
+const migration0098 = readFileSync(resolve(
+  __dirname,
+  "../../../../db/migrations/0098_multipart_writer_abort_and_terminal_replay.sql",
+), "utf8");
+const multipartRow = `ROW(
+  $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+)::content.multipart_media_blob_writer_attempt_payload`;
+const beginSignature =
+  "content.begin_media_upload_session_completion_attempt_with_owner(uuid,integer,content.multipart_media_blob_writer_attempt_payload)";
+const closeSignature =
+  "content.close_media_upload_session_current_blob_writer_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,bigint,timestamp with time zone,integer)";
+const helperSignature =
+  "content.multipart_media_blob_writer_terminal_replay_status_internal(content.media_blob_writer_attempts,content.multipart_media_blob_writer_attempt_payload)";
+const oldCloseSignature =
+  "content.close_media_upload_session_blob_writer(text,uuid,uuid,uuid,uuid,text,text,text,text,bigint,timestamp with time zone,integer)";
+const oldAttemptCloseSignature =
+  "content.close_media_upload_session_blob_writer_attempts(uuid,uuid,content.multipart_media_blob_writer_attempt_payload,integer)";
+
+function digest(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+
+function multipart(
+  fixture: PostgresIntegrationFixture,
+  overrides: Partial<MultipartPayload>,
+): MultipartPayload {
+  const sessionId = overrides.sessionId ?? randomUUID();
+  const mediaAssetId = overrides.mediaAssetId ?? randomUUID();
+  const sha256 = overrides.sha256 ?? digest();
+  return {
+    userId: fixture.userId,
+    workspaceId: fixture.workspaceId,
+    sessionId,
+    mediaAssetId,
+    replicaId: fixture.replicaId,
+    lastOperationId: randomUUID(),
+    sha256,
+    stagingStorageKey:
+      `media/uploads/workspaces/${fixture.workspaceId}/assets/${mediaAssetId}/sessions/${sessionId}`,
+    blobStorageKey: buildMediaBlobStorageKey(sha256),
+    s3UploadId: `upload-${randomUUID()}`,
+    mimeType: "application/octet-stream",
+    sizeBytes: 42,
+    partSizeBytes: 42,
+    partCount: 1,
+    sourceUrl: null,
+    assetCreatedAt: fixture.createdAt,
+    clientUpdatedAt: fixture.createdAt,
+    sessionExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    normalizationVersion: "passthrough-v1",
+    partsFingerprint: digest(),
+    ...overrides,
+  };
+}
+
+function multipartValues(payload: MultipartPayload): Array<SqlValue> {
+  return [
+    payload.userId,
+    payload.workspaceId,
+    payload.sessionId,
+    payload.mediaAssetId,
+    payload.replicaId,
+    payload.lastOperationId,
+    payload.sha256,
+    payload.stagingStorageKey,
+    payload.blobStorageKey,
+    payload.s3UploadId,
+    payload.mimeType,
+    payload.sizeBytes,
+    payload.partSizeBytes,
+    payload.partCount,
+    payload.sourceUrl,
+    payload.assetCreatedAt,
+    payload.clientUpdatedAt,
+    payload.sessionExpiresAt,
+    payload.normalizationVersion,
+    payload.partsFingerprint,
+  ];
+}
+
+function closeValues(payload: MultipartPayload): Array<SqlValue> {
+  return [
+    payload.userId,
+    payload.workspaceId,
+    payload.sessionId,
+    payload.mediaAssetId,
+    payload.replicaId,
+    payload.lastOperationId,
+    payload.sha256,
+    payload.blobStorageKey,
+    payload.mimeType,
+    payload.sizeBytes,
+    payload.sessionExpiresAt,
+    cleanupDelayMs,
+  ];
+}
+
+async function scoped<Result>(
+  fixture: PostgresIntegrationFixture,
+  userId: string,
+  workspaceId: string,
+  callback: (client: pg.PoolClient) => Promise<Result>,
+): Promise<Result> {
+  const client = await fixture.runtimePool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      "SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)",
+      [userId, workspaceId],
+    );
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function insertSession(
+  executor: QueryExecutor,
+  payload: MultipartPayload,
+  state: "active" | "completing" | "aborting",
+): Promise<void> {
+  await executor.query(
+    `INSERT INTO content.media_upload_sessions (
+       media_upload_session_id,workspace_id,media_asset_id,media_blob_sha256,
+       staging_storage_key,blob_storage_key,s3_upload_id,mime_type,size_bytes,
+       part_size_bytes,part_count,state,source_url,asset_created_at,client_updated_at,
+       last_modified_by_replica_id,last_operation_id,expires_at
+     ) VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18
+     )`,
+    [
+      payload.sessionId,
+      payload.workspaceId,
+      payload.mediaAssetId,
+      payload.sha256,
+      payload.stagingStorageKey,
+      payload.blobStorageKey,
+      payload.s3UploadId,
+      payload.mimeType,
+      payload.sizeBytes,
+      payload.partSizeBytes,
+      payload.partCount,
+      state,
+      payload.sourceUrl,
+      payload.assetCreatedAt,
+      payload.clientUpdatedAt,
+      payload.replicaId,
+      payload.lastOperationId,
+      payload.sessionExpiresAt,
+    ],
+  );
+}
+
+async function beginMultipart(
+  fixture: PostgresIntegrationFixture,
+  attemptToken: string,
+  payload: MultipartPayload,
+  leaseDurationMs: number,
+): Promise<BeginRow> {
+  return scoped(
+    fixture,
+    fixture.userId,
+    fixture.workspaceId,
+    async (client) => (await client.query<BeginRow>(
+      `SELECT *
+       FROM content.begin_media_upload_session_completion_attempt_with_owner(
+         $1,$2,${multipartRow}
+       )`,
+      [attemptToken, leaseDurationMs, ...multipartValues(payload)],
+    )).rows[0],
+  );
+}
+
+async function multipartStatus(
+  fixture: PostgresIntegrationFixture,
+  functionName: string,
+  attemptToken: string,
+  reservationToken: string,
+  payload: MultipartPayload,
+): Promise<string> {
+  return scoped(
+    fixture,
+    fixture.userId,
+    fixture.workspaceId,
+    async (client) => (await client.query<StatusRow>(
+      `SELECT content.${functionName}(
+         $1,$2,${multipartRow},$23
+       ) AS status`,
+      [
+        attemptToken,
+        reservationToken,
+        ...multipartValues(payload),
+        cleanupDelayMs,
+      ],
+    )).rows[0].status,
+  );
+}
+
+async function closeCurrentWriter(
+  fixture: PostgresIntegrationFixture,
+  payload: MultipartPayload,
+): Promise<string> {
+  return scoped(
+    fixture,
+    fixture.userId,
+    fixture.workspaceId,
+    async (client) => closeCurrentWriterInExecutor(client, payload),
+  );
+}
+
+async function closeCurrentWriterInExecutor(
+  executor: QueryExecutor,
+  payload: MultipartPayload,
+): Promise<string> {
+  return (await executor.query<StatusRow>(
+    `SELECT content.close_media_upload_session_current_blob_writer_with_owner(
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12
+     ) AS status`,
+    closeValues(payload),
+  )).rows[0].status;
+}
+
+async function insertAsset(
+  executor: QueryExecutor,
+  payload: MultipartPayload,
+): Promise<string> {
+  const mediaBlobId = randomUUID();
+  await executor.query(
+    `WITH blob AS (
+       INSERT INTO content.media_blobs (
+         media_blob_id,sha256,mime_type,size_bytes,storage_key,normalization_version
+       ) VALUES ($1,$2,$3,$4,$5,$6)
+       RETURNING media_blob_id
+     )
+     INSERT INTO content.media_assets (
+       media_asset_id,workspace_id,media_blob_id,source_url,created_at,
+       client_updated_at,last_modified_by_replica_id,last_operation_id
+     )
+     SELECT $7,$8,media_blob_id,$9,$10,$11,$12,$13
+     FROM blob`,
+    [
+      mediaBlobId,
+      payload.sha256,
+      payload.mimeType,
+      payload.sizeBytes,
+      payload.blobStorageKey,
+      payload.normalizationVersion,
+      payload.mediaAssetId,
+      payload.workspaceId,
+      payload.sourceUrl,
+      payload.assetCreatedAt,
+      payload.clientUpdatedAt,
+      payload.replicaId,
+      payload.lastOperationId,
+    ],
+  );
+  return mediaBlobId;
+}
+
+async function seed0097ConflictingTerminalHistory(
+  fixture: PostgresIntegrationFixture,
+): Promise<UpgradeHistory> {
+  const original = multipart(fixture, {});
+  await insertSession(fixture.ownerPool, original, "active");
+  const originalAttempt = randomUUID();
+  const originalBegin = await beginMultipart(
+    fixture,
+    originalAttempt,
+    original,
+    60_000,
+  );
+  assert.equal(originalBegin.attempt_status, "acquired");
+  assert.ok(originalBegin.reservation_token !== null);
+  assert.ok(originalBegin.normalization_version !== null);
+  const canonicalOriginal = {
+    ...original,
+    normalizationVersion: originalBegin.normalization_version,
+  };
+  assert.equal(
+    await multipartStatus(
+      fixture,
+      "fence_media_upload_session_completion_attempt_apply_with_owner",
+      originalAttempt,
+      originalBegin.reservation_token,
+      canonicalOriginal,
+    ),
+    "ready",
+  );
+  await insertAsset(fixture.ownerPool, canonicalOriginal);
+  assert.equal(
+    await multipartStatus(
+      fixture,
+      "finish_media_upload_session_completion_attempt_apply_with_owner",
+      originalAttempt,
+      originalBegin.reservation_token,
+      canonicalOriginal,
+    ),
+    "live_applied",
+  );
+
+  const conflicting = { ...original, partsFingerprint: digest() };
+  const conflictingBegin = await beginMultipart(
+    fixture,
+    randomUUID(),
+    conflicting,
+    60_000,
+  );
+  assert.equal(conflictingBegin.attempt_status, "already_applied");
+  const history = (await fixture.ownerPool.query<Readonly<{
+    completed_parts_fingerprint: string;
+    outcome: string;
+  }>>(
+    `SELECT attempts.completed_parts_fingerprint, attempts.outcome
+     FROM content.media_blob_writer_attempts AS attempts
+     WHERE attempts.media_upload_session_id = $1
+       AND attempts.state IN ('applied', 'referenced')
+     ORDER BY attempts.created_at, attempts.terminal_at, attempts.attempt_token`,
+    [original.sessionId],
+  )).rows;
+  assert.deepEqual(history, [
+    {
+      completed_parts_fingerprint: original.partsFingerprint,
+      outcome: "live_applied",
+    },
+    {
+      completed_parts_fingerprint: conflicting.partsFingerprint,
+      outcome: "already_applied",
+    },
+  ]);
+  return { original, conflicting };
+}
+
+async function writerState(
+  fixture: PostgresIntegrationFixture,
+  payload: MultipartPayload,
+): Promise<StateRow> {
+  const row = (await fixture.ownerPool.query<StateRow>(
+    `SELECT
+       sessions.state AS session_state,
+       attempts.state AS attempt_state,
+       attempts.outcome AS attempt_outcome,
+       reservations.state AS reservation_state
+     FROM content.media_upload_sessions AS sessions
+     INNER JOIN content.media_blob_writer_attempts AS attempts
+       ON attempts.media_upload_session_id = sessions.media_upload_session_id
+     INNER JOIN content.media_blob_writer_reservations AS reservations
+       ON reservations.reservation_token = attempts.reservation_token
+     WHERE sessions.media_upload_session_id = $1
+     ORDER BY attempts.created_at DESC, attempts.attempt_token DESC
+     LIMIT 1`,
+    [payload.sessionId],
+  )).rows[0];
+  if (row === undefined) {
+    throw new Error(
+      `Multipart writer state is missing. sessionId=${payload.sessionId}`,
+    );
+  }
+  return row;
+}
+
+async function mutationSnapshot(
+  fixture: PostgresIntegrationFixture,
+  payload: MultipartPayload,
+): Promise<string> {
+  const row = (await fixture.ownerPool.query<Readonly<{ snapshot: string }>>(
+    `SELECT jsonb_build_object(
+       'session', (
+         SELECT to_jsonb(sessions)
+         FROM content.media_upload_sessions AS sessions
+         WHERE sessions.media_upload_session_id = $1
+       ),
+       'attempts', (
+         SELECT COALESCE(
+           jsonb_agg(to_jsonb(attempts) ORDER BY attempts.created_at, attempts.attempt_token),
+           '[]'::jsonb
+         )
+         FROM content.media_blob_writer_attempts AS attempts
+         WHERE attempts.media_upload_session_id = $1
+       ),
+       'reservation', (
+         SELECT to_jsonb(reservations)
+         FROM content.media_blob_writer_reservations AS reservations
+         WHERE reservations.writer_kind = 'multipart_completion'
+           AND reservations.operation_id = $1::text
+       ),
+       'lifecycle', (
+         SELECT to_jsonb(lifecycles)
+         FROM content.media_blob_lifecycles AS lifecycles
+         WHERE lifecycles.sha256 = $2
+       ),
+       'asset', (
+         SELECT to_jsonb(assets)
+         FROM content.media_assets AS assets
+         WHERE assets.media_asset_id = $3
+       )
+     )::text AS snapshot`,
+    [payload.sessionId, payload.sha256, payload.mediaAssetId],
+  )).rows[0];
+  if (row === undefined) {
+    throw new Error(
+      `Multipart mutation snapshot is missing. sessionId=${payload.sessionId}`,
+    );
+  }
+  return row.snapshot;
+}
+
+async function waitForLock(
+  fixture: PostgresIntegrationFixture,
+  processId: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const waiting = (await fixture.ownerPool.query<Readonly<{ waiting: boolean }>>(
+      "SELECT wait_event_type = 'Lock' AS waiting FROM pg_stat_activity WHERE pid = $1",
+      [processId],
+    )).rows[0]?.waiting;
+    if (waiting === true) return;
+    await fixture.ownerPool.query("SELECT pg_sleep(0.01)");
+  }
+  assert.fail(
+    `PostgreSQL worker did not enter the expected lock wait. pid=${processId}`,
+  );
+}
+
+async function apply0098UpgradeAndAssertSecurity(
+  fixture: PostgresIntegrationFixture,
+): Promise<UpgradeHistory | null> {
+  const client = await fixture.ownerPool.connect();
+  let upgradeHistory: UpgradeHistory | null = null;
+  try {
+    const baseline = (await client.query<Readonly<{
+      major: number;
+      migrations: number;
+      latest: string;
+      close_present: boolean;
+      history_index_present: boolean;
+    }>>(
+      `SELECT
+         current_setting('server_version_num')::int / 10000 AS major,
+         count(*)::int AS migrations,
+         max(filename) AS latest,
+         to_regprocedure($1) IS NOT NULL AS close_present,
+         to_regclass(
+           'content.media_blob_writer_attempts_multipart_session_history'
+         ) IS NOT NULL AS history_index_present
+       FROM public.schema_migrations`,
+      [closeSignature],
+    )).rows[0];
+    if (baseline === undefined) {
+      throw new Error("PostgreSQL migration baseline query returned no row.");
+    }
+    assert.equal(baseline.major, 18);
+
+    if (!baseline.close_present) {
+      assert.deepEqual(
+        { migrations: baseline.migrations, latest: baseline.latest },
+        {
+          migrations: 99,
+          latest: "0097_direct_multipart_writer_attempt_fencing.sql",
+        },
+      );
+      assert.equal(baseline.history_index_present, false);
+      upgradeHistory = await seed0097ConflictingTerminalHistory(fixture);
+      await client.query("BEGIN");
+      await client.query(migration0098);
+      await client.query(
+        "INSERT INTO public.schema_migrations(filename) VALUES ($1)",
+        ["0098_multipart_writer_abort_and_terminal_replay.sql"],
+      );
+      await client.query("COMMIT");
+    } else {
+      assert.deepEqual(
+        { migrations: baseline.migrations, latest: baseline.latest },
+        {
+          migrations: 100,
+          latest: "0098_multipart_writer_abort_and_terminal_replay.sql",
+        },
+      );
+      assert.equal(baseline.history_index_present, true);
+    }
+
+    const security = (await client.query<Readonly<{
+      backend_begin: boolean;
+      backend_close: boolean;
+      backend_helper: boolean;
+      auth_begin: boolean;
+      auth_close: boolean;
+      reporting_begin: boolean;
+      reporting_close: boolean;
+      no_public_begin: boolean;
+      no_public_close: boolean;
+      no_public_helper: boolean;
+      hardened: boolean;
+      old_close: boolean;
+      old_attempt_close: boolean;
+      backend_attempt_table: boolean;
+      history_index_present: boolean;
+    }>>(
+      `SELECT
+         has_function_privilege('backend_app',$1,'EXECUTE') AS backend_begin,
+         has_function_privilege('backend_app',$2,'EXECUTE') AS backend_close,
+         has_function_privilege('backend_app',$3,'EXECUTE') AS backend_helper,
+         has_function_privilege('auth_app',$1,'EXECUTE') AS auth_begin,
+         has_function_privilege('auth_app',$2,'EXECUTE') AS auth_close,
+         has_function_privilege('reporting_readonly',$1,'EXECUTE') AS reporting_begin,
+         has_function_privilege('reporting_readonly',$2,'EXECUTE') AS reporting_close,
+         NOT EXISTS (
+           SELECT 1
+           FROM pg_proc AS functions
+           CROSS JOIN LATERAL aclexplode(
+             COALESCE(functions.proacl,acldefault('f',functions.proowner))
+           ) AS privileges
+           WHERE functions.oid = $1::regprocedure
+             AND privileges.grantee = 0
+         ) AS no_public_begin,
+         NOT EXISTS (
+           SELECT 1
+           FROM pg_proc AS functions
+           CROSS JOIN LATERAL aclexplode(
+             COALESCE(functions.proacl,acldefault('f',functions.proowner))
+           ) AS privileges
+           WHERE functions.oid = $2::regprocedure
+             AND privileges.grantee = 0
+         ) AS no_public_close,
+         NOT EXISTS (
+           SELECT 1
+           FROM pg_proc AS functions
+           CROSS JOIN LATERAL aclexplode(
+             COALESCE(functions.proacl,acldefault('f',functions.proowner))
+           ) AS privileges
+           WHERE functions.oid = $3::regprocedure
+             AND privileges.grantee = 0
+         ) AS no_public_helper,
+         (
+           SELECT bool_and(
+             functions.prosecdef
+             AND functions.proconfig = ARRAY['search_path=pg_catalog']
+           )
+           FROM pg_proc AS functions
+           WHERE functions.oid = ANY(ARRAY[
+             $1::regprocedure,$2::regprocedure,$3::regprocedure
+           ])
+         ) AS hardened,
+         to_regprocedure($4) IS NOT NULL AS old_close,
+         to_regprocedure($5) IS NOT NULL AS old_attempt_close,
+         has_table_privilege(
+           'backend_app','content.media_blob_writer_attempts','SELECT'
+         ) AS backend_attempt_table,
+         to_regclass(
+           'content.media_blob_writer_attempts_multipart_session_history'
+         ) IS NOT NULL AS history_index_present`,
+      [
+        beginSignature,
+        closeSignature,
+        helperSignature,
+        oldCloseSignature,
+        oldAttemptCloseSignature,
+      ],
+    )).rows[0];
+    assert.deepEqual(security, {
+      backend_begin: true,
+      backend_close: true,
+      backend_helper: false,
+      auth_begin: false,
+      auth_close: false,
+      reporting_begin: false,
+      reporting_close: false,
+      no_public_begin: true,
+      no_public_close: true,
+      no_public_helper: true,
+      hardened: true,
+      old_close: true,
+      old_attempt_close: true,
+      backend_attempt_table: false,
+      history_index_present: true,
+    });
+    return upgradeHistory;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function captureOwnedMedia(
+  fixture: PostgresIntegrationFixture,
+): Promise<OwnedMedia> {
+  const row = (await fixture.ownerPool.query<Readonly<{
+    blob_ids: ReadonlyArray<string>;
+    sha256s: ReadonlyArray<string>;
+  }>>(
+    `WITH owned_sha256s AS (
+       SELECT attempts.sha256
+       FROM content.media_blob_writer_attempts AS attempts
+       WHERE attempts.workspace_id = $1
+       UNION
+       SELECT reservations.sha256
+       FROM content.media_blob_writer_reservations AS reservations
+       WHERE reservations.workspace_id = $1
+       UNION
+       SELECT blobs.sha256
+       FROM content.media_assets AS assets
+       INNER JOIN content.media_blobs AS blobs
+         ON blobs.media_blob_id = assets.media_blob_id
+       WHERE assets.workspace_id = $1
+     )
+     SELECT
+       ARRAY(
+         SELECT blobs.media_blob_id
+         FROM content.media_blobs AS blobs
+         WHERE blobs.sha256 IN (SELECT sha256 FROM owned_sha256s)
+       ) AS blob_ids,
+       ARRAY(SELECT sha256 FROM owned_sha256s) AS sha256s`,
+    [fixture.workspaceId],
+  )).rows[0];
+  if (row === undefined) {
+    throw new Error("PostgreSQL owned-media capture returned no row.");
+  }
+  return { blobIds: row.blob_ids, sha256s: row.sha256s };
+}
+
+async function removeOwnedMedia(
+  fixture: PostgresIntegrationFixture,
+): Promise<void> {
+  const owned = await captureOwnedMedia(fixture);
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_upload_sessions WHERE workspace_id = $1",
+    [fixture.workspaceId],
+  );
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_assets WHERE workspace_id = $1",
+    [fixture.workspaceId],
+  );
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_blob_writer_attempts WHERE workspace_id = $1",
+    [fixture.workspaceId],
+  );
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_blob_writer_reservations WHERE workspace_id = $1",
+    [fixture.workspaceId],
+  );
+  await fixture.ownerPool.query(
+    `DELETE FROM content.media_blobs AS blobs
+     WHERE blobs.media_blob_id = ANY($1::uuid[])
+       AND NOT EXISTS (
+         SELECT 1
+         FROM content.media_assets AS assets
+         WHERE assets.media_blob_id = blobs.media_blob_id
+       )
+       AND NOT EXISTS (
+         SELECT 1
+         FROM catalog.package_media_assets AS assets
+         WHERE assets.media_blob_id = blobs.media_blob_id
+       )`,
+    [owned.blobIds],
+  );
+  await fixture.ownerPool.query(
+    `DELETE FROM content.media_blob_lifecycles AS lifecycles
+     WHERE lifecycles.sha256 = ANY($1::text[])
+       AND NOT EXISTS (
+         SELECT 1
+         FROM content.media_blobs AS blobs
+         WHERE blobs.sha256 = lifecycles.sha256
+       )
+       AND NOT EXISTS (
+         SELECT 1
+         FROM content.media_blob_writer_reservations AS reservations
+         WHERE reservations.sha256 = lifecycles.sha256
+       )`,
+    [owned.sha256s],
+  );
+  const remaining = (await fixture.ownerPool.query<Readonly<{
+    sessions: number;
+    assets: number;
+    attempts: number;
+    reservations: number;
+    blobs: number;
+    lifecycles: number;
+  }>>(
+    `SELECT
+       (SELECT count(*)::int FROM content.media_upload_sessions WHERE workspace_id = $1) AS sessions,
+       (SELECT count(*)::int FROM content.media_assets WHERE workspace_id = $1) AS assets,
+       (SELECT count(*)::int FROM content.media_blob_writer_attempts WHERE workspace_id = $1) AS attempts,
+       (SELECT count(*)::int FROM content.media_blob_writer_reservations WHERE workspace_id = $1) AS reservations,
+       (SELECT count(*)::int FROM content.media_blobs WHERE media_blob_id = ANY($2::uuid[])) AS blobs,
+       (SELECT count(*)::int FROM content.media_blob_lifecycles WHERE sha256 = ANY($3::text[])) AS lifecycles`,
+    [fixture.workspaceId, owned.blobIds, owned.sha256s],
+  )).rows[0];
+  assert.deepEqual(remaining, {
+    sessions: 0,
+    assets: 0,
+    attempts: 0,
+    reservations: 0,
+    blobs: 0,
+    lifecycles: 0,
+  });
+}
+
+test(
+  "multipart abort closes the stored writer and terminal replay uses durable parts",
+  async () => {
+    await withPostgresIntegrationFixture(async (fixture) => {
+      try {
+        const upgradeHistory = await apply0098UpgradeAndAssertSecurity(fixture);
+        if (upgradeHistory !== null) {
+          const originalReplay = await beginMultipart(
+            fixture,
+            randomUUID(),
+            upgradeHistory.original,
+            60_000,
+          );
+          assert.deepEqual(
+            [originalReplay.attempt_status, originalReplay.reservation_token],
+            ["live_applied", null],
+          );
+          const originalSnapshot = await mutationSnapshot(
+            fixture,
+            upgradeHistory.original,
+          );
+          const conflictingReplay = await beginMultipart(
+            fixture,
+            randomUUID(),
+            upgradeHistory.conflicting,
+            60_000,
+          );
+          assert.equal(conflictingReplay.attempt_status, "stale_attempt");
+          assert.equal(
+            await mutationSnapshot(fixture, upgradeHistory.original),
+            originalSnapshot,
+          );
+        }
+
+        const legacy = multipart(fixture, {});
+        await insertSession(fixture.ownerPool, legacy, "aborting");
+        assert.equal(await closeCurrentWriter(fixture, legacy), "no_writer_closed");
+        assert.equal(await closeCurrentWriter(fixture, legacy), "already_closed");
+
+        const live = multipart(fixture, {});
+        await insertSession(fixture.ownerPool, live, "active");
+        const liveAttempt = randomUUID();
+        const liveBegin = await beginMultipart(fixture, liveAttempt, live, 60_000);
+        assert.equal(liveBegin.attempt_status, "acquired");
+        assert.ok(liveBegin.reservation_token !== null);
+        const liveBefore = await mutationSnapshot(fixture, live);
+        assert.equal(await closeCurrentWriter(fixture, live), "access_active");
+        assert.equal(await mutationSnapshot(fixture, live), liveBefore);
+        await fixture.ownerPool.query(
+          `UPDATE content.media_upload_sessions
+           SET state = 'aborting'
+           WHERE media_upload_session_id = $1`,
+          [live.sessionId],
+        );
+        assert.equal(await closeCurrentWriter(fixture, live), "aborted");
+        assert.deepEqual(await writerState(fixture, live), {
+          session_state: "aborted",
+          attempt_state: "cancelled",
+          attempt_outcome: "aborted",
+          reservation_state: "unreferenced",
+        });
+        assert.equal(await closeCurrentWriter(fixture, live), "aborted");
+
+        const crashed = multipart(fixture, {});
+        await insertSession(fixture.ownerPool, crashed, "active");
+        const crashedAttempt = randomUUID();
+        const crashedBegin = await beginMultipart(
+          fixture,
+          crashedAttempt,
+          crashed,
+          60_000,
+        );
+        assert.equal(crashedBegin.attempt_status, "acquired");
+        await fixture.ownerPool.query(
+          `UPDATE content.media_blob_writer_attempts
+           SET lease_expires_at = pg_catalog.clock_timestamp() - interval '1 second'
+           WHERE attempt_token = $1`,
+          [crashedAttempt],
+        );
+        await fixture.ownerPool.query(
+          `UPDATE content.media_upload_sessions
+           SET state = 'aborting'
+           WHERE media_upload_session_id = $1`,
+          [crashed.sessionId],
+        );
+        assert.equal(await closeCurrentWriter(fixture, crashed), "aborted");
+
+        const recoveredReference = multipart(fixture, {});
+        await insertSession(
+          fixture.ownerPool,
+          recoveredReference,
+          "active",
+        );
+        const recoveredReferenceAttempt = randomUUID();
+        const recoveredReferenceBegin = await beginMultipart(
+          fixture,
+          recoveredReferenceAttempt,
+          recoveredReference,
+          60_000,
+        );
+        assert.equal(recoveredReferenceBegin.attempt_status, "acquired");
+        assert.ok(recoveredReferenceBegin.reservation_token !== null);
+        assert.ok(recoveredReferenceBegin.normalization_version !== null);
+        const canonicalRecoveredReference = {
+          ...recoveredReference,
+          normalizationVersion:
+            recoveredReferenceBegin.normalization_version,
+        };
+        assert.equal(
+          await multipartStatus(
+            fixture,
+            "resolve_media_upload_session_completion_attempt_failure_with_owner",
+            recoveredReferenceAttempt,
+            recoveredReferenceBegin.reservation_token,
+            canonicalRecoveredReference,
+          ),
+          "unreferenced_restored",
+        );
+        assert.deepEqual(await writerState(fixture, recoveredReference), {
+          session_state: "active",
+          attempt_state: "unreferenced",
+          attempt_outcome: "unreferenced_restored",
+          reservation_state: "unreferenced",
+        });
+        await insertAsset(fixture.ownerPool, canonicalRecoveredReference);
+        await fixture.ownerPool.query(
+          `UPDATE content.media_upload_sessions
+           SET state = 'aborting'
+           WHERE media_upload_session_id = $1`,
+          [recoveredReference.sessionId],
+        );
+        assert.equal(
+          await closeCurrentWriter(fixture, recoveredReference),
+          "referenced",
+        );
+        assert.deepEqual(await writerState(fixture, recoveredReference), {
+          session_state: "completed",
+          attempt_state: "referenced",
+          attempt_outcome: "referenced",
+          reservation_state: "finalized",
+        });
+
+        const expiring = multipart(fixture, {
+          sessionExpiresAt: new Date(Date.now() + 250).toISOString(),
+        });
+        await insertSession(fixture.ownerPool, expiring, "active");
+        const expiringAttempt = randomUUID();
+        const expiringBegin = await beginMultipart(
+          fixture,
+          expiringAttempt,
+          expiring,
+          100,
+        );
+        assert.equal(expiringBegin.attempt_status, "acquired");
+        await fixture.ownerPool.query(
+          `SELECT pg_sleep(
+             GREATEST(
+               0,
+               EXTRACT(
+                 EPOCH FROM ($1::timestamptz - pg_catalog.clock_timestamp())
+               ) + 0.05
+             )
+           )`,
+          [expiring.sessionExpiresAt],
+        );
+        assert.equal(await closeCurrentWriter(fixture, expiring), "aborted");
+
+        const completed = multipart(fixture, {});
+        await insertSession(fixture.ownerPool, completed, "active");
+        const completedAttempt = randomUUID();
+        const completedBegin = await beginMultipart(
+          fixture,
+          completedAttempt,
+          completed,
+          60_000,
+        );
+        assert.equal(completedBegin.attempt_status, "acquired");
+        assert.ok(completedBegin.reservation_token !== null);
+        assert.ok(completedBegin.normalization_version !== null);
+        const canonicalCompleted = {
+          ...completed,
+          normalizationVersion: completedBegin.normalization_version,
+        };
+        assert.equal(
+          await multipartStatus(
+            fixture,
+            "fence_media_upload_session_completion_attempt_apply_with_owner",
+            completedAttempt,
+            completedBegin.reservation_token,
+            canonicalCompleted,
+          ),
+          "ready",
+        );
+        await insertAsset(fixture.ownerPool, canonicalCompleted);
+        assert.equal(
+          await multipartStatus(
+            fixture,
+            "finish_media_upload_session_completion_attempt_apply_with_owner",
+            completedAttempt,
+            completedBegin.reservation_token,
+            canonicalCompleted,
+          ),
+          "live_applied",
+        );
+        await fixture.ownerPool.query(
+          `UPDATE content.media_assets
+           SET
+             source_url = $1,
+             client_updated_at = client_updated_at + interval '1 minute',
+             last_operation_id = $2
+           WHERE media_asset_id = $3`,
+          [
+            "https://example.invalid/later-edit",
+            randomUUID(),
+            completed.mediaAssetId,
+          ],
+        );
+        const completedBefore = await mutationSnapshot(fixture, completed);
+        const freshReplay = await beginMultipart(
+          fixture,
+          randomUUID(),
+          {
+            ...completed,
+            lastOperationId: randomUUID(),
+            sourceUrl: "https://example.invalid/retry-metadata",
+            assetCreatedAt: new Date(Date.now() - 60_000).toISOString(),
+            clientUpdatedAt: new Date(Date.now() + 60_000).toISOString(),
+          },
+          60_000,
+        );
+        assert.deepEqual(
+          [freshReplay.attempt_status, freshReplay.reservation_token],
+          ["live_applied", null],
+        );
+        assert.equal(await mutationSnapshot(fixture, completed), completedBefore);
+
+        const fingerprintBefore = await mutationSnapshot(fixture, completed);
+        const mismatchedFingerprint = await beginMultipart(
+          fixture,
+          randomUUID(),
+          { ...completed, partsFingerprint: digest() },
+          60_000,
+        );
+        assert.equal(mismatchedFingerprint.attempt_status, "stale_attempt");
+        assert.equal(
+          await mutationSnapshot(fixture, completed),
+          fingerprintBefore,
+        );
+
+        const identityBefore = await mutationSnapshot(fixture, completed);
+        const mismatchedIdentity = await beginMultipart(
+          fixture,
+          randomUUID(),
+          { ...completed, sizeBytes: completed.sizeBytes + 1 },
+          60_000,
+        );
+        assert.equal(mismatchedIdentity.attempt_status, "stale");
+        assert.equal(await mutationSnapshot(fixture, completed), identityBefore);
+
+        const deniedBefore = await mutationSnapshot(fixture, completed);
+        const denied = await scoped(
+          fixture,
+          `non-owner-${randomUUID()}`,
+          fixture.workspaceId,
+          async (client) => closeCurrentWriterInExecutor(client, completed),
+        );
+        assert.equal(denied, "access_denied");
+        assert.equal(await mutationSnapshot(fixture, completed), deniedBefore);
+        assert.equal(await closeCurrentWriter(fixture, completed), "live_applied");
+        assert.deepEqual(await writerState(fixture, completed), {
+          session_state: "completed",
+          attempt_state: "applied",
+          attempt_outcome: "live_applied",
+          reservation_state: "finalized",
+        });
+
+        const referenced = multipart(fixture, {});
+        await insertSession(fixture.ownerPool, referenced, "active");
+        const referencedAttempt = randomUUID();
+        const referencedBegin = await beginMultipart(
+          fixture,
+          referencedAttempt,
+          referenced,
+          60_000,
+        );
+        assert.equal(referencedBegin.attempt_status, "acquired");
+        assert.ok(referencedBegin.reservation_token !== null);
+        assert.ok(referencedBegin.normalization_version !== null);
+        const canonicalReferenced = {
+          ...referenced,
+          normalizationVersion: referencedBegin.normalization_version,
+        };
+        await insertAsset(fixture.ownerPool, canonicalReferenced);
+        assert.equal(
+          await multipartStatus(
+            fixture,
+            "resolve_media_upload_session_completion_attempt_failure_with_owner",
+            referencedAttempt,
+            referencedBegin.reservation_token,
+            canonicalReferenced,
+          ),
+          "referenced",
+        );
+        assert.equal(await closeCurrentWriter(fixture, referenced), "referenced");
+        assert.deepEqual(await writerState(fixture, referenced), {
+          session_state: "completed",
+          attempt_state: "referenced",
+          attempt_outcome: "referenced",
+          reservation_state: "finalized",
+        });
+
+        const race = multipart(fixture, {});
+        await insertSession(fixture.ownerPool, race, "active");
+        const raceAttempt = randomUUID();
+        const raceBegin = await beginMultipart(
+          fixture,
+          raceAttempt,
+          race,
+          60_000,
+        );
+        assert.equal(raceBegin.attempt_status, "acquired");
+        assert.ok(raceBegin.reservation_token !== null);
+        assert.ok(raceBegin.normalization_version !== null);
+        const canonicalRace = {
+          ...race,
+          normalizationVersion: raceBegin.normalization_version,
+        };
+        const completing = await fixture.runtimePool.connect();
+        const aborting = await fixture.runtimePool.connect();
+        try {
+          for (const client of [completing, aborting]) {
+            await client.query("BEGIN");
+            await client.query(
+              "SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)",
+              [fixture.userId, fixture.workspaceId],
+            );
+            await client.query(
+              "SET LOCAL statement_timeout = '4s'; SET LOCAL lock_timeout = '4s'",
+            );
+          }
+          const fence = (await completing.query<StatusRow>(
+            `SELECT content.fence_media_upload_session_completion_attempt_apply_with_owner(
+               $1,$2,${multipartRow},$23
+             ) AS status`,
+            [
+              raceAttempt,
+              raceBegin.reservation_token,
+              ...multipartValues(canonicalRace),
+              cleanupDelayMs,
+            ],
+          )).rows[0].status;
+          assert.equal(fence, "ready");
+          await insertAsset(completing, canonicalRace);
+
+          const abortProcessId = (await aborting.query<Readonly<{ pid: number }>>(
+            "SELECT pg_backend_pid() AS pid",
+          )).rows[0].pid;
+          const pendingAbort = aborting.query(
+            `UPDATE content.media_upload_sessions
+             SET state = 'aborting', completed_at = NULL, aborted_at = NULL
+             WHERE media_upload_session_id = $1
+               AND state IN ('active', 'completing')`,
+            [race.sessionId],
+          ).then(async () => closeCurrentWriterInExecutor(aborting, race));
+          await waitForLock(fixture, abortProcessId);
+
+          const finish = (await completing.query<StatusRow>(
+            `SELECT content.finish_media_upload_session_completion_attempt_apply_with_owner(
+               $1,$2,${multipartRow},$23
+             ) AS status`,
+            [
+              raceAttempt,
+              raceBegin.reservation_token,
+              ...multipartValues(canonicalRace),
+              cleanupDelayMs,
+            ],
+          )).rows[0].status;
+          assert.equal(finish, "live_applied");
+          await completing.query("COMMIT");
+          assert.equal(await pendingAbort, "live_applied");
+          await aborting.query("COMMIT");
+        } finally {
+          await Promise.allSettled([
+            completing.query("ROLLBACK"),
+            aborting.query("ROLLBACK"),
+          ]);
+          completing.release();
+          aborting.release();
+        }
+        assert.deepEqual(await writerState(fixture, race), {
+          session_state: "completed",
+          attempt_state: "applied",
+          attempt_outcome: "live_applied",
+          reservation_state: "finalized",
+        });
+      } finally {
+        await removeOwnedMedia(fixture);
+      }
+    });
+  },
+);

--- a/db/migrations/0098_multipart_writer_abort_and_terminal_replay.sql
+++ b/db/migrations/0098_multipart_writer_abort_and_terminal_replay.sql
@@ -1,0 +1,1086 @@
+-- Current additive migration for multipart abort ownership and completed-attempt replay.
+-- Schemas touched/read explicitly: content, org, security, sync, pg_catalog.
+
+CREATE INDEX media_blob_writer_attempts_multipart_session_history
+  ON content.media_blob_writer_attempts (
+    media_upload_session_id,
+    state,
+    terminal_at,
+    created_at,
+    attempt_token
+  )
+  WHERE writer_kind = 'multipart_completion';
+
+CREATE FUNCTION content.multipart_media_blob_writer_terminal_replay_status_internal(
+  p_attempt content.media_blob_writer_attempts,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TEXT
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT CASE
+    WHEN (p_attempt).attempt_token IS NULL THEN 'stale_attempt'
+    WHEN (p_attempt).user_id IS DISTINCT FROM p_payload.user_id
+      OR (p_attempt).replica_id IS DISTINCT FROM p_payload.replica_id
+    THEN 'ownership_mismatch'
+    WHEN (p_attempt).writer_kind IS DISTINCT FROM 'multipart_completion'
+      OR (p_attempt).workspace_id IS DISTINCT FROM p_payload.workspace_id
+      OR (p_attempt).media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+      OR (p_attempt).operation_id IS DISTINCT FROM p_payload.media_upload_session_id::TEXT
+      OR (p_attempt).media_upload_session_id IS DISTINCT FROM p_payload.media_upload_session_id
+      OR (p_attempt).sha256 IS DISTINCT FROM p_payload.sha256
+      OR (p_attempt).blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key
+      OR (p_attempt).mime_type IS DISTINCT FROM p_payload.mime_type
+      OR (p_attempt).size_bytes IS DISTINCT FROM p_payload.size_bytes
+      OR (p_attempt).requested_normalization_version IS DISTINCT FROM p_payload.normalization_version
+      OR (p_attempt).staging_storage_key IS DISTINCT FROM p_payload.staging_storage_key
+      OR (p_attempt).s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id
+      OR (p_attempt).part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes
+      OR (p_attempt).part_count IS DISTINCT FROM p_payload.part_count
+      OR (p_attempt).session_expires_at IS DISTINCT FROM p_payload.session_expires_at
+      OR (p_attempt).completed_parts_fingerprint IS DISTINCT FROM p_payload.completed_parts_fingerprint
+    THEN 'stale_attempt'
+    ELSE 'ready'
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  p_attempt_token UUID,
+  p_lease_duration_ms INTEGER,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing_attempt content.media_blob_writer_attempts%ROWTYPE;
+  peer_attempt content.media_blob_writer_attempts%ROWTYPE;
+  terminal_attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reservation_result RECORD;
+  apply_payload content.multipart_media_blob_writer_attempt_payload;
+  fence_status TEXT;
+  takeover BOOLEAN := false;
+  leased_until TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_lease_duration_ms IS NULL
+    OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+    OR content.multipart_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN
+    RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO existing_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.state <> 'leased';
+
+  IF FOUND THEN
+    IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id()
+      OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id()
+    THEN
+      RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    fence_status := content.multipart_media_blob_writer_terminal_replay_status_internal(
+      existing_attempt,
+      p_payload
+    );
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      p_payload.user_id || ':' || p_payload.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_payload.workspace_id
+      AND memberships.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_payload.replica_id
+      AND replicas.workspace_id = p_payload.workspace_id
+      AND replicas.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id
+  FOR UPDATE;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended('attempt:' || p_attempt_token::TEXT, 3::BIGINT)
+  );
+
+  SELECT attempts.*
+  INTO existing_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+
+  IF FOUND THEN
+    IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id()
+      OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id()
+    THEN
+      RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    IF existing_attempt.state <> 'leased' THEN
+      fence_status := content.multipart_media_blob_writer_terminal_replay_status_internal(
+        existing_attempt,
+        p_payload
+      );
+      IF fence_status <> 'ready' THEN
+        RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+        RETURN;
+      END IF;
+
+      RETURN QUERY
+      SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    apply_payload := p_payload;
+    apply_payload.normalization_version := existing_attempt.normalization_version;
+    fence_status := content.multipart_media_blob_writer_attempt_identity_status_internal(
+      existing_attempt,
+      existing_attempt.reservation_token,
+      apply_payload
+    );
+    IF existing_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version
+    THEN
+      fence_status := 'stale_attempt';
+    END IF;
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    fence_status := content.fence_media_upload_session_completion_attempt_apply_with_owner(
+      p_attempt_token,
+      existing_attempt.reservation_token,
+      apply_payload,
+      3600000
+    );
+    IF fence_status = 'ready' THEN
+      leased_until := pg_catalog.clock_timestamp()
+        + (p_lease_duration_ms * interval '1 millisecond');
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET lease_expires_at = leased_until
+      WHERE attempts.attempt_token = p_attempt_token
+        AND attempts.state = 'leased'
+        AND attempts.lease_expires_at > pg_catalog.clock_timestamp();
+      IF NOT FOUND THEN
+        fence_status := 'stale_attempt';
+      ELSE
+        fence_status := 'replayed';
+      END IF;
+    END IF;
+
+    IF fence_status = 'replayed' THEN
+      RETURN QUERY
+      SELECT
+        fence_status,
+        existing_attempt.reservation_token,
+        existing_attempt.normalization_version,
+        leased_until;
+    ELSE
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    END IF;
+    RETURN;
+  END IF;
+
+  INSERT INTO sync.workspace_sync_metadata (
+    workspace_id,
+    min_available_hot_change_id,
+    updated_at
+  )
+  VALUES (p_payload.workspace_id, 0, pg_catalog.statement_timestamp())
+  ON CONFLICT (workspace_id) DO NOTHING;
+
+  PERFORM 1
+  FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_payload.workspace_id
+  FOR UPDATE;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_payload.sha256
+  FOR UPDATE;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion'
+    AND reservations.workspace_id = p_payload.workspace_id
+    AND reservations.media_asset_id = p_payload.media_asset_id
+    AND reservations.operation_id = p_payload.media_upload_session_id::TEXT
+  FOR UPDATE;
+
+  IF FOUND THEN
+    SELECT snapshots.*
+    INTO owner_snapshot
+    FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token
+    FOR UPDATE;
+  END IF;
+
+  SELECT attempts.*
+  INTO peer_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.workspace_id = p_payload.workspace_id
+    AND attempts.media_asset_id = p_payload.media_asset_id
+    AND attempts.operation_id = p_payload.media_upload_session_id::TEXT
+    AND attempts.state = 'leased'
+  FOR UPDATE;
+
+  SELECT attempts.*
+  INTO terminal_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.media_upload_session_id = p_payload.media_upload_session_id
+    AND attempts.state IN ('applied', 'referenced')
+  ORDER BY
+    attempts.created_at,
+    attempts.terminal_at,
+    attempts.attempt_token
+  LIMIT 1
+  FOR UPDATE;
+
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+    OR NOT EXISTS (
+      SELECT 1
+      FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = p_payload.workspace_id
+        AND memberships.user_id = p_payload.user_id
+    )
+  THEN
+    RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_payload.replica_id
+      AND replicas.workspace_id = p_payload.workspace_id
+      AND replicas.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.media_upload_session_id IS NULL
+    OR session.workspace_id IS DISTINCT FROM p_payload.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_payload.sha256
+    OR session.staging_storage_key IS DISTINCT FROM p_payload.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_payload.mime_type
+    OR session.size_bytes IS DISTINCT FROM p_payload.size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_payload.part_count
+    OR session.expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.last_modified_by_replica_id IS DISTINCT FROM p_payload.replica_id THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state <> 'completed'
+    AND (
+      session.last_operation_id IS DISTINCT FROM p_payload.last_operation_id
+      OR session.source_url IS DISTINCT FROM p_payload.source_url
+      OR session.asset_created_at IS DISTINCT FROM p_payload.asset_created_at
+      OR session.client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+    )
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state = 'aborting' THEN
+    RETURN QUERY SELECT 'aborting'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF session.state = 'aborted' THEN
+    RETURN QUERY SELECT 'aborted'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF session.state = 'active'
+    AND session.expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF session.state NOT IN ('active', 'completing', 'completed') THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF lifecycle.sha256 IS NOT NULL
+    AND (
+      lifecycle.storage_key IS DISTINCT FROM p_payload.blob_storage_key
+      OR lifecycle.mime_type IS DISTINCT FROM p_payload.mime_type
+      OR lifecycle.size_bytes IS DISTINCT FROM p_payload.size_bytes
+    )
+  THEN
+    RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN
+    RETURN QUERY
+    SELECT
+      'cleanup_claimed'::TEXT,
+      NULL::UUID,
+      lifecycle.normalization_version,
+      NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF reservation.reservation_token IS NOT NULL
+    AND (
+      reservation.sha256 IS DISTINCT FROM p_payload.sha256
+      OR owner_snapshot.reservation_token IS NULL
+    )
+  THEN
+    RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF owner_snapshot.reservation_token IS NOT NULL
+    AND (
+      owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id
+      OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id
+    )
+  THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state <> 'completed'
+    AND owner_snapshot.reservation_token IS NOT NULL
+    AND (
+      owner_snapshot.session_last_operation_id IS DISTINCT FROM p_payload.last_operation_id
+      OR owner_snapshot.session_expires_at IS DISTINCT FROM p_payload.session_expires_at
+      OR owner_snapshot.session_source_url IS DISTINCT FROM p_payload.source_url
+      OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_payload.asset_created_at
+      OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+    )
+  THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state = 'completed' THEN
+    IF reservation.reservation_token IS NULL
+      OR reservation.state <> 'finalized'
+      OR terminal_attempt.attempt_token IS NULL
+    THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    fence_status := content.multipart_media_blob_writer_terminal_replay_status_internal(
+      terminal_attempt,
+      p_payload
+    );
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    IF terminal_attempt.reservation_token IS DISTINCT FROM reservation.reservation_token
+      OR terminal_attempt.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+    THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT terminal_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF owner_snapshot.reservation_token IS NOT NULL
+    AND owner_snapshot.session_expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF peer_attempt.attempt_token IS NOT NULL THEN
+    apply_payload := p_payload;
+    apply_payload.normalization_version := peer_attempt.normalization_version;
+    fence_status := content.multipart_media_blob_writer_attempt_identity_status_internal(
+      peer_attempt,
+      peer_attempt.reservation_token,
+      apply_payload
+    );
+    IF fence_status <> 'ready'
+      OR peer_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version
+    THEN
+      RETURN QUERY
+      SELECT
+        CASE WHEN fence_status = 'ready' THEN 'stale_attempt' ELSE fence_status END,
+        NULL::UUID,
+        NULL::TEXT,
+        NULL::TIMESTAMPTZ;
+      RETURN;
+    ELSIF peer_attempt.reservation_token IS DISTINCT FROM reservation.reservation_token
+      OR peer_attempt.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+      OR reservation.state NOT IN ('active', 'ambiguous', 'finalized')
+    THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    ELSIF peer_attempt.lease_expires_at > pg_catalog.clock_timestamp() THEN
+      RETURN QUERY
+      SELECT 'busy'::TEXT, NULL::UUID, NULL::TEXT, peer_attempt.lease_expires_at;
+      RETURN;
+    END IF;
+
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'expired',
+      outcome = 'stale_attempt',
+      terminal_at = pg_catalog.clock_timestamp()
+    WHERE attempts.attempt_token = peer_attempt.attempt_token
+      AND attempts.state = 'leased';
+    takeover := true;
+  END IF;
+
+  SELECT *
+  INTO reservation_result
+  FROM content.reserve_owned_media_blob_writer_internal(
+    p_payload.user_id,
+    p_payload.replica_id,
+    p_payload.sha256,
+    p_payload.blob_storage_key,
+    p_payload.mime_type,
+    p_payload.size_bytes,
+    p_payload.normalization_version,
+    'multipart_completion',
+    p_payload.workspace_id,
+    p_payload.media_asset_id,
+    p_payload.media_upload_session_id::TEXT,
+    p_payload.last_operation_id,
+    p_payload.session_expires_at,
+    p_payload.source_url,
+    p_payload.asset_created_at,
+    p_payload.client_updated_at
+  );
+
+  IF reservation_result.reservation_status = 'cleanup_claimed' THEN
+    RETURN QUERY
+    SELECT
+      'cleanup_claimed'::TEXT,
+      NULL::UUID,
+      reservation_result.normalization_version,
+      NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF reservation_result.reservation_status = 'ownership_mismatch' THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF reservation_result.reservation_status <> 'reserved'
+    OR reservation_result.reservation_token IS NULL
+  THEN
+    RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state = 'active' THEN
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'completing'
+    WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id
+      AND sessions.state = 'active';
+  END IF;
+
+  leased_until := pg_catalog.clock_timestamp()
+    + (p_lease_duration_ms * interval '1 millisecond');
+  INSERT INTO content.media_blob_writer_attempts (
+    attempt_token,
+    reservation_token,
+    writer_kind,
+    user_id,
+    workspace_id,
+    media_asset_id,
+    operation_id,
+    last_operation_id,
+    replica_id,
+    sha256,
+    blob_storage_key,
+    mime_type,
+    size_bytes,
+    requested_normalization_version,
+    normalization_version,
+    source_url,
+    asset_created_at,
+    client_updated_at,
+    media_upload_session_id,
+    staging_storage_key,
+    s3_upload_id,
+    part_size_bytes,
+    part_count,
+    session_expires_at,
+    completed_parts_fingerprint,
+    state,
+    lease_expires_at
+  )
+  VALUES (
+    p_attempt_token,
+    reservation_result.reservation_token,
+    'multipart_completion',
+    p_payload.user_id,
+    p_payload.workspace_id,
+    p_payload.media_asset_id,
+    p_payload.media_upload_session_id::TEXT,
+    p_payload.last_operation_id,
+    p_payload.replica_id,
+    p_payload.sha256,
+    p_payload.blob_storage_key,
+    p_payload.mime_type,
+    p_payload.size_bytes,
+    p_payload.normalization_version,
+    reservation_result.normalization_version,
+    p_payload.source_url,
+    p_payload.asset_created_at,
+    p_payload.client_updated_at,
+    p_payload.media_upload_session_id,
+    p_payload.staging_storage_key,
+    p_payload.s3_upload_id,
+    p_payload.part_size_bytes,
+    p_payload.part_count,
+    p_payload.session_expires_at,
+    p_payload.completed_parts_fingerprint,
+    'leased',
+    leased_until
+  );
+
+  apply_payload := p_payload;
+  apply_payload.normalization_version := reservation_result.normalization_version;
+  fence_status := content.fence_media_upload_session_completion_attempt_apply_with_owner(
+    p_attempt_token,
+    reservation_result.reservation_token,
+    apply_payload,
+    3600000
+  );
+  IF fence_status = 'ready' THEN
+    fence_status := CASE WHEN takeover THEN 'expired_takeover' ELSE 'acquired' END;
+  END IF;
+
+  IF fence_status IN ('acquired', 'expired_takeover') THEN
+    RETURN QUERY
+    SELECT
+      fence_status,
+      reservation_result.reservation_token,
+      reservation_result.normalization_version,
+      leased_until;
+  ELSE
+    RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+  END IF;
+END;
+$$;
+
+CREATE FUNCTION content.close_media_upload_session_current_blob_writer_with_owner(
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_media_upload_session_id UUID,
+  p_media_asset_id UUID,
+  p_last_modified_by_replica_id UUID,
+  p_last_operation_id TEXT,
+  p_sha256 TEXT,
+  p_storage_key TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_expires_at TIMESTAMPTZ,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+  selected_attempt content.media_blob_writer_attempts%ROWTYPE;
+  current_attempt content.media_blob_writer_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reference RECORD;
+  session_found BOOLEAN;
+  access_present BOOLEAN;
+  replica_matches BOOLEAN;
+  abort_proven BOOLEAN;
+  expiry_proven BOOLEAN;
+  exact_reference_found BOOLEAN;
+  terminalization_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+    OR p_user_id IS NULL
+    OR p_workspace_id IS NULL
+    OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL
+    OR p_last_modified_by_replica_id IS NULL
+    OR p_last_operation_id IS NULL
+    OR p_sha256 IS NULL
+    OR p_storage_key IS NULL
+    OR p_mime_type IS NULL
+    OR p_size_bytes IS NULL
+    OR p_expires_at IS NULL
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT)
+  );
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+  FOR UPDATE;
+  session_found := FOUND;
+
+  IF session_found
+    AND (
+      session.workspace_id IS DISTINCT FROM p_workspace_id
+      OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+      OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+      OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+      OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+      OR session.blob_storage_key IS DISTINCT FROM p_storage_key
+      OR session.mime_type IS DISTINCT FROM p_mime_type
+      OR session.size_bytes IS DISTINCT FROM p_size_bytes
+      OR session.expires_at IS DISTINCT FROM p_expires_at
+    )
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT attempts.*
+  INTO selected_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.media_upload_session_id = p_media_upload_session_id
+  ORDER BY
+    (attempts.state = 'leased') DESC,
+    attempts.terminal_at DESC NULLS LAST,
+    attempts.created_at DESC,
+    attempts.attempt_token DESC
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN content.close_media_upload_session_blob_writer(
+      p_user_id,
+      p_workspace_id,
+      p_media_upload_session_id,
+      p_media_asset_id,
+      p_last_modified_by_replica_id,
+      p_last_operation_id,
+      p_sha256,
+      p_storage_key,
+      p_mime_type,
+      p_size_bytes,
+      p_expires_at,
+      p_cleanup_delay_ms
+    );
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = selected_attempt.sha256
+  FOR UPDATE;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = selected_attempt.reservation_token
+  FOR UPDATE;
+
+  IF FOUND THEN
+    SELECT snapshots.*
+    INTO owner_snapshot
+    FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token
+    FOR UPDATE;
+  END IF;
+
+  SELECT attempts.*
+  INTO current_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = selected_attempt.attempt_token
+  FOR UPDATE;
+
+  SELECT
+    assets.workspace_id,
+    blobs.sha256,
+    blobs.storage_key,
+    blobs.mime_type,
+    blobs.size_bytes,
+    blobs.normalization_version
+  INTO reference
+  FROM content.media_assets AS assets
+  INNER JOIN content.media_blobs AS blobs
+    ON blobs.media_blob_id = assets.media_blob_id
+  WHERE assets.media_asset_id = p_media_asset_id
+    AND assets.deleted_at IS NULL
+  FOR UPDATE OF assets, blobs;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  )
+  INTO access_present;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_last_modified_by_replica_id
+      AND replicas.workspace_id = p_workspace_id
+      AND replicas.user_id = p_user_id
+  )
+  INTO replica_matches;
+
+  IF current_attempt.attempt_token IS NULL
+    OR current_attempt.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR current_attempt.media_upload_session_id IS DISTINCT FROM p_media_upload_session_id
+    OR current_attempt.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR current_attempt.workspace_id IS DISTINCT FROM p_workspace_id
+    OR current_attempt.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR current_attempt.sha256 IS DISTINCT FROM p_sha256
+    OR current_attempt.blob_storage_key IS DISTINCT FROM p_storage_key
+    OR current_attempt.mime_type IS DISTINCT FROM p_mime_type
+    OR current_attempt.size_bytes IS DISTINCT FROM p_size_bytes
+    OR current_attempt.session_expires_at IS DISTINCT FROM p_expires_at
+  THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  IF current_attempt.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+  THEN
+    RETURN 'ownership_mismatch';
+  END IF;
+
+  IF current_attempt.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+  THEN
+    RETURN CASE WHEN access_present THEN 'replica_mismatch' ELSE 'access_denied' END;
+  END IF;
+
+  IF current_attempt.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+  THEN
+    RETURN 'ownership_mismatch';
+  END IF;
+
+  IF lifecycle.sha256 IS NULL
+    OR reservation.reservation_token IS NULL
+    OR owner_snapshot.reservation_token IS NULL
+    OR reservation.reservation_token IS DISTINCT FROM current_attempt.reservation_token
+    OR reservation.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR reservation.workspace_id IS DISTINCT FROM p_workspace_id
+    OR reservation.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR reservation.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM current_attempt.normalization_version
+  THEN
+    RETURN 'writer_conflict';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM content.media_blob_writer_attempts AS successors
+    WHERE successors.writer_kind = 'multipart_completion'
+      AND successors.media_upload_session_id = p_media_upload_session_id
+      AND successors.state = 'leased'
+      AND successors.attempt_token <> current_attempt.attempt_token
+  ) THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  exact_reference_found :=
+    reference.workspace_id IS NOT NULL
+    AND reference.workspace_id IS NOT DISTINCT FROM p_workspace_id
+    AND reference.sha256 IS NOT DISTINCT FROM p_sha256
+    AND reference.storage_key IS NOT DISTINCT FROM p_storage_key
+    AND reference.mime_type IS NOT DISTINCT FROM p_mime_type
+    AND reference.size_bytes IS NOT DISTINCT FROM p_size_bytes
+    AND reference.normalization_version IS NOT DISTINCT FROM current_attempt.normalization_version;
+
+  IF exact_reference_found AND current_attempt.state <> 'leased' THEN
+    UPDATE content.media_blob_writer_reservations AS reservations
+    SET state = 'finalized'
+    WHERE reservations.reservation_token = reservation.reservation_token;
+
+    UPDATE content.media_blob_lifecycles AS lifecycles
+    SET
+      cleanup_eligible_at = NULL,
+      cleanup_lease_token = NULL,
+      cleanup_lease_expires_at = NULL,
+      updated_at = pg_catalog.clock_timestamp()
+    WHERE lifecycles.sha256 = current_attempt.sha256;
+
+    IF current_attempt.state NOT IN ('applied', 'referenced') THEN
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET
+        state = 'referenced',
+        outcome = 'referenced',
+        terminal_at = pg_catalog.clock_timestamp()
+      WHERE attempts.attempt_token = current_attempt.attempt_token;
+    END IF;
+
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'completed',
+        completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()),
+        aborted_at = NULL
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+
+    RETURN CASE
+      WHEN current_attempt.state IN ('applied', 'referenced') THEN current_attempt.outcome
+      ELSE 'referenced'
+    END;
+  END IF;
+
+  IF current_attempt.state IN ('applied', 'referenced') THEN
+    IF reservation.state IS DISTINCT FROM 'finalized' THEN
+      RETURN 'writer_conflict';
+    END IF;
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'completed',
+        completed_at = COALESCE(sessions.completed_at, current_attempt.terminal_at, pg_catalog.clock_timestamp()),
+        aborted_at = NULL
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN current_attempt.outcome;
+  ELSIF current_attempt.state = 'peer_conflict' THEN
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'aborted',
+        completed_at = NULL,
+        aborted_at = COALESCE(sessions.aborted_at, current_attempt.terminal_at, pg_catalog.clock_timestamp())
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN 'peer_conflict';
+  ELSIF current_attempt.state = 'cancelled' THEN
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'aborted',
+        completed_at = NULL,
+        aborted_at = COALESCE(sessions.aborted_at, current_attempt.terminal_at, pg_catalog.clock_timestamp())
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN current_attempt.outcome;
+  END IF;
+
+  abort_proven := session_found AND session.state IN ('aborting', 'aborted');
+  expiry_proven := COALESCE(session.expires_at, owner_snapshot.session_expires_at)
+    <= pg_catalog.clock_timestamp();
+
+  IF current_attempt.state = 'unreferenced' THEN
+    IF NOT abort_proven AND NOT expiry_proven THEN
+      RETURN CASE WHEN access_present THEN 'access_active' ELSE 'access_denied' END;
+    END IF;
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'aborted',
+        completed_at = NULL,
+        aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp())
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN 'already_closed';
+  END IF;
+
+  IF current_attempt.state = 'leased'
+    AND current_attempt.lease_expires_at > pg_catalog.clock_timestamp()
+    AND NOT abort_proven
+  THEN
+    RETURN CASE
+      WHEN access_present AND p_expires_at > pg_catalog.clock_timestamp() THEN 'access_active'
+      ELSE 'busy'
+    END;
+  END IF;
+
+  IF NOT abort_proven AND NOT expiry_proven THEN
+    RETURN CASE WHEN access_present THEN 'access_active' ELSE 'access_denied' END;
+  END IF;
+
+  IF replica_matches IS DISTINCT FROM true AND access_present THEN
+    RETURN 'replica_mismatch';
+  END IF;
+
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'cleanup_claimed';
+  END IF;
+
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    reservation.reservation_token,
+    current_attempt.sha256,
+    current_attempt.blob_storage_key,
+    current_attempt.mime_type,
+    current_attempt.size_bytes,
+    current_attempt.normalization_version,
+    'multipart_completion',
+    current_attempt.workspace_id,
+    current_attempt.media_asset_id,
+    current_attempt.operation_id,
+    p_cleanup_delay_ms
+  );
+
+  IF terminalization_status = 'referenced' THEN
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'completed',
+        completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()),
+        aborted_at = NULL
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    IF current_attempt.state = 'leased' THEN
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET
+        state = 'referenced',
+        outcome = 'referenced',
+        terminal_at = pg_catalog.clock_timestamp()
+      WHERE attempts.attempt_token = current_attempt.attempt_token
+        AND attempts.state = 'leased';
+    END IF;
+    RETURN 'referenced';
+  ELSIF terminalization_status <> 'unreferenced' THEN
+    RETURN 'stale';
+  END IF;
+
+  IF session_found THEN
+    UPDATE content.media_upload_sessions AS sessions
+    SET
+      state = 'aborted',
+      completed_at = NULL,
+      aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp())
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+  END IF;
+
+  IF current_attempt.state = 'leased' THEN
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'cancelled',
+      outcome = 'aborted',
+      terminal_at = pg_catalog.clock_timestamp()
+    WHERE attempts.attempt_token = current_attempt.attempt_token
+      AND attempts.state = 'leased';
+  END IF;
+
+  RETURN 'aborted';
+END;
+$$;
+
+COMMENT ON FUNCTION content.multipart_media_blob_writer_terminal_replay_status_internal(
+  content.media_blob_writer_attempts,
+  content.multipart_media_blob_writer_attempt_payload
+) IS
+  'Compares completed multipart replay against immutable writer identity and the durable parts fingerprint.';
+COMMENT ON FUNCTION content.close_media_upload_session_current_blob_writer_with_owner(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER
+) IS
+  'Closes the database-selected current multipart attempt and reservation with the session, or uses the legacy closure only when no attempt exists.';
+
+REVOKE ALL ON FUNCTION content.multipart_media_blob_writer_terminal_replay_status_internal(
+  content.media_blob_writer_attempts,
+  content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  UUID,
+  INTEGER,
+  content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.close_media_upload_session_current_blob_writer_with_owner(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  UUID,
+  INTEGER,
+  content.multipart_media_blob_writer_attempt_payload
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.close_media_upload_session_current_blob_writer_with_owner(
+  TEXT, UUID, UUID, UUID, UUID, TEXT, TEXT, TEXT, TEXT, BIGINT, TIMESTAMPTZ, INTEGER
+) TO backend_app;


### PR DESCRIPTION
## Summary
- add atomic current multipart-writer abort closure with legacy fallback
- harden completed-session replay against authoritative terminal identity and parts fingerprint
- add PostgreSQL 18 current and upgrade integration coverage

## Validation
- PostgreSQL 18 current 0098 boundary
- PostgreSQL 18 0097 to 0098 boundary, including conflicting historical fingerprints
- PostgreSQL 18 0096 to 0097 boundary
- backend lint and build
- runner JavaScript syntax
- git diff --check