### PR TITLE
chore: align dependency and SDK drift

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -39,7 +39,7 @@ jobs:
           yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-36" \
+            "platforms;android-37.0" \
             "build-tools;37.0.0"
 
       - name: Run Android unit tests, build debug artifacts, and lint
@@ -100,9 +100,9 @@ jobs:
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
             "emulator" \
-            "platforms;android-36" \
+            "platforms;android-37.0" \
             "build-tools;37.0.0" \
-            "system-images;android-36;google_apis;x86_64"
+            "system-images;android-37.0;google_apis;x86_64"
 
       - name: Enable KVM access
         run: |
@@ -113,7 +113,7 @@ jobs:
       - name: Run data:local instrumentation suite on emulator
         uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
-          api-level: 36
+          api-level: 37.0
           target: google_apis
           arch: x86_64
           disable-animations: true

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -473,7 +473,7 @@ jobs:
           yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-36" \
+            "platforms;android-37.0" \
             "build-tools;37.0.0"
 
       - name: Validate Android signing secrets

--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -353,7 +353,7 @@ jobs:
         run: npm run build --prefix apps/admin
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6.2.2
+        uses: aws-actions/configure-aws-credentials@v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,16 +8,16 @@
       "name": "flashcards-open-source-app-api",
       "version": "1.17.0",
       "devDependencies": {
-        "@redocly/cli": "^2.39.0"
+        "@redocly/cli": "^2.41.1"
       },
       "engines": {
         "node": "24.x"
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.39.0.tgz",
-      "integrity": "sha512-xA0Z9YMEhlzbpn/BVErlE2UzuKfahp9llBwEnVtAYuhWdF8UCIm+cgYX8f/gHQIJ/TKwB93awAewTOgEsbZFZw==",
+      "version": "2.41.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.41.1.tgz",
+      "integrity": "sha512-Rde/CpjSMxTBWUCbkECtR4S1YTF8NE+tQgnI1Y7M4wxMLGy8yhmUmTHRUDlKSha97bfBfvjryYuEuZfocD2UNw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/api/package.json
+++ b/api/package.json
@@ -7,11 +7,11 @@
     "lint": "redocly lint src/openapi.yaml"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.39.0"
+    "@redocly/cli": "^2.41.1"
   },
   "overrides": {
-    "fast-xml-parser": "5.10.0",
-    "js-yaml": "5.2.1",
+    "fast-xml-parser": "5.10.1",
+    "js-yaml": "5.2.2",
     "protobufjs": "^8.7.1"
   },
   "engines": {

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.17.0",
       "dependencies": {
         "d3": "^7.9.0",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
         "@types/d3": "^7.4.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.3",
+        "@vitejs/plugin-react": "^6.0.4",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       },
       "engines": {
         "node": "24.x"
@@ -1032,9 +1032,9 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
-      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1889,24 +1889,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/robust-predicates": {
@@ -2038,16 +2038,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -9,16 +9,16 @@
   },
   "dependencies": {
     "d3": "^7.9.0",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "@types/d3": "^7.4.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.3",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "engines": {
     "node": "24.x"

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -16,16 +16,16 @@ We do not want an Android app that imitates iPhone UI. We want a modern Android 
 - UI stack: Jetpack Compose
 - Design system: Material 3
 - Minimum supported Android version: Android 14, `minSdk = 34`
-- Compile target: Android 16, `compileSdk = 36`
-- Runtime target: Android 16, `targetSdk = 36`
-- Testing focus: Android 16 / API 36 only
+- Compile target: Android 17, `compileSdk = 37`
+- Runtime target: Android 17, `targetSdk = 37`
+- Testing focus: Android 17 / API 37 only
 - Primary local storage: Room on top of SQLite
 
-The development focus is Android 14, 15, and 16. We do not spend effort validating or polishing older Android versions.
+The development focus is Android 14, 15, 16, and 17. We do not spend effort validating or polishing older Android versions.
 
 ## Dependency Version Pin
 
-AndroidX and other dependency versions in `gradle/libs.versions.toml` must stay at the highest versions still compatible with `compileSdk = 36`, our stable baseline. Some newer releases — currently `androidx.core:core-ktx >= 1.19.0` and `androidx.lifecycle >= 2.11.0` — require `compileSdk = 37` (Android 17), which is not yet a stable SDK, so they fail the Android build at `:app:checkDebugAarMetadata`. Do not bump these past their `compileSdk 36`-compatible versions (`coreKtx = 1.18.0`, `lifecycle = 2.10.0`) until the whole app intentionally moves to `compileSdk 37`. Automated dependency-drift updates must respect this pin, because Gradle is not run during their validation and cannot catch the break locally.
+AndroidX and other dependency versions in `gradle/libs.versions.toml` must stay at the highest stable versions compatible with `compileSdk = 37`, our current stable baseline. Automated dependency-drift updates must not adopt dependencies that require a preview SDK beyond API 37, because Gradle is not run during their validation and cannot catch that break locally.
 
 ## Design Rule
 
@@ -149,8 +149,8 @@ For the current Android Play Store feature graphics, the expected workflow is:
 
 The current local Android app uses:
 
-- `compileSdk = 36`
-- `targetSdk = 36`
+- `compileSdk = 37`
+- `targetSdk = 37`
 - `minSdk = 34`
 - Room on top of SQLite for local storage
 - Material 3 + Compose + Navigation Compose + `NavigationSuiteScaffold`
@@ -162,7 +162,7 @@ Test only on the final supported Android target.
 - Do not try to cover the Android app exhaustively with tests
 - Do not add isolated unit tests by default
 - Prefer native integration, parity, and instrumentation tests when they validate a real module boundary or user flow
-- Run Android tests only against Android 16 / API 36
+- Run Android tests only against Android 17 / API 37
 - Do not spend time on test matrices for older API levels
 - Do not add compatibility code for older Android versions unless explicitly requested
 - Prefer background local emulator runs without a visible emulator window by default

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -135,12 +135,12 @@ fun sentryTracesSampleRateLiteral(buildTypeName: String): String {
 
 android {
     namespace = "com.flashcardsopensourceapp.app"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.flashcardsopensourceapp.app"
         minSdk = androidMinSdk
-        targetSdk = 36
+        targetSdk = 37
         versionCode = androidVersionCode ?: 1
         versionName = "1.17.0"
         testInstrumentationRunner = "com.flashcardsopensourceapp.app.FlashcardsAndroidTestRunner"

--- a/apps/android/ci/Dockerfile
+++ b/apps/android/ci/Dockerfile
@@ -1,8 +1,8 @@
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:576.0.0-stable
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:577.0.0-stable
 
-ARG ANDROID_CMDLINE_TOOLS_VERSION=15641748
+ARG ANDROID_CMDLINE_TOOLS_VERSION=15859902
 ARG ANDROID_BUILD_TOOLS_VERSION=37.0.0
-ARG ANDROID_PLATFORM_VERSION=36
+ARG ANDROID_PLATFORM_VERSION=37.0
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV ANDROID_SDK_ROOT=/opt/android-sdk

--- a/apps/android/core/observability/build.gradle.kts
+++ b/apps/android/core/observability/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.core.observability"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/core/ui/build.gradle.kts
+++ b/apps/android/core/ui/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.core.ui"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/data/local/build.gradle.kts
+++ b/apps/android/data/local/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.data.local"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/docs/marketing-screenshot-runbook.md
+++ b/apps/android/docs/marketing-screenshot-runbook.md
@@ -67,17 +67,17 @@ For marketing screenshot generation, the visible emulator UI is unnecessary and 
 1. Stop all Android emulators.
 2. Stop all booted iOS simulators.
 3. Verify `adb devices` is empty before starting a new Android run.
-4. Start exactly one Android API 36 emulator in headless mode, currently `Medium_Phone_API_36.1`.
+4. Start exactly one Android API 37 emulator in headless mode, currently `Medium_Phone_API_37.0`.
    Recommended local command:
 
    ```bash
-   emulator @Medium_Phone_API_36.1 -no-window -no-audio -gpu auto
+   emulator @Medium_Phone_API_37.0 -no-window -no-audio -gpu auto
    ```
 
    If the emulator still needs startup diagnosis on a weak machine, keep the same headless shape and add only temporary debug flags:
 
    ```bash
-   emulator @Medium_Phone_API_36.1 -no-window -no-audio -gpu auto -verbose -debug init,metrics -logcat '*:s ActivityManager:i AndroidTestOrchestrator:i TestRunner:i'
+   emulator @Medium_Phone_API_37.0 -no-window -no-audio -gpu auto -verbose -debug init,metrics -logcat '*:s ActivityManager:i AndroidTestOrchestrator:i TestRunner:i'
    ```
 
    Avoid forcing the deprecated `-gpu swiftshader_indirect` mode for this local screenshot flow.
@@ -143,7 +143,7 @@ bash scripts/android/capture-android-marketing-screenshots.sh
 
 Each wrapper script does the following:
 
-1. Verifies that an Android API 36 device is connected.
+1. Verifies that an Android API 37 device is connected.
 2. Dismisses blocking system dialogs.
 3. Runs one manual-only instrumentation class through `:app:connectedMarketingScreenshotAndroidTest`.
 4. Pulls the generated PNG file or files from `/sdcard/Download/flashcards-marketing-screenshots/` into the committed media directory.

--- a/apps/android/docs/marketing-screenshots.md
+++ b/apps/android/docs/marketing-screenshots.md
@@ -49,8 +49,8 @@ The unified screenshot flow captures an exam-prep concept card about opportunity
 
 Prerequisites:
 
-- Start a local Android emulator or device on API 36.
-- For a local headless emulator, prefer `emulator @Medium_Phone_API_36.1 -no-window -no-audio -gpu auto`.
+- Start a local Android emulator or device on API 37.
+- For a local headless emulator, prefer `emulator @Medium_Phone_API_37.0 -no-window -no-audio -gpu auto`.
 - Run from the repository root.
 
 Command:

--- a/apps/android/feature/ai/build.gradle.kts
+++ b/apps/android/feature/ai/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.feature.ai"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/feature/cards/build.gradle.kts
+++ b/apps/android/feature/cards/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.feature.cards"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/feature/friendinvite/build.gradle.kts
+++ b/apps/android/feature/friendinvite/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.feature.friendinvite"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/feature/progress/build.gradle.kts
+++ b/apps/android/feature/progress/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.feature.progress"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/feature/review/build.gradle.kts
+++ b/apps/android/feature/review/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.feature.review"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/feature/settings/build.gradle.kts
+++ b/apps/android/feature/settings/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.flashcardsopensourceapp.feature.settings"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 34

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -1,20 +1,16 @@
 [versions]
-agp = "9.3.0"
+agp = "9.3.1"
 kotlin = "2.4.10"
 ksp = "2.3.10"
-# Pinned for compileSdk 36 (our stable baseline — see apps/android/README.md):
-# coreKtx >= 1.19.0 requires compileSdk 37 (Android 17, not yet stable) and breaks the Android build.
-coreKtx = "1.18.0"
+coreKtx = "1.19.0"
 splashscreen = "1.2.0"
 activityCompose = "1.13.0"
-# Pinned for compileSdk 36: lifecycle >= 2.11.0 requires compileSdk 37 (see coreKtx note above).
-lifecycle = "2.10.0"
+lifecycle = "2.11.0"
 navigationCompose = "2.9.8"
 composeBom = "2026.06.01"
 lottieCompose = "6.7.1"
 coil = "3.5.0"
-# Pinned for compileSdk 36: markdown renderer >= 0.42.0 requires compileSdk 37.
-markdownRenderer = "0.41.0"
+markdownRenderer = "0.43.0"
 room = "2.8.4"
 work = "2.11.2"
 adaptive = "1.2.0"
@@ -28,10 +24,10 @@ espresso = "3.7.0"
 uiautomator = "2.4.0"
 testOrchestrator = "1.6.1"
 securityCrypto = "1.1.0"
-json = "20260522"
+json = "20260719"
 okhttp = "5.4.0"
-sentry = "8.48.0"
-sentryAndroidGradlePlugin = "6.14.0"
+sentry = "8.50.1"
+sentryAndroidGradlePlugin = "6.16.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -8,11 +8,11 @@
       "name": "flashcards-auth",
       "version": "1.17.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1087.0",
-        "@hono/node-server": "^2.0.9",
-        "@sentry/aws-serverless": "^10.65.0",
+        "@aws-sdk/client-secrets-manager": "^3.1097.0",
+        "@hono/node-server": "^2.0.12",
+        "@sentry/aws-serverless": "^10.68.0",
         "aws-jwt-verify": "^5.2.1",
-        "hono": "^4.12.30",
+        "hono": "^4.12.32",
         "pg": "^8.22.0"
       },
       "devDependencies": {
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
-      "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/estree": "^1.0.8",
@@ -43,12 +43,12 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz",
-      "integrity": "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.1.tgz",
+      "integrity": "sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==",
       "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "es-module-lexer": "^2.1.0",
         "magic-string": "^0.30.21",
         "module-details-from-path": "^1.0.4"
@@ -58,28 +58,28 @@
       }
     },
     "node_modules/@apm-js-collab/tracing-hooks": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.1.tgz",
-      "integrity": "sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1087.0.tgz",
-      "integrity": "sha512-muY3Z3S8iFUIum2ir97iwGSW4xsRtzfgI74xmfDibuvkaUb4YnBKcJ+V5OOwoiZCKa9rFrR6gXjFfEN3zvbmPA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1097.0.tgz",
+      "integrity": "sha512-EAyknLfabMWA1kAVgcBO6iTYBWFVnoX8WRrKEbPf6npNZUKv7oJoZBK+I0OvRK0o3P0ynbey64pDlspWXB9dag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -88,16 +88,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.2.tgz",
-      "integrity": "sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@aws-sdk/xml-builder": "^3.972.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.3",
-        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -107,14 +107,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.58.tgz",
-      "integrity": "sha512-vyGtvK1rY940eq7JT0yIGKuZ+2kpPSJcHibSvGlit5oiMFDamzC7cxBGLl4FLnd6suihMXDI2FSF2dL6TmBqPA==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -123,16 +123,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.60.tgz",
-      "integrity": "sha512-g9b9YzDrD5pcKiPBJfCSXRfFMrA39eR0guUhZ5SRm+7vMAVc43+effxbcamxBjSd5bUhrdKo5te/yQuWurLXLA==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -141,22 +141,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.2.tgz",
-      "integrity": "sha512-Yr7yxNyQ8aHt9Ww0RPFUZx+xiem+vl7vuwhP0tniTijoesJNV5jou9HCgVpI0GEPAF+89TkOvilE5uRrZJnjaw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-login": "^3.972.64",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -165,15 +165,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.64.tgz",
-      "integrity": "sha512-YQoSI4d6kXvoenoG/0Jv/PqaAuukHzGmGXGyHBQYeEUNsYovlNAn/Sw1wp/WQbhcQ3HsEMGgjEahvD3igz6ecQ==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -182,20 +182,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.68.tgz",
-      "integrity": "sha512-4akjzW9CjorByYfqXBXmYUh/h7Io3U4DtVgGGh9TQraZ7ZlyJqNyHwDRGiUFnHD+BTOeTbCesCa4sJaK7BGZ7A==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-ini": "^3.973.2",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -204,14 +204,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.58.tgz",
-      "integrity": "sha512-1nYitRCaDmXWUrpBJt6WlcGjLx1JVsMY8rlYuHHsTYTSaYikbixYdQSyINN2VYq1F798uTO9qHAzytL25M8g3A==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -220,16 +220,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.2.tgz",
-      "integrity": "sha512-pjMLaLU/JZi5lVfmR14V1OZqRBTuMHf6AwGNZA0K9hK+JKtO3jcLBarfD8iq5oc8cSowvc/9R32sqMVXZPo6xQ==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/token-providers": "3.1087.0",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -238,15 +238,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.64.tgz",
-      "integrity": "sha512-7Buc7p0OvDHW7iBsu4b+YdS0WnaFBDGKDfbVQqaac9dkWiSiUtIoarBDsA1RmOVXZijaZJDoHJFIQiicQvWRlQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -255,17 +255,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.32.tgz",
-      "integrity": "sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -274,13 +274,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.40.tgz",
-      "integrity": "sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/signature-v4": "^5.6.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -289,15 +289,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1087.0.tgz",
-      "integrity": "sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.1.tgz",
-      "integrity": "sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.35.tgz",
-      "integrity": "sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.9.tgz",
-      "integrity": "sha512-cNMw3ziCdDcx0+ldta60zvUL5XO0OLt521n2hjPp0PB0ugczDCEczXsf33qQbkKIXWGFQ03f0LC85u6YK8pCLA==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -854,12 +854,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
-      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -870,13 +870,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
-      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -887,14 +887,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
-      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -914,17 +914,17 @@
       }
     },
     "node_modules/@sentry/aws-serverless": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.65.0.tgz",
-      "integrity": "sha512-DzfTcpLKhzAHZGE/H+1SI/iWJ1zHRT+Wr7tNU+uhrG4zxdGH2eLrQ7uJmY0OJzJ+sQURgoFR+qY4ZHN6MJWZqQ==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.68.0.tgz",
+      "integrity": "sha512-5zHoYH3e+ft8Dr6OR2DF2c0Dqhekre6ubbCLPvLXgaS6XuJmFi02+nCyOnn5ibQP8CmjH+iQVzAarwbxQHx+PA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.220.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node": "10.65.0",
-        "@sentry/node-core": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node": "10.68.0",
+        "@sentry/node-core": "10.68.0",
         "@types/aws-lambda": "^8.10.161"
       },
       "engines": {
@@ -932,40 +932,40 @@
       }
     },
     "node_modules/@sentry/conventions": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
-      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
-      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1"
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.65.0.tgz",
-      "integrity": "sha512-t35dcdyksysVch/m/XdLgGJqGKJhr9eMD30Ctn3TeQ8yMB0wNXySfjPR5Yg93fpjmfaHtzc6iYIXRAvgNVfrvA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.68.0.tgz",
+      "integrity": "sha512-bnvRzEehquG/894DD3BWNCBUbDWsLQfYPU+SNCMd6G4Ext75RthVkRs8R0sRaE6b8Tw9HSEgySHL834Tf8lVsA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.220.0",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node-core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
-        "@sentry/server-utils": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node-core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
+        "@sentry/server-utils": "10.68.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -973,14 +973,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.65.0.tgz",
-      "integrity": "sha512-U01X9mPT+jZnsLPmPWfBU67Ka+t/Sdd9RGAuvGoKdrI6N47a/9PDkM9oCW+kj0fmZwogZHTgSnzJU5oi3pImgA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.68.0.tgz",
+      "integrity": "sha512-VreORXnruy8A2SyprZKENAq3ArGwn35KPewLQSQ5dgDXSFtUj2scLuzZoVsZ/Uyt83td0WPvD6Lv0X7MvSYAMQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -1012,13 +1012,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.65.0.tgz",
-      "integrity": "sha512-8C6FPvm3XBvUrkM52dX3Gz0p2H0Ij8t4sahUA+GTiCz0WM0fnyPeQPGC/b6I4jamV9UXyCZRnE1UEEGCoD+c7A==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.68.0.tgz",
+      "integrity": "sha512-JDNH9dacX0MSi7FRvabPCJUAXRMTe16bE/Gajc/7Gfcw7Rwvo4DZ0nd162PCSAW9QoEjUT12upDehEHJuFmsXg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
       },
       "engines": {
         "node": ">=18"
@@ -1030,26 +1030,25 @@
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.65.0.tgz",
-      "integrity": "sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.68.0.tgz",
+      "integrity": "sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==",
       "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
-        "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
-        "@apm-js-collab/tracing-hooks": "^0.10.1",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "magic-string": "~0.30.0"
+        "@apm-js-collab/code-transformer-bundler-plugins": "0.7.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "meriyah": "^6.1.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1060,12 +1059,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
-      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1074,12 +1073,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
-      "integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1088,12 +1087,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1102,12 +1101,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
-      "integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1633,18 +1632,18 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
-      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
+      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
       "license": "Apache-2.0",
       "dependencies": {
         "cjs-module-lexer": "^2.2.0",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -10,11 +10,11 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1087.0",
-    "@hono/node-server": "^2.0.9",
-    "@sentry/aws-serverless": "^10.65.0",
+    "@aws-sdk/client-secrets-manager": "^3.1097.0",
+    "@hono/node-server": "^2.0.12",
+    "@sentry/aws-serverless": "^10.68.0",
     "aws-jwt-verify": "^5.2.1",
-    "hono": "^4.12.30",
+    "hono": "^4.12.32",
     "pg": "^8.22.0"
   },
   "devDependencies": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -8,29 +8,29 @@
       "name": "flashcards-open-source-app-backend",
       "version": "1.17.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.1087.0",
-        "@aws-sdk/client-lambda": "^3.1087.0",
-        "@aws-sdk/client-s3": "^3.1087.0",
-        "@aws-sdk/client-secrets-manager": "^3.1087.0",
-        "@aws-sdk/s3-request-presigner": "^3.1087.0",
-        "@hono/node-server": "^2.0.9",
+        "@aws-sdk/client-cognito-identity-provider": "^3.1097.0",
+        "@aws-sdk/client-lambda": "^3.1097.0",
+        "@aws-sdk/client-s3": "^3.1097.0",
+        "@aws-sdk/client-secrets-manager": "^3.1097.0",
+        "@aws-sdk/s3-request-presigner": "^3.1097.0",
+        "@hono/node-server": "^2.0.12",
         "@langfuse/openai": "^5.9.1",
         "@langfuse/otel": "^5.9.1",
         "@langfuse/tracing": "^5.9.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
-        "@opentelemetry/sdk-trace-base": "^2.9.0",
-        "@sentry/aws-serverless": "^10.65.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
+        "@sentry/aws-serverless": "^10.68.0",
         "aws-jwt-verify": "^5.2.1",
-        "hono": "^4.12.30",
-        "openai": "^6.47.0",
+        "hono": "^4.12.32",
+        "openai": "^7.1.0",
         "pg": "^8.22.0",
         "sharp": "^0.35.3",
         "yauzl": "^3.4.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@sentry/cli": "^3.6.0",
+        "@sentry/cli": "^3.6.2",
         "@types/aws-lambda": "^8.10.162",
         "@types/node": "^24.13.3",
         "@types/pg": "^8.20.0",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
-      "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/estree": "^1.0.8",
@@ -60,12 +60,12 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz",
-      "integrity": "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.1.tgz",
+      "integrity": "sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==",
       "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "es-module-lexer": "^2.1.0",
         "magic-string": "^0.30.21",
         "module-details-from-path": "^1.0.4"
@@ -75,25 +75,25 @@
       }
     },
     "node_modules/@apm-js-collab/tracing-hooks": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.1.tgz",
-      "integrity": "sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.17.tgz",
-      "integrity": "sha512-k45iXM7w8Pyknnz/vTXSS/IkLDNFdgnBQI7Hmq+uhsrW7NGT/BiUJGlv20QSKzihmH1XDvSCRILICaKi57/35w==",
+      "version": "3.1000.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.22.tgz",
+      "integrity": "sha512-YsSac72lcCOSjk5X4fMc20SjltkGUDjckB2vYZcEd/RpgB+huzeQwVZrOWxUvLVo+5D7X9sURgmAAPmErgCQ7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -102,17 +102,17 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1087.0.tgz",
-      "integrity": "sha512-/qgonE1ZCH3/cCg7vPRgJDquDVPZUoxVc2JBnMg2Ejqi1WmmrRtgzAZ3PDNijkymHl3KLxBjFDbNOQ1q8hPJZA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1097.0.tgz",
+      "integrity": "sha512-ZVCOLDGTan3vwbjlvZyulFSlMWxdasb/FuUkJTDDyGCS38vC7IFVRlXQAmtH7yE6j7I0Z4hNKN7CimSDMKGfKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -121,17 +121,17 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1087.0.tgz",
-      "integrity": "sha512-qZVBwoJjdphfnvTpDoeg7vCF16tGmP5B15f7hcGJm7J2mQGRPXA+II16b9jguORgud3y6CHHjsBfcg8o5cHNew==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1097.0.tgz",
+      "integrity": "sha512-HpslEz/ZsArAbIf5ZYJocmPcO8D9xqf4tAvVrSsMQLeUtg7W6Sw0PimRfm2BivUrUEklY5tzZdRl74zkmHYnpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -140,20 +140,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1087.0.tgz",
-      "integrity": "sha512-44ua5vo5JiFFSnG3oeeWTMfSjOtblQSoJiGbf37s0W4Lr7IY9NmIVkBHIfD4hBI1VEKdvJhDmvuJawwTfi2pvw==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1097.0.tgz",
+      "integrity": "sha512-iCBD95hrynpxiOzD301pUW9H3mxKcEfMErLqdg58WcIZnEqJuOd7JwcARsV3/y6OWj1t6j2tpS9lGt6X4OnPFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.17",
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.63",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/checksums": "^3.1000.22",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.68",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -162,17 +162,17 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1087.0.tgz",
-      "integrity": "sha512-muY3Z3S8iFUIum2ir97iwGSW4xsRtzfgI74xmfDibuvkaUb4YnBKcJ+V5OOwoiZCKa9rFrR6gXjFfEN3zvbmPA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1097.0.tgz",
+      "integrity": "sha512-EAyknLfabMWA1kAVgcBO6iTYBWFVnoX8WRrKEbPf6npNZUKv7oJoZBK+I0OvRK0o3P0ynbey64pDlspWXB9dag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -181,16 +181,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.2.tgz",
-      "integrity": "sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@aws-sdk/xml-builder": "^3.972.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.3",
-        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -200,14 +200,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.58.tgz",
-      "integrity": "sha512-vyGtvK1rY940eq7JT0yIGKuZ+2kpPSJcHibSvGlit5oiMFDamzC7cxBGLl4FLnd6suihMXDI2FSF2dL6TmBqPA==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -216,16 +216,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.60.tgz",
-      "integrity": "sha512-g9b9YzDrD5pcKiPBJfCSXRfFMrA39eR0guUhZ5SRm+7vMAVc43+effxbcamxBjSd5bUhrdKo5te/yQuWurLXLA==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -234,22 +234,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.2.tgz",
-      "integrity": "sha512-Yr7yxNyQ8aHt9Ww0RPFUZx+xiem+vl7vuwhP0tniTijoesJNV5jou9HCgVpI0GEPAF+89TkOvilE5uRrZJnjaw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-login": "^3.972.64",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -258,15 +258,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.64.tgz",
-      "integrity": "sha512-YQoSI4d6kXvoenoG/0Jv/PqaAuukHzGmGXGyHBQYeEUNsYovlNAn/Sw1wp/WQbhcQ3HsEMGgjEahvD3igz6ecQ==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -275,20 +275,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.68.tgz",
-      "integrity": "sha512-4akjzW9CjorByYfqXBXmYUh/h7Io3U4DtVgGGh9TQraZ7ZlyJqNyHwDRGiUFnHD+BTOeTbCesCa4sJaK7BGZ7A==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-ini": "^3.973.2",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -297,14 +297,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.58.tgz",
-      "integrity": "sha512-1nYitRCaDmXWUrpBJt6WlcGjLx1JVsMY8rlYuHHsTYTSaYikbixYdQSyINN2VYq1F798uTO9qHAzytL25M8g3A==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -313,16 +313,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.2.tgz",
-      "integrity": "sha512-pjMLaLU/JZi5lVfmR14V1OZqRBTuMHf6AwGNZA0K9hK+JKtO3jcLBarfD8iq5oc8cSowvc/9R32sqMVXZPo6xQ==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/token-providers": "3.1087.0",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -331,15 +331,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.64.tgz",
-      "integrity": "sha512-7Buc7p0OvDHW7iBsu4b+YdS0WnaFBDGKDfbVQqaac9dkWiSiUtIoarBDsA1RmOVXZijaZJDoHJFIQiicQvWRlQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -348,15 +348,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.63.tgz",
-      "integrity": "sha512-EklitJscj/Aq2Pk8nz0xSxvL+VMSP29iFqouQU0Ow05JKn5y/OhI81ujkfVS72MjD1yeoU9uIdT8c/W6vhktQw==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.68.tgz",
+      "integrity": "sha512-JA/LRxCSXQAsFHyIZzgncYdcTQTOL3ZS8R7EAeDwoSoWcNG8yxDAacrwFTZIyVSMvkogvlKHRvmrMU68UyQbkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -365,17 +365,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.32.tgz",
-      "integrity": "sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -384,15 +384,15 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1087.0.tgz",
-      "integrity": "sha512-tfwcw5sviZTMCYsaFGpi0XyA1O8exrjHAYDjqtTPqnroG/zaRpTi2btWT3rpxwVrKUFgEwYwPNgtHrDSVIHQMQ==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1097.0.tgz",
+      "integrity": "sha512-TgmZH1nCj26l5eNM/kxpQYwDtEWsB6jRi4bVFYipMFR2Mch815Gw/g0jkavNU0RUdYIqyPv6mzaQ545KC2Jdqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -401,13 +401,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.40.tgz",
-      "integrity": "sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/signature-v4": "^5.6.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -416,15 +416,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1087.0.tgz",
-      "integrity": "sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.1.tgz",
-      "integrity": "sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.35.tgz",
-      "integrity": "sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.9.tgz",
-      "integrity": "sha512-cNMw3ziCdDcx0+ldta60zvUL5XO0OLt521n2hjPp0PB0ugczDCEczXsf33qQbkKIXWGFQ03f0LC85u6YK8pCLA==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -1538,12 +1538,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1577,18 +1577,6 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -1615,6 +1603,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
       "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1646,12 +1635,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
-      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/api-logs": "0.221.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
@@ -1660,6 +1649,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
@@ -1705,6 +1706,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1757,6 +1759,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
       "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.9.0",
         "@opentelemetry/resources": "2.9.0",
@@ -1770,14 +1773,62 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
-      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1797,27 +1848,44 @@
       }
     },
     "node_modules/@sentry/aws-serverless": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.65.0.tgz",
-      "integrity": "sha512-DzfTcpLKhzAHZGE/H+1SI/iWJ1zHRT+Wr7tNU+uhrG4zxdGH2eLrQ7uJmY0OJzJ+sQURgoFR+qY4ZHN6MJWZqQ==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.68.0.tgz",
+      "integrity": "sha512-5zHoYH3e+ft8Dr6OR2DF2c0Dqhekre6ubbCLPvLXgaS6XuJmFi02+nCyOnn5ibQP8CmjH+iQVzAarwbxQHx+PA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.220.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node": "10.65.0",
-        "@sentry/node-core": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node": "10.68.0",
+        "@sentry/node-core": "10.68.0",
         "@types/aws-lambda": "^8.10.161"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@sentry/aws-serverless/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@sentry/cli": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.6.0.tgz",
-      "integrity": "sha512-79XC8o59G/i3VqmnoQD74a/QD/422eQQlUqiPd3sEvcYCxnaZialRVAsxuNEFd6sx4aVGpqt775MMDT9cV/lMg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.6.2.tgz",
+      "integrity": "sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
@@ -1834,20 +1902,20 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "3.6.0",
-        "@sentry/cli-linux-arm": "3.6.0",
-        "@sentry/cli-linux-arm64": "3.6.0",
-        "@sentry/cli-linux-i686": "3.6.0",
-        "@sentry/cli-linux-x64": "3.6.0",
-        "@sentry/cli-win32-arm64": "3.6.0",
-        "@sentry/cli-win32-i686": "3.6.0",
-        "@sentry/cli-win32-x64": "3.6.0"
+        "@sentry/cli-darwin": "3.6.2",
+        "@sentry/cli-linux-arm": "3.6.2",
+        "@sentry/cli-linux-arm64": "3.6.2",
+        "@sentry/cli-linux-i686": "3.6.2",
+        "@sentry/cli-linux-x64": "3.6.2",
+        "@sentry/cli-win32-arm64": "3.6.2",
+        "@sentry/cli-win32-i686": "3.6.2",
+        "@sentry/cli-win32-x64": "3.6.2"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.6.0.tgz",
-      "integrity": "sha512-C2SWHKaEP8NoYkLDr5jwrzklTwlJkzPIx7lu2LZrwBuHG/sNhWdili0ED2mD86b6Q90hlcMtuBm5IHUwcZ6FTQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.6.2.tgz",
+      "integrity": "sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw==",
       "dev": true,
       "license": "FSL-1.1-MIT",
       "optional": true,
@@ -1859,9 +1927,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.6.0.tgz",
-      "integrity": "sha512-S9xsDZTvybOGbrqqZ7DvF7JCNKp4cakDWJ4LdvQX+z82cHQSoLkYOXkA3EafDfWV9BGIRMIXitMMiSsV2PMU4g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.6.2.tgz",
+      "integrity": "sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q==",
       "cpu": [
         "arm"
       ],
@@ -1878,9 +1946,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.6.0.tgz",
-      "integrity": "sha512-Rc+DB8vuTDpwqY2BxIPnooYk2ZDYQytF+n4nfi6pZZsJtr3SFFe+3wIWVmCVqxiHkaISb33+iJIDxOOqhkSNbQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.6.2.tgz",
+      "integrity": "sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg==",
       "cpu": [
         "arm64"
       ],
@@ -1897,9 +1965,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.6.0.tgz",
-      "integrity": "sha512-PQ7+ctNmWtHgmbKa+rJheHU7D9GHJXafgWYfVW6gt7R0Ag9LxiDVYLGjrL4G/i7AGFNgudXFaLkGKNX7HUjc+g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.6.2.tgz",
+      "integrity": "sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ==",
       "cpu": [
         "x86",
         "ia32"
@@ -1917,9 +1985,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.6.0.tgz",
-      "integrity": "sha512-c+7xNg5BAaPE8N2Q6pg3Q/kt97JSaskuQIjRxHaFuDbCkJvww4VozY6mW5NUMJaW48rEs3mahWKamTLqJsO3wQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.6.2.tgz",
+      "integrity": "sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow==",
       "cpu": [
         "x64"
       ],
@@ -1936,9 +2004,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.6.0.tgz",
-      "integrity": "sha512-zhZ7YyGreHSKZ92Mwb9h4cEyL0I/eND7W6XIUXUW0BCCmxFOMc71vlQpUw8gijHIsFDbv8c8a6VOSkeRuwbSwQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.6.2.tgz",
+      "integrity": "sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw==",
       "cpu": [
         "arm64"
       ],
@@ -1953,9 +2021,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.6.0.tgz",
-      "integrity": "sha512-JaxzVDdyetrPBp8NHh2yNAYdDk79ROXqfAfjQwG5z6V764MMMrf2WrhQ7EwoKXOPtBLm/drbOcYgaxHuDZKGRw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.6.2.tgz",
+      "integrity": "sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ==",
       "cpu": [
         "x86",
         "ia32"
@@ -1971,9 +2039,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.6.0.tgz",
-      "integrity": "sha512-LW0078VlxaUeVMMLA15A1zhkvZ5vby/lwthtBXPoBSDdTcgbTE4D4gQXM9vEapV28SvCO3fVIek3pbtrkaeDMw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.6.2.tgz",
+      "integrity": "sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg==",
       "cpu": [
         "x64"
       ],
@@ -1988,40 +2056,40 @@
       }
     },
     "node_modules/@sentry/conventions": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
-      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
-      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1"
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.65.0.tgz",
-      "integrity": "sha512-t35dcdyksysVch/m/XdLgGJqGKJhr9eMD30Ctn3TeQ8yMB0wNXySfjPR5Yg93fpjmfaHtzc6iYIXRAvgNVfrvA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.68.0.tgz",
+      "integrity": "sha512-bnvRzEehquG/894DD3BWNCBUbDWsLQfYPU+SNCMd6G4Ext75RthVkRs8R0sRaE6b8Tw9HSEgySHL834Tf8lVsA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.220.0",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node-core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
-        "@sentry/server-utils": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node-core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
+        "@sentry/server-utils": "10.68.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2029,14 +2097,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.65.0.tgz",
-      "integrity": "sha512-U01X9mPT+jZnsLPmPWfBU67Ka+t/Sdd9RGAuvGoKdrI6N47a/9PDkM9oCW+kj0fmZwogZHTgSnzJU5oi3pImgA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.68.0.tgz",
+      "integrity": "sha512-VreORXnruy8A2SyprZKENAq3ArGwn35KPewLQSQ5dgDXSFtUj2scLuzZoVsZ/Uyt83td0WPvD6Lv0X7MvSYAMQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2067,14 +2135,31 @@
         }
       }
     },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.65.0.tgz",
-      "integrity": "sha512-8C6FPvm3XBvUrkM52dX3Gz0p2H0Ij8t4sahUA+GTiCz0WM0fnyPeQPGC/b6I4jamV9UXyCZRnE1UEEGCoD+c7A==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.68.0.tgz",
+      "integrity": "sha512-JDNH9dacX0MSi7FRvabPCJUAXRMTe16bE/Gajc/7Gfcw7Rwvo4DZ0nd162PCSAW9QoEjUT12upDehEHJuFmsXg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
       },
       "engines": {
         "node": ">=18"
@@ -2086,26 +2171,25 @@
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.65.0.tgz",
-      "integrity": "sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.68.0.tgz",
+      "integrity": "sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==",
       "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
-        "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
-        "@apm-js-collab/tracing-hooks": "^0.10.1",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "magic-string": "~0.30.0"
+        "@apm-js-collab/code-transformer-bundler-plugins": "0.7.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "meriyah": "^6.1.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -2116,12 +2200,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
-      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2130,12 +2214,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
-      "integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2144,12 +2228,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2158,12 +2242,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
-      "integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3056,9 +3140,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -3208,9 +3292,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3460,10 +3544,13 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.47.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.47.0.tgz",
-      "integrity": "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.1.0.tgz",
+      "integrity": "sha512-7xWJ9iO5z5u1dnIUGwoUmZHkSyrUYXX2cUxo2E/26iKFrSC8IdEak7z94d5UntU7z+S/Cid33hYymwMSab2fZQ==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
       "peerDependencies": {
         "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
         "@smithy/hash-node": ">=4.3.0 <5",
@@ -4117,9 +4204,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,29 +13,29 @@
     "test:mcp": "npm run bundle --prefix ../../api && node --test --import tsx src/entrypoints/lambda-mcp.test.ts src/mcp/server.test.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.1087.0",
-    "@aws-sdk/client-lambda": "^3.1087.0",
-    "@aws-sdk/client-s3": "^3.1087.0",
-    "@aws-sdk/client-secrets-manager": "^3.1087.0",
-    "@aws-sdk/s3-request-presigner": "^3.1087.0",
-    "@hono/node-server": "^2.0.9",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1097.0",
+    "@aws-sdk/client-lambda": "^3.1097.0",
+    "@aws-sdk/client-s3": "^3.1097.0",
+    "@aws-sdk/client-secrets-manager": "^3.1097.0",
+    "@aws-sdk/s3-request-presigner": "^3.1097.0",
+    "@hono/node-server": "^2.0.12",
     "@langfuse/openai": "^5.9.1",
     "@langfuse/otel": "^5.9.1",
     "@langfuse/tracing": "^5.9.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.220.0",
-    "@opentelemetry/sdk-trace-base": "^2.9.0",
-    "@sentry/aws-serverless": "^10.65.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@opentelemetry/instrumentation": "^0.221.0",
+    "@opentelemetry/sdk-trace-base": "^2.10.0",
+    "@sentry/aws-serverless": "^10.68.0",
     "aws-jwt-verify": "^5.2.1",
-    "hono": "^4.12.30",
-    "openai": "^6.47.0",
+    "hono": "^4.12.32",
+    "openai": "^7.1.0",
     "pg": "^8.22.0",
     "sharp": "^0.35.3",
     "yauzl": "^3.4.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@sentry/cli": "^3.6.0",
+    "@sentry/cli": "^3.6.2",
     "@types/aws-lambda": "^8.10.162",
     "@types/node": "^24.13.3",
     "@types/pg": "^8.20.0",
@@ -45,7 +45,7 @@
   },
   "overrides": {
     "protobufjs": "^8.7.1",
-    "undici": "6.27.0"
+    "undici": "6.28.0"
   },
   "engines": {
     "node": "24.x"

--- a/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "53eb9bd5da18e208cfd80e86863d3f4c7ba21b1d",
-        "version" : "9.21.0"
+        "revision" : "afa7510e05b99f35c1febe47566bfd868fa53fb9",
+        "version" : "9.23.0"
       }
     },
     {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,26 +9,26 @@
       "version": "1.17.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.9",
-        "@sentry/react": "^10.65.0",
+        "@sentry/react": "^10.68.0",
         "heic-to": "^1.5.2",
         "lottie-web": "^5.13.0",
         "qrcode.react": "^4.2.0",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.0",
         "@sentry/vite-plugin": "^5.4.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.3",
+        "@vitejs/plugin-react": "^6.0.4",
         "fake-indexeddb": "^6.2.5",
-        "jsdom": "^29.1.1",
+        "jsdom": "^30.0.0",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vitest": "4.1.10"
       },
       "engines": {
@@ -36,55 +36,57 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.0.tgz",
+      "integrity": "sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "20 || >=22"
       }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -360,9 +362,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "dev": true,
       "funding": [
         {
@@ -384,9 +386,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
-      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
       "dev": true,
       "funding": [
         {
@@ -401,7 +403,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.1.0",
-        "@csstools/css-calc": "^3.2.1"
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -649,19 +651,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -947,30 +949,72 @@
       "license": "MIT"
     },
     "node_modules/@sentry/browser": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.65.0.tgz",
-      "integrity": "sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.68.0.tgz",
+      "integrity": "sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.65.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/feedback": "10.65.0",
-        "@sentry/replay": "10.65.0",
-        "@sentry/replay-canvas": "10.65.0"
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/feedback": "10.68.0",
+        "@sentry/replay": "10.68.0",
+        "@sentry/replay-canvas": "10.68.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.65.0.tgz",
-      "integrity": "sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.68.0.tgz",
+      "integrity": "sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils/node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/browser-utils/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
@@ -1185,6 +1229,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
       "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1194,6 +1239,7 @@
       "version": "10.65.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
       "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.15.1"
@@ -1203,26 +1249,47 @@
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.65.0.tgz",
-      "integrity": "sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.68.0.tgz",
+      "integrity": "sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.65.0"
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback/node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/feedback/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.65.0.tgz",
-      "integrity": "sha512-fvHxpuvid0wt9/1N3itcKDyKOjqmYHw3MBSt5Pki3Iz4CL2CmgQp9ZFv/CA7UhMnEvn2Gd+Qc2UKxujZWd8FLg==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.68.0.tgz",
+      "integrity": "sha512-rIq4QR4ScMHHx9JJZv7Jgw31bMdUVJMx+ykHIJb7htjY6mj78sjKs+KpCsMDnvJxDhSmvftGM1KfKD4BggL7OQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.65.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
+        "@sentry/browser": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
       },
       "engines": {
         "node": ">=18"
@@ -1231,27 +1298,90 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
-    "node_modules/@sentry/replay": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.65.0.tgz",
-      "integrity": "sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==",
+    "node_modules/@sentry/react/node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.65.0",
-        "@sentry/core": "10.65.0"
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.68.0.tgz",
+      "integrity": "sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/core": "10.68.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.65.0.tgz",
-      "integrity": "sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.68.0.tgz",
+      "integrity": "sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.65.0",
-        "@sentry/replay": "10.65.0"
+        "@sentry/core": "10.68.0",
+        "@sentry/replay": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas/node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/replay-canvas/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
@@ -1726,9 +1856,9 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
-      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1931,16 +2061,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2075,18 +2205,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -2544,39 +2667,39 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-JQHfRGmmKmaZoUAvIgff5jjG/0SzTQlGz8c7t72KzBzo8ZULEjAjnYE0sNwBOUA4QtWwYE2xoYitg8NFsmiYxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.2.5",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@exodus/bytes": "^1.15.1",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
+        "lru-cache": "^11.5.2",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.7.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "whatwg-url": "^17.1.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.0.0"
+        "canvas": "^3.2.3"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -2592,6 +2715,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -4051,35 +4189,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {
@@ -4158,24 +4296,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-markdown": {
@@ -4206,41 +4344,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/remark-gfm": {
@@ -4381,12 +4502,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -4622,13 +4737,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/unified": {
@@ -4778,16 +4893,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,36 +13,27 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.9",
-    "@sentry/react": "^10.65.0",
+    "@sentry/react": "^10.68.0",
     "heic-to": "^1.5.2",
     "lottie-web": "^5.13.0",
     "qrcode.react": "^4.2.0",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.0",
     "@sentry/vite-plugin": "^5.4.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.3",
+    "@vitejs/plugin-react": "^6.0.4",
     "fake-indexeddb": "^6.2.5",
-    "jsdom": "^29.1.1",
+    "jsdom": "^30.0.0",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4",
+    "vite": "^8.1.5",
     "vitest": "4.1.10"
-  },
-  "overrides": {
-    "undici": "7.28.0",
-    "jsdom": {
-      "cssstyle": "6.2.0"
-    },
-    "cssstyle": {
-      "@asamuzakjp/css-color": "6.0.5"
-    }
   },
   "engines": {
     "node": "24.x"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useCallback, useEffect, useRef, useState, type ReactElement } from "react";
-import { BrowserRouter, NavLink, Navigate, Route, Routes as RouterRoutes, useLocation, useParams } from "react-router-dom";
+import { BrowserRouter, NavLink, Navigate, Route, Routes as RouterRoutes, useLocation, useParams } from "react-router";
 import { AccountMenu } from "./AccountMenu";
 import {
   clearAllLocalBrowserData,

--- a/apps/web/src/dev/previews/invite/FriendInvitePreviewScreen.tsx
+++ b/apps/web/src/dev/previews/invite/FriendInvitePreviewScreen.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from "react";
-import { Link, Navigate, useParams } from "react-router-dom";
+import { Link, Navigate, useParams } from "react-router";
 import {
   FriendInviteErrorPanel,
   FriendInviteInactivePanel,

--- a/apps/web/src/observability/instrument.ts
+++ b/apps/web/src/observability/instrument.ts
@@ -7,7 +7,7 @@ import {
   useLocation,
   useNavigationType,
   type Routes,
-} from "react-router-dom";
+} from "react-router";
 import webPackageInfo from "../../package.json";
 import { getAppConfig } from "../config";
 

--- a/apps/web/src/screens/cards/form/CardFormScreen.tsx
+++ b/apps/web/src/screens/cards/form/CardFormScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useAppData } from "../../../appData";
 import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 import { useAiCardHandoff } from "../../../chat/handoff/useAiCardHandoff";

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useAppData } from "../../../appData";
 import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 import { getCardFilterActiveDimensionCount, normalizeCardFilter } from "../../../cardFilters";

--- a/apps/web/src/screens/invite/FriendInviteScreen.test.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import ReactDOM from "react-dom/client";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppErrorDialogProvider } from "../../appError/AppErrorContext";
 import { I18nProvider } from "../../i18n";

--- a/apps/web/src/screens/invite/FriendInviteScreen.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactElement } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import {
   ApiError,
   acceptFriendInvitation,

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { useAppData } from "../../appData";
 import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import {

--- a/apps/web/src/screens/progress/ProgressScreenTestSupport.tsx
+++ b/apps/web/src/screens/progress/ProgressScreenTestSupport.tsx
@@ -1,6 +1,6 @@
 import { act } from "react";
 import ReactDOM from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, vi } from "vitest";
 import type { AppDataContextValue } from "../../appData";
 import { AppErrorDialogProvider } from "../../appError/AppErrorContext";

--- a/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement, type Ref } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { buildLoginUrl } from "../../../api";
 import { resolveBestLeaderboardPlacement } from "../../../appData/progress/leaderboardPlacement";
 import { useI18n } from "../../../i18n";

--- a/apps/web/src/screens/progress/leaderboard/ProgressStreakLeaderboardSection.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressStreakLeaderboardSection.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { buildLoginUrl } from "../../../api";
 import { useI18n } from "../../../i18n";
 import { settingsLeaderboardParticipationRoute } from "../../../routes";

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { ReviewRating } from "../../../../../backend/src/scheduling";
 import { useI18n } from "../../../i18n";
 import { cardsRoute, chatRoute } from "../../../routes";

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { formatReviewProgressBadgeValue } from "../../../appData/progress/badge/reviewProgressBadge";
 import { useI18n } from "../../../i18n";
 import { progressLeaderboardRoute, progressStreakRoute } from "../../../routes";

--- a/apps/web/src/screens/review/filters/ReviewFilterMenu.tsx
+++ b/apps/web/src/screens/review/filters/ReviewFilterMenu.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { AnchoredFloatingOverlay } from "../../../floating";
 import { useI18n } from "../../../i18n";
 import type { ReviewFilter } from "../../../types";

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { act, useEffect, type ReactElement } from "react";
 import ReactDOM from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, vi } from "vitest";
 import { I18nProvider } from "../../../i18n";
 import { AppErrorDialogProvider } from "../../../appError/AppErrorContext";

--- a/apps/web/src/screens/settings/FeedbackSettingsScreen.feedback.test.tsx
+++ b/apps/web/src/screens/settings/FeedbackSettingsScreen.feedback.test.tsx
@@ -2,7 +2,7 @@
 import "fake-indexeddb/auto";
 import { act } from "react";
 import ReactDOM from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppErrorDialogProvider } from "../../appError/AppErrorContext";
 import type { AppDataContextValue } from "../../appData";

--- a/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act, type ReactElement } from "react";
 import ReactDOM from "react-dom/client";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppDataContextValue } from "../../appData";
 import { AppErrorDialogProvider } from "../../appError/AppErrorContext";

--- a/apps/web/src/screens/settings/SettingsShared.tsx
+++ b/apps/web/src/screens/settings/SettingsShared.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type SettingsTab = "general" | "current-workspace" | "workspace" | "account" | "device" | "access" | "test";
 

--- a/apps/web/src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx
@@ -2,7 +2,7 @@
 
 import { act } from "react";
 import ReactDOM from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AppErrorDialogProvider } from "../../appError/AppErrorContext";
 import { createStorageMock } from "../../api/ApiTestSupport";

--- a/apps/web/src/screens/settings/access/AccessPermissionDetailScreen.tsx
+++ b/apps/web/src/screens/settings/access/AccessPermissionDetailScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactElement } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import {
   explainBrowserMediaPermissionError,
   isExpectedBrowserMediaPermissionError,

--- a/apps/web/src/screens/settings/workspace/TagsScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/TagsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useAppData } from "../../../appData";
 import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";

--- a/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useAppData } from "../../../../appData";
 import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
 import { ALL_CARDS_REVIEW_FILTER, isCardDue } from "../../../../appData/domain";

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type ReactElement } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useAppData } from "../../../../appData";
 import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
 import { ALL_CARDS_DECK_SLUG, buildDeckFilterDefinition } from "../../../../deckFilters";

--- a/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useAppData } from "../../../../appData";
 import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
 import { ALL_CARDS_DECK_SLUG } from "../../../../deckFilters";

--- a/apps/web/src/screens/share/AppPlatformLinks.tsx
+++ b/apps/web/src/screens/share/AppPlatformLinks.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 const appStoreBadgeSrc: string = "/home/app-store-badge.svg";
 const googlePlayLockupSrc: string = "/home/google-play-lockup.png";

--- a/apps/web/src/screens/share/ShareAppScreen.test.tsx
+++ b/apps/web/src/screens/share/ShareAppScreen.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from "react";
 import ReactDOM from "react-dom/client";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../i18n";
 import { reviewRoute, shareRoute } from "../../routes";

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -76,7 +76,7 @@ GitHub Actions reusable workflow: `.github/workflows/android-ci-reusable.yml`
 - Runs `:app:lintDebug`
 - Delegates the GitHub-hosted Android Gradle entrypoints to repo-root shell scripts in `scripts/android/`
 - Uploads the debug APK, Android test APK, unit test reports, and lint report as workflow artifacts
-- Boots a headless Android 16 / API 36 emulator in GitHub Actions with `-gpu auto`
+- Boots a headless Android 17 / API 37 emulator in GitHub Actions with `-gpu auto`
 - Runs `:data:local:connectedDebugAndroidTest` on that emulator
 - Uploads `data:local` instrumentation reports from the emulator run when the Gradle task produced them
 - Reuses the caller-provided `ANDROID_VERSION_CODE` across Android CI/build artifacts
@@ -93,7 +93,7 @@ The automatic Android CI flow is:
 
 1. `android-ci.yml` starts on `push main` for Android-impacting changes
 2. Android unit tests, debug builds, and lint run in GitHub Actions
-3. `data:local` Android instrumentation runs on a GitHub-hosted Android 16 emulator
+3. `data:local` Android instrumentation runs on a GitHub-hosted Android 17 emulator
 4. The workflow stops there: no Firebase Test Lab submission and no Google Play draft upload
 
 The manual Android release flow is:
@@ -323,9 +323,9 @@ gcloud services enable androidpublisher.googleapis.com \
 
 ### 7. Choose the Firebase Test Lab device
 
-This repository intentionally tests Android 16 / API 36 only.
+This repository intentionally tests Android 17 / API 37 only.
 
-Before setting the GitHub variables, list supported Test Lab devices for your project and choose a device that supports API 36:
+Before setting the GitHub variables, list supported Test Lab devices for your project and choose a device that supports API 37:
 
 ```bash
 gcloud firebase test android models list --project "YOUR_GCP_PROJECT_ID"
@@ -401,7 +401,7 @@ For local instrumentation runs, prefer one clean emulator only:
 
 - stop all running Android emulators before the run
 - verify `adb devices` shows only one target emulator before starting Gradle
-- when launching a local headless emulator manually, prefer `emulator @Medium_Phone_API_36.1 -no-window -no-audio -gpu auto`
+- when launching a local headless emulator manually, prefer `emulator @Medium_Phone_API_37.0 -no-window -no-audio -gpu auto`
 - for temporary local startup diagnosis only, keep the same command and add `-verbose -debug init,metrics -logcat '*:s ActivityManager:i AndroidTestOrchestrator:i TestRunner:i'`
 - prefer a clean rebuild and one clean test run when validating a local fix
 - do not reuse a second emulator or a half-failed prior emulator session for the same verification pass

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -8,16 +8,16 @@
       "name": "flashcards-open-source-app-aws",
       "version": "1.17.0",
       "dependencies": {
-        "@aws-crypto/client-node": "^5.0.0",
-        "@aws-sdk/client-cloudwatch": "^3.1087.0",
-        "@aws-sdk/client-s3": "^3.1087.0",
-        "@sentry/aws-serverless": "^10.65.0",
-        "aws-cdk-lib": "^2.261.0",
-        "constructs": "^10.6.0"
+        "@aws-crypto/client-node": "^5.0.2",
+        "@aws-sdk/client-cloudwatch": "^3.1097.0",
+        "@aws-sdk/client-s3": "^3.1097.0",
+        "@sentry/aws-serverless": "^10.68.0",
+        "aws-cdk-lib": "^2.262.1",
+        "constructs": "^10.7.1"
       },
       "devDependencies": {
         "@types/node": "^24.13.3",
-        "aws-cdk": "^2.1131.0",
+        "aws-cdk": "^2.1133.0",
         "esbuild": "^0.28.1",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3"
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
-      "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/estree": "^1.0.8",
@@ -44,12 +44,12 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz",
-      "integrity": "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.1.tgz",
+      "integrity": "sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==",
       "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "es-module-lexer": "^2.1.0",
         "magic-string": "^0.30.21",
         "module-details-from-path": "^1.0.4"
@@ -59,12 +59,12 @@
       }
     },
     "node_modules/@apm-js-collab/tracing-hooks": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.1.tgz",
-      "integrity": "sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
       }
@@ -82,9 +82,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.11.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.11.0.tgz",
-      "integrity": "sha512-qpkGINVp8CIaXXkEX5sPmARPk8bbvCFXhMHm/Nmae3K3V+OzDVthntuFVwGxl/jzfdrKPIhbkE9Mrxk+f1mK3A==",
+      "version": "54.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.14.0.tgz",
+      "integrity": "sha512-JCZCzgp3SuXQVljaKqXnttHzcezEHt9Ag/YipK0XwUFD+Iz2T4jY7gUc3pA25Uq6pzY2n9DvO/nEU++dPXW4Rw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -118,69 +118,69 @@
       }
     },
     "node_modules/@aws-crypto/branch-keystore-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/branch-keystore-node/-/branch-keystore-node-5.0.0.tgz",
-      "integrity": "sha512-obfPqAPI9W5XrNLwa3TodRd2ywH+7p5AHb9BHY/anRAoWAMYJ8aWjop2oBJCCmOBahtKS475T0mmjHOcgZYTiQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/branch-keystore-node/-/branch-keystore-node-5.0.2.tgz",
+      "integrity": "sha512-Bpfa2DUHbcjj4XrZkgxldCUCeK+lZyQ/oSi3bapFJq4vHA+yA55ax2LbMZg2IP7ht6uH4kRG+iqWo5HPT5d+AQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/kms-keyring": "^5.0.0",
+        "@aws-crypto/kms-keyring": "^5.0.2",
         "@aws-sdk/client-dynamodb": "^3.616.0",
         "@aws-sdk/client-kms": "^3.616.0",
         "@aws-sdk/util-dynamodb": "^3.616.0",
         "tslib": "^2.2.0",
-        "uuid": "^9.0.0"
+        "uuid": "^11.1.1"
       }
     },
     "node_modules/@aws-crypto/cache-material": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-5.0.0.tgz",
-      "integrity": "sha512-6qufEs+uCd3oCA7qTxQVNvxyhgI16wlPMDj8KaHCsjOIQqmP+GlT7Hc3WIA5PgSkNOzeEDILfB79EPN8LyEeLQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-5.0.2.tgz",
+      "integrity": "sha512-IYddhLIE6QownHsr3g8sjAmQxt7t5R2tIeHRu3OBynswqqSEM1i3dIjnbZADYvKIv7mb9ye7hHZw6NbqS02ucw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management": "^5.0.0",
-        "@aws-crypto/serialize": "^5.0.0",
+        "@aws-crypto/material-management": "^5.0.2",
+        "@aws-crypto/serialize": "^5.0.2",
         "@types/lru-cache": "^5.1.0",
         "lru-cache": "^6.0.0",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/caching-materials-manager-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-5.0.0.tgz",
-      "integrity": "sha512-RLaXOrlJR4knrNgog4py+4RkBZNEMmgNn5yaeNx/9QdMx6VHmN9fBx2O1t9ei1FjY9M59hdsA6qo2+qTbi2OKQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-5.0.2.tgz",
+      "integrity": "sha512-FuCaTjuTUu/g0o0AAn8nIniB1HknLSg1Gt/28nCmTJKzTRBkoktt5Y4fSOQjN/2uGJH10QqGyT5E46P2ja17sA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/cache-material": "^5.0.0",
-        "@aws-crypto/material-management-node": "^5.0.0",
+        "@aws-crypto/cache-material": "^5.0.2",
+        "@aws-crypto/material-management-node": "^5.0.2",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/client-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-5.0.0.tgz",
-      "integrity": "sha512-e5jxzQOJZtOeI1aJH/imu0olZ+2dRdh0sWQBOhsHJyWTVyu4YyrhiZaRuOdgP0DLsJdbsKaykf8HFVayvwH/hw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-5.0.2.tgz",
+      "integrity": "sha512-MH4IAmIIJ/BMnSBCAPO6APRdapy7gEShRRLrvFV/a3VA7e92pjgej6UG8GDEWHgEpvGng2Jg67ysThlkyFcATw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/branch-keystore-node": "^5.0.0",
-        "@aws-crypto/caching-materials-manager-node": "^5.0.0",
-        "@aws-crypto/decrypt-node": "^5.0.0",
-        "@aws-crypto/encrypt-node": "^5.0.0",
-        "@aws-crypto/kms-keyring": "^5.0.0",
-        "@aws-crypto/kms-keyring-node": "^5.0.0",
-        "@aws-crypto/material-management-node": "^5.0.0",
-        "@aws-crypto/raw-aes-keyring-node": "^5.0.0",
-        "@aws-crypto/raw-rsa-keyring-node": "^5.0.0",
+        "@aws-crypto/branch-keystore-node": "^5.0.2",
+        "@aws-crypto/caching-materials-manager-node": "^5.0.2",
+        "@aws-crypto/decrypt-node": "^5.0.2",
+        "@aws-crypto/encrypt-node": "^5.0.2",
+        "@aws-crypto/kms-keyring": "^5.0.2",
+        "@aws-crypto/kms-keyring-node": "^5.0.2",
+        "@aws-crypto/material-management-node": "^5.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^5.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^5.0.2",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/decrypt-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-5.0.0.tgz",
-      "integrity": "sha512-YhWXt3k46Z7HaMRqlxyYAqdTwrK2dLPTIg2P2l14txnTxnpUUwziDPm76ahOWBfLZ4dCuFptWnjGCnkCtHm3TQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-5.0.2.tgz",
+      "integrity": "sha512-CCXjVeXIsMynlXxyNRmjYelazWYrtxSNVQuZuSyFxqIWIbbmSoY5ecmF3e6s7Qq2gUeiJsKexwb0y+0WvmZ4Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management-node": "^5.0.0",
-        "@aws-crypto/serialize": "^5.0.0",
+        "@aws-crypto/material-management-node": "^5.0.2",
+        "@aws-crypto/serialize": "^5.0.2",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.1.1",
         "readable-stream": "^3.6.0",
@@ -188,13 +188,13 @@
       }
     },
     "node_modules/@aws-crypto/encrypt-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-5.0.0.tgz",
-      "integrity": "sha512-H79qZcdQdA4rZfWYJgwesLX4c1HGHtonJ4Z+DyooAUZWx6zCFs9vox9Mdy5AocRlWnLOjKigy/PZ9axBSOvZRw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-5.0.2.tgz",
+      "integrity": "sha512-PQq1rJ2spoQSd1xX/r/1yEfycjp05JSewytyEizKyaxhOT6zaG01h9kBWJhf68CKPUw68uMBKoWrB4fDw+oq3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management-node": "^5.0.0",
-        "@aws-crypto/serialize": "^5.0.0",
+        "@aws-crypto/material-management-node": "^5.0.2",
+        "@aws-crypto/serialize": "^5.0.2",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.1.3",
         "readable-stream": "^3.6.0",
@@ -202,130 +202,130 @@
       }
     },
     "node_modules/@aws-crypto/hkdf-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-5.0.0.tgz",
-      "integrity": "sha512-eGcXVkhnWOab8NJo3lD3WkVzF7/BHuIiJAIckFKvmPUIOmwxS209N23sGwHERzkS/dSFXJ62hEF+FatLSUJ5Qg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-5.0.2.tgz",
+      "integrity": "sha512-VJC1zsQ9e/u/ru0Gtk0MTXmokzWzNgc0d9txqwLK/ZQT0LzHDDsrdvNqLmXnu9u+Wx3/E+hB17ZDnmaTpsklYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/kdf-ctr-mode-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kdf-ctr-mode-node/-/kdf-ctr-mode-node-5.0.0.tgz",
-      "integrity": "sha512-zCYmmE1k7LYXpm+02OLX2TH0JfeHXUcxcqaGBsnpqgwAQhgepa63emxIbZ6cpm+9W/BXqfg937ksp83es2rhJA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kdf-ctr-mode-node/-/kdf-ctr-mode-node-5.0.2.tgz",
+      "integrity": "sha512-b2gxEa4zF+kvVyS35TdvxYBfwKaTE18wfZFNvBqYzNymAS3PtYMEah50DxGhvb35U/3j5pXBugTb6cfZ1qHwpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/kms-keyring": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-5.0.0.tgz",
-      "integrity": "sha512-hR5hJ5su4Fe6H8AUksd8VpiAPl/VQ6DQp3SPmRC9hrGvrGXn+XSF6c4h75ul7zmOQk9ARGydKyGpmix1o5LWBA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-5.0.2.tgz",
+      "integrity": "sha512-05iY+lmtkDUNP+2awmTdaSRU6MkmqurqurArHhrMG27bN6VNf+PtspAUlN1K+LPhhhY6TQY/zNLxGpIzLFdcMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management": "^5.0.0",
+        "@aws-crypto/material-management": "^5.0.2",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/kms-keyring-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-5.0.0.tgz",
-      "integrity": "sha512-7eejNCz7AaLkVL5LGeKg5HcwXtvapQYqqocYOk37eHEEYaDbc4LlqxtEXslCk3RR2e68UI2kClO3qb6cu8/8sQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-5.0.2.tgz",
+      "integrity": "sha512-AL1Gtz69EILFlwNSEStRr87MwalkLnV3znRDVeCFNV0A5SwRT3FVPj6m1r8+/ExGsVbp+IFG/oemlITmScBmtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/branch-keystore-node": "^5.0.0",
-        "@aws-crypto/cache-material": "^5.0.0",
-        "@aws-crypto/kdf-ctr-mode-node": "^5.0.0",
-        "@aws-crypto/kms-keyring": "^5.0.0",
-        "@aws-crypto/material-management-node": "^5.0.0",
-        "@aws-crypto/serialize": "^5.0.0",
+        "@aws-crypto/branch-keystore-node": "^5.0.2",
+        "@aws-crypto/cache-material": "^5.0.2",
+        "@aws-crypto/kdf-ctr-mode-node": "^5.0.2",
+        "@aws-crypto/kms-keyring": "^5.0.2",
+        "@aws-crypto/material-management-node": "^5.0.2",
+        "@aws-crypto/serialize": "^5.0.2",
         "@aws-sdk/client-dynamodb": "^3.621.0",
         "@aws-sdk/client-kms": "^3.362.0",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/material-management": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-5.0.0.tgz",
-      "integrity": "sha512-lGDbFYCuL+qXCUhCmXAEH73XqANL+QlHMl1v7sDRvEVuoYqp1U/frMlvdY8W3DwneW3GRiEELYN0bgFBToFd6Q==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-5.0.2.tgz",
+      "integrity": "sha512-LyrgDGPfd4w/ZRgsqGYAH+i0hbYNllk8VWd5ZkRd/ofFmlmm5UfTiirxOzVYTN8QmRhgwWvVhtCkN9Ipyn4hPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "asn1.js": "^5.3.0",
         "bn.js": "^5.2.3",
         "tslib": "^2.2.0",
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.1"
       }
     },
     "node_modules/@aws-crypto/material-management-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-5.0.0.tgz",
-      "integrity": "sha512-PSESkcSfINKDV90ezaKej+eCuFkGtQR7K6eXXCkFrthCRs7ismLCLHz/A3sNIC/1f2I4G2g+w/nGHo00vP7WFg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-5.0.2.tgz",
+      "integrity": "sha512-36DOENaITlydQ6xduVGpX3G9U67n/tpLUT9QGDH75kAhhK7s1RJcBrLJ4Bhz3piRL4D5FkY18h4AXfqQlw3BoA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/hkdf-node": "^5.0.0",
-        "@aws-crypto/material-management": "^5.0.0",
-        "@aws-crypto/serialize": "^5.0.0",
+        "@aws-crypto/hkdf-node": "^5.0.2",
+        "@aws-crypto/material-management": "^5.0.2",
+        "@aws-crypto/serialize": "^5.0.2",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/raw-aes-keyring-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-5.0.0.tgz",
-      "integrity": "sha512-16z5TQaiYvsnRo46u8HZp7yIAWhtxqgda2BXbaCXqclzcaEp6spokwZyYl0SdpxNChlXacUEspcvPoOUohNQCg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-5.0.2.tgz",
+      "integrity": "sha512-BuYJQq1Q1RJAkaxXj/VAT2nQCC1t4v3tChE44jHNm0S2afID/A2ChvMtJb/bvWNMgvoIB+sViV5ieG6Rk/RqJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management-node": "^5.0.0",
-        "@aws-crypto/raw-keyring": "^5.0.0",
-        "@aws-crypto/serialize": "^5.0.0",
+        "@aws-crypto/material-management-node": "^5.0.2",
+        "@aws-crypto/raw-keyring": "^5.0.2",
+        "@aws-crypto/serialize": "^5.0.2",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/raw-keyring": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-5.0.0.tgz",
-      "integrity": "sha512-xNQwfkVJuExJtrVXaVkQtyTgERMicUcV3/Qoc9sM9sefUi9Rl+zgtPAjqhN8BavzuSxs13M5OCZm4VE+NlOfww==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-5.0.2.tgz",
+      "integrity": "sha512-ITtsg+HmvVe1wISGtVElKMCtvnR+lNYT+2bkuxKLvRmo4mBXqc76A5fl+XcJK4hp5ZYqJp9aQeolVGja587e6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management": "^5.0.0",
-        "@aws-crypto/serialize": "^5.0.0",
+        "@aws-crypto/material-management": "^5.0.2",
+        "@aws-crypto/serialize": "^5.0.2",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/raw-rsa-keyring-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-5.0.0.tgz",
-      "integrity": "sha512-JpPKW0Z4bwwftBN0EpvEcYbZIvlCEtzYK1uaI9Gr5UG7wRgxl/FJd0iWHZVjmWEgKmqVgrd5qPcxH9EMCbxUBg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-5.0.2.tgz",
+      "integrity": "sha512-wM8HB9lkUb5o3c299hL51x55j8yVMvZRZaj0YLTwg4qVl+4pYCjY/rbo9iRDQA1VDm/Une9By77c2FcoQjWEug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management-node": "^5.0.0",
-        "@aws-crypto/raw-keyring": "^5.0.0",
+        "@aws-crypto/material-management-node": "^5.0.2",
+        "@aws-crypto/raw-keyring": "^5.0.2",
         "tslib": "^2.2.0"
       }
     },
     "node_modules/@aws-crypto/serialize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-5.0.0.tgz",
-      "integrity": "sha512-9x8f4boWN4UXDJvaK7aocQN7fh9x9wMjQyRTeJqOky7cXnl76EVRvuUh2Mwcel3xKRP86Ac6Hu06yayGDf4ppg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-5.0.2.tgz",
+      "integrity": "sha512-TKFABiTVow9VYk0m1nUKQYzj/DYG6x7HquBuva+VByFO5rJDxdsPrHNehTXgcQop3Huz5juP/vwrJK4F9/vMpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/material-management": "^5.0.0",
+        "@aws-crypto/material-management": "^5.0.2",
         "asn1.js": "^5.3.0",
         "bn.js": "^5.2.3",
         "tslib": "^2.2.0",
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.1"
       }
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.17.tgz",
-      "integrity": "sha512-k45iXM7w8Pyknnz/vTXSS/IkLDNFdgnBQI7Hmq+uhsrW7NGT/BiUJGlv20QSKzihmH1XDvSCRILICaKi57/35w==",
+      "version": "3.1000.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.22.tgz",
+      "integrity": "sha512-YsSac72lcCOSjk5X4fMc20SjltkGUDjckB2vYZcEd/RpgB+huzeQwVZrOWxUvLVo+5D7X9sURgmAAPmErgCQ7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -334,18 +334,18 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1087.0.tgz",
-      "integrity": "sha512-UTDttmkkxUbQ+GkCkp0AnA0ZF2Yni/1FcvbBJ6AgGNbyb1t8QlAK14j+xVPoUOTprft5PD1Coal5hN+0FKBjcw==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1097.0.tgz",
+      "integrity": "sha512-xlzNpiVkTR6HGyTPoiq08jgYki2OHlEzurOSRVJnPabJV2Q+tbxnDVS2l1fS16YCi3nqrAf8OEJr2q7tuLMW2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/middleware-compression": "^4.5.8",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/middleware-compression": "^4.5.13",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -354,19 +354,19 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1087.0.tgz",
-      "integrity": "sha512-3Rsk29aQltTbAI5QKXqhnVNyLAGTeiU3UkErqiqplduV2jdj8l+ySL45yhq7z/GXN7Q1Rh6x38dRsxazwOTUfQ==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1097.0.tgz",
+      "integrity": "sha512-LSn51uzuJLkZkCI3JjjnXow81rV3vVxm6vdoPu0NYm7jW8CUJ0qKVivze/SOkmne6Li+a8375RzxNgJipmKbjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/dynamodb-codec": "^3.973.32",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.24",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/dynamodb-codec": "^3.973.37",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.26",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -375,17 +375,17 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1087.0.tgz",
-      "integrity": "sha512-BV3mnxy9G+Pj27myaeZZ0F9inT3R9iX4OmiP3dAqd9TGluA2MViUNEp1KYECj9Aaxzfd4y2uL1i7KYLFme+tRA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1097.0.tgz",
+      "integrity": "sha512-mwPT8TFQ05Cmf7rNKCQ4K6pq/+sSTb++PYeZ4olGdjjb+aBaWrpflJMnmtmrHODs0GAwf5touQAEFA4jGEs8KA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -394,20 +394,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1087.0.tgz",
-      "integrity": "sha512-44ua5vo5JiFFSnG3oeeWTMfSjOtblQSoJiGbf37s0W4Lr7IY9NmIVkBHIfD4hBI1VEKdvJhDmvuJawwTfi2pvw==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1097.0.tgz",
+      "integrity": "sha512-iCBD95hrynpxiOzD301pUW9H3mxKcEfMErLqdg58WcIZnEqJuOd7JwcARsV3/y6OWj1t6j2tpS9lGt6X4OnPFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.17",
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-node": "^3.972.68",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.63",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/checksums": "^3.1000.22",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.68",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -416,16 +416,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.2.tgz",
-      "integrity": "sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@aws-sdk/xml-builder": "^3.972.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.3",
-        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -435,14 +435,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.58.tgz",
-      "integrity": "sha512-vyGtvK1rY940eq7JT0yIGKuZ+2kpPSJcHibSvGlit5oiMFDamzC7cxBGLl4FLnd6suihMXDI2FSF2dL6TmBqPA==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -451,16 +451,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.60.tgz",
-      "integrity": "sha512-g9b9YzDrD5pcKiPBJfCSXRfFMrA39eR0guUhZ5SRm+7vMAVc43+effxbcamxBjSd5bUhrdKo5te/yQuWurLXLA==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -469,22 +469,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.2.tgz",
-      "integrity": "sha512-Yr7yxNyQ8aHt9Ww0RPFUZx+xiem+vl7vuwhP0tniTijoesJNV5jou9HCgVpI0GEPAF+89TkOvilE5uRrZJnjaw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-login": "^3.972.64",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -493,15 +493,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.64.tgz",
-      "integrity": "sha512-YQoSI4d6kXvoenoG/0Jv/PqaAuukHzGmGXGyHBQYeEUNsYovlNAn/Sw1wp/WQbhcQ3HsEMGgjEahvD3igz6ecQ==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -510,20 +510,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.68.tgz",
-      "integrity": "sha512-4akjzW9CjorByYfqXBXmYUh/h7Io3U4DtVgGGh9TQraZ7ZlyJqNyHwDRGiUFnHD+BTOeTbCesCa4sJaK7BGZ7A==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-ini": "^3.973.2",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -532,14 +532,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.58.tgz",
-      "integrity": "sha512-1nYitRCaDmXWUrpBJt6WlcGjLx1JVsMY8rlYuHHsTYTSaYikbixYdQSyINN2VYq1F798uTO9qHAzytL25M8g3A==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -548,16 +548,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.2.tgz",
-      "integrity": "sha512-pjMLaLU/JZi5lVfmR14V1OZqRBTuMHf6AwGNZA0K9hK+JKtO3jcLBarfD8iq5oc8cSowvc/9R32sqMVXZPo6xQ==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/token-providers": "3.1087.0",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -566,15 +566,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.64.tgz",
-      "integrity": "sha512-7Buc7p0OvDHW7iBsu4b+YdS0WnaFBDGKDfbVQqaac9dkWiSiUtIoarBDsA1RmOVXZijaZJDoHJFIQiicQvWRlQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -583,13 +583,13 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.32.tgz",
-      "integrity": "sha512-mc2IvGFtgNgYnySd1wWdx78flpHdAYvbl9C/tnAzGT0D0przwGeHSB6W3L8grldIXjAG1elWJdyDYiiZaz1dCw==",
+      "version": "3.973.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.37.tgz",
+      "integrity": "sha512-NYaWEWv5owB3usPcaVBMcdXbqzBYf2QCf+wU3AP5MpOXRiMF7qE6O1RaCUZGYCM9Lv7jtvfqCrmgYiicshyYeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -611,14 +611,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.24.tgz",
-      "integrity": "sha512-1NwwiqMZw5LMnFZ8LsPYkuVN+nFf5oWRxgeb4WfsyOw0MKcA8qGI8Yq4AjvEzWHzp1a1aq8TEMqqlh2IiKVKgQ==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.26.tgz",
+      "integrity": "sha512-suOMAYAM43aSyC3cLBvvJIuNyg96nUsPvYQUrq4G+8Prt2qTpFETgaiXX7JP1gIcK5FF0Z2IdyEsPXseZATOPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.9",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -627,15 +627,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.63.tgz",
-      "integrity": "sha512-EklitJscj/Aq2Pk8nz0xSxvL+VMSP29iFqouQU0Ow05JKn5y/OhI81ujkfVS72MjD1yeoU9uIdT8c/W6vhktQw==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.68.tgz",
+      "integrity": "sha512-JA/LRxCSXQAsFHyIZzgncYdcTQTOL3ZS8R7EAeDwoSoWcNG8yxDAacrwFTZIyVSMvkogvlKHRvmrMU68UyQbkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -644,17 +644,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.32.tgz",
-      "integrity": "sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -663,13 +663,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.40.tgz",
-      "integrity": "sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/signature-v4": "^5.6.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -678,15 +678,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1087.0.tgz",
-      "integrity": "sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.1.tgz",
-      "integrity": "sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -708,9 +708,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.6.tgz",
-      "integrity": "sha512-xLimZjA/ebA7jZn4NNkvLgj9WRl14rhidGND6oPt14s7ywe3I64g9X+WJpBraU5UR7loRq2K1tAXZj0FXkWLZg==",
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
+      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -719,13 +719,13 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1082.0"
+        "@aws-sdk/client-dynamodb": "^3.1088.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.35.tgz",
-      "integrity": "sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1280,12 +1280,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
-      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1296,13 +1296,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
-      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1313,14 +1313,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
-      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1340,17 +1340,17 @@
       }
     },
     "node_modules/@sentry/aws-serverless": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.65.0.tgz",
-      "integrity": "sha512-DzfTcpLKhzAHZGE/H+1SI/iWJ1zHRT+Wr7tNU+uhrG4zxdGH2eLrQ7uJmY0OJzJ+sQURgoFR+qY4ZHN6MJWZqQ==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.68.0.tgz",
+      "integrity": "sha512-5zHoYH3e+ft8Dr6OR2DF2c0Dqhekre6ubbCLPvLXgaS6XuJmFi02+nCyOnn5ibQP8CmjH+iQVzAarwbxQHx+PA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.220.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node": "10.65.0",
-        "@sentry/node-core": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node": "10.68.0",
+        "@sentry/node-core": "10.68.0",
         "@types/aws-lambda": "^8.10.161"
       },
       "engines": {
@@ -1358,40 +1358,40 @@
       }
     },
     "node_modules/@sentry/conventions": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
-      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
-      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1"
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.65.0.tgz",
-      "integrity": "sha512-t35dcdyksysVch/m/XdLgGJqGKJhr9eMD30Ctn3TeQ8yMB0wNXySfjPR5Yg93fpjmfaHtzc6iYIXRAvgNVfrvA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.68.0.tgz",
+      "integrity": "sha512-bnvRzEehquG/894DD3BWNCBUbDWsLQfYPU+SNCMd6G4Ext75RthVkRs8R0sRaE6b8Tw9HSEgySHL834Tf8lVsA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.220.0",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node-core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
-        "@sentry/server-utils": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node-core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
+        "@sentry/server-utils": "10.68.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -1399,14 +1399,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.65.0.tgz",
-      "integrity": "sha512-U01X9mPT+jZnsLPmPWfBU67Ka+t/Sdd9RGAuvGoKdrI6N47a/9PDkM9oCW+kj0fmZwogZHTgSnzJU5oi3pImgA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.68.0.tgz",
+      "integrity": "sha512-VreORXnruy8A2SyprZKENAq3ArGwn35KPewLQSQ5dgDXSFtUj2scLuzZoVsZ/Uyt83td0WPvD6Lv0X7MvSYAMQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -1438,13 +1438,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.65.0.tgz",
-      "integrity": "sha512-8C6FPvm3XBvUrkM52dX3Gz0p2H0Ij8t4sahUA+GTiCz0WM0fnyPeQPGC/b6I4jamV9UXyCZRnE1UEEGCoD+c7A==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.68.0.tgz",
+      "integrity": "sha512-JDNH9dacX0MSi7FRvabPCJUAXRMTe16bE/Gajc/7Gfcw7Rwvo4DZ0nd162PCSAW9QoEjUT12upDehEHJuFmsXg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
       },
       "engines": {
         "node": ">=18"
@@ -1456,26 +1456,25 @@
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.65.0.tgz",
-      "integrity": "sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.68.0.tgz",
+      "integrity": "sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==",
       "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
-        "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
-        "@apm-js-collab/tracing-hooks": "^0.10.1",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "magic-string": "~0.30.0"
+        "@apm-js-collab/code-transformer-bundler-plugins": "0.7.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "meriyah": "^6.1.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1486,12 +1485,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
-      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1500,12 +1499,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
-      "integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1514,12 +1513,12 @@
       }
     },
     "node_modules/@smithy/middleware-compression": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.5.9.tgz",
-      "integrity": "sha512-/9lZ7lVBPZoAnN/hJiTSml8qgzgw2pG6RzPveBZl1vnPxNN7F3UEYMZBI3xRSyc+tJjLsZbSlT3/DttjH199hw==",
+      "version": "4.5.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.5.15.tgz",
+      "integrity": "sha512-l9YqQGIDdn1va+9RzPndvIoXB8HgqJ0kItC1iz2L2ID5PgwMlfAd7HrYD0hQgN6yvlgY2DC4rDRayFthsrY5Mw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "fflate": "0.8.1",
         "tslib": "^2.6.2"
@@ -1529,12 +1528,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1543,12 +1542,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
-      "integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1693,9 +1692,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1131.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1131.0.tgz",
-      "integrity": "sha512-02oAVG4IBFwPtPlDE95H8tDJFfDuxJLdvyrdav6rn72mup/LIZRCfp95IB9kfM+FL4vQ9gn/QCEI7y7aNDTpKA==",
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1706,10 +1705,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.261.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.261.0.tgz",
-      "integrity": "sha512-e52e3Abjg0HkuRWlWwtSv5+ZiMW1rhCDdL9ff7lzWXInU8xdfLJpuoimfa0IJwjiNGyphppgg52Azx9M80OA0g==",
+      "version": "2.262.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.1.tgz",
+      "integrity": "sha512-B6YP4r6ojUZCDhl+qBu/CrWzcipR8sIgshcqYvgw013sghPXmVkYdJ3yuI9+DKML3YLSjQrHy1nGJs+Nqq7JCg==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -1726,17 +1726,18 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.282",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
-        "@aws-cdk/cloud-assembly-api": "^2.2.5",
-        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.5.1-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.8.1",
+        "semver": "^7.8.5",
         "yaml": "1.10.3"
       },
       "engines": {
@@ -1747,18 +1748,26 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.5.1-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1775,7 +1784,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1794,7 +1803,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.5",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1880,7 +1889,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1925,9 +1934,9 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
-      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.7.1.tgz",
+      "integrity": "sha512-ulK25Sg2Nv1jW+A9VeV7fu9GFN9KdVTNWdXMoapNRwqkQzSdToro/Tttk3Ak5BGI80NRA/d2nSzKnoZ27LizLw==",
       "license": "Apache-2.0"
     },
     "node_modules/create-require": {
@@ -2061,9 +2070,9 @@
       "license": "MIT"
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
-      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
+      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
       "license": "Apache-2.0",
       "dependencies": {
         "cjs-module-lexer": "^2.2.0",

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -12,16 +12,16 @@
     "test": "npm run build && node --test \"dist/**/*.test.js\""
   },
   "dependencies": {
-    "@aws-crypto/client-node": "^5.0.0",
-    "@aws-sdk/client-cloudwatch": "^3.1087.0",
-    "@aws-sdk/client-s3": "^3.1087.0",
-    "@sentry/aws-serverless": "^10.65.0",
-    "aws-cdk-lib": "^2.261.0",
-    "constructs": "^10.6.0"
+    "@aws-crypto/client-node": "^5.0.2",
+    "@aws-sdk/client-cloudwatch": "^3.1097.0",
+    "@aws-sdk/client-s3": "^3.1097.0",
+    "@sentry/aws-serverless": "^10.68.0",
+    "aws-cdk-lib": "^2.262.1",
+    "constructs": "^10.7.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
-    "aws-cdk": "^2.1131.0",
+    "aws-cdk": "^2.1133.0",
     "esbuild": "^0.28.1",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"

--- a/scripts/android/capture-android-marketing-screenshots.sh
+++ b/scripts/android/capture-android-marketing-screenshots.sh
@@ -21,18 +21,18 @@ file_names=(
 if [[ "$(adb get-state 2>/dev/null)" != "device" ]]; then
     cat >&2 <<'EOF'
 No Android device or emulator is connected.
-Start one headless API 36 emulator first, for example:
-  emulator @Medium_Phone_API_36.1 -no-window -no-audio -gpu auto
+Start one headless API 37 emulator first, for example:
+  emulator @Medium_Phone_API_37.0 -no-window -no-audio -gpu auto
 
 If the local emulator is flaky and you need more startup visibility, use:
-  emulator @Medium_Phone_API_36.1 -no-window -no-audio -gpu auto -verbose -debug init,metrics -logcat '*:s ActivityManager:i AndroidTestOrchestrator:i TestRunner:i'
+  emulator @Medium_Phone_API_37.0 -no-window -no-audio -gpu auto -verbose -debug init,metrics -logcat '*:s ActivityManager:i AndroidTestOrchestrator:i TestRunner:i'
 EOF
     exit 1
 fi
 
 device_sdk="$(adb shell getprop ro.build.version.sdk | tr -d '\r')"
-if [[ "$device_sdk" != "36" ]]; then
-    echo "Connected Android device must run API 36. Current SDK: $device_sdk" >&2
+if [[ "$device_sdk" != "37" ]]; then
+    echo "Connected Android device must run API 37. Current SDK: $device_sdk" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- align npm dependencies, lockfiles, AWS SDK/CDK, Sentry, and web tooling
- migrate web routing to React Router 8.3.0
- move Android compile/target tooling and documentation to API 37
- update iOS Sentry resolution and the pinned AWS credentials Action

## Validation
- API lint and bundle
- admin production build
- auth: 35 tests and build
- backend: 891 tests and build
- web: 608 tests and production build
- infra: 37 tests
- npm clean installs, audits, signature checks, config parsing, and git diff --check

Heavy Android/iOS simulator validation is deferred to CI by repository policy. Latest aws-cdk-lib still bundles the reported brace-expansion advisory; no consumer override is available.