### PR TITLE
ci(android): write correct AVD heap property

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -119,7 +119,9 @@ jobs:
           arch: x86_64
           profile: pixel_7_pro
           ram-size: 4096M
-          heap-size: 512M
+          # emulator-runner v2.38.0 writes hw.heapSize, but the emulator reads vm.heapSize.
+          pre-emulator-launch-script: |
+            echo "vm.heapSize=512" >> "${ANDROID_AVD_HOME}/test.avd/config.ini"
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim
           script: cd apps/android && ANDROID_VERSION_CODE="${{ inputs.android_version_code }}" ./gradlew --no-daemon :data:local:connectedDebugAndroidTest


### PR DESCRIPTION
## Summary
- replace emulator-runner's ineffective heap-size input with a pre-launch AVD config update
- write vm.heapSize as an integer measured in MB
- document the emulator-runner property-name mismatch

## Validation
- parsed .github/workflows/android-ci-reusable.yml with Ruby YAML
- git diff --check
- Gradle not run (requires explicit permission)