### PR TITLE
fix(android): preserve API 37.0 emulator identifier

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -113,7 +113,8 @@ jobs:
       - name: Run data:local instrumentation suite on emulator
         uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
-          api-level: 37.0
+          # Quote the SDK package ID so YAML preserves 37.0 instead of normalizing it to 37.
+          api-level: "37.0"
           target: google_apis
           arch: x86_64
           disable-animations: true


### PR DESCRIPTION
## Summary
- quote the emulator runner API level so YAML preserves the `37.0` SDK package identifier
- document why the quoted string is required

## Validation
- `git diff --check`
- fresh worker review: no P0-P4 findings
- Gradle intentionally not run; automatic Android CI is the integration gate