### PR TITLE
Integrate generated promotion blob writer

### DIFF
--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../database";
 import {
+  MediaBlobWriterFenceError,
   reserveMediaBlobWriterInExecutor,
   type MediaBlobWriterReservation,
 } from "../../mediaAssets/blobLifecycle";
@@ -14,8 +15,10 @@ import { imageJpegCardMediaBlobNormalizationVersion } from "../../mediaAssets/ty
 import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
 import { InactiveChatRunClaimError } from "../runs/claimFence";
 import {
+  assertGeneratedMediaBlobStorageCapabilityForMutation,
   claimGeneratedMediaPromotionJobs,
   enqueueGeneratedMediaPromotionJob,
+  failGeneratedMediaPromotionJobAfterAccessRevocation,
   failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor,
   failGeneratedMediaPromotionJobWithExecutor,
   failGeneratedMediaPromotionJobWithBlobWriterInExecutor,
@@ -24,9 +27,12 @@ import {
   isGeneratedMediaPromotionOperationAppliedWithExecutor,
   markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor,
   markGeneratedMediaPromotionJobAppliedWithExecutor,
+  markGeneratedMediaBlobWriterAmbiguous,
+  reserveGeneratedMediaBlobWriter,
   rescheduleGeneratedMediaPromotionJobWithExecutor,
   type ClaimedGeneratedMediaPromotionJob,
   type EnqueueGeneratedMediaPromotionJobInput,
+  type GeneratedMediaBlobStorageCapability,
 } from "./promotionJobs";
 import {
   applyGeneratedMediaPromotionJob, failGeneratedMediaPromotionJob,
@@ -143,6 +149,55 @@ function withSha256(
   sha256: string,
 ): EnqueueGeneratedMediaPromotionJobInput {
   return { ...input, sha256, blobStorageKey: buildMediaBlobStorageKey(sha256) };
+}
+function immutablePayloadMismatches(
+  job: ClaimedGeneratedMediaPromotionJob,
+): ReadonlyArray<ClaimedGeneratedMediaPromotionJob> {
+  const operationId = randomUUID();
+  const workspaceId = randomUUID();
+  const mediaAssetId = randomUUID();
+  const sha256 = uniqueSha256();
+  return [
+    {
+      ...job,
+      operationId,
+      stagingStorageKey: buildMediaUploadStagingStorageKey(
+        job.workspaceId,
+        job.mediaAssetId,
+        operationId,
+      ),
+    },
+    { ...job, userId: "forged-generated-promotion-user" },
+    {
+      ...job,
+      workspaceId,
+      stagingStorageKey: buildMediaUploadStagingStorageKey(
+        workspaceId,
+        job.mediaAssetId,
+        job.operationId,
+      ),
+    },
+    { ...job, cardId: randomUUID() },
+    { ...job, targetSide: job.targetSide === "front" ? "back" : "front" },
+    { ...job, altText: "Forged immutable alt text" },
+    {
+      ...job,
+      mediaAssetId,
+      stagingStorageKey: buildMediaUploadStagingStorageKey(
+        job.workspaceId,
+        mediaAssetId,
+        job.operationId,
+      ),
+    },
+    { ...job, replicaId: randomUUID() },
+    {
+      ...job,
+      sha256,
+      blobStorageKey: buildMediaBlobStorageKey(sha256),
+    },
+    { ...job, mimeType: "image/png" },
+    { ...job, sizeBytes: job.sizeBytes + 1 },
+  ];
 }
 async function reserveGeneratedWriter(
   fixture: PostgresIntegrationFixture,
@@ -269,7 +324,7 @@ async function assertRevocationMigrationUpgrade(
     client.release();
   }
 }
-test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS", async () => {
+test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS", async (testContext) => {
   await withPostgresIntegrationFixture(async (fixture) => {
     const run = await createRun(fixture);
     const concurrentInput = { ...createInput(fixture, run), targetSide: "front" as const };
@@ -354,7 +409,112 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
         })),
       GeneratedMediaPromotionJobLeaseLostError,
     );
-    await applyGeneratedMediaPromotionJob(applied, Date.now() + 10_000);
+    for (const mismatchedJob of immutablePayloadMismatches(applied)) {
+      await assert.rejects(
+        reserveGeneratedMediaBlobWriter(mismatchedJob, Date.now() + 10_000),
+        GeneratedMediaPromotionJobLeaseLostError,
+      );
+    }
+    assert.equal((await fixture.ownerPool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+       FROM content.media_blob_writer_reservations
+       WHERE writer_kind = 'generated_promotion'
+         AND workspace_id = $1
+         AND media_asset_id = $2
+         AND operation_id = $3`,
+      [applied.workspaceId, applied.mediaAssetId, applied.operationId],
+    )).rows[0]?.count, "0");
+    let forgedStorageCalls = 0;
+    let forgedApplyCalls = 0;
+    const forgedResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+      { ...applied, altText: "Forged processor payload" },
+      {
+        leaseOwner: applied.leaseOwner, leaseDurationMs: 60_000,
+        maximumJobs: 1, deadlineAtMs: Date.now() + 10_000,
+        observationScope: testObservationScope, signal: new AbortController().signal,
+      },
+      {
+        claimJobsFn: async () => [],
+        reserveWriterFn: reserveGeneratedMediaBlobWriter,
+        promoteObjectFn: async () => {
+          forgedStorageCalls += 1;
+        },
+        applyJobFn: async () => {
+          forgedApplyCalls += 1;
+        },
+        rescheduleJobFn: async () => {
+          assert.fail("A forged job must not be rescheduled.");
+        },
+        failJobFn: async () => {
+          assert.fail("A forged job must not reach failure application.");
+        },
+        failAfterAccessRevocationFn: async () => {
+          assert.fail("A forged job must not reach access-revocation resolution.");
+        },
+        markWriterAmbiguousFn: async () => {
+          assert.fail("A forged job must not mark a writer ambiguous.");
+        },
+        nowFn: Date.now,
+      },
+    );
+    assert.equal(forgedResult.outcome, "lease_lost");
+    assert.equal(forgedStorageCalls, 0);
+    assert.equal(forgedApplyCalls, 0);
+    const appliedWriter = await reserveGeneratedMediaBlobWriter(applied, Date.now() + 10_000);
+    assert.doesNotThrow(() => assertGeneratedMediaBlobStorageCapabilityForMutation(
+      appliedWriter.storageCapability,
+      appliedWriter.writer,
+    ));
+    for (const mismatchedWriter of [
+      { ...appliedWriter.writer, reservationToken: randomUUID() },
+      { ...appliedWriter.writer, altText: "Mismatched immutable generated payload" },
+    ]) {
+      assert.throws(
+        () => assertGeneratedMediaBlobStorageCapabilityForMutation(
+          appliedWriter.storageCapability,
+          mismatchedWriter,
+        ),
+        MediaBlobWriterFenceError,
+      );
+    }
+    assert.throws(
+      () => assertGeneratedMediaBlobStorageCapabilityForMutation(
+        Object.freeze({}) as GeneratedMediaBlobStorageCapability,
+        appliedWriter.writer,
+      ),
+      MediaBlobWriterFenceError,
+    );
+    for (const copiedCapability of [
+      Object.freeze({ ...appliedWriter.storageCapability }),
+      Object.freeze(Object.create(appliedWriter.storageCapability)),
+      Object.freeze(structuredClone(appliedWriter.storageCapability)),
+    ] as ReadonlyArray<GeneratedMediaBlobStorageCapability>) {
+      assert.throws(
+        () => assertGeneratedMediaBlobStorageCapabilityForMutation(
+          copiedCapability,
+          appliedWriter.writer,
+        ),
+        MediaBlobWriterFenceError,
+      );
+    }
+    const dateNowMock = testContext.mock.method(
+      Date,
+      "now",
+      () => Date.parse(appliedWriter.writer.leaseExpiresAt),
+    );
+    try {
+      assert.throws(
+        () => assertGeneratedMediaBlobStorageCapabilityForMutation(
+          appliedWriter.storageCapability,
+          appliedWriter.writer,
+        ),
+        MediaBlobWriterFenceError,
+      );
+    } finally {
+      dateNowMock.mock.restore();
+    }
+    await applyGeneratedMediaPromotionJob(appliedWriter, Date.now() + 10_000);
+    await applyGeneratedMediaPromotionJob(appliedWriter, Date.now() + 10_000);
     await transition(fixture, async (executor) => {
       assert.equal(await isGeneratedMediaPromotionOperationAppliedWithExecutor(
         executor, applied.jobId, applied.operationId,
@@ -480,12 +640,30 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     const terminalInput = inputs[3];
     if (terminalInput === undefined) throw new Error("Missing terminal input.");
     const terminal = byJobId(claimed, terminalInput.jobId);
+    const terminalWriter = await reserveGeneratedMediaBlobWriter(terminal, Date.now() + 10_000);
+    await transition(fixture, (executor) =>
+      rescheduleGeneratedMediaPromotionJobWithExecutor(executor, {
+        ...terminal,
+        nextAttemptAt: new Date(Date.now() + 60_000),
+        error: {
+          code: "DATABASE_TRANSIENT",
+          message: "Generated writer retry must recover without an in-memory token.",
+        },
+      }));
+    await fixture.ownerPool.query(
+      "UPDATE content.generated_media_promotion_jobs SET next_attempt_at = created_at WHERE job_id = $1",
+      [terminal.jobId],
+    );
     await fixture.ownerPool.query(
       "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
       [fixture.workspaceId, fixture.userId],
     );
+    const reclaimedTerminal = byJobId(
+      await claim("integration-revoked", 1),
+      terminal.jobId,
+    );
     const revokedResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
-      terminal,
+      reclaimedTerminal,
       {
         leaseOwner: "integration-revoked", leaseDurationMs: 60_000,
         maximumJobs: 1, deadlineAtMs: Date.now() + 10_000,
@@ -493,15 +671,22 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
       },
       {
         claimJobsFn: claimGeneratedMediaPromotionJobs,
+        reserveWriterFn: reserveGeneratedMediaBlobWriter,
         promoteObjectFn: async () => {},
         applyJobFn: applyGeneratedMediaPromotionJob,
         rescheduleJobFn: rescheduleGeneratedMediaPromotionJob,
         failJobFn: failGeneratedMediaPromotionJob,
+        failAfterAccessRevocationFn: failGeneratedMediaPromotionJobAfterAccessRevocation,
+        markWriterAmbiguousFn: markGeneratedMediaBlobWriterAmbiguous,
         nowFn: Date.now,
       },
     );
     assert.equal(revokedResult.outcome, "failed");
     assert.equal(revokedResult.errorCode, "WORKSPACE_ACCESS_REVOKED");
+    assert.equal((await fixture.ownerPool.query<{ state: string }>(
+      "SELECT state FROM content.media_blob_writer_reservations WHERE reservation_token = $1",
+      [terminalWriter.reservationToken],
+    )).rows[0]?.state, "unreferenced");
     await assert.rejects(
       transition(fixture, async (executor) =>
         failGeneratedMediaPromotionJobWithExecutor(executor, {
@@ -573,8 +758,8 @@ test("access revocation resolves an exact generated writer and fences stale leas
       fixture, metadataConflict, conflictingSha256,
     );
     assert.equal(
-      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
-        fixture.runtimePool, rescheduled,
+      await failGeneratedMediaPromotionJobAfterAccessRevocation(
+        rescheduled, Date.now() + 10_000,
       ),
       "access_active",
     );
@@ -621,8 +806,8 @@ test("access revocation resolves an exact generated writer and fences stale leas
       [fixture.workspaceId, fixture.userId],
     );
     assert.equal(
-      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
-        fixture.runtimePool, ambiguous,
+      await failGeneratedMediaPromotionJobAfterAccessRevocation(
+        ambiguous, Date.now() + 10_000,
       ),
       "access_active",
     );
@@ -668,12 +853,27 @@ test("access revocation resolves an exact generated writer and fences stale leas
       ),
       "failed",
     );
-    assert.equal(
-      await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
-        fixture.runtimePool, ambiguous,
-      ),
-      "failed",
+    const ambiguousResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+      ambiguous,
+      {
+        leaseOwner: "revocation-integration-initial", leaseDurationMs: 60_000,
+        maximumJobs: 1, deadlineAtMs: Date.now() + 10_000,
+        observationScope: testObservationScope, signal: new AbortController().signal,
+      },
+      {
+        claimJobsFn: claimGeneratedMediaPromotionJobs,
+        reserveWriterFn: reserveGeneratedMediaBlobWriter,
+        promoteObjectFn: async () => {},
+        applyJobFn: applyGeneratedMediaPromotionJob,
+        rescheduleJobFn: rescheduleGeneratedMediaPromotionJob,
+        failJobFn: failGeneratedMediaPromotionJob,
+        failAfterAccessRevocationFn: failGeneratedMediaPromotionJobAfterAccessRevocation,
+        markWriterAmbiguousFn: markGeneratedMediaBlobWriterAmbiguous,
+        nowFn: Date.now,
+      },
     );
+    assert.equal(ambiguousResult.outcome, "failed");
+    assert.equal(ambiguousResult.errorCode, "WORKSPACE_ACCESS_REVOKED");
     assert.equal(
       await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
         fixture.runtimePool, absent,

--- a/apps/backend/src/chat/cardImages/promotionJobs.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.ts
@@ -3,9 +3,16 @@ import {
   type DatabaseExecutor,
   type SqlValue,
 } from "../../database";
-import { unsafeQueryWithDeadline } from "../../database/unsafe";
+import { unsafeQueryWithDeadline, unsafeTransactionWithDeadline } from "../../database/unsafe";
+import {
+  MediaBlobWriterFenceError,
+  reserveMediaBlobWriterInExecutor,
+  type MediaBlobWriterReservation,
+  type MediaBlobWriterReservationInput,
+} from "../../mediaAssets/blobLifecycle";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
 import {
+  imageJpegCardMediaBlobNormalizationVersion,
   mediaBlobNormalizationVersions,
   type MediaBlobNormalizationVersion,
 } from "../../mediaAssets/types";
@@ -63,6 +70,19 @@ export type GeneratedMediaPromotionBlobWriterInput =
     reservationToken: string;
     normalizationVersion: MediaBlobNormalizationVersion;
   }>;
+export type GeneratedMediaBlobWriterExactInput =
+  GeneratedMediaPromotionBlobWriterInput & Readonly<{
+    reservationState: MediaBlobWriterReservation["state"];
+  }>;
+declare const generatedMediaBlobStorageCapabilityType: unique symbol;
+export type GeneratedMediaBlobStorageCapability = Readonly<{
+  readonly [generatedMediaBlobStorageCapabilityType]: true;
+}>;
+export type GeneratedMediaBlobWriterReservation =
+  MediaBlobWriterReservation & Readonly<{
+    writer: GeneratedMediaBlobWriterExactInput;
+    storageCapability: GeneratedMediaBlobStorageCapability;
+  }>;
 export type FailGeneratedMediaPromotionJobWithBlobWriterInput =
   GeneratedMediaPromotionBlobWriterInput & Readonly<{ error: SafeGeneratedMediaPromotionJobError }>;
 export type GeneratedMediaPromotionAccessRevocationOutcome =
@@ -100,6 +120,8 @@ type AppliedScopeRow = Readonly<{ scope_status: string }>;
 type OperationAppliedRow = Readonly<{ applied: boolean }>;
 type AccessRevocationRow = Readonly<{ revocation_status: string }>;
 type InsertedRow = Readonly<{ job_id: string }>;
+const generatedMediaBlobStorageCapabilityClaims =
+  new WeakMap<GeneratedMediaBlobStorageCapability, GeneratedMediaBlobWriterExactInput>();
 export class GeneratedMediaPromotionJobConflictError extends Error {
   readonly code = "GENERATED_MEDIA_PROMOTION_JOB_CONFLICT";
   constructor(jobId: string, operationId: string, fieldName: string) {
@@ -188,6 +210,131 @@ function requireBlobWriterInput(input: GeneratedMediaPromotionBlobWriterInput): 
   requireUuid(input.reservationToken, "reservationToken");
   if (!mediaBlobNormalizationVersions.some((version) => version === input.normalizationVersion)) {
     throw new TypeError("normalizationVersion is unsupported.");
+  }
+}
+function snapshotGeneratedMediaBlobWriterExactInput(
+  input: GeneratedMediaBlobWriterExactInput,
+): GeneratedMediaBlobWriterExactInput {
+  const lastErrorInput = input.lastError;
+  const lastError = lastErrorInput === null
+    ? null
+    : Object.freeze({
+      code: lastErrorInput.code,
+      message: lastErrorInput.message,
+    });
+  const snapshot: GeneratedMediaBlobWriterExactInput = {
+    jobId: input.jobId,
+    operationId: input.operationId,
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    cardId: input.cardId,
+    targetSide: input.targetSide,
+    altText: input.altText,
+    mediaAssetId: input.mediaAssetId,
+    replicaId: input.replicaId,
+    stagingStorageKey: input.stagingStorageKey,
+    blobStorageKey: input.blobStorageKey,
+    sha256: input.sha256,
+    mimeType: input.mimeType,
+    sizeBytes: input.sizeBytes,
+    state: input.state,
+    retryCount: input.retryCount,
+    nextAttemptAt: input.nextAttemptAt,
+    leaseToken: input.leaseToken,
+    leaseOwner: input.leaseOwner,
+    leaseExpiresAt: input.leaseExpiresAt,
+    lastError,
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt,
+    reservationToken: input.reservationToken,
+    normalizationVersion: input.normalizationVersion,
+    reservationState: input.reservationState,
+  };
+  requireBlobWriterInput(snapshot);
+  if (snapshot.state !== "leased") {
+    throw new MediaBlobWriterFenceError("snapshot_generated_storage_writer_state");
+  }
+  if (
+    snapshot.leaseOwner !== snapshot.leaseOwner.trim()
+    || snapshot.leaseOwner.length < 1
+    || snapshot.leaseOwner.length > 200
+    || controlCharacterPattern.test(snapshot.leaseOwner)
+  ) {
+    throw new TypeError(
+      "leaseOwner must be 1 to 200 trimmed characters without control characters.",
+    );
+  }
+  const leaseExpiresAtMs = Date.parse(snapshot.leaseExpiresAt);
+  if (!Number.isFinite(leaseExpiresAtMs)) {
+    throw new TypeError("leaseExpiresAt must be a valid timestamp.");
+  }
+  return Object.freeze(snapshot);
+}
+function hasExactGeneratedMediaBlobWriterInput(
+  expected: GeneratedMediaBlobWriterExactInput,
+  actual: GeneratedMediaBlobWriterExactInput,
+): boolean {
+  return expected.jobId === actual.jobId
+    && expected.operationId === actual.operationId
+    && expected.userId === actual.userId
+    && expected.workspaceId === actual.workspaceId
+    && expected.cardId === actual.cardId
+    && expected.targetSide === actual.targetSide
+    && expected.altText === actual.altText
+    && expected.mediaAssetId === actual.mediaAssetId
+    && expected.replicaId === actual.replicaId
+    && expected.stagingStorageKey === actual.stagingStorageKey
+    && expected.blobStorageKey === actual.blobStorageKey
+    && expected.sha256 === actual.sha256
+    && expected.mimeType === actual.mimeType
+    && expected.sizeBytes === actual.sizeBytes
+    && expected.state === actual.state
+    && expected.retryCount === actual.retryCount
+    && expected.nextAttemptAt === actual.nextAttemptAt
+    && expected.leaseToken === actual.leaseToken
+    && expected.leaseOwner === actual.leaseOwner
+    && expected.leaseExpiresAt === actual.leaseExpiresAt
+    && expected.lastError?.code === actual.lastError?.code
+    && expected.lastError?.message === actual.lastError?.message
+    && expected.createdAt === actual.createdAt
+    && expected.updatedAt === actual.updatedAt
+    && expected.reservationToken === actual.reservationToken
+    && expected.normalizationVersion === actual.normalizationVersion
+    && expected.reservationState === actual.reservationState;
+}
+function createGeneratedMediaBlobStorageCapability(
+  input: GeneratedMediaBlobWriterExactInput,
+): Readonly<{
+  writer: GeneratedMediaBlobWriterExactInput;
+  storageCapability: GeneratedMediaBlobStorageCapability;
+}> {
+  const writer = snapshotGeneratedMediaBlobWriterExactInput(input);
+  if (Date.parse(writer.leaseExpiresAt) <= Date.now()) {
+    throw new MediaBlobWriterFenceError("issue_generated_storage_capability_expired");
+  }
+  const storageCapability = Object.freeze({}) as GeneratedMediaBlobStorageCapability;
+  generatedMediaBlobStorageCapabilityClaims.set(storageCapability, writer);
+  return Object.freeze({ writer, storageCapability });
+}
+export function assertGeneratedMediaBlobStorageCapabilityForMutation(
+  storageCapability: GeneratedMediaBlobStorageCapability,
+  writer: GeneratedMediaBlobWriterExactInput,
+): void {
+  const exactWriter = snapshotGeneratedMediaBlobWriterExactInput(writer);
+  const claim = typeof storageCapability === "object" && storageCapability !== null
+    ? generatedMediaBlobStorageCapabilityClaims.get(storageCapability)
+    : undefined;
+  if (
+    claim === undefined
+    || !Object.isFrozen(storageCapability)
+    || !Object.isFrozen(claim)
+    || !hasExactGeneratedMediaBlobWriterInput(claim, exactWriter)
+    || claim.reservationState !== "active"
+  ) {
+    throw new MediaBlobWriterFenceError("verify_generated_storage_capability");
+  }
+  if (Date.parse(claim.leaseExpiresAt) <= Date.now()) {
+    throw new MediaBlobWriterFenceError("verify_generated_storage_capability_expired");
   }
 }
 function blobWriterTransitionParams(
@@ -441,6 +588,15 @@ export async function failGeneratedMediaPromotionJobAfterAccessRevocationWithExe
     `PostgreSQL returned an invalid promotion access-revocation status. jobId=${input.jobId}`,
   );
 }
+
+export async function failGeneratedMediaPromotionJobAfterAccessRevocation(
+  job: ClaimedGeneratedMediaPromotionJob,
+  deadlineAtMs: number,
+): Promise<GeneratedMediaPromotionAccessRevocationOutcome> {
+  return unsafeTransactionWithDeadline(deadlineAtMs, (executor) =>
+    failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(executor, job));
+}
+
 export async function applyGeneratedMediaPromotionJobScopeWithExecutor(
   executor: DatabaseExecutor,
   input: GeneratedMediaPromotionJobLeaseInput,
@@ -496,4 +652,73 @@ export async function failGeneratedMediaPromotionJobWithExecutor(
     [input.jobId, input.leaseToken, input.error.code, input.error.message],
     input.jobId,
   );
+}
+
+function toBlobWriterInput(job: ClaimedGeneratedMediaPromotionJob): MediaBlobWriterReservationInput {
+  return {
+    writerKind: "generated_promotion",
+    workspaceId: job.workspaceId,
+    mediaAssetId: job.mediaAssetId,
+    operationId: job.operationId,
+    sha256: job.sha256,
+    storageKey: job.blobStorageKey,
+    mimeType: job.mimeType,
+    sizeBytes: job.sizeBytes,
+    normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+  };
+}
+
+function toGeneratedMediaPromotionBlobWriterInput(
+  job: ClaimedGeneratedMediaPromotionJob,
+  reservation: MediaBlobWriterReservation,
+): GeneratedMediaPromotionBlobWriterInput {
+  return {
+    ...job,
+    reservationToken: reservation.reservationToken,
+    normalizationVersion: reservation.normalizationVersion,
+  };
+}
+
+async function lockExactGeneratedMediaPromotionJobForWriterReservation(
+  executor: DatabaseExecutor,
+  job: ClaimedGeneratedMediaPromotionJob,
+): Promise<void> {
+  const status = await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+    executor,
+    job,
+  );
+  if (status !== "access_active") {
+    throw new GeneratedMediaPromotionJobLeaseLostError(job.jobId);
+  }
+}
+
+export async function reserveGeneratedMediaBlobWriter(
+  job: ClaimedGeneratedMediaPromotionJob,
+  deadlineAtMs: number,
+): Promise<GeneratedMediaBlobWriterReservation> {
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
+    await applyGeneratedMediaPromotionJobScopeWithExecutor(executor, job);
+    await lockExactGeneratedMediaPromotionJobForWriterReservation(executor, job);
+    const reservation = await reserveMediaBlobWriterInExecutor(
+      executor,
+      toBlobWriterInput(job),
+    );
+    const capability = createGeneratedMediaBlobStorageCapability({
+      ...toGeneratedMediaPromotionBlobWriterInput(job, reservation),
+      reservationState: reservation.state,
+    });
+    return Object.freeze({ ...reservation, ...capability });
+  });
+}
+
+export async function markGeneratedMediaBlobWriterAmbiguous(
+  reservation: GeneratedMediaBlobWriterReservation,
+  deadlineAtMs: number,
+): Promise<void> {
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
+    await markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor(
+      executor,
+      reservation.writer,
+    );
+  });
 }

--- a/apps/backend/src/chat/cardImages/promotionProcessor.test.ts
+++ b/apps/backend/src/chat/cardImages/promotionProcessor.test.ts
@@ -1,16 +1,27 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { TransientDatabaseHttpError } from "../../database/transient";
+import {
+  DatabaseCommitOutcomeUnknownError,
+  TransientDatabaseHttpError,
+} from "../../database/transient";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
 import {
   testMediaAssetId, testObservationScope, testSha256, testWorkspaceId,
 } from "../../mediaAssets/storage/testHelpers";
-import type { ClaimedGeneratedMediaPromotionJob } from "./promotionJobs";
+import { imageJpegCardMediaBlobNormalizationVersion } from "../../mediaAssets/types";
+import {
+  GeneratedMediaPromotionJobAccessRevokedError,
+  type ClaimedGeneratedMediaPromotionJob,
+  type GeneratedMediaBlobStorageCapability,
+  type GeneratedMediaBlobWriterReservation,
+} from "./promotionJobs";
 import { processClaimedGeneratedMediaPromotionJobWithDependencies } from "./promotionProcessor";
 const jobId = "33333333-3333-4333-8333-333333333333";
 const operationId = "44444444-4444-4444-8444-444444444444";
 const timestamp = "2026-07-25T00:00:00.000Z";
 const nowMs = Date.parse(timestamp);
+const writerReservationToken = "88888888-8888-4888-8888-888888888888";
+const storageCapability = Object.freeze({}) as GeneratedMediaBlobStorageCapability;
 const job: ClaimedGeneratedMediaPromotionJob = {
   jobId, operationId, userId: "user-1", workspaceId: testWorkspaceId,
   cardId: "55555555-5555-4555-8555-555555555555",
@@ -24,6 +35,20 @@ const job: ClaimedGeneratedMediaPromotionJob = {
   leaseOwner: "test-worker", leaseExpiresAt: "2026-07-25T00:03:00.000Z",
   lastError: null, createdAt: timestamp, updatedAt: timestamp,
 };
+function writerReservation(): GeneratedMediaBlobWriterReservation {
+  return Object.freeze({
+    reservationToken: writerReservationToken,
+    state: "active",
+    normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+    writer: Object.freeze({
+      ...job,
+      reservationToken: writerReservationToken,
+      normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+      reservationState: "active",
+    }),
+    storageCapability,
+  });
+}
 test("processor reschedules transient database boundary errors", async () => {
   const result = await processClaimedGeneratedMediaPromotionJobWithDependencies(
     job,
@@ -34,7 +59,11 @@ test("processor reschedules transient database boundary errors", async () => {
     },
     {
       claimJobsFn: async () => [],
-      promoteObjectFn: async () => {},
+      reserveWriterFn: async () => writerReservation(),
+      promoteObjectFn: async (promotionInput) => {
+        assert.equal(promotionInput.writer.reservationToken, writerReservationToken);
+        assert.equal(promotionInput.storageCapability, storageCapability);
+      },
       applyJobFn: async () => {
         throw new TransientDatabaseHttpError(
           Object.assign(new Error("deadlock detected"), { code: "40P01" }),
@@ -45,9 +74,105 @@ test("processor reschedules transient database boundary errors", async () => {
         assert.equal(error.code, "DATABASE_TRANSIENT");
       },
       failJobFn: async () => { assert.fail("Transient database errors must not fail the job."); },
+      failAfterAccessRevocationFn: async () => "failed",
+      markWriterAmbiguousFn: async () => {},
       nowFn: () => nowMs,
     },
   );
   assert.equal(result.outcome, "rescheduled");
   assert.equal(result.errorCode, "DATABASE_TRANSIENT");
+});
+
+test("processor replays the complete job after an unknown commit", async () => {
+  let applyCalls = 0;
+  let ambiguityCalls = 0;
+  const result = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+    job,
+    {
+      leaseOwner: "test-worker", leaseDurationMs: 180_000,
+      maximumJobs: 1, deadlineAtMs: nowMs + 60_000,
+      observationScope: testObservationScope, signal: new AbortController().signal,
+    },
+    {
+      claimJobsFn: async () => [],
+      reserveWriterFn: async () => writerReservation(),
+      promoteObjectFn: async () => {},
+      applyJobFn: async (reservation) => {
+        assert.equal(reservation.reservationToken, writerReservationToken);
+        assert.equal(
+          reservation.normalizationVersion,
+          imageJpegCardMediaBlobNormalizationVersion,
+        );
+        applyCalls += 1;
+        if (applyCalls === 1) {
+          throw new DatabaseCommitOutcomeUnknownError(new Error("connection lost during commit"));
+        }
+      },
+      rescheduleJobFn: async () => {
+        assert.fail("A referenced unknown commit must replay instead of rescheduling.");
+      },
+      failJobFn: async () => {
+        assert.fail("A referenced unknown commit must not fail the job.");
+      },
+      failAfterAccessRevocationFn: async () => "failed",
+      markWriterAmbiguousFn: async (reservation) => {
+        assert.equal(reservation.writer.jobId, job.jobId);
+        assert.equal(reservation.reservationToken, writerReservationToken);
+        ambiguityCalls += 1;
+      },
+      nowFn: () => nowMs,
+    },
+  );
+
+  assert.equal(result.outcome, "applied");
+  assert.equal(applyCalls, 2);
+  assert.equal(ambiguityCalls, 1);
+});
+
+test("processor resolves access revocation through the fenced boundary during unknown-commit replay", async () => {
+  let applyCalls = 0;
+  let ambiguityCalls = 0;
+  let accessRevocationCalls = 0;
+  const reservation = writerReservation();
+  const result = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+    job,
+    {
+      leaseOwner: "test-worker", leaseDurationMs: 180_000,
+      maximumJobs: 1, deadlineAtMs: nowMs + 60_000,
+      observationScope: testObservationScope, signal: new AbortController().signal,
+    },
+    {
+      claimJobsFn: async () => [],
+      reserveWriterFn: async () => reservation,
+      promoteObjectFn: async () => {},
+      applyJobFn: async () => {
+        applyCalls += 1;
+        if (applyCalls === 1) {
+          throw new DatabaseCommitOutcomeUnknownError(new Error("connection lost during commit"));
+        }
+        throw new GeneratedMediaPromotionJobAccessRevokedError(job.jobId);
+      },
+      rescheduleJobFn: async () => {
+        assert.fail("Access revocation replay must not reschedule the job.");
+      },
+      failJobFn: async () => {
+        assert.fail("Access revocation replay must use the dedicated resolution boundary.");
+      },
+      failAfterAccessRevocationFn: async (claimedJob) => {
+        assert.equal(claimedJob, reservation.writer);
+        accessRevocationCalls += 1;
+        return "access_active";
+      },
+      markWriterAmbiguousFn: async () => {
+        ambiguityCalls += 1;
+      },
+      nowFn: () => nowMs,
+    },
+  );
+
+  assert.equal(result.outcome, "interrupted");
+  assert.equal(result.errorCode, "WORKSPACE_ACCESS_RECHECK_REQUIRED");
+  assert.equal(applyCalls, 2);
+  assert.equal(ambiguityCalls, 1);
+  assert.equal(accessRevocationCalls, 1);
 });

--- a/apps/backend/src/chat/cardImages/promotionProcessor.ts
+++ b/apps/backend/src/chat/cardImages/promotionProcessor.ts
@@ -9,22 +9,28 @@ import {
   upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
 } from "../../mediaAssets/persistence";
 import {
+  finalizeMediaBlobWriterInExecutor,
+} from "../../mediaAssets/blobLifecycle";
+import {
   GeneratedMediaPromotionStorageTerminalError, GeneratedMediaPromotionStorageTransientError,
   promoteGeneratedMediaObject,
 } from "../../mediaAssets/storage";
-import {
-  imageJpegCardMediaBlobMimeType, imageJpegCardMediaBlobNormalizationVersion,
-  passthroughMediaBlobNormalizationVersion, type MediaAsset,
-} from "../../mediaAssets/types";
+import type { MediaAsset } from "../../mediaAssets/types";
 import type { BackendObservationScope } from "../../observability/sentry";
 import { HttpError } from "../../shared/errors";
 import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../sync/replication/changes";
 import {
   applyGeneratedMediaPromotionJobScopeWithExecutor, claimGeneratedMediaPromotionJobs,
+  failGeneratedMediaPromotionJobAfterAccessRevocation,
+  failGeneratedMediaPromotionJobWithBlobWriterInExecutor,
   failGeneratedMediaPromotionJobWithExecutor, GeneratedMediaPromotionJobAccessRevokedError,
   GeneratedMediaPromotionJobLeaseLostError,
+  isGeneratedMediaPromotionOperationAppliedWithExecutor,
+  markGeneratedMediaBlobWriterAmbiguous,
   markGeneratedMediaPromotionJobAppliedWithExecutor, rescheduleGeneratedMediaPromotionJobWithExecutor,
-  type ClaimedGeneratedMediaPromotionJob, type SafeGeneratedMediaPromotionJobError,
+  reserveGeneratedMediaBlobWriter,
+  type ClaimedGeneratedMediaPromotionJob, type GeneratedMediaBlobWriterReservation,
+  type SafeGeneratedMediaPromotionJobError,
 } from "./promotionJobs";
 const maximumJobAttempts = 5;
 const retryBaseDelayMs = 30_000;
@@ -52,9 +58,13 @@ export type GeneratedMediaPromotionBatchResult = Readonly<{
 }>;
 export type GeneratedMediaPromotionProcessorDependencies = Readonly<{
   claimJobsFn: typeof claimGeneratedMediaPromotionJobs; promoteObjectFn: typeof promoteGeneratedMediaObject;
+  reserveWriterFn: typeof reserveGeneratedMediaBlobWriter;
   applyJobFn: typeof applyGeneratedMediaPromotionJob;
   rescheduleJobFn: typeof rescheduleGeneratedMediaPromotionJob;
-  failJobFn: typeof failGeneratedMediaPromotionJob; nowFn: () => number;
+  failJobFn: typeof failGeneratedMediaPromotionJob;
+  failAfterAccessRevocationFn: typeof failGeneratedMediaPromotionJobAfterAccessRevocation;
+  markWriterAmbiguousFn: typeof markGeneratedMediaBlobWriterAmbiguous;
+  nowFn: () => number;
 }>;
 function assertPersistedMediaIdentity(
   mediaAsset: MediaAsset,
@@ -80,8 +90,16 @@ function assertPersistedMediaIdentity(
 }
 async function applyGeneratedMediaPromotionJobInExecutor(
   executor: DatabaseExecutor,
-  job: ClaimedGeneratedMediaPromotionJob,
+  reservation: GeneratedMediaBlobWriterReservation,
 ): Promise<void> {
+  const job = reservation.writer;
+  if (await isGeneratedMediaPromotionOperationAppliedWithExecutor(
+    executor,
+    job.jobId,
+    job.operationId,
+  )) {
+    return;
+  }
   await applyGeneratedMediaPromotionJobScopeWithExecutor(executor, job);
   await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, job.workspaceId);
   const existingRow = await findMediaAssetRowForUpdateInExecutor(
@@ -102,11 +120,15 @@ async function applyGeneratedMediaPromotionJobInExecutor(
       clientUpdatedAt: job.createdAt, lastModifiedByReplicaId: job.replicaId,
       lastOperationId: job.operationId,
     },
-    job.mimeType === imageJpegCardMediaBlobMimeType
-      ? imageJpegCardMediaBlobNormalizationVersion
-      : passthroughMediaBlobNormalizationVersion,
+    reservation.normalizationVersion,
   );
   assertPersistedMediaIdentity(mediaResult.mediaAsset, job);
+  await finalizeMediaBlobWriterInExecutor(executor, {
+    reservationToken: reservation.reservationToken,
+    sha256: job.sha256,
+    workspaceId: job.workspaceId,
+    mediaAssetId: job.mediaAssetId,
+  });
   await appendManagedImageToCardSideInExecutor(
     executor, job.workspaceId,
     {
@@ -121,11 +143,11 @@ async function applyGeneratedMediaPromotionJobInExecutor(
   await markGeneratedMediaPromotionJobAppliedWithExecutor(executor, job);
 }
 export async function applyGeneratedMediaPromotionJob(
-  job: ClaimedGeneratedMediaPromotionJob,
+  reservation: GeneratedMediaBlobWriterReservation,
   deadlineAtMs: number,
 ): Promise<void> {
   return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => (
-    applyGeneratedMediaPromotionJobInExecutor(executor, job)
+    applyGeneratedMediaPromotionJobInExecutor(executor, reservation)
   ));
 }
 export async function rescheduleGeneratedMediaPromotionJob(
@@ -142,9 +164,17 @@ export async function failGeneratedMediaPromotionJob(
   job: ClaimedGeneratedMediaPromotionJob,
   deadlineAtMs: number,
   error: SafeGeneratedMediaPromotionJobError,
+  reservation: GeneratedMediaBlobWriterReservation | null,
 ): Promise<void> {
   return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
-    await failGeneratedMediaPromotionJobWithExecutor(executor, { ...job, error });
+    if (reservation === null) {
+      await failGeneratedMediaPromotionJobWithExecutor(executor, { ...job, error });
+      return;
+    }
+    await failGeneratedMediaPromotionJobWithBlobWriterInExecutor(executor, {
+      ...reservation.writer,
+      error,
+    });
   });
 }
 function terminalError(error: unknown): SafeGeneratedMediaPromotionJobError | null {
@@ -174,6 +204,7 @@ function terminalError(error: unknown): SafeGeneratedMediaPromotionJobError | nu
 function isTransientFailure(error: unknown): boolean {
   return error instanceof GeneratedMediaPromotionStorageTransientError
     || error instanceof TransientDatabaseHttpError
+    || (error instanceof HttpError && error.code === "MEDIA_BLOB_LIFECYCLE_BUSY")
     || isTransientDatabaseError(error);
 }
 function retryError(error: unknown): SafeGeneratedMediaPromotionJobError {
@@ -201,6 +232,7 @@ async function settleKnownFailure(
   dependencies: GeneratedMediaPromotionProcessorDependencies,
   error: SafeGeneratedMediaPromotionJobError,
   retryable: boolean,
+  reservation: GeneratedMediaBlobWriterReservation | null,
 ): Promise<GeneratedMediaPromotionJobResult> {
   try {
     if (retryable && job.retryCount < maximumJobAttempts - 1) {
@@ -215,7 +247,12 @@ async function settleKnownFailure(
         message: "Generated-media promotion exhausted its bounded transient retry budget.",
       }
       : error;
-    await dependencies.failJobFn(job, input.deadlineAtMs, terminalErrorValue);
+    await dependencies.failJobFn(
+      job,
+      input.deadlineAtMs,
+      terminalErrorValue,
+      reservation,
+    );
     return result(job, "failed", terminalErrorValue.code);
   } catch (transitionError) {
     if (transitionError instanceof GeneratedMediaPromotionJobLeaseLostError) {
@@ -233,23 +270,22 @@ async function settleKnownFailure(
     throw transitionError;
   }
 }
-export async function processClaimedGeneratedMediaPromotionJobWithDependencies(
+
+async function settleAccessRevocation(
   job: ClaimedGeneratedMediaPromotionJob,
   input: GeneratedMediaPromotionBatchInput,
   dependencies: GeneratedMediaPromotionProcessorDependencies,
 ): Promise<GeneratedMediaPromotionJobResult> {
   try {
-    input.signal.throwIfAborted();
-    await dependencies.promoteObjectFn({
-      workspaceId: job.workspaceId, mediaAssetId: job.mediaAssetId,
-      operationId: job.operationId, stagingStorageKey: job.stagingStorageKey,
-      blobStorageKey: job.blobStorageKey, mimeType: job.mimeType,
-      sizeBytes: job.sizeBytes, sha256: job.sha256,
-      observationScope: input.observationScope, signal: input.signal,
-    });
-    input.signal.throwIfAborted();
-    await dependencies.applyJobFn(job, input.deadlineAtMs);
-    return result(job, "applied", null);
+    const outcome = await dependencies.failAfterAccessRevocationFn(
+      job,
+      input.deadlineAtMs,
+    );
+    if (outcome === "applied") return result(job, "applied", null);
+    if (outcome === "failed") {
+      return result(job, "failed", "WORKSPACE_ACCESS_REVOKED");
+    }
+    return result(job, "interrupted", "WORKSPACE_ACCESS_RECHECK_REQUIRED");
   } catch (error) {
     if (error instanceof GeneratedMediaPromotionJobLeaseLostError) {
       return result(job, "lease_lost", null);
@@ -260,12 +296,120 @@ export async function processClaimedGeneratedMediaPromotionJobWithDependencies(
     if (input.signal.aborted || error instanceof DatabaseDeadlineExceededError) {
       return result(job, "interrupted", "WORKER_DEADLINE");
     }
+    throw error;
+  }
+}
+
+export async function processClaimedGeneratedMediaPromotionJobWithDependencies(
+  job: ClaimedGeneratedMediaPromotionJob,
+  input: GeneratedMediaPromotionBatchInput,
+  dependencies: GeneratedMediaPromotionProcessorDependencies,
+): Promise<GeneratedMediaPromotionJobResult> {
+  let reservation: GeneratedMediaBlobWriterReservation | null = null;
+  try {
+    input.signal.throwIfAborted();
+    reservation = await dependencies.reserveWriterFn(job, input.deadlineAtMs);
+    if (reservation.state === "finalized" || reservation.state === "ambiguous") {
+      await dependencies.applyJobFn(reservation, input.deadlineAtMs);
+      return result(job, "applied", null);
+    }
+    const writer = reservation.writer;
+    await dependencies.promoteObjectFn({
+      writer,
+      storageCapability: reservation.storageCapability,
+      workspaceId: writer.workspaceId, mediaAssetId: writer.mediaAssetId,
+      operationId: writer.operationId, stagingStorageKey: writer.stagingStorageKey,
+      blobStorageKey: writer.blobStorageKey, mimeType: writer.mimeType,
+      sizeBytes: writer.sizeBytes, sha256: writer.sha256,
+      observationScope: input.observationScope, signal: input.signal,
+    });
+    input.signal.throwIfAborted();
+    await dependencies.applyJobFn(reservation, input.deadlineAtMs);
+    return result(job, "applied", null);
+  } catch (error) {
+    if (error instanceof GeneratedMediaPromotionJobLeaseLostError) {
+      return result(job, "lease_lost", null);
+    }
+    if (error instanceof GeneratedMediaPromotionJobAccessRevokedError) {
+      return settleAccessRevocation(
+        reservation?.writer ?? job,
+        input,
+        dependencies,
+      );
+    }
+    if (error instanceof DatabaseCommitOutcomeUnknownError) {
+      if (reservation === null) {
+        return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+      }
+      let ambiguityTransitionError: unknown = null;
+      try {
+        await dependencies.markWriterAmbiguousFn(
+          reservation,
+          input.deadlineAtMs,
+        );
+      } catch (transitionError) {
+        ambiguityTransitionError = transitionError;
+      }
+      try {
+        await dependencies.applyJobFn(reservation, input.deadlineAtMs);
+        return result(job, "applied", null);
+      } catch (operationReplayError) {
+        if (operationReplayError instanceof GeneratedMediaPromotionJobLeaseLostError) {
+          return result(job, "lease_lost", null);
+        }
+        if (operationReplayError instanceof GeneratedMediaPromotionJobAccessRevokedError) {
+          return settleAccessRevocation(reservation.writer, input, dependencies);
+        }
+        if (
+          operationReplayError instanceof DatabaseCommitOutcomeUnknownError
+          || operationReplayError instanceof DatabaseDeadlineExceededError
+          || isTransientFailure(operationReplayError)
+        ) {
+          return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+        }
+        const knownTerminalError = terminalError(operationReplayError);
+        if (knownTerminalError !== null) {
+          return settleKnownFailure(
+            job,
+            input,
+            dependencies,
+            knownTerminalError,
+            false,
+            reservation,
+          );
+        }
+        if (ambiguityTransitionError !== null) {
+          throw new AggregateError(
+            [ambiguityTransitionError, operationReplayError],
+            "Generated-media promotion ambiguity transition and deterministic operation replay both failed.",
+          );
+        }
+        throw operationReplayError;
+      }
+    }
+    if (input.signal.aborted || error instanceof DatabaseDeadlineExceededError) {
+      return result(job, "interrupted", "WORKER_DEADLINE");
+    }
     if (isTransientFailure(error)) {
-      return settleKnownFailure(job, input, dependencies, retryError(error), true);
+      return settleKnownFailure(
+        job,
+        input,
+        dependencies,
+        retryError(error),
+        true,
+        reservation,
+      );
     }
     const knownTerminalError = terminalError(error);
     if (knownTerminalError !== null) {
-      return settleKnownFailure(job, input, dependencies, knownTerminalError, false);
+      return settleKnownFailure(
+        job,
+        input,
+        dependencies,
+        knownTerminalError,
+        false,
+        reservation,
+      );
     }
     throw error;
   }
@@ -313,10 +457,13 @@ export async function runGeneratedMediaPromotionBatchWithDependencies(
 }
 const defaultDependencies: GeneratedMediaPromotionProcessorDependencies = {
   claimJobsFn: claimGeneratedMediaPromotionJobs,
+  reserveWriterFn: reserveGeneratedMediaBlobWriter,
   promoteObjectFn: promoteGeneratedMediaObject,
   applyJobFn: applyGeneratedMediaPromotionJob,
   rescheduleJobFn: rescheduleGeneratedMediaPromotionJob,
   failJobFn: failGeneratedMediaPromotionJob,
+  failAfterAccessRevocationFn: failGeneratedMediaPromotionJobAfterAccessRevocation,
+  markWriterAmbiguousFn: markGeneratedMediaBlobWriterAmbiguous,
   nowFn: Date.now,
 };
 export async function runGeneratedMediaPromotionBatch(

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
@@ -2,11 +2,19 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
 import { CopyObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import type {
+  GeneratedMediaBlobStorageCapability,
+  GeneratedMediaBlobWriterExactInput,
+} from "../../chat/cardImages/promotionJobs";
+import { MediaBlobWriterFenceError } from "../blobLifecycle";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../storageKeys";
+import { imageJpegCardMediaBlobNormalizationVersion } from "../types";
 import {
   GeneratedMediaPromotionStorageTerminalError,
   GeneratedMediaPromotionStorageTransientError,
+  getGeneratedMediaPromotionS3Client,
   loadGeneratedMediaStagingObjectWithDependencies,
+  promoteGeneratedMediaObjectWithCapabilityVerifier,
   promoteGeneratedMediaObjectWithDependencies,
   storeGeneratedMediaStagingObjectWithDependencies,
   type GeneratedMediaObjectPromotionInput,
@@ -20,14 +28,49 @@ import {
 const operationId = "33333333-3333-4333-8333-333333333333";
 const mimeType = "image/jpeg";
 const sizeBytes = 42;
+const reservationToken = "77777777-7777-4777-8777-777777777777";
+const storageCapability = Object.freeze({}) as GeneratedMediaBlobStorageCapability;
+type CapabilityVerifier = (
+  capability: GeneratedMediaBlobStorageCapability,
+  writer: GeneratedMediaBlobWriterExactInput,
+) => void;
 function input(signal: AbortSignal): GeneratedMediaObjectPromotionInput {
-  return {
+  const promotion = {
     workspaceId: testWorkspaceId, mediaAssetId: testMediaAssetId, operationId,
     stagingStorageKey: buildMediaUploadStagingStorageKey(testWorkspaceId, testMediaAssetId, operationId),
     blobStorageKey: buildMediaBlobStorageKey(testSha256),
     mimeType, sizeBytes, sha256: testSha256,
     observationScope: testObservationScope, signal,
   };
+  const writer: GeneratedMediaBlobWriterExactInput = Object.freeze({
+    jobId: "88888888-8888-4888-8888-888888888888",
+    operationId: promotion.operationId,
+    userId: "user-1",
+    workspaceId: promotion.workspaceId,
+    cardId: "99999999-9999-4999-8999-999999999999",
+    targetSide: "back",
+    altText: "Generated image",
+    mediaAssetId: promotion.mediaAssetId,
+    replicaId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    stagingStorageKey: promotion.stagingStorageKey,
+    blobStorageKey: promotion.blobStorageKey,
+    sha256: promotion.sha256,
+    mimeType: promotion.mimeType,
+    sizeBytes: promotion.sizeBytes,
+    state: "leased",
+    retryCount: 0,
+    nextAttemptAt: "2099-07-30T09:00:00.000Z",
+    leaseToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    leaseOwner: "test-worker",
+    leaseExpiresAt: "2099-07-30T09:05:00.000Z",
+    lastError: null,
+    createdAt: "2099-07-30T09:00:00.000Z",
+    updatedAt: "2099-07-30T09:00:00.000Z",
+    reservationToken,
+    normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+    reservationState: "active",
+  });
+  return { ...promotion, writer, storageCapability };
 }
 function headResponse(
   promotionInput: GeneratedMediaObjectPromotionInput,
@@ -62,11 +105,28 @@ async function promote(
   promotionInput: GeneratedMediaObjectPromotionInput,
   send: S3Client["send"],
 ): Promise<void> {
+  return promoteWithVerifier(promotionInput, send, verifyTestCapability);
+}
+async function promoteWithVerifier(
+  promotionInput: GeneratedMediaObjectPromotionInput,
+  send: S3Client["send"],
+  verifyCapability: CapabilityVerifier,
+): Promise<void> {
   const client = createTestS3Client();
   client.send = send;
-  await promoteGeneratedMediaObjectWithDependencies(promotionInput, {
-    s3Client: client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
-  });
+  await promoteGeneratedMediaObjectWithCapabilityVerifier(
+    promotionInput,
+    {
+      s3Client: client, getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+    },
+    verifyCapability,
+  );
+}
+function verifyTestCapability(
+  capability: GeneratedMediaBlobStorageCapability,
+  _writer: GeneratedMediaBlobWriterExactInput,
+): void {
+  assert.equal(capability, storageCapability);
 }
 function stagingInput(bytes: Buffer): StoreGeneratedMediaStagingObjectInput {
   const sha256 = createHash("sha256").update(bytes).digest("hex");
@@ -148,23 +208,31 @@ test("generated promotion handles 409/412 and cross-workspace reuses a tenant-ne
       reusedIdentity.workspaceId, reusedIdentity.mediaAssetId, reusedIdentity.operationId,
     ),
   };
+  const exactReusedInput: GeneratedMediaObjectPromotionInput = {
+    ...reusedInput,
+    writer: Object.freeze({
+      ...reusedInput.writer,
+      ...reusedIdentity,
+      stagingStorageKey: reusedInput.stagingStorageKey,
+    }),
+  };
   let copied = false;
-  await promote(reusedInput, (async (command: unknown) => {
+  await promote(exactReusedInput, (async (command: unknown) => {
     if (command instanceof CopyObjectCommand) copied = true;
-    if (command instanceof HeadObjectCommand && command.input.Key === reusedInput.stagingStorageKey) {
-      return stagingResponse(reusedInput);
+    if (command instanceof HeadObjectCommand && command.input.Key === exactReusedInput.stagingStorageKey) {
+      return stagingResponse(exactReusedInput);
     }
-    return permanentResponse(reusedInput);
+    return permanentResponse(exactReusedInput);
   }) as S3Client["send"]);
   assert.equal(copied, false);
   await assert.rejects(
-    promote(reusedInput, (async (command: unknown) => {
-      if (command instanceof HeadObjectCommand && command.input.Key === reusedInput.stagingStorageKey) {
-        return stagingResponse(reusedInput);
+    promote(exactReusedInput, (async (command: unknown) => {
+      if (command instanceof HeadObjectCommand && command.input.Key === exactReusedInput.stagingStorageKey) {
+        return stagingResponse(exactReusedInput);
       }
-      return headResponse(reusedInput, {
-        "flashcards-sha256": reusedInput.sha256, "tenant-user-id": "private-user",
-      }, reusedInput.sha256);
+      return headResponse(exactReusedInput, {
+        "flashcards-sha256": exactReusedInput.sha256, "tenant-user-id": "private-user",
+      }, exactReusedInput.sha256);
     }) as S3Client["send"]),
     (error: unknown) => error instanceof GeneratedMediaPromotionStorageTerminalError
       && error.code === "PERMANENT_BLOB_CONFLICT",
@@ -234,6 +302,33 @@ test("generated promotion terminates corrupt objects, bounds retry, and obeys it
   );
   assert.equal(blobHeads, 1);
   assert.equal(copyAttempts, 3);
+  let authorizationChecks = 0;
+  let revalidatedCopyAttempts = 0;
+  const revalidationInput = input(new AbortController().signal);
+  await assert.rejects(
+    promoteWithVerifier(
+      revalidationInput,
+      (async (command: unknown) => {
+        if (command instanceof HeadObjectCommand) {
+          if (command.input.Key === revalidationInput.stagingStorageKey) {
+            return stagingResponse(revalidationInput);
+          }
+          throw createS3Error(404, "NotFound", "missing");
+        }
+        revalidatedCopyAttempts += 1;
+        throw createS3Error(409, "ConditionalRequestConflict", "retry");
+      }) as S3Client["send"],
+      () => {
+        authorizationChecks += 1;
+        if (authorizationChecks === 4) {
+          throw new MediaBlobWriterFenceError("test_retry_revalidation");
+        }
+      },
+    ),
+    MediaBlobWriterFenceError,
+  );
+  assert.equal(authorizationChecks, 4);
+  assert.equal(revalidatedCopyAttempts, 1);
   const abortController = new AbortController();
   const deadlineInput = input(abortController.signal);
   let deadlineCopyAttempts = 0;
@@ -254,4 +349,40 @@ test("generated promotion terminates corrupt objects, bounds retry, and obeys it
   setTimeout(() => abortController.abort(deadlineReason), 10);
   await assert.rejects(operation, (error: unknown) => error === deadlineReason);
   assert.equal(deadlineCopyAttempts, 1);
+});
+
+test("generated promotion rejects forged capabilities and mismatched payloads before S3", async () => {
+  for (const promotionInput of [
+    input(new AbortController().signal),
+    {
+      ...input(new AbortController().signal),
+      sha256: "0".repeat(64),
+      blobStorageKey: buildMediaBlobStorageKey("0".repeat(64)),
+    },
+  ]) {
+    let calls = 0;
+    await assert.rejects(
+      promoteGeneratedMediaObjectWithDependencies(
+        promotionInput,
+        {
+          s3Client: Object.assign(createTestS3Client(), {
+            send: async () => {
+              calls += 1;
+              return {};
+            },
+          }),
+          getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+        },
+      ),
+      MediaBlobWriterFenceError,
+    );
+    assert.equal(calls, 0);
+  }
+});
+
+test("production generated promotion disables SDK-internal retries", async () => {
+  assert.equal(
+    await getGeneratedMediaPromotionS3Client().config.maxAttempts(),
+    1,
+  );
 });

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
@@ -1,6 +1,14 @@
-import { CopyObjectCommand, HeadObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  CopyObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client,
+} from "@aws-sdk/client-s3";
 import { createHash } from "node:crypto";
+import {
+  assertGeneratedMediaBlobStorageCapabilityForMutation,
+  type GeneratedMediaBlobStorageCapability,
+  type GeneratedMediaBlobWriterExactInput,
+} from "../../chat/cardImages/promotionJobs";
 import { addBackendBreadcrumb, type BackendObservationScope } from "../../observability/sentry";
+import { MediaBlobWriterFenceError } from "../blobLifecycle";
 import { imageJpegCardMediaBlobMimeType, type MediaAssetObjectMetadata } from "../types";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../storageKeys";
 import { getMediaAssetsS3Client, getMediaAssetsStorageConfig } from "./config";
@@ -12,6 +20,7 @@ import {
   uploadProofMediaAssetIdKey, uploadProofSha256Key, uploadProofWorkspaceIdKey,
 } from "./proof";
 const maximumS3Attempts = 3;
+let generatedMediaPromotionS3Client: S3Client | undefined;
 type GeneratedMediaStorageRequestInput = Readonly<{
   workspaceId: string; mediaAssetId: string; operationId: string; signal: AbortSignal;
   observationScope: BackendObservationScope;
@@ -25,9 +34,15 @@ export type StoreGeneratedMediaStagingObjectInput = GeneratedMediaStagingObjectI
   bytes: Buffer; mimeType: typeof imageJpegCardMediaBlobMimeType; sizeBytes: number; sha256: string;
 }>;
 export type GeneratedMediaObjectPromotionInput = GeneratedMediaStagingObjectInput & Readonly<{
+  writer: GeneratedMediaBlobWriterExactInput;
+  storageCapability: GeneratedMediaBlobStorageCapability;
   blobStorageKey: string; mimeType: string; sizeBytes: number; sha256: string;
 }>;
 type GeneratedMediaObjectMetadata = MediaAssetObjectMetadata & Readonly<{ customMetadata: Readonly<Record<string, string>> }>;
+type GeneratedMediaBlobStorageCapabilityVerifier = (
+  storageCapability: GeneratedMediaBlobStorageCapability,
+  writer: GeneratedMediaBlobWriterExactInput,
+) => void;
 export class GeneratedMediaPromotionStorageTerminalError extends Error {
   constructor(readonly code: string, readonly safeMessage: string, readonly statusCode: number | null) {
     super(safeMessage);
@@ -133,7 +148,33 @@ function validateContent(input: Readonly<{
     && Number.isSafeInteger(input.sizeBytes) && input.sizeBytes > 0;
   if (!proofFieldsValid) terminal("INVALID_MEDIA_PROOF", "Generated-media promotion proof fields are not normalized.", null);
 }
-function validatePromotionInput(input: GeneratedMediaObjectPromotionInput): void {
+function assertPromotionInputMatchesWriter(input: GeneratedMediaObjectPromotionInput): void {
+  if (
+    input.workspaceId !== input.writer.workspaceId
+    || input.mediaAssetId !== input.writer.mediaAssetId
+    || input.operationId !== input.writer.operationId
+    || input.stagingStorageKey !== input.writer.stagingStorageKey
+    || input.blobStorageKey !== input.writer.blobStorageKey
+    || input.mimeType !== input.writer.mimeType
+    || input.sizeBytes !== input.writer.sizeBytes
+    || input.sha256 !== input.writer.sha256
+  ) {
+    throw new MediaBlobWriterFenceError("verify_generated_storage_input");
+  }
+}
+function assertPromotionMutationAuthorized(
+  input: GeneratedMediaObjectPromotionInput,
+  verifyCapability: GeneratedMediaBlobStorageCapabilityVerifier,
+): void {
+  input.signal.throwIfAborted();
+  assertPromotionInputMatchesWriter(input);
+  verifyCapability(input.storageCapability, input.writer);
+}
+function validatePromotionInput(
+  input: GeneratedMediaObjectPromotionInput,
+  verifyCapability: GeneratedMediaBlobStorageCapabilityVerifier,
+): void {
+  assertPromotionMutationAuthorized(input, verifyCapability);
   validateStagingIdentity(input);
   validateContent(input);
   if (input.blobStorageKey !== buildMediaBlobStorageKey(input.sha256)) {
@@ -144,16 +185,20 @@ async function headObject(
   input: GeneratedMediaStorageRequestInput,
   key: string,
   dependencies: MediaAssetStorageDependencies,
+  authorizeAttempt: () => void,
 ): Promise<GeneratedMediaObjectMetadata | null> {
   try {
-    return toMetadata(await runS3(input, "head_object", async () => dependencies.s3Client.send(
-      new HeadObjectCommand({
-        Bucket: dependencies.getMediaAssetsStorageConfigFn().bucketName,
-        Key: key,
-        ChecksumMode: "ENABLED",
-      }),
-      { abortSignal: input.signal },
-    )));
+    return toMetadata(await runS3(input, "head_object", async () => {
+      authorizeAttempt();
+      return dependencies.s3Client.send(
+        new HeadObjectCommand({
+          Bucket: dependencies.getMediaAssetsStorageConfigFn().bucketName,
+          Key: key,
+          ChecksumMode: "ENABLED",
+        }),
+        { abortSignal: input.signal },
+      );
+    }));
   } catch (error) {
     input.signal.throwIfAborted();
     const statusCode = getS3ErrorStatusCode(error);
@@ -233,22 +278,26 @@ function assertPermanent(input: GeneratedMediaObjectPromotionInput, metadata: Ge
 async function copyObject(
   input: GeneratedMediaObjectPromotionInput,
   dependencies: MediaAssetStorageDependencies,
+  verifyCapability: GeneratedMediaBlobStorageCapabilityVerifier,
 ): Promise<void> {
   const bucketName = dependencies.getMediaAssetsStorageConfigFn().bucketName;
   try {
-    await runS3(input, "copy_object", async () => dependencies.s3Client.send(
-      new CopyObjectCommand({
-        Bucket: bucketName,
-        Key: input.blobStorageKey,
-        CopySource: `${bucketName}/${input.stagingStorageKey.split("/").map(encodeURIComponent).join("/")}`,
-        ContentType: input.mimeType,
-        ChecksumAlgorithm: "SHA256",
-        IfNoneMatch: "*",
-        MetadataDirective: "REPLACE",
-        Metadata: { [uploadProofSha256Key]: input.sha256 },
-      }),
-      { abortSignal: input.signal },
-    ));
+    await runS3(input, "copy_object", async () => {
+      assertPromotionMutationAuthorized(input, verifyCapability);
+      return dependencies.s3Client.send(
+        new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: input.blobStorageKey,
+          CopySource: `${bucketName}/${input.stagingStorageKey.split("/").map(encodeURIComponent).join("/")}`,
+          ContentType: input.mimeType,
+          ChecksumAlgorithm: "SHA256",
+          IfNoneMatch: "*",
+          MetadataDirective: "REPLACE",
+          Metadata: { [uploadProofSha256Key]: input.sha256 },
+        }),
+        { abortSignal: input.signal },
+      );
+    });
   } catch (error) {
     input.signal.throwIfAborted();
     const statusCode = getS3ErrorStatusCode(error);
@@ -293,7 +342,12 @@ export async function loadGeneratedMediaStagingObjectWithDependencies(
   dependencies: MediaAssetStorageDependencies,
 ): Promise<GeneratedMediaStagingObject | null> {
   validateStagingIdentity(input);
-  const metadata = await headObject(input, input.stagingStorageKey, dependencies);
+  const metadata = await headObject(
+    input,
+    input.stagingStorageKey,
+    dependencies,
+    () => input.signal.throwIfAborted(),
+  );
   return metadata === null ? null : readStagingObject(input, metadata);
 }
 export async function storeGeneratedMediaStagingObjectWithDependencies(
@@ -319,17 +373,46 @@ export async function promoteGeneratedMediaObjectWithDependencies(
   input: GeneratedMediaObjectPromotionInput,
   dependencies: MediaAssetStorageDependencies,
 ): Promise<void> {
-  validatePromotionInput(input);
-  const staging = await headObject(input, input.stagingStorageKey, dependencies);
+  return promoteGeneratedMediaObjectWithCapabilityVerifier(
+    input,
+    dependencies,
+    assertGeneratedMediaBlobStorageCapabilityForMutation,
+  );
+}
+export async function promoteGeneratedMediaObjectWithCapabilityVerifier(
+  input: GeneratedMediaObjectPromotionInput,
+  dependencies: MediaAssetStorageDependencies,
+  verifyCapability: GeneratedMediaBlobStorageCapabilityVerifier,
+): Promise<void> {
+  validatePromotionInput(input, verifyCapability);
+  const staging = await headObject(
+    input,
+    input.stagingStorageKey,
+    dependencies,
+    () => input.signal.throwIfAborted(),
+  );
   if (staging === null) terminal("STAGING_NOT_FOUND", "The staged object is missing.", 404);
   assertStaging(input, staging);
-  const existing = await headObject(input, input.blobStorageKey, dependencies);
+  const authorizePermanentAttempt = (): void => {
+    assertPromotionMutationAuthorized(input, verifyCapability);
+  };
+  const existing = await headObject(
+    input,
+    input.blobStorageKey,
+    dependencies,
+    authorizePermanentAttempt,
+  );
   if (existing !== null) {
     assertPermanent(input, existing);
     return;
   }
-  await copyObject(input, dependencies);
-  const promoted = await headObject(input, input.blobStorageKey, dependencies);
+  await copyObject(input, dependencies, verifyCapability);
+  const promoted = await headObject(
+    input,
+    input.blobStorageKey,
+    dependencies,
+    authorizePermanentAttempt,
+  );
   if (promoted === null) throw new GeneratedMediaPromotionStorageTransientError(404);
   assertPermanent(input, promoted);
 }
@@ -337,9 +420,16 @@ export async function promoteGeneratedMediaObject(
   input: GeneratedMediaObjectPromotionInput,
 ): Promise<void> {
   return promoteGeneratedMediaObjectWithDependencies(input, {
-    s3Client: getMediaAssetsS3Client(),
+    s3Client: getGeneratedMediaPromotionS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });
+}
+export function getGeneratedMediaPromotionS3Client(): S3Client {
+  if (generatedMediaPromotionS3Client !== undefined) {
+    return generatedMediaPromotionS3Client;
+  }
+  generatedMediaPromotionS3Client = new S3Client({ maxAttempts: 1 });
+  return generatedMediaPromotionS3Client;
 }
 export async function loadGeneratedMediaStagingObject(
   input: GeneratedMediaStagingObjectInput,


### PR DESCRIPTION
## Summary
- reserve and fence the exact generated-promotion media blob writer before permanent storage
- bind permanent mutations and retries to the immutable job payload, reservation token, and active lease
- atomically settle writer, promotion job, and card application state, including unknown-commit and access-revocation replay
- use a single-attempt production S3 client so the explicit authorized loop owns retries

## Validation
- focused generated-promotion tests: 8/8
- PostgreSQL 18 migration-boundary suites through 0101: passed
- generated-promotion PostgreSQL integration: 2/2
- full backend tests: 996/996
- lint/typecheck: passed
- backend build: passed
- git diff --check and exact six-file scope/security audits: passed