### PR TITLE
Add media blob cleanup reconciler

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -403,13 +403,15 @@ jobs:
             --output cdk.context.local.json \
             --aws-deploy-role-arn "${AWS_DEPLOY_ROLE_ARN}"
           npx cdk deploy --all --require-approval never \
+            -c generatedMediaPromotionScheduleState=DISABLED \
+            -c mediaBlobCleanupEnabled=false \
             -c multipartCompletionReconciliationScheduleState=DISABLED
 
       - name: Run database migrations
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0101_multipart_foreground_completion_fencing.sql
+            --require-migration 0102_media_blob_cleanup_reconciler.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws
@@ -417,9 +419,11 @@ jobs:
           SENTRY_UPLOAD_BACKEND_SOURCEMAPS: false
         run: |
           npx cdk deploy --all --require-approval never \
+            -c generatedMediaPromotionScheduleState=ENABLED \
+            -c mediaBlobCleanupEnabled=true \
             -c multipartCompletionReconciliationScheduleState=ENABLED
 
-      - name: Verify reconciliation schedule is enabled
+      - name: Verify cleanup-capable reconciliation schedules are enabled
         run: |
           bash scripts/checks/check-multipart-completion-reconciliation-schedule.sh \
             --stack-name ${{ env.STACK_NAME }} \

--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -85,6 +85,13 @@ const createdRolesByMigration = new Map([
 ]);
 const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0102_media_blob_cleanup_reconciler.sql",
+    expectedMigrationCount: 104,
+    testFiles: Object.freeze([
+      "src/mediaAssets/mediaBlobCleanup.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0101_multipart_foreground_completion_fencing.sql",
     expectedMigrationCount: 103,
     testFiles: Object.freeze([

--- a/apps/backend/src/chat/cardImages/promotionJobs.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.ts
@@ -5,6 +5,10 @@ import {
 } from "../../database";
 import { unsafeQueryWithDeadline, unsafeTransactionWithDeadline } from "../../database/unsafe";
 import {
+  getDatabaseErrorFields,
+} from "../../database/transient";
+import {
+  MediaBlobLifecycleBusyError,
   MediaBlobWriterFenceError,
   reserveMediaBlobWriterInExecutor,
   type MediaBlobWriterReservation,
@@ -23,6 +27,8 @@ const sha256Pattern = /^[0-9a-f]{64}$/u;
 const mimeTypePattern = /^[a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*$/u;
 const safeErrorCodePattern = /^[A-Z][A-Z0-9_]{0,63}$/u;
 const controlCharacterPattern = /[\u0000-\u001f\u007f-\u009f]/u;
+const cleanupAdmissionConstraint =
+  "generated_media_promotion_cleanup_admission";
 export type GeneratedMediaPromotionJobPayload = Readonly<{
   jobId: string;
   operationId: string;
@@ -87,6 +93,15 @@ export type FailGeneratedMediaPromotionJobWithBlobWriterInput =
   GeneratedMediaPromotionBlobWriterInput & Readonly<{ error: SafeGeneratedMediaPromotionJobError }>;
 export type GeneratedMediaPromotionAccessRevocationOutcome =
   "access_active" | "applied" | "failed";
+
+function isCleanupAdmissionFenceError(error: unknown): boolean {
+  return getDatabaseErrorFields(error).sqlState === "55P03"
+    && typeof error === "object"
+    && error !== null
+    && "constraint" in error
+    && error.constraint === cleanupAdmissionConstraint;
+}
+
 type StoredPayloadRow = Readonly<{
   job_id: string;
   operation_id: string;
@@ -421,49 +436,56 @@ export async function enqueueGeneratedMediaPromotionJob(
   input: EnqueueGeneratedMediaPromotionJobInput,
 ): Promise<EnqueueGeneratedMediaPromotionJobResult> {
   requirePayload(input);
-  return transactionWithWorkspaceScopeDeadline(
-    { userId: input.userId, workspaceId: input.workspaceId },
-    input.deadlineAtMs,
-    async (executor) => {
-      await assertActiveChatRunClaimWithExecutor(executor, input);
-      await assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId);
-      const inserted = await executor.query<InsertedRow>(
-        `INSERT INTO content.generated_media_promotion_jobs (
-           job_id, operation_id, user_id, workspace_id, card_id, target_side, alt_text,
-           media_asset_id, replica_id, staging_storage_key, blob_storage_key,
-           sha256, mime_type, size_bytes
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-         ON CONFLICT DO NOTHING
-         RETURNING job_id`,
-        [
-          input.jobId, input.operationId, input.userId, input.workspaceId,
-          input.cardId, input.targetSide, input.altText, input.mediaAssetId, input.replicaId,
-          input.stagingStorageKey, input.blobStorageKey, input.sha256,
-          input.mimeType, input.sizeBytes,
-        ],
-      );
-      if (inserted.rows[0]?.job_id === input.jobId) {
-        return { outcome: "created", jobId: input.jobId };
-      }
-      const existing = await executor.query<StoredPayloadRow>(
-        `SELECT ${storedPayloadColumns}
-         FROM content.generated_media_promotion_jobs
-         WHERE job_id = $1 OR operation_id = $2`,
-        [input.jobId, input.operationId],
-      );
-      const mismatch = existing.rows.length === 1
-        ? findPayloadMismatch(toPayload(existing.rows[0] as StoredPayloadRow), input)
-        : "jobId";
-      if (mismatch !== null) {
-        throw new GeneratedMediaPromotionJobConflictError(
-          input.jobId,
-          input.operationId,
-          mismatch,
+  try {
+    return await transactionWithWorkspaceScopeDeadline(
+      { userId: input.userId, workspaceId: input.workspaceId },
+      input.deadlineAtMs,
+      async (executor) => {
+        await assertActiveChatRunClaimWithExecutor(executor, input);
+        await assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId);
+        const inserted = await executor.query<InsertedRow>(
+          `INSERT INTO content.generated_media_promotion_jobs (
+             job_id, operation_id, user_id, workspace_id, card_id, target_side, alt_text,
+             media_asset_id, replica_id, staging_storage_key, blob_storage_key,
+             sha256, mime_type, size_bytes
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+           ON CONFLICT DO NOTHING
+           RETURNING job_id`,
+          [
+            input.jobId, input.operationId, input.userId, input.workspaceId,
+            input.cardId, input.targetSide, input.altText, input.mediaAssetId, input.replicaId,
+            input.stagingStorageKey, input.blobStorageKey, input.sha256,
+            input.mimeType, input.sizeBytes,
+          ],
         );
-      }
-      return { outcome: "existing", jobId: input.jobId };
-    },
-  );
+        if (inserted.rows[0]?.job_id === input.jobId) {
+          return { outcome: "created", jobId: input.jobId };
+        }
+        const existing = await executor.query<StoredPayloadRow>(
+          `SELECT ${storedPayloadColumns}
+           FROM content.generated_media_promotion_jobs
+           WHERE job_id = $1 OR operation_id = $2`,
+          [input.jobId, input.operationId],
+        );
+        const mismatch = existing.rows.length === 1
+          ? findPayloadMismatch(toPayload(existing.rows[0] as StoredPayloadRow), input)
+          : "jobId";
+        if (mismatch !== null) {
+          throw new GeneratedMediaPromotionJobConflictError(
+            input.jobId,
+            input.operationId,
+            mismatch,
+          );
+        }
+        return { outcome: "existing", jobId: input.jobId };
+      },
+    );
+  } catch (error) {
+    if (isCleanupAdmissionFenceError(error)) {
+      throw new MediaBlobLifecycleBusyError();
+    }
+    throw error;
+  }
 }
 export async function claimGeneratedMediaPromotionJobs(
   input: ClaimGeneratedMediaPromotionJobsInput,

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.test.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  GeneratedMediaPromotionBatchResult,
+} from "../../chat/cardImages/promotionProcessor";
+import {
+  MediaBlobCleanupBatchError,
+  type MediaBlobCleanupBatchResult,
+} from "../../mediaAssets/blobCleanupProcessor";
+import { createBackendObservationScope } from "../../observability/sentry";
+import {
+  readMediaBlobCleanupEnabled,
+  resolveMediaBlobCleanupFailureResult,
+  runGeneratedMediaScheduledWorkloads,
+  type GeneratedMediaScheduledWorkloadDependencies,
+  type GeneratedMediaScheduledWorkloadInput,
+} from "./lambda-generated-media-promotion";
+
+const observationScope = createBackendObservationScope(
+  "generated-media-promotion",
+  "request-1",
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+);
+
+const promotionResult: GeneratedMediaPromotionBatchResult = {
+  claimed: 1,
+  applied: 1,
+  ambiguous: 0,
+  failed: 0,
+  interrupted: 0,
+  leaseLost: 0,
+  rescheduled: 0,
+  results: [],
+};
+
+const cleanupResult: MediaBlobCleanupBatchResult = {
+  claimed: 1,
+  deleted: 1,
+  notFound: 0,
+  blocked: 0,
+  stale: 0,
+  alreadyCompleted: 0,
+  retryScheduled: 0,
+  reconciliationRequired: 0,
+  interrupted: 0,
+  results: [],
+};
+
+function input(
+  signal: AbortSignal,
+  cleanupEnabled: boolean,
+): GeneratedMediaScheduledWorkloadInput {
+  return {
+    leaseOwner: "generated-media-promotion:request-1",
+    deadlineAtMs: 10_000,
+    cleanupEnabled,
+    observationScope,
+    signal,
+  };
+}
+
+test("cleanup runtime gate defaults off and accepts only explicit booleans", () => {
+  assert.equal(readMediaBlobCleanupEnabled(undefined), false);
+  assert.equal(readMediaBlobCleanupEnabled("false"), false);
+  assert.equal(readMediaBlobCleanupEnabled("true"), true);
+  assert.throws(
+    () => readMediaBlobCleanupEnabled("TRUE"),
+    /MEDIA_BLOB_CLEANUP_ENABLED must be true or false/u,
+  );
+});
+
+test("disabled cleanup leaves generated-media promotion running", async () => {
+  const calls: Array<string> = [];
+  const dependencies: GeneratedMediaScheduledWorkloadDependencies = {
+    runPromotionFn: async () => {
+      calls.push("promotion");
+      return promotionResult;
+    },
+    runCleanupFn: async () => {
+      calls.push("cleanup");
+      return cleanupResult;
+    },
+    nowFn: () => 0,
+  };
+
+  const result = await runGeneratedMediaScheduledWorkloads(
+    input(new AbortController().signal, false),
+    dependencies,
+  );
+
+  assert.deepEqual(calls, ["promotion"]);
+  assert.equal(result.promotion, promotionResult);
+  assert.deepEqual(result.cleanup, {
+    claimed: 0,
+    deleted: 0,
+    notFound: 0,
+    blocked: 0,
+    stale: 0,
+    alreadyCompleted: 0,
+    retryScheduled: 0,
+    reconciliationRequired: 0,
+    interrupted: 1,
+    results: [],
+  });
+});
+
+test("scheduled work prioritizes promotion and reports cleanup interruption when its budget is exhausted", async () => {
+  const calls: Array<string> = [];
+  let nowMs = 0;
+  const dependencies: GeneratedMediaScheduledWorkloadDependencies = {
+    runPromotionFn: async () => {
+      calls.push("promotion");
+      nowMs = 9_500;
+      return promotionResult;
+    },
+    runCleanupFn: async () => {
+      calls.push("cleanup");
+      return cleanupResult;
+    },
+    nowFn: () => nowMs,
+  };
+
+  const result = await runGeneratedMediaScheduledWorkloads(
+    input(new AbortController().signal, true),
+    dependencies,
+  );
+
+  assert.deepEqual(calls, ["promotion"]);
+  assert.equal(result.promotion, promotionResult);
+  assert.deepEqual(result.cleanup, {
+    claimed: 0,
+    deleted: 0,
+    notFound: 0,
+    blocked: 0,
+    stale: 0,
+    alreadyCompleted: 0,
+    retryScheduled: 0,
+    reconciliationRequired: 0,
+    interrupted: 1,
+    results: [],
+  });
+});
+
+test("scheduled work aggregates successful promotion and cleanup results in priority order", async () => {
+  const calls: Array<string> = [];
+  const dependencies: GeneratedMediaScheduledWorkloadDependencies = {
+    runPromotionFn: async () => {
+      calls.push("promotion");
+      return promotionResult;
+    },
+    runCleanupFn: async () => {
+      calls.push("cleanup");
+      return cleanupResult;
+    },
+    nowFn: () => 0,
+  };
+
+  const result = await runGeneratedMediaScheduledWorkloads(
+    input(new AbortController().signal, true),
+    dependencies,
+  );
+
+  assert.deepEqual(calls, ["promotion", "cleanup"]);
+  assert.equal(result.promotion, promotionResult);
+  assert.equal(result.cleanup, cleanupResult);
+});
+
+test("scheduled work surfaces cleanup failure after promotion and aggregates both failures", async () => {
+  const promotionFailure = new Error("promotion failed");
+  const cleanupFailure = new Error("cleanup failed");
+  const calls: Array<string> = [];
+  const cleanupFailureDependencies: GeneratedMediaScheduledWorkloadDependencies = {
+    runPromotionFn: async () => {
+      calls.push("promotion");
+      return promotionResult;
+    },
+    runCleanupFn: async () => {
+      calls.push("cleanup");
+      throw cleanupFailure;
+    },
+    nowFn: () => 0,
+  };
+
+  await assert.rejects(
+    runGeneratedMediaScheduledWorkloads(
+      input(new AbortController().signal, true),
+      cleanupFailureDependencies,
+    ),
+    (error: unknown) => error === cleanupFailure,
+  );
+  assert.deepEqual(calls, ["promotion", "cleanup"]);
+
+  const bothFailureDependencies: GeneratedMediaScheduledWorkloadDependencies = {
+    runPromotionFn: async () => {
+      throw promotionFailure;
+    },
+    runCleanupFn: async () => {
+      throw cleanupFailure;
+    },
+    nowFn: () => 0,
+  };
+  await assert.rejects(
+    runGeneratedMediaScheduledWorkloads(
+      input(new AbortController().signal, true),
+      bothFailureDependencies,
+    ),
+    (error: unknown) => (
+      error instanceof AggregateError
+      && error.errors[0] === promotionFailure
+      && error.errors[1] === cleanupFailure
+    ),
+  );
+});
+
+test("scheduled work preserves the exact partial cleanup batch for failure telemetry", async () => {
+  const partialResult: MediaBlobCleanupBatchResult = {
+    claimed: 2,
+    deleted: 1,
+    notFound: 0,
+    blocked: 0,
+    stale: 0,
+    alreadyCompleted: 0,
+    retryScheduled: 1,
+    reconciliationRequired: 0,
+    interrupted: 0,
+    results: [{
+      sha256: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+      cleanupGeneration: 9,
+      outcome: "retry_scheduled",
+    }],
+  };
+  const cleanupFailure = new MediaBlobCleanupBatchError(
+    partialResult,
+    [new Error("cleanup failed after partial progress")],
+  );
+  const dependencies: GeneratedMediaScheduledWorkloadDependencies = {
+    runPromotionFn: async () => promotionResult,
+    runCleanupFn: async () => {
+      throw cleanupFailure;
+    },
+    nowFn: () => 0,
+  };
+
+  await assert.rejects(
+    runGeneratedMediaScheduledWorkloads(
+      input(new AbortController().signal, true),
+      dependencies,
+    ),
+    (error: unknown) => (
+      error === cleanupFailure
+      && resolveMediaBlobCleanupFailureResult(error) === partialResult
+    ),
+  );
+});

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
@@ -4,16 +4,30 @@ import {
   type GeneratedMediaPromotionBatchResult,
 } from "../../chat/cardImages/promotionProcessor";
 import {
+  MediaBlobCleanupBatchError,
+  runMediaBlobCleanupBatch,
+  type MediaBlobCleanupBatchResult,
+} from "../../mediaAssets/blobCleanupProcessor";
+import {
   addBackendBreadcrumb, captureBackendException, createBackendObservationScope,
-  initializeBackendSentry, normalizeCaughtError, type GeneratedMediaPromotionBatchDetails,
+  type BackendObservationScope,
+  type GeneratedMediaPromotionBatchDetails,
+  initializeBackendSentry, type MediaBlobCleanupBatchDetails,
+  normalizeCaughtError,
   wrapBackendHandler,
 } from "../../observability/sentry";
 initializeBackendSentry("generated-media-promotion");
 export const generatedMediaPromotionMaximumJobs = 5;
 export const generatedMediaPromotionLeaseDurationMs = 180_000;
+export const mediaBlobCleanupMaximumCandidates = 5;
+export const mediaBlobCleanupLeaseDurationMs = 60_000;
 export const generatedMediaPromotionFinalizationReserveMs = 10_000;
+export const mediaBlobCleanupMinimumStartBudgetMs = 1_000;
+export const mediaBlobCleanupEnabledEnvironmentName =
+  "MEDIA_BLOB_CLEANUP_ENABLED";
 type GeneratedMediaPromotionResponse = Omit<GeneratedMediaPromotionBatchResult, "results"> & Readonly<{
   ok: true;
+  cleanup: Omit<MediaBlobCleanupBatchResult, "results">;
 }>;
 function emptyDetails(): GeneratedMediaPromotionBatchDetails {
   return {
@@ -34,6 +48,167 @@ function toDetails(result: GeneratedMediaPromotionBatchResult): GeneratedMediaPr
     })),
   };
 }
+function emptyCleanupResult(): MediaBlobCleanupBatchResult {
+  return {
+    claimed: 0, deleted: 0, notFound: 0, blocked: 0, stale: 0,
+    alreadyCompleted: 0, retryScheduled: 0, reconciliationRequired: 0,
+    interrupted: 0, results: [],
+  };
+}
+function interruptedCleanupResult(): MediaBlobCleanupBatchResult {
+  return {
+    ...emptyCleanupResult(),
+    interrupted: 1,
+  };
+}
+export function readMediaBlobCleanupEnabled(
+  value: string | undefined,
+): boolean {
+  if (value === undefined) return false;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(
+    `${mediaBlobCleanupEnabledEnvironmentName} must be true or false when set.`,
+  );
+}
+export function resolveMediaBlobCleanupFailureResult(
+  error: unknown,
+): MediaBlobCleanupBatchResult {
+  return error instanceof MediaBlobCleanupBatchError
+    ? error.result
+    : emptyCleanupResult();
+}
+function toCleanupDetails(result: MediaBlobCleanupBatchResult): MediaBlobCleanupBatchDetails {
+  return {
+    maximumCandidates: mediaBlobCleanupMaximumCandidates,
+    claimed: result.claimed, deleted: result.deleted, notFound: result.notFound,
+    blocked: result.blocked, stale: result.stale,
+    alreadyCompleted: result.alreadyCompleted,
+    retryScheduled: result.retryScheduled,
+    reconciliationRequired: result.reconciliationRequired,
+    interrupted: result.interrupted,
+    results: result.results.map((item) => ({
+      sha256: item.sha256,
+      cleanupGeneration: item.cleanupGeneration,
+      outcome: item.outcome,
+    })),
+  };
+}
+
+export type GeneratedMediaScheduledWorkloadDependencies = Readonly<{
+  runPromotionFn: typeof runGeneratedMediaPromotionBatch;
+  runCleanupFn: typeof runMediaBlobCleanupBatch;
+  nowFn: () => number;
+}>;
+
+export type GeneratedMediaScheduledWorkloadInput = Readonly<{
+  leaseOwner: string;
+  deadlineAtMs: number;
+  cleanupEnabled: boolean;
+  observationScope: BackendObservationScope;
+  signal: AbortSignal;
+}>;
+
+export type GeneratedMediaScheduledWorkloadResult = Readonly<{
+  promotion: GeneratedMediaPromotionBatchResult;
+  cleanup: MediaBlobCleanupBatchResult;
+}>;
+
+export async function runGeneratedMediaScheduledWorkloads(
+  input: GeneratedMediaScheduledWorkloadInput,
+  dependencies: GeneratedMediaScheduledWorkloadDependencies,
+): Promise<GeneratedMediaScheduledWorkloadResult> {
+  let promotionResult: GeneratedMediaPromotionBatchResult | null = null;
+  let promotionError: unknown = null;
+  try {
+    promotionResult = await dependencies.runPromotionFn({
+      leaseOwner: input.leaseOwner,
+      leaseDurationMs: generatedMediaPromotionLeaseDurationMs,
+      maximumJobs: generatedMediaPromotionMaximumJobs,
+      deadlineAtMs: input.deadlineAtMs,
+      observationScope: input.observationScope,
+      signal: input.signal,
+    });
+    addBackendBreadcrumb({
+      action: "generated_media_promotion_batch_completed",
+      scope: input.observationScope,
+      details: toDetails(promotionResult),
+    });
+  } catch (error) {
+    promotionError = error;
+    captureBackendException({
+      action: "generated_media_promotion_batch_failed",
+      error: normalizeCaughtError(error),
+      scope: input.observationScope,
+      details: emptyDetails(),
+    });
+  }
+
+  let cleanupResult = emptyCleanupResult();
+  let cleanupError: unknown = null;
+  if (
+    !input.cleanupEnabled
+    || input.signal.aborted
+    || dependencies.nowFn() + mediaBlobCleanupMinimumStartBudgetMs
+      >= input.deadlineAtMs
+  ) {
+    cleanupResult = interruptedCleanupResult();
+    addBackendBreadcrumb({
+      action: "media_blob_cleanup_batch_completed",
+      scope: input.observationScope,
+      details: toCleanupDetails(cleanupResult),
+    });
+  } else {
+    try {
+      cleanupResult = await dependencies.runCleanupFn({
+        leaseDurationMs: mediaBlobCleanupLeaseDurationMs,
+        maximumCandidates: mediaBlobCleanupMaximumCandidates,
+        deadlineAtMs: input.deadlineAtMs,
+        observationScope: input.observationScope,
+        signal: input.signal,
+      });
+      addBackendBreadcrumb({
+        action: "media_blob_cleanup_batch_completed",
+        scope: input.observationScope,
+        details: toCleanupDetails(cleanupResult),
+      });
+    } catch (error) {
+      cleanupError = error;
+      cleanupResult = resolveMediaBlobCleanupFailureResult(error);
+      captureBackendException({
+        action: "media_blob_cleanup_batch_failed",
+        error: normalizeCaughtError(error),
+        scope: input.observationScope,
+        details: toCleanupDetails(cleanupResult),
+      });
+    }
+  }
+
+  if (promotionError !== null && cleanupError !== null) {
+    throw new AggregateError(
+      [promotionError, cleanupError],
+      "Generated-media promotion and media-blob cleanup both failed.",
+    );
+  }
+  if (promotionError !== null) throw promotionError;
+  if (cleanupError !== null) throw cleanupError;
+  if (promotionResult === null) {
+    throw new Error(
+      "Generated-media promotion did not return a result or a failure.",
+    );
+  }
+  return {
+    promotion: promotionResult,
+    cleanup: cleanupResult,
+  };
+}
+
+const scheduledWorkloadDependencies: GeneratedMediaScheduledWorkloadDependencies = {
+  runPromotionFn: runGeneratedMediaPromotionBatch,
+  runCleanupFn: runMediaBlobCleanupBatch,
+  nowFn: Date.now,
+};
+
 const generatedMediaPromotionHandler: Handler<unknown, GeneratedMediaPromotionResponse> =
 async (_event, context) => {
   const observationScope = createBackendObservationScope(
@@ -48,33 +223,35 @@ async (_event, context) => {
     Math.max(0, deadlineAtMs - Date.now()),
   );
   try {
-    const result = await runGeneratedMediaPromotionBatch({
-      leaseOwner: `generated-media-promotion:${context.awsRequestId}`,
-      leaseDurationMs: generatedMediaPromotionLeaseDurationMs,
-      maximumJobs: generatedMediaPromotionMaximumJobs,
-      deadlineAtMs,
-      observationScope,
-      signal: abortController.signal,
-    });
-    addBackendBreadcrumb({
-      action: "generated_media_promotion_batch_completed",
-      scope: observationScope,
-      details: toDetails(result),
-    });
+    const workloadResult = await runGeneratedMediaScheduledWorkloads(
+      {
+        leaseOwner: `generated-media-promotion:${context.awsRequestId}`,
+        deadlineAtMs,
+        cleanupEnabled: readMediaBlobCleanupEnabled(
+          process.env[mediaBlobCleanupEnabledEnvironmentName],
+        ),
+        observationScope,
+        signal: abortController.signal,
+      },
+      scheduledWorkloadDependencies,
+    );
+    const result = workloadResult.promotion;
+    const cleanupResult = workloadResult.cleanup;
     return {
       ok: true,
       claimed: result.claimed, applied: result.applied, ambiguous: result.ambiguous,
       failed: result.failed, interrupted: result.interrupted,
       leaseLost: result.leaseLost, rescheduled: result.rescheduled,
+      cleanup: {
+        claimed: cleanupResult.claimed, deleted: cleanupResult.deleted,
+        notFound: cleanupResult.notFound, blocked: cleanupResult.blocked,
+        stale: cleanupResult.stale,
+        alreadyCompleted: cleanupResult.alreadyCompleted,
+        retryScheduled: cleanupResult.retryScheduled,
+        reconciliationRequired: cleanupResult.reconciliationRequired,
+        interrupted: cleanupResult.interrupted,
+      },
     };
-  } catch (error) {
-    captureBackendException({
-      action: "generated_media_promotion_batch_failed",
-      error: normalizeCaughtError(error),
-      scope: observationScope,
-      details: emptyDetails(),
-    });
-    throw error;
   } finally {
     clearTimeout(deadlineTimer);
   }

--- a/apps/backend/src/mediaAssets/blobCleanupProcessor.test.ts
+++ b/apps/backend/src/mediaAssets/blobCleanupProcessor.test.ts
@@ -1,0 +1,752 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DatabaseDeadlineExceededError } from "../database";
+import { DatabaseCommitOutcomeUnknownError } from "../database/transient";
+import { createBackendObservationScope } from "../observability/sentry";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+import {
+  MediaBlobCleanupBatchError,
+  runMediaBlobCleanupBatchWithDependencies,
+  type MediaBlobCleanupProcessorDependencies,
+} from "./blobCleanupProcessor";
+import type { MediaBlobCleanupClaim } from "./blobCleanupRepository";
+import {
+  MediaBlobCleanupStorageAmbiguousDeleteError,
+  MediaBlobCleanupStorageTransientError,
+} from "./storage";
+
+const sha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
+const cleanupToken = "77777777-7777-4777-8777-777777777777";
+const leaseToken = "88888888-8888-4888-8888-888888888888";
+const observationScope = createBackendObservationScope(
+  "generated-media-promotion",
+  "request-1",
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+);
+
+function claim(generation: number): MediaBlobCleanupClaim {
+  return {
+    cleanupToken,
+    leaseToken,
+    sha256,
+    storageKey: buildMediaBlobStorageKey(sha256),
+    cleanupGeneration: generation,
+    leaseExpiresAt: "2099-07-30T12:00:00.000Z",
+    failureCount: 0,
+    status: "claimed",
+  };
+}
+
+function input(signal: AbortSignal) {
+  return {
+    leaseDurationMs: 60_000,
+    maximumCandidates: 5,
+    deadlineAtMs: 10_000,
+    observationScope,
+    signal,
+  };
+}
+
+test("cleanup replays exact database operations across commit ambiguity before and after S3 deletion", async () => {
+  const claimed = claim(9);
+  const claimTokens: Array<string> = [];
+  let claimCalls = 0;
+  let authorizeCalls = 0;
+  let renewCalls = 0;
+  let deleteCalls = 0;
+  let completeCalls = 0;
+  const renewalTokens: Array<string> = [];
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async (token) => {
+      claimTokens.push(token);
+      claimCalls += 1;
+      if (claimCalls === 1) {
+        throw new DatabaseCommitOutcomeUnknownError(
+          new Error("claim commit response lost"),
+        );
+      }
+      return claimCalls === 2 ? claimed : null;
+    },
+    authorizeFn: async (exactClaim) => {
+      assert.equal(exactClaim, claimed);
+      authorizeCalls += 1;
+      if (authorizeCalls === 1) {
+        throw new DatabaseCommitOutcomeUnknownError(
+          new Error("authorization commit response lost"),
+        );
+      }
+      return {
+        storageKey: exactClaim.storageKey,
+        status: "authorized",
+      };
+    },
+    renewFn: async (_exactClaim, renewalToken) => {
+      renewalTokens.push(renewalToken);
+      renewCalls += 1;
+      if (renewCalls === 1) {
+        throw new DatabaseCommitOutcomeUnknownError(
+          new Error("renewal commit response lost"),
+        );
+      }
+      return {
+        leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+        status: "renewed",
+      };
+    },
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("head_object");
+      deleteCalls += 1;
+      assert.equal(deleteInput.storageKey, claimed.storageKey);
+      assert.equal(deleteInput.cleanupGeneration, claimed.cleanupGeneration);
+      return "deleted";
+    },
+    recordFailureFn: async () => ({
+      status: "retry_scheduled",
+      nextAttemptAt: "2099-07-30T12:02:00.000Z",
+      failureCount: 1,
+    }),
+    completeFn: async (exactClaim) => {
+      assert.equal(exactClaim, claimed);
+      completeCalls += 1;
+      if (completeCalls === 1) {
+        throw new DatabaseCommitOutcomeUnknownError(
+          new Error("completion commit response lost"),
+        );
+      }
+      return "completed";
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  const result = await runMediaBlobCleanupBatchWithDependencies(
+    input(new AbortController().signal),
+    dependencies,
+  );
+  assert.deepEqual(claimTokens, [cleanupToken, cleanupToken, cleanupToken]);
+  assert.equal(authorizeCalls, 2);
+  assert.equal(renewCalls, 3);
+  assert.equal(renewalTokens[0], renewalTokens[1]);
+  assert.equal(deleteCalls, 1);
+  assert.equal(completeCalls, 2);
+  assert.deepEqual(result, {
+    claimed: 1,
+    deleted: 1,
+    notFound: 0,
+    blocked: 0,
+    stale: 0,
+    alreadyCompleted: 0,
+    retryScheduled: 0,
+    reconciliationRequired: 0,
+    interrupted: 0,
+    results: [{
+      sha256,
+      cleanupGeneration: 9,
+      outcome: "deleted",
+    }],
+  });
+});
+
+test("cleanup never deletes after exact lease authorization becomes stale", async () => {
+  let deleteCalls = 0;
+  let claimCalls = 0;
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      return claimCalls === 1 ? claim(10) : null;
+    },
+    authorizeFn: async () => ({
+      storageKey: buildMediaBlobStorageKey(sha256),
+      status: "stale",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: null,
+      status: "stale",
+    }),
+    deleteFn: async () => {
+      deleteCalls += 1;
+      return "deleted";
+    },
+    completeFn: async () => "stale",
+    recordFailureFn: async () => ({
+      status: "stale",
+      nextAttemptAt: null,
+      failureCount: 0,
+    }),
+    createTokenFn: () => leaseToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  const result = await runMediaBlobCleanupBatchWithDependencies(
+    input(new AbortController().signal),
+    dependencies,
+  );
+
+  assert.equal(result.claimed, 1);
+  assert.equal(result.stale, 1);
+  assert.equal(deleteCalls, 0);
+});
+
+test("cleanup stops before S3 when exact lease renewal is stale", async () => {
+  let claimCalls = 0;
+  let storageOperations = 0;
+  let completionCalls = 0;
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      return claimCalls === 1 ? claim(11) : null;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: null,
+      status: "stale",
+    }),
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("head_object");
+      storageOperations += 1;
+      return "deleted";
+    },
+    completeFn: async () => {
+      completionCalls += 1;
+      return "completed";
+    },
+    recordFailureFn: async () => {
+      throw new Error("stale renewal must not be recorded as owned failure");
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  const result = await runMediaBlobCleanupBatchWithDependencies(
+    input(new AbortController().signal),
+    dependencies,
+  );
+
+  assert.equal(result.stale, 1);
+  assert.equal(storageOperations, 0);
+  assert.equal(completionCalls, 0);
+});
+
+test("cleanup reports reconciliation when abort follows the durable delete transition", async () => {
+  const controller = new AbortController();
+  const abortReason = new Error("Lambda finalization reserve reached.");
+  let claimCalls = 0;
+  let failureRecordCalls = 0;
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      return claimCalls === 1 ? claim(12) : null;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+      status: "renewed",
+    }),
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("delete_object");
+      controller.abort(abortReason);
+      deleteInput.signal.throwIfAborted();
+      return "deleted";
+    },
+    completeFn: async () => "completed",
+    recordFailureFn: async () => {
+      failureRecordCalls += 1;
+      throw new Error("An aborted invocation must not start failure persistence.");
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(controller.signal),
+      dependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.result.claimed === 1
+      && error.result.reconciliationRequired === 1
+      && error.failures.length === 2
+      && error.failures[0]?.name
+        === "MediaBlobCleanupReconciliationRequiredError"
+      && error.failures[1]?.name
+        === "MediaBlobCleanupFailurePersistenceError"
+    ),
+  );
+  assert.equal(failureRecordCalls, 0);
+});
+
+test("cleanup persists terminal reconciliation when completion is interrupted after delete", async () => {
+  let claimCalls = 0;
+  const completionDeadlineError = new DatabaseDeadlineExceededError(
+    "executor_operations",
+    10_000,
+    new Error("Completion deadline elapsed."),
+  );
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      return claimCalls === 1 ? claim(13) : null;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async (
+      _exactClaim,
+      _renewalToken,
+      phase,
+    ) => {
+      if (phase === "complete") throw completionDeadlineError;
+      return {
+        leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+        status: "renewed",
+      };
+    },
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("delete_object");
+      return "deleted";
+    },
+    completeFn: async () => "completed",
+    recordFailureFn: async (_exactClaim, failureInput) => {
+      assert.equal(failureInput.disposition, "terminal");
+      assert.equal(failureInput.phase, "renew");
+      return {
+        status: "reconciliation_required",
+        nextAttemptAt: null,
+        failureCount: 1,
+      };
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(new AbortController().signal),
+      dependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.result.claimed === 1
+      && error.result.reconciliationRequired === 1
+      && error.failures.length === 1
+      && error.failures[0]?.name
+        === "MediaBlobCleanupReconciliationRequiredError"
+    ),
+  );
+});
+
+test("cleanup treats commit-unknown delete renewal as terminal reconciliation", async () => {
+  let claimCalls = 0;
+  let renewalCalls = 0;
+  const commitUnknownError = new DatabaseCommitOutcomeUnknownError(
+    new Error("Delete renewal commit response was lost."),
+  );
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      return claimCalls === 1 ? claim(14) : null;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => {
+      renewalCalls += 1;
+      throw commitUnknownError;
+    },
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("delete_object");
+      return "deleted";
+    },
+    completeFn: async () => "completed",
+    recordFailureFn: async (_exactClaim, failureInput) => {
+      assert.equal(failureInput.disposition, "terminal");
+      assert.equal(failureInput.phase, "renew");
+      return {
+        status: "reconciliation_required",
+        nextAttemptAt: null,
+        failureCount: 1,
+      };
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(new AbortController().signal),
+      dependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.result.reconciliationRequired === 1
+      && error.failures.length === 1
+      && error.failures[0] === commitUnknownError
+    ),
+  );
+  assert.equal(renewalCalls, 3);
+});
+
+test("cleanup preserves the original and persistence failures with prior progress", async () => {
+  let claimCalls = 0;
+  const originalError = new MediaBlobCleanupStorageTransientError(
+    "head_object",
+    503,
+    new Error("SlowDown"),
+  );
+  const persistenceError = new Error("Failure transaction was rejected.");
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      if (claimCalls === 1) return claim(15);
+      if (claimCalls === 2) return claim(16);
+      return null;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+      status: "renewed",
+    }),
+    deleteFn: async (deleteInput) => {
+      if (deleteInput.cleanupGeneration === 16) throw originalError;
+      return "not_found";
+    },
+    completeFn: async () => "completed",
+    recordFailureFn: async () => {
+      throw persistenceError;
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(new AbortController().signal),
+      dependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.result.claimed === 2
+      && error.result.notFound === 1
+      && error.result.interrupted === 1
+      && error.failures.length === 2
+      && error.failures[0] === originalError
+      && error.failures[1]?.name
+        === "MediaBlobCleanupFailurePersistenceError"
+      && error.failures[1]?.cause === persistenceError
+    ),
+  );
+});
+
+test("cleanup wraps claim and process failures with exact partial results", async () => {
+  const priorFailure = new MediaBlobCleanupStorageTransientError(
+    "head_object",
+    503,
+    new Error("SlowDown"),
+  );
+  const claimError = new Error("Global cleanup claim failed.");
+  let claimCalls = 0;
+  const claimFailureDependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      if (claimCalls === 1) return claim(17);
+      throw claimError;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+      status: "renewed",
+    }),
+    deleteFn: async () => {
+      throw priorFailure;
+    },
+    completeFn: async () => "completed",
+    recordFailureFn: async () => ({
+      status: "retry_scheduled",
+      nextAttemptAt: "2099-07-30T12:02:00.000Z",
+      failureCount: 1,
+    }),
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(new AbortController().signal),
+      claimFailureDependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.result.claimed === 1
+      && error.result.retryScheduled === 1
+      && error.failures.length === 2
+      && error.failures[0] === priorFailure
+      && error.failures[1] === claimError
+    ),
+  );
+
+  const malformedClaim = {
+    ...claim(18),
+    leaseExpiresAt: "not-an-instant",
+  };
+  let malformedClaimCalls = 0;
+  const processFailureDependencies: MediaBlobCleanupProcessorDependencies = {
+    ...claimFailureDependencies,
+    claimFn: async () => {
+      malformedClaimCalls += 1;
+      return malformedClaimCalls === 1 ? malformedClaim : null;
+    },
+  };
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(new AbortController().signal),
+      processFailureDependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.result.claimed === 1
+      && error.result.interrupted === 1
+      && error.failures.length === 1
+      && error.failures[0] instanceof TypeError
+    ),
+  );
+});
+
+test("cleanup schedules exhausted transient failure and continues unrelated claims before raising", async () => {
+  let claimCalls = 0;
+  let failureRecordCalls = 0;
+  const completedGenerations: Array<number> = [];
+  const transientError = new MediaBlobCleanupStorageTransientError(
+    "head_object",
+    503,
+    new Error("SlowDown"),
+  );
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      if (claimCalls === 1) return claim(20);
+      if (claimCalls === 2) return claim(21);
+      return null;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+      status: "renewed",
+    }),
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("head_object");
+      if (deleteInput.cleanupGeneration === 20) throw transientError;
+      return "not_found";
+    },
+    completeFn: async (exactClaim) => {
+      completedGenerations.push(exactClaim.cleanupGeneration);
+      return "completed";
+    },
+    recordFailureFn: async (_exactClaim, failureInput) => {
+      failureRecordCalls += 1;
+      assert.equal(failureInput.disposition, "retry");
+      assert.equal(failureInput.retryDelayMs, 60_000);
+      assert.equal(failureInput.phase, "head_object");
+      if (failureRecordCalls === 1) {
+        throw new DatabaseCommitOutcomeUnknownError(
+          new Error("failure decision commit response lost"),
+        );
+      }
+      return {
+        status: "retry_scheduled",
+        nextAttemptAt: "2099-07-30T12:02:00.000Z",
+        failureCount: 1,
+      };
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(new AbortController().signal),
+      dependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.failures.length === 1
+      && error.failures[0] === transientError
+      && error.result.claimed === 2
+      && error.result.retryScheduled === 1
+      && error.result.notFound === 1
+    ),
+  );
+  assert.equal(failureRecordCalls, 2);
+  assert.deepEqual(completedGenerations, [21]);
+  assert.equal(claimCalls, 3);
+});
+
+test("cleanup records terminal reconciliation and does not starve another claim", async () => {
+  let claimCalls = 0;
+  const completedGenerations: Array<number> = [];
+  const terminalError = new MediaBlobCleanupStorageAmbiguousDeleteError(
+    503,
+    buildMediaBlobStorageKey(sha256),
+    new Error("conditional delete response was lost"),
+  );
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      if (claimCalls === 1) return claim(30);
+      if (claimCalls === 2) return claim(31);
+      return null;
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+      status: "renewed",
+    }),
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("head_object");
+      if (deleteInput.cleanupGeneration === 30) throw terminalError;
+      return "deleted";
+    },
+    completeFn: async (exactClaim) => {
+      completedGenerations.push(exactClaim.cleanupGeneration);
+      return "completed";
+    },
+    recordFailureFn: async (_exactClaim, failureInput) => {
+      assert.equal(failureInput.disposition, "terminal");
+      assert.equal(failureInput.retryDelayMs, 0);
+      assert.equal(failureInput.phase, "delete_object");
+      return {
+        status: "reconciliation_required",
+        nextAttemptAt: null,
+        failureCount: 1,
+      };
+    },
+    createTokenFn: () => cleanupToken,
+    nowFn: () => 0,
+    waitFn: async () => {},
+  };
+
+  await assert.rejects(
+    runMediaBlobCleanupBatchWithDependencies(
+      input(new AbortController().signal),
+      dependencies,
+    ),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupBatchError
+      && error.failures.length === 1
+      && error.failures[0] === terminalError
+      && error.result.claimed === 2
+      && error.result.reconciliationRequired === 1
+      && error.result.deleted === 1
+    ),
+  );
+  assert.deepEqual(completedGenerations, [31]);
+  assert.equal(claimCalls, 3);
+});
+
+test("cleanup respects its batch bound, deadline budget, and abort signal", async () => {
+  let nowMs = 0;
+  let claimCalls = 0;
+  const dependencies: MediaBlobCleanupProcessorDependencies = {
+    claimFn: async () => {
+      claimCalls += 1;
+      return claim(claimCalls);
+    },
+    authorizeFn: async (exactClaim) => ({
+      storageKey: exactClaim.storageKey,
+      status: "authorized",
+    }),
+    renewFn: async () => ({
+      leaseExpiresAt: "2099-07-30T12:01:00.000Z",
+      status: "renewed",
+    }),
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("head_object");
+      nowMs = 9_500;
+      return "not_found";
+    },
+    completeFn: async () => "completed",
+    recordFailureFn: async () => ({
+      status: "retry_scheduled",
+      nextAttemptAt: "2099-07-30T12:02:00.000Z",
+      failureCount: 1,
+    }),
+    createTokenFn: () => cleanupToken,
+    nowFn: () => nowMs,
+    waitFn: async () => {},
+  };
+  const deadlineResult = await runMediaBlobCleanupBatchWithDependencies(
+    input(new AbortController().signal),
+    dependencies,
+  );
+  assert.equal(deadlineResult.claimed, 1);
+  assert.equal(deadlineResult.notFound, 1);
+  assert.equal(deadlineResult.interrupted, 1);
+  assert.equal(claimCalls, 1);
+
+  const controller = new AbortController();
+  controller.abort(new Error("Lambda finalization reserve reached."));
+  claimCalls = 0;
+  const abortedResult = await runMediaBlobCleanupBatchWithDependencies(
+    input(controller.signal),
+    dependencies,
+  );
+  assert.equal(abortedResult.claimed, 0);
+  assert.equal(abortedResult.interrupted, 1);
+  assert.equal(claimCalls, 0);
+
+  nowMs = 0;
+  const boundedDependencies: MediaBlobCleanupProcessorDependencies = {
+    ...dependencies,
+    deleteFn: async (deleteInput) => {
+      await deleteInput.renewLease("head_object");
+      return "not_found";
+    },
+  };
+  const boundedResult = await runMediaBlobCleanupBatchWithDependencies(
+    {
+      ...input(new AbortController().signal),
+      maximumCandidates: 2,
+    },
+    boundedDependencies,
+  );
+  assert.equal(boundedResult.claimed, 2);
+  assert.equal(boundedResult.interrupted, 0);
+  assert.equal(claimCalls, 2);
+});

--- a/apps/backend/src/mediaAssets/blobCleanupProcessor.ts
+++ b/apps/backend/src/mediaAssets/blobCleanupProcessor.ts
@@ -1,0 +1,846 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as wait } from "node:timers/promises";
+import { DatabaseDeadlineExceededError } from "../database";
+import {
+  DatabaseCommitOutcomeUnknownError,
+  getDatabaseErrorFields,
+  isTransientDatabaseError,
+  TransientDatabaseHttpError,
+} from "../database/transient";
+import { addBackendRuntimeBreadcrumb } from "../observability/runtime";
+import type { BackendObservationScope } from "../observability/sentry";
+import {
+  authorizeMediaBlobCleanup,
+  claimNextMediaBlobCleanup,
+  completeMediaBlobCleanup,
+  recordMediaBlobCleanupFailure,
+  renewMediaBlobCleanupLease,
+  type MediaBlobCleanupClaim,
+  type MediaBlobCleanupFailureDisposition,
+  type MediaBlobCleanupFailurePhase,
+  type MediaBlobCleanupLeaseRenewalPhase,
+} from "./blobCleanupRepository";
+import {
+  deletePermanentMediaBlob,
+  MediaBlobCleanupStorageAmbiguousDeleteError,
+  MediaBlobCleanupStorageConditionalConflictError,
+  MediaBlobCleanupStorageTerminalError,
+  MediaBlobCleanupStorageTransientError,
+  type PermanentMediaBlobDeleteOutcome,
+} from "./storage";
+
+const minimumNewCandidateBudgetMs = 1_000;
+const cleanupLeaseFinalizationReserveMs = 1_000;
+const maximumDatabaseAttemptCount = 3;
+const databaseRetryBaseDelayMs = 50;
+const cleanupRetryBaseDelayMs = 60_000;
+const cleanupRetryMaximumDelayMs = 3_600_000;
+
+export type MediaBlobCleanupOutcome =
+  | "deleted"
+  | "not_found"
+  | "blocked"
+  | "stale"
+  | "already_completed"
+  | "retry_scheduled"
+  | "reconciliation_required"
+  | "interrupted";
+
+export type MediaBlobCleanupResult = Readonly<{
+  sha256: string;
+  cleanupGeneration: number;
+  outcome: MediaBlobCleanupOutcome;
+}>;
+
+export type MediaBlobCleanupBatchInput = Readonly<{
+  leaseDurationMs: number;
+  maximumCandidates: number;
+  deadlineAtMs: number;
+  observationScope: BackendObservationScope;
+  signal: AbortSignal;
+}>;
+
+export type MediaBlobCleanupBatchResult = Readonly<{
+  claimed: number;
+  deleted: number;
+  notFound: number;
+  blocked: number;
+  stale: number;
+  alreadyCompleted: number;
+  retryScheduled: number;
+  reconciliationRequired: number;
+  interrupted: number;
+  results: ReadonlyArray<MediaBlobCleanupResult>;
+}>;
+
+export class MediaBlobCleanupBatchError extends Error {
+  readonly result: MediaBlobCleanupBatchResult;
+  readonly failures: ReadonlyArray<Error>;
+
+  constructor(
+    result: MediaBlobCleanupBatchResult,
+    failures: ReadonlyArray<Error>,
+  ) {
+    super(
+      `Media-blob cleanup batch completed with ${String(failures.length)} deferred failure(s).`,
+      { cause: failures.at(-1) },
+    );
+    this.name = "MediaBlobCleanupBatchError";
+    this.result = result;
+    this.failures = Object.freeze([...failures]);
+  }
+}
+
+export type MediaBlobCleanupProcessorDependencies = Readonly<{
+  claimFn: typeof claimNextMediaBlobCleanup;
+  authorizeFn: typeof authorizeMediaBlobCleanup;
+  renewFn: typeof renewMediaBlobCleanupLease;
+  deleteFn: typeof deletePermanentMediaBlob;
+  completeFn: typeof completeMediaBlobCleanup;
+  recordFailureFn: typeof recordMediaBlobCleanupFailure;
+  createTokenFn: () => string;
+  nowFn: () => number;
+  waitFn: (
+    delayMs: number,
+    signal: AbortSignal,
+  ) => Promise<void>;
+}>;
+
+type CleanupDatabasePhase =
+  | "claim"
+  | "authorize"
+  | "renew"
+  | "complete"
+  | "record_failure";
+
+type ClaimProcessingResult = Readonly<{
+  result: MediaBlobCleanupResult;
+  deferredErrors: ReadonlyArray<Error>;
+}>;
+
+const noDeferredErrors: ReadonlyArray<Error> = Object.freeze([]);
+
+class MediaBlobCleanupLeaseLostError extends Error {
+  constructor(readonly status: "completed" | "stale") {
+    super(`Media-blob cleanup lease renewal returned ${status}.`);
+    this.name = "MediaBlobCleanupLeaseLostError";
+  }
+}
+
+class MediaBlobCleanupFailurePersistenceError extends Error {
+  readonly code = "MEDIA_BLOB_CLEANUP_FAILURE_PERSISTENCE_FAILED";
+
+  constructor(message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = "MediaBlobCleanupFailurePersistenceError";
+  }
+}
+
+class MediaBlobCleanupReconciliationRequiredError extends Error {
+  readonly code = "MEDIA_BLOB_CLEANUP_RECONCILIATION_REQUIRED";
+
+  constructor(message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = "MediaBlobCleanupReconciliationRequiredError";
+  }
+}
+
+type MediaBlobCleanupStorageError =
+  | MediaBlobCleanupStorageAmbiguousDeleteError
+  | MediaBlobCleanupStorageConditionalConflictError
+  | MediaBlobCleanupStorageTerminalError
+  | MediaBlobCleanupStorageTransientError;
+
+function isMediaBlobCleanupStorageError(
+  error: unknown,
+): error is MediaBlobCleanupStorageError {
+  return error instanceof MediaBlobCleanupStorageAmbiguousDeleteError
+    || error instanceof MediaBlobCleanupStorageConditionalConflictError
+    || error instanceof MediaBlobCleanupStorageTerminalError
+    || error instanceof MediaBlobCleanupStorageTransientError;
+}
+
+function isRetryableDatabaseFailure(error: unknown): boolean {
+  return error instanceof DatabaseCommitOutcomeUnknownError
+    || error instanceof TransientDatabaseHttpError
+    || isTransientDatabaseError(error);
+}
+
+async function runDatabaseOperation<Result>(
+  phase: CleanupDatabasePhase,
+  claim: MediaBlobCleanupClaim | null,
+  input: MediaBlobCleanupBatchInput,
+  dependencies: MediaBlobCleanupProcessorDependencies,
+  operation: () => Promise<Result>,
+): Promise<Result> {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= maximumDatabaseAttemptCount; attempt += 1) {
+    input.signal.throwIfAborted();
+    try {
+      return await operation();
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (!isRetryableDatabaseFailure(error)) throw error;
+      lastError = error;
+      if (attempt === maximumDatabaseAttemptCount) break;
+      const delayMs = databaseRetryBaseDelayMs * (2 ** (attempt - 1));
+      const errorFields = getDatabaseErrorFields(error);
+      addBackendRuntimeBreadcrumb({
+        action: "media_blob_cleanup_retry",
+        scope: input.observationScope,
+        details: {
+          phase,
+          attempt,
+          maxAttempts: maximumDatabaseAttemptCount,
+          sha256: claim?.sha256 ?? null,
+          cleanupGeneration: claim?.cleanupGeneration ?? null,
+          statusCode: null,
+          errorCode: errorFields.errorCode,
+          errorClass: errorFields.errorClass,
+        },
+      });
+      if (dependencies.nowFn() + delayMs >= input.deadlineAtMs) {
+        throw new DatabaseDeadlineExceededError(
+          "executor_operations",
+          input.deadlineAtMs,
+          error,
+        );
+      }
+      await dependencies.waitFn(delayMs, input.signal);
+    }
+  }
+  throw lastError;
+}
+
+function toResult(
+  claim: MediaBlobCleanupClaim,
+  outcome: MediaBlobCleanupOutcome,
+): MediaBlobCleanupResult {
+  return Object.freeze({
+    sha256: claim.sha256,
+    cleanupGeneration: claim.cleanupGeneration,
+    outcome,
+  });
+}
+
+function countOutcome(
+  results: ReadonlyArray<MediaBlobCleanupResult>,
+  outcome: MediaBlobCleanupOutcome,
+): number {
+  return results.filter((result) => result.outcome === outcome).length;
+}
+
+function toBatchResult(
+  results: ReadonlyArray<MediaBlobCleanupResult>,
+  interruptedBeforeClaim: boolean,
+): MediaBlobCleanupBatchResult {
+  const immutableResults = Object.freeze([...results]);
+  return Object.freeze({
+    claimed: immutableResults.length,
+    deleted: countOutcome(immutableResults, "deleted"),
+    notFound: countOutcome(immutableResults, "not_found"),
+    blocked: countOutcome(immutableResults, "blocked"),
+    stale: countOutcome(immutableResults, "stale"),
+    alreadyCompleted: countOutcome(immutableResults, "already_completed"),
+    retryScheduled: countOutcome(immutableResults, "retry_scheduled"),
+    reconciliationRequired: countOutcome(
+      immutableResults,
+      "reconciliation_required",
+    ),
+    interrupted:
+      countOutcome(immutableResults, "interrupted")
+      + (interruptedBeforeClaim ? 1 : 0),
+    results: immutableResults,
+  });
+}
+
+function normalizeDeferredError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new Error("Media-blob cleanup failed with a non-Error value.", {
+      cause: error,
+    });
+}
+
+function isInterrupted(
+  error: unknown,
+  signal: AbortSignal,
+): boolean {
+  return signal.aborted || error instanceof DatabaseDeadlineExceededError;
+}
+
+function createRenewableDeadlineSignal(
+  parentSignal: AbortSignal,
+  invocationDeadlineAtMs: number,
+  leaseExpiresAtMs: number,
+  nowMs: number,
+): Readonly<{
+  signal: AbortSignal;
+  refresh: (renewedLeaseExpiresAtMs: number, refreshedAtMs: number) => void;
+  dispose: () => void;
+}> {
+  const controller = new AbortController();
+  let timer: NodeJS.Timeout | null = null;
+  const refresh = (
+    renewedLeaseExpiresAtMs: number,
+    refreshedAtMs: number,
+  ): void => {
+    if (timer !== null) clearTimeout(timer);
+    const storageDeadlineAtMs = Math.min(
+      invocationDeadlineAtMs - cleanupLeaseFinalizationReserveMs,
+      renewedLeaseExpiresAtMs - cleanupLeaseFinalizationReserveMs,
+    );
+    timer = setTimeout(
+      () => controller.abort(
+        new Error("Media-blob cleanup storage lease deadline reached."),
+      ),
+      Math.max(0, storageDeadlineAtMs - refreshedAtMs),
+    );
+    timer.unref();
+  };
+  refresh(leaseExpiresAtMs, nowMs);
+  return {
+    signal: AbortSignal.any([parentSignal, controller.signal]),
+    refresh,
+    dispose: () => {
+      if (timer !== null) clearTimeout(timer);
+    },
+  };
+}
+
+function resolveFailurePhase(
+  error: unknown,
+  currentPhase: MediaBlobCleanupFailurePhase,
+): MediaBlobCleanupFailurePhase {
+  if (isMediaBlobCleanupStorageError(error)) {
+    return error.operation;
+  }
+  return currentPhase;
+}
+
+function resolveFailureDisposition(
+  error: unknown,
+  deleteTransitionMayHaveCommitted: boolean,
+): MediaBlobCleanupFailureDisposition {
+  return (
+    !deleteTransitionMayHaveCommitted
+    && (
+      error instanceof MediaBlobCleanupStorageTransientError
+      || isRetryableDatabaseFailure(error)
+    )
+  )
+    ? "retry"
+    : "terminal";
+}
+
+function boundedFailureField(value: string | null, fallback: string): string {
+  const normalized = value === null || value.length === 0 ? fallback : value;
+  return normalized.slice(0, 128);
+}
+
+function resolveFailureFields(error: unknown): Readonly<{
+  errorCode: string;
+  errorClass: string;
+}> {
+  const databaseFields = getDatabaseErrorFields(error);
+  const explicitCode = isMediaBlobCleanupStorageError(error)
+    ? error.code
+    : error instanceof MediaBlobCleanupReconciliationRequiredError
+    || error instanceof MediaBlobCleanupFailurePersistenceError
+    ? error.code
+    : databaseFields.errorCode;
+  return {
+    errorCode: boundedFailureField(explicitCode, "UNCLASSIFIED_FAILURE"),
+    errorClass: boundedFailureField(
+      error instanceof Error ? error.name : databaseFields.errorClass,
+      "UnknownError",
+    ),
+  };
+}
+
+function cleanupRetryDelayMs(failureCount: number): number {
+  return Math.min(
+    cleanupRetryMaximumDelayMs,
+    cleanupRetryBaseDelayMs * (2 ** Math.min(failureCount, 5)),
+  );
+}
+
+async function persistCleanupFailure(
+  claim: MediaBlobCleanupClaim,
+  phase: MediaBlobCleanupFailurePhase,
+  error: unknown,
+  deleteTransitionMayHaveCommitted: boolean,
+  input: MediaBlobCleanupBatchInput,
+  dependencies: MediaBlobCleanupProcessorDependencies,
+): Promise<ClaimProcessingResult> {
+  const disposition = resolveFailureDisposition(
+    error,
+    deleteTransitionMayHaveCommitted,
+  );
+  const retryDelayMs = disposition === "retry"
+    ? cleanupRetryDelayMs(claim.failureCount)
+    : 0;
+  const failureFields = resolveFailureFields(error);
+  const failureToken = dependencies.createTokenFn();
+  const decision = await runDatabaseOperation(
+    "record_failure",
+    claim,
+    input,
+    dependencies,
+    () => dependencies.recordFailureFn(
+      claim,
+      {
+        failureToken,
+        disposition,
+        retryDelayMs,
+        phase,
+        ...failureFields,
+      },
+      input.deadlineAtMs,
+    ),
+  );
+  addBackendRuntimeBreadcrumb({
+    action: "media_blob_cleanup_failure_recorded",
+    scope: input.observationScope,
+    details: {
+      phase,
+      disposition,
+      status: decision.status,
+      sha256: claim.sha256,
+      cleanupGeneration: claim.cleanupGeneration,
+      failureCount: decision.failureCount,
+      nextAttemptAt: decision.nextAttemptAt,
+      errorCode: failureFields.errorCode,
+      errorClass: failureFields.errorClass,
+    },
+  });
+  if (decision.status === "completed") {
+    return {
+      result: toResult(claim, "already_completed"),
+      deferredErrors: noDeferredErrors,
+    };
+  }
+  if (decision.status === "retry_scheduled") {
+    return {
+      result: toResult(claim, "retry_scheduled"),
+      deferredErrors: Object.freeze([normalizeDeferredError(error)]),
+    };
+  }
+  if (decision.status === "reconciliation_required") {
+    return {
+      result: toResult(claim, "reconciliation_required"),
+      deferredErrors: Object.freeze([normalizeDeferredError(error)]),
+    };
+  }
+  return {
+    result: toResult(
+      claim,
+      deleteTransitionMayHaveCommitted ? "reconciliation_required" : "stale",
+    ),
+    deferredErrors: Object.freeze([normalizeDeferredError(error)]),
+  };
+}
+
+async function persistCleanupFailureOrReport(
+  claim: MediaBlobCleanupClaim,
+  phase: MediaBlobCleanupFailurePhase,
+  error: unknown,
+  deleteTransitionMayHaveCommitted: boolean,
+  input: MediaBlobCleanupBatchInput,
+  dependencies: MediaBlobCleanupProcessorDependencies,
+): Promise<ClaimProcessingResult> {
+  const normalizedError = normalizeDeferredError(error);
+  if (
+    input.signal.aborted
+    || dependencies.nowFn() >= input.deadlineAtMs
+  ) {
+    return {
+      result: toResult(
+        claim,
+        deleteTransitionMayHaveCommitted
+          ? "reconciliation_required"
+          : "interrupted",
+      ),
+      deferredErrors: Object.freeze([
+        normalizedError,
+        new MediaBlobCleanupFailurePersistenceError(
+          "Media-blob cleanup failure state could not be persisted because the invocation deadline or abort signal was exhausted.",
+          normalizedError,
+        ),
+      ]),
+    };
+  }
+  try {
+    return await persistCleanupFailure(
+      claim,
+      phase,
+      normalizedError,
+      deleteTransitionMayHaveCommitted,
+      input,
+      dependencies,
+    );
+  } catch (persistenceError) {
+    return {
+      result: toResult(
+        claim,
+        deleteTransitionMayHaveCommitted
+          ? "reconciliation_required"
+          : "interrupted",
+      ),
+      deferredErrors: Object.freeze([
+        normalizedError,
+        new MediaBlobCleanupFailurePersistenceError(
+          "Media-blob cleanup failed to persist its exact failure state.",
+          persistenceError,
+        ),
+      ]),
+    };
+  }
+}
+
+async function processClaim(
+  claim: MediaBlobCleanupClaim,
+  input: MediaBlobCleanupBatchInput,
+  dependencies: MediaBlobCleanupProcessorDependencies,
+): Promise<ClaimProcessingResult> {
+  if (claim.status === "blocked") {
+    return {
+      result: toResult(claim, "blocked"),
+      deferredErrors: noDeferredErrors,
+    };
+  }
+  if (claim.status === "stale") {
+    return {
+      result: toResult(claim, "stale"),
+      deferredErrors: noDeferredErrors,
+    };
+  }
+  if (claim.status === "completed") {
+    return {
+      result: toResult(claim, "already_completed"),
+      deferredErrors: noDeferredErrors,
+    };
+  }
+  if (claim.status === "retry_wait") {
+    return {
+      result: toResult(claim, "retry_scheduled"),
+      deferredErrors: noDeferredErrors,
+    };
+  }
+  if (claim.status === "reconciliation_required") {
+    return {
+      result: toResult(claim, "reconciliation_required"),
+      deferredErrors: noDeferredErrors,
+    };
+  }
+
+  let leaseExpiresAt = claim.leaseExpiresAt;
+  let leaseExpiresAtMs = Date.parse(leaseExpiresAt);
+  if (!Number.isFinite(leaseExpiresAtMs)) {
+    throw new TypeError("Cleanup claim has an invalid lease expiry.");
+  }
+  const storageDeadlineAtMs = Math.min(
+    input.deadlineAtMs,
+    leaseExpiresAtMs - cleanupLeaseFinalizationReserveMs,
+  );
+  if (
+    input.signal.aborted
+    || dependencies.nowFn() + minimumNewCandidateBudgetMs
+      >= storageDeadlineAtMs
+  ) {
+    return {
+      result: toResult(claim, "interrupted"),
+      deferredErrors: noDeferredErrors,
+    };
+  }
+  const deadlineSignal = createRenewableDeadlineSignal(
+    input.signal,
+    input.deadlineAtMs,
+    leaseExpiresAtMs,
+    dependencies.nowFn(),
+  );
+  const storageInput: MediaBlobCleanupBatchInput = {
+    ...input,
+    deadlineAtMs: storageDeadlineAtMs,
+    signal: deadlineSignal.signal,
+  };
+  let currentPhase: MediaBlobCleanupFailurePhase = "authorize";
+  let deleteTransitionMayHaveCommitted = false;
+
+  const renewLease = async (
+    nextPhase: MediaBlobCleanupLeaseRenewalPhase,
+  ): Promise<void> => {
+    deadlineSignal.signal.throwIfAborted();
+    currentPhase = "renew";
+    const renewalDeadlineAtMs = Math.min(
+      input.deadlineAtMs,
+      leaseExpiresAtMs,
+    );
+    const renewalToken = dependencies.createTokenFn();
+    if (nextPhase === "delete_object") {
+      deleteTransitionMayHaveCommitted = true;
+    }
+    const renewal = await runDatabaseOperation(
+      "renew",
+      claim,
+      { ...input, deadlineAtMs: renewalDeadlineAtMs },
+      dependencies,
+      () => dependencies.renewFn(
+        claim,
+        renewalToken,
+        nextPhase,
+        leaseExpiresAt,
+        input.leaseDurationMs,
+        renewalDeadlineAtMs,
+      ),
+    );
+    if (renewal.status !== "renewed") {
+      if (nextPhase === "delete_object") {
+        deleteTransitionMayHaveCommitted = false;
+      }
+      throw new MediaBlobCleanupLeaseLostError(renewal.status);
+    }
+    if (renewal.leaseExpiresAt === null) {
+      throw new TypeError("Cleanup renewal did not return a lease expiry.");
+    }
+    const renewedLeaseExpiresAtMs = Date.parse(renewal.leaseExpiresAt);
+    if (!Number.isFinite(renewedLeaseExpiresAtMs)) {
+      throw new TypeError("Cleanup renewal has an invalid lease expiry.");
+    }
+    leaseExpiresAt = renewal.leaseExpiresAt;
+    leaseExpiresAtMs = renewedLeaseExpiresAtMs;
+    deadlineSignal.refresh(leaseExpiresAtMs, dependencies.nowFn());
+    currentPhase = nextPhase;
+  };
+
+  try {
+    currentPhase = "authorize";
+    const authorization = await runDatabaseOperation(
+      "authorize",
+      claim,
+      storageInput,
+      dependencies,
+      () => dependencies.authorizeFn(claim, storageDeadlineAtMs),
+    );
+    if (authorization.status === "blocked") {
+      return {
+        result: toResult(claim, "blocked"),
+        deferredErrors: noDeferredErrors,
+      };
+    }
+    if (authorization.status === "stale") {
+      return {
+        result: toResult(claim, "stale"),
+        deferredErrors: noDeferredErrors,
+      };
+    }
+    if (authorization.status === "completed") {
+      return {
+        result: toResult(claim, "already_completed"),
+        deferredErrors: noDeferredErrors,
+      };
+    }
+    if (authorization.storageKey !== claim.storageKey) {
+      throw new TypeError(
+        "Cleanup authorization did not return the exact claimed permanent storage key.",
+      );
+    }
+    const deleteOutcome: PermanentMediaBlobDeleteOutcome =
+      await dependencies.deleteFn({
+        sha256: claim.sha256,
+        storageKey: authorization.storageKey,
+        cleanupGeneration: claim.cleanupGeneration,
+        renewLease: async (operation) => renewLease(operation),
+        signal: deadlineSignal.signal,
+        observationScope: input.observationScope,
+      });
+    await renewLease("complete");
+    const completionDeadlineAtMs = Math.min(input.deadlineAtMs, leaseExpiresAtMs);
+    const completion = await runDatabaseOperation(
+      "complete",
+      claim,
+      { ...input, deadlineAtMs: completionDeadlineAtMs },
+      dependencies,
+      () => dependencies.completeFn(claim, completionDeadlineAtMs),
+    );
+    if (
+      completion !== "completed"
+      && deleteTransitionMayHaveCommitted
+    ) {
+      return {
+        result: toResult(claim, "reconciliation_required"),
+        deferredErrors: Object.freeze([
+          new MediaBlobCleanupReconciliationRequiredError(
+            "Media-blob cleanup completion was rejected after the delete transition committed.",
+            new MediaBlobCleanupLeaseLostError("stale"),
+          ),
+        ]),
+      };
+    }
+    return {
+      result: completion === "completed"
+        ? toResult(claim, deleteOutcome)
+        : toResult(claim, "stale"),
+      deferredErrors: noDeferredErrors,
+    };
+  } catch (error) {
+    if (error instanceof MediaBlobCleanupLeaseLostError) {
+      if (
+        deleteTransitionMayHaveCommitted
+        && error.status !== "completed"
+      ) {
+        return {
+          result: toResult(claim, "reconciliation_required"),
+          deferredErrors: Object.freeze([
+            new MediaBlobCleanupReconciliationRequiredError(
+              "Media-blob cleanup lost its exact lease after the delete transition may have committed.",
+              error,
+            ),
+          ]),
+        };
+      }
+      return {
+        result: toResult(
+          claim,
+          error.status === "completed" ? "already_completed" : "stale",
+        ),
+        deferredErrors: noDeferredErrors,
+      };
+    }
+    if (isMediaBlobCleanupStorageError(error)) {
+      return persistCleanupFailureOrReport(
+        claim,
+        resolveFailurePhase(error, currentPhase),
+        error,
+        deleteTransitionMayHaveCommitted,
+        input,
+        dependencies,
+      );
+    }
+    if (
+      isInterrupted(error, input.signal)
+      || isInterrupted(error, deadlineSignal.signal)
+    ) {
+      if (deleteTransitionMayHaveCommitted) {
+        const reconciliationError =
+          new MediaBlobCleanupReconciliationRequiredError(
+            "Media-blob cleanup was interrupted after the delete transition may have committed.",
+            error,
+          );
+        return persistCleanupFailureOrReport(
+          claim,
+          currentPhase,
+          reconciliationError,
+          true,
+          input,
+          dependencies,
+        );
+      }
+      return {
+        result: toResult(claim, "interrupted"),
+        deferredErrors: noDeferredErrors,
+      };
+    }
+    return persistCleanupFailureOrReport(
+      claim,
+      resolveFailurePhase(error, currentPhase),
+      error,
+      deleteTransitionMayHaveCommitted,
+      input,
+      dependencies,
+    );
+  } finally {
+    deadlineSignal.dispose();
+  }
+}
+
+export async function runMediaBlobCleanupBatchWithDependencies(
+  input: MediaBlobCleanupBatchInput,
+  dependencies: MediaBlobCleanupProcessorDependencies,
+): Promise<MediaBlobCleanupBatchResult> {
+  if (
+    !Number.isSafeInteger(input.maximumCandidates)
+    || input.maximumCandidates < 1
+    || input.maximumCandidates > 100
+  ) {
+    throw new RangeError("maximumCandidates must be between 1 and 100.");
+  }
+  const results: Array<MediaBlobCleanupResult> = [];
+  let interruptedBeforeClaim = false;
+  const deferredErrors: Array<Error> = [];
+  while (results.length < input.maximumCandidates) {
+    if (
+      input.signal.aborted
+      || dependencies.nowFn() + minimumNewCandidateBudgetMs
+        >= input.deadlineAtMs
+    ) {
+      interruptedBeforeClaim = true;
+      break;
+    }
+    let claim: MediaBlobCleanupClaim | null;
+    try {
+      const cleanupToken = dependencies.createTokenFn();
+      claim = await runDatabaseOperation(
+        "claim",
+        null,
+        input,
+        dependencies,
+        () => dependencies.claimFn(
+          cleanupToken,
+          input.leaseDurationMs,
+          input.deadlineAtMs,
+        ),
+      );
+    } catch (error) {
+      if (isInterrupted(error, input.signal)) {
+        interruptedBeforeClaim = true;
+        break;
+      }
+      throw new MediaBlobCleanupBatchError(
+        toBatchResult(results, false),
+        [...deferredErrors, normalizeDeferredError(error)],
+      );
+    }
+    if (claim === null) break;
+    let processed: ClaimProcessingResult;
+    try {
+      processed = await processClaim(claim, input, dependencies);
+    } catch (error) {
+      throw new MediaBlobCleanupBatchError(
+        toBatchResult(
+          [...results, toResult(claim, "interrupted")],
+          false,
+        ),
+        [...deferredErrors, normalizeDeferredError(error)],
+      );
+    }
+    results.push(processed.result);
+    deferredErrors.push(...processed.deferredErrors);
+    if (processed.result.outcome === "interrupted") break;
+  }
+  const result = toBatchResult(results, interruptedBeforeClaim);
+  if (deferredErrors.length > 0) {
+    throw new MediaBlobCleanupBatchError(result, deferredErrors);
+  }
+  return result;
+}
+
+const defaultDependencies: MediaBlobCleanupProcessorDependencies = {
+  claimFn: claimNextMediaBlobCleanup,
+  authorizeFn: authorizeMediaBlobCleanup,
+  renewFn: renewMediaBlobCleanupLease,
+  deleteFn: deletePermanentMediaBlob,
+  completeFn: completeMediaBlobCleanup,
+  recordFailureFn: recordMediaBlobCleanupFailure,
+  createTokenFn: randomUUID,
+  nowFn: Date.now,
+  waitFn: async (delayMs, signal) => {
+    await wait(delayMs, undefined, { signal });
+  },
+};
+
+export async function runMediaBlobCleanupBatch(
+  input: MediaBlobCleanupBatchInput,
+): Promise<MediaBlobCleanupBatchResult> {
+  return runMediaBlobCleanupBatchWithDependencies(input, defaultDependencies);
+}

--- a/apps/backend/src/mediaAssets/blobCleanupRepository.ts
+++ b/apps/backend/src/mediaAssets/blobCleanupRepository.ts
@@ -1,0 +1,460 @@
+import type { DatabaseExecutor } from "../database";
+import { unsafeTransactionWithDeadline } from "../database/unsafe";
+import { buildMediaBlobStorageKey } from "./storageKeys";
+
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export type MediaBlobCleanupClaimStatus =
+  | "claimed"
+  | "blocked"
+  | "completed"
+  | "retry_wait"
+  | "reconciliation_required"
+  | "stale";
+
+export type MediaBlobCleanupClaim = Readonly<{
+  cleanupToken: string;
+  leaseToken: string;
+  sha256: string;
+  storageKey: string;
+  cleanupGeneration: number;
+  leaseExpiresAt: string;
+  failureCount: number;
+  status: MediaBlobCleanupClaimStatus;
+}>;
+
+export type MediaBlobCleanupAuthorizationStatus =
+  | "authorized"
+  | "blocked"
+  | "completed"
+  | "stale";
+
+export type MediaBlobCleanupAuthorization = Readonly<{
+  storageKey: string | null;
+  status: MediaBlobCleanupAuthorizationStatus;
+}>;
+
+export type MediaBlobCleanupCompletionStatus = "completed" | "stale";
+
+export type MediaBlobCleanupLeaseRenewalStatus =
+  | "renewed"
+  | "completed"
+  | "stale";
+
+export type MediaBlobCleanupLeaseRenewal = Readonly<{
+  leaseExpiresAt: string | null;
+  status: MediaBlobCleanupLeaseRenewalStatus;
+}>;
+
+export type MediaBlobCleanupLeaseRenewalPhase =
+  | "head_object"
+  | "delete_object"
+  | "complete";
+
+export type MediaBlobCleanupFailurePhase =
+  | "authorize"
+  | "renew"
+  | "head_object"
+  | "delete_object"
+  | "complete";
+
+export type MediaBlobCleanupFailureDisposition = "retry" | "terminal";
+
+export type MediaBlobCleanupFailureStatus =
+  | "retry_scheduled"
+  | "reconciliation_required"
+  | "completed"
+  | "stale";
+
+export type MediaBlobCleanupFailureDecision = Readonly<{
+  status: MediaBlobCleanupFailureStatus;
+  nextAttemptAt: string | null;
+  failureCount: number;
+}>;
+
+export type MediaBlobCleanupFailureInput = Readonly<{
+  failureToken: string;
+  disposition: MediaBlobCleanupFailureDisposition;
+  retryDelayMs: number;
+  phase: MediaBlobCleanupFailurePhase;
+  errorCode: string;
+  errorClass: string;
+}>;
+
+type CleanupClaimRow = Readonly<{
+  cleanup_token: string;
+  lease_token: string;
+  sha256: string;
+  storage_key: string;
+  cleanup_generation: string;
+  lease_expires_at: Date;
+  claim_status: string;
+  failure_count: number;
+}>;
+
+type CleanupAuthorizationRow = Readonly<{
+  storage_key: string | null;
+  authorization_status: string;
+}>;
+
+type CleanupCompletionRow = Readonly<{
+  completion_status: string;
+}>;
+
+type CleanupLeaseRenewalRow = Readonly<{
+  lease_expires_at: Date | null;
+  renewal_status: string;
+}>;
+
+type CleanupFailureRow = Readonly<{
+  failure_status: string;
+  next_attempt_at: Date | null;
+  failure_count: number;
+}>;
+
+function assertCleanupToken(cleanupToken: string): void {
+  if (!uuidPattern.test(cleanupToken)) {
+    throw new TypeError("cleanupToken must be a normalized UUID.");
+  }
+}
+
+function assertCleanupGeneration(cleanupGeneration: number): void {
+  if (!Number.isSafeInteger(cleanupGeneration) || cleanupGeneration < 1) {
+    throw new RangeError("cleanupGeneration must be a positive safe integer.");
+  }
+}
+
+function parseCleanupGeneration(value: string): number {
+  const cleanupGeneration = Number(value);
+  assertCleanupGeneration(cleanupGeneration);
+  return cleanupGeneration;
+}
+
+function parseClaimStatus(value: string): MediaBlobCleanupClaimStatus {
+  if (
+    value === "claimed"
+    || value === "blocked"
+    || value === "completed"
+    || value === "retry_wait"
+    || value === "reconciliation_required"
+    || value === "stale"
+  ) {
+    return value;
+  }
+  throw new TypeError("PostgreSQL returned an invalid media-blob cleanup claim status.");
+}
+
+function parseFailureCount(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(
+      "PostgreSQL returned an invalid media-blob cleanup failure count.",
+    );
+  }
+  return value;
+}
+
+function parseAuthorizationStatus(
+  value: string,
+): MediaBlobCleanupAuthorizationStatus {
+  if (
+    value === "authorized"
+    || value === "blocked"
+    || value === "completed"
+    || value === "stale"
+  ) {
+    return value;
+  }
+  throw new TypeError(
+    "PostgreSQL returned an invalid media-blob cleanup authorization status.",
+  );
+}
+
+function parseLeaseRenewalStatus(
+  value: string,
+): MediaBlobCleanupLeaseRenewalStatus {
+  if (value === "renewed" || value === "completed" || value === "stale") {
+    return value;
+  }
+  throw new TypeError(
+    "PostgreSQL returned an invalid media-blob cleanup lease renewal status.",
+  );
+}
+
+function parseFailureStatus(value: string): MediaBlobCleanupFailureStatus {
+  if (
+    value === "retry_scheduled"
+    || value === "reconciliation_required"
+    || value === "completed"
+    || value === "stale"
+  ) {
+    return value;
+  }
+  throw new TypeError(
+    "PostgreSQL returned an invalid media-blob cleanup failure status.",
+  );
+}
+
+function mapClaimRow(row: CleanupClaimRow): MediaBlobCleanupClaim {
+  assertCleanupToken(row.cleanup_token);
+  assertCleanupToken(row.lease_token);
+  if (!sha256Pattern.test(row.sha256)) {
+    throw new TypeError("PostgreSQL returned an invalid cleanup SHA-256.");
+  }
+  if (row.storage_key !== buildMediaBlobStorageKey(row.sha256)) {
+    throw new TypeError(
+      "PostgreSQL returned a non-deterministic media-blob cleanup storage key.",
+    );
+  }
+  if (!(row.lease_expires_at instanceof Date)) {
+    throw new TypeError(
+      "PostgreSQL returned an invalid media-blob cleanup lease expiry.",
+    );
+  }
+  return {
+    cleanupToken: row.cleanup_token,
+    leaseToken: row.lease_token,
+    sha256: row.sha256,
+    storageKey: row.storage_key,
+    cleanupGeneration: parseCleanupGeneration(row.cleanup_generation),
+    leaseExpiresAt: row.lease_expires_at.toISOString(),
+    failureCount: parseFailureCount(row.failure_count),
+    status: parseClaimStatus(row.claim_status),
+  };
+}
+
+async function claimNextMediaBlobCleanupInExecutor(
+  executor: DatabaseExecutor,
+  cleanupToken: string,
+  leaseDurationMs: number,
+): Promise<MediaBlobCleanupClaim | null> {
+  assertCleanupToken(cleanupToken);
+  if (
+    !Number.isSafeInteger(leaseDurationMs)
+    || leaseDurationMs < 1
+    || leaseDurationMs > 3_600_000
+  ) {
+    throw new RangeError(
+      "leaseDurationMs must be between 1 and 3600000.",
+    );
+  }
+  const result = await executor.query<CleanupClaimRow>(
+    "SELECT * FROM content.claim_next_media_blob_cleanup($1, $2)",
+    [cleanupToken, leaseDurationMs],
+  );
+  const row = result.rows[0];
+  return row === undefined ? null : mapClaimRow(row);
+}
+
+export async function claimNextMediaBlobCleanup(
+  cleanupToken: string,
+  leaseDurationMs: number,
+  deadlineAtMs: number,
+): Promise<MediaBlobCleanupClaim | null> {
+  return unsafeTransactionWithDeadline(
+    deadlineAtMs,
+    (executor) => claimNextMediaBlobCleanupInExecutor(
+      executor,
+      cleanupToken,
+      leaseDurationMs,
+    ),
+  );
+}
+
+async function authorizeMediaBlobCleanupInExecutor(
+  executor: DatabaseExecutor,
+  claim: MediaBlobCleanupClaim,
+): Promise<MediaBlobCleanupAuthorization> {
+  assertCleanupToken(claim.cleanupToken);
+  assertCleanupToken(claim.leaseToken);
+  assertCleanupGeneration(claim.cleanupGeneration);
+  const result = await executor.query<CleanupAuthorizationRow>(
+    "SELECT * FROM content.authorize_media_blob_cleanup($1, $2, $3)",
+    [claim.cleanupToken, claim.cleanupGeneration, claim.leaseToken],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new TypeError(
+      "PostgreSQL did not return a media-blob cleanup authorization.",
+    );
+  }
+  if (
+    row.storage_key !== null
+    && row.storage_key !== buildMediaBlobStorageKey(claim.sha256)
+  ) {
+    throw new TypeError(
+      "PostgreSQL authorized a different media-blob cleanup storage key.",
+    );
+  }
+  return {
+    storageKey: row.storage_key,
+    status: parseAuthorizationStatus(row.authorization_status),
+  };
+}
+
+export async function authorizeMediaBlobCleanup(
+  claim: MediaBlobCleanupClaim,
+  deadlineAtMs: number,
+): Promise<MediaBlobCleanupAuthorization> {
+  return unsafeTransactionWithDeadline(
+    deadlineAtMs,
+    (executor) => authorizeMediaBlobCleanupInExecutor(executor, claim),
+  );
+}
+
+export async function renewMediaBlobCleanupLease(
+  claim: MediaBlobCleanupClaim,
+  renewalToken: string,
+  phase: MediaBlobCleanupLeaseRenewalPhase,
+  expectedLeaseExpiresAt: string,
+  leaseDurationMs: number,
+  deadlineAtMs: number,
+): Promise<MediaBlobCleanupLeaseRenewal> {
+  assertCleanupToken(claim.cleanupToken);
+  assertCleanupToken(claim.leaseToken);
+  assertCleanupToken(renewalToken);
+  assertCleanupGeneration(claim.cleanupGeneration);
+  const expectedExpiry = new Date(expectedLeaseExpiresAt);
+  if (Number.isNaN(expectedExpiry.getTime())) {
+    throw new TypeError("expectedLeaseExpiresAt must be an ISO timestamp.");
+  }
+  if (
+    !Number.isSafeInteger(leaseDurationMs)
+    || leaseDurationMs < 1
+    || leaseDurationMs > 3_600_000
+  ) {
+    throw new RangeError("leaseDurationMs must be between 1 and 3600000.");
+  }
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
+    const result = await executor.query<CleanupLeaseRenewalRow>(
+      "SELECT * FROM content.renew_media_blob_cleanup_lease($1, $2, $3, $4, $5, $6, $7)",
+      [
+        claim.cleanupToken,
+        claim.cleanupGeneration,
+        claim.leaseToken,
+        renewalToken,
+        phase,
+        expectedExpiry,
+        leaseDurationMs,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new TypeError(
+        "PostgreSQL returned an invalid media-blob cleanup lease renewal.",
+      );
+    }
+    const status = parseLeaseRenewalStatus(row.renewal_status);
+    if (
+      (status === "renewed" && !(row.lease_expires_at instanceof Date))
+      || (status !== "renewed" && row.lease_expires_at !== null)
+    ) {
+      throw new TypeError(
+        "PostgreSQL returned an invalid media-blob cleanup lease renewal.",
+      );
+    }
+    return {
+      leaseExpiresAt: row.lease_expires_at?.toISOString() ?? null,
+      status,
+    };
+  });
+}
+
+function assertFailureText(value: string, fieldName: string): void {
+  if (value.length < 1 || value.length > 128) {
+    throw new RangeError(`${fieldName} must contain 1 to 128 characters.`);
+  }
+}
+
+export async function recordMediaBlobCleanupFailure(
+  claim: MediaBlobCleanupClaim,
+  input: MediaBlobCleanupFailureInput,
+  deadlineAtMs: number,
+): Promise<MediaBlobCleanupFailureDecision> {
+  assertCleanupToken(claim.cleanupToken);
+  assertCleanupToken(claim.leaseToken);
+  assertCleanupGeneration(claim.cleanupGeneration);
+  assertCleanupToken(input.failureToken);
+  assertFailureText(input.errorCode, "errorCode");
+  assertFailureText(input.errorClass, "errorClass");
+  if (
+    !Number.isSafeInteger(input.retryDelayMs)
+    || (
+      input.disposition === "retry"
+      && (input.retryDelayMs < 1 || input.retryDelayMs > 3_600_000)
+    )
+    || (input.disposition === "terminal" && input.retryDelayMs !== 0)
+  ) {
+    throw new RangeError(
+      "retryDelayMs must match the cleanup failure disposition.",
+    );
+  }
+  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
+    const result = await executor.query<CleanupFailureRow>(
+      "SELECT * FROM content.record_media_blob_cleanup_failure($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+      [
+        claim.cleanupToken,
+        claim.cleanupGeneration,
+        claim.leaseToken,
+        input.failureToken,
+        input.disposition,
+        input.retryDelayMs,
+        input.phase,
+        input.errorCode,
+        input.errorClass,
+      ],
+    );
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new TypeError(
+        "PostgreSQL returned an invalid media-blob cleanup failure decision.",
+      );
+    }
+    const status = parseFailureStatus(row.failure_status);
+    if (
+      (status === "retry_scheduled"
+        && !(row.next_attempt_at instanceof Date))
+      || (status !== "retry_scheduled" && row.next_attempt_at !== null)
+    ) {
+      throw new TypeError(
+        "PostgreSQL returned an invalid media-blob cleanup failure decision.",
+      );
+    }
+    return {
+      status,
+      nextAttemptAt: row.next_attempt_at?.toISOString() ?? null,
+      failureCount: parseFailureCount(row.failure_count),
+    };
+  });
+}
+
+async function completeMediaBlobCleanupInExecutor(
+  executor: DatabaseExecutor,
+  claim: MediaBlobCleanupClaim,
+): Promise<MediaBlobCleanupCompletionStatus> {
+  assertCleanupToken(claim.cleanupToken);
+  assertCleanupToken(claim.leaseToken);
+  assertCleanupGeneration(claim.cleanupGeneration);
+  const result = await executor.query<CleanupCompletionRow>(
+    "SELECT content.complete_media_blob_cleanup($1, $2, $3) AS completion_status",
+    [claim.cleanupToken, claim.cleanupGeneration, claim.leaseToken],
+  );
+  const status = result.rows[0]?.completion_status;
+  if (status === "completed" || status === "stale") {
+    return status;
+  }
+  throw new TypeError(
+    "PostgreSQL returned an invalid media-blob cleanup completion status.",
+  );
+}
+
+export async function completeMediaBlobCleanup(
+  claim: MediaBlobCleanupClaim,
+  deadlineAtMs: number,
+): Promise<MediaBlobCleanupCompletionStatus> {
+  return unsafeTransactionWithDeadline(
+    deadlineAtMs,
+    (executor) => completeMediaBlobCleanupInExecutor(executor, claim),
+  );
+}

--- a/apps/backend/src/mediaAssets/mediaBlobCleanup.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/mediaBlobCleanup.postgres.integration.ts
@@ -1,0 +1,1436 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { setTimeout as wait } from "node:timers/promises";
+import test from "node:test";
+import {
+  enqueueGeneratedMediaPromotionJob,
+  type EnqueueGeneratedMediaPromotionJobInput,
+} from "../chat/cardImages/promotionJobs";
+import {
+  transactionWithWorkspaceScope,
+} from "../database";
+import {
+  type PostgresIntegrationFixture,
+  withPostgresIntegrationFixture,
+} from "../testSupport/postgresIntegration";
+import {
+  authorizeMediaBlobCleanup,
+  claimNextMediaBlobCleanup,
+  completeMediaBlobCleanup,
+  recordMediaBlobCleanupFailure,
+  renewMediaBlobCleanupLease,
+  type MediaBlobCleanupClaim,
+} from "./blobCleanupRepository";
+import {
+  MediaBlobLifecycleBusyError,
+  reserveMediaBlobWriterInExecutor,
+} from "./blobLifecycle";
+import {
+  buildMediaBlobStorageKey,
+  buildMediaUploadStagingStorageKey,
+} from "./storageKeys";
+import { imageJpegCardMediaBlobNormalizationVersion } from "./types";
+
+const deadlineOffsetMs = 30_000;
+type RunFixture = Readonly<{
+  sessionId: string;
+  runId: string;
+  claimToken: string;
+}>;
+type ClaimTokenRow = Readonly<{ claim_token: string }>;
+
+function createSha256(): string {
+  return createHash("sha256").update(randomUUID()).digest("hex");
+}
+
+function deadlineAtMs(): number {
+  return Date.now() + deadlineOffsetMs;
+}
+
+function hasPostgresCode(error: unknown, code: string): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === code;
+}
+
+async function createRun(
+  fixture: PostgresIntegrationFixture,
+): Promise<RunFixture> {
+  const sessionId = randomUUID();
+  const runId = randomUUID();
+  const assistantItemId = randomUUID();
+  const result = await fixture.ownerPool.query<ClaimTokenRow>(
+    `WITH inserted_session AS (
+       INSERT INTO ai.chat_sessions (
+         session_id, user_id, workspace_id, status, active_run_id
+       ) VALUES ($1, $2, $3, 'running', $4)
+     ), inserted_item AS (
+       INSERT INTO ai.chat_items (
+         item_id, session_id, item_kind, state, payload
+       ) VALUES (
+         $5, $1, 'message', 'in_progress',
+         '{"role":"assistant","content":[]}'::jsonb
+       )
+     )
+     INSERT INTO ai.chat_runs (
+       run_id, session_id, assistant_item_id, status, request_id, model_id,
+       reasoning_effort, timezone, turn_input, worker_claimed_at,
+       worker_heartbeat_at, started_at
+     ) VALUES (
+       $4, $1, $5, 'running', $6, 'gpt-5.4', 'medium', 'Europe/Madrid',
+       '[]'::jsonb, statement_timestamp(), statement_timestamp(),
+       statement_timestamp()
+     )
+     RETURNING worker_claimed_at::text AS claim_token`,
+    [
+      sessionId,
+      fixture.userId,
+      fixture.workspaceId,
+      runId,
+      assistantItemId,
+      `cleanup-enqueue-${runId}`,
+    ],
+  );
+  const claimToken = result.rows[0]?.claim_token;
+  if (claimToken === undefined) {
+    throw new Error(`Run fixture has no claim token. runId=${runId}`);
+  }
+  return { sessionId, runId, claimToken };
+}
+
+function createPromotionInput(
+  fixture: PostgresIntegrationFixture,
+  run: RunFixture,
+  sha256: string,
+): EnqueueGeneratedMediaPromotionJobInput {
+  const jobId = randomUUID();
+  const operationId = randomUUID();
+  const mediaAssetId = randomUUID();
+  return {
+    userId: fixture.userId,
+    workspaceId: fixture.workspaceId,
+    sessionId: run.sessionId,
+    runId: run.runId,
+    claimToken: run.claimToken,
+    deadlineAtMs: deadlineAtMs(),
+    jobId,
+    operationId,
+    cardId: fixture.cardId,
+    targetSide: "back",
+    altText: "Generated cleanup admission integration",
+    mediaAssetId,
+    replicaId: fixture.replicaId,
+    stagingStorageKey: buildMediaUploadStagingStorageKey(
+      fixture.workspaceId,
+      mediaAssetId,
+      operationId,
+    ),
+    blobStorageKey: buildMediaBlobStorageKey(sha256),
+    sha256,
+    mimeType: "image/jpeg",
+    sizeBytes: 42,
+  };
+}
+
+async function waitForBlockedBackendQuery(
+  fixture: PostgresIntegrationFixture,
+  queryFragment: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const result = await fixture.ownerPool.query<Readonly<{
+      blocked: boolean;
+    }>>(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM pg_catalog.pg_stat_activity
+         WHERE usename = 'backend_app'
+           AND wait_event_type = 'Lock'
+           AND query LIKE $1
+       ) AS blocked`,
+      [`%${queryFragment}%`],
+    );
+    if (result.rows[0]?.blocked === true) return;
+    await wait(10);
+  }
+  throw new Error(
+    `Timed out waiting for blocked backend query. queryFragment=${queryFragment}`,
+  );
+}
+
+async function waitForBlockedPostgresPid(
+  fixture: PostgresIntegrationFixture,
+  pid: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const result = await fixture.ownerPool.query<Readonly<{
+      blocked: boolean;
+    }>>(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM pg_catalog.pg_stat_activity
+         WHERE pid = $1
+           AND wait_event_type = 'Lock'
+       ) AS blocked`,
+      [pid],
+    );
+    if (result.rows[0]?.blocked === true) return;
+    await wait(10);
+  }
+  throw new Error(`Timed out waiting for blocked PostgreSQL query. pid=${pid}`);
+}
+
+async function createCandidate(
+  fixture: PostgresIntegrationFixture,
+  sha256: string,
+): Promise<void> {
+  await fixture.ownerPool.query(
+    `INSERT INTO content.media_blob_lifecycles (
+       sha256, storage_key, mime_type, size_bytes, normalization_version,
+       cleanup_eligible_at
+     ) VALUES ($1, $2, 'image/jpeg', 42, $3, now() - interval '1 second')`,
+    [
+      sha256,
+      buildMediaBlobStorageKey(sha256),
+      imageJpegCardMediaBlobNormalizationVersion,
+    ],
+  );
+}
+
+async function claimCandidate(
+  token: string,
+): Promise<MediaBlobCleanupClaim | null> {
+  return claimNextMediaBlobCleanup(token, 60_000, deadlineAtMs());
+}
+
+async function insertGeneratedJob(
+  fixture: PostgresIntegrationFixture,
+  sha256: string,
+  state: "pending" | "leased" | "failed",
+): Promise<string> {
+  const jobId = randomUUID();
+  const operationId = randomUUID();
+  const mediaAssetId = randomUUID();
+  const leased = state === "leased";
+  const failed = state === "failed";
+  await fixture.ownerPool.query(
+    `INSERT INTO content.generated_media_promotion_jobs (
+       job_id, operation_id, user_id, workspace_id, card_id, target_side,
+       alt_text, media_asset_id, replica_id, staging_storage_key,
+       blob_storage_key, sha256, mime_type, size_bytes, state,
+       retry_count, next_attempt_at, lease_token, lease_owner, lease_expires_at,
+       last_error_code, last_error_message, created_at, updated_at
+     ) VALUES (
+       $1, $2, $3, $4, $5, 'back', 'Generated cleanup integration',
+       $6, $7, $8, $9, $10, 'image/jpeg', 42, $11,
+       CASE WHEN $11 = 'pending' THEN 2 ELSE 0 END,
+       CASE WHEN $11 = 'failed' THEN NULL ELSE now() END,
+       CASE WHEN $12 THEN $13::uuid ELSE NULL END,
+       CASE WHEN $12 THEN 'cleanup-integration' ELSE NULL END,
+       CASE WHEN $12 THEN now() + interval '5 minutes' ELSE NULL END,
+       CASE
+         WHEN $11 = 'pending' THEN 'STORAGE_TRANSIENT'
+         WHEN $14 THEN 'RETRY_EXHAUSTED'
+         ELSE NULL
+       END,
+       CASE
+         WHEN $11 = 'pending' THEN 'Generated-media promotion will retry.'
+         WHEN $14 THEN 'Generated-media promotion failed terminally.'
+         ELSE NULL
+       END,
+       $15, $15
+     )`,
+    [
+      jobId,
+      operationId,
+      fixture.userId,
+      fixture.workspaceId,
+      fixture.cardId,
+      mediaAssetId,
+      fixture.replicaId,
+      buildMediaUploadStagingStorageKey(
+        fixture.workspaceId,
+        mediaAssetId,
+        operationId,
+      ),
+      buildMediaBlobStorageKey(sha256),
+      sha256,
+      state,
+      leased,
+      randomUUID(),
+      failed,
+      fixture.createdAt,
+    ],
+  );
+  return jobId;
+}
+
+async function deleteCleanupFixtures(
+  fixture: PostgresIntegrationFixture,
+  sha256s: ReadonlyArray<string>,
+  generatedJobIds: ReadonlyArray<string>,
+): Promise<void> {
+  await fixture.ownerPool.query(
+    "DELETE FROM content.generated_media_promotion_jobs WHERE job_id = ANY($1::uuid[])",
+    [generatedJobIds],
+  );
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_blob_cleanup_claims WHERE cleanup_token IN (SELECT cleanup_token FROM content.media_blob_cleanup_attempts WHERE sha256 = ANY($1::text[]))",
+    [sha256s],
+  );
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_blob_cleanup_attempts WHERE sha256 = ANY($1::text[])",
+    [sha256s],
+  );
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_blob_writer_reservations WHERE sha256 = ANY($1::text[])",
+    [sha256s],
+  );
+  await fixture.ownerPool.query(
+    "DELETE FROM content.media_blob_lifecycles WHERE sha256 = ANY($1::text[])",
+    [sha256s],
+  );
+}
+
+test("terminal generated failure is cleanable while live promotion states and global references block deletion", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const terminalSha = createSha256();
+    const pendingSha = createSha256();
+    const leasedSha = createSha256();
+    const ambiguousSha = createSha256();
+    const referencedSha = createSha256();
+    const sha256s = [
+      terminalSha,
+      pendingSha,
+      leasedSha,
+      ambiguousSha,
+      referencedSha,
+    ];
+    const jobIds: Array<string> = [];
+    const crossWorkspaceId = randomUUID();
+    const crossReplicaId = randomUUID();
+    const crossBlobId = randomUUID();
+    try {
+      for (const sha256 of sha256s) await createCandidate(fixture, sha256);
+      jobIds.push(await insertGeneratedJob(fixture, terminalSha, "failed"));
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_blob_writer_reservations (
+           sha256, writer_kind, workspace_id, media_asset_id, operation_id,
+           state
+         ) VALUES (
+           $1, 'generated_promotion', $2, $3, $4, 'unreferenced'
+         )`,
+        [terminalSha, fixture.workspaceId, randomUUID(), randomUUID()],
+      );
+      jobIds.push(await insertGeneratedJob(fixture, pendingSha, "pending"));
+      jobIds.push(await insertGeneratedJob(fixture, leasedSha, "leased"));
+      jobIds.push(await insertGeneratedJob(fixture, ambiguousSha, "leased"));
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_blob_writer_reservations (
+           sha256, writer_kind, workspace_id, media_asset_id, operation_id,
+           state, ambiguous_at
+         ) VALUES ($1, 'generated_promotion', $2, $3, $4, 'ambiguous', now())`,
+        [ambiguousSha, fixture.workspaceId, randomUUID(), randomUUID()],
+      );
+
+      await fixture.ownerPool.query(
+        `WITH workspace AS (
+           INSERT INTO org.workspaces (
+             workspace_id, name, fsrs_client_updated_at,
+             fsrs_last_modified_by_replica_id, fsrs_last_operation_id
+           ) VALUES ($1, 'Cross-workspace cleanup reference', $2, $3, $4)
+           RETURNING workspace_id
+         ), membership AS (
+           INSERT INTO org.workspace_memberships (workspace_id, user_id, role)
+           SELECT workspace_id, $5, 'owner' FROM workspace
+         )
+         INSERT INTO sync.workspace_replicas (
+           replica_id, workspace_id, user_id, actor_kind, installation_id,
+           actor_key, platform, app_version
+         ) VALUES ($3, $1, $5, 'ai_chat', NULL, $6, 'system', 'integration')`,
+        [
+          crossWorkspaceId,
+          fixture.createdAt,
+          crossReplicaId,
+          randomUUID(),
+          fixture.userId,
+          randomUUID(),
+        ],
+      );
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_blobs (
+           media_blob_id, sha256, mime_type, size_bytes, storage_key,
+           normalization_version
+         ) VALUES ($1, $2, 'image/jpeg', 42, $3, $4)`,
+        [
+          crossBlobId,
+          referencedSha,
+          buildMediaBlobStorageKey(referencedSha),
+          imageJpegCardMediaBlobNormalizationVersion,
+        ],
+      );
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_assets (
+           media_asset_id, workspace_id, media_blob_id, source_url,
+           created_at, client_updated_at, last_modified_by_replica_id,
+           last_operation_id
+         ) VALUES ($1, $2, $3, NULL, $4, $4, $5, $6)`,
+        [
+          randomUUID(),
+          crossWorkspaceId,
+          crossBlobId,
+          fixture.createdAt,
+          crossReplicaId,
+          randomUUID(),
+        ],
+      );
+      await fixture.ownerPool.query(
+        "UPDATE content.media_blob_lifecycles SET cleanup_eligible_at = now() - interval '1 second' WHERE sha256 = $1",
+        [referencedSha],
+      );
+
+      const terminalClaim = await claimCandidate(randomUUID());
+      assert.equal(terminalClaim?.sha256, terminalSha);
+      assert.equal(
+        (await authorizeMediaBlobCleanup(terminalClaim, deadlineAtMs())).status,
+        "authorized",
+      );
+      assert.equal(
+        await completeMediaBlobCleanup(terminalClaim, deadlineAtMs()),
+        "completed",
+      );
+      assert.equal(
+        await completeMediaBlobCleanup(terminalClaim, deadlineAtMs()),
+        "completed",
+      );
+      assert.equal(await claimCandidate(randomUUID()), null);
+    } finally {
+      await fixture.ownerPool.query(
+        "DELETE FROM org.workspaces WHERE workspace_id = $1",
+        [crossWorkspaceId],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blobs WHERE media_blob_id = $1",
+        [crossBlobId],
+      );
+      await deleteCleanupFixtures(fixture, sha256s, jobIds);
+    }
+  });
+});
+
+test("generated promotion enqueue serializes with cleanup authorization on the lifecycle row", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const enqueueFirstSha = createSha256();
+    const authorizeFirstSha = createSha256();
+    const sha256s = [enqueueFirstSha, authorizeFirstSha];
+    const run = await createRun(fixture);
+    const enqueueFirstInput = createPromotionInput(
+      fixture,
+      run,
+      enqueueFirstSha,
+    );
+    const authorizeFirstInput = createPromotionInput(
+      fixture,
+      run,
+      authorizeFirstSha,
+    );
+    const jobIds = [enqueueFirstInput.jobId, authorizeFirstInput.jobId];
+    const lockClient = await fixture.ownerPool.connect();
+    let transactionOpen = false;
+    let enqueuePromise:
+      Promise<Awaited<ReturnType<typeof enqueueGeneratedMediaPromotionJob>>>
+      | null = null;
+    let authorizationPromise:
+      Promise<Awaited<ReturnType<typeof authorizeMediaBlobCleanup>>>
+      | null = null;
+    try {
+      await createCandidate(fixture, enqueueFirstSha);
+      const enqueueFirstClaim = await claimCandidate(randomUUID());
+      assert.ok(enqueueFirstClaim !== null);
+      assert.equal(enqueueFirstClaim.sha256, enqueueFirstSha);
+
+      await lockClient.query("BEGIN");
+      transactionOpen = true;
+      await lockClient.query(
+        `SELECT 1
+         FROM content.media_blob_lifecycles
+         WHERE sha256 = $1
+         FOR UPDATE`,
+        [enqueueFirstSha],
+      );
+      enqueuePromise = enqueueGeneratedMediaPromotionJob(enqueueFirstInput);
+      await waitForBlockedBackendQuery(
+        fixture,
+        "INSERT INTO content.generated_media_promotion_jobs",
+      );
+      authorizationPromise = authorizeMediaBlobCleanup(
+        enqueueFirstClaim,
+        deadlineAtMs(),
+      );
+      await waitForBlockedBackendQuery(
+        fixture,
+        "authorize_media_blob_cleanup",
+      );
+      await lockClient.query("COMMIT");
+      transactionOpen = false;
+
+      assert.equal((await enqueuePromise).outcome, "created");
+      assert.equal((await authorizationPromise).status, "blocked");
+      assert.equal(
+        (await enqueueGeneratedMediaPromotionJob(enqueueFirstInput)).outcome,
+        "existing",
+      );
+      enqueuePromise = null;
+      authorizationPromise = null;
+
+      await createCandidate(fixture, authorizeFirstSha);
+      const authorizeFirstClaim = await claimCandidate(randomUUID());
+      assert.ok(authorizeFirstClaim !== null);
+      assert.equal(authorizeFirstClaim.sha256, authorizeFirstSha);
+
+      await lockClient.query("BEGIN");
+      transactionOpen = true;
+      await lockClient.query(
+        `SELECT 1
+         FROM content.media_blob_lifecycles
+         WHERE sha256 = $1
+         FOR UPDATE`,
+        [authorizeFirstSha],
+      );
+      authorizationPromise = authorizeMediaBlobCleanup(
+        authorizeFirstClaim,
+        deadlineAtMs(),
+      );
+      await waitForBlockedBackendQuery(
+        fixture,
+        "authorize_media_blob_cleanup",
+      );
+      enqueuePromise = enqueueGeneratedMediaPromotionJob(authorizeFirstInput);
+      await waitForBlockedBackendQuery(
+        fixture,
+        "INSERT INTO content.generated_media_promotion_jobs",
+      );
+      await lockClient.query("COMMIT");
+      transactionOpen = false;
+
+      assert.equal((await authorizationPromise).status, "authorized");
+      await assert.rejects(
+        enqueuePromise,
+        (error: unknown) => error instanceof MediaBlobLifecycleBusyError,
+      );
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => executor.query(
+            `INSERT INTO content.generated_media_promotion_jobs (
+               job_id, operation_id, user_id, workspace_id, card_id,
+               target_side, alt_text, media_asset_id, replica_id,
+               staging_storage_key, blob_storage_key, sha256, mime_type,
+               size_bytes
+             ) VALUES (
+               $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
+             )`,
+            [
+              authorizeFirstInput.jobId,
+              authorizeFirstInput.operationId,
+              authorizeFirstInput.userId,
+              authorizeFirstInput.workspaceId,
+              authorizeFirstInput.cardId,
+              authorizeFirstInput.targetSide,
+              authorizeFirstInput.altText,
+              authorizeFirstInput.mediaAssetId,
+              authorizeFirstInput.replicaId,
+              authorizeFirstInput.stagingStorageKey,
+              authorizeFirstInput.blobStorageKey,
+              authorizeFirstInput.sha256,
+              authorizeFirstInput.mimeType,
+              authorizeFirstInput.sizeBytes,
+            ],
+          ),
+        ),
+        (error: unknown) => hasPostgresCode(error, "55P03"),
+      );
+      enqueuePromise = null;
+      authorizationPromise = null;
+    } finally {
+      if (transactionOpen) await lockClient.query("ROLLBACK");
+      lockClient.release();
+      await Promise.allSettled([
+        ...(enqueuePromise === null ? [] : [enqueuePromise]),
+        ...(authorizationPromise === null ? [] : [authorizationPromise]),
+      ]);
+      await deleteCleanupFixtures(fixture, sha256s, jobIds);
+    }
+  });
+});
+
+test("direct, multipart, and generated writers block claims and exact generations fence races", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const writerKinds = [
+      "direct_ingestion",
+      "multipart_completion",
+      "generated_promotion",
+    ] as const;
+    const writerShas = writerKinds.map(() => createSha256());
+    const raceSha = createSha256();
+    const sha256s = [...writerShas, raceSha];
+    try {
+      for (const sha256 of sha256s) await createCandidate(fixture, sha256);
+      for (let index = 0; index < writerKinds.length; index += 1) {
+        await fixture.ownerPool.query(
+          `INSERT INTO content.media_blob_writer_reservations (
+             sha256, writer_kind, workspace_id, media_asset_id, operation_id
+           ) VALUES ($1, $2, $3, $4, $5)`,
+          [
+            writerShas[index],
+            writerKinds[index],
+            fixture.workspaceId,
+            randomUUID(),
+            randomUUID(),
+          ],
+        );
+      }
+      const firstToken = randomUUID();
+      const firstClaim = await claimCandidate(firstToken);
+      assert.equal(firstClaim?.sha256, raceSha);
+      assert.deepEqual(await claimCandidate(firstToken), firstClaim);
+
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, {
+            writerKind: "direct_ingestion",
+            workspaceId: fixture.workspaceId,
+            mediaAssetId: randomUUID(),
+            operationId: randomUUID(),
+            sha256: raceSha,
+            storageKey: buildMediaBlobStorageKey(raceSha),
+            mimeType: "image/jpeg",
+            sizeBytes: 42,
+            normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+          }),
+        ),
+        (error: unknown) => error instanceof MediaBlobLifecycleBusyError,
+      );
+
+      await fixture.ownerPool.query(
+        `UPDATE content.media_blob_lifecycles
+         SET cleanup_lease_expires_at = now() - interval '1 second'
+         WHERE sha256 = $1`,
+        [raceSha],
+      );
+      const secondClaim = await claimCandidate(randomUUID());
+      assert.equal(secondClaim?.sha256, raceSha);
+      assert.equal(
+        secondClaim.cleanupGeneration,
+        firstClaim.cleanupGeneration + 1,
+      );
+      assert.equal(
+        (await authorizeMediaBlobCleanup(firstClaim, deadlineAtMs())).status,
+        "stale",
+      );
+      assert.equal(
+        await completeMediaBlobCleanup(firstClaim, deadlineAtMs()),
+        "stale",
+      );
+      assert.equal(
+        (await authorizeMediaBlobCleanup(secondClaim, deadlineAtMs())).status,
+        "authorized",
+      );
+      assert.equal(
+        await completeMediaBlobCleanup(secondClaim, deadlineAtMs()),
+        "completed",
+      );
+      assert.equal(await claimCandidate(randomUUID()), null);
+    } finally {
+      await deleteCleanupFixtures(fixture, sha256s, []);
+    }
+  });
+});
+
+test("authorized deletion keeps writers fenced while an expired lease is safely resumed", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const sha256 = createSha256();
+    try {
+      await createCandidate(fixture, sha256);
+      const firstClaim = await claimCandidate(randomUUID());
+      assert.ok(firstClaim !== null);
+      assert.equal(
+        (await authorizeMediaBlobCleanup(firstClaim, deadlineAtMs())).status,
+        "authorized",
+      );
+      const renewalToken = randomUUID();
+      const renewed = await renewMediaBlobCleanupLease(
+        firstClaim,
+        renewalToken,
+        "head_object",
+        firstClaim.leaseExpiresAt,
+        60_000,
+        deadlineAtMs(),
+      );
+      assert.equal(renewed.status, "renewed");
+      assert.ok(renewed.leaseExpiresAt !== null);
+      assert.ok(
+        Date.parse(renewed.leaseExpiresAt)
+          > Date.parse(firstClaim.leaseExpiresAt),
+      );
+      assert.deepEqual(
+        await renewMediaBlobCleanupLease(
+          firstClaim,
+          renewalToken,
+          "head_object",
+          firstClaim.leaseExpiresAt,
+          60_000,
+          deadlineAtMs(),
+        ),
+        renewed,
+      );
+      await assert.rejects(
+        renewMediaBlobCleanupLease(
+          firstClaim,
+          renewalToken,
+          "head_object",
+          firstClaim.leaseExpiresAt,
+          30_000,
+          deadlineAtMs(),
+        ),
+        (error: unknown) => hasPostgresCode(error, "23514"),
+      );
+      const secondRenewal = await renewMediaBlobCleanupLease(
+        firstClaim,
+        randomUUID(),
+        "head_object",
+        renewed.leaseExpiresAt,
+        60_000,
+        deadlineAtMs(),
+      );
+      assert.equal(secondRenewal.status, "renewed");
+      assert.ok(secondRenewal.leaseExpiresAt !== null);
+      assert.ok(
+        Date.parse(secondRenewal.leaseExpiresAt)
+          > Date.parse(renewed.leaseExpiresAt),
+      );
+      assert.equal(
+        (
+          await renewMediaBlobCleanupLease(
+            firstClaim,
+            renewalToken,
+            "head_object",
+            firstClaim.leaseExpiresAt,
+            60_000,
+            deadlineAtMs(),
+          )
+        ).status,
+        "stale",
+      );
+      assert.equal(
+        (
+          await renewMediaBlobCleanupLease(
+            firstClaim,
+            randomUUID(),
+            "head_object",
+            firstClaim.leaseExpiresAt,
+            60_000,
+            deadlineAtMs(),
+          )
+        ).status,
+        "stale",
+      );
+      assert.equal(
+        (
+          await renewMediaBlobCleanupLease(
+            { ...firstClaim, leaseToken: randomUUID() },
+            randomUUID(),
+            "head_object",
+            renewed.leaseExpiresAt,
+            60_000,
+            deadlineAtMs(),
+          )
+        ).status,
+        "stale",
+      );
+
+      await fixture.ownerPool.query(
+        `UPDATE content.media_blob_cleanup_attempts
+         SET lease_expires_at = now() - interval '1 second'
+         WHERE cleanup_token = $1`,
+        [firstClaim.cleanupToken],
+      );
+      const lifecycleFence = (await fixture.ownerPool.query<Readonly<{
+        is_infinite: boolean;
+      }>>(
+        `SELECT cleanup_lease_expires_at = 'infinity'::timestamptz AS is_infinite
+         FROM content.media_blob_lifecycles
+         WHERE sha256 = $1`,
+        [sha256],
+      )).rows[0];
+      assert.equal(lifecycleFence?.is_infinite, true);
+
+      for (const writerKind of [
+        "direct_ingestion",
+        "multipart_completion",
+        "generated_promotion",
+      ] as const) {
+        await assert.rejects(
+          transactionWithWorkspaceScope(
+            { userId: fixture.userId, workspaceId: fixture.workspaceId },
+            (executor) => reserveMediaBlobWriterInExecutor(executor, {
+              writerKind,
+              workspaceId: fixture.workspaceId,
+              mediaAssetId: randomUUID(),
+              operationId: randomUUID(),
+              sha256,
+              storageKey: buildMediaBlobStorageKey(sha256),
+              mimeType: "image/jpeg",
+              sizeBytes: 42,
+              normalizationVersion:
+                imageJpegCardMediaBlobNormalizationVersion,
+            }),
+          ),
+          (error: unknown) => error instanceof MediaBlobLifecycleBusyError,
+        );
+      }
+
+      const replacementToken = randomUUID();
+      const replacementClaim = await claimCandidate(replacementToken);
+      assert.ok(replacementClaim !== null);
+      assert.equal(replacementClaim.cleanupToken, firstClaim.cleanupToken);
+      assert.equal(
+        replacementClaim.cleanupGeneration,
+        firstClaim.cleanupGeneration,
+      );
+      assert.equal(replacementClaim.leaseToken, replacementToken);
+      assert.deepEqual(
+        await claimCandidate(replacementToken),
+        replacementClaim,
+      );
+      assert.equal(
+        (await authorizeMediaBlobCleanup(firstClaim, deadlineAtMs())).status,
+        "stale",
+      );
+      assert.equal(
+        (
+          await renewMediaBlobCleanupLease(
+            firstClaim,
+            renewalToken,
+            "head_object",
+            firstClaim.leaseExpiresAt,
+            60_000,
+            deadlineAtMs(),
+          )
+        ).status,
+        "stale",
+      );
+      assert.equal(
+        await completeMediaBlobCleanup(firstClaim, deadlineAtMs()),
+        "stale",
+      );
+      assert.equal(
+        (
+          await authorizeMediaBlobCleanup(
+            replacementClaim,
+            deadlineAtMs(),
+          )
+        ).status,
+        "authorized",
+      );
+      const replacementRenewal = await renewMediaBlobCleanupLease(
+        replacementClaim,
+        randomUUID(),
+        "head_object",
+        replacementClaim.leaseExpiresAt,
+        60_000,
+        deadlineAtMs(),
+      );
+      assert.equal(replacementRenewal.status, "renewed");
+      assert.equal(
+        await completeMediaBlobCleanup(replacementClaim, deadlineAtMs()),
+        "completed",
+      );
+
+      await assert.doesNotReject(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, {
+            writerKind: "direct_ingestion",
+            workspaceId: fixture.workspaceId,
+            mediaAssetId: randomUUID(),
+            operationId: randomUUID(),
+            sha256,
+            storageKey: buildMediaBlobStorageKey(sha256),
+            mimeType: "image/jpeg",
+            sizeBytes: 42,
+            normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+          }),
+        ),
+      );
+    } finally {
+      await deleteCleanupFixtures(fixture, [sha256], []);
+    }
+  });
+});
+
+test("workspace deletion preserves authorized and deleting cleanup fences", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const workspaceId = randomUUID();
+    const replicaId = randomUUID();
+    const authorizedSha = createSha256();
+    const deletingSha = createSha256();
+    const sha256s = [authorizedSha, deletingSha];
+    const lockClient = await fixture.ownerPool.connect();
+    const deleteClient = await fixture.ownerPool.connect();
+    let lockTransactionOpen = false;
+    let deletePromise: Promise<unknown> | null = null;
+    try {
+      await fixture.ownerPool.query(
+        `WITH workspace AS (
+           INSERT INTO org.workspaces (
+             workspace_id, name, fsrs_client_updated_at,
+             fsrs_last_modified_by_replica_id, fsrs_last_operation_id
+           ) VALUES (
+             $1, 'Cleanup fence workspace delete', $2, $3, $4
+           )
+           RETURNING workspace_id
+         ), membership AS (
+           INSERT INTO org.workspace_memberships (
+             workspace_id, user_id, role
+           )
+           SELECT workspace_id, $5, 'owner'
+           FROM workspace
+         )
+         INSERT INTO sync.workspace_replicas (
+           replica_id, workspace_id, user_id, actor_kind, installation_id,
+           actor_key, platform, app_version
+         ) VALUES (
+           $3, $1, $5, 'ai_chat', NULL, $6, 'system', 'integration'
+         )`,
+        [
+          workspaceId,
+          fixture.createdAt,
+          replicaId,
+          randomUUID(),
+          fixture.userId,
+          randomUUID(),
+        ],
+      );
+      for (const sha256 of sha256s) await createCandidate(fixture, sha256);
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_blob_writer_reservations (
+           sha256, writer_kind, workspace_id, media_asset_id, operation_id,
+           state
+         ) VALUES
+           ($1, 'direct_ingestion', $3, $4, $5, 'unreferenced'),
+           ($2, 'multipart_completion', $3, $6, $7, 'unreferenced')`,
+        [
+          authorizedSha,
+          deletingSha,
+          workspaceId,
+          randomUUID(),
+          randomUUID(),
+          randomUUID(),
+          randomUUID(),
+        ],
+      );
+
+      const firstClaim = await claimCandidate(randomUUID());
+      const secondClaim = await claimCandidate(randomUUID());
+      assert.ok(firstClaim !== null);
+      assert.ok(secondClaim !== null);
+      const claimsBySha = new Map(
+        [firstClaim, secondClaim].map((claim) => [claim.sha256, claim]),
+      );
+      const authorizedClaim = claimsBySha.get(authorizedSha);
+      const deletingClaim = claimsBySha.get(deletingSha);
+      assert.ok(authorizedClaim !== undefined);
+      assert.ok(deletingClaim !== undefined);
+      assert.equal(
+        (await authorizeMediaBlobCleanup(
+          authorizedClaim,
+          deadlineAtMs(),
+        )).status,
+        "authorized",
+      );
+      assert.equal(
+        (await authorizeMediaBlobCleanup(
+          deletingClaim,
+          deadlineAtMs(),
+        )).status,
+        "authorized",
+      );
+      assert.equal(
+        (
+          await renewMediaBlobCleanupLease(
+            deletingClaim,
+            randomUUID(),
+            "delete_object",
+            deletingClaim.leaseExpiresAt,
+            60_000,
+            deadlineAtMs(),
+          )
+        ).status,
+        "renewed",
+      );
+
+      await lockClient.query("BEGIN");
+      lockTransactionOpen = true;
+      await lockClient.query(
+        `SELECT sha256
+         FROM content.media_blob_lifecycles
+         WHERE sha256 = ANY($1::text[])
+         ORDER BY sha256
+         FOR UPDATE`,
+        [sha256s],
+      );
+      const deletePid = (
+        await deleteClient.query<Readonly<{ pid: number }>>(
+          "SELECT pg_backend_pid() AS pid",
+        )
+      ).rows[0]?.pid;
+      assert.ok(deletePid !== undefined);
+      deletePromise = deleteClient.query(
+        "DELETE FROM org.workspaces WHERE workspace_id = $1",
+        [workspaceId],
+      );
+      await waitForBlockedPostgresPid(fixture, deletePid);
+      await lockClient.query("COMMIT");
+      lockTransactionOpen = false;
+      await deletePromise;
+      deletePromise = null;
+
+      const rows = (await fixture.ownerPool.query<Readonly<{
+        sha256: string;
+        state: string;
+        lease_token: string;
+        lifecycle_lease_token: string;
+        is_infinite: boolean;
+      }>>(
+        `SELECT
+           attempts.sha256,
+           attempts.state,
+           attempts.lease_token::text AS lease_token,
+           lifecycles.cleanup_lease_token::text AS lifecycle_lease_token,
+           lifecycles.cleanup_lease_expires_at =
+             'infinity'::timestamptz AS is_infinite
+         FROM content.media_blob_cleanup_attempts AS attempts
+         INNER JOIN content.media_blob_lifecycles AS lifecycles
+           ON lifecycles.sha256 = attempts.sha256
+         WHERE attempts.sha256 = ANY($1::text[])
+         ORDER BY attempts.sha256`,
+        [sha256s],
+      )).rows;
+      const stateBySha = new Map(rows.map((row) => [row.sha256, row]));
+      assert.deepEqual(stateBySha.get(authorizedSha), {
+        sha256: authorizedSha,
+        state: "authorized",
+        lease_token: authorizedClaim.leaseToken,
+        lifecycle_lease_token: authorizedClaim.leaseToken,
+        is_infinite: true,
+      });
+      assert.deepEqual(stateBySha.get(deletingSha), {
+        sha256: deletingSha,
+        state: "deleting",
+        lease_token: deletingClaim.leaseToken,
+        lifecycle_lease_token: deletingClaim.leaseToken,
+        is_infinite: true,
+      });
+
+      for (const sha256 of sha256s) {
+        await assert.rejects(
+          transactionWithWorkspaceScope(
+            { userId: fixture.userId, workspaceId: fixture.workspaceId },
+            (executor) => reserveMediaBlobWriterInExecutor(executor, {
+              writerKind: "direct_ingestion",
+              workspaceId: fixture.workspaceId,
+              mediaAssetId: randomUUID(),
+              operationId: randomUUID(),
+              sha256,
+              storageKey: buildMediaBlobStorageKey(sha256),
+              mimeType: "image/jpeg",
+              sizeBytes: 42,
+              normalizationVersion:
+                imageJpegCardMediaBlobNormalizationVersion,
+            }),
+          ),
+          (error: unknown) => error instanceof MediaBlobLifecycleBusyError,
+        );
+      }
+    } finally {
+      if (lockTransactionOpen) await lockClient.query("ROLLBACK");
+      await Promise.allSettled(deletePromise === null ? [] : [deletePromise]);
+      lockClient.release();
+      deleteClient.release();
+      await fixture.ownerPool.query(
+        "DELETE FROM org.workspaces WHERE workspace_id = $1",
+        [workspaceId],
+      );
+      await deleteCleanupFixtures(fixture, sha256s, []);
+    }
+  });
+});
+
+test("a begun conditional delete remains durably fenced instead of being reclaimed", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const sha256 = createSha256();
+    try {
+      await createCandidate(fixture, sha256);
+      const cleanupClaim = await claimCandidate(randomUUID());
+      assert.ok(cleanupClaim !== null);
+      assert.equal(
+        (await authorizeMediaBlobCleanup(cleanupClaim, deadlineAtMs())).status,
+        "authorized",
+      );
+      const deleteRenewal = await renewMediaBlobCleanupLease(
+        cleanupClaim,
+        randomUUID(),
+        "delete_object",
+        cleanupClaim.leaseExpiresAt,
+        60_000,
+        deadlineAtMs(),
+      );
+      assert.equal(deleteRenewal.status, "renewed");
+      assert.ok(deleteRenewal.leaseExpiresAt !== null);
+      await assert.rejects(
+        recordMediaBlobCleanupFailure(
+          cleanupClaim,
+          {
+            failureToken: randomUUID(),
+            disposition: "retry",
+            retryDelayMs: 60_000,
+            phase: "renew",
+            errorCode: "DATABASE_COMMIT_OUTCOME_UNKNOWN",
+            errorClass: "DatabaseCommitOutcomeUnknownError",
+          },
+          deadlineAtMs(),
+        ),
+        (error: unknown) => hasPostgresCode(error, "23514"),
+      );
+
+      await fixture.ownerPool.query(
+        `UPDATE content.media_blob_cleanup_attempts
+         SET lease_expires_at = now() - interval '1 second'
+         WHERE cleanup_token = $1`,
+        [cleanupClaim.cleanupToken],
+      );
+      assert.equal(await claimCandidate(randomUUID()), null);
+      assert.equal(
+        await completeMediaBlobCleanup(cleanupClaim, deadlineAtMs()),
+        "stale",
+      );
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, {
+            writerKind: "direct_ingestion",
+            workspaceId: fixture.workspaceId,
+            mediaAssetId: randomUUID(),
+            operationId: randomUUID(),
+            sha256,
+            storageKey: buildMediaBlobStorageKey(sha256),
+            mimeType: "image/jpeg",
+            sizeBytes: 42,
+            normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+          }),
+        ),
+        (error: unknown) => error instanceof MediaBlobLifecycleBusyError,
+      );
+      const attemptState = (await fixture.ownerPool.query<Readonly<{
+        state: string;
+        is_infinite: boolean;
+      }>>(
+        `SELECT
+           attempts.state,
+           lifecycles.cleanup_lease_expires_at =
+             'infinity'::timestamptz AS is_infinite
+         FROM content.media_blob_cleanup_attempts AS attempts
+         INNER JOIN content.media_blob_lifecycles AS lifecycles
+           ON lifecycles.sha256 = attempts.sha256
+         WHERE attempts.cleanup_token = $1`,
+        [cleanupClaim.cleanupToken],
+      )).rows[0];
+      assert.deepEqual(attemptState, {
+        state: "deleting",
+        is_infinite: true,
+      });
+    } finally {
+      await deleteCleanupFixtures(fixture, [sha256], []);
+    }
+  });
+});
+
+test("cleanup retry and terminal failure states retain fences without starving due work", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const sha256s = [createSha256(), createSha256(), createSha256()];
+    try {
+      for (const sha256 of sha256s) await createCandidate(fixture, sha256);
+
+      const retryClaim = await claimCandidate(randomUUID());
+      assert.ok(retryClaim !== null);
+      assert.equal(
+        (await authorizeMediaBlobCleanup(retryClaim, deadlineAtMs())).status,
+        "authorized",
+      );
+      const retryFailureToken = randomUUID();
+      const retryDecision = await recordMediaBlobCleanupFailure(
+        retryClaim,
+        {
+          failureToken: retryFailureToken,
+          disposition: "retry",
+          retryDelayMs: 300_000,
+          phase: "head_object",
+          errorCode: "MEDIA_BLOB_CLEANUP_STORAGE_TRANSIENT",
+          errorClass: "MediaBlobCleanupStorageTransientError",
+        },
+        deadlineAtMs(),
+      );
+      assert.equal(retryDecision.status, "retry_scheduled");
+      assert.equal(retryDecision.failureCount, 1);
+      assert.ok(retryDecision.nextAttemptAt !== null);
+      assert.deepEqual(
+        await recordMediaBlobCleanupFailure(
+          retryClaim,
+          {
+            failureToken: retryFailureToken,
+            disposition: "retry",
+            retryDelayMs: 300_000,
+            phase: "head_object",
+            errorCode: "MEDIA_BLOB_CLEANUP_STORAGE_TRANSIENT",
+            errorClass: "MediaBlobCleanupStorageTransientError",
+          },
+          deadlineAtMs(),
+        ),
+        retryDecision,
+      );
+
+      const terminalClaim = await claimCandidate(randomUUID());
+      assert.ok(terminalClaim !== null);
+      assert.notEqual(terminalClaim.sha256, retryClaim.sha256);
+      assert.equal(
+        (await authorizeMediaBlobCleanup(terminalClaim, deadlineAtMs())).status,
+        "authorized",
+      );
+      const terminalDecision = await recordMediaBlobCleanupFailure(
+        terminalClaim,
+        {
+          failureToken: randomUUID(),
+          disposition: "terminal",
+          retryDelayMs: 0,
+          phase: "delete_object",
+          errorCode: "MEDIA_BLOB_CLEANUP_DELETE_AMBIGUOUS",
+          errorClass: "MediaBlobCleanupStorageAmbiguousDeleteError",
+        },
+        deadlineAtMs(),
+      );
+      assert.deepEqual(
+        {
+          status: terminalDecision.status,
+          nextAttemptAt: terminalDecision.nextAttemptAt,
+          failureCount: terminalDecision.failureCount,
+        },
+        {
+          status: "reconciliation_required",
+          nextAttemptAt: null,
+          failureCount: 1,
+        },
+      );
+
+      await assert.rejects(
+        transactionWithWorkspaceScope(
+          { userId: fixture.userId, workspaceId: fixture.workspaceId },
+          (executor) => reserveMediaBlobWriterInExecutor(executor, {
+            writerKind: "direct_ingestion",
+            workspaceId: fixture.workspaceId,
+            mediaAssetId: randomUUID(),
+            operationId: randomUUID(),
+            sha256: terminalClaim.sha256,
+            storageKey: terminalClaim.storageKey,
+            mimeType: "image/jpeg",
+            sizeBytes: 42,
+            normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
+          }),
+        ),
+        (error: unknown) => error instanceof MediaBlobLifecycleBusyError,
+      );
+
+      const unrelatedClaim = await claimCandidate(randomUUID());
+      assert.ok(unrelatedClaim !== null);
+      assert.notEqual(unrelatedClaim.sha256, retryClaim.sha256);
+      assert.notEqual(unrelatedClaim.sha256, terminalClaim.sha256);
+      assert.equal(
+        (
+          await authorizeMediaBlobCleanup(unrelatedClaim, deadlineAtMs())
+        ).status,
+        "authorized",
+      );
+      assert.equal(
+        await completeMediaBlobCleanup(unrelatedClaim, deadlineAtMs()),
+        "completed",
+      );
+      assert.equal(await claimCandidate(randomUUID()), null);
+
+      await fixture.ownerPool.query(
+        `UPDATE content.media_blob_cleanup_attempts
+         SET next_attempt_at = now() - interval '1 second'
+         WHERE cleanup_token = $1`,
+        [retryClaim.cleanupToken],
+      );
+      const retryReplacement = await claimCandidate(randomUUID());
+      assert.ok(retryReplacement !== null);
+      assert.equal(retryReplacement.cleanupToken, retryClaim.cleanupToken);
+      assert.equal(
+        retryReplacement.cleanupGeneration,
+        retryClaim.cleanupGeneration,
+      );
+      assert.equal(retryReplacement.failureCount, 1);
+      assert.equal(
+        (
+          await authorizeMediaBlobCleanup(
+            retryReplacement,
+            deadlineAtMs(),
+          )
+        ).status,
+        "authorized",
+      );
+      assert.equal(
+        await completeMediaBlobCleanup(retryReplacement, deadlineAtMs()),
+        "completed",
+      );
+      assert.equal(await claimCandidate(randomUUID()), null);
+    } finally {
+      await deleteCleanupFixtures(fixture, sha256s, []);
+    }
+  });
+});
+
+test("cleanup reclaim index matches the due-work predicate and ordering", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const index = (await fixture.ownerPool.query<Readonly<{
+      is_valid: boolean;
+      definition: string;
+      predicate: string | null;
+    }>>(
+      `SELECT
+         indexes.indisvalid AS is_valid,
+         pg_catalog.pg_get_indexdef(indexes.indexrelid) AS definition,
+         pg_catalog.pg_get_expr(
+           indexes.indpred,
+           indexes.indrelid
+         ) AS predicate
+       FROM pg_catalog.pg_index AS indexes
+       INNER JOIN pg_catalog.pg_class AS index_relations
+         ON index_relations.oid = indexes.indexrelid
+       INNER JOIN pg_catalog.pg_namespace AS namespaces
+         ON namespaces.oid = index_relations.relnamespace
+       WHERE namespaces.nspname = 'content'
+         AND index_relations.relname =
+           'media_blob_cleanup_attempts_due_reclaim'`,
+    )).rows[0];
+
+    assert.ok(index !== undefined);
+    assert.equal(index.is_valid, true);
+    assert.match(
+      index.definition,
+      /COALESCE\(next_attempt_at, lease_expires_at\)/u,
+    );
+    assert.match(index.definition, /authorized_at/u);
+    assert.match(index.definition, /sha256/u);
+    assert.match(index.predicate ?? "", /authorized/u);
+    assert.match(index.predicate ?? "", /retry_wait/u);
+  });
+});
+
+test("cleanup tables stay private and only backend_app can execute reconciler functions", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const row = (await fixture.ownerPool.query<Readonly<{
+      backend_table_access: boolean;
+      backend_claims_table_access: boolean;
+      backend_renewals_table_access: boolean;
+      backend_failures_table_access: boolean;
+      auth_table_access: boolean;
+      reporting_table_access: boolean;
+      backend_claim_access: boolean;
+      backend_authorize_access: boolean;
+      backend_complete_access: boolean;
+      backend_renew_access: boolean;
+      backend_record_failure_access: boolean;
+      backend_legacy_claim_access: boolean;
+      auth_claim_access: boolean;
+      reporting_claim_access: boolean;
+    }>>(
+      `SELECT
+         has_table_privilege(
+           'backend_app', 'content.media_blob_cleanup_attempts', 'SELECT'
+         ) AS backend_table_access,
+         has_table_privilege(
+           'backend_app', 'content.media_blob_cleanup_claims', 'SELECT'
+         ) AS backend_claims_table_access,
+         has_table_privilege(
+           'backend_app', 'content.media_blob_cleanup_renewals', 'SELECT'
+         ) AS backend_renewals_table_access,
+         has_table_privilege(
+           'backend_app', 'content.media_blob_cleanup_failures', 'SELECT'
+         ) AS backend_failures_table_access,
+         has_table_privilege(
+           'auth_app', 'content.media_blob_cleanup_attempts', 'SELECT'
+         ) AS auth_table_access,
+         has_table_privilege(
+           'reporting_readonly', 'content.media_blob_cleanup_attempts', 'SELECT'
+         ) AS reporting_table_access,
+         has_function_privilege(
+           'backend_app',
+           'content.claim_next_media_blob_cleanup(uuid,integer)',
+           'EXECUTE'
+         ) AS backend_claim_access,
+         has_function_privilege(
+           'backend_app',
+           'content.authorize_media_blob_cleanup(uuid,bigint,uuid)',
+           'EXECUTE'
+         ) AS backend_authorize_access,
+         has_function_privilege(
+           'backend_app',
+           'content.complete_media_blob_cleanup(uuid,bigint,uuid)',
+           'EXECUTE'
+         ) AS backend_complete_access,
+         has_function_privilege(
+           'backend_app',
+           'content.renew_media_blob_cleanup_lease(uuid,bigint,uuid,uuid,text,timestamptz,integer)',
+           'EXECUTE'
+         ) AS backend_renew_access,
+         has_function_privilege(
+           'backend_app',
+           'content.record_media_blob_cleanup_failure(uuid,bigint,uuid,uuid,text,integer,text,text,text)',
+           'EXECUTE'
+         ) AS backend_record_failure_access,
+         has_function_privilege(
+           'backend_app',
+           'content.claim_media_blob_cleanup(text,integer)',
+           'EXECUTE'
+         ) AS backend_legacy_claim_access,
+         has_function_privilege(
+           'auth_app',
+           'content.claim_next_media_blob_cleanup(uuid,integer)',
+           'EXECUTE'
+         ) AS auth_claim_access,
+         has_function_privilege(
+           'reporting_readonly',
+           'content.claim_next_media_blob_cleanup(uuid,integer)',
+           'EXECUTE'
+         ) AS reporting_claim_access`,
+    )).rows[0];
+    assert.deepEqual(row, {
+      backend_table_access: false,
+      backend_claims_table_access: false,
+      backend_renewals_table_access: false,
+      backend_failures_table_access: false,
+      auth_table_access: false,
+      reporting_table_access: false,
+      backend_claim_access: true,
+      backend_authorize_access: true,
+      backend_complete_access: true,
+      backend_renew_access: true,
+      backend_record_failure_access: true,
+      backend_legacy_claim_access: false,
+      auth_claim_access: false,
+      reporting_claim_access: false,
+    });
+  });
+});

--- a/apps/backend/src/mediaAssets/storage/blobCleanup.test.ts
+++ b/apps/backend/src/mediaAssets/storage/blobCleanup.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  type S3Client,
+} from "@aws-sdk/client-s3";
+import { buildMediaBlobStorageKey } from "../storageKeys";
+import {
+  deletePermanentMediaBlobWithDependencies,
+  MediaBlobCleanupStorageAmbiguousDeleteError,
+  MediaBlobCleanupStorageConditionalConflictError,
+  MediaBlobCleanupStorageTerminalError,
+  MediaBlobCleanupStorageTransientError,
+} from "./blobCleanup";
+import { getMediaBlobCleanupS3Client } from "./config";
+import {
+  createS3Error,
+  createTestS3Client,
+  getTestMediaAssetsStorageConfig,
+  testObservationScope,
+  testSha256,
+} from "./testHelpers";
+
+const storageKey = buildMediaBlobStorageKey(testSha256);
+
+function input() {
+  return {
+    sha256: testSha256,
+    storageKey,
+    cleanupGeneration: 7,
+    renewLease: async () => {},
+    signal: new AbortController().signal,
+    observationScope: testObservationScope,
+  };
+}
+
+async function removeWithSend(send: S3Client["send"]) {
+  const client = createTestS3Client();
+  client.send = send;
+  return deletePermanentMediaBlobWithDependencies(input(), {
+    s3Client: client,
+    getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+  });
+}
+
+test("permanent blob cleanup treats only an exact-key HEAD 404 as idempotent success", async () => {
+  let calls = 0;
+  assert.equal(await removeWithSend((async (command: unknown) => {
+    calls += 1;
+    assert.ok(command instanceof HeadObjectCommand);
+    assert.equal(command.input.Key, storageKey);
+    throw createS3Error(404, "NotFound", "missing");
+  }) as S3Client["send"]), "not_found");
+  assert.equal(calls, 1);
+
+  await assert.rejects(
+    removeWithSend((async () => {
+      throw createS3Error(403, "AccessDenied", "denied");
+    }) as S3Client["send"]),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupStorageTerminalError
+      && error.operation === "head_object"
+      && error.statusCode === 403
+    ),
+  );
+});
+
+test("permanent blob cleanup deletes only the validated content-addressed key", async () => {
+  const commands: Array<string> = [];
+  assert.equal(await removeWithSend((async (command: unknown) => {
+    if (command instanceof HeadObjectCommand) {
+      commands.push(`head:${String(command.input.Key)}`);
+      return { ETag: "\"exact-etag\"" };
+    }
+    assert.ok(command instanceof DeleteObjectCommand);
+    assert.equal(command.input.IfMatch, "\"exact-etag\"");
+    commands.push(`delete:${String(command.input.Key)}`);
+    return {};
+  }) as S3Client["send"]), "deleted");
+  assert.deepEqual(commands, [`head:${storageKey}`, `delete:${storageKey}`]);
+
+  await assert.rejects(
+    deletePermanentMediaBlobWithDependencies(
+      { ...input(), storageKey: "media/uploads/staging-object" },
+      {
+        s3Client: createTestS3Client(),
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    /exact content-addressed storage key/u,
+  );
+});
+
+test("permanent blob cleanup renews its exact lease before every S3 operation", async () => {
+  const commands: Array<string> = [];
+  let renewals = 0;
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    assert.ok(
+      command instanceof HeadObjectCommand
+      || command instanceof DeleteObjectCommand,
+    );
+    commands.push(command.constructor.name);
+    return command instanceof HeadObjectCommand
+      ? { ETag: "\"exact-etag\"" }
+      : {};
+  }) as S3Client["send"];
+  assert.equal(
+    await deletePermanentMediaBlobWithDependencies(
+      {
+        ...input(),
+        renewLease: async () => {
+          renewals += 1;
+          if (renewals === 2) {
+            throw new Error("exact cleanup lease was lost");
+          }
+        },
+      },
+      {
+        s3Client: client,
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ).then(
+      () => "unexpected success",
+      (error: unknown) => {
+        assert.match(String(error), /exact cleanup lease was lost/u);
+        return "lease rejected";
+      },
+    ),
+    "lease rejected",
+  );
+  assert.equal(renewals, 2);
+  assert.deepEqual(commands, ["HeadObjectCommand"]);
+});
+
+test("permanent blob cleanup treats DELETE 404 after HEAD success as idempotent success", async () => {
+  const commands: Array<string> = [];
+  assert.equal(await removeWithSend((async (command: unknown) => {
+    if (command instanceof HeadObjectCommand) {
+      commands.push("head");
+      return { ETag: "\"exact-etag\"" };
+    }
+    assert.ok(command instanceof DeleteObjectCommand);
+    commands.push("delete");
+    throw createS3Error(404, "NoSuchKey", "removed concurrently");
+  }) as S3Client["send"]), "not_found");
+  assert.deepEqual(commands, ["head", "delete"]);
+});
+
+test("permanent blob cleanup preserves an ambiguous conditional delete for durable reconciliation", async () => {
+  let headCalls = 0;
+  let deleteCalls = 0;
+  await assert.rejects(
+    removeWithSend((async (command: unknown) => {
+      if (command instanceof HeadObjectCommand) {
+        headCalls += 1;
+        return { ETag: "\"exact-etag\"" };
+      }
+      assert.ok(command instanceof DeleteObjectCommand);
+      assert.equal(command.input.IfMatch, "\"exact-etag\"");
+      deleteCalls += 1;
+      throw createS3Error(503, "SlowDown", "commit outcome unknown");
+    }) as S3Client["send"]),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupStorageAmbiguousDeleteError
+      && error.operation === "delete_object"
+      && error.statusCode === 503
+    ),
+  );
+  assert.equal(headCalls, 1);
+  assert.equal(deleteCalls, 1);
+});
+
+test("permanent blob cleanup bounds only non-mutating HEAD retries", async () => {
+  let boundedHeadCalls = 0;
+  await assert.rejects(
+    removeWithSend((async (command: unknown) => {
+      assert.ok(command instanceof HeadObjectCommand);
+      boundedHeadCalls += 1;
+      throw createS3Error(503, "SlowDown", "retry");
+    }) as S3Client["send"]),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupStorageTransientError
+      && error.operation === "head_object"
+      && error.statusCode === 503
+    ),
+  );
+  assert.equal(boundedHeadCalls, 3);
+});
+
+test("permanent blob cleanup retains its fence on a conditional delete conflict", async () => {
+  await assert.rejects(
+    removeWithSend((async (command: unknown) => {
+      if (command instanceof HeadObjectCommand) {
+        return { ETag: "\"replaced-object\"" };
+      }
+      assert.ok(command instanceof DeleteObjectCommand);
+      throw createS3Error(
+        412,
+        "PreconditionFailed",
+        "object no longer matches the observed ETag",
+      );
+    }) as S3Client["send"]),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupStorageConditionalConflictError
+      && error.statusCode === 412
+      && error.storageKey === storageKey
+    ),
+  );
+});
+
+test("permanent blob cleanup requires an exact ETag and disables SDK retries", async () => {
+  let calls = 0;
+  await assert.rejects(
+    removeWithSend((async (command: unknown) => {
+      calls += 1;
+      assert.ok(command instanceof HeadObjectCommand);
+      return {};
+    }) as S3Client["send"]),
+    (error: unknown) => (
+      error instanceof MediaBlobCleanupStorageTerminalError
+      && error.operation === "head_object"
+    ),
+  );
+  assert.equal(calls, 1);
+  assert.equal(await getMediaBlobCleanupS3Client().config.maxAttempts(), 1);
+});

--- a/apps/backend/src/mediaAssets/storage/blobCleanup.ts
+++ b/apps/backend/src/mediaAssets/storage/blobCleanup.ts
@@ -1,0 +1,344 @@
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  S3ServiceException,
+} from "@aws-sdk/client-s3";
+import { setTimeout as wait } from "node:timers/promises";
+import { addBackendRuntimeBreadcrumb } from "../../observability/runtime";
+import { buildMediaBlobStorageKey } from "../storageKeys";
+import type {
+  DeletePermanentMediaBlobInput,
+  MediaAssetStorageDependencies,
+} from "./contracts";
+import { getS3ErrorStatusCode } from "./errors";
+
+const maximumAttemptCount = 3;
+const retryBaseDelayMs = 50;
+
+export type PermanentMediaBlobDeleteOutcome = "deleted" | "not_found";
+type CleanupStorageOperation = "head_object" | "delete_object";
+
+type S3ErrorFields = Readonly<{
+  $retryable?: unknown;
+  code?: unknown;
+  name?: unknown;
+}>;
+
+export class MediaBlobCleanupStorageTransientError extends Error {
+  readonly code = "MEDIA_BLOB_CLEANUP_STORAGE_TRANSIENT";
+
+  constructor(
+    readonly operation: CleanupStorageOperation,
+    readonly statusCode: number | null,
+    cause: unknown,
+  ) {
+    super(
+      `Permanent media-blob cleanup exhausted transient S3 retries. operation=${operation}; statusCode=${String(statusCode)}`,
+      { cause },
+    );
+    this.name = "MediaBlobCleanupStorageTransientError";
+  }
+}
+
+export class MediaBlobCleanupStorageTerminalError extends Error {
+  readonly code = "MEDIA_BLOB_CLEANUP_STORAGE_REJECTED";
+
+  constructor(
+    readonly operation: CleanupStorageOperation,
+    readonly statusCode: number | null,
+    readonly storageKey: string,
+    cause: unknown,
+  ) {
+    super(
+      `Permanent media-blob cleanup S3 request was rejected. operation=${operation}; storageKey=${storageKey}; statusCode=${String(statusCode)}`,
+      { cause },
+    );
+    this.name = "MediaBlobCleanupStorageTerminalError";
+  }
+}
+
+export class MediaBlobCleanupStorageConditionalConflictError extends Error {
+  readonly code = "MEDIA_BLOB_CLEANUP_CONDITIONAL_CONFLICT";
+  readonly operation = "delete_object";
+
+  constructor(
+    readonly statusCode: number,
+    readonly storageKey: string,
+    cause: unknown,
+  ) {
+    super(
+      `Permanent media-blob cleanup conditional delete conflicted with the observed object. storageKey=${storageKey}; statusCode=${String(statusCode)}`,
+      { cause },
+    );
+    this.name = "MediaBlobCleanupStorageConditionalConflictError";
+  }
+}
+
+export class MediaBlobCleanupStorageAmbiguousDeleteError extends Error {
+  readonly code = "MEDIA_BLOB_CLEANUP_DELETE_AMBIGUOUS";
+  readonly operation = "delete_object";
+
+  constructor(
+    readonly statusCode: number | null,
+    readonly storageKey: string,
+    cause: unknown,
+  ) {
+    super(
+      `Permanent media-blob cleanup conditional delete has an unknown commit outcome and requires reconciliation. storageKey=${storageKey}; statusCode=${String(statusCode)}`,
+      { cause },
+    );
+    this.name = "MediaBlobCleanupStorageAmbiguousDeleteError";
+  }
+}
+
+function readS3ErrorFields(error: unknown): S3ErrorFields | null {
+  return typeof error === "object" && error !== null
+    ? error as S3ErrorFields
+    : null;
+}
+
+function getS3ErrorCode(error: unknown): string | null {
+  const fields = readS3ErrorFields(error);
+  if (typeof fields?.name === "string") return fields.name;
+  return typeof fields?.code === "string" ? fields.code : null;
+}
+
+function isS3TransportError(error: unknown): boolean {
+  const fields = readS3ErrorFields(error);
+  return fields?.name === "TimeoutError"
+    || (
+      typeof fields?.code === "string"
+      && [
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "EPIPE",
+        "ETIMEDOUT",
+        "EHOSTUNREACH",
+        "ENETUNREACH",
+        "ENOTFOUND",
+        "EAI_AGAIN",
+      ].includes(fields.code)
+    );
+}
+
+function isRecognizedS3Error(error: unknown): boolean {
+  return error instanceof S3ServiceException || isS3TransportError(error);
+}
+
+function isMissingObjectError(error: unknown): boolean {
+  return error instanceof S3ServiceException
+    && (
+      getS3ErrorStatusCode(error) === 404
+      || error.name === "NoSuchKey"
+    );
+}
+
+function isTransientS3Error(error: unknown): boolean {
+  if (!isRecognizedS3Error(error)) return false;
+  const statusCode = getS3ErrorStatusCode(error);
+  const fields = readS3ErrorFields(error);
+  return fields?.$retryable !== undefined
+    || isS3TransportError(error)
+    || (
+      statusCode !== null
+      && ([408, 409, 425, 429].includes(statusCode) || statusCode >= 500)
+    );
+}
+
+function isConditionalDeleteConflict(error: unknown): boolean {
+  const statusCode = getS3ErrorStatusCode(error);
+  const errorCode = getS3ErrorCode(error);
+  return statusCode === 409
+    || statusCode === 412
+    || errorCode === "ConditionalRequestConflict"
+    || errorCode === "PreconditionFailed";
+}
+
+function isDefinitiveDeleteRejection(error: unknown): boolean {
+  const statusCode = getS3ErrorStatusCode(error);
+  return error instanceof S3ServiceException
+    && statusCode !== null
+    && statusCode >= 400
+    && statusCode < 500
+    && ![408, 409, 412, 425, 429].includes(statusCode);
+}
+
+function assertExactETag(
+  etag: string | undefined,
+  storageKey: string,
+): string {
+  if (etag === undefined || !/^"[^"\r\n]+"$/u.test(etag)) {
+    throw new MediaBlobCleanupStorageTerminalError(
+      "head_object",
+      null,
+      storageKey,
+      new TypeError(
+        "S3 HEAD did not return a valid exact ETag for conditional cleanup deletion.",
+      ),
+    );
+  }
+  return etag;
+}
+
+function assertCleanupInput(input: DeletePermanentMediaBlobInput): void {
+  if (input.storageKey !== buildMediaBlobStorageKey(input.sha256)) {
+    throw new TypeError(
+      "Permanent media-blob cleanup requires the exact content-addressed storage key.",
+    );
+  }
+  if (
+    !Number.isSafeInteger(input.cleanupGeneration)
+    || input.cleanupGeneration < 1
+  ) {
+    throw new RangeError("cleanupGeneration must be a positive safe integer.");
+  }
+}
+
+function readBucketName(dependencies: MediaAssetStorageDependencies): string {
+  const { bucketName } = dependencies.getMediaAssetsStorageConfigFn();
+  if (
+    typeof bucketName !== "string"
+    || bucketName.trim() === ""
+    || bucketName.trim() !== bucketName
+  ) {
+    throw new Error(
+      "Media asset storage bucket name must be a non-empty trimmed string.",
+    );
+  }
+  return bucketName;
+}
+
+function addRetryBreadcrumb(
+  input: DeletePermanentMediaBlobInput,
+  operation: CleanupStorageOperation,
+  attempt: number,
+  error: unknown,
+): void {
+  addBackendRuntimeBreadcrumb({
+    action: "media_blob_cleanup_retry",
+    scope: input.observationScope,
+    details: {
+      phase: operation,
+      attempt,
+      maxAttempts: maximumAttemptCount,
+      sha256: input.sha256,
+      cleanupGeneration: input.cleanupGeneration,
+      statusCode: getS3ErrorStatusCode(error),
+      errorCode: getS3ErrorCode(error),
+      errorClass: error instanceof Error ? error.name : "UnknownError",
+    },
+  });
+}
+
+async function waitBeforeRetry(
+  input: DeletePermanentMediaBlobInput,
+  attempt: number,
+): Promise<void> {
+  await wait(
+    retryBaseDelayMs * (2 ** (attempt - 1)),
+    undefined,
+    { signal: input.signal },
+  );
+}
+
+async function loadObjectETag(
+  input: DeletePermanentMediaBlobInput,
+  bucketName: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<string | null> {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= maximumAttemptCount; attempt += 1) {
+    input.signal.throwIfAborted();
+    await input.renewLease("head_object");
+    input.signal.throwIfAborted();
+    try {
+      const response = await dependencies.s3Client.send(
+        new HeadObjectCommand({
+          Bucket: bucketName,
+          Key: input.storageKey,
+        }),
+        { abortSignal: input.signal },
+      );
+      return assertExactETag(response.ETag, input.storageKey);
+    } catch (error) {
+      input.signal.throwIfAborted();
+      if (isMissingObjectError(error)) return null;
+      if (error instanceof MediaBlobCleanupStorageTerminalError) throw error;
+      if (!isRecognizedS3Error(error)) throw error;
+      if (!isTransientS3Error(error)) {
+        throw new MediaBlobCleanupStorageTerminalError(
+          "head_object",
+          getS3ErrorStatusCode(error),
+          input.storageKey,
+          error,
+        );
+      }
+      lastError = error;
+      if (attempt === maximumAttemptCount) break;
+      addRetryBreadcrumb(input, "head_object", attempt, error);
+      await waitBeforeRetry(input, attempt);
+    }
+  }
+  throw new MediaBlobCleanupStorageTransientError(
+    "head_object",
+    getS3ErrorStatusCode(lastError),
+    lastError,
+  );
+}
+
+async function deleteExistingObject(
+  input: DeletePermanentMediaBlobInput,
+  bucketName: string,
+  etag: string,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<PermanentMediaBlobDeleteOutcome> {
+  input.signal.throwIfAborted();
+  await input.renewLease("delete_object");
+  input.signal.throwIfAborted();
+  try {
+    await dependencies.s3Client.send(
+      new DeleteObjectCommand({
+        Bucket: bucketName,
+        Key: input.storageKey,
+        IfMatch: etag,
+      }),
+      { abortSignal: input.signal },
+    );
+    return "deleted";
+  } catch (error) {
+    if (isMissingObjectError(error)) return "not_found";
+    if (isConditionalDeleteConflict(error)) {
+      throw new MediaBlobCleanupStorageConditionalConflictError(
+        getS3ErrorStatusCode(error) ?? 412,
+        input.storageKey,
+        error,
+      );
+    }
+    if (isDefinitiveDeleteRejection(error)) {
+      throw new MediaBlobCleanupStorageTerminalError(
+        "delete_object",
+        getS3ErrorStatusCode(error),
+        input.storageKey,
+        error,
+      );
+    }
+    throw new MediaBlobCleanupStorageAmbiguousDeleteError(
+      getS3ErrorStatusCode(error),
+      input.storageKey,
+      error,
+    );
+  }
+}
+
+export async function deletePermanentMediaBlobWithDependencies(
+  input: DeletePermanentMediaBlobInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<PermanentMediaBlobDeleteOutcome> {
+  assertCleanupInput(input);
+  const bucketName = readBucketName(dependencies);
+  const etag = await loadObjectETag(input, bucketName, dependencies);
+  if (etag === null) {
+    return "not_found";
+  }
+  return deleteExistingObject(input, bucketName, etag, dependencies);
+}

--- a/apps/backend/src/mediaAssets/storage/config.ts
+++ b/apps/backend/src/mediaAssets/storage/config.ts
@@ -9,6 +9,7 @@ export const downloadUrlExpiresSeconds = 60 * 60;
 export const multipartUploadExpiresSeconds = 24 * 60 * 60;
 
 let mediaAssetsS3Client: S3Client | undefined;
+let mediaBlobCleanupS3Client: S3Client | undefined;
 
 export function getMediaAssetsS3Client(): S3Client {
   if (mediaAssetsS3Client !== undefined) {
@@ -17,6 +18,15 @@ export function getMediaAssetsS3Client(): S3Client {
 
   mediaAssetsS3Client = new S3Client({});
   return mediaAssetsS3Client;
+}
+
+export function getMediaBlobCleanupS3Client(): S3Client {
+  if (mediaBlobCleanupS3Client !== undefined) {
+    return mediaBlobCleanupS3Client;
+  }
+
+  mediaBlobCleanupS3Client = new S3Client({ maxAttempts: 1 });
+  return mediaBlobCleanupS3Client;
 }
 
 function getRequiredMediaAssetsEnv(envName: string): string {

--- a/apps/backend/src/mediaAssets/storage/contracts.ts
+++ b/apps/backend/src/mediaAssets/storage/contracts.ts
@@ -21,6 +21,17 @@ export type MediaAssetStorageContext = Readonly<{
   observationScope: BackendObservationScope;
 }>;
 
+export type DeletePermanentMediaBlobInput = Readonly<{
+  sha256: string;
+  storageKey: string;
+  cleanupGeneration: number;
+  renewLease: (
+    operation: "head_object" | "delete_object",
+  ) => Promise<void>;
+  signal: AbortSignal;
+  observationScope: BackendObservationScope;
+}>;
+
 export type PresignMediaAssetUploadInput = Readonly<{
   workspaceId: string;
   mediaAssetId: string;

--- a/apps/backend/src/mediaAssets/storage/index.ts
+++ b/apps/backend/src/mediaAssets/storage/index.ts
@@ -5,6 +5,7 @@ import type {
   PresignedMediaAssetUploadPart,
 } from "../types";
 import {
+  getMediaBlobCleanupS3Client,
   getMediaAssetsS3Client,
   getMediaAssetsStorageConfig,
 } from "./config";
@@ -14,6 +15,7 @@ import type {
   AssertMediaAssetObjectInput,
   CompleteMultipartMediaAssetUploadInput,
   CreateMultipartMediaAssetUploadInput,
+  DeletePermanentMediaBlobInput,
   LoadedMediaAssetObjectBytes,
   LoadMediaAssetObjectBytesInput,
   PresignMediaAssetDownloadInput,
@@ -23,6 +25,7 @@ import type {
   ReconcileMultipartMediaAssetUploadInput,
   StoreMediaAssetBlobBytesInput,
 } from "./contracts";
+import { deletePermanentMediaBlobWithDependencies } from "./blobCleanup";
 import {
   abortMultipartMediaAssetUploadWithDependencies,
   abortMultipartMediaAssetUploadUntilDeadlineWithDependencies,
@@ -69,6 +72,7 @@ export type {
   AssertMediaAssetObjectInput,
   CompleteMultipartMediaAssetUploadInput,
   CreateMultipartMediaAssetUploadInput,
+  DeletePermanentMediaBlobInput,
   LoadedMediaAssetObjectBytes,
   LoadMediaAssetObjectBytesInput,
   MediaAssetStorageDependencies,
@@ -79,6 +83,14 @@ export type {
   ReconcileMultipartMediaAssetUploadInput,
   StoreMediaAssetBlobBytesInput,
 } from "./contracts";
+export {
+  deletePermanentMediaBlobWithDependencies,
+  MediaBlobCleanupStorageAmbiguousDeleteError,
+  MediaBlobCleanupStorageConditionalConflictError,
+  MediaBlobCleanupStorageTerminalError,
+  MediaBlobCleanupStorageTransientError,
+  type PermanentMediaBlobDeleteOutcome,
+} from "./blobCleanup";
 export {
   abortMultipartMediaAssetUploadWithDependencies,
   abortMultipartMediaAssetUploadUntilDeadlineWithDependencies,
@@ -113,6 +125,15 @@ export async function createMultipartMediaAssetUpload(
 ): Promise<CreatedMultipartMediaAssetUpload> {
   return createMultipartMediaAssetUploadWithDependencies(input, {
     s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export async function deletePermanentMediaBlob(
+  input: DeletePermanentMediaBlobInput,
+): Promise<import("./blobCleanup").PermanentMediaBlobDeleteOutcome> {
+  return deletePermanentMediaBlobWithDependencies(input, {
+    s3Client: getMediaBlobCleanupS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });
 }

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -696,6 +696,54 @@ export type GeneratedMediaPromotionBatchDetails = Readonly<{
   }>>;
 }>;
 
+export type MediaBlobCleanupBatchDetails = Readonly<{
+  maximumCandidates: number;
+  claimed: number;
+  deleted: number;
+  notFound: number;
+  blocked: number;
+  stale: number;
+  alreadyCompleted: number;
+  retryScheduled: number;
+  reconciliationRequired: number;
+  interrupted: number;
+  results: ReadonlyArray<Readonly<{
+    sha256: string;
+    cleanupGeneration: number;
+    outcome: string;
+  }>>;
+}>;
+
+export type MediaBlobCleanupRetryDetails = Readonly<{
+  phase:
+    | "claim"
+    | "authorize"
+    | "renew"
+    | "head_object"
+    | "delete_object"
+    | "complete"
+    | "record_failure";
+  attempt: number;
+  maxAttempts: number;
+  sha256: string | null;
+  cleanupGeneration: number | null;
+  statusCode: number | null;
+  errorCode: string | null;
+  errorClass: string;
+}>;
+
+export type MediaBlobCleanupFailureRecordedDetails = Readonly<{
+  phase: "authorize" | "renew" | "head_object" | "delete_object" | "complete";
+  disposition: "retry" | "terminal";
+  status: "retry_scheduled" | "reconciliation_required" | "completed" | "stale";
+  sha256: string;
+  cleanupGeneration: number;
+  failureCount: number;
+  nextAttemptAt: string | null;
+  errorCode: string;
+  errorClass: string;
+}>;
+
 export type MultipartCompletionFailureReportBatchDetails = Readonly<{
   maximumReports: number;
   claimed: number;
@@ -839,6 +887,9 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"streak_leaderboard_snapshot_generated", StreakLeaderboardSnapshotGeneratedDetails>
   | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>
   | EventByAction<"generated_media_promotion_batch_completed", GeneratedMediaPromotionBatchDetails>
+  | EventByAction<"media_blob_cleanup_batch_completed", MediaBlobCleanupBatchDetails>
+  | EventByAction<"media_blob_cleanup_retry", MediaBlobCleanupRetryDetails>
+  | EventByAction<"media_blob_cleanup_failure_recorded", MediaBlobCleanupFailureRecordedDetails>
   | EventByAction<"multipart_completion_reconciliation_batch_completed", MultipartCompletionReconciliationBatchDetails>
   | EventByAction<"multipart_completion_reconciliation_job_terminally_failed", MultipartCompletionReconciliationTerminalFailureDetails>
   | EventByAction<"database_transient_retry", DatabaseTransientRetryDetails>
@@ -1108,6 +1159,9 @@ export type BackendExceptionEvent =
     error: Error;
   }>)
   | (EventByAction<"generated_media_promotion_batch_failed", GeneratedMediaPromotionBatchDetails> & Readonly<{
+    error: Error;
+  }>)
+  | (EventByAction<"media_blob_cleanup_batch_failed", MediaBlobCleanupBatchDetails> & Readonly<{
     error: Error;
   }>)
   | (EventByAction<"multipart_completion_reconciliation_batch_failed", MultipartCompletionReconciliationBatchDetails> & Readonly<{

--- a/db/migrations/0102_media_blob_cleanup_reconciler.sql
+++ b/db/migrations/0102_media_blob_cleanup_reconciler.sql
@@ -1,0 +1,1407 @@
+-- Current additive migration for globally reconciled permanent media-blob cleanup.
+-- Schemas touched/read explicitly: content, catalog, pg_catalog.
+
+ALTER TABLE content.media_blob_lifecycles
+  ADD COLUMN cleanup_generation BIGINT NOT NULL DEFAULT 0,
+  ADD CONSTRAINT media_blob_lifecycles_cleanup_generation_nonnegative
+    CHECK (cleanup_generation >= 0);
+
+CREATE TABLE content.media_blob_cleanup_attempts (
+  cleanup_token UUID PRIMARY KEY,
+  sha256 TEXT NOT NULL
+    REFERENCES content.media_blob_lifecycles(sha256) ON DELETE RESTRICT,
+  cleanup_generation BIGINT NOT NULL CHECK (cleanup_generation > 0),
+  lease_token UUID NOT NULL,
+  storage_key TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'claimed'
+    CHECK (
+      state IN (
+        'claimed',
+        'authorized',
+        'deleting',
+        'retry_wait',
+        'reconciliation_required',
+        'blocked',
+        'completed'
+      )
+    ),
+  lease_expires_at TIMESTAMPTZ NOT NULL,
+  next_attempt_at TIMESTAMPTZ,
+  failure_count INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT pg_catalog.statement_timestamp(),
+  authorized_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  CONSTRAINT media_blob_cleanup_attempts_generation_unique
+    UNIQUE (sha256, cleanup_generation),
+  CONSTRAINT media_blob_cleanup_attempts_storage_key_deterministic
+    CHECK (
+      storage_key =
+        'media/blobs/sha256/'
+        || pg_catalog.substring(sha256, 1, 2)
+        || '/'
+        || pg_catalog.substring(sha256, 3, 2)
+        || '/'
+        || sha256
+    ),
+  CONSTRAINT media_blob_cleanup_attempts_state_shape
+    CHECK (
+      (
+        state = 'claimed'
+        AND authorized_at IS NULL
+        AND completed_at IS NULL
+      )
+      OR (
+        state = 'authorized'
+        AND authorized_at IS NOT NULL
+        AND completed_at IS NULL
+        AND next_attempt_at IS NULL
+      )
+      OR (
+        state = 'deleting'
+        AND authorized_at IS NOT NULL
+        AND completed_at IS NULL
+        AND next_attempt_at IS NULL
+      )
+      OR (
+        state = 'retry_wait'
+        AND authorized_at IS NOT NULL
+        AND completed_at IS NULL
+        AND next_attempt_at IS NOT NULL
+        AND failure_count > 0
+      )
+      OR (
+        state = 'reconciliation_required'
+        AND authorized_at IS NOT NULL
+        AND completed_at IS NULL
+        AND next_attempt_at IS NULL
+        AND failure_count > 0
+      )
+      OR (
+        state = 'blocked'
+        AND completed_at IS NULL
+        AND next_attempt_at IS NULL
+      )
+      OR (
+        state = 'completed'
+        AND authorized_at IS NOT NULL
+        AND completed_at IS NOT NULL
+        AND completed_at >= authorized_at
+        AND next_attempt_at IS NULL
+      )
+    )
+);
+
+CREATE TABLE content.media_blob_cleanup_claims (
+  claim_token UUID PRIMARY KEY,
+  cleanup_token UUID NOT NULL
+    REFERENCES content.media_blob_cleanup_attempts(cleanup_token)
+    ON DELETE CASCADE,
+  lease_expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT pg_catalog.statement_timestamp()
+);
+
+CREATE TABLE content.media_blob_cleanup_renewals (
+  renewal_token UUID PRIMARY KEY,
+  cleanup_token UUID NOT NULL
+    REFERENCES content.media_blob_cleanup_attempts(cleanup_token)
+    ON DELETE CASCADE,
+  cleanup_generation BIGINT NOT NULL CHECK (cleanup_generation > 0),
+  lease_token UUID NOT NULL,
+  phase TEXT NOT NULL
+    CHECK (phase IN ('head_object', 'delete_object', 'complete')),
+  expected_lease_expires_at TIMESTAMPTZ NOT NULL,
+  lease_duration_ms INTEGER NOT NULL
+    CHECK (lease_duration_ms BETWEEN 1 AND 3600000),
+  renewed_lease_expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT pg_catalog.statement_timestamp(),
+  CHECK (renewed_lease_expires_at > expected_lease_expires_at)
+);
+
+CREATE TABLE content.media_blob_cleanup_failures (
+  failure_token UUID PRIMARY KEY,
+  cleanup_token UUID NOT NULL
+    REFERENCES content.media_blob_cleanup_attempts(cleanup_token)
+    ON DELETE CASCADE,
+  cleanup_generation BIGINT NOT NULL CHECK (cleanup_generation > 0),
+  lease_token UUID NOT NULL,
+  disposition TEXT NOT NULL
+    CHECK (disposition IN ('retry', 'terminal')),
+  retry_delay_ms INTEGER NOT NULL
+    CHECK (retry_delay_ms BETWEEN 0 AND 3600000),
+  phase TEXT NOT NULL
+    CHECK (
+      phase IN (
+        'authorize',
+        'renew',
+        'head_object',
+        'delete_object',
+        'complete'
+      )
+    ),
+  next_attempt_at TIMESTAMPTZ,
+  failure_count INTEGER NOT NULL CHECK (failure_count > 0),
+  error_code TEXT NOT NULL CHECK (error_code <> ''),
+  error_class TEXT NOT NULL CHECK (error_class <> ''),
+  failed_at TIMESTAMPTZ NOT NULL DEFAULT pg_catalog.statement_timestamp(),
+  CONSTRAINT media_blob_cleanup_failures_disposition_shape
+    CHECK (
+      (
+        disposition = 'retry'
+        AND retry_delay_ms > 0
+        AND next_attempt_at IS NOT NULL
+      )
+      OR (
+        disposition = 'terminal'
+        AND retry_delay_ms = 0
+        AND next_attempt_at IS NULL
+      )
+    )
+);
+
+CREATE INDEX media_blob_cleanup_attempts_sha_history
+  ON content.media_blob_cleanup_attempts(sha256, cleanup_generation DESC);
+
+CREATE INDEX media_blob_cleanup_attempts_due_reclaim
+  ON content.media_blob_cleanup_attempts(
+    (COALESCE(next_attempt_at, lease_expires_at)),
+    authorized_at,
+    sha256
+  )
+  WHERE state IN ('authorized', 'retry_wait');
+
+CREATE INDEX media_blob_cleanup_claims_attempt
+  ON content.media_blob_cleanup_claims(cleanup_token, created_at DESC);
+
+CREATE INDEX media_blob_cleanup_renewals_attempt
+  ON content.media_blob_cleanup_renewals(cleanup_token, created_at DESC);
+
+CREATE INDEX media_blob_cleanup_failures_attempt
+  ON content.media_blob_cleanup_failures(cleanup_token, failed_at DESC);
+
+CREATE INDEX generated_media_promotion_jobs_cleanup_reference
+  ON content.generated_media_promotion_jobs(sha256, state)
+  WHERE state IN ('pending', 'leased');
+
+COMMENT ON TABLE content.media_blob_cleanup_attempts IS
+  'Private durable claim, authorization, and completion history for exact-generation permanent media-blob cleanup reconciliation.';
+COMMENT ON TABLE content.media_blob_cleanup_claims IS
+  'Private caller-stable cleanup lease history used to resume one authorized deletion without opening writer admission.';
+COMMENT ON TABLE content.media_blob_cleanup_renewals IS
+  'Private caller-stable exact cleanup lease renewal history for deterministic commit-unknown replay.';
+COMMENT ON TABLE content.media_blob_cleanup_failures IS
+  'Private idempotent failure decisions for bounded retry scheduling and terminal cleanup reconciliation.';
+COMMENT ON COLUMN content.media_blob_lifecycles.cleanup_generation IS
+  'Monotonic fence incremented for every globally claimed cleanup attempt.';
+COMMENT ON COLUMN content.media_blob_lifecycles.cleanup_lease_expires_at IS
+  'Finite claimant lease expiry before authorization; infinity while an authorized deletion durably fences all writers.';
+
+CREATE OR REPLACE FUNCTION content.terminalize_media_blob_writers_before_workspace_delete()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  owner_user_id TEXT;
+  affected_sha256s TEXT[];
+  affected_sha256 TEXT;
+  terminalized_at TIMESTAMPTZ;
+BEGIN
+  FOR owner_user_id IN
+    SELECT owners.user_id
+    FROM (
+      SELECT memberships.user_id
+      FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = OLD.workspace_id
+      UNION
+      SELECT snapshots.user_id
+      FROM content.media_blob_writer_owner_snapshots AS snapshots
+      WHERE snapshots.workspace_id = OLD.workspace_id
+      UNION
+      SELECT attempts.user_id
+      FROM content.media_blob_writer_attempts AS attempts
+      WHERE attempts.workspace_id = OLD.workspace_id
+    ) AS owners
+    ORDER BY owners.user_id
+  LOOP
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+      pg_catalog.hashtextextended(
+        owner_user_id || ':' || OLD.workspace_id::TEXT,
+        0::BIGINT
+      )
+    );
+  END LOOP;
+
+  PERFORM 1
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = OLD.workspace_id
+  ORDER BY sessions.media_upload_session_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = OLD.workspace_id
+  FOR UPDATE;
+
+  SELECT pg_catalog.array_agg(DISTINCT writers.sha256 ORDER BY writers.sha256)
+  INTO affected_sha256s
+  FROM (
+    SELECT reservations.sha256
+    FROM content.media_blob_writer_reservations AS reservations
+    WHERE reservations.workspace_id = OLD.workspace_id
+      AND reservations.writer_kind IN (
+        'direct_ingestion',
+        'multipart_completion'
+      )
+    UNION
+    SELECT attempts.sha256
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.workspace_id = OLD.workspace_id
+  ) AS writers;
+
+  IF affected_sha256s IS NULL THEN
+    RETURN OLD;
+  END IF;
+
+  FOREACH affected_sha256 IN ARRAY affected_sha256s
+  LOOP
+    PERFORM 1
+    FROM content.media_blob_lifecycles AS lifecycles
+    WHERE lifecycles.sha256 = affected_sha256
+    FOR UPDATE;
+  END LOOP;
+
+  PERFORM 1
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN (
+      'direct_ingestion',
+      'multipart_completion'
+    )
+  ORDER BY
+    reservations.sha256,
+    reservations.writer_kind,
+    reservations.media_asset_id,
+    reservations.operation_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.workspace_id = OLD.workspace_id
+  ORDER BY snapshots.reservation_token
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.workspace_id = OLD.workspace_id
+  ORDER BY
+    attempts.writer_kind,
+    attempts.media_asset_id,
+    attempts.operation_id,
+    attempts.attempt_token
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_assets AS assets
+  WHERE assets.workspace_id = OLD.workspace_id
+  ORDER BY assets.media_asset_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_blobs AS blobs
+  WHERE blobs.sha256 = ANY(affected_sha256s)
+  ORDER BY blobs.sha256
+  FOR SHARE;
+
+  DELETE FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = OLD.workspace_id;
+
+  DELETE FROM content.media_assets AS assets
+  WHERE assets.workspace_id = OLD.workspace_id;
+
+  UPDATE content.media_blob_writer_reservations AS reservations
+  SET state = 'unreferenced'
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN (
+      'direct_ingestion',
+      'multipart_completion'
+    )
+    AND reservations.state <> 'unreferenced';
+
+  terminalized_at := pg_catalog.clock_timestamp();
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = 'cancelled',
+    outcome = 'aborted',
+    terminal_at = terminalized_at
+  WHERE attempts.workspace_id = OLD.workspace_id
+    AND attempts.state = 'leased';
+
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET
+    cleanup_eligible_at = GREATEST(
+      COALESCE(
+        lifecycles.cleanup_eligible_at,
+        '-infinity'::TIMESTAMPTZ
+      ),
+      terminalized_at + interval '1 hour'
+    ),
+    cleanup_lease_token = CASE
+      WHEN lifecycles.cleanup_lease_expires_at =
+        'infinity'::TIMESTAMPTZ
+      THEN lifecycles.cleanup_lease_token
+      ELSE NULL
+    END,
+    cleanup_lease_expires_at = CASE
+      WHEN lifecycles.cleanup_lease_expires_at =
+        'infinity'::TIMESTAMPTZ
+      THEN lifecycles.cleanup_lease_expires_at
+      ELSE NULL
+    END,
+    updated_at = terminalized_at
+  WHERE lifecycles.sha256 = ANY(affected_sha256s)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM content.media_assets AS assets
+      INNER JOIN content.media_blobs AS blobs
+        ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256
+        AND assets.deleted_at IS NULL
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM catalog.package_media_assets AS assets
+      INNER JOIN content.media_blobs AS blobs
+        ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM content.media_blob_writer_reservations AS reservations
+      WHERE reservations.sha256 = lifecycles.sha256
+        AND reservations.state NOT IN ('finalized', 'unreferenced')
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM content.media_blob_writer_attempts AS attempts
+      WHERE attempts.sha256 = lifecycles.sha256
+        AND attempts.state = 'leased'
+    );
+
+  RETURN OLD;
+END;
+$$;
+
+CREATE FUNCTION content.generated_media_promotion_cleanup_admission_internal()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM content.generated_media_promotion_jobs AS jobs
+    WHERE jobs.job_id = NEW.job_id
+      OR jobs.operation_id = NEW.operation_id
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = NEW.sha256
+  FOR UPDATE;
+
+  IF FOUND
+    AND lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at = 'infinity'::TIMESTAMPTZ
+  THEN
+    RAISE EXCEPTION
+      'Generated-media promotion enqueue conflicts with active cleanup deletion fence'
+      USING
+        ERRCODE = '55P03',
+        CONSTRAINT = 'generated_media_promotion_cleanup_admission';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER generated_media_promotion_cleanup_admission
+BEFORE INSERT ON content.generated_media_promotion_jobs
+FOR EACH ROW
+EXECUTE FUNCTION content.generated_media_promotion_cleanup_admission_internal();
+
+CREATE FUNCTION content.media_blob_cleanup_blocked_internal(p_sha256 TEXT)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    EXISTS (
+      SELECT 1
+      FROM content.media_assets AS media_assets
+      INNER JOIN content.media_blobs AS media_blobs
+        ON media_blobs.media_blob_id = media_assets.media_blob_id
+      WHERE media_blobs.sha256 = p_sha256
+        AND media_assets.deleted_at IS NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM catalog.package_media_assets AS package_media_assets
+      INNER JOIN content.media_blobs AS media_blobs
+        ON media_blobs.media_blob_id = package_media_assets.media_blob_id
+      WHERE media_blobs.sha256 = p_sha256
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM content.media_blob_writer_reservations AS reservations
+      WHERE reservations.sha256 = p_sha256
+        AND reservations.state IN ('active', 'ambiguous')
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM content.media_blob_writer_attempts AS attempts
+      WHERE attempts.sha256 = p_sha256
+        AND (
+          attempts.state = 'leased'
+          OR attempts.reconciliation_state IN ('pending', 'leased')
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM content.generated_media_promotion_jobs AS jobs
+      WHERE jobs.sha256 = p_sha256
+        AND jobs.state IN ('pending', 'leased')
+    );
+$$;
+
+CREATE FUNCTION content.claim_next_media_blob_cleanup(
+  p_claim_token UUID,
+  p_lease_duration_ms INTEGER
+)
+RETURNS TABLE (
+  cleanup_token UUID,
+  lease_token UUID,
+  sha256 TEXT,
+  storage_key TEXT,
+  cleanup_generation BIGINT,
+  lease_expires_at TIMESTAMPTZ,
+  claim_status TEXT,
+  failure_count INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing_claim content.media_blob_cleanup_claims%ROWTYPE;
+  existing_attempt content.media_blob_cleanup_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  claim_time TIMESTAMPTZ;
+BEGIN
+  IF p_claim_token IS NULL THEN
+    RAISE EXCEPTION 'p_claim_token is required' USING ERRCODE = '22023';
+  END IF;
+  IF p_lease_duration_ms IS NULL OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+  THEN
+    RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'media-blob-cleanup:' || p_claim_token::TEXT,
+      0::BIGINT
+    )
+  );
+
+  SELECT claims.*
+  INTO existing_claim
+  FROM content.media_blob_cleanup_claims AS claims
+  WHERE claims.claim_token = p_claim_token;
+
+  IF FOUND THEN
+    SELECT attempts.*
+    INTO existing_attempt
+    FROM content.media_blob_cleanup_attempts AS attempts
+    WHERE attempts.cleanup_token = existing_claim.cleanup_token;
+
+    SELECT lifecycles.*
+    INTO lifecycle
+    FROM content.media_blob_lifecycles AS lifecycles
+    WHERE lifecycles.sha256 = existing_attempt.sha256;
+
+    RETURN QUERY
+    SELECT
+      existing_attempt.cleanup_token,
+      existing_claim.claim_token,
+      existing_attempt.sha256,
+      existing_attempt.storage_key,
+      existing_attempt.cleanup_generation,
+      existing_claim.lease_expires_at,
+      CASE
+        WHEN existing_attempt.state = 'completed' THEN 'completed'
+        WHEN existing_attempt.state = 'blocked' THEN 'blocked'
+        WHEN existing_attempt.state = 'retry_wait' THEN 'retry_wait'
+        WHEN existing_attempt.state = 'reconciliation_required'
+          THEN 'reconciliation_required'
+        WHEN existing_attempt.state = 'deleting'
+          THEN 'reconciliation_required'
+        WHEN existing_attempt.lease_token = existing_claim.claim_token
+          AND existing_attempt.lease_expires_at = existing_claim.lease_expires_at
+          AND lifecycle.cleanup_lease_token = existing_claim.claim_token
+          AND lifecycle.cleanup_generation = existing_attempt.cleanup_generation
+          AND existing_attempt.lease_expires_at > pg_catalog.clock_timestamp()
+          THEN 'claimed'
+        ELSE 'stale'
+      END,
+      existing_attempt.failure_count;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO existing_attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  INNER JOIN content.media_blob_lifecycles AS lifecycles
+    ON lifecycles.sha256 = attempts.sha256
+    AND lifecycles.cleanup_generation = attempts.cleanup_generation
+    AND lifecycles.cleanup_lease_token = attempts.lease_token
+  WHERE (
+      attempts.state = 'authorized'
+      AND attempts.lease_expires_at <= pg_catalog.clock_timestamp()
+    )
+    OR (
+      attempts.state = 'retry_wait'
+      AND attempts.next_attempt_at <= pg_catalog.clock_timestamp()
+    )
+  ORDER BY
+    COALESCE(attempts.next_attempt_at, attempts.lease_expires_at),
+    attempts.authorized_at,
+    attempts.sha256
+  FOR UPDATE OF attempts, lifecycles SKIP LOCKED
+  LIMIT 1;
+
+  IF FOUND THEN
+    claim_time := pg_catalog.date_trunc(
+      'milliseconds',
+      pg_catalog.clock_timestamp()
+    );
+    UPDATE content.media_blob_cleanup_attempts AS attempts
+    SET
+      state = 'authorized',
+      lease_token = p_claim_token,
+      lease_expires_at =
+        claim_time + (p_lease_duration_ms * interval '1 millisecond'),
+      next_attempt_at = NULL
+    WHERE attempts.cleanup_token = existing_attempt.cleanup_token
+    RETURNING * INTO existing_attempt;
+
+    UPDATE content.media_blob_lifecycles AS lifecycles
+    SET
+      cleanup_lease_token = p_claim_token,
+      cleanup_lease_expires_at = 'infinity'::TIMESTAMPTZ,
+      updated_at = claim_time
+    WHERE lifecycles.sha256 = existing_attempt.sha256
+      AND lifecycles.cleanup_generation =
+        existing_attempt.cleanup_generation;
+
+    INSERT INTO content.media_blob_cleanup_claims (
+      claim_token,
+      cleanup_token,
+      lease_expires_at
+    )
+    VALUES (
+      p_claim_token,
+      existing_attempt.cleanup_token,
+      existing_attempt.lease_expires_at
+    );
+
+    RETURN QUERY
+    SELECT
+      existing_attempt.cleanup_token,
+      p_claim_token,
+      existing_attempt.sha256,
+      existing_attempt.storage_key,
+      existing_attempt.cleanup_generation,
+      existing_attempt.lease_expires_at,
+      'claimed'::TEXT,
+      existing_attempt.failure_count;
+    RETURN;
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.cleanup_eligible_at IS NOT NULL
+    AND lifecycles.cleanup_eligible_at <= pg_catalog.clock_timestamp()
+    AND (
+      lifecycles.cleanup_lease_token IS NULL
+      OR lifecycles.cleanup_lease_expires_at <= pg_catalog.clock_timestamp()
+    )
+    AND content.media_blob_cleanup_blocked_internal(lifecycles.sha256) IS false
+  ORDER BY lifecycles.cleanup_eligible_at, lifecycles.sha256
+  FOR UPDATE SKIP LOCKED
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  claim_time := pg_catalog.date_trunc(
+    'milliseconds',
+    pg_catalog.clock_timestamp()
+  );
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET
+    cleanup_generation = lifecycles.cleanup_generation + 1,
+    cleanup_lease_token = p_claim_token,
+    cleanup_lease_expires_at =
+      claim_time + (p_lease_duration_ms * interval '1 millisecond'),
+    updated_at = claim_time
+  WHERE lifecycles.sha256 = lifecycle.sha256
+  RETURNING lifecycles.* INTO lifecycle;
+
+  INSERT INTO content.media_blob_cleanup_attempts (
+    cleanup_token,
+    sha256,
+    cleanup_generation,
+    lease_token,
+    storage_key,
+    lease_expires_at
+  )
+  VALUES (
+    p_claim_token,
+    lifecycle.sha256,
+    lifecycle.cleanup_generation,
+    p_claim_token,
+    lifecycle.storage_key,
+    lifecycle.cleanup_lease_expires_at
+  )
+  RETURNING * INTO existing_attempt;
+
+  INSERT INTO content.media_blob_cleanup_claims (
+    claim_token,
+    cleanup_token,
+    lease_expires_at
+  )
+  VALUES (
+    p_claim_token,
+    existing_attempt.cleanup_token,
+    existing_attempt.lease_expires_at
+  );
+
+  RETURN QUERY
+  SELECT
+    existing_attempt.cleanup_token,
+    p_claim_token,
+    existing_attempt.sha256,
+    existing_attempt.storage_key,
+    existing_attempt.cleanup_generation,
+    existing_attempt.lease_expires_at,
+    'claimed'::TEXT,
+    existing_attempt.failure_count;
+END;
+$$;
+
+CREATE FUNCTION content.authorize_media_blob_cleanup(
+  p_cleanup_token UUID,
+  p_cleanup_generation BIGINT,
+  p_lease_token UUID
+)
+RETURNS TABLE (
+  storage_key TEXT,
+  authorization_status TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_cleanup_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  decision_time TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_token IS NULL OR p_cleanup_generation IS NULL
+    OR p_lease_token IS NULL
+    OR p_cleanup_generation < 1
+  THEN
+    RAISE EXCEPTION 'Exact cleanup token and positive generation are required'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token;
+  IF NOT FOUND OR attempt.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+  THEN
+    RETURN QUERY SELECT NULL::TEXT, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = attempt.sha256
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT attempt.storage_key, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT NULL::TEXT, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  IF attempt.state = 'completed' THEN
+    RETURN QUERY SELECT attempt.storage_key, 'completed'::TEXT;
+    RETURN;
+  ELSIF attempt.state = 'blocked' THEN
+    RETURN QUERY SELECT attempt.storage_key, 'blocked'::TEXT;
+    RETURN;
+  END IF;
+
+  decision_time := pg_catalog.date_trunc(
+    'milliseconds',
+    pg_catalog.clock_timestamp()
+  );
+  IF attempt.lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.lease_expires_at <= decision_time
+    OR lifecycle.cleanup_lease_token IS DISTINCT FROM p_lease_token
+    OR lifecycle.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+    OR lifecycle.storage_key IS DISTINCT FROM attempt.storage_key
+  THEN
+    RETURN QUERY SELECT attempt.storage_key, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  IF attempt.state IN ('authorized', 'deleting') THEN
+    RETURN QUERY SELECT attempt.storage_key, 'authorized'::TEXT;
+    RETURN;
+  END IF;
+
+  IF content.media_blob_cleanup_blocked_internal(attempt.sha256) THEN
+    UPDATE content.media_blob_cleanup_attempts AS attempts
+    SET state = 'blocked'
+    WHERE attempts.cleanup_token = p_cleanup_token;
+    UPDATE content.media_blob_lifecycles AS lifecycles
+    SET
+      cleanup_lease_token = NULL,
+      cleanup_lease_expires_at = NULL,
+      updated_at = decision_time
+    WHERE lifecycles.sha256 = attempt.sha256
+      AND lifecycles.cleanup_lease_token = p_lease_token
+      AND lifecycles.cleanup_generation = p_cleanup_generation;
+    RETURN QUERY SELECT attempt.storage_key, 'blocked'::TEXT;
+    RETURN;
+  END IF;
+
+  UPDATE content.media_blob_cleanup_attempts AS attempts
+  SET
+    state = 'authorized',
+    authorized_at = COALESCE(attempts.authorized_at, decision_time)
+  WHERE attempts.cleanup_token = p_cleanup_token;
+
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET
+    cleanup_lease_expires_at = 'infinity'::TIMESTAMPTZ,
+    updated_at = decision_time
+  WHERE lifecycles.sha256 = attempt.sha256
+    AND lifecycles.cleanup_lease_token = p_lease_token
+    AND lifecycles.cleanup_generation = p_cleanup_generation;
+
+  RETURN QUERY SELECT attempt.storage_key, 'authorized'::TEXT;
+END;
+$$;
+
+CREATE FUNCTION content.complete_media_blob_cleanup(
+  p_cleanup_token UUID,
+  p_cleanup_generation BIGINT,
+  p_lease_token UUID
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  attempt content.media_blob_cleanup_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  completion_time TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_token IS NULL OR p_cleanup_generation IS NULL
+    OR p_lease_token IS NULL
+    OR p_cleanup_generation < 1
+  THEN
+    RAISE EXCEPTION 'Exact cleanup token and positive generation are required'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token;
+  IF NOT FOUND OR attempt.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = attempt.sha256
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN 'stale';
+  END IF;
+
+  IF attempt.state = 'completed' THEN
+    RETURN 'completed';
+  END IF;
+
+  completion_time := pg_catalog.date_trunc(
+    'milliseconds',
+    pg_catalog.clock_timestamp()
+  );
+  IF attempt.state NOT IN ('authorized', 'deleting')
+    OR attempt.lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.lease_expires_at <= completion_time
+    OR lifecycle.cleanup_lease_token IS DISTINCT FROM p_lease_token
+    OR lifecycle.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+    OR lifecycle.cleanup_lease_expires_at IS DISTINCT FROM
+      'infinity'::TIMESTAMPTZ
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  UPDATE content.media_blob_cleanup_attempts AS attempts
+  SET state = 'completed', completed_at = completion_time
+  WHERE attempts.cleanup_token = p_cleanup_token;
+
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET
+    cleanup_eligible_at = NULL,
+    cleanup_lease_token = NULL,
+    cleanup_lease_expires_at = NULL,
+    updated_at = completion_time
+  WHERE lifecycles.sha256 = attempt.sha256
+    AND lifecycles.cleanup_lease_token = p_lease_token
+    AND lifecycles.cleanup_generation = p_cleanup_generation;
+
+  RETURN 'completed';
+END;
+$$;
+
+CREATE FUNCTION content.renew_media_blob_cleanup_lease(
+  p_cleanup_token UUID,
+  p_cleanup_generation BIGINT,
+  p_lease_token UUID,
+  p_renewal_token UUID,
+  p_phase TEXT,
+  p_expected_lease_expires_at TIMESTAMPTZ,
+  p_lease_duration_ms INTEGER
+)
+RETURNS TABLE (
+  lease_expires_at TIMESTAMPTZ,
+  renewal_status TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  recorded_renewal content.media_blob_cleanup_renewals%ROWTYPE;
+  attempt content.media_blob_cleanup_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  renewal_time TIMESTAMPTZ;
+  renewed_lease_expires_at TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_token IS NULL OR p_cleanup_generation IS NULL
+    OR p_lease_token IS NULL
+    OR p_renewal_token IS NULL
+    OR p_expected_lease_expires_at IS NULL
+    OR p_cleanup_generation < 1
+  THEN
+    RAISE EXCEPTION 'Exact cleanup token and positive generation are required'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_phase NOT IN ('head_object', 'delete_object', 'complete') THEN
+    RAISE EXCEPTION 'p_phase is not a cleanup lease renewal phase'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_lease_duration_ms IS NULL OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000
+  THEN
+    RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'media-blob-cleanup-renewal:' || p_renewal_token::TEXT,
+      0::BIGINT
+    )
+  );
+
+  SELECT renewals.*
+  INTO recorded_renewal
+  FROM content.media_blob_cleanup_renewals AS renewals
+  WHERE renewals.renewal_token = p_renewal_token;
+
+  IF FOUND THEN
+    IF recorded_renewal.cleanup_token IS DISTINCT FROM p_cleanup_token
+      OR recorded_renewal.cleanup_generation IS DISTINCT FROM
+        p_cleanup_generation
+      OR recorded_renewal.lease_token IS DISTINCT FROM p_lease_token
+      OR recorded_renewal.phase IS DISTINCT FROM p_phase
+      OR recorded_renewal.expected_lease_expires_at IS DISTINCT FROM
+        p_expected_lease_expires_at
+      OR recorded_renewal.lease_duration_ms IS DISTINCT FROM
+        p_lease_duration_ms
+    THEN
+      RAISE EXCEPTION
+        'p_renewal_token was reused with different cleanup renewal parameters'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token;
+  IF NOT FOUND OR attempt.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+  THEN
+    RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = attempt.sha256
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  IF attempt.state = 'completed' THEN
+    RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'completed'::TEXT;
+    RETURN;
+  END IF;
+
+  renewal_time := pg_catalog.date_trunc(
+    'milliseconds',
+    pg_catalog.clock_timestamp()
+  );
+  IF attempt.state NOT IN ('authorized', 'deleting')
+    OR attempt.lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.lease_expires_at <= renewal_time
+    OR lifecycle.cleanup_lease_token IS DISTINCT FROM p_lease_token
+    OR lifecycle.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+    OR lifecycle.cleanup_lease_expires_at IS DISTINCT FROM
+      'infinity'::TIMESTAMPTZ
+  THEN
+    RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'stale'::TEXT;
+    RETURN;
+  END IF;
+  IF attempt.state = 'deleting' AND p_phase = 'head_object' THEN
+    RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  IF recorded_renewal.renewal_token IS NOT NULL THEN
+    IF attempt.lease_expires_at IS DISTINCT FROM
+      recorded_renewal.renewed_lease_expires_at
+    THEN
+      RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'stale'::TEXT;
+      RETURN;
+    END IF;
+    RETURN QUERY
+    SELECT recorded_renewal.renewed_lease_expires_at, 'renewed'::TEXT;
+    RETURN;
+  END IF;
+
+  IF attempt.lease_expires_at IS DISTINCT FROM p_expected_lease_expires_at THEN
+    RETURN QUERY SELECT NULL::TIMESTAMPTZ, 'stale'::TEXT;
+    RETURN;
+  END IF;
+
+  renewed_lease_expires_at := GREATEST(
+    renewal_time + (p_lease_duration_ms * interval '1 millisecond'),
+    p_expected_lease_expires_at + interval '1 millisecond'
+  );
+
+  INSERT INTO content.media_blob_cleanup_renewals (
+    renewal_token,
+    cleanup_token,
+    cleanup_generation,
+    lease_token,
+    phase,
+    expected_lease_expires_at,
+    lease_duration_ms,
+    renewed_lease_expires_at
+  )
+  VALUES (
+    p_renewal_token,
+    p_cleanup_token,
+    p_cleanup_generation,
+    p_lease_token,
+    p_phase,
+    p_expected_lease_expires_at,
+    p_lease_duration_ms,
+    renewed_lease_expires_at
+  );
+
+  UPDATE content.media_blob_cleanup_attempts AS attempts
+  SET
+    state = CASE
+      WHEN p_phase = 'delete_object' THEN 'deleting'
+      ELSE attempts.state
+    END,
+    lease_expires_at = renewed_lease_expires_at
+  WHERE attempts.cleanup_token = p_cleanup_token;
+
+  UPDATE content.media_blob_cleanup_claims AS claims
+  SET lease_expires_at = renewed_lease_expires_at
+  WHERE claims.claim_token = p_lease_token
+    AND claims.cleanup_token = p_cleanup_token;
+
+  RETURN QUERY SELECT renewed_lease_expires_at, 'renewed'::TEXT;
+END;
+$$;
+
+CREATE FUNCTION content.record_media_blob_cleanup_failure(
+  p_cleanup_token UUID,
+  p_cleanup_generation BIGINT,
+  p_lease_token UUID,
+  p_failure_token UUID,
+  p_disposition TEXT,
+  p_retry_delay_ms INTEGER,
+  p_phase TEXT,
+  p_error_code TEXT,
+  p_error_class TEXT
+)
+RETURNS TABLE (
+  failure_status TEXT,
+  next_attempt_at TIMESTAMPTZ,
+  failure_count INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  recorded_failure content.media_blob_cleanup_failures%ROWTYPE;
+  attempt content.media_blob_cleanup_attempts%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  failure_time TIMESTAMPTZ;
+  retry_at TIMESTAMPTZ;
+  recorded_failure_count INTEGER;
+BEGIN
+  IF p_cleanup_token IS NULL OR p_cleanup_generation IS NULL
+    OR p_lease_token IS NULL OR p_failure_token IS NULL
+    OR p_cleanup_generation < 1
+  THEN
+    RAISE EXCEPTION 'Exact cleanup, lease, failure token, and positive generation are required'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_disposition NOT IN ('retry', 'terminal') THEN
+    RAISE EXCEPTION 'p_disposition must be retry or terminal'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_phase NOT IN (
+    'authorize',
+    'renew',
+    'head_object',
+    'delete_object',
+    'complete'
+  ) THEN
+    RAISE EXCEPTION 'p_phase is not a cleanup failure phase'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_error_code IS NULL OR p_error_code = ''
+    OR p_error_class IS NULL OR p_error_class = ''
+    OR pg_catalog.length(p_error_code) > 128
+    OR pg_catalog.length(p_error_class) > 128
+  THEN
+    RAISE EXCEPTION 'Cleanup failure code and class must contain at most 128 characters'
+      USING ERRCODE = '22023';
+  END IF;
+  IF (
+      p_disposition = 'retry'
+      AND (
+        p_retry_delay_ms IS NULL
+        OR p_retry_delay_ms NOT BETWEEN 1 AND 3600000
+      )
+    )
+    OR (
+      p_disposition = 'terminal'
+      AND p_retry_delay_ms IS DISTINCT FROM 0
+    )
+  THEN
+    RAISE EXCEPTION 'Retry failures require a bounded delay and terminal failures require zero delay'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'media-blob-cleanup-failure:' || p_failure_token::TEXT,
+      0::BIGINT
+    )
+  );
+
+  SELECT failures.*
+  INTO recorded_failure
+  FROM content.media_blob_cleanup_failures AS failures
+  WHERE failures.failure_token = p_failure_token;
+
+  IF FOUND THEN
+    IF recorded_failure.cleanup_token IS DISTINCT FROM p_cleanup_token
+      OR recorded_failure.cleanup_generation IS DISTINCT FROM
+        p_cleanup_generation
+      OR recorded_failure.lease_token IS DISTINCT FROM p_lease_token
+      OR recorded_failure.disposition IS DISTINCT FROM p_disposition
+      OR recorded_failure.retry_delay_ms IS DISTINCT FROM p_retry_delay_ms
+      OR recorded_failure.phase IS DISTINCT FROM p_phase
+      OR recorded_failure.error_code IS DISTINCT FROM p_error_code
+      OR recorded_failure.error_class IS DISTINCT FROM p_error_class
+    THEN
+      RAISE EXCEPTION 'p_failure_token was reused with different cleanup failure parameters'
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN QUERY
+    SELECT
+      CASE recorded_failure.disposition
+        WHEN 'retry' THEN 'retry_scheduled'
+        ELSE 'reconciliation_required'
+      END,
+      recorded_failure.next_attempt_at,
+      recorded_failure.failure_count;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token;
+  IF NOT FOUND OR attempt.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TIMESTAMPTZ, 0;
+    RETURN;
+  END IF;
+
+  SELECT lifecycles.*
+  INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = attempt.sha256
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TIMESTAMPTZ, attempt.failure_count;
+    RETURN;
+  END IF;
+
+  SELECT attempts.*
+  INTO attempt
+  FROM content.media_blob_cleanup_attempts AS attempts
+  WHERE attempts.cleanup_token = p_cleanup_token
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TIMESTAMPTZ, 0;
+    RETURN;
+  END IF;
+
+  IF attempt.state = 'completed' THEN
+    RETURN QUERY
+    SELECT 'completed'::TEXT, NULL::TIMESTAMPTZ, attempt.failure_count;
+    RETURN;
+  END IF;
+
+  failure_time := pg_catalog.date_trunc(
+    'milliseconds',
+    pg_catalog.clock_timestamp()
+  );
+  IF attempt.state NOT IN ('authorized', 'deleting')
+    OR attempt.lease_token IS DISTINCT FROM p_lease_token
+    OR attempt.lease_expires_at <= failure_time
+    OR lifecycle.cleanup_lease_token IS DISTINCT FROM p_lease_token
+    OR lifecycle.cleanup_generation IS DISTINCT FROM p_cleanup_generation
+    OR lifecycle.cleanup_lease_expires_at IS DISTINCT FROM
+      'infinity'::TIMESTAMPTZ
+  THEN
+    RETURN QUERY
+    SELECT 'stale'::TEXT, NULL::TIMESTAMPTZ, attempt.failure_count;
+    RETURN;
+  END IF;
+
+  IF attempt.state = 'deleting' AND p_disposition = 'retry' THEN
+    RAISE EXCEPTION
+      'A deleting media-blob cleanup attempt cannot return to automatic retry'
+      USING ERRCODE = '23514';
+  END IF;
+
+  recorded_failure_count := attempt.failure_count + 1;
+  retry_at := CASE
+    WHEN p_disposition = 'retry'
+      THEN failure_time + (p_retry_delay_ms * interval '1 millisecond')
+    ELSE NULL
+  END;
+
+  INSERT INTO content.media_blob_cleanup_failures (
+    failure_token,
+    cleanup_token,
+    cleanup_generation,
+    lease_token,
+    disposition,
+    retry_delay_ms,
+    phase,
+    next_attempt_at,
+    failure_count,
+    error_code,
+    error_class,
+    failed_at
+  )
+  VALUES (
+    p_failure_token,
+    p_cleanup_token,
+    p_cleanup_generation,
+    p_lease_token,
+    p_disposition,
+    p_retry_delay_ms,
+    p_phase,
+    retry_at,
+    recorded_failure_count,
+    p_error_code,
+    p_error_class,
+    failure_time
+  );
+
+  UPDATE content.media_blob_cleanup_attempts AS attempts
+  SET
+    state = CASE p_disposition
+      WHEN 'retry' THEN 'retry_wait'
+      ELSE 'reconciliation_required'
+    END,
+    lease_expires_at = failure_time,
+    next_attempt_at = retry_at,
+    failure_count = recorded_failure_count
+  WHERE attempts.cleanup_token = p_cleanup_token;
+
+  RETURN QUERY
+  SELECT
+    CASE p_disposition
+      WHEN 'retry' THEN 'retry_scheduled'
+      ELSE 'reconciliation_required'
+    END,
+    retry_at,
+    recorded_failure_count;
+END;
+$$;
+
+REVOKE ALL ON TABLE content.media_blob_cleanup_attempts
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON TABLE content.media_blob_cleanup_claims
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON TABLE content.media_blob_cleanup_renewals
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON TABLE content.media_blob_cleanup_failures
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.terminalize_media_blob_writers_before_workspace_delete()
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.generated_media_promotion_cleanup_admission_internal()
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.media_blob_cleanup_blocked_internal(TEXT)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.claim_media_blob_cleanup(TEXT, INTEGER)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.claim_next_media_blob_cleanup(UUID, INTEGER)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.authorize_media_blob_cleanup(UUID, BIGINT, UUID)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.complete_media_blob_cleanup(UUID, BIGINT, UUID)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.renew_media_blob_cleanup_lease(
+  UUID,
+  BIGINT,
+  UUID,
+  UUID,
+  TEXT,
+  TIMESTAMPTZ,
+  INTEGER
+)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.record_media_blob_cleanup_failure(
+  UUID,
+  BIGINT,
+  UUID,
+  UUID,
+  TEXT,
+  INTEGER,
+  TEXT,
+  TEXT,
+  TEXT
+)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.claim_next_media_blob_cleanup(UUID, INTEGER)
+TO backend_app;
+GRANT EXECUTE ON FUNCTION content.authorize_media_blob_cleanup(UUID, BIGINT, UUID)
+TO backend_app;
+GRANT EXECUTE ON FUNCTION content.complete_media_blob_cleanup(UUID, BIGINT, UUID)
+TO backend_app;
+GRANT EXECUTE ON FUNCTION content.renew_media_blob_cleanup_lease(
+  UUID,
+  BIGINT,
+  UUID,
+  UUID,
+  TEXT,
+  TIMESTAMPTZ,
+  INTEGER
+)
+TO backend_app;
+GRANT EXECUTE ON FUNCTION content.record_media_blob_cleanup_failure(
+  UUID,
+  BIGINT,
+  UUID,
+  UUID,
+  TEXT,
+  INTEGER,
+  TEXT,
+  TEXT,
+  TEXT
+)
+TO backend_app;

--- a/infra/aws/lib/ci-cd.ts
+++ b/infra/aws/lib/ci-cd.ts
@@ -17,6 +17,7 @@ export interface CiCdProps {
   streakLeaderboardSnapshotFn: lambda.IFunction;
   progressActiveDaysBackfillFn: lambda.IFunction;
   migrationFn: lambda.IFunction;
+  generatedMediaPromotionScheduleArn: string;
   multipartCompletionReconciliationScheduleArn: string;
   userPoolArn: string;
   webBucket: s3.IBucket;
@@ -30,6 +31,16 @@ export function createMultipartCompletionReconciliationScheduleReadStatement(
 ): iam.PolicyStatement {
   return new iam.PolicyStatement({
     sid: "ReadMultipartCompletionReconciliationSchedule",
+    actions: ["scheduler:GetSchedule"],
+    resources: [scheduleArn],
+  });
+}
+
+export function createGeneratedMediaPromotionScheduleReadStatement(
+  scheduleArn: string,
+): iam.PolicyStatement {
+  return new iam.PolicyStatement({
+    sid: "ReadGeneratedMediaPromotionSchedule",
     actions: ["scheduler:GetSchedule"],
     resources: [scheduleArn],
   });
@@ -63,6 +74,9 @@ export function ciCd(scope: Construct, props: CiCdProps): void {
       actions: ["lambda:InvokeFunction"],
       resources: [props.migrationFn.functionArn],
     }),
+    createGeneratedMediaPromotionScheduleReadStatement(
+      props.generatedMediaPromotionScheduleArn,
+    ),
     createMultipartCompletionReconciliationScheduleReadStatement(
       props.multipartCompletionReconciliationScheduleArn,
     ),

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -44,6 +44,7 @@ export interface OutputsProps {
   apexRedirectDistribution: cloudfront.Distribution | undefined;
   apexRedirectCustomDomain: string | undefined;
   mediaAssetsBucket: s3.IBucket;
+  generatedMediaPromotionScheduleName: string;
   multipartCompletionReconciliationScheduleName: string;
   dbAccessInstance?: ec2.Instance;
   analyticsSshUsername?: string;
@@ -144,6 +145,16 @@ export function outputs(scope: Construct, props: OutputsProps): void {
     value: props.migrationFn.functionName,
     description: "Lambda function name for database migrations",
   });
+
+  new cdk.CfnOutput(
+    scope,
+    "GeneratedMediaPromotionScheduleName",
+    {
+      value: props.generatedMediaPromotionScheduleName,
+      description:
+        "EventBridge Scheduler name for generated-media promotion and blob cleanup",
+    },
+  );
 
   new cdk.CfnOutput(
     scope,

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import {
+  createGeneratedMediaPromotionScheduleReadStatement,
+} from "../ci-cd";
+import {
+  generatedMediaPromotionScheduleExpression,
+  generatedMediaPromotionScheduleName,
+} from "./generated-media-promotion";
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("generated-media promotion schedule also runs bounded media-blob cleanup", () => {
+  assert.equal(generatedMediaPromotionScheduleExpression, "rate(1 minute)");
+  assert.equal(
+    generatedMediaPromotionScheduleName,
+    "flashcards-open-source-app-generated-media-promotion",
+  );
+  const handlerSource = readSource(
+    "../../apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts",
+  );
+  assert.match(handlerSource, /mediaBlobCleanupMaximumCandidates = 5/u);
+  assert.match(handlerSource, /mediaBlobCleanupLeaseDurationMs = 60_000/u);
+  assert.match(
+    handlerSource,
+    /generatedMediaPromotionFinalizationReserveMs = 10_000/u,
+  );
+  assert.match(handlerSource, /runMediaBlobCleanupBatch/u);
+  assert.match(handlerSource, /runGeneratedMediaPromotionBatch/u);
+  assert.ok(
+    handlerSource.indexOf("runPromotionFn") <
+      handlerSource.indexOf("runCleanupFn"),
+  );
+  const scheduleSource = readSource(
+    "lib/scheduled-jobs/generated-media-promotion.ts",
+  );
+  assert.match(
+    scheduleSource,
+    /name: generatedMediaPromotionScheduleName/u,
+  );
+  assert.match(
+    scheduleSource,
+    /MEDIA_BLOB_CLEANUP_ENABLED: props\.mediaBlobCleanupEnabled \? "true" : "false"/u,
+  );
+  const stackSource = readSource("lib/stack.ts");
+  assert.match(
+    stackSource,
+    /scheduleState: generatedMediaPromotionScheduleState/u,
+  );
+  assert.match(stackSource, /mediaBlobCleanupEnabled,/u);
+  assert.match(
+    stackSource,
+    /if \(value === undefined\) return false;/u,
+  );
+  assert.match(
+    stackSource,
+    /mediaBlobCleanupEnabled must be true or false/u,
+  );
+});
+
+test("shared worker has exact permanent-prefix access and no public route", () => {
+  const scheduleSource = readSource(
+    "lib/scheduled-jobs/generated-media-promotion.ts",
+  );
+  assert.match(scheduleSource, /actions: \["s3:DeleteObject"\]/u);
+  assert.match(
+    scheduleSource,
+    /Null:\s*\{\s*"s3:if-match": "false"/u,
+  );
+  assert.equal(
+    scheduleSource.match(
+      /arnForObjects\("media\/blobs\/sha256\/\*"\)/gu,
+    )?.length,
+    3,
+  );
+  assert.doesNotMatch(scheduleSource, /arnForObjects\("media\/blobs\/\*"\)/u);
+  assert.match(
+    scheduleSource,
+    /actions: \["s3:GetObject"\],[\s\S]{0,100}media\/uploads\/\*/u,
+  );
+  assert.doesNotMatch(
+    scheduleSource,
+    /actions: \[[^\]]*"s3:DeleteObject"[^\]]*\][\s\S]{0,120}media\/uploads/u,
+  );
+
+  const gatewaySource = readSource("lib/gateways/api-gateway.ts");
+  assert.doesNotMatch(
+    gatewaySource,
+    /media.blob.cleanup|media-blob-cleanup|blob-cleanup/iu,
+  );
+});
+
+test("release disables cleanup until migration 0102 is confirmed", () => {
+  for (const relativePath of [
+    "../../.github/workflows/aws-web-release.yml",
+    "../../scripts/deploy/bootstrap.sh",
+  ]) {
+    const source = readSource(relativePath);
+    const disabled = source.indexOf(
+      "generatedMediaPromotionScheduleState=DISABLED",
+    );
+    const cleanupDisabled = source.indexOf(
+      "mediaBlobCleanupEnabled=false",
+    );
+    const migration = source.indexOf(
+      "--require-migration 0102_media_blob_cleanup_reconciler.sql",
+    );
+    const enabled = source.indexOf(
+      "generatedMediaPromotionScheduleState=ENABLED",
+    );
+    const cleanupEnabled = source.indexOf(
+      "mediaBlobCleanupEnabled=true",
+    );
+    const verification = source.indexOf(
+      "check-multipart-completion-reconciliation-schedule.sh",
+      enabled,
+    );
+    assert.ok(disabled >= 0);
+    assert.ok(cleanupDisabled > disabled);
+    assert.ok(cleanupDisabled < migration);
+    assert.ok(migration > disabled);
+    assert.ok(enabled > migration);
+    assert.ok(cleanupEnabled > enabled);
+    assert.ok(cleanupEnabled < verification);
+    assert.ok(verification > enabled);
+  }
+
+  const outputsSource = readSource("lib/outputs.ts");
+  assert.match(outputsSource, /"GeneratedMediaPromotionScheduleName"/u);
+  const verificationScript = readSource(
+    "../../scripts/checks/check-multipart-completion-reconciliation-schedule.sh",
+  );
+  assert.match(
+    verificationScript,
+    /check_schedule "GeneratedMediaPromotionScheduleName"/u,
+  );
+});
+
+test("release verification can read only the exact generated-media schedule", () => {
+  const scheduleArn =
+    "arn:aws:scheduler:eu-west-1:123456789012:schedule/default/flashcards-open-source-app-generated-media-promotion";
+  assert.deepEqual(
+    createGeneratedMediaPromotionScheduleReadStatement(
+      scheduleArn,
+    ).toStatementJson(),
+    {
+      Action: "scheduler:GetSchedule",
+      Effect: "Allow",
+      Resource: scheduleArn,
+      Sid: "ReadGeneratedMediaPromotionSchedule",
+    },
+  );
+
+  const stackSource = readSource("lib/stack.ts");
+  assert.match(
+    stackSource,
+    /generatedMediaPromotionScheduleArn:[\s\S]*generatedMediaPromotionResult\.promotionScheduleArn/u,
+  );
+  const ciCdSource = readSource("lib/ci-cd.ts");
+  assert.doesNotMatch(
+    ciCdSource,
+    /actions:\s*\[[^\]]*"scheduler:\*"/u,
+  );
+  assert.doesNotMatch(
+    ciCdSource,
+    /resources:\s*\[[^\]]*"\*"[^\]]*\][\s\S]{0,160}scheduler:GetSchedule/u,
+  );
+});

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.ts
@@ -13,9 +13,18 @@ export interface GeneratedMediaPromotionProps {
   vpc: ec2.Vpc; lambdaSg: ec2.SecurityGroup; db: rds.DatabaseInstance;
   backendDbSecret: cdk.aws_secretsmanager.Secret; mediaAssetsBucket: s3.IBucket;
   sentryDsnSecretArn: string; sentryEnvironment: string; sentryRelease: string; sentryTracesSampleRate: string;
+  mediaBlobCleanupEnabled: boolean;
+  scheduleState: GeneratedMediaPromotionScheduleState;
 }
-export interface GeneratedMediaPromotionResult { promotionFunction: lambdaNodejs.NodejsFunction }
+export interface GeneratedMediaPromotionResult {
+  promotionFunction: lambdaNodejs.NodejsFunction;
+  promotionScheduleArn: string;
+  promotionScheduleName: string;
+}
+export type GeneratedMediaPromotionScheduleState = "DISABLED" | "ENABLED";
 export const generatedMediaPromotionScheduleExpression = "rate(1 minute)";
+export const generatedMediaPromotionScheduleName =
+  "flashcards-open-source-app-generated-media-promotion";
 export function generatedMediaPromotion(
   scope: Construct, props: GeneratedMediaPromotionProps): GeneratedMediaPromotionResult {
   const promotionFunction = new lambdaNodejs.NodejsFunction(
@@ -42,6 +51,7 @@ export function generatedMediaPromotion(
         NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
         DB_SECRET_ARN: props.backendDbSecret.secretArn, DB_HOST: props.db.dbInstanceEndpointAddress,
         DB_NAME: "flashcards", MEDIA_ASSETS_S3_BUCKET_NAME: props.mediaAssetsBucket.bucketName,
+        MEDIA_BLOB_CLEANUP_ENABLED: props.mediaBlobCleanupEnabled ? "true" : "false",
         SENTRY_ENVIRONMENT: props.sentryEnvironment, SENTRY_RELEASE: props.sentryRelease,
         SENTRY_TRACES_SAMPLE_RATE: props.sentryTracesSampleRate,
       },
@@ -54,12 +64,24 @@ export function generatedMediaPromotion(
   promotionFunction.addEnvironment("SENTRY_DSN", sentryDsnSecret.secretValue.unsafeUnwrap());
   promotionFunction.addToRolePolicy(new iam.PolicyStatement({
     actions: ["s3:GetObject"],
-    resources: [props.mediaAssetsBucket.arnForObjects("media/uploads/*"),
-      props.mediaAssetsBucket.arnForObjects("media/blobs/*")],
+    resources: [props.mediaAssetsBucket.arnForObjects("media/uploads/*")],
+  }));
+  promotionFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:GetObject"],
+    resources: [props.mediaAssetsBucket.arnForObjects("media/blobs/sha256/*")],
   }));
   promotionFunction.addToRolePolicy(new iam.PolicyStatement({
     actions: ["s3:PutObject"],
-    resources: [props.mediaAssetsBucket.arnForObjects("media/blobs/*")],
+    resources: [props.mediaAssetsBucket.arnForObjects("media/blobs/sha256/*")],
+  }));
+  promotionFunction.addToRolePolicy(new iam.PolicyStatement({
+    actions: ["s3:DeleteObject"],
+    resources: [props.mediaAssetsBucket.arnForObjects("media/blobs/sha256/*")],
+    conditions: {
+      Null: {
+        "s3:if-match": "false",
+      },
+    },
   }));
   const schedulerRole = new iam.Role(scope, "GeneratedMediaPromotionSchedulerRole",
     { assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com") });
@@ -67,13 +89,23 @@ export function generatedMediaPromotion(
     actions: ["lambda:InvokeFunction"],
     resources: [promotionFunction.functionArn],
   }));
-  new scheduler.CfnSchedule(scope, "GeneratedMediaPromotionSchedule", {
-    description: "Reconcile durable generated-media promotion jobs", flexibleTimeWindow: { mode: "OFF" },
-    scheduleExpression: generatedMediaPromotionScheduleExpression,
-    scheduleExpressionTimezone: "UTC",
-    state: "ENABLED", target: {
-      arn: promotionFunction.functionArn, input: "{}", roleArn: schedulerRole.roleArn,
+  const promotionSchedule = new scheduler.CfnSchedule(
+    scope,
+    "GeneratedMediaPromotionSchedule",
+    {
+      description: "Reconcile generated-media promotions and orphaned permanent blobs",
+      flexibleTimeWindow: { mode: "OFF" },
+      name: generatedMediaPromotionScheduleName,
+      scheduleExpression: generatedMediaPromotionScheduleExpression,
+      scheduleExpressionTimezone: "UTC",
+      state: props.scheduleState, target: {
+        arn: promotionFunction.functionArn, input: "{}", roleArn: schedulerRole.roleArn,
+      },
     },
-  });
-  return { promotionFunction };
+  );
+  return {
+    promotionFunction,
+    promotionScheduleArn: promotionSchedule.attrArn,
+    promotionScheduleName: generatedMediaPromotionScheduleName,
+  };
 }

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0101_multipart_foreground_completion_fencing.sql",
+    "--require-migration 0102_media_blob_cleanup_reconciler.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -221,7 +221,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
   assert.ok(scheduleVerification > enabledDeploy);
   assert.match(
     workflow,
-    /name: Verify reconciliation schedule is enabled/,
+    /name: Verify cleanup-capable reconciliation schedules are enabled/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");
@@ -234,10 +234,10 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
   );
   assert.match(
     verificationScript,
-    /OutputKey=='MultipartCompletionReconciliationScheduleName'/,
+    /check_schedule "MultipartCompletionReconciliationScheduleName"/,
   );
   assert.match(verificationScript, /aws scheduler get-schedule/);
-  assert.match(verificationScript, /SCHEDULE_STATE" != "ENABLED"/);
+  assert.match(verificationScript, /schedule_state" != "ENABLED"/);
 
   const bootstrapScript = readLibSource(
     "../../scripts/deploy/bootstrap.sh",
@@ -246,7 +246,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0101_multipart_foreground_completion_fencing.sql",
+    "--require-migration 0102_media_blob_cleanup_reconciler.sql",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -19,7 +19,10 @@ import { globalMetrics } from "./scheduled-jobs/global-metrics";
 import { communityLeaderboard } from "./scheduled-jobs/community-leaderboard";
 import { streakLeaderboard } from "./scheduled-jobs/streak-leaderboard";
 import { progressActiveDaysBackfill } from "./scheduled-jobs/progress-active-days-backfill";
-import { generatedMediaPromotion } from "./scheduled-jobs/generated-media-promotion";
+import {
+  generatedMediaPromotion,
+  type GeneratedMediaPromotionScheduleState,
+} from "./scheduled-jobs/generated-media-promotion";
 import {
   multipartCompletionReconciliation,
   type MultipartCompletionReconciliationScheduleState,
@@ -45,13 +48,11 @@ function getOptionalRawContextValue(stack: cdk.Stack, key: string): string | und
   return value;
 }
 
-function getMultipartCompletionReconciliationScheduleState(
+function getScheduledJobState(
   stack: cdk.Stack,
-): MultipartCompletionReconciliationScheduleState {
-  const value = getOptionalContextValue(
-    stack,
-    "multipartCompletionReconciliationScheduleState",
-  );
+  contextKey: string,
+): "DISABLED" | "ENABLED" {
+  const value = getOptionalContextValue(stack, contextKey);
   if (value === undefined) {
     return "DISABLED";
   }
@@ -59,8 +60,16 @@ function getMultipartCompletionReconciliationScheduleState(
     return value;
   }
   throw new Error(
-    "multipartCompletionReconciliationScheduleState must be DISABLED or ENABLED",
+    `${contextKey} must be DISABLED or ENABLED`,
   );
+}
+
+function getMediaBlobCleanupEnabled(stack: cdk.Stack): boolean {
+  const value = stack.node.tryGetContext("mediaBlobCleanupEnabled");
+  if (value === undefined) return false;
+  if (value === true || value === "true") return true;
+  if (value === false || value === "false") return false;
+  throw new Error("mediaBlobCleanupEnabled must be true or false");
 }
 
 interface BackendSentryContext {
@@ -179,8 +188,17 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     // When disabled, no client can fetch global stats from that endpoint.
     const rawGlobalMetricsVisible = getOptionalRawContextValue(this, "globalMetricsVisible");
     const globalMetricsVisible = rawGlobalMetricsVisible === "true";
-    const multipartCompletionReconciliationScheduleState =
-      getMultipartCompletionReconciliationScheduleState(this);
+    const generatedMediaPromotionScheduleState:
+      GeneratedMediaPromotionScheduleState = getScheduledJobState(
+        this,
+        "generatedMediaPromotionScheduleState",
+      );
+    const mediaBlobCleanupEnabled = getMediaBlobCleanupEnabled(this);
+    const multipartCompletionReconciliationScheduleState:
+      MultipartCompletionReconciliationScheduleState = getScheduledJobState(
+        this,
+        "multipartCompletionReconciliationScheduleState",
+      );
     const analyticsAccessRequested =
       analyticsSshPublicKeysValue !== undefined ||
       analyticsSshAllowedCidrsValue !== undefined ||
@@ -226,6 +244,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       db: dbResult.db,
       backendDbSecret: dbResult.backendDbSecret,
       mediaAssetsBucket: mediaAssetsResult.bucket,
+      mediaBlobCleanupEnabled,
+      scheduleState: generatedMediaPromotionScheduleState,
       ...sentryContext,
     });
     const multipartCompletionReconciliationResult =
@@ -380,6 +400,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       streakLeaderboardSnapshotFn: streakLeaderboardResult.snapshotFunction,
       progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
       migrationFn,
+      generatedMediaPromotionScheduleArn:
+        generatedMediaPromotionResult.promotionScheduleArn,
       multipartCompletionReconciliationScheduleArn:
         multipartCompletionReconciliationResult.reconciliationScheduleArn,
       userPoolArn: authResult.userPool.userPoolArn,
@@ -425,6 +447,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       apexRedirectDistribution: web.apexRedirectDistribution,
       apexRedirectCustomDomain: web.apexRedirectCustomDomain,
       mediaAssetsBucket: mediaAssetsResult.bucket,
+      generatedMediaPromotionScheduleName:
+        generatedMediaPromotionResult.promotionScheduleName,
       multipartCompletionReconciliationScheduleName:
         multipartCompletionReconciliationResult.reconciliationScheduleName,
       dbAccessInstance: analyticsAccessResult?.dbAccessInstance,

--- a/scripts/checks/check-multipart-completion-reconciliation-schedule.sh
+++ b/scripts/checks/check-multipart-completion-reconciliation-schedule.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify that the deployed multipart completion reconciliation schedule is enabled.
+# Verify that both cleanup-capable reconciliation schedules are enabled.
 
 set -euo pipefail
 
@@ -19,26 +19,35 @@ if [[ -z "$REGION" ]]; then
   exit 1
 fi
 
-SCHEDULE_NAME="$(aws cloudformation describe-stacks \
-  --stack-name "$STACK_NAME" \
-  --region "$REGION" \
-  --query "Stacks[0].Outputs[?OutputKey=='MultipartCompletionReconciliationScheduleName'].OutputValue" \
-  --output text)"
+check_schedule() {
+  local output_key="$1"
+  local schedule_name
+  local schedule_state
 
-if [[ -z "$SCHEDULE_NAME" || "$SCHEDULE_NAME" == "None" ]]; then
-  echo "ERROR: MultipartCompletionReconciliationScheduleName output not found." >&2
-  exit 1
-fi
+  schedule_name="$(aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='${output_key}'].OutputValue" \
+    --output text)"
 
-SCHEDULE_STATE="$(aws scheduler get-schedule \
-  --name "$SCHEDULE_NAME" \
-  --region "$REGION" \
-  --query State \
-  --output text)"
+  if [[ -z "$schedule_name" || "$schedule_name" == "None" ]]; then
+    echo "ERROR: ${output_key} output not found." >&2
+    exit 1
+  fi
 
-if [[ "$SCHEDULE_STATE" != "ENABLED" ]]; then
-  echo "ERROR: Schedule ${SCHEDULE_NAME} is ${SCHEDULE_STATE}; expected ENABLED." >&2
-  exit 1
-fi
+  schedule_state="$(aws scheduler get-schedule \
+    --name "$schedule_name" \
+    --region "$REGION" \
+    --query State \
+    --output text)"
 
-echo "Multipart completion reconciliation schedule is enabled: ${SCHEDULE_NAME}"
+  if [[ "$schedule_state" != "ENABLED" ]]; then
+    echo "ERROR: Schedule ${schedule_name} is ${schedule_state}; expected ENABLED." >&2
+    exit 1
+  fi
+
+  echo "Reconciliation schedule is enabled: ${schedule_name}"
+}
+
+check_schedule "GeneratedMediaPromotionScheduleName"
+check_schedule "MultipartCompletionReconciliationScheduleName"

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -143,18 +143,22 @@ npx cdk bootstrap --region "$REGION"
 
 echo "=== CDK deploy with reconciliation schedule disabled ==="
 npx cdk deploy --all --require-approval never \
+  -c generatedMediaPromotionScheduleState=DISABLED \
+  -c mediaBlobCleanupEnabled=false \
   -c multipartCompletionReconciliationScheduleState=DISABLED
 
 echo "=== Run database migrations ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0101_multipart_foreground_completion_fencing.sql
+  --require-migration 0102_media_blob_cleanup_reconciler.sql
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \
+  -c generatedMediaPromotionScheduleState=ENABLED \
+  -c mediaBlobCleanupEnabled=true \
   -c multipartCompletionReconciliationScheduleState=ENABLED
 
-echo "=== Verify reconciliation schedule ==="
+echo "=== Verify cleanup-capable reconciliation schedules ==="
 bash "${ROOT_DIR}/scripts/checks/check-multipart-completion-reconciliation-schedule.sh" \
   --stack-name "$STACK_NAME" \
   --region "$REGION"


### PR DESCRIPTION
## Summary
- add a bounded, lease/generation-fenced permanent media-blob cleanup reconciler
- integrate cleanup after generated-media promotion with safe rollout gating and least-privilege S3 access
- add PostgreSQL, storage, processor, scheduled-handler, and static infrastructure evidence

## Validation
- focused processor/storage/handler: 25/25
- PostgreSQL 18 lifecycle integration: 65/65
- full backend: 1,021/1,021
- backend lint/typecheck/build
- static infrastructure: 49/49; infra TypeScript --noEmit
- shell, YAML, IAM, migration, scope, no-public-route, and diff audits