### PR TITLE
Add durable multipart completion reconciler

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/checks/check-agent-api-smoke.sh'
       - 'scripts/checks/check-api-health.sh'
       - 'scripts/checks/check-demo-cognito-users.sh'
+      - 'scripts/checks/check-multipart-completion-reconciliation-schedule.sh'
       - 'scripts/checks/check-mcp-smoke.sh'
       - 'scripts/checks/check-public-endpoints.sh'
       - 'scripts/deploy/deploy-admin.sh'
@@ -64,7 +65,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          aws_release_script_pattern='^scripts/(checks/(check-agent-api-smoke|check-api-health|check-demo-cognito-users|check-mcp-smoke|check-public-endpoints)\.sh|deploy/(deploy-admin|deploy-web|migrate-aws)\.sh|generate/(generate-global-metrics-snapshot\.sh|write-ci-cdk-context\.py))$'
+          aws_release_script_pattern='^scripts/(checks/(check-agent-api-smoke|check-api-health|check-demo-cognito-users|check-mcp-smoke|check-multipart-completion-reconciliation-schedule|check-public-endpoints)\.sh|deploy/(deploy-admin|deploy-web|migrate-aws)\.sh|generate/(generate-global-metrics-snapshot\.sh|write-ci-cdk-context\.py))$'
 
           changed_files_path="${RUNNER_TEMP}/changed-files.txt"
           before_sha="${PUSH_BEFORE_SHA:-}"
@@ -358,7 +359,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: CDK deploy
+      - name: CDK deploy with reconciliation schedule disabled
         working-directory: infra/aws
         env:
           AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
@@ -401,13 +402,31 @@ jobs:
           python3 ../../scripts/generate/write-ci-cdk-context.py \
             --output cdk.context.local.json \
             --aws-deploy-role-arn "${AWS_DEPLOY_ROLE_ARN}"
-          npx cdk deploy --all --require-approval never
+          npx cdk deploy --all --require-approval never \
+            -c multipartCompletionReconciliationScheduleState=DISABLED
+
+      - name: Run database migrations
+        run: |
+          bash scripts/deploy/migrate-aws.sh \
+            --stack-name ${{ env.STACK_NAME }} \
+            --require-migration 0099_durable_multipart_completion_reconciliation.sql
+
+      - name: CDK deploy with reconciliation schedule enabled
+        working-directory: infra/aws
+        env:
+          SENTRY_UPLOAD_BACKEND_SOURCEMAPS: false
+        run: |
+          npx cdk deploy --all --require-approval never \
+            -c multipartCompletionReconciliationScheduleState=ENABLED
+
+      - name: Verify reconciliation schedule is enabled
+        run: |
+          bash scripts/checks/check-multipart-completion-reconciliation-schedule.sh \
+            --stack-name ${{ env.STACK_NAME }} \
+            --region ${{ env.AWS_REGION }}
 
       - name: Check demo Cognito users
         run: bash scripts/checks/check-demo-cognito-users.sh --stack-name ${{ env.STACK_NAME }} --region ${{ env.AWS_REGION }}
-
-      - name: Run database migrations
-        run: bash scripts/deploy/migrate-aws.sh --stack-name ${{ env.STACK_NAME }}
 
       - name: Seed global metrics snapshot
         run: bash scripts/generate/generate-global-metrics-snapshot.sh --stack-name ${{ env.STACK_NAME }}

--- a/api/src/components/schemas/CatalogPackageInstallConfirmInput.yaml
+++ b/api/src/components/schemas/CatalogPackageInstallConfirmInput.yaml
@@ -25,7 +25,10 @@ properties:
   operationIdPrefix:
     type: string
     minLength: 1
-    maxLength: 160
+    maxLength: 1007
+    pattern: '^([!-~]|[!-~][ -~]*[!-~])$'
     description: >-
-      Prefix used to derive per-card and per-media sync operation ids. The
-      backend rejects conflicts with existing workspace operation ids.
+      Printable ASCII prefix without leading or trailing spaces. The maximum
+      reserves space for the longest :media:<index> suffix supported by the
+      catalog installer. The backend rejects conflicts with existing workspace
+      operation ids.

--- a/api/src/components/schemas/MediaAsset.yaml
+++ b/api/src/components/schemas/MediaAsset.yaml
@@ -44,7 +44,7 @@ properties:
   lastModifiedByReplicaId:
     $ref: ./UuidString.yaml
   lastOperationId:
-    type: string
+    $ref: ./MediaAssetLastOperationIdResponse.yaml
   updatedAt:
     type: string
     format: date-time

--- a/api/src/components/schemas/MediaAssetLastOperationId.yaml
+++ b/api/src/components/schemas/MediaAssetLastOperationId.yaml
@@ -1,0 +1,8 @@
+type: string
+minLength: 1
+maxLength: 1024
+pattern: '^([!-~]|[!-~][ -~]*[!-~])$'
+description: >-
+  A printable ASCII identifier without leading or trailing spaces. UUIDs,
+  ULIDs, and identifiers with ASCII suffixes are supported.
+example: 43b7ec15-8f61-4f10-9cd2-c467c77804ba

--- a/api/src/components/schemas/MediaAssetLastOperationIdResponse.yaml
+++ b/api/src/components/schemas/MediaAssetLastOperationIdResponse.yaml
@@ -1,0 +1,10 @@
+type: string
+minLength: 1
+pattern: '[^ ]'
+description: >-
+  The operation identifier stored on a media asset. New writes use the
+  printable-ASCII MediaAssetLastOperationId contract, but reads can still
+  return legacy identifiers written before that contract was introduced.
+  Legacy rows are non-empty after trimming ASCII spaces and have no historical
+  database length limit.
+example: 43b7ec15-8f61-4f10-9cd2-c467c77804ba

--- a/api/src/components/schemas/MediaAssetUploadSessionCreateInput.yaml
+++ b/api/src/components/schemas/MediaAssetUploadSessionCreateInput.yaml
@@ -54,7 +54,4 @@ properties:
   lastModifiedByReplicaId:
     $ref: ./UuidString.yaml
   lastOperationId:
-    type: string
-    minLength: 1
-    maxLength: 1024
-    example: import-media-asset-43b7ec15
+    $ref: ./MediaAssetLastOperationId.yaml

--- a/api/src/components/schemas/WorkspacePackageImportConfirmOptions.yaml
+++ b/api/src/components/schemas/WorkspacePackageImportConfirmOptions.yaml
@@ -39,3 +39,9 @@ properties:
   operationIdPrefix:
     type: string
     minLength: 1
+    maxLength: 1013
+    pattern: '^([!-~]|[!-~][ -~]*[!-~])$'
+    description: >-
+      Printable ASCII prefix without leading or trailing spaces. The maximum
+      reserves space for the longest :media:<index> suffix supported by a
+      workspace package import.

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_images.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_images.yaml
@@ -48,9 +48,7 @@ post:
       in: header
       required: true
       schema:
-        type: string
-        minLength: 1
-        maxLength: 1024
+        $ref: ../components/schemas/MediaAssetLastOperationId.yaml
   requestBody:
     required: true
     content:

--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -85,6 +85,17 @@ const createdRolesByMigration = new Map([
 ]);
 const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0099_durable_multipart_completion_reconciliation.sql",
+    expectedMigrationCount: 101,
+    testFiles: Object.freeze([
+      "src/database/deadline.postgres.integration.ts",
+      "src/mediaAssets/blobLifecycle.postgres.integration.ts",
+      "src/mediaAssets/directIngestionApply.postgres.integration.ts",
+      "src/mediaAssets/multipartCompletionReconciliation.postgres.integration.ts",
+      "src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0098_multipart_writer_abort_and_terminal_replay.sql",
     expectedMigrationCount: 100,
     testFiles: Object.freeze([
@@ -1993,6 +2004,228 @@ async function assertHistoricalSeedBoundary(client) {
   );
 }
 
+async function seedMigration0099LegacyInvalidMediaAsset(client) {
+  const userId = "migration-0099-legacy-invalid-media-asset";
+  const workspaceId = "09900000-0000-4000-8000-000000000001";
+  const replicaId = "09900000-0000-4000-8000-000000000002";
+  const mediaBlobId = "09900000-0000-4000-8000-000000000003";
+  const mediaAssetId = "09900000-0000-4000-8000-000000000004";
+  const sha256 = "9".repeat(64);
+  const timestamp = "2026-07-29T00:00:00.000Z";
+
+  await client.query(
+    "INSERT INTO org.user_settings (user_id) VALUES ($1)",
+    [userId],
+  );
+  await client.query(
+    `INSERT INTO org.workspaces (
+       workspace_id, name, fsrs_client_updated_at,
+       fsrs_last_modified_by_replica_id, fsrs_last_operation_id
+     ) VALUES ($1, $2, $3, $4, $5)`,
+    [
+      workspaceId,
+      "Migration 0099 legacy media asset",
+      timestamp,
+      replicaId,
+      "migration-0099-legacy-workspace",
+    ],
+  );
+  await client.query(
+    `INSERT INTO org.workspace_memberships (
+       workspace_id, user_id, role
+     ) VALUES ($1, $2, 'owner')`,
+    [workspaceId, userId],
+  );
+  await client.query(
+    `INSERT INTO sync.workspace_replicas (
+       replica_id, workspace_id, user_id, actor_kind, installation_id,
+       actor_key, platform, app_version
+     ) VALUES ($1, $2, $3, 'ai_chat', NULL, $4, 'system', $5)`,
+    [
+      replicaId,
+      workspaceId,
+      userId,
+      "migration-0099-legacy-replica",
+      "postgres-integration",
+    ],
+  );
+  await client.query(
+    `INSERT INTO content.media_blobs (
+       media_blob_id, sha256, mime_type, size_bytes, storage_key,
+       normalization_version
+     ) VALUES ($1, $2, 'image/png', 1, $3, 'passthrough-v1')`,
+    [
+      mediaBlobId,
+      sha256,
+      `media/blobs/sha256/${sha256.slice(0, 2)}/${sha256.slice(2, 4)}/${sha256}`,
+    ],
+  );
+  await client.query(
+    `INSERT INTO content.media_assets (
+       media_asset_id, workspace_id, media_blob_id, source_url, created_at,
+       client_updated_at, last_modified_by_replica_id, last_operation_id
+     ) VALUES ($1, $2, $3, NULL, $4, $4, $5, $6)`,
+    [
+      mediaAssetId,
+      workspaceId,
+      mediaBlobId,
+      timestamp,
+      replicaId,
+      "migration-0099-legacy-\u00a0operation",
+    ],
+  );
+
+  const legacyActiveSessionId =
+    "09940000-0000-4000-8000-000000000001";
+  const legacyActiveMediaAssetId =
+    "09940000-0000-4000-8000-000000000002";
+  const legacyActiveSha256 = "d".repeat(64);
+  await client.query(
+    `INSERT INTO content.media_upload_sessions (
+       media_upload_session_id, workspace_id, media_asset_id,
+       media_blob_sha256, staging_storage_key, blob_storage_key,
+       s3_upload_id, mime_type, size_bytes, part_size_bytes, part_count,
+       state, source_url, asset_created_at, client_updated_at,
+       last_modified_by_replica_id, last_operation_id, expires_at
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6, 'migration-0099-legacy-active-upload',
+       'application/octet-stream', 1, 1, 1, 'active', NULL, $7, $7, $8,
+       'migration-0099-legacy-\u00a0active', '2099-07-29T00:00:00.000Z'
+     )`,
+    [
+      legacyActiveSessionId,
+      workspaceId,
+      legacyActiveMediaAssetId,
+      legacyActiveSha256,
+      `media/uploads/workspaces/${workspaceId}/assets/${legacyActiveMediaAssetId}/sessions/${legacyActiveSessionId}`,
+      `media/blobs/sha256/${legacyActiveSha256.slice(0, 2)}/${legacyActiveSha256.slice(2, 4)}/${legacyActiveSha256}`,
+      timestamp,
+      replicaId,
+    ],
+  );
+
+  const legacyAttemptFixtures = [
+    {
+      kind: "replay",
+      sessionId: "09910000-0000-4000-8000-000000000001",
+      mediaAssetId: "09910000-0000-4000-8000-000000000002",
+      attemptToken: "09910000-0000-4000-8000-000000000003",
+      sha256: "a".repeat(64),
+      lastOperationId: "migration-0099-legacy-\u00a0replay",
+      partsFingerprint: "1".repeat(64),
+    },
+    {
+      kind: "cleanup",
+      sessionId: "09920000-0000-4000-8000-000000000001",
+      mediaAssetId: "09920000-0000-4000-8000-000000000002",
+      attemptToken: "09920000-0000-4000-8000-000000000003",
+      sha256: "b".repeat(64),
+      lastOperationId: "migration-0099-legacy-\u00a0cleanup",
+      partsFingerprint: "2".repeat(64),
+    },
+    {
+      kind: "handoff",
+      sessionId: "09930000-0000-4000-8000-000000000001",
+      mediaAssetId: "09930000-0000-4000-8000-000000000002",
+      attemptToken: "09930000-0000-4000-8000-000000000003",
+      sha256: "c".repeat(64),
+      lastOperationId: "migration-0099-legacy-\u00a0handoff",
+      partsFingerprint: "3".repeat(64),
+    },
+  ];
+  const sessionExpiresAt = "2099-07-29T00:00:00.000Z";
+  await client.query(
+    "SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)",
+    [userId, workspaceId],
+  );
+  for (const fixture of legacyAttemptFixtures) {
+    const stagingStorageKey =
+      `media/uploads/workspaces/${workspaceId}/assets/${fixture.mediaAssetId}/sessions/${fixture.sessionId}`;
+    const blobStorageKey =
+      `media/blobs/sha256/${fixture.sha256.slice(0, 2)}/${fixture.sha256.slice(2, 4)}/${fixture.sha256}`;
+    const uploadId = `migration-0099-${fixture.kind}-upload`;
+    await client.query(
+      `INSERT INTO content.media_upload_sessions (
+         media_upload_session_id, workspace_id, media_asset_id,
+         media_blob_sha256, staging_storage_key, blob_storage_key,
+         s3_upload_id, mime_type, size_bytes, part_size_bytes, part_count,
+         state, source_url, asset_created_at, client_updated_at,
+         last_modified_by_replica_id, last_operation_id, expires_at
+       ) VALUES (
+         $1, $2, $3, $4, $5, $6, $7, 'application/octet-stream',
+         1, 1, 1, 'completing', NULL, $8, $8, $9, $10, $11
+       )`,
+      [
+        fixture.sessionId,
+        workspaceId,
+        fixture.mediaAssetId,
+        fixture.sha256,
+        stagingStorageKey,
+        blobStorageKey,
+        uploadId,
+        timestamp,
+        replicaId,
+        fixture.lastOperationId,
+        sessionExpiresAt,
+      ],
+    );
+    const begun = await client.query(
+      `SELECT attempt_status, reservation_token
+       FROM content.begin_media_upload_session_completion_attempt_with_owner(
+         $1,
+         3600000,
+         ROW(
+           $2,$3,$4,$5,$6,$7,$8,$9,$10,$11,
+           'application/octet-stream',1,1,1,NULL,$12,$12,$13,
+           'passthrough-v1',$14
+         )::content.multipart_media_blob_writer_attempt_payload
+       )`,
+      [
+        fixture.attemptToken,
+        userId,
+        workspaceId,
+        fixture.sessionId,
+        fixture.mediaAssetId,
+        replicaId,
+        fixture.lastOperationId,
+        fixture.sha256,
+        stagingStorageKey,
+        blobStorageKey,
+        uploadId,
+        timestamp,
+        sessionExpiresAt,
+        fixture.partsFingerprint,
+      ],
+    );
+    if (
+      begun.rows[0]?.attempt_status !== "acquired"
+      || typeof begun.rows[0]?.reservation_token !== "string"
+    ) {
+      throw new Error(
+        `Migration 0099 legacy multipart attempt seed failed. kind=${fixture.kind} result=${JSON.stringify(begun.rows[0])}`,
+      );
+    }
+  }
+  await client.query(
+    `UPDATE content.media_blob_writer_attempts
+     SET state='cancelled', outcome='aborted', terminal_at=$2
+     WHERE attempt_token=$1`,
+    [legacyAttemptFixtures[0].attemptToken, timestamp],
+  );
+  await client.query(
+    `UPDATE content.media_upload_sessions
+     SET state='aborted', aborted_at=$2
+     WHERE media_upload_session_id=$1`,
+    [legacyAttemptFixtures[0].sessionId, timestamp],
+  );
+  await client.query(
+    `UPDATE content.media_upload_sessions
+     SET state='aborting'
+     WHERE media_upload_session_id=$1`,
+    [legacyAttemptFixtures[1].sessionId],
+  );
+}
+
 async function createExpectedMigrationRoles(
   client,
   fileName,
@@ -2122,6 +2355,16 @@ async function applySingleMigration(
           join(migrationsDirectory, fileName),
           "utf8",
         );
+        if (
+          fileName
+          === "0099_durable_multipart_completion_reconciliation.sql"
+        ) {
+          await client.query("BEGIN");
+          transactionStarted = true;
+          await seedMigration0099LegacyInvalidMediaAsset(client);
+          await client.query("COMMIT");
+          transactionStarted = false;
+        }
         await client.query("BEGIN");
         transactionStarted = true;
         if (

--- a/apps/backend/src/catalog/distribution/install.test.ts
+++ b/apps/backend/src/catalog/distribution/install.test.ts
@@ -5,6 +5,7 @@ import type { DatabaseExecutor, SqlValue } from "../../database";
 import { createCatalogInstallRoutes } from "../../routes/catalogInstall";
 import { HttpError } from "../../shared/errors";
 import {
+  catalogPackageInstallOperationIdPrefixMaximumLength,
   installCatalogPackageVersionInExecutor,
   previewCatalogPackageInstallInExecutor,
 } from "./install";
@@ -283,6 +284,48 @@ test("catalog install rejects invalid client timestamps as bad input", async () 
   assert.equal(queryCount, 0);
 });
 
+test("catalog install rejects unsafe operation prefixes before database work", async () => {
+  let queryCount = 0;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(): Promise<pg.QueryResult<Row>> {
+      queryCount += 1;
+      throw new Error("operationIdPrefix validation should run before database queries");
+    },
+  };
+  const invalidPrefixes = [
+    " leading-space",
+    "trailing-space ",
+    "unsafe\nprefix",
+    "unsafe\u00a0prefix",
+    "a".repeat(catalogPackageInstallOperationIdPrefixMaximumLength + 1),
+  ];
+
+  for (const operationIdPrefix of invalidPrefixes) {
+    await assert.rejects(
+      installCatalogPackageVersionInExecutor(
+        executor,
+        testWorkspaceId,
+        testPackageVersionId,
+        {
+          installId: "catalog-install-invalid-operation-prefix",
+          installedAt: testInstallTimestamp,
+          clientUpdatedAt: testInstallTimestamp,
+          lastModifiedByReplicaId: testWorkspaceReplicaId,
+          operationIdPrefix,
+        },
+      ),
+      (error: unknown): boolean => {
+        assert.ok(error instanceof HttpError);
+        assert.equal(error.statusCode, 400);
+        assert.equal(error.code, "CATALOG_PACKAGE_INSTALL_INVALID_INPUT");
+        assert.match(error.message, /operationIdPrefix.*printable ASCII/);
+        return true;
+      },
+    );
+  }
+  assert.equal(queryCount, 0);
+});
+
 test("catalog install rejects invalid package card source createdAt", async () => {
   const queries: Array<Readonly<{ text: string; params: ReadonlyArray<SqlValue> }>> = [];
   const installInput = {
@@ -497,4 +540,71 @@ test("catalog install route rejects unauthorized workspace access before install
     },
   );
   assert.equal(previewCalled, false);
+});
+
+test("catalog install route rejects unsafe operation prefixes without sanitizing them", async () => {
+  let installCalled = false;
+  const app = createCatalogInstallRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {
+        authorizationHeader: undefined,
+        sessionToken: undefined,
+        csrfTokenHeader: undefined,
+        originHeader: undefined,
+        refererHeader: undefined,
+        secFetchSiteHeader: undefined,
+      },
+      requestContext: {
+        userId: "user-1",
+        subjectUserId: "subject-user-1",
+        selectedWorkspaceId: null,
+        email: "user@example.com",
+        locale: "en",
+        userSettingsCreatedAt: testTimestamp,
+        preferences: {
+          reviewReactionAnimationsEnabled: true,
+        },
+        transport: "api_key",
+        connectionId: "connection-1",
+        guestSessionId: null,
+        guestPlatform: null,
+      },
+    }),
+    assertUserHasWorkspaceAccessFn: async () => undefined,
+    installCatalogPackageVersionFn: async () => {
+      installCalled = true;
+      throw new Error("catalog install must not run for an unsafe operationIdPrefix");
+    },
+  });
+  app.onError((error) => {
+    throw error;
+  });
+
+  await assert.rejects(
+    async () => app.request(
+      `http://localhost/workspaces/${testWorkspaceId}/catalog/package-versions/${testPackageVersionId}/install`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          installId: "catalog-install-route-invalid-prefix",
+          installedAt: testInstallTimestamp,
+          clientUpdatedAt: testInstallTimestamp,
+          lastModifiedByReplicaId: testWorkspaceReplicaId,
+          operationIdPrefix: " trailing-space ",
+        }),
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "CATALOG_PACKAGE_INSTALL_INVALID_INPUT");
+      assert.match(error.message, /operationIdPrefix.*printable ASCII/);
+      return true;
+    },
+  );
+  assert.equal(installCalled, false);
 });

--- a/apps/backend/src/catalog/distribution/install.ts
+++ b/apps/backend/src/catalog/distribution/install.ts
@@ -6,6 +6,11 @@ import {
 } from "../../database";
 import type { CardMetadata, CardSourceMetadata } from "../../cards/types";
 import { normalizeCardMetadata } from "../../cards/shared";
+import {
+  isValidMediaAssetLastOperationId,
+  isValidMediaAssetLastOperationIdPrefix,
+  maximumMediaAssetLastOperationIdLength,
+} from "../../mediaAssets/lastOperationId";
 import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
 import { HttpError } from "../../shared/errors";
 import { normalizeIsoTimestamp } from "../../sync/conflicts/lww";
@@ -33,6 +38,19 @@ import type {
 } from "../types";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const maximumJavaScriptArrayIndex = 4_294_967_294;
+const catalogPackageInstallMediaLastOperationIdMaximumSuffix =
+  `:media:${maximumJavaScriptArrayIndex}`;
+const catalogPackageInstallCardLastOperationIdMaximumSuffix =
+  `:card:${maximumJavaScriptArrayIndex}`;
+const catalogPackageInstallLastOperationIdMaximumSuffixLength = Math.max(
+  catalogPackageInstallMediaLastOperationIdMaximumSuffix.length,
+  catalogPackageInstallCardLastOperationIdMaximumSuffix.length,
+);
+
+export const catalogPackageInstallOperationIdPrefixMaximumLength =
+  maximumMediaAssetLastOperationIdLength
+  - catalogPackageInstallLastOperationIdMaximumSuffixLength;
 
 type CatalogPackageInstallVersionRow = Readonly<{
   package_version_id: string;
@@ -126,6 +144,31 @@ function normalizeBoundedNonEmptyString(value: string, fieldName: string, maximu
   return normalizedValue;
 }
 
+export function isValidCatalogPackageInstallOperationIdPrefix(
+  value: string,
+): boolean {
+  return isValidMediaAssetLastOperationIdPrefix(
+    value,
+    catalogPackageInstallOperationIdPrefixMaximumLength,
+  );
+}
+
+function normalizeCatalogPackageInstallOperationIdPrefix(value: string): string {
+  if (isValidCatalogPackageInstallOperationIdPrefix(value)) {
+    return value;
+  }
+
+  throw new HttpError(
+    400,
+    [
+      "operationIdPrefix must be",
+      `1 to ${catalogPackageInstallOperationIdPrefixMaximumLength}`,
+      "printable ASCII characters without leading or trailing spaces.",
+    ].join(" "),
+    "CATALOG_PACKAGE_INSTALL_INVALID_INPUT",
+  );
+}
+
 function normalizeCatalogInstallIsoTimestamp(value: string, fieldName: string): string {
   try {
     return normalizeIsoTimestamp(value, fieldName);
@@ -146,7 +189,7 @@ function normalizeCatalogPackageInstallConfirmInput(
     installedAt: normalizeCatalogInstallIsoTimestamp(input.installedAt, "installedAt"),
     clientUpdatedAt: normalizeCatalogInstallIsoTimestamp(input.clientUpdatedAt, "clientUpdatedAt"),
     lastModifiedByReplicaId: normalizeUuidString(input.lastModifiedByReplicaId, "lastModifiedByReplicaId"),
-    operationIdPrefix: normalizeBoundedNonEmptyString(input.operationIdPrefix, "operationIdPrefix", 160),
+    operationIdPrefix: normalizeCatalogPackageInstallOperationIdPrefix(input.operationIdPrefix),
   };
 }
 
@@ -318,11 +361,29 @@ function createCatalogPackageInstallPreview(
 }
 
 function buildCatalogInstallMediaOperationId(operationIdPrefix: string, mediaAssetIndex: number): string {
-  return `${operationIdPrefix}:media:${mediaAssetIndex}`;
+  const lastOperationId = `${operationIdPrefix}:media:${mediaAssetIndex}`;
+  if (isValidMediaAssetLastOperationId(lastOperationId)) {
+    return lastOperationId;
+  }
+
+  throw new HttpError(
+    400,
+    "Derived catalog media lastOperationId is invalid.",
+    "CATALOG_PACKAGE_INSTALL_INVALID_INPUT",
+  );
 }
 
 function buildCatalogInstallCardOperationId(operationIdPrefix: string, cardIndex: number): string {
-  return `${operationIdPrefix}:card:${cardIndex}`;
+  const lastOperationId = `${operationIdPrefix}:card:${cardIndex}`;
+  if (isValidMediaAssetLastOperationId(lastOperationId)) {
+    return lastOperationId;
+  }
+
+  throw new HttpError(
+    400,
+    "Derived catalog card lastOperationId is invalid.",
+    "CATALOG_PACKAGE_INSTALL_INVALID_INPUT",
+  );
 }
 
 function buildCatalogInstallOperationIds(

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -41,8 +41,10 @@ export {
   loadPublicCatalogPackageVersionCardPreviewInExecutor,
 } from "./distribution/public";
 export {
+  catalogPackageInstallOperationIdPrefixMaximumLength,
   installCatalogPackageVersion,
   installCatalogPackageVersionInExecutor,
+  isValidCatalogPackageInstallOperationIdPrefix,
   previewCatalogPackageInstall,
   previewCatalogPackageInstallInExecutor,
 } from "./distribution/install";

--- a/apps/backend/src/database/migrationRunner.ts
+++ b/apps/backend/src/database/migrationRunner.ts
@@ -5,6 +5,7 @@ import { getDatabaseCredentialsSecret } from "../aws/secrets";
 
 interface MigrationRunResult {
   appliedMigrations: ReadonlyArray<string>;
+  installedMigrations: ReadonlyArray<string>;
   appliedViews: ReadonlyArray<string>;
   configuredRuntimeRoles: ReadonlyArray<RuntimeRoleConfigurationResult>;
 }
@@ -178,6 +179,15 @@ async function applyPendingMigrations(
   return appliedMigrations;
 }
 
+async function listInstalledMigrations(
+  client: pg.Client,
+): Promise<ReadonlyArray<string>> {
+  const result = await client.query<Readonly<{ filename: string }>>(
+    "SELECT filename FROM public.schema_migrations ORDER BY filename",
+  );
+  return result.rows.map((row) => row.filename);
+}
+
 async function applyViews(client: pg.Client, directoryPath: string): Promise<ReadonlyArray<string>> {
   const appliedViews: Array<string> = [];
   const viewFiles = await listSqlFiles(directoryPath);
@@ -316,6 +326,7 @@ export async function runMigrations(): Promise<MigrationRunResult> {
   try {
     await ensureSchemaMigrationsTable(client);
     const appliedMigrations = await applyPendingMigrations(client, getMigrationsDirectoryPath());
+    const installedMigrations = await listInstalledMigrations(client);
     const appliedViews = await applyViews(client, getViewsDirectoryPath());
     await syncBootstrapAdminGrants(client, process.env.ADMIN_EMAILS);
     const managedRuntimeRoles = getManagedRuntimeRoles({
@@ -334,6 +345,7 @@ export async function runMigrations(): Promise<MigrationRunResult> {
 
     return {
       appliedMigrations,
+      installedMigrations,
       appliedViews,
       configuredRuntimeRoles,
     };

--- a/apps/backend/src/entrypoints/migrate-lambda.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.ts
@@ -21,6 +21,7 @@ type MigrationLambdaRuntimeRoleResult = Readonly<{
 
 type MigrationLambdaResult = Readonly<{
   appliedMigrations: ReadonlyArray<string>;
+  installedMigrations: ReadonlyArray<string>;
   appliedViews: ReadonlyArray<string>;
   configuredRuntimeRoles: ReadonlyArray<MigrationLambdaRuntimeRoleResult>;
 }>;

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.test.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBackendObservationScope } from "../../observability/sentry";
+import {
+  MultipartCompletionFailureReportBatchError,
+  MultipartCompletionReconciliationBatchError,
+  type MultipartCompletionFailureReportBatchResult,
+  type MultipartCompletionReconciliationBatchResult,
+} from "../../mediaAssets/multipartCompletionReconciliation";
+import {
+  calculateMultipartCompletionReconciliationDeadlineAtMs,
+  getMultipartCompletionReconciliationFailureDetails,
+  multipartCompletionFailureReportMaximumJobs,
+  multipartCompletionReconciliationFinalizationReserveMs,
+  multipartCompletionReconciliationLeaseDurationMs,
+  multipartCompletionReconciliationMaximumJobs,
+  reportMultipartCompletionReconciliationBatchCompleted,
+  reportMultipartCompletionReconciliationTerminalFailure,
+} from "./lambda-multipart-completion-reconciliation";
+
+test("multipart completion worker keeps a finalization reserve and bounded batch", () => {
+  const nowMs = 1_800_000_000_000;
+  assert.equal(multipartCompletionReconciliationMaximumJobs, 5);
+  assert.equal(multipartCompletionFailureReportMaximumJobs, 5);
+  assert.equal(multipartCompletionReconciliationLeaseDurationMs, 180_000);
+  assert.equal(multipartCompletionReconciliationFinalizationReserveMs, 10_000);
+  assert.equal(
+    calculateMultipartCompletionReconciliationDeadlineAtMs(nowMs, 120_000),
+    nowMs + 110_000,
+  );
+  assert.equal(
+    calculateMultipartCompletionReconciliationDeadlineAtMs(nowMs, 5_000),
+    nowMs,
+  );
+});
+
+test("multipart completion worker rejects invalid deadline inputs", () => {
+  assert.throws(
+    () => calculateMultipartCompletionReconciliationDeadlineAtMs(0, 1),
+    RangeError,
+  );
+  assert.throws(
+    () => calculateMultipartCompletionReconciliationDeadlineAtMs(1, -1),
+    RangeError,
+  );
+});
+
+test("multipart completion worker emits a flattened batch Lambda JSON message", () => {
+  const failureReports: MultipartCompletionFailureReportBatchResult = {
+    claimed: 0,
+    ambiguous: 0,
+    leaseLost: 0,
+    reported: 0,
+    results: [],
+  };
+  const result: MultipartCompletionReconciliationBatchResult = {
+    claimed: 2,
+    applied: 1,
+    ambiguous: 0,
+    failed: 1,
+    interrupted: 0,
+    leaseLost: 0,
+    rescheduled: 0,
+    results: [
+      {
+        attemptToken: "attempt-applied",
+        workspaceId: "workspace-1",
+        outcome: "applied",
+        retryCount: 0,
+        errorCode: null,
+      },
+      {
+        attemptToken: "attempt-failed",
+        workspaceId: "workspace-1",
+        outcome: "failed",
+        retryCount: 1,
+        errorCode: "MULTIPART_BLOB_OBJECT_MISMATCH",
+      },
+    ],
+  };
+  const originalConsoleLog = console.log;
+  let message: unknown = null;
+  console.log = (value?: unknown): void => {
+    message = value;
+  };
+  try {
+    reportMultipartCompletionReconciliationBatchCompleted(
+      result,
+      failureReports,
+      createBackendObservationScope(
+        "multipart-completion-reconciliation",
+        "request-1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+    );
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  assert.equal(typeof message, "object");
+  assert.notEqual(message, null);
+  const lambdaEnvelope = {
+    timestamp: "2026-07-29T00:00:00.000Z",
+    level: "INFO",
+    requestId: "request-1",
+    message: message as Readonly<Record<string, unknown>>,
+  };
+  assert.equal(
+    lambdaEnvelope.message.action,
+    "multipart_completion_reconciliation_batch_completed",
+  );
+  assert.equal(lambdaEnvelope.message.failed, 1);
+  assert.deepEqual(lambdaEnvelope.message.failureReports, {
+    maximumReports: multipartCompletionFailureReportMaximumJobs,
+    claimed: 0,
+    ambiguous: 0,
+    leaseLost: 0,
+    reported: 0,
+    results: [],
+  });
+  assert.equal("details" in lambdaEnvelope.message, false);
+});
+
+test("multipart completion worker emits one flattened metric event per terminal failure", () => {
+  const originalConsoleLog = console.log;
+  let message: unknown = null;
+  console.log = (value?: unknown): void => {
+    message = value;
+  };
+  try {
+    reportMultipartCompletionReconciliationTerminalFailure(
+      {
+        failureEventId: "55555555-5555-4555-8555-555555555555",
+        attemptToken: "attempt-failed",
+        workspaceId: "workspace-1",
+        retryCount: 4,
+        errorCode: "RETRY_EXHAUSTED",
+        deliveryAttempt: 2,
+      },
+      createBackendObservationScope(
+        "multipart-completion-reconciliation",
+        "request-1",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+    );
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  assert.equal(typeof message, "object");
+  assert.notEqual(message, null);
+  const lambdaEnvelope = {
+    timestamp: "2026-07-29T00:00:00.000Z",
+    level: "INFO",
+    requestId: "request-1",
+    message: message as Readonly<Record<string, unknown>>,
+  };
+  assert.equal(
+    lambdaEnvelope.message.action,
+    "multipart_completion_reconciliation_job_terminally_failed",
+  );
+  assert.equal(
+    lambdaEnvelope.message.failureEventId,
+    "55555555-5555-4555-8555-555555555555",
+  );
+  assert.equal(lambdaEnvelope.message.attemptToken, "<redacted-secret>");
+  assert.equal(lambdaEnvelope.message.workspaceId, "workspace-1");
+  assert.equal(lambdaEnvelope.message.retryCount, 4);
+  assert.equal(lambdaEnvelope.message.errorCode, "RETRY_EXHAUSTED");
+  assert.equal(lambdaEnvelope.message.deliveryAttempt, 2);
+  assert.equal("details" in lambdaEnvelope.message, false);
+});
+
+test("multipart completion worker attaches partial results to a batch failure", () => {
+  const partialResult: MultipartCompletionReconciliationBatchResult = {
+    claimed: 1,
+    applied: 0,
+    ambiguous: 0,
+    failed: 1,
+    interrupted: 0,
+    leaseLost: 0,
+    rescheduled: 0,
+    results: [
+      {
+        attemptToken: "attempt-failed",
+        workspaceId: "workspace-1",
+        outcome: "failed",
+        retryCount: 2,
+        errorCode: "DURABLE_STATE_CONFLICT",
+      },
+    ],
+  };
+
+  assert.deepEqual(
+    getMultipartCompletionReconciliationFailureDetails(
+      new MultipartCompletionReconciliationBatchError(
+        partialResult,
+        new Error("unexpected second job failure"),
+      ),
+      null,
+    ),
+    {
+      maximumJobs: multipartCompletionReconciliationMaximumJobs,
+      claimed: 1,
+      applied: 0,
+      ambiguous: 0,
+      failed: 1,
+      interrupted: 0,
+      leaseLost: 0,
+      rescheduled: 0,
+      results: [
+        {
+          attemptToken: "attempt-failed",
+          outcome: "failed",
+          retryCount: 2,
+          errorCode: "DURABLE_STATE_CONFLICT",
+        },
+      ],
+      failureReports: {
+        maximumReports: multipartCompletionFailureReportMaximumJobs,
+        claimed: 0,
+        ambiguous: 0,
+        leaseLost: 0,
+        reported: 0,
+        results: [],
+      },
+    },
+  );
+});
+
+test("multipart completion worker attaches partial report delivery results to a batch failure", () => {
+  const partialResult: MultipartCompletionFailureReportBatchResult = {
+    claimed: 1,
+    ambiguous: 0,
+    leaseLost: 0,
+    reported: 1,
+    results: [{
+      failureEventId: "55555555-5555-4555-8555-555555555555",
+      outcome: "reported",
+    }],
+  };
+
+  assert.deepEqual(
+    getMultipartCompletionReconciliationFailureDetails(
+      new MultipartCompletionFailureReportBatchError(
+        partialResult,
+        new Error("unexpected second report failure"),
+      ),
+      null,
+    ),
+    {
+      maximumJobs: multipartCompletionReconciliationMaximumJobs,
+      claimed: 0,
+      applied: 0,
+      ambiguous: 0,
+      failed: 0,
+      interrupted: 0,
+      leaseLost: 0,
+      rescheduled: 0,
+      results: [],
+      failureReports: {
+        maximumReports: multipartCompletionFailureReportMaximumJobs,
+        claimed: 1,
+        ambiguous: 0,
+        leaseLost: 0,
+        reported: 1,
+        results: [{
+          failureEventId: "55555555-5555-4555-8555-555555555555",
+          outcome: "reported",
+        }],
+      },
+    },
+  );
+});

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.ts
@@ -1,0 +1,258 @@
+import type { Handler } from "aws-lambda";
+import {
+  MultipartCompletionFailureReportBatchError,
+  MultipartCompletionReconciliationBatchError,
+  runMultipartCompletionFailureReportBatch,
+  runMultipartCompletionReconciliationBatch,
+  type MultipartCompletionFailureReportBatchResult,
+  type MultipartCompletionReconciliationBatchResult,
+} from "../../mediaAssets/multipartCompletionReconciliation";
+import { createCloudWatchRecord } from "../../observability/cloudWatch";
+import {
+  addBackendSentryBreadcrumb,
+  captureBackendException,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  type BackendObservationScope,
+  type MultipartCompletionFailureReportBatchDetails,
+  type MultipartCompletionReconciliationBatchDetails,
+  type MultipartCompletionReconciliationTerminalFailureDetails,
+  wrapBackendHandler,
+} from "../../observability/sentry";
+
+initializeBackendSentry("multipart-completion-reconciliation");
+
+export const multipartCompletionReconciliationMaximumJobs = 5;
+export const multipartCompletionFailureReportMaximumJobs = 5;
+export const multipartCompletionReconciliationLeaseDurationMs = 180_000;
+export const multipartCompletionReconciliationFinalizationReserveMs = 10_000;
+
+export function calculateMultipartCompletionReconciliationDeadlineAtMs(
+  nowMs: number,
+  remainingTimeMs: number,
+): number {
+  if (
+    Number.isSafeInteger(nowMs) === false
+    || nowMs < 1
+    || Number.isSafeInteger(remainingTimeMs) === false
+    || remainingTimeMs < 0
+  ) {
+    throw new RangeError(
+      "Multipart completion reconciliation deadline inputs must be non-negative safe integers.",
+    );
+  }
+  return nowMs + Math.max(
+    0,
+    remainingTimeMs
+      - multipartCompletionReconciliationFinalizationReserveMs,
+  );
+}
+
+type MultipartCompletionReconciliationResponse =
+  Omit<MultipartCompletionReconciliationBatchResult, "results">
+  & Readonly<{ ok: true }>;
+
+function emptyFailureReportDetails():
+MultipartCompletionFailureReportBatchDetails {
+  return {
+    maximumReports: multipartCompletionFailureReportMaximumJobs,
+    claimed: 0,
+    ambiguous: 0,
+    leaseLost: 0,
+    reported: 0,
+    results: [],
+  };
+}
+
+function toFailureReportDetails(
+  result: MultipartCompletionFailureReportBatchResult,
+): MultipartCompletionFailureReportBatchDetails {
+  return {
+    maximumReports: multipartCompletionFailureReportMaximumJobs,
+    claimed: result.claimed,
+    ambiguous: result.ambiguous,
+    leaseLost: result.leaseLost,
+    reported: result.reported,
+    results: result.results.map((item) => ({
+      failureEventId: item.failureEventId,
+      outcome: item.outcome,
+    })),
+  };
+}
+
+function failureReportDetails(
+  result: MultipartCompletionFailureReportBatchResult | null,
+): MultipartCompletionFailureReportBatchDetails {
+  return result === null
+    ? emptyFailureReportDetails()
+    : toFailureReportDetails(result);
+}
+
+function emptyDetails(
+  reports: MultipartCompletionFailureReportBatchDetails,
+): MultipartCompletionReconciliationBatchDetails {
+  return {
+    maximumJobs: multipartCompletionReconciliationMaximumJobs,
+    claimed: 0,
+    applied: 0,
+    ambiguous: 0,
+    failed: 0,
+    interrupted: 0,
+    leaseLost: 0,
+    rescheduled: 0,
+    results: [],
+    failureReports: reports,
+  };
+}
+
+function toDetails(
+  result: MultipartCompletionReconciliationBatchResult,
+  reports: MultipartCompletionFailureReportBatchDetails,
+): MultipartCompletionReconciliationBatchDetails {
+  return {
+    maximumJobs: multipartCompletionReconciliationMaximumJobs,
+    claimed: result.claimed,
+    applied: result.applied,
+    ambiguous: result.ambiguous,
+    failed: result.failed,
+    interrupted: result.interrupted,
+    leaseLost: result.leaseLost,
+    rescheduled: result.rescheduled,
+    results: result.results.map((item) => ({
+      attemptToken: item.attemptToken,
+      outcome: item.outcome,
+      retryCount: item.retryCount,
+      errorCode: item.errorCode,
+    })),
+    failureReports: reports,
+  };
+}
+
+export function getMultipartCompletionReconciliationFailureDetails(
+  error: unknown,
+  completedFailureReports: MultipartCompletionFailureReportBatchResult | null,
+): MultipartCompletionReconciliationBatchDetails {
+  const reports = error instanceof MultipartCompletionFailureReportBatchError
+    ? toFailureReportDetails(error.partialResult)
+    : failureReportDetails(completedFailureReports);
+  if (error instanceof MultipartCompletionReconciliationBatchError) {
+    return toDetails(error.partialResult, reports);
+  }
+  return emptyDetails(reports);
+}
+
+export function reportMultipartCompletionReconciliationBatchCompleted(
+  result: MultipartCompletionReconciliationBatchResult,
+  failureReports: MultipartCompletionFailureReportBatchResult,
+  observationScope: BackendObservationScope,
+): void {
+  const event = {
+    action: "multipart_completion_reconciliation_batch_completed",
+    scope: observationScope,
+    details: toDetails(result, toFailureReportDetails(failureReports)),
+  } as const;
+  console.log(createCloudWatchRecord(event));
+  addBackendSentryBreadcrumb(event);
+}
+
+export function reportMultipartCompletionReconciliationTerminalFailure(
+  details: MultipartCompletionReconciliationTerminalFailureDetails,
+  observationScope: BackendObservationScope,
+): void {
+  const event = {
+    action: "multipart_completion_reconciliation_job_terminally_failed",
+    scope: observationScope,
+    details,
+  } as const;
+  console.log(createCloudWatchRecord(event));
+  addBackendSentryBreadcrumb(event);
+}
+
+const multipartCompletionReconciliationHandler: Handler<
+  unknown,
+  MultipartCompletionReconciliationResponse
+> = async (_event, context) => {
+  const observationScope = createBackendObservationScope(
+    "multipart-completion-reconciliation",
+    context.awsRequestId ?? null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+  const deadlineAtMs =
+    calculateMultipartCompletionReconciliationDeadlineAtMs(
+      Date.now(),
+      context.getRemainingTimeInMillis(),
+  );
+  const abortController = new AbortController();
+  const deadlineTimer = setTimeout(
+    () => abortController.abort(
+      new Error("Multipart completion reconciliation worker deadline reached."),
+    ),
+    Math.max(0, deadlineAtMs - Date.now()),
+  );
+  let failureReportResult: MultipartCompletionFailureReportBatchResult | null =
+    null;
+  try {
+    failureReportResult = await runMultipartCompletionFailureReportBatch({
+      leaseOwner:
+        `multipart-completion-failure-report:${context.awsRequestId}`,
+      leaseDurationMs: multipartCompletionReconciliationLeaseDurationMs,
+      maximumReports: multipartCompletionFailureReportMaximumJobs,
+      deadlineAtMs,
+      reportTerminalFailure: (details) =>
+        reportMultipartCompletionReconciliationTerminalFailure(
+          details,
+          observationScope,
+        ),
+      signal: abortController.signal,
+    });
+    const result = await runMultipartCompletionReconciliationBatch({
+      leaseOwner: `multipart-completion-reconciliation:${context.awsRequestId}`,
+      leaseDurationMs: multipartCompletionReconciliationLeaseDurationMs,
+      maximumJobs: multipartCompletionReconciliationMaximumJobs,
+      deadlineAtMs,
+      observationScope,
+      signal: abortController.signal,
+    });
+    reportMultipartCompletionReconciliationBatchCompleted(
+      result,
+      failureReportResult,
+      observationScope,
+    );
+    return {
+      ok: true,
+      claimed: result.claimed,
+      applied: result.applied,
+      ambiguous: result.ambiguous,
+      failed: result.failed,
+      interrupted: result.interrupted,
+      leaseLost: result.leaseLost,
+      rescheduled: result.rescheduled,
+    };
+  } catch (error) {
+    captureBackendException({
+      action: "multipart_completion_reconciliation_batch_failed",
+      error: normalizeCaughtError(error),
+      scope: observationScope,
+      details: getMultipartCompletionReconciliationFailureDetails(
+        error,
+        failureReportResult,
+      ),
+    });
+    throw error;
+  } finally {
+    clearTimeout(deadlineTimer);
+  }
+};
+
+export const handler = wrapBackendHandler(
+  multipartCompletionReconciliationHandler,
+);

--- a/apps/backend/src/mediaAssets/index.test.ts
+++ b/apps/backend/src/mediaAssets/index.test.ts
@@ -6,6 +6,7 @@ import {
   buildMediaMultipartUploadStagingStorageKey,
   buildMediaUploadStagingStorageKey,
 } from "./storageKeys";
+import { isValidMediaAssetLastOperationId } from "./lastOperationId";
 import {
   maximumImageIngestionOriginalBytes,
   maximumMultipartUploadBytes,
@@ -104,6 +105,60 @@ test("media asset upload validators keep direct uploads compatible and cap multi
       return true;
     },
   );
+});
+
+test("media asset upload validators reject unsafe last operation identifiers", () => {
+  assert.throws(
+    () => parseMediaAssetUploadSessionCreateInput({
+      mediaAssetId: testMediaAssetId,
+      mimeType: "image/png",
+      sizeBytes: 42,
+      sha256: testSha256,
+      partSizeBytes: 42,
+      partCount: 1,
+      sourceUrl: null,
+      createdAt: "2026-02-28T09:00:00.000Z",
+      clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+      lastModifiedByReplicaId: "55555555-5555-4555-8555-555555555555",
+      lastOperationId: "operation\nmultipart",
+    }),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "MEDIA_ASSET_LAST_OPERATION_ID_INVALID");
+      return true;
+    },
+  );
+});
+
+test("media asset last operation identifiers use one printable ASCII contract", () => {
+  const accepted = [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    "550e8400-e29b-41d4-a716-446655440000:media:99",
+    "operation with internal spaces",
+    "a".repeat(1_024),
+  ];
+  const rejected = [
+    "",
+    " leading-space",
+    "trailing-space ",
+    "operation\tcontrol",
+    "operation\ncontrol",
+    "operation\u00a0nbsp",
+    "operation-😀",
+    "😀".repeat(512),
+    "\ud800",
+    "\udc00",
+    "a".repeat(1_025),
+  ];
+
+  for (const value of accepted) {
+    assert.equal(isValidMediaAssetLastOperationId(value), true, value);
+  }
+  for (const value of rejected) {
+    assert.equal(isValidMediaAssetLastOperationId(value), false, value);
+  }
 });
 
 test("deadline-aware image request reading cancels its underlying body stream", async () => {

--- a/apps/backend/src/mediaAssets/lastOperationId.ts
+++ b/apps/backend/src/mediaAssets/lastOperationId.ts
@@ -1,0 +1,20 @@
+const mediaAssetLastOperationIdPattern =
+  /^([!-~]|[!-~][ -~]*[!-~])$/u;
+export const maximumMediaAssetLastOperationIdLength = 1_024;
+
+export function isValidMediaAssetLastOperationId(value: string): boolean {
+  return (
+    value.length <= maximumMediaAssetLastOperationIdLength
+    && mediaAssetLastOperationIdPattern.test(value)
+  );
+}
+
+export function isValidMediaAssetLastOperationIdPrefix(
+  value: string,
+  maximumLength: number,
+): boolean {
+  return (
+    value.length <= maximumLength
+    && mediaAssetLastOperationIdPattern.test(value)
+  );
+}

--- a/apps/backend/src/mediaAssets/multipartCompletionReconciliation.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipartCompletionReconciliation.postgres.integration.ts
@@ -1,0 +1,2150 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import test from "node:test";
+import type pg from "pg";
+import {
+  type PostgresIntegrationFixture,
+  withPostgresIntegrationFixture,
+} from "../testSupport/postgresIntegration";
+import { HttpError } from "../shared/errors";
+import {
+  applyMultipartCompletionReconciliation,
+  claimMultipartCompletionFailureReports,
+  claimMultipartCompletionReconciliations,
+  deliverMultipartCompletionFailureReport,
+  failMultipartCompletionReconciliation,
+  finishMultipartCompletionFailureReport,
+  MultipartCompletionFailureReportLeaseLostError,
+  MultipartCompletionReconciliationLeaseLostError,
+  readMultipartCompletionReconciliationOutcome,
+  renewMultipartCompletionReconciliationLease,
+  rescheduleMultipartCompletionReconciliation,
+  type ClaimedMultipartCompletionFailureReport,
+  type ClaimedMultipartCompletionReconciliation,
+} from "./multipartCompletionReconciliation";
+import { isValidMediaAssetLastOperationId } from "./lastOperationId";
+import {
+  beginMediaAssetUploadSessionAbortForWorkspace,
+  beginMediaAssetUploadSessionCompletionForWorkspace,
+  completeMediaAssetUploadSessionForWorkspace,
+  markMediaAssetUploadSessionAbortedForWorkspace,
+  recordMediaAssetUploadSessionForWorkspace,
+} from "./uploadSessions";
+import {
+  buildMediaBlobStorageKey,
+  buildMediaMultipartUploadStagingStorageKey,
+} from "./storageKeys";
+
+type MultipartPayload = Readonly<{
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  mediaAssetId: string;
+  replicaId: string;
+  lastOperationId: string;
+  sha256: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  s3UploadId: string;
+  mimeType: string;
+  sizeBytes: number;
+  partSizeBytes: number;
+  partCount: number;
+  sourceUrl: string | null;
+  assetCreatedAt: string;
+  clientUpdatedAt: string;
+  sessionExpiresAt: string;
+  normalizationVersion: string;
+  partsFingerprint: string;
+}>;
+
+type BeginRow = Readonly<{
+  attempt_status: string;
+  reservation_token: string | null;
+  normalization_version: string | null;
+}>;
+type StatusRow = Readonly<{ status: string }>;
+type StateRow = Readonly<{
+  session_state: string;
+  attempt_state: string;
+  attempt_outcome: string;
+  reconciliation_state: string;
+  reservation_state: string;
+}>;
+type CountRow = Readonly<{ count: number }>;
+type SqlValue = string | number | null;
+type QueryExecutor = Pick<pg.PoolClient | pg.Pool, "query">;
+
+const multipartRow = `ROW(
+  $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+)::content.multipart_media_blob_writer_attempt_payload`;
+
+function digest(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+
+function createPayload(
+  fixture: PostgresIntegrationFixture,
+): MultipartPayload {
+  const sessionId = randomUUID();
+  const mediaAssetId = randomUUID();
+  const sha256 = digest();
+  return {
+    userId: fixture.userId,
+    workspaceId: fixture.workspaceId,
+    sessionId,
+    mediaAssetId,
+    replicaId: fixture.replicaId,
+    lastOperationId: randomUUID(),
+    sha256,
+    stagingStorageKey:
+      `media/uploads/workspaces/${fixture.workspaceId}/assets/${mediaAssetId}/sessions/${sessionId}`,
+    blobStorageKey: buildMediaBlobStorageKey(sha256),
+    s3UploadId: `upload-${randomUUID()}`,
+    mimeType: "application/octet-stream",
+    sizeBytes: 42,
+    partSizeBytes: 42,
+    partCount: 1,
+    sourceUrl: null,
+    assetCreatedAt: fixture.createdAt,
+    clientUpdatedAt: fixture.createdAt,
+    sessionExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    normalizationVersion: "passthrough-v1",
+    partsFingerprint: digest(),
+  };
+}
+
+const migration0099LegacyUserId =
+  "migration-0099-legacy-invalid-media-asset";
+const migration0099LegacyWorkspaceId =
+  "09900000-0000-4000-8000-000000000001";
+const migration0099LegacyReplicaId =
+  "09900000-0000-4000-8000-000000000002";
+const migration0099LegacyTimestamp = "2026-07-29T00:00:00.000Z";
+const migration0099LegacySessionExpiresAt =
+  "2099-07-29T00:00:00.000Z";
+const migration0099LegacyActiveSessionId =
+  "09940000-0000-4000-8000-000000000001";
+const migration0099LegacyActiveMediaAssetId =
+  "09940000-0000-4000-8000-000000000002";
+const migration0099LegacyActiveSha256 = "d".repeat(64);
+
+function createMigration0099LegacyPayload(
+  input: Readonly<{
+    sessionId: string;
+    mediaAssetId: string;
+    sha256: string;
+    lastOperationId: string;
+    uploadId: string;
+    partsFingerprint: string;
+  }>,
+): MultipartPayload {
+  return {
+    userId: migration0099LegacyUserId,
+    workspaceId: migration0099LegacyWorkspaceId,
+    sessionId: input.sessionId,
+    mediaAssetId: input.mediaAssetId,
+    replicaId: migration0099LegacyReplicaId,
+    lastOperationId: input.lastOperationId,
+    sha256: input.sha256,
+    stagingStorageKey:
+      `media/uploads/workspaces/${migration0099LegacyWorkspaceId}/assets/${input.mediaAssetId}/sessions/${input.sessionId}`,
+    blobStorageKey: buildMediaBlobStorageKey(input.sha256),
+    s3UploadId: input.uploadId,
+    mimeType: "application/octet-stream",
+    sizeBytes: 1,
+    partSizeBytes: 1,
+    partCount: 1,
+    sourceUrl: null,
+    assetCreatedAt: migration0099LegacyTimestamp,
+    clientUpdatedAt: migration0099LegacyTimestamp,
+    sessionExpiresAt: migration0099LegacySessionExpiresAt,
+    normalizationVersion: "passthrough-v1",
+    partsFingerprint: input.partsFingerprint,
+  };
+}
+
+function payloadValues(payload: MultipartPayload): Array<SqlValue> {
+  return [
+    payload.userId,
+    payload.workspaceId,
+    payload.sessionId,
+    payload.mediaAssetId,
+    payload.replicaId,
+    payload.lastOperationId,
+    payload.sha256,
+    payload.stagingStorageKey,
+    payload.blobStorageKey,
+    payload.s3UploadId,
+    payload.mimeType,
+    payload.sizeBytes,
+    payload.partSizeBytes,
+    payload.partCount,
+    payload.sourceUrl,
+    payload.assetCreatedAt,
+    payload.clientUpdatedAt,
+    payload.sessionExpiresAt,
+    payload.normalizationVersion,
+    payload.partsFingerprint,
+  ];
+}
+
+async function scoped<Result>(
+  fixture: PostgresIntegrationFixture,
+  callback: (client: pg.PoolClient) => Promise<Result>,
+): Promise<Result> {
+  return scopedAs(
+    fixture,
+    fixture.userId,
+    fixture.workspaceId,
+    callback,
+  );
+}
+
+async function scopedAs<Result>(
+  fixture: PostgresIntegrationFixture,
+  userId: string,
+  workspaceId: string,
+  callback: (client: pg.PoolClient) => Promise<Result>,
+): Promise<Result> {
+  const client = await fixture.runtimePool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      "SELECT set_config('app.user_id',$1,true),set_config('app.workspace_id',$2,true)",
+      [userId, workspaceId],
+    );
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function insertSession(
+  executor: QueryExecutor,
+  payload: MultipartPayload,
+): Promise<void> {
+  await executor.query(
+    `INSERT INTO content.media_upload_sessions (
+       media_upload_session_id,workspace_id,media_asset_id,media_blob_sha256,
+       staging_storage_key,blob_storage_key,s3_upload_id,mime_type,size_bytes,
+       part_size_bytes,part_count,state,source_url,asset_created_at,client_updated_at,
+       last_modified_by_replica_id,last_operation_id,expires_at
+     ) VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'completing',$12,$13,$14,$15,$16,$17
+     )`,
+    [
+      payload.sessionId,
+      payload.workspaceId,
+      payload.mediaAssetId,
+      payload.sha256,
+      payload.stagingStorageKey,
+      payload.blobStorageKey,
+      payload.s3UploadId,
+      payload.mimeType,
+      payload.sizeBytes,
+      payload.partSizeBytes,
+      payload.partCount,
+      payload.sourceUrl,
+      payload.assetCreatedAt,
+      payload.clientUpdatedAt,
+      payload.replicaId,
+      payload.lastOperationId,
+      payload.sessionExpiresAt,
+    ],
+  );
+}
+
+async function beginAttempt(
+  fixture: PostgresIntegrationFixture,
+  attemptToken: string,
+  payload: MultipartPayload,
+): Promise<BeginRow> {
+  return beginAttemptAs(
+    fixture,
+    fixture.userId,
+    fixture.workspaceId,
+    attemptToken,
+    payload,
+  );
+}
+
+async function beginAttemptAs(
+  fixture: PostgresIntegrationFixture,
+  userId: string,
+  workspaceId: string,
+  attemptToken: string,
+  payload: MultipartPayload,
+): Promise<BeginRow> {
+  return scopedAs(
+    fixture,
+    userId,
+    workspaceId,
+    async (client) => (await client.query<BeginRow>(
+      `SELECT *
+       FROM content.begin_media_upload_session_completion_attempt_with_owner(
+         $1,$2,${multipartRow}
+       )`,
+      [attemptToken, 60_000, ...payloadValues(payload)],
+    )).rows[0],
+  );
+}
+
+async function handoffAttempt(
+  fixture: PostgresIntegrationFixture,
+  attemptToken: string,
+  reservationToken: string,
+  payload: MultipartPayload,
+): Promise<string> {
+  return handoffAttemptAs(
+    fixture,
+    fixture.userId,
+    fixture.workspaceId,
+    attemptToken,
+    reservationToken,
+    payload,
+  );
+}
+
+async function handoffAttemptAs(
+  fixture: PostgresIntegrationFixture,
+  userId: string,
+  workspaceId: string,
+  attemptToken: string,
+  reservationToken: string,
+  payload: MultipartPayload,
+): Promise<string> {
+  return scopedAs(
+    fixture,
+    userId,
+    workspaceId,
+    async (client) => (await client.query<StatusRow>(
+      `SELECT content.handoff_media_upload_session_completion_attempt(
+         $1,$2,${multipartRow}
+       ) AS status`,
+      [attemptToken, reservationToken, ...payloadValues(payload)],
+    )).rows[0].status,
+  );
+}
+
+async function createHandedOffAttempt(
+  fixture: PostgresIntegrationFixture,
+): Promise<Readonly<{
+  payload: MultipartPayload;
+  attemptToken: string;
+  reservationToken: string;
+}>> {
+  const payload = createPayload(fixture);
+  const attemptToken = randomUUID();
+  await insertSession(fixture.ownerPool, payload);
+  const begun = await beginAttempt(fixture, attemptToken, payload);
+  assert.equal(begun.attempt_status, "acquired");
+  assert.equal(begun.normalization_version, payload.normalizationVersion);
+  assert.notEqual(begun.reservation_token, null);
+  const reservationToken = begun.reservation_token as string;
+  assert.equal(
+    await handoffAttempt(
+      fixture,
+      attemptToken,
+      reservationToken,
+      payload,
+    ),
+    "handed_off",
+  );
+  assert.equal(
+    await handoffAttempt(
+      fixture,
+      attemptToken,
+      reservationToken,
+      payload,
+    ),
+    "already_pending",
+  );
+  return { payload, attemptToken, reservationToken };
+}
+
+async function insertExactReference(
+  fixture: PostgresIntegrationFixture,
+  payload: MultipartPayload,
+): Promise<void> {
+  await fixture.ownerPool.query(
+    `WITH blob AS (
+       INSERT INTO content.media_blobs (
+         media_blob_id,sha256,mime_type,size_bytes,storage_key,
+         normalization_version
+       ) VALUES ($1,$2,$3,$4,$5,$6)
+       RETURNING media_blob_id
+     )
+     INSERT INTO content.media_assets (
+       media_asset_id,workspace_id,media_blob_id,source_url,created_at,
+       client_updated_at,last_modified_by_replica_id,last_operation_id
+     )
+     SELECT $7,$8,media_blob_id,$9,$10,$11,$12,$13
+     FROM blob`,
+    [
+      randomUUID(),
+      payload.sha256,
+      payload.mimeType,
+      payload.sizeBytes,
+      payload.blobStorageKey,
+      payload.normalizationVersion,
+      payload.mediaAssetId,
+      payload.workspaceId,
+      payload.sourceUrl,
+      payload.assetCreatedAt,
+      payload.clientUpdatedAt,
+      payload.replicaId,
+      payload.lastOperationId,
+    ],
+  );
+}
+
+async function closeCurrentWriter(
+  fixture: PostgresIntegrationFixture,
+  payload: MultipartPayload,
+): Promise<string> {
+  return closeCurrentWriterAs(
+    fixture,
+    fixture.userId,
+    fixture.workspaceId,
+    payload,
+  );
+}
+
+async function closeCurrentWriterAs(
+  fixture: PostgresIntegrationFixture,
+  userId: string,
+  workspaceId: string,
+  payload: MultipartPayload,
+): Promise<string> {
+  return scopedAs(
+    fixture,
+    userId,
+    workspaceId,
+    async (client) => (await client.query<StatusRow>(
+      `SELECT content.close_media_upload_session_current_blob_writer_with_owner(
+         $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12
+       ) AS status`,
+      [
+        payload.userId,
+        payload.workspaceId,
+        payload.sessionId,
+        payload.mediaAssetId,
+        payload.replicaId,
+        payload.lastOperationId,
+        payload.sha256,
+        payload.blobStorageKey,
+        payload.mimeType,
+        payload.sizeBytes,
+        payload.sessionExpiresAt,
+        3_600_000,
+      ],
+    )).rows[0].status,
+  );
+}
+
+async function claimOne(
+  leaseOwner: string,
+): Promise<ClaimedMultipartCompletionReconciliation> {
+  const jobs = await claimMultipartCompletionReconciliations({
+    leaseOwner,
+    leaseDurationMs: 60_000,
+    limit: 1,
+    deadlineAtMs: Date.now() + 30_000,
+  });
+  assert.equal(jobs.length, 1);
+  return jobs[0] as ClaimedMultipartCompletionReconciliation;
+}
+
+async function claimFailureReportOne(
+  leaseOwner: string,
+  attemptToken: string,
+): Promise<ClaimedMultipartCompletionFailureReport> {
+  const reports = await claimMultipartCompletionFailureReports({
+    leaseOwner,
+    leaseDurationMs: 60_000,
+    limit: 100,
+    deadlineAtMs: Date.now() + 30_000,
+  });
+  const report = reports.find(
+    (candidate) => candidate.attemptToken === attemptToken,
+  );
+  assert.notEqual(report, undefined);
+  return report as ClaimedMultipartCompletionFailureReport;
+}
+
+async function createFailedAttempt(
+  fixture: PostgresIntegrationFixture,
+  leaseOwner: string,
+): Promise<Awaited<ReturnType<typeof createHandedOffAttempt>>> {
+  const handedOff = await createHandedOffAttempt(fixture);
+  const reconciliationLease = await claimOne(leaseOwner);
+  assert.equal(
+    await failMultipartCompletionReconciliation(
+      reconciliationLease,
+      Date.now() + 30_000,
+      {
+        code: "RETRY_EXHAUSTED",
+        message:
+          "Multipart completion reconciliation exhausted its transient retry budget.",
+      },
+    ),
+    "failed",
+  );
+  return handedOff;
+}
+
+async function state(
+  fixture: PostgresIntegrationFixture,
+  attemptToken: string,
+): Promise<StateRow> {
+  return (await fixture.ownerPool.query<StateRow>(
+    `SELECT
+       sessions.state AS session_state,
+       attempts.state AS attempt_state,
+       attempts.outcome AS attempt_outcome,
+       attempts.reconciliation_state,
+       reservations.state AS reservation_state
+     FROM content.media_blob_writer_attempts AS attempts
+     INNER JOIN content.media_upload_sessions AS sessions
+       ON sessions.media_upload_session_id = attempts.media_upload_session_id
+     INNER JOIN content.media_blob_writer_reservations AS reservations
+       ON reservations.reservation_token = attempts.reservation_token
+     WHERE attempts.attempt_token = $1`,
+    [attemptToken],
+  )).rows[0];
+}
+
+test("migration 0099 fences durable handoff, replay, retry, revocation, and apply", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const baseline = (await fixture.ownerPool.query<Readonly<{
+      major: number;
+      migrations: number;
+      latest: string;
+    }>>(
+      `SELECT
+         current_setting('server_version_num')::int / 10000 AS major,
+         count(*)::int AS migrations,
+         max(filename) AS latest
+       FROM public.schema_migrations`,
+    )).rows[0];
+    assert.deepEqual(baseline, {
+      major: 18,
+      migrations: 101,
+      latest: "0099_durable_multipart_completion_reconciliation.sql",
+    });
+    const security = (await fixture.ownerPool.query<Readonly<{
+      backend_claim: boolean;
+      auth_claim: boolean;
+      reporting_claim: boolean;
+      public_claim: boolean;
+      backend_internal: boolean;
+      backend_job_internal: boolean;
+      backend_last_operation_internal: boolean;
+      backend_canonical_payload_internal: boolean;
+      backend_table: boolean;
+      backend_report_claim: boolean;
+      auth_report_claim: boolean;
+      public_report_claim: boolean;
+      backend_report_delivery_lock: boolean;
+      auth_report_delivery_lock: boolean;
+      public_report_delivery_lock: boolean;
+      backend_report_finish: boolean;
+      backend_outcome: boolean;
+    }>>(
+      `SELECT
+         has_function_privilege(
+           'backend_app',
+           'content.claim_media_upload_session_completion_reconciliations(text,integer,integer)',
+           'EXECUTE'
+         ) AS backend_claim,
+         has_function_privilege(
+           'auth_app',
+           'content.claim_media_upload_session_completion_reconciliations(text,integer,integer)',
+           'EXECUTE'
+         ) AS auth_claim,
+         has_function_privilege(
+           'reporting_readonly',
+           'content.claim_media_upload_session_completion_reconciliations(text,integer,integer)',
+           'EXECUTE'
+         ) AS reporting_claim,
+         has_function_privilege(
+           'public',
+           'content.claim_media_upload_session_completion_reconciliations(text,integer,integer)',
+           'EXECUTE'
+         ) AS public_claim,
+         has_function_privilege(
+           'backend_app',
+           'content.multipart_completion_reconciliation_error_valid_internal(text,text)',
+           'EXECUTE'
+         ) AS backend_internal,
+         has_function_privilege(
+           'backend_app',
+           'content.multipart_completion_reconciliation_job_valid_internal(content.media_blob_writer_attempts)',
+           'EXECUTE'
+         ) AS backend_job_internal,
+         has_function_privilege(
+           'backend_app',
+           'content.media_asset_last_operation_id_valid_internal(text)',
+           'EXECUTE'
+         ) AS backend_last_operation_internal,
+         has_function_privilege(
+           'backend_app',
+           'content.multipart_media_blob_writer_attempt_payload_canonical_valid_internal(content.multipart_media_blob_writer_attempt_payload)',
+           'EXECUTE'
+         ) AS backend_canonical_payload_internal,
+         has_table_privilege(
+           'backend_app',
+           'content.media_blob_writer_attempts',
+           'SELECT'
+         ) AS backend_table,
+         has_function_privilege(
+           'backend_app',
+           'content.claim_media_upload_session_completion_failure_reports(text,integer,integer)',
+           'EXECUTE'
+         ) AS backend_report_claim,
+         has_function_privilege(
+           'auth_app',
+           'content.claim_media_upload_session_completion_failure_reports(text,integer,integer)',
+           'EXECUTE'
+         ) AS auth_report_claim,
+         has_function_privilege(
+           'public',
+           'content.claim_media_upload_session_completion_failure_reports(text,integer,integer)',
+           'EXECUTE'
+         ) AS public_report_claim,
+         has_function_privilege(
+           'backend_app',
+           'content.lock_media_upload_session_completion_failure_report_delivery(uuid,uuid,uuid)',
+           'EXECUTE'
+         ) AS backend_report_delivery_lock,
+         has_function_privilege(
+           'auth_app',
+           'content.lock_media_upload_session_completion_failure_report_delivery(uuid,uuid,uuid)',
+           'EXECUTE'
+         ) AS auth_report_delivery_lock,
+         has_function_privilege(
+           'public',
+           'content.lock_media_upload_session_completion_failure_report_delivery(uuid,uuid,uuid)',
+           'EXECUTE'
+         ) AS public_report_delivery_lock,
+         has_function_privilege(
+           'backend_app',
+           'content.finish_media_upload_session_completion_failure_report(uuid,uuid,uuid)',
+           'EXECUTE'
+         ) AS backend_report_finish,
+         has_function_privilege(
+           'backend_app',
+           'content.get_media_upload_session_completion_reconciliation_outcome(uuid)',
+           'EXECUTE'
+         ) AS backend_outcome`,
+    )).rows[0];
+    assert.deepEqual(security, {
+      backend_claim: true,
+      auth_claim: false,
+      reporting_claim: false,
+      public_claim: false,
+      backend_internal: false,
+      backend_job_internal: false,
+      backend_last_operation_internal: false,
+      backend_canonical_payload_internal: false,
+      backend_table: false,
+      backend_report_claim: true,
+      auth_report_claim: false,
+      public_report_claim: false,
+      backend_report_delivery_lock: true,
+      auth_report_delivery_lock: false,
+      public_report_delivery_lock: false,
+      backend_report_finish: true,
+      backend_outcome: true,
+    });
+
+    const successful = await createHandedOffAttempt(fixture);
+    assert.equal(
+      await scoped(
+        fixture,
+        async (client) => (await client.query<StatusRow>(
+          `SELECT content.check_media_upload_session_completion_pending_with_owner(
+             $1,$2,$3,$4
+           ) AS status`,
+          [
+            fixture.userId,
+            fixture.workspaceId,
+            successful.payload.sessionId,
+            successful.payload.mediaAssetId,
+          ],
+        )).rows[0].status,
+      ),
+      "pending",
+    );
+    assert.equal(
+      await scoped(
+        fixture,
+        async (client) => (await client.query<StatusRow>(
+          `SELECT content.check_media_asset_completion_pending_with_owner(
+             $1,$2,$3
+           ) AS status`,
+          [
+            fixture.userId,
+            fixture.workspaceId,
+            successful.payload.mediaAssetId,
+          ],
+        )).rows[0].status,
+      ),
+      "pending",
+    );
+
+    const successfulJob = await claimOne("worker-success");
+    assert.equal(successfulJob.attemptToken, successful.attemptToken);
+    assert.deepEqual(
+      await claimMultipartCompletionReconciliations({
+        leaseOwner: "duplicate-worker",
+        leaseDurationMs: 60_000,
+        limit: 1,
+        deadlineAtMs: Date.now() + 30_000,
+      }),
+      [],
+    );
+    assert.equal(
+      await applyMultipartCompletionReconciliation(
+        successfulJob,
+        Date.now() + 30_000,
+      ),
+      "applied",
+    );
+    assert.deepEqual(await state(fixture, successful.attemptToken), {
+      session_state: "completed",
+      attempt_state: "applied",
+      attempt_outcome: "live_applied",
+      reconciliation_state: "applied",
+      reservation_state: "finalized",
+    });
+    const uploadCount = (await fixture.ownerPool.query<CountRow>(
+      `SELECT count(*)::int AS count
+       FROM content.media_upload_sessions
+       WHERE workspace_id=$1 AND media_asset_id=$2`,
+      [fixture.workspaceId, successful.payload.mediaAssetId],
+    )).rows[0].count;
+    assert.equal(uploadCount, 1);
+    const replayStatus = (await fixture.runtimePool.query<StatusRow>(
+      `SELECT content.finish_media_upload_session_completion_reconciliation(
+         $1,$2,$3
+       ) AS status`,
+      [
+        successfulJob.attemptToken,
+        successfulJob.leaseToken,
+        3_600_000,
+      ],
+    )).rows[0].status;
+    assert.equal(replayStatus, "already_applied");
+
+    const retried = await createHandedOffAttempt(fixture);
+    const firstLease = await claimOne("worker-retry-one");
+    const retryAt = new Date(Date.now() + 60_000);
+    await rescheduleMultipartCompletionReconciliation(
+      firstLease,
+      Date.now() + 30_000,
+      retryAt,
+      {
+        code: "MULTIPART_STORAGE_TRANSIENT",
+        message: "Multipart completion storage is temporarily unavailable.",
+      },
+    );
+    assert.deepEqual(
+      await claimMultipartCompletionReconciliations({
+        leaseOwner: "worker-too-early",
+        leaseDurationMs: 60_000,
+        limit: 1,
+        deadlineAtMs: Date.now() + 30_000,
+      }),
+      [],
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET reconciliation_next_attempt_at = reconciliation_handed_off_at
+       WHERE attempt_token = $1`,
+      [retried.attemptToken],
+    );
+    const secondLease = await claimOne("worker-retry-two");
+    await assert.rejects(
+      renewMultipartCompletionReconciliationLease(
+        firstLease,
+        60_000,
+        Date.now() + 30_000,
+      ),
+      MultipartCompletionReconciliationLeaseLostError,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET
+         reconciliation_updated_at = reconciliation_handed_off_at,
+         reconciliation_lease_expires_at =
+           reconciliation_handed_off_at + interval '1 microsecond'
+       WHERE attempt_token = $1`,
+      [retried.attemptToken],
+    );
+    const reclaimedLease = await claimOne("worker-retry-three");
+    assert.notEqual(reclaimedLease.leaseToken, secondLease.leaseToken);
+    await assert.rejects(
+      renewMultipartCompletionReconciliationLease(
+        secondLease,
+        60_000,
+        Date.now() + 30_000,
+      ),
+      MultipartCompletionReconciliationLeaseLostError,
+    );
+    assert.equal(
+      await failMultipartCompletionReconciliation(
+        reclaimedLease,
+        Date.now() + 30_000,
+        {
+          code: "RETRY_EXHAUSTED",
+          message:
+            "Multipart completion reconciliation exhausted its transient retry budget.",
+        },
+      ),
+      "failed",
+    );
+    assert.deepEqual(await state(fixture, retried.attemptToken), {
+      session_state: "aborted",
+      attempt_state: "unreferenced",
+      attempt_outcome: "unreferenced",
+      reconciliation_state: "failed",
+      reservation_state: "unreferenced",
+    });
+    const failureReplay = (await fixture.runtimePool.query<StatusRow>(
+      `SELECT content.fail_media_upload_session_completion_reconciliation(
+         $1,$2,$3,$4,$5
+       ) AS status`,
+      [
+        reclaimedLease.attemptToken,
+        reclaimedLease.leaseToken,
+        "RETRY_EXHAUSTED",
+        "Multipart completion reconciliation exhausted its transient retry budget.",
+        3_600_000,
+      ],
+    )).rows[0].status;
+    assert.equal(failureReplay, "failed");
+
+    const revoked = await createHandedOffAttempt(fixture);
+    const revokedLease = await claimOne("worker-revoked");
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspace_memberships WHERE workspace_id=$1 AND user_id=$2",
+      [fixture.workspaceId, fixture.userId],
+    );
+    const revokedStatus = (await fixture.runtimePool.query<StatusRow>(
+      `SELECT content.apply_media_upload_session_completion_reconciliation_scope(
+         $1,$2
+       ) AS status`,
+      [revokedLease.attemptToken, revokedLease.leaseToken],
+    )).rows[0].status;
+    assert.equal(revokedStatus, "access_revoked");
+    assert.equal(
+      await failMultipartCompletionReconciliation(
+        revokedLease,
+        Date.now() + 30_000,
+        {
+          code: "WORKSPACE_ACCESS_REVOKED",
+          message:
+            "Workspace or replica access was revoked before multipart completion finished.",
+        },
+      ),
+      "failed",
+    );
+    assert.equal(
+      (await state(fixture, revoked.attemptToken)).reconciliation_state,
+      "failed",
+    );
+    await fixture.ownerPool.query(
+      `INSERT INTO org.workspace_memberships (workspace_id,user_id,role)
+       VALUES ($1,$2,'owner')`,
+      [fixture.workspaceId, fixture.userId],
+    );
+
+    const abortRacePayload = createPayload(fixture);
+    const abortRaceAttemptToken = randomUUID();
+    await insertSession(fixture.ownerPool, abortRacePayload);
+    const abortRaceBegin = await beginAttempt(
+      fixture,
+      abortRaceAttemptToken,
+      abortRacePayload,
+    );
+    assert.notEqual(abortRaceBegin.reservation_token, null);
+    await fixture.ownerPool.query(
+      `UPDATE content.media_upload_sessions
+       SET state='aborting'
+       WHERE media_upload_session_id=$1`,
+      [abortRacePayload.sessionId],
+    );
+    assert.equal(
+      await handoffAttempt(
+        fixture,
+        abortRaceAttemptToken,
+        abortRaceBegin.reservation_token as string,
+        abortRacePayload,
+      ),
+      "aborting",
+    );
+    assert.equal(
+      (await fixture.ownerPool.query<CountRow>(
+        `SELECT count(*)::int AS count
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1 AND reconciliation_state IS NOT NULL`,
+        [abortRaceAttemptToken],
+      )).rows[0].count,
+      0,
+    );
+
+    const deletionPending = await createHandedOffAttempt(fixture);
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspaces WHERE workspace_id=$1",
+      [fixture.workspaceId],
+    );
+    const deletedState = (await fixture.ownerPool.query<Readonly<{
+      state: string;
+      outcome: string;
+      reconciliation_state: string;
+      error_code: string;
+      failure_event_id: string;
+      failure_report_state: string;
+      sessions: number;
+    }>>(
+      `SELECT
+         attempts.state,
+         attempts.outcome,
+         attempts.reconciliation_state,
+         attempts.reconciliation_last_error_code AS error_code,
+         attempts.reconciliation_failure_event_id AS failure_event_id,
+         attempts.reconciliation_failure_report_state AS failure_report_state,
+         (
+           SELECT count(*)::int
+           FROM content.media_upload_sessions
+           WHERE workspace_id=$2
+         ) AS sessions
+       FROM content.media_blob_writer_attempts AS attempts
+       WHERE attempts.attempt_token=$1`,
+      [deletionPending.attemptToken, fixture.workspaceId],
+    )).rows[0];
+    assert.match(
+      deletedState.failure_event_id,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+    assert.notEqual(
+      deletedState.failure_event_id,
+      deletionPending.attemptToken,
+    );
+    assert.deepEqual({
+      ...deletedState,
+      failure_event_id: "<stable-event-id>",
+    }, {
+      state: "cancelled",
+      outcome: "aborted",
+      reconciliation_state: "failed",
+      error_code: "WORKSPACE_DELETED",
+      failure_event_id: "<stable-event-id>",
+      failure_report_state: "pending",
+      sessions: 0,
+    });
+  });
+});
+
+test("migration 0099 durably reports every terminal reconciliation failure", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const handedOff = await createHandedOffAttempt(fixture);
+    const reconciliationLease = await claimOne("worker-terminal-report");
+    assert.equal(
+      await failMultipartCompletionReconciliation(
+        reconciliationLease,
+        Date.now() + 30_000,
+        {
+          code: "RETRY_EXHAUSTED",
+          message:
+            "Multipart completion reconciliation exhausted its transient retry budget.",
+        },
+      ),
+      "failed",
+    );
+    assert.deepEqual(
+      await readMultipartCompletionReconciliationOutcome(
+        handedOff.attemptToken,
+        Date.now() + 30_000,
+      ),
+      {
+        status: "failed",
+        errorCode: "RETRY_EXHAUSTED",
+      },
+    );
+
+    const pending = (await fixture.ownerPool.query<Readonly<{
+      event_id: string;
+      report_state: string;
+      delivery_count: number;
+    }>>(
+      `SELECT
+         reconciliation_failure_event_id AS event_id,
+         reconciliation_failure_report_state AS report_state,
+         reconciliation_failure_report_delivery_count AS delivery_count
+       FROM content.media_blob_writer_attempts
+       WHERE attempt_token=$1`,
+      [handedOff.attemptToken],
+    )).rows[0];
+    assert.notEqual(pending.event_id, handedOff.attemptToken);
+    assert.equal(pending.report_state, "pending");
+    assert.equal(pending.delivery_count, 0);
+
+    const firstReport = await claimFailureReportOne(
+      "failure-reporter-one",
+      handedOff.attemptToken,
+    );
+    assert.equal(firstReport.failureEventId, pending.event_id);
+    assert.equal(firstReport.attemptToken, handedOff.attemptToken);
+    assert.equal(firstReport.deliveryAttempt, 1);
+    assert.equal(firstReport.errorCode, "RETRY_EXHAUSTED");
+    assert.equal(
+      (
+        await claimMultipartCompletionFailureReports({
+          leaseOwner: "failure-reporter-duplicate",
+          leaseDurationMs: 60_000,
+          limit: 100,
+          deadlineAtMs: Date.now() + 30_000,
+        })
+      ).some((report) => report.attemptToken === handedOff.attemptToken),
+      false,
+    );
+
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET
+         reconciliation_failure_report_updated_at =
+           reconciliation_handed_off_at,
+         reconciliation_failure_report_lease_expires_at =
+           reconciliation_handed_off_at + interval '1 microsecond'
+       WHERE attempt_token=$1`,
+      [handedOff.attemptToken],
+    );
+    const secondReport = await claimFailureReportOne(
+      "failure-reporter-two",
+      handedOff.attemptToken,
+    );
+    assert.equal(secondReport.failureEventId, firstReport.failureEventId);
+    assert.equal(secondReport.deliveryAttempt, 2);
+    assert.notEqual(secondReport.leaseToken, firstReport.leaseToken);
+    await assert.rejects(
+      finishMultipartCompletionFailureReport(
+        firstReport,
+        Date.now() + 30_000,
+      ),
+      MultipartCompletionFailureReportLeaseLostError,
+    );
+    await finishMultipartCompletionFailureReport(
+      secondReport,
+      Date.now() + 30_000,
+    );
+    await finishMultipartCompletionFailureReport(
+      secondReport,
+      Date.now() + 30_000,
+    );
+
+    const reported = (await fixture.ownerPool.query<Readonly<{
+      report_state: string;
+      delivery_count: number;
+      lease_cleared: boolean;
+      reported_at_present: boolean;
+    }>>(
+      `SELECT
+         reconciliation_failure_report_state AS report_state,
+         reconciliation_failure_report_delivery_count AS delivery_count,
+         (
+           reconciliation_failure_report_lease_token IS NULL
+           AND reconciliation_failure_report_lease_owner IS NULL
+           AND reconciliation_failure_report_lease_expires_at IS NULL
+         ) AS lease_cleared,
+         reconciliation_failure_reported_at IS NOT NULL AS reported_at_present
+       FROM content.media_blob_writer_attempts
+       WHERE attempt_token=$1`,
+      [handedOff.attemptToken],
+    )).rows[0];
+    assert.deepEqual(reported, {
+      report_state: "reported",
+      delivery_count: 2,
+      lease_cleared: true,
+      reported_at_present: true,
+    });
+    assert.equal(
+      (
+        await claimMultipartCompletionFailureReports({
+          leaseOwner: "failure-reporter-after-finish",
+          leaseDurationMs: 60_000,
+          limit: 100,
+          deadlineAtMs: Date.now() + 30_000,
+        })
+      ).some((report) => report.attemptToken === handedOff.attemptToken),
+      false,
+    );
+    assert.equal(
+      await failMultipartCompletionReconciliation(
+        reconciliationLease,
+        Date.now() + 30_000,
+        {
+          code: "RETRY_EXHAUSTED",
+          message:
+            "Multipart completion reconciliation exhausted its transient retry budget.",
+        },
+      ),
+      "failed",
+    );
+    assert.equal(
+      (await fixture.ownerPool.query<Readonly<{ report_state: string }>>(
+        `SELECT reconciliation_failure_report_state AS report_state
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1`,
+        [handedOff.attemptToken],
+      )).rows[0].report_state,
+      "reported",
+    );
+  });
+});
+
+test("migration 0099 closes pending and leased exact references as applied reconciliation", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    for (const reconciliationState of ["pending", "leased"] as const) {
+      const handedOff = await createHandedOffAttempt(fixture);
+      const claimed = reconciliationState === "leased"
+        ? await claimOne(`worker-exact-${reconciliationState}`)
+        : null;
+      await insertExactReference(fixture, handedOff.payload);
+
+      assert.equal(
+        await closeCurrentWriter(fixture, handedOff.payload),
+        "referenced",
+      );
+      assert.deepEqual(await state(fixture, handedOff.attemptToken), {
+        session_state: "completed",
+        attempt_state: "referenced",
+        attempt_outcome: "referenced",
+        reconciliation_state: "applied",
+        reservation_state: "finalized",
+      });
+      const closure = (await fixture.ownerPool.query<Readonly<{
+        retry_count: number;
+        next_attempt_cleared: boolean;
+        lease_cleared: boolean;
+        error_cleared: boolean;
+        applied_at_present: boolean;
+      }>>(
+        `SELECT
+           reconciliation_retry_count AS retry_count,
+           reconciliation_next_attempt_at IS NULL AS next_attempt_cleared,
+           (
+             reconciliation_lease_token IS NULL
+             AND reconciliation_lease_owner IS NULL
+             AND reconciliation_lease_expires_at IS NULL
+           ) AS lease_cleared,
+           (
+             reconciliation_last_error_code IS NULL
+             AND reconciliation_last_error_message IS NULL
+           ) AS error_cleared,
+           reconciliation_applied_at IS NOT NULL AS applied_at_present
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1`,
+        [handedOff.attemptToken],
+      )).rows[0];
+      assert.deepEqual(closure, {
+        retry_count: 0,
+        next_attempt_cleared: true,
+        lease_cleared: true,
+        error_cleared: true,
+        applied_at_present: true,
+      });
+
+      if (claimed !== null) {
+        const replay = (await fixture.runtimePool.query<StatusRow>(
+          `SELECT content.finish_media_upload_session_completion_reconciliation(
+             $1,$2,$3
+           ) AS status`,
+          [claimed.attemptToken, claimed.leaseToken, 3_600_000],
+        )).rows[0].status;
+        assert.equal(replay, "already_applied");
+      }
+    }
+  });
+});
+
+test("migration 0099 blocks successor attempts while reconciliation is pending or leased", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    for (const reconciliationState of ["pending", "leased"] as const) {
+      const handedOff = await createHandedOffAttempt(fixture);
+      const claimed = reconciliationState === "leased"
+        ? await claimOne(`worker-successor-${reconciliationState}`)
+        : null;
+      const successorAttemptToken = randomUUID();
+
+      const blockedSuccessor = await beginAttempt(
+        fixture,
+        successorAttemptToken,
+        handedOff.payload,
+      );
+      assert.equal(blockedSuccessor.attempt_status, "busy");
+      assert.equal(blockedSuccessor.reservation_token, null);
+      assert.equal(blockedSuccessor.normalization_version, null);
+      assert.equal(
+        (await fixture.ownerPool.query<CountRow>(
+          `SELECT count(*)::int AS count
+           FROM content.media_blob_writer_attempts
+           WHERE media_upload_session_id=$1`,
+          [handedOff.payload.sessionId],
+        )).rows[0].count,
+        1,
+      );
+
+      const failureLease = claimed
+        ?? await claimOne(`worker-successor-${reconciliationState}-failure`);
+      assert.equal(
+        await failMultipartCompletionReconciliation(
+          failureLease,
+          Date.now() + 30_000,
+          {
+            code: "RETRY_EXHAUSTED",
+            message:
+              "Multipart completion reconciliation exhausted its transient retry budget.",
+          },
+        ),
+        "failed",
+      );
+      assert.deepEqual(await state(fixture, handedOff.attemptToken), {
+        session_state: "aborted",
+        attempt_state: "unreferenced",
+        attempt_outcome: "unreferenced",
+        reconciliation_state: "failed",
+        reservation_state: "unreferenced",
+      });
+      assert.equal(
+        (
+          await beginAttempt(
+            fixture,
+            successorAttemptToken,
+            handedOff.payload,
+          )
+        ).attempt_status,
+        "aborted",
+      );
+      assert.equal(
+        (await fixture.ownerPool.query<CountRow>(
+          `SELECT count(*)::int AS count
+           FROM content.media_blob_writer_attempts
+           WHERE media_upload_session_id=$1`,
+          [handedOff.payload.sessionId],
+        )).rows[0].count,
+        1,
+      );
+    }
+  });
+});
+
+test("migration 0099 shares the TypeScript last operation identifier contract", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const values = [
+      "550e8400-e29b-41d4-a716-446655440000",
+      "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+      "550e8400-e29b-41d4-a716-446655440000:media:99",
+      "operation with internal spaces",
+      "a".repeat(1_024),
+      "",
+      " leading-space",
+      "trailing-space ",
+      "operation\tcontrol",
+      "operation\ncontrol",
+      "operation\u00a0nbsp",
+      "operation-😀",
+      "😀".repeat(512),
+      "\ud800",
+      "\udc00",
+      "a".repeat(1_025),
+    ];
+
+    for (const value of values) {
+      const sqlValid = (await fixture.ownerPool.query<Readonly<{
+        valid: boolean;
+      }>>(
+        `SELECT content.media_asset_last_operation_id_valid_internal($1)
+           AS valid`,
+        [value],
+      )).rows[0].valid;
+      assert.equal(sqlValid, isValidMediaAssetLastOperationId(value), value);
+    }
+  });
+});
+
+test("migration 0099 enforces canonical media asset identifiers without backfilling legacy rows", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const constraint = (await fixture.ownerPool.query<Readonly<{
+      validated: boolean;
+    }>>(
+      `SELECT constraints.convalidated AS validated
+       FROM pg_catalog.pg_constraint AS constraints
+       INNER JOIN pg_catalog.pg_class AS tables
+         ON tables.oid = constraints.conrelid
+       INNER JOIN pg_catalog.pg_namespace AS schemas
+         ON schemas.oid = tables.relnamespace
+       WHERE schemas.nspname = 'content'
+         AND tables.relname = 'media_assets'
+         AND constraints.conname =
+           'media_assets_last_operation_id_canonical'`,
+    )).rows[0];
+    assert.deepEqual(constraint, { validated: false });
+
+    const legacyMediaAssetId = "09900000-0000-4000-8000-000000000004";
+    const legacy = (await fixture.ownerPool.query<Readonly<{
+      last_operation_id: string;
+    }>>(
+      `SELECT last_operation_id
+       FROM content.media_assets
+       WHERE media_asset_id=$1`,
+      [legacyMediaAssetId],
+    )).rows[0];
+    assert.deepEqual(legacy, {
+      last_operation_id: "migration-0099-legacy-\u00a0operation",
+    });
+    await fixture.ownerPool.query(
+      `UPDATE content.media_assets
+       SET last_operation_id='migration-0099-legacy-recovered'
+       WHERE media_asset_id=$1`,
+      [legacyMediaAssetId],
+    );
+
+    const sha256 = digest();
+    const mediaBlobId = randomUUID();
+    const mediaAssetId = randomUUID();
+    await fixture.ownerPool.query(
+      `INSERT INTO content.media_blobs (
+         media_blob_id, sha256, mime_type, size_bytes, storage_key,
+         normalization_version
+       ) VALUES ($1, $2, 'image/png', 1, $3, 'passthrough-v1')`,
+      [mediaBlobId, sha256, buildMediaBlobStorageKey(sha256)],
+    );
+    await assert.rejects(
+      fixture.ownerPool.query(
+        `INSERT INTO content.media_assets (
+           media_asset_id, workspace_id, media_blob_id, source_url, created_at,
+           client_updated_at, last_modified_by_replica_id, last_operation_id
+         ) VALUES ($1, $2, $3, NULL, $4, $4, $5, $6)`,
+        [
+          mediaAssetId,
+          fixture.workspaceId,
+          mediaBlobId,
+          fixture.createdAt,
+          fixture.replicaId,
+          "new\u00a0invalid-operation",
+        ],
+      ),
+      (error: unknown): boolean => {
+        assert.equal((error as Readonly<{ code?: string }>).code, "23514");
+        assert.match(
+          String((error as Readonly<{ constraint?: string }>).constraint),
+          /media_assets_last_operation_id_canonical/,
+        );
+        return true;
+      },
+    );
+    await fixture.ownerPool.query(
+      `INSERT INTO content.media_assets (
+         media_asset_id, workspace_id, media_blob_id, source_url, created_at,
+         client_updated_at, last_modified_by_replica_id, last_operation_id
+       ) VALUES ($1, $2, $3, NULL, $4, $4, $5, $6)`,
+      [
+        mediaAssetId,
+        fixture.workspaceId,
+        mediaBlobId,
+        fixture.createdAt,
+        fixture.replicaId,
+        "new-valid-operation",
+      ],
+    );
+    await assert.rejects(
+      fixture.ownerPool.query(
+        `UPDATE content.media_assets
+         SET last_operation_id=$2
+         WHERE media_asset_id=$1`,
+        [mediaAssetId, "updated\ninvalid-operation"],
+      ),
+      (error: unknown): boolean => {
+        assert.equal((error as Readonly<{ code?: string }>).code, "23514");
+        return true;
+      },
+    );
+  });
+});
+
+test("migration 0099 rejects a legacy active session before storage and allows canonical replacement", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    await assert.rejects(
+      beginMediaAssetUploadSessionCompletionForWorkspace(
+        migration0099LegacyUserId,
+        migration0099LegacyWorkspaceId,
+        migration0099LegacyActiveSessionId,
+        [{ partNumber: 1 }],
+      ),
+      (error: unknown): boolean => {
+        assert.ok(error instanceof HttpError);
+        assert.equal(error.statusCode, 409);
+        assert.equal(
+          error.code,
+          "MEDIA_ASSET_UPLOAD_SESSION_RESTART_REQUIRED",
+        );
+        assert.match(error.message, /Abort this upload session/);
+        assert.match(error.message, /create a new upload session/);
+        return true;
+      },
+    );
+
+    const preAbortState = (await fixture.ownerPool.query<Readonly<{
+      session_state: string;
+      attempts: number;
+      reservations: number;
+    }>>(
+      `SELECT
+         sessions.state AS session_state,
+         (
+           SELECT count(*)::int
+           FROM content.media_blob_writer_attempts AS attempts
+           WHERE attempts.media_upload_session_id =
+             sessions.media_upload_session_id
+         ) AS attempts,
+         (
+           SELECT count(*)::int
+           FROM content.media_blob_writer_reservations AS reservations
+           WHERE reservations.writer_kind = 'multipart_completion'
+             AND reservations.workspace_id = sessions.workspace_id
+             AND reservations.media_asset_id = sessions.media_asset_id
+             AND reservations.operation_id =
+               sessions.media_upload_session_id::text
+         ) AS reservations
+       FROM content.media_upload_sessions AS sessions
+       WHERE sessions.media_upload_session_id=$1`,
+      [migration0099LegacyActiveSessionId],
+    )).rows[0];
+    assert.deepEqual(preAbortState, {
+      session_state: "active",
+      attempts: 0,
+      reservations: 0,
+    });
+
+    const abortStart = await beginMediaAssetUploadSessionAbortForWorkspace(
+      migration0099LegacyUserId,
+      migration0099LegacyWorkspaceId,
+      migration0099LegacyActiveSessionId,
+    );
+    assert.equal(abortStart.status, "abort_required");
+    assert.equal(abortStart.uploadSession.state, "aborting");
+    const aborted = await markMediaAssetUploadSessionAbortedForWorkspace(
+      migration0099LegacyUserId,
+      migration0099LegacyWorkspaceId,
+      migration0099LegacyActiveSessionId,
+    );
+    assert.equal(aborted.state, "aborted");
+
+    const replacementSessionId = randomUUID();
+    const replacementOperationId =
+      `migration-0099-replacement-${randomUUID()}`;
+    const replacement = await recordMediaAssetUploadSessionForWorkspace(
+      migration0099LegacyUserId,
+      migration0099LegacyWorkspaceId,
+      replacementSessionId,
+      {
+        mediaAssetId: migration0099LegacyActiveMediaAssetId,
+        mimeType: "application/octet-stream",
+        sizeBytes: 1,
+        sha256: migration0099LegacyActiveSha256,
+        partSizeBytes: 1,
+        partCount: 1,
+        sourceUrl: null,
+        createdAt: migration0099LegacyTimestamp,
+        clientUpdatedAt: migration0099LegacyTimestamp,
+        lastModifiedByReplicaId: migration0099LegacyReplicaId,
+        lastOperationId: replacementOperationId,
+      },
+      buildMediaMultipartUploadStagingStorageKey(
+        migration0099LegacyWorkspaceId,
+        migration0099LegacyActiveMediaAssetId,
+        replacementSessionId,
+      ),
+      buildMediaBlobStorageKey(migration0099LegacyActiveSha256),
+      `replacement-upload-${replacementSessionId}`,
+      migration0099LegacySessionExpiresAt,
+    );
+    assert.equal(replacement.status, "upload_required");
+
+    const replacementStart =
+      await beginMediaAssetUploadSessionCompletionForWorkspace(
+        migration0099LegacyUserId,
+        migration0099LegacyWorkspaceId,
+        replacementSessionId,
+        [{ partNumber: 1 }],
+      );
+    assert.equal(replacementStart.status, "complete_required");
+    const mediaAssetBeforeReplacementCompletion =
+      await fixture.ownerPool.query<Readonly<{ media_asset_id: string }>>(
+        `SELECT media_asset_id
+         FROM content.media_assets
+         WHERE workspace_id=$1
+           AND media_asset_id=$2`,
+        [
+          migration0099LegacyWorkspaceId,
+          migration0099LegacyActiveMediaAssetId,
+        ],
+      );
+    assert.equal(mediaAssetBeforeReplacementCompletion.rowCount, 0);
+    const completed = await completeMediaAssetUploadSessionForWorkspace(
+      migration0099LegacyUserId,
+      migration0099LegacyWorkspaceId,
+      replacementSessionId,
+    );
+    assert.equal(
+      completed.mediaAsset.lastOperationId,
+      replacementOperationId,
+    );
+
+    const converged = (await fixture.ownerPool.query<Readonly<{
+      legacy_state: string;
+      replacement_state: string;
+      completing_sessions: number;
+      attempts: number;
+      reservations: number;
+    }>>(
+      `SELECT
+         (
+           SELECT state
+           FROM content.media_upload_sessions
+           WHERE media_upload_session_id=$1
+         ) AS legacy_state,
+         (
+           SELECT state
+           FROM content.media_upload_sessions
+           WHERE media_upload_session_id=$2
+         ) AS replacement_state,
+         (
+           SELECT count(*)::int
+           FROM content.media_upload_sessions
+           WHERE workspace_id=$3
+             AND media_asset_id=$4
+             AND state='completing'
+         ) AS completing_sessions,
+         (
+           SELECT count(*)::int
+           FROM content.media_blob_writer_attempts
+           WHERE media_upload_session_id IN ($1, $2)
+         ) AS attempts,
+         (
+           SELECT count(*)::int
+           FROM content.media_blob_writer_reservations
+           WHERE writer_kind='multipart_completion'
+             AND workspace_id=$3
+             AND media_asset_id=$4
+         ) AS reservations`,
+      [
+        migration0099LegacyActiveSessionId,
+        replacementSessionId,
+        migration0099LegacyWorkspaceId,
+        migration0099LegacyActiveMediaAssetId,
+      ],
+    )).rows[0];
+    assert.deepEqual(converged, {
+      legacy_state: "aborted",
+      replacement_state: "completed",
+      completing_sessions: 0,
+      attempts: 0,
+      reservations: 0,
+    });
+  });
+});
+
+test("migration 0099 safely replays and closes multipart attempts seeded under 0098 legacy identity rules", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const replayPayload = createMigration0099LegacyPayload({
+      sessionId: "09910000-0000-4000-8000-000000000001",
+      mediaAssetId: "09910000-0000-4000-8000-000000000002",
+      sha256: "a".repeat(64),
+      lastOperationId: "migration-0099-legacy-\u00a0replay",
+      uploadId: "migration-0099-replay-upload",
+      partsFingerprint: "1".repeat(64),
+    });
+    const replayAttemptToken = "09910000-0000-4000-8000-000000000003";
+    assert.equal(
+      (
+        await beginAttemptAs(
+          fixture,
+          migration0099LegacyUserId,
+          migration0099LegacyWorkspaceId,
+          replayAttemptToken,
+          replayPayload,
+        )
+      ).attempt_status,
+      "aborted",
+    );
+    assert.equal(
+      (
+        await beginAttemptAs(
+          fixture,
+          migration0099LegacyUserId,
+          migration0099LegacyWorkspaceId,
+          replayAttemptToken,
+          {
+            ...replayPayload,
+            lastOperationId:
+              "migration-0099-legacy-\u00a0replay-changed",
+          },
+        )
+      ).attempt_status,
+      "aborted",
+    );
+    assert.equal(
+      (await fixture.ownerPool.query<Readonly<{
+        last_operation_id: string;
+      }>>(
+        `SELECT last_operation_id
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1`,
+        [replayAttemptToken],
+      )).rows[0].last_operation_id,
+      replayPayload.lastOperationId,
+    );
+
+    const cleanupPayload = createMigration0099LegacyPayload({
+      sessionId: "09920000-0000-4000-8000-000000000001",
+      mediaAssetId: "09920000-0000-4000-8000-000000000002",
+      sha256: "b".repeat(64),
+      lastOperationId: "migration-0099-legacy-\u00a0cleanup",
+      uploadId: "migration-0099-cleanup-upload",
+      partsFingerprint: "2".repeat(64),
+    });
+    const cleanupAttemptToken = "09920000-0000-4000-8000-000000000003";
+    assert.equal(
+      await closeCurrentWriterAs(
+        fixture,
+        migration0099LegacyUserId,
+        migration0099LegacyWorkspaceId,
+        cleanupPayload,
+      ),
+      "aborted",
+    );
+    const cleanupState = (await fixture.ownerPool.query<Readonly<{
+      attempt_state: string;
+      attempt_outcome: string;
+      reconciliation_state: string | null;
+      reservation_state: string;
+      session_state: string;
+    }>>(
+      `SELECT
+         attempts.state AS attempt_state,
+         attempts.outcome AS attempt_outcome,
+         attempts.reconciliation_state,
+         reservations.state AS reservation_state,
+         sessions.state AS session_state
+       FROM content.media_blob_writer_attempts AS attempts
+       INNER JOIN content.media_blob_writer_reservations AS reservations
+         ON reservations.reservation_token = attempts.reservation_token
+       INNER JOIN content.media_upload_sessions AS sessions
+         ON sessions.media_upload_session_id =
+           attempts.media_upload_session_id
+       WHERE attempts.attempt_token=$1`,
+      [cleanupAttemptToken],
+    )).rows[0];
+    assert.deepEqual(cleanupState, {
+      attempt_state: "cancelled",
+      attempt_outcome: "aborted",
+      reconciliation_state: null,
+      reservation_state: "unreferenced",
+      session_state: "aborted",
+    });
+
+    const handoffPayload = createMigration0099LegacyPayload({
+      sessionId: "09930000-0000-4000-8000-000000000001",
+      mediaAssetId: "09930000-0000-4000-8000-000000000002",
+      sha256: "c".repeat(64),
+      lastOperationId: "migration-0099-legacy-\u00a0handoff",
+      uploadId: "migration-0099-handoff-upload",
+      partsFingerprint: "3".repeat(64),
+    });
+    const handoffAttemptToken = "09930000-0000-4000-8000-000000000003";
+    const replayed = await beginAttemptAs(
+      fixture,
+      migration0099LegacyUserId,
+      migration0099LegacyWorkspaceId,
+      handoffAttemptToken,
+      handoffPayload,
+    );
+    assert.equal(replayed.attempt_status, "replayed");
+    assert.notEqual(replayed.reservation_token, null);
+    assert.equal(
+      await handoffAttemptAs(
+        fixture,
+        migration0099LegacyUserId,
+        migration0099LegacyWorkspaceId,
+        handoffAttemptToken,
+        replayed.reservation_token as string,
+        handoffPayload,
+      ),
+      "handed_off",
+    );
+    const quarantined = (await fixture.ownerPool.query<Readonly<{
+      attempt_state: string;
+      attempt_outcome: string;
+      reconciliation_state: string;
+      error_code: string;
+    }>>(
+      `SELECT
+         state AS attempt_state,
+         outcome AS attempt_outcome,
+         reconciliation_state,
+         reconciliation_last_error_code AS error_code
+       FROM content.media_blob_writer_attempts
+       WHERE attempt_token=$1`,
+      [handoffAttemptToken],
+    )).rows[0];
+    assert.deepEqual(quarantined, {
+      attempt_state: "expired",
+      attempt_outcome: "stale_attempt",
+      reconciliation_state: "leased",
+      error_code: "INVALID_RECONCILIATION_PAYLOAD",
+    });
+
+    const legacySuccessorToken = randomUUID();
+    assert.equal(
+      (
+        await beginAttemptAs(
+          fixture,
+          migration0099LegacyUserId,
+          migration0099LegacyWorkspaceId,
+          legacySuccessorToken,
+          handoffPayload,
+        )
+      ).attempt_status,
+      "stale",
+    );
+    const changedIdentitySuccessorToken = randomUUID();
+    assert.equal(
+      (
+        await beginAttemptAs(
+          fixture,
+          migration0099LegacyUserId,
+          migration0099LegacyWorkspaceId,
+          changedIdentitySuccessorToken,
+          {
+            ...handoffPayload,
+            lastOperationId: "migration-0099-canonical-successor",
+          },
+        )
+      ).attempt_status,
+      "stale",
+    );
+    assert.equal(
+      (await fixture.ownerPool.query<CountRow>(
+        `SELECT count(*)::int AS count
+         FROM content.media_blob_writer_attempts
+         WHERE media_upload_session_id=$1`,
+        [handoffPayload.sessionId],
+      )).rows[0].count,
+      1,
+    );
+
+    assert.deepEqual(
+      await claimMultipartCompletionReconciliations({
+        leaseOwner: "worker-legacy-0098-attempt",
+        leaseDurationMs: 60_000,
+        limit: 1,
+        deadlineAtMs: Date.now() + 30_000,
+      }),
+      [],
+    );
+    const terminal = (await fixture.ownerPool.query<Readonly<{
+      attempt_state: string;
+      attempt_outcome: string;
+      reconciliation_state: string;
+      failure_report_state: string;
+      active_reconciliations: number;
+      session_attempts: number;
+    }>>(
+      `SELECT
+         attempts.state AS attempt_state,
+         attempts.outcome AS attempt_outcome,
+         attempts.reconciliation_state,
+         attempts.reconciliation_failure_report_state AS failure_report_state,
+         (
+           SELECT count(*)::int
+           FROM content.media_blob_writer_attempts AS active
+           WHERE active.media_upload_session_id =
+             attempts.media_upload_session_id
+             AND active.reconciliation_state IN ('pending', 'leased')
+         ) AS active_reconciliations,
+         (
+           SELECT count(*)::int
+           FROM content.media_blob_writer_attempts AS session_attempts
+           WHERE session_attempts.media_upload_session_id =
+             attempts.media_upload_session_id
+         ) AS session_attempts
+       FROM content.media_blob_writer_attempts AS attempts
+       WHERE attempts.attempt_token=$1`,
+      [handoffAttemptToken],
+    )).rows[0];
+    assert.deepEqual(terminal, {
+      attempt_state: "unreferenced",
+      attempt_outcome: "unreferenced",
+      reconciliation_state: "failed",
+      failure_report_state: "pending",
+      active_reconciliations: 0,
+      session_attempts: 1,
+    });
+  });
+});
+
+test("migration 0099 rejects unsafe operation identifiers before durable handoff", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const payload: MultipartPayload = {
+      ...createPayload(fixture),
+      lastOperationId: "unsafe\u00a0operation",
+    };
+    await insertSession(fixture.ownerPool, payload);
+    const attemptToken = randomUUID();
+
+    assert.deepEqual(await beginAttempt(fixture, attemptToken, payload), {
+      attempt_status: "stale",
+      reservation_token: null,
+      normalization_version: null,
+      lease_expires_at: null,
+    });
+    assert.equal(
+      (await fixture.ownerPool.query<CountRow>(
+        `SELECT count(*)::int AS count
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1`,
+        [attemptToken],
+      )).rows[0].count,
+      0,
+    );
+  });
+});
+
+test("migration 0099 terminalizes a legacy invalid durable job without leasing it to the worker", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const handedOff = await createHandedOffAttempt(fixture);
+    const invalidLastOperationId = "legacy\u00a0operation";
+
+    await assert.rejects(
+      fixture.ownerPool.query(
+        `UPDATE content.media_blob_writer_attempts
+         SET last_operation_id=$2
+         WHERE attempt_token=$1`,
+        [handedOff.attemptToken, invalidLastOperationId],
+      ),
+      (error: unknown): boolean => {
+        assert.equal((error as Readonly<{ code?: string }>).code, "23514");
+        return true;
+      },
+    );
+
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET
+         last_operation_id=$2,
+         reconciliation_state='leased',
+         reconciliation_lease_token=$3,
+         reconciliation_lease_owner='legacy-pre-contract-worker',
+         reconciliation_lease_expires_at =
+           reconciliation_handed_off_at + interval '1 microsecond',
+         reconciliation_last_error_code='INVALID_RECONCILIATION_PAYLOAD',
+         reconciliation_last_error_message =
+           'Durable multipart completion payload is invalid.',
+         reconciliation_updated_at=reconciliation_handed_off_at
+       WHERE attempt_token=$1`,
+      [handedOff.attemptToken, invalidLastOperationId, randomUUID()],
+    );
+
+    assert.deepEqual(
+      await claimMultipartCompletionReconciliations({
+        leaseOwner: "worker-invalid-legacy",
+        leaseDurationMs: 60_000,
+        limit: 1,
+        deadlineAtMs: Date.now() + 30_000,
+      }),
+      [],
+    );
+    assert.deepEqual(await state(fixture, handedOff.attemptToken), {
+      session_state: "aborted",
+      attempt_state: "unreferenced",
+      attempt_outcome: "unreferenced",
+      reconciliation_state: "failed",
+      reservation_state: "unreferenced",
+    });
+    const terminal = (await fixture.ownerPool.query<Readonly<{
+      error_code: string;
+      report_state: string;
+      reconciliation_lease_cleared: boolean;
+    }>>(
+      `SELECT
+         reconciliation_last_error_code AS error_code,
+         reconciliation_failure_report_state AS report_state,
+         (
+           reconciliation_lease_token IS NULL
+           AND reconciliation_lease_owner IS NULL
+           AND reconciliation_lease_expires_at IS NULL
+         ) AS reconciliation_lease_cleared
+       FROM content.media_blob_writer_attempts
+       WHERE attempt_token=$1`,
+      [handedOff.attemptToken],
+    )).rows[0];
+    assert.deepEqual(terminal, {
+      error_code: "INVALID_RECONCILIATION_PAYLOAD",
+      report_state: "pending",
+      reconciliation_lease_cleared: true,
+    });
+    const report = await claimFailureReportOne(
+      "failure-reporter-invalid-legacy",
+      handedOff.attemptToken,
+    );
+    assert.equal(report.errorCode, "INVALID_RECONCILIATION_PAYLOAD");
+
+    const successorAttemptToken = randomUUID();
+    assert.equal(
+      (
+        await beginAttempt(
+          fixture,
+          successorAttemptToken,
+          handedOff.payload,
+        )
+      ).attempt_status,
+      "aborted",
+    );
+    assert.equal(
+      (await fixture.ownerPool.query<CountRow>(
+        `SELECT count(*)::int AS count
+         FROM content.media_blob_writer_attempts
+         WHERE media_upload_session_id=$1`,
+        [handedOff.payload.sessionId],
+      )).rows[0].count,
+      1,
+    );
+  });
+});
+
+test("migration 0099 exact-reference recovery cancels only unclaimed or expired failure reports", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const pending = await createFailedAttempt(
+      fixture,
+      "worker-failed-exact-pending",
+    );
+    await insertExactReference(fixture, pending.payload);
+    assert.equal(await closeCurrentWriter(fixture, pending.payload), "referenced");
+
+    const expired = await createFailedAttempt(
+      fixture,
+      "worker-failed-exact-expired",
+    );
+    const staleReport = await claimFailureReportOne(
+      "failure-reporter-expired-before-exact",
+      expired.attemptToken,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET
+         reconciliation_failure_report_updated_at =
+           reconciliation_handed_off_at,
+         reconciliation_failure_report_lease_expires_at =
+           reconciliation_handed_off_at + interval '1 microsecond'
+       WHERE attempt_token=$1`,
+      [expired.attemptToken],
+    );
+    await insertExactReference(fixture, expired.payload);
+    assert.equal(await closeCurrentWriter(fixture, expired.payload), "referenced");
+
+    for (const handedOff of [pending, expired]) {
+      assert.deepEqual(await state(fixture, handedOff.attemptToken), {
+        session_state: "completed",
+        attempt_state: "referenced",
+        attempt_outcome: "referenced",
+        reconciliation_state: "applied",
+        reservation_state: "finalized",
+      });
+      const recovered = (await fixture.ownerPool.query<Readonly<{
+        event_cleared: boolean;
+        report_state_cleared: boolean;
+        delivery_count: number;
+        report_lease_cleared: boolean;
+        report_timestamps_cleared: boolean;
+      }>>(
+        `SELECT
+           reconciliation_failure_event_id IS NULL AS event_cleared,
+           reconciliation_failure_report_state IS NULL AS report_state_cleared,
+           reconciliation_failure_report_delivery_count AS delivery_count,
+           (
+             reconciliation_failure_report_lease_token IS NULL
+             AND reconciliation_failure_report_lease_owner IS NULL
+             AND reconciliation_failure_report_lease_expires_at IS NULL
+           ) AS report_lease_cleared,
+           (
+             reconciliation_failure_report_updated_at IS NULL
+             AND reconciliation_failure_reported_at IS NULL
+           ) AS report_timestamps_cleared
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1`,
+        [handedOff.attemptToken],
+      )).rows[0];
+      assert.deepEqual(recovered, {
+        event_cleared: true,
+        report_state_cleared: true,
+        delivery_count: 0,
+        report_lease_cleared: true,
+        report_timestamps_cleared: true,
+      });
+    }
+
+    const emittedEventIds: Array<string> = [];
+    await assert.rejects(
+      deliverMultipartCompletionFailureReport(
+        staleReport,
+        Date.now() + 30_000,
+        (details) => emittedEventIds.push(details.failureEventId),
+      ),
+      MultipartCompletionFailureReportLeaseLostError,
+    );
+    assert.deepEqual(emittedEventIds, []);
+  });
+});
+
+test("migration 0099 serializes active failure reporting with exact-reference recovery", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const handedOff = await createFailedAttempt(
+      fixture,
+      "worker-failed-exact-active",
+    );
+    const report = await claimFailureReportOne(
+      "failure-reporter-active-before-exact",
+      handedOff.attemptToken,
+    );
+    await insertExactReference(fixture, handedOff.payload);
+
+    assert.equal(
+      await closeCurrentWriter(fixture, handedOff.payload),
+      "cleanup_claimed",
+    );
+    assert.equal(
+      (await state(fixture, handedOff.attemptToken)).reconciliation_state,
+      "failed",
+    );
+
+    const emittedEventIds: Array<string> = [];
+    let concurrentRecovery: Promise<string> | null = null;
+    await deliverMultipartCompletionFailureReport(
+      report,
+      Date.now() + 30_000,
+      (details) => {
+        emittedEventIds.push(details.failureEventId);
+        concurrentRecovery = closeCurrentWriter(fixture, handedOff.payload);
+      },
+    );
+    if (concurrentRecovery === null) {
+      throw new Error("Concurrent exact-reference recovery was not started.");
+    }
+    assert.equal(await concurrentRecovery, "referenced");
+    assert.deepEqual(emittedEventIds, [report.failureEventId]);
+    assert.deepEqual(await state(fixture, handedOff.attemptToken), {
+      session_state: "completed",
+      attempt_state: "referenced",
+      attempt_outcome: "referenced",
+      reconciliation_state: "applied",
+      reservation_state: "finalized",
+    });
+
+    const audit = (await fixture.ownerPool.query<Readonly<{
+      event_id: string;
+      report_state: string;
+      delivery_count: number;
+      lease_cleared: boolean;
+      reported_at_present: boolean;
+    }>>(
+      `SELECT
+         reconciliation_failure_event_id AS event_id,
+         reconciliation_failure_report_state AS report_state,
+         reconciliation_failure_report_delivery_count AS delivery_count,
+         (
+           reconciliation_failure_report_lease_token IS NULL
+           AND reconciliation_failure_report_lease_owner IS NULL
+           AND reconciliation_failure_report_lease_expires_at IS NULL
+         ) AS lease_cleared,
+         reconciliation_failure_reported_at IS NOT NULL AS reported_at_present
+       FROM content.media_blob_writer_attempts
+       WHERE attempt_token=$1`,
+      [handedOff.attemptToken],
+    )).rows[0];
+    assert.deepEqual(audit, {
+      event_id: report.failureEventId,
+      report_state: "reported",
+      delivery_count: 1,
+      lease_cleared: true,
+      reported_at_present: true,
+    });
+
+    await deliverMultipartCompletionFailureReport(
+      report,
+      Date.now() + 30_000,
+      (details) => emittedEventIds.push(details.failureEventId),
+    );
+    assert.deepEqual(emittedEventIds, [report.failureEventId]);
+  });
+});
+
+test("migration 0099 fences stale reporters before and after durable recovery", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const handedOff = await createFailedAttempt(
+      fixture,
+      "worker-failed-exact-stale",
+    );
+    const staleReport = await claimFailureReportOne(
+      "failure-reporter-stale",
+      handedOff.attemptToken,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET
+         reconciliation_failure_report_updated_at =
+           reconciliation_handed_off_at,
+         reconciliation_failure_report_lease_expires_at =
+           reconciliation_handed_off_at + interval '1 microsecond'
+       WHERE attempt_token=$1`,
+      [handedOff.attemptToken],
+    );
+    const currentReport = await claimFailureReportOne(
+      "failure-reporter-current",
+      handedOff.attemptToken,
+    );
+    const emittedEventIds: Array<string> = [];
+
+    await assert.rejects(
+      deliverMultipartCompletionFailureReport(
+        staleReport,
+        Date.now() + 30_000,
+        (details) => emittedEventIds.push(details.failureEventId),
+      ),
+      MultipartCompletionFailureReportLeaseLostError,
+    );
+    await deliverMultipartCompletionFailureReport(
+      currentReport,
+      Date.now() + 30_000,
+      (details) => emittedEventIds.push(details.failureEventId),
+    );
+    assert.deepEqual(emittedEventIds, [currentReport.failureEventId]);
+
+    await insertExactReference(fixture, handedOff.payload);
+    assert.equal(await closeCurrentWriter(fixture, handedOff.payload), "referenced");
+    await deliverMultipartCompletionFailureReport(
+      staleReport,
+      Date.now() + 30_000,
+      (details) => emittedEventIds.push(details.failureEventId),
+    );
+    assert.deepEqual(emittedEventIds, [currentReport.failureEventId]);
+  });
+});

--- a/apps/backend/src/mediaAssets/multipartCompletionReconciliation.test.ts
+++ b/apps/backend/src/mediaAssets/multipartCompletionReconciliation.test.ts
@@ -1,0 +1,844 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DatabaseDeadlineExceededError } from "../database";
+import { DatabaseCommitOutcomeUnknownError } from "../database/transient";
+import { createBackendObservationScope } from "../observability/sentry";
+import { HttpError } from "../shared/errors";
+import {
+  MultipartCompletionReconciliationStorageTerminalError,
+  MultipartCompletionReconciliationStorageTransientError,
+} from "./storage";
+import {
+  buildMediaBlobStorageKey,
+  buildMediaMultipartUploadStagingStorageKey,
+} from "./storageKeys";
+import {
+  MultipartCompletionFailureReportBatchError,
+  MultipartCompletionFailureReportLeaseLostError,
+  MultipartCompletionReconciliationAccessRevokedError,
+  MultipartCompletionReconciliationBatchError,
+  MultipartCompletionReconciliationLeaseLostError,
+  processClaimedMultipartCompletionFailureReportWithDependencies,
+  processClaimedMultipartCompletionReconciliationWithDependencies,
+  runMultipartCompletionFailureReportBatchWithDependencies,
+  runMultipartCompletionReconciliationBatchWithDependencies,
+  type ClaimedMultipartCompletionFailureReport,
+  type ClaimedMultipartCompletionReconciliation,
+  type MultipartCompletionFailureReportBatchInput,
+  type MultipartCompletionFailureReportProcessorDependencies,
+  type MultipartCompletionReconciliationBatchInput,
+  type MultipartCompletionReconciliationProcessorDependencies,
+  type MultipartCompletionReconciliationSafeError,
+} from "./multipartCompletionReconciliation";
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+const sessionId = "22222222-2222-4222-8222-222222222222";
+const mediaAssetId = "33333333-3333-4333-8333-333333333333";
+const replicaId = "44444444-4444-4444-8444-444444444444";
+const attemptToken = "55555555-5555-4555-8555-555555555555";
+const reservationToken = "66666666-6666-4666-8666-666666666666";
+const leaseToken = "77777777-7777-4777-8777-777777777777";
+const failureEventId = "99999999-9999-4999-8999-999999999999";
+const sha256 = "8".repeat(64);
+const nowMs = Date.parse("2026-01-02T03:04:05.000Z");
+
+function createJob(
+  retryCount: number,
+): ClaimedMultipartCompletionReconciliation {
+  return {
+    attemptToken,
+    reservationToken,
+    userId: "user-1",
+    workspaceId,
+    sessionId,
+    mediaAssetId,
+    replicaId,
+    lastOperationId: "operation-1",
+    sha256,
+    stagingStorageKey: buildMediaMultipartUploadStagingStorageKey(
+      workspaceId,
+      mediaAssetId,
+      sessionId,
+    ),
+    blobStorageKey: buildMediaBlobStorageKey(sha256),
+    s3UploadId: "s3-upload-id",
+    mimeType: "application/octet-stream",
+    sizeBytes: 10,
+    partSizeBytes: 5,
+    partCount: 2,
+    sourceUrl: null,
+    assetCreatedAt: "2026-01-01T00:00:00.000Z",
+    clientUpdatedAt: "2026-01-01T00:00:00.000Z",
+    sessionExpiresAt: "2026-01-03T00:00:00.000Z",
+    normalizationVersion: "passthrough-v1",
+    completedPartsFingerprint: "9".repeat(64),
+    retryCount,
+    leaseToken,
+    leaseOwner: "worker-1",
+    leaseExpiresAt: "2026-01-02T03:07:05.000Z",
+    handedOffAt: "2026-01-02T03:03:05.000Z",
+    updatedAt: "2026-01-02T03:04:05.000Z",
+  };
+}
+
+function createBatchInput(
+  signal: AbortSignal,
+): MultipartCompletionReconciliationBatchInput {
+  return {
+    leaseOwner: "worker-1",
+    leaseDurationMs: 180_000,
+    maximumJobs: 5,
+    deadlineAtMs: nowMs + 100_000,
+    observationScope: createBackendObservationScope(
+      "multipart-completion-reconciliation",
+      "request-1",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ),
+    signal,
+  };
+}
+
+function createDependencies(
+  reconcileStorageFn:
+    MultipartCompletionReconciliationProcessorDependencies["reconcileStorageFn"],
+  renewLeaseFn:
+    MultipartCompletionReconciliationProcessorDependencies["renewLeaseFn"],
+  applyJobFn:
+    MultipartCompletionReconciliationProcessorDependencies["applyJobFn"],
+  rescheduleJobFn:
+    MultipartCompletionReconciliationProcessorDependencies["rescheduleJobFn"],
+  failJobFn:
+    MultipartCompletionReconciliationProcessorDependencies["failJobFn"],
+): MultipartCompletionReconciliationProcessorDependencies {
+  return {
+    claimJobsFn: async () => [],
+    reconcileStorageFn,
+    renewLeaseFn,
+    applyJobFn,
+    rescheduleJobFn,
+    failJobFn,
+    readJobOutcomeFn: async () => ({
+      status: "active",
+      errorCode: null,
+    }),
+    nowFn: () => nowMs,
+  };
+}
+
+function createFailureReport(
+  deliveryAttempt: number,
+): ClaimedMultipartCompletionFailureReport {
+  return {
+    failureEventId,
+    attemptToken,
+    workspaceId,
+    retryCount: 4,
+    errorCode: "RETRY_EXHAUSTED",
+    deliveryAttempt,
+    leaseToken,
+    leaseOwner: "failure-reporter-1",
+    leaseExpiresAt: "2026-01-02T03:07:05.000Z",
+  };
+}
+
+function createFailureReportInput(
+  signal: AbortSignal,
+  reportTerminalFailure:
+    MultipartCompletionFailureReportBatchInput["reportTerminalFailure"],
+): MultipartCompletionFailureReportBatchInput {
+  return {
+    leaseOwner: "failure-reporter-1",
+    leaseDurationMs: 180_000,
+    maximumReports: 5,
+    deadlineAtMs: nowMs + 100_000,
+    reportTerminalFailure,
+    signal,
+  };
+}
+
+test("renews the exact lease during storage and applies one completion", async () => {
+  const job = createJob(0);
+  let renewed = 0;
+  let applied = 0;
+  const dependencies = createDependencies(
+    async (input) => {
+      await input.renewLease();
+    },
+    async (renewedJob) => {
+      assert.equal(renewedJob.attemptToken, job.attemptToken);
+      assert.equal(renewedJob.leaseToken, job.leaseToken);
+      renewed += 1;
+    },
+    async () => {
+      applied += 1;
+      return "applied";
+    },
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async () => {
+      throw new Error("unexpected failure");
+    },
+  );
+
+  const outcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      dependencies,
+    );
+
+  assert.equal(outcome.outcome, "applied");
+  assert.equal(renewed, 1);
+  assert.equal(applied, 1);
+});
+
+test("reschedules transient storage failure with bounded exponential delay", async () => {
+  const job = createJob(1);
+  const rescheduledAt: Array<Date> = [];
+  const rescheduledErrors: Array<MultipartCompletionReconciliationSafeError> = [];
+  const dependencies = createDependencies(
+    async () => {
+      throw new MultipartCompletionReconciliationStorageTransientError(
+        "head_object",
+        503,
+        new Error("temporarily unavailable"),
+      );
+    },
+    async () => undefined,
+    async () => "applied",
+    async (_job, _deadlineAtMs, nextAttemptAt, error) => {
+      rescheduledAt.push(nextAttemptAt);
+      rescheduledErrors.push(error);
+    },
+    async () => {
+      throw new Error("unexpected failure");
+    },
+  );
+
+  const outcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      dependencies,
+    );
+
+  assert.equal(outcome.outcome, "rescheduled");
+  assert.equal(
+    rescheduledAt[0]?.toISOString(),
+    new Date(nowMs + 60_000).toISOString(),
+  );
+  assert.equal(
+    rescheduledErrors[0]?.code,
+    "MULTIPART_STORAGE_TRANSIENT",
+  );
+});
+
+test("terminalizes retry exhaustion with a stable safe error", async () => {
+  const job = createJob(4);
+  const failedErrors: Array<MultipartCompletionReconciliationSafeError> = [];
+  const dependencies = createDependencies(
+    async () => {
+      throw new MultipartCompletionReconciliationStorageTransientError(
+        "copy_object",
+        503,
+        new Error("temporarily unavailable"),
+      );
+    },
+    async () => undefined,
+    async () => "applied",
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async (_job, _deadlineAtMs, error) => {
+      failedErrors.push(error);
+      return "failed";
+    },
+  );
+
+  const outcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      dependencies,
+    );
+
+  assert.equal(outcome.outcome, "failed");
+  assert.equal(failedErrors[0]?.code, "RETRY_EXHAUSTED");
+});
+
+test("terminalizes access revocation after storage succeeds", async () => {
+  const job = createJob(0);
+  const failedErrors: Array<MultipartCompletionReconciliationSafeError> = [];
+  const dependencies = createDependencies(
+    async () => undefined,
+    async () => undefined,
+    async () => {
+      throw new MultipartCompletionReconciliationAccessRevokedError(
+        job.attemptToken,
+      );
+    },
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async (_job, _deadlineAtMs, error) => {
+      failedErrors.push(error);
+      return "failed";
+    },
+  );
+
+  const outcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      dependencies,
+    );
+
+  assert.equal(outcome.outcome, "failed");
+  assert.equal(failedErrors[0]?.code, "WORKSPACE_ACCESS_REVOKED");
+});
+
+test("terminalizes only an explicit storage domain failure", async () => {
+  const job = createJob(0);
+  const failedErrors: Array<MultipartCompletionReconciliationSafeError> = [];
+  const dependencies = createDependencies(
+    async () => {
+      throw new MultipartCompletionReconciliationStorageTerminalError(
+        "MULTIPART_PARTS_INVALID",
+        "Multipart upload parts are invalid.",
+        null,
+        null,
+      );
+    },
+    async () => undefined,
+    async () => "applied",
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async (_job, _deadlineAtMs, error) => {
+      failedErrors.push(error);
+      return "failed";
+    },
+  );
+
+  const outcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      dependencies,
+    );
+
+  assert.equal(outcome.outcome, "failed");
+  assert.equal(outcome.errorCode, "MULTIPART_PARTS_INVALID");
+  assert.deepEqual(failedErrors, [{
+    code: "MULTIPART_PARTS_INVALID",
+    message: "Multipart upload parts are invalid.",
+  }]);
+});
+
+test("propagates unrelated HTTP and programming errors without settling the job", async () => {
+  const errors = [
+    new HttpError(500, "unrelated HTTP failure"),
+    new TypeError("local request construction failed"),
+    new RangeError("local invariant failed"),
+  ] as const;
+
+  for (const expectedError of errors) {
+    let settlementCalls = 0;
+    const dependencies = createDependencies(
+      async () => {
+        throw expectedError;
+      },
+      async () => undefined,
+      async () => "applied",
+      async () => {
+        settlementCalls += 1;
+      },
+      async () => {
+        settlementCalls += 1;
+        return "failed";
+      },
+    );
+
+    await assert.rejects(
+      processClaimedMultipartCompletionReconciliationWithDependencies(
+        createJob(0),
+        createBatchInput(new AbortController().signal),
+        dependencies,
+      ),
+      (error: unknown) => error === expectedError,
+    );
+    assert.equal(settlementCalls, 0);
+  }
+});
+
+test("resolves an unknown failure commit from durable state", async () => {
+  const job = createJob(4);
+  const baseDependencies = createDependencies(
+    async () => {
+      throw new MultipartCompletionReconciliationStorageTerminalError(
+        "MULTIPART_UPLOAD_NOT_FOUND",
+        "Multipart upload no longer exists.",
+        null,
+        null,
+      );
+    },
+    async () => undefined,
+    async () => "applied",
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async () => {
+      throw new DatabaseCommitOutcomeUnknownError(
+        new Error("commit response lost"),
+      );
+    },
+  );
+
+  const failedOutcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      {
+        ...baseDependencies,
+        readJobOutcomeFn: async () => ({
+          status: "failed",
+          errorCode: "MULTIPART_UPLOAD_NOT_FOUND",
+        }),
+      },
+    );
+  assert.equal(failedOutcome.outcome, "failed");
+  assert.equal(failedOutcome.errorCode, "MULTIPART_UPLOAD_NOT_FOUND");
+
+  const appliedOutcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      {
+        ...baseDependencies,
+        readJobOutcomeFn: async () => ({
+          status: "applied",
+          errorCode: null,
+        }),
+      },
+    );
+  assert.equal(appliedOutcome.outcome, "applied");
+
+  const unavailableOutcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      {
+        ...baseDependencies,
+        readJobOutcomeFn: async () => {
+          throw new DatabaseCommitOutcomeUnknownError(
+            new Error("outcome read unavailable"),
+          );
+        },
+      },
+    );
+  assert.equal(unavailableOutcome.outcome, "ambiguous");
+});
+
+test("leaves unknown database commit and lease loss for durable replay", async () => {
+  const job = createJob(0);
+  const unknownDependencies = createDependencies(
+    async () => undefined,
+    async () => undefined,
+    async () => {
+      throw new DatabaseCommitOutcomeUnknownError(
+        new Error("commit response lost"),
+      );
+    },
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async () => {
+      throw new Error("unexpected failure");
+    },
+  );
+  const unknownOutcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      unknownDependencies,
+    );
+  assert.equal(unknownOutcome.outcome, "ambiguous");
+
+  const leaseLostDependencies = createDependencies(
+    async (input) => input.renewLease(),
+    async () => {
+      throw new MultipartCompletionReconciliationLeaseLostError(
+        job.attemptToken,
+      );
+    },
+    async () => "applied",
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async () => {
+      throw new Error("unexpected failure");
+    },
+  );
+  const leaseLostOutcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      leaseLostDependencies,
+    );
+  assert.equal(leaseLostOutcome.outcome, "lease_lost");
+});
+
+test("stops safely at a database deadline and bounds batch claims", async () => {
+  const job = createJob(0);
+  const deadlineDependencies = createDependencies(
+    async () => undefined,
+    async () => undefined,
+    async () => {
+      throw new DatabaseDeadlineExceededError(
+        "before_commit",
+        nowMs + 100,
+        null,
+      );
+    },
+    async () => {
+      throw new Error("unexpected reschedule");
+    },
+    async () => {
+      throw new Error("unexpected failure");
+    },
+  );
+  const deadlineOutcome =
+    await processClaimedMultipartCompletionReconciliationWithDependencies(
+      job,
+      createBatchInput(new AbortController().signal),
+      deadlineDependencies,
+    );
+  assert.equal(deadlineOutcome.outcome, "interrupted");
+
+  let claimCount = 0;
+  const boundedDependencies: MultipartCompletionReconciliationProcessorDependencies = {
+    ...createDependencies(
+      async () => undefined,
+      async () => undefined,
+      async () => "applied",
+      async () => undefined,
+      async () => "failed",
+    ),
+    claimJobsFn: async () => {
+      claimCount += 1;
+      return [job];
+    },
+  };
+  const batch = await runMultipartCompletionReconciliationBatchWithDependencies(
+    { ...createBatchInput(new AbortController().signal), maximumJobs: 2 },
+    boundedDependencies,
+  );
+  assert.equal(batch.claimed, 2);
+  assert.equal(batch.applied, 2);
+  assert.equal(claimCount, 2);
+});
+
+test("preserves completed results when a later batch job throws", async () => {
+  const firstJob = createJob(0);
+  const secondJob: ClaimedMultipartCompletionReconciliation = {
+    ...createJob(0),
+    attemptToken: "88888888-8888-4888-8888-888888888888",
+  };
+  const jobs = [firstJob, secondJob];
+  let storageCalls = 0;
+  const dependencies: MultipartCompletionReconciliationProcessorDependencies = {
+    ...createDependencies(
+      async () => {
+        storageCalls += 1;
+        if (storageCalls === 1) {
+          throw new MultipartCompletionReconciliationStorageTerminalError(
+            "MULTIPART_UPLOAD_NOT_FOUND",
+            "Multipart upload no longer exists.",
+            null,
+            null,
+          );
+        }
+        throw new Error("unexpected later job failure");
+      },
+      async () => undefined,
+      async () => "applied",
+      async () => {
+        throw new Error("unexpected reschedule");
+      },
+      async () => "failed",
+    ),
+    claimJobsFn: async () => {
+      const job = jobs.shift();
+      return job === undefined ? [] : [job];
+    },
+  };
+  const input: MultipartCompletionReconciliationBatchInput = {
+    ...createBatchInput(new AbortController().signal),
+    maximumJobs: 2,
+  };
+
+  await assert.rejects(
+    runMultipartCompletionReconciliationBatchWithDependencies(
+      input,
+      dependencies,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof MultipartCompletionReconciliationBatchError);
+      assert.deepEqual(error.partialResult, {
+        claimed: 1,
+        applied: 0,
+        ambiguous: 0,
+        failed: 1,
+        interrupted: 0,
+        leaseLost: 0,
+        rescheduled: 0,
+        results: [
+          {
+            attemptToken: firstJob.attemptToken,
+            workspaceId: firstJob.workspaceId,
+            outcome: "failed",
+            retryCount: firstJob.retryCount,
+            errorCode: "MULTIPART_UPLOAD_NOT_FOUND",
+          },
+        ],
+      });
+      assert.match(String(error.cause), /unexpected later job failure/);
+      return true;
+    },
+  );
+});
+
+test("confirms an unknown failure-report acknowledgement without duplicate emission", async () => {
+  const report = createFailureReport(1);
+  const reportedDetails: Array<unknown> = [];
+  let deliveryCalls = 0;
+  let finishCalls = 0;
+  const dependencies: MultipartCompletionFailureReportProcessorDependencies = {
+    claimReportsFn: async () => [],
+    deliverReportFn: async (claimedReport, _deadlineAtMs, reportFailure) => {
+      deliveryCalls += 1;
+      reportFailure({
+        failureEventId: claimedReport.failureEventId,
+        attemptToken: claimedReport.attemptToken,
+        workspaceId: claimedReport.workspaceId,
+        retryCount: claimedReport.retryCount,
+        errorCode: claimedReport.errorCode,
+        deliveryAttempt: claimedReport.deliveryAttempt,
+      });
+      throw new DatabaseCommitOutcomeUnknownError(
+        new Error("commit response lost"),
+      );
+    },
+    finishReportFn: async () => {
+      finishCalls += 1;
+    },
+    nowFn: () => nowMs,
+  };
+
+  const reportResult =
+    await processClaimedMultipartCompletionFailureReportWithDependencies(
+      report,
+      createFailureReportInput(
+        new AbortController().signal,
+        (details) => reportedDetails.push(details),
+      ),
+      dependencies,
+    );
+
+  assert.equal(reportResult.outcome, "reported");
+  assert.equal(deliveryCalls, 1);
+  assert.equal(finishCalls, 1);
+  assert.deepEqual(reportedDetails, [
+    {
+      failureEventId: report.failureEventId,
+      attemptToken: report.attemptToken,
+      workspaceId: report.workspaceId,
+      retryCount: report.retryCount,
+      errorCode: report.errorCode,
+      deliveryAttempt: 1,
+    },
+  ]);
+});
+
+test("retries reporter failure and lease loss with a stable event identity", async () => {
+  const firstDelivery = createFailureReport(1);
+  const secondDelivery: ClaimedMultipartCompletionFailureReport = {
+    ...createFailureReport(2),
+    leaseToken: "88888888-8888-4888-8888-888888888888",
+  };
+  let deliveryCalls = 0;
+  const dependencies: MultipartCompletionFailureReportProcessorDependencies = {
+    claimReportsFn: async () => [],
+    deliverReportFn: async (report, _deadlineAtMs, reportFailure) => {
+      deliveryCalls += 1;
+      if (report.deliveryAttempt === 1) {
+        throw new MultipartCompletionFailureReportLeaseLostError(
+          report.failureEventId,
+        );
+      }
+      reportFailure({
+        failureEventId: report.failureEventId,
+        attemptToken: report.attemptToken,
+        workspaceId: report.workspaceId,
+        retryCount: report.retryCount,
+        errorCode: report.errorCode,
+        deliveryAttempt: report.deliveryAttempt,
+      });
+    },
+    finishReportFn: async () => undefined,
+    nowFn: () => nowMs,
+  };
+  const emittedEventIds: Array<string> = [];
+  const input = createFailureReportInput(
+    new AbortController().signal,
+    (details) => emittedEventIds.push(details.failureEventId),
+  );
+
+  const leaseLost =
+    await processClaimedMultipartCompletionFailureReportWithDependencies(
+      firstDelivery,
+      input,
+      dependencies,
+    );
+  const reported =
+    await processClaimedMultipartCompletionFailureReportWithDependencies(
+      secondDelivery,
+      input,
+      dependencies,
+    );
+
+  assert.equal(leaseLost.outcome, "lease_lost");
+  assert.equal(reported.outcome, "reported");
+  assert.equal(deliveryCalls, 2);
+  assert.deepEqual(emittedEventIds, [failureEventId]);
+
+  let claimed = false;
+  const batch = await runMultipartCompletionFailureReportBatchWithDependencies(
+    { ...input, maximumReports: 1 },
+    {
+      ...dependencies,
+      claimReportsFn: async () => {
+        if (claimed) return [];
+        claimed = true;
+        return [secondDelivery];
+      },
+    },
+  );
+  assert.equal(batch.claimed, 1);
+  assert.equal(batch.reported, 1);
+});
+
+test("leaves an interrupted report unacknowledged for a later delivery", async () => {
+  const firstDelivery = createFailureReport(1);
+  const secondDelivery: ClaimedMultipartCompletionFailureReport = {
+    ...createFailureReport(2),
+    leaseToken: "88888888-8888-4888-8888-888888888888",
+  };
+  let deliveryCalls = 0;
+  const dependencies: MultipartCompletionFailureReportProcessorDependencies = {
+    claimReportsFn: async () => [],
+    deliverReportFn: async (report, _deadlineAtMs, reportFailure) => {
+      deliveryCalls += 1;
+      reportFailure({
+        failureEventId: report.failureEventId,
+        attemptToken: report.attemptToken,
+        workspaceId: report.workspaceId,
+        retryCount: report.retryCount,
+        errorCode: report.errorCode,
+        deliveryAttempt: report.deliveryAttempt,
+      });
+    },
+    finishReportFn: async () => undefined,
+    nowFn: () => nowMs,
+  };
+
+  await assert.rejects(
+    processClaimedMultipartCompletionFailureReportWithDependencies(
+      firstDelivery,
+      createFailureReportInput(
+        new AbortController().signal,
+        () => {
+          throw new Error("log delivery interrupted");
+        },
+      ),
+      dependencies,
+    ),
+    /log delivery interrupted/,
+  );
+  assert.equal(deliveryCalls, 1);
+
+  const observedEventIds: Array<string> = [];
+  const eventual =
+    await processClaimedMultipartCompletionFailureReportWithDependencies(
+      secondDelivery,
+      createFailureReportInput(
+        new AbortController().signal,
+        (details) => observedEventIds.push(details.failureEventId),
+      ),
+      dependencies,
+    );
+  assert.equal(eventual.outcome, "reported");
+  assert.equal(deliveryCalls, 2);
+  assert.deepEqual(observedEventIds, [failureEventId]);
+});
+
+test("preserves delivered failure reports when a later report claim throws", async () => {
+  const firstReport = createFailureReport(1);
+  let claimCalls = 0;
+  const dependencies: MultipartCompletionFailureReportProcessorDependencies = {
+    claimReportsFn: async () => {
+      claimCalls += 1;
+      if (claimCalls === 1) return [firstReport];
+      throw new Error("unexpected later failure-report claim");
+    },
+    deliverReportFn: async (report, _deadlineAtMs, reportFailure) => {
+      reportFailure({
+        failureEventId: report.failureEventId,
+        attemptToken: report.attemptToken,
+        workspaceId: report.workspaceId,
+        retryCount: report.retryCount,
+        errorCode: report.errorCode,
+        deliveryAttempt: report.deliveryAttempt,
+      });
+    },
+    finishReportFn: async () => undefined,
+    nowFn: () => nowMs,
+  };
+
+  await assert.rejects(
+    runMultipartCompletionFailureReportBatchWithDependencies(
+      createFailureReportInput(
+        new AbortController().signal,
+        () => undefined,
+      ),
+      dependencies,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof MultipartCompletionFailureReportBatchError);
+      assert.deepEqual(error.partialResult, {
+        claimed: 1,
+        ambiguous: 0,
+        leaseLost: 0,
+        reported: 1,
+        results: [{
+          failureEventId,
+          outcome: "reported",
+        }],
+      });
+      assert.match(
+        String(error.cause),
+        /unexpected later failure-report claim/,
+      );
+      return true;
+    },
+  );
+});

--- a/apps/backend/src/mediaAssets/multipartCompletionReconciliation.ts
+++ b/apps/backend/src/mediaAssets/multipartCompletionReconciliation.ts
@@ -1,0 +1,1394 @@
+import {
+  DatabaseDeadlineExceededError,
+  type DatabaseExecutor,
+} from "../database";
+import {
+  unsafeQueryWithDeadline,
+  unsafeTransactionWithDeadline,
+} from "../database/unsafe";
+import {
+  DatabaseCommitOutcomeUnknownError,
+  isTransientDatabaseError,
+  TransientDatabaseHttpError,
+} from "../database/transient";
+import type {
+  BackendObservationScope,
+  MultipartCompletionReconciliationTerminalFailureDetails,
+} from "../observability/sentry";
+import { mediaBlobCleanupDelayMs } from "./blobLifecycle";
+import { isValidMediaAssetLastOperationId } from "./lastOperationId";
+import {
+  upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
+} from "./persistence";
+import {
+  MultipartCompletionReconciliationStorageTerminalError,
+  MultipartCompletionReconciliationStorageTransientError,
+  reconcileMultipartMediaAssetUpload,
+} from "./storage";
+import {
+  buildMediaBlobStorageKey,
+  buildMediaMultipartUploadStagingStorageKey,
+} from "./storageKeys";
+import {
+  mediaBlobNormalizationVersions,
+  type MediaAsset,
+  type MediaBlobNormalizationVersion,
+} from "./types";
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+const safeErrorCodePattern = /^[A-Z][A-Z0-9_]{0,63}$/u;
+const mimeTypePattern =
+  /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/u;
+const controlCharacterPattern = /[\u0000-\u001f\u007f-\u009f]/u;
+const maximumJobAttempts = 5;
+const retryBaseDelayMs = 30_000;
+const retryMaximumDelayMs = 15 * 60_000;
+const minimumNewJobBudgetMs = 1_000;
+
+export type ClaimedMultipartCompletionReconciliation = Readonly<{
+  attemptToken: string;
+  reservationToken: string;
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  mediaAssetId: string;
+  replicaId: string;
+  lastOperationId: string;
+  sha256: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  s3UploadId: string;
+  mimeType: string;
+  sizeBytes: number;
+  partSizeBytes: number;
+  partCount: number;
+  sourceUrl: string | null;
+  assetCreatedAt: string;
+  clientUpdatedAt: string;
+  sessionExpiresAt: string;
+  normalizationVersion: MediaBlobNormalizationVersion;
+  completedPartsFingerprint: string;
+  retryCount: number;
+  leaseToken: string;
+  leaseOwner: string;
+  leaseExpiresAt: string;
+  handedOffAt: string;
+  updatedAt: string;
+}>;
+
+export type MultipartCompletionReconciliationSafeError = Readonly<{
+  code: string;
+  message: string;
+}>;
+
+export type MultipartCompletionReconciliationJobOutcome =
+  | "applied"
+  | "ambiguous"
+  | "failed"
+  | "interrupted"
+  | "lease_lost"
+  | "rescheduled";
+
+export type MultipartCompletionReconciliationJobResult = Readonly<{
+  attemptToken: string;
+  workspaceId: string;
+  outcome: MultipartCompletionReconciliationJobOutcome;
+  retryCount: number;
+  errorCode: string | null;
+}>;
+
+export type MultipartCompletionReconciliationBatchInput = Readonly<{
+  leaseOwner: string;
+  leaseDurationMs: number;
+  maximumJobs: number;
+  deadlineAtMs: number;
+  observationScope: BackendObservationScope;
+  signal: AbortSignal;
+}>;
+
+export type MultipartCompletionReconciliationBatchResult = Readonly<{
+  claimed: number;
+  applied: number;
+  ambiguous: number;
+  failed: number;
+  interrupted: number;
+  leaseLost: number;
+  rescheduled: number;
+  results: ReadonlyArray<MultipartCompletionReconciliationJobResult>;
+}>;
+
+export type MultipartCompletionReconciliationDurableOutcome = Readonly<{
+  status: "active" | "applied" | "failed" | "missing";
+  errorCode: string | null;
+}>;
+
+export type ClaimedMultipartCompletionFailureReport = Readonly<{
+  failureEventId: string;
+  attemptToken: string;
+  workspaceId: string;
+  retryCount: number;
+  errorCode: string;
+  deliveryAttempt: number;
+  leaseToken: string;
+  leaseOwner: string;
+  leaseExpiresAt: string;
+}>;
+
+export type MultipartCompletionFailureReportBatchInput = Readonly<{
+  leaseOwner: string;
+  leaseDurationMs: number;
+  maximumReports: number;
+  deadlineAtMs: number;
+  reportTerminalFailure: (
+    details: MultipartCompletionReconciliationTerminalFailureDetails,
+  ) => void;
+  signal: AbortSignal;
+}>;
+
+export type MultipartCompletionFailureReportOutcome =
+  | "ambiguous"
+  | "lease_lost"
+  | "reported";
+
+export type MultipartCompletionFailureReportResult = Readonly<{
+  failureEventId: string;
+  outcome: MultipartCompletionFailureReportOutcome;
+}>;
+
+export type MultipartCompletionFailureReportBatchResult = Readonly<{
+  claimed: number;
+  ambiguous: number;
+  leaseLost: number;
+  reported: number;
+  results: ReadonlyArray<MultipartCompletionFailureReportResult>;
+}>;
+
+type ClaimedRow = Readonly<{
+  attempt_token: string;
+  reservation_token: string;
+  writer_kind: string;
+  state: string;
+  outcome: string | null;
+  user_id: string;
+  workspace_id: string;
+  media_upload_session_id: string | null;
+  media_asset_id: string;
+  replica_id: string;
+  last_operation_id: string | null;
+  sha256: string;
+  staging_storage_key: string | null;
+  blob_storage_key: string;
+  s3_upload_id: string | null;
+  mime_type: string;
+  size_bytes: string | number;
+  part_size_bytes: string | number | null;
+  part_count: number | null;
+  source_url: string | null;
+  asset_created_at: Date;
+  client_updated_at: Date;
+  session_expires_at: Date | null;
+  normalization_version: string;
+  completed_parts_fingerprint: string | null;
+  reconciliation_retry_count: number;
+  reconciliation_state: string | null;
+  reconciliation_lease_token: string | null;
+  reconciliation_lease_owner: string | null;
+  reconciliation_lease_expires_at: Date | null;
+  reconciliation_handed_off_at: Date | null;
+  reconciliation_updated_at: Date | null;
+}>;
+
+type StatusRow = Readonly<{ status: string }>;
+type RenewalRow = Readonly<{
+  renewal_status: string;
+  lease_expires_at: Date | null;
+}>;
+type DurableOutcomeRow = Readonly<{
+  reconciliation_status: string;
+  reconciliation_error_code: string | null;
+}>;
+type ClaimedFailureReportRow = Readonly<{
+  failure_event_id: string;
+  attempt_token: string;
+  workspace_id: string;
+  reconciliation_retry_count: number;
+  reconciliation_last_error_code: string;
+  failure_report_delivery_count: number;
+  failure_report_lease_token: string;
+  failure_report_lease_owner: string;
+  failure_report_lease_expires_at: Date;
+}>;
+
+export class MultipartCompletionReconciliationLeaseLostError extends Error {
+  readonly code = "MULTIPART_COMPLETION_RECONCILIATION_LEASE_LOST";
+
+  constructor(attemptToken: string) {
+    super(
+      `Multipart completion reconciliation lease is no longer active. attemptToken=${attemptToken}`,
+    );
+    this.name = "MultipartCompletionReconciliationLeaseLostError";
+  }
+}
+
+export class MultipartCompletionFailureReportLeaseLostError extends Error {
+  readonly code = "MULTIPART_COMPLETION_FAILURE_REPORT_LEASE_LOST";
+
+  constructor(failureEventId: string) {
+    super(
+      `Multipart completion failure-report lease is no longer active. failureEventId=${failureEventId}`,
+    );
+    this.name = "MultipartCompletionFailureReportLeaseLostError";
+  }
+}
+
+export class MultipartCompletionReconciliationAccessRevokedError extends Error {
+  readonly code = "WORKSPACE_ACCESS_REVOKED";
+
+  constructor(attemptToken: string) {
+    super(
+      `Multipart completion reconciliation workspace access was revoked. attemptToken=${attemptToken}`,
+    );
+    this.name = "MultipartCompletionReconciliationAccessRevokedError";
+  }
+}
+
+export class MultipartCompletionReconciliationStateConflictError extends Error {
+  readonly code = "DURABLE_STATE_CONFLICT";
+
+  constructor(attemptToken: string, status: string) {
+    super(
+      `Multipart completion reconciliation conflicts with durable state. attemptToken=${attemptToken}; status=${status}`,
+    );
+    this.name = "MultipartCompletionReconciliationStateConflictError";
+  }
+}
+
+function toSafeInteger(
+  value: string | number,
+  fieldName: string,
+): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (Number.isSafeInteger(parsed) === false) {
+    throw new TypeError(`PostgreSQL returned an invalid ${fieldName}.`);
+  }
+  return parsed;
+}
+
+function toIsoString(value: Date | null, fieldName: string): string {
+  if (
+    value === null
+    || value instanceof Date === false
+    || Number.isFinite(value.getTime()) === false
+  ) {
+    throw new TypeError(`PostgreSQL returned an invalid ${fieldName}.`);
+  }
+  return value.toISOString();
+}
+
+function requireUuid(value: string, fieldName: string): void {
+  if (uuidPattern.test(value) === false) {
+    throw new TypeError(`${fieldName} must be a lowercase UUID.`);
+  }
+}
+
+function requireClaimedJob(
+  job: ClaimedMultipartCompletionReconciliation,
+): void {
+  requireUuid(job.attemptToken, "attemptToken");
+  requireUuid(job.reservationToken, "reservationToken");
+  requireUuid(job.workspaceId, "workspaceId");
+  requireUuid(job.sessionId, "sessionId");
+  requireUuid(job.mediaAssetId, "mediaAssetId");
+  requireUuid(job.replicaId, "replicaId");
+  requireUuid(job.leaseToken, "leaseToken");
+  if (
+    job.userId !== job.userId.trim()
+    || job.userId === ""
+    || controlCharacterPattern.test(job.userId)
+  ) {
+    throw new TypeError(
+      "userId must be non-empty, trimmed, and contain no control characters.",
+    );
+  }
+  if (
+    job.leaseOwner !== job.leaseOwner.trim()
+    || job.leaseOwner.length < 1
+    || job.leaseOwner.length > 200
+    || controlCharacterPattern.test(job.leaseOwner)
+  ) {
+    throw new TypeError("leaseOwner is invalid.");
+  }
+  if (
+    isValidMediaAssetLastOperationId(job.lastOperationId) === false
+  ) {
+    throw new TypeError("lastOperationId is invalid.");
+  }
+  if (sha256Pattern.test(job.sha256) === false) {
+    throw new TypeError("sha256 must be a normalized lowercase SHA-256 digest.");
+  }
+  if (sha256Pattern.test(job.completedPartsFingerprint) === false) {
+    throw new TypeError(
+      "completedPartsFingerprint must be a normalized lowercase SHA-256 digest.",
+    );
+  }
+  if (mimeTypePattern.test(job.mimeType) === false) {
+    throw new TypeError("mimeType must be a normalized lowercase MIME type.");
+  }
+  if (
+    Number.isSafeInteger(job.sizeBytes) === false
+    || job.sizeBytes < 1
+    || Number.isSafeInteger(job.partSizeBytes) === false
+    || job.partSizeBytes < 1
+    || Number.isSafeInteger(job.partCount) === false
+    || job.partCount < 1
+    || job.partCount > 10_000
+    || Number.isSafeInteger(job.retryCount) === false
+    || job.retryCount < 0
+  ) {
+    throw new RangeError("Durable multipart size, part, or retry fields are invalid.");
+  }
+  if (
+    job.stagingStorageKey !== buildMediaMultipartUploadStagingStorageKey(
+      job.workspaceId,
+      job.mediaAssetId,
+      job.sessionId,
+    )
+    || job.blobStorageKey !== buildMediaBlobStorageKey(job.sha256)
+  ) {
+    throw new TypeError("Durable multipart storage keys are not deterministic.");
+  }
+  if (
+    job.s3UploadId !== job.s3UploadId.trim()
+    || job.s3UploadId === ""
+    || controlCharacterPattern.test(job.s3UploadId)
+  ) {
+    throw new TypeError("s3UploadId is invalid.");
+  }
+}
+
+function requireClaimedFailureReport(
+  report: ClaimedMultipartCompletionFailureReport,
+): void {
+  requireUuid(report.failureEventId, "failureEventId");
+  requireUuid(report.attemptToken, "attemptToken");
+  requireUuid(report.workspaceId, "workspaceId");
+  requireUuid(report.leaseToken, "leaseToken");
+  if (
+    report.leaseOwner !== report.leaseOwner.trim()
+    || report.leaseOwner.length < 1
+    || report.leaseOwner.length > 200
+    || controlCharacterPattern.test(report.leaseOwner)
+  ) {
+    throw new TypeError("failure report leaseOwner is invalid.");
+  }
+  if (
+    Number.isSafeInteger(report.retryCount) === false
+    || report.retryCount < 0
+    || Number.isSafeInteger(report.deliveryAttempt) === false
+    || report.deliveryAttempt < 1
+  ) {
+    throw new RangeError(
+      "Failure report retry and delivery counts must be non-negative safe integers.",
+    );
+  }
+  if (safeErrorCodePattern.test(report.errorCode) === false) {
+    throw new TypeError("Failure report errorCode is invalid.");
+  }
+}
+
+function toClaimedJob(row: ClaimedRow): ClaimedMultipartCompletionReconciliation {
+  const normalizationVersion = mediaBlobNormalizationVersions.find(
+    (candidate) => candidate === row.normalization_version,
+  );
+  if (
+    row.writer_kind !== "multipart_completion"
+    || row.state !== "expired"
+    || row.outcome !== "stale_attempt"
+    || row.reconciliation_state !== "leased"
+    ||
+    row.media_upload_session_id === null
+    || row.last_operation_id === null
+    || row.staging_storage_key === null
+    || row.s3_upload_id === null
+    || row.part_size_bytes === null
+    || row.part_count === null
+    || row.completed_parts_fingerprint === null
+    || row.reconciliation_lease_token === null
+    || row.reconciliation_lease_owner === null
+    || normalizationVersion === undefined
+  ) {
+    throw new TypeError(
+      `PostgreSQL returned an incomplete claimed multipart reconciliation. attemptToken=${row.attempt_token}`,
+    );
+  }
+  const job: ClaimedMultipartCompletionReconciliation = {
+    attemptToken: row.attempt_token,
+    reservationToken: row.reservation_token,
+    userId: row.user_id,
+    workspaceId: row.workspace_id,
+    sessionId: row.media_upload_session_id,
+    mediaAssetId: row.media_asset_id,
+    replicaId: row.replica_id,
+    lastOperationId: row.last_operation_id,
+    sha256: row.sha256,
+    stagingStorageKey: row.staging_storage_key,
+    blobStorageKey: row.blob_storage_key,
+    s3UploadId: row.s3_upload_id,
+    mimeType: row.mime_type,
+    sizeBytes: toSafeInteger(row.size_bytes, "size_bytes"),
+    partSizeBytes: toSafeInteger(row.part_size_bytes, "part_size_bytes"),
+    partCount: row.part_count,
+    sourceUrl: row.source_url,
+    assetCreatedAt: toIsoString(row.asset_created_at, "asset_created_at"),
+    clientUpdatedAt: toIsoString(row.client_updated_at, "client_updated_at"),
+    sessionExpiresAt: toIsoString(
+      row.session_expires_at,
+      "session_expires_at",
+    ),
+    normalizationVersion,
+    completedPartsFingerprint: row.completed_parts_fingerprint,
+    retryCount: row.reconciliation_retry_count,
+    leaseToken: row.reconciliation_lease_token,
+    leaseOwner: row.reconciliation_lease_owner,
+    leaseExpiresAt: toIsoString(
+      row.reconciliation_lease_expires_at,
+      "reconciliation_lease_expires_at",
+    ),
+    handedOffAt: toIsoString(
+      row.reconciliation_handed_off_at,
+      "reconciliation_handed_off_at",
+    ),
+    updatedAt: toIsoString(
+      row.reconciliation_updated_at,
+      "reconciliation_updated_at",
+    ),
+  };
+  requireClaimedJob(job);
+  return job;
+}
+
+function toClaimedFailureReport(
+  row: ClaimedFailureReportRow,
+): ClaimedMultipartCompletionFailureReport {
+  const report: ClaimedMultipartCompletionFailureReport = {
+    failureEventId: row.failure_event_id,
+    attemptToken: row.attempt_token,
+    workspaceId: row.workspace_id,
+    retryCount: row.reconciliation_retry_count,
+    errorCode: row.reconciliation_last_error_code,
+    deliveryAttempt: row.failure_report_delivery_count,
+    leaseToken: row.failure_report_lease_token,
+    leaseOwner: row.failure_report_lease_owner,
+    leaseExpiresAt: toIsoString(
+      row.failure_report_lease_expires_at,
+      "failure_report_lease_expires_at",
+    ),
+  };
+  requireClaimedFailureReport(report);
+  return report;
+}
+
+function validateClaimInput(
+  input: Readonly<{
+    leaseOwner: string;
+    leaseDurationMs: number;
+    limit: number;
+  }>,
+): void {
+  if (
+    input.leaseOwner !== input.leaseOwner.trim()
+    || input.leaseOwner.length < 1
+    || input.leaseOwner.length > 200
+    || controlCharacterPattern.test(input.leaseOwner)
+  ) {
+    throw new TypeError(
+      "leaseOwner must be 1 to 200 trimmed characters without control characters.",
+    );
+  }
+  if (
+    Number.isSafeInteger(input.leaseDurationMs) === false
+    || input.leaseDurationMs < 1
+    || input.leaseDurationMs > 3_600_000
+  ) {
+    throw new RangeError("leaseDurationMs must be between 1 and 3600000.");
+  }
+  if (
+    Number.isSafeInteger(input.limit) === false
+    || input.limit < 1
+    || input.limit > 100
+  ) {
+    throw new RangeError("limit must be between 1 and 100.");
+  }
+}
+
+export async function claimMultipartCompletionReconciliations(
+  input: Readonly<{
+    leaseOwner: string;
+    leaseDurationMs: number;
+    limit: number;
+    deadlineAtMs: number;
+  }>,
+): Promise<ReadonlyArray<ClaimedMultipartCompletionReconciliation>> {
+  validateClaimInput(input);
+  const result = await unsafeQueryWithDeadline<ClaimedRow>(
+    input.deadlineAtMs,
+    "SELECT * FROM content.claim_media_upload_session_completion_reconciliations($1, $2, $3)",
+    [input.leaseOwner, input.leaseDurationMs, input.limit],
+  );
+  return result.rows.map(toClaimedJob);
+}
+
+export async function claimMultipartCompletionFailureReports(
+  input: Readonly<{
+    leaseOwner: string;
+    leaseDurationMs: number;
+    limit: number;
+    deadlineAtMs: number;
+  }>,
+): Promise<ReadonlyArray<ClaimedMultipartCompletionFailureReport>> {
+  validateClaimInput(input);
+  const result = await unsafeQueryWithDeadline<ClaimedFailureReportRow>(
+    input.deadlineAtMs,
+    "SELECT * FROM content.claim_media_upload_session_completion_failure_reports($1, $2, $3)",
+    [input.leaseOwner, input.leaseDurationMs, input.limit],
+  );
+  return result.rows.map(toClaimedFailureReport);
+}
+
+export async function renewMultipartCompletionReconciliationLease(
+  job: ClaimedMultipartCompletionReconciliation,
+  leaseDurationMs: number,
+  deadlineAtMs: number,
+): Promise<void> {
+  requireClaimedJob(job);
+  const result = await unsafeQueryWithDeadline<RenewalRow>(
+    deadlineAtMs,
+    `SELECT renewal_status, lease_expires_at
+     FROM content.renew_media_upload_session_completion_reconciliation($1, $2, $3)`,
+    [job.attemptToken, job.leaseToken, leaseDurationMs],
+  );
+  if (result.rows[0]?.renewal_status !== "renewed") {
+    throw new MultipartCompletionReconciliationLeaseLostError(job.attemptToken);
+  }
+}
+
+async function readStatus(
+  deadlineAtMs: number,
+  text: string,
+  params: ReadonlyArray<string | number | Date>,
+): Promise<string> {
+  const result = await unsafeQueryWithDeadline<StatusRow>(
+    deadlineAtMs,
+    text,
+    params,
+  );
+  const status = result.rows[0]?.status;
+  if (typeof status !== "string" || status === "") {
+    throw new TypeError("PostgreSQL returned an invalid reconciliation status.");
+  }
+  return status;
+}
+
+export async function readMultipartCompletionReconciliationOutcome(
+  attemptToken: string,
+  deadlineAtMs: number,
+): Promise<MultipartCompletionReconciliationDurableOutcome> {
+  requireUuid(attemptToken, "attemptToken");
+  const result = await unsafeQueryWithDeadline<DurableOutcomeRow>(
+    deadlineAtMs,
+    `SELECT reconciliation_status, reconciliation_error_code
+     FROM content.get_media_upload_session_completion_reconciliation_outcome($1)`,
+    [attemptToken],
+  );
+  const row = result.rows[0];
+  if (
+    row === undefined
+    || (
+      row.reconciliation_status !== "active"
+      && row.reconciliation_status !== "applied"
+      && row.reconciliation_status !== "failed"
+      && row.reconciliation_status !== "missing"
+    )
+    || (
+      row.reconciliation_status === "failed"
+      && (
+        row.reconciliation_error_code === null
+        || safeErrorCodePattern.test(row.reconciliation_error_code) === false
+      )
+    )
+    || (
+      row.reconciliation_status !== "failed"
+      && row.reconciliation_error_code !== null
+    )
+  ) {
+    throw new TypeError(
+      "PostgreSQL returned an invalid durable reconciliation outcome.",
+    );
+  }
+  return {
+    status: row.reconciliation_status,
+    errorCode: row.reconciliation_error_code,
+  };
+}
+
+export async function finishMultipartCompletionFailureReport(
+  report: ClaimedMultipartCompletionFailureReport,
+  deadlineAtMs: number,
+): Promise<void> {
+  requireClaimedFailureReport(report);
+  const status = await readStatus(
+    deadlineAtMs,
+    `SELECT content.finish_media_upload_session_completion_failure_report(
+       $1, $2, $3
+     ) AS status`,
+    [report.failureEventId, report.attemptToken, report.leaseToken],
+  );
+  if (status === "reported" || status === "already_reported") return;
+  throw new MultipartCompletionFailureReportLeaseLostError(
+    report.failureEventId,
+  );
+}
+
+function toTerminalFailureDetails(
+  report: ClaimedMultipartCompletionFailureReport,
+): MultipartCompletionReconciliationTerminalFailureDetails {
+  return {
+    failureEventId: report.failureEventId,
+    attemptToken: report.attemptToken,
+    workspaceId: report.workspaceId,
+    retryCount: report.retryCount,
+    errorCode: report.errorCode,
+    deliveryAttempt: report.deliveryAttempt,
+  };
+}
+
+export async function deliverMultipartCompletionFailureReport(
+  report: ClaimedMultipartCompletionFailureReport,
+  deadlineAtMs: number,
+  reportTerminalFailure:
+    MultipartCompletionFailureReportBatchInput["reportTerminalFailure"],
+): Promise<void> {
+  requireClaimedFailureReport(report);
+  await unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
+    const lockResult = await executor.query<StatusRow>(
+      `SELECT content.lock_media_upload_session_completion_failure_report_delivery(
+         $1, $2, $3
+       ) AS status`,
+      [report.failureEventId, report.attemptToken, report.leaseToken],
+    );
+    const lockStatus = lockResult.rows[0]?.status;
+    if (lockStatus === "already_reported") return;
+    if (lockStatus !== "ready") {
+      throw new MultipartCompletionFailureReportLeaseLostError(
+        report.failureEventId,
+      );
+    }
+
+    reportTerminalFailure(toTerminalFailureDetails(report));
+    const finishResult = await executor.query<StatusRow>(
+      `SELECT content.finish_media_upload_session_completion_failure_report(
+         $1, $2, $3
+       ) AS status`,
+      [report.failureEventId, report.attemptToken, report.leaseToken],
+    );
+    const finishStatus = finishResult.rows[0]?.status;
+    if (finishStatus === "reported" || finishStatus === "already_reported") {
+      return;
+    }
+    throw new MultipartCompletionFailureReportLeaseLostError(
+      report.failureEventId,
+    );
+  });
+}
+
+export async function rescheduleMultipartCompletionReconciliation(
+  job: ClaimedMultipartCompletionReconciliation,
+  deadlineAtMs: number,
+  nextAttemptAt: Date,
+  error: MultipartCompletionReconciliationSafeError,
+): Promise<void> {
+  const status = await readStatus(
+    deadlineAtMs,
+    `SELECT content.reschedule_media_upload_session_completion_reconciliation(
+       $1, $2, $3, $4, $5
+     ) AS status`,
+    [
+      job.attemptToken,
+      job.leaseToken,
+      nextAttemptAt,
+      error.code,
+      error.message,
+    ],
+  );
+  if (status === "rescheduled") return;
+  throw new MultipartCompletionReconciliationLeaseLostError(job.attemptToken);
+}
+
+export async function failMultipartCompletionReconciliation(
+  job: ClaimedMultipartCompletionReconciliation,
+  deadlineAtMs: number,
+  error: MultipartCompletionReconciliationSafeError,
+): Promise<"applied" | "failed"> {
+  const status = await readStatus(
+    deadlineAtMs,
+    `SELECT content.fail_media_upload_session_completion_reconciliation(
+       $1, $2, $3, $4, $5
+     ) AS status`,
+    [
+      job.attemptToken,
+      job.leaseToken,
+      error.code,
+      error.message,
+      mediaBlobCleanupDelayMs,
+    ],
+  );
+  if (status === "applied" || status === "failed") return status;
+  throw new MultipartCompletionReconciliationLeaseLostError(job.attemptToken);
+}
+
+function assertPersistedMediaIdentity(
+  mediaAsset: MediaAsset,
+  job: ClaimedMultipartCompletionReconciliation,
+): void {
+  if (
+    mediaAsset.mediaAssetId !== job.mediaAssetId
+    || mediaAsset.workspaceId !== job.workspaceId
+    || mediaAsset.mimeType !== job.mimeType
+    || mediaAsset.sizeBytes !== job.sizeBytes
+    || mediaAsset.sha256 !== job.sha256
+    || mediaAsset.sourceUrl !== job.sourceUrl
+    || mediaAsset.createdAt !== job.assetCreatedAt
+    || mediaAsset.clientUpdatedAt !== job.clientUpdatedAt
+    || mediaAsset.lastModifiedByReplicaId !== job.replicaId
+    || mediaAsset.lastOperationId !== job.lastOperationId
+    || mediaAsset.deletedAt !== null
+  ) {
+    throw new MultipartCompletionReconciliationStateConflictError(
+      job.attemptToken,
+      "media_asset_identity_conflict",
+    );
+  }
+}
+
+async function applyMultipartCompletionReconciliationInExecutor(
+  executor: DatabaseExecutor,
+  job: ClaimedMultipartCompletionReconciliation,
+): Promise<"applied" | "already_applied"> {
+  const scopeResult = await executor.query<StatusRow>(
+    `SELECT content.apply_media_upload_session_completion_reconciliation_scope(
+       $1, $2
+     ) AS status`,
+    [job.attemptToken, job.leaseToken],
+  );
+  const scopeStatus = scopeResult.rows[0]?.status;
+  if (scopeStatus === "applied") return "already_applied";
+  if (scopeStatus === "access_revoked" || scopeStatus === "replica_revoked") {
+    throw new MultipartCompletionReconciliationAccessRevokedError(
+      job.attemptToken,
+    );
+  }
+  if (scopeStatus === "lease_lost" || scopeStatus === "failed") {
+    throw new MultipartCompletionReconciliationLeaseLostError(job.attemptToken);
+  }
+  if (scopeStatus !== "scoped") {
+    throw new MultipartCompletionReconciliationStateConflictError(
+      job.attemptToken,
+      scopeStatus ?? "missing",
+    );
+  }
+
+  const result = await upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
+    executor,
+    job.workspaceId,
+    {
+      mediaAssetId: job.mediaAssetId,
+      mimeType: job.mimeType,
+      sizeBytes: job.sizeBytes,
+      sha256: job.sha256,
+      sourceUrl: job.sourceUrl,
+      createdAt: job.assetCreatedAt,
+      deletedAt: null,
+    },
+    {
+      clientUpdatedAt: job.clientUpdatedAt,
+      lastModifiedByReplicaId: job.replicaId,
+      lastOperationId: job.lastOperationId,
+    },
+    job.normalizationVersion,
+  );
+  assertPersistedMediaIdentity(result.mediaAsset, job);
+
+  const finishResult = await executor.query<StatusRow>(
+    `SELECT content.finish_media_upload_session_completion_reconciliation(
+       $1, $2, $3
+     ) AS status`,
+    [job.attemptToken, job.leaseToken, mediaBlobCleanupDelayMs],
+  );
+  const finishStatus = finishResult.rows[0]?.status;
+  if (finishStatus === "applied" || finishStatus === "already_applied") {
+    return finishStatus;
+  }
+  if (finishStatus === "lease_lost" || finishStatus === "failed") {
+    throw new MultipartCompletionReconciliationLeaseLostError(job.attemptToken);
+  }
+  if (finishStatus === "access_revoked") {
+    throw new MultipartCompletionReconciliationAccessRevokedError(
+      job.attemptToken,
+    );
+  }
+  throw new MultipartCompletionReconciliationStateConflictError(
+    job.attemptToken,
+    finishStatus ?? "missing",
+  );
+}
+
+export async function applyMultipartCompletionReconciliation(
+  job: ClaimedMultipartCompletionReconciliation,
+  deadlineAtMs: number,
+): Promise<"applied" | "already_applied"> {
+  requireClaimedJob(job);
+  return unsafeTransactionWithDeadline(
+    deadlineAtMs,
+    async (executor) => applyMultipartCompletionReconciliationInExecutor(
+      executor,
+      job,
+    ),
+  );
+}
+
+export type MultipartCompletionReconciliationProcessorDependencies = Readonly<{
+  claimJobsFn: typeof claimMultipartCompletionReconciliations;
+  reconcileStorageFn: typeof reconcileMultipartMediaAssetUpload;
+  renewLeaseFn: typeof renewMultipartCompletionReconciliationLease;
+  applyJobFn: typeof applyMultipartCompletionReconciliation;
+  rescheduleJobFn: typeof rescheduleMultipartCompletionReconciliation;
+  failJobFn: typeof failMultipartCompletionReconciliation;
+  readJobOutcomeFn: typeof readMultipartCompletionReconciliationOutcome;
+  nowFn: () => number;
+}>;
+
+function result(
+  job: ClaimedMultipartCompletionReconciliation,
+  outcome: MultipartCompletionReconciliationJobOutcome,
+  errorCode: string | null,
+): MultipartCompletionReconciliationJobResult {
+  return {
+    attemptToken: job.attemptToken,
+    workspaceId: job.workspaceId,
+    outcome,
+    retryCount: job.retryCount,
+    errorCode,
+  };
+}
+
+function terminalError(
+  error: unknown,
+): MultipartCompletionReconciliationSafeError | null {
+  if (error instanceof MultipartCompletionReconciliationStorageTerminalError) {
+    return { code: error.code, message: error.safeMessage };
+  }
+  if (error instanceof MultipartCompletionReconciliationAccessRevokedError) {
+    return {
+      code: error.code,
+      message: "Workspace or replica access was revoked before multipart completion finished.",
+    };
+  }
+  if (error instanceof MultipartCompletionReconciliationStateConflictError) {
+    return {
+      code: "DURABLE_STATE_CONFLICT",
+      message: "Durable multipart completion conflicts with current media state.",
+    };
+  }
+  return null;
+}
+
+function isTransientFailure(error: unknown): boolean {
+  return error instanceof MultipartCompletionReconciliationStorageTransientError
+    || error instanceof TransientDatabaseHttpError
+    || isTransientDatabaseError(error);
+}
+
+function retryError(
+  error: unknown,
+): MultipartCompletionReconciliationSafeError {
+  if (error instanceof MultipartCompletionReconciliationStorageTransientError) {
+    return { code: error.code, message: error.safeMessage };
+  }
+  return {
+    code: "DATABASE_TRANSIENT",
+    message: "PostgreSQL is temporarily unavailable.",
+  };
+}
+
+function calculateRetryAt(
+  job: ClaimedMultipartCompletionReconciliation,
+  nowMs: number,
+): Date {
+  const delayMs = Math.min(
+    retryBaseDelayMs * (2 ** job.retryCount),
+    retryMaximumDelayMs,
+  );
+  return new Date(nowMs + delayMs);
+}
+
+async function resolveUnknownFailureTransition(
+  job: ClaimedMultipartCompletionReconciliation,
+  input: MultipartCompletionReconciliationBatchInput,
+  dependencies: MultipartCompletionReconciliationProcessorDependencies,
+): Promise<MultipartCompletionReconciliationJobResult> {
+  try {
+    const durableOutcome = await dependencies.readJobOutcomeFn(
+      job.attemptToken,
+      input.deadlineAtMs,
+    );
+    if (durableOutcome.status === "applied") {
+      return result(job, "applied", null);
+    }
+    if (durableOutcome.status === "failed") {
+      return result(job, "failed", durableOutcome.errorCode);
+    }
+    return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+  } catch (resolutionError) {
+    if (
+      input.signal.aborted
+      || resolutionError instanceof DatabaseDeadlineExceededError
+    ) {
+      return result(job, "interrupted", "WORKER_DEADLINE");
+    }
+    if (
+      resolutionError instanceof DatabaseCommitOutcomeUnknownError
+      || resolutionError instanceof TransientDatabaseHttpError
+      || isTransientDatabaseError(resolutionError)
+    ) {
+      return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+    }
+    throw resolutionError;
+  }
+}
+
+function settledFailureResult(
+  job: ClaimedMultipartCompletionReconciliation,
+  failureOutcome: "applied" | "failed",
+  error: MultipartCompletionReconciliationSafeError,
+): MultipartCompletionReconciliationJobResult {
+  return result(
+    job,
+    failureOutcome === "applied" ? "applied" : "failed",
+    failureOutcome === "applied" ? null : error.code,
+  );
+}
+
+function knownFailureTransitionErrorResult(
+  job: ClaimedMultipartCompletionReconciliation,
+  input: MultipartCompletionReconciliationBatchInput,
+  transitionError: unknown,
+): MultipartCompletionReconciliationJobResult | null {
+  if (
+    transitionError instanceof MultipartCompletionReconciliationLeaseLostError
+  ) {
+    return result(job, "lease_lost", null);
+  }
+  if (
+    input.signal.aborted
+    || transitionError instanceof DatabaseDeadlineExceededError
+  ) {
+    return result(job, "interrupted", "WORKER_DEADLINE");
+  }
+  return null;
+}
+
+async function settleTerminalFailure(
+  job: ClaimedMultipartCompletionReconciliation,
+  input: MultipartCompletionReconciliationBatchInput,
+  dependencies: MultipartCompletionReconciliationProcessorDependencies,
+  error: MultipartCompletionReconciliationSafeError,
+): Promise<MultipartCompletionReconciliationJobResult> {
+  try {
+    const failureOutcome = await dependencies.failJobFn(
+      job,
+      input.deadlineAtMs,
+      error,
+    );
+    return settledFailureResult(job, failureOutcome, error);
+  } catch (transitionError) {
+    const knownResult = knownFailureTransitionErrorResult(
+      job,
+      input,
+      transitionError,
+    );
+    if (knownResult !== null) return knownResult;
+    if (transitionError instanceof DatabaseCommitOutcomeUnknownError) {
+      return resolveUnknownFailureTransition(
+        job,
+        input,
+        dependencies,
+      );
+    }
+    throw transitionError;
+  }
+}
+
+async function settleTransientFailure(
+  job: ClaimedMultipartCompletionReconciliation,
+  input: MultipartCompletionReconciliationBatchInput,
+  dependencies: MultipartCompletionReconciliationProcessorDependencies,
+  error: MultipartCompletionReconciliationSafeError,
+): Promise<MultipartCompletionReconciliationJobResult> {
+  if (job.retryCount >= maximumJobAttempts - 1) {
+    return settleTerminalFailure(
+      job,
+      input,
+      dependencies,
+      {
+        code: "RETRY_EXHAUSTED",
+        message:
+          "Multipart completion reconciliation exhausted its transient retry budget.",
+      },
+    );
+  }
+  try {
+    await dependencies.rescheduleJobFn(
+      job,
+      input.deadlineAtMs,
+      calculateRetryAt(job, dependencies.nowFn()),
+      error,
+    );
+    return result(job, "rescheduled", error.code);
+  } catch (transitionError) {
+    const knownResult = knownFailureTransitionErrorResult(
+      job,
+      input,
+      transitionError,
+    );
+    if (knownResult !== null) return knownResult;
+    if (transitionError instanceof DatabaseCommitOutcomeUnknownError) {
+      return resolveUnknownFailureTransition(
+        job,
+        input,
+        dependencies,
+      );
+    }
+    throw transitionError;
+  }
+}
+
+export async function processClaimedMultipartCompletionReconciliationWithDependencies(
+  job: ClaimedMultipartCompletionReconciliation,
+  input: MultipartCompletionReconciliationBatchInput,
+  dependencies: MultipartCompletionReconciliationProcessorDependencies,
+): Promise<MultipartCompletionReconciliationJobResult> {
+  try {
+    input.signal.throwIfAborted();
+    await dependencies.reconcileStorageFn({
+      workspaceId: job.workspaceId,
+      mediaAssetId: job.mediaAssetId,
+      stagingStorageKey: job.stagingStorageKey,
+      blobStorageKey: job.blobStorageKey,
+      s3UploadId: job.s3UploadId,
+      mimeType: job.mimeType,
+      sizeBytes: job.sizeBytes,
+      sha256: job.sha256,
+      lastOperationId: job.lastOperationId,
+      partCount: job.partCount,
+      completedPartsFingerprint: job.completedPartsFingerprint,
+      renewLease: async () => dependencies.renewLeaseFn(
+        job,
+        input.leaseDurationMs,
+        input.deadlineAtMs,
+      ),
+      signal: input.signal,
+      observationScope: input.observationScope,
+    });
+    input.signal.throwIfAborted();
+    await dependencies.applyJobFn(job, input.deadlineAtMs);
+    return result(job, "applied", null);
+  } catch (error) {
+    if (error instanceof MultipartCompletionReconciliationLeaseLostError) {
+      return result(job, "lease_lost", null);
+    }
+    if (error instanceof DatabaseCommitOutcomeUnknownError) {
+      return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+    }
+    if (input.signal.aborted || error instanceof DatabaseDeadlineExceededError) {
+      return result(job, "interrupted", "WORKER_DEADLINE");
+    }
+    if (isTransientFailure(error)) {
+      return settleTransientFailure(
+        job,
+        input,
+        dependencies,
+        retryError(error),
+      );
+    }
+    const knownTerminalError = terminalError(error);
+    if (knownTerminalError !== null) {
+      return settleTerminalFailure(
+        job,
+        input,
+        dependencies,
+        knownTerminalError,
+      );
+    }
+    throw error;
+  }
+}
+
+function countOutcome(
+  results: ReadonlyArray<MultipartCompletionReconciliationJobResult>,
+  outcome: MultipartCompletionReconciliationJobOutcome,
+): number {
+  return results.filter((item) => item.outcome === outcome).length;
+}
+
+function toBatchResult(
+  results: ReadonlyArray<MultipartCompletionReconciliationJobResult>,
+): MultipartCompletionReconciliationBatchResult {
+  return {
+    claimed: results.length,
+    applied: countOutcome(results, "applied"),
+    ambiguous: countOutcome(results, "ambiguous"),
+    failed: countOutcome(results, "failed"),
+    interrupted: countOutcome(results, "interrupted"),
+    leaseLost: countOutcome(results, "lease_lost"),
+    rescheduled: countOutcome(results, "rescheduled"),
+    results,
+  };
+}
+
+export class MultipartCompletionReconciliationBatchError extends Error {
+  constructor(
+    readonly partialResult: MultipartCompletionReconciliationBatchResult,
+    cause: unknown,
+  ) {
+    super(
+      "Multipart completion reconciliation batch failed after processing one or more jobs.",
+      { cause },
+    );
+    this.name = "MultipartCompletionReconciliationBatchError";
+  }
+}
+
+export async function runMultipartCompletionReconciliationBatchWithDependencies(
+  input: MultipartCompletionReconciliationBatchInput,
+  dependencies: MultipartCompletionReconciliationProcessorDependencies,
+): Promise<MultipartCompletionReconciliationBatchResult> {
+  const results: Array<MultipartCompletionReconciliationJobResult> = [];
+  try {
+    while (
+      results.length < input.maximumJobs
+      && input.signal.aborted === false
+      && dependencies.nowFn() + minimumNewJobBudgetMs < input.deadlineAtMs
+    ) {
+      const claimed = await dependencies.claimJobsFn({
+        leaseOwner: input.leaseOwner,
+        leaseDurationMs: input.leaseDurationMs,
+        limit: 1,
+        deadlineAtMs: input.deadlineAtMs,
+      });
+      const job = claimed[0];
+      if (job === undefined) break;
+      const jobResult =
+        await processClaimedMultipartCompletionReconciliationWithDependencies(
+          job,
+          input,
+          dependencies,
+        );
+      results.push(jobResult);
+      if (jobResult.outcome === "interrupted") break;
+    }
+  } catch (error) {
+    throw new MultipartCompletionReconciliationBatchError(
+      toBatchResult(results),
+      error,
+    );
+  }
+  return toBatchResult(results);
+}
+
+const defaultDependencies: MultipartCompletionReconciliationProcessorDependencies = {
+  claimJobsFn: claimMultipartCompletionReconciliations,
+  reconcileStorageFn: reconcileMultipartMediaAssetUpload,
+  renewLeaseFn: renewMultipartCompletionReconciliationLease,
+  applyJobFn: applyMultipartCompletionReconciliation,
+  rescheduleJobFn: rescheduleMultipartCompletionReconciliation,
+  failJobFn: failMultipartCompletionReconciliation,
+  readJobOutcomeFn: readMultipartCompletionReconciliationOutcome,
+  nowFn: Date.now,
+};
+
+export async function runMultipartCompletionReconciliationBatch(
+  input: MultipartCompletionReconciliationBatchInput,
+): Promise<MultipartCompletionReconciliationBatchResult> {
+  return runMultipartCompletionReconciliationBatchWithDependencies(
+    input,
+    defaultDependencies,
+  );
+}
+
+export type MultipartCompletionFailureReportProcessorDependencies = Readonly<{
+  claimReportsFn: typeof claimMultipartCompletionFailureReports;
+  deliverReportFn: typeof deliverMultipartCompletionFailureReport;
+  finishReportFn: typeof finishMultipartCompletionFailureReport;
+  nowFn: () => number;
+}>;
+
+function failureReportResult(
+  report: ClaimedMultipartCompletionFailureReport,
+  outcome: MultipartCompletionFailureReportOutcome,
+): MultipartCompletionFailureReportResult {
+  return {
+    failureEventId: report.failureEventId,
+    outcome,
+  };
+}
+
+async function deliverFailureReportWithConfirmation(
+  report: ClaimedMultipartCompletionFailureReport,
+  input: MultipartCompletionFailureReportBatchInput,
+  dependencies: MultipartCompletionFailureReportProcessorDependencies,
+): Promise<MultipartCompletionFailureReportResult> {
+  try {
+    await dependencies.deliverReportFn(
+      report,
+      input.deadlineAtMs,
+      input.reportTerminalFailure,
+    );
+    return failureReportResult(report, "reported");
+  } catch (error) {
+    if (error instanceof MultipartCompletionFailureReportLeaseLostError) {
+      return failureReportResult(report, "lease_lost");
+    }
+    if (error instanceof DatabaseCommitOutcomeUnknownError) {
+      try {
+        await dependencies.finishReportFn(report, input.deadlineAtMs);
+        return failureReportResult(report, "reported");
+      } catch (confirmationError) {
+        if (
+          confirmationError instanceof MultipartCompletionFailureReportLeaseLostError
+        ) {
+          return failureReportResult(report, "lease_lost");
+        }
+        if (
+          input.signal.aborted
+          || confirmationError instanceof DatabaseDeadlineExceededError
+          || confirmationError instanceof DatabaseCommitOutcomeUnknownError
+          || confirmationError instanceof TransientDatabaseHttpError
+          || isTransientDatabaseError(confirmationError)
+        ) {
+          return failureReportResult(report, "ambiguous");
+        }
+        throw confirmationError;
+      }
+    }
+    if (
+      input.signal.aborted
+      || error instanceof DatabaseDeadlineExceededError
+      || error instanceof TransientDatabaseHttpError
+      || isTransientDatabaseError(error)
+    ) {
+      return failureReportResult(report, "ambiguous");
+    }
+    throw error;
+  }
+}
+
+export async function processClaimedMultipartCompletionFailureReportWithDependencies(
+  report: ClaimedMultipartCompletionFailureReport,
+  input: MultipartCompletionFailureReportBatchInput,
+  dependencies: MultipartCompletionFailureReportProcessorDependencies,
+): Promise<MultipartCompletionFailureReportResult> {
+  requireClaimedFailureReport(report);
+  input.signal.throwIfAborted();
+  return deliverFailureReportWithConfirmation(
+    report,
+    input,
+    dependencies,
+  );
+}
+
+function countFailureReportOutcome(
+  results: ReadonlyArray<MultipartCompletionFailureReportResult>,
+  outcome: MultipartCompletionFailureReportOutcome,
+): number {
+  return results.filter((item) => item.outcome === outcome).length;
+}
+
+function toFailureReportBatchResult(
+  results: ReadonlyArray<MultipartCompletionFailureReportResult>,
+): MultipartCompletionFailureReportBatchResult {
+  return {
+    claimed: results.length,
+    ambiguous: countFailureReportOutcome(results, "ambiguous"),
+    leaseLost: countFailureReportOutcome(results, "lease_lost"),
+    reported: countFailureReportOutcome(results, "reported"),
+    results,
+  };
+}
+
+export class MultipartCompletionFailureReportBatchError extends Error {
+  constructor(
+    readonly partialResult: MultipartCompletionFailureReportBatchResult,
+    cause: unknown,
+  ) {
+    super(
+      "Multipart completion failure-report batch failed after processing one or more reports.",
+      { cause },
+    );
+    this.name = "MultipartCompletionFailureReportBatchError";
+  }
+}
+
+export async function runMultipartCompletionFailureReportBatchWithDependencies(
+  input: MultipartCompletionFailureReportBatchInput,
+  dependencies: MultipartCompletionFailureReportProcessorDependencies,
+): Promise<MultipartCompletionFailureReportBatchResult> {
+  const results: Array<MultipartCompletionFailureReportResult> = [];
+  try {
+    while (
+      results.length < input.maximumReports
+      && input.signal.aborted === false
+      && dependencies.nowFn() + minimumNewJobBudgetMs < input.deadlineAtMs
+    ) {
+      const claimed = await dependencies.claimReportsFn({
+        leaseOwner: input.leaseOwner,
+        leaseDurationMs: input.leaseDurationMs,
+        limit: 1,
+        deadlineAtMs: input.deadlineAtMs,
+      });
+      const report = claimed[0];
+      if (report === undefined) break;
+      results.push(
+        await processClaimedMultipartCompletionFailureReportWithDependencies(
+          report,
+          input,
+          dependencies,
+        ),
+      );
+    }
+  } catch (error) {
+    throw new MultipartCompletionFailureReportBatchError(
+      toFailureReportBatchResult(results),
+      error,
+    );
+  }
+  return toFailureReportBatchResult(results);
+}
+
+const defaultFailureReportDependencies:
+MultipartCompletionFailureReportProcessorDependencies = {
+  claimReportsFn: claimMultipartCompletionFailureReports,
+  deliverReportFn: deliverMultipartCompletionFailureReport,
+  finishReportFn: finishMultipartCompletionFailureReport,
+  nowFn: Date.now,
+};
+
+export async function runMultipartCompletionFailureReportBatch(
+  input: MultipartCompletionFailureReportBatchInput,
+): Promise<MultipartCompletionFailureReportBatchResult> {
+  return runMultipartCompletionFailureReportBatchWithDependencies(
+    input,
+    defaultFailureReportDependencies,
+  );
+}

--- a/apps/backend/src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts
@@ -534,12 +534,19 @@ async function apply0098UpgradeAndAssertSecurity(
       );
       await client.query("COMMIT");
     } else {
+      const expectedBaseline = baseline.latest
+        === "0099_durable_multipart_completion_reconciliation.sql"
+        ? {
+            migrations: 101,
+            latest: "0099_durable_multipart_completion_reconciliation.sql",
+          }
+        : {
+            migrations: 100,
+            latest: "0098_multipart_writer_abort_and_terminal_replay.sql",
+          };
       assert.deepEqual(
         { migrations: baseline.migrations, latest: baseline.latest },
-        {
-          migrations: 100,
-          latest: "0098_multipart_writer_abort_and_terminal_replay.sql",
-        },
+        expectedBaseline,
       );
       assert.equal(baseline.history_index_present, true);
     }

--- a/apps/backend/src/mediaAssets/persistence/snapshots.test.ts
+++ b/apps/backend/src/mediaAssets/persistence/snapshots.test.ts
@@ -477,6 +477,29 @@ test("mapMediaAssetRow omits backend-only blob storage fields from public media 
   assert.equal(Object.prototype.hasOwnProperty.call(mediaAsset, "normalizationVersion"), false);
 });
 
+test("mapMediaAssetRow preserves legacy non-canonical operation identifiers on reads", () => {
+  const mediaBlob = createMediaBlobRow({
+    mediaBlobId: testMediaBlobId,
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: testSha256,
+    storageKey: testStorageKey,
+  });
+  const legacyLastOperationId = "legacy\u00a0operation";
+  const mediaAsset = mapMediaAssetRow(createMediaAssetRow({
+    mediaAssetId: testMediaAssetId,
+    mediaBlob,
+    sourceUrl: null,
+    clientUpdatedAt: "2026-02-28T09:00:00.000Z",
+    lastModifiedByReplicaId: "replica-old",
+    lastOperationId: legacyLastOperationId,
+    updatedAt: "2026-02-28T09:00:00.000Z",
+    deletedAt: null,
+  }));
+
+  assert.equal(mediaAsset.lastOperationId, legacyLastOperationId);
+});
+
 test("mapMediaBlobRow exposes backend-only blob normalization version", () => {
   const mediaBlob = mapMediaBlobRow(createMediaBlobRow({
     mediaBlobId: testMediaBlobId,
@@ -518,6 +541,36 @@ test("upsertMediaAssetSnapshotInExecutor reuses one blob row for duplicate logic
   assert.equal(blobRowsBySha256.size, 1);
   assert.equal(assetRowsById.get(testMediaAssetId)?.media_blob_id, testMediaBlobId);
   assert.equal(assetRowsById.get(secondMediaAssetId)?.media_blob_id, testMediaBlobId);
+});
+
+test("upsertMediaAssetSnapshotInExecutor rejects unsafe last operation identifiers before database work", async () => {
+  let queryCount = 0;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(): Promise<pg.QueryResult<Row>> {
+      queryCount += 1;
+      throw new Error("lastOperationId validation should run before database queries");
+    },
+  };
+
+  await assert.rejects(
+    upsertMediaAssetSnapshotInExecutor(
+      executor,
+      testWorkspaceId,
+      createSnapshotInput(testMediaAssetId),
+      {
+        clientUpdatedAt: "2026-02-28T10:00:00.000Z",
+        lastModifiedByReplicaId: "replica-new",
+        lastOperationId: "unsafe\u00a0operation",
+      },
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "MEDIA_ASSET_LAST_OPERATION_ID_INVALID");
+      return true;
+    },
+  );
+  assert.equal(queryCount, 0);
 });
 
 test("upsertMediaAssetSnapshotInExecutor rejects sha256 blob metadata collisions", async () => {

--- a/apps/backend/src/mediaAssets/persistence/snapshots.ts
+++ b/apps/backend/src/mediaAssets/persistence/snapshots.ts
@@ -20,6 +20,7 @@ import type {
   MediaAssetSyncMutationResult,
   MediaBlobNormalizationVersion,
 } from "../types";
+import { isValidMediaAssetLastOperationId } from "../lastOperationId";
 import { passthroughMediaBlobNormalizationVersion } from "../types";
 import { expectMediaAssetSourceUrl } from "../validators";
 import {
@@ -53,6 +54,14 @@ function toInputLwwMetadata(metadata: MediaAssetMutationMetadata): LwwMetadata {
 export function normalizeMediaAssetMutationMetadata(
   metadata: MediaAssetMutationMetadata,
 ): MediaAssetMutationMetadata {
+  if (isValidMediaAssetLastOperationId(metadata.lastOperationId) === false) {
+    throw new HttpError(
+      400,
+      "lastOperationId must be 1 to 1024 printable ASCII characters without leading or trailing spaces",
+      "MEDIA_ASSET_LAST_OPERATION_ID_INVALID",
+    );
+  }
+
   return {
     clientUpdatedAt: normalizeIsoTimestamp(metadata.clientUpdatedAt, "clientUpdatedAt"),
     lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
@@ -260,9 +269,9 @@ export async function upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
   metadata: MediaAssetMutationMetadata,
   normalizationVersion: MediaBlobNormalizationVersion,
 ): Promise<MediaAssetSyncMutationResult> {
-  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
   const normalizedInput = normalizeMediaAssetSnapshotInput(input);
   const normalizedMetadata = normalizeMediaAssetMutationMetadata(metadata);
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
 
   let existingRow = await findMediaAssetRowForUpdateInExecutor(executor, workspaceId, normalizedInput.mediaAssetId);
   if (existingRow === null) {

--- a/apps/backend/src/mediaAssets/storage/contracts.ts
+++ b/apps/backend/src/mediaAssets/storage/contracts.ts
@@ -110,6 +110,23 @@ export type CompleteMultipartMediaAssetUploadInput = Readonly<{
   observationScope: BackendObservationScope;
 }>;
 
+export type ReconcileMultipartMediaAssetUploadInput = Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  s3UploadId: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  lastOperationId: string;
+  partCount: number;
+  completedPartsFingerprint: string;
+  renewLease: () => Promise<void>;
+  signal: AbortSignal;
+  observationScope: BackendObservationScope;
+}>;
+
 export type AbortMultipartMediaAssetUploadInput = Readonly<{
   workspaceId: string;
   mediaAssetId: string;
@@ -137,6 +154,7 @@ export type MediaAssetStorageOperation =
   | "create_presigned_part_upload"
   | "complete_multipart_upload"
   | "abort_multipart_upload"
+  | "list_multipart_upload_parts"
   | "head_object"
   | "get_object"
   | "copy_object"

--- a/apps/backend/src/mediaAssets/storage/errors.ts
+++ b/apps/backend/src/mediaAssets/storage/errors.ts
@@ -9,22 +9,106 @@ import type {
 
 const maxS3AttemptCount = 3;
 
-export function getS3ErrorStatusCode(error: unknown): number | null {
+export const mediaAssetStorageMaximumAttemptCount = maxS3AttemptCount;
+
+export type MultipartCompletionReconciliationStorageTerminalErrorCode =
+  | "MULTIPART_UPLOAD_NOT_FOUND"
+  | "MULTIPART_PARTS_INVALID"
+  | "MULTIPART_PARTS_FINGERPRINT_MISMATCH"
+  | "MULTIPART_STAGING_OBJECT_MISMATCH"
+  | "MULTIPART_BLOB_OBJECT_MISMATCH"
+  | "S3_REQUEST_REJECTED";
+
+export type MultipartCompletionReconciliationS3Diagnostics = Readonly<{
+  operation: MediaAssetStorageOperation;
+  statusCode: number | null;
+  errorClass: string;
+  awsRequestId: string | null;
+  awsExtendedRequestId: string | null;
+}>;
+
+export class MultipartCompletionReconciliationStorageTransientError extends Error {
+  readonly code = "MULTIPART_STORAGE_TRANSIENT";
+  readonly safeMessage =
+    "Multipart completion storage is temporarily unavailable.";
+
+  constructor(
+    readonly operation: MediaAssetStorageOperation,
+    readonly statusCode: number | null,
+    cause: unknown,
+  ) {
+    super(
+      `Multipart completion reconciliation storage operation failed transiently. operation=${operation}; statusCode=${String(statusCode)}`,
+      { cause },
+    );
+    this.name = "MultipartCompletionReconciliationStorageTransientError";
+  }
+}
+
+export class MultipartCompletionReconciliationStorageTerminalError extends Error {
+  readonly safeMessage: string;
+
+  constructor(
+    readonly code: MultipartCompletionReconciliationStorageTerminalErrorCode,
+    safeMessage: string,
+    readonly s3Diagnostics:
+      MultipartCompletionReconciliationS3Diagnostics | null,
+    cause: unknown | null,
+  ) {
+    super(safeMessage, { cause });
+    this.name = "MultipartCompletionReconciliationStorageTerminalError";
+    this.safeMessage = safeMessage;
+  }
+}
+
+type S3ResponseMetadata = Readonly<{
+  httpStatusCode?: unknown;
+  requestId?: unknown;
+  extendedRequestId?: unknown;
+}>;
+
+function getS3ResponseMetadata(error: unknown): S3ResponseMetadata | null {
   if (typeof error !== "object" || error === null || !("$metadata" in error)) {
     return null;
   }
 
-  const metadata = (error as Readonly<{
-    $metadata?: Readonly<{
-      httpStatusCode?: unknown;
-    }>;
-  }>).$metadata;
+  const metadata = (error as Readonly<{ $metadata?: unknown }>).$metadata;
+  return typeof metadata === "object" && metadata !== null
+    ? metadata as S3ResponseMetadata
+    : null;
+}
 
+export function getS3ErrorStatusCode(error: unknown): number | null {
+  const metadata = getS3ResponseMetadata(error);
   return typeof metadata?.httpStatusCode === "number" ? metadata.httpStatusCode : null;
 }
 
 function getS3ErrorName(error: unknown): string {
-  return error instanceof Error ? error.name : "UnknownError";
+  const errorName = error instanceof Error ? error.name : "UnknownError";
+  return /^[A-Za-z0-9._-]{1,128}$/u.test(errorName)
+    ? errorName
+    : "UnknownError";
+}
+
+function getSafeAwsRequestId(value: unknown): string | null {
+  return typeof value === "string"
+    && /^[\x21-\x7e]{1,512}$/u.test(value)
+    ? value
+    : null;
+}
+
+export function createMultipartCompletionReconciliationS3Diagnostics(
+  operation: MediaAssetStorageOperation,
+  error: unknown,
+): MultipartCompletionReconciliationS3Diagnostics {
+  const metadata = getS3ResponseMetadata(error);
+  return {
+    operation,
+    statusCode: getS3ErrorStatusCode(error),
+    errorClass: getS3ErrorName(error),
+    awsRequestId: getSafeAwsRequestId(metadata?.requestId),
+    awsExtendedRequestId: getSafeAwsRequestId(metadata?.extendedRequestId),
+  };
 }
 
 function isHeadObjectUploadNotAvailableStatusCode(statusCode: number | null): boolean {
@@ -44,12 +128,28 @@ export async function runMediaAssetStorageOperationWithRetries<Result>(
   operation: MediaAssetStorageOperation,
   run: () => Promise<Result>,
 ): Promise<Result> {
+  return runMediaAssetStorageOperationWithRetriesAndOptionalAbortSignal(
+    context,
+    operation,
+    null,
+    run,
+  );
+}
+
+async function runMediaAssetStorageOperationWithRetriesAndOptionalAbortSignal<Result>(
+  context: MediaAssetStorageContext,
+  operation: MediaAssetStorageOperation,
+  signal: AbortSignal | null,
+  run: () => Promise<Result>,
+): Promise<Result> {
   let lastError: unknown = null;
 
   for (let attempt = 1; attempt <= maxS3AttemptCount; attempt += 1) {
+    signal?.throwIfAborted();
     try {
       return await run();
     } catch (error) {
+      signal?.throwIfAborted();
       lastError = error;
       if (attempt === maxS3AttemptCount) {
         break;
@@ -78,6 +178,24 @@ export async function runMediaAssetStorageOperationWithRetries<Result>(
   }
 
   throw lastError;
+}
+
+export function runMediaAssetStorageOperationWithRetriesAndAbortSignal<Result>(
+  context: MediaAssetStorageContext,
+  operation: MediaAssetStorageOperation,
+  signal: AbortSignal,
+  run: () => Promise<Result>,
+): Promise<Result> {
+  return runMediaAssetStorageOperationWithRetriesAndOptionalAbortSignal(
+    context,
+    operation,
+    signal,
+    run,
+  );
+}
+
+export function rethrowMediaAssetStorageAbortReason(signal: AbortSignal): void {
+  if (signal.aborted) signal.throwIfAborted();
 }
 
 export function createMediaAssetStorageError(

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
@@ -96,13 +96,15 @@ async function runS3<Result>(
   throw new GeneratedMediaPromotionStorageTransientError(lastStatusCode);
 }
 function toMetadata(response: Readonly<{
-  ContentLength?: number; ContentType?: string; ChecksumSHA256?: string;
+  ContentLength?: number; ContentType?: string; ETag?: string;
+  ChecksumSHA256?: string;
   ChecksumType?: "COMPOSITE" | "FULL_OBJECT";
   Metadata?: Readonly<Record<string, string>>;
 }>): GeneratedMediaObjectMetadata {
   return {
     sizeBytes: response.ContentLength ?? null,
     mimeType: response.ContentType ?? null,
+    eTag: response.ETag ?? null,
     checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
     checksumType: response.ChecksumType ?? null,
     customMetadata: response.Metadata ?? {},

--- a/apps/backend/src/mediaAssets/storage/index.ts
+++ b/apps/backend/src/mediaAssets/storage/index.ts
@@ -19,6 +19,7 @@ import type {
   PresignMediaAssetUploadInput,
   PresignMultipartMediaAssetUploadPartsInput,
   PromoteMediaAssetUploadInput,
+  ReconcileMultipartMediaAssetUploadInput,
   StoreMediaAssetBlobBytesInput,
 } from "./contracts";
 import {
@@ -26,6 +27,7 @@ import {
   completeMultipartMediaAssetUploadWithDependencies,
   createMultipartMediaAssetUploadWithDependencies,
 } from "./multipart";
+import { reconcileMultipartMediaAssetUploadWithDependencies } from "./multipartReconciliation";
 import {
   assertMediaAssetObjectMatchesWithDependencies,
   loadMediaAssetObjectBytesWithDependencies,
@@ -71,6 +73,7 @@ export type {
   PresignMediaAssetUploadInput,
   PresignMultipartMediaAssetUploadPartsInput,
   PromoteMediaAssetUploadInput,
+  ReconcileMultipartMediaAssetUploadInput,
   StoreMediaAssetBlobBytesInput,
 } from "./contracts";
 export {
@@ -78,6 +81,14 @@ export {
   completeMultipartMediaAssetUploadWithDependencies,
   createMultipartMediaAssetUploadWithDependencies,
 } from "./multipart";
+export {
+  createMultipartCompletedPartsFingerprint,
+  reconcileMultipartMediaAssetUploadWithDependencies,
+} from "./multipartReconciliation";
+export {
+  MultipartCompletionReconciliationStorageTerminalError,
+  MultipartCompletionReconciliationStorageTransientError,
+} from "./errors";
 export {
   assertMediaAssetObjectMatchesWithDependencies,
   loadMediaAssetObjectBytesWithDependencies,
@@ -178,6 +189,15 @@ export async function abortMultipartMediaAssetUpload(
   input: AbortMultipartMediaAssetUploadInput,
 ): Promise<void> {
   return abortMultipartMediaAssetUploadWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function reconcileMultipartMediaAssetUpload(
+  input: ReconcileMultipartMediaAssetUploadInput,
+): Promise<void> {
+  return reconcileMultipartMediaAssetUploadWithDependencies(input, {
     s3Client: getMediaAssetsS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });

--- a/apps/backend/src/mediaAssets/storage/multipartReconciliation.test.ts
+++ b/apps/backend/src/mediaAssets/storage/multipartReconciliation.test.ts
@@ -1,0 +1,1686 @@
+import {
+  CompleteMultipartUploadCommand,
+  CopyObjectCommand,
+  HeadObjectCommand,
+  ListPartsCommand,
+  S3Client,
+  S3ServiceException,
+} from "@aws-sdk/client-s3";
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  configureBackendRuntimeObservability,
+  resetBackendRuntimeObservability,
+} from "../../observability/runtime";
+import type { BackendBreadcrumbEvent } from "../../observability/sentry/events";
+import type { ReconcileMultipartMediaAssetUploadInput } from "./contracts";
+import {
+  MultipartCompletionReconciliationStorageTerminalError,
+  MultipartCompletionReconciliationStorageTransientError,
+} from "./errors";
+import {
+  createMultipartCompletedPartsFingerprint,
+  reconcileMultipartMediaAssetUploadWithDependencies,
+} from "./multipartReconciliation";
+import {
+  createHeadObjectResponse,
+  createS3Error,
+  getTestMediaAssetsStorageConfig,
+  getUnexpectedS3CommandName,
+  testBlobStorageKey,
+  testLastOperationId,
+  testMediaAssetId,
+  testObservationScope,
+  testSha256,
+  testStagingStorageKey,
+  testWorkspaceId,
+} from "./testHelpers";
+
+const listedParts = [
+  {
+    partNumber: 1,
+    eTag: "\"part-one\"",
+    sha256: "1".repeat(64),
+  },
+  {
+    partNumber: 2,
+    eTag: "\"part-two\"",
+    sha256: "2".repeat(64),
+  },
+] as const;
+
+function createListPartsResponse(): Readonly<{
+  Parts: ReadonlyArray<Readonly<{
+    PartNumber: number;
+    ETag: string;
+    ChecksumSHA256: string;
+  }>>;
+  IsTruncated: false;
+}> {
+  return {
+    Parts: listedParts.map((part) => ({
+      PartNumber: part.partNumber,
+      ETag: part.eTag,
+      ChecksumSHA256: Buffer.from(part.sha256, "hex").toString("base64"),
+    })),
+    IsTruncated: false,
+  };
+}
+
+function createInput(
+  completedPartsFingerprint: string,
+  renewLease: () => Promise<void>,
+): ReconcileMultipartMediaAssetUploadInput {
+  return {
+    workspaceId: testWorkspaceId,
+    mediaAssetId: testMediaAssetId,
+    stagingStorageKey: testStagingStorageKey,
+    blobStorageKey: testBlobStorageKey,
+    s3UploadId: "s3-upload-id",
+    mimeType: "application/octet-stream",
+    sizeBytes: 10,
+    sha256: testSha256,
+    lastOperationId: testLastOperationId,
+    partCount: listedParts.length,
+    completedPartsFingerprint,
+    renewLease,
+    signal: new AbortController().signal,
+    observationScope: testObservationScope,
+  };
+}
+
+function createMultipartHeadResponse(
+  checksumType: "COMPOSITE" | "FULL_OBJECT",
+  eTag: string,
+): ReturnType<typeof createHeadObjectResponse> {
+  return createHeadObjectResponse({
+    sizeBytes: 10,
+    mimeType: "application/octet-stream",
+    sha256: testSha256,
+    checksumSha256: checksumType === "FULL_OBJECT"
+      ? testSha256
+      : "a".repeat(64),
+    checksumType,
+    eTag,
+  });
+}
+
+function createPermanentBlobHeadResponse(
+  checksumSha256: string,
+): ReturnType<typeof createHeadObjectResponse> {
+  return {
+    ...createHeadObjectResponse({
+      sizeBytes: 10,
+      mimeType: "application/octet-stream",
+      sha256: testSha256,
+      checksumSha256,
+      checksumType: "FULL_OBJECT",
+      eTag: "\"blob-etag\"",
+    }),
+    Metadata: {
+      "flashcards-sha256": testSha256,
+    },
+  };
+}
+
+function createS3ClientWithSend(
+  send: (command: unknown) => Promise<unknown>,
+): S3Client {
+  const s3Client = new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  s3Client.send = send as S3Client["send"];
+  return s3Client;
+}
+
+function createNormalizationBoundaryS3Client(
+  onCopy: () => Promise<unknown>,
+): S3Client {
+  return createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      return createMultipartHeadResponse(
+        "COMPOSITE",
+        "\"multipart-etag\"",
+      );
+    }
+    if (command instanceof CopyObjectCommand) {
+      assert.equal(command.input.Key, testStagingStorageKey);
+      return onCopy();
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+}
+
+function createPromotionBoundaryS3Client(
+  onCopy: () => Promise<unknown>,
+): S3Client {
+  return createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      return createMultipartHeadResponse(
+        "FULL_OBJECT",
+        "\"normalized-etag\"",
+      );
+    }
+    if (command instanceof CopyObjectCommand) {
+      assert.equal(command.input.Key, testBlobStorageKey);
+      return onCopy();
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+}
+
+test("preserves missing storage configuration before HEAD", async () => {
+  const configurationError = new Error(
+    "MEDIA_ASSETS_S3_BUCKET_NAME is required for media asset storage.",
+  );
+  let s3Calls = 0;
+  const s3Client = createS3ClientWithSend(async () => {
+    s3Calls += 1;
+    return {};
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      {
+        s3Client,
+        getMediaAssetsStorageConfigFn: () => {
+          throw configurationError;
+        },
+      },
+    ),
+    (error: unknown) => error === configurationError,
+  );
+  assert.equal(s3Calls, 0);
+});
+
+test("rejects invalid storage configuration before HEAD", async () => {
+  let s3Calls = 0;
+  const s3Client = createS3ClientWithSend(async () => {
+    s3Calls += 1;
+    return {};
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      {
+        s3Client,
+        getMediaAssetsStorageConfigFn: () => ({ bucketName: " " }),
+      },
+    ),
+    {
+      name: "Error",
+      message:
+        "Media asset storage bucket name must be a non-empty trimmed string.",
+    },
+  );
+  assert.equal(s3Calls, 0);
+});
+
+test("preserves a local HEAD request-construction failure", async () => {
+  const localError = new TypeError("local HEAD request construction failed");
+  const s3Client = createS3ClientWithSend(async (command) => {
+    assert.ok(command instanceof HeadObjectCommand);
+    throw localError;
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === localError,
+  );
+});
+
+test("preserves a fake metadata-shaped error from HEAD", async () => {
+  const localError = Object.assign(
+    new Error("local error with HTTP-shaped metadata"),
+    { $metadata: { httpStatusCode: 503 } },
+  );
+  const s3Client = createS3ClientWithSend(async (command) => {
+    assert.ok(command instanceof HeadObjectCommand);
+    throw localError;
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === localError,
+  );
+});
+
+test("treats an S3 403 HEAD response as an explicit storage rejection", async () => {
+  let s3Calls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    assert.ok(command instanceof HeadObjectCommand);
+    s3Calls += 1;
+    throw createS3Error(403, "AccessDenied", "HEAD access denied");
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "S3_REQUEST_REJECTED");
+      return true;
+    },
+  );
+  assert.equal(s3Calls, 1);
+});
+
+test("treats an S3 404 HEAD response as object absence", async () => {
+  let blobPresent = false;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        if (blobPresent) return createPermanentBlobHeadResponse(testSha256);
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      return createMultipartHeadResponse("FULL_OBJECT", "\"staging-etag\"");
+    }
+    if (command instanceof CopyObjectCommand) {
+      assert.equal(command.input.Key, testBlobStorageKey);
+      blobPresent = true;
+      return {};
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(blobPresent, true);
+});
+
+test("retries a real S3 service failure and an identified transport failure", async () => {
+  const failures = [
+    createS3Error(503, "ServiceUnavailable", "S3 temporarily unavailable"),
+    Object.assign(new Error("socket timed out"), { code: "ETIMEDOUT" }),
+  ] as const;
+
+  for (const failure of failures) {
+    let s3Calls = 0;
+    const s3Client = createS3ClientWithSend(async (command) => {
+      assert.ok(command instanceof HeadObjectCommand);
+      s3Calls += 1;
+      throw failure;
+    });
+
+    await assert.rejects(
+      reconcileMultipartMediaAssetUploadWithDependencies(
+        createInput(
+          createMultipartCompletedPartsFingerprint(listedParts),
+          async () => undefined,
+        ),
+        {
+          s3Client,
+          getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+        },
+      ),
+      (error: unknown) => {
+        assert.ok(
+          error
+            instanceof MultipartCompletionReconciliationStorageTransientError,
+        );
+        assert.equal(error.operation, "head_object");
+        return true;
+      },
+    );
+    assert.equal(s3Calls, 3);
+  }
+});
+
+test("preserves a local ListParts request-construction failure", async () => {
+  const localError = new TypeError(
+    "local ListParts request construction failed",
+  );
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) throw localError;
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === localError,
+  );
+});
+
+test("preserves a local CompleteMultipartUpload request-construction failure", async () => {
+  const localError = new TypeError(
+    "local CompleteMultipartUpload request construction failed",
+  );
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      return {
+        Parts: listedParts.map((part) => ({
+          PartNumber: part.partNumber,
+          ETag: part.eTag,
+          ChecksumSHA256: Buffer.from(
+            part.sha256,
+            "hex",
+          ).toString("base64"),
+        })),
+        IsTruncated: false,
+      };
+    }
+    if (command instanceof CompleteMultipartUploadCommand) throw localError;
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === localError,
+  );
+});
+
+test("preserves a local staging normalization request-construction failure", async () => {
+  const localError = new TypeError(
+    "local staging normalization request construction failed",
+  );
+  const s3Client = createNormalizationBoundaryS3Client(async () => {
+    throw localError;
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === localError,
+  );
+});
+
+test("preserves a local blob promotion request-construction failure", async () => {
+  const localError = new TypeError(
+    "local blob promotion request construction failed",
+  );
+  const s3Client = createPromotionBoundaryS3Client(async () => {
+    throw localError;
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === localError,
+  );
+});
+
+test("accepts an exact permanent blob before reading expired staging state", async () => {
+  const observedHeadKeys: Array<string | undefined> = [];
+  const s3Client = new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  s3Client.send = (async (command: unknown) => {
+    if (command instanceof HeadObjectCommand) {
+      observedHeadKeys.push(command.input.Key);
+      if (command.input.Key === testBlobStorageKey) {
+        return createPermanentBlobHeadResponse(testSha256);
+      }
+      throw createS3Error(404, "NotFound", "expired staging");
+    }
+    throw new Error(`Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.deepEqual(observedHeadKeys, [testBlobStorageKey]);
+});
+
+test("rejects noncanonical permanent metadata without falling back to staging", async () => {
+  let stagingRead = false;
+  const s3Client = new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  s3Client.send = (async (command: unknown) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        return {
+          ...createPermanentBlobHeadResponse(testSha256),
+          Metadata: {
+            "flashcards-sha256": testSha256,
+            "flashcards-workspace-id": testWorkspaceId,
+          },
+        };
+      }
+      stagingRead = true;
+      throw createS3Error(404, "NotFound", "expired staging");
+    }
+    throw new Error(`Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_BLOB_OBJECT_MISMATCH");
+      return true;
+    },
+  );
+  assert.equal(stagingRead, false);
+});
+
+test("recovers completion between the initial staging HEAD and ListParts", async () => {
+  let stagingState: "absent" | "composite" | "full" = "absent";
+  let blobPresent = false;
+  let completeCalls = 0;
+  const copyKeys: Array<string | undefined> = [];
+  const headKeys: Array<string | undefined> = [];
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      headKeys.push(command.input.Key);
+      if (command.input.Key === testBlobStorageKey) {
+        if (blobPresent === false) {
+          throw createS3Error(404, "NotFound", "missing blob");
+        }
+        return createPermanentBlobHeadResponse(testSha256);
+      }
+      if (stagingState === "absent") {
+        throw createS3Error(404, "NotFound", "missing staging");
+      }
+      return createMultipartHeadResponse(
+        stagingState === "composite" ? "COMPOSITE" : "FULL_OBJECT",
+        stagingState === "composite"
+          ? "\"multipart-etag\""
+          : "\"normalized-etag\"",
+      );
+    }
+    if (command instanceof ListPartsCommand) {
+      stagingState = "composite";
+      throw createS3Error(
+        404,
+        "NoSuchUpload",
+        "completion won before ListParts",
+      );
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      completeCalls += 1;
+      return {};
+    }
+    if (command instanceof CopyObjectCommand) {
+      copyKeys.push(command.input.Key);
+      if (command.input.Key === testStagingStorageKey) {
+        stagingState = "full";
+      } else {
+        blobPresent = true;
+      }
+      return {};
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(completeCalls, 0);
+  assert.deepEqual(copyKeys, [
+    testStagingStorageKey,
+    testBlobStorageKey,
+  ]);
+  assert.deepEqual(headKeys, [
+    testBlobStorageKey,
+    testStagingStorageKey,
+    testBlobStorageKey,
+    testStagingStorageKey,
+    testStagingStorageKey,
+    testBlobStorageKey,
+    testBlobStorageKey,
+  ]);
+});
+
+test("accepts exact permanent promotion observed after CompleteMultipartUpload NoSuchUpload", async () => {
+  let blobHeadCalls = 0;
+  let completeCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        blobHeadCalls += 1;
+        if (blobHeadCalls === 1) {
+          throw createS3Error(404, "NotFound", "missing blob");
+        }
+        return createPermanentBlobHeadResponse(testSha256);
+      }
+      throw createS3Error(404, "NotFound", "missing staging");
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      completeCalls += 1;
+      throw createS3Error(
+        404,
+        "NoSuchUpload",
+        "same-SHA promotion completed first",
+      );
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(blobHeadCalls, 2);
+  assert.equal(completeCalls, 1);
+});
+
+test("resumes exact staging observed after CompleteMultipartUpload NoSuchUpload", async () => {
+  let stagingState: "absent" | "composite" | "full" = "absent";
+  let blobPresent = false;
+  let completeCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        if (blobPresent) return createPermanentBlobHeadResponse(testSha256);
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      if (stagingState === "absent") {
+        throw createS3Error(404, "NotFound", "missing staging");
+      }
+      return createMultipartHeadResponse(
+        stagingState === "composite" ? "COMPOSITE" : "FULL_OBJECT",
+        stagingState === "composite"
+          ? "\"multipart-etag\""
+          : "\"normalized-etag\"",
+      );
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      completeCalls += 1;
+      stagingState = "composite";
+      throw createS3Error(404, "NoSuchUpload", "completion became visible");
+    }
+    if (command instanceof CopyObjectCommand) {
+      if (command.input.Key === testStagingStorageKey) {
+        stagingState = "full";
+      } else {
+        blobPresent = true;
+      }
+      return {};
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(completeCalls, 1);
+  assert.equal(stagingState, "full");
+  assert.equal(blobPresent, true);
+});
+
+test("rejects mismatched permanent promotion after CompleteMultipartUpload NoSuchUpload", async () => {
+  let blobHeadCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        blobHeadCalls += 1;
+        if (blobHeadCalls === 1) {
+          throw createS3Error(404, "NotFound", "missing blob");
+        }
+        return createPermanentBlobHeadResponse("f".repeat(64));
+      }
+      throw createS3Error(404, "NotFound", "missing staging");
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      throw createS3Error(404, "NoSuchUpload", "promotion raced");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_BLOB_OBJECT_MISMATCH");
+      return true;
+    },
+  );
+});
+
+test("rejects mismatched staging observed after CompleteMultipartUpload NoSuchUpload", async () => {
+  let stagingHeadCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      stagingHeadCalls += 1;
+      if (stagingHeadCalls === 1) {
+        throw createS3Error(404, "NotFound", "missing staging");
+      }
+      return {
+        ...createMultipartHeadResponse("COMPOSITE", "\"multipart-etag\""),
+        ContentLength: 11,
+      };
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      throw createS3Error(404, "NoSuchUpload", "staging raced");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_STAGING_OBJECT_MISMATCH");
+      return true;
+    },
+  );
+});
+
+test("terminalizes CompleteMultipartUpload NoSuchUpload only after both objects remain absent", async () => {
+  let blobHeadCalls = 0;
+  let stagingHeadCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        blobHeadCalls += 1;
+      } else {
+        stagingHeadCalls += 1;
+      }
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_UPLOAD_NOT_FOUND");
+      return true;
+    },
+  );
+  assert.equal(blobHeadCalls, 2);
+  assert.equal(stagingHeadCalls, 3);
+});
+
+test("preserves lease loss and deadline during CompleteMultipartUpload NoSuchUpload recovery", async () => {
+  const leaseLostError = new Error("multipart reconciliation lease lost");
+  let renewals = 0;
+  const leaseClient = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => {
+          renewals += 1;
+          if (renewals === 5) throw leaseLostError;
+        },
+      ),
+      {
+        s3Client: leaseClient,
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown) => error === leaseLostError,
+  );
+
+  const controller = new AbortController();
+  const deadlineError = new Error("multipart reconciliation deadline");
+  const deadlineClient = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      controller.abort(deadlineError);
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      {
+        ...createInput(
+          createMultipartCompletedPartsFingerprint(listedParts),
+          async () => undefined,
+        ),
+        signal: controller.signal,
+      },
+      {
+        s3Client: deadlineClient,
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown) => error === deadlineError,
+  );
+});
+
+test("preserves sanitized runtime diagnostics for a terminal S3 rejection", async (context) => {
+  const breadcrumbs: Array<BackendBreadcrumbEvent> = [];
+  configureBackendRuntimeObservability(
+    "multipart-completion-reconciliation",
+    {
+      addBreadcrumb: (event) => {
+        breadcrumbs.push(event);
+      },
+      captureWarning: () => undefined,
+      captureException: () => undefined,
+    },
+  );
+  context.after(() => {
+    resetBackendRuntimeObservability();
+  });
+  const s3Error = new S3ServiceException({
+    name: "AccessDenied",
+    $fault: "client",
+    $metadata: {
+      httpStatusCode: 400,
+      requestId: "aws-request-id",
+      extendedRequestId: "aws-extended-request-id",
+    },
+    message: "completion rejected with private provider context",
+  });
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      return createListPartsResponse();
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      throw s3Error;
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "S3_REQUEST_REJECTED");
+      assert.equal(error.cause, s3Error);
+      assert.deepEqual(error.s3Diagnostics, {
+        operation: "complete_multipart_upload",
+        statusCode: 400,
+        errorClass: "AccessDenied",
+        awsRequestId: "aws-request-id",
+        awsExtendedRequestId: "aws-extended-request-id",
+      });
+      return true;
+    },
+  );
+  assert.deepEqual(breadcrumbs, [
+    {
+      action: "media_asset_storage_terminal",
+      scope: testObservationScope,
+      details: {
+        workspaceId: testWorkspaceId,
+        mediaAssetId: testMediaAssetId,
+        operation: "complete_multipart_upload",
+        statusCode: 400,
+        errorClass: "AccessDenied",
+        awsRequestId: "aws-request-id",
+        awsExtendedRequestId: "aws-extended-request-id",
+      },
+    },
+  ]);
+  assert.equal(
+    JSON.stringify(breadcrumbs).includes("private provider context"),
+    false,
+  );
+});
+
+test("accepts exact permanent promotion completed before ListParts", async () => {
+  let blobPresent = false;
+  let stagingHeadCalls = 0;
+  let copyCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        if (blobPresent === false) {
+          throw createS3Error(404, "NotFound", "missing blob");
+        }
+        return createPermanentBlobHeadResponse(testSha256);
+      }
+      stagingHeadCalls += 1;
+      throw createS3Error(404, "NotFound", "missing staging");
+    }
+    if (command instanceof ListPartsCommand) {
+      blobPresent = true;
+      throw createS3Error(
+        404,
+        "NoSuchUpload",
+        "promotion won before ListParts",
+      );
+    }
+    if (command instanceof CopyObjectCommand) {
+      copyCalls += 1;
+      return {};
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(stagingHeadCalls, 1);
+  assert.equal(copyCalls, 0);
+});
+
+test("rejects mismatched permanent promotion observed after NoSuchUpload", async () => {
+  let blobHeadCalls = 0;
+  let stagingHeadCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        blobHeadCalls += 1;
+        if (blobHeadCalls === 1) {
+          throw createS3Error(404, "NotFound", "missing blob");
+        }
+        return createPermanentBlobHeadResponse("f".repeat(64));
+      }
+      stagingHeadCalls += 1;
+      throw createS3Error(404, "NotFound", "missing staging");
+    }
+    if (command instanceof ListPartsCommand) {
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_BLOB_OBJECT_MISMATCH");
+      return true;
+    },
+  );
+  assert.equal(blobHeadCalls, 2);
+  assert.equal(stagingHeadCalls, 1);
+});
+
+test("rejects mismatched staging completion observed after NoSuchUpload", async () => {
+  let stagingHeadCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      stagingHeadCalls += 1;
+      if (stagingHeadCalls === 1) {
+        throw createS3Error(404, "NotFound", "missing staging");
+      }
+      return {
+        ...createMultipartHeadResponse(
+          "COMPOSITE",
+          "\"multipart-etag\"",
+        ),
+        ContentLength: 11,
+      };
+    }
+    if (command instanceof ListPartsCommand) {
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_STAGING_OBJECT_MISMATCH");
+      return true;
+    },
+  );
+  assert.equal(stagingHeadCalls, 2);
+});
+
+test("terminalizes NoSuchUpload only after both object rechecks remain absent", async () => {
+  let blobHeadCalls = 0;
+  let stagingHeadCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testBlobStorageKey) {
+        blobHeadCalls += 1;
+      } else {
+        stagingHeadCalls += 1;
+      }
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_UPLOAD_NOT_FOUND");
+      return true;
+    },
+  );
+  assert.equal(blobHeadCalls, 2);
+  assert.equal(stagingHeadCalls, 2);
+});
+
+test("retries a transient permanent-object recheck after NoSuchUpload", async () => {
+  let blobHeadCalls = 0;
+  let renewals = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testStagingStorageKey) {
+        throw createS3Error(404, "NotFound", "missing staging");
+      }
+      blobHeadCalls += 1;
+      if (blobHeadCalls === 1) {
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      if (blobHeadCalls === 2) {
+        throw createS3Error(500, "InternalError", "temporary HEAD failure");
+      }
+      return createPermanentBlobHeadResponse(testSha256);
+    }
+    if (command instanceof ListPartsCommand) {
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => {
+        renewals += 1;
+      },
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(blobHeadCalls, 3);
+  assert.equal(renewals, 5);
+});
+
+test("stops NoSuchUpload recovery at the active deadline", async () => {
+  const controller = new AbortController();
+  const deadlineError = new Error("multipart reconciliation deadline");
+  let headCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      headCalls += 1;
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      controller.abort(deadlineError);
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+  const input = {
+    ...createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    signal: controller.signal,
+  };
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      input,
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === deadlineError,
+  );
+  assert.equal(headCalls, 2);
+});
+
+test("propagates lease loss before NoSuchUpload object rechecks", async () => {
+  const leaseLostError = new Error("multipart reconciliation lease lost");
+  let renewals = 0;
+  let headCalls = 0;
+  const s3Client = createS3ClientWithSend(async (command) => {
+    if (command instanceof HeadObjectCommand) {
+      headCalls += 1;
+      throw createS3Error(404, "NotFound", "missing object");
+    }
+    if (command instanceof ListPartsCommand) {
+      throw createS3Error(404, "NoSuchUpload", "upload disappeared");
+    }
+    throw new Error(
+      `Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`,
+    );
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => {
+          renewals += 1;
+          if (renewals === 4) throw leaseLostError;
+        },
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === leaseLostError,
+  );
+  assert.equal(renewals, 4);
+  assert.equal(headCalls, 2);
+});
+
+test("preserves a staging normalization lease renewal failure", async () => {
+  const leaseError = new Error("staging normalization lease renewal failed");
+  let renewals = 0;
+  let copyCalls = 0;
+  const s3Client = createNormalizationBoundaryS3Client(async () => {
+    copyCalls += 1;
+    return {};
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => {
+          renewals += 1;
+          if (renewals === 3) throw leaseError;
+        },
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === leaseError,
+  );
+  assert.equal(renewals, 3);
+  assert.equal(copyCalls, 0);
+});
+
+test("preserves cancellation before staging normalization", async () => {
+  const controller = new AbortController();
+  const cancellationError = new Error("staging normalization cancelled");
+  let renewals = 0;
+  let copyCalls = 0;
+  const s3Client = createNormalizationBoundaryS3Client(async () => {
+    copyCalls += 1;
+    return {};
+  });
+  const input = {
+    ...createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => {
+        renewals += 1;
+        if (renewals === 3) controller.abort(cancellationError);
+      },
+    ),
+    signal: controller.signal,
+  };
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      input,
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === cancellationError,
+  );
+  assert.equal(renewals, 3);
+  assert.equal(copyCalls, 0);
+});
+
+test("normalizes a genuine staging normalization S3 rejection", async () => {
+  let copyCalls = 0;
+  const s3Client = createNormalizationBoundaryS3Client(async () => {
+    copyCalls += 1;
+    throw createS3Error(400, "AccessDenied", "normalization rejected");
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "S3_REQUEST_REJECTED");
+      return true;
+    },
+  );
+  assert.equal(copyCalls, 1);
+});
+
+test("preserves a blob promotion lease renewal failure", async () => {
+  const leaseError = new Error("blob promotion lease renewal failed");
+  let renewals = 0;
+  let copyCalls = 0;
+  const s3Client = createPromotionBoundaryS3Client(async () => {
+    copyCalls += 1;
+    return {};
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => {
+          renewals += 1;
+          if (renewals === 4) throw leaseError;
+        },
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === leaseError,
+  );
+  assert.equal(renewals, 4);
+  assert.equal(copyCalls, 0);
+});
+
+test("preserves cancellation before blob promotion", async () => {
+  const controller = new AbortController();
+  const cancellationError = new Error("blob promotion cancelled");
+  let renewals = 0;
+  let copyCalls = 0;
+  const s3Client = createPromotionBoundaryS3Client(async () => {
+    copyCalls += 1;
+    return {};
+  });
+  const input = {
+    ...createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => {
+        renewals += 1;
+        if (renewals === 4) controller.abort(cancellationError);
+      },
+    ),
+    signal: controller.signal,
+  };
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      input,
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => error === cancellationError,
+  );
+  assert.equal(renewals, 4);
+  assert.equal(copyCalls, 0);
+});
+
+test("normalizes a genuine blob promotion S3 rejection", async () => {
+  let copyCalls = 0;
+  const s3Client = createPromotionBoundaryS3Client(async () => {
+    copyCalls += 1;
+    throw createS3Error(400, "AccessDenied", "promotion rejected");
+  });
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput(
+        createMultipartCompletedPartsFingerprint(listedParts),
+        async () => undefined,
+      ),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "S3_REQUEST_REJECTED");
+      return true;
+    },
+  );
+  assert.equal(copyCalls, 1);
+});
+
+test("reconciles paginated multipart parts, normalizes staging, and promotes without GET", async () => {
+  let stagingState: "absent" | "composite" | "full" = "absent";
+  let blobPresent = false;
+  let renewals = 0;
+  const listCommands: Array<ListPartsCommand> = [];
+  const completeCommands: Array<CompleteMultipartUploadCommand> = [];
+  const copyCommands: Array<CopyObjectCommand> = [];
+  const s3Client = new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  s3Client.send = (async (command: unknown) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testStagingStorageKey) {
+        if (stagingState === "absent") {
+          throw createS3Error(404, "NotFound", "missing staging");
+        }
+        return createMultipartHeadResponse(
+          stagingState === "composite" ? "COMPOSITE" : "FULL_OBJECT",
+          stagingState === "composite"
+            ? "\"multipart-etag\""
+            : "\"normalized-etag\"",
+        );
+      }
+      if (command.input.Key === testBlobStorageKey) {
+        if (blobPresent === false) {
+          throw createS3Error(404, "NotFound", "missing blob");
+        }
+        return createPermanentBlobHeadResponse(testSha256);
+      }
+    }
+    if (command instanceof ListPartsCommand) {
+      listCommands.push(command);
+      if (command.input.PartNumberMarker === undefined) {
+        return {
+          Parts: [{
+            PartNumber: 1,
+            ETag: listedParts[0].eTag,
+            ChecksumSHA256: Buffer.from(
+              listedParts[0].sha256,
+              "hex",
+            ).toString("base64"),
+          }],
+          IsTruncated: true,
+          NextPartNumberMarker: "1",
+        };
+      }
+      return {
+        Parts: [{
+          PartNumber: 2,
+          ETag: listedParts[1].eTag,
+          ChecksumSHA256: Buffer.from(
+            listedParts[1].sha256,
+            "hex",
+          ).toString("base64"),
+        }],
+        IsTruncated: false,
+      };
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      completeCommands.push(command);
+      stagingState = "composite";
+      return {};
+    }
+    if (command instanceof CopyObjectCommand) {
+      copyCommands.push(command);
+      if (command.input.Key === testStagingStorageKey) {
+        stagingState = "full";
+      } else if (command.input.Key === testBlobStorageKey) {
+        blobPresent = true;
+      }
+      return {};
+    }
+    throw new Error(`Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => {
+        renewals += 1;
+      },
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(listCommands.length, 2);
+  assert.equal(listCommands[0]?.input.PartNumberMarker, undefined);
+  assert.equal(listCommands[1]?.input.PartNumberMarker, "1");
+  assert.equal(completeCommands.length, 1);
+  assert.deepEqual(
+    completeCommands[0]?.input.MultipartUpload?.Parts?.map((part) => ({
+      partNumber: part.PartNumber,
+      eTag: part.ETag,
+      sha256: Buffer.from(part.ChecksumSHA256 ?? "", "base64").toString("hex"),
+    })),
+    listedParts,
+  );
+  assert.equal(copyCommands.length, 2);
+  assert.equal(copyCommands[0]?.input.Key, testStagingStorageKey);
+  assert.equal(copyCommands[0]?.input.CopySourceIfMatch, "\"multipart-etag\"");
+  assert.equal(copyCommands[1]?.input.Key, testBlobStorageKey);
+  assert.equal(copyCommands[1]?.input.IfNoneMatch, "*");
+  assert.ok(renewals >= 9);
+});
+
+test("rejects a ListParts fingerprint mismatch before completing", async () => {
+  let completed = false;
+  const s3Client = new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  s3Client.send = (async (command: unknown) => {
+    if (command instanceof HeadObjectCommand) {
+      throw createS3Error(404, "NotFound", "missing staging");
+    }
+    if (command instanceof ListPartsCommand) {
+      return {
+        Parts: listedParts.map((part) => ({
+          PartNumber: part.partNumber,
+          ETag: part.eTag,
+          ChecksumSHA256: Buffer.from(part.sha256, "hex").toString("base64"),
+        })),
+        IsTruncated: false,
+      };
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      completed = true;
+      return {};
+    }
+    throw new Error(`Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await assert.rejects(
+    reconcileMultipartMediaAssetUploadWithDependencies(
+      createInput("f".repeat(64), async () => undefined),
+      { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+    ),
+    (error: unknown) => {
+      assert.ok(
+        error instanceof MultipartCompletionReconciliationStorageTerminalError,
+      );
+      assert.equal(error.code, "MULTIPART_PARTS_FINGERPRINT_MISMATCH");
+      return true;
+    },
+  );
+  assert.equal(completed, false);
+});
+
+test("resumes unknown complete, normalization, and promotion outcomes from HEAD state", async () => {
+  let stagingState: "absent" | "composite" | "full" = "absent";
+  let blobPresent = false;
+  let completeCalls = 0;
+  let stagingCopyCalls = 0;
+  let blobCopyCalls = 0;
+  const s3Client = new S3Client({
+    credentials: {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+    },
+    region: "us-east-1",
+  });
+  s3Client.send = (async (command: unknown) => {
+    if (command instanceof HeadObjectCommand) {
+      if (command.input.Key === testStagingStorageKey) {
+        if (stagingState === "absent") {
+          throw createS3Error(404, "NotFound", "missing staging");
+        }
+        return createMultipartHeadResponse(
+          stagingState === "composite" ? "COMPOSITE" : "FULL_OBJECT",
+          stagingState === "composite"
+            ? "\"multipart-etag\""
+            : "\"normalized-etag\"",
+        );
+      }
+      if (blobPresent === false) {
+        throw createS3Error(404, "NotFound", "missing blob");
+      }
+      return createPermanentBlobHeadResponse(testSha256);
+    }
+    if (command instanceof ListPartsCommand) {
+      return {
+        Parts: listedParts.map((part) => ({
+          PartNumber: part.partNumber,
+          ETag: part.eTag,
+          ChecksumSHA256: Buffer.from(part.sha256, "hex").toString("base64"),
+        })),
+        IsTruncated: false,
+      };
+    }
+    if (command instanceof CompleteMultipartUploadCommand) {
+      completeCalls += 1;
+      stagingState = "composite";
+      throw createS3Error(500, "InternalError", "unknown complete outcome");
+    }
+    if (command instanceof CopyObjectCommand) {
+      if (command.input.Key === testStagingStorageKey) {
+        stagingCopyCalls += 1;
+        stagingState = "full";
+        throw createS3Error(500, "InternalError", "unknown normalize outcome");
+      }
+      blobCopyCalls += 1;
+      blobPresent = true;
+      throw createS3Error(500, "InternalError", "unknown promote outcome");
+    }
+    throw new Error(`Unexpected S3 command: ${getUnexpectedS3CommandName(command)}`);
+  }) as S3Client["send"];
+
+  await reconcileMultipartMediaAssetUploadWithDependencies(
+    createInput(
+      createMultipartCompletedPartsFingerprint(listedParts),
+      async () => undefined,
+    ),
+    { s3Client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig },
+  );
+
+  assert.equal(completeCalls, 1);
+  assert.equal(stagingCopyCalls, 1);
+  assert.equal(blobCopyCalls, 1);
+});

--- a/apps/backend/src/mediaAssets/storage/multipartReconciliation.ts
+++ b/apps/backend/src/mediaAssets/storage/multipartReconciliation.ts
@@ -1,0 +1,870 @@
+import {
+  CompleteMultipartUploadCommand,
+  CopyObjectCommand,
+  HeadObjectCommand,
+  ListPartsCommand,
+  S3ServiceException,
+  type CompletedPart,
+  type ListPartsCommandOutput,
+} from "@aws-sdk/client-s3";
+import { createHash } from "node:crypto";
+import { addBackendRuntimeBreadcrumb } from "../../observability/runtime";
+import { HttpError } from "../../shared/errors";
+import type { MediaAssetObjectMetadata } from "../types";
+import type {
+  AssertMediaAssetObjectInput,
+  MediaAssetStorageDependencies,
+  MediaAssetStorageOperation,
+  ReconcileMultipartMediaAssetUploadInput,
+} from "./contracts";
+import {
+  createMultipartCompletionReconciliationS3Diagnostics,
+  getS3ErrorStatusCode,
+  isCopyObjectIfNoneMatchFailure,
+  isNoSuchMultipartUploadError,
+  mediaAssetStorageMaximumAttemptCount,
+  MultipartCompletionReconciliationStorageTerminalError,
+  MultipartCompletionReconciliationStorageTransientError,
+} from "./errors";
+import {
+  assertMediaAssetObjectContentMatches,
+  assertMediaAssetObjectMetadataMatches,
+  assertMediaAssetObjectShapeAndProofMatches,
+  createUploadProofMetadata,
+  toBase64Sha256Digest,
+  toHexSha256Digest,
+  uploadProofSha256Key,
+  uploadProofLastOperationIdSha256Key,
+  uploadProofMediaAssetIdKey,
+  uploadProofWorkspaceIdKey,
+} from "./proof";
+
+const maximumMultipartPartCount = 10_000;
+const listPartsPageSize = 1_000;
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+
+type ListedMultipartPart = Readonly<{
+  partNumber: number;
+  eTag: string;
+  sha256: string;
+}>;
+
+type MultipartReconciliationObjectMetadata =
+  MediaAssetObjectMetadata
+  & Readonly<{ customMetadata: Readonly<Record<string, string>> }>;
+
+class S3OperationRejectedError extends Error {
+  constructor(readonly s3Error: unknown) {
+    super("Multipart reconciliation S3 operation was rejected.", {
+      cause: s3Error,
+    });
+    this.name = "S3OperationRejectedError";
+  }
+}
+
+type S3ErrorFields = Readonly<{
+  $retryable?: unknown;
+  code?: unknown;
+  name?: unknown;
+}>;
+
+function readS3ErrorFields(error: unknown): S3ErrorFields | null {
+  return typeof error === "object" && error !== null
+    ? error as S3ErrorFields
+    : null;
+}
+
+function isS3TransportError(error: unknown): boolean {
+  const fields = readS3ErrorFields(error);
+  return fields?.name === "TimeoutError"
+    || (typeof fields?.code === "string"
+      && [
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "EPIPE",
+        "ETIMEDOUT",
+        "EHOSTUNREACH",
+        "ENETUNREACH",
+        "ENOTFOUND",
+        "EAI_AGAIN",
+      ].includes(fields.code));
+}
+
+function isRecognizedS3Error(error: unknown): boolean {
+  return error instanceof S3ServiceException
+    || isS3TransportError(error);
+}
+
+function isMissingS3ObjectError(error: unknown): boolean {
+  return error instanceof S3ServiceException
+    && (
+      getS3ErrorStatusCode(error) === 404
+      || error.name === "NoSuchKey"
+    );
+}
+
+function createCopySource(bucketName: string, storageKey: string): string {
+  return `${bucketName}/${storageKey.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+function isTransientS3Error(error: unknown): boolean {
+  if (isRecognizedS3Error(error) === false) return false;
+  const statusCode = getS3ErrorStatusCode(error);
+  const fields = readS3ErrorFields(error);
+  return fields?.$retryable !== undefined
+    || isS3TransportError(error)
+    || (statusCode !== null
+      && ([408, 409, 425, 429].includes(statusCode) || statusCode >= 500));
+}
+
+function readBucketName(
+  dependencies: MediaAssetStorageDependencies,
+): string {
+  const { bucketName } = dependencies.getMediaAssetsStorageConfigFn();
+  if (
+    typeof bucketName !== "string"
+    || bucketName.trim() === ""
+    || bucketName.trim() !== bucketName
+  ) {
+    throw new Error(
+      "Media asset storage bucket name must be a non-empty trimmed string.",
+    );
+  }
+  return bucketName;
+}
+
+function createTerminalStorageError(
+  code:
+    | "MULTIPART_UPLOAD_NOT_FOUND"
+    | "MULTIPART_PARTS_INVALID"
+    | "MULTIPART_PARTS_FINGERPRINT_MISMATCH"
+    | "MULTIPART_STAGING_OBJECT_MISMATCH"
+    | "MULTIPART_BLOB_OBJECT_MISMATCH"
+    | "S3_REQUEST_REJECTED",
+  safeMessage: string,
+): MultipartCompletionReconciliationStorageTerminalError {
+  return new MultipartCompletionReconciliationStorageTerminalError(
+    code,
+    safeMessage,
+    null,
+    null,
+  );
+}
+
+function createTerminalS3StorageError(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  operation: MediaAssetStorageOperation,
+  safeMessage: string,
+  error: unknown,
+): MultipartCompletionReconciliationStorageTerminalError {
+  const diagnostics =
+    createMultipartCompletionReconciliationS3Diagnostics(operation, error);
+  addBackendRuntimeBreadcrumb({
+    action: "media_asset_storage_terminal",
+    scope: input.observationScope,
+    details: {
+      workspaceId: input.workspaceId,
+      mediaAssetId: input.mediaAssetId,
+      ...diagnostics,
+    },
+  });
+  return new MultipartCompletionReconciliationStorageTerminalError(
+    "S3_REQUEST_REJECTED",
+    safeMessage,
+    diagnostics,
+    error,
+  );
+}
+
+async function runS3Operation<Result>(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  operation: MediaAssetStorageOperation,
+  run: () => Promise<Result>,
+): Promise<Result> {
+  let lastError: unknown = null;
+  for (
+    let attempt = 1;
+    attempt <= mediaAssetStorageMaximumAttemptCount;
+    attempt += 1
+  ) {
+    input.signal.throwIfAborted();
+    await input.renewLease();
+    input.signal.throwIfAborted();
+    try {
+      return await run();
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (isRecognizedS3Error(error) === false) throw error;
+      lastError = error;
+      if (isTransientS3Error(error) === false) {
+        throw new S3OperationRejectedError(error);
+      }
+      if (attempt === mediaAssetStorageMaximumAttemptCount) break;
+      addStorageRetryBreadcrumb(input, operation, attempt, error);
+    }
+  }
+
+  throw new MultipartCompletionReconciliationStorageTransientError(
+    operation,
+    getS3ErrorStatusCode(lastError),
+    lastError,
+  );
+}
+
+function addStorageRetryBreadcrumb(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  operation: MediaAssetStorageOperation,
+  attempt: number,
+  error: unknown,
+): void {
+  addBackendRuntimeBreadcrumb({
+    action: "media_asset_storage_retry",
+    scope: input.observationScope,
+    details: {
+      operation,
+      attempt,
+      maxAttempts: mediaAssetStorageMaximumAttemptCount,
+      workspaceId: input.workspaceId,
+      mediaAssetId: input.mediaAssetId,
+      statusCode: getS3ErrorStatusCode(error),
+      errorClass: error instanceof Error ? error.name : "UnknownError",
+    },
+  });
+}
+
+function toObjectMetadata(response: Readonly<{
+  ContentLength?: number;
+  ContentType?: string;
+  ETag?: string;
+  ChecksumSHA256?: string;
+  ChecksumType?: "COMPOSITE" | "FULL_OBJECT";
+  Metadata?: Readonly<Record<string, string>>;
+}>): MultipartReconciliationObjectMetadata {
+  return {
+    sizeBytes: response.ContentLength ?? null,
+    mimeType: response.ContentType ?? null,
+    eTag: response.ETag ?? null,
+    checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
+    checksumType: response.ChecksumType ?? null,
+    uploadProof: {
+      workspaceId: response.Metadata?.[uploadProofWorkspaceIdKey] ?? null,
+      mediaAssetId: response.Metadata?.[uploadProofMediaAssetIdKey] ?? null,
+      lastOperationIdSha256:
+        response.Metadata?.[uploadProofLastOperationIdSha256Key] ?? null,
+      sha256: response.Metadata?.[uploadProofSha256Key] ?? null,
+    },
+    customMetadata: response.Metadata ?? {},
+  };
+}
+
+async function headObject(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  storageKey: string,
+  bucketName: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<MultipartReconciliationObjectMetadata | null> {
+  const command = new HeadObjectCommand({
+    Bucket: bucketName,
+    Key: storageKey,
+    ChecksumMode: "ENABLED",
+  });
+  try {
+    const response = await runS3Operation(
+      input,
+      "head_object",
+      async () => dependencies.s3Client.send(
+        command,
+        { abortSignal: input.signal },
+      ),
+    );
+    return toObjectMetadata(response);
+  } catch (error) {
+    input.signal.throwIfAborted();
+    if (
+      error instanceof MultipartCompletionReconciliationStorageTransientError
+    ) {
+      throw error;
+    }
+    if (!(error instanceof S3OperationRejectedError)) throw error;
+    if (isMissingS3ObjectError(error.s3Error)) return null;
+    const statusCode = getS3ErrorStatusCode(error.s3Error);
+    throw createTerminalS3StorageError(
+      input,
+      "head_object",
+      `Object storage rejected multipart reconciliation HEAD. statusCode=${String(statusCode)}`,
+      error.s3Error,
+    );
+  }
+}
+
+function createObjectInput(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  storageKey: string,
+): AssertMediaAssetObjectInput {
+  return {
+    workspaceId: input.workspaceId,
+    mediaAssetId: input.mediaAssetId,
+    storageKey,
+    mimeType: input.mimeType,
+    sizeBytes: input.sizeBytes,
+    sha256: input.sha256,
+    lastOperationId: input.lastOperationId,
+    observationScope: input.observationScope,
+  };
+}
+
+function assertStagingShapeAndProof(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  metadata: MediaAssetObjectMetadata,
+): void {
+  try {
+    assertMediaAssetObjectShapeAndProofMatches(
+      createObjectInput(input, input.stagingStorageKey),
+      metadata,
+    );
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw createTerminalStorageError(
+        "MULTIPART_STAGING_OBJECT_MISMATCH",
+        "Multipart staging object does not match its durable completion proof.",
+      );
+    }
+    throw error;
+  }
+}
+
+function assertStagingFullObject(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  metadata: MediaAssetObjectMetadata,
+): void {
+  try {
+    assertMediaAssetObjectMetadataMatches(
+      createObjectInput(input, input.stagingStorageKey),
+      metadata,
+    );
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw createTerminalStorageError(
+        "MULTIPART_STAGING_OBJECT_MISMATCH",
+        "Multipart staging object does not match its durable full-object checksum.",
+      );
+    }
+    throw error;
+  }
+}
+
+function assertBlobFullObject(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  metadata: MultipartReconciliationObjectMetadata,
+): void {
+  try {
+    assertMediaAssetObjectContentMatches(
+      createObjectInput(input, input.blobStorageKey),
+      metadata,
+    );
+    if (
+      Object.keys(metadata.customMetadata).length !== 1
+      || metadata.customMetadata[uploadProofSha256Key] !== input.sha256
+    ) {
+      throw new HttpError(
+        409,
+        "Existing media blob contains invalid permanent-object metadata.",
+        "MEDIA_ASSET_UPLOAD_MISMATCH",
+      );
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw createTerminalStorageError(
+        "MULTIPART_BLOB_OBJECT_MISMATCH",
+        "Existing media blob does not match the durable multipart completion.",
+      );
+    }
+    throw error;
+  }
+}
+
+export function createMultipartCompletedPartsFingerprint(
+  parts: ReadonlyArray<ListedMultipartPart>,
+): string {
+  const canonicalParts = [...parts]
+    .sort((left, right) => left.partNumber - right.partNumber)
+    .map((part) => [part.partNumber, part.eTag, part.sha256] as const);
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalParts))
+    .digest("hex");
+}
+
+function readListedPart(
+  part: Readonly<{
+    PartNumber?: number;
+    ETag?: string;
+    ChecksumSHA256?: string;
+  }>,
+): ListedMultipartPart {
+  const partNumber = part.PartNumber;
+  const eTag = part.ETag;
+  const sha256 = toHexSha256Digest(part.ChecksumSHA256);
+  if (
+    typeof partNumber !== "number"
+    || Number.isSafeInteger(partNumber) === false
+    || partNumber < 1
+    || partNumber > maximumMultipartPartCount
+    || typeof eTag !== "string"
+    || eTag.trim() === ""
+    || eTag.length > 256
+    || sha256 === null
+    || sha256Pattern.test(sha256) === false
+  ) {
+    throw createTerminalStorageError(
+      "MULTIPART_PARTS_INVALID",
+      "S3 returned an invalid multipart part number, ETag, or SHA-256 checksum.",
+    );
+  }
+  return { partNumber, eTag, sha256 };
+}
+
+async function listMultipartParts(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  bucketName: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<ReadonlyArray<ListedMultipartPart>> {
+  const parts: Array<ListedMultipartPart> = [];
+  let partNumberMarker: string | undefined;
+  while (true) {
+    let response: ListPartsCommandOutput;
+    const command = new ListPartsCommand({
+      Bucket: bucketName,
+      Key: input.stagingStorageKey,
+      UploadId: input.s3UploadId,
+      MaxParts: listPartsPageSize,
+      PartNumberMarker: partNumberMarker,
+    });
+    try {
+      response = await runS3Operation(
+        input,
+        "list_multipart_upload_parts",
+        async () => dependencies.s3Client.send(
+          command,
+          { abortSignal: input.signal },
+        ),
+      );
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (
+        error instanceof MultipartCompletionReconciliationStorageTransientError
+      ) {
+        throw error;
+      }
+      if (!(error instanceof S3OperationRejectedError)) throw error;
+      if (isNoSuchMultipartUploadError(error.s3Error)) throw error.s3Error;
+      throw createTerminalS3StorageError(
+        input,
+        "list_multipart_upload_parts",
+        `Object storage rejected ListParts. statusCode=${String(getS3ErrorStatusCode(error.s3Error))}`,
+        error.s3Error,
+      );
+    }
+
+    for (const rawPart of response.Parts ?? []) {
+      parts.push(readListedPart(rawPart));
+      if (parts.length > maximumMultipartPartCount) {
+        throw createTerminalStorageError(
+          "MULTIPART_PARTS_INVALID",
+          "Multipart upload exceeded the supported 10,000-part limit.",
+        );
+      }
+    }
+
+    if (response.IsTruncated !== true) break;
+    const nextMarker = response.NextPartNumberMarker;
+    if (
+      typeof nextMarker !== "string"
+      || nextMarker.trim() === ""
+      || nextMarker === partNumberMarker
+    ) {
+      throw createTerminalStorageError(
+        "MULTIPART_PARTS_INVALID",
+        "S3 returned an invalid ListParts pagination marker.",
+      );
+    }
+    partNumberMarker = nextMarker;
+  }
+
+  const orderedParts = [...parts].sort(
+    (left, right) => left.partNumber - right.partNumber,
+  );
+  if (
+    orderedParts.length !== input.partCount
+    || orderedParts.some((part, index) => part.partNumber !== index + 1)
+  ) {
+    throw createTerminalStorageError(
+      "MULTIPART_PARTS_INVALID",
+      "S3 multipart parts are incomplete, duplicated, or non-contiguous.",
+    );
+  }
+  if (
+    createMultipartCompletedPartsFingerprint(orderedParts)
+    !== input.completedPartsFingerprint
+  ) {
+    throw createTerminalStorageError(
+      "MULTIPART_PARTS_FINGERPRINT_MISMATCH",
+      "S3 multipart parts do not match the immutable completion fingerprint.",
+    );
+  }
+  return orderedParts;
+}
+
+function toCompletedParts(
+  parts: ReadonlyArray<ListedMultipartPart>,
+): Array<CompletedPart> {
+  return parts.map((part) => ({
+    PartNumber: part.partNumber,
+    ETag: part.eTag,
+    ChecksumSHA256: toBase64Sha256Digest(part.sha256),
+  }));
+}
+
+async function completeMultipartUpload(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  parts: ReadonlyArray<ListedMultipartPart>,
+  bucketName: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<MultipartReconciliationObjectMetadata> {
+  let lastError: unknown = null;
+  const completedParts = toCompletedParts(parts);
+  for (
+    let attempt = 1;
+    attempt <= mediaAssetStorageMaximumAttemptCount;
+    attempt += 1
+  ) {
+    input.signal.throwIfAborted();
+    await input.renewLease();
+    input.signal.throwIfAborted();
+    const command = new CompleteMultipartUploadCommand({
+      Bucket: bucketName,
+      Key: input.stagingStorageKey,
+      UploadId: input.s3UploadId,
+      MultipartUpload: { Parts: completedParts },
+    });
+    try {
+      await dependencies.s3Client.send(
+        command,
+        { abortSignal: input.signal },
+      );
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (isRecognizedS3Error(error) === false) throw error;
+      lastError = error;
+      const observed = await headObject(
+        input,
+        input.stagingStorageKey,
+        bucketName,
+        dependencies,
+      );
+      if (observed !== null) return observed;
+      if (isNoSuchMultipartUploadError(error)) {
+        throw error;
+      }
+      if (isTransientS3Error(error) === false) {
+        throw createTerminalS3StorageError(
+          input,
+          "complete_multipart_upload",
+          `Object storage rejected CompleteMultipartUpload. statusCode=${String(getS3ErrorStatusCode(error))}`,
+          error,
+        );
+      }
+      if (attempt < mediaAssetStorageMaximumAttemptCount) {
+        addStorageRetryBreadcrumb(
+          input,
+          "complete_multipart_upload",
+          attempt,
+          error,
+        );
+        continue;
+      }
+      throw new MultipartCompletionReconciliationStorageTransientError(
+        "complete_multipart_upload",
+        getS3ErrorStatusCode(error),
+        error,
+      );
+    }
+
+    const observed = await headObject(
+      input,
+      input.stagingStorageKey,
+      bucketName,
+      dependencies,
+    );
+    if (observed !== null) return observed;
+    lastError = new Error(
+      "CompleteMultipartUpload succeeded but the staging object is not visible.",
+    );
+  }
+
+  throw new MultipartCompletionReconciliationStorageTransientError(
+    "complete_multipart_upload",
+    getS3ErrorStatusCode(lastError),
+    lastError,
+  );
+}
+
+async function normalizeStagingObject(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  initialMetadata: MediaAssetObjectMetadata,
+  bucketName: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  let metadata = initialMetadata;
+  for (
+    let attempt = 1;
+    attempt <= mediaAssetStorageMaximumAttemptCount;
+    attempt += 1
+  ) {
+    if (metadata.checksumType === "FULL_OBJECT") {
+      assertStagingFullObject(input, metadata);
+      return;
+    }
+    assertStagingShapeAndProof(input, metadata);
+    if (metadata.eTag === null) {
+      throw createTerminalStorageError(
+        "MULTIPART_STAGING_OBJECT_MISMATCH",
+        "Multipart staging object is missing the ETag required for fenced normalization.",
+      );
+    }
+
+    input.signal.throwIfAborted();
+    await input.renewLease();
+    input.signal.throwIfAborted();
+    const command = new CopyObjectCommand({
+      Bucket: bucketName,
+      Key: input.stagingStorageKey,
+      CopySource: createCopySource(
+        bucketName,
+        input.stagingStorageKey,
+      ),
+      CopySourceIfMatch: metadata.eTag,
+      ContentType: input.mimeType,
+      ChecksumAlgorithm: "SHA256",
+      MetadataDirective: "REPLACE",
+      Metadata: createUploadProofMetadata(input),
+    });
+    try {
+      await dependencies.s3Client.send(
+        command,
+        { abortSignal: input.signal },
+      );
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (isRecognizedS3Error(error) === false) throw error;
+      if (
+        isCopyObjectIfNoneMatchFailure(error) === false
+        && isTransientS3Error(error) === false
+      ) {
+        throw createTerminalS3StorageError(
+          input,
+          "copy_object",
+          `Object storage rejected staging normalization. statusCode=${String(getS3ErrorStatusCode(error))}`,
+          error,
+        );
+      }
+      if (
+        isTransientS3Error(error)
+        && attempt < mediaAssetStorageMaximumAttemptCount
+      ) {
+        addStorageRetryBreadcrumb(input, "copy_object", attempt, error);
+      }
+    }
+
+    const observed = await headObject(
+      input,
+      input.stagingStorageKey,
+      bucketName,
+      dependencies,
+    );
+    if (observed === null) {
+      throw createTerminalStorageError(
+        "MULTIPART_STAGING_OBJECT_MISMATCH",
+        "Multipart staging object disappeared during normalization.",
+      );
+    }
+    metadata = observed;
+  }
+
+  throw new MultipartCompletionReconciliationStorageTransientError(
+    "copy_object",
+    null,
+    new Error("Multipart staging normalization did not converge."),
+  );
+}
+
+async function promoteStagingObject(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  bucketName: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  let existing = await headObject(
+    input,
+    input.blobStorageKey,
+    bucketName,
+    dependencies,
+  );
+  if (existing !== null) {
+    assertBlobFullObject(input, existing);
+    return;
+  }
+
+  for (
+    let attempt = 1;
+    attempt <= mediaAssetStorageMaximumAttemptCount;
+    attempt += 1
+  ) {
+    input.signal.throwIfAborted();
+    await input.renewLease();
+    input.signal.throwIfAborted();
+    const command = new CopyObjectCommand({
+      Bucket: bucketName,
+      Key: input.blobStorageKey,
+      CopySource: createCopySource(
+        bucketName,
+        input.stagingStorageKey,
+      ),
+      ContentType: input.mimeType,
+      ChecksumAlgorithm: "SHA256",
+      IfNoneMatch: "*",
+      MetadataDirective: "REPLACE",
+      Metadata: {
+        [uploadProofSha256Key]: input.sha256,
+      },
+    });
+    try {
+      await dependencies.s3Client.send(
+        command,
+        { abortSignal: input.signal },
+      );
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (isRecognizedS3Error(error) === false) throw error;
+      if (
+        isCopyObjectIfNoneMatchFailure(error) === false
+        && isTransientS3Error(error) === false
+      ) {
+        throw createTerminalS3StorageError(
+          input,
+          "copy_object",
+          `Object storage rejected blob promotion. statusCode=${String(getS3ErrorStatusCode(error))}`,
+          error,
+        );
+      }
+      if (
+        isTransientS3Error(error)
+        && attempt < mediaAssetStorageMaximumAttemptCount
+      ) {
+        addStorageRetryBreadcrumb(input, "copy_object", attempt, error);
+      }
+    }
+
+    existing = await headObject(
+      input,
+      input.blobStorageKey,
+      bucketName,
+      dependencies,
+    );
+    if (existing !== null) {
+      assertBlobFullObject(input, existing);
+      return;
+    }
+  }
+
+  throw new MultipartCompletionReconciliationStorageTransientError(
+    "copy_object",
+    null,
+    new Error("Multipart blob promotion did not converge."),
+  );
+}
+
+export async function reconcileMultipartMediaAssetUploadWithDependencies(
+  input: ReconcileMultipartMediaAssetUploadInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  input.signal.throwIfAborted();
+  if (
+    input.partCount < 1
+    || input.partCount > maximumMultipartPartCount
+    || Number.isSafeInteger(input.partCount) === false
+    || sha256Pattern.test(input.completedPartsFingerprint) === false
+  ) {
+    throw createTerminalStorageError(
+      "MULTIPART_PARTS_INVALID",
+      `Durable multipart completion payload is invalid for workspaceId=${input.workspaceId} mediaAssetId=${input.mediaAssetId}.`,
+    );
+  }
+
+  const bucketName = readBucketName(dependencies);
+  const existingBlob = await headObject(
+    input,
+    input.blobStorageKey,
+    bucketName,
+    dependencies,
+  );
+  if (existingBlob !== null) {
+    assertBlobFullObject(input, existingBlob);
+    return;
+  }
+
+  let staging = await headObject(
+    input,
+    input.stagingStorageKey,
+    bucketName,
+    dependencies,
+  );
+  if (staging === null) {
+    try {
+      const parts = await listMultipartParts(
+        input,
+        bucketName,
+        dependencies,
+      );
+      staging = await completeMultipartUpload(
+        input,
+        parts,
+        bucketName,
+        dependencies,
+      );
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (isNoSuchMultipartUploadError(error) === false) throw error;
+
+      const completedBlob = await headObject(
+        input,
+        input.blobStorageKey,
+        bucketName,
+        dependencies,
+      );
+      if (completedBlob !== null) {
+        assertBlobFullObject(input, completedBlob);
+        return;
+      }
+
+      staging = await headObject(
+        input,
+        input.stagingStorageKey,
+        bucketName,
+        dependencies,
+      );
+      if (staging === null) {
+        throw createTerminalStorageError(
+          "MULTIPART_UPLOAD_NOT_FOUND",
+          "Multipart upload no longer exists and no completed object was found.",
+        );
+      }
+    }
+  }
+
+  await normalizeStagingObject(
+    input,
+    staging,
+    bucketName,
+    dependencies,
+  );
+  await promoteStagingObject(input, bucketName, dependencies);
+}

--- a/apps/backend/src/mediaAssets/storage/objects.ts
+++ b/apps/backend/src/mediaAssets/storage/objects.ts
@@ -140,6 +140,7 @@ export async function loadMediaAssetObjectMetadataWithDependencies(
     return {
       sizeBytes: typeof response.ContentLength === "number" ? response.ContentLength : null,
       mimeType: typeof response.ContentType === "string" ? response.ContentType : null,
+      eTag: typeof response.ETag === "string" ? response.ETag : null,
       checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
       checksumType: response.ChecksumType ?? null,
       uploadProof: {

--- a/apps/backend/src/mediaAssets/storage/promotion.ts
+++ b/apps/backend/src/mediaAssets/storage/promotion.ts
@@ -177,6 +177,7 @@ async function assertStoredMediaAssetBlobObjectContentMatchesWithDependencies(
   }
   assertMediaAssetObjectContentMatches(blobObjectInput, {
     sizeBytes: response.ContentLength ?? null, mimeType: response.ContentType ?? null,
+    eTag: response.ETag ?? null,
     checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
     checksumType: response.ChecksumType ?? null,
     uploadProof: {

--- a/apps/backend/src/mediaAssets/storage/proof.ts
+++ b/apps/backend/src/mediaAssets/storage/proof.ts
@@ -54,6 +54,7 @@ function createMediaAssetUploadMismatchError(
   const mismatchedFields = [
     ...(objectMetadata.sizeBytes === input.sizeBytes ? [] : ["sizeBytes"]),
     ...(objectMetadata.mimeType === input.mimeType ? [] : ["mimeType"]),
+    ...(objectMetadata.checksumType === "FULL_OBJECT" ? [] : ["checksumType"]),
     ...(objectMetadata.checksumSha256 === input.sha256 ? [] : ["sha256"]),
   ];
 
@@ -119,7 +120,10 @@ export function assertMediaAssetObjectContentMatches(
   objectMetadata: MediaAssetObjectMetadata,
 ): void {
   assertMediaAssetObjectShapeMatches(input, objectMetadata);
-  if (objectMetadata.checksumSha256 !== input.sha256) {
+  if (
+    objectMetadata.checksumType !== "FULL_OBJECT"
+    || objectMetadata.checksumSha256 !== input.sha256
+  ) {
     throw createMediaAssetUploadMismatchError(input, objectMetadata);
   }
 }

--- a/apps/backend/src/mediaAssets/storage/testHelpers.ts
+++ b/apps/backend/src/mediaAssets/storage/testHelpers.ts
@@ -1,4 +1,7 @@
-import { S3Client } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  S3ServiceException,
+} from "@aws-sdk/client-s3";
 import {
   createBackendObservationScope,
   type BackendObservationScope,
@@ -10,11 +13,7 @@ import {
   buildMediaUploadStagingStorageKey,
 } from "../storageKeys";
 
-export type S3Error = Error & {
-  $metadata: Readonly<{
-    httpStatusCode: number;
-  }>;
-};
+export type S3Error = S3ServiceException;
 
 export const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
 export const testMediaAssetId = "22222222-2222-4222-8222-222222222222";
@@ -55,12 +54,12 @@ export function getTestMediaAssetsStorageConfig(): MediaAssetsStorageConfig {
 }
 
 export function createS3Error(statusCode: number, name: string, message: string): S3Error {
-  const error = new Error(message) as S3Error;
-  error.name = name;
-  error.$metadata = {
-    httpStatusCode: statusCode,
-  };
-  return error;
+  return new S3ServiceException({
+    name,
+    $fault: statusCode >= 500 ? "server" : "client",
+    $metadata: { httpStatusCode: statusCode },
+    message,
+  });
 }
 
 export function createFailingS3Client(error: S3Error): S3Client {
@@ -96,9 +95,11 @@ export function createHeadObjectResponse(fixture: Readonly<{
   lastOperationIdSha256?: string;
   checksumSha256?: string;
   checksumType?: "COMPOSITE" | "FULL_OBJECT";
+  eTag?: string;
 }>): Readonly<{
   ContentLength: number;
   ContentType: string;
+  ETag: string;
   ChecksumSHA256: string;
   ChecksumType: "COMPOSITE" | "FULL_OBJECT";
   Metadata: Readonly<Record<string, string>>;
@@ -106,6 +107,7 @@ export function createHeadObjectResponse(fixture: Readonly<{
   return {
     ContentLength: fixture.sizeBytes,
     ContentType: fixture.mimeType,
+    ETag: fixture.eTag ?? "\"test-object-etag\"",
     ChecksumSHA256: Buffer.from(fixture.checksumSha256 ?? fixture.sha256, "hex").toString("base64"),
     ChecksumType: fixture.checksumType ?? "FULL_OBJECT",
     Metadata: {

--- a/apps/backend/src/mediaAssets/types.ts
+++ b/apps/backend/src/mediaAssets/types.ts
@@ -285,6 +285,7 @@ export type PresignedMediaAssetUploadPart = Readonly<{
 export type MediaAssetObjectMetadata = Readonly<{
   sizeBytes: number | null;
   mimeType: string | null;
+  eTag: string | null;
   checksumSha256: string | null;
   checksumType: "COMPOSITE" | "FULL_OBJECT" | null;
   uploadProof: Readonly<{

--- a/apps/backend/src/mediaAssets/uploadSessions/index.test.ts
+++ b/apps/backend/src/mediaAssets/uploadSessions/index.test.ts
@@ -66,6 +66,7 @@ function createUploadSessionCompletionExecutor(): Readonly<{
   getSessionState: () => MediaAssetUploadSessionRow["state"];
   getCompletionUpdateCount: () => number;
   getRecoveryUpdateCount: () => number;
+  setLastOperationId: (lastOperationId: string) => void;
 }> {
   let sessionRow = createMediaAssetUploadSessionRow("active");
   let completionUpdateCount = 0;
@@ -116,6 +117,12 @@ function createUploadSessionCompletionExecutor(): Readonly<{
     getSessionState: () => sessionRow.state,
     getCompletionUpdateCount: () => completionUpdateCount,
     getRecoveryUpdateCount: () => recoveryUpdateCount,
+    setLastOperationId: (lastOperationId: string) => {
+      sessionRow = {
+        ...sessionRow,
+        last_operation_id: lastOperationId,
+      };
+    },
   };
 }
 
@@ -213,4 +220,50 @@ test("recoverMediaAssetUploadSessionCompletionInExecutor restores storage-reject
   assert.equal(retried.uploadSession.state, "completing");
   assert.equal(completion.getSessionState(), "completing");
   assert.equal(completion.getCompletionUpdateCount(), 2);
+});
+
+test("legacy upload-session identity stays abortable before storage completion", async () => {
+  const active = createUploadSessionCompletionExecutor();
+  active.setLastOperationId("legacy\u00a0operation");
+
+  assert.deepEqual(
+    await beginMediaAssetUploadSessionCompletionInExecutor(
+      active.executor,
+      testWorkspaceId,
+      testUploadSessionId,
+      [{ partNumber: 1 }, { partNumber: 2 }],
+    ),
+    {
+      status: "legacy_operation_id_restart_required",
+      sessionId: testUploadSessionId,
+    },
+  );
+  assert.equal(active.getSessionState(), "active");
+  assert.equal(active.getCompletionUpdateCount(), 0);
+  assert.equal(active.getRecoveryUpdateCount(), 0);
+
+  const completing = createUploadSessionCompletionExecutor();
+  const started = await beginMediaAssetUploadSessionCompletionInExecutor(
+    completing.executor,
+    testWorkspaceId,
+    testUploadSessionId,
+    [{ partNumber: 1 }, { partNumber: 2 }],
+  );
+  assert.equal(started.status, "complete_required");
+  completing.setLastOperationId("legacy\u00a0operation");
+
+  assert.deepEqual(
+    await beginMediaAssetUploadSessionCompletionInExecutor(
+      completing.executor,
+      testWorkspaceId,
+      testUploadSessionId,
+      [{ partNumber: 1 }, { partNumber: 2 }],
+    ),
+    {
+      status: "legacy_operation_id_restart_required",
+      sessionId: testUploadSessionId,
+    },
+  );
+  assert.equal(completing.getSessionState(), "active");
+  assert.equal(completing.getRecoveryUpdateCount(), 1);
 });

--- a/apps/backend/src/mediaAssets/uploadSessions/index.ts
+++ b/apps/backend/src/mediaAssets/uploadSessions/index.ts
@@ -43,6 +43,7 @@ import {
   mediaBlobNormalizationVersions,
   passthroughMediaBlobNormalizationVersion,
 } from "../types";
+import { isValidMediaAssetLastOperationId } from "../lastOperationId";
 import { assertReplicaBelongsToWorkspaceInExecutor } from "../workspaceReplicas";
 
 export type MediaAssetUploadSessionWriterClosure =
@@ -114,6 +115,12 @@ type OwnedMultipartReservationRow = Readonly<{
   reservation_token: string | null; reservation_state: string | null;
   reservation_status: string; normalization_version: string;
 }>;
+type MediaAssetUploadSessionCompletionStartTransition =
+  | MediaAssetUploadSessionCompletionStartResult
+  | Readonly<{
+    status: "legacy_operation_id_restart_required";
+    sessionId: string;
+  }>;
 
 const MEDIA_UPLOAD_SESSION_COLUMNS = [
   "media_upload_session_id",
@@ -309,6 +316,20 @@ function createMediaAssetUploadSessionNotFoundError(sessionId: string): HttpErro
     404,
     `Media asset upload session not found. sessionId=${sessionId}`,
     "MEDIA_ASSET_UPLOAD_SESSION_NOT_FOUND",
+  );
+}
+
+function createMediaAssetUploadSessionRestartRequiredError(
+  sessionId: string,
+): HttpError {
+  return new HttpError(
+    409,
+    [
+      "Media asset upload session uses a legacy operation identifier.",
+      "Abort this upload session and create a new upload session before retrying completion.",
+      `sessionId=${sessionId}`,
+    ].join(" "),
+    "MEDIA_ASSET_UPLOAD_SESSION_RESTART_REQUIRED",
   );
 }
 
@@ -551,8 +572,22 @@ export async function beginMediaAssetUploadSessionCompletionForWorkspace(
   sessionId: string,
   parts: ReadonlyArray<Readonly<{ partNumber: number }>>,
 ): Promise<MediaAssetUploadSessionCompletionStartResult> {
-  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) =>
-    beginMediaAssetUploadSessionCompletionInExecutor(executor, workspaceId, sessionId, parts));
+  const transition = await transactionWithWorkspaceScope(
+    { userId, workspaceId },
+    async (executor) =>
+      beginMediaAssetUploadSessionCompletionInExecutor(
+        executor,
+        workspaceId,
+        sessionId,
+        parts,
+      ),
+  );
+  if (transition.status === "legacy_operation_id_restart_required") {
+    throw createMediaAssetUploadSessionRestartRequiredError(
+      transition.sessionId,
+    );
+  }
+  return transition;
 }
 
 export async function beginMediaAssetUploadSessionCompletionInExecutor(
@@ -560,7 +595,7 @@ export async function beginMediaAssetUploadSessionCompletionInExecutor(
   workspaceId: string,
   sessionId: string,
   parts: ReadonlyArray<Readonly<{ partNumber: number }>>,
-): Promise<MediaAssetUploadSessionCompletionStartResult> {
+): Promise<MediaAssetUploadSessionCompletionStartTransition> {
   const row = await findMediaAssetUploadSessionRowForUpdateInExecutor(executor, workspaceId, sessionId);
   if (row === null) {
     throw createMediaAssetUploadSessionNotFoundError(sessionId);
@@ -576,6 +611,28 @@ export async function beginMediaAssetUploadSessionCompletionInExecutor(
   }
 
   assertMediaAssetUploadSessionCanComplete(session);
+  if (isValidMediaAssetLastOperationId(session.lastOperationId) === false) {
+    if (session.state === "completing") {
+      const result = await executor.query<Readonly<{ state: string }>>(
+        `UPDATE content.media_upload_sessions
+         SET state = 'active'
+         WHERE workspace_id = $1
+           AND media_upload_session_id = $2
+           AND state = 'completing'
+         RETURNING state`,
+        [workspaceId, sessionId],
+      );
+      if (result.rows[0]?.state !== "active") {
+        throw new Error(
+          `Legacy media asset upload session recovery did not return an active row. sessionId=${sessionId}`,
+        );
+      }
+    }
+    return {
+      status: "legacy_operation_id_restart_required",
+      sessionId,
+    };
+  }
   assertMediaAssetUploadSessionCompletionPartsMatch(session, parts);
   if (session.state === "completing") {
     return {

--- a/apps/backend/src/mediaAssets/validators.ts
+++ b/apps/backend/src/mediaAssets/validators.ts
@@ -12,11 +12,11 @@ import type {
   MediaAssetUploadSessionCreateInput,
   MediaAssetUploadSessionPartUrlsInput,
 } from "./types";
+import { isValidMediaAssetLastOperationId } from "./lastOperationId";
 
 const mimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i;
 const sha256Pattern = /^[0-9a-f]{64}$/i;
 const maximumSourceUrlLength = 2_048;
-const maximumLastOperationIdLength = 1_024;
 const maximumETagLength = 256;
 export const maximumSinglePutUploadBytes = 5_368_709_120;
 export const minimumMultipartPartSizeBytes = 5_242_880;
@@ -219,12 +219,18 @@ export function expectMediaAssetSourceUrl(value: unknown, fieldName: string): st
 }
 
 function expectLastOperationId(value: unknown, fieldName: string): string {
-  const lastOperationId = expectNonEmptyString(value, fieldName);
-  if (lastOperationId.length > maximumLastOperationIdLength) {
-    throw new HttpError(400, `${fieldName} must be at most ${maximumLastOperationIdLength} characters`);
+  if (
+    typeof value !== "string"
+    || isValidMediaAssetLastOperationId(value) === false
+  ) {
+    throw new HttpError(
+      400,
+      `${fieldName} must be 1 to 1024 printable ASCII characters without leading or trailing spaces`,
+      "MEDIA_ASSET_LAST_OPERATION_ID_INVALID",
+    );
   }
 
-  return lastOperationId;
+  return value;
 }
 
 function expectPartNumber(value: unknown, fieldName: string): number {

--- a/apps/backend/src/observability/cloudWatch.ts
+++ b/apps/backend/src/observability/cloudWatch.ts
@@ -13,7 +13,9 @@ function getLogRecordDetails(event: BackendLogEvent): unknown {
   return "error" in event ? redactCloudWatchExceptionDetailTextFields(event.details) : event.details;
 }
 
-function createCloudWatchRecord(event: BackendLogEvent): SanitizedTelemetryValue {
+export function createCloudWatchRecord(
+  event: BackendLogEvent,
+): SanitizedTelemetryValue {
   const errorContext = "error" in event ? getBackendErrorLogDetails(event.error) : {};
   const message = "message" in event ? { message: event.message } : {};
   return sanitizeCloudWatchLogValue({

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -9,6 +9,7 @@ export type BackendService =
   | "streak-leaderboard-snapshot"
   | "progress-active-days-backfill"
   | "generated-media-promotion"
+  | "multipart-completion-reconciliation"
   | "migration";
 
 export type BackendObservationScope = Readonly<{
@@ -685,6 +686,38 @@ export type GeneratedMediaPromotionBatchDetails = Readonly<{
   }>>;
 }>;
 
+export type MultipartCompletionFailureReportBatchDetails = Readonly<{
+  maximumReports: number;
+  claimed: number;
+  ambiguous: number;
+  leaseLost: number;
+  reported: number;
+  results: ReadonlyArray<Readonly<{
+    failureEventId: string;
+    outcome: string;
+  }>>;
+}>;
+
+export type MultipartCompletionReconciliationBatchDetails = Readonly<{
+  maximumJobs: number; claimed: number; applied: number; ambiguous: number;
+  failed: number; interrupted: number; leaseLost: number; rescheduled: number;
+  results: ReadonlyArray<Readonly<{
+    attemptToken: string; outcome: string; retryCount: number;
+    errorCode: string | null;
+  }>>;
+  failureReports: MultipartCompletionFailureReportBatchDetails;
+}>;
+
+export type MultipartCompletionReconciliationTerminalFailureDetails =
+  Readonly<{
+    failureEventId: string;
+    attemptToken: string;
+    workspaceId: string;
+    retryCount: number;
+    errorCode: string;
+    deliveryAttempt: number;
+  }>;
+
 export type DatabaseTransientRetryDetails = Readonly<{
   attempt: number;
   maxAttempts: number;
@@ -733,6 +766,7 @@ export type MediaAssetStorageRetryDetails = Readonly<{
     | "create_presigned_part_upload"
     | "complete_multipart_upload"
     | "abort_multipart_upload"
+    | "list_multipart_upload_parts"
     | "head_object"
     | "get_object"
     | "copy_object"
@@ -743,6 +777,16 @@ export type MediaAssetStorageRetryDetails = Readonly<{
   mediaAssetId: string;
   statusCode: number | null;
   errorClass: string;
+}>;
+
+export type MediaAssetStorageTerminalDetails = Readonly<{
+  operation: MediaAssetStorageRetryDetails["operation"];
+  workspaceId: string;
+  mediaAssetId: string;
+  statusCode: number | null;
+  errorClass: string;
+  awsRequestId: string | null;
+  awsExtendedRequestId: string | null;
 }>;
 
 export type FeedbackEmailRetryDetails = Readonly<{
@@ -785,9 +829,12 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"streak_leaderboard_snapshot_generated", StreakLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>
   | EventByAction<"generated_media_promotion_batch_completed", GeneratedMediaPromotionBatchDetails>
+  | EventByAction<"multipart_completion_reconciliation_batch_completed", MultipartCompletionReconciliationBatchDetails>
+  | EventByAction<"multipart_completion_reconciliation_job_terminally_failed", MultipartCompletionReconciliationTerminalFailureDetails>
   | EventByAction<"database_transient_retry", DatabaseTransientRetryDetails>
   | EventByAction<"global_metrics_s3_retry", GlobalMetricsS3RetryDetails>
   | EventByAction<"media_asset_storage_retry", MediaAssetStorageRetryDetails>
+  | EventByAction<"media_asset_storage_terminal", MediaAssetStorageTerminalDetails>
   | EventByAction<"sync_push", SyncPushDetails>
   | EventByAction<"sync_push_error", SyncConflictFailureDetailsFor<SyncPushDetails>>
   | EventByAction<"sync_pull", SyncPullDetails>
@@ -1047,6 +1094,9 @@ export type BackendExceptionEvent =
     error: Error;
   }>)
   | (EventByAction<"generated_media_promotion_batch_failed", GeneratedMediaPromotionBatchDetails> & Readonly<{
+    error: Error;
+  }>)
+  | (EventByAction<"multipart_completion_reconciliation_batch_failed", MultipartCompletionReconciliationBatchDetails> & Readonly<{
     error: Error;
   }>)
   | (EventByAction<"migration_failed", MigrationFailureDetails> & Readonly<{ error: Error }>)

--- a/apps/backend/src/routes/catalogInstall.ts
+++ b/apps/backend/src/routes/catalogInstall.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import {
+  catalogPackageInstallOperationIdPrefixMaximumLength,
   installCatalogPackageVersion,
+  isValidCatalogPackageInstallOperationIdPrefix,
   previewCatalogPackageInstall,
 } from "../catalog";
 import type {
@@ -53,6 +55,25 @@ function parseCatalogPackageVersionIdParam(value: string | undefined): string {
   }
 }
 
+function parseCatalogPackageInstallOperationIdPrefix(value: unknown): string {
+  if (
+    typeof value === "string"
+    && isValidCatalogPackageInstallOperationIdPrefix(value)
+  ) {
+    return value;
+  }
+
+  throw new HttpError(
+    400,
+    [
+      "operationIdPrefix must be",
+      `1 to ${catalogPackageInstallOperationIdPrefixMaximumLength}`,
+      "printable ASCII characters without leading or trailing spaces.",
+    ].join(" "),
+    "CATALOG_PACKAGE_INSTALL_INVALID_INPUT",
+  );
+}
+
 function parseCatalogPackageInstallConfirmInput(value: unknown): CatalogPackageInstallConfirmInput {
   const record = expectRecord(value);
   return {
@@ -60,7 +81,7 @@ function parseCatalogPackageInstallConfirmInput(value: unknown): CatalogPackageI
     installedAt: expectNonEmptyString(record.installedAt, "installedAt"),
     clientUpdatedAt: expectNonEmptyString(record.clientUpdatedAt, "clientUpdatedAt"),
     lastModifiedByReplicaId: expectUuidString(record.lastModifiedByReplicaId, "lastModifiedByReplicaId"),
-    operationIdPrefix: expectNonEmptyString(record.operationIdPrefix, "operationIdPrefix"),
+    operationIdPrefix: parseCatalogPackageInstallOperationIdPrefix(record.operationIdPrefix),
   };
 }
 

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -8,12 +8,24 @@ import {
   createAgentWorkspaceReadyEnvelope,
   createAgentWorkspacesEnvelope,
 } from "../../agent/setup";
+import {
+  catalogPackageInstallOperationIdPrefixMaximumLength,
+  isValidCatalogPackageInstallOperationIdPrefix,
+} from "../../catalog";
+import {
+  isValidMediaAssetLastOperationId,
+  maximumMediaAssetLastOperationIdLength,
+} from "../../mediaAssets/lastOperationId";
 import { loadOpenApiDocument } from "../../shared/openapi";
 import { maximumImageIngestionOriginalBytes } from "../../mediaAssets/validators";
 import {
   workspacePackageImportConfirmRouteMaxZipBytes,
   workspacePackageImportPreviewRouteMaxZipBytes,
 } from "../workspacePackages";
+import {
+  isValidWorkspacePackageImportOperationIdPrefix,
+  workspacePackageImportOperationIdPrefixMaximumLength,
+} from "../../workspacePackages/import/operationIds";
 import type { RequestContext } from "../../server/requestContext";
 import type { WorkspaceSummary } from "../../workspaces";
 
@@ -22,9 +34,12 @@ const operationMethodNames = ["get", "post", "put", "patch", "delete", "options"
 type OperationMethodName = (typeof operationMethodNames)[number];
 type PathItemForTest = Readonly<Partial<Record<OperationMethodName, object>>>;
 type OpenApiBinarySchemaForTest = Readonly<{
+  $ref?: string;
   type?: string;
   format?: string;
+  minLength?: number;
   maxLength?: number;
+  pattern?: string;
   properties?: Readonly<Record<string, OpenApiBinarySchemaForTest>>;
 }>;
 type OpenApiMediaTypeForTest = Readonly<{
@@ -291,6 +306,82 @@ test("published OpenAPI exposes the curated agent, media transfer, and admin cat
     "/catalog/package-versions/{packageVersionId}/media-assets/{packageMediaKey}/download-url"
   ]?.get as OpenApiOperationForTest | undefined;
   assert.ok(publicCatalogDownloadUrlOperation?.responses?.["415"] !== undefined);
+});
+
+test("published OpenAPI shares the backend last operation identifier contract", () => {
+  const schemas = loadPublishedOpenApiDocument().components?.schemas ?? {};
+  const canonicalSchema = schemas.MediaAssetLastOperationId as OpenApiBinarySchemaForTest | undefined;
+  const responseSchema =
+    schemas.MediaAssetLastOperationIdResponse as OpenApiBinarySchemaForTest | undefined;
+  const mediaAssetSchema = schemas.MediaAsset as OpenApiBinarySchemaForTest | undefined;
+  const uploadSessionSchema =
+    schemas.MediaAssetUploadSessionCreateInput as OpenApiBinarySchemaForTest | undefined;
+  const workspaceImportSchema =
+    schemas.WorkspacePackageImportConfirmOptions as OpenApiBinarySchemaForTest | undefined;
+  const catalogInstallSchema =
+    schemas.CatalogPackageInstallConfirmInput as OpenApiBinarySchemaForTest | undefined;
+  const mediaAssetLastOperationId = mediaAssetSchema?.properties?.lastOperationId;
+  const uploadSessionLastOperationId =
+    uploadSessionSchema?.properties?.lastOperationId;
+  const workspaceImportPrefix = workspaceImportSchema?.properties?.operationIdPrefix;
+  const catalogInstallPrefix = catalogInstallSchema?.properties?.operationIdPrefix;
+
+  assert.equal(canonicalSchema?.minLength, 1);
+  assert.equal(canonicalSchema?.maxLength, maximumMediaAssetLastOperationIdLength);
+  assert.equal(responseSchema?.minLength, 1);
+  assert.equal(responseSchema?.maxLength, undefined);
+  assert.equal(
+    mediaAssetLastOperationId?.$ref,
+    "#/components/schemas/MediaAssetLastOperationIdResponse",
+  );
+  assert.equal(
+    uploadSessionLastOperationId?.$ref,
+    "#/components/schemas/MediaAssetLastOperationId",
+  );
+  assert.equal(
+    workspaceImportPrefix?.maxLength,
+    workspacePackageImportOperationIdPrefixMaximumLength,
+  );
+  assert.equal(
+    catalogInstallPrefix?.maxLength,
+    catalogPackageInstallOperationIdPrefixMaximumLength,
+  );
+
+  const canonicalPattern = new RegExp(canonicalSchema?.pattern ?? "");
+  const responsePattern = new RegExp(responseSchema?.pattern ?? "");
+  const workspaceImportPattern = new RegExp(workspaceImportPrefix?.pattern ?? "");
+  const catalogInstallPattern = new RegExp(catalogInstallPrefix?.pattern ?? "");
+  const values = [
+    "550e8400-e29b-41d4-a716-446655440000",
+    "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    "operation with internal spaces",
+    " leading-space",
+    "trailing-space ",
+    "operation\ncontrol",
+    "operation\u00a0nbsp",
+  ];
+  for (const value of values) {
+    assert.equal(canonicalPattern.test(value), isValidMediaAssetLastOperationId(value), value);
+    assert.equal(
+      workspaceImportPattern.test(value),
+      isValidWorkspacePackageImportOperationIdPrefix(value),
+      value,
+    );
+    assert.equal(
+      catalogInstallPattern.test(value),
+      isValidCatalogPackageInstallOperationIdPrefix(value),
+      value,
+    );
+  }
+  for (const [value, expected] of [
+    ["", false],
+    ["   ", false],
+    ["legacy\u00a0operation", true],
+    ["legacy-操作", true],
+    ["legacy\noperation", true],
+  ] as const) {
+    assert.equal(responsePattern.test(value), expected, value);
+  }
 });
 
 test("agent discovery advertises the published media, package, and catalog surface", () => {

--- a/apps/backend/src/routes/workspacePackages/import.test.ts
+++ b/apps/backend/src/routes/workspacePackages/import.test.ts
@@ -15,6 +15,7 @@ import {
   workspacePackageImportConfirmRouteMaxZipBytes,
   workspacePackageImportPreviewRouteMaxZipBytes,
 } from "./index";
+import { workspacePackageImportOperationIdPrefixMaximumLength } from "../../workspacePackages/import/operationIds";
 import {
   cardId,
   createRequestContext,
@@ -669,6 +670,36 @@ test("POST /workspaces/:workspaceId/packages/import rejects malformed multipart,
       expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
       errorPattern: /options are invalid/,
       detailsPattern: /lastModifiedByReplicaId/,
+    },
+    {
+      name: "unsafe operation id prefix",
+      createRequestInit: () => ({
+        method: "POST",
+        body: createWorkspacePackageImportConfirmFormData(zipBytes, {
+          ...validOptions,
+          operationIdPrefix: "unsafe\u00a0prefix",
+        }),
+      }),
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+      errorPattern: /options are invalid/,
+      detailsPattern: /operationIdPrefix/,
+    },
+    {
+      name: "oversized operation id prefix",
+      createRequestInit: () => ({
+        method: "POST",
+        body: createWorkspacePackageImportConfirmFormData(zipBytes, {
+          ...validOptions,
+          operationIdPrefix: "a".repeat(
+            workspacePackageImportOperationIdPrefixMaximumLength + 1,
+          ),
+        }),
+      }),
+      expectedStatus: 400,
+      expectedCode: "WORKSPACE_PACKAGE_IMPORT_OPTIONS_INVALID",
+      errorPattern: /options are invalid/,
+      detailsPattern: /operationIdPrefix/,
     },
   ];
 

--- a/apps/backend/src/routes/workspacePackages/import.ts
+++ b/apps/backend/src/routes/workspacePackages/import.ts
@@ -9,6 +9,10 @@ import {
   type WorkspacePackageImportPlanOptions,
   type WorkspacePackageImportPreview,
 } from "../../workspacePackages";
+import {
+  isValidWorkspacePackageImportOperationIdPrefix,
+  workspacePackageImportOperationIdPrefixMaximumLength,
+} from "../../workspacePackages/import/operationIds";
 import { assertUserHasWorkspaceAccess } from "../../workspaces";
 import {
   loadRequestContextFromRequest,
@@ -70,7 +74,11 @@ const workspacePackageImportConfirmRouteOptionsSchema = z.object({
   importId: z.string().min(1),
   clientUpdatedAt: workspacePackageImportConfirmTimestampSchema,
   lastModifiedByReplicaId: workspacePackageImportConfirmUuidSchema,
-  operationIdPrefix: z.string().min(1),
+  operationIdPrefix: z.string()
+    .max(workspacePackageImportOperationIdPrefixMaximumLength)
+    .refine(isValidWorkspacePackageImportOperationIdPrefix, {
+      message: "operationIdPrefix must use printable ASCII without leading or trailing spaces",
+    }),
 }).refine(
   (input): boolean => input.addImportTag === false || input.importTag.trim() !== "",
   {

--- a/apps/backend/src/workspacePackages/import/apply/importCards.test.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importCards.test.ts
@@ -186,6 +186,27 @@ test("workspace package import card persistence returns empty results without op
   assert.deepEqual(harness.createCardCalls, []);
 });
 
+test("workspace package import card persistence rejects unsafe prefixes before opening a transaction", async () => {
+  const harness = createPersistenceHarness();
+
+  await assert.rejects(
+    () => persistWorkspacePackageImportCardsWithDependencies(
+      {
+        ...createPersistenceInput([]),
+        operationIdPrefix: " unsafe-prefix",
+      },
+      harness.dependencies,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID");
+      return true;
+    },
+  );
+  assert.deepEqual(harness.transactionCalls, []);
+  assert.deepEqual(harness.createCardCalls, []);
+});
+
 test("workspace package import card persistence maps one planned card inside one transaction", async () => {
   const plannedCard = createPlannedCard(
     "Prompt",

--- a/apps/backend/src/workspacePackages/import/apply/importCards.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importCards.ts
@@ -11,6 +11,11 @@ import {
   type WorkspaceDatabaseScope,
 } from "../../../database";
 import { HttpError } from "../../../shared/errors";
+import { workspacePackageImportZipDefaultMaxCards } from "../importZip";
+import {
+  assertValidWorkspacePackageImportOperationIdPrefix,
+  buildWorkspacePackageImportCardLastOperationId,
+} from "../operationIds";
 import type { WorkspacePackageImportPlannedCard } from "../planning/importPlan";
 
 const workspacePackageImportCardPersistenceBatchSize = 100;
@@ -80,10 +85,6 @@ function createCardPersistenceError(
   return new Error(message);
 }
 
-function buildImportCardLastOperationId(operationIdPrefix: string, cardIndex: number): string {
-  return `${operationIdPrefix}:card:${cardIndex}`;
-}
-
 function buildBulkCreateCardItem(
   input: WorkspacePackageImportCardPersistenceInput,
   plannedCard: WorkspacePackageImportPlannedCard,
@@ -100,7 +101,10 @@ function buildBulkCreateCardItem(
     metadata: {
       clientUpdatedAt: input.clientUpdatedAt,
       lastModifiedByReplicaId: input.lastModifiedByReplicaId,
-      lastOperationId: buildImportCardLastOperationId(input.operationIdPrefix, cardIndex),
+      lastOperationId: buildWorkspacePackageImportCardLastOperationId(
+        input.operationIdPrefix,
+        cardIndex,
+      ),
     },
   };
 }
@@ -140,6 +144,18 @@ export async function persistWorkspacePackageImportCardsWithDependencies(
   input: WorkspacePackageImportCardPersistenceInput,
   dependencies: WorkspacePackageImportCardPersistenceDependencies,
 ): Promise<WorkspacePackageImportCardPersistenceResult> {
+  assertValidWorkspacePackageImportOperationIdPrefix(input.operationIdPrefix);
+  if (input.plannedCards.length > workspacePackageImportZipDefaultMaxCards) {
+    throw new HttpError(
+      400,
+      [
+        "Workspace package contains too many cards.",
+        `cardCount=${input.plannedCards.length}`,
+        `maximumCount=${workspacePackageImportZipDefaultMaxCards}`,
+      ].join(" "),
+      "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID",
+    );
+  }
   const items = input.plannedCards.map((plannedCard, cardIndex) => buildBulkCreateCardItem(
     input,
     plannedCard,

--- a/apps/backend/src/workspacePackages/import/apply/importConfirm.test.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importConfirm.test.ts
@@ -349,6 +349,28 @@ test("workspace package import confirmation rejects wrong workspace replica befo
   assert.equal(harness.calls.persistInputs.length, 0);
 });
 
+test("workspace package import confirmation rejects unsafe operation prefixes before external work", async () => {
+  const harness = createConfirmHarness(createCardsJson());
+
+  await assert.rejects(
+    () => confirmWorkspacePackageImportWithDependencies(
+      {
+        ...createConfirmInput(),
+        operationIdPrefix: "unsafe\u00a0prefix",
+      },
+      harness.dependencies,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID");
+      assert.match(error.message, /operationIdPrefix.*printable ASCII/);
+      return true;
+    },
+  );
+  assert.deepEqual(harness.calls.order, []);
+});
+
 test("workspace package import confirmation validates semantic options before media ingestion", async () => {
   const harness = createConfirmHarness(createCardsJson());
   const baseInput = createConfirmInput();

--- a/apps/backend/src/workspacePackages/import/apply/importConfirm.ts
+++ b/apps/backend/src/workspacePackages/import/apply/importConfirm.ts
@@ -32,6 +32,7 @@ import {
   type WorkspacePackageImportPlanOptions,
   type WorkspacePackageImportPlanPreflightInput,
 } from "../planning/importPlan";
+import { assertValidWorkspacePackageImportOperationIdPrefix } from "../operationIds";
 
 export type WorkspacePackageImportConfirmInput = Readonly<{
   userId: string;
@@ -219,6 +220,7 @@ export async function confirmWorkspacePackageImportWithDependencies(
   input: WorkspacePackageImportConfirmInput,
   dependencies: WorkspacePackageImportConfirmDependencies,
 ): Promise<WorkspacePackageImportConfirmResult> {
+  assertValidWorkspacePackageImportOperationIdPrefix(input.operationIdPrefix);
   await dependencies.assertReplicaBelongsToWorkspaceFn(
     input.userId,
     input.workspaceId,

--- a/apps/backend/src/workspacePackages/import/media/importMediaAssets.test.ts
+++ b/apps/backend/src/workspacePackages/import/media/importMediaAssets.test.ts
@@ -22,6 +22,10 @@ import {
   type WorkspacePackageImportMediaAssetIngestionInput,
   type WorkspacePackageImportReferencedMediaFile,
 } from "../../index";
+import {
+  buildWorkspacePackageImportMediaLastOperationId,
+  workspacePackageImportOperationIdPrefixMaximumLength,
+} from "../operationIds";
 
 const testUserId = "user-1";
 const testWorkspaceId = "11111111-1111-4111-8111-111111111111";
@@ -218,6 +222,37 @@ test("workspace package import media asset ingestion rejects duplicate portable 
     /referencedMediaFiles contain duplicate or invalid portable paths.*media\/duplicate\.png/,
   );
   assert.deepEqual(harness.calls, []);
+});
+
+test("workspace package import media asset ingestion rejects unsafe prefixes before ingestion", async () => {
+  const mediaFile = createMediaFile("media/image.png", Buffer.from("image bytes"));
+  const harness = createIngestionHarness(["asset-1"]);
+
+  await assert.rejects(
+    () => ingestWorkspacePackageImportMediaAssetsWithDependencies(
+      {
+        ...createTestInput([mediaFile]),
+        operationIdPrefix: "unsafe\nprefix",
+      },
+      harness.dependencies,
+    ),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.code, "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID");
+      return true;
+    },
+  );
+  assert.deepEqual(harness.calls, []);
+});
+
+test("workspace package import operation prefix reserves the maximum media suffix", () => {
+  const lastOperationId = buildWorkspacePackageImportMediaLastOperationId(
+    "a".repeat(workspacePackageImportOperationIdPrefixMaximumLength),
+    9_999,
+  );
+
+  assert.equal(lastOperationId.length, 1_024);
+  assert.match(lastOperationId, /:media:9999$/);
 });
 
 test("workspace package import media asset ingestion includes portable path when ingestion fails", async () => {

--- a/apps/backend/src/workspacePackages/import/media/importMediaAssets.ts
+++ b/apps/backend/src/workspacePackages/import/media/importMediaAssets.ts
@@ -8,6 +8,11 @@ import type { MediaAsset } from "../../../mediaAssets/types";
 import type { BackendObservationScope } from "../../../observability/sentry";
 import { HttpError } from "../../../shared/errors";
 import { validateUniquePortableMediaPaths } from "../../markdownMedia";
+import { workspacePackageImportZipDefaultMaxMediaFiles } from "../importZip";
+import {
+  assertValidWorkspacePackageImportOperationIdPrefix,
+  buildWorkspacePackageImportMediaLastOperationId,
+} from "../operationIds";
 import type { WorkspacePackageImportReferencedMediaFile } from "./importMedia";
 
 export type WorkspacePackageImportMediaAssetIngestionInput = Readonly<{
@@ -67,10 +72,6 @@ function assertReferencedMediaFilesHaveUniquePortablePaths(
   }
 }
 
-function buildMediaImportLastOperationId(operationIdPrefix: string, mediaFileIndex: number): string {
-  return `${operationIdPrefix}:media:${mediaFileIndex}`;
-}
-
 function buildImageMediaAssetIngestionInput(
   input: WorkspacePackageImportMediaAssetIngestionInput,
   mediaFile: WorkspacePackageImportReferencedMediaFile,
@@ -86,7 +87,10 @@ function buildImageMediaAssetIngestionInput(
       createdAt: input.createdAt,
       clientUpdatedAt: input.clientUpdatedAt,
       lastModifiedByReplicaId: input.lastModifiedByReplicaId,
-      lastOperationId: buildMediaImportLastOperationId(input.operationIdPrefix, mediaFileIndex),
+      lastOperationId: buildWorkspacePackageImportMediaLastOperationId(
+        input.operationIdPrefix,
+        mediaFileIndex,
+      ),
     },
     imageBytes: mediaFile.bytes,
     observationScope: input.observationScope,
@@ -111,6 +115,18 @@ export async function ingestWorkspacePackageImportMediaAssetsWithDependencies(
   input: WorkspacePackageImportMediaAssetIngestionInput,
   dependencies: WorkspacePackageImportMediaAssetIngestionDependencies,
 ): Promise<WorkspacePackageImportMediaAssetIngestionResult> {
+  assertValidWorkspacePackageImportOperationIdPrefix(input.operationIdPrefix);
+  if (input.referencedMediaFiles.length > workspacePackageImportZipDefaultMaxMediaFiles) {
+    throw new HttpError(
+      400,
+      [
+        "Workspace package contains too many referenced media files.",
+        `mediaFileCount=${input.referencedMediaFiles.length}`,
+        `maximumCount=${workspacePackageImportZipDefaultMaxMediaFiles}`,
+      ].join(" "),
+      "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID",
+    );
+  }
   assertReferencedMediaFilesHaveUniquePortablePaths(input.referencedMediaFiles);
 
   const importedMediaAssets: Array<WorkspacePackageImportedMediaAsset> = [];

--- a/apps/backend/src/workspacePackages/import/operationIds.ts
+++ b/apps/backend/src/workspacePackages/import/operationIds.ts
@@ -1,0 +1,110 @@
+import {
+  isValidMediaAssetLastOperationId,
+  isValidMediaAssetLastOperationIdPrefix,
+  maximumMediaAssetLastOperationIdLength,
+} from "../../mediaAssets/lastOperationId";
+import { HttpError } from "../../shared/errors";
+import {
+  workspacePackageImportZipDefaultMaxCards,
+  workspacePackageImportZipDefaultMaxMediaFiles,
+} from "./importZip";
+
+const workspacePackageImportMediaLastOperationIdMaximumSuffix =
+  `:media:${workspacePackageImportZipDefaultMaxMediaFiles - 1}`;
+const workspacePackageImportCardLastOperationIdMaximumSuffix =
+  `:card:${workspacePackageImportZipDefaultMaxCards - 1}`;
+const workspacePackageImportLastOperationIdMaximumSuffixLength = Math.max(
+  workspacePackageImportMediaLastOperationIdMaximumSuffix.length,
+  workspacePackageImportCardLastOperationIdMaximumSuffix.length,
+);
+
+export const workspacePackageImportOperationIdPrefixMaximumLength =
+  maximumMediaAssetLastOperationIdLength
+  - workspacePackageImportLastOperationIdMaximumSuffixLength;
+
+function createWorkspacePackageImportOperationIdError(message: string): HttpError {
+  return new HttpError(
+    400,
+    message,
+    "WORKSPACE_PACKAGE_IMPORT_INPUT_INVALID",
+  );
+}
+
+export function isValidWorkspacePackageImportOperationIdPrefix(
+  value: string,
+): boolean {
+  return isValidMediaAssetLastOperationIdPrefix(
+    value,
+    workspacePackageImportOperationIdPrefixMaximumLength,
+  );
+}
+
+export function assertValidWorkspacePackageImportOperationIdPrefix(
+  value: string,
+): void {
+  if (isValidWorkspacePackageImportOperationIdPrefix(value)) {
+    return;
+  }
+
+  throw createWorkspacePackageImportOperationIdError(
+    [
+      "operationIdPrefix must be",
+      `1 to ${workspacePackageImportOperationIdPrefixMaximumLength}`,
+      "printable ASCII characters without leading or trailing spaces.",
+    ].join(" "),
+  );
+}
+
+function assertWorkspacePackageImportOperationIndex(
+  index: number,
+  maximumCount: number,
+  entityName: string,
+): void {
+  if (Number.isInteger(index) && index >= 0 && index < maximumCount) {
+    return;
+  }
+
+  throw createWorkspacePackageImportOperationIdError(
+    `${entityName} operation index is outside the supported package limit. index=${index} maximumCount=${maximumCount}`,
+  );
+}
+
+function assertWorkspacePackageImportLastOperationId(
+  value: string,
+): string {
+  if (isValidMediaAssetLastOperationId(value)) {
+    return value;
+  }
+
+  throw createWorkspacePackageImportOperationIdError(
+    "Derived workspace package lastOperationId is invalid.",
+  );
+}
+
+export function buildWorkspacePackageImportMediaLastOperationId(
+  operationIdPrefix: string,
+  mediaFileIndex: number,
+): string {
+  assertWorkspacePackageImportOperationIndex(
+    mediaFileIndex,
+    workspacePackageImportZipDefaultMaxMediaFiles,
+    "Media file",
+  );
+  return assertWorkspacePackageImportLastOperationId(
+    `${operationIdPrefix}:media:${mediaFileIndex}`,
+  );
+}
+
+export function buildWorkspacePackageImportCardLastOperationId(
+  operationIdPrefix: string,
+  cardIndex: number,
+): string {
+  assertWorkspacePackageImportOperationIndex(
+    cardIndex,
+    workspacePackageImportZipDefaultMaxCards,
+    "Card",
+  );
+  return assertWorkspacePackageImportLastOperationId(
+    `${operationIdPrefix}:card:${cardIndex}`,
+  );
+}

--- a/db/migrations/0099_durable_multipart_completion_reconciliation.sql
+++ b/db/migrations/0099_durable_multipart_completion_reconciliation.sql
@@ -1,0 +1,3191 @@
+-- Current additive migration for durable multipart completion handoff and reconciliation.
+-- Schemas touched/read explicitly: content, org, security, sync, pg_catalog, public.
+
+CREATE FUNCTION content.media_asset_last_operation_id_valid_internal(
+  p_last_operation_id TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    p_last_operation_id IS NOT NULL
+    AND pg_catalog.char_length(p_last_operation_id) BETWEEN 1 AND 1024
+    AND p_last_operation_id COLLATE "C" ~
+      '^([!-~]|[!-~][ -~]*[!-~])$';
+$$;
+
+ALTER TABLE content.media_assets
+  ADD CONSTRAINT media_assets_last_operation_id_canonical
+  CHECK (
+    pg_catalog.char_length(last_operation_id) BETWEEN 1 AND 1024
+    AND last_operation_id COLLATE "C" ~
+      '^([!-~]|[!-~][ -~]*[!-~])$'
+  ) NOT VALID;
+
+ALTER TABLE content.media_blob_writer_attempts
+  ADD COLUMN reconciliation_state TEXT,
+  ADD COLUMN reconciliation_retry_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN reconciliation_next_attempt_at TIMESTAMPTZ,
+  ADD COLUMN reconciliation_lease_token UUID,
+  ADD COLUMN reconciliation_lease_owner TEXT,
+  ADD COLUMN reconciliation_lease_expires_at TIMESTAMPTZ,
+  ADD COLUMN reconciliation_last_error_code TEXT,
+  ADD COLUMN reconciliation_last_error_message TEXT,
+  ADD COLUMN reconciliation_handed_off_at TIMESTAMPTZ,
+  ADD COLUMN reconciliation_updated_at TIMESTAMPTZ,
+  ADD COLUMN reconciliation_applied_at TIMESTAMPTZ,
+  ADD COLUMN reconciliation_failure_event_id UUID,
+  ADD COLUMN reconciliation_failure_report_state TEXT,
+  ADD COLUMN reconciliation_failure_report_delivery_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN reconciliation_failure_report_lease_token UUID,
+  ADD COLUMN reconciliation_failure_report_lease_owner TEXT,
+  ADD COLUMN reconciliation_failure_report_lease_expires_at TIMESTAMPTZ,
+  ADD COLUMN reconciliation_failure_report_updated_at TIMESTAMPTZ,
+  ADD COLUMN reconciliation_failure_reported_at TIMESTAMPTZ,
+  ADD CONSTRAINT media_blob_writer_attempts_reconciliation_state
+    CHECK (
+      reconciliation_state IS NULL
+      OR reconciliation_state IN ('pending', 'leased', 'applied', 'failed')
+    ),
+  ADD CONSTRAINT media_blob_writer_attempts_reconciliation_retry_count
+    CHECK (reconciliation_retry_count >= 0),
+  ADD CONSTRAINT media_blob_writer_attempts_failure_report_state
+    CHECK (
+      reconciliation_failure_report_state IS NULL
+      OR reconciliation_failure_report_state IN ('pending', 'leased', 'reported')
+    ),
+  ADD CONSTRAINT media_blob_writer_attempts_failure_report_delivery_count
+    CHECK (reconciliation_failure_report_delivery_count >= 0),
+  ADD CONSTRAINT media_blob_writer_attempts_failure_event_unique
+    UNIQUE (reconciliation_failure_event_id),
+  ADD CONSTRAINT media_blob_writer_attempts_reconciliation_error_safe
+    CHECK (
+      (
+        reconciliation_last_error_code IS NULL
+        AND reconciliation_last_error_message IS NULL
+      )
+      OR (
+        reconciliation_last_error_code IS NOT NULL
+        AND reconciliation_last_error_message IS NOT NULL
+        AND reconciliation_last_error_code ~ '^[A-Z][A-Z0-9_]{0,63}$'
+        AND reconciliation_last_error_message =
+          pg_catalog.btrim(reconciliation_last_error_message)
+        AND pg_catalog.char_length(reconciliation_last_error_message)
+          BETWEEN 1 AND 500
+        AND reconciliation_last_error_message !~ '[[:cntrl:]]'
+      )
+    ),
+  ADD CONSTRAINT media_blob_writer_attempts_reconciliation_shape
+    CHECK (
+      (
+        reconciliation_state IS NULL
+        AND reconciliation_retry_count = 0
+        AND reconciliation_next_attempt_at IS NULL
+        AND reconciliation_lease_token IS NULL
+        AND reconciliation_lease_owner IS NULL
+        AND reconciliation_lease_expires_at IS NULL
+        AND reconciliation_last_error_code IS NULL
+        AND reconciliation_last_error_message IS NULL
+        AND reconciliation_handed_off_at IS NULL
+        AND reconciliation_updated_at IS NULL
+        AND reconciliation_applied_at IS NULL
+      )
+      OR (
+        writer_kind = 'multipart_completion'
+        AND reconciliation_handed_off_at IS NOT NULL
+        AND reconciliation_updated_at IS NOT NULL
+        AND reconciliation_updated_at >= reconciliation_handed_off_at
+        AND (
+          (
+            reconciliation_state = 'pending'
+            AND state = 'expired'
+            AND outcome = 'stale_attempt'
+            AND terminal_at IS NOT NULL
+            AND reconciliation_next_attempt_at IS NOT NULL
+            AND reconciliation_next_attempt_at >= reconciliation_handed_off_at
+            AND reconciliation_lease_token IS NULL
+            AND reconciliation_lease_owner IS NULL
+            AND reconciliation_lease_expires_at IS NULL
+            AND reconciliation_applied_at IS NULL
+          )
+          OR (
+            reconciliation_state = 'leased'
+            AND state = 'expired'
+            AND outcome = 'stale_attempt'
+            AND terminal_at IS NOT NULL
+            AND reconciliation_next_attempt_at IS NOT NULL
+            AND reconciliation_lease_token IS NOT NULL
+            AND reconciliation_lease_owner IS NOT NULL
+            AND reconciliation_lease_owner =
+              pg_catalog.btrim(reconciliation_lease_owner)
+            AND reconciliation_lease_owner <> ''
+            AND pg_catalog.char_length(reconciliation_lease_owner) <= 200
+            AND reconciliation_lease_owner !~ '[[:cntrl:]]'
+            AND reconciliation_lease_expires_at IS NOT NULL
+            AND reconciliation_lease_expires_at > reconciliation_updated_at
+            AND reconciliation_applied_at IS NULL
+          )
+          OR (
+            reconciliation_state = 'applied'
+            AND state IN ('applied', 'referenced')
+            AND outcome IN ('live_applied', 'already_applied', 'referenced')
+            AND terminal_at IS NOT NULL
+            AND reconciliation_next_attempt_at IS NULL
+            AND reconciliation_lease_token IS NULL
+            AND reconciliation_lease_owner IS NULL
+            AND reconciliation_lease_expires_at IS NULL
+            AND reconciliation_last_error_code IS NULL
+            AND reconciliation_last_error_message IS NULL
+            AND reconciliation_applied_at IS NOT NULL
+            AND reconciliation_applied_at >= reconciliation_handed_off_at
+          )
+          OR (
+            reconciliation_state = 'failed'
+            AND state IN (
+              'peer_conflict',
+              'unreferenced',
+              'cancelled',
+              'expired'
+            )
+            AND outcome IN (
+              'peer_conflict',
+              'unreferenced',
+              'already_closed',
+              'aborted',
+              'stale_attempt'
+            )
+            AND terminal_at IS NOT NULL
+            AND reconciliation_next_attempt_at IS NULL
+            AND reconciliation_lease_token IS NULL
+            AND reconciliation_lease_owner IS NULL
+            AND reconciliation_lease_expires_at IS NULL
+            AND reconciliation_last_error_code IS NOT NULL
+            AND reconciliation_last_error_message IS NOT NULL
+            AND reconciliation_applied_at IS NULL
+          )
+        )
+      )
+    ),
+  ADD CONSTRAINT media_blob_writer_attempts_failure_report_shape
+    CHECK (
+      (
+        reconciliation_state IS DISTINCT FROM 'failed'
+        AND reconciliation_failure_event_id IS NULL
+        AND reconciliation_failure_report_state IS NULL
+        AND reconciliation_failure_report_delivery_count = 0
+        AND reconciliation_failure_report_lease_token IS NULL
+        AND reconciliation_failure_report_lease_owner IS NULL
+        AND reconciliation_failure_report_lease_expires_at IS NULL
+        AND reconciliation_failure_report_updated_at IS NULL
+        AND reconciliation_failure_reported_at IS NULL
+      )
+      OR (
+        reconciliation_state IN ('failed', 'applied')
+        AND reconciliation_failure_event_id IS NOT NULL
+        AND reconciliation_failure_report_state IS NOT NULL
+        AND reconciliation_failure_report_updated_at IS NOT NULL
+        AND reconciliation_failure_report_updated_at >=
+          reconciliation_handed_off_at
+        AND (
+          (
+            reconciliation_state = 'failed'
+            AND reconciliation_failure_report_state = 'pending'
+            AND reconciliation_failure_report_lease_token IS NULL
+            AND reconciliation_failure_report_lease_owner IS NULL
+            AND reconciliation_failure_report_lease_expires_at IS NULL
+            AND reconciliation_failure_reported_at IS NULL
+          )
+          OR (
+            reconciliation_state = 'failed'
+            AND reconciliation_failure_report_state = 'leased'
+            AND reconciliation_failure_report_delivery_count > 0
+            AND reconciliation_failure_report_lease_token IS NOT NULL
+            AND reconciliation_failure_report_lease_owner IS NOT NULL
+            AND reconciliation_failure_report_lease_owner =
+              pg_catalog.btrim(reconciliation_failure_report_lease_owner)
+            AND reconciliation_failure_report_lease_owner <> ''
+            AND pg_catalog.char_length(
+              reconciliation_failure_report_lease_owner
+            ) <= 200
+            AND reconciliation_failure_report_lease_owner !~ '[[:cntrl:]]'
+            AND reconciliation_failure_report_lease_expires_at IS NOT NULL
+            AND reconciliation_failure_report_lease_expires_at >
+              reconciliation_failure_report_updated_at
+            AND reconciliation_failure_reported_at IS NULL
+          )
+          OR (
+            reconciliation_failure_report_state = 'reported'
+            AND reconciliation_failure_report_delivery_count > 0
+            AND reconciliation_failure_report_lease_token IS NULL
+            AND reconciliation_failure_report_lease_owner IS NULL
+            AND reconciliation_failure_report_lease_expires_at IS NULL
+            AND reconciliation_failure_reported_at IS NOT NULL
+            AND reconciliation_failure_reported_at =
+              reconciliation_failure_report_updated_at
+          )
+        )
+      )
+    ),
+  ADD CONSTRAINT
+    media_blob_writer_attempts_reconciliation_last_operation_safe
+    CHECK (
+      reconciliation_state IS NULL
+      OR reconciliation_state IN ('applied', 'failed')
+      OR (
+        content.media_asset_last_operation_id_valid_internal(
+          last_operation_id
+        )
+      )
+      OR (
+        reconciliation_state = 'leased'
+        AND reconciliation_last_error_code =
+          'INVALID_RECONCILIATION_PAYLOAD'
+        AND reconciliation_last_error_message =
+          'Durable multipart completion payload is invalid.'
+      )
+    ) NOT VALID;
+
+CREATE INDEX media_blob_writer_attempts_reconciliation_due
+  ON content.media_blob_writer_attempts (
+    reconciliation_next_attempt_at,
+    reconciliation_handed_off_at,
+    attempt_token
+  )
+  WHERE reconciliation_state = 'pending';
+
+CREATE INDEX media_blob_writer_attempts_reconciliation_reclaim
+  ON content.media_blob_writer_attempts (
+    reconciliation_lease_expires_at,
+    reconciliation_handed_off_at,
+    attempt_token
+  )
+  WHERE reconciliation_state = 'leased';
+
+CREATE INDEX media_blob_writer_attempts_failure_report_claim
+  ON content.media_blob_writer_attempts (
+    reconciliation_failure_report_state,
+    reconciliation_failure_report_lease_expires_at,
+    reconciliation_failure_report_updated_at,
+    reconciliation_failure_event_id
+  )
+  WHERE reconciliation_failure_report_state IN ('pending', 'leased');
+
+COMMENT ON COLUMN content.media_blob_writer_attempts.reconciliation_state IS
+  'Durable multipart completion recovery lifecycle. NULL means the request retained responsibility and no worker handoff occurred.';
+COMMENT ON COLUMN content.media_blob_writer_attempts.reconciliation_lease_token IS
+  'Exact worker fencing token for one claimed durable multipart completion.';
+COMMENT ON COLUMN content.media_blob_writer_attempts.reconciliation_handed_off_at IS
+  'Timestamp when an HTTP request atomically expired its attempt lease while preserving the reservation for scheduled recovery.';
+COMMENT ON COLUMN content.media_blob_writer_attempts.reconciliation_failure_event_id IS
+  'Stable at-least-once terminal-failure telemetry identity. It is distinct from fencing tokens so duplicate deliveries are identifiable without exposing secrets.';
+COMMENT ON COLUMN content.media_blob_writer_attempts.reconciliation_failure_report_state IS
+  'Durable terminal-failure telemetry outbox state, independently claimable after reconciliation terminalizes.';
+
+CREATE FUNCTION content.multipart_completion_reconciliation_error_valid_internal(
+  p_error_code TEXT,
+  p_error_message TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    p_error_code ~ '^[A-Z][A-Z0-9_]{0,63}$'
+    AND p_error_message = pg_catalog.btrim(p_error_message)
+    AND pg_catalog.char_length(p_error_message) BETWEEN 1 AND 500
+    AND p_error_message !~ '[[:cntrl:]]';
+$$;
+
+CREATE OR REPLACE FUNCTION
+  content.multipart_media_blob_writer_attempt_payload_valid_internal(
+    p_payload content.multipart_media_blob_writer_attempt_payload
+  )
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    p_payload.user_id IS NOT NULL
+    AND p_payload.user_id = pg_catalog.btrim(p_payload.user_id)
+    AND p_payload.user_id <> ''
+    AND p_payload.workspace_id IS NOT NULL
+    AND p_payload.media_upload_session_id IS NOT NULL
+    AND p_payload.media_asset_id IS NOT NULL
+    AND p_payload.replica_id IS NOT NULL
+    AND p_payload.last_operation_id IS NOT NULL
+    AND p_payload.last_operation_id =
+      pg_catalog.btrim(p_payload.last_operation_id)
+    AND pg_catalog.char_length(p_payload.last_operation_id)
+      BETWEEN 1 AND 1024
+    AND p_payload.sha256 ~ '^[0-9a-f]{64}$'
+    AND p_payload.staging_storage_key =
+      'media/uploads/workspaces/'
+      || pg_catalog.lower(p_payload.workspace_id::TEXT)
+      || '/assets/'
+      || pg_catalog.lower(p_payload.media_asset_id::TEXT)
+      || '/sessions/'
+      || pg_catalog.lower(p_payload.media_upload_session_id::TEXT)
+    AND p_payload.blob_storage_key =
+      'media/blobs/sha256/'
+      || pg_catalog.substring(p_payload.sha256, 1, 2)
+      || '/'
+      || pg_catalog.substring(p_payload.sha256, 3, 2)
+      || '/'
+      || p_payload.sha256
+    AND p_payload.s3_upload_id IS NOT NULL
+    AND p_payload.s3_upload_id = pg_catalog.btrim(p_payload.s3_upload_id)
+    AND p_payload.s3_upload_id <> ''
+    AND p_payload.mime_type =
+      pg_catalog.lower(pg_catalog.btrim(p_payload.mime_type))
+    AND p_payload.mime_type ~
+      '^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$'
+    AND p_payload.size_bytes > 0
+    AND p_payload.part_size_bytes > 0
+    AND p_payload.part_count BETWEEN 1 AND 10000
+    AND p_payload.asset_created_at IS NOT NULL
+    AND p_payload.client_updated_at IS NOT NULL
+    AND p_payload.session_expires_at IS NOT NULL
+    AND p_payload.normalization_version IN (
+      'passthrough-v1',
+      'image-jpeg-card-v1'
+    )
+    AND p_payload.completed_parts_fingerprint ~ '^[0-9a-f]{64}$';
+$$;
+
+CREATE FUNCTION
+  content.multipart_media_blob_writer_attempt_payload_canonical_valid_internal(
+    p_payload content.multipart_media_blob_writer_attempt_payload
+  )
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    content.multipart_media_blob_writer_attempt_payload_valid_internal(
+      p_payload
+    )
+    AND p_payload.user_id !~ '[[:cntrl:]]'
+    AND content.media_asset_last_operation_id_valid_internal(
+      p_payload.last_operation_id
+    )
+    AND p_payload.s3_upload_id !~ '[[:cntrl:]]'
+    AND p_payload.size_bytes <= 9007199254740991
+    AND p_payload.part_size_bytes <= 9007199254740991;
+$$;
+
+CREATE OR REPLACE FUNCTION
+  content.multipart_media_blob_writer_terminal_replay_status_internal(
+    p_attempt content.media_blob_writer_attempts,
+    p_payload content.multipart_media_blob_writer_attempt_payload
+  )
+RETURNS TEXT
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT CASE
+    WHEN (p_attempt).attempt_token IS NULL THEN 'stale_attempt'
+    WHEN (p_attempt).user_id IS DISTINCT FROM p_payload.user_id
+      OR (p_attempt).replica_id IS DISTINCT FROM p_payload.replica_id
+    THEN 'ownership_mismatch'
+    WHEN (p_attempt).writer_kind IS DISTINCT FROM 'multipart_completion'
+      OR (p_attempt).workspace_id IS DISTINCT FROM p_payload.workspace_id
+      OR (p_attempt).media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+      OR (p_attempt).operation_id IS DISTINCT FROM
+        p_payload.media_upload_session_id::TEXT
+      OR (p_attempt).media_upload_session_id IS DISTINCT FROM
+        p_payload.media_upload_session_id
+      OR (p_attempt).sha256 IS DISTINCT FROM p_payload.sha256
+      OR (p_attempt).blob_storage_key IS DISTINCT FROM
+        p_payload.blob_storage_key
+      OR (p_attempt).mime_type IS DISTINCT FROM p_payload.mime_type
+      OR (p_attempt).size_bytes IS DISTINCT FROM p_payload.size_bytes
+      OR (p_attempt).requested_normalization_version IS DISTINCT FROM
+        p_payload.normalization_version
+      OR (p_attempt).staging_storage_key IS DISTINCT FROM
+        p_payload.staging_storage_key
+      OR (p_attempt).s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id
+      OR (p_attempt).part_size_bytes IS DISTINCT FROM
+        p_payload.part_size_bytes
+      OR (p_attempt).part_count IS DISTINCT FROM p_payload.part_count
+      OR (p_attempt).session_expires_at IS DISTINCT FROM
+        p_payload.session_expires_at
+      OR (p_attempt).completed_parts_fingerprint IS DISTINCT FROM
+        p_payload.completed_parts_fingerprint
+    THEN 'stale_attempt'
+    ELSE 'ready'
+  END;
+$$;
+
+CREATE FUNCTION
+  content.multipart_completion_reconciliation_job_valid_internal(
+    p_attempt content.media_blob_writer_attempts
+  )
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SECURITY DEFINER
+  SET search_path = pg_catalog
+AS $$
+  SELECT
+    (p_attempt).writer_kind = 'multipart_completion'
+    AND (p_attempt).state = 'expired'
+    AND (p_attempt).outcome = 'stale_attempt'
+    AND (p_attempt).reconciliation_state IN ('pending', 'leased')
+    AND (p_attempt).reconciliation_retry_count BETWEEN 0 AND 2147483647
+    AND content.multipart_media_blob_writer_attempt_payload_canonical_valid_internal(
+      ROW(
+        (p_attempt).user_id,
+        (p_attempt).workspace_id,
+        (p_attempt).media_upload_session_id,
+        (p_attempt).media_asset_id,
+        (p_attempt).replica_id,
+        (p_attempt).last_operation_id,
+        (p_attempt).sha256,
+        (p_attempt).staging_storage_key,
+        (p_attempt).blob_storage_key,
+        (p_attempt).s3_upload_id,
+        (p_attempt).mime_type,
+        (p_attempt).size_bytes,
+        (p_attempt).part_size_bytes,
+        (p_attempt).part_count,
+        (p_attempt).source_url,
+        (p_attempt).asset_created_at,
+        (p_attempt).client_updated_at,
+        (p_attempt).session_expires_at,
+        (p_attempt).normalization_version,
+        (p_attempt).completed_parts_fingerprint
+      )::content.multipart_media_blob_writer_attempt_payload
+    );
+$$;
+
+CREATE FUNCTION content.handoff_media_upload_session_completion_attempt(
+  p_attempt_token UUID,
+  p_reservation_token UUID,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+  identity_status TEXT;
+  canonical_payload BOOLEAN;
+  handed_off_at TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_reservation_token IS NULL
+    OR content.multipart_media_blob_writer_attempt_payload_valid_internal(
+      p_payload
+    ) IS DISTINCT FROM true
+  THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      p_payload.user_id || ':' || p_payload.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_payload.workspace_id
+      AND memberships.user_id = p_payload.user_id
+  ) THEN
+    RETURN 'access_denied';
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id
+  FOR UPDATE;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+
+  identity_status :=
+    content.multipart_media_blob_writer_attempt_identity_status_internal(
+      attempt,
+      p_reservation_token,
+      p_payload
+    );
+  IF identity_status <> 'ready' THEN
+    RETURN identity_status;
+  END IF;
+
+  IF attempt.reconciliation_state IN ('pending', 'leased') THEN
+    RETURN 'already_pending';
+  ELSIF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'already_applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  END IF;
+
+  IF attempt.state <> 'leased' THEN
+    RETURN COALESCE(attempt.outcome, 'stale_attempt');
+  END IF;
+
+  IF session.media_upload_session_id IS NULL
+    OR session.workspace_id IS DISTINCT FROM p_payload.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM p_payload.replica_id
+    OR session.last_operation_id IS DISTINCT FROM p_payload.last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_payload.sha256
+    OR session.staging_storage_key IS DISTINCT FROM p_payload.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_payload.mime_type
+    OR session.size_bytes IS DISTINCT FROM p_payload.size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_payload.part_count
+    OR session.source_url IS DISTINCT FROM p_payload.source_url
+    OR session.asset_created_at IS DISTINCT FROM p_payload.asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+    OR session.expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  IF session.state = 'aborting' THEN
+    RETURN 'aborting';
+  ELSIF session.state = 'aborted' THEN
+    RETURN 'aborted';
+  ELSIF session.state <> 'completing' THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM content.media_blob_writer_reservations AS reservations
+    WHERE reservations.reservation_token = p_reservation_token
+      AND reservations.writer_kind = 'multipart_completion'
+      AND reservations.workspace_id = p_payload.workspace_id
+      AND reservations.media_asset_id = p_payload.media_asset_id
+      AND reservations.operation_id =
+        p_payload.media_upload_session_id::TEXT
+      AND reservations.sha256 = p_payload.sha256
+      AND reservations.state IN ('active', 'ambiguous', 'finalized')
+    FOR UPDATE
+  ) THEN
+    RETURN 'writer_conflict';
+  END IF;
+
+  canonical_payload :=
+    content.multipart_media_blob_writer_attempt_payload_canonical_valid_internal(
+      p_payload
+    );
+  handed_off_at := pg_catalog.clock_timestamp();
+  IF canonical_payload THEN
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'expired',
+      outcome = 'stale_attempt',
+      terminal_at = handed_off_at,
+      reconciliation_state = 'pending',
+      reconciliation_retry_count = 0,
+      reconciliation_next_attempt_at = handed_off_at,
+      reconciliation_lease_token = NULL,
+      reconciliation_lease_owner = NULL,
+      reconciliation_lease_expires_at = NULL,
+      reconciliation_last_error_code = NULL,
+      reconciliation_last_error_message = NULL,
+      reconciliation_handed_off_at = handed_off_at,
+      reconciliation_updated_at = handed_off_at,
+      reconciliation_applied_at = NULL
+    WHERE attempts.attempt_token = p_attempt_token
+      AND attempts.state = 'leased'
+      AND attempts.reconciliation_state IS NULL;
+  ELSE
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'expired',
+      outcome = 'stale_attempt',
+      terminal_at = handed_off_at,
+      reconciliation_state = 'leased',
+      reconciliation_retry_count = 0,
+      reconciliation_next_attempt_at = handed_off_at,
+      reconciliation_lease_token = public.gen_random_uuid(),
+      reconciliation_lease_owner = 'legacy-invalid-payload',
+      reconciliation_lease_expires_at =
+        handed_off_at + interval '1 microsecond',
+      reconciliation_last_error_code =
+        'INVALID_RECONCILIATION_PAYLOAD',
+      reconciliation_last_error_message =
+        'Durable multipart completion payload is invalid.',
+      reconciliation_handed_off_at = handed_off_at,
+      reconciliation_updated_at = handed_off_at,
+      reconciliation_applied_at = NULL
+    WHERE attempts.attempt_token = p_attempt_token
+      AND attempts.state = 'leased'
+      AND attempts.reconciliation_state IS NULL;
+  END IF;
+  IF NOT FOUND THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  RETURN 'handed_off';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  p_attempt_token UUID,
+  p_lease_duration_ms INTEGER,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing_attempt content.media_blob_writer_attempts%ROWTYPE;
+  peer_attempt content.media_blob_writer_attempts%ROWTYPE;
+  terminal_attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reservation_result RECORD;
+  apply_payload content.multipart_media_blob_writer_attempt_payload;
+  fence_status TEXT;
+  takeover BOOLEAN := false;
+  leased_until TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_lease_duration_ms IS NULL
+    OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+    OR content.multipart_media_blob_writer_attempt_payload_valid_internal(p_payload) IS DISTINCT FROM true
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+  THEN
+    RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO existing_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.state <> 'leased'
+  FOR UPDATE;
+
+  IF FOUND THEN
+    IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id()
+      OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id()
+    THEN
+      RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    fence_status := content.multipart_media_blob_writer_terminal_replay_status_internal(
+      existing_attempt,
+      p_payload
+    );
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      p_payload.user_id || ':' || p_payload.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_payload.workspace_id
+      AND memberships.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_payload.replica_id
+      AND replicas.workspace_id = p_payload.workspace_id
+      AND replicas.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id
+  FOR UPDATE;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended('attempt:' || p_attempt_token::TEXT, 3::BIGINT)
+  );
+
+  SELECT attempts.*
+  INTO existing_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+
+  IF FOUND THEN
+    IF existing_attempt.user_id IS DISTINCT FROM security.current_user_id()
+      OR existing_attempt.workspace_id IS DISTINCT FROM security.current_workspace_id()
+    THEN
+      RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    IF existing_attempt.state <> 'leased' THEN
+      fence_status := content.multipart_media_blob_writer_terminal_replay_status_internal(
+        existing_attempt,
+        p_payload
+      );
+      IF fence_status <> 'ready' THEN
+        RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+        RETURN;
+      END IF;
+
+      RETURN QUERY
+      SELECT existing_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    apply_payload := p_payload;
+    apply_payload.normalization_version := existing_attempt.normalization_version;
+    fence_status := content.multipart_media_blob_writer_attempt_identity_status_internal(
+      existing_attempt,
+      existing_attempt.reservation_token,
+      apply_payload
+    );
+    IF existing_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version
+    THEN
+      fence_status := 'stale_attempt';
+    END IF;
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    fence_status := content.fence_media_upload_session_completion_attempt_apply_with_owner(
+      p_attempt_token,
+      existing_attempt.reservation_token,
+      apply_payload,
+      3600000
+    );
+    IF fence_status = 'ready' THEN
+      leased_until := pg_catalog.clock_timestamp()
+        + (p_lease_duration_ms * interval '1 millisecond');
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET lease_expires_at = leased_until
+      WHERE attempts.attempt_token = p_attempt_token
+        AND attempts.state = 'leased'
+        AND attempts.lease_expires_at > pg_catalog.clock_timestamp();
+      IF NOT FOUND THEN
+        fence_status := 'stale_attempt';
+      ELSE
+        fence_status := 'replayed';
+      END IF;
+    END IF;
+
+    IF fence_status = 'replayed' THEN
+      RETURN QUERY
+      SELECT
+        fence_status,
+        existing_attempt.reservation_token,
+        existing_attempt.normalization_version,
+        leased_until;
+    ELSE
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    END IF;
+    RETURN;
+  END IF;
+
+  IF content.multipart_media_blob_writer_attempt_payload_canonical_valid_internal(
+    p_payload
+  ) IS DISTINCT FROM true
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  INSERT INTO sync.workspace_sync_metadata (
+    workspace_id,
+    min_available_hot_change_id,
+    updated_at
+  )
+  VALUES (p_payload.workspace_id, 0, pg_catalog.statement_timestamp())
+  ON CONFLICT (workspace_id) DO NOTHING;
+
+  PERFORM 1
+  FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = p_payload.workspace_id
+  FOR UPDATE;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_payload.sha256
+  FOR UPDATE;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.writer_kind = 'multipart_completion'
+    AND reservations.workspace_id = p_payload.workspace_id
+    AND reservations.media_asset_id = p_payload.media_asset_id
+    AND reservations.operation_id = p_payload.media_upload_session_id::TEXT
+  FOR UPDATE;
+
+  IF FOUND THEN
+    SELECT snapshots.*
+    INTO owner_snapshot
+    FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token
+    FOR UPDATE;
+  END IF;
+
+  SELECT attempts.*
+  INTO peer_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.workspace_id = p_payload.workspace_id
+    AND attempts.media_asset_id = p_payload.media_asset_id
+    AND attempts.operation_id = p_payload.media_upload_session_id::TEXT
+    AND (
+      attempts.state = 'leased'
+      OR attempts.reconciliation_state IN ('pending', 'leased')
+    )
+  FOR UPDATE;
+
+  SELECT attempts.*
+  INTO terminal_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.media_upload_session_id = p_payload.media_upload_session_id
+    AND attempts.state IN ('applied', 'referenced')
+  ORDER BY
+    attempts.created_at,
+    attempts.terminal_at,
+    attempts.attempt_token
+  LIMIT 1
+  FOR UPDATE;
+
+  IF security.current_user_id() IS DISTINCT FROM p_payload.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_payload.workspace_id
+    OR NOT EXISTS (
+      SELECT 1
+      FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = p_payload.workspace_id
+        AND memberships.user_id = p_payload.user_id
+    )
+  THEN
+    RETURN QUERY SELECT 'access_denied'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_payload.replica_id
+      AND replicas.workspace_id = p_payload.workspace_id
+      AND replicas.user_id = p_payload.user_id
+  ) THEN
+    RETURN QUERY SELECT 'replica_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.media_upload_session_id IS NULL
+    OR session.workspace_id IS DISTINCT FROM p_payload.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_payload.sha256
+    OR session.staging_storage_key IS DISTINCT FROM p_payload.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_payload.mime_type
+    OR session.size_bytes IS DISTINCT FROM p_payload.size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_payload.part_count
+    OR session.expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.last_modified_by_replica_id IS DISTINCT FROM p_payload.replica_id THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state <> 'completed'
+    AND (
+      session.last_operation_id IS DISTINCT FROM p_payload.last_operation_id
+      OR session.source_url IS DISTINCT FROM p_payload.source_url
+      OR session.asset_created_at IS DISTINCT FROM p_payload.asset_created_at
+      OR session.client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+    )
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state = 'aborting' THEN
+    RETURN QUERY SELECT 'aborting'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF session.state = 'aborted' THEN
+    RETURN QUERY SELECT 'aborted'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF session.state = 'active'
+    AND session.expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF session.state NOT IN ('active', 'completing', 'completed') THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF lifecycle.sha256 IS NOT NULL
+    AND (
+      lifecycle.storage_key IS DISTINCT FROM p_payload.blob_storage_key
+      OR lifecycle.mime_type IS DISTINCT FROM p_payload.mime_type
+      OR lifecycle.size_bytes IS DISTINCT FROM p_payload.size_bytes
+    )
+  THEN
+    RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN
+    RETURN QUERY
+    SELECT
+      'cleanup_claimed'::TEXT,
+      NULL::UUID,
+      lifecycle.normalization_version,
+      NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF reservation.reservation_token IS NOT NULL
+    AND (
+      reservation.sha256 IS DISTINCT FROM p_payload.sha256
+      OR owner_snapshot.reservation_token IS NULL
+    )
+  THEN
+    RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF owner_snapshot.reservation_token IS NOT NULL
+    AND (
+      owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id
+      OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id
+    )
+  THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state <> 'completed'
+    AND owner_snapshot.reservation_token IS NOT NULL
+    AND (
+      owner_snapshot.session_last_operation_id IS DISTINCT FROM p_payload.last_operation_id
+      OR owner_snapshot.session_expires_at IS DISTINCT FROM p_payload.session_expires_at
+      OR owner_snapshot.session_source_url IS DISTINCT FROM p_payload.source_url
+      OR owner_snapshot.session_asset_created_at IS DISTINCT FROM p_payload.asset_created_at
+      OR owner_snapshot.session_client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+    )
+  THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state = 'completed' THEN
+    IF reservation.reservation_token IS NULL
+      OR reservation.state <> 'finalized'
+      OR terminal_attempt.attempt_token IS NULL
+    THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    fence_status := content.multipart_media_blob_writer_terminal_replay_status_internal(
+      terminal_attempt,
+      p_payload
+    );
+    IF fence_status <> 'ready' THEN
+      RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    IF terminal_attempt.reservation_token IS DISTINCT FROM reservation.reservation_token
+      OR terminal_attempt.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+    THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT terminal_attempt.outcome, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF owner_snapshot.reservation_token IS NOT NULL
+    AND owner_snapshot.session_expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF peer_attempt.attempt_token IS NOT NULL THEN
+    apply_payload := p_payload;
+    apply_payload.normalization_version := peer_attempt.normalization_version;
+    fence_status := content.multipart_media_blob_writer_attempt_identity_status_internal(
+      peer_attempt,
+      peer_attempt.reservation_token,
+      apply_payload
+    );
+    IF fence_status <> 'ready'
+      OR peer_attempt.requested_normalization_version IS DISTINCT FROM p_payload.normalization_version
+    THEN
+      RETURN QUERY
+      SELECT
+        CASE WHEN fence_status = 'ready' THEN 'stale_attempt' ELSE fence_status END,
+        NULL::UUID,
+        NULL::TEXT,
+        NULL::TIMESTAMPTZ;
+      RETURN;
+    ELSIF peer_attempt.reservation_token IS DISTINCT FROM reservation.reservation_token
+      OR peer_attempt.normalization_version IS DISTINCT FROM lifecycle.normalization_version
+      OR reservation.state NOT IN ('active', 'ambiguous', 'finalized')
+    THEN
+      RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+      RETURN;
+    ELSIF peer_attempt.reconciliation_state IN ('pending', 'leased') THEN
+      RETURN QUERY
+      SELECT
+        'busy'::TEXT,
+        NULL::UUID,
+        NULL::TEXT,
+        peer_attempt.reconciliation_lease_expires_at;
+      RETURN;
+    ELSIF peer_attempt.lease_expires_at > pg_catalog.clock_timestamp() THEN
+      RETURN QUERY
+      SELECT 'busy'::TEXT, NULL::UUID, NULL::TEXT, peer_attempt.lease_expires_at;
+      RETURN;
+    END IF;
+
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'expired',
+      outcome = 'stale_attempt',
+      terminal_at = pg_catalog.clock_timestamp()
+    WHERE attempts.attempt_token = peer_attempt.attempt_token
+      AND attempts.state = 'leased';
+    takeover := true;
+  END IF;
+
+  SELECT *
+  INTO reservation_result
+  FROM content.reserve_owned_media_blob_writer_internal(
+    p_payload.user_id,
+    p_payload.replica_id,
+    p_payload.sha256,
+    p_payload.blob_storage_key,
+    p_payload.mime_type,
+    p_payload.size_bytes,
+    p_payload.normalization_version,
+    'multipart_completion',
+    p_payload.workspace_id,
+    p_payload.media_asset_id,
+    p_payload.media_upload_session_id::TEXT,
+    p_payload.last_operation_id,
+    p_payload.session_expires_at,
+    p_payload.source_url,
+    p_payload.asset_created_at,
+    p_payload.client_updated_at
+  );
+
+  IF reservation_result.reservation_status = 'cleanup_claimed' THEN
+    RETURN QUERY
+    SELECT
+      'cleanup_claimed'::TEXT,
+      NULL::UUID,
+      reservation_result.normalization_version,
+      NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF reservation_result.reservation_status = 'ownership_mismatch' THEN
+    RETURN QUERY SELECT 'ownership_mismatch'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  ELSIF reservation_result.reservation_status <> 'reserved'
+    OR reservation_result.reservation_token IS NULL
+  THEN
+    RETURN QUERY SELECT 'writer_conflict'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  IF session.state = 'active' THEN
+    UPDATE content.media_upload_sessions AS sessions
+    SET state = 'completing'
+    WHERE sessions.media_upload_session_id = p_payload.media_upload_session_id
+      AND sessions.state = 'active';
+  END IF;
+
+  leased_until := pg_catalog.clock_timestamp()
+    + (p_lease_duration_ms * interval '1 millisecond');
+  INSERT INTO content.media_blob_writer_attempts (
+    attempt_token,
+    reservation_token,
+    writer_kind,
+    user_id,
+    workspace_id,
+    media_asset_id,
+    operation_id,
+    last_operation_id,
+    replica_id,
+    sha256,
+    blob_storage_key,
+    mime_type,
+    size_bytes,
+    requested_normalization_version,
+    normalization_version,
+    source_url,
+    asset_created_at,
+    client_updated_at,
+    media_upload_session_id,
+    staging_storage_key,
+    s3_upload_id,
+    part_size_bytes,
+    part_count,
+    session_expires_at,
+    completed_parts_fingerprint,
+    state,
+    lease_expires_at
+  )
+  VALUES (
+    p_attempt_token,
+    reservation_result.reservation_token,
+    'multipart_completion',
+    p_payload.user_id,
+    p_payload.workspace_id,
+    p_payload.media_asset_id,
+    p_payload.media_upload_session_id::TEXT,
+    p_payload.last_operation_id,
+    p_payload.replica_id,
+    p_payload.sha256,
+    p_payload.blob_storage_key,
+    p_payload.mime_type,
+    p_payload.size_bytes,
+    p_payload.normalization_version,
+    reservation_result.normalization_version,
+    p_payload.source_url,
+    p_payload.asset_created_at,
+    p_payload.client_updated_at,
+    p_payload.media_upload_session_id,
+    p_payload.staging_storage_key,
+    p_payload.s3_upload_id,
+    p_payload.part_size_bytes,
+    p_payload.part_count,
+    p_payload.session_expires_at,
+    p_payload.completed_parts_fingerprint,
+    'leased',
+    leased_until
+  );
+
+  apply_payload := p_payload;
+  apply_payload.normalization_version := reservation_result.normalization_version;
+  fence_status := content.fence_media_upload_session_completion_attempt_apply_with_owner(
+    p_attempt_token,
+    reservation_result.reservation_token,
+    apply_payload,
+    3600000
+  );
+  IF fence_status = 'ready' THEN
+    fence_status := CASE WHEN takeover THEN 'expired_takeover' ELSE 'acquired' END;
+  END IF;
+
+  IF fence_status IN ('acquired', 'expired_takeover') THEN
+    RETURN QUERY
+    SELECT
+      fence_status,
+      reservation_result.reservation_token,
+      reservation_result.normalization_version,
+      leased_until;
+  ELSE
+    RETURN QUERY SELECT fence_status, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION content.close_media_upload_session_current_blob_writer_with_owner(
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_media_upload_session_id UUID,
+  p_media_asset_id UUID,
+  p_last_modified_by_replica_id UUID,
+  p_last_operation_id TEXT,
+  p_sha256 TEXT,
+  p_storage_key TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_expires_at TIMESTAMPTZ,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+  selected_attempt content.media_blob_writer_attempts%ROWTYPE;
+  current_attempt content.media_blob_writer_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  reference RECORD;
+  session_found BOOLEAN;
+  access_present BOOLEAN;
+  replica_matches BOOLEAN;
+  abort_proven BOOLEAN;
+  expiry_proven BOOLEAN;
+  exact_reference_found BOOLEAN;
+  terminalization_status TEXT;
+  reconciled_at TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+    OR p_user_id IS NULL
+    OR p_workspace_id IS NULL
+    OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL
+    OR p_last_modified_by_replica_id IS NULL
+    OR p_last_operation_id IS NULL
+    OR p_sha256 IS NULL
+    OR p_storage_key IS NULL
+    OR p_mime_type IS NULL
+    OR p_size_bytes IS NULL
+    OR p_expires_at IS NULL
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(p_user_id || ':' || p_workspace_id::TEXT, 0::BIGINT)
+  );
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+  FOR UPDATE;
+  session_found := FOUND;
+
+  IF session_found
+    AND (
+      session.workspace_id IS DISTINCT FROM p_workspace_id
+      OR session.media_asset_id IS DISTINCT FROM p_media_asset_id
+      OR session.last_modified_by_replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+      OR session.last_operation_id IS DISTINCT FROM p_last_operation_id
+      OR session.media_blob_sha256 IS DISTINCT FROM p_sha256
+      OR session.blob_storage_key IS DISTINCT FROM p_storage_key
+      OR session.mime_type IS DISTINCT FROM p_mime_type
+      OR session.size_bytes IS DISTINCT FROM p_size_bytes
+      OR session.expires_at IS DISTINCT FROM p_expires_at
+    )
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT attempts.*
+  INTO selected_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.media_upload_session_id = p_media_upload_session_id
+  ORDER BY
+    (attempts.state = 'leased') DESC,
+    attempts.terminal_at DESC NULLS LAST,
+    attempts.created_at DESC,
+    attempts.attempt_token DESC
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN content.close_media_upload_session_blob_writer(
+      p_user_id,
+      p_workspace_id,
+      p_media_upload_session_id,
+      p_media_asset_id,
+      p_last_modified_by_replica_id,
+      p_last_operation_id,
+      p_sha256,
+      p_storage_key,
+      p_mime_type,
+      p_size_bytes,
+      p_expires_at,
+      p_cleanup_delay_ms
+    );
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = selected_attempt.sha256
+  FOR UPDATE;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = selected_attempt.reservation_token
+  FOR UPDATE;
+
+  IF FOUND THEN
+    SELECT snapshots.*
+    INTO owner_snapshot
+    FROM content.media_blob_writer_owner_snapshots AS snapshots
+    WHERE snapshots.reservation_token = reservation.reservation_token
+    FOR UPDATE;
+  END IF;
+
+  SELECT attempts.*
+  INTO current_attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = selected_attempt.attempt_token
+  FOR UPDATE;
+
+  SELECT
+    assets.workspace_id,
+    blobs.sha256,
+    blobs.storage_key,
+    blobs.mime_type,
+    blobs.size_bytes,
+    blobs.normalization_version
+  INTO reference
+  FROM content.media_assets AS assets
+  INNER JOIN content.media_blobs AS blobs
+    ON blobs.media_blob_id = assets.media_blob_id
+  WHERE assets.media_asset_id = p_media_asset_id
+    AND assets.deleted_at IS NULL
+  FOR UPDATE OF assets, blobs;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  )
+  INTO access_present;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM sync.workspace_replicas AS replicas
+    WHERE replicas.replica_id = p_last_modified_by_replica_id
+      AND replicas.workspace_id = p_workspace_id
+      AND replicas.user_id = p_user_id
+  )
+  INTO replica_matches;
+
+  IF current_attempt.attempt_token IS NULL
+    OR current_attempt.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR current_attempt.media_upload_session_id IS DISTINCT FROM p_media_upload_session_id
+    OR current_attempt.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR current_attempt.workspace_id IS DISTINCT FROM p_workspace_id
+    OR current_attempt.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR current_attempt.sha256 IS DISTINCT FROM p_sha256
+    OR current_attempt.blob_storage_key IS DISTINCT FROM p_storage_key
+    OR current_attempt.mime_type IS DISTINCT FROM p_mime_type
+    OR current_attempt.size_bytes IS DISTINCT FROM p_size_bytes
+    OR current_attempt.session_expires_at IS DISTINCT FROM p_expires_at
+  THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  IF current_attempt.user_id IS DISTINCT FROM p_user_id
+    OR owner_snapshot.user_id IS DISTINCT FROM p_user_id
+  THEN
+    RETURN 'ownership_mismatch';
+  END IF;
+
+  IF current_attempt.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_last_modified_by_replica_id
+  THEN
+    RETURN CASE WHEN access_present THEN 'replica_mismatch' ELSE 'access_denied' END;
+  END IF;
+
+  IF current_attempt.last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM p_last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM p_expires_at
+  THEN
+    RETURN 'ownership_mismatch';
+  END IF;
+
+  IF lifecycle.sha256 IS NULL
+    OR reservation.reservation_token IS NULL
+    OR owner_snapshot.reservation_token IS NULL
+    OR reservation.reservation_token IS DISTINCT FROM current_attempt.reservation_token
+    OR reservation.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR reservation.workspace_id IS DISTINCT FROM p_workspace_id
+    OR reservation.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR reservation.operation_id IS DISTINCT FROM p_media_upload_session_id::TEXT
+    OR reservation.sha256 IS DISTINCT FROM p_sha256
+    OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM current_attempt.normalization_version
+  THEN
+    RETURN 'writer_conflict';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM content.media_blob_writer_attempts AS successors
+    WHERE successors.writer_kind = 'multipart_completion'
+      AND successors.media_upload_session_id = p_media_upload_session_id
+      AND successors.state = 'leased'
+      AND successors.attempt_token <> current_attempt.attempt_token
+  ) THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  exact_reference_found :=
+    reference.workspace_id IS NOT NULL
+    AND reference.workspace_id IS NOT DISTINCT FROM p_workspace_id
+    AND reference.sha256 IS NOT DISTINCT FROM p_sha256
+    AND reference.storage_key IS NOT DISTINCT FROM p_storage_key
+    AND reference.mime_type IS NOT DISTINCT FROM p_mime_type
+    AND reference.size_bytes IS NOT DISTINCT FROM p_size_bytes
+    AND reference.normalization_version IS NOT DISTINCT FROM current_attempt.normalization_version;
+
+  IF exact_reference_found AND current_attempt.state <> 'leased' THEN
+    reconciled_at := pg_catalog.clock_timestamp();
+
+    IF current_attempt.reconciliation_failure_report_state = 'leased'
+      AND current_attempt.reconciliation_failure_report_lease_expires_at >
+        reconciled_at
+    THEN
+      RETURN 'cleanup_claimed';
+    END IF;
+
+    UPDATE content.media_blob_writer_reservations AS reservations
+    SET state = 'finalized'
+    WHERE reservations.reservation_token = reservation.reservation_token;
+
+    UPDATE content.media_blob_lifecycles AS lifecycles
+    SET
+      cleanup_eligible_at = NULL,
+      cleanup_lease_token = NULL,
+      cleanup_lease_expires_at = NULL,
+      updated_at = reconciled_at
+    WHERE lifecycles.sha256 = current_attempt.sha256;
+
+    IF current_attempt.state NOT IN ('applied', 'referenced') THEN
+      IF current_attempt.reconciliation_state IS NULL THEN
+        UPDATE content.media_blob_writer_attempts AS attempts
+        SET
+          state = 'referenced',
+          outcome = 'referenced',
+          terminal_at = reconciled_at
+        WHERE attempts.attempt_token = current_attempt.attempt_token;
+      ELSIF
+        current_attempt.reconciliation_failure_report_state = 'reported'
+      THEN
+        UPDATE content.media_blob_writer_attempts AS attempts
+        SET
+          state = 'referenced',
+          outcome = 'referenced',
+          terminal_at = reconciled_at,
+          reconciliation_state = 'applied',
+          reconciliation_next_attempt_at = NULL,
+          reconciliation_lease_token = NULL,
+          reconciliation_lease_owner = NULL,
+          reconciliation_lease_expires_at = NULL,
+          reconciliation_last_error_code = NULL,
+          reconciliation_last_error_message = NULL,
+          reconciliation_updated_at = reconciled_at,
+          reconciliation_applied_at = reconciled_at
+        WHERE attempts.attempt_token = current_attempt.attempt_token;
+      ELSE
+        UPDATE content.media_blob_writer_attempts AS attempts
+        SET
+          state = 'referenced',
+          outcome = 'referenced',
+          terminal_at = reconciled_at,
+          reconciliation_state = 'applied',
+          reconciliation_next_attempt_at = NULL,
+          reconciliation_lease_token = NULL,
+          reconciliation_lease_owner = NULL,
+          reconciliation_lease_expires_at = NULL,
+          reconciliation_last_error_code = NULL,
+          reconciliation_last_error_message = NULL,
+          reconciliation_updated_at = reconciled_at,
+          reconciliation_applied_at = reconciled_at,
+          reconciliation_failure_event_id = NULL,
+          reconciliation_failure_report_state = NULL,
+          reconciliation_failure_report_delivery_count = 0,
+          reconciliation_failure_report_lease_token = NULL,
+          reconciliation_failure_report_lease_owner = NULL,
+          reconciliation_failure_report_lease_expires_at = NULL,
+          reconciliation_failure_report_updated_at = NULL,
+          reconciliation_failure_reported_at = NULL
+        WHERE attempts.attempt_token = current_attempt.attempt_token;
+      END IF;
+    END IF;
+
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'completed',
+        completed_at = COALESCE(sessions.completed_at, reconciled_at),
+        aborted_at = NULL
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+
+    RETURN CASE
+      WHEN current_attempt.state IN ('applied', 'referenced') THEN current_attempt.outcome
+      ELSE 'referenced'
+    END;
+  END IF;
+
+  IF current_attempt.state IN ('applied', 'referenced') THEN
+    IF reservation.state IS DISTINCT FROM 'finalized' THEN
+      RETURN 'writer_conflict';
+    END IF;
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'completed',
+        completed_at = COALESCE(
+          sessions.completed_at,
+          current_attempt.terminal_at,
+          pg_catalog.clock_timestamp()
+        ),
+        aborted_at = NULL
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN current_attempt.outcome;
+  ELSIF current_attempt.state = 'peer_conflict' THEN
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'aborted',
+        completed_at = NULL,
+        aborted_at = COALESCE(
+          sessions.aborted_at,
+          current_attempt.terminal_at,
+          pg_catalog.clock_timestamp()
+        )
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN 'peer_conflict';
+  ELSIF current_attempt.state = 'cancelled' THEN
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'aborted',
+        completed_at = NULL,
+        aborted_at = COALESCE(
+          sessions.aborted_at,
+          current_attempt.terminal_at,
+          pg_catalog.clock_timestamp()
+        )
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN current_attempt.outcome;
+  END IF;
+
+  abort_proven := session_found AND session.state IN ('aborting', 'aborted');
+  expiry_proven := COALESCE(session.expires_at, owner_snapshot.session_expires_at)
+    <= pg_catalog.clock_timestamp();
+
+  IF current_attempt.state = 'unreferenced' THEN
+    IF NOT abort_proven AND NOT expiry_proven THEN
+      RETURN CASE WHEN access_present THEN 'access_active' ELSE 'access_denied' END;
+    END IF;
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'aborted',
+        completed_at = NULL,
+        aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp())
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    RETURN 'already_closed';
+  END IF;
+
+  IF current_attempt.state = 'leased'
+    AND current_attempt.lease_expires_at > pg_catalog.clock_timestamp()
+    AND NOT abort_proven
+  THEN
+    RETURN CASE
+      WHEN access_present AND p_expires_at > pg_catalog.clock_timestamp() THEN 'access_active'
+      ELSE 'busy'
+    END;
+  END IF;
+
+  IF NOT abort_proven AND NOT expiry_proven THEN
+    RETURN CASE WHEN access_present THEN 'access_active' ELSE 'access_denied' END;
+  END IF;
+
+  IF replica_matches IS DISTINCT FROM true AND access_present THEN
+    RETURN 'replica_mismatch';
+  END IF;
+
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'cleanup_claimed';
+  END IF;
+
+  terminalization_status := content.terminalize_media_blob_writer_failure(
+    reservation.reservation_token,
+    current_attempt.sha256,
+    current_attempt.blob_storage_key,
+    current_attempt.mime_type,
+    current_attempt.size_bytes,
+    current_attempt.normalization_version,
+    'multipart_completion',
+    current_attempt.workspace_id,
+    current_attempt.media_asset_id,
+    current_attempt.operation_id,
+    p_cleanup_delay_ms
+  );
+
+  IF terminalization_status = 'referenced' THEN
+    IF session_found THEN
+      UPDATE content.media_upload_sessions AS sessions
+      SET
+        state = 'completed',
+        completed_at = COALESCE(sessions.completed_at, pg_catalog.clock_timestamp()),
+        aborted_at = NULL
+      WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+    END IF;
+    IF current_attempt.state = 'leased' THEN
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET
+        state = 'referenced',
+        outcome = 'referenced',
+        terminal_at = pg_catalog.clock_timestamp()
+      WHERE attempts.attempt_token = current_attempt.attempt_token
+        AND attempts.state = 'leased';
+    END IF;
+    RETURN 'referenced';
+  ELSIF terminalization_status <> 'unreferenced' THEN
+    RETURN 'stale';
+  END IF;
+
+  IF session_found THEN
+    UPDATE content.media_upload_sessions AS sessions
+    SET
+      state = 'aborted',
+      completed_at = NULL,
+      aborted_at = COALESCE(sessions.aborted_at, pg_catalog.clock_timestamp())
+    WHERE sessions.media_upload_session_id = p_media_upload_session_id;
+  END IF;
+
+  IF current_attempt.state = 'leased' THEN
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'cancelled',
+      outcome = 'aborted',
+      terminal_at = pg_catalog.clock_timestamp()
+    WHERE attempts.attempt_token = current_attempt.attempt_token
+      AND attempts.state = 'leased';
+  END IF;
+
+  RETURN 'aborted';
+END;
+$$;
+
+COMMENT ON FUNCTION content.close_media_upload_session_current_blob_writer_with_owner(
+  TEXT,
+  UUID,
+  UUID,
+  UUID,
+  UUID,
+  TEXT,
+  TEXT,
+  TEXT,
+  TEXT,
+  BIGINT,
+  TIMESTAMPTZ,
+  INTEGER
+) IS
+  'Closes the current multipart attempt and resolves exact-reference recovery after any active failure-report delivery finishes.';
+
+CREATE FUNCTION content.renew_media_upload_session_completion_reconciliation(
+  p_attempt_token UUID,
+  p_lease_token UUID,
+  p_lease_duration_ms INTEGER
+)
+RETURNS TABLE (
+  renewal_status TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  renewed_at TIMESTAMPTZ;
+  renewed_until TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_lease_token IS NULL
+    OR p_lease_duration_ms IS NULL
+    OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+  THEN
+    RETURN QUERY SELECT 'lease_lost'::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+
+  renewed_at := pg_catalog.clock_timestamp();
+  renewed_until :=
+    renewed_at + (p_lease_duration_ms * interval '1 millisecond');
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    reconciliation_lease_expires_at = renewed_until,
+    reconciliation_updated_at = renewed_at
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_state = 'leased'
+    AND attempts.reconciliation_lease_token = p_lease_token
+    AND attempts.reconciliation_lease_expires_at > renewed_at;
+  IF FOUND THEN
+    RETURN QUERY SELECT 'renewed'::TEXT, renewed_until;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF attempt.reconciliation_state = 'applied' THEN
+    RETURN QUERY SELECT 'applied'::TEXT, NULL::TIMESTAMPTZ;
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN QUERY SELECT 'failed'::TEXT, NULL::TIMESTAMPTZ;
+  ELSE
+    RETURN QUERY SELECT 'lease_lost'::TEXT, NULL::TIMESTAMPTZ;
+  END IF;
+END;
+$$;
+
+CREATE FUNCTION content.reschedule_media_upload_session_completion_reconciliation(
+  p_attempt_token UUID,
+  p_lease_token UUID,
+  p_next_attempt_at TIMESTAMPTZ,
+  p_error_code TEXT,
+  p_error_message TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  rescheduled_at TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_lease_token IS NULL
+    OR p_next_attempt_at IS NULL
+    OR content.multipart_completion_reconciliation_error_valid_internal(
+      p_error_code,
+      p_error_message
+    ) IS DISTINCT FROM true
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  rescheduled_at := pg_catalog.clock_timestamp();
+  IF p_next_attempt_at < rescheduled_at THEN
+    RETURN 'stale';
+  END IF;
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    reconciliation_state = 'pending',
+    reconciliation_retry_count = attempts.reconciliation_retry_count + 1,
+    reconciliation_next_attempt_at = p_next_attempt_at,
+    reconciliation_lease_token = NULL,
+    reconciliation_lease_owner = NULL,
+    reconciliation_lease_expires_at = NULL,
+    reconciliation_last_error_code = p_error_code,
+    reconciliation_last_error_message = p_error_message,
+    reconciliation_updated_at = rescheduled_at
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_state = 'leased'
+    AND attempts.reconciliation_lease_token = p_lease_token
+    AND attempts.reconciliation_lease_expires_at > rescheduled_at;
+  IF FOUND THEN
+    RETURN 'rescheduled';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  END IF;
+  RETURN 'lease_lost';
+END;
+$$;
+
+CREATE FUNCTION content.apply_media_upload_session_completion_reconciliation_scope(
+  p_attempt_token UUID,
+  p_lease_token UUID
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt_snapshot content.media_blob_writer_attempts%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+BEGIN
+  SELECT attempts.*
+  INTO attempt_snapshot
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      attempt_snapshot.user_id || ':' || attempt_snapshot.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+  IF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  ELSIF attempt.reconciliation_state <> 'leased'
+    OR attempt.reconciliation_lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.reconciliation_lease_expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  PERFORM 1
+  FROM org.workspace_memberships AS memberships
+  WHERE memberships.workspace_id = attempt.workspace_id
+    AND memberships.user_id = attempt.user_id
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RETURN 'access_revoked';
+  END IF;
+
+  PERFORM 1
+  FROM sync.workspace_replicas AS replicas
+  WHERE replicas.replica_id = attempt.replica_id
+    AND replicas.workspace_id = attempt.workspace_id
+    AND replicas.user_id = attempt.user_id
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RETURN 'replica_revoked';
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id
+  FOR UPDATE;
+  IF NOT FOUND
+    OR session.workspace_id IS DISTINCT FROM attempt.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM attempt.media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM attempt.replica_id
+    OR session.last_operation_id IS DISTINCT FROM attempt.last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM attempt.sha256
+    OR session.staging_storage_key IS DISTINCT FROM attempt.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM attempt.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM attempt.s3_upload_id
+    OR session.mime_type IS DISTINCT FROM attempt.mime_type
+    OR session.size_bytes IS DISTINCT FROM attempt.size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM attempt.part_size_bytes
+    OR session.part_count IS DISTINCT FROM attempt.part_count
+    OR session.source_url IS DISTINCT FROM attempt.source_url
+    OR session.asset_created_at IS DISTINCT FROM attempt.asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM attempt.client_updated_at
+    OR session.expires_at IS DISTINCT FROM attempt.session_expires_at
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  IF session.state = 'aborting' THEN
+    RETURN 'aborting';
+  ELSIF session.state = 'aborted' THEN
+    RETURN 'aborted';
+  ELSIF session.state NOT IN ('completing', 'completed') THEN
+    RETURN 'stale';
+  END IF;
+
+  PERFORM pg_catalog.set_config('app.user_id', attempt.user_id, true);
+  PERFORM pg_catalog.set_config(
+    'app.workspace_id',
+    attempt.workspace_id::TEXT,
+    true
+  );
+  RETURN 'scoped';
+END;
+$$;
+
+CREATE FUNCTION content.finish_media_upload_session_completion_reconciliation(
+  p_attempt_token UUID,
+  p_lease_token UUID,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  asset RECORD;
+  terminalization_status TEXT;
+  applied_at TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  ELSIF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'already_applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  ELSIF attempt.reconciliation_state <> 'leased'
+    OR attempt.reconciliation_lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.reconciliation_lease_expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM attempt.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM attempt.workspace_id
+    OR NOT EXISTS (
+      SELECT 1
+      FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = attempt.workspace_id
+        AND memberships.user_id = attempt.user_id
+    )
+  THEN
+    RETURN 'access_revoked';
+  END IF;
+
+  SELECT *
+  INTO asset
+  FROM content.classify_media_upload_session_completion_asset_internal(
+    attempt.workspace_id,
+    attempt.media_asset_id,
+    attempt.sha256,
+    attempt.blob_storage_key,
+    attempt.mime_type,
+    attempt.size_bytes,
+    attempt.normalization_version,
+    attempt.source_url,
+    attempt.asset_created_at,
+    attempt.client_updated_at,
+    attempt.replica_id,
+    attempt.last_operation_id
+  );
+  IF asset.asset_status = 'peer_conflict' THEN
+    RETURN 'peer_conflict';
+  ELSIF asset.asset_status <> 'exact' THEN
+    RETURN 'stale';
+  END IF;
+
+  terminalization_status :=
+    content.terminalize_media_blob_writer_failure(
+      attempt.reservation_token,
+      attempt.sha256,
+      attempt.blob_storage_key,
+      attempt.mime_type,
+      attempt.size_bytes,
+      attempt.normalization_version,
+      'multipart_completion',
+      attempt.workspace_id,
+      attempt.media_asset_id,
+      attempt.operation_id,
+      p_cleanup_delay_ms
+    );
+  IF terminalization_status <> 'referenced' THEN
+    RETURN 'stale';
+  END IF;
+
+  applied_at := pg_catalog.clock_timestamp();
+  UPDATE content.media_upload_sessions AS sessions
+  SET
+    state = 'completed',
+    completed_at = COALESCE(sessions.completed_at, applied_at),
+    aborted_at = NULL
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id
+    AND sessions.state IN ('completing', 'completed');
+  IF NOT FOUND THEN
+    RETURN 'stale';
+  END IF;
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = 'applied',
+    outcome = 'live_applied',
+    terminal_at = applied_at,
+    reconciliation_state = 'applied',
+    reconciliation_next_attempt_at = NULL,
+    reconciliation_lease_token = NULL,
+    reconciliation_lease_owner = NULL,
+    reconciliation_lease_expires_at = NULL,
+    reconciliation_last_error_code = NULL,
+    reconciliation_last_error_message = NULL,
+    reconciliation_updated_at = applied_at,
+    reconciliation_applied_at = applied_at
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_state = 'leased'
+    AND attempts.reconciliation_lease_token = p_lease_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  RETURN 'applied';
+END;
+$$;
+
+CREATE FUNCTION content.fail_media_upload_session_completion_reconciliation(
+  p_attempt_token UUID,
+  p_lease_token UUID,
+  p_error_code TEXT,
+  p_error_message TEXT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt_snapshot content.media_blob_writer_attempts%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  asset RECORD;
+  terminalization_status TEXT;
+  failed_at TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_lease_token IS NULL
+    OR p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+    OR content.multipart_completion_reconciliation_error_valid_internal(
+      p_error_code,
+      p_error_message
+    ) IS DISTINCT FROM true
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt_snapshot
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      attempt_snapshot.user_id || ':' || attempt_snapshot.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+  IF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  ELSIF attempt.reconciliation_state <> 'leased'
+    OR attempt.reconciliation_lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.reconciliation_lease_expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id
+  FOR UPDATE;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = attempt.sha256
+  FOR UPDATE;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = attempt.reservation_token
+  FOR UPDATE;
+
+  IF session.media_upload_session_id IS NULL
+    OR lifecycle.sha256 IS NULL
+    OR reservation.reservation_token IS NULL
+    OR session.workspace_id IS DISTINCT FROM attempt.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM attempt.media_asset_id
+    OR session.media_blob_sha256 IS DISTINCT FROM attempt.sha256
+    OR session.staging_storage_key IS DISTINCT FROM attempt.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM attempt.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM attempt.s3_upload_id
+    OR reservation.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR reservation.workspace_id IS DISTINCT FROM attempt.workspace_id
+    OR reservation.media_asset_id IS DISTINCT FROM attempt.media_asset_id
+    OR reservation.operation_id IS DISTINCT FROM attempt.operation_id
+    OR reservation.sha256 IS DISTINCT FROM attempt.sha256
+    OR lifecycle.storage_key IS DISTINCT FROM attempt.blob_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM attempt.mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM attempt.size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM attempt.normalization_version
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT *
+  INTO asset
+  FROM content.classify_media_upload_session_completion_asset_internal(
+    attempt.workspace_id,
+    attempt.media_asset_id,
+    attempt.sha256,
+    attempt.blob_storage_key,
+    attempt.mime_type,
+    attempt.size_bytes,
+    attempt.normalization_version,
+    attempt.source_url,
+    attempt.asset_created_at,
+    attempt.client_updated_at,
+    attempt.replica_id,
+    attempt.last_operation_id
+  );
+
+  terminalization_status :=
+    content.terminalize_media_blob_writer_failure(
+      attempt.reservation_token,
+      attempt.sha256,
+      attempt.blob_storage_key,
+      attempt.mime_type,
+      attempt.size_bytes,
+      attempt.normalization_version,
+      'multipart_completion',
+      attempt.workspace_id,
+      attempt.media_asset_id,
+      attempt.operation_id,
+      p_cleanup_delay_ms
+    );
+  failed_at := pg_catalog.clock_timestamp();
+
+  IF asset.asset_status = 'exact'
+    OR terminalization_status = 'referenced'
+  THEN
+    IF terminalization_status <> 'referenced' THEN
+      RETURN 'stale';
+    END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET
+      state = 'completed',
+      completed_at = COALESCE(sessions.completed_at, failed_at),
+      aborted_at = NULL
+    WHERE sessions.media_upload_session_id = attempt.media_upload_session_id;
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'referenced',
+      outcome = 'referenced',
+      terminal_at = failed_at,
+      reconciliation_state = 'applied',
+      reconciliation_next_attempt_at = NULL,
+      reconciliation_lease_token = NULL,
+      reconciliation_lease_owner = NULL,
+      reconciliation_lease_expires_at = NULL,
+      reconciliation_last_error_code = NULL,
+      reconciliation_last_error_message = NULL,
+      reconciliation_updated_at = failed_at,
+      reconciliation_applied_at = failed_at
+    WHERE attempts.attempt_token = p_attempt_token
+      AND attempts.reconciliation_state = 'leased'
+      AND attempts.reconciliation_lease_token = p_lease_token;
+    RETURN 'applied';
+  END IF;
+
+  IF terminalization_status <> 'unreferenced' THEN
+    RETURN 'stale';
+  END IF;
+
+  UPDATE content.media_upload_sessions AS sessions
+  SET
+    state = 'aborted',
+    completed_at = NULL,
+    aborted_at = COALESCE(sessions.aborted_at, failed_at)
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id;
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = CASE
+      WHEN asset.asset_status = 'peer_conflict' THEN 'peer_conflict'
+      ELSE 'unreferenced'
+    END,
+    outcome = CASE
+      WHEN asset.asset_status = 'peer_conflict' THEN 'peer_conflict'
+      ELSE 'unreferenced'
+    END,
+    terminal_at = failed_at,
+    reconciliation_state = 'failed',
+    reconciliation_next_attempt_at = NULL,
+    reconciliation_lease_token = NULL,
+    reconciliation_lease_owner = NULL,
+    reconciliation_lease_expires_at = NULL,
+    reconciliation_last_error_code = p_error_code,
+    reconciliation_last_error_message = p_error_message,
+    reconciliation_updated_at = failed_at,
+    reconciliation_applied_at = NULL,
+    reconciliation_failure_event_id = public.gen_random_uuid(),
+    reconciliation_failure_report_state = 'pending',
+    reconciliation_failure_report_delivery_count = 0,
+    reconciliation_failure_report_lease_token = NULL,
+    reconciliation_failure_report_lease_owner = NULL,
+    reconciliation_failure_report_lease_expires_at = NULL,
+    reconciliation_failure_report_updated_at = failed_at,
+    reconciliation_failure_reported_at = NULL
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_state = 'leased'
+    AND attempts.reconciliation_lease_token = p_lease_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  RETURN 'failed';
+END;
+$$;
+
+CREATE FUNCTION content.claim_media_upload_session_completion_reconciliations(
+  p_lease_owner TEXT,
+  p_lease_duration_ms INTEGER,
+  p_limit INTEGER
+)
+RETURNS SETOF content.media_blob_writer_attempts
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  claim_started_at TIMESTAMPTZ;
+  invalid_candidate RECORD;
+  invalid_attempt content.media_blob_writer_attempts%ROWTYPE;
+  invalid_lease_token UUID;
+  invalid_status TEXT;
+  invalid_processed INTEGER := 0;
+  quarantined_at TIMESTAMPTZ;
+BEGIN
+  IF p_lease_owner IS NULL
+    OR p_lease_owner <> pg_catalog.btrim(p_lease_owner)
+    OR p_lease_owner = ''
+    OR pg_catalog.char_length(p_lease_owner) > 200
+    OR p_lease_owner ~ '[[:cntrl:]]'
+  THEN
+    RAISE EXCEPTION 'p_lease_owner must be 1 to 200 trimmed characters'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_lease_duration_ms IS NULL
+    OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+  THEN
+    RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_limit IS NULL OR p_limit NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'p_limit must be between 1 and 100'
+      USING ERRCODE = '22023';
+  END IF;
+
+  claim_started_at := pg_catalog.clock_timestamp();
+  FOR invalid_candidate IN
+    SELECT
+      attempts.attempt_token,
+      attempts.user_id,
+      attempts.workspace_id
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE (
+      (
+        attempts.reconciliation_state = 'pending'
+        AND attempts.reconciliation_next_attempt_at <= claim_started_at
+      )
+      OR (
+        attempts.reconciliation_state = 'leased'
+        AND attempts.reconciliation_lease_expires_at <= claim_started_at
+      )
+    )
+      AND content.multipart_completion_reconciliation_job_valid_internal(
+        attempts
+      ) IS DISTINCT FROM true
+    ORDER BY
+      CASE
+        WHEN attempts.reconciliation_state = 'leased'
+        THEN attempts.reconciliation_lease_expires_at
+        ELSE attempts.reconciliation_next_attempt_at
+      END,
+      attempts.reconciliation_handed_off_at,
+      attempts.attempt_token
+    LIMIT p_limit
+  LOOP
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+      pg_catalog.hashtextextended(
+        invalid_candidate.user_id
+          || ':'
+          || invalid_candidate.workspace_id::TEXT,
+        0::BIGINT
+      )
+    );
+
+    SELECT attempts.*
+    INTO invalid_attempt
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.attempt_token = invalid_candidate.attempt_token
+    FOR UPDATE;
+    IF NOT FOUND
+      OR (
+        NOT (
+          (
+            invalid_attempt.reconciliation_state = 'pending'
+            AND invalid_attempt.reconciliation_next_attempt_at <=
+              claim_started_at
+          )
+          OR (
+            invalid_attempt.reconciliation_state = 'leased'
+            AND invalid_attempt.reconciliation_lease_expires_at <=
+              claim_started_at
+          )
+        )
+      )
+      OR content.multipart_completion_reconciliation_job_valid_internal(
+        invalid_attempt
+      ) IS TRUE
+    THEN
+      CONTINUE;
+    END IF;
+
+    quarantined_at := pg_catalog.clock_timestamp();
+    invalid_lease_token := public.gen_random_uuid();
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      reconciliation_state = 'leased',
+      reconciliation_lease_token = invalid_lease_token,
+      reconciliation_lease_owner = p_lease_owner,
+      reconciliation_lease_expires_at =
+        quarantined_at + (p_lease_duration_ms * interval '1 millisecond'),
+      reconciliation_last_error_code =
+        'INVALID_RECONCILIATION_PAYLOAD',
+      reconciliation_last_error_message =
+        'Durable multipart completion payload is invalid.',
+      reconciliation_updated_at = quarantined_at
+    WHERE attempts.attempt_token = invalid_attempt.attempt_token;
+
+    invalid_status :=
+      content.fail_media_upload_session_completion_reconciliation(
+        invalid_attempt.attempt_token,
+        invalid_lease_token,
+        'INVALID_RECONCILIATION_PAYLOAD',
+        'Durable multipart completion payload is invalid.',
+        3600000
+      );
+    IF invalid_status NOT IN ('applied', 'failed') THEN
+      quarantined_at := pg_catalog.clock_timestamp();
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET
+        state = 'expired',
+        outcome = 'stale_attempt',
+        terminal_at = COALESCE(attempts.terminal_at, quarantined_at),
+        reconciliation_state = 'failed',
+        reconciliation_next_attempt_at = NULL,
+        reconciliation_lease_token = NULL,
+        reconciliation_lease_owner = NULL,
+        reconciliation_lease_expires_at = NULL,
+        reconciliation_last_error_code =
+          'INVALID_RECONCILIATION_PAYLOAD',
+        reconciliation_last_error_message =
+          'Durable multipart completion payload is invalid.',
+        reconciliation_updated_at = quarantined_at,
+        reconciliation_applied_at = NULL,
+        reconciliation_failure_event_id = public.gen_random_uuid(),
+        reconciliation_failure_report_state = 'pending',
+        reconciliation_failure_report_delivery_count = 0,
+        reconciliation_failure_report_lease_token = NULL,
+        reconciliation_failure_report_lease_owner = NULL,
+        reconciliation_failure_report_lease_expires_at = NULL,
+        reconciliation_failure_report_updated_at = quarantined_at,
+        reconciliation_failure_reported_at = NULL
+      WHERE attempts.attempt_token = invalid_attempt.attempt_token
+        AND attempts.reconciliation_state = 'leased'
+        AND attempts.reconciliation_lease_token = invalid_lease_token;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION
+          'Invalid multipart reconciliation could not be terminalized. attempt_token=%',
+          invalid_attempt.attempt_token
+          USING ERRCODE = '40001';
+      END IF;
+    END IF;
+    invalid_processed := invalid_processed + 1;
+  END LOOP;
+
+  claim_started_at := pg_catalog.clock_timestamp();
+  RETURN QUERY
+  WITH claimable AS (
+    SELECT attempts.attempt_token
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE (
+      (
+        attempts.reconciliation_state = 'pending'
+        AND attempts.reconciliation_next_attempt_at <= claim_started_at
+      )
+      OR (
+        attempts.reconciliation_state = 'leased'
+        AND attempts.reconciliation_lease_expires_at <= claim_started_at
+      )
+    )
+      AND content.multipart_completion_reconciliation_job_valid_internal(
+        attempts
+      ) IS TRUE
+    ORDER BY
+      CASE
+        WHEN attempts.reconciliation_state = 'leased'
+        THEN attempts.reconciliation_lease_expires_at
+        ELSE attempts.reconciliation_next_attempt_at
+      END,
+      attempts.reconciliation_handed_off_at,
+      attempts.attempt_token
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit - invalid_processed
+  )
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    reconciliation_state = 'leased',
+    reconciliation_lease_token = public.gen_random_uuid(),
+    reconciliation_lease_owner = p_lease_owner,
+    reconciliation_lease_expires_at =
+      claim_started_at + (p_lease_duration_ms * interval '1 millisecond'),
+    reconciliation_updated_at = claim_started_at
+  FROM claimable
+  WHERE attempts.attempt_token = claimable.attempt_token
+  RETURNING attempts.*;
+END;
+$$;
+
+CREATE FUNCTION content.get_media_upload_session_completion_reconciliation_outcome(
+  p_attempt_token UUID
+)
+RETURNS TABLE (
+  reconciliation_status TEXT,
+  reconciliation_error_code TEXT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    CASE attempts.reconciliation_state
+      WHEN 'applied' THEN 'applied'
+      WHEN 'failed' THEN 'failed'
+      WHEN 'pending' THEN 'active'
+      WHEN 'leased' THEN 'active'
+      ELSE 'missing'
+    END,
+    CASE
+      WHEN attempts.reconciliation_state = 'failed'
+      THEN attempts.reconciliation_last_error_code
+      ELSE NULL
+    END
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  UNION ALL
+  SELECT 'missing'::TEXT, NULL::TEXT
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.attempt_token = p_attempt_token
+  )
+  LIMIT 1;
+$$;
+
+CREATE FUNCTION content.claim_media_upload_session_completion_failure_reports(
+  p_lease_owner TEXT,
+  p_lease_duration_ms INTEGER,
+  p_limit INTEGER
+)
+RETURNS TABLE (
+  failure_event_id UUID,
+  attempt_token UUID,
+  workspace_id UUID,
+  reconciliation_retry_count INTEGER,
+  reconciliation_last_error_code TEXT,
+  failure_report_delivery_count INTEGER,
+  failure_report_lease_token UUID,
+  failure_report_lease_owner TEXT,
+  failure_report_lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  claimed_at TIMESTAMPTZ;
+BEGIN
+  IF p_lease_owner IS NULL
+    OR p_lease_owner <> pg_catalog.btrim(p_lease_owner)
+    OR p_lease_owner = ''
+    OR pg_catalog.char_length(p_lease_owner) > 200
+    OR p_lease_owner ~ '[[:cntrl:]]'
+  THEN
+    RAISE EXCEPTION 'p_lease_owner must be 1 to 200 trimmed characters'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_lease_duration_ms IS NULL
+    OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+  THEN
+    RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_limit IS NULL OR p_limit NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'p_limit must be between 1 and 100'
+      USING ERRCODE = '22023';
+  END IF;
+
+  claimed_at := pg_catalog.clock_timestamp();
+  RETURN QUERY
+  WITH claimable AS (
+    SELECT attempts.attempt_token
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.reconciliation_state = 'failed'
+      AND (
+        attempts.reconciliation_failure_report_state = 'pending'
+        OR (
+          attempts.reconciliation_failure_report_state = 'leased'
+          AND attempts.reconciliation_failure_report_lease_expires_at <=
+            claimed_at
+        )
+      )
+    ORDER BY
+      CASE
+        WHEN attempts.reconciliation_failure_report_state = 'leased'
+        THEN attempts.reconciliation_failure_report_lease_expires_at
+        ELSE attempts.reconciliation_failure_report_updated_at
+      END,
+      attempts.reconciliation_failure_event_id
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit
+  )
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    reconciliation_failure_report_state = 'leased',
+    reconciliation_failure_report_delivery_count =
+      attempts.reconciliation_failure_report_delivery_count + 1,
+    reconciliation_failure_report_lease_token = public.gen_random_uuid(),
+    reconciliation_failure_report_lease_owner = p_lease_owner,
+    reconciliation_failure_report_lease_expires_at =
+      claimed_at + (p_lease_duration_ms * interval '1 millisecond'),
+    reconciliation_failure_report_updated_at = claimed_at
+  FROM claimable
+  WHERE attempts.attempt_token = claimable.attempt_token
+  RETURNING
+    attempts.reconciliation_failure_event_id,
+    attempts.attempt_token,
+    attempts.workspace_id,
+    attempts.reconciliation_retry_count,
+    attempts.reconciliation_last_error_code,
+    attempts.reconciliation_failure_report_delivery_count,
+    attempts.reconciliation_failure_report_lease_token,
+    attempts.reconciliation_failure_report_lease_owner,
+    attempts.reconciliation_failure_report_lease_expires_at;
+END;
+$$;
+
+CREATE FUNCTION content.finish_media_upload_session_completion_failure_report(
+  p_failure_event_id UUID,
+  p_attempt_token UUID,
+  p_lease_token UUID
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  reported_at TIMESTAMPTZ;
+BEGIN
+  IF p_failure_event_id IS NULL
+    OR p_attempt_token IS NULL
+    OR p_lease_token IS NULL
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  reported_at := pg_catalog.clock_timestamp();
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    reconciliation_failure_report_state = 'reported',
+    reconciliation_failure_report_lease_token = NULL,
+    reconciliation_failure_report_lease_owner = NULL,
+    reconciliation_failure_report_lease_expires_at = NULL,
+    reconciliation_failure_report_updated_at = reported_at,
+    reconciliation_failure_reported_at = reported_at
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_failure_event_id = p_failure_event_id
+    AND attempts.reconciliation_failure_report_state = 'leased'
+    AND attempts.reconciliation_failure_report_lease_token = p_lease_token
+    AND attempts.reconciliation_failure_report_lease_expires_at > reported_at;
+  IF FOUND THEN
+    RETURN 'reported';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_failure_event_id = p_failure_event_id;
+  IF attempt.reconciliation_failure_report_state = 'reported' THEN
+    RETURN 'already_reported';
+  END IF;
+  RETURN 'lease_lost';
+END;
+$$;
+
+CREATE FUNCTION
+  content.lock_media_upload_session_completion_failure_report_delivery(
+    p_failure_event_id UUID,
+    p_attempt_token UUID,
+    p_lease_token UUID
+  )
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  locked_at TIMESTAMPTZ;
+BEGIN
+  IF p_failure_event_id IS NULL
+    OR p_attempt_token IS NULL
+    OR p_lease_token IS NULL
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  locked_at := pg_catalog.clock_timestamp();
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_failure_event_id = p_failure_event_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+  IF attempt.reconciliation_failure_report_state = 'reported' THEN
+    RETURN 'already_reported';
+  END IF;
+  IF attempt.reconciliation_state = 'failed'
+    AND attempt.reconciliation_failure_report_state = 'leased'
+    AND attempt.reconciliation_failure_report_lease_token = p_lease_token
+    AND attempt.reconciliation_failure_report_lease_expires_at > locked_at
+  THEN
+    RETURN 'ready';
+  END IF;
+  RETURN 'lease_lost';
+END;
+$$;
+
+COMMENT ON FUNCTION
+  content.lock_media_upload_session_completion_failure_report_delivery(
+    UUID,
+    UUID,
+    UUID
+  ) IS
+  'Authorizes one failure-report emission while retaining its row lock through acknowledgement in the caller transaction.';
+
+CREATE FUNCTION content.check_media_upload_session_completion_pending_with_owner(
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_media_upload_session_id UUID,
+  p_media_asset_id UUID
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF p_user_id IS NULL
+    OR p_user_id <> pg_catalog.btrim(p_user_id)
+    OR p_user_id = ''
+    OR p_workspace_id IS NULL
+    OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL
+  THEN
+    RETURN 'stale';
+  END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      p_user_id || ':' || p_workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+  IF NOT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM 1
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+    AND sessions.workspace_id = p_workspace_id
+    AND sessions.media_asset_id = p_media_asset_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN 'session_not_found';
+  END IF;
+
+  PERFORM 1
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.media_upload_session_id = p_media_upload_session_id
+    AND attempts.workspace_id = p_workspace_id
+    AND attempts.media_asset_id = p_media_asset_id
+    AND attempts.reconciliation_state IN ('pending', 'leased')
+  ORDER BY attempts.attempt_token
+  FOR UPDATE;
+  RETURN CASE WHEN FOUND THEN 'pending' ELSE 'not_pending' END;
+END;
+$$;
+
+CREATE FUNCTION content.check_media_asset_completion_pending_with_owner(
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_media_asset_id UUID
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF p_user_id IS NULL
+    OR p_user_id <> pg_catalog.btrim(p_user_id)
+    OR p_user_id = ''
+    OR p_workspace_id IS NULL
+    OR p_media_asset_id IS NULL
+  THEN
+    RETURN 'stale';
+  END IF;
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      p_user_id || ':' || p_workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'multipart-asset:' || p_workspace_id::TEXT || ':' || p_media_asset_id::TEXT,
+      4::BIGINT
+    )
+  );
+  IF NOT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM 1
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = p_workspace_id
+    AND sessions.media_asset_id = p_media_asset_id
+  ORDER BY sessions.media_upload_session_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.workspace_id = p_workspace_id
+    AND attempts.media_asset_id = p_media_asset_id
+    AND (
+      attempts.state = 'leased'
+      OR attempts.reconciliation_state IN ('pending', 'leased')
+    )
+  ORDER BY attempts.attempt_token
+  FOR UPDATE;
+  RETURN CASE WHEN FOUND THEN 'pending' ELSE 'not_pending' END;
+END;
+$$;
+
+CREATE FUNCTION content.fail_multipart_completion_reconciliations_before_workspace_delete()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  failed_at TIMESTAMPTZ;
+BEGIN
+  failed_at := pg_catalog.clock_timestamp();
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = 'cancelled',
+    outcome = 'aborted',
+    terminal_at = failed_at,
+    reconciliation_state = 'failed',
+    reconciliation_next_attempt_at = NULL,
+    reconciliation_lease_token = NULL,
+    reconciliation_lease_owner = NULL,
+    reconciliation_lease_expires_at = NULL,
+    reconciliation_last_error_code = 'WORKSPACE_DELETED',
+    reconciliation_last_error_message =
+      'Workspace was deleted before multipart completion reconciliation finished.',
+    reconciliation_updated_at = failed_at,
+    reconciliation_applied_at = NULL,
+    reconciliation_failure_event_id = public.gen_random_uuid(),
+    reconciliation_failure_report_state = 'pending',
+    reconciliation_failure_report_delivery_count = 0,
+    reconciliation_failure_report_lease_token = NULL,
+    reconciliation_failure_report_lease_owner = NULL,
+    reconciliation_failure_report_lease_expires_at = NULL,
+    reconciliation_failure_report_updated_at = failed_at,
+    reconciliation_failure_reported_at = NULL
+  WHERE attempts.workspace_id = OLD.workspace_id
+    AND attempts.reconciliation_state IN ('pending', 'leased');
+  RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER zz_fail_multipart_completion_reconciliations_before_workspace_delete
+  BEFORE DELETE ON org.workspaces
+  FOR EACH ROW
+  EXECUTE FUNCTION
+    content.fail_multipart_completion_reconciliations_before_workspace_delete();
+
+REVOKE ALL ON TABLE content.media_blob_writer_attempts
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.multipart_completion_reconciliation_error_valid_internal(TEXT, TEXT)
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.media_asset_last_operation_id_valid_internal(TEXT)
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.multipart_completion_reconciliation_job_valid_internal(
+    content.media_blob_writer_attempts
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.multipart_media_blob_writer_attempt_payload_valid_internal(
+    content.multipart_media_blob_writer_attempt_payload
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.multipart_media_blob_writer_attempt_payload_canonical_valid_internal(
+    content.multipart_media_blob_writer_attempt_payload
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.close_media_upload_session_current_blob_writer_with_owner(
+    TEXT,
+    UUID,
+    UUID,
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    TEXT,
+    TEXT,
+    BIGINT,
+    TIMESTAMPTZ,
+    INTEGER
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.handoff_media_upload_session_completion_attempt(
+    UUID,
+    UUID,
+    content.multipart_media_blob_writer_attempt_payload
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.claim_media_upload_session_completion_reconciliations(
+    TEXT,
+    INTEGER,
+    INTEGER
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.renew_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    INTEGER
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.reschedule_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    TIMESTAMPTZ,
+    TEXT,
+    TEXT
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.apply_media_upload_session_completion_reconciliation_scope(UUID, UUID)
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.finish_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    INTEGER
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.fail_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    INTEGER
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.get_media_upload_session_completion_reconciliation_outcome(UUID)
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.claim_media_upload_session_completion_failure_reports(
+    TEXT,
+    INTEGER,
+    INTEGER
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.finish_media_upload_session_completion_failure_report(
+    UUID,
+    UUID,
+    UUID
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.lock_media_upload_session_completion_failure_report_delivery(
+    UUID,
+    UUID,
+    UUID
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.check_media_upload_session_completion_pending_with_owner(
+    TEXT,
+    UUID,
+    UUID,
+    UUID
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.check_media_asset_completion_pending_with_owner(TEXT, UUID, UUID)
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.fail_multipart_completion_reconciliations_before_workspace_delete()
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION
+  content.close_media_upload_session_current_blob_writer_with_owner(
+    TEXT,
+    UUID,
+    UUID,
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    TEXT,
+    TEXT,
+    BIGINT,
+    TIMESTAMPTZ,
+    INTEGER
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.handoff_media_upload_session_completion_attempt(
+    UUID,
+    UUID,
+    content.multipart_media_blob_writer_attempt_payload
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.claim_media_upload_session_completion_reconciliations(
+    TEXT,
+    INTEGER,
+    INTEGER
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.renew_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    INTEGER
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.reschedule_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    TIMESTAMPTZ,
+    TEXT,
+    TEXT
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.apply_media_upload_session_completion_reconciliation_scope(UUID, UUID)
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.finish_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    INTEGER
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.fail_media_upload_session_completion_reconciliation(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    INTEGER
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.get_media_upload_session_completion_reconciliation_outcome(UUID)
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.claim_media_upload_session_completion_failure_reports(
+    TEXT,
+    INTEGER,
+    INTEGER
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.finish_media_upload_session_completion_failure_report(
+    UUID,
+    UUID,
+    UUID
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.lock_media_upload_session_completion_failure_report_delivery(
+    UUID,
+    UUID,
+    UUID
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.check_media_upload_session_completion_pending_with_owner(
+    TEXT,
+    UUID,
+    UUID,
+    UUID
+  )
+  TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.check_media_asset_completion_pending_with_owner(TEXT, UUID, UUID)
+  TO backend_app;

--- a/infra/aws/lib/ci-cd.ts
+++ b/infra/aws/lib/ci-cd.ts
@@ -17,11 +17,22 @@ export interface CiCdProps {
   streakLeaderboardSnapshotFn: lambda.IFunction;
   progressActiveDaysBackfillFn: lambda.IFunction;
   migrationFn: lambda.IFunction;
+  multipartCompletionReconciliationScheduleArn: string;
   userPoolArn: string;
   webBucket: s3.IBucket;
   webDistribution: cloudfront.Distribution;
   adminBucket: s3.IBucket;
   adminDistribution: cloudfront.Distribution;
+}
+
+export function createMultipartCompletionReconciliationScheduleReadStatement(
+  scheduleArn: string,
+): iam.PolicyStatement {
+  return new iam.PolicyStatement({
+    sid: "ReadMultipartCompletionReconciliationSchedule",
+    actions: ["scheduler:GetSchedule"],
+    resources: [scheduleArn],
+  });
 }
 
 export function ciCd(scope: Construct, props: CiCdProps): void {
@@ -52,6 +63,9 @@ export function ciCd(scope: Construct, props: CiCdProps): void {
       actions: ["lambda:InvokeFunction"],
       resources: [props.migrationFn.functionArn],
     }),
+    createMultipartCompletionReconciliationScheduleReadStatement(
+      props.multipartCompletionReconciliationScheduleArn,
+    ),
     new iam.PolicyStatement({
       sid: "ReadAuthLambdaConfiguration",
       actions: ["lambda:GetFunctionConfiguration"],

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -43,6 +43,7 @@ export interface MonitoringProps {
   streakLeaderboardSnapshotFn: lambda.IFunction;
   progressActiveDaysBackfillFn: lambda.IFunction;
   generatedMediaPromotionFn: lambda.IFunction;
+  multipartCompletionReconciliationFn: lambda.Function;
 }
 
 export interface MonitoringResult {
@@ -58,6 +59,12 @@ const directImageIngestionHandled5xxMetricName: string =
   "DirectImageIngestionHandledHttp5xx";
 const directImageIngestionHandled5xxAction: string =
   "direct_image_ingestion_handled_http_5xx";
+const multipartCompletionReconciliationFailureMetricNamespace: string =
+  "FlashcardsOpenSourceApp/MultipartCompletionReconciliation";
+const multipartCompletionReconciliationFailureMetricName: string =
+  "FailedJobs";
+export const multipartCompletionReconciliationFailureMetricValue: string =
+  "1";
 
 function createAuthApiAccessLog5xxFilterPattern(): logs.IFilterPattern {
   return logs.FilterPattern.any(
@@ -75,6 +82,17 @@ logs.IFilterPattern {
     ),
     logs.FilterPattern.numberValue("$.message.statusCode", ">=", 500),
     logs.FilterPattern.numberValue("$.message.statusCode", "<", 600),
+  );
+}
+
+export function createMultipartCompletionReconciliationFailureFilterPattern():
+logs.IFilterPattern {
+  return logs.FilterPattern.all(
+    logs.FilterPattern.stringValue(
+      "$.message.action",
+      "=",
+      "multipart_completion_reconciliation_job_terminally_failed",
+    ),
   );
 }
 
@@ -399,6 +417,72 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     alarmDescription: "Generated-media promotion Lambda has not run for ten minutes",
     treatMissingData: cloudwatch.TreatMissingData.BREACHING,
   }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(
+    scope,
+    "MultipartCompletionReconciliationLambdaErrorAlarm",
+    {
+      metric: props.multipartCompletionReconciliationFn.metricErrors({
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      alarmDescription:
+        "Multipart completion reconciliation Lambda had unhandled errors",
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    },
+  ).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(
+    scope,
+    "MultipartCompletionReconciliationStaleAlarm",
+    {
+      metric: props.multipartCompletionReconciliationFn.metricInvocations({
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+      alarmDescription:
+        "Multipart completion reconciliation Lambda has not run for ten minutes",
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+    },
+  ).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  const multipartCompletionReconciliationFailureMetricFilter =
+    new logs.MetricFilter(
+      scope,
+      "MultipartCompletionReconciliationFailureMetricFilter",
+      {
+        logGroup: props.multipartCompletionReconciliationFn.logGroup,
+        filterPattern:
+          createMultipartCompletionReconciliationFailureFilterPattern(),
+        metricNamespace:
+          multipartCompletionReconciliationFailureMetricNamespace,
+        metricName: multipartCompletionReconciliationFailureMetricName,
+        metricValue: multipartCompletionReconciliationFailureMetricValue,
+        defaultValue: 0,
+      },
+    );
+  new cloudwatch.Alarm(
+    scope,
+    "MultipartCompletionReconciliationFailedJobsAlarm",
+    {
+      metric: multipartCompletionReconciliationFailureMetricFilter.metric({
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      alarmDescription:
+        "Multipart completion reconciliation terminally failed one or more jobs",
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    },
+  ).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
 
   return { alertTopic };
 }

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -44,6 +44,7 @@ export interface OutputsProps {
   apexRedirectDistribution: cloudfront.Distribution | undefined;
   apexRedirectCustomDomain: string | undefined;
   mediaAssetsBucket: s3.IBucket;
+  multipartCompletionReconciliationScheduleName: string;
   dbAccessInstance?: ec2.Instance;
   analyticsSshUsername?: string;
 }
@@ -143,6 +144,16 @@ export function outputs(scope: Construct, props: OutputsProps): void {
     value: props.migrationFn.functionName,
     description: "Lambda function name for database migrations",
   });
+
+  new cdk.CfnOutput(
+    scope,
+    "MultipartCompletionReconciliationScheduleName",
+    {
+      value: props.multipartCompletionReconciliationScheduleName,
+      description:
+        "EventBridge Scheduler name for multipart completion reconciliation",
+    },
+  );
 
   new cdk.CfnOutput(scope, "GlobalMetricsSnapshotFunctionName", {
     value: props.globalMetricsSnapshotFunction.functionName,

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import {
+  createMultipartCompletionReconciliationFailureFilterPattern,
+  multipartCompletionReconciliationFailureMetricValue,
+} from "../monitoring";
+import {
+  createMultipartCompletionReconciliationScheduleReadStatement,
+} from "../ci-cd";
+import {
+  createMultipartCompletionReconciliationListBucketStatement,
+  multipartCompletionReconciliationScheduleExpression,
+  multipartCompletionReconciliationScheduleName,
+} from "./multipart-completion-reconciliation";
+
+function readLibSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("multipart completion reconciliation is scheduled every minute", () => {
+  assert.equal(
+    multipartCompletionReconciliationScheduleExpression,
+    "rate(1 minute)",
+  );
+  assert.equal(
+    multipartCompletionReconciliationScheduleName,
+    "flashcards-open-source-app-multipart-completion-reconciliation",
+  );
+});
+
+test("multipart completion reconciliation Lambda has bounded runtime and exact S3 access", () => {
+  const source = readLibSource(
+    "lib/scheduled-jobs/multipart-completion-reconciliation.ts",
+  );
+
+  assert.match(
+    source,
+    /new lambdaNodejs\.NodejsFunction\([\s\S]*"MultipartCompletionReconciliationHandler"/,
+  );
+  assert.match(
+    source,
+    /lambda-multipart-completion-reconciliation\.ts/,
+  );
+  assert.match(source, /timeout: cdk\.Duration\.minutes\(2\)/);
+  assert.match(source, /memorySize: 512/);
+  assert.match(source, /loggingFormat: lambda\.LoggingFormat\.JSON/);
+  assert.match(
+    source,
+    /applicationLogLevelV2: lambda\.ApplicationLogLevel\.INFO/,
+  );
+  assert.match(
+    source,
+    /systemLogLevelV2: lambda\.SystemLogLevel\.INFO/,
+  );
+  assert.match(source, /subnetType: ec2\.SubnetType\.PRIVATE_WITH_EGRESS/);
+  assert.match(source, /DB_SECRET_ARN: props\.backendDbSecret\.secretArn/);
+  assert.match(
+    source,
+    /MEDIA_ASSETS_S3_BUCKET_NAME: props\.mediaAssetsBucket\.bucketName/,
+  );
+  assert.match(
+    source,
+    /"media\/uploads\/workspaces\/\*\/assets\/\*\/sessions\/\*"/,
+  );
+  assert.match(source, /"media\/blobs\/sha256\/\*"/);
+  assert.match(source, /actions: \["s3:GetObject"\]/);
+  assert.match(source, /actions: \["s3:PutObject"\]/);
+  assert.match(source, /actions: \["s3:ListMultipartUploadParts"\]/);
+  assert.match(source, /actions: \["s3:ListBucket"\]/);
+  assert.doesNotMatch(source, /s3:DeleteObject|s3:AbortMultipartUpload/);
+});
+
+test("multipart reconciliation can distinguish missing objects only in its exact prefixes", () => {
+  const bucketArn = "arn:aws:s3:::test-media-assets-bucket";
+
+  assert.deepEqual(
+    createMultipartCompletionReconciliationListBucketStatement(
+      bucketArn,
+    ).toStatementJson(),
+    {
+      Action: "s3:ListBucket",
+      Condition: {
+        StringLike: {
+          "s3:prefix": [
+            "media/uploads/workspaces/*/assets/*/sessions/*",
+            "media/blobs/sha256/*",
+          ],
+        },
+      },
+      Effect: "Allow",
+      Resource: bucketArn,
+      Sid: "ListMultipartCompletionReconciliationObjects",
+    },
+  );
+});
+
+test("multipart completion reconciliation schedule can invoke only its Lambda", () => {
+  const source = readLibSource(
+    "lib/scheduled-jobs/multipart-completion-reconciliation.ts",
+  );
+
+  assert.match(
+    source,
+    /new scheduler\.CfnSchedule\([\s\S]*"MultipartCompletionReconciliationSchedule"/,
+  );
+  assert.match(
+    source,
+    /scheduleExpression: multipartCompletionReconciliationScheduleExpression/,
+  );
+  assert.match(
+    source,
+    /name: multipartCompletionReconciliationScheduleName/,
+  );
+  assert.match(source, /state: props\.scheduleState/);
+  assert.match(
+    source,
+    /new iam\.Role\([\s\S]*"MultipartCompletionReconciliationSchedulerRole"/,
+  );
+  assert.match(source, /actions: \["lambda:InvokeFunction"\]/);
+  assert.match(source, /resources: \[reconciliationFunction\.functionArn\]/);
+});
+
+test("stack wires multipart reconciliation into monitoring without an HTTP route", () => {
+  const stackSource = readLibSource("lib/stack.ts");
+  const apiGatewaySource = readLibSource("lib/gateways/api-gateway.ts");
+
+  assert.match(
+    stackSource,
+    /const multipartCompletionReconciliationResult =[\s\S]*multipartCompletionReconciliation\(this, \{/,
+  );
+  assert.match(
+    stackSource,
+    /multipartCompletionReconciliationFn:[\s\S]*multipartCompletionReconciliationResult\.reconciliationFunction/,
+  );
+  assert.match(
+    stackSource,
+    /scheduleState: multipartCompletionReconciliationScheduleState/,
+  );
+  assert.match(
+    stackSource,
+    /if \(value === undefined\) \{[\s\S]*return "DISABLED"/,
+  );
+  assert.doesNotMatch(
+    apiGatewaySource,
+    /multipartCompletionReconciliation|multipart-completion-reconciliation/,
+  );
+});
+
+test("monitoring covers worker errors, staleness, and terminal job failures", () => {
+  const source = readLibSource("lib/monitoring.ts");
+  const pattern =
+    createMultipartCompletionReconciliationFailureFilterPattern()
+      .logPatternString;
+
+  assert.match(
+    pattern,
+    /multipart_completion_reconciliation_job_terminally_failed/,
+  );
+  assert.doesNotMatch(pattern, /message\.failed/);
+  assert.doesNotMatch(pattern, /message\.details\.failed/);
+  const failedEnvelope = {
+    timestamp: "2026-07-29T00:00:00.000Z",
+    level: "INFO",
+    requestId: "request-1",
+    message: {
+      action: "multipart_completion_reconciliation_job_terminally_failed",
+      attemptToken: "attempt-1",
+      errorCode: "RETRY_EXHAUSTED",
+    },
+  };
+  assert.equal(
+    multipartCompletionReconciliationFailureMetricValue,
+    "1",
+  );
+  assert.equal(
+    failedEnvelope.message.action,
+    "multipart_completion_reconciliation_job_terminally_failed",
+  );
+  assert.match(
+    source,
+    /metricValue: multipartCompletionReconciliationFailureMetricValue/,
+  );
+  assert.match(
+    source,
+    /"MultipartCompletionReconciliationLambdaErrorAlarm"/,
+  );
+  assert.match(source, /"MultipartCompletionReconciliationStaleAlarm"/);
+  assert.match(
+    source,
+    /"MultipartCompletionReconciliationFailureMetricFilter"/,
+  );
+  assert.match(
+    source,
+    /"MultipartCompletionReconciliationFailedJobsAlarm"/,
+  );
+});
+
+test("release deploys the schedule disabled, migrates, then enables and verifies it", () => {
+  const workflow = readLibSource(
+    "../../.github/workflows/aws-web-release.yml",
+  );
+  const disabledDeploy = workflow.indexOf(
+    "multipartCompletionReconciliationScheduleState=DISABLED",
+  );
+  const requiredMigration = workflow.indexOf(
+    "--require-migration 0099_durable_multipart_completion_reconciliation.sql",
+  );
+  const enabledDeploy = workflow.indexOf(
+    "multipartCompletionReconciliationScheduleState=ENABLED",
+  );
+  const scheduleVerification = workflow.indexOf(
+    "check-multipart-completion-reconciliation-schedule.sh",
+    enabledDeploy,
+  );
+
+  assert.ok(disabledDeploy >= 0);
+  assert.ok(requiredMigration > disabledDeploy);
+  assert.ok(enabledDeploy > requiredMigration);
+  assert.ok(scheduleVerification > enabledDeploy);
+  assert.match(
+    workflow,
+    /name: Verify reconciliation schedule is enabled/,
+  );
+
+  const outputsSource = readLibSource("lib/outputs.ts");
+  assert.match(
+    outputsSource,
+    /"MultipartCompletionReconciliationScheduleName"/,
+  );
+  const verificationScript = readLibSource(
+    "../../scripts/checks/check-multipart-completion-reconciliation-schedule.sh",
+  );
+  assert.match(
+    verificationScript,
+    /OutputKey=='MultipartCompletionReconciliationScheduleName'/,
+  );
+  assert.match(verificationScript, /aws scheduler get-schedule/);
+  assert.match(verificationScript, /SCHEDULE_STATE" != "ENABLED"/);
+
+  const bootstrapScript = readLibSource(
+    "../../scripts/deploy/bootstrap.sh",
+  );
+  const bootstrapDisabled = bootstrapScript.indexOf(
+    "multipartCompletionReconciliationScheduleState=DISABLED",
+  );
+  const bootstrapMigration = bootstrapScript.indexOf(
+    "--require-migration 0099_durable_multipart_completion_reconciliation.sql",
+  );
+  const bootstrapEnabled = bootstrapScript.indexOf(
+    "multipartCompletionReconciliationScheduleState=ENABLED",
+  );
+  const bootstrapVerification = bootstrapScript.indexOf(
+    "check-multipart-completion-reconciliation-schedule.sh",
+  );
+  assert.ok(bootstrapDisabled >= 0);
+  assert.ok(bootstrapMigration > bootstrapDisabled);
+  assert.ok(bootstrapEnabled > bootstrapMigration);
+  assert.ok(bootstrapVerification > bootstrapEnabled);
+});
+
+test("release verification can read only the exact reconciliation schedule", () => {
+  const scheduleArn =
+    "arn:aws:scheduler:eu-west-1:123456789012:schedule/default/flashcards-open-source-app-multipart-completion-reconciliation";
+  assert.deepEqual(
+    createMultipartCompletionReconciliationScheduleReadStatement(
+      scheduleArn,
+    ).toStatementJson(),
+    {
+      Action: "scheduler:GetSchedule",
+      Effect: "Allow",
+      Resource: scheduleArn,
+      Sid: "ReadMultipartCompletionReconciliationSchedule",
+    },
+  );
+
+  const stackSource = readLibSource("lib/stack.ts");
+  assert.match(
+    stackSource,
+    /multipartCompletionReconciliationScheduleArn:[\s\S]*multipartCompletionReconciliationResult\.reconciliationScheduleArn/,
+  );
+  const ciCdSource = readLibSource("lib/ci-cd.ts");
+  assert.doesNotMatch(
+    ciCdSource,
+    /actions:\s*\[[^\]]*"scheduler:\*"/,
+  );
+  assert.doesNotMatch(
+    ciCdSource,
+    /resources:\s*\[[^\]]*"\*"[^\]]*\][\s\S]{0,160}scheduler:GetSchedule/,
+  );
+});

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.ts
@@ -1,0 +1,185 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as scheduler from "aws-cdk-lib/aws-scheduler";
+import { Construct } from "constructs";
+import {
+  backendNodejsProjectPaths,
+  resolveFromRepoRoot,
+} from "../nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "../sentry-source-maps";
+
+export interface MultipartCompletionReconciliationProps {
+  vpc: ec2.Vpc;
+  lambdaSg: ec2.SecurityGroup;
+  db: rds.DatabaseInstance;
+  backendDbSecret: cdk.aws_secretsmanager.Secret;
+  mediaAssetsBucket: s3.IBucket;
+  sentryDsnSecretArn: string;
+  sentryEnvironment: string;
+  sentryRelease: string;
+  sentryTracesSampleRate: string;
+  scheduleState: MultipartCompletionReconciliationScheduleState;
+}
+
+export interface MultipartCompletionReconciliationResult {
+  reconciliationFunction: lambdaNodejs.NodejsFunction;
+  reconciliationScheduleArn: string;
+  reconciliationScheduleName: string;
+}
+
+export type MultipartCompletionReconciliationScheduleState =
+  | "DISABLED"
+  | "ENABLED";
+
+export const multipartCompletionReconciliationScheduleExpression =
+  "rate(1 minute)";
+export const multipartCompletionReconciliationScheduleName =
+  "flashcards-open-source-app-multipart-completion-reconciliation";
+const multipartCompletionReconciliationStagingListPrefix =
+  "media/uploads/workspaces/*/assets/*/sessions/*";
+const multipartCompletionReconciliationBlobListPrefix =
+  "media/blobs/sha256/*";
+
+export function createMultipartCompletionReconciliationListBucketStatement(
+  bucketArn: string,
+): iam.PolicyStatement {
+  return new iam.PolicyStatement({
+    sid: "ListMultipartCompletionReconciliationObjects",
+    actions: ["s3:ListBucket"],
+    resources: [bucketArn],
+    conditions: {
+      StringLike: {
+        "s3:prefix": [
+          multipartCompletionReconciliationStagingListPrefix,
+          multipartCompletionReconciliationBlobListPrefix,
+        ],
+      },
+    },
+  });
+}
+
+export function multipartCompletionReconciliation(
+  scope: Construct,
+  props: MultipartCompletionReconciliationProps,
+): MultipartCompletionReconciliationResult {
+  const reconciliationFunction = new lambdaNodejs.NodejsFunction(
+    scope,
+    "MultipartCompletionReconciliationHandler",
+    {
+      entry: resolveFromRepoRoot(
+        "apps",
+        "backend",
+        "src",
+        "entrypoints",
+        "scheduledJobs",
+        "lambda-multipart-completion-reconciliation.ts",
+      ),
+      handler: "handler",
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.minutes(2),
+      memorySize: 512,
+      loggingFormat: lambda.LoggingFormat.JSON,
+      applicationLogLevelV2: lambda.ApplicationLogLevel.INFO,
+      systemLogLevelV2: lambda.SystemLogLevel.INFO,
+      vpc: props.vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      securityGroups: [props.lambdaSg],
+      ...backendNodejsProjectPaths,
+      bundling: {
+        minify: true,
+        sourceMap: true,
+        commandHooks: {
+          beforeBundling: () => [],
+          beforeInstall: () => [],
+          afterBundling: (_inputDir: string, outputDir: string) => [
+            `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+            createSentrySourceMapUploadCommand(outputDir),
+          ],
+        },
+      },
+      environment: {
+        NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
+        DB_SECRET_ARN: props.backendDbSecret.secretArn,
+        DB_HOST: props.db.dbInstanceEndpointAddress,
+        DB_NAME: "flashcards",
+        MEDIA_ASSETS_S3_BUCKET_NAME: props.mediaAssetsBucket.bucketName,
+        SENTRY_ENVIRONMENT: props.sentryEnvironment,
+        SENTRY_RELEASE: props.sentryRelease,
+        SENTRY_TRACES_SAMPLE_RATE: props.sentryTracesSampleRate,
+      },
+    },
+  );
+  props.backendDbSecret.grantRead(reconciliationFunction);
+  const sentryDsnSecret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+    scope,
+    "MultipartCompletionReconciliationSentryDsnSecret",
+    props.sentryDsnSecretArn,
+  );
+  sentryDsnSecret.grantRead(reconciliationFunction);
+  reconciliationFunction.addEnvironment(
+    "SENTRY_DSN",
+    sentryDsnSecret.secretValue.unsafeUnwrap(),
+  );
+
+  const stagingObjects = props.mediaAssetsBucket.arnForObjects(
+    "media/uploads/workspaces/*/assets/*/sessions/*",
+  );
+  const blobObjects = props.mediaAssetsBucket.arnForObjects(
+    "media/blobs/sha256/*",
+  );
+  reconciliationFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:GetObject"],
+    resources: [stagingObjects, blobObjects],
+  }));
+  reconciliationFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:PutObject"],
+    resources: [stagingObjects, blobObjects],
+  }));
+  reconciliationFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:ListMultipartUploadParts"],
+    resources: [stagingObjects],
+  }));
+  reconciliationFunction.addToRolePolicy(
+    createMultipartCompletionReconciliationListBucketStatement(
+      props.mediaAssetsBucket.bucketArn,
+    ),
+  );
+
+  const schedulerRole = new iam.Role(
+    scope,
+    "MultipartCompletionReconciliationSchedulerRole",
+    { assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com") },
+  );
+  schedulerRole.addToPolicy(new iam.PolicyStatement({
+    actions: ["lambda:InvokeFunction"],
+    resources: [reconciliationFunction.functionArn],
+  }));
+  const reconciliationSchedule = new scheduler.CfnSchedule(
+    scope,
+    "MultipartCompletionReconciliationSchedule",
+    {
+      description: "Reconcile durable multipart upload completions",
+      flexibleTimeWindow: { mode: "OFF" },
+      name: multipartCompletionReconciliationScheduleName,
+      scheduleExpression: multipartCompletionReconciliationScheduleExpression,
+      scheduleExpressionTimezone: "UTC",
+      state: props.scheduleState,
+      target: {
+        arn: reconciliationFunction.functionArn,
+        input: "{}",
+        roleArn: schedulerRole.roleArn,
+      },
+    },
+  );
+  return {
+    reconciliationFunction,
+    reconciliationScheduleArn: reconciliationSchedule.attrArn,
+    reconciliationScheduleName:
+      multipartCompletionReconciliationScheduleName,
+  };
+}

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -20,6 +20,10 @@ import { communityLeaderboard } from "./scheduled-jobs/community-leaderboard";
 import { streakLeaderboard } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfill } from "./scheduled-jobs/progress-active-days-backfill";
 import { generatedMediaPromotion } from "./scheduled-jobs/generated-media-promotion";
+import {
+  multipartCompletionReconciliation,
+  type MultipartCompletionReconciliationScheduleState,
+} from "./scheduled-jobs/multipart-completion-reconciliation";
 import { mediaAssets } from "./media-assets";
 
 function getOptionalContextValue(stack: cdk.Stack, key: string): string | undefined {
@@ -39,6 +43,24 @@ function getOptionalRawContextValue(stack: cdk.Stack, key: string): string | und
   }
 
   return value;
+}
+
+function getMultipartCompletionReconciliationScheduleState(
+  stack: cdk.Stack,
+): MultipartCompletionReconciliationScheduleState {
+  const value = getOptionalContextValue(
+    stack,
+    "multipartCompletionReconciliationScheduleState",
+  );
+  if (value === undefined) {
+    return "DISABLED";
+  }
+  if (value === "DISABLED" || value === "ENABLED") {
+    return value;
+  }
+  throw new Error(
+    "multipartCompletionReconciliationScheduleState must be DISABLED or ENABLED",
+  );
 }
 
 interface BackendSentryContext {
@@ -157,6 +179,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     // When disabled, no client can fetch global stats from that endpoint.
     const rawGlobalMetricsVisible = getOptionalRawContextValue(this, "globalMetricsVisible");
     const globalMetricsVisible = rawGlobalMetricsVisible === "true";
+    const multipartCompletionReconciliationScheduleState =
+      getMultipartCompletionReconciliationScheduleState(this);
     const analyticsAccessRequested =
       analyticsSshPublicKeysValue !== undefined ||
       analyticsSshAllowedCidrsValue !== undefined ||
@@ -204,6 +228,16 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       mediaAssetsBucket: mediaAssetsResult.bucket,
       ...sentryContext,
     });
+    const multipartCompletionReconciliationResult =
+      multipartCompletionReconciliation(this, {
+        vpc: net.vpc,
+        lambdaSg: net.lambdaSg,
+        db: dbResult.db,
+        backendDbSecret: dbResult.backendDbSecret,
+        mediaAssetsBucket: mediaAssetsResult.bucket,
+        scheduleState: multipartCompletionReconciliationScheduleState,
+        ...sentryContext,
+      });
     let analyticsAccessResult: AnalyticsAccessResult | undefined;
     if (analyticsAccessRequested) {
       if (analyticsSshPublicKeysValue === undefined) {
@@ -330,6 +364,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       streakLeaderboardSnapshotFn: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
       generatedMediaPromotionFn: generatedMediaPromotionResult.promotionFunction,
+      multipartCompletionReconciliationFn:
+        multipartCompletionReconciliationResult.reconciliationFunction,
     });
 
     ciCd(this, {
@@ -344,6 +380,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       streakLeaderboardSnapshotFn: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
       migrationFn,
+      multipartCompletionReconciliationScheduleArn:
+        multipartCompletionReconciliationResult.reconciliationScheduleArn,
       userPoolArn: authResult.userPool.userPoolArn,
       webBucket: web.bucket,
       webDistribution: web.distribution,
@@ -387,6 +425,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       apexRedirectDistribution: web.apexRedirectDistribution,
       apexRedirectCustomDomain: web.apexRedirectCustomDomain,
       mediaAssetsBucket: mediaAssetsResult.bucket,
+      multipartCompletionReconciliationScheduleName:
+        multipartCompletionReconciliationResult.reconciliationScheduleName,
       dbAccessInstance: analyticsAccessResult?.dbAccessInstance,
       reportingDbSecret: dbResult.reportingDbSecret,
       analyticsSshUsername: analyticsAccessResult?.sshUsername,

--- a/scripts/checks/check-multipart-completion-reconciliation-schedule.sh
+++ b/scripts/checks/check-multipart-completion-reconciliation-schedule.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify that the deployed multipart completion reconciliation schedule is enabled.
+
+set -euo pipefail
+
+STACK_NAME="FlashcardsOpenSourceApp"
+REGION="${AWS_REGION:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack-name) STACK_NAME="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$REGION" ]]; then
+  echo "Usage: $0 --region <aws-region> [--stack-name <stack-name>]" >&2
+  exit 1
+fi
+
+SCHEDULE_NAME="$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='MultipartCompletionReconciliationScheduleName'].OutputValue" \
+  --output text)"
+
+if [[ -z "$SCHEDULE_NAME" || "$SCHEDULE_NAME" == "None" ]]; then
+  echo "ERROR: MultipartCompletionReconciliationScheduleName output not found." >&2
+  exit 1
+fi
+
+SCHEDULE_STATE="$(aws scheduler get-schedule \
+  --name "$SCHEDULE_NAME" \
+  --region "$REGION" \
+  --query State \
+  --output text)"
+
+if [[ "$SCHEDULE_STATE" != "ENABLED" ]]; then
+  echo "ERROR: Schedule ${SCHEDULE_NAME} is ${SCHEDULE_STATE}; expected ENABLED." >&2
+  exit 1
+fi
+
+echo "Multipart completion reconciliation schedule is enabled: ${SCHEDULE_NAME}"

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -141,11 +141,23 @@ echo "=== CDK bootstrap ==="
 cd "$CDK_DIR"
 npx cdk bootstrap --region "$REGION"
 
-echo "=== CDK deploy ==="
-npx cdk deploy --all --require-approval never
+echo "=== CDK deploy with reconciliation schedule disabled ==="
+npx cdk deploy --all --require-approval never \
+  -c multipartCompletionReconciliationScheduleState=DISABLED
 
 echo "=== Run database migrations ==="
-bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" --stack-name "$STACK_NAME"
+bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
+  --stack-name "$STACK_NAME" \
+  --require-migration 0099_durable_multipart_completion_reconciliation.sql
+
+echo "=== CDK deploy with reconciliation schedule enabled ==="
+npx cdk deploy --all --require-approval never \
+  -c multipartCompletionReconciliationScheduleState=ENABLED
+
+echo "=== Verify reconciliation schedule ==="
+bash "${ROOT_DIR}/scripts/checks/check-multipart-completion-reconciliation-schedule.sh" \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION"
 
 echo "=== Seed global metrics snapshot ==="
 bash "${ROOT_DIR}/scripts/generate/generate-global-metrics-snapshot.sh" --stack-name "$STACK_NAME"

--- a/scripts/deploy/migrate-aws.sh
+++ b/scripts/deploy/migrate-aws.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 
 STACK_NAME="FlashcardsOpenSourceApp"
 FUNCTION_NAME=""
+REQUIRED_MIGRATION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --stack-name) STACK_NAME="$2"; shift 2 ;;
     --function-name) FUNCTION_NAME="$2"; shift 2 ;;
+    --require-migration) REQUIRED_MIGRATION="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -35,13 +37,14 @@ INVOKE_METADATA=$(aws lambda invoke \
   --payload '{}' \
   "$RESPONSE_FILE")
 
-python3 - "$RESPONSE_FILE" "$INVOKE_METADATA" <<'PY'
+python3 - "$RESPONSE_FILE" "$INVOKE_METADATA" "$REQUIRED_MIGRATION" <<'PY'
 import json
 import pathlib
 import sys
 
 response_path = pathlib.Path(sys.argv[1])
 metadata = json.loads(sys.argv[2])
+required_migration = sys.argv[3]
 payload = json.loads(response_path.read_text())
 
 function_error = metadata.get("FunctionError")
@@ -52,11 +55,25 @@ if not isinstance(payload, dict):
     raise SystemExit(f"ERROR: Unexpected migration payload: {payload!r}")
 
 applied_migrations = payload.get("appliedMigrations", [])
+installed_migrations = payload.get("installedMigrations")
 applied_views = payload.get("appliedViews", [])
 configured_runtime_roles = payload.get("configuredRuntimeRoles", [])
 
+if not isinstance(installed_migrations, list) or not all(
+    isinstance(item, str) for item in installed_migrations
+):
+    raise SystemExit(
+        f"ERROR: Unexpected installedMigrations payload: {installed_migrations!r}"
+    )
+if required_migration and required_migration not in installed_migrations:
+    raise SystemExit(
+        f"ERROR: Required migration is not installed: {required_migration}"
+    )
+
 print("Migrations complete.")
 print(f"Applied migrations: {', '.join(applied_migrations) if applied_migrations else 'none'}")
+if required_migration:
+    print(f"Verified required migration: {required_migration}")
 print(f"Applied views: {', '.join(applied_views) if applied_views else 'none'}")
 if not isinstance(configured_runtime_roles, list):
     raise SystemExit(f"ERROR: Unexpected configuredRuntimeRoles payload: {configured_runtime_roles!r}")


### PR DESCRIPTION
## Summary

- add migration 0099 durable multipart completion reconciliation and terminal-failure reporting contracts
- add resumable S3 recovery, scheduled reconciliation runtime, structured diagnostics, IAM, monitoring, and schema-before-schedule rollout
- enforce canonical new media operation identifiers while preserving legacy read, replay, cleanup, and restart behavior

## Validation

- focused storage/processor tests: 51/51
- backend tests: 960/960
- infrastructure tests: 45/45
- PostgreSQL 18: 0099 18/18, 0098 5/5, 0097 1/1, 0096 2/2
- backend lint/build and OpenAPI lint/bundle
- shell and workflow YAML syntax
- diff and whitespace checks

HTTP route activation remains deferred to the dependent 10B change.
