### PR TITLE
Start ADB before Android emulator

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -121,6 +121,7 @@ jobs:
           ram-size: 4096M
           # emulator-runner v2.38.0 writes hw.heapSize, but the emulator reads vm.heapSize.
           pre-emulator-launch-script: |
+            adb start-server
             echo "vm.heapSize=512" >> "${ANDROID_AVD_HOME}/test.avd/config.ini"
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader -no-snapshot -noaudio -no-boot-anim


### PR DESCRIPTION
## Summary
- start the ADB server in the emulator runner pre-launch hook
- preserve the existing API 37 emulator configuration

## Validation
- git diff --check
- review gate: no P0-P4 findings
- Gradle and emulator tests not run per repository policy