### PR TITLE
Allocate RAM for Android 17 emulator

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -117,6 +117,7 @@ jobs:
           api-level: "37.0"
           target: google_apis
           arch: x86_64
+          ram-size: 4096M
           disable-animations: true
           emulator-options: -no-window -gpu auto -no-snapshot -noaudio -no-boot-anim
           script: cd apps/android && ANDROID_VERSION_CODE="${{ inputs.android_version_code }}" ./gradlew --no-daemon :data:local:connectedDebugAndroidTest


### PR DESCRIPTION
## Summary
- allocate 4 GB RAM to the Android 17 emulator used by the reusable Android CI workflow
- preserve the quoted Android 37.0 SDK identifier and all existing instrumentation settings

## Validation
- `git diff --check`
- YAML syntax validation
- worker-owned review: no P0-P4 findings
- Gradle intentionally not run; automatic Android CI after merge is the integration gate