### PR TITLE
ci(android): allocate emulator heap

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -119,6 +119,7 @@ jobs:
           arch: x86_64
           profile: pixel_7_pro
           ram-size: 4096M
+          heap-size: 512M
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim
           script: cd apps/android && ANDROID_VERSION_CODE="${{ inputs.android_version_code }}" ./gradlew --no-daemon :data:local:connectedDebugAndroidTest


### PR DESCRIPTION
## Summary

- allocate a 512M application heap for the Android 17 CI emulator
- preserve the existing Pixel 7 Pro profile, 4096M RAM, API 37.0 package identifier, and emulator options

## Validation

- YAML parse passed
- `git diff --check` passed
- fresh review found no P0-P4 issues
- Gradle not run per repository policy