### PR TITLE
Add initiating auth migration gate

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -411,7 +411,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0102_media_blob_cleanup_reconciler.sql
+            --require-migration 0103_ai_chat_initiating_auth_classification.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -85,6 +85,13 @@ const createdRolesByMigration = new Map([
 ]);
 const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0103_ai_chat_initiating_auth_classification.sql",
+    expectedMigrationCount: 105,
+    testFiles: Object.freeze([
+      "src/database/aiChatInitiatingAuthClassification.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0102_media_blob_cleanup_reconciler.sql",
     expectedMigrationCount: 104,
     testFiles: Object.freeze([
@@ -2249,6 +2256,83 @@ async function seedMigration0099LegacyInvalidMediaAsset(client) {
   );
 }
 
+async function seedMigration0103LegacyChatRun(client) {
+  const userId = "migration-0103-legacy-chat-user";
+  const workspaceId = "10300000-0000-4000-8000-000000000001";
+  const replicaId = "10300000-0000-4000-8000-000000000002";
+  const sessionId = "10300000-0000-4000-8000-000000000003";
+  const assistantItemId = "10300000-0000-4000-8000-000000000004";
+  const runId = "10300000-0000-4000-8000-000000000005";
+  const timestamp = "2026-07-30T00:00:00.000Z";
+
+  await client.query(
+    "INSERT INTO org.user_settings (user_id) VALUES ($1)",
+    [userId],
+  );
+  await client.query(
+    `INSERT INTO org.workspaces (
+       workspace_id, name, fsrs_client_updated_at,
+       fsrs_last_modified_by_replica_id, fsrs_last_operation_id
+     ) VALUES ($1, $2, $3, $4, $5)`,
+    [
+      workspaceId,
+      "Migration 0103 legacy chat run",
+      timestamp,
+      replicaId,
+      "migration-0103-legacy-workspace",
+    ],
+  );
+  await client.query(
+    `INSERT INTO org.workspace_memberships (
+       workspace_id, user_id, role
+     ) VALUES ($1, $2, 'owner')`,
+    [workspaceId, userId],
+  );
+  await client.query(
+    `INSERT INTO sync.workspace_replicas (
+       replica_id, workspace_id, user_id, actor_kind, installation_id,
+       actor_key, platform, app_version
+     ) VALUES ($1, $2, $3, 'ai_chat', NULL, $4, 'system', $5)`,
+    [
+      replicaId,
+      workspaceId,
+      userId,
+      "migration-0103-legacy-replica",
+      "postgres-integration",
+    ],
+  );
+  await client.query(
+    `INSERT INTO ai.chat_sessions (
+       session_id, user_id, workspace_id, status, active_run_id
+     ) VALUES ($1, $2, $3, 'running', $4)`,
+    [sessionId, userId, workspaceId, runId],
+  );
+  await client.query(
+    `INSERT INTO ai.chat_items (
+       item_id, session_id, item_kind, state, payload
+     ) VALUES (
+       $1, $2, 'message', 'in_progress',
+       '{"role":"assistant","content":[]}'::jsonb
+     )`,
+    [assistantItemId, sessionId],
+  );
+  await client.query(
+    `INSERT INTO ai.chat_runs (
+       run_id, session_id, assistant_item_id, status, request_id, model_id,
+       reasoning_effort, timezone, turn_input
+     ) VALUES (
+       $1, $2, $3, 'queued', $4, 'gpt-5.4', 'medium', 'Europe/Madrid',
+       '[]'::jsonb
+     )`,
+    [
+      runId,
+      sessionId,
+      assistantItemId,
+      "migration-0103-legacy-request",
+    ],
+  );
+}
+
 async function createExpectedMigrationRoles(
   client,
   fileName,
@@ -2385,6 +2469,16 @@ async function applySingleMigration(
           await client.query("BEGIN");
           transactionStarted = true;
           await seedMigration0099LegacyInvalidMediaAsset(client);
+          await client.query("COMMIT");
+          transactionStarted = false;
+        }
+        if (
+          fileName
+          === "0103_ai_chat_initiating_auth_classification.sql"
+        ) {
+          await client.query("BEGIN");
+          transactionStarted = true;
+          await seedMigration0103LegacyChatRun(client);
           await client.query("COMMIT");
           transactionStarted = false;
         }

--- a/apps/backend/src/database/aiChatInitiatingAuthClassification.postgres.integration.ts
+++ b/apps/backend/src/database/aiChatInitiatingAuthClassification.postgres.integration.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import pg from "pg";
+
+const legacyUserId = "migration-0103-legacy-chat-user";
+const legacyWorkspaceId = "10300000-0000-4000-8000-000000000001";
+const legacyRunId = "10300000-0000-4000-8000-000000000005";
+
+type ColumnContractRow = Readonly<{
+  data_type: string;
+  is_not_null: boolean;
+  column_default: string | null;
+  comment: string | null;
+  backend_can_select: boolean;
+  backend_can_insert: boolean;
+  auth_can_select: boolean;
+  reporting_can_select: boolean;
+}>;
+
+type ClassificationRow = Readonly<{
+  initiating_auth_is_signed_in: boolean;
+}>;
+
+type RuntimeRunFixture = Readonly<{
+  assistantItemId: string;
+  requestId: string;
+  runId: string;
+  sessionId: string;
+}>;
+
+function requireDatabaseUrl(
+  environmentVariable: "DATABASE_URL" | "TEST_DATABASE_ADMIN_URL",
+): string {
+  const databaseUrl = process.env[environmentVariable]?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error(
+      `${environmentVariable} is required for the initiating-auth migration integration test.`,
+    );
+  }
+  return databaseUrl;
+}
+
+function hasPostgresCode(error: unknown, code: string): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === code;
+}
+
+function createRuntimeRunFixture(): RuntimeRunFixture {
+  const runId = randomUUID();
+  return {
+    assistantItemId: randomUUID(),
+    requestId: `migration-0103-runtime-${runId}`,
+    runId,
+    sessionId: randomUUID(),
+  };
+}
+
+async function insertRuntimeRunScaffolding(
+  client: pg.PoolClient,
+  fixture: RuntimeRunFixture,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO ai.chat_sessions (
+       session_id, user_id, workspace_id, status, active_run_id
+     ) VALUES ($1, $2, $3, 'running', $4)`,
+    [
+      fixture.sessionId,
+      legacyUserId,
+      legacyWorkspaceId,
+      fixture.runId,
+    ],
+  );
+  await client.query(
+    `INSERT INTO ai.chat_items (
+       item_id, session_id, item_kind, state, payload
+     ) VALUES (
+       $1, $2, 'message', 'in_progress',
+       '{"role":"assistant","content":[]}'::jsonb
+     )`,
+    [
+      fixture.assistantItemId,
+      fixture.sessionId,
+    ],
+  );
+}
+
+async function insertRuntimeRunWithClassification(
+  client: pg.PoolClient,
+  initiatingAuthIsSignedIn: boolean | null,
+): Promise<boolean> {
+  const fixture = createRuntimeRunFixture();
+  await insertRuntimeRunScaffolding(client, fixture);
+  const result = await client.query<ClassificationRow>(
+    `INSERT INTO ai.chat_runs (
+       run_id, session_id, assistant_item_id, status, request_id, model_id,
+       reasoning_effort, timezone, turn_input,
+       initiating_auth_is_signed_in
+     ) VALUES (
+       $1, $2, $3, 'queued', $4, 'gpt-5.4', 'medium', 'Europe/Madrid',
+       '[]'::jsonb, $5
+     )
+     RETURNING initiating_auth_is_signed_in`,
+    [
+      fixture.runId,
+      fixture.sessionId,
+      fixture.assistantItemId,
+      fixture.requestId,
+      initiatingAuthIsSignedIn,
+    ],
+  );
+  const classification = result.rows[0]?.initiating_auth_is_signed_in;
+  if (classification === undefined) {
+    throw new Error(
+      `Inserted chat run returned no auth classification. runId=${fixture.runId}`,
+    );
+  }
+  return classification;
+}
+
+async function insertRuntimeRunWithDefaultClassification(
+  client: pg.PoolClient,
+): Promise<boolean> {
+  const fixture = createRuntimeRunFixture();
+  await insertRuntimeRunScaffolding(client, fixture);
+  const result = await client.query<ClassificationRow>(
+    `INSERT INTO ai.chat_runs (
+       run_id, session_id, assistant_item_id, status, request_id, model_id,
+       reasoning_effort, timezone, turn_input
+     ) VALUES (
+       $1, $2, $3, 'queued', $4, 'gpt-5.4', 'medium', 'Europe/Madrid',
+       '[]'::jsonb
+     )
+     RETURNING initiating_auth_is_signed_in`,
+    [
+      fixture.runId,
+      fixture.sessionId,
+      fixture.assistantItemId,
+      fixture.requestId,
+    ],
+  );
+  const classification = result.rows[0]?.initiating_auth_is_signed_in;
+  if (classification === undefined) {
+    throw new Error(
+      `Inserted chat run returned no default auth classification. runId=${fixture.runId}`,
+    );
+  }
+  return classification;
+}
+
+test("migration 0103 adds the initiating-auth classification at the SQL boundary", async () => {
+  const ownerPool = new pg.Pool({
+    connectionString: requireDatabaseUrl("TEST_DATABASE_ADMIN_URL"),
+    application_name: "initiating-auth-migration-owner",
+  });
+  const runtimePool = new pg.Pool({
+    connectionString: requireDatabaseUrl("DATABASE_URL"),
+    application_name: "initiating-auth-migration-runtime",
+  });
+
+  try {
+    const contract = await ownerPool.query<ColumnContractRow>(`
+      SELECT
+        pg_catalog.format_type(attributes.atttypid, attributes.atttypmod)
+          AS data_type,
+        attributes.attnotnull AS is_not_null,
+        pg_catalog.pg_get_expr(defaults.adbin, defaults.adrelid)
+          AS column_default,
+        pg_catalog.col_description(
+          attributes.attrelid,
+          attributes.attnum
+        ) AS comment,
+        pg_catalog.has_column_privilege(
+          'backend_app',
+          'ai.chat_runs',
+          'initiating_auth_is_signed_in',
+          'SELECT'
+        ) AS backend_can_select,
+        pg_catalog.has_column_privilege(
+          'backend_app',
+          'ai.chat_runs',
+          'initiating_auth_is_signed_in',
+          'INSERT'
+        ) AS backend_can_insert,
+        pg_catalog.has_column_privilege(
+          'auth_app',
+          'ai.chat_runs',
+          'initiating_auth_is_signed_in',
+          'SELECT'
+        ) AS auth_can_select,
+        pg_catalog.has_column_privilege(
+          'reporting_readonly',
+          'ai.chat_runs',
+          'initiating_auth_is_signed_in',
+          'SELECT'
+        ) AS reporting_can_select
+      FROM pg_catalog.pg_attribute AS attributes
+      LEFT JOIN pg_catalog.pg_attrdef AS defaults
+        ON defaults.adrelid = attributes.attrelid
+       AND defaults.adnum = attributes.attnum
+      WHERE attributes.attrelid = 'ai.chat_runs'::pg_catalog.regclass
+        AND attributes.attname = 'initiating_auth_is_signed_in'
+        AND NOT attributes.attisdropped
+    `);
+    assert.deepEqual(contract.rows, [{
+      data_type: "boolean",
+      is_not_null: true,
+      column_default: "false",
+      comment:
+        "Immutable classification of the transport that initiated the run. Existing rows default to guest-ineligible.",
+      backend_can_select: true,
+      backend_can_insert: true,
+      auth_can_select: false,
+      reporting_can_select: false,
+    }]);
+
+    const ownerLegacyRow = await ownerPool.query<ClassificationRow>(
+      `SELECT initiating_auth_is_signed_in
+       FROM ai.chat_runs
+       WHERE run_id = $1`,
+      [legacyRunId],
+    );
+    assert.deepEqual(ownerLegacyRow.rows, [{
+      initiating_auth_is_signed_in: false,
+    }]);
+
+    const runtimeClient = await runtimePool.connect();
+    try {
+      await runtimeClient.query("BEGIN");
+      await runtimeClient.query(
+        `SELECT
+           set_config('app.user_id', $1, true),
+           set_config('app.workspace_id', $2, true)`,
+        [legacyUserId, legacyWorkspaceId],
+      );
+      const runtimeLegacyRow = await runtimeClient.query<ClassificationRow>(
+        `SELECT initiating_auth_is_signed_in
+         FROM ai.chat_runs
+         WHERE run_id = $1`,
+        [legacyRunId],
+      );
+      assert.deepEqual(runtimeLegacyRow.rows, [{
+        initiating_auth_is_signed_in: false,
+      }]);
+      assert.equal(
+        await insertRuntimeRunWithClassification(runtimeClient, true),
+        true,
+      );
+      assert.equal(
+        await insertRuntimeRunWithDefaultClassification(runtimeClient),
+        false,
+      );
+
+      await runtimeClient.query("SAVEPOINT null_classification_probe");
+      try {
+        await insertRuntimeRunWithClassification(runtimeClient, null);
+        assert.fail("Expected a null initiating-auth classification to be rejected.");
+      } catch (error) {
+        assert.ok(
+          hasPostgresCode(error, "23502"),
+          `Expected PostgreSQL not-null violation 23502. error=${String(error)}`,
+        );
+      }
+      await runtimeClient.query("ROLLBACK TO SAVEPOINT null_classification_probe");
+      await runtimeClient.query("ROLLBACK");
+    } finally {
+      runtimeClient.release();
+    }
+  } finally {
+    await Promise.all([runtimePool.end(), ownerPool.end()]);
+  }
+});

--- a/db/migrations/0103_ai_chat_initiating_auth_classification.sql
+++ b/db/migrations/0103_ai_chat_initiating_auth_classification.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ai.chat_runs
+  ADD COLUMN initiating_auth_is_signed_in BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN ai.chat_runs.initiating_auth_is_signed_in IS
+  'Immutable classification of the transport that initiated the run. Existing rows default to guest-ineligible.';

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -94,7 +94,7 @@ test("shared worker has exact permanent-prefix access and no public route", () =
   );
 });
 
-test("release disables cleanup until migration 0102 is confirmed", () => {
+test("release disables cleanup until migration 0103 is confirmed", () => {
   for (const relativePath of [
     "../../.github/workflows/aws-web-release.yml",
     "../../scripts/deploy/bootstrap.sh",
@@ -107,7 +107,7 @@ test("release disables cleanup until migration 0102 is confirmed", () => {
       "mediaBlobCleanupEnabled=false",
     );
     const migration = source.indexOf(
-      "--require-migration 0102_media_blob_cleanup_reconciler.sql",
+      "--require-migration 0103_ai_chat_initiating_auth_classification.sql",
     );
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0102_media_blob_cleanup_reconciler.sql",
+    "--require-migration 0103_ai_chat_initiating_auth_classification.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -246,7 +246,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0102_media_blob_cleanup_reconciler.sql",
+    "--require-migration 0103_ai_chat_initiating_auth_classification.sql",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -150,7 +150,7 @@ npx cdk deploy --all --require-approval never \
 echo "=== Run database migrations ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0102_media_blob_cleanup_reconciler.sql
+  --require-migration 0103_ai_chat_initiating_auth_classification.sql
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \


### PR DESCRIPTION
## Summary

- add migration 0103 for the immutable initiating-auth classification
- validate legacy/default/non-null/RLS/runtime-role behavior at a SQL-only PostgreSQL boundary
- advance AWS/bootstrap migration gates while preserving the existing two-pass schedule rollout

## Validation

- PostgreSQL 18 lifecycle: 66/66 through migration 0103
- backend: 1021/1021 tests; lint, typecheck, and build passed
- infra: TypeScript build and 49/49 tests passed without synth
- shell syntax, workflow YAML parsing, migration/order audits, runtime-reader exclusion, and git diff check passed
- fresh review: no P0-P4 findings and green light for commit