### PR TITLE
Align Android emulator timeout budget

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -78,7 +78,7 @@ jobs:
       - build
     if: ${{ inputs.run_data_local_instrumentation }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- increase the Android data:local emulator instrumentation job timeout from 10 to 20 minutes
- preserve the emulator runner boot timeout and all existing emulator configuration

## Validation
- parsed `.github/workflows/android-ci-reusable.yml` with Ruby YAML
- `git diff --check`
- fresh review: no P0-P4 findings
- Gradle not run (requires explicit permission)