### PR TITLE
Add Android generated-image lifecycle placeholders

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
@@ -4,6 +4,17 @@ private const val managedMediaAssetSchemePrefix: String = "fcasset:"
 private const val managedImageFallbackAltText: String = "Image"
 private val managedMediaAssetReferenceRegex: Regex = Regex("""fcasset:([^\s)]+)""")
 
+enum class ManagedMediaReferenceState {
+    READY,
+    PENDING,
+    FAILED
+}
+
+data class ManagedMediaReference(
+    val mediaAssetId: String,
+    val state: ManagedMediaReferenceState
+)
+
 fun managedImageMarkdownReference(
     mediaAssetId: String,
     altText: String
@@ -16,9 +27,51 @@ fun managedImageMarkdownReference(
 fun extractManagedMediaAssetReferences(markdown: String): Set<String> {
     return managedMediaAssetReferenceRegex
         .findAll(input = markdown)
-        .map { matchResult -> matchResult.groupValues[1].trim() }
-        .filter { mediaAssetId -> mediaAssetId.isNotEmpty() }
+        .mapNotNull { matchResult ->
+            parseManagedMediaReference(reference = matchResult.value)?.mediaAssetId
+        }
         .toSet()
+}
+
+fun parseManagedMediaReference(reference: String): ManagedMediaReference? {
+    val normalizedReference: String = reference.trim()
+    if (normalizedReference.startsWith(prefix = managedMediaAssetSchemePrefix, ignoreCase = true).not()) {
+        return null
+    }
+
+    val rawReference: String = normalizedReference
+        .drop(n = managedMediaAssetSchemePrefix.length)
+        .trimStart('/')
+        .substringBefore(delimiter = "#")
+    val mediaAssetId: String = rawReference.substringBefore(delimiter = "?").trim()
+    if (mediaAssetId.isEmpty()) {
+        return null
+    }
+
+    val state: ManagedMediaReferenceState = parseManagedMediaReferenceState(
+        query = rawReference.substringAfter(delimiter = "?", missingDelimiterValue = "")
+    )
+    return ManagedMediaReference(
+        mediaAssetId = mediaAssetId,
+        state = state
+    )
+}
+
+private fun parseManagedMediaReferenceState(query: String): ManagedMediaReferenceState {
+    val stateValues: List<String> = query
+        .split(separator = "&")
+        .mapNotNull { queryPart ->
+            val parameterName: String = queryPart.substringBefore(delimiter = "=")
+            if (parameterName != "state") {
+                return@mapNotNull null
+            }
+            queryPart.substringAfter(delimiter = "=", missingDelimiterValue = "")
+        }
+    return when (stateValues.singleOrNull()) {
+        "pending" -> ManagedMediaReferenceState.PENDING
+        "failed" -> ManagedMediaReferenceState.FAILED
+        else -> ManagedMediaReferenceState.READY
+    }
 }
 
 private fun normalizeManagedMediaAssetId(mediaAssetId: String): String {

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.cards.editor
 
+import com.flashcardsopensourceapp.data.local.model.media.ManagedMediaReferenceState
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
 
 enum class CardEditorTextField {
@@ -24,6 +25,7 @@ data class CardEditorTextSelection(
 data class CardEditorManagedImageReference(
     val referenceKey: String,
     val mediaAssetId: String,
+    val state: ManagedMediaReferenceState,
     val label: String?
 ) {
     init {

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
+import com.flashcardsopensourceapp.data.local.model.media.ManagedMediaReference
+import com.flashcardsopensourceapp.data.local.model.media.ManagedMediaReferenceState
+import com.flashcardsopensourceapp.data.local.model.media.parseManagedMediaReference
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
 import com.flashcardsopensourceapp.data.local.repository.CardsRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
@@ -63,14 +66,40 @@ class CardEditorViewModel(
         } else {
             cardsRepository.observeCard(cardId = editingCardId)
         }
+        var previousObservedCard: CardSummary? = null
 
         viewModelScope.launch {
             cardFlow.collect { card ->
-                if (card == null || inputState.value.hasLoadedInitialValues) {
+                if (card == null) {
                     return@collect
                 }
 
+                val previousCard: CardSummary? = previousObservedCard
                 inputState.update { state ->
+                    if (state.hasLoadedInitialValues && previousCard != null) {
+                        val refreshedFrontText = refreshManagedImageReferenceStates(
+                            text = state.frontText,
+                            selection = state.frontTextSelection,
+                            previousObservedText = previousCard.frontText,
+                            observedText = card.frontText
+                        )
+                        val refreshedBackText = refreshManagedImageReferenceStates(
+                            text = state.backText,
+                            selection = state.backTextSelection,
+                            previousObservedText = previousCard.backText,
+                            observedText = card.backText
+                        )
+                        return@update state.copy(
+                            frontText = refreshedFrontText.text,
+                            backText = refreshedBackText.text,
+                            frontTextSelection = refreshedFrontText.selection,
+                            backTextSelection = refreshedBackText.selection
+                        )
+                    }
+                    if (state.hasLoadedInitialValues) {
+                        return@update state
+                    }
+
                     state.copy(
                         frontText = card.frontText,
                         backText = card.backText,
@@ -78,6 +107,7 @@ class CardEditorViewModel(
                         hasLoadedInitialValues = true
                     )
                 }
+                previousObservedCard = card
             }
         }
 
@@ -423,10 +453,18 @@ private data class CardEditorTextEditResult(
     val selection: CardEditorTextSelection
 )
 
+private data class ManagedImageReferenceIdentity(
+    val mediaAssetId: String,
+    val markdownWithoutDestination: String
+)
+
 private data class ManagedImageReferenceMatch(
     val reference: CardEditorManagedImageReference,
+    val identity: ManagedImageReferenceIdentity,
     val startIndex: Int,
-    val endIndexExclusive: Int
+    val endIndexExclusive: Int,
+    val destination: String,
+    val destinationRange: IntRange
 )
 
 private fun validateCardEditorInput(
@@ -463,7 +501,7 @@ private fun toggleTagSelection(selectedTags: List<String>, tag: String): List<St
     return selectedTags + tag
 }
 
-private val managedImageMarkdownRegex = Regex("""!\[([^\]\n]*)]\(fcasset:([^\s)]+)\)""")
+private val managedImageMarkdownRegex = Regex("""!\[([^\]\n]*)]\((fcasset:[^\s)]+)\)""")
 
 private fun insertMarkdownAtSelection(
     text: String,
@@ -525,22 +563,165 @@ private fun parseManagedImageReferences(text: String): List<CardEditorManagedIma
 }
 
 private fun findManagedImageReferenceMatches(text: String): List<ManagedImageReferenceMatch> {
-    return managedImageMarkdownRegex.findAll(input = text).map { match ->
+    return managedImageMarkdownRegex.findAll(input = text).mapNotNull { match ->
         val startIndex = match.range.first
         val endIndexExclusive = match.range.last + 1
         val rawLabel = match.groupValues[1].trim()
         val label = if (rawLabel.isEmpty()) null else rawLabel
-        val mediaAssetId = match.groupValues[2].trim()
+        val destinationGroup: MatchGroup = match.groups[2] ?: return@mapNotNull null
+        val parsedReference: ManagedMediaReference = parseManagedMediaReference(
+            reference = destinationGroup.value
+        ) ?: return@mapNotNull null
         ManagedImageReferenceMatch(
             reference = CardEditorManagedImageReference(
-                referenceKey = "$startIndex:$endIndexExclusive:$mediaAssetId",
-                mediaAssetId = mediaAssetId,
+                referenceKey = "$startIndex:$endIndexExclusive:${parsedReference.mediaAssetId}",
+                mediaAssetId = parsedReference.mediaAssetId,
+                state = parsedReference.state,
                 label = label
             ),
+            identity = ManagedImageReferenceIdentity(
+                mediaAssetId = parsedReference.mediaAssetId,
+                markdownWithoutDestination = text.substring(
+                    startIndex = startIndex,
+                    endIndex = destinationGroup.range.first
+                ) + text.substring(
+                    startIndex = destinationGroup.range.last + 1,
+                    endIndex = endIndexExclusive
+                )
+            ),
             startIndex = startIndex,
-            endIndexExclusive = endIndexExclusive
+            endIndexExclusive = endIndexExclusive,
+            destination = destinationGroup.value,
+            destinationRange = destinationGroup.range
         )
     }.toList()
+}
+
+private fun refreshManagedImageReferenceStates(
+    text: String,
+    selection: CardEditorTextSelection,
+    previousObservedText: String,
+    observedText: String
+): CardEditorTextEditResult {
+    val replacements: List<Pair<ManagedImageReferenceMatch, String>> =
+        managedImageReferenceReplacements(
+            previousObservedText = previousObservedText,
+            currentText = text,
+            observedText = observedText
+        ).sortedBy { (match, _) ->
+            match.destinationRange.first
+        }
+
+    var refreshedText: String = text
+    var refreshedSelection: CardEditorTextSelection = selection
+    replacements.asReversed().forEach { (match, replacement) ->
+        refreshedText = refreshedText.replaceRange(
+            range = match.destinationRange,
+            replacement = replacement
+        )
+        refreshedSelection = shiftSelectionAfterReplacement(
+            selection = refreshedSelection,
+            replacedStartIndex = match.destinationRange.first,
+            replacedEndIndexExclusive = match.destinationRange.last + 1,
+            replacementLength = replacement.length
+        )
+    }
+
+    return CardEditorTextEditResult(
+        text = refreshedText,
+        selection = clampCardEditorTextSelection(
+            selection = refreshedSelection,
+            text = refreshedText
+        )
+    )
+}
+
+private fun managedImageReferenceReplacements(
+    previousObservedText: String,
+    currentText: String,
+    observedText: String
+): List<Pair<ManagedImageReferenceMatch, String>> {
+    val previousMatchesByIdentity:
+        Map<ManagedImageReferenceIdentity, List<ManagedImageReferenceMatch>> =
+        findManagedImageReferenceMatches(text = previousObservedText).groupBy { match ->
+            match.identity
+        }
+    val currentMatchesByIdentity:
+        Map<ManagedImageReferenceIdentity, List<ManagedImageReferenceMatch>> =
+        findManagedImageReferenceMatches(text = currentText).groupBy { match ->
+            match.identity
+        }
+    val observedMatchesByIdentity:
+        Map<ManagedImageReferenceIdentity, List<ManagedImageReferenceMatch>> =
+        findManagedImageReferenceMatches(text = observedText).groupBy { match ->
+            match.identity
+        }
+
+    return previousMatchesByIdentity.flatMap { (identity, previousMatches) ->
+        val currentMatches: List<ManagedImageReferenceMatch> = currentMatchesByIdentity[
+            identity
+        ] ?: return@flatMap emptyList()
+        val observedMatches: List<ManagedImageReferenceMatch> = observedMatchesByIdentity[
+            identity
+        ] ?: return@flatMap emptyList()
+        if (currentMatches.size != previousMatches.size ||
+            observedMatches.size != previousMatches.size
+        ) {
+            return@flatMap emptyList()
+        }
+
+        if (previousMatches.size == 1) {
+            val previousMatch: ManagedImageReferenceMatch = previousMatches.single()
+            val currentMatch: ManagedImageReferenceMatch = currentMatches.single()
+            val observedMatch: ManagedImageReferenceMatch = observedMatches.single()
+            if (previousMatch.reference.state == ManagedMediaReferenceState.READY ||
+                currentMatch.destination != previousMatch.destination ||
+                previousMatch.destination == observedMatch.destination
+            ) {
+                return@flatMap emptyList()
+            }
+            return@flatMap listOf(currentMatch to observedMatch.destination)
+        }
+
+        duplicateManagedImageReferenceReplacements(
+            previousMatches = previousMatches,
+            currentMatches = currentMatches,
+            observedMatches = observedMatches
+        )
+    }
+}
+
+private fun duplicateManagedImageReferenceReplacements(
+    previousMatches: List<ManagedImageReferenceMatch>,
+    currentMatches: List<ManagedImageReferenceMatch>,
+    observedMatches: List<ManagedImageReferenceMatch>
+): List<Pair<ManagedImageReferenceMatch, String>> {
+    val previousDestinationCounts: Map<String, Int> =
+        previousMatches.groupingBy(ManagedImageReferenceMatch::destination).eachCount()
+    val currentDestinationCounts: Map<String, Int> =
+        currentMatches.groupingBy(ManagedImageReferenceMatch::destination).eachCount()
+    if (currentDestinationCounts != previousDestinationCounts) {
+        return emptyList()
+    }
+
+    val observedDestination: String = observedMatches
+        .map(ManagedImageReferenceMatch::destination)
+        .distinct()
+        .singleOrNull()
+        ?: return emptyList()
+    val eligiblePreviousDestinations: Set<String> = previousMatches
+        .filter { match ->
+            match.reference.state != ManagedMediaReferenceState.READY &&
+                match.destination != observedDestination
+        }
+        .mapTo(destination = mutableSetOf(), transform = ManagedImageReferenceMatch::destination)
+    return currentMatches.mapNotNull { currentMatch ->
+        if (currentMatch.destination in eligiblePreviousDestinations) {
+            currentMatch to observedDestination
+        } else {
+            null
+        }
+    }
 }
 
 private fun clampCardEditorTextSelection(
@@ -552,6 +733,44 @@ private fun clampCardEditorTextSelection(
     val normalizedStart = minOf(start, end)
     val normalizedEnd = maxOf(start, end)
     return CardEditorTextSelection(start = normalizedStart, end = normalizedEnd)
+}
+
+private fun shiftSelectionAfterReplacement(
+    selection: CardEditorTextSelection,
+    replacedStartIndex: Int,
+    replacedEndIndexExclusive: Int,
+    replacementLength: Int
+): CardEditorTextSelection {
+    val shiftedStart: Int = shiftTextOffsetAfterReplacement(
+        offset = selection.start,
+        replacedStartIndex = replacedStartIndex,
+        replacedEndIndexExclusive = replacedEndIndexExclusive,
+        replacementLength = replacementLength
+    )
+    val shiftedEnd: Int = shiftTextOffsetAfterReplacement(
+        offset = selection.end,
+        replacedStartIndex = replacedStartIndex,
+        replacedEndIndexExclusive = replacedEndIndexExclusive,
+        replacementLength = replacementLength
+    )
+    return CardEditorTextSelection(
+        start = minOf(shiftedStart, shiftedEnd),
+        end = maxOf(shiftedStart, shiftedEnd)
+    )
+}
+
+private fun shiftTextOffsetAfterReplacement(
+    offset: Int,
+    replacedStartIndex: Int,
+    replacedEndIndexExclusive: Int,
+    replacementLength: Int
+): Int {
+    val replacedLength: Int = replacedEndIndexExclusive - replacedStartIndex
+    return when {
+        offset <= replacedStartIndex -> offset
+        offset >= replacedEndIndexExclusive -> offset + replacementLength - replacedLength
+        else -> replacedStartIndex + minOf(offset - replacedStartIndex, replacementLength)
+    }
 }
 
 private fun shiftSelectionAfterRemoval(

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
@@ -49,7 +49,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
@@ -58,6 +61,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
+import com.flashcardsopensourceapp.data.local.model.media.ManagedMediaReferenceState
 import com.flashcardsopensourceapp.feature.cards.R
 import com.flashcardsopensourceapp.feature.cards.cardTextEditorAddMediaButtonTag
 import com.flashcardsopensourceapp.feature.cards.cardTextEditorManagedMediaPreviewItemTag
@@ -67,7 +71,15 @@ import kotlinx.coroutines.CancellationException
 private sealed interface CardEditorManagedImagePreviewState {
     data object Loading : CardEditorManagedImagePreviewState
     data class Ready(val uri: String) : CardEditorManagedImagePreviewState
+    data object Pending : CardEditorManagedImagePreviewState
+    data object Failed : CardEditorManagedImagePreviewState
     data object Unavailable : CardEditorManagedImagePreviewState
+}
+
+private enum class CardEditorManagedImagePlaceholderStyle {
+    PROGRESS,
+    UNAVAILABLE,
+    WARNING
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -233,9 +245,25 @@ private fun CardEditorManagedImagePreviewItem(
 ) {
     val currentLoadManagedImageUri = rememberUpdatedState(newValue = onLoadManagedImageUri)
     val previewState by produceState<CardEditorManagedImagePreviewState>(
-        initialValue = CardEditorManagedImagePreviewState.Loading,
-        key1 = reference.mediaAssetId
+        initialValue = cardEditorManagedImageReferencePreviewState(state = reference.state),
+        key1 = reference.mediaAssetId,
+        key2 = reference.state
     ) {
+        when (reference.state) {
+            ManagedMediaReferenceState.PENDING -> {
+                value = CardEditorManagedImagePreviewState.Pending
+                return@produceState
+            }
+
+            ManagedMediaReferenceState.FAILED -> {
+                value = CardEditorManagedImagePreviewState.Failed
+                return@produceState
+            }
+
+            ManagedMediaReferenceState.READY -> {
+                value = CardEditorManagedImagePreviewState.Loading
+            }
+        }
         value = try {
             CardEditorManagedImagePreviewState.Ready(
                 uri = currentLoadManagedImageUri.value(reference.mediaAssetId)
@@ -293,15 +321,57 @@ private fun CardEditorManagedImagePreviewSurface(
     label: String
 ) {
     when (state) {
-        CardEditorManagedImagePreviewState.Loading -> CardEditorManagedImagePlaceholder(
-            label = stringResource(id = R.string.cards_editor_image_loading),
-            isLoading = true
-        )
+        CardEditorManagedImagePreviewState.Loading -> {
+            val statusText = stringResource(id = R.string.cards_editor_image_loading)
+            CardEditorManagedImagePlaceholder(
+                label = statusText,
+                accessibilityLabel = stringResource(
+                    id = R.string.cards_editor_image_status_content_description,
+                    label,
+                    statusText
+                ),
+                style = CardEditorManagedImagePlaceholderStyle.PROGRESS
+            )
+        }
 
-        CardEditorManagedImagePreviewState.Unavailable -> CardEditorManagedImagePlaceholder(
-            label = stringResource(id = R.string.cards_editor_image_unavailable),
-            isLoading = false
-        )
+        CardEditorManagedImagePreviewState.Pending -> {
+            val statusText = stringResource(id = R.string.cards_editor_image_processing)
+            CardEditorManagedImagePlaceholder(
+                label = statusText,
+                accessibilityLabel = stringResource(
+                    id = R.string.cards_editor_image_status_content_description,
+                    label,
+                    statusText
+                ),
+                style = CardEditorManagedImagePlaceholderStyle.PROGRESS
+            )
+        }
+
+        CardEditorManagedImagePreviewState.Failed -> {
+            val statusText = stringResource(id = R.string.cards_editor_image_processing_failed)
+            CardEditorManagedImagePlaceholder(
+                label = statusText,
+                accessibilityLabel = stringResource(
+                    id = R.string.cards_editor_image_status_content_description,
+                    label,
+                    statusText
+                ),
+                style = CardEditorManagedImagePlaceholderStyle.WARNING
+            )
+        }
+
+        CardEditorManagedImagePreviewState.Unavailable -> {
+            val statusText = stringResource(id = R.string.cards_editor_image_unavailable)
+            CardEditorManagedImagePlaceholder(
+                label = statusText,
+                accessibilityLabel = stringResource(
+                    id = R.string.cards_editor_image_status_content_description,
+                    label,
+                    statusText
+                ),
+                style = CardEditorManagedImagePlaceholderStyle.UNAVAILABLE
+            )
+        }
 
         is CardEditorManagedImagePreviewState.Ready -> CardEditorManagedImage(
             uri = state.uri,
@@ -335,15 +405,27 @@ private fun CardEditorManagedImage(
             contentDescription = label,
             contentScale = ContentScale.Crop,
             loading = {
+                val statusText = stringResource(id = R.string.cards_editor_image_loading)
                 CardEditorManagedImagePlaceholder(
-                    label = stringResource(id = R.string.cards_editor_image_loading),
-                    isLoading = true
+                    label = statusText,
+                    accessibilityLabel = stringResource(
+                        id = R.string.cards_editor_image_status_content_description,
+                        label,
+                        statusText
+                    ),
+                    style = CardEditorManagedImagePlaceholderStyle.PROGRESS
                 )
             },
             error = {
+                val statusText = stringResource(id = R.string.cards_editor_image_unavailable)
                 CardEditorManagedImagePlaceholder(
-                    label = stringResource(id = R.string.cards_editor_image_unavailable),
-                    isLoading = false
+                    label = statusText,
+                    accessibilityLabel = stringResource(
+                        id = R.string.cards_editor_image_status_content_description,
+                        label,
+                        statusText
+                    ),
+                    style = CardEditorManagedImagePlaceholderStyle.UNAVAILABLE
                 )
             },
             modifier = Modifier
@@ -352,6 +434,16 @@ private fun CardEditorManagedImage(
                 .clip(RoundedCornerShape(8.dp))
                 .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
         )
+    }
+}
+
+private fun cardEditorManagedImageReferencePreviewState(
+    state: ManagedMediaReferenceState
+): CardEditorManagedImagePreviewState {
+    return when (state) {
+        ManagedMediaReferenceState.READY -> CardEditorManagedImagePreviewState.Loading
+        ManagedMediaReferenceState.PENDING -> CardEditorManagedImagePreviewState.Pending
+        ManagedMediaReferenceState.FAILED -> CardEditorManagedImagePreviewState.Failed
     }
 }
 
@@ -365,40 +457,63 @@ private fun cardEditorManagedImageMemoryCacheKey(
 @Composable
 private fun CardEditorManagedImagePlaceholder(
     label: String,
-    isLoading: Boolean
+    accessibilityLabel: String,
+    style: CardEditorManagedImagePlaceholderStyle
 ) {
+    val containerColor = when (style) {
+        CardEditorManagedImagePlaceholderStyle.PROGRESS,
+        CardEditorManagedImagePlaceholderStyle.UNAVAILABLE -> MaterialTheme.colorScheme.surfaceContainerHighest
+
+        CardEditorManagedImagePlaceholderStyle.WARNING -> MaterialTheme.colorScheme.errorContainer
+    }
+    val contentColor = when (style) {
+        CardEditorManagedImagePlaceholderStyle.PROGRESS,
+        CardEditorManagedImagePlaceholderStyle.UNAVAILABLE -> MaterialTheme.colorScheme.onSurfaceVariant
+
+        CardEditorManagedImagePlaceholderStyle.WARNING -> MaterialTheme.colorScheme.onErrorContainer
+    }
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(min = 104.dp)
+            .clearAndSetSemantics {
+                contentDescription = accessibilityLabel
+                if (style == CardEditorManagedImagePlaceholderStyle.PROGRESS) {
+                    progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate
+                }
+            }
             .clip(RoundedCornerShape(8.dp))
-            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
+            .background(color = containerColor)
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(12.dp)
         ) {
-            if (isLoading) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp))
-            } else {
-                Icon(
+            when (style) {
+                CardEditorManagedImagePlaceholderStyle.PROGRESS -> CircularProgressIndicator(
+                    color = contentColor,
+                    modifier = Modifier.size(24.dp)
+                )
+
+                CardEditorManagedImagePlaceholderStyle.UNAVAILABLE,
+                CardEditorManagedImagePlaceholderStyle.WARNING -> Icon(
                     imageVector = Icons.Outlined.WarningAmber,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = contentColor,
                     modifier = Modifier.size(24.dp)
                 )
             }
             Icon(
                 imageVector = Icons.Outlined.Image,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                tint = contentColor,
                 modifier = Modifier.size(20.dp)
             )
             Text(
                 text = label,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = contentColor,
                 style = MaterialTheme.typography.bodySmall
             )
         }

--- a/apps/android/feature/cards/src/main/res/values/strings.xml
+++ b/apps/android/feature/cards/src/main/res/values/strings.xml
@@ -42,6 +42,9 @@
     <string name="cards_editor_adding_image_content_description">Adding image</string>
     <string name="cards_editor_image_label">Image</string>
     <string name="cards_editor_image_loading">Loading image</string>
+    <string name="cards_editor_image_processing">Processing image...</string>
+    <string name="cards_editor_image_processing_failed">Image processing failed</string>
+    <string name="cards_editor_image_status_content_description">%1$s. %2$s</string>
     <string name="cards_editor_image_unavailable">Image unavailable</string>
     <string name="cards_editor_remove_image">Remove</string>
     <string name="cards_editor_image_reference_missing">The image reference is no longer in this card text.</string>

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.feature.review
 
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
+import com.flashcardsopensourceapp.data.local.model.media.ManagedMediaReferenceState
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 
@@ -40,6 +41,7 @@ sealed interface ReviewManagedMarkdownBlock {
 
 data class ReviewManagedMediaReference(
     val mediaAssetId: String,
+    val state: ManagedMediaReferenceState,
     val label: String?,
     val isImageSyntax: Boolean,
     val mediaAsset: MediaAsset?

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
@@ -1,6 +1,8 @@
 package com.flashcardsopensourceapp.feature.review
 
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
+import com.flashcardsopensourceapp.data.local.model.media.ManagedMediaReference
+import com.flashcardsopensourceapp.data.local.model.media.parseManagedMediaReference
 
 /*
  Keep review content presentation heuristics aligned with:
@@ -27,8 +29,6 @@ private val reviewMarkdownLinkOrImageRegex: Regex = Regex(
 )
 private val reviewFenceOpeningRegex: Regex = Regex(pattern = """^\s{0,3}(`{3,}|~{3,})(.*)$""")
 private val reviewFenceClosingRegex: Regex = Regex(pattern = """^\s{0,3}(`{3,}|~{3,})\s*$""")
-private const val reviewManagedMediaSchemePrefix: String = "fcasset:"
-
 private data class ReviewManagedMediaMatch(
     val range: IntRange,
     val reference: ReviewManagedMediaReference
@@ -121,24 +121,7 @@ internal fun isReviewFenceClosingLine(
 }
 
 internal fun parseReviewManagedMediaAssetId(reference: String): String? {
-    val trimmedReference: String = reference.trim()
-    if (trimmedReference.lowercase().startsWith(prefix = reviewManagedMediaSchemePrefix).not()) {
-        return null
-    }
-
-    var rawAssetId: String = trimmedReference.drop(n = reviewManagedMediaSchemePrefix.length)
-    while (rawAssetId.startsWith(prefix = "/")) {
-        rawAssetId = rawAssetId.drop(n = 1)
-    }
-
-    val fragmentOrQueryStart: Int = rawAssetId.indexOfAny(chars = charArrayOf('?', '#'))
-    val mediaAssetId: String = if (fragmentOrQueryStart >= 0) {
-        rawAssetId.substring(startIndex = 0, endIndex = fragmentOrQueryStart)
-    } else {
-        rawAssetId
-    }.trim()
-
-    return mediaAssetId.ifEmpty { null }
+    return parseManagedMediaReference(reference = reference)?.mediaAssetId
 }
 
 private fun makeReviewManagedMarkdownContent(
@@ -204,17 +187,18 @@ private fun findReviewManagedMediaMatches(
             } else {
                 reviewManagedMediaReferenceRegex.findAll(input = line).forEach { match ->
                     val rawReference: String = match.groups[3]?.value ?: return@forEach
-                    val mediaAssetId: String = parseReviewManagedMediaAssetId(
+                    val parsedReference: ManagedMediaReference = parseManagedMediaReference(
                         reference = rawReference
                     ) ?: return@forEach
                     add(
                         ReviewManagedMediaMatch(
                             range = (lineStart + match.range.first)..(lineStart + match.range.last),
                             reference = ReviewManagedMediaReference(
-                                mediaAssetId = mediaAssetId,
+                                mediaAssetId = parsedReference.mediaAssetId,
+                                state = parsedReference.state,
                                 label = match.groups[2]?.value?.trim()?.ifEmpty { null },
                                 isImageSyntax = match.groups[1] != null,
-                                mediaAsset = mediaAssetsById[mediaAssetId]
+                                mediaAsset = mediaAssetsById[parsedReference.mediaAssetId]
                             )
                         )
                     )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
@@ -49,6 +49,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
@@ -57,6 +61,7 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import com.flashcardsopensourceapp.data.local.model.media.MediaAsset
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
+import com.flashcardsopensourceapp.data.local.model.media.ManagedMediaReferenceState
 import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -79,6 +84,11 @@ private enum class ReviewManagedMediaCategory {
     AUDIO,
     VIDEO,
     ATTACHMENT
+}
+
+private enum class ReviewManagedMediaImageStateStyle {
+    PROGRESS,
+    WARNING
 }
 
 private sealed interface ReviewManagedMediaFileState {
@@ -117,6 +127,45 @@ internal fun ReviewManagedMediaContent(
         mediaAsset = mediaAsset,
         categoryLabel = categoryLabel
     )
+    when (reference.state) {
+        ManagedMediaReferenceState.PENDING -> {
+            val supportingText = stringResource(id = R.string.review_media_processing)
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = supportingText,
+                accessibilityLabel = stringResource(
+                    id = R.string.review_media_status_content_description,
+                    label,
+                    supportingText
+                ),
+                style = ReviewManagedMediaImageStateStyle.PROGRESS,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+            )
+            return
+        }
+
+        ManagedMediaReferenceState.FAILED -> {
+            val supportingText = stringResource(id = R.string.review_media_processing_failed)
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = supportingText,
+                accessibilityLabel = stringResource(
+                    id = R.string.review_media_status_content_description,
+                    label,
+                    supportingText
+                ),
+                style = ReviewManagedMediaImageStateStyle.WARNING,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+            )
+            return
+        }
+
+        ManagedMediaReferenceState.READY -> Unit
+    }
     if (isUnavailable) {
         ReviewManagedMediaPlaceholderRow(
             label = label,
@@ -178,25 +227,39 @@ private fun ReviewManagedMediaImageFile(
     }
 
     when (val state = mediaFileState) {
-        ReviewManagedMediaFileState.Loading -> ReviewManagedMediaImageState(
-            label = label,
-            supportingText = stringResource(id = R.string.review_media_loading),
-            icon = Icons.Outlined.Image,
-            showProgress = true,
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
-        )
+        ReviewManagedMediaFileState.Loading -> {
+            val supportingText = stringResource(id = R.string.review_media_loading)
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = supportingText,
+                accessibilityLabel = stringResource(
+                    id = R.string.review_media_status_content_description,
+                    label,
+                    supportingText
+                ),
+                style = ReviewManagedMediaImageStateStyle.PROGRESS,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+            )
+        }
 
-        ReviewManagedMediaFileState.Unavailable -> ReviewManagedMediaImageState(
-            label = label,
-            supportingText = stringResource(id = R.string.review_media_unavailable),
-            icon = Icons.Outlined.WarningAmber,
-            showProgress = false,
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
-        )
+        ReviewManagedMediaFileState.Unavailable -> {
+            val supportingText = stringResource(id = R.string.review_media_unavailable)
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = supportingText,
+                accessibilityLabel = stringResource(
+                    id = R.string.review_media_status_content_description,
+                    label,
+                    supportingText
+                ),
+                style = ReviewManagedMediaImageStateStyle.WARNING,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+            )
+        }
 
         is ReviewManagedMediaFileState.Ready -> ReviewManagedMediaImage(
             label = label,
@@ -239,11 +302,16 @@ private fun ReviewManagedMediaImage(
             contentDescription = label,
             contentScale = ContentScale.Fit,
             loading = {
+                val supportingText = stringResource(id = R.string.review_media_loading)
                 ReviewManagedMediaImageState(
                     label = label,
-                    supportingText = stringResource(id = R.string.review_media_loading),
-                    icon = Icons.Outlined.Image,
-                    showProgress = true,
+                    supportingText = supportingText,
+                    accessibilityLabel = stringResource(
+                        id = R.string.review_media_status_content_description,
+                        label,
+                        supportingText
+                    ),
+                    style = ReviewManagedMediaImageStateStyle.PROGRESS,
                     modifier = Modifier.fillMaxSize()
                 )
             },
@@ -255,11 +323,16 @@ private fun ReviewManagedMediaImage(
                 )
             },
             error = {
+                val supportingText = stringResource(id = R.string.review_media_unavailable)
                 ReviewManagedMediaImageState(
                     label = label,
-                    supportingText = stringResource(id = R.string.review_media_unavailable),
-                    icon = Icons.Outlined.WarningAmber,
-                    showProgress = false,
+                    supportingText = supportingText,
+                    accessibilityLabel = stringResource(
+                        id = R.string.review_media_status_content_description,
+                        label,
+                        supportingText
+                    ),
+                    style = ReviewManagedMediaImageStateStyle.WARNING,
                     modifier = Modifier.fillMaxSize()
                 )
             },
@@ -323,41 +396,56 @@ private fun reviewManagedMediaImageAspectRatio(
 private fun ReviewManagedMediaImageState(
     label: String,
     supportingText: String,
-    icon: ImageVector,
-    showProgress: Boolean,
+    accessibilityLabel: String,
+    style: ReviewManagedMediaImageStateStyle,
     modifier: Modifier
 ) {
+    val containerColor = when (style) {
+        ReviewManagedMediaImageStateStyle.PROGRESS -> MaterialTheme.colorScheme.surfaceContainerHighest
+        ReviewManagedMediaImageStateStyle.WARNING -> MaterialTheme.colorScheme.errorContainer
+    }
+    val contentColor = when (style) {
+        ReviewManagedMediaImageStateStyle.PROGRESS -> MaterialTheme.colorScheme.onSurfaceVariant
+        ReviewManagedMediaImageStateStyle.WARNING -> MaterialTheme.colorScheme.onErrorContainer
+    }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier
+            .clearAndSetSemantics {
+                contentDescription = accessibilityLabel
+                if (style == ReviewManagedMediaImageStateStyle.PROGRESS) {
+                    progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate
+                }
+            }
             .background(
-                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                color = containerColor,
                 shape = RoundedCornerShape(reviewManagedMediaSurfaceCornerRadius)
             )
             .padding(16.dp)
     ) {
-        if (showProgress) {
-            CircularProgressIndicator(
+        when (style) {
+            ReviewManagedMediaImageStateStyle.PROGRESS -> CircularProgressIndicator(
+                color = contentColor,
                 modifier = Modifier.size(reviewManagedMediaIconSize)
             )
-        } else {
-            Icon(
-                imageVector = icon,
+
+            ReviewManagedMediaImageStateStyle.WARNING -> Icon(
+                imageVector = Icons.Outlined.WarningAmber,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                tint = contentColor,
                 modifier = Modifier.size(reviewManagedMediaIconSize)
             )
         }
         Text(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface
+            color = contentColor
         )
         Text(
             text = supportingText,
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = contentColor
         )
     }
 }

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -67,6 +67,9 @@
     <string name="review_media_image_label">Managed image</string>
     <string name="review_media_loading">Loading media...</string>
     <string name="review_media_open_attachment">Open</string>
+    <string name="review_media_processing">Processing image...</string>
+    <string name="review_media_processing_failed">Image processing failed</string>
+    <string name="review_media_status_content_description">%1$s. %2$s</string>
     <string name="review_media_unavailable">Media unavailable</string>
     <string name="review_media_video_label">Video attachment</string>
     <string name="review_no_back_text">No back text</string>


### PR DESCRIPTION
## Summary
- parse generated-image lifecycle state from managed-media Markdown
- render native pending and failed placeholders in Review and Card editor/preview
- reconcile Room updates conservatively without overwriting draft edits

## Validation
- `git diff --check`
- `xmllint --noout` for both touched resource XML files
- independent pre-commit review: no P0-P4 findings
- Gradle, Android CI, Firebase, device tests, and iOS validation not run per explicit instruction