### PR TITLE
Add multipart foreground fencing boundaries

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -409,7 +409,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0100_multipart_replacement_creation_claim.sql
+            --require-migration 0101_multipart_foreground_completion_fencing.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -85,6 +85,14 @@ const createdRolesByMigration = new Map([
 ]);
 const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0101_multipart_foreground_completion_fencing.sql",
+    expectedMigrationCount: 103,
+    testFiles: Object.freeze([
+      "src/mediaAssets/atomicMultipartWriter.postgres.integration.ts",
+      "src/mediaAssets/multipartForegroundFencing.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0100_multipart_replacement_creation_claim.sql",
     expectedMigrationCount: 102,
     testFiles: Object.freeze([

--- a/apps/backend/src/mediaAssets/multipartForegroundFencing.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipartForegroundFencing.postgres.integration.ts
@@ -1,0 +1,1695 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
+import test from "node:test";
+import type pg from "pg";
+import {
+  type PostgresIntegrationFixture,
+  withPostgresIntegrationFixture,
+} from "../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+
+type MultipartPayload = Readonly<{
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  mediaAssetId: string;
+  replicaId: string;
+  lastOperationId: string;
+  sha256: string;
+  stagingStorageKey: string;
+  blobStorageKey: string;
+  s3UploadId: string;
+  mimeType: string;
+  sizeBytes: number;
+  partSizeBytes: number;
+  partCount: number;
+  sourceUrl: string | null;
+  assetCreatedAt: string;
+  clientUpdatedAt: string;
+  sessionExpiresAt: string;
+  normalizationVersion: string;
+  partsFingerprint: string;
+}>;
+
+type BeginRow = Readonly<{
+  attempt_status: string;
+  reservation_token: string | null;
+  normalization_version: string | null;
+  lease_expires_at: string | Date | null;
+}>;
+type StatusRow = Readonly<{ status: string }>;
+type PidRow = Readonly<{ pid: number }>;
+type ClaimedRow = Readonly<{
+  attempt_token: string;
+  reconciliation_lease_token: string;
+}>;
+type BoundaryState = Readonly<{
+  session_state: string;
+  session_last_operation_id: string;
+  attempt_state: string;
+  attempt_outcome: string | null;
+  lease_expires_at: Date;
+  terminal_at: Date | null;
+  reconciliation_state: string | null;
+  reconciliation_lease_token: string | null;
+  reconciliation_handed_off_at: Date | null;
+  reservation_state: string;
+}>;
+type QueryExecutor = Pick<pg.Pool | pg.PoolClient, "query">;
+type SqlValue = string | number | null;
+
+const multipartRow = `ROW(
+  $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+)::content.multipart_media_blob_writer_attempt_payload`;
+const abortSignature =
+  "content.begin_media_upload_session_abort_with_owner(text,uuid,uuid,uuid)";
+const revokedHandoffSignature =
+  "content.handoff_media_upload_session_completion_attempt_after_access_revocation(uuid,uuid,content.multipart_media_blob_writer_attempt_payload)";
+
+function digest(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+
+function createPayload(
+  fixture: PostgresIntegrationFixture,
+  mediaAssetId: string,
+): MultipartPayload {
+  const sessionId = randomUUID();
+  const sha256 = digest();
+  return {
+    userId: fixture.userId,
+    workspaceId: fixture.workspaceId,
+    sessionId,
+    mediaAssetId,
+    replicaId: fixture.replicaId,
+    lastOperationId: randomUUID(),
+    sha256,
+    stagingStorageKey:
+      `media/uploads/workspaces/${fixture.workspaceId}/assets/${mediaAssetId}/sessions/${sessionId}`,
+    blobStorageKey: buildMediaBlobStorageKey(sha256),
+    s3UploadId: `upload-${randomUUID()}`,
+    mimeType: "application/octet-stream",
+    sizeBytes: 42,
+    partSizeBytes: 42,
+    partCount: 1,
+    sourceUrl: null,
+    assetCreatedAt: fixture.createdAt,
+    clientUpdatedAt: fixture.createdAt,
+    sessionExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    normalizationVersion: "passthrough-v1",
+    partsFingerprint: digest(),
+  };
+}
+
+function payloadValues(payload: MultipartPayload): ReadonlyArray<SqlValue> {
+  return [
+    payload.userId,
+    payload.workspaceId,
+    payload.sessionId,
+    payload.mediaAssetId,
+    payload.replicaId,
+    payload.lastOperationId,
+    payload.sha256,
+    payload.stagingStorageKey,
+    payload.blobStorageKey,
+    payload.s3UploadId,
+    payload.mimeType,
+    payload.sizeBytes,
+    payload.partSizeBytes,
+    payload.partCount,
+    payload.sourceUrl,
+    payload.assetCreatedAt,
+    payload.clientUpdatedAt,
+    payload.sessionExpiresAt,
+    payload.normalizationVersion,
+    payload.partsFingerprint,
+  ];
+}
+
+async function beginScopedTransaction(
+  client: pg.PoolClient,
+  userId: string,
+  workspaceId: string,
+): Promise<void> {
+  await client.query("BEGIN");
+  await client.query(
+    `SELECT
+       set_config('app.user_id',$1,true),
+       set_config('app.workspace_id',$2,true)`,
+    [userId, workspaceId],
+  );
+}
+
+async function scoped<Result>(
+  fixture: PostgresIntegrationFixture,
+  callback: (client: pg.PoolClient) => Promise<Result>,
+): Promise<Result> {
+  const client = await fixture.runtimePool.connect();
+  try {
+    await beginScopedTransaction(
+      client,
+      fixture.userId,
+      fixture.workspaceId,
+    );
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function insertSession(
+  executor: QueryExecutor,
+  payload: MultipartPayload,
+): Promise<void> {
+  await executor.query(
+    `INSERT INTO content.media_upload_sessions (
+       media_upload_session_id,workspace_id,media_asset_id,media_blob_sha256,
+       staging_storage_key,blob_storage_key,s3_upload_id,mime_type,size_bytes,
+       part_size_bytes,part_count,state,source_url,asset_created_at,
+       client_updated_at,last_modified_by_replica_id,last_operation_id,
+       expires_at
+     ) VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'active',$12,$13,$14,$15,$16,$17
+     )`,
+    [
+      payload.sessionId,
+      payload.workspaceId,
+      payload.mediaAssetId,
+      payload.sha256,
+      payload.stagingStorageKey,
+      payload.blobStorageKey,
+      payload.s3UploadId,
+      payload.mimeType,
+      payload.sizeBytes,
+      payload.partSizeBytes,
+      payload.partCount,
+      payload.sourceUrl,
+      payload.assetCreatedAt,
+      payload.clientUpdatedAt,
+      payload.replicaId,
+      payload.lastOperationId,
+      payload.sessionExpiresAt,
+    ],
+  );
+}
+
+async function insertExactReference(
+  executor: QueryExecutor,
+  payload: MultipartPayload,
+): Promise<void> {
+  await executor.query(
+    `WITH blob AS (
+       INSERT INTO content.media_blobs (
+         media_blob_id,sha256,mime_type,size_bytes,storage_key,
+         normalization_version
+       ) VALUES ($1,$2,$3,$4,$5,$6)
+       RETURNING media_blob_id
+     )
+     INSERT INTO content.media_assets (
+       media_asset_id,workspace_id,media_blob_id,source_url,created_at,
+       client_updated_at,last_modified_by_replica_id,last_operation_id
+     )
+     SELECT $7,$8,media_blob_id,$9,$10,$11,$12,$13
+     FROM blob`,
+    [
+      randomUUID(),
+      payload.sha256,
+      payload.mimeType,
+      payload.sizeBytes,
+      payload.blobStorageKey,
+      payload.normalizationVersion,
+      payload.mediaAssetId,
+      payload.workspaceId,
+      payload.sourceUrl,
+      payload.assetCreatedAt,
+      payload.clientUpdatedAt,
+      payload.replicaId,
+      payload.lastOperationId,
+    ],
+  );
+}
+
+async function beginAttempt(
+  executor: QueryExecutor,
+  attemptToken: string,
+  payload: MultipartPayload,
+): Promise<BeginRow> {
+  return (await executor.query<BeginRow>(
+    `SELECT *
+     FROM content.begin_media_upload_session_completion_attempt_with_owner(
+       $1,$2,${multipartRow}
+     )`,
+    [attemptToken, 60_000, ...payloadValues(payload)],
+  )).rows[0];
+}
+
+async function createAttempt(
+  fixture: PostgresIntegrationFixture,
+  payload: MultipartPayload,
+): Promise<Readonly<{
+  attemptToken: string;
+  reservationToken: string;
+}>> {
+  await insertSession(fixture.ownerPool, payload);
+  const attemptToken = randomUUID();
+  const begun = await scoped(
+    fixture,
+    (client) => beginAttempt(client, attemptToken, payload),
+  );
+  assert.equal(begun.attempt_status, "acquired");
+  assert.notEqual(begun.reservation_token, null);
+  assert.equal(begun.normalization_version, payload.normalizationVersion);
+  return {
+    attemptToken,
+    reservationToken: begun.reservation_token as string,
+  };
+}
+
+async function beginAbort(
+  executor: QueryExecutor,
+  fixture: PostgresIntegrationFixture,
+  payload: MultipartPayload,
+): Promise<string> {
+  return beginAbortForUser(executor, fixture.userId, payload);
+}
+
+async function beginAbortForUser(
+  executor: QueryExecutor,
+  userId: string,
+  payload: MultipartPayload,
+): Promise<string> {
+  return (await executor.query<StatusRow>(
+    `SELECT content.begin_media_upload_session_abort_with_owner(
+       $1,$2,$3,$4
+     ) AS status`,
+    [
+      userId,
+      payload.workspaceId,
+      payload.sessionId,
+      payload.mediaAssetId,
+    ],
+  )).rows[0].status;
+}
+
+async function handoffWithOwner(
+  executor: QueryExecutor,
+  attemptToken: string,
+  reservationToken: string,
+  payload: MultipartPayload,
+): Promise<string> {
+  return (await executor.query<StatusRow>(
+    `SELECT content.handoff_media_upload_session_completion_attempt(
+       $1,$2,${multipartRow}
+     ) AS status`,
+    [attemptToken, reservationToken, ...payloadValues(payload)],
+  )).rows[0].status;
+}
+
+async function handoffAfterAccessRevocation(
+  executor: QueryExecutor,
+  attemptToken: string,
+  reservationToken: string,
+  payload: MultipartPayload,
+): Promise<string> {
+  return (await executor.query<StatusRow>(
+    `SELECT
+       content.handoff_media_upload_session_completion_attempt_after_access_revocation(
+         $1,$2,${multipartRow}
+       ) AS status`,
+    [attemptToken, reservationToken, ...payloadValues(payload)],
+  )).rows[0].status;
+}
+
+async function claimAttempt(
+  fixture: PostgresIntegrationFixture,
+  attemptToken: string,
+): Promise<ClaimedRow> {
+  const claimed = (await fixture.runtimePool.query<ClaimedRow>(
+    `SELECT attempt_token,reconciliation_lease_token
+     FROM content.claim_media_upload_session_completion_reconciliations(
+       $1,$2,$3
+     )`,
+    [`migration-0101-${randomUUID()}`, 60_000, 100],
+  )).rows.find((row) => row.attempt_token === attemptToken);
+  assert.notEqual(claimed, undefined);
+  return claimed as ClaimedRow;
+}
+
+async function applyReconciliationScope(
+  executor: QueryExecutor,
+  claimed: ClaimedRow,
+): Promise<string> {
+  return (await executor.query<StatusRow>(
+    `SELECT
+       content.apply_media_upload_session_completion_reconciliation_scope(
+         $1,$2
+       ) AS status`,
+    [claimed.attempt_token, claimed.reconciliation_lease_token],
+  )).rows[0].status;
+}
+
+async function finishReconciliation(
+  executor: QueryExecutor,
+  claimed: ClaimedRow,
+): Promise<string> {
+  return (await executor.query<StatusRow>(
+    `SELECT content.finish_media_upload_session_completion_reconciliation(
+       $1,$2,$3
+     ) AS status`,
+    [claimed.attempt_token, claimed.reconciliation_lease_token, 3_600_000],
+  )).rows[0].status;
+}
+
+async function failReconciliation(
+  executor: QueryExecutor,
+  claimed: ClaimedRow,
+): Promise<string> {
+  return (await executor.query<StatusRow>(
+    `SELECT content.fail_media_upload_session_completion_reconciliation(
+       $1,$2,$3,$4,$5
+     ) AS status`,
+    [
+      claimed.attempt_token,
+      claimed.reconciliation_lease_token,
+      "TEST_FAILURE",
+      "Deterministic migration 0101 reconciliation failure.",
+      3_600_000,
+    ],
+  )).rows[0].status;
+}
+
+async function readBoundaryState(
+  fixture: PostgresIntegrationFixture,
+  attemptToken: string,
+): Promise<BoundaryState> {
+  return (await fixture.ownerPool.query<BoundaryState>(
+    `SELECT
+       sessions.state AS session_state,
+       sessions.last_operation_id AS session_last_operation_id,
+       attempts.state AS attempt_state,
+       attempts.outcome AS attempt_outcome,
+       attempts.lease_expires_at,
+       attempts.terminal_at,
+       attempts.reconciliation_state,
+       attempts.reconciliation_lease_token,
+       attempts.reconciliation_handed_off_at,
+       reservations.state AS reservation_state
+     FROM content.media_blob_writer_attempts AS attempts
+     INNER JOIN content.media_upload_sessions AS sessions
+       ON sessions.media_upload_session_id=attempts.media_upload_session_id
+     INNER JOIN content.media_blob_writer_reservations AS reservations
+       ON reservations.reservation_token=attempts.reservation_token
+     WHERE attempts.attempt_token=$1`,
+    [attemptToken],
+  )).rows[0];
+}
+
+async function changeCurrentAccess(
+  fixture: PostgresIntegrationFixture,
+  otherUserId: string,
+  accessPresent: boolean,
+): Promise<void> {
+  const client = await fixture.ownerPool.connect();
+  try {
+    await client.query("BEGIN");
+    if (accessPresent) {
+      await client.query(
+        "UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2",
+        [fixture.userId, fixture.replicaId],
+      );
+      await client.query(
+        `INSERT INTO org.workspace_memberships (workspace_id,user_id,role)
+         VALUES ($1,$2,'owner')`,
+        [fixture.workspaceId, fixture.userId],
+      );
+      await client.query(
+        "DELETE FROM org.user_settings WHERE user_id=$1",
+        [otherUserId],
+      );
+    } else {
+      await client.query(
+        "INSERT INTO org.user_settings (user_id) VALUES ($1)",
+        [otherUserId],
+      );
+      await client.query(
+        "UPDATE sync.workspace_replicas SET user_id=$1 WHERE replica_id=$2",
+        [otherUserId, fixture.replicaId],
+      );
+      await client.query(
+        `DELETE FROM org.workspace_memberships
+         WHERE workspace_id=$1 AND user_id=$2`,
+        [fixture.workspaceId, fixture.userId],
+      );
+    }
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function backendPid(client: pg.PoolClient): Promise<number> {
+  return (await client.query<PidRow>(
+    "SELECT pg_catalog.pg_backend_pid() AS pid",
+  )).rows[0].pid;
+}
+
+async function waitUntilBlockedBy(
+  observer: QueryExecutor,
+  waitingPid: number,
+  blockingPid: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const blocked = (await observer.query<Readonly<{ blocked: boolean }>>(
+      `SELECT $2::INTEGER = ANY(
+         pg_catalog.pg_blocking_pids($1::INTEGER)
+       ) AS blocked`,
+      [waitingPid, blockingPid],
+    )).rows[0]?.blocked;
+    if (blocked === true) return;
+    await delay(10);
+  }
+  throw new Error(
+    `PostgreSQL transaction did not reach the expected lock wait. waitingPid=${waitingPid} blockingPid=${blockingPid}`,
+  );
+}
+
+async function waitUntilAdvisoryBlockedBy(
+  observer: QueryExecutor,
+  waitingPid: number,
+  blockingPid: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const blocked = (await observer.query<Readonly<{ blocked: boolean }>>(
+      `SELECT
+         activity.wait_event = 'advisory'
+         AND $2::INTEGER = ANY(
+           pg_catalog.pg_blocking_pids($1::INTEGER)
+         ) AS blocked
+       FROM pg_catalog.pg_stat_activity AS activity
+       WHERE activity.pid=$1`,
+      [waitingPid, blockingPid],
+    )).rows[0]?.blocked;
+    if (blocked === true) return;
+    await delay(10);
+  }
+  throw new Error(
+    `PostgreSQL transaction did not wait on the canonical advisory fence. waitingPid=${waitingPid} blockingPid=${blockingPid}`,
+  );
+}
+
+async function lockMediaAsset(
+  client: pg.PoolClient,
+  payload: MultipartPayload,
+): Promise<void> {
+  await client.query(
+    `SELECT pg_catalog.pg_advisory_xact_lock(
+       pg_catalog.hashtextextended(
+         'multipart-asset:' || $1::TEXT || ':' || $2::TEXT,
+         4::BIGINT
+       )
+     )`,
+    [payload.workspaceId, payload.mediaAssetId],
+  );
+}
+
+async function insertWorkspaceMember(
+  fixture: PostgresIntegrationFixture,
+  userId: string,
+): Promise<void> {
+  await fixture.ownerPool.query(
+    "INSERT INTO org.user_settings (user_id) VALUES ($1)",
+    [userId],
+  );
+  await fixture.ownerPool.query(
+    `INSERT INTO org.workspace_memberships (workspace_id,user_id,role)
+     VALUES ($1,$2,'member')`,
+    [fixture.workspaceId, userId],
+  );
+}
+
+async function releaseClients(
+  clients: ReadonlyArray<pg.PoolClient>,
+  testError: Error | null,
+): Promise<void> {
+  const rollbackResults = await Promise.allSettled(
+    clients.map((client) => client.query("ROLLBACK")),
+  );
+  for (const client of clients) client.release();
+  const rollbackErrors = rollbackResults.flatMap((result) => (
+    result.status === "rejected" ? [result.reason as unknown] : []
+  ));
+  if (rollbackErrors.length > 0) {
+    throw new AggregateError(
+      testError === null
+        ? rollbackErrors
+        : [testError, ...rollbackErrors],
+      "PostgreSQL race transaction cleanup failed.",
+    );
+  }
+}
+
+test("migration 0101 exposes only the two hardened backend boundaries", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const contract = (await fixture.ownerPool.query<Readonly<{
+      major: number;
+      migrations: number;
+      latest: string;
+      abort_backend: boolean;
+      handoff_backend: boolean;
+      public_execute: boolean;
+      abort_auth: boolean;
+      handoff_reporting: boolean;
+      direct_attempt_table: boolean;
+      abort_result: string;
+      handoff_result: string;
+      hardened: boolean;
+    }>>(
+      `SELECT
+         current_setting('server_version_num')::INTEGER / 10000 AS major,
+         count(*)::INTEGER AS migrations,
+         max(filename) AS latest,
+         has_function_privilege('backend_app',$1,'EXECUTE') AS abort_backend,
+         has_function_privilege('backend_app',$2,'EXECUTE') AS handoff_backend,
+         EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_proc AS functions
+           CROSS JOIN LATERAL pg_catalog.aclexplode(
+             COALESCE(
+               functions.proacl,
+               pg_catalog.acldefault('f',functions.proowner)
+             )
+           ) AS privileges
+           WHERE functions.oid = ANY(
+             ARRAY[$1::regprocedure,$2::regprocedure]
+           )
+             AND privileges.grantee = 0
+             AND privileges.privilege_type = 'EXECUTE'
+         ) AS public_execute,
+         has_function_privilege('auth_app',$1,'EXECUTE') AS abort_auth,
+         has_function_privilege(
+           'reporting_readonly',$2,'EXECUTE'
+         ) AS handoff_reporting,
+         has_table_privilege(
+           'backend_app',
+           'content.media_blob_writer_attempts',
+           'SELECT,INSERT,UPDATE,DELETE'
+         ) AS direct_attempt_table,
+         pg_catalog.pg_get_function_result($1::regprocedure) AS abort_result,
+         pg_catalog.pg_get_function_result($2::regprocedure) AS handoff_result,
+         (
+           SELECT pg_catalog.bool_and(
+             functions.prosecdef
+             AND functions.proconfig = ARRAY['search_path=pg_catalog']
+           )
+           FROM pg_catalog.pg_proc AS functions
+           WHERE functions.oid = ANY(
+             ARRAY[$1::regprocedure,$2::regprocedure]
+           )
+         ) AS hardened
+       FROM public.schema_migrations`,
+      [abortSignature, revokedHandoffSignature],
+    )).rows[0];
+    assert.deepEqual(contract, {
+      major: 18,
+      migrations: 103,
+      latest: "0101_multipart_foreground_completion_fencing.sql",
+      abort_backend: true,
+      handoff_backend: true,
+      public_execute: false,
+      abort_auth: false,
+      handoff_reporting: false,
+      direct_attempt_table: false,
+      abort_result: "text",
+      handoff_result: "text",
+      hardened: true,
+    });
+  });
+});
+
+test("migration 0101 admits abort only after foreground completion is fenced", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const active = createPayload(fixture, randomUUID());
+    await insertSession(fixture.ownerPool, active);
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, active)),
+      "abort_required",
+    );
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, active)),
+      "abort_required",
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_upload_sessions
+       SET state='aborted',aborted_at=pg_catalog.clock_timestamp()
+       WHERE media_upload_session_id=$1`,
+      [active.sessionId],
+    );
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, active)),
+      "already_aborted",
+    );
+
+    const missing = createPayload(fixture, randomUUID());
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, missing)),
+      "not_found",
+    );
+    const stale = createPayload(fixture, randomUUID());
+    await insertSession(fixture.ownerPool, stale);
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => beginAbort(
+          client,
+          fixture,
+          { ...stale, mediaAssetId: randomUUID() },
+        ),
+      ),
+      "stale",
+    );
+    assert.equal(
+      (await fixture.ownerPool.query<StatusRow>(
+        `SELECT state AS status
+         FROM content.media_upload_sessions
+         WHERE media_upload_session_id=$1`,
+        [stale.sessionId],
+      )).rows[0].status,
+      "active",
+    );
+    const deniedClient = await fixture.runtimePool.connect();
+    try {
+      await beginScopedTransaction(
+        deniedClient,
+        fixture.userId,
+        fixture.outOfScopeWorkspaceId,
+      );
+      assert.equal(
+        await beginAbort(deniedClient, fixture, stale),
+        "access_denied",
+      );
+      await deniedClient.query("COMMIT");
+    } finally {
+      await deniedClient.query("ROLLBACK");
+      deniedClient.release();
+    }
+
+    const live = createPayload(fixture, randomUUID());
+    const liveAttempt = await createAttempt(fixture, live);
+    const liveBefore = await readBoundaryState(
+      fixture,
+      liveAttempt.attemptToken,
+    );
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, live)),
+      "completion_in_progress",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, liveAttempt.attemptToken),
+      liveBefore,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_upload_sessions
+       SET state='aborting'
+       WHERE media_upload_session_id=$1`,
+      [live.sessionId],
+    );
+    const abortingLiveBefore = await readBoundaryState(
+      fixture,
+      liveAttempt.attemptToken,
+    );
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, live)),
+      "completion_in_progress",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, liveAttempt.attemptToken),
+      abortingLiveBefore,
+    );
+
+    const expired = createPayload(fixture, randomUUID());
+    const expiredAttempt = await createAttempt(fixture, expired);
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET lease_expires_at=pg_catalog.clock_timestamp() - interval '1 second'
+       WHERE attempt_token=$1`,
+      [expiredAttempt.attemptToken],
+    );
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, expired)),
+      "abort_required",
+    );
+    const expiredAfter = await readBoundaryState(
+      fixture,
+      expiredAttempt.attemptToken,
+    );
+    assert.equal(expiredAfter.session_state, "aborting");
+    assert.equal(expiredAfter.attempt_state, "expired");
+    assert.equal(expiredAfter.attempt_outcome, "stale_attempt");
+    assert.notEqual(expiredAfter.terminal_at, null);
+    assert.equal(expiredAfter.reconciliation_state, null);
+
+    const abortingExpired = createPayload(fixture, randomUUID());
+    const abortingExpiredAttempt = await createAttempt(
+      fixture,
+      abortingExpired,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET lease_expires_at=pg_catalog.clock_timestamp() - interval '1 second'
+       WHERE attempt_token=$1`,
+      [abortingExpiredAttempt.attemptToken],
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_upload_sessions
+       SET state='aborting'
+       WHERE media_upload_session_id=$1`,
+      [abortingExpired.sessionId],
+    );
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => beginAbort(client, fixture, abortingExpired),
+      ),
+      "abort_required",
+    );
+    const abortingExpiredAfter = await readBoundaryState(
+      fixture,
+      abortingExpiredAttempt.attemptToken,
+    );
+    assert.equal(abortingExpiredAfter.session_state, "aborting");
+    assert.equal(abortingExpiredAfter.attempt_state, "expired");
+    assert.equal(abortingExpiredAfter.attempt_outcome, "stale_attempt");
+    assert.notEqual(abortingExpiredAfter.terminal_at, null);
+    assert.equal(abortingExpiredAfter.reconciliation_state, null);
+
+    const pending = createPayload(fixture, randomUUID());
+    const pendingAttempt = await createAttempt(fixture, pending);
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => handoffWithOwner(
+          client,
+          pendingAttempt.attemptToken,
+          pendingAttempt.reservationToken,
+          pending,
+        ),
+      ),
+      "handed_off",
+    );
+    const pendingBefore = await readBoundaryState(
+      fixture,
+      pendingAttempt.attemptToken,
+    );
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, pending)),
+      "completion_pending",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, pendingAttempt.attemptToken),
+      pendingBefore,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_upload_sessions
+       SET state='aborting'
+       WHERE media_upload_session_id=$1`,
+      [pending.sessionId],
+    );
+    const abortingPendingBefore = await readBoundaryState(
+      fixture,
+      pendingAttempt.attemptToken,
+    );
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, pending)),
+      "completion_pending",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, pendingAttempt.attemptToken),
+      abortingPendingBefore,
+    );
+
+    const claimed = (await fixture.runtimePool.query<ClaimedRow>(
+      `SELECT attempt_token,reconciliation_lease_token
+       FROM content.claim_media_upload_session_completion_reconciliations(
+         $1,$2,$3
+       )`,
+      [`migration-0101-${randomUUID()}`, 60_000, 1],
+    )).rows[0];
+    assert.equal(claimed.attempt_token, pendingAttempt.attemptToken);
+    const leasedBefore = await readBoundaryState(
+      fixture,
+      pendingAttempt.attemptToken,
+    );
+    assert.equal(leasedBefore.reconciliation_state, "leased");
+    assert.equal(
+      await scoped(fixture, (client) => beginAbort(client, fixture, pending)),
+      "completion_pending",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, pendingAttempt.attemptToken),
+      leasedBefore,
+    );
+  });
+});
+
+test("migration 0101 service handoff uses exact durable ownership after access loss", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const payload = createPayload(fixture, randomUUID());
+    const attempt = await createAttempt(fixture, payload);
+    const initialState = await readBoundaryState(fixture, attempt.attemptToken);
+
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        randomUUID(),
+        payload,
+      ),
+      "writer_conflict",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        { ...payload, partsFingerprint: digest() },
+      ),
+      "stale_attempt",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        { ...payload, replicaId: randomUUID() },
+      ),
+      "ownership_mismatch",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        { ...payload, userId: `wrong-${randomUUID()}` },
+      ),
+      "ownership_mismatch",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_owner_snapshots
+       SET session_last_operation_id=$1
+       WHERE reservation_token=$2`,
+      [randomUUID(), attempt.reservationToken],
+    );
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        payload,
+      ),
+      "ownership_mismatch",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_owner_snapshots
+       SET session_last_operation_id=$1
+       WHERE reservation_token=$2`,
+      [payload.lastOperationId, attempt.reservationToken],
+    );
+
+    await fixture.ownerPool.query(
+      `UPDATE content.media_upload_sessions
+       SET last_operation_id=$1
+       WHERE media_upload_session_id=$2`,
+      [randomUUID(), payload.sessionId],
+    );
+    const sessionMismatchBefore = await readBoundaryState(
+      fixture,
+      attempt.attemptToken,
+    );
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        payload,
+      ),
+      "stale_attempt",
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      sessionMismatchBefore,
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_upload_sessions
+       SET last_operation_id=$1
+       WHERE media_upload_session_id=$2`,
+      [payload.lastOperationId, payload.sessionId],
+    );
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+
+    const otherUserId = `migration-0101-revoked-${randomUUID()}`;
+    await changeCurrentAccess(fixture, otherUserId, false);
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        payload,
+      ),
+      "handed_off",
+    );
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        payload,
+      ),
+      "already_pending",
+    );
+    await changeCurrentAccess(fixture, otherUserId, true);
+
+    const duplicatePayload = createPayload(fixture, randomUUID());
+    const duplicateAttempt = await createAttempt(fixture, duplicatePayload);
+    const duplicateResults = await Promise.all([
+      handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        duplicateAttempt.attemptToken,
+        duplicateAttempt.reservationToken,
+        duplicatePayload,
+      ),
+      handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        duplicateAttempt.attemptToken,
+        duplicateAttempt.reservationToken,
+        duplicatePayload,
+      ),
+    ]);
+    assert.deepEqual(
+      duplicateResults.sort(),
+      ["already_pending", "handed_off"],
+    );
+    const claimedAttempts = (await fixture.runtimePool.query<ClaimedRow>(
+      `SELECT attempt_token,reconciliation_lease_token
+       FROM content.claim_media_upload_session_completion_reconciliations(
+         $1,$2,$3
+       )`,
+      [`migration-0101-terminal-${randomUUID()}`, 60_000, 100],
+    )).rows;
+    const claimedDuplicate = claimedAttempts.find(
+      (claimed) => claimed.attempt_token === duplicateAttempt.attemptToken,
+    );
+    assert.notEqual(claimedDuplicate, undefined);
+    assert.equal(
+      (await fixture.runtimePool.query<StatusRow>(
+        `SELECT
+           content.fail_media_upload_session_completion_reconciliation(
+             $1,$2,$3,$4,$5
+           ) AS status`,
+        [
+          duplicateAttempt.attemptToken,
+          (claimedDuplicate as ClaimedRow).reconciliation_lease_token,
+          "TEST_FAILURE",
+          "Deterministic migration 0101 terminal replay failure.",
+          3_600_000,
+        ],
+      )).rows[0].status,
+      "failed",
+    );
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        duplicateAttempt.attemptToken,
+        duplicateAttempt.reservationToken,
+        duplicatePayload,
+      ),
+      "failed",
+    );
+
+    const terminalPayload = createPayload(fixture, randomUUID());
+    await insertSession(fixture.ownerPool, terminalPayload);
+    await insertExactReference(fixture.ownerPool, terminalPayload);
+    const terminalAttemptToken = randomUUID();
+    const terminal = await scoped(
+      fixture,
+      (client) => beginAttempt(
+        client,
+        terminalAttemptToken,
+        terminalPayload,
+      ),
+    );
+    assert.equal(terminal.attempt_status, "already_applied");
+    const terminalReservation = (await fixture.ownerPool.query<Readonly<{
+      reservation_token: string;
+    }>>(
+      `SELECT reservation_token
+       FROM content.media_blob_writer_attempts
+       WHERE attempt_token=$1`,
+      [terminalAttemptToken],
+    )).rows[0].reservation_token;
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        terminalAttemptToken,
+        terminalReservation,
+        terminalPayload,
+      ),
+      "already_applied",
+    );
+  });
+});
+
+test("migration 0101 derives revoked handoff fences from durable identity", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const payload = createPayload(fixture, randomUUID());
+    const attempt = await createAttempt(fixture, payload);
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => handoffWithOwner(
+          client,
+          attempt.attemptToken,
+          attempt.reservationToken,
+          payload,
+        ),
+      ),
+      "handed_off",
+    );
+    const claimed = await claimAttempt(fixture, attempt.attemptToken);
+    const initialState = await readBoundaryState(
+      fixture,
+      attempt.attemptToken,
+    );
+
+    const mismatchedWorkspaceId = randomUUID();
+    const workspaceMismatch = {
+      ...payload,
+      workspaceId: mismatchedWorkspaceId,
+      stagingStorageKey:
+        `media/uploads/workspaces/${mismatchedWorkspaceId}/assets/${payload.mediaAssetId}/sessions/${payload.sessionId}`,
+    };
+    const scopeClient = await fixture.runtimePool.connect();
+    const workspaceHandoffClient = await fixture.runtimePool.connect();
+    const workspaceClients = [scopeClient, workspaceHandoffClient];
+    let workspaceError: Error | null = null;
+    try {
+      await scopeClient.query("BEGIN");
+      assert.equal(
+        await applyReconciliationScope(scopeClient, claimed),
+        "scoped",
+      );
+      await workspaceHandoffClient.query("BEGIN");
+      const scopePid = await backendPid(scopeClient);
+      const handoffPid = await backendPid(workspaceHandoffClient);
+      const handoffPromise = handoffAfterAccessRevocation(
+        workspaceHandoffClient,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        workspaceMismatch,
+      );
+      await waitUntilAdvisoryBlockedBy(
+        fixture.ownerPool,
+        handoffPid,
+        scopePid,
+      );
+      await scopeClient.query("ROLLBACK");
+      assert.equal(await handoffPromise, "stale_attempt");
+      await workspaceHandoffClient.query("COMMIT");
+    } catch (error) {
+      workspaceError =
+        error instanceof Error ? error : new Error(String(error));
+      throw workspaceError;
+    } finally {
+      await releaseClients(workspaceClients, workspaceError);
+    }
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+
+    await insertExactReference(fixture.ownerPool, payload);
+    const mismatchedMediaAssetId = randomUUID();
+    const assetMismatch = {
+      ...payload,
+      mediaAssetId: mismatchedMediaAssetId,
+      stagingStorageKey:
+        `media/uploads/workspaces/${payload.workspaceId}/assets/${mismatchedMediaAssetId}/sessions/${payload.sessionId}`,
+    };
+    const finishClient = await fixture.runtimePool.connect();
+    const assetHandoffClient = await fixture.runtimePool.connect();
+    const assetClients = [finishClient, assetHandoffClient];
+    let assetError: Error | null = null;
+    try {
+      await beginScopedTransaction(
+        finishClient,
+        fixture.userId,
+        fixture.workspaceId,
+      );
+      assert.equal(
+        await finishReconciliation(finishClient, claimed),
+        "applied",
+      );
+      await assetHandoffClient.query("BEGIN");
+      const finishPid = await backendPid(finishClient);
+      const handoffPid = await backendPid(assetHandoffClient);
+      const handoffPromise = handoffAfterAccessRevocation(
+        assetHandoffClient,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        assetMismatch,
+      );
+      await waitUntilAdvisoryBlockedBy(
+        fixture.ownerPool,
+        handoffPid,
+        finishPid,
+      );
+      await finishClient.query("ROLLBACK");
+      assert.equal(await handoffPromise, "stale_attempt");
+      await assetHandoffClient.query("COMMIT");
+    } catch (error) {
+      assetError = error instanceof Error ? error : new Error(String(error));
+      throw assetError;
+    } finally {
+      await releaseClients(assetClients, assetError);
+    }
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+  });
+});
+
+test("migration 0101 serializes abort, heartbeat, handoff, and access removal", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const heartbeatPayload = createPayload(fixture, randomUUID());
+    const heartbeatAttempt = await createAttempt(fixture, heartbeatPayload);
+    const heartbeatBlocker = await fixture.ownerPool.connect();
+    const heartbeatClient = await fixture.runtimePool.connect();
+    const heartbeatAbortClient = await fixture.runtimePool.connect();
+    const heartbeatClients = [
+      heartbeatBlocker,
+      heartbeatClient,
+      heartbeatAbortClient,
+    ];
+    let heartbeatError: Error | null = null;
+    try {
+      await heartbeatBlocker.query("BEGIN");
+      await lockMediaAsset(heartbeatBlocker, heartbeatPayload);
+      await beginScopedTransaction(
+        heartbeatClient,
+        fixture.userId,
+        fixture.workspaceId,
+      );
+      await beginScopedTransaction(
+        heartbeatAbortClient,
+        fixture.userId,
+        fixture.workspaceId,
+      );
+      const blockerPid = await backendPid(heartbeatBlocker);
+      const heartbeatPid = await backendPid(heartbeatClient);
+      const abortPid = await backendPid(heartbeatAbortClient);
+      const heartbeatPromise = beginAttempt(
+        heartbeatClient,
+        heartbeatAttempt.attemptToken,
+        heartbeatPayload,
+      );
+      await waitUntilBlockedBy(
+        heartbeatBlocker,
+        heartbeatPid,
+        blockerPid,
+      );
+      const abortPromise = beginAbort(
+        heartbeatAbortClient,
+        fixture,
+        heartbeatPayload,
+      );
+      await waitUntilBlockedBy(
+        heartbeatBlocker,
+        abortPid,
+        heartbeatPid,
+      );
+      await heartbeatBlocker.query("COMMIT");
+      assert.equal((await heartbeatPromise).attempt_status, "replayed");
+      await heartbeatClient.query("COMMIT");
+      assert.equal(await abortPromise, "completion_in_progress");
+      await heartbeatAbortClient.query("COMMIT");
+    } catch (error) {
+      heartbeatError =
+        error instanceof Error ? error : new Error(String(error));
+      throw heartbeatError;
+    } finally {
+      await releaseClients(heartbeatClients, heartbeatError);
+    }
+
+    const handoffPayload = createPayload(fixture, randomUUID());
+    const handoffAttempt = await createAttempt(fixture, handoffPayload);
+    const handoffBlocker = await fixture.ownerPool.connect();
+    const handoffClient = await fixture.runtimePool.connect();
+    const handoffAbortClient = await fixture.runtimePool.connect();
+    const handoffClients = [
+      handoffBlocker,
+      handoffClient,
+      handoffAbortClient,
+    ];
+    let handoffError: Error | null = null;
+    try {
+      await handoffBlocker.query("BEGIN");
+      await lockMediaAsset(handoffBlocker, handoffPayload);
+      await handoffClient.query("BEGIN");
+      await beginScopedTransaction(
+        handoffAbortClient,
+        fixture.userId,
+        fixture.workspaceId,
+      );
+      const blockerPid = await backendPid(handoffBlocker);
+      const handoffPid = await backendPid(handoffClient);
+      const abortPid = await backendPid(handoffAbortClient);
+      const handoffPromise = handoffAfterAccessRevocation(
+        handoffClient,
+        handoffAttempt.attemptToken,
+        handoffAttempt.reservationToken,
+        handoffPayload,
+      );
+      await waitUntilBlockedBy(
+        handoffBlocker,
+        handoffPid,
+        blockerPid,
+      );
+      const abortPromise = beginAbort(
+        handoffAbortClient,
+        fixture,
+        handoffPayload,
+      );
+      await waitUntilBlockedBy(handoffBlocker, abortPid, handoffPid);
+      await handoffBlocker.query("COMMIT");
+      assert.equal(await handoffPromise, "handed_off");
+      await handoffClient.query("COMMIT");
+      assert.equal(await abortPromise, "completion_pending");
+      await handoffAbortClient.query("COMMIT");
+    } catch (error) {
+      handoffError =
+        error instanceof Error ? error : new Error(String(error));
+      throw handoffError;
+    } finally {
+      await releaseClients(handoffClients, handoffError);
+    }
+
+    const abortPayload = createPayload(fixture, randomUUID());
+    const abortAttempt = await createAttempt(fixture, abortPayload);
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET lease_expires_at=pg_catalog.clock_timestamp() - interval '1 second'
+       WHERE attempt_token=$1`,
+      [abortAttempt.attemptToken],
+    );
+    const abortBlocker = await fixture.ownerPool.connect();
+    const abortClient = await fixture.runtimePool.connect();
+    const staleHandoffClient = await fixture.runtimePool.connect();
+    const abortClients = [abortBlocker, abortClient, staleHandoffClient];
+    let abortError: Error | null = null;
+    try {
+      await abortBlocker.query("BEGIN");
+      await lockMediaAsset(abortBlocker, abortPayload);
+      await beginScopedTransaction(
+        abortClient,
+        fixture.userId,
+        fixture.workspaceId,
+      );
+      await staleHandoffClient.query("BEGIN");
+      const blockerPid = await backendPid(abortBlocker);
+      const abortPid = await backendPid(abortClient);
+      const handoffPid = await backendPid(staleHandoffClient);
+      const abortPromise = beginAbort(abortClient, fixture, abortPayload);
+      await waitUntilBlockedBy(abortBlocker, abortPid, blockerPid);
+      const handoffPromise = handoffAfterAccessRevocation(
+        staleHandoffClient,
+        abortAttempt.attemptToken,
+        abortAttempt.reservationToken,
+        abortPayload,
+      );
+      await waitUntilBlockedBy(abortBlocker, handoffPid, abortPid);
+      await abortBlocker.query("COMMIT");
+      assert.equal(await abortPromise, "abort_required");
+      await abortClient.query("COMMIT");
+      assert.equal(await handoffPromise, "stale_attempt");
+      await staleHandoffClient.query("COMMIT");
+    } catch (error) {
+      abortError = error instanceof Error ? error : new Error(String(error));
+      throw abortError;
+    } finally {
+      await releaseClients(abortClients, abortError);
+    }
+
+    const revokedPayload = createPayload(fixture, randomUUID());
+    const revokedAttempt = await createAttempt(fixture, revokedPayload);
+    const sessionBlocker = await fixture.ownerPool.connect();
+    const revokedClient = await fixture.runtimePool.connect();
+    const revokedClients = [sessionBlocker, revokedClient];
+    const otherUserId = `migration-0101-during-${randomUUID()}`;
+    let revokedError: Error | null = null;
+    let accessRemoved = false;
+    try {
+      await sessionBlocker.query("BEGIN");
+      await sessionBlocker.query(
+        `SELECT 1
+         FROM content.media_upload_sessions
+         WHERE media_upload_session_id=$1
+         FOR UPDATE`,
+        [revokedPayload.sessionId],
+      );
+      await revokedClient.query("BEGIN");
+      const blockerPid = await backendPid(sessionBlocker);
+      const revokedPid = await backendPid(revokedClient);
+      const revokedPromise = handoffAfterAccessRevocation(
+        revokedClient,
+        revokedAttempt.attemptToken,
+        revokedAttempt.reservationToken,
+        revokedPayload,
+      );
+      await waitUntilBlockedBy(sessionBlocker, revokedPid, blockerPid);
+      await changeCurrentAccess(fixture, otherUserId, false);
+      accessRemoved = true;
+      await sessionBlocker.query("COMMIT");
+      assert.equal(await revokedPromise, "handed_off");
+      await revokedClient.query("COMMIT");
+    } catch (error) {
+      revokedError =
+        error instanceof Error ? error : new Error(String(error));
+      throw revokedError;
+    } finally {
+      await releaseClients(revokedClients, revokedError);
+      if (accessRemoved) {
+        await changeCurrentAccess(fixture, otherUserId, true);
+      }
+    }
+  });
+});
+
+test("migration 0101 uses one asset fence for cross-member abort and reconciliation", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const payload = createPayload(fixture, randomUUID());
+    const attempt = await createAttempt(fixture, payload);
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => handoffWithOwner(
+          client,
+          attempt.attemptToken,
+          attempt.reservationToken,
+          payload,
+        ),
+      ),
+      "handed_off",
+    );
+    const claimed = await claimAttempt(fixture, attempt.attemptToken);
+    const initialState = await readBoundaryState(
+      fixture,
+      attempt.attemptToken,
+    );
+    const otherUserId = `migration-0101-member-${randomUUID()}`;
+    await insertWorkspaceMember(fixture, otherUserId);
+
+    const sessionBlocker = await fixture.ownerPool.connect();
+    const abortClient = await fixture.runtimePool.connect();
+    const reconciliationClient = await fixture.runtimePool.connect();
+    const clients = [sessionBlocker, abortClient, reconciliationClient];
+    let raceError: Error | null = null;
+    try {
+      await sessionBlocker.query("BEGIN");
+      await sessionBlocker.query(
+        `SELECT 1
+         FROM content.media_upload_sessions
+         WHERE media_upload_session_id=$1
+         FOR UPDATE`,
+        [payload.sessionId],
+      );
+      await beginScopedTransaction(
+        abortClient,
+        otherUserId,
+        fixture.workspaceId,
+      );
+      await reconciliationClient.query("BEGIN");
+
+      const blockerPid = await backendPid(sessionBlocker);
+      const abortPid = await backendPid(abortClient);
+      const reconciliationPid = await backendPid(reconciliationClient);
+      const abortPromise = beginAbortForUser(
+        abortClient,
+        otherUserId,
+        payload,
+      );
+      await waitUntilBlockedBy(sessionBlocker, abortPid, blockerPid);
+
+      const reconciliationPromise = applyReconciliationScope(
+        reconciliationClient,
+        claimed,
+      );
+      await waitUntilBlockedBy(
+        sessionBlocker,
+        reconciliationPid,
+        abortPid,
+      );
+
+      await sessionBlocker.query("COMMIT");
+      assert.equal(await abortPromise, "completion_pending");
+      await abortClient.query("COMMIT");
+      assert.equal(await reconciliationPromise, "scoped");
+      await reconciliationClient.query("ROLLBACK");
+    } catch (error) {
+      raceError = error instanceof Error ? error : new Error(String(error));
+      throw raceError;
+    } finally {
+      await releaseClients(clients, raceError);
+    }
+
+    assert.deepEqual(
+      await readBoundaryState(fixture, attempt.attemptToken),
+      initialState,
+    );
+
+    const finishPayload = createPayload(fixture, randomUUID());
+    const finishAttempt = await createAttempt(fixture, finishPayload);
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => handoffWithOwner(
+          client,
+          finishAttempt.attemptToken,
+          finishAttempt.reservationToken,
+          finishPayload,
+        ),
+      ),
+      "handed_off",
+    );
+    const finishClaim = await claimAttempt(
+      fixture,
+      finishAttempt.attemptToken,
+    );
+    await insertExactReference(fixture.ownerPool, finishPayload);
+    const finishBefore = await readBoundaryState(
+      fixture,
+      finishAttempt.attemptToken,
+    );
+    const finishBlocker = await fixture.ownerPool.connect();
+    const finishClient = await fixture.runtimePool.connect();
+    const finishClients = [finishBlocker, finishClient];
+    let finishError: Error | null = null;
+    try {
+      await finishBlocker.query("BEGIN");
+      await lockMediaAsset(finishBlocker, finishPayload);
+      await beginScopedTransaction(
+        finishClient,
+        fixture.userId,
+        fixture.workspaceId,
+      );
+      const blockerPid = await backendPid(finishBlocker);
+      const finishPid = await backendPid(finishClient);
+      const finishPromise = finishReconciliation(
+        finishClient,
+        finishClaim,
+      );
+      await waitUntilBlockedBy(finishBlocker, finishPid, blockerPid);
+      await fixture.ownerPool.query(
+        `SELECT 1
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1
+         FOR UPDATE NOWAIT`,
+        [finishAttempt.attemptToken],
+      );
+      await finishBlocker.query("COMMIT");
+      assert.equal(await finishPromise, "applied");
+      await finishClient.query("ROLLBACK");
+    } catch (error) {
+      finishError =
+        error instanceof Error ? error : new Error(String(error));
+      throw finishError;
+    } finally {
+      await releaseClients(finishClients, finishError);
+    }
+    assert.deepEqual(
+      await readBoundaryState(fixture, finishAttempt.attemptToken),
+      finishBefore,
+    );
+
+    const failPayload = createPayload(fixture, randomUUID());
+    const failAttempt = await createAttempt(fixture, failPayload);
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => handoffWithOwner(
+          client,
+          failAttempt.attemptToken,
+          failAttempt.reservationToken,
+          failPayload,
+        ),
+      ),
+      "handed_off",
+    );
+    const failClaim = await claimAttempt(fixture, failAttempt.attemptToken);
+    const failBefore = await readBoundaryState(
+      fixture,
+      failAttempt.attemptToken,
+    );
+    const failBlocker = await fixture.ownerPool.connect();
+    const failClient = await fixture.runtimePool.connect();
+    const failClients = [failBlocker, failClient];
+    let failError: Error | null = null;
+    try {
+      await failBlocker.query("BEGIN");
+      await lockMediaAsset(failBlocker, failPayload);
+      await failClient.query("BEGIN");
+      const blockerPid = await backendPid(failBlocker);
+      const failPid = await backendPid(failClient);
+      const failPromise = failReconciliation(failClient, failClaim);
+      await waitUntilBlockedBy(failBlocker, failPid, blockerPid);
+      await fixture.ownerPool.query(
+        `SELECT 1
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1
+         FOR UPDATE NOWAIT`,
+        [failAttempt.attemptToken],
+      );
+      await failBlocker.query("COMMIT");
+      assert.equal(await failPromise, "failed");
+      await failClient.query("ROLLBACK");
+    } catch (error) {
+      failError = error instanceof Error ? error : new Error(String(error));
+      throw failError;
+    } finally {
+      await releaseClients(failClients, failError);
+    }
+    assert.deepEqual(
+      await readBoundaryState(fixture, failAttempt.attemptToken),
+      failBefore,
+    );
+
+    const invalidPayload = createPayload(fixture, randomUUID());
+    const invalidAttempt = await createAttempt(fixture, invalidPayload);
+    assert.equal(
+      await scoped(
+        fixture,
+        (client) => handoffWithOwner(
+          client,
+          invalidAttempt.attemptToken,
+          invalidAttempt.reservationToken,
+          invalidPayload,
+        ),
+      ),
+      "handed_off",
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.media_blob_writer_attempts
+       SET
+         last_operation_id=$2,
+         reconciliation_state='leased',
+         reconciliation_lease_token=$3,
+         reconciliation_lease_owner='legacy-pre-contract-worker',
+         reconciliation_lease_expires_at =
+           reconciliation_handed_off_at + interval '1 microsecond',
+         reconciliation_last_error_code='INVALID_RECONCILIATION_PAYLOAD',
+         reconciliation_last_error_message =
+           'Durable multipart completion payload is invalid.',
+         reconciliation_updated_at=reconciliation_handed_off_at
+       WHERE attempt_token=$1`,
+      [
+        invalidAttempt.attemptToken,
+        "legacy\u00a0operation",
+        randomUUID(),
+      ],
+    );
+    const invalidBefore = await readBoundaryState(
+      fixture,
+      invalidAttempt.attemptToken,
+    );
+    const claimBlocker = await fixture.ownerPool.connect();
+    const claimClient = await fixture.runtimePool.connect();
+    const claimClients = [claimBlocker, claimClient];
+    let claimError: Error | null = null;
+    try {
+      await claimBlocker.query("BEGIN");
+      await lockMediaAsset(claimBlocker, invalidPayload);
+      await claimClient.query("BEGIN");
+      const blockerPid = await backendPid(claimBlocker);
+      const claimPid = await backendPid(claimClient);
+      const claimPromise = claimClient.query(
+        `SELECT attempt_token
+         FROM content.claim_media_upload_session_completion_reconciliations(
+           $1,$2,$3
+         )`,
+        [`migration-0101-invalid-${randomUUID()}`, 60_000, 1],
+      );
+      await waitUntilBlockedBy(claimBlocker, claimPid, blockerPid);
+      await fixture.ownerPool.query(
+        `SELECT 1
+         FROM content.media_blob_writer_attempts
+         WHERE attempt_token=$1
+         FOR UPDATE NOWAIT`,
+        [invalidAttempt.attemptToken],
+      );
+      await claimBlocker.query("COMMIT");
+      assert.equal((await claimPromise).rowCount, 0);
+      await claimClient.query("ROLLBACK");
+    } catch (error) {
+      claimError = error instanceof Error ? error : new Error(String(error));
+      throw claimError;
+    } finally {
+      await releaseClients(claimClients, claimError);
+    }
+    assert.deepEqual(
+      await readBoundaryState(fixture, invalidAttempt.attemptToken),
+      invalidBefore,
+    );
+  });
+});

--- a/db/migrations/0101_multipart_foreground_completion_fencing.sql
+++ b/db/migrations/0101_multipart_foreground_completion_fencing.sql
@@ -1,0 +1,1154 @@
+-- Current additive migration for multipart foreground-writer fencing.
+-- Schemas touched/read explicitly: content, org, sync, security, pg_catalog, public.
+
+CREATE FUNCTION content.begin_media_upload_session_abort_with_owner(
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_media_upload_session_id UUID,
+  p_media_asset_id UUID
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  session content.media_upload_sessions%ROWTYPE;
+  fenced_at TIMESTAMPTZ;
+  fenced_attempt_count INTEGER;
+BEGIN
+  IF p_user_id IS NULL
+    OR p_user_id <> pg_catalog.btrim(p_user_id)
+    OR p_user_id = ''
+    OR pg_catalog.char_length(p_user_id) > 200
+    OR p_user_id ~ '[[:cntrl:]]'
+    OR p_workspace_id IS NULL
+    OR p_media_upload_session_id IS NULL
+    OR p_media_asset_id IS NULL
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM p_user_id
+    OR security.current_workspace_id() IS DISTINCT FROM p_workspace_id
+  THEN
+    RETURN 'access_denied';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      p_user_id || ':' || p_workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'multipart-asset:'
+        || p_workspace_id::TEXT
+        || ':'
+        || p_media_asset_id::TEXT,
+      4::BIGINT
+    )
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = p_workspace_id
+      AND memberships.user_id = p_user_id
+  ) THEN
+    RETURN 'access_denied';
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN 'not_found';
+  ELSIF session.workspace_id IS DISTINCT FROM p_workspace_id THEN
+    RETURN 'access_denied';
+  ELSIF session.media_asset_id IS DISTINCT FROM p_media_asset_id THEN
+    RETURN 'stale';
+  END IF;
+
+  PERFORM 1
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.media_upload_session_id = p_media_upload_session_id
+  ORDER BY attempts.attempt_token
+  FOR UPDATE;
+
+  IF session.state = 'aborted' THEN
+    RETURN 'already_aborted';
+  ELSIF session.state = 'completed' THEN
+    RETURN 'stale';
+  END IF;
+
+  fenced_at := pg_catalog.clock_timestamp();
+  IF EXISTS (
+    SELECT 1
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.writer_kind = 'multipart_completion'
+      AND attempts.media_upload_session_id = p_media_upload_session_id
+      AND attempts.state = 'leased'
+      AND attempts.lease_expires_at > fenced_at
+  ) THEN
+    RETURN 'completion_in_progress';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.writer_kind = 'multipart_completion'
+      AND attempts.media_upload_session_id = p_media_upload_session_id
+      AND attempts.reconciliation_state IN ('pending', 'leased')
+  ) THEN
+    RETURN 'completion_pending';
+  END IF;
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = 'expired',
+    outcome = 'stale_attempt',
+    terminal_at = fenced_at
+  WHERE attempts.writer_kind = 'multipart_completion'
+    AND attempts.media_upload_session_id = p_media_upload_session_id
+    AND attempts.state = 'leased'
+    AND attempts.lease_expires_at <= fenced_at
+    AND attempts.reconciliation_state IS NULL;
+  GET DIAGNOSTICS fenced_attempt_count = ROW_COUNT;
+
+  IF session.state = 'aborting' THEN
+    RETURN 'abort_required';
+  ELSIF session.state = 'completing' THEN
+    IF fenced_attempt_count = 0 THEN
+      RETURN 'stale';
+    END IF;
+  ELSIF session.state <> 'active' THEN
+    RETURN 'stale';
+  END IF;
+
+  UPDATE content.media_upload_sessions AS sessions
+  SET state = 'aborting'
+  WHERE sessions.media_upload_session_id = p_media_upload_session_id
+    AND sessions.workspace_id = p_workspace_id
+    AND sessions.media_asset_id = p_media_asset_id
+    AND sessions.state IN ('active', 'completing');
+  IF NOT FOUND THEN
+    RETURN 'stale';
+  END IF;
+
+  RETURN 'abort_required';
+END;
+$$;
+
+CREATE FUNCTION
+  content.handoff_media_upload_session_completion_attempt_after_access_revocation(
+    p_attempt_token UUID,
+    p_reservation_token UUID,
+    p_payload content.multipart_media_blob_writer_attempt_payload
+  )
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt_snapshot content.media_blob_writer_attempts%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  owner_snapshot content.media_blob_writer_owner_snapshots%ROWTYPE;
+  creation_claim_expires_at TIMESTAMPTZ;
+  identity_status TEXT;
+  canonical_payload BOOLEAN;
+  handed_off_at TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_reservation_token IS NULL
+    OR content.multipart_media_blob_writer_attempt_payload_valid_internal(
+      p_payload
+    ) IS DISTINCT FROM true
+  THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt_snapshot
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF NOT FOUND THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      attempt_snapshot.user_id
+        || ':'
+        || attempt_snapshot.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+  creation_claim_expires_at :=
+    content.lock_upload_creation_claim_for_completion_internal(
+      attempt_snapshot.workspace_id,
+      attempt_snapshot.media_asset_id,
+      attempt_snapshot.media_upload_session_id
+    );
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id =
+    attempt_snapshot.media_upload_session_id
+  FOR UPDATE;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+
+  IF attempt.attempt_token IS NULL
+    OR attempt.user_id IS DISTINCT FROM attempt_snapshot.user_id
+    OR attempt.workspace_id IS DISTINCT FROM attempt_snapshot.workspace_id
+    OR attempt.media_asset_id IS DISTINCT FROM attempt_snapshot.media_asset_id
+    OR attempt.media_upload_session_id IS DISTINCT FROM
+      attempt_snapshot.media_upload_session_id
+  THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  identity_status :=
+    content.multipart_media_blob_writer_attempt_identity_status_internal(
+      attempt,
+      p_reservation_token,
+      p_payload
+    );
+  IF identity_status <> 'ready' THEN
+    RETURN identity_status;
+  END IF;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = p_reservation_token
+  FOR UPDATE;
+
+  IF reservation.reservation_token IS NULL
+    OR reservation.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR reservation.workspace_id IS DISTINCT FROM p_payload.workspace_id
+    OR reservation.media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+    OR reservation.operation_id IS DISTINCT FROM
+      p_payload.media_upload_session_id::TEXT
+    OR reservation.sha256 IS DISTINCT FROM p_payload.sha256
+  THEN
+    RETURN 'writer_conflict';
+  END IF;
+
+  SELECT snapshots.*
+  INTO owner_snapshot
+  FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.reservation_token = p_reservation_token
+  FOR UPDATE;
+
+  IF owner_snapshot.reservation_token IS NULL
+    OR owner_snapshot.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR owner_snapshot.workspace_id IS DISTINCT FROM p_payload.workspace_id
+    OR owner_snapshot.media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+    OR owner_snapshot.operation_id IS DISTINCT FROM
+      p_payload.media_upload_session_id::TEXT
+    OR owner_snapshot.sha256 IS DISTINCT FROM p_payload.sha256
+    OR owner_snapshot.user_id IS DISTINCT FROM p_payload.user_id
+    OR owner_snapshot.replica_id IS DISTINCT FROM p_payload.replica_id
+    OR owner_snapshot.session_last_operation_id IS DISTINCT FROM
+      p_payload.last_operation_id
+    OR owner_snapshot.session_expires_at IS DISTINCT FROM
+      p_payload.session_expires_at
+    OR owner_snapshot.session_source_url IS DISTINCT FROM p_payload.source_url
+    OR owner_snapshot.session_asset_created_at IS DISTINCT FROM
+      p_payload.asset_created_at
+    OR owner_snapshot.session_client_updated_at IS DISTINCT FROM
+      p_payload.client_updated_at
+  THEN
+    RETURN 'ownership_mismatch';
+  END IF;
+
+  IF attempt.reconciliation_state IN ('pending', 'leased') THEN
+    RETURN 'already_pending';
+  ELSIF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'already_applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  ELSIF attempt.state <> 'leased' THEN
+    RETURN COALESCE(attempt.outcome, 'stale_attempt');
+  END IF;
+
+  IF reservation.state NOT IN ('active', 'ambiguous', 'finalized') THEN
+    RETURN 'writer_conflict';
+  END IF;
+
+  IF creation_claim_expires_at IS NOT NULL THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  IF session.media_upload_session_id IS NULL
+    OR session.workspace_id IS DISTINCT FROM p_payload.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM p_payload.media_asset_id
+    OR session.media_blob_sha256 IS DISTINCT FROM p_payload.sha256
+    OR session.staging_storage_key IS DISTINCT FROM
+      p_payload.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM p_payload.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM p_payload.s3_upload_id
+    OR session.mime_type IS DISTINCT FROM p_payload.mime_type
+    OR session.size_bytes IS DISTINCT FROM p_payload.size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM p_payload.part_size_bytes
+    OR session.part_count IS DISTINCT FROM p_payload.part_count
+    OR session.last_operation_id IS DISTINCT FROM p_payload.last_operation_id
+    OR session.source_url IS DISTINCT FROM p_payload.source_url
+    OR session.asset_created_at IS DISTINCT FROM p_payload.asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM p_payload.client_updated_at
+    OR session.expires_at IS DISTINCT FROM p_payload.session_expires_at
+  THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  IF session.last_modified_by_replica_id IS DISTINCT FROM p_payload.replica_id
+  THEN
+    RETURN 'ownership_mismatch';
+  END IF;
+
+  IF session.state = 'aborting' THEN
+    RETURN 'aborting';
+  ELSIF session.state = 'aborted' THEN
+    RETURN 'aborted';
+  ELSIF session.state <> 'completing' THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  canonical_payload :=
+    content.multipart_media_blob_writer_attempt_payload_canonical_valid_internal(
+      p_payload
+    );
+  handed_off_at := pg_catalog.clock_timestamp();
+  IF canonical_payload THEN
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'expired',
+      outcome = 'stale_attempt',
+      terminal_at = handed_off_at,
+      reconciliation_state = 'pending',
+      reconciliation_retry_count = 0,
+      reconciliation_next_attempt_at = handed_off_at,
+      reconciliation_lease_token = NULL,
+      reconciliation_lease_owner = NULL,
+      reconciliation_lease_expires_at = NULL,
+      reconciliation_last_error_code = NULL,
+      reconciliation_last_error_message = NULL,
+      reconciliation_handed_off_at = handed_off_at,
+      reconciliation_updated_at = handed_off_at,
+      reconciliation_applied_at = NULL
+    WHERE attempts.attempt_token = p_attempt_token
+      AND attempts.state = 'leased'
+      AND attempts.reconciliation_state IS NULL;
+  ELSE
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'expired',
+      outcome = 'stale_attempt',
+      terminal_at = handed_off_at,
+      reconciliation_state = 'leased',
+      reconciliation_retry_count = 0,
+      reconciliation_next_attempt_at = handed_off_at,
+      reconciliation_lease_token = public.gen_random_uuid(),
+      reconciliation_lease_owner = 'legacy-invalid-payload',
+      reconciliation_lease_expires_at =
+        handed_off_at + interval '1 microsecond',
+      reconciliation_last_error_code =
+        'INVALID_RECONCILIATION_PAYLOAD',
+      reconciliation_last_error_message =
+        'Durable multipart completion payload is invalid.',
+      reconciliation_handed_off_at = handed_off_at,
+      reconciliation_updated_at = handed_off_at,
+      reconciliation_applied_at = NULL
+    WHERE attempts.attempt_token = p_attempt_token
+      AND attempts.state = 'leased'
+      AND attempts.reconciliation_state IS NULL;
+  END IF;
+  IF NOT FOUND THEN
+    RETURN 'stale_attempt';
+  END IF;
+
+  RETURN 'handed_off';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION
+  content.claim_media_upload_session_completion_reconciliations(
+    p_lease_owner TEXT,
+    p_lease_duration_ms INTEGER,
+    p_limit INTEGER
+  )
+RETURNS SETOF content.media_blob_writer_attempts
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  claim_started_at TIMESTAMPTZ;
+  invalid_candidate RECORD;
+  invalid_attempt content.media_blob_writer_attempts%ROWTYPE;
+  invalid_lease_token UUID;
+  invalid_status TEXT;
+  invalid_processed INTEGER := 0;
+  quarantined_at TIMESTAMPTZ;
+BEGIN
+  IF p_lease_owner IS NULL
+    OR p_lease_owner <> pg_catalog.btrim(p_lease_owner)
+    OR p_lease_owner = ''
+    OR pg_catalog.char_length(p_lease_owner) > 200
+    OR p_lease_owner ~ '[[:cntrl:]]'
+  THEN
+    RAISE EXCEPTION 'p_lease_owner must be 1 to 200 trimmed characters'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_lease_duration_ms IS NULL
+    OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+  THEN
+    RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_limit IS NULL OR p_limit NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'p_limit must be between 1 and 100'
+      USING ERRCODE = '22023';
+  END IF;
+
+  claim_started_at := pg_catalog.clock_timestamp();
+  FOR invalid_candidate IN
+    SELECT
+      attempts.attempt_token,
+      attempts.user_id,
+      attempts.workspace_id,
+      attempts.media_asset_id
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE (
+      (
+        attempts.reconciliation_state = 'pending'
+        AND attempts.reconciliation_next_attempt_at <= claim_started_at
+      )
+      OR (
+        attempts.reconciliation_state = 'leased'
+        AND attempts.reconciliation_lease_expires_at <= claim_started_at
+      )
+    )
+      AND content.multipart_completion_reconciliation_job_valid_internal(
+        attempts
+      ) IS DISTINCT FROM true
+    ORDER BY
+      CASE
+        WHEN attempts.reconciliation_state = 'leased'
+        THEN attempts.reconciliation_lease_expires_at
+        ELSE attempts.reconciliation_next_attempt_at
+      END,
+      attempts.reconciliation_handed_off_at,
+      attempts.attempt_token
+    LIMIT p_limit
+  LOOP
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+      pg_catalog.hashtextextended(
+        invalid_candidate.user_id
+          || ':'
+          || invalid_candidate.workspace_id::TEXT,
+        0::BIGINT
+      )
+    );
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+      pg_catalog.hashtextextended(
+        'multipart-asset:'
+          || invalid_candidate.workspace_id::TEXT
+          || ':'
+          || invalid_candidate.media_asset_id::TEXT,
+        4::BIGINT
+      )
+    );
+
+    SELECT attempts.*
+    INTO invalid_attempt
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.attempt_token = invalid_candidate.attempt_token
+    FOR UPDATE;
+    IF NOT FOUND
+      OR (
+        NOT (
+          (
+            invalid_attempt.reconciliation_state = 'pending'
+            AND invalid_attempt.reconciliation_next_attempt_at <=
+              claim_started_at
+          )
+          OR (
+            invalid_attempt.reconciliation_state = 'leased'
+            AND invalid_attempt.reconciliation_lease_expires_at <=
+              claim_started_at
+          )
+        )
+      )
+      OR content.multipart_completion_reconciliation_job_valid_internal(
+        invalid_attempt
+      ) IS TRUE
+    THEN
+      CONTINUE;
+    END IF;
+
+    quarantined_at := pg_catalog.clock_timestamp();
+    invalid_lease_token := public.gen_random_uuid();
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      reconciliation_state = 'leased',
+      reconciliation_lease_token = invalid_lease_token,
+      reconciliation_lease_owner = p_lease_owner,
+      reconciliation_lease_expires_at =
+        quarantined_at + (p_lease_duration_ms * interval '1 millisecond'),
+      reconciliation_last_error_code =
+        'INVALID_RECONCILIATION_PAYLOAD',
+      reconciliation_last_error_message =
+        'Durable multipart completion payload is invalid.',
+      reconciliation_updated_at = quarantined_at
+    WHERE attempts.attempt_token = invalid_attempt.attempt_token;
+
+    invalid_status :=
+      content.fail_media_upload_session_completion_reconciliation(
+        invalid_attempt.attempt_token,
+        invalid_lease_token,
+        'INVALID_RECONCILIATION_PAYLOAD',
+        'Durable multipart completion payload is invalid.',
+        3600000
+      );
+    IF invalid_status NOT IN ('applied', 'failed') THEN
+      quarantined_at := pg_catalog.clock_timestamp();
+      UPDATE content.media_blob_writer_attempts AS attempts
+      SET
+        state = 'expired',
+        outcome = 'stale_attempt',
+        terminal_at = COALESCE(attempts.terminal_at, quarantined_at),
+        reconciliation_state = 'failed',
+        reconciliation_next_attempt_at = NULL,
+        reconciliation_lease_token = NULL,
+        reconciliation_lease_owner = NULL,
+        reconciliation_lease_expires_at = NULL,
+        reconciliation_last_error_code =
+          'INVALID_RECONCILIATION_PAYLOAD',
+        reconciliation_last_error_message =
+          'Durable multipart completion payload is invalid.',
+        reconciliation_updated_at = quarantined_at,
+        reconciliation_applied_at = NULL,
+        reconciliation_failure_event_id = public.gen_random_uuid(),
+        reconciliation_failure_report_state = 'pending',
+        reconciliation_failure_report_delivery_count = 0,
+        reconciliation_failure_report_lease_token = NULL,
+        reconciliation_failure_report_lease_owner = NULL,
+        reconciliation_failure_report_lease_expires_at = NULL,
+        reconciliation_failure_report_updated_at = quarantined_at,
+        reconciliation_failure_reported_at = NULL
+      WHERE attempts.attempt_token = invalid_attempt.attempt_token
+        AND attempts.reconciliation_state = 'leased'
+        AND attempts.reconciliation_lease_token = invalid_lease_token;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION
+          'Invalid multipart reconciliation could not be terminalized. attempt_token=%',
+          invalid_attempt.attempt_token
+          USING ERRCODE = '40001';
+      END IF;
+    END IF;
+    invalid_processed := invalid_processed + 1;
+  END LOOP;
+
+  claim_started_at := pg_catalog.clock_timestamp();
+  RETURN QUERY
+  WITH claimable AS (
+    SELECT attempts.attempt_token
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE (
+      (
+        attempts.reconciliation_state = 'pending'
+        AND attempts.reconciliation_next_attempt_at <= claim_started_at
+      )
+      OR (
+        attempts.reconciliation_state = 'leased'
+        AND attempts.reconciliation_lease_expires_at <= claim_started_at
+      )
+    )
+      AND content.multipart_completion_reconciliation_job_valid_internal(
+        attempts
+      ) IS TRUE
+    ORDER BY
+      CASE
+        WHEN attempts.reconciliation_state = 'leased'
+        THEN attempts.reconciliation_lease_expires_at
+        ELSE attempts.reconciliation_next_attempt_at
+      END,
+      attempts.reconciliation_handed_off_at,
+      attempts.attempt_token
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit - invalid_processed
+  )
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    reconciliation_state = 'leased',
+    reconciliation_lease_token = public.gen_random_uuid(),
+    reconciliation_lease_owner = p_lease_owner,
+    reconciliation_lease_expires_at =
+      claim_started_at + (p_lease_duration_ms * interval '1 millisecond'),
+    reconciliation_updated_at = claim_started_at
+  FROM claimable
+  WHERE attempts.attempt_token = claimable.attempt_token
+  RETURNING attempts.*;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION
+  content.apply_media_upload_session_completion_reconciliation_scope(
+    p_attempt_token UUID,
+    p_lease_token UUID
+  )
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt_snapshot content.media_blob_writer_attempts%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+BEGIN
+  SELECT attempts.*
+  INTO attempt_snapshot
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      attempt_snapshot.user_id
+        || ':'
+        || attempt_snapshot.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'multipart-asset:'
+        || attempt_snapshot.workspace_id::TEXT
+        || ':'
+        || attempt_snapshot.media_asset_id::TEXT,
+      4::BIGINT
+    )
+  );
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+  IF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  ELSIF attempt.reconciliation_state <> 'leased'
+    OR attempt.reconciliation_lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.reconciliation_lease_expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  PERFORM 1
+  FROM org.workspace_memberships AS memberships
+  WHERE memberships.workspace_id = attempt.workspace_id
+    AND memberships.user_id = attempt.user_id
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RETURN 'access_revoked';
+  END IF;
+
+  PERFORM 1
+  FROM sync.workspace_replicas AS replicas
+  WHERE replicas.replica_id = attempt.replica_id
+    AND replicas.workspace_id = attempt.workspace_id
+    AND replicas.user_id = attempt.user_id
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RETURN 'replica_revoked';
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id
+  FOR UPDATE;
+  IF NOT FOUND
+    OR session.workspace_id IS DISTINCT FROM attempt.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM attempt.media_asset_id
+    OR session.last_modified_by_replica_id IS DISTINCT FROM attempt.replica_id
+    OR session.last_operation_id IS DISTINCT FROM attempt.last_operation_id
+    OR session.media_blob_sha256 IS DISTINCT FROM attempt.sha256
+    OR session.staging_storage_key IS DISTINCT FROM attempt.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM attempt.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM attempt.s3_upload_id
+    OR session.mime_type IS DISTINCT FROM attempt.mime_type
+    OR session.size_bytes IS DISTINCT FROM attempt.size_bytes
+    OR session.part_size_bytes IS DISTINCT FROM attempt.part_size_bytes
+    OR session.part_count IS DISTINCT FROM attempt.part_count
+    OR session.source_url IS DISTINCT FROM attempt.source_url
+    OR session.asset_created_at IS DISTINCT FROM attempt.asset_created_at
+    OR session.client_updated_at IS DISTINCT FROM attempt.client_updated_at
+    OR session.expires_at IS DISTINCT FROM attempt.session_expires_at
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  IF session.state = 'aborting' THEN
+    RETURN 'aborting';
+  ELSIF session.state = 'aborted' THEN
+    RETURN 'aborted';
+  ELSIF session.state NOT IN ('completing', 'completed') THEN
+    RETURN 'stale';
+  END IF;
+
+  PERFORM pg_catalog.set_config('app.user_id', attempt.user_id, true);
+  PERFORM pg_catalog.set_config(
+    'app.workspace_id',
+    attempt.workspace_id::TEXT,
+    true
+  );
+  RETURN 'scoped';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION
+  content.finish_media_upload_session_completion_reconciliation(
+    p_attempt_token UUID,
+    p_lease_token UUID,
+    p_cleanup_delay_ms INTEGER
+  )
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt_snapshot content.media_blob_writer_attempts%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  asset RECORD;
+  terminalization_status TEXT;
+  applied_at TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt_snapshot
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'multipart-asset:'
+        || attempt_snapshot.workspace_id::TEXT
+        || ':'
+        || attempt_snapshot.media_asset_id::TEXT,
+      4::BIGINT
+    )
+  );
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  ELSIF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'already_applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  ELSIF attempt.reconciliation_state <> 'leased'
+    OR attempt.reconciliation_lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.reconciliation_lease_expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  IF security.current_user_id() IS DISTINCT FROM attempt.user_id
+    OR security.current_workspace_id() IS DISTINCT FROM attempt.workspace_id
+    OR NOT EXISTS (
+      SELECT 1
+      FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = attempt.workspace_id
+        AND memberships.user_id = attempt.user_id
+    )
+  THEN
+    RETURN 'access_revoked';
+  END IF;
+
+  SELECT *
+  INTO asset
+  FROM content.classify_media_upload_session_completion_asset_internal(
+    attempt.workspace_id,
+    attempt.media_asset_id,
+    attempt.sha256,
+    attempt.blob_storage_key,
+    attempt.mime_type,
+    attempt.size_bytes,
+    attempt.normalization_version,
+    attempt.source_url,
+    attempt.asset_created_at,
+    attempt.client_updated_at,
+    attempt.replica_id,
+    attempt.last_operation_id
+  );
+  IF asset.asset_status = 'peer_conflict' THEN
+    RETURN 'peer_conflict';
+  ELSIF asset.asset_status <> 'exact' THEN
+    RETURN 'stale';
+  END IF;
+
+  terminalization_status :=
+    content.terminalize_media_blob_writer_failure(
+      attempt.reservation_token,
+      attempt.sha256,
+      attempt.blob_storage_key,
+      attempt.mime_type,
+      attempt.size_bytes,
+      attempt.normalization_version,
+      'multipart_completion',
+      attempt.workspace_id,
+      attempt.media_asset_id,
+      attempt.operation_id,
+      p_cleanup_delay_ms
+    );
+  IF terminalization_status <> 'referenced' THEN
+    RETURN 'stale';
+  END IF;
+
+  applied_at := pg_catalog.clock_timestamp();
+  UPDATE content.media_upload_sessions AS sessions
+  SET
+    state = 'completed',
+    completed_at = COALESCE(sessions.completed_at, applied_at),
+    aborted_at = NULL
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id
+    AND sessions.state IN ('completing', 'completed');
+  IF NOT FOUND THEN
+    RETURN 'stale';
+  END IF;
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = 'applied',
+    outcome = 'live_applied',
+    terminal_at = applied_at,
+    reconciliation_state = 'applied',
+    reconciliation_next_attempt_at = NULL,
+    reconciliation_lease_token = NULL,
+    reconciliation_lease_owner = NULL,
+    reconciliation_lease_expires_at = NULL,
+    reconciliation_last_error_code = NULL,
+    reconciliation_last_error_message = NULL,
+    reconciliation_updated_at = applied_at,
+    reconciliation_applied_at = applied_at
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_state = 'leased'
+    AND attempts.reconciliation_lease_token = p_lease_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  RETURN 'applied';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION
+  content.fail_media_upload_session_completion_reconciliation(
+    p_attempt_token UUID,
+    p_lease_token UUID,
+    p_error_code TEXT,
+    p_error_message TEXT,
+    p_cleanup_delay_ms INTEGER
+  )
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt_snapshot content.media_blob_writer_attempts%ROWTYPE;
+  attempt content.media_blob_writer_attempts%ROWTYPE;
+  session content.media_upload_sessions%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  reservation content.media_blob_writer_reservations%ROWTYPE;
+  asset RECORD;
+  terminalization_status TEXT;
+  failed_at TIMESTAMPTZ;
+BEGIN
+  IF p_attempt_token IS NULL
+    OR p_lease_token IS NULL
+    OR p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+    OR content.multipart_completion_reconciliation_error_valid_internal(
+      p_error_code,
+      p_error_message
+    ) IS DISTINCT FROM true
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt_snapshot
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      attempt_snapshot.user_id
+        || ':'
+        || attempt_snapshot.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'multipart-asset:'
+        || attempt_snapshot.workspace_id::TEXT
+        || ':'
+        || attempt_snapshot.media_asset_id::TEXT,
+      4::BIGINT
+    )
+  );
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.attempt_token = p_attempt_token
+  FOR UPDATE;
+  IF attempt.reconciliation_state = 'applied' THEN
+    RETURN 'applied';
+  ELSIF attempt.reconciliation_state = 'failed' THEN
+    RETURN 'failed';
+  ELSIF attempt.reconciliation_state <> 'leased'
+    OR attempt.reconciliation_lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.reconciliation_lease_expires_at <= pg_catalog.clock_timestamp()
+  THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  SELECT sessions.*
+  INTO session
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id
+  FOR UPDATE;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = attempt.sha256
+  FOR UPDATE;
+
+  SELECT reservations.*
+  INTO reservation
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.reservation_token = attempt.reservation_token
+  FOR UPDATE;
+
+  IF session.media_upload_session_id IS NULL
+    OR lifecycle.sha256 IS NULL
+    OR reservation.reservation_token IS NULL
+    OR session.workspace_id IS DISTINCT FROM attempt.workspace_id
+    OR session.media_asset_id IS DISTINCT FROM attempt.media_asset_id
+    OR session.media_blob_sha256 IS DISTINCT FROM attempt.sha256
+    OR session.staging_storage_key IS DISTINCT FROM attempt.staging_storage_key
+    OR session.blob_storage_key IS DISTINCT FROM attempt.blob_storage_key
+    OR session.s3_upload_id IS DISTINCT FROM attempt.s3_upload_id
+    OR reservation.writer_kind IS DISTINCT FROM 'multipart_completion'
+    OR reservation.workspace_id IS DISTINCT FROM attempt.workspace_id
+    OR reservation.media_asset_id IS DISTINCT FROM attempt.media_asset_id
+    OR reservation.operation_id IS DISTINCT FROM attempt.operation_id
+    OR reservation.sha256 IS DISTINCT FROM attempt.sha256
+    OR lifecycle.storage_key IS DISTINCT FROM attempt.blob_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM attempt.mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM attempt.size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM
+      attempt.normalization_version
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT *
+  INTO asset
+  FROM content.classify_media_upload_session_completion_asset_internal(
+    attempt.workspace_id,
+    attempt.media_asset_id,
+    attempt.sha256,
+    attempt.blob_storage_key,
+    attempt.mime_type,
+    attempt.size_bytes,
+    attempt.normalization_version,
+    attempt.source_url,
+    attempt.asset_created_at,
+    attempt.client_updated_at,
+    attempt.replica_id,
+    attempt.last_operation_id
+  );
+
+  terminalization_status :=
+    content.terminalize_media_blob_writer_failure(
+      attempt.reservation_token,
+      attempt.sha256,
+      attempt.blob_storage_key,
+      attempt.mime_type,
+      attempt.size_bytes,
+      attempt.normalization_version,
+      'multipart_completion',
+      attempt.workspace_id,
+      attempt.media_asset_id,
+      attempt.operation_id,
+      p_cleanup_delay_ms
+    );
+  failed_at := pg_catalog.clock_timestamp();
+
+  IF asset.asset_status = 'exact'
+    OR terminalization_status = 'referenced'
+  THEN
+    IF terminalization_status <> 'referenced' THEN
+      RETURN 'stale';
+    END IF;
+    UPDATE content.media_upload_sessions AS sessions
+    SET
+      state = 'completed',
+      completed_at = COALESCE(sessions.completed_at, failed_at),
+      aborted_at = NULL
+    WHERE sessions.media_upload_session_id = attempt.media_upload_session_id;
+    UPDATE content.media_blob_writer_attempts AS attempts
+    SET
+      state = 'referenced',
+      outcome = 'referenced',
+      terminal_at = failed_at,
+      reconciliation_state = 'applied',
+      reconciliation_next_attempt_at = NULL,
+      reconciliation_lease_token = NULL,
+      reconciliation_lease_owner = NULL,
+      reconciliation_lease_expires_at = NULL,
+      reconciliation_last_error_code = NULL,
+      reconciliation_last_error_message = NULL,
+      reconciliation_updated_at = failed_at,
+      reconciliation_applied_at = failed_at
+    WHERE attempts.attempt_token = p_attempt_token
+      AND attempts.reconciliation_state = 'leased'
+      AND attempts.reconciliation_lease_token = p_lease_token;
+    RETURN 'applied';
+  END IF;
+
+  IF terminalization_status <> 'unreferenced' THEN
+    RETURN 'stale';
+  END IF;
+
+  UPDATE content.media_upload_sessions AS sessions
+  SET
+    state = 'aborted',
+    completed_at = NULL,
+    aborted_at = COALESCE(sessions.aborted_at, failed_at)
+  WHERE sessions.media_upload_session_id = attempt.media_upload_session_id;
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = CASE
+      WHEN asset.asset_status = 'peer_conflict' THEN 'peer_conflict'
+      ELSE 'unreferenced'
+    END,
+    outcome = CASE
+      WHEN asset.asset_status = 'peer_conflict' THEN 'peer_conflict'
+      ELSE 'unreferenced'
+    END,
+    terminal_at = failed_at,
+    reconciliation_state = 'failed',
+    reconciliation_next_attempt_at = NULL,
+    reconciliation_lease_token = NULL,
+    reconciliation_lease_owner = NULL,
+    reconciliation_lease_expires_at = NULL,
+    reconciliation_last_error_code = p_error_code,
+    reconciliation_last_error_message = p_error_message,
+    reconciliation_updated_at = failed_at,
+    reconciliation_applied_at = NULL,
+    reconciliation_failure_event_id = public.gen_random_uuid(),
+    reconciliation_failure_report_state = 'pending',
+    reconciliation_failure_report_delivery_count = 0,
+    reconciliation_failure_report_lease_token = NULL,
+    reconciliation_failure_report_lease_owner = NULL,
+    reconciliation_failure_report_lease_expires_at = NULL,
+    reconciliation_failure_report_updated_at = failed_at,
+    reconciliation_failure_reported_at = NULL
+  WHERE attempts.attempt_token = p_attempt_token
+    AND attempts.reconciliation_state = 'leased'
+    AND attempts.reconciliation_lease_token = p_lease_token;
+  IF NOT FOUND THEN
+    RETURN 'lease_lost';
+  END IF;
+
+  RETURN 'failed';
+END;
+$$;
+
+COMMENT ON FUNCTION content.begin_media_upload_session_abort_with_owner(
+  TEXT,
+  UUID,
+  UUID,
+  UUID
+) IS
+  'Admits an exact multipart abort only after fencing expired foreground completion and rejecting live or durably handed-off completion.';
+COMMENT ON FUNCTION
+  content.handoff_media_upload_session_completion_attempt_after_access_revocation(
+    UUID,
+    UUID,
+    content.multipart_media_blob_writer_attempt_payload
+  ) IS
+  'Service-authorized exact multipart completion handoff using immutable ownership evidence after membership or replica access changes.';
+
+REVOKE ALL ON FUNCTION content.begin_media_upload_session_abort_with_owner(
+  TEXT,
+  UUID,
+  UUID,
+  UUID
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.handoff_media_upload_session_completion_attempt_after_access_revocation(
+    UUID,
+    UUID,
+    content.multipart_media_blob_writer_attempt_payload
+  )
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.begin_media_upload_session_abort_with_owner(
+  TEXT,
+  UUID,
+  UUID,
+  UUID
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.handoff_media_upload_session_completion_attempt_after_access_revocation(
+    UUID,
+    UUID,
+    content.multipart_media_blob_writer_attempt_payload
+  )
+  TO backend_app;

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0100_multipart_replacement_creation_claim.sql",
+    "--require-migration 0101_multipart_foreground_completion_fencing.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -246,7 +246,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0100_multipart_replacement_creation_claim.sql",
+    "--require-migration 0101_multipart_foreground_completion_fencing.sql",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -148,7 +148,7 @@ npx cdk deploy --all --require-approval never \
 echo "=== Run database migrations ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0100_multipart_replacement_creation_claim.sql
+  --require-migration 0101_multipart_foreground_completion_fencing.sql
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \


### PR DESCRIPTION
## Summary
- add migration 0101 foreground abort and access-revoked handoff boundaries
- align durable multipart reconciliation on canonical advisory fences
- add PostgreSQL 18 concurrency and ownership coverage
- advance release migration verification to 0101

## Validation
- PostgreSQL 18 migrations 0096–0101
- backend lint, build, and 963 tests
- AWS infrastructure 45 tests
- workflow, shell, and diff checks