### PR TITLE
Fix Android durable completion cancellation

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/media/LocalMediaUploadTransferRepositoryCompletionRetryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/media/LocalMediaUploadTransferRepositoryCompletionRetryTest.kt
@@ -33,10 +33,7 @@ import java.security.MessageDigest
 import java.time.ZoneId
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -85,7 +82,7 @@ class LocalMediaUploadTransferRepositoryCompletionRetryTest {
                 ),
                 CompletionOutcome.Success(
                     applied = false,
-                    cancelBeforeReturn = false
+                    waitForCancellationBeforeReturn = false
                 )
             )
         )
@@ -174,7 +171,7 @@ class LocalMediaUploadTransferRepositoryCompletionRetryTest {
                 ),
                 CompletionOutcome.Success(
                     applied = false,
-                    cancelBeforeReturn = true
+                    waitForCancellationBeforeReturn = true
                 )
             )
         )
@@ -182,7 +179,10 @@ class LocalMediaUploadTransferRepositoryCompletionRetryTest {
             context.repository.runDueUploads()
         }
 
-        joinAll(uploadJob)
+        context.remoteGateway.replaySuccessReady.await()
+        uploadJob.cancel(CancellationException("Upload worker cancelled after completion replay"))
+        context.remoteGateway.releaseReplaySuccess.complete(Unit)
+        uploadJob.join()
 
         assertEquals(1, context.remoteGateway.createRequests.size)
         assertEquals(1, context.signedPutUploader.uploadedBodies.size)
@@ -204,7 +204,10 @@ class LocalMediaUploadTransferRepositoryCompletionRetryTest {
                     code = "MEDIA_ASSET_UPLOAD_SESSION_COMPLETION_IN_PROGRESS",
                     retryAfterDelayMillis = 0L
                 ),
-                CompletionOutcome.Terminal(code = "MEDIA_ASSET_UPLOAD_PROOF_MISMATCH")
+                CompletionOutcome.Terminal(
+                    code = "MEDIA_ASSET_UPLOAD_PROOF_MISMATCH",
+                    message = terminalCompletionMessage
+                )
             )
         )
 
@@ -264,7 +267,10 @@ class LocalMediaUploadTransferRepositoryCompletionRetryTest {
     fun repositoryAbortsTerminalCompletionFailure() = runBlocking {
         val context = createRepositoryContext(
             completionOutcomes = listOf(
-                CompletionOutcome.Terminal(code = "MEDIA_ASSET_UPLOAD_PROOF_MISMATCH")
+                CompletionOutcome.Terminal(
+                    code = "MEDIA_ASSET_UPLOAD_PROOF_MISMATCH",
+                    message = terminalCompletionMessage
+                )
             )
         )
 
@@ -276,7 +282,8 @@ class LocalMediaUploadTransferRepositoryCompletionRetryTest {
         assertEquals(listOf(sessionId), context.remoteGateway.abortSessionIds)
         val failedTransfer = loadTransfer()
         assertEquals(MediaTransferStatus.FAILED.wireKey, failedTransfer.status)
-        assertTrue(failedTransfer.lastError?.contains("MEDIA_ASSET_UPLOAD_PROOF_MISMATCH") == true)
+        assertTrue(failedTransfer.lastError?.contains(terminalCompletionMessage) == true)
+        assertTrue(failedTransfer.lastError?.contains("completion-request-terminal") == true)
     }
 
     private suspend fun createRepositoryContext(
@@ -356,6 +363,8 @@ class LocalMediaUploadTransferRepositoryCompletionRetryTest {
         const val sessionId: String = completionTestSessionId
         const val transferId: String = "media-upload-transfer-1"
         const val nowMillis: Long = 1_000L
+        const val terminalCompletionMessage: String =
+            "Uploaded media asset proof does not match the authenticated upload session"
     }
 }
 
@@ -373,13 +382,14 @@ private sealed interface CompletionOutcome {
 
     data class Success(
         val applied: Boolean,
-        val cancelBeforeReturn: Boolean
+        val waitForCancellationBeforeReturn: Boolean
     ) : CompletionOutcome
 
     data object InvalidSuccess : CompletionOutcome
 
     data class Terminal(
-        val code: String
+        val code: String,
+        val message: String
     ) : CompletionOutcome
 }
 
@@ -399,6 +409,8 @@ private class RecordingMediaUploadGateway(
     val completionRequests = mutableListOf<CompleteMediaAssetUploadSessionRequest>()
     val abortSessionIds = mutableListOf<String>()
     val firstCompletionAttempt = CompletableDeferred<Unit>()
+    val replaySuccessReady = CompletableDeferred<Unit>()
+    val releaseReplaySuccess = CompletableDeferred<Unit>()
 
     override suspend fun fetchCloudAccount(
         apiBaseUrl: String,
@@ -489,10 +501,9 @@ private class RecordingMediaUploadGateway(
                 androidObservationAlreadyCaptured = false
             )
             is CompletionOutcome.Success -> {
-                if (outcome.cancelBeforeReturn) {
-                    currentCoroutineContext().cancel(
-                        CancellationException("Upload worker cancelled after completion replay")
-                    )
+                if (outcome.waitForCancellationBeforeReturn) {
+                    replaySuccessReady.complete(Unit)
+                    releaseReplaySuccess.await()
                 }
                 MediaAssetUploadCompletion(
                     mediaAsset = createMediaAsset(),
@@ -506,9 +517,15 @@ private class RecordingMediaUploadGateway(
                 applied = false
             )
             is CompletionOutcome.Terminal -> throw CloudRemoteException(
-                message = "Completion payload is invalid",
-                statusCode = 400,
-                responseBody = """{"code":"${outcome.code}"}""",
+                message = "${outcome.message} Reference: completion-request-terminal",
+                statusCode = 409,
+                responseBody = """
+                    {
+                      "error": "${outcome.message}",
+                      "requestId": "completion-request-terminal",
+                      "code": "${outcome.code}"
+                    }
+                """.trimIndent(),
                 errorCode = outcome.code,
                 requestId = "completion-request-terminal",
                 syncConflict = null,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/LocalMediaUploadTransferRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/LocalMediaUploadTransferRepository.kt
@@ -237,45 +237,12 @@ class LocalMediaUploadTransferRepository(
                         cloudSession = cloudSession
                     )
                     val mediaAsset: MediaAsset = completionResult.completion.mediaAsset
-                    val retryableCompletionCause: CloudRemoteException? =
-                        completionResult.retryableCompletionCause
-                    try {
-                        requireMediaAssetMatchesTransfer(
-                            mediaAsset = mediaAsset,
-                            transfer = transfer
-                        )
-                    } catch (error: Exception) {
-                        if (retryableCompletionCause != null) {
-                            throw MediaUploadCompletionTerminalException(
-                                reason = MediaUploadCompletionTerminalReason.INTERRUPTED,
-                                completionCause = retryableCompletionCause,
-                                interruptionCause = error
-                            )
-                        }
-                        throw error
-                    }
-                    if (retryableCompletionCause == null) {
+                    if (completionResult.retryableCompletionCause == null) {
                         persistSuccessfulUpload(
                             transfer = transfer,
                             uploadFilePlan = uploadFilePlan,
                             mediaAsset = mediaAsset
                         )
-                    } else {
-                        try {
-                            withContext(context = NonCancellable) {
-                                persistSuccessfulUpload(
-                                    transfer = transfer,
-                                    uploadFilePlan = uploadFilePlan,
-                                    mediaAsset = mediaAsset
-                                )
-                            }
-                        } catch (error: Exception) {
-                            throw MediaUploadCompletionTerminalException(
-                                reason = MediaUploadCompletionTerminalReason.INTERRUPTED,
-                                completionCause = retryableCompletionCause,
-                                interruptionCause = error
-                            )
-                        }
                     }
                     activeUploadSession = null
                 }
@@ -369,6 +336,13 @@ class LocalMediaUploadTransferRepository(
             },
             wait = { delayMillis ->
                 delay(timeMillis = delayMillis)
+            },
+            persistReplaySuccess = { completion ->
+                persistSuccessfulUpload(
+                    transfer = transfer,
+                    uploadFilePlan = uploadFilePlan,
+                    mediaAsset = completion.mediaAsset
+                )
             }
         )
     }
@@ -618,7 +592,8 @@ internal fun shouldAbortMediaUploadSessionAfterFailure(error: Exception): Boolea
 
 internal suspend fun retryMediaUploadSessionCompletion(
     complete: suspend () -> MediaAssetUploadCompletion,
-    wait: suspend (Long) -> Unit
+    wait: suspend (Long) -> Unit,
+    persistReplaySuccess: suspend (MediaAssetUploadCompletion) -> Unit
 ): MediaUploadCompletionReplayResult {
     var attemptNumber = 1
     var lastRetryableCompletionError: CloudRemoteException? = null
@@ -635,9 +610,19 @@ internal suspend fun retryMediaUploadSessionCompletion(
         }
 
         try {
+            val completionError: CloudRemoteException? = lastRetryableCompletionError
+            val completion: MediaAssetUploadCompletion = if (completionError == null) {
+                complete()
+            } else {
+                withContext(context = NonCancellable) {
+                    val replayCompletion: MediaAssetUploadCompletion = complete()
+                    persistReplaySuccess(replayCompletion)
+                    replayCompletion
+                }
+            }
             return MediaUploadCompletionReplayResult(
-                completion = complete(),
-                retryableCompletionCause = lastRetryableCompletionError
+                completion = completion,
+                retryableCompletionCause = completionError
             )
         } catch (error: CancellationException) {
             val completionError = lastRetryableCompletionError

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/media/MediaUploadCompletionRetryTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/media/MediaUploadCompletionRetryTest.kt
@@ -57,6 +57,8 @@ class MediaUploadCompletionRetryTest {
             },
             wait = { delayMillis ->
                 retryDelays += delayMillis
+            },
+            persistReplaySuccess = {
             }
         )
 
@@ -86,6 +88,8 @@ class MediaUploadCompletionRetryTest {
                 },
                 wait = {
                     throw CancellationException("Upload worker cancelled")
+                },
+                persistReplaySuccess = {
                 }
             )
             fail("Expected cancellation")
@@ -113,6 +117,8 @@ class MediaUploadCompletionRetryTest {
                 },
                 wait = {
                     retryDelayCount += 1
+                },
+                persistReplaySuccess = {
                 }
             )
             fail("Expected retry exhaustion")
@@ -141,6 +147,8 @@ class MediaUploadCompletionRetryTest {
                 },
                 wait = {
                     retryDelayCount += 1
+                },
+                persistReplaySuccess = {
                 }
             )
             fail("Expected terminal completion failure")


### PR DESCRIPTION
## Summary

- keep a successful same-session completion replay and its Room success disposition inside one durable non-cancellable boundary after the first structured retryable completion response
- preserve cancellable Retry-After backoff, bounded completion-only retries, ordered parts, the existing initial terminal abort path, and no abort or full re-upload after durable completion begins
- replace the self-cancelling replay fixture with deterministic external cancellation and model terminal failures using the real gateway error, request-ID, and HTTP 409 shape

## Root causes

1. The prior implementation protected only the local Room write. Cancellation could still discard a successful replay response before local disposition, causing the retry state to be persisted as failed.
2. The terminal instrumentation test reached and verified the production abort path, but its synthetic exception message did not match the gateway-rendered actionable error envelope, so its later lastError assertion was invalid.

## Validation

- fresh independent recovery review: no P0-P4 findings; green light
- git diff --check
- source and fixture contract checks
- no local Gradle task or emulator run, per repository instructions; GitHub Android CI is the runtime gate
