### PR TITLE
Ignore expected managed media cancellations

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/Media/ReviewManagedMediaStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Media/ReviewManagedMediaStoreSupport.swift
@@ -117,10 +117,14 @@ extension FlashcardsStore {
                 unavailableReason: nil
             )
         } catch {
-            self.captureReviewManagedMediaLoadFailure(
-                error: error,
-                stage: "cache_download"
-            )
+            let isExpectedCancellation: Bool =
+                Task.isCancelled && isRequestCancellationError(error: error)
+            if isExpectedCancellation == false {
+                self.captureReviewManagedMediaLoadFailure(
+                    error: error,
+                    stage: "cache_download"
+                )
+            }
             return ReviewManagedMediaLoadResult(
                 mediaAsset: localMediaAsset,
                 mediaURL: nil,


### PR DESCRIPTION
## Summary
- suppress managed-media cancellation reporting only when the surrounding Swift task is cancelled
- keep reporting unexpected URLSession cancellations and all other download failures
- preserve the existing managed-media load result contract

## Validation
- git diff --check
- independent read-only review: no P0-P4 findings
- iOS build attempted but stopped before source compilation because Sentry XCFramework extraction failed with no space left on device