### PR TITLE
Retry API response body failures

### DIFF
--- a/apps/web/src/api/transport/errors.ts
+++ b/apps/web/src/api/transport/errors.ts
@@ -31,32 +31,84 @@ export class ApiError extends Error {
 }
 
 type ApiNetworkErrorParams = Readonly<{
+  statusCode: number;
+  requestId: string | null;
+  responseBodyKind: ApiResponseBodyKind;
   endpoint: string;
   originalErrorName: string;
   originalErrorMessage: string;
   attemptCount: number;
+  source: "fetch" | "response_body";
+}>;
+
+type ApiNetworkErrorCauseParams = Omit<
+  ApiNetworkErrorParams,
+  "originalErrorName" | "originalErrorMessage"
+> & Readonly<{
+  error: unknown;
 }>;
 
 export class ApiNetworkError extends ApiError {
   readonly originalErrorName: string;
   readonly originalErrorMessage: string;
   readonly attemptCount: number;
+  readonly source: ApiNetworkErrorParams["source"];
 
   constructor(params: ApiNetworkErrorParams) {
     super({
-      statusCode: 0,
+      statusCode: params.statusCode,
       message: `The API is unavailable. Try again. (${params.endpoint}; ${params.originalErrorName}: ${params.originalErrorMessage})`,
       code: apiNetworkErrorCode,
-      requestId: null,
+      requestId: params.requestId,
       retryAfterMs: null,
       endpoint: params.endpoint,
-      responseBodyKind: "empty",
+      responseBodyKind: params.responseBodyKind,
     });
     this.name = "ApiNetworkError";
     this.originalErrorName = params.originalErrorName;
     this.originalErrorMessage = params.originalErrorMessage;
     this.attemptCount = params.attemptCount;
+    this.source = params.source;
   }
+}
+
+function readOriginalErrorName(error: unknown): string {
+  if (error instanceof Error && error.name.trim() !== "") {
+    return error.name;
+  }
+
+  return typeof error;
+}
+
+function readOriginalErrorMessage(
+  error: unknown,
+  source: ApiNetworkErrorParams["source"],
+): string {
+  if (error instanceof Error && error.message.trim() !== "") {
+    return error.message;
+  }
+
+  const errorMessage = String(error);
+  if (errorMessage.trim() !== "") {
+    return errorMessage;
+  }
+
+  return source === "fetch"
+    ? "Unknown fetch failure"
+    : "Unknown response body read failure";
+}
+
+export function createApiNetworkError(params: ApiNetworkErrorCauseParams): ApiNetworkError {
+  return new ApiNetworkError({
+    statusCode: params.statusCode,
+    requestId: params.requestId,
+    responseBodyKind: params.responseBodyKind,
+    endpoint: params.endpoint,
+    originalErrorName: readOriginalErrorName(params.error),
+    originalErrorMessage: readOriginalErrorMessage(params.error, params.source),
+    attemptCount: params.attemptCount,
+    source: params.source,
+  });
 }
 
 export class AuthRedirectError extends Error {

--- a/apps/web/src/api/transport/response.ts
+++ b/apps/web/src/api/transport/response.ts
@@ -2,7 +2,12 @@ import {
   ApiContractError,
   enrichApiContractError,
 } from "../../apiContracts/core";
-import { ApiError, type ApiResponseBodyKind } from "./errors";
+import {
+  ApiError,
+  ApiNetworkError,
+  createApiNetworkError,
+  type ApiResponseBodyKind,
+} from "./errors";
 
 type JsonObject = Readonly<{
   readonly [key: string]: unknown;
@@ -21,6 +26,11 @@ export type ParsedResponsePayload = Readonly<{
 }>;
 
 export type ContractResponseParser<ParsedValue> = (value: unknown, endpoint: string) => ParsedValue;
+
+export type ResponseBodyReadErrorContext = Readonly<{
+  attemptCount: number;
+  endpoint: string;
+}>;
 
 function isJsonObject(value: unknown): value is JsonObject {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -70,6 +80,22 @@ function getHeaderRequestId(response: Response): string | null {
     ?? response.headers.get("X-Amzn-RequestId")
     ?? response.headers.get("X-Amz-Apigw-Id");
   return requestId === null || requestId.trim() === "" ? null : requestId;
+}
+
+function createResponseBodyNetworkError(
+  response: Response,
+  error: unknown,
+  context: ResponseBodyReadErrorContext,
+): ApiNetworkError {
+  return createApiNetworkError({
+    statusCode: response.status,
+    requestId: getHeaderRequestId(response),
+    responseBodyKind: "empty",
+    endpoint: context.endpoint,
+    error,
+    attemptCount: context.attemptCount,
+    source: "response_body",
+  });
 }
 
 function getRetryAfterMs(response: Response): number | null {
@@ -128,8 +154,34 @@ export async function readJsonResponse(response: Response): Promise<ParsedRespon
   }
 }
 
-export async function parseJsonPayload(response: Response, endpoint: string): Promise<ParsedResponsePayload> {
-  const payload = await readJsonResponse(response);
+async function readJsonResponseWithNetworkError(
+  response: Response,
+  context: ResponseBodyReadErrorContext,
+): Promise<ParsedResponsePayload> {
+  try {
+    return await readJsonResponse(response);
+  } catch (error) {
+    throw createResponseBodyNetworkError(response, error, context);
+  }
+}
+
+export async function readBlobResponse(
+  response: Response,
+  bodyReadErrorContext: ResponseBodyReadErrorContext,
+): Promise<Blob> {
+  try {
+    return await response.blob();
+  } catch (error) {
+    throw createResponseBodyNetworkError(response, error, bodyReadErrorContext);
+  }
+}
+
+export async function parseJsonPayload(
+  response: Response,
+  endpoint: string,
+  bodyReadErrorContext: ResponseBodyReadErrorContext,
+): Promise<ParsedResponsePayload> {
+  const payload = await readJsonResponseWithNetworkError(response, bodyReadErrorContext);
 
   if (!response.ok) {
     const fallbackMessage = typeof payload.value === "string" ? payload.value : `Request failed with status ${response.status}`;
@@ -147,12 +199,17 @@ export async function parseJsonPayload(response: Response, endpoint: string): Pr
   return payload;
 }
 
-export async function isRecoverableSessionCsrfResponse(response: Response): Promise<boolean> {
+export async function isRecoverableSessionCsrfResponse(
+  response: Response,
+  bodyReadErrorContext: ResponseBodyReadErrorContext,
+): Promise<boolean> {
   if (response.status !== 403) {
     return false;
   }
 
-  return isRecoverableSessionCsrfPayload((await readJsonResponse(response.clone())).value);
+  return isRecoverableSessionCsrfPayload(
+    (await readJsonResponseWithNetworkError(response.clone(), bodyReadErrorContext)).value,
+  );
 }
 
 export function parseContractResponse<ParsedValue>(

--- a/apps/web/src/api/transport/transport.test.ts
+++ b/apps/web/src/api/transport/transport.test.ts
@@ -57,6 +57,39 @@ function createWorkspacesResponse(): Response {
   });
 }
 
+function createFailingResponse(
+  error: Error,
+  requestId: string,
+  statusCode: number,
+  contentType: string,
+): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      controller.error(error);
+    },
+  });
+
+  return new Response(stream, {
+    status: statusCode,
+    headers: {
+      "Content-Type": contentType,
+      "X-Request-Id": requestId,
+    },
+  });
+}
+
+function createFailingJsonResponse(
+  error: Error,
+  requestId: string,
+  statusCode: number,
+): Response {
+  return createFailingResponse(error, requestId, statusCode, "application/json");
+}
+
+function createFailingBlobResponse(error: Error, requestId: string): Response {
+  return createFailingResponse(error, requestId, 200, "application/octet-stream");
+}
+
 type DeferredResponsePromise = Readonly<{
   promise: Promise<Response>;
   reject: (error: Error) => void;
@@ -494,6 +527,57 @@ describe("unsafe request session transport", () => {
     expect(new Headers(retriedRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-2");
   });
 
+  it("retries a failed stale-CSRF response body read with the shared network budget", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createFailingJsonResponse(
+        new TypeError("Load failed"),
+        "csrf-request-1",
+        403,
+      ))
+      .mockResolvedValueOnce(createNewChatSessionResponse("session-1"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createTransportBackedChatSession("session-1")).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "POST /chat/new",
+      attemptCount: 1,
+      source: "response_body",
+      statusCode: 403,
+      requestId: "csrf-request-1",
+    }));
+  });
+
+  it("does not retry a failed stale-CSRF response body read without network retry", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createFailingJsonResponse(
+        new TypeError("Load failed"),
+        "csrf-request-no-retry",
+        403,
+      ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(stopChatRun("session-1", "workspace-1", null)).rejects.toMatchObject({
+      statusCode: 403,
+      code: "API_NETWORK_ERROR",
+      requestId: "csrf-request-no-retry",
+      endpoint: "POST /chat/stop",
+      attemptCount: 1,
+      source: "response_body",
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
   it("uses normal auth recovery when the retry after stale CSRF returns unauthorized", async () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(createSessionResponse({
@@ -643,6 +727,122 @@ describe("API transport network retry", () => {
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
     }));
+  });
+
+  it("retries a response body read failure with response metadata", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createFailingJsonResponse(new TypeError("Load failed"), "request-1", 200))
+      .mockResolvedValueOnce(createSessionResponse(null));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getSession()).resolves.toMatchObject({
+      userId: "user-1",
+      selectedWorkspaceId: "workspace-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "GET /me",
+      attemptCount: 1,
+      maximumAttemptCount: 4,
+      nextAttemptCount: 2,
+      source: "response_body",
+      statusCode: 200,
+      requestId: "request-1",
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Load failed",
+    }));
+  });
+
+  it("shares one retry budget across fetch and response body failures", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createFailingJsonResponse(new TypeError("Load failed"), "request-1", 200))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createFailingJsonResponse(new TypeError("Load failed"), "request-3", 200))
+      .mockResolvedValueOnce(createSessionResponse(null));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getSession()).resolves.toMatchObject({
+      userId: "user-1",
+      selectedWorkspaceId: "workspace-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(consoleWarnSpy.mock.calls.map((call) => call[1])).toEqual([
+      expect.objectContaining({
+        attemptCount: 1,
+        source: "response_body",
+        requestId: "request-1",
+      }),
+      expect.objectContaining({
+        attemptCount: 2,
+        source: "fetch",
+        requestId: null,
+      }),
+      expect.objectContaining({
+        attemptCount: 3,
+        source: "response_body",
+        requestId: "request-3",
+      }),
+    ]);
+  });
+
+  it("raises a structured API network error after response body retry attempts are exhausted", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockImplementation(() => Promise.resolve(
+        createFailingJsonResponse(new TypeError("Load failed"), "request-terminal", 200),
+      ));
+    vi.stubGlobal("fetch", fetchMock);
+    const sessionPromise = getSession();
+
+    await expect(sessionPromise).rejects.toBeInstanceOf(ApiNetworkError);
+    await expect(sessionPromise).rejects.toMatchObject({
+      statusCode: 200,
+      code: "API_NETWORK_ERROR",
+      requestId: "request-terminal",
+      endpoint: "GET /me",
+      responseBodyKind: "empty",
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Load failed",
+      attemptCount: 4,
+      source: "response_body",
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry response body failures when network retry is disabled", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createFailingJsonResponse(
+        new TypeError("Load failed"),
+        "request-no-retry",
+        200,
+      ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(requestJson(
+      "/response-body-no-retry",
+      { method: "GET" },
+      allowAuthRecovery,
+    )).rejects.toMatchObject({
+      statusCode: 200,
+      code: "API_NETWORK_ERROR",
+      requestId: "request-no-retry",
+      endpoint: "GET /response-body-no-retry",
+      attemptCount: 1,
+      source: "response_body",
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it("raises a structured API network error after session bootstrap retry attempts are exhausted", async () => {
@@ -1036,6 +1236,93 @@ describe("API transport network retry", () => {
 });
 
 describe("API transport binary responses", () => {
+  it("retries a successful response whose blob body cannot be read", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createFailingBlobResponse(new TypeError("Load failed"), "blob-request-1"))
+      .mockResolvedValueOnce(new Response("workspace-package", {
+        status: 200,
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "X-Request-Id": "blob-request-2",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const payload = await requestBlob(
+      "/workspaces/workspace-1/packages/export",
+      { method: "GET" },
+      allowAuthRecoveryWithTransientNetworkRetry,
+    );
+
+    await expect(payload.blob.text()).resolves.toBe("workspace-package");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "GET /workspaces/workspace-1/packages/export",
+      attemptCount: 1,
+      source: "response_body",
+      statusCode: 200,
+      requestId: "blob-request-1",
+    }));
+  });
+
+  it("does not retry a blob body read failure without network retry", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createFailingBlobResponse(
+        new TypeError("Load failed"),
+        "blob-request-no-retry",
+      ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(requestBlob(
+      "/workspaces/workspace-1/packages/export",
+      { method: "GET" },
+      allowAuthRecovery,
+    )).rejects.toMatchObject({
+      statusCode: 200,
+      code: "API_NETWORK_ERROR",
+      requestId: "blob-request-no-retry",
+      endpoint: "GET /workspaces/workspace-1/packages/export",
+      attemptCount: 1,
+      source: "response_body",
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("raises a structured API network error after blob body retry attempts are exhausted", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockImplementation(() => Promise.resolve(createFailingBlobResponse(
+        new TypeError("Load failed"),
+        "blob-request-terminal",
+      )));
+    vi.stubGlobal("fetch", fetchMock);
+    const blobPromise = requestBlob(
+      "/workspaces/workspace-1/packages/export",
+      { method: "GET" },
+      allowAuthRecoveryWithTransientNetworkRetry,
+    );
+
+    await expect(blobPromise).rejects.toMatchObject({
+      statusCode: 200,
+      code: "API_NETWORK_ERROR",
+      requestId: "blob-request-terminal",
+      endpoint: "GET /workspaces/workspace-1/packages/export",
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Load failed",
+      attemptCount: 4,
+      source: "response_body",
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(3);
+  });
+
   it("converts non-OK JSON errors into ApiError metadata", async () => {
     primeSessionCsrfToken("csrf-token-1");
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()

--- a/apps/web/src/api/transport/transport.ts
+++ b/apps/web/src/api/transport/transport.ts
@@ -3,12 +3,18 @@ import { markBrowserReauthRequired } from "../../accountDeletion";
 import { getAppConfig } from "../../config";
 import type { SessionInfo } from "../../types";
 import { buildLoginUrl, getPreferredAuthUiLocale } from "../authUrls";
-import { ApiError, ApiNetworkError, AuthRedirectError } from "./errors";
+import {
+  ApiError,
+  ApiNetworkError,
+  AuthRedirectError,
+  createApiNetworkError,
+} from "./errors";
 import {
   getJsonErrorMessage,
   isRecoverableSessionCsrfResponse,
   parseContractResponse,
   parseJsonPayload,
+  readBlobResponse,
   readJsonResponse,
   type ParsedResponsePayload,
 } from "./response";
@@ -19,6 +25,7 @@ export type AuthRecoveryMode = "allow" | "skip";
 export type NetworkRetryMode = "none" | "transient";
 type NavigateToUrl = (url: string) => void;
 type PrepareForAuthRedirect = () => void;
+type NetworkRequestAttempt<Result> = (attemptCount: number) => Promise<Result>;
 export type BlobResponsePayload = Readonly<{
   blob: Blob;
   headers: Headers;
@@ -193,34 +200,20 @@ function createHeaders(init: RequestInit): Headers {
   return headers;
 }
 
-function readOriginalErrorName(error: unknown): string {
-  if (error instanceof Error && error.name.trim() !== "") {
-    return error.name;
-  }
-
-  return typeof error;
-}
-
-function readOriginalErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim() !== "") {
-    return error.message;
-  }
-
-  const errorMessage = String(error);
-  return errorMessage.trim() === "" ? "Unknown fetch failure" : errorMessage;
-}
-
-function createApiNetworkError(
+function createFetchApiNetworkError(
   pathname: string,
   init: RequestInit,
   error: unknown,
   attemptCount: number,
 ): ApiNetworkError {
-  return new ApiNetworkError({
+  return createApiNetworkError({
+    statusCode: 0,
+    requestId: null,
+    responseBodyKind: "empty",
     endpoint: buildSanitizedRequestEndpoint(pathname, init),
-    originalErrorName: readOriginalErrorName(error),
-    originalErrorMessage: readOriginalErrorMessage(error),
+    error,
     attemptCount,
+    source: "fetch",
   });
 }
 
@@ -273,6 +266,9 @@ function warnApiTransportRetry(error: ApiNetworkError): void {
     attemptCount: error.attemptCount,
     maximumAttemptCount: apiNetworkRetryMaximumAttemptCount,
     nextAttemptCount: error.attemptCount + 1,
+    source: error.source,
+    statusCode: error.statusCode,
+    requestId: error.requestId,
     originalErrorName: error.originalErrorName,
     originalErrorMessage: error.originalErrorMessage,
   });
@@ -289,23 +285,26 @@ async function performFetch(pathname: string, init: RequestInit, attemptCount: n
       headers,
     });
   } catch (error) {
-    throw createApiNetworkError(pathname, init, error, attemptCount);
+    throw createFetchApiNetworkError(pathname, init, error, attemptCount);
   }
 }
 
-async function performFetchWithNetworkRetry(
-  pathname: string,
+async function performWithNetworkRetry<Result>(
+  endpoint: string,
   init: RequestInit,
   options: RequestOptions,
-): Promise<Response> {
+  performAttempt: NetworkRequestAttempt<Result>,
+): Promise<Result> {
   let attemptCount = 1;
 
   while (true) {
     try {
-      return await performFetch(pathname, init, attemptCount);
+      return await performAttempt(attemptCount);
     } catch (error) {
       if (
         error instanceof ApiNetworkError === false
+        || error.endpoint !== endpoint
+        || error.attemptCount !== attemptCount
         || init.signal?.aborted === true
         || options.networkRetryMode === "none"
         || hasRemainingNetworkRetryAttempt(attemptCount) === false
@@ -649,12 +648,14 @@ async function requestResponse(
   pathname: string,
   init: RequestInit,
   options: RequestOptions,
+  attemptCount: number,
 ): Promise<Response> {
   if (isUnsafeMethod(getMethod(init))) {
     await ensureSessionTransportReadyForUnsafeRequest(options);
   }
 
-  let response: Response = await performFetchWithNetworkRetry(pathname, init, options);
+  const endpoint = buildSanitizedRequestEndpoint(pathname, init);
+  let response: Response = await performFetch(pathname, init, attemptCount);
   if (options.authRecoveryMode === "skip") {
     return response;
   }
@@ -669,18 +670,21 @@ async function requestResponse(
 
       didRecoverSession = true;
       await recoverSession(options);
-      response = await performFetchWithNetworkRetry(pathname, init, options);
+      response = await performFetch(pathname, init, attemptCount);
       continue;
     }
 
     if (
       didRecoverSessionCsrf === false
       && isUnsafeMethod(getMethod(init))
-      && await isRecoverableSessionCsrfResponse(response)
+      && await isRecoverableSessionCsrfResponse(response, {
+        attemptCount,
+        endpoint,
+      })
     ) {
       didRecoverSessionCsrf = true;
       await recoverSessionCsrf(options);
-      response = await performFetchWithNetworkRetry(pathname, init, options);
+      response = await performFetch(pathname, init, attemptCount);
       continue;
     }
 
@@ -693,8 +697,18 @@ export async function requestJson(
   init: RequestInit,
   options: RequestOptions,
 ): Promise<ParsedResponsePayload> {
-  const response = await requestResponse(pathname, init, options);
-  return parseJsonPayload(response, buildRequestEndpoint(pathname, init));
+  const endpoint = buildSanitizedRequestEndpoint(pathname, init);
+  return performWithNetworkRetry(endpoint, init, options, async (attemptCount: number) => {
+    const response = await requestResponse(pathname, init, options, attemptCount);
+    return parseJsonPayload(
+      response,
+      buildRequestEndpoint(pathname, init),
+      {
+        attemptCount,
+        endpoint,
+      },
+    );
+  });
 }
 
 export async function requestBlob(
@@ -702,18 +716,27 @@ export async function requestBlob(
   init: RequestInit,
   options: RequestOptions,
 ): Promise<BlobResponsePayload> {
-  const response = await requestResponse(pathname, init, options);
   const endpoint = buildRequestEndpoint(pathname, init);
-  if (!response.ok) {
-    await parseJsonPayload(response, endpoint);
-    throw new Error(`Non-OK blob response for ${endpoint} did not raise an API error`);
-  }
+  const sanitizedEndpoint = buildSanitizedRequestEndpoint(pathname, init);
+  return performWithNetworkRetry(sanitizedEndpoint, init, options, async (attemptCount: number) => {
+    const response = await requestResponse(pathname, init, options, attemptCount);
+    if (!response.ok) {
+      await parseJsonPayload(response, endpoint, {
+        attemptCount,
+        endpoint: sanitizedEndpoint,
+      });
+      throw new Error(`Non-OK blob response for ${endpoint} did not raise an API error`);
+    }
 
-  return {
-    blob: await response.blob(),
-    headers: response.headers,
-    statusCode: response.status,
-  };
+    return {
+      blob: await readBlobResponse(response, {
+        attemptCount,
+        endpoint: sanitizedEndpoint,
+      }),
+      headers: response.headers,
+      statusCode: response.status,
+    };
+  });
 }
 
 /**

--- a/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
@@ -139,10 +139,14 @@ describe("useProgressSource lifecycle", () => {
 
   it("keeps leaderboard API network failures inline without technical capture", async () => {
     const networkError = new ApiNetworkError({
+      statusCode: 0,
+      requestId: null,
+      responseBodyKind: "empty",
       endpoint: "GET /me/progress/leaderboard",
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
       attemptCount: 3,
+      source: "fetch",
     });
     loadProgressLeaderboardMock.mockRejectedValueOnce(networkError);
 

--- a/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.bootstrap.test.tsx
@@ -224,10 +224,14 @@ describe("useWorkspaceSession bootstrap", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const networkSyncError = new ApiNetworkError({
+      statusCode: 0,
+      requestId: null,
+      responseBodyKind: "empty",
       endpoint: "POST /sync/push",
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
       attemptCount: 4,
+      source: "fetch",
     });
     const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {
       const wasCaptured = observeSyncFailure({

--- a/apps/web/src/observability/instrument.test.ts
+++ b/apps/web/src/observability/instrument.test.ts
@@ -361,10 +361,14 @@ describe("Sentry privacy sanitizer", () => {
     const event: WebExceptionEvent = {
       action: "chat_snapshot_failed",
       error: new ApiNetworkError({
+        statusCode: 0,
+        requestId: null,
+        responseBodyKind: "empty",
         endpoint: "GET /chat",
         originalErrorName: "TypeError",
         originalErrorMessage: "Failed to fetch",
         attemptCount: 3,
+        source: "fetch",
       }),
       scope,
       details: {
@@ -384,10 +388,14 @@ describe("Sentry privacy sanitizer", () => {
   it("treats browser API network app operation errors as expected", () => {
     const wasCaptured = captureAppOperationError(
       new ApiNetworkError({
+        statusCode: 0,
+        requestId: null,
+        responseBodyKind: "empty",
         endpoint: "GET /me",
         originalErrorName: "TypeError",
         originalErrorMessage: "Failed to fetch",
         attemptCount: 3,
+        source: "fetch",
       }),
       {
         feature: "app",


### PR DESCRIPTION
## Summary
- normalize JSON and blob response-body read failures as expected API network errors
- share one four-attempt retry budget across fetch and body failures
- preserve HTTP status and request IDs, including stale-CSRF response probes

## Validation
- 107 targeted Vitest tests passed
- npm run build passed
- git diff --check passed
- fresh independent review found no P0-P4 issues

Fixes FLASHCARDS-WEB-19: https://samo-danni-eood.sentry.io/issues/136142855/