### PR TITLE
Use Pixel 7 Pro for Android 17 CI

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -117,6 +117,7 @@ jobs:
           api-level: "37.0"
           target: google_apis
           arch: x86_64
+          profile: pixel_7_pro
           ram-size: 4096M
           disable-animations: true
           emulator-options: -no-window -gpu auto -no-snapshot -noaudio -no-boot-anim


### PR DESCRIPTION
## Summary
- configure the Android 17 emulator with the supported Pixel 7 Pro hardware profile
- preserve the API 37.0 package identifier, emulator options, and 4096 MB RAM allocation

## Validation
- parsed `.github/workflows/android-ci-reusable.yml` with Ruby Psych 5.1.2
- `git --no-pager diff --check`
- Gradle not run per repository policy