### PR TITLE
feat(web): reconcile Review editor media lifecycle

### DIFF
--- a/apps/web/src/screens/review/components/card/ReviewEditorModal.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewEditorModal.tsx
@@ -16,6 +16,7 @@ export type ReviewEditorModalProps = Readonly<{
   formState: CardFormState;
   isEditorPresented: boolean;
   isEditorSaving: boolean;
+  isSubmissionBlocked: boolean;
   localReadVersion: number;
   managedMediaState: CardFormManagedMediaState;
   workspaceId: string | null;
@@ -36,6 +37,7 @@ export function ReviewEditorModal(props: ReviewEditorModalProps): ReactElement |
     formState,
     isEditorPresented,
     isEditorSaving,
+    isSubmissionBlocked,
     localReadVersion,
     managedMediaState,
     workspaceId,
@@ -67,7 +69,7 @@ export function ReviewEditorModal(props: ReviewEditorModalProps): ReactElement |
             <button
               type="button"
               className="ghost-btn review-editor-ai-btn"
-              disabled={isEditorSaving || isAuthoringMedia}
+              disabled={isEditorSaving || isAuthoringMedia || isSubmissionBlocked}
               onClick={() => void onEditWithAi()}
               data-testid="review-editor-edit-with-ai"
             >
@@ -78,6 +80,7 @@ export function ReviewEditorModal(props: ReviewEditorModalProps): ReactElement |
               className="ghost-btn"
               disabled={isEditorSaving || isAuthoringMedia}
               onClick={onClose}
+              data-testid="review-editor-cancel"
             >
               {t("common.cancel")}
             </button>
@@ -92,7 +95,7 @@ export function ReviewEditorModal(props: ReviewEditorModalProps): ReactElement |
             <button
               type="button"
               className="primary-btn"
-              disabled={isEditorSaving || isAuthoringMedia}
+              disabled={isEditorSaving || isAuthoringMedia || isSubmissionBlocked}
               onClick={() => void onSave()}
             >
               {isEditorSaving ? t("reviewEditor.saving") : t("reviewEditor.save")}
@@ -100,7 +103,18 @@ export function ReviewEditorModal(props: ReviewEditorModalProps): ReactElement |
           </div>
         </div>
 
-        {editorErrorMessage !== "" ? <p className="error-banner">{editorErrorMessage}</p> : null}
+        {isSubmissionBlocked ? (
+          <p
+            className="error-banner"
+            role="alert"
+            data-testid="review-editor-lifecycle-conflict"
+          >
+            {t("cardForm.errors.mediaLifecycleConflict")}
+          </p>
+        ) : null}
+        {editorErrorMessage !== "" ? (
+          <p className="error-banner" role="alert">{editorErrorMessage}</p>
+        ) : null}
 
         <CardFormFields
           tagSuggestions={tagSuggestions}

--- a/apps/web/src/screens/review/components/card/useReviewCardEditor.ts
+++ b/apps/web/src/screens/review/components/card/useReviewCardEditor.ts
@@ -1,12 +1,15 @@
-import { useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
 import type { TranslationKey } from "../../../../i18n";
 import { UnsupportedImagePreparationError } from "../../../../media/imagePreparation";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import { getExpectedCardMutationInlineErrorMessage } from "../../../cards/cardMutationErrors";
 import {
+  cancelCardFormTextareaSelectionRestore,
+  captureCardFormTextareaSelection,
   createCardFormManagedMediaState,
   isCardFormManagedMediaProcessing,
+  scheduleCardFormTextareaSelectionRestore,
   toCardFormState,
   type CardFormImageMediaRequest,
   type CardFormMediaUploadRetryRequest,
@@ -14,14 +17,47 @@ import {
   type CardFormManagedMediaFieldState,
   type CardFormManagedMediaState,
   type CardFormState,
+  type CardFormTextareaSelectionRestore,
+  type CardFormTextareaSelectionSnapshot,
 } from "../../../cards/form/CardForm";
 import { prepareCardImageMediaAuthoring } from "../../../cards/form/cardImageAuthoring";
+import {
+  isGeneratedMediaLifecycleConflictPresent,
+  mergeGeneratedMediaLifecycleConflicts,
+  reconcileGeneratedMediaLifecycleChanges,
+  type GeneratedMediaLifecycleConflict,
+  type GeneratedMediaLifecycleTextReplacements,
+} from "../../../cards/form/cardFormMediaLifecycle";
 import { markMediaUploadTransferDueForRetry } from "../../../../localDb/mediaTransfers";
 import type { Card } from "../../../../types";
+
+export type ReviewEditorPresentationToken = Readonly<{
+  presentationGeneration: number;
+}>;
+
+type ReviewEditorIdentity = ReviewEditorPresentationToken & Readonly<{
+  cardId: string;
+  workspaceId: string | null;
+}>;
+
+type ReviewCardObservationMarker = Readonly<Pick<
+  Card,
+  | "cardId"
+  | "clientUpdatedAt"
+  | "lastModifiedByReplicaId"
+  | "lastOperationId"
+  | "updatedAt"
+>>;
+
+type PendingReviewEditorTextareaSelectionRestore = Readonly<{
+  removeBlurListener: () => void;
+  restore: CardFormTextareaSelectionRestore;
+}>;
 
 type UseReviewCardEditorParams = Readonly<{
   deleteCardItem: (cardId: string) => Promise<Card>;
   installationId: string | null;
+  localReadVersion: number;
   queueCards: ReadonlyArray<Card>;
   runMediaUploadTransfers: () => void;
   selectedCard: Card | null;
@@ -40,23 +76,60 @@ export type UseReviewCardEditorResult = Readonly<{
   editorErrorMessage: string;
   editingCard: Card | null;
   editorFormState: CardFormState;
+  captureEditorPresentationToken: () => ReviewEditorPresentationToken | null;
   handleEditorDelete: () => Promise<void>;
   handlePrepareImageMedia: (request: CardFormImageMediaRequest) => Promise<string | null>;
   handleEditorSaveForAiHandoff: () => Promise<Card | null>;
   handleRetryMediaUploadTransfer: (request: CardFormMediaUploadRetryRequest) => Promise<void>;
   handleEditorSave: () => Promise<void>;
   handleOpenEditor: (card: Card) => void;
+  handleCloseEditor: () => void;
+  handleCloseEditorIfCurrent: (token: ReviewEditorPresentationToken) => void;
   isEditorPresented: boolean;
   isEditorSaving: boolean;
+  isEditorSubmissionAllowed: () => boolean;
+  isEditorSubmissionBlocked: boolean;
   managedMediaState: CardFormManagedMediaState;
   setEditorFormState: (nextFormState: CardFormState) => void;
-  setIsEditorPresented: (value: boolean) => void;
 }>;
+
+function areReviewEditorIdentitiesEqual(
+  left: ReviewEditorIdentity | null,
+  right: ReviewEditorIdentity,
+): boolean {
+  return left !== null
+    && left.cardId === right.cardId
+    && left.presentationGeneration === right.presentationGeneration
+    && left.workspaceId === right.workspaceId;
+}
+
+function toReviewCardObservationMarker(card: Card): ReviewCardObservationMarker {
+  return {
+    cardId: card.cardId,
+    clientUpdatedAt: card.clientUpdatedAt,
+    lastModifiedByReplicaId: card.lastModifiedByReplicaId,
+    lastOperationId: card.lastOperationId,
+    updatedAt: card.updatedAt,
+  };
+}
+
+function areReviewCardObservationMarkersEqual(
+  left: ReviewCardObservationMarker | null,
+  right: ReviewCardObservationMarker,
+): boolean {
+  return left !== null
+    && left.cardId === right.cardId
+    && left.clientUpdatedAt === right.clientUpdatedAt
+    && left.lastModifiedByReplicaId === right.lastModifiedByReplicaId
+    && left.lastOperationId === right.lastOperationId
+    && left.updatedAt === right.updatedAt;
+}
 
 export function useReviewCardEditor(params: UseReviewCardEditorParams): UseReviewCardEditorResult {
   const {
     deleteCardItem,
     installationId,
+    localReadVersion,
     queueCards,
     runMediaUploadTransfers,
     selectedCard,
@@ -67,25 +140,257 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
     workspaceId,
   } = params;
   const { showCapturedTechnicalError } = useAppErrorDialog();
+  const editorIdentityRef = useRef<ReviewEditorIdentity | null>(null);
+  const reconciliationBaselineCardRef = useRef<Card | null>(null);
+  const lastProcessedObservedCardMarkerRef = useRef<ReviewCardObservationMarker | null>(null);
+  const editorFormStateRef = useRef<CardFormState>(toCardFormState(null));
+  const editorFormRevisionRef = useRef<number>(0);
+  const mediaLifecycleConflictRef = useRef<GeneratedMediaLifecycleConflict | null>(null);
+  const pendingTextareaSelectionRestoreRef = useRef<PendingReviewEditorTextareaSelectionRestore | null>(null);
+  const textareaSelectionRestoreGenerationRef = useRef<number>(0);
+  const syncGenerationRef = useRef<number>(0);
+  const presentationGenerationRef = useRef<number>(0);
+  const isEditorPresentedRef = useRef<boolean>(false);
   const [isEditorPresented, setIsEditorPresented] = useState<boolean>(false);
   const [editingCardId, setEditingCardId] = useState<string>("");
-  const [editorFormState, setEditorFormState] = useState<CardFormState>(toCardFormState(null));
+  const [editorFormState, setEditorFormState] = useState<CardFormState>(editorFormStateRef.current);
   const [editorErrorMessage, setEditorErrorMessage] = useState<string>("");
+  const [mediaLifecycleConflict, setMediaLifecycleConflict] = useState<GeneratedMediaLifecycleConflict | null>(null);
   const [isEditorSaving, setIsEditorSaving] = useState<boolean>(false);
   const [managedMediaState, setManagedMediaState] = useState<CardFormManagedMediaState>(createCardFormManagedMediaState);
-  const editingCard = queueCards.find((card) => card.cardId === editingCardId) ?? selectedCard ?? null;
+  const observedEditingCard = queueCards.find((card) => card.cardId === editingCardId)
+    ?? (selectedCard?.cardId === editingCardId ? selectedCard : null);
+  const editingCard = isEditorPresented
+    ? reconciliationBaselineCardRef.current
+    : observedEditingCard;
   const isAuthoringMedia = isCardFormManagedMediaProcessing(managedMediaState);
+  const isEditorSubmissionBlocked = mediaLifecycleConflict !== null
+    && isGeneratedMediaLifecycleConflictPresent(mediaLifecycleConflict, editorFormState);
+
+  const cancelPendingTextareaSelectionRestore = useCallback(
+    function cancelPendingTextareaSelectionRestore(): void {
+      textareaSelectionRestoreGenerationRef.current += 1;
+      const pendingRestore = pendingTextareaSelectionRestoreRef.current;
+      pendingTextareaSelectionRestoreRef.current = null;
+      if (pendingRestore !== null) {
+        pendingRestore.removeBlurListener();
+        cancelCardFormTextareaSelectionRestore(pendingRestore.restore);
+      }
+    },
+    [],
+  );
+
+  const resetTextareaSelectionRestore = useCallback(
+    function resetTextareaSelectionRestore(): void {
+      cancelPendingTextareaSelectionRestore();
+      syncGenerationRef.current += 1;
+    },
+    [cancelPendingTextareaSelectionRestore],
+  );
+
+  const scheduleTextareaSelectionRestore = useCallback(
+    function scheduleTextareaSelectionRestore(
+      selection: CardFormTextareaSelectionSnapshot | null,
+      replacements: GeneratedMediaLifecycleTextReplacements,
+      nextFormState: CardFormState,
+      identity: ReviewEditorIdentity,
+      syncGeneration: number,
+    ): void {
+      cancelPendingTextareaSelectionRestore();
+      const restoreGeneration = textareaSelectionRestoreGenerationRef.current;
+      let didFinishSynchronously = false;
+      let removeBlurListener = (): void => undefined;
+      const restore = scheduleCardFormTextareaSelectionRestore(
+        selection,
+        replacements,
+        nextFormState,
+        () => (
+          textareaSelectionRestoreGenerationRef.current === restoreGeneration
+          && syncGenerationRef.current === syncGeneration
+          && isEditorPresentedRef.current
+          && areReviewEditorIdentitiesEqual(editorIdentityRef.current, identity)
+        ),
+        () => {
+          didFinishSynchronously = true;
+          removeBlurListener();
+          if (textareaSelectionRestoreGenerationRef.current !== restoreGeneration) {
+            return;
+          }
+
+          pendingTextareaSelectionRestoreRef.current = null;
+        },
+      );
+      if (restore === null || didFinishSynchronously) {
+        return;
+      }
+
+      const textarea = document.getElementById(restore.selection.textareaId);
+      const handleTextareaBlur = function handleTextareaBlur(): void {
+        cancelPendingTextareaSelectionRestore();
+      };
+      if (textarea instanceof HTMLTextAreaElement) {
+        textarea.addEventListener("blur", handleTextareaBlur, { once: true });
+        removeBlurListener = () => {
+          textarea.removeEventListener("blur", handleTextareaBlur);
+        };
+      }
+      pendingTextareaSelectionRestoreRef.current = {
+        removeBlurListener,
+        restore,
+      };
+    },
+    [cancelPendingTextareaSelectionRestore],
+  );
+
+  const handleCloseEditor = useCallback(function handleCloseEditor(): void {
+    isEditorPresentedRef.current = false;
+    editorIdentityRef.current = null;
+    editorFormRevisionRef.current += 1;
+    reconciliationBaselineCardRef.current = null;
+    lastProcessedObservedCardMarkerRef.current = null;
+    mediaLifecycleConflictRef.current = null;
+    resetTextareaSelectionRestore();
+    setMediaLifecycleConflict(null);
+    setIsEditorSaving(false);
+    setIsEditorPresented(false);
+  }, [resetTextareaSelectionRestore]);
+
+  const handleCloseEditorIfCurrent = useCallback(function handleCloseEditorIfCurrent(
+    token: ReviewEditorPresentationToken,
+  ): void {
+    if (editorIdentityRef.current !== token) {
+      return;
+    }
+
+    handleCloseEditor();
+  }, [handleCloseEditor]);
+
+  function captureEditorPresentationToken(): ReviewEditorPresentationToken | null {
+    return editorIdentityRef.current;
+  }
+
+  function isEditorPresentationCurrent(token: ReviewEditorPresentationToken): boolean {
+    return isEditorPresentedRef.current && editorIdentityRef.current === token;
+  }
+
+  useLayoutEffect(() => {
+    if (isEditorPresented === false) {
+      return;
+    }
+
+    const identity = editorIdentityRef.current;
+    if (identity === null || identity.workspaceId !== workspaceId) {
+      handleCloseEditor();
+      return;
+    }
+    if (observedEditingCard === null || observedEditingCard.cardId !== identity.cardId) {
+      return;
+    }
+
+    const observedCardMarker = toReviewCardObservationMarker(observedEditingCard);
+    if (
+      areReviewCardObservationMarkersEqual(
+        lastProcessedObservedCardMarkerRef.current,
+        observedCardMarker,
+      )
+    ) {
+      return;
+    }
+
+    const previousEditingCard = reconciliationBaselineCardRef.current;
+    if (previousEditingCard === null || previousEditingCard.cardId !== observedEditingCard.cardId) {
+      reconciliationBaselineCardRef.current = observedEditingCard;
+      lastProcessedObservedCardMarkerRef.current = observedCardMarker;
+      return;
+    }
+
+    const carriedSelection = pendingTextareaSelectionRestoreRef.current?.restore.selection ?? null;
+    const selection = carriedSelection ?? captureCardFormTextareaSelection("review-card-editor");
+    cancelPendingTextareaSelectionRestore();
+    const reconciliation = reconcileGeneratedMediaLifecycleChanges(
+      previousEditingCard,
+      observedEditingCard,
+      editorFormStateRef.current,
+    );
+    const syncGeneration = syncGenerationRef.current + 1;
+    syncGenerationRef.current = syncGeneration;
+    reconciliationBaselineCardRef.current = observedEditingCard;
+    lastProcessedObservedCardMarkerRef.current = observedCardMarker;
+    editorFormRevisionRef.current += 1;
+    editorFormStateRef.current = reconciliation.formState;
+    setEditorFormState(reconciliation.formState);
+
+    const existingConflict = mediaLifecycleConflictRef.current;
+    const discoveredConflict = reconciliation.conflict.references.length === 0
+      ? null
+      : reconciliation.conflict;
+    const nextConflict = discoveredConflict === null
+      ? existingConflict
+      : existingConflict === null
+        ? discoveredConflict
+        : mergeGeneratedMediaLifecycleConflicts(existingConflict, discoveredConflict);
+    mediaLifecycleConflictRef.current = nextConflict;
+    setMediaLifecycleConflict(nextConflict);
+    scheduleTextareaSelectionRestore(
+      selection,
+      reconciliation.textReplacements,
+      reconciliation.formState,
+      identity,
+      syncGeneration,
+    );
+  }, [
+    cancelPendingTextareaSelectionRestore,
+    handleCloseEditor,
+    isEditorPresented,
+    localReadVersion,
+    observedEditingCard,
+    scheduleTextareaSelectionRestore,
+    workspaceId,
+  ]);
+
+  useEffect(() => () => {
+    resetTextareaSelectionRestore();
+  }, [resetTextareaSelectionRestore]);
 
   function handleOpenEditor(card: Card): void {
+    resetTextareaSelectionRestore();
+    const initialFormState = toCardFormState(card);
+    const presentationGeneration = presentationGenerationRef.current + 1;
+    presentationGenerationRef.current = presentationGeneration;
+    editorIdentityRef.current = {
+      cardId: card.cardId,
+      presentationGeneration,
+      workspaceId,
+    };
+    reconciliationBaselineCardRef.current = card;
+    lastProcessedObservedCardMarkerRef.current = toReviewCardObservationMarker(card);
+    mediaLifecycleConflictRef.current = null;
+    editorFormRevisionRef.current += 1;
+    editorFormStateRef.current = initialFormState;
+    isEditorPresentedRef.current = true;
     setEditingCardId(card.cardId);
-    setEditorFormState(toCardFormState(card));
+    setEditorFormState(initialFormState);
     setEditorErrorMessage("");
+    setMediaLifecycleConflict(null);
     setManagedMediaState(createCardFormManagedMediaState());
+    setIsEditorSaving(false);
     setIsEditorPresented(true);
   }
 
+  function handleEditorFormStateChange(nextFormState: CardFormState): void {
+    editorFormRevisionRef.current += 1;
+    editorFormStateRef.current = nextFormState;
+    setEditorFormState(nextFormState);
+  }
+
+  function isEditorSubmissionAllowed(): boolean {
+    const conflict = mediaLifecycleConflictRef.current;
+    return conflict === null
+      || isGeneratedMediaLifecycleConflictPresent(conflict, editorFormStateRef.current) === false;
+  }
+
   async function handleEditorSave(): Promise<void> {
-    if (isAuthoringMedia) {
+    if (isAuthoringMedia || isEditorSubmissionAllowed() === false) {
       return;
     }
 
@@ -94,18 +399,37 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       return;
     }
 
+    const presentationToken = captureEditorPresentationToken();
+    if (presentationToken === null) {
+      return;
+    }
+    const submittedFormRevision = editorFormRevisionRef.current;
+    const submittedFormState = editorFormStateRef.current;
     setIsEditorSaving(true);
     setEditorErrorMessage("");
     setErrorMessage("");
 
     try {
-      await updateCardItem(editingCardId, {
-        frontText: editorFormState.frontText,
-        backText: editorFormState.backText,
-        tags: editorFormState.tags,
+      const savedCard = await updateCardItem(editingCardId, {
+        frontText: submittedFormState.frontText,
+        backText: submittedFormState.backText,
+        tags: submittedFormState.tags,
       });
-      setIsEditorPresented(false);
+      if (isEditorPresentationCurrent(presentationToken) === false) {
+        return;
+      }
+
+      reconciliationBaselineCardRef.current = savedCard;
+      if (editorFormRevisionRef.current !== submittedFormRevision) {
+        return;
+      }
+
+      handleCloseEditorIfCurrent(presentationToken);
     } catch (error) {
+      if (isEditorPresentationCurrent(presentationToken) === false) {
+        return;
+      }
+
       const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("reviewEditor.errors.cardNotFound"));
       if (expectedErrorMessage !== null) {
         setEditorErrorMessage(expectedErrorMessage);
@@ -123,12 +447,14 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       showCapturedTechnicalError(error);
       setEditorErrorMessage(t("appError.technicalError.message"));
     } finally {
-      setIsEditorSaving(false);
+      if (isEditorPresentationCurrent(presentationToken)) {
+        setIsEditorSaving(false);
+      }
     }
   }
 
   async function handleEditorSaveForAiHandoff(): Promise<Card | null> {
-    if (isAuthoringMedia) {
+    if (isAuthoringMedia || isEditorSubmissionAllowed() === false) {
       return null;
     }
 
@@ -137,18 +463,41 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       return null;
     }
 
+    const presentationToken = captureEditorPresentationToken();
+    if (presentationToken === null) {
+      return null;
+    }
+    const submittedFormRevision = editorFormRevisionRef.current;
+    const submittedFormState = editorFormStateRef.current;
     setIsEditorSaving(true);
     setEditorErrorMessage("");
     setErrorMessage("");
 
     try {
       const savedCard = await updateCardItem(editingCardId, {
-        frontText: editorFormState.frontText,
-        backText: editorFormState.backText,
-        tags: editorFormState.tags,
+        frontText: submittedFormState.frontText,
+        backText: submittedFormState.backText,
+        tags: submittedFormState.tags,
       });
+      if (isEditorPresentationCurrent(presentationToken) === false) {
+        return null;
+      }
+
+      const savedFormState = toCardFormState(savedCard);
+      reconciliationBaselineCardRef.current = savedCard;
+      if (editorFormRevisionRef.current !== submittedFormRevision) {
+        return null;
+      }
+
+      editorFormRevisionRef.current += 1;
+      editorFormStateRef.current = savedFormState;
+      setEditorFormState(savedFormState);
       return savedCard;
     } catch (error) {
+      if (isEditorPresentationCurrent(presentationToken) === false) {
+        return null;
+      }
+
       const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("reviewEditor.errors.cardNotFound"));
       if (expectedErrorMessage !== null) {
         setEditorErrorMessage(expectedErrorMessage);
@@ -167,7 +516,9 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       setEditorErrorMessage(t("appError.technicalError.message"));
       return null;
     } finally {
-      setIsEditorSaving(false);
+      if (isEditorPresentationCurrent(presentationToken)) {
+        setIsEditorSaving(false);
+      }
     }
   }
 
@@ -191,7 +542,7 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
 
     try {
       await deleteCardItem(editingCardId);
-      setIsEditorPresented(false);
+      handleCloseEditor();
     } catch (error) {
       const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("reviewEditor.errors.cardNotFound"));
       if (expectedErrorMessage !== null) {
@@ -310,6 +661,7 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
   }
 
   return {
+    captureEditorPresentationToken,
     editorErrorMessage,
     editingCard,
     editorFormState,
@@ -319,10 +671,13 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
     handleRetryMediaUploadTransfer,
     handleEditorSave,
     handleOpenEditor,
+    handleCloseEditor,
+    handleCloseEditorIfCurrent,
     isEditorPresented,
     isEditorSaving,
+    isEditorSubmissionAllowed,
+    isEditorSubmissionBlocked,
     managedMediaState,
-    setEditorFormState,
-    setIsEditorPresented,
+    setEditorFormState: handleEditorFormStateChange,
   };
 }

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.editor.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.editor.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import "fake-indexeddb/auto";
+import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Card } from "../../../types";
 import { clearWebSyncCache } from "../../../localDb/core/cache";
@@ -11,13 +12,24 @@ import {
 import {
   clickElementAsync,
   createCard,
+  createDeferredPromise,
   loadReviewQueueSnapshotMock,
   setTextFieldValueAsync,
   setupReviewScreenTest,
 } from "../testSupport/ReviewScreenTestSupport";
 
+const mocks = vi.hoisted(() => ({
+  handoffCardToAiMock: vi.fn(),
+}));
+
+vi.mock("../../../chat/handoff/useAiCardHandoff", () => ({
+  useAiCardHandoff: () => mocks.handoffCardToAiMock,
+}));
+
 beforeEach(async () => {
   await clearWebSyncCache();
+  mocks.handoffCardToAiMock.mockReset();
+  mocks.handoffCardToAiMock.mockResolvedValue(true);
 });
 
 const {
@@ -25,8 +37,52 @@ const {
   getContainer,
   getState,
   renderReviewScreen,
+  rerenderReviewScreen,
   revealAnswer,
 } = setupReviewScreenTest();
+
+type AnimationFrameController = Readonly<{
+  cancelledIds: () => ReadonlyArray<number>;
+  flushAll: () => Promise<void>;
+  latestScheduledId: () => number | null;
+  restore: () => void;
+}>;
+
+function installAnimationFrameController(): AnimationFrameController {
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const cancelledAnimationFrameIds: Array<number> = [];
+  let nextAnimationFrameId = 1;
+  const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    const animationFrameId = nextAnimationFrameId;
+    nextAnimationFrameId += 1;
+    callbacks.set(animationFrameId, callback);
+    return animationFrameId;
+  });
+  const cancelAnimationFrameSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation((animationFrameId) => {
+    cancelledAnimationFrameIds.push(animationFrameId);
+  });
+
+  return {
+    cancelledIds: () => [...cancelledAnimationFrameIds],
+    flushAll: async (): Promise<void> => {
+      const scheduledCallbacks = [...callbacks.entries()].reverse();
+      callbacks.clear();
+      for (const [, callback] of scheduledCallbacks) {
+        await act(async () => {
+          callback(0);
+        });
+      }
+    },
+    latestScheduledId: () => {
+      const scheduledIds = [...callbacks.keys()];
+      return scheduledIds.at(-1) ?? null;
+    },
+    restore: () => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    },
+  };
+}
 
 describe("ReviewScreen editor controls", () => {
   it("saves card edits from the review editor", async () => {
@@ -68,6 +124,1016 @@ describe("ReviewScreen editor controls", () => {
       frontText: "After",
       backText: "Existing back",
       tags: ["grammar"],
+    });
+  });
+
+  it("preserves edits made while an AI pre-save is pending and does not hand off stale text", async () => {
+    const state = getState();
+    const card = createCard({
+      cardId: "card-ai-pre-save-edit-race",
+      frontText: "Initial question",
+      backText: "Answer",
+      tags: ["grammar"],
+    });
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    const pendingUpdate = createDeferredPromise<Card>();
+    state.appData.updateCardItem.mockReturnValue(pendingUpdate.promise);
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    const frontTextField = document.getElementById("review-card-editor-front-text");
+    const aiButton = document.querySelector("[data-testid='review-editor-edit-with-ai']");
+    if (
+      !(frontTextField instanceof HTMLTextAreaElement)
+      || !(aiButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("Review editor AI controls were not found");
+    }
+
+    const submittedFrontText = "Question submitted before the race";
+    await setTextFieldValueAsync(frontTextField, submittedFrontText);
+    await clickElementAsync(aiButton);
+
+    await vi.waitFor(() => {
+      expect(state.appData.updateCardItem).toHaveBeenCalledWith(
+        "card-ai-pre-save-edit-race",
+        {
+          frontText: submittedFrontText,
+          backText: "Answer",
+          tags: ["grammar"],
+        },
+      );
+    });
+
+    const latestFrontText = "Question edited while the save is pending";
+    await setTextFieldValueAsync(frontTextField, latestFrontText);
+    await act(async () => {
+      pendingUpdate.resolve({
+        ...card,
+        frontText: submittedFrontText,
+        clientUpdatedAt: "2026-03-10T10:00:00.000Z",
+        lastOperationId: "operation-ai-pre-save-race",
+        updatedAt: "2026-03-10T10:00:00.000Z",
+      });
+      await pendingUpdate.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(frontTextField.value).toBe(latestFrontText);
+      expect(aiButton.disabled).toBe(false);
+      expect(mocks.handoffCardToAiMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not let an obsolete AI handoff close a reopened editor", async () => {
+    const state = getState();
+    const card = createCard({
+      cardId: "card-ai-handoff-presentation-race",
+      frontText: "Question",
+      backText: "Answer",
+    });
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    const pendingHandoff = createDeferredPromise<boolean>();
+    mocks.handoffCardToAiMock.mockReturnValue(pendingHandoff.promise);
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    const aiButton = document.querySelector("[data-testid='review-editor-edit-with-ai']");
+    if (!(aiButton instanceof HTMLButtonElement)) {
+      throw new Error("Review editor AI button was not found");
+    }
+    await clickElementAsync(aiButton);
+
+    await vi.waitFor(() => {
+      expect(mocks.handoffCardToAiMock).toHaveBeenCalledWith(card);
+    });
+
+    const cancelButton = document.querySelector("[data-testid='review-editor-cancel']");
+    if (!(cancelButton instanceof HTMLButtonElement)) {
+      throw new Error("Review editor cancel button was not found");
+    }
+    await clickElementAsync(cancelButton);
+    await clickElementAsync(editButton);
+
+    const reopenedFrontTextField = document.getElementById("review-card-editor-front-text");
+    if (!(reopenedFrontTextField instanceof HTMLTextAreaElement)) {
+      throw new Error("Reopened Review editor front field was not found");
+    }
+    const reopenedDraft = "Draft from the reopened editor";
+    await setTextFieldValueAsync(reopenedFrontTextField, reopenedDraft);
+
+    await act(async () => {
+      pendingHandoff.resolve(true);
+      await pendingHandoff.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector(".review-editor-modal")).not.toBeNull();
+      expect(reopenedFrontTextField.value).toBe(reopenedDraft);
+    });
+  });
+
+  it("reconciles synced media lifecycle markers without overwriting editor text changes", async () => {
+    const state = getState();
+    const pendingFrontText = [
+      "Question",
+      "",
+      '![Primary diagram](<fcasset:front-image?variant=large&state=pending#front> "Generated")',
+      "",
+      "![Secondary diagram](fcasset:secondary-image?state=pending)",
+    ].join("\n");
+    const failedBackText = 'Answer\n\n![Example](<fcasset:back-image?variant=large&state=failed#back> "Generated")';
+    const readyFrontText = [
+      "Question",
+      "",
+      '![Primary diagram](<fcasset:front-image?variant=large&state=ready#front> "Generated")',
+      "",
+      "![Secondary diagram](fcasset:secondary-image?state=pending)",
+    ].join("\n");
+    const readyBackText = 'Answer\n\n![Example](<fcasset:back-image?variant=large&state=promoted#back> "Generated")';
+    const card = createCard({
+      cardId: "card-media-lifecycle-sync",
+      frontText: pendingFrontText,
+      backText: failedBackText,
+      tags: ["grammar"],
+    });
+    const refreshedCard = {
+      ...card,
+      frontText: readyFrontText.replace("Question", "Remotely edited question"),
+      backText: readyBackText.replace("Answer", "Remotely edited answer"),
+      tags: ["grammar", "remote"],
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    state.appData.updateCardItem.mockResolvedValue(refreshedCard);
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    const frontTextField = document.getElementById("review-card-editor-front-text");
+    const backTextField = document.getElementById("review-card-editor-back-text");
+    if (!(frontTextField instanceof HTMLTextAreaElement) || !(backTextField instanceof HTMLTextAreaElement)) {
+      throw new Error("Review editor text fields were not found");
+    }
+
+    const editedBackText = 'Edited answer\n\n![Example](<fcasset:back-image?variant=large&state=failed#back> "Generated")';
+    await setTextFieldValueAsync(backTextField, editedBackText);
+
+    const tagsTrigger = document.querySelector('[data-testid="card-form-tags-trigger"]');
+    if (!(tagsTrigger instanceof HTMLElement)) {
+      throw new Error("Review editor tags trigger was not found");
+    }
+    await clickElementAsync(tagsTrigger);
+
+    const tagsInput = document.getElementById("review-card-editor-tags-input");
+    if (!(tagsInput instanceof HTMLInputElement)) {
+      throw new Error("Review editor tags input was not found");
+    }
+    await setTextFieldValueAsync(tagsInput, "custom");
+    await act(async () => {
+      tagsInput.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+      }));
+    });
+    await clickElementAsync(tagsTrigger);
+
+    const selectedText = "Secondary diagram";
+    const selectionStart = pendingFrontText.indexOf(selectedText);
+    await act(async () => {
+      frontTextField.focus();
+      frontTextField.setSelectionRange(
+        selectionStart,
+        selectionStart + selectedText.length,
+        "backward",
+      );
+    });
+
+    state.cards = [refreshedCard];
+    state.reviewQueue = [refreshedCard];
+    state.reviewTimeline = [refreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    const reconciledFrontText = readyFrontText.replace("Question", "Remotely edited question");
+    const reconciledBackText = readyBackText.replace("Answer", "Edited answer");
+    await vi.waitFor(() => {
+      expect(frontTextField.value).toBe(reconciledFrontText);
+      expect(backTextField.value).toBe(reconciledBackText);
+      const reconciledSelectionStart = reconciledFrontText.indexOf(selectedText);
+      expect(document.activeElement).toBe(frontTextField);
+      expect(frontTextField.selectionStart).toBe(reconciledSelectionStart);
+      expect(frontTextField.selectionEnd).toBe(
+        reconciledSelectionStart + selectedText.length,
+      );
+      expect(frontTextField.selectionDirection).toBe("backward");
+    });
+
+    const saveButton = document.querySelector(".review-editor-modal .primary-btn");
+    if (!(saveButton instanceof HTMLButtonElement)) {
+      throw new Error("Review editor save button was not found");
+    }
+    await clickElementAsync(saveButton);
+
+    expect(state.appData.updateCardItem).toHaveBeenCalledWith("card-media-lifecycle-sync", {
+      frontText: reconciledFrontText,
+      backText: reconciledBackText,
+      tags: ["grammar", "custom"],
+    });
+  });
+
+  it("advances the observed baseline across unresolved lifecycle refreshes", async () => {
+    const state = getState();
+    const selectionText = "Selection anchor";
+    const pendingFrontText = "Question\n\n![Diagram](fcasset:chained-refresh-image?state=pending)";
+    const readyFrontText = "Question\n\n![Diagram](fcasset:chained-refresh-image)";
+    const initialBackText = `Answer A\n\n${selectionText}`;
+    const refreshedBackText = `Answer B\n\n${selectionText}`;
+    const laterBackText = `Answer C\n\n${selectionText}`;
+    const card = createCard({
+      cardId: "card-media-lifecycle-chained-refresh",
+      frontText: pendingFrontText,
+      backText: initialBackText,
+      tags: ["grammar"],
+    });
+    const refreshedCard = {
+      ...card,
+      frontText: readyFrontText,
+      backText: refreshedBackText,
+      tags: ["grammar", "remote-b"],
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    const laterRefreshedCard = {
+      ...refreshedCard,
+      backText: laterBackText,
+      tags: ["grammar", "remote-c"],
+      updatedAt: "2026-03-10T11:00:00.000Z",
+    };
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    const frontTextField = document.getElementById("review-card-editor-front-text");
+    const backTextField = document.getElementById("review-card-editor-back-text");
+    if (
+      !(frontTextField instanceof HTMLTextAreaElement)
+      || !(backTextField instanceof HTMLTextAreaElement)
+    ) {
+      throw new Error("Review editor text fields were not found");
+    }
+    const editedFrontText = pendingFrontText.replace("Diagram", "Locally edited diagram");
+    await setTextFieldValueAsync(frontTextField, editedFrontText);
+    const selectionStart = initialBackText.indexOf(selectionText);
+    await act(async () => {
+      backTextField.focus();
+      backTextField.setSelectionRange(
+        selectionStart,
+        selectionStart + selectionText.length,
+        "forward",
+      );
+    });
+
+    state.cards = [refreshedCard];
+    state.reviewQueue = [refreshedCard];
+    state.reviewTimeline = [refreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    const blockedControls = await vi.waitFor(() => {
+      const alert = document.querySelector("[data-testid='review-editor-lifecycle-conflict']");
+      const saveButton = document.querySelector(".review-editor-modal .primary-btn");
+      const aiButton = document.querySelector("[data-testid='review-editor-edit-with-ai']");
+      const tagsTrigger = document.querySelector('[data-testid="card-form-tags-trigger"]');
+      if (
+        !(alert instanceof HTMLElement)
+        || !(saveButton instanceof HTMLButtonElement)
+        || !(aiButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error("Blocked Review editor controls were not found");
+      }
+      expect(frontTextField.value).toBe(editedFrontText);
+      expect(backTextField.value).toBe(refreshedBackText);
+      expect(tagsTrigger?.textContent).toContain("remote-b");
+      expect(saveButton.disabled).toBe(true);
+      expect(aiButton.disabled).toBe(true);
+      const refreshedSelectionStart = refreshedBackText.indexOf(selectionText);
+      expect(document.activeElement).toBe(backTextField);
+      expect(backTextField.selectionStart).toBe(refreshedSelectionStart);
+      expect(backTextField.selectionEnd).toBe(
+        refreshedSelectionStart + selectionText.length,
+      );
+      expect(backTextField.selectionDirection).toBe("forward");
+      return { aiButton, saveButton };
+    });
+
+    state.cards = [laterRefreshedCard];
+    state.reviewQueue = [laterRefreshedCard];
+    state.reviewTimeline = [laterRefreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      const tagsTrigger = document.querySelector('[data-testid="card-form-tags-trigger"]');
+      expect(frontTextField.value).toBe(editedFrontText);
+      expect(backTextField.value).toBe(laterBackText);
+      expect(tagsTrigger?.textContent).toContain("remote-c");
+      expect(document.querySelector("[data-testid='review-editor-lifecycle-conflict']")).not.toBeNull();
+      expect(blockedControls.saveButton.disabled).toBe(true);
+      expect(blockedControls.aiButton.disabled).toBe(true);
+      const refreshedSelectionStart = laterBackText.indexOf(selectionText);
+      expect(document.activeElement).toBe(backTextField);
+      expect(backTextField.selectionStart).toBe(refreshedSelectionStart);
+      expect(backTextField.selectionEnd).toBe(
+        refreshedSelectionStart + selectionText.length,
+      );
+      expect(backTextField.selectionDirection).toBe("forward");
+    });
+
+    await clickElementAsync(blockedControls.saveButton);
+    await clickElementAsync(blockedControls.aiButton);
+    expect(state.appData.updateCardItem).not.toHaveBeenCalled();
+    expect(mocks.handoffCardToAiMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels obsolete selection restores and preserves the editor through failed or missing refreshes", async () => {
+    const state = getState();
+    const selectedText = "Selection 😀 anchor";
+    const pendingReference = "![Diagram](fcasset:selection-race-image?state=pending)";
+    const readyReference = "![Diagram](fcasset:selection-race-image)";
+    const initialFrontText = `A\n\n${pendingReference}\n\n${selectedText}`;
+    const refreshedFrontText = `BBBB\n\n${readyReference}\n\n${selectedText}`;
+    const laterFrontText = `CC\n\n${readyReference}\n\n${selectedText}`;
+    const card = createCard({
+      cardId: "card-media-lifecycle-selection-race",
+      frontText: initialFrontText,
+      backText: "Answer",
+    });
+    const refreshedCard = {
+      ...card,
+      frontText: refreshedFrontText,
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    const laterRefreshedCard = {
+      ...refreshedCard,
+      frontText: laterFrontText,
+      updatedAt: "2026-03-10T11:00:00.000Z",
+    };
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    const frontTextField = document.getElementById("review-card-editor-front-text");
+    if (!(frontTextField instanceof HTMLTextAreaElement)) {
+      throw new Error("Review editor front field was not found");
+    }
+    const selectionStart = initialFrontText.indexOf(selectedText);
+    await act(async () => {
+      frontTextField.focus();
+      frontTextField.setSelectionRange(
+        selectionStart,
+        selectionStart + selectedText.length,
+        "backward",
+      );
+    });
+
+    const animationFrames = installAnimationFrameController();
+    try {
+      state.cards = [refreshedCard];
+      state.reviewQueue = [refreshedCard];
+      state.reviewTimeline = [refreshedCard];
+      state.appData.localReadVersion += 1;
+      await rerenderReviewScreen();
+
+      const firstRestoreId = animationFrames.latestScheduledId();
+      if (firstRestoreId === null) {
+        throw new Error("First Review editor selection restore was not scheduled");
+      }
+
+      state.cards = [laterRefreshedCard];
+      state.reviewQueue = [laterRefreshedCard];
+      state.reviewTimeline = [laterRefreshedCard];
+      state.appData.localReadVersion += 1;
+      await rerenderReviewScreen();
+
+      const laterRestoreId = animationFrames.latestScheduledId();
+      if (laterRestoreId === null || laterRestoreId === firstRestoreId) {
+        throw new Error("Later Review editor selection restore was not scheduled");
+      }
+      expect(animationFrames.cancelledIds()).toContain(firstRestoreId);
+      expect(frontTextField.value).toBe(laterFrontText);
+
+      await act(async () => {
+        frontTextField.blur();
+      });
+      expect(animationFrames.cancelledIds()).toContain(laterRestoreId);
+      expect(document.activeElement).toBe(document.body);
+
+      loadReviewQueueSnapshotMock.mockRejectedValueOnce(new Error("refresh unavailable"));
+      state.appData.localReadVersion += 1;
+      await rerenderReviewScreen();
+
+      expect(document.querySelector(".review-editor-modal")).not.toBeNull();
+      expect(frontTextField.value).toBe(laterFrontText);
+      expect(document.activeElement).not.toBe(frontTextField);
+
+      state.cards = [];
+      state.reviewQueue = [];
+      state.reviewTimeline = [];
+      state.appData.localReadVersion += 1;
+      await rerenderReviewScreen();
+
+      expect(document.querySelector(".review-editor-modal")).not.toBeNull();
+      expect(frontTextField.value).toBe(laterFrontText);
+      await animationFrames.flushAll();
+      expect(document.activeElement).not.toBe(frontTextField);
+      expect(frontTextField.value).toBe(laterFrontText);
+    } finally {
+      animationFrames.restore();
+    }
+  });
+
+  it("retains dormant lifecycle conflicts after a failed AI handoff", async () => {
+    const state = getState();
+    const pendingReference = "![Diagram](fcasset:failed-handoff-image?state=pending)";
+    const readyReference = "![Diagram](fcasset:failed-handoff-image)";
+    const pendingFrontText = `Question\n\n${pendingReference}`;
+    const readyFrontText = `Question\n\n${readyReference}`;
+    const card = createCard({
+      cardId: "card-media-lifecycle-handoff",
+      frontText: pendingFrontText,
+      backText: "Answer",
+      tags: ["grammar"],
+    });
+    const refreshedCard = {
+      ...card,
+      frontText: readyFrontText,
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    state.cards = [refreshedCard];
+    state.reviewQueue = [refreshedCard];
+    state.reviewTimeline = [refreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    const controls = await vi.waitFor(() => {
+      const frontTextField = document.getElementById("review-card-editor-front-text");
+      const backTextField = document.getElementById("review-card-editor-back-text");
+      const saveButton = document.querySelector(".review-editor-modal .primary-btn");
+      const aiButton = document.querySelector("[data-testid='review-editor-edit-with-ai']");
+      if (
+        !(frontTextField instanceof HTMLTextAreaElement)
+        || !(backTextField instanceof HTMLTextAreaElement)
+        || !(saveButton instanceof HTMLButtonElement)
+        || !(aiButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error("Review editor controls were not found");
+      }
+      expect(frontTextField.value).toBe(readyFrontText);
+      return {
+        aiButton,
+        backTextField,
+        frontTextField,
+        saveButton,
+      };
+    });
+
+    const editedFrontText = readyFrontText.replace("Question", "Edited question");
+    await setTextFieldValueAsync(controls.frontTextField, editedFrontText);
+    const savedCard = {
+      ...refreshedCard,
+      frontText: editedFrontText,
+    };
+    state.appData.updateCardItem.mockResolvedValue(savedCard);
+    mocks.handoffCardToAiMock.mockResolvedValue(false);
+    await clickElementAsync(controls.aiButton);
+
+    await vi.waitFor(() => {
+      expect(state.appData.updateCardItem).toHaveBeenCalledTimes(1);
+      expect(mocks.handoffCardToAiMock).toHaveBeenCalledWith(savedCard);
+    });
+
+    const pastedBackText = `Edited answer\n\n${pendingReference}`;
+    await setTextFieldValueAsync(controls.backTextField, pastedBackText);
+
+    await vi.waitFor(() => {
+      expect(document.querySelector("[data-testid='review-editor-lifecycle-conflict']")?.textContent).toContain(
+        "A managed image changed",
+      );
+      expect(controls.saveButton.disabled).toBe(true);
+      expect(controls.aiButton.disabled).toBe(true);
+    });
+    await clickElementAsync(controls.saveButton);
+    await clickElementAsync(controls.aiButton);
+    expect(state.appData.updateCardItem).toHaveBeenCalledTimes(1);
+    expect(mocks.handoffCardToAiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains a successful AI pre-save when its version bump refresh fails against the stale queue", async () => {
+    const state = getState();
+    const pendingReference = "![Diagram](fcasset:pre-save-refresh-image?state=pending)";
+    const readyReference = "![Diagram](fcasset:pre-save-refresh-image)";
+    const initialCard = createCard({
+      cardId: "card-media-lifecycle-pre-save-refresh",
+      frontText: `Question\n\n${pendingReference}`,
+      backText: "Answer",
+      tags: ["grammar"],
+    });
+    const refreshedCard = {
+      ...initialCard,
+      frontText: `Question\n\n${readyReference}`,
+      clientUpdatedAt: "2026-03-10T10:00:00.000Z",
+      lastModifiedByReplicaId: "device-remote",
+      lastOperationId: "operation-remote-ready",
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    state.cards = [initialCard];
+    state.reviewQueue = [initialCard];
+    state.reviewTimeline = [initialCard];
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    state.cards = [refreshedCard];
+    state.reviewQueue = [refreshedCard];
+    state.reviewTimeline = [refreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    const controls = await vi.waitFor(() => {
+      const frontTextField = document.getElementById("review-card-editor-front-text");
+      const backTextField = document.getElementById("review-card-editor-back-text");
+      const aiButton = document.querySelector("[data-testid='review-editor-edit-with-ai']");
+      const saveButton = document.querySelector(".review-editor-modal .primary-btn");
+      if (
+        !(frontTextField instanceof HTMLTextAreaElement)
+        || !(backTextField instanceof HTMLTextAreaElement)
+        || !(aiButton instanceof HTMLButtonElement)
+        || !(saveButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error("Review editor controls were not found");
+      }
+      expect(frontTextField.value).toBe(refreshedCard.frontText);
+      return {
+        aiButton,
+        backTextField,
+        frontTextField,
+        saveButton,
+      };
+    });
+
+    const savedFrontText = refreshedCard.frontText.replace("Question", "Saved question");
+    await setTextFieldValueAsync(controls.frontTextField, savedFrontText);
+    const firstSavedCard = {
+      ...refreshedCard,
+      frontText: savedFrontText,
+      clientUpdatedAt: "2026-03-10T11:00:00.000Z",
+      lastModifiedByReplicaId: "device-local",
+      lastOperationId: "operation-local-pre-save",
+      updatedAt: "2026-03-10T11:00:00.000Z",
+    };
+    const secondSavedCard = {
+      ...firstSavedCard,
+      clientUpdatedAt: "2026-03-10T12:00:00.000Z",
+      lastOperationId: "operation-local-final-save",
+      updatedAt: "2026-03-10T12:00:00.000Z",
+    };
+    let updateCallCount = 0;
+    state.appData.updateCardItem.mockImplementation(async (_cardId, input): Promise<Card> => {
+      updateCallCount += 1;
+      state.appData.localReadVersion += 1;
+      return {
+        ...(updateCallCount === 1 ? firstSavedCard : secondSavedCard),
+        ...input,
+      };
+    });
+    loadReviewQueueSnapshotMock.mockRejectedValueOnce(new Error("refresh unavailable"));
+    mocks.handoffCardToAiMock.mockResolvedValue(false);
+    await clickElementAsync(controls.aiButton);
+
+    await vi.waitFor(() => {
+      expect(state.appData.updateCardItem).toHaveBeenCalledTimes(1);
+      expect(mocks.handoffCardToAiMock).toHaveBeenCalledWith(firstSavedCard);
+      expect(controls.frontTextField.value).toBe(savedFrontText);
+      expect(document.querySelector(".review-editor-modal")).not.toBeNull();
+    });
+
+    await setTextFieldValueAsync(
+      controls.backTextField,
+      `Answer\n\n${pendingReference}`,
+    );
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector("[data-testid='review-editor-lifecycle-conflict']"),
+      ).not.toBeNull();
+      expect(controls.saveButton.disabled).toBe(true);
+    });
+    await setTextFieldValueAsync(controls.backTextField, "Answer");
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector("[data-testid='review-editor-lifecycle-conflict']"),
+      ).toBeNull();
+      expect(controls.saveButton.disabled).toBe(false);
+    });
+
+    await clickElementAsync(controls.saveButton);
+
+    expect(state.appData.updateCardItem).toHaveBeenLastCalledWith(
+      "card-media-lifecycle-pre-save-refresh",
+      {
+        frontText: savedFrontText,
+        backText: "Answer",
+        tags: ["grammar"],
+      },
+    );
+  });
+
+  it("retains a successful AI pre-save while omitted and applies each later queue revision once", async () => {
+    const state = getState();
+    const initialCard = createCard({
+      cardId: "card-pre-save-omitted-refresh",
+      frontText: "Question",
+      backText: "Answer",
+      tags: ["grammar"],
+    });
+    state.cards = [initialCard];
+    state.reviewQueue = [initialCard];
+    state.reviewTimeline = [initialCard];
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    const frontTextField = document.getElementById("review-card-editor-front-text");
+    const backTextField = document.getElementById("review-card-editor-back-text");
+    const aiButton = document.querySelector("[data-testid='review-editor-edit-with-ai']");
+    if (
+      !(frontTextField instanceof HTMLTextAreaElement)
+      || !(backTextField instanceof HTMLTextAreaElement)
+      || !(aiButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("Review editor controls were not found");
+    }
+
+    const savedFrontText = "Saved question";
+    await setTextFieldValueAsync(frontTextField, savedFrontText);
+    const savedCard = {
+      ...initialCard,
+      frontText: savedFrontText,
+      clientUpdatedAt: "2026-03-10T10:00:00.000Z",
+      lastModifiedByReplicaId: "device-local",
+      lastOperationId: "operation-local-omitted",
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    state.appData.updateCardItem.mockImplementation(async (_cardId, input): Promise<Card> => {
+      state.appData.localReadVersion += 1;
+      return {
+        ...savedCard,
+        ...input,
+      };
+    });
+    state.appData.getCardById.mockImplementation(async (cardId: string): Promise<Card> => {
+      throw new Error(`Card not found: ${cardId}`);
+    });
+    state.cards = [];
+    state.reviewQueue = [];
+    state.reviewTimeline = [];
+    mocks.handoffCardToAiMock.mockResolvedValue(false);
+    await clickElementAsync(aiButton);
+
+    await vi.waitFor(() => {
+      expect(mocks.handoffCardToAiMock).toHaveBeenCalledWith(savedCard);
+      expect(document.querySelector(".review-editor-modal")).not.toBeNull();
+      expect(frontTextField.value).toBe(savedFrontText);
+    });
+
+    const laterCard = {
+      ...savedCard,
+      frontText: "Remotely refreshed question",
+      backText: "Remotely refreshed answer",
+      tags: ["grammar", "remote"],
+      clientUpdatedAt: "2026-03-10T11:00:00.000Z",
+      lastModifiedByReplicaId: "device-remote",
+      lastOperationId: "operation-remote-later",
+      updatedAt: "2026-03-10T11:00:00.000Z",
+    };
+    state.cards = [laterCard];
+    state.reviewQueue = [laterCard];
+    state.reviewTimeline = [laterCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(frontTextField.value).toBe(laterCard.frontText);
+      expect(backTextField.value).toBe(laterCard.backText);
+      expect(
+        document.querySelector('[data-testid="card-form-tags-trigger"]')?.textContent,
+      ).toContain("remote");
+    });
+
+    const locallyEditedBackText = "Locally edited after the later revision";
+    await setTextFieldValueAsync(backTextField, locallyEditedBackText);
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(frontTextField.value).toBe(laterCard.frontText);
+      expect(backTextField.value).toBe(locallyEditedBackText);
+    });
+  });
+
+  it("retains dormant conflicts after failed Save and resets them only after close", async () => {
+    const state = getState();
+    const pendingReference = "![Diagram](fcasset:failed-save-image?state=pending)";
+    const readyReference = "![Diagram](fcasset:failed-save-image)";
+    const card = createCard({
+      cardId: "card-media-lifecycle-failed-save",
+      frontText: `Question\n\n${pendingReference}`,
+      backText: "Answer",
+    });
+    const refreshedCard = {
+      ...card,
+      frontText: `Question\n\n${readyReference}`,
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    state.cards = [refreshedCard];
+    state.reviewQueue = [refreshedCard];
+    state.reviewTimeline = [refreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    const controls = await vi.waitFor(() => {
+      const backTextField = document.getElementById("review-card-editor-back-text");
+      const cancelButton = document.querySelector("[data-testid='review-editor-cancel']");
+      const saveButton = document.querySelector(".review-editor-modal .primary-btn");
+      if (
+        !(backTextField instanceof HTMLTextAreaElement)
+        || !(cancelButton instanceof HTMLButtonElement)
+        || !(saveButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error("Review editor controls were not found");
+      }
+      expect(saveButton.disabled).toBe(false);
+      return { backTextField, cancelButton, saveButton };
+    });
+
+    state.appData.updateCardItem.mockRejectedValue(new Error("save unavailable"));
+    await clickElementAsync(controls.saveButton);
+
+    await vi.waitFor(() => {
+      const actionAlerts = document.querySelectorAll(
+        ".review-editor-modal .error-banner[role='alert']",
+      );
+      expect(actionAlerts.length).toBe(1);
+      expect(
+        document.querySelector("[data-testid='review-editor-lifecycle-conflict']"),
+      ).toBeNull();
+    });
+
+    await setTextFieldValueAsync(
+      controls.backTextField,
+      `Answer\n\n${pendingReference}`,
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector("[data-testid='review-editor-lifecycle-conflict']"),
+      ).not.toBeNull();
+      expect(
+        document.querySelectorAll(".review-editor-modal .error-banner[role='alert']").length,
+      ).toBe(2);
+      expect(controls.saveButton.disabled).toBe(true);
+    });
+
+    await clickElementAsync(controls.cancelButton);
+    expect(document.querySelector(".review-editor-modal")).toBeNull();
+
+    await clickElementAsync(editButton);
+    const reopenedBackTextField = document.getElementById("review-card-editor-back-text");
+    const reopenedSaveButton = document.querySelector(".review-editor-modal .primary-btn");
+    if (
+      !(reopenedBackTextField instanceof HTMLTextAreaElement)
+      || !(reopenedSaveButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("Reopened Review editor controls were not found");
+    }
+    await setTextFieldValueAsync(
+      reopenedBackTextField,
+      `Answer\n\n${pendingReference}`,
+    );
+
+    expect(
+      document.querySelector("[data-testid='review-editor-lifecycle-conflict']"),
+    ).toBeNull();
+    expect(reopenedSaveButton.disabled).toBe(false);
+  });
+
+  it("blocks editor submission when a stale reference moves between card sides", async () => {
+    const state = getState();
+    const pendingReference = "![Diagram](fcasset:front-image?state=pending)";
+    const pendingFrontText = `Question\n\n${pendingReference}`;
+    const card = createCard({
+      cardId: "card-media-lifecycle-conflict",
+      frontText: pendingFrontText,
+      backText: "Answer",
+      tags: ["grammar"],
+    });
+    const refreshedCard = {
+      ...card,
+      frontText: "Remotely edited question\n\n![Diagram](fcasset:front-image)",
+      tags: ["grammar", "remote"],
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    };
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    state.appData.updateCardItem.mockResolvedValue(refreshedCard);
+    vi.useRealTimers();
+
+    await renderReviewScreen();
+
+    const editButton = getContainer().querySelector(".review-pane-edit-btn");
+    if (!(editButton instanceof HTMLButtonElement)) {
+      throw new Error("Review edit button was not found");
+    }
+    await clickElementAsync(editButton);
+
+    const frontTextField = document.getElementById("review-card-editor-front-text");
+    const backTextField = document.getElementById("review-card-editor-back-text");
+    if (
+      !(frontTextField instanceof HTMLTextAreaElement)
+      || !(backTextField instanceof HTMLTextAreaElement)
+    ) {
+      throw new Error("Review editor fields were not found");
+    }
+    const movedFrontText = "Edited question after moving the outdated reference";
+    const ambiguousMovedBackText = `Edited answer\n\n${pendingReference}\n\n${pendingReference}`;
+    await setTextFieldValueAsync(backTextField, ambiguousMovedBackText);
+    await setTextFieldValueAsync(frontTextField, movedFrontText);
+
+    state.cards = [refreshedCard];
+    state.reviewQueue = [refreshedCard];
+    state.reviewTimeline = [refreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    const conflictMessage = "A managed image changed while this card was open. Remove or edit the outdated pending or failed image reference before saving or using Edit with AI.";
+    const blockedControls = await vi.waitFor(() => {
+      const alert = document.querySelector("[data-testid='review-editor-lifecycle-conflict']");
+      const saveButton = document.querySelector(".review-editor-modal .primary-btn");
+      const aiButton = document.querySelector("[data-testid='review-editor-edit-with-ai']");
+      if (
+        !(alert instanceof HTMLElement)
+        || !(saveButton instanceof HTMLButtonElement)
+        || !(aiButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error("Blocked Review editor controls were not found");
+      }
+      expect(alert.textContent).toBe(conflictMessage);
+      expect(saveButton.disabled).toBe(true);
+      expect(aiButton.disabled).toBe(true);
+      expect(frontTextField.value).toBe(movedFrontText);
+      expect(backTextField.value).toBe(ambiguousMovedBackText);
+      return { aiButton, saveButton };
+    });
+
+    await clickElementAsync(blockedControls.saveButton);
+    await clickElementAsync(blockedControls.aiButton);
+    expect(state.appData.updateCardItem).not.toHaveBeenCalled();
+
+    const cutBackText = "Edited answer while the outdated reference is cut";
+    await setTextFieldValueAsync(backTextField, cutBackText);
+
+    await vi.waitFor(() => {
+      expect(document.querySelector("[data-testid='review-editor-lifecycle-conflict']")).toBeNull();
+      expect(blockedControls.saveButton.disabled).toBe(false);
+      expect(blockedControls.aiButton.disabled).toBe(false);
+    });
+
+    const editedStaleReference = '![Edited diagram](<fcasset:front-image?variant=large&state=pending#draft> "Edited title")';
+    const editedStaleBackText = `${cutBackText}\n\n${editedStaleReference}`;
+    await setTextFieldValueAsync(backTextField, editedStaleBackText);
+
+    await vi.waitFor(() => {
+      expect(document.querySelector("[data-testid='review-editor-lifecycle-conflict']")).not.toBeNull();
+      expect(blockedControls.saveButton.disabled).toBe(true);
+      expect(blockedControls.aiButton.disabled).toBe(true);
+    });
+
+    const laterRefreshedCard = {
+      ...refreshedCard,
+      backText: "Remotely edited answer",
+      updatedAt: "2026-03-10T11:00:00.000Z",
+    };
+    state.cards = [laterRefreshedCard];
+    state.reviewQueue = [laterRefreshedCard];
+    state.reviewTimeline = [laterRefreshedCard];
+    state.appData.localReadVersion += 1;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(document.querySelector("[data-testid='review-editor-lifecycle-conflict']")).not.toBeNull();
+      expect(blockedControls.saveButton.disabled).toBe(true);
+      expect(blockedControls.aiButton.disabled).toBe(true);
+      expect(frontTextField.value).toBe(movedFrontText);
+      expect(backTextField.value).toBe(editedStaleBackText);
+    });
+    await clickElementAsync(blockedControls.saveButton);
+    await clickElementAsync(blockedControls.aiButton);
+    expect(state.appData.updateCardItem).not.toHaveBeenCalled();
+
+    const resolvedBackText = "Edited answer without the outdated reference";
+    await setTextFieldValueAsync(backTextField, resolvedBackText);
+
+    await vi.waitFor(() => {
+      expect(document.querySelector("[data-testid='review-editor-lifecycle-conflict']")).toBeNull();
+      expect(blockedControls.saveButton.disabled).toBe(false);
+      expect(blockedControls.aiButton.disabled).toBe(false);
+    });
+    await clickElementAsync(blockedControls.saveButton);
+
+    expect(state.appData.updateCardItem).toHaveBeenCalledWith("card-media-lifecycle-conflict", {
+      frontText: movedFrontText,
+      backText: resolvedBackText,
+      tags: ["grammar", "remote"],
     });
   });
 

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -247,6 +247,7 @@ export function useReviewScreenController(
     selectedReviewFilter: resolvedReviewFilter,
   });
   const {
+    captureEditorPresentationToken,
     editorErrorMessage,
     editingCard,
     editorFormState,
@@ -256,14 +257,18 @@ export function useReviewScreenController(
     handleEditorSave,
     handlePrepareImageMedia,
     handleOpenEditor,
+    handleCloseEditor,
+    handleCloseEditorIfCurrent,
     isEditorPresented,
     isEditorSaving,
+    isEditorSubmissionAllowed,
+    isEditorSubmissionBlocked,
     managedMediaState,
     setEditorFormState,
-    setIsEditorPresented,
   } = useReviewCardEditor({
     deleteCardItem,
     installationId: cloudSettings?.installationId ?? null,
+    localReadVersion,
     queueCards,
     runMediaUploadTransfers,
     selectedCard,
@@ -765,10 +770,14 @@ export function useReviewScreenController(
   }
 
   async function handleEditorAiHandoff(): Promise<void> {
-    if (editingCard === null) {
+    if (editingCard === null || isEditorSubmissionAllowed() === false) {
       return;
     }
 
+    const presentationToken = captureEditorPresentationToken();
+    if (presentationToken === null) {
+      return;
+    }
     const cardForHandoff = isCardFormStateDirty(editingCard, editorFormState)
       ? await handleEditorSaveForAiHandoff()
       : editingCard;
@@ -778,12 +787,8 @@ export function useReviewScreenController(
 
     const didHandoff = await handoffCardToAi(cardForHandoff);
     if (didHandoff) {
-      setIsEditorPresented(false);
+      handleCloseEditorIfCurrent(presentationToken);
     }
-  }
-
-  function handleCloseEditor(): void {
-    setIsEditorPresented(false);
   }
 
   function handleDismissHardReminder(): void {
@@ -928,6 +933,7 @@ export function useReviewScreenController(
       formState: editorFormState,
       isEditorPresented,
       isEditorSaving,
+      isSubmissionBlocked: isEditorSubmissionBlocked,
       localReadVersion,
       managedMediaState,
       workspaceId: activeWorkspace?.workspaceId ?? null,


### PR DESCRIPTION
## Summary

- reconcile generated-media lifecycle updates into active Review editor drafts
- preserve conflict memory, textarea selections, semantic queue baselines, and same-card state across refresh failures
- guard AI pre-save draft mutations and bind async handoff completion to the initiating editor presentation

## Validation

- Node 24.18.0 focused Review/Card/media boundaries: 3 files, 60 tests passed
- Node 24.18.0 full Web suite: 79 files, 663 tests passed
- production Web build passed
- package-lock dry-run passed
- npm audit: 0 vulnerabilities
- diff, exact scope, ancestry, and immutable stash checks passed