### PR TITLE
Use SwiftShader for Android 17 CI

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -120,7 +120,7 @@ jobs:
           profile: pixel_7_pro
           ram-size: 4096M
           disable-animations: true
-          emulator-options: -no-window -gpu auto -no-snapshot -noaudio -no-boot-anim
+          emulator-options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim
           script: cd apps/android && ANDROID_VERSION_CODE="${{ inputs.android_version_code }}" ./gradlew --no-daemon :data:local:connectedDebugAndroidTest
 
       - name: Detect data:local instrumentation reports

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -76,7 +76,7 @@ GitHub Actions reusable workflow: `.github/workflows/android-ci-reusable.yml`
 - Runs `:app:lintDebug`
 - Delegates the GitHub-hosted Android Gradle entrypoints to repo-root shell scripts in `scripts/android/`
 - Uploads the debug APK, Android test APK, unit test reports, and lint report as workflow artifacts
-- Boots a headless Android 17 / API 37 emulator in GitHub Actions with `-gpu auto`
+- Boots a headless Android 17 / API 37 emulator in GitHub Actions with `-gpu swiftshader`
 - Runs `:data:local:connectedDebugAndroidTest` on that emulator
 - Uploads `data:local` instrumentation reports from the emulator run when the Gradle task produced them
 - Reuses the caller-provided `ANDROID_VERSION_CODE` across Android CI/build artifacts


### PR DESCRIPTION
Summary:
- use the explicit SwiftShader renderer for the Android 17 GitHub Actions emulator
- keep the Android CI guide aligned with the workflow

Validation:
- parsed the reusable workflow as YAML
- git diff --check
- Gradle not run per repository policy