### PR TITLE
Add generated image placeholder lifecycle

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -411,7 +411,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0103_ai_chat_initiating_auth_classification.sql
+            --require-migration 0104_generated_image_placeholder_terminal_state.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -85,8 +85,8 @@ const createdRolesByMigration = new Map([
 ]);
 const boundaryDefinitions = Object.freeze([
   Object.freeze({
-    migrationFileName: "0103_ai_chat_initiating_auth_classification.sql",
-    expectedMigrationCount: 105,
+    migrationFileName: "0104_generated_image_placeholder_terminal_state.sql",
+    expectedMigrationCount: 106,
     testFiles: Object.freeze([
       "src/cards/generatedImageAppend.postgres.integration.ts",
       "src/chat/cardImages/operation.postgres.integration.ts",

--- a/apps/backend/src/cards/generatedImageAppend.postgres.integration.ts
+++ b/apps/backend/src/cards/generatedImageAppend.postgres.integration.ts
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import test from "node:test";
 import pg from "pg";
 import type { DatabaseExecutor, SqlValue } from "../database";
 import { HttpError } from "../shared/errors";
 import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
-import { appendManagedImageToCardSideInExecutor } from "./index";
+import {
+  appendManagedImageToCardSideInExecutor,
+  appendPendingManagedImageToCardSideInExecutor,
+  markPendingManagedImageFailedOnCardSideInExecutor,
+  markPendingManagedImageReadyOnCardSideInExecutor,
+} from "./index";
 import type { AppendManagedImageToCardSideInput, AppendManagedImageToCardSideResult } from "./types";
 
 const futureClientUpdatedAt = "2099-01-01T00:00:00.000Z";
@@ -306,5 +312,274 @@ test("card image append is atomic, lock-safe, RLS-scoped, and duplicate-free", a
         assert.equal(await countCardHotChanges(fixture), 1);
       }
     }
+  });
+});
+
+test("generated image placeholders transition in place without changing unrelated Markdown", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const mediaAssetId = randomUUID();
+    const input: AppendManagedImageToCardSideInput = {
+      cardId: fixture.cardId,
+      targetSide: "back",
+      mediaAssetId,
+      altText: "Generated lifecycle image",
+    };
+    const metadata = {
+      clientUpdatedAt: fixture.createdAt,
+      lastModifiedByReplicaId: fixture.replicaId,
+      lastOperationId: randomUUID(),
+    };
+    const pendingUrl = `fcasset:${mediaAssetId}?state=pending`;
+    const readyUrl = `fcasset:${mediaAssetId}`;
+    const failedUrl = `fcasset:${mediaAssetId}?state=failed`;
+
+    const pending = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => appendPendingManagedImageToCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        input,
+        metadata,
+      ),
+    );
+    assert.equal(pending.applied, true);
+    assert.equal(pending.placeholderApplied, true);
+    assert.equal(
+      pending.card.backText,
+      `Original answer\n\n![Generated lifecycle image](${pendingUrl})`,
+    );
+
+    const pendingRetry = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => appendPendingManagedImageToCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        { ...input, altText: "Changed retry alt text" },
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    assert.equal(pendingRetry.applied, false);
+    assert.equal(pendingRetry.placeholderApplied, true);
+
+    await fixture.ownerPool.query(
+      `UPDATE content.cards
+       SET back_text = $1 || E'\\n\\n' || back_text || E'\\n\\nConcurrent editor suffix'
+       WHERE workspace_id = $2 AND card_id = $3`,
+      ["Concurrent editor prefix", fixture.workspaceId, fixture.cardId],
+    );
+    const ready = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => markPendingManagedImageReadyOnCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        input,
+        { ...metadata, lastOperationId: randomUUID() },
+        async () => {},
+      ),
+    );
+    assert.equal(ready.applied, true);
+    assert.equal(ready.card.backText.includes(pendingUrl), false);
+    assert.equal(ready.card.backText.includes(`![Generated lifecycle image](${readyUrl})`), true);
+    assert.equal(ready.card.backText.startsWith("Concurrent editor prefix\n\nOriginal answer"), true);
+    assert.equal(ready.card.backText.endsWith("Concurrent editor suffix"), true);
+
+    const failAfterReady = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => markPendingManagedImageFailedOnCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        input,
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    assert.equal(failAfterReady.applied, false);
+    assert.equal(failAfterReady.card.backText.includes(readyUrl), true);
+
+    const failedMediaAssetId = randomUUID();
+    const failedInput = {
+      ...input,
+      mediaAssetId: failedMediaAssetId,
+      altText: "Failed generated lifecycle image",
+    };
+    await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => appendPendingManagedImageToCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        failedInput,
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    const failed = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => markPendingManagedImageFailedOnCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        failedInput,
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    assert.equal(failed.applied, true);
+    assert.equal(
+      failed.card.backText.includes(
+        `![Failed generated lifecycle image](fcasset:${failedMediaAssetId}?state=failed)`,
+      ),
+      true,
+    );
+    assert.equal(failed.card.backText.includes(failedUrl), false);
+
+    const fencedMediaAssetId = randomUUID();
+    const fencedPendingUrl = `fcasset:${fencedMediaAssetId}?state=pending`;
+    await fixture.ownerPool.query(
+      "UPDATE content.cards SET back_text = $1 WHERE workspace_id = $2 AND card_id = $3",
+      [
+        ["```markdown", `![Literal](${fencedPendingUrl})`, "```", "Visible answer"].join("\n"),
+        fixture.workspaceId,
+        fixture.cardId,
+      ],
+    );
+    const fencedInput = {
+      ...input,
+      mediaAssetId: fencedMediaAssetId,
+      altText: "Active generated image",
+    };
+    await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => appendPendingManagedImageToCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        fencedInput,
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    const fencedReady = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => markPendingManagedImageReadyOnCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        fencedInput,
+        { ...metadata, lastOperationId: randomUUID() },
+        async () => {},
+      ),
+    );
+    assert.equal(
+      fencedReady.card.backText,
+      [
+        "```markdown",
+        `![Literal](${fencedPendingUrl})`,
+        "```",
+        "Visible answer",
+        "",
+        `![Active generated image](fcasset:${fencedMediaAssetId})`,
+      ].join("\n"),
+    );
+
+    const tombstonedReadyInput = {
+      ...input,
+      mediaAssetId: randomUUID(),
+      altText: "Tombstoned ready image",
+    };
+    await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => appendPendingManagedImageToCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        tombstonedReadyInput,
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    const firstDeletedAt = new Date(Date.parse(fixture.createdAt) + 60_000).toISOString();
+    await fixture.ownerPool.query(
+      "UPDATE content.cards SET deleted_at = $1 WHERE workspace_id = $2 AND card_id = $3",
+      [firstDeletedAt, fixture.workspaceId, fixture.cardId],
+    );
+    const tombstonedReady = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => markPendingManagedImageReadyOnCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        tombstonedReadyInput,
+        { ...metadata, lastOperationId: randomUUID() },
+        async () => {},
+      ),
+    );
+    assert.equal(tombstonedReady.applied, true);
+    assert.equal(tombstonedReady.card.deletedAt, firstDeletedAt);
+    assert.equal(
+      tombstonedReady.card.backText.includes(
+        `fcasset:${tombstonedReadyInput.mediaAssetId}?state=pending`,
+      ),
+      false,
+    );
+    assert.equal(
+      tombstonedReady.card.backText.includes(`fcasset:${tombstonedReadyInput.mediaAssetId}`),
+      true,
+    );
+    await assert.rejects(
+      withRuntimeTransaction(
+        fixture,
+        fixture.workspaceId,
+        (executor) => appendPendingManagedImageToCardSideInExecutor(
+          executor,
+          fixture.workspaceId,
+          { ...input, mediaAssetId: randomUUID(), altText: "Blocked tombstone append" },
+          { ...metadata, lastOperationId: randomUUID() },
+        ),
+      ),
+      (error: unknown) => error instanceof HttpError && error.statusCode === 404,
+    );
+
+    await fixture.ownerPool.query(
+      "UPDATE content.cards SET deleted_at = NULL WHERE workspace_id = $1 AND card_id = $2",
+      [fixture.workspaceId, fixture.cardId],
+    );
+    const tombstonedFailedInput = {
+      ...input,
+      mediaAssetId: randomUUID(),
+      altText: "Tombstoned failed image",
+    };
+    await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => appendPendingManagedImageToCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        tombstonedFailedInput,
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    const secondDeletedAt = new Date(Date.parse(firstDeletedAt) + 60_000).toISOString();
+    await fixture.ownerPool.query(
+      "UPDATE content.cards SET deleted_at = $1 WHERE workspace_id = $2 AND card_id = $3",
+      [secondDeletedAt, fixture.workspaceId, fixture.cardId],
+    );
+    const tombstonedFailed = await withRuntimeTransaction(
+      fixture,
+      fixture.workspaceId,
+      (executor) => markPendingManagedImageFailedOnCardSideInExecutor(
+        executor,
+        fixture.workspaceId,
+        tombstonedFailedInput,
+        { ...metadata, lastOperationId: randomUUID() },
+      ),
+    );
+    assert.equal(tombstonedFailed.applied, true);
+    assert.equal(tombstonedFailed.card.deletedAt, secondDeletedAt);
+    assert.equal(
+      tombstonedFailed.card.backText.includes(
+        `fcasset:${tombstonedFailedInput.mediaAssetId}?state=failed`,
+      ),
+      true,
+    );
   });
 });

--- a/apps/backend/src/cards/index.ts
+++ b/apps/backend/src/cards/index.ts
@@ -6,6 +6,7 @@
 export type {
   AppendManagedImageToCardSideInput,
   AppendManagedImageToCardSideResult,
+  AppendPendingManagedImageToCardSideResult,
   BulkCreateCardItem,
   BulkDeleteCardItem,
   BulkDeleteCardsResult,
@@ -50,6 +51,7 @@ export {
 export {
   appendManagedImageToCardSideInExecutor,
   appendManagedImageToCardText,
+  appendPendingManagedImageToCardSideInExecutor,
   buildManagedImageMarkdownReference,
   createCard,
   createCards,
@@ -57,11 +59,22 @@ export {
   deleteCard,
   deleteCards,
   deleteCardInExecutor,
+  hasPendingManagedImageOnCardSideInExecutor,
+  isManagedImageSettlementConflictError,
+  managedImageMarkdownComplexitySettlementConflictCode,
+  ManagedImageMarkdownComplexitySettlementConflictError,
+  PendingManagedImageSettlementConflictError,
   updateCard,
   updateCards,
   updateCardInExecutor,
   upsertCardSnapshot,
   upsertCardSnapshotInExecutor,
+  markPendingManagedImageFailedOnCardSideInExecutor,
+  markPendingManagedImageReadyOnCardSideInExecutor,
+} from "./mutations";
+
+export type {
+  ManagedImageSettlementConflictError,
 } from "./mutations";
 
 export {

--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -9,8 +9,16 @@ import {
   incomingLwwMetadataWins,
   normalizeIsoTimestamp,
 } from "../sync/conflicts/lww";
-import { findLatestSyncChangeId, lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../sync/replication/changes";
-import { extractMarkdownImageFcAssetIds } from "../workspacePackages/markdownMedia";
+import {
+  findLatestSyncChangeId,
+  lockWorkspaceSyncMetadataForHotChangesInExecutor,
+  type HotChangeWriteLock,
+} from "../sync/replication/changes";
+import {
+  extractMarkdownImageDestinationUrls,
+  isMarkdownComplexityLimitError,
+  rewriteMarkdownImageDestinationUrl,
+} from "../workspacePackages/markdownMedia";
 import {
   createSyncConflictHttpError,
   findSyncConflictWorkspaceIdInExecutor,
@@ -30,6 +38,7 @@ import {
 import type {
   AppendManagedImageToCardSideInput,
   AppendManagedImageToCardSideResult,
+  AppendPendingManagedImageToCardSideResult,
   BulkCreateCardItem,
   BulkDeleteCardItem,
   BulkDeleteCardsResult,
@@ -48,6 +57,59 @@ import type {
 const MAX_CARD_BATCH_SIZE = 100;
 
 type AppendedManagedImageCardText = Readonly<{ text: string; applied: boolean }>;
+
+const pendingManagedImageSettlementConflictCode =
+  "GENERATED_IMAGE_PENDING_MARKER_CONFLICT";
+export const managedImageMarkdownComplexitySettlementConflictCode =
+  "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT";
+
+export class PendingManagedImageSettlementConflictError extends HttpError {
+  readonly conflictCode = pendingManagedImageSettlementConflictCode;
+  readonly pendingMarkerCount: number;
+
+  constructor(targetSide: CardTextSide, pendingMarkerCount: number) {
+    super(
+      409,
+      `Generated image settlement requires exactly one pending marker on the ${targetSide} side; found ${pendingMarkerCount}. Card text was preserved.`,
+      pendingManagedImageSettlementConflictCode,
+    );
+    this.pendingMarkerCount = pendingMarkerCount;
+  }
+}
+
+export class ManagedImageMarkdownComplexitySettlementConflictError extends HttpError {
+  readonly conflictCode =
+    managedImageMarkdownComplexitySettlementConflictCode;
+
+  constructor(targetSide: CardTextSide) {
+    super(
+      409,
+      `Generated image settlement could not inspect the ${targetSide} side because its Markdown exceeds parser complexity limits. Card text was preserved.`,
+      managedImageMarkdownComplexitySettlementConflictCode,
+    );
+  }
+}
+
+export type ManagedImageSettlementConflictError =
+  PendingManagedImageSettlementConflictError
+  | ManagedImageMarkdownComplexitySettlementConflictError;
+
+export function isManagedImageSettlementConflictError(
+  error: unknown,
+): error is ManagedImageSettlementConflictError {
+  return error instanceof PendingManagedImageSettlementConflictError
+    || error instanceof ManagedImageMarkdownComplexitySettlementConflictError;
+}
+
+function translateManagedImageSettlementParserError(
+  error: unknown,
+  targetSide: CardTextSide,
+): never {
+  if (isMarkdownComplexityLimitError(error)) {
+    throw new ManagedImageMarkdownComplexitySettlementConflictError(targetSide);
+  }
+  throw error;
+}
 
 const cardTextColumnBySide: Readonly<Record<CardTextSide, "front_text" | "back_text">> = {
   front: "front_text",
@@ -81,9 +143,37 @@ function buildNormalizedManagedImageMarkdownReference(mediaAssetId: string, altT
   return `![${altText}](fcasset:${mediaAssetId})`;
 }
 
-function hasExactManagedImageMarkdownReference(text: string, mediaAssetId: string): boolean {
-  return extractMarkdownImageFcAssetIds(text)
-    .some((referencedMediaAssetId) => referencedMediaAssetId.toLowerCase() === mediaAssetId);
+function buildPendingManagedImageMarkdownReference(mediaAssetId: string, altText: string): string {
+  return `![${altText}](fcasset:${mediaAssetId}?state=pending)`;
+}
+
+function buildReadyManagedImageUrl(mediaAssetId: string): string {
+  return `fcasset:${mediaAssetId}`;
+}
+
+function buildPendingManagedImageUrl(mediaAssetId: string): string {
+  return `fcasset:${mediaAssetId}?state=pending`;
+}
+
+function buildFailedManagedImageUrl(mediaAssetId: string): string {
+  return `fcasset:${mediaAssetId}?state=failed`;
+}
+
+function managedImageUrlReferencesMediaAsset(url: string, mediaAssetId: string): boolean {
+  const normalizedUrl = url.toLowerCase();
+  const normalizedPrefix = `fcasset:${mediaAssetId}`;
+  return normalizedUrl === normalizedPrefix
+    || normalizedUrl.startsWith(`${normalizedPrefix}?`)
+    || normalizedUrl.startsWith(`${normalizedPrefix}#`);
+}
+
+function hasManagedImageMarkdownReference(text: string, mediaAssetId: string): boolean {
+  return extractMarkdownImageDestinationUrls(text)
+    .some((url) => managedImageUrlReferencesMediaAsset(url, mediaAssetId));
+}
+
+function hasExactManagedImageUrl(text: string, url: string): boolean {
+  return extractMarkdownImageDestinationUrls(text).some((candidate) => candidate === url);
 }
 
 function appendMarkdownBlock(text: string, markdownBlock: string): string {
@@ -97,13 +187,14 @@ function appendNormalizedManagedImageToCardText(
   text: string,
   mediaAssetId: string,
   markdownReference: string,
+  expectedUrl: string,
 ): AppendedManagedImageCardText {
-  if (hasExactManagedImageMarkdownReference(text, mediaAssetId)) {
+  if (hasManagedImageMarkdownReference(text, mediaAssetId)) {
     return { text, applied: false };
   }
 
   const appendedText = appendMarkdownBlock(text, markdownReference);
-  if (!hasExactManagedImageMarkdownReference(appendedText, mediaAssetId)) {
+  if (!hasExactManagedImageUrl(appendedText, expectedUrl)) {
     throw new HttpError(
       409,
       "Close the selected card side's unterminated Markdown fence or HTML block before appending an image.",
@@ -139,7 +230,12 @@ export function appendManagedImageToCardText(
     normalizedMediaAssetId,
     normalizeManagedImageAltText(altText),
   );
-  return appendNormalizedManagedImageToCardText(text, normalizedMediaAssetId, markdownReference);
+  return appendNormalizedManagedImageToCardText(
+    text,
+    normalizedMediaAssetId,
+    markdownReference,
+    buildReadyManagedImageUrl(normalizedMediaAssetId),
+  );
 }
 
 function normalizeRequiredCardText(value: string, fieldName: string): string {
@@ -314,21 +410,66 @@ async function loadActiveCardRowForMutation(
   return result.rows[0];
 }
 
-export async function appendManagedImageToCardSideInExecutor(
+async function applyLockedManagedImageCardTextMutationInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
-  input: AppendManagedImageToCardSideInput,
+  cardId: string,
+  targetSide: CardTextSide,
   metadata: CardMutationMetadata,
+  hotChangeWriteLock: HotChangeWriteLock,
+  row: CardRow,
+  mutateText: (currentText: string) => AppendedManagedImageCardText,
 ): Promise<AppendManagedImageToCardSideResult> {
-  const targetSide = normalizeCardTextSide(input.targetSide);
-  const cardId = expectUuidString(input.cardId, "cardId");
-  const mediaAssetId = expectUuidString(input.mediaAssetId, "mediaAssetId");
-  const markdownReference = buildNormalizedManagedImageMarkdownReference(
-    mediaAssetId,
-    normalizeManagedImageAltText(input.altText),
-  );
-  const normalizedMetadata = normalizeCardMutationMetadata(metadata);
+  const currentText = targetSide === "front" ? row.front_text : row.back_text;
+  const mutatedText = mutateText(currentText);
+  if (!mutatedText.applied) {
+    return { card: mapCard(row), applied: false };
+  }
 
+  const generatedClientUpdatedAt = deriveGeneratedCardMutationTimestamp(
+    new Date(),
+    row.client_updated_at,
+  );
+  const targetColumn = cardTextColumnBySide[targetSide];
+  const updateResult = await executor.query<CardRow>(
+    [
+      "UPDATE content.cards",
+      `SET ${targetColumn} = $1, client_updated_at = $2,`,
+      "last_modified_by_replica_id = $3, last_operation_id = $4, updated_at = now()",
+      "WHERE workspace_id = $5 AND card_id = $6",
+      "AND deleted_at IS NOT DISTINCT FROM $7::timestamptz",
+      "RETURNING",
+      CARD_COLUMNS,
+    ].join(" "),
+    [
+      mutatedText.text,
+      generatedClientUpdatedAt,
+      metadata.lastModifiedByReplicaId,
+      metadata.lastOperationId,
+      workspaceId,
+      cardId,
+      row.deleted_at,
+    ],
+  );
+
+  const updatedRow = updateResult.rows[0];
+  if (updatedRow === undefined) {
+    throw new Error("Locked card row disappeared before managed-image mutation");
+  }
+
+  const card = mapCard(updatedRow);
+  await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, card);
+  return { card, applied: true };
+}
+
+async function applyManagedImageCardTextMutationInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  cardId: string,
+  targetSide: CardTextSide,
+  metadata: CardMutationMetadata,
+  mutateText: (currentText: string) => AppendedManagedImageCardText,
+): Promise<AppendManagedImageToCardSideResult> {
   const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(
     executor,
     workspaceId,
@@ -338,45 +479,219 @@ export async function appendManagedImageToCardSideInExecutor(
     throw new HttpError(404, "Card not found");
   }
 
-  const currentText = targetSide === "front" ? row.front_text : row.back_text;
-  const appendedText = appendNormalizedManagedImageToCardText(
-    currentText,
-    mediaAssetId,
-    markdownReference,
+  return applyLockedManagedImageCardTextMutationInExecutor(
+    executor,
+    workspaceId,
+    cardId,
+    targetSide,
+    metadata,
+    hotChangeWriteLock,
+    row,
+    mutateText,
   );
-  if (appendedText.applied === false) {
-    return { card: mapCard(row), applied: false };
-  }
+}
 
-  const generatedClientUpdatedAt = deriveGeneratedCardMutationTimestamp(new Date(), row.client_updated_at);
-  const targetColumn = cardTextColumnBySide[targetSide];
-  const updateResult = await executor.query<CardRow>(
-    [
-      "UPDATE content.cards",
-      `SET ${targetColumn} = $1, client_updated_at = $2,`,
-      "last_modified_by_replica_id = $3, last_operation_id = $4, updated_at = now()",
-      "WHERE workspace_id = $5 AND card_id = $6 AND deleted_at IS NULL",
-      "RETURNING",
-      CARD_COLUMNS,
-    ].join(" "),
-    [
-      appendedText.text,
-      generatedClientUpdatedAt,
-      normalizedMetadata.lastModifiedByReplicaId,
-      normalizedMetadata.lastOperationId,
-      workspaceId,
-      cardId,
-    ],
+async function applyManagedImageLifecycleTransitionInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  cardId: string,
+  targetSide: CardTextSide,
+  metadata: CardMutationMetadata,
+  mutateText: (currentText: string) => AppendedManagedImageCardText,
+): Promise<AppendManagedImageToCardSideResult> {
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(
+    executor,
+    workspaceId,
   );
-
-  const updatedRow = updateResult.rows[0];
-  if (updatedRow === undefined) {
+  const row = await loadCardRowForMutation(executor, workspaceId, cardId);
+  if (row === undefined) {
     throw new HttpError(404, "Card not found");
   }
 
-  const card = mapCard(updatedRow);
-  await recordCardSyncChange(executor, workspaceId, hotChangeWriteLock, card);
-  return { card, applied: true };
+  return applyLockedManagedImageCardTextMutationInExecutor(
+    executor,
+    workspaceId,
+    cardId,
+    targetSide,
+    metadata,
+    hotChangeWriteLock,
+    row,
+    mutateText,
+  );
+}
+
+export async function appendManagedImageToCardSideInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: AppendManagedImageToCardSideInput,
+  metadata: CardMutationMetadata,
+): Promise<AppendManagedImageToCardSideResult> {
+  const targetSide = normalizeCardTextSide(input.targetSide);
+  const cardId = expectUuidString(input.cardId, "cardId");
+  const mediaAssetId = expectUuidString(input.mediaAssetId, "mediaAssetId");
+  const normalizedAltText = normalizeManagedImageAltText(input.altText);
+  const normalizedMetadata = normalizeCardMutationMetadata(metadata);
+  const readyUrl = buildReadyManagedImageUrl(mediaAssetId);
+
+  return applyManagedImageCardTextMutationInExecutor(
+    executor,
+    workspaceId,
+    cardId,
+    targetSide,
+    normalizedMetadata,
+    (currentText) => appendNormalizedManagedImageToCardText(
+      currentText,
+      mediaAssetId,
+      buildNormalizedManagedImageMarkdownReference(mediaAssetId, normalizedAltText),
+      readyUrl,
+    ),
+  );
+}
+
+export async function appendPendingManagedImageToCardSideInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: AppendManagedImageToCardSideInput,
+  metadata: CardMutationMetadata,
+): Promise<AppendPendingManagedImageToCardSideResult> {
+  const targetSide = normalizeCardTextSide(input.targetSide);
+  const cardId = expectUuidString(input.cardId, "cardId");
+  const mediaAssetId = expectUuidString(input.mediaAssetId, "mediaAssetId");
+  const pendingUrl = buildPendingManagedImageUrl(mediaAssetId);
+  const markdownReference = buildPendingManagedImageMarkdownReference(
+    mediaAssetId,
+    normalizeManagedImageAltText(input.altText),
+  );
+  const normalizedMetadata = normalizeCardMutationMetadata(metadata);
+  const result = await applyManagedImageCardTextMutationInExecutor(
+    executor,
+    workspaceId,
+    cardId,
+    targetSide,
+    normalizedMetadata,
+    (currentText) => appendNormalizedManagedImageToCardText(
+      currentText,
+      mediaAssetId,
+      markdownReference,
+      pendingUrl,
+    ),
+  );
+  const cardText = targetSide === "front" ? result.card.frontText : result.card.backText;
+  return {
+    ...result,
+    placeholderApplied: hasExactManagedImageUrl(cardText, pendingUrl),
+  };
+}
+
+export async function hasPendingManagedImageOnCardSideInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: AppendManagedImageToCardSideInput,
+): Promise<boolean> {
+  const targetSide = normalizeCardTextSide(input.targetSide);
+  const cardId = expectUuidString(input.cardId, "cardId");
+  const mediaAssetId = expectUuidString(input.mediaAssetId, "mediaAssetId");
+  normalizeManagedImageAltText(input.altText);
+  await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, workspaceId);
+  const row = await loadCardRowForMutation(executor, workspaceId, cardId);
+  if (row === undefined) {
+    return false;
+  }
+
+  const cardText = targetSide === "front" ? row.front_text : row.back_text;
+  return hasExactManagedImageUrl(cardText, buildPendingManagedImageUrl(mediaAssetId));
+}
+
+export async function markPendingManagedImageReadyOnCardSideInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: AppendManagedImageToCardSideInput,
+  metadata: CardMutationMetadata,
+  beforeCardChange: (lockedExecutor: DatabaseExecutor) => Promise<void>,
+): Promise<AppendManagedImageToCardSideResult> {
+  const targetSide = normalizeCardTextSide(input.targetSide);
+  const cardId = expectUuidString(input.cardId, "cardId");
+  const mediaAssetId = expectUuidString(input.mediaAssetId, "mediaAssetId");
+  normalizeManagedImageAltText(input.altText);
+  const normalizedMetadata = normalizeCardMutationMetadata(metadata);
+  const pendingUrl = buildPendingManagedImageUrl(mediaAssetId);
+  const readyUrl = buildReadyManagedImageUrl(mediaAssetId);
+  const hotChangeWriteLock = await lockWorkspaceSyncMetadataForHotChangesInExecutor(
+    executor,
+    workspaceId,
+  );
+  const row = await loadCardRowForMutation(executor, workspaceId, cardId);
+  if (row === undefined) {
+    throw new HttpError(404, "Card not found");
+  }
+  const currentText = targetSide === "front" ? row.front_text : row.back_text;
+  let transitionedText: string;
+  try {
+    const pendingMarkerCount = extractMarkdownImageDestinationUrls(currentText)
+      .filter((destination) => destination === pendingUrl)
+      .length;
+    if (pendingMarkerCount !== 1) {
+      throw new PendingManagedImageSettlementConflictError(
+        targetSide,
+        pendingMarkerCount,
+      );
+    }
+    transitionedText = rewriteMarkdownImageDestinationUrl(
+      currentText,
+      pendingUrl,
+      readyUrl,
+    );
+  } catch (error) {
+    return translateManagedImageSettlementParserError(error, targetSide);
+  }
+
+  await beforeCardChange(executor);
+  return applyLockedManagedImageCardTextMutationInExecutor(
+    executor,
+    workspaceId,
+    cardId,
+    targetSide,
+    normalizedMetadata,
+    hotChangeWriteLock,
+    row,
+    () => ({ text: transitionedText, applied: true }),
+  );
+}
+
+export async function markPendingManagedImageFailedOnCardSideInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: AppendManagedImageToCardSideInput,
+  metadata: CardMutationMetadata,
+): Promise<AppendManagedImageToCardSideResult> {
+  const targetSide = normalizeCardTextSide(input.targetSide);
+  const cardId = expectUuidString(input.cardId, "cardId");
+  const mediaAssetId = expectUuidString(input.mediaAssetId, "mediaAssetId");
+  normalizeManagedImageAltText(input.altText);
+  const normalizedMetadata = normalizeCardMutationMetadata(metadata);
+
+  return applyManagedImageLifecycleTransitionInExecutor(
+    executor,
+    workspaceId,
+    cardId,
+    targetSide,
+    normalizedMetadata,
+    (currentText) => {
+      try {
+        const failedText = rewriteMarkdownImageDestinationUrl(
+          currentText,
+          buildPendingManagedImageUrl(mediaAssetId),
+          buildFailedManagedImageUrl(mediaAssetId),
+        );
+        return {
+          text: failedText,
+          applied: failedText !== currentText,
+        };
+      } catch (error) {
+        return translateManagedImageSettlementParserError(error, targetSide);
+      }
+    },
+  );
 }
 
 async function insertCardRowForSnapshotInExecutor(

--- a/apps/backend/src/cards/types.ts
+++ b/apps/backend/src/cards/types.ts
@@ -172,6 +172,11 @@ export type AppendManagedImageToCardSideResult = Readonly<{
   applied: boolean;
 }>;
 
+export type AppendPendingManagedImageToCardSideResult =
+  AppendManagedImageToCardSideResult & Readonly<{
+    placeholderApplied: boolean;
+  }>;
+
 export type CreateCardInput = Readonly<{
   frontText: string;
   backText: string;

--- a/apps/backend/src/catalog/authoring/authoring.test.ts
+++ b/apps/backend/src/catalog/authoring/authoring.test.ts
@@ -6,6 +6,7 @@ import { HttpError } from "../../shared/errors";
 import { attachCatalogPackageDraftMediaAssetInExecutor } from "./draftMedia";
 import { createCatalogPackageDraftInExecutor, updateCatalogPackageDraftInExecutor } from "./drafts";
 import {
+  createCatalogPackageVersionFromCardsInExecutor,
   createCatalogPackageVersionFromWorkspaceSelectionInExecutor,
   publishCatalogPackageVersionInExecutor,
 } from "./versions";
@@ -675,4 +676,101 @@ test("workspace-selected catalog versions reject invalid managed media reference
     },
   );
   assert.equal(queries.length, 2);
+});
+
+test("workspace-selected catalog versions reject non-ready managed media references", async () => {
+  const pendingUrl = `fcasset:${testWorkspaceMediaAssetId}?state=pending`;
+  const unsupportedUrl = `FcAsSeT:${testWorkspaceMediaAssetId}?state=pending`;
+  const queries: Array<string> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      queries.push(text);
+      if (text.includes("set_config('app.user_id'")) {
+        assert.deepEqual(params, ["admin-user-id", testWorkspaceId]);
+        return createQueryResult([]);
+      }
+
+      if (text.includes("FROM content.cards")) {
+        assert.deepEqual(params, [testWorkspaceId, [testWorkspaceCardId]]);
+        return createQueryResult([{
+          card_id: testWorkspaceCardId,
+          front_text: `Prompt ![diagram](${pendingUrl}) ![unsupported](${unsupportedUrl})`,
+          back_text: "Answer",
+          card_type: "basic",
+          metadata: { version: 1, source: null },
+          tags: [],
+        } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  await assert.rejects(
+    createCatalogPackageVersionFromWorkspaceSelectionInExecutor(
+      executor,
+      testPackageId,
+      {
+        packageVersionId: testPackageVersionId,
+        workspaceId: testWorkspaceId,
+        cardIds: [testWorkspaceCardId],
+      },
+      "admin-user-id",
+      "admin@example.com",
+    ),
+    (error: unknown) => error instanceof HttpError
+      && error.statusCode === 409
+      && error.code === "CATALOG_WORKSPACE_MANAGED_MEDIA_NOT_READY"
+      && error.message.includes(pendingUrl)
+      && error.message.includes(unsupportedUrl)
+      && error.message.includes("retry after promotion and attachment settle")
+      && error.message.includes("Unsupported managed media lifecycle URLs"),
+  );
+  assert.equal(queries.length, 2);
+});
+
+test("direct catalog card snapshots reject non-ready managed media references", async () => {
+  const failedUrl = `fcasset:${testPackageMediaKey}?state=failed`;
+  const unsupportedUrl = `fcasset:${testPackageMediaKey}?state=ready`;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      _params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      throw new Error(`Catalog normalization unexpectedly queried PostgreSQL: ${text}`);
+    },
+  };
+
+  await assert.rejects(
+    createCatalogPackageVersionFromCardsInExecutor(
+      executor,
+      testPackageId,
+      {
+        packageVersionId: testPackageVersionId,
+        cards: [{
+          packageCardId: testWorkspaceCardId,
+          stableCardKey: "card-1",
+          ordinal: 1,
+          frontText: `Prompt ![failed](${failedUrl}) ![unsupported](${unsupportedUrl})`,
+          backText: "Answer",
+          cardType: "basic",
+          metadata: { version: 1, source: null },
+          tags: [],
+          mediaAssetKeys: [],
+        }],
+      },
+      "admin@example.com",
+    ),
+    (error: unknown) => error instanceof HttpError
+      && error.statusCode === 409
+      && error.code === "CATALOG_MANAGED_MEDIA_NOT_READY"
+      && error.message.includes(failedUrl)
+      && error.message.includes(unsupportedUrl)
+      && error.message.includes("Failed managed media is terminal")
+      && error.message.includes("remove the reference or regenerate and reattach the image")
+      && error.message.includes("Unsupported managed media lifecycle URLs"),
+  );
 });

--- a/apps/backend/src/catalog/authoring/versions.ts
+++ b/apps/backend/src/catalog/authoring/versions.ts
@@ -26,8 +26,10 @@ import {
 } from "../rows";
 import {
   extractMarkdownFcAssetIds,
+  extractMarkdownManagedMediaLifecycleIssues,
   rewriteMarkdownFcAssetUrlsToFcAssets,
 } from "../../workspacePackages";
+import type { ManagedMediaLifecycleIssues } from "../../workspacePackages";
 import type {
   CatalogPackageCardSnapshotInput,
   CatalogPackageStatus,
@@ -53,6 +55,62 @@ type CatalogWorkspaceMediaAssetRow = Readonly<{
   media_asset_id: string;
   media_blob_id: string;
 }>;
+
+function collectCardManagedMediaLifecycleIssues(
+  frontText: string,
+  backText: string,
+): ManagedMediaLifecycleIssues {
+  const pendingDestinations = new Set<string>();
+  const failedDestinations = new Set<string>();
+  const unsupportedDestinations = new Set<string>();
+  for (const markdown of [frontText, backText]) {
+    const issues = extractMarkdownManagedMediaLifecycleIssues(markdown);
+    for (const destination of issues.pendingDestinations) {
+      pendingDestinations.add(destination);
+    }
+    for (const destination of issues.failedDestinations) {
+      failedDestinations.add(destination);
+    }
+    for (const destination of issues.unsupportedDestinations) {
+      unsupportedDestinations.add(destination);
+    }
+  }
+  return {
+    pendingDestinations: [...pendingDestinations],
+    failedDestinations: [...failedDestinations],
+    unsupportedDestinations: [...unsupportedDestinations],
+  };
+}
+
+function describeManagedMediaLifecycleIssues(issues: ManagedMediaLifecycleIssues): string {
+  const remediation: Array<string> = [];
+  if (issues.pendingDestinations.length !== 0) {
+    remediation.push(
+      "Pending managed media is still being promoted and attached; retry after promotion and attachment settle. "
+        + `pendingManagedMedia=${issues.pendingDestinations.join(",")}`,
+    );
+  }
+  if (issues.failedDestinations.length !== 0) {
+    remediation.push(
+      "Failed managed media is terminal; remove the reference or regenerate and reattach the image. "
+        + `failedManagedMedia=${issues.failedDestinations.join(",")}`,
+    );
+  }
+  if (issues.unsupportedDestinations.length !== 0) {
+    remediation.push(
+      "Unsupported managed media lifecycle URLs must use fcasset:<id>, "
+        + "fcasset:<id>?state=pending, or fcasset:<id>?state=failed. "
+        + `unsupportedManagedMedia=${issues.unsupportedDestinations.join(",")}`,
+    );
+  }
+  return remediation.join(" ");
+}
+
+function hasManagedMediaLifecycleIssues(issues: ManagedMediaLifecycleIssues): boolean {
+  return issues.pendingDestinations.length !== 0
+    || issues.failedDestinations.length !== 0
+    || issues.unsupportedDestinations.length !== 0;
+}
 
 export function isCatalogPackageVersionStatusTransitionAllowed(
   fromStatus: CatalogPackageStatus,
@@ -100,13 +158,24 @@ function normalizeCatalogPackageCardSnapshotInput(
   if (Number.isSafeInteger(card.ordinal) === false || card.ordinal < 1) {
     throw new HttpError(400, "card.ordinal must be a positive safe integer", "CATALOG_INVALID_INPUT");
   }
+  const frontText = normalizeNonEmptyString(card.frontText, "card.frontText");
+  const backText = normalizeNonEmptyString(card.backText, "card.backText");
+  const managedMediaIssues = collectCardManagedMediaLifecycleIssues(frontText, backText);
+  if (hasManagedMediaLifecycleIssues(managedMediaIssues)) {
+    throw new HttpError(
+      409,
+      "Catalog package cards require valid ready managed media references. "
+        + describeManagedMediaLifecycleIssues(managedMediaIssues),
+      "CATALOG_MANAGED_MEDIA_NOT_READY",
+    );
+  }
 
   return {
     packageCardId: card.packageCardId,
     stableCardKey: normalizeNonEmptyString(card.stableCardKey, "card.stableCardKey"),
     ordinal: card.ordinal,
-    frontText: normalizeNonEmptyString(card.frontText, "card.frontText"),
-    backText: normalizeNonEmptyString(card.backText, "card.backText"),
+    frontText,
+    backText,
     cardType: normalizeNonEmptyString(card.cardType, "card.cardType"),
     metadata: card.metadata,
     tags: normalizeTextArray(card.tags, "card.tags", false),
@@ -454,7 +523,22 @@ function normalizeWorkspaceMediaAssetIds(mediaAssetIds: ReadonlyArray<string>): 
   return [...new Set(normalizedMediaAssetIds)];
 }
 
+function assertWorkspaceCardManagedMediaReady(row: CatalogWorkspaceCardRow): void {
+  const managedMediaIssues = collectCardManagedMediaLifecycleIssues(row.front_text, row.back_text);
+  if (!hasManagedMediaLifecycleIssues(managedMediaIssues)) {
+    return;
+  }
+
+  throw new HttpError(
+    409,
+    "Workspace catalog versions require valid ready managed media references before publication. "
+      + `cardId=${row.card_id} ${describeManagedMediaLifecycleIssues(managedMediaIssues)}`,
+    "CATALOG_WORKSPACE_MANAGED_MEDIA_NOT_READY",
+  );
+}
+
 function getWorkspaceCardMediaAssetIds(row: CatalogWorkspaceCardRow): ReadonlyArray<string> {
+  assertWorkspaceCardManagedMediaReady(row);
   return normalizeWorkspaceMediaAssetIds([
     ...extractMarkdownFcAssetIds(row.front_text),
     ...extractMarkdownFcAssetIds(row.back_text),
@@ -462,6 +546,9 @@ function getWorkspaceCardMediaAssetIds(row: CatalogWorkspaceCardRow): ReadonlyAr
 }
 
 function getWorkspaceCardsMediaAssetIds(rows: ReadonlyArray<CatalogWorkspaceCardRow>): ReadonlyArray<string> {
+  for (const row of rows) {
+    assertWorkspaceCardManagedMediaReady(row);
+  }
   return normalizeWorkspaceMediaAssetIds(rows.flatMap((row) => [
     ...extractMarkdownFcAssetIds(row.front_text),
     ...extractMarkdownFcAssetIds(row.back_text),

--- a/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
@@ -306,6 +306,7 @@ test("generated image operation reconciles ambiguous enqueue without early card 
         assert.equal(storageCalls, 1);
         assert.deepEqual(results.map((result) => result.reused).sort(), [true, true]);
         assert.equal(results.every((result) => result.cardAppendApplied === false), true);
+        assert.equal(results.every((result) => result.placeholderApplied), true);
         assert.deepEqual(results.map((result) => result.status), ["already_queued", "already_queued"]);
         assert.equal(enqueueCalls, 3);
         assert.equal(await countMediaAsset(fixture, operationMetadata.mediaAssetId), 0);
@@ -313,7 +314,10 @@ test("generated image operation reconciles ambiguous enqueue without early card 
           "SELECT back_text FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
           [fixture.workspaceId, fixture.cardId],
         );
-        assert.equal(card.rows[0]?.back_text, "Original answer");
+        assert.equal(
+          card.rows[0]?.back_text,
+          `Original answer\n\n![Generated integration diagram](fcasset:${operationMetadata.mediaAssetId}?state=pending)`,
+        );
         const job = await fixture.ownerPool.query<PromotionJobRow>(
           `SELECT user_id, operation_id, card_id, replica_id, sha256, state
            FROM content.generated_media_promotion_jobs
@@ -358,6 +362,7 @@ test("generated image operation reconciles ambiguous enqueue without early card 
         );
         assert.equal(completedRetry.reused, true);
         assert.equal(completedRetry.cardAppendApplied, false);
+        assert.equal(completedRetry.placeholderApplied, true);
         assert.equal(completedRetry.status, "already_queued");
         assert.equal(providerCalls, 1);
         await closeSessionAdvisoryLockPoolForTests();
@@ -452,6 +457,7 @@ test("persisted provider start blocks replay without staging and permits staged 
         enqueueGeneratedMediaPromotionJobFn: async (job) => ({
           outcome: "created",
           jobId: job.jobId,
+          placeholderApplied: true,
         }),
       });
 

--- a/apps/backend/src/chat/cardImages/operation.test.ts
+++ b/apps/backend/src/chat/cardImages/operation.test.ts
@@ -131,7 +131,11 @@ test("generated image orchestration stages before durable enqueue", async () => 
       assert.equal(input.signal.aborted, false);
       assert.deepEqual(operationMetadata, metadata);
       assert.equal(preparedImage.stagingStorageKey, "media/uploads/test");
-      return { outcome: "created", jobId: metadata.operationId };
+      return {
+        outcome: "created",
+        jobId: metadata.operationId,
+        placeholderApplied: true,
+      };
     },
   };
 
@@ -148,6 +152,7 @@ test("generated image orchestration stages before durable enqueue", async () => 
     targetSide: "back",
     mediaRegistrationApplied: false,
     cardAppendApplied: false,
+    placeholderApplied: true,
     reused: false,
     sourceUrl: null,
   });
@@ -369,7 +374,11 @@ test("generated image operation validates raw Unicode length before normalizing 
     }),
     enqueuePromotionJobFn: async (input) => {
       assert.equal(input.altText, altText);
-      return { outcome: "created", jobId: metadata.operationId };
+      return {
+        outcome: "created",
+        jobId: metadata.operationId,
+        placeholderApplied: true,
+      };
     },
   };
 
@@ -434,7 +443,11 @@ test("ambiguous enqueue accepts only a confirmed reconciliation result", async (
         if (enqueueCallCount === 1) {
           throw commitUnknownError;
         }
-        return { outcome, jobId: metadata.operationId };
+        return {
+          outcome,
+          jobId: metadata.operationId,
+          placeholderApplied: true,
+        };
       }),
     );
 
@@ -449,7 +462,11 @@ test("ambiguous enqueue preserves the original error for inconclusive reconcilia
     undefined,
     null,
     { outcome: "pending", jobId: metadata.operationId },
-    { outcome: "existing", jobId: "66666666-6666-4666-8666-666666666666" },
+    {
+      outcome: "existing",
+      jobId: "66666666-6666-4666-8666-666666666666",
+      placeholderApplied: true,
+    },
   ];
 
   for (const inconclusiveResult of inconclusiveResults) {

--- a/apps/backend/src/chat/cardImages/operation.ts
+++ b/apps/backend/src/chat/cardImages/operation.ts
@@ -279,7 +279,9 @@ function isConfirmedPromotionEnqueueResult(
     && "outcome" in result
     && (result.outcome === "created" || result.outcome === "existing")
     && "jobId" in result
-    && result.jobId === expectedJobId;
+    && result.jobId === expectedJobId
+    && "placeholderApplied" in result
+    && typeof result.placeholderApplied === "boolean";
 }
 
 async function enqueueGeneratedCardImagePromotionWithCommitReconciliation(
@@ -367,6 +369,7 @@ export async function generateCardImageWithDependencies(
           targetSide: lockedInput.targetSide,
           mediaRegistrationApplied: false,
           cardAppendApplied: false,
+          placeholderApplied: enqueueResult.placeholderApplied,
           reused: preparedImage.reused || enqueueResult.outcome === "existing",
           sourceUrl: null,
         };

--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -9,10 +9,13 @@ import {
   reserveMediaBlobWriterInExecutor,
   type MediaBlobWriterReservation,
 } from "../../mediaAssets/blobLifecycle";
+import { GeneratedMediaPromotionStorageTerminalError } from "../../mediaAssets/storage";
 import { testObservationScope } from "../../mediaAssets/storage/testHelpers";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
 import { imageJpegCardMediaBlobNormalizationVersion } from "../../mediaAssets/types";
+import { processSyncPull } from "../../sync";
 import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
+import { extractMarkdownImageDestinationUrls } from "../../workspacePackages/markdownMedia";
 import { InactiveChatRunClaimError } from "../runs/claimFence";
 import {
   assertGeneratedMediaBlobStorageCapabilityForMutation,
@@ -24,6 +27,7 @@ import {
   failGeneratedMediaPromotionJobWithBlobWriterInExecutor,
   GeneratedMediaPromotionJobConflictError,
   GeneratedMediaPromotionJobLeaseLostError,
+  GeneratedMediaPromotionProtocolInactiveError,
   isGeneratedMediaPromotionOperationAppliedWithExecutor,
   markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor,
   markGeneratedMediaPromotionJobAppliedWithExecutor,
@@ -53,14 +57,30 @@ type RevocationStateRow = Readonly<{
 type AccessNoOpStateRow = Readonly<{
   job_state: string; job_error_code: string | null; reservation_state: string;
 }>;
+type PlaceholderConflictStateRow = Readonly<{
+  job_id: string; job_state: string; job_error_code: string | null;
+  reservation_state: string; cleanup_scheduled: boolean; media_asset_count: string;
+}>;
+type AccessRevocationBoundaryRow = Readonly<{ revocation_status: string }>;
+type HotChangeIdRow = Readonly<{ change_id: string | number }>;
 type RevocationUpgradeRow = Readonly<{
   function_exists: boolean; security_definer: boolean; exact_search_path: boolean;
   backend_execute: boolean; auth_execute: boolean; reporting_execute: boolean;
+  lock_function_exists: boolean; lock_security_definer: boolean;
+  lock_exact_search_path: boolean; lock_backend_execute: boolean;
+  lock_auth_execute: boolean; lock_reporting_execute: boolean;
+  compatibility_function_exists: boolean; compatibility_backend_execute: boolean;
   backend_reservation_select: boolean; backend_job_update: boolean;
   writer_support_function_exists: boolean;
+  protocol_column_exists: boolean; protocol_constraint_exists: boolean;
+  backend_protocol_select: boolean; backend_protocol_insert: boolean;
+  legacy_claim_backend_execute: boolean; current_claim_function_exists: boolean;
+  current_claim_security_definer: boolean; current_claim_exact_search_path: boolean;
+  current_claim_backend_execute: boolean; current_claim_auth_execute: boolean;
+  protocol_activation_exists: boolean; protocol_activation_backend_execute: boolean;
 }>;
-const revocationMigrationSql = readFileSync(resolve(
-  __dirname, "../../../../../db/migrations/0093_generated_media_writer_revocation.sql",
+const placeholderTerminalStateMigrationSql = readFileSync(resolve(
+  __dirname, "../../../../../db/migrations/0104_generated_image_placeholder_terminal_state.sql",
 ), "utf8");
 async function createRun(fixture: PostgresIntegrationFixture): Promise<RunFixture> {
   const sessionId = randomUUID();
@@ -139,6 +159,32 @@ Promise<ReadonlyArray<ClaimedGeneratedMediaPromotionJob>> {
     leaseOwner, leaseDurationMs: 60_000, limit, deadlineAtMs: Date.now() + 10_000,
   });
 }
+async function callAccessRevocationBoundary(
+  executor: DatabaseExecutor,
+  job: ClaimedGeneratedMediaPromotionJob,
+  expectedCardText: string,
+  failedCardText: string,
+  errorCode: "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT",
+): Promise<string> {
+  const result = await executor.query<AccessRevocationBoundaryRow>(
+    `SELECT content.fail_generated_media_promotion_job_after_access_revocation(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+       $16, $17, $18, $19
+     ) AS revocation_status`,
+    [
+      job.jobId, job.leaseToken, job.operationId, job.userId,
+      job.workspaceId, job.cardId, job.targetSide, job.altText,
+      job.mediaAssetId, job.replicaId, job.stagingStorageKey,
+      job.blobStorageKey, job.sha256, job.mimeType, job.sizeBytes,
+      expectedCardText, failedCardText, errorCode, 3_600_000,
+    ],
+  );
+  const status = result.rows[0]?.revocation_status;
+  if (status === undefined) {
+    throw new Error(`Access-revocation boundary returned no status. jobId=${job.jobId}`);
+  }
+  return status;
+}
 function hasPostgresCode(error: unknown, code: string): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === code;
 }
@@ -150,6 +196,37 @@ function withSha256(
   sha256: string,
 ): EnqueueGeneratedMediaPromotionJobInput {
   return { ...input, sha256, blobStorageKey: buildMediaBlobStorageKey(sha256) };
+}
+async function loadPlaceholderConflictStates(
+  fixture: PostgresIntegrationFixture,
+  inputs: ReadonlyArray<EnqueueGeneratedMediaPromotionJobInput>,
+): Promise<ReadonlyArray<PlaceholderConflictStateRow>> {
+  const result = await fixture.ownerPool.query<PlaceholderConflictStateRow>(
+    `SELECT
+       jobs.job_id::text AS job_id,
+       jobs.state AS job_state,
+       jobs.last_error_code AS job_error_code,
+       reservations.state AS reservation_state,
+       lifecycles.cleanup_eligible_at IS NOT NULL AS cleanup_scheduled,
+       (
+         SELECT count(*)::text
+         FROM content.media_assets AS media_assets
+         WHERE media_assets.workspace_id = jobs.workspace_id
+           AND media_assets.media_asset_id = jobs.media_asset_id
+       ) AS media_asset_count
+     FROM content.generated_media_promotion_jobs AS jobs
+     INNER JOIN content.media_blob_writer_reservations AS reservations
+       ON reservations.writer_kind = 'generated_promotion'
+      AND reservations.workspace_id = jobs.workspace_id
+      AND reservations.media_asset_id = jobs.media_asset_id
+      AND reservations.operation_id = jobs.operation_id::text
+     INNER JOIN content.media_blob_lifecycles AS lifecycles
+       ON lifecycles.sha256 = jobs.sha256
+     WHERE jobs.job_id = ANY($1::uuid[])
+     ORDER BY jobs.job_id`,
+    [inputs.map((input) => input.jobId)],
+  );
+  return result.rows;
 }
 function immutablePayloadMismatches(
   job: ClaimedGeneratedMediaPromotionJob,
@@ -230,10 +307,11 @@ async function rawRevocationStatus(
   params: ReadonlyArray<string | number>,
 ): Promise<string> {
   const result = await fixture.runtimePool.query<{ revocation_status: string }>(
-    `SELECT content.fail_generated_media_promotion_job_after_access_revocation(
-       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16
-     ) AS revocation_status`,
-    [...params],
+    `SELECT revocation_status
+     FROM content.lock_generated_media_promotion_job_after_access_revocation(
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15
+     )`,
+    params.slice(0, 15),
   );
   const status = result.rows[0]?.revocation_status;
   if (status === undefined) throw new Error("PostgreSQL returned no revocation status.");
@@ -263,35 +341,57 @@ async function assertRevocationMigrationUpgrade(
   const client = await fixture.ownerPool.connect();
   try {
     await client.query("BEGIN");
-    await client.query(`
-      DROP FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
-        UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
-        TEXT, TEXT, BIGINT, INTEGER
-      )
-    `);
-    await client.query(revocationMigrationSql);
+    await client.query(placeholderTerminalStateMigrationSql);
     const upgrade = await client.query<RevocationUpgradeRow>(
       `SELECT
          to_regprocedure(
-           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)'
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)'
          ) IS NOT NULL AS function_exists,
          procedures.prosecdef AS security_definer,
          procedures.proconfig = ARRAY['search_path=pg_catalog'] AS exact_search_path,
          has_function_privilege(
            'backend_app',
-           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)',
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)',
            'EXECUTE'
          ) AS backend_execute,
          has_function_privilege(
            'auth_app',
-           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)',
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)',
            'EXECUTE'
          ) AS auth_execute,
          has_function_privilege(
            'reporting_readonly',
-           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)',
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)',
            'EXECUTE'
          ) AS reporting_execute,
+         to_regprocedure(
+           'content.lock_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint)'
+         ) IS NOT NULL AS lock_function_exists,
+         lock_procedures.prosecdef AS lock_security_definer,
+         lock_procedures.proconfig = ARRAY['search_path=pg_catalog'] AS lock_exact_search_path,
+         has_function_privilege(
+           'backend_app',
+           'content.lock_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint)',
+           'EXECUTE'
+         ) AS lock_backend_execute,
+         has_function_privilege(
+           'auth_app',
+           'content.lock_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint)',
+           'EXECUTE'
+         ) AS lock_auth_execute,
+         has_function_privilege(
+           'reporting_readonly',
+           'content.lock_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint)',
+           'EXECUTE'
+         ) AS lock_reporting_execute,
+         to_regprocedure(
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)'
+         ) IS NOT NULL AS compatibility_function_exists,
+         has_function_privilege(
+           'backend_app',
+           'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)',
+           'EXECUTE'
+         ) AS compatibility_backend_execute,
          has_table_privilege(
            'backend_app', 'content.media_blob_writer_reservations', 'SELECT'
          ) AS backend_reservation_select,
@@ -300,10 +400,74 @@ async function assertRevocationMigrationUpgrade(
          ) AS backend_job_update,
          to_regprocedure(
            'content.fail_generated_media_promotion_job_with_blob_writer(uuid,uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)'
-         ) IS NOT NULL AS writer_support_function_exists
+         ) IS NOT NULL AS writer_support_function_exists,
+         EXISTS (
+           SELECT 1
+           FROM information_schema.columns AS columns
+           WHERE columns.table_schema = 'content'
+             AND columns.table_name = 'generated_media_promotion_jobs'
+             AND columns.column_name = 'protocol_version'
+             AND columns.is_nullable = 'NO'
+             AND columns.column_default = '1'
+         ) AS protocol_column_exists,
+         EXISTS (
+           SELECT 1
+           FROM pg_catalog.pg_constraint AS constraints
+           WHERE constraints.conrelid = 'content.generated_media_promotion_jobs'::regclass
+             AND constraints.conname = 'generated_media_promotion_jobs_protocol_version'
+         ) AS protocol_constraint_exists,
+         has_column_privilege(
+           'backend_app',
+           'content.generated_media_promotion_jobs',
+           'protocol_version',
+           'SELECT'
+         ) AS backend_protocol_select,
+         has_column_privilege(
+           'backend_app',
+           'content.generated_media_promotion_jobs',
+           'protocol_version',
+           'INSERT'
+         ) AS backend_protocol_insert,
+         has_function_privilege(
+           'backend_app',
+           'content.claim_generated_media_promotion_jobs(text,integer,integer)',
+           'EXECUTE'
+         ) AS legacy_claim_backend_execute,
+         to_regprocedure(
+           'content.claim_generated_media_promotion_jobs(text,integer,integer,integer)'
+         ) IS NOT NULL AS current_claim_function_exists,
+         current_claim_procedures.prosecdef AS current_claim_security_definer,
+         current_claim_procedures.proconfig = ARRAY['search_path=pg_catalog']
+           AS current_claim_exact_search_path,
+         has_function_privilege(
+           'backend_app',
+           'content.claim_generated_media_promotion_jobs(text,integer,integer,integer)',
+           'EXECUTE'
+         ) AS current_claim_backend_execute,
+         has_function_privilege(
+           'auth_app',
+           'content.claim_generated_media_promotion_jobs(text,integer,integer,integer)',
+           'EXECUTE'
+         ) AS current_claim_auth_execute,
+         to_regprocedure(
+           'content.generated_media_promotion_protocol_v2_active()'
+         ) IS NOT NULL AS protocol_activation_exists,
+         has_function_privilege(
+           'backend_app',
+           'content.generated_media_promotion_protocol_v2_active()',
+           'EXECUTE'
+         ) AS protocol_activation_backend_execute
        FROM pg_proc AS procedures
+       CROSS JOIN pg_proc AS lock_procedures
+       CROSS JOIN pg_proc AS current_claim_procedures
        WHERE procedures.oid = to_regprocedure(
-         'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,integer)'
+         'content.fail_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint,text,text,text,integer)'
+       )
+         AND lock_procedures.oid = to_regprocedure(
+           'content.lock_generated_media_promotion_job_after_access_revocation(uuid,uuid,uuid,text,uuid,uuid,text,text,uuid,uuid,text,text,text,text,bigint)'
+       )
+         AND current_claim_procedures.oid = to_regprocedure(
+           'content.claim_generated_media_promotion_jobs(text,integer,integer,integer)'
        )`,
     );
     assert.deepEqual(upgrade.rows[0], {
@@ -313,9 +477,29 @@ async function assertRevocationMigrationUpgrade(
       backend_execute: true,
       auth_execute: false,
       reporting_execute: false,
+      lock_function_exists: true,
+      lock_security_definer: true,
+      lock_exact_search_path: true,
+      lock_backend_execute: true,
+      lock_auth_execute: false,
+      lock_reporting_execute: false,
+      compatibility_function_exists: true,
+      compatibility_backend_execute: true,
       backend_reservation_select: false,
       backend_job_update: false,
       writer_support_function_exists: true,
+      protocol_column_exists: true,
+      protocol_constraint_exists: true,
+      backend_protocol_select: true,
+      backend_protocol_insert: true,
+      legacy_claim_backend_execute: true,
+      current_claim_function_exists: true,
+      current_claim_security_definer: true,
+      current_claim_exact_search_path: true,
+      current_claim_backend_execute: true,
+      current_claim_auth_execute: false,
+      protocol_activation_exists: true,
+      protocol_activation_backend_execute: true,
     });
     await client.query("ROLLBACK");
   } catch (error) {
@@ -362,7 +546,39 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     ]);
     assert.deepEqual(
       await enqueueGeneratedMediaPromotionJob(concurrentInput),
-      { outcome: "existing", jobId: concurrentInput.jobId },
+      {
+        outcome: "existing",
+        jobId: concurrentInput.jobId,
+        placeholderApplied: true,
+      },
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.cards
+       SET front_text = replace(front_text, $1, '')
+       WHERE workspace_id = $2 AND card_id = $3`,
+      [
+        `![${concurrentInput.altText}](fcasset:${concurrentInput.mediaAssetId}?state=pending)`,
+        fixture.workspaceId,
+        fixture.cardId,
+      ],
+    );
+    assert.deepEqual(
+      await enqueueGeneratedMediaPromotionJob(concurrentInput),
+      {
+        outcome: "existing",
+        jobId: concurrentInput.jobId,
+        placeholderApplied: false,
+      },
+    );
+    await fixture.ownerPool.query(
+      `UPDATE content.cards
+       SET front_text = front_text || E'\\n\\n' || $1
+       WHERE workspace_id = $2 AND card_id = $3`,
+      [
+        `![${concurrentInput.altText}](fcasset:${concurrentInput.mediaAssetId}?state=pending)`,
+        fixture.workspaceId,
+        fixture.cardId,
+      ],
     );
     await assert.rejects(
       enqueueGeneratedMediaPromotionJob({
@@ -380,6 +596,18 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     for (const input of inputs.slice(1)) {
       assert.equal((await enqueueGeneratedMediaPromotionJob(input)).outcome, "created");
     }
+    const protocolVersions = await fixture.ownerPool.query<{ protocol_version: number }>(
+      `SELECT DISTINCT protocol_version
+       FROM content.generated_media_promotion_jobs
+       WHERE job_id = ANY($1::uuid[])`,
+      [inputs.map((input) => input.jobId)],
+    );
+    assert.deepEqual(protocolVersions.rows, [{ protocol_version: 2 }]);
+    const oldWorkerClaims = await fixture.runtimePool.query<{ job_id: string }>(
+      "SELECT job_id FROM content.claim_generated_media_promotion_jobs($1, $2, $3)",
+      ["pre-lifecycle-worker", 60_000, inputs.length],
+    );
+    assert.deepEqual(oldWorkerClaims.rows, []);
     const wrongScopeCount = await transactionWithWorkspaceScope(
       { userId: fixture.userId, workspaceId: randomUUID() },
       async (executor) => executor.query<{ count: string }>(
@@ -514,6 +742,11 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     } finally {
       dateNowMock.mock.restore();
     }
+    const promotionDeletedAt = new Date(Date.parse(fixture.createdAt) + 60_000).toISOString();
+    await fixture.ownerPool.query(
+      "UPDATE content.cards SET deleted_at = $1 WHERE workspace_id = $2 AND card_id = $3",
+      [promotionDeletedAt, fixture.workspaceId, fixture.cardId],
+    );
     await applyGeneratedMediaPromotionJob(appliedWriter, Date.now() + 10_000);
     await applyGeneratedMediaPromotionJob(appliedWriter, Date.now() + 10_000);
     await transition(fixture, async (executor) => {
@@ -524,8 +757,12 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
         executor, applied.jobId, randomUUID(),
       ), false);
     });
-    const appliedCard = await fixture.ownerPool.query<{ front_text: string; back_text: string }>(
-      "SELECT front_text, back_text FROM content.cards WHERE workspace_id = $1 AND card_id = $2",
+    const appliedCard = await fixture.ownerPool.query<{
+      front_text: string; back_text: string; deleted_at: Date;
+    }>(
+      `SELECT front_text, back_text, deleted_at
+       FROM content.cards
+       WHERE workspace_id = $1 AND card_id = $2`,
       [fixture.workspaceId, fixture.cardId],
     );
     assert.equal(appliedCard.rows[0]?.back_text, "Original answer");
@@ -534,6 +771,7 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
       1,
     );
     assert.ok(appliedCard.rows[0]?.front_text.startsWith("Original question\n\n![Generated integration image]"));
+    assert.equal(appliedCard.rows[0]?.deleted_at.toISOString(), promotionDeletedAt);
     assert.equal(
       (await fixture.ownerPool.query<{ count: string }>(
         "SELECT count(*)::text AS count FROM content.media_assets WHERE media_asset_id = $1",
@@ -566,18 +804,11 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
     const reclaimedInput = inputs[2];
     if (reclaimedInput === undefined) throw new Error("Missing reclaim input.");
     const expired = byJobId(claimed, reclaimedInput.jobId);
-    const writer = await transition(fixture, async (executor) =>
-      reserveMediaBlobWriterInExecutor(executor, {
-        writerKind: "generated_promotion", workspaceId: expired.workspaceId,
-        mediaAssetId: expired.mediaAssetId, operationId: expired.operationId,
-        sha256: expired.sha256, storageKey: expired.blobStorageKey,
-        mimeType: expired.mimeType, sizeBytes: expired.sizeBytes,
-        normalizationVersion: imageJpegCardMediaBlobNormalizationVersion,
-      }));
-    const writerInput = {
-      ...expired, reservationToken: writer.reservationToken,
-      normalizationVersion: writer.normalizationVersion,
-    };
+    const writer = await reserveGeneratedMediaBlobWriter(
+      expired,
+      Date.now() + 10_000,
+    );
+    const writerInput = writer.writer;
     await assert.rejects(
       transition(fixture, (executor) =>
         markGeneratedMediaPromotionBlobWriterAmbiguousWithExecutor(executor, {
@@ -622,12 +853,16 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
         })),
       GeneratedMediaPromotionJobLeaseLostError,
     );
-    await transition(fixture, async (executor) =>
-      failGeneratedMediaPromotionJobWithBlobWriterInExecutor(executor, {
-        ...reclaimed, reservationToken: writer.reservationToken,
-        normalizationVersion: writer.normalizationVersion,
-        error: { code: "CORRUPT_STAGING", message: "Staged object proof is invalid." },
-      }));
+    const reclaimedWriter = await reserveGeneratedMediaBlobWriter(
+      reclaimed,
+      Date.now() + 10_000,
+    );
+    await failGeneratedMediaPromotionJob(
+      reclaimed,
+      Date.now() + 10_000,
+      { code: "CORRUPT_STAGING", message: "Staged object proof is invalid." },
+      reclaimedWriter,
+    );
     assert.deepEqual((await fixture.ownerPool.query<{
       job_state: string; reservation_state: string;
     }>(
@@ -638,6 +873,19 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
        WHERE jobs.job_id = $1`,
       [reclaimed.jobId, writer.reservationToken],
     )).rows[0], { job_state: "failed", reservation_state: "unreferenced" });
+    const failedCard = await fixture.ownerPool.query<{ back_text: string; deleted_at: Date }>(
+      `SELECT back_text, deleted_at
+       FROM content.cards
+       WHERE workspace_id = $1 AND card_id = $2`,
+      [fixture.workspaceId, fixture.cardId],
+    );
+    assert.equal(
+      failedCard.rows[0]?.back_text.includes(
+        `![Generated integration image](fcasset:${reclaimed.mediaAssetId}?state=failed)`,
+      ),
+      true,
+    );
+    assert.equal(failedCard.rows[0]?.deleted_at.toISOString(), promotionDeletedAt);
     const terminalInput = inputs[3];
     if (terminalInput === undefined) throw new Error("Missing terminal input.");
     const terminal = byJobId(claimed, terminalInput.jobId);
@@ -728,6 +976,485 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
   });
 });
 
+test("promotion settlement preserves card text when the expected pending marker is absent or duplicated", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const run = await createRun(fixture);
+    const removedInput = withSha256(createInput(fixture, run), uniqueSha256());
+    const movedInput = withSha256(createInput(fixture, run), uniqueSha256());
+    const duplicatedInput = withSha256(createInput(fixture, run), uniqueSha256());
+    const inputs = [removedInput, movedInput, duplicatedInput];
+    for (const input of inputs) {
+      assert.equal((await enqueueGeneratedMediaPromotionJob(input)).outcome, "created");
+    }
+    const pendingMarker = (input: EnqueueGeneratedMediaPromotionJobInput): string => (
+      `![${input.altText}](fcasset:${input.mediaAssetId}?state=pending)`
+    );
+    const removedMarker = pendingMarker(removedInput);
+    const movedMarker = pendingMarker(movedInput);
+    const duplicatedMarker = pendingMarker(duplicatedInput);
+    await fixture.ownerPool.query(
+      `UPDATE content.cards
+       SET front_text = front_text || E'\\n\\n' || $1,
+           back_text = replace(replace(back_text, $2, ''), $1, '')
+             || E'\\n\\n' || $3
+       WHERE workspace_id = $4 AND card_id = $5`,
+      [
+        movedMarker,
+        removedMarker,
+        duplicatedMarker,
+        fixture.workspaceId,
+        fixture.cardId,
+      ],
+    );
+    const expectedCard = (await fixture.ownerPool.query<{
+      front_text: string; back_text: string;
+    }>(
+      `SELECT front_text, back_text
+       FROM content.cards
+       WHERE workspace_id = $1 AND card_id = $2`,
+      [fixture.workspaceId, fixture.cardId],
+    )).rows[0];
+    if (expectedCard === undefined) throw new Error("Conflict test card was not found.");
+    assert.equal(expectedCard.front_text.includes(movedMarker), true);
+    assert.equal(expectedCard.back_text.includes(removedMarker), false);
+    assert.equal(expectedCard.back_text.includes(movedMarker), false);
+    assert.equal(
+      expectedCard.back_text.split(duplicatedMarker).length - 1,
+      2,
+    );
+
+    const claimed = await claim("placeholder-conflict-worker", inputs.length);
+    assert.equal(claimed.length, inputs.length);
+    for (const input of inputs) {
+      const job = byJobId(claimed, input.jobId);
+      const jobResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+        job,
+        {
+          leaseOwner: job.leaseOwner,
+          leaseDurationMs: 60_000,
+          maximumJobs: 1,
+          deadlineAtMs: Date.now() + 10_000,
+          observationScope: testObservationScope,
+          signal: new AbortController().signal,
+        },
+        {
+          claimJobsFn: claimGeneratedMediaPromotionJobs,
+          reserveWriterFn: reserveGeneratedMediaBlobWriter,
+          promoteObjectFn: async () => {},
+          applyJobFn: applyGeneratedMediaPromotionJob,
+          rescheduleJobFn: rescheduleGeneratedMediaPromotionJob,
+          failJobFn: async () => {
+            assert.fail("The locked apply transaction must terminalize marker conflicts.");
+          },
+          failAfterAccessRevocationFn: async () => {
+            assert.fail("Marker conflicts must not use access-revocation settlement.");
+          },
+          markWriterAmbiguousFn: markGeneratedMediaBlobWriterAmbiguous,
+          nowFn: Date.now,
+        },
+      );
+      assert.equal(jobResult.outcome, "failed");
+      assert.equal(
+        jobResult.errorCode,
+        "GENERATED_IMAGE_PENDING_MARKER_CONFLICT",
+      );
+    }
+
+    const settledCard = (await fixture.ownerPool.query<{
+      front_text: string; back_text: string;
+    }>(
+      `SELECT front_text, back_text
+       FROM content.cards
+       WHERE workspace_id = $1 AND card_id = $2`,
+      [fixture.workspaceId, fixture.cardId],
+    )).rows[0];
+    assert.deepEqual(settledCard, expectedCard);
+    assert.deepEqual(
+      await loadPlaceholderConflictStates(fixture, inputs),
+      inputs
+        .map((input) => ({
+          job_id: input.jobId,
+          job_state: "failed",
+          job_error_code: "GENERATED_IMAGE_PENDING_MARKER_CONFLICT",
+          reservation_state: "unreferenced",
+          cleanup_scheduled: true,
+          media_asset_count: "0",
+        }))
+        .sort((left, right) => left.job_id.localeCompare(right.job_id)),
+    );
+  });
+});
+
+test("parser-limit Markdown terminalizes success, failure, and revoked jobs without changing card text", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const run = await createRun(fixture);
+    const successInput = withSha256(createInput(fixture, run), uniqueSha256());
+    const failureInput = withSha256(createInput(fixture, run), uniqueSha256());
+    const revokedInput = withSha256(createInput(fixture, run), uniqueSha256());
+    const inputs = [successInput, failureInput, revokedInput];
+    for (const input of inputs) {
+      assert.equal((await enqueueGeneratedMediaPromotionJob(input)).outcome, "created");
+    }
+    const parserLimitMarkdown = "[".repeat(1_001);
+    await fixture.ownerPool.query(
+      `UPDATE content.cards
+       SET back_text = $1
+       WHERE workspace_id = $2 AND card_id = $3`,
+      [parserLimitMarkdown, fixture.workspaceId, fixture.cardId],
+    );
+    const claimed = await claim("parser-complexity-worker", inputs.length);
+    assert.equal(claimed.length, inputs.length);
+    const processorInput = (job: ClaimedGeneratedMediaPromotionJob) => ({
+      leaseOwner: job.leaseOwner,
+      leaseDurationMs: 60_000,
+      maximumJobs: 1,
+      deadlineAtMs: Date.now() + 10_000,
+      observationScope: testObservationScope,
+      signal: new AbortController().signal,
+    });
+    const dependencies = {
+      claimJobsFn: claimGeneratedMediaPromotionJobs,
+      reserveWriterFn: reserveGeneratedMediaBlobWriter,
+      promoteObjectFn: async () => {},
+      applyJobFn: applyGeneratedMediaPromotionJob,
+      rescheduleJobFn: rescheduleGeneratedMediaPromotionJob,
+      failJobFn: failGeneratedMediaPromotionJob,
+      failAfterAccessRevocationFn: failGeneratedMediaPromotionJobAfterAccessRevocation,
+      markWriterAmbiguousFn: markGeneratedMediaBlobWriterAmbiguous,
+      nowFn: Date.now,
+    };
+
+    const successJob = byJobId(claimed, successInput.jobId);
+    const successResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+      successJob,
+      processorInput(successJob),
+      dependencies,
+    );
+    assert.deepEqual(
+      { outcome: successResult.outcome, errorCode: successResult.errorCode },
+      {
+        outcome: "failed",
+        errorCode: "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT",
+      },
+    );
+
+    const failureJob = byJobId(claimed, failureInput.jobId);
+    const failureResult = await processClaimedGeneratedMediaPromotionJobWithDependencies(
+      failureJob,
+      processorInput(failureJob),
+      {
+        ...dependencies,
+        promoteObjectFn: async () => {
+          throw new GeneratedMediaPromotionStorageTerminalError(
+            "STAGING_OBJECT_INVALID",
+            "The staged generated image failed integrity validation.",
+            null,
+          );
+        },
+      },
+    );
+    assert.deepEqual(
+      { outcome: failureResult.outcome, errorCode: failureResult.errorCode },
+      {
+        outcome: "failed",
+        errorCode: "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT",
+      },
+    );
+
+    const revokedJob = byJobId(claimed, revokedInput.jobId);
+    await reserveGeneratedMediaBlobWriter(revokedJob, Date.now() + 10_000);
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
+      [fixture.workspaceId, fixture.userId],
+    );
+    assert.equal(
+      await failGeneratedMediaPromotionJobAfterAccessRevocation(
+        revokedJob,
+        Date.now() + 10_000,
+      ),
+      "failed_markdown_complexity",
+    );
+
+    assert.equal(
+      (await fixture.ownerPool.query<{ back_text: string }>(
+        `SELECT back_text
+         FROM content.cards
+         WHERE workspace_id = $1 AND card_id = $2`,
+        [fixture.workspaceId, fixture.cardId],
+      )).rows[0]?.back_text,
+      parserLimitMarkdown,
+    );
+    assert.deepEqual(
+      await loadPlaceholderConflictStates(fixture, inputs),
+      inputs
+        .map((input) => ({
+          job_id: input.jobId,
+          job_state: "failed",
+          job_error_code: "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT",
+          reservation_state: "unreferenced",
+          cleanup_scheduled: true,
+          media_asset_count: "0",
+        }))
+        .sort((left, right) => left.job_id.localeCompare(right.job_id)),
+    );
+    assert.deepEqual(await claim("parser-complexity-reclaimer", inputs.length), []);
+  });
+});
+
+test("Markdown-complexity revocation settlement accepts only byte-preserving card text", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const run = await createRun(fixture);
+    const input = withSha256(createInput(fixture, run), uniqueSha256());
+    assert.equal((await enqueueGeneratedMediaPromotionJob(input)).outcome, "created");
+    const job = byJobId(await claim("complexity-boundary-worker", 1), input.jobId);
+    await reserveGeneratedMediaBlobWriter(job, Date.now() + 10_000);
+    const pendingCardText = (await fixture.ownerPool.query<{ back_text: string }>(
+      `SELECT back_text
+       FROM content.cards
+       WHERE workspace_id = $1 AND card_id = $2`,
+      [fixture.workspaceId, fixture.cardId],
+    )).rows[0]?.back_text;
+    if (pendingCardText === undefined) {
+      throw new Error("Complexity-boundary fixture card was not found.");
+    }
+    const failedCardText = pendingCardText.replace(
+      `fcasset:${input.mediaAssetId}?state=pending`,
+      `fcasset:${input.mediaAssetId}?state=failed`,
+    );
+    assert.notEqual(failedCardText, pendingCardText);
+    await fixture.ownerPool.query(
+      "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
+      [fixture.workspaceId, fixture.userId],
+    );
+
+    assert.equal(
+      await transition(fixture, (executor) => callAccessRevocationBoundary(
+        executor,
+        job,
+        pendingCardText,
+        failedCardText,
+        "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT",
+      )),
+      "stale",
+    );
+    assert.deepEqual(
+      (await fixture.ownerPool.query<{
+        card_text: string; job_state: string; reservation_state: string;
+      }>(
+        `SELECT cards.back_text AS card_text,
+                jobs.state AS job_state,
+                reservations.state AS reservation_state
+         FROM content.cards AS cards
+         INNER JOIN content.generated_media_promotion_jobs AS jobs
+           ON jobs.workspace_id = cards.workspace_id
+          AND jobs.card_id = cards.card_id
+         INNER JOIN content.media_blob_writer_reservations AS reservations
+           ON reservations.workspace_id = jobs.workspace_id
+          AND reservations.media_asset_id = jobs.media_asset_id
+          AND reservations.operation_id = jobs.operation_id::text
+         WHERE jobs.job_id = $1`,
+        [input.jobId],
+      )).rows[0],
+      {
+        card_text: pendingCardText,
+        job_state: "leased",
+        reservation_state: "active",
+      },
+    );
+
+    assert.equal(
+      await transition(fixture, (executor) => callAccessRevocationBoundary(
+        executor,
+        job,
+        pendingCardText,
+        pendingCardText,
+        "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT",
+      )),
+      "failed",
+    );
+    assert.equal(
+      (await fixture.ownerPool.query<{ back_text: string }>(
+        `SELECT back_text
+         FROM content.cards
+         WHERE workspace_id = $1 AND card_id = $2`,
+        [fixture.workspaceId, fixture.cardId],
+      )).rows[0]?.back_text,
+      pendingCardText,
+    );
+    assert.deepEqual(
+      await loadPlaceholderConflictStates(fixture, [input]),
+      [{
+        job_id: input.jobId,
+        job_state: "failed",
+        job_error_code: "GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT",
+        reservation_state: "unreferenced",
+        cleanup_scheduled: true,
+        media_asset_count: "0",
+      }],
+    );
+  });
+});
+
+test("ready promotion sync pages the media asset before the ready card", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const run = await createRun(fixture);
+    const input = withSha256(createInput(fixture, run), uniqueSha256());
+    assert.equal((await enqueueGeneratedMediaPromotionJob(input)).outcome, "created");
+    const pendingChange = await fixture.ownerPool.query<HotChangeIdRow>(
+      `SELECT change_id
+       FROM sync.hot_changes
+       WHERE workspace_id = $1
+         AND entity_type = 'card'
+         AND entity_id = $2
+         AND operation_id = $3
+       ORDER BY change_id DESC
+       LIMIT 1`,
+      [fixture.workspaceId, fixture.cardId, input.operationId],
+    );
+    const pendingChangeId = Number(pendingChange.rows[0]?.change_id);
+    assert.equal(Number.isSafeInteger(pendingChangeId), true);
+
+    const job = byJobId(await claim("sync-order-worker", 1), input.jobId);
+    const writer = await reserveGeneratedMediaBlobWriter(job, Date.now() + 10_000);
+    await applyGeneratedMediaPromotionJob(writer, Date.now() + 10_000);
+    const installationId = `sync-order-${randomUUID()}`;
+
+    const firstPage = await processSyncPull(
+      fixture.workspaceId,
+      fixture.userId,
+      {
+        installationId,
+        platform: "web",
+        appVersion: "postgres-integration",
+        afterHotChangeId: pendingChangeId,
+        limit: 1,
+        includeMediaAssets: true,
+      },
+    );
+    assert.equal(firstPage.hasMore, true);
+    assert.equal(firstPage.changes.length, 1);
+    assert.equal(firstPage.changes[0]?.entityType, "media_asset");
+    assert.equal(firstPage.changes[0]?.entityId, input.mediaAssetId);
+
+    const secondPage = await processSyncPull(
+      fixture.workspaceId,
+      fixture.userId,
+      {
+        installationId,
+        platform: "web",
+        appVersion: "postgres-integration",
+        afterHotChangeId: firstPage.nextHotChangeId,
+        limit: 1,
+        includeMediaAssets: true,
+      },
+    );
+    assert.equal(secondPage.hasMore, false);
+    assert.equal(secondPage.changes.length, 1);
+    const readyCardChange = secondPage.changes[0];
+    assert.equal(readyCardChange?.entityType, "card");
+    assert.equal(readyCardChange?.entityId, input.cardId);
+    if (readyCardChange?.entityType !== "card") {
+      throw new Error("Second sync page did not contain the ready card.");
+    }
+    assert.deepEqual(
+      extractMarkdownImageDestinationUrls(readyCardChange.payload.backText),
+      [`fcasset:${input.mediaAssetId}`],
+    );
+  });
+});
+
+test("protocol activation fences lifecycle jobs from pre-change workers", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const run = await createRun(fixture);
+    const input = createInput(fixture, run);
+    const client = await fixture.ownerPool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        "DROP FUNCTION content.generated_media_promotion_protocol_v2_active()",
+      );
+      await client.query("COMMIT");
+
+      await assert.rejects(
+        enqueueGeneratedMediaPromotionJob(input),
+        GeneratedMediaPromotionProtocolInactiveError,
+      );
+      assert.equal(
+        (await fixture.ownerPool.query<{ count: string }>(
+          "SELECT count(*)::text AS count FROM content.generated_media_promotion_jobs WHERE job_id = $1",
+          [input.jobId],
+        )).rows[0]?.count,
+        "0",
+      );
+      assert.deepEqual(
+        extractMarkdownImageDestinationUrls(
+          (await fixture.ownerPool.query<{ back_text: string }>(
+            `SELECT back_text
+             FROM content.cards
+             WHERE workspace_id = $1 AND card_id = $2`,
+            [fixture.workspaceId, fixture.cardId],
+          )).rows[0]?.back_text ?? "",
+        ),
+        [],
+      );
+
+      await client.query("BEGIN");
+      await client.query(placeholderTerminalStateMigrationSql);
+      await client.query("COMMIT");
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+
+    assert.deepEqual(
+      await enqueueGeneratedMediaPromotionJob(input),
+      {
+        outcome: "created",
+        jobId: input.jobId,
+        placeholderApplied: true,
+      },
+    );
+    assert.deepEqual(
+      (await fixture.runtimePool.query<{ job_id: string }>(
+        "SELECT job_id FROM content.claim_generated_media_promotion_jobs($1, $2, $3)",
+        ["pre-lifecycle-worker", 60_000, 1],
+      )).rows,
+      [],
+    );
+
+    const claimed = await claim("lifecycle-worker", 1);
+    assert.equal(claimed[0]?.jobId, input.jobId);
+    const writer = await reserveGeneratedMediaBlobWriter(
+      byJobId(claimed, input.jobId),
+      Date.now() + 10_000,
+    );
+    await applyGeneratedMediaPromotionJob(writer, Date.now() + 10_000);
+
+    assert.deepEqual(
+      (await fixture.ownerPool.query<{ state: string; protocol_version: number }>(
+        `SELECT state, protocol_version
+         FROM content.generated_media_promotion_jobs
+         WHERE job_id = $1`,
+        [input.jobId],
+      )).rows[0],
+      { state: "applied", protocol_version: 2 },
+    );
+    assert.deepEqual(
+      extractMarkdownImageDestinationUrls(
+        (await fixture.ownerPool.query<{ back_text: string }>(
+          `SELECT back_text
+           FROM content.cards
+           WHERE workspace_id = $1 AND card_id = $2`,
+          [fixture.workspaceId, fixture.cardId],
+        )).rows[0]?.back_text ?? "",
+      ),
+      [`fcasset:${input.mediaAssetId}`],
+    );
+  });
+});
+
 test("promotion job payload uses Unicode code points for alt-text limits", async () => {
   await withPostgresIntegrationFixture(async (fixture) => {
     const run = await createRun(fixture);
@@ -739,7 +1466,11 @@ test("promotion job payload uses Unicode code points for alt-text limits", async
 
     assert.deepEqual(
       await enqueueGeneratedMediaPromotionJob(input),
-      { outcome: "created", jobId: input.jobId },
+      {
+        outcome: "created",
+        jobId: input.jobId,
+        placeholderApplied: true,
+      },
     );
     const jobs = await claim("unicode-alt-text-worker", 1);
     assert.equal(jobs.length, 1);
@@ -876,6 +1607,24 @@ test("access revocation resolves an exact generated writer and fences stale leas
         job_error_code: "DATABASE_COMMIT_OUTCOME_UNKNOWN",
         reservation_state: "ambiguous",
       },
+    );
+    const parserFencePendingUrl =
+      `fcasset:${rescheduled.mediaAssetId}?state=pending`;
+    const parserFenceLink = `[Literal lifecycle link](${parserFencePendingUrl})`;
+    const parserFenceInlineCode = `\`![Literal lifecycle image](${parserFencePendingUrl})\``;
+    const deletedAt = new Date(Date.parse(fixture.createdAt) + 120_000).toISOString();
+    await fixture.ownerPool.query(
+      `UPDATE content.cards
+       SET back_text = back_text || E'\\n\\n' || $1 || E'\\n' || $2,
+           deleted_at = $3
+       WHERE workspace_id = $4 AND card_id = $5`,
+      [
+        parserFenceLink,
+        parserFenceInlineCode,
+        deletedAt,
+        fixture.workspaceId,
+        fixture.cardId,
+      ],
     );
     await fixture.ownerPool.query(
       "DELETE FROM org.workspace_memberships WHERE workspace_id = $1 AND user_id = $2",
@@ -1037,6 +1786,59 @@ test("access revocation resolves an exact generated writer and fences stale leas
       reservation_state: "active",
       reservation_sha256: conflictingSha256,
     });
+    const terminalizedCard = await fixture.ownerPool.query<{
+      back_text: string;
+      card_hot_changes: string;
+      deleted_at: Date;
+    }>(
+      `SELECT
+         cards.back_text,
+         cards.deleted_at,
+         (
+           SELECT count(*)::TEXT
+           FROM sync.hot_changes AS changes
+           WHERE changes.workspace_id = cards.workspace_id
+             AND changes.entity_type = 'card'
+             AND changes.entity_id = cards.card_id::TEXT
+         ) AS card_hot_changes
+       FROM content.cards AS cards
+       WHERE cards.workspace_id = $1 AND cards.card_id = $2`,
+      [fixture.workspaceId, fixture.cardId],
+    );
+    const terminalizedCardRow = terminalizedCard.rows[0];
+    assert.ok(terminalizedCardRow);
+    const terminalizedImageDestinations = extractMarkdownImageDestinationUrls(
+      terminalizedCardRow.back_text,
+    );
+    for (const failedJob of [
+      reclaimedRescheduled,
+      ambiguous,
+      absent,
+      replacement,
+    ]) {
+      assert.equal(
+        terminalizedImageDestinations.includes(
+          `fcasset:${failedJob.mediaAssetId}?state=failed`,
+        ),
+        true,
+      );
+      assert.equal(
+        terminalizedImageDestinations.includes(
+          `fcasset:${failedJob.mediaAssetId}?state=pending`,
+        ),
+        false,
+      );
+    }
+    assert.equal(
+      terminalizedCardRow.back_text.includes(
+        `fcasset:${metadataConflict.mediaAssetId}?state=pending`,
+      ),
+      true,
+    );
+    assert.equal(terminalizedCardRow.back_text.includes(parserFenceLink), true);
+    assert.equal(terminalizedCardRow.back_text.includes(parserFenceInlineCode), true);
+    assert.equal(terminalizedCardRow.deleted_at.toISOString(), deletedAt);
+    assert.equal(terminalizedCardRow.card_hot_changes, "10");
     await assert.rejects(
       fixture.runtimePool.query(
         "SELECT reservation_token FROM content.media_blob_writer_reservations LIMIT 1",

--- a/apps/backend/src/chat/cardImages/promotionJobs.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.ts
@@ -1,4 +1,9 @@
 import {
+  appendPendingManagedImageToCardSideInExecutor,
+  hasPendingManagedImageOnCardSideInExecutor,
+  ManagedImageMarkdownComplexitySettlementConflictError,
+} from "../../cards";
+import {
   transactionWithWorkspaceScopeDeadline,
   type DatabaseExecutor,
   type SqlValue,
@@ -21,6 +26,11 @@ import {
   type MediaBlobNormalizationVersion,
 } from "../../mediaAssets/types";
 import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
+import { HttpError } from "../../shared/errors";
+import {
+  isMarkdownComplexityLimitError,
+  rewriteMarkdownImageDestinationUrl,
+} from "../../workspacePackages/markdownMedia";
 import { assertActiveChatRunClaimWithExecutor, type ChatRunClaimFenceParams } from "../runs/claimFence";
 import {
   hasValidGeneratedImageAltTextCharactersAndLength,
@@ -33,6 +43,10 @@ const safeErrorCodePattern = /^[A-Z][A-Z0-9_]{0,63}$/u;
 const controlCharacterPattern = /[\u0000-\u001f\u007f-\u009f]/u;
 const cleanupAdmissionConstraint =
   "generated_media_promotion_cleanup_admission";
+const generatedMediaPromotionLifecycleProtocolVersion = 2;
+const generatedMediaPromotionLifecycleProtocolMarker =
+  "content.generated_media_promotion_protocol_v2_active()";
+export type GeneratedMediaPromotionProtocolVersion = 1 | 2;
 export type GeneratedMediaPromotionJobPayload = Readonly<{
   jobId: string;
   operationId: string;
@@ -52,7 +66,11 @@ export type GeneratedMediaPromotionJobPayload = Readonly<{
 export type EnqueueGeneratedMediaPromotionJobInput = ChatRunClaimFenceParams
   & GeneratedMediaPromotionJobPayload & Readonly<{ deadlineAtMs: number }>;
 export type EnqueueGeneratedMediaPromotionJobResult =
-  Readonly<{ outcome: "created" | "existing"; jobId: string }>;
+  Readonly<{
+    outcome: "created" | "existing";
+    jobId: string;
+    placeholderApplied: boolean;
+  }>;
 export type ClaimedGeneratedMediaPromotionJob =
   GeneratedMediaPromotionJobPayload
   & Readonly<{
@@ -96,7 +114,7 @@ export type GeneratedMediaBlobWriterReservation =
 export type FailGeneratedMediaPromotionJobWithBlobWriterInput =
   GeneratedMediaPromotionBlobWriterInput & Readonly<{ error: SafeGeneratedMediaPromotionJobError }>;
 export type GeneratedMediaPromotionAccessRevocationOutcome =
-  "access_active" | "applied" | "failed";
+  "access_active" | "applied" | "failed" | "failed_markdown_complexity";
 
 function isCleanupAdmissionFenceError(error: unknown): boolean {
   return getDatabaseErrorFields(error).sqlState === "55P03"
@@ -137,10 +155,28 @@ type ClaimedJobRow = StoredPayloadRow & Readonly<{
 type TransitionRow = Readonly<{ transitioned: boolean }>;
 type AppliedScopeRow = Readonly<{ scope_status: string }>;
 type OperationAppliedRow = Readonly<{ applied: boolean }>;
+type ProtocolActivationRow = Readonly<{ active: boolean }>;
+type ProtocolVersionRow = Readonly<{ protocol_version: number }>;
+type AccessRevocationLockRow = Readonly<{
+  revocation_status: string;
+  card_text: string | null;
+}>;
 type AccessRevocationRow = Readonly<{ revocation_status: string }>;
 type InsertedRow = Readonly<{ job_id: string }>;
 const generatedMediaBlobStorageCapabilityClaims =
   new WeakMap<GeneratedMediaBlobStorageCapability, GeneratedMediaBlobWriterExactInput>();
+
+function accessRevocationPayloadParams(
+  input: ClaimedGeneratedMediaPromotionJob,
+): ReadonlyArray<SqlValue> {
+  return [
+    input.jobId, input.leaseToken, input.operationId, input.userId,
+    input.workspaceId, input.cardId, input.targetSide, input.altText,
+    input.mediaAssetId, input.replicaId, input.stagingStorageKey,
+    input.blobStorageKey, input.sha256, input.mimeType, input.sizeBytes,
+  ];
+}
+
 export class GeneratedMediaPromotionJobConflictError extends Error {
   readonly code = "GENERATED_MEDIA_PROMOTION_JOB_CONFLICT";
   constructor(jobId: string, operationId: string, fieldName: string) {
@@ -162,6 +198,16 @@ export class GeneratedMediaPromotionJobAccessRevokedError extends Error {
   constructor(jobId: string) {
     super(`Generated-media promotion job workspace access was revoked. jobId=${jobId}`);
     this.name = "GeneratedMediaPromotionJobAccessRevokedError";
+  }
+}
+export class GeneratedMediaPromotionProtocolInactiveError extends Error {
+  readonly code = "GENERATED_MEDIA_PROMOTION_PROTOCOL_INACTIVE";
+  constructor() {
+    super(
+      "Generated-media promotion protocol v2 is not active. "
+        + "Complete migration 0104 before admitting lifecycle-marker jobs.",
+    );
+    this.name = "GeneratedMediaPromotionProtocolInactiveError";
   }
 }
 function requireUuid(value: string, fieldName: string): void {
@@ -403,6 +449,57 @@ function toIsoString(value: Date, fieldName: string): string {
   }
   return value.toISOString();
 }
+function parseGeneratedMediaPromotionProtocolVersion(
+  value: number,
+): GeneratedMediaPromotionProtocolVersion {
+  if (value !== 1 && value !== 2) {
+    throw new TypeError(
+      `PostgreSQL returned an invalid generated-media promotion protocol version. protocolVersion=${value}`,
+    );
+  }
+  return value;
+}
+async function assertGeneratedMediaPromotionLifecycleProtocolActiveInExecutor(
+  executor: DatabaseExecutor,
+): Promise<void> {
+  const result = await executor.query<ProtocolActivationRow>(
+    `SELECT COALESCE(
+       has_function_privilege(
+         current_user,
+         to_regprocedure($1),
+         'EXECUTE'
+       ),
+       FALSE
+     ) AS active`,
+    [generatedMediaPromotionLifecycleProtocolMarker],
+  );
+  const active = result.rows[0]?.active;
+  if (typeof active !== "boolean") {
+    throw new TypeError("PostgreSQL returned an invalid generated-media protocol activation state.");
+  }
+  if (!active) {
+    throw new GeneratedMediaPromotionProtocolInactiveError();
+  }
+}
+export async function loadGeneratedMediaPromotionProtocolVersionInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  jobId: string,
+): Promise<GeneratedMediaPromotionProtocolVersion> {
+  requireUuid(workspaceId, "workspaceId");
+  requireUuid(jobId, "jobId");
+  const result = await executor.query<ProtocolVersionRow>(
+    `SELECT protocol_version
+     FROM content.generated_media_promotion_jobs
+     WHERE workspace_id = $1 AND job_id = $2`,
+    [workspaceId, jobId],
+  );
+  const protocolVersion = result.rows[0]?.protocol_version;
+  if (protocolVersion === undefined) {
+    throw new GeneratedMediaPromotionJobLeaseLostError(jobId);
+  }
+  return parseGeneratedMediaPromotionProtocolVersion(protocolVersion);
+}
 function toClaimedJob(row: ClaimedJobRow): ClaimedGeneratedMediaPromotionJob {
   if (
     row.state !== "leased"
@@ -448,23 +545,53 @@ export async function enqueueGeneratedMediaPromotionJob(
       async (executor) => {
         await assertActiveChatRunClaimWithExecutor(executor, input);
         await assertReplicaBelongsToWorkspaceInExecutor(executor, input.workspaceId, input.replicaId);
+        await assertGeneratedMediaPromotionLifecycleProtocolActiveInExecutor(executor);
         const inserted = await executor.query<InsertedRow>(
           `INSERT INTO content.generated_media_promotion_jobs (
              job_id, operation_id, user_id, workspace_id, card_id, target_side, alt_text,
              media_asset_id, replica_id, staging_storage_key, blob_storage_key,
-             sha256, mime_type, size_bytes
-           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+             sha256, mime_type, size_bytes, protocol_version
+           ) VALUES (
+             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+           )
            ON CONFLICT DO NOTHING
            RETURNING job_id`,
           [
             input.jobId, input.operationId, input.userId, input.workspaceId,
             input.cardId, input.targetSide, input.altText, input.mediaAssetId, input.replicaId,
             input.stagingStorageKey, input.blobStorageKey, input.sha256,
-            input.mimeType, input.sizeBytes,
+            input.mimeType, input.sizeBytes, generatedMediaPromotionLifecycleProtocolVersion,
           ],
         );
-        if (inserted.rows[0]?.job_id === input.jobId) {
-          return { outcome: "created", jobId: input.jobId };
+        const insertedRow = inserted.rows[0];
+        if (insertedRow?.job_id === input.jobId) {
+          const placeholder = await appendPendingManagedImageToCardSideInExecutor(
+            executor,
+            input.workspaceId,
+            {
+              cardId: input.cardId,
+              targetSide: input.targetSide,
+              mediaAssetId: input.mediaAssetId,
+              altText: input.altText,
+            },
+            {
+              clientUpdatedAt: new Date().toISOString(),
+              lastModifiedByReplicaId: input.replicaId,
+              lastOperationId: input.operationId,
+            },
+          );
+          if (!placeholder.placeholderApplied) {
+            throw new HttpError(
+              409,
+              "The generated-image placeholder conflicts with an existing managed image reference.",
+              "GENERATED_IMAGE_PLACEHOLDER_CONFLICT",
+            );
+          }
+          return {
+            outcome: "created",
+            jobId: input.jobId,
+            placeholderApplied: true,
+          };
         }
         const existing = await executor.query<StoredPayloadRow>(
           `SELECT ${storedPayloadColumns}
@@ -482,7 +609,21 @@ export async function enqueueGeneratedMediaPromotionJob(
             mismatch,
           );
         }
-        return { outcome: "existing", jobId: input.jobId };
+        const placeholderApplied = await hasPendingManagedImageOnCardSideInExecutor(
+          executor,
+          input.workspaceId,
+          {
+            cardId: input.cardId,
+            targetSide: input.targetSide,
+            mediaAssetId: input.mediaAssetId,
+            altText: input.altText,
+          },
+        );
+        return {
+          outcome: "existing",
+          jobId: input.jobId,
+          placeholderApplied,
+        };
       },
     );
   } catch (error) {
@@ -512,8 +653,13 @@ export async function claimGeneratedMediaPromotionJobs(
   }
   const result = await unsafeQueryWithDeadline<ClaimedJobRow>(
     input.deadlineAtMs,
-    "SELECT * FROM content.claim_generated_media_promotion_jobs($1, $2, $3)",
-    [input.leaseOwner, input.leaseDurationMs, input.limit],
+    "SELECT * FROM content.claim_generated_media_promotion_jobs($1, $2, $3, $4)",
+    [
+      input.leaseOwner,
+      input.leaseDurationMs,
+      input.limit,
+      generatedMediaPromotionLifecycleProtocolVersion,
+    ],
   );
   return result.rows.map(toClaimedJob);
 }
@@ -588,26 +734,99 @@ export async function failGeneratedMediaPromotionJobWithBlobWriterInExecutor(
     input.jobId,
   );
 }
+async function lockGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+  executor: DatabaseExecutor,
+  input: ClaimedGeneratedMediaPromotionJob,
+): Promise<AccessRevocationLockRow> {
+  requirePayload(input);
+  requireUuid(input.leaseToken, "leaseToken");
+  const payloadParams = accessRevocationPayloadParams(input);
+  const lockResult = await executor.query<AccessRevocationLockRow>(
+    `SELECT revocation_status, card_text
+     FROM content.lock_generated_media_promotion_job_after_access_revocation(
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+     )`,
+    payloadParams,
+  );
+  const lockRow = lockResult.rows[0];
+  const lockStatus = lockRow?.revocation_status;
+  if (lockStatus === "stale") {
+    throw new GeneratedMediaPromotionJobLeaseLostError(input.jobId);
+  }
+  if (
+    lockRow === undefined
+    || (
+      lockStatus !== "access_active"
+      && lockStatus !== "access_revoked"
+      && lockStatus !== "applied"
+    )
+  ) {
+    throw new TypeError(
+      `PostgreSQL returned an invalid promotion access-revocation lock status. jobId=${input.jobId}`,
+    );
+  }
+  return lockRow;
+}
+
 export async function failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
   executor: DatabaseExecutor,
   input: ClaimedGeneratedMediaPromotionJob,
 ): Promise<GeneratedMediaPromotionAccessRevocationOutcome> {
-  requirePayload(input);
-  requireUuid(input.leaseToken, "leaseToken");
+  const lockRow = await lockGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+    executor,
+    input,
+  );
+  const lockStatus = lockRow.revocation_status;
+  if (lockStatus === "access_active" || lockStatus === "applied") return lockStatus;
+  const pendingUrl = `fcasset:${input.mediaAssetId}?state=pending`;
+  const failedUrl = `fcasset:${input.mediaAssetId}?state=failed`;
+  let settlementConflict:
+    ManagedImageMarkdownComplexitySettlementConflictError | null = null;
+  let failedCardText = lockRow.card_text;
+  if (lockRow.card_text !== null) {
+    try {
+      failedCardText = rewriteMarkdownImageDestinationUrl(
+        lockRow.card_text,
+        pendingUrl,
+        failedUrl,
+      );
+    } catch (error) {
+      if (!isMarkdownComplexityLimitError(error)) throw error;
+      settlementConflict =
+        new ManagedImageMarkdownComplexitySettlementConflictError(input.targetSide);
+    }
+  }
+  const failureError: SafeGeneratedMediaPromotionJobError =
+    settlementConflict === null
+      ? {
+        code: "WORKSPACE_ACCESS_REVOKED",
+        message: "Workspace access was revoked before generated-media promotion completed.",
+      }
+      : {
+        code: settlementConflict.conflictCode,
+        message: settlementConflict.message,
+      };
+  requireSafeError(failureError);
   const result = await executor.query<AccessRevocationRow>(
     `SELECT content.fail_generated_media_promotion_job_after_access_revocation(
-       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+       $16, $17, $18, $19
      ) AS revocation_status`,
     [
-      input.jobId, input.leaseToken, input.operationId, input.userId,
-      input.workspaceId, input.cardId, input.targetSide, input.altText,
-      input.mediaAssetId, input.replicaId, input.stagingStorageKey,
-      input.blobStorageKey, input.sha256, input.mimeType, input.sizeBytes,
+      ...accessRevocationPayloadParams(input),
+      lockRow.card_text,
+      failedCardText,
+      failureError.code,
       3_600_000,
     ],
   );
   const status = result.rows[0]?.revocation_status;
-  if (status === "access_active" || status === "applied" || status === "failed") return status;
+  if (status === "access_active" || status === "applied") return status;
+  if (status === "failed") {
+    return settlementConflict === null
+      ? "failed"
+      : "failed_markdown_complexity";
+  }
   if (status === "stale") {
     throw new GeneratedMediaPromotionJobLeaseLostError(input.jobId);
   }
@@ -710,13 +929,17 @@ async function lockExactGeneratedMediaPromotionJobForWriterReservation(
   executor: DatabaseExecutor,
   job: ClaimedGeneratedMediaPromotionJob,
 ): Promise<void> {
-  const status = await failGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
+  const lock = await lockGeneratedMediaPromotionJobAfterAccessRevocationWithExecutor(
     executor,
     job,
   );
-  if (status !== "access_active") {
-    throw new GeneratedMediaPromotionJobLeaseLostError(job.jobId);
+  if (lock.revocation_status === "access_active") {
+    return;
   }
+  if (lock.revocation_status === "access_revoked") {
+    throw new GeneratedMediaPromotionJobAccessRevokedError(job.jobId);
+  }
+  throw new GeneratedMediaPromotionJobLeaseLostError(job.jobId);
 }
 
 export async function reserveGeneratedMediaBlobWriter(

--- a/apps/backend/src/chat/cardImages/promotionProcessor.ts
+++ b/apps/backend/src/chat/cardImages/promotionProcessor.ts
@@ -1,4 +1,11 @@
-import { appendManagedImageToCardSideInExecutor } from "../../cards";
+import {
+  appendManagedImageToCardSideInExecutor,
+  isManagedImageSettlementConflictError,
+  managedImageMarkdownComplexitySettlementConflictCode,
+  markPendingManagedImageFailedOnCardSideInExecutor,
+  markPendingManagedImageReadyOnCardSideInExecutor,
+  type ManagedImageSettlementConflictError,
+} from "../../cards";
 import { DatabaseDeadlineExceededError, type DatabaseExecutor } from "../../database";
 import { unsafeTransactionWithDeadline } from "../../database/unsafe";
 import {
@@ -26,6 +33,7 @@ import {
   failGeneratedMediaPromotionJobWithExecutor, GeneratedMediaPromotionJobAccessRevokedError,
   GeneratedMediaPromotionJobLeaseLostError,
   isGeneratedMediaPromotionOperationAppliedWithExecutor,
+  loadGeneratedMediaPromotionProtocolVersionInExecutor,
   markGeneratedMediaBlobWriterAmbiguous,
   markGeneratedMediaPromotionJobAppliedWithExecutor, rescheduleGeneratedMediaPromotionJobWithExecutor,
   reserveGeneratedMediaBlobWriter,
@@ -36,6 +44,16 @@ const maximumJobAttempts = 5;
 const retryBaseDelayMs = 30_000;
 const retryMaximumDelayMs = 15 * 60_000;
 const minimumNewJobBudgetMs = 1_000;
+
+function toSafeManagedImageSettlementConflict(
+  error: ManagedImageSettlementConflictError,
+): SafeGeneratedMediaPromotionJobError {
+  return {
+    code: error.conflictCode,
+    message: error.message,
+  };
+}
+
 export type GeneratedMediaPromotionJobOutcome =
   | "applied"
   | "ambiguous"
@@ -91,64 +109,99 @@ function assertPersistedMediaIdentity(
 async function applyGeneratedMediaPromotionJobInExecutor(
   executor: DatabaseExecutor,
   reservation: GeneratedMediaBlobWriterReservation,
-): Promise<void> {
+): Promise<ManagedImageSettlementConflictError | null> {
   const job = reservation.writer;
   if (await isGeneratedMediaPromotionOperationAppliedWithExecutor(
     executor,
     job.jobId,
     job.operationId,
   )) {
-    return;
+    return null;
   }
   await applyGeneratedMediaPromotionJobScopeWithExecutor(executor, job);
-  await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, job.workspaceId);
-  const existingRow = await findMediaAssetRowForUpdateInExecutor(
-    executor, job.workspaceId, job.mediaAssetId,
-  );
-  if (existingRow !== null) {
-    assertPersistedMediaIdentity(mapMediaAssetRow(existingRow), job);
-  }
-  const mediaResult = await upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
+  const protocolVersion = await loadGeneratedMediaPromotionProtocolVersionInExecutor(
     executor,
     job.workspaceId,
-    {
-      mediaAssetId: job.mediaAssetId, mimeType: job.mimeType,
-      sizeBytes: job.sizeBytes, sha256: job.sha256,
-      sourceUrl: null, createdAt: job.createdAt, deletedAt: null,
-    },
-    {
-      clientUpdatedAt: job.createdAt, lastModifiedByReplicaId: job.replicaId,
-      lastOperationId: job.operationId,
-    },
-    reservation.normalizationVersion,
+    job.jobId,
   );
-  assertPersistedMediaIdentity(mediaResult.mediaAsset, job);
-  await finalizeMediaBlobWriterInExecutor(executor, {
-    reservationToken: reservation.reservationToken,
-    sha256: job.sha256,
-    workspaceId: job.workspaceId,
-    mediaAssetId: job.mediaAssetId,
-  });
-  await appendManagedImageToCardSideInExecutor(
-    executor, job.workspaceId,
-    {
-      cardId: job.cardId, targetSide: job.targetSide,
-      mediaAssetId: job.mediaAssetId, altText: job.altText,
-    },
-    {
-      clientUpdatedAt: job.createdAt, lastModifiedByReplicaId: job.replicaId,
-      lastOperationId: job.operationId,
-    },
-  );
+  await lockWorkspaceSyncMetadataForHotChangesInExecutor(executor, job.workspaceId);
+  const cardMutationInput = {
+    cardId: job.cardId, targetSide: job.targetSide,
+    mediaAssetId: job.mediaAssetId, altText: job.altText,
+  };
+  const cardMutationMetadata = {
+    clientUpdatedAt: job.createdAt, lastModifiedByReplicaId: job.replicaId,
+    lastOperationId: job.operationId,
+  };
+  const registerMediaAsset = async (lockedExecutor: DatabaseExecutor): Promise<void> => {
+    const existingRow = await findMediaAssetRowForUpdateInExecutor(
+      lockedExecutor,
+      job.workspaceId,
+      job.mediaAssetId,
+    );
+    if (existingRow !== null) {
+      assertPersistedMediaIdentity(mapMediaAssetRow(existingRow), job);
+    }
+    const mediaResult = await upsertMediaAssetSnapshotWithBlobNormalizationInExecutor(
+      lockedExecutor,
+      job.workspaceId,
+      {
+        mediaAssetId: job.mediaAssetId, mimeType: job.mimeType,
+        sizeBytes: job.sizeBytes, sha256: job.sha256,
+        sourceUrl: null, createdAt: job.createdAt, deletedAt: null,
+      },
+      {
+        clientUpdatedAt: job.createdAt, lastModifiedByReplicaId: job.replicaId,
+        lastOperationId: job.operationId,
+      },
+      reservation.normalizationVersion,
+    );
+    assertPersistedMediaIdentity(mediaResult.mediaAsset, job);
+    await finalizeMediaBlobWriterInExecutor(lockedExecutor, {
+      reservationToken: reservation.reservationToken,
+      sha256: job.sha256,
+      workspaceId: job.workspaceId,
+      mediaAssetId: job.mediaAssetId,
+    });
+  };
+  if (protocolVersion === 2) {
+    try {
+      await markPendingManagedImageReadyOnCardSideInExecutor(
+        executor,
+        job.workspaceId,
+        cardMutationInput,
+        cardMutationMetadata,
+        registerMediaAsset,
+      );
+    } catch (error) {
+      if (!isManagedImageSettlementConflictError(error)) throw error;
+      await failGeneratedMediaPromotionJobWithBlobWriterInExecutor(executor, {
+        ...reservation.writer,
+        error: toSafeManagedImageSettlementConflict(error),
+      });
+      return error;
+    }
+  }
+  if (protocolVersion === 1) {
+    await registerMediaAsset(executor);
+    await appendManagedImageToCardSideInExecutor(
+      executor,
+      job.workspaceId,
+      cardMutationInput,
+      cardMutationMetadata,
+    );
+  }
   await markGeneratedMediaPromotionJobAppliedWithExecutor(executor, job);
+  return null;
 }
 export async function applyGeneratedMediaPromotionJob(
   reservation: GeneratedMediaBlobWriterReservation,
   deadlineAtMs: number,
 ): Promise<void> {
-  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => (
+  const settlementConflict = await unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => (
     applyGeneratedMediaPromotionJobInExecutor(executor, reservation)
   ));
+  if (settlementConflict !== null) throw settlementConflict;
 }
 export async function rescheduleGeneratedMediaPromotionJob(
   job: ClaimedGeneratedMediaPromotionJob,
@@ -166,16 +219,57 @@ export async function failGeneratedMediaPromotionJob(
   error: SafeGeneratedMediaPromotionJobError,
   reservation: GeneratedMediaBlobWriterReservation | null,
 ): Promise<void> {
-  return unsafeTransactionWithDeadline(deadlineAtMs, async (executor) => {
-    if (reservation === null) {
-      await failGeneratedMediaPromotionJobWithExecutor(executor, { ...job, error });
-      return;
-    }
-    await failGeneratedMediaPromotionJobWithBlobWriterInExecutor(executor, {
-      ...reservation.writer,
-      error,
-    });
-  });
+  const settlementConflict = await unsafeTransactionWithDeadline(
+    deadlineAtMs,
+    async (executor): Promise<ManagedImageSettlementConflictError | null> => {
+      await applyGeneratedMediaPromotionJobScopeWithExecutor(executor, job);
+      const protocolVersion = await loadGeneratedMediaPromotionProtocolVersionInExecutor(
+        executor,
+        job.workspaceId,
+        job.jobId,
+      );
+      let terminalErrorValue = error;
+      let cardSettlementConflict: ManagedImageSettlementConflictError | null = null;
+      if (protocolVersion === 2) {
+        try {
+          await markPendingManagedImageFailedOnCardSideInExecutor(
+            executor,
+            job.workspaceId,
+            {
+              cardId: job.cardId,
+              targetSide: job.targetSide,
+              mediaAssetId: job.mediaAssetId,
+              altText: job.altText,
+            },
+            {
+              clientUpdatedAt: job.createdAt,
+              lastModifiedByReplicaId: job.replicaId,
+              lastOperationId: job.operationId,
+            },
+          );
+        } catch (transitionError) {
+          if (!isManagedImageSettlementConflictError(transitionError)) {
+            throw transitionError;
+          }
+          cardSettlementConflict = transitionError;
+          terminalErrorValue = toSafeManagedImageSettlementConflict(transitionError);
+        }
+      }
+      if (reservation === null) {
+        await failGeneratedMediaPromotionJobWithExecutor(
+          executor,
+          { ...job, error: terminalErrorValue },
+        );
+        return cardSettlementConflict;
+      }
+      await failGeneratedMediaPromotionJobWithBlobWriterInExecutor(executor, {
+        ...reservation.writer,
+        error: terminalErrorValue,
+      });
+      return cardSettlementConflict;
+    },
+  );
+  if (settlementConflict !== null) throw settlementConflict;
 }
 function terminalError(error: unknown): SafeGeneratedMediaPromotionJobError | null {
   if (error instanceof GeneratedMediaPromotionStorageTerminalError) {
@@ -258,8 +352,14 @@ async function settleKnownFailure(
     if (transitionError instanceof GeneratedMediaPromotionJobLeaseLostError) {
       return result(job, "lease_lost", null);
     }
+    if (isManagedImageSettlementConflictError(transitionError)) {
+      return result(job, "failed", transitionError.conflictCode);
+    }
     if (transitionError instanceof DatabaseCommitOutcomeUnknownError) {
       return result(job, "ambiguous", "DATABASE_COMMIT_OUTCOME_UNKNOWN");
+    }
+    if (transitionError instanceof GeneratedMediaPromotionJobAccessRevokedError) {
+      return settleAccessRevocation(job, input, dependencies);
     }
     if (
       input.signal.aborted
@@ -284,6 +384,13 @@ async function settleAccessRevocation(
     if (outcome === "applied") return result(job, "applied", null);
     if (outcome === "failed") {
       return result(job, "failed", "WORKSPACE_ACCESS_REVOKED");
+    }
+    if (outcome === "failed_markdown_complexity") {
+      return result(
+        job,
+        "failed",
+        managedImageMarkdownComplexitySettlementConflictCode,
+      );
     }
     return result(job, "interrupted", "WORKSPACE_ACCESS_RECHECK_REQUIRED");
   } catch (error) {
@@ -330,6 +437,9 @@ export async function processClaimedGeneratedMediaPromotionJobWithDependencies(
     if (error instanceof GeneratedMediaPromotionJobLeaseLostError) {
       return result(job, "lease_lost", null);
     }
+    if (isManagedImageSettlementConflictError(error)) {
+      return result(job, "failed", error.conflictCode);
+    }
     if (error instanceof GeneratedMediaPromotionJobAccessRevokedError) {
       return settleAccessRevocation(
         reservation?.writer ?? job,
@@ -356,6 +466,9 @@ export async function processClaimedGeneratedMediaPromotionJobWithDependencies(
       } catch (operationReplayError) {
         if (operationReplayError instanceof GeneratedMediaPromotionJobLeaseLostError) {
           return result(job, "lease_lost", null);
+        }
+        if (isManagedImageSettlementConflictError(operationReplayError)) {
+          return result(job, "failed", operationReplayError.conflictCode);
         }
         if (operationReplayError instanceof GeneratedMediaPromotionJobAccessRevokedError) {
           return settleAccessRevocation(reservation.writer, input, dependencies);

--- a/apps/backend/src/chat/cardImages/types.ts
+++ b/apps/backend/src/chat/cardImages/types.ts
@@ -26,6 +26,7 @@ export type GeneratedCardImageResult = Readonly<{
   targetSide: CardTextSide;
   mediaRegistrationApplied: boolean;
   cardAppendApplied: boolean;
+  placeholderApplied: boolean;
   reused: boolean;
   sourceUrl: null;
 }>;

--- a/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
@@ -284,6 +284,7 @@ test("generated image reuse is stable when reclaim changes preceding SQL call co
       return {
         outcome: existing ? "existing" : "created",
         jobId: metadata.operationId,
+        placeholderApplied: true,
       };
     },
   };

--- a/apps/backend/src/chat/openai/tools/tools.test.ts
+++ b/apps/backend/src/chat/openai/tools/tools.test.ts
@@ -127,6 +127,7 @@ const dependencies: OpenAIToolDependencies = {
     mediaAssetId,
     mediaRegistrationApplied: false,
     cardAppendApplied: false,
+    placeholderApplied: true,
     reused: false,
     sourceUrl: null,
   }),
@@ -277,11 +278,12 @@ test("generated image execution reserves and binds before identity or external w
   assert.deepEqual(
     [
       JSON.parse(result.output).status,
+      JSON.parse(result.output).placeholderApplied,
       result.succeeded,
       result.shouldInvalidateMainContent,
       /fcasset|base64|imagePrompt/u.test(result.output),
     ],
-    ["queued", true, true, false],
+    ["queued", true, true, true, false],
   );
 });
 
@@ -308,6 +310,7 @@ test("reclaimed execution reuses immutable payload when model wording changes", 
       return {
         ...await dependencies.generateCardImage(input),
         status: "already_queued",
+        placeholderApplied: false,
         reused: true,
       };
     },
@@ -315,6 +318,7 @@ test("reclaimed execution reuses immutable payload when model wording changes", 
 
   assert.equal(bindCallCount, 0);
   assert.equal(JSON.parse(result.output).status, "already_queued");
+  assert.equal(JSON.parse(result.output).placeholderApplied, false);
   assert.equal(result.shouldInvalidateMainContent, false);
 });
 

--- a/apps/backend/src/chat/openai/tools/tools.ts
+++ b/apps/backend/src/chat/openai/tools/tools.ts
@@ -440,13 +440,14 @@ async function executeGeneratedImageToolCall(
         cardId: result.cardId,
         targetSide: result.targetSide,
         mediaAssetId: result.mediaAssetId,
+        placeholderApplied: result.placeholderApplied,
       },
       {
         attempt: reservation.attempt,
         status: result.status,
         succeeded: true,
         isMutating: mutated,
-        shouldInvalidateMainContent: mutated,
+        shouldInvalidateMainContent: result.placeholderApplied,
         stopReason: null,
       },
     );

--- a/apps/backend/src/workspacePackages/core.test.ts
+++ b/apps/backend/src/workspacePackages/core.test.ts
@@ -4,8 +4,10 @@ import {
   extractMarkdownFcAssetIds,
   extractMarkdownImageFcAssetIds,
   extractMarkdownLinkDestinationUrls,
+  extractMarkdownManagedMediaLifecycleReferences,
   extractMarkdownNonCodeTextSegments,
   extractMarkdownPortableMediaPaths,
+  parseManagedMediaLifecycleReference,
   parseWorkspacePackageCardsJsonV1,
   rewriteMarkdownFcAssetUrlsToFcAssets,
   rewriteMarkdownFcAssetUrlsToPortablePaths,
@@ -23,6 +25,7 @@ import { extractReferencedWorkspacePackageExportMediaAssetIds } from "./export/e
 import { extractReferencedWorkspacePackageMediaPaths } from "./import/importZip";
 import {
   rewriteMarkdownFcAssetUrlsToSharedPortablePathsFromMap,
+  rewriteMarkdownImageDestinationUrl,
 } from "./markdownMedia";
 
 const testMetadata: WorkspacePackageCardMetadataV1 = {
@@ -194,6 +197,110 @@ test("Markdown media helpers skip fenced code blocks and inline code spans", () 
       "[real](fcasset:real-link)",
     ].join("\n"),
   );
+});
+
+test("Markdown image destination replacement preserves links and code examples", () => {
+  const pendingUrl = "fcasset:11111111-1111-4111-8111-111111111111?state=pending";
+  const readyUrl = "fcasset:11111111-1111-4111-8111-111111111111";
+  const markdown = [
+    `\`![inline code](${pendingUrl})\``,
+    "```markdown",
+    `![fenced code](${pendingUrl})`,
+    "```",
+    `[source link](${pendingUrl})`,
+    `![active image](${pendingUrl})`,
+  ].join("\n");
+
+  assert.equal(
+    rewriteMarkdownImageDestinationUrl(markdown, pendingUrl, readyUrl),
+    [
+      `\`![inline code](${pendingUrl})\``,
+      "```markdown",
+      `![fenced code](${pendingUrl})`,
+      "```",
+      `[source link](${pendingUrl})`,
+      `![active image](${readyUrl})`,
+    ].join("\n"),
+  );
+});
+
+test("managed media lifecycle references are typed and block non-ready package exports", () => {
+  const mediaAssetId = "11111111-1111-4111-8111-111111111111";
+  const readyUrl = `fcasset:${mediaAssetId}`;
+  const pendingUrl = `${readyUrl}?state=pending`;
+  const failedUrl = `${readyUrl}?state=failed`;
+  const markdown = [
+    `![ready](${readyUrl})`,
+    `![pending](${pendingUrl})`,
+    `[failed source](${failedUrl})`,
+    `\`![literal](${pendingUrl})\``,
+  ].join("\n");
+
+  assert.deepEqual(parseManagedMediaLifecycleReference(readyUrl), {
+    mediaAssetId,
+    state: "ready",
+    destination: readyUrl,
+  });
+  assert.deepEqual(
+    extractMarkdownManagedMediaLifecycleReferences(markdown),
+    [
+      { mediaAssetId, state: "ready", destination: readyUrl, isImage: true },
+      { mediaAssetId, state: "pending", destination: pendingUrl, isImage: true },
+      { mediaAssetId, state: "failed", destination: failedUrl, isImage: false },
+    ],
+  );
+  assert.throws(
+    () => extractReferencedWorkspacePackageExportMediaAssetIds([{
+      card_id: "card-1",
+      front_text: markdown,
+      back_text: "Answer",
+      card_type: "basic",
+      metadata: null,
+      tags: [],
+    }]),
+    (error: unknown) => error instanceof HttpError
+      && error.statusCode === 409
+      && error.code === "WORKSPACE_PACKAGE_EXPORT_MANAGED_MEDIA_NOT_READY"
+      && error.message.includes(pendingUrl)
+      && error.message.includes(failedUrl)
+      && error.message.includes("retry after promotion and attachment settle")
+      && error.message.includes("Failed managed media is terminal")
+      && error.message.includes("remove the reference or regenerate and reattach the image"),
+  );
+
+  const unsupportedUrls = [
+    `FCASSET:${mediaAssetId}`,
+    `FCASSET:${mediaAssetId}?state=pending`,
+    `FcAsSeT:${mediaAssetId}?state=failed`,
+    `${readyUrl}?state=ready`,
+    `${readyUrl}?state`,
+    `${readyUrl}?state=`,
+    `${readyUrl}?state=unknown`,
+    `${readyUrl}?state=pending&state=failed`,
+    `${readyUrl}?v=1`,
+    `${readyUrl}?state=pending&v=1`,
+    `${readyUrl}#preview`,
+    `${readyUrl}?state=failed#preview`,
+    `${readyUrl}?state=pending&amp;v=1`,
+  ];
+  for (const unsupportedUrl of unsupportedUrls) {
+    assert.equal(parseManagedMediaLifecycleReference(unsupportedUrl), null);
+    assert.throws(
+      () => extractReferencedWorkspacePackageExportMediaAssetIds([{
+        card_id: "card-1",
+        front_text: `![unsupported](${unsupportedUrl})`,
+        back_text: "Answer",
+        card_type: "basic",
+        metadata: null,
+        tags: [],
+      }]),
+      (error: unknown) => error instanceof HttpError
+        && error.statusCode === 409
+        && error.code === "WORKSPACE_PACKAGE_EXPORT_MANAGED_MEDIA_NOT_READY"
+        && error.message.includes("Unsupported managed media lifecycle URLs")
+        && error.message.includes(unsupportedUrl),
+    );
+  }
 });
 
 test("Markdown portable media helpers rewrite only package media destinations", () => {

--- a/apps/backend/src/workspacePackages/export/exportPreview.ts
+++ b/apps/backend/src/workspacePackages/export/exportPreview.ts
@@ -5,7 +5,10 @@ import {
 } from "../../database";
 import { MEDIA_ASSET_JOIN_CLAUSE } from "../../mediaAssets";
 import { HttpError } from "../../shared/errors";
-import { extractMarkdownFcAssetIds } from "../markdownMedia";
+import {
+  extractMarkdownFcAssetIds,
+  extractMarkdownManagedMediaLifecycleIssues,
+} from "../markdownMedia";
 import type { WorkspacePackageMetadataV1 } from "../types";
 
 export const workspacePackageExportPreviewDefaultMaxSelectedCards = 5_000;
@@ -399,8 +402,23 @@ export function extractReferencedWorkspacePackageExportMediaAssetIds(
   cards: ReadonlyArray<WorkspacePackageExportSelectedCardRow>,
 ): ReadonlyArray<string> {
   const mediaAssetIds = new Set<string>();
+  const pendingDestinations = new Set<string>();
+  const failedDestinations = new Set<string>();
+  const unsupportedDestinations = new Set<string>();
 
   for (const card of cards) {
+    for (const markdown of [card.front_text, card.back_text]) {
+      const issues = extractMarkdownManagedMediaLifecycleIssues(markdown);
+      for (const destination of issues.pendingDestinations) {
+        pendingDestinations.add(destination);
+      }
+      for (const destination of issues.failedDestinations) {
+        failedDestinations.add(destination);
+      }
+      for (const destination of issues.unsupportedDestinations) {
+        unsupportedDestinations.add(destination);
+      }
+    }
     for (const mediaAssetId of extractMarkdownFcAssetIds(card.front_text)) {
       mediaAssetIds.add(mediaAssetId);
     }
@@ -408,6 +426,37 @@ export function extractReferencedWorkspacePackageExportMediaAssetIds(
     for (const mediaAssetId of extractMarkdownFcAssetIds(card.back_text)) {
       mediaAssetIds.add(mediaAssetId);
     }
+  }
+  if (
+    pendingDestinations.size !== 0
+    || failedDestinations.size !== 0
+    || unsupportedDestinations.size !== 0
+  ) {
+    const remediation: Array<string> = [];
+    if (pendingDestinations.size !== 0) {
+      remediation.push(
+        "Pending managed media is still being promoted and attached; retry after promotion and attachment settle. "
+          + `pendingManagedMedia=${[...pendingDestinations].join(",")}`,
+      );
+    }
+    if (failedDestinations.size !== 0) {
+      remediation.push(
+        "Failed managed media is terminal; remove the reference or regenerate and reattach the image. "
+          + `failedManagedMedia=${[...failedDestinations].join(",")}`,
+      );
+    }
+    if (unsupportedDestinations.size !== 0) {
+      remediation.push(
+        "Unsupported managed media lifecycle URLs must use fcasset:<id>, "
+          + "fcasset:<id>?state=pending, or fcasset:<id>?state=failed. "
+          + `unsupportedManagedMedia=${[...unsupportedDestinations].join(",")}`,
+      );
+    }
+    throw new HttpError(
+      409,
+      `Workspace package export requires valid ready managed media references. ${remediation.join(" ")}`,
+      "WORKSPACE_PACKAGE_EXPORT_MANAGED_MEDIA_NOT_READY",
+    );
   }
 
   return [...mediaAssetIds];

--- a/apps/backend/src/workspacePackages/index.ts
+++ b/apps/backend/src/workspacePackages/index.ts
@@ -2,8 +2,11 @@ export {
   extractMarkdownFcAssetIds,
   extractMarkdownImageFcAssetIds,
   extractMarkdownLinkDestinationUrls,
+  extractMarkdownManagedMediaLifecycleIssues,
+  extractMarkdownManagedMediaLifecycleReferences,
   extractMarkdownNonCodeTextSegments,
   extractMarkdownPortableMediaPaths,
+  parseManagedMediaLifecycleReference,
   rewriteMarkdownFcAssetUrlsToPortablePaths,
   rewriteMarkdownFcAssetUrlsToPortablePathsFromMap,
   rewriteMarkdownFcAssetUrlsToFcAssets,
@@ -17,6 +20,9 @@ export {
 export type {
   FcAssetIdResolver,
   FcAssetPortablePathResolver,
+  ManagedMediaLifecycleIssues,
+  ManagedMediaLifecycleReference,
+  ManagedMediaLifecycleState,
   PortableMediaAssetIdResolver,
 } from "./markdownMedia";
 

--- a/apps/backend/src/workspacePackages/markdownMedia.ts
+++ b/apps/backend/src/workspacePackages/markdownMedia.ts
@@ -6,6 +6,21 @@ type MarkdownUrlRewrite = Readonly<{
   replacementUrl: string;
 }>;
 
+export type ManagedMediaLifecycleState = "ready" | "pending" | "failed";
+
+export type ManagedMediaLifecycleReference = Readonly<{
+  mediaAssetId: string;
+  state: ManagedMediaLifecycleState;
+  destination: string;
+  isImage: boolean;
+}>;
+
+export type ManagedMediaLifecycleIssues = Readonly<{
+  pendingDestinations: ReadonlyArray<string>;
+  failedDestinations: ReadonlyArray<string>;
+  unsupportedDestinations: ReadonlyArray<string>;
+}>;
+
 type MarkdownLinkDestination = Readonly<{
   labelStartIndex: number;
   labelEndIndex: number;
@@ -169,6 +184,9 @@ export type FcAssetIdResolver = (assetId: string) => string;
 export type PortableMediaAssetIdResolver = (portableMediaPath: string) => string;
 
 const fcAssetUrlPattern = /^fcasset:([A-Za-z0-9][A-Za-z0-9._-]*)$/;
+const managedMediaLifecycleUrlPattern =
+  /^fcasset:([A-Za-z0-9][A-Za-z0-9._-]*)(?:\?state=(pending|failed))?$/;
+const managedMediaSchemePrefix = "fcasset:";
 const absoluteUrlPattern = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const localMediaPathWithLeadingDotSegmentsPattern = /^(?:\.\.?[\\/])+media(?:[\\/]|$)/;
 const portableMediaPathSegmentPattern = /^[A-Za-z0-9._-]+$/;
@@ -195,6 +213,8 @@ const markdownAtxHeadingStart: MarkdownBlockStart = { kind: "atx-heading" };
 const markdownLineChunkCapacity = 8_192;
 const markdownMaximumInlineLabelDepth = 1_000;
 const markdownMaximumLinkDestinationParenthesisDepth = 32;
+const markdownComplexityLimitErrorCode =
+  "MARKDOWN_COMPLEXITY_LIMIT_EXCEEDED";
 
 class MarkdownComplexityError extends Error {
   readonly sourceIndex: number;
@@ -215,8 +235,13 @@ function translateMarkdownComplexityError(error: MarkdownComplexityError): HttpE
   return new HttpError(
     400,
     error.message,
-    "MARKDOWN_COMPLEXITY_LIMIT_EXCEEDED",
+    markdownComplexityLimitErrorCode,
   );
+}
+
+export function isMarkdownComplexityLimitError(error: unknown): error is HttpError {
+  return error instanceof HttpError
+    && error.code === markdownComplexityLimitErrorCode;
 }
 
 function runMarkdownHelper<Result>(operation: () => Result): Result {
@@ -237,6 +262,30 @@ function matchFcAssetId(url: string): string | null {
   }
 
   return match[1] ?? null;
+}
+
+export function parseManagedMediaLifecycleReference(
+  destination: string,
+): Omit<ManagedMediaLifecycleReference, "isImage"> | null {
+  const match = managedMediaLifecycleUrlPattern.exec(destination);
+  if (match === null) {
+    return null;
+  }
+  const mediaAssetId = match[1];
+  const lifecycleState = match[2];
+  if (mediaAssetId === undefined) {
+    return null;
+  }
+  const state: ManagedMediaLifecycleState = lifecycleState === "pending"
+    ? "pending"
+    : lifecycleState === "failed"
+      ? "failed"
+      : "ready";
+  return {
+    mediaAssetId,
+    state,
+    destination,
+  };
 }
 
 function countRepeatedCharacter(markdown: string, index: number, marker: "`" | "~"): number {
@@ -2899,6 +2948,91 @@ export function extractMarkdownImageFcAssetIds(markdown: string): ReadonlyArray<
   return runMarkdownHelper(() => extractMarkdownImageFcAssetIdsUnchecked(markdown));
 }
 
+function extractMarkdownImageDestinationUrlsUnchecked(markdown: string): ReadonlyArray<string> {
+  const destinations: Array<string> = [];
+  for (const destination of iterateMarkdownActiveDestinations(markdown)) {
+    if (!destination.hasDestination || !destination.isImage) {
+      continue;
+    }
+    destinations.push(destination.destination);
+  }
+  return destinations;
+}
+
+export function extractMarkdownImageDestinationUrls(markdown: string): ReadonlyArray<string> {
+  return runMarkdownHelper(() => extractMarkdownImageDestinationUrlsUnchecked(markdown));
+}
+
+function extractMarkdownManagedMediaLifecycleReferencesUnchecked(
+  markdown: string,
+): ReadonlyArray<ManagedMediaLifecycleReference> {
+  const references: Array<ManagedMediaLifecycleReference> = [];
+  for (const destination of iterateMarkdownActiveDestinations(markdown)) {
+    if (!destination.hasDestination) {
+      continue;
+    }
+    const reference = parseManagedMediaLifecycleReference(destination.destination);
+    if (reference === null) {
+      continue;
+    }
+    references.push({
+      ...reference,
+      isImage: destination.isImage,
+    });
+  }
+  return references;
+}
+
+export function extractMarkdownManagedMediaLifecycleReferences(
+  markdown: string,
+): ReadonlyArray<ManagedMediaLifecycleReference> {
+  return runMarkdownHelper(() => (
+    extractMarkdownManagedMediaLifecycleReferencesUnchecked(markdown)
+  ));
+}
+
+function extractMarkdownManagedMediaLifecycleIssuesUnchecked(
+  markdown: string,
+): ManagedMediaLifecycleIssues {
+  const pendingDestinations: Array<string> = [];
+  const failedDestinations: Array<string> = [];
+  const unsupportedDestinations: Array<string> = [];
+  for (const destination of iterateMarkdownActiveDestinations(markdown)) {
+    if (!destination.hasDestination) {
+      continue;
+    }
+    const reference = parseManagedMediaLifecycleReference(destination.destination);
+    if (reference?.state === "pending") {
+      pendingDestinations.push(reference.destination);
+      continue;
+    }
+    if (reference?.state === "failed") {
+      failedDestinations.push(reference.destination);
+      continue;
+    }
+    if (
+      reference === null
+      && destination.destination.slice(0, managedMediaSchemePrefix.length).toLowerCase()
+        === managedMediaSchemePrefix
+    ) {
+      unsupportedDestinations.push(destination.destination);
+    }
+  }
+  return {
+    pendingDestinations,
+    failedDestinations,
+    unsupportedDestinations,
+  };
+}
+
+export function extractMarkdownManagedMediaLifecycleIssues(
+  markdown: string,
+): ManagedMediaLifecycleIssues {
+  return runMarkdownHelper(() => (
+    extractMarkdownManagedMediaLifecycleIssuesUnchecked(markdown)
+  ));
+}
+
 function extractMarkdownLinkDestinationUrlsUnchecked(markdown: string): ReadonlyArray<string> {
   const destinations: Array<string> = [];
   for (const linkDestination of iterateMarkdownActiveDestinations(markdown)) {
@@ -2913,6 +3047,41 @@ function extractMarkdownLinkDestinationUrlsUnchecked(markdown: string): Readonly
 
 export function extractMarkdownLinkDestinationUrls(markdown: string): ReadonlyArray<string> {
   return runMarkdownHelper(() => extractMarkdownLinkDestinationUrlsUnchecked(markdown));
+}
+
+export function rewriteMarkdownImageDestinationUrl(
+  markdown: string,
+  currentUrl: string,
+  replacementUrl: string,
+): string {
+  return runMarkdownHelper(() => {
+    const rewrites: Array<MarkdownUrlRewrite> = [];
+    for (const destination of iterateMarkdownActiveDestinations(markdown)) {
+      if (
+        !destination.hasDestination
+        || !destination.isImage
+        || destination.destination !== currentUrl
+      ) {
+        continue;
+      }
+      rewrites.push({
+        startIndex: destination.startIndex,
+        endIndex: destination.endIndex,
+        replacementUrl,
+      });
+    }
+
+    let rewrittenMarkdown = "";
+    let cursorIndex = 0;
+    for (const rewrite of rewrites) {
+      rewrittenMarkdown += markdown.slice(cursorIndex, rewrite.startIndex);
+      rewrittenMarkdown += rewrite.replacementUrl;
+      cursorIndex = rewrite.endIndex;
+    }
+    return rewrites.length === 0
+      ? markdown
+      : rewrittenMarkdown + markdown.slice(cursorIndex);
+  });
 }
 
 function extractMarkdownPortableMediaPathsUnchecked(markdown: string): ReadonlyArray<string> {

--- a/db/migrations/0104_generated_image_placeholder_terminal_state.sql
+++ b/db/migrations/0104_generated_image_placeholder_terminal_state.sql
@@ -1,0 +1,718 @@
+-- Migration status: Current / additive.
+-- Introduces: lifecycle-marker promotion protocol fencing and parser-safe failed
+-- generated-image placeholder settlement after workspace access revocation.
+-- Schemas touched/read explicitly: content, org, sync, pg_catalog.
+
+DROP FUNCTION IF EXISTS content.generated_media_promotion_protocol_v2_active();
+
+DROP FUNCTION IF EXISTS content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, INTEGER
+);
+
+ALTER TABLE content.generated_media_promotion_jobs
+  ADD COLUMN IF NOT EXISTS protocol_version INTEGER NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN content.generated_media_promotion_jobs.protocol_version IS
+  'Immutable promotion protocol: 1 is legacy append-on-success; 2 owns pending/ready/failed card markers.';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint AS constraints
+    WHERE constraints.conrelid = 'content.generated_media_promotion_jobs'::regclass
+      AND constraints.conname = 'generated_media_promotion_jobs_protocol_version'
+  ) THEN
+    ALTER TABLE content.generated_media_promotion_jobs
+      ADD CONSTRAINT generated_media_promotion_jobs_protocol_version
+      CHECK (protocol_version IN (1, 2));
+  END IF;
+END;
+$$;
+
+GRANT SELECT (protocol_version), INSERT (protocol_version)
+  ON content.generated_media_promotion_jobs TO backend_app;
+
+CREATE OR REPLACE FUNCTION content.claim_generated_media_promotion_jobs(
+  p_lease_owner TEXT,
+  p_lease_duration_ms INTEGER,
+  p_limit INTEGER,
+  p_max_protocol_version INTEGER
+)
+RETURNS SETOF content.generated_media_promotion_jobs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF p_lease_owner IS NULL OR btrim(p_lease_owner) = ''
+    OR p_lease_owner IS DISTINCT FROM btrim(p_lease_owner)
+    OR char_length(p_lease_owner) > 200
+    OR p_lease_owner ~ '[[:cntrl:]]'
+  THEN
+    RAISE EXCEPTION 'p_lease_owner must be 1 to 200 trimmed characters'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_lease_duration_ms IS NULL OR p_lease_duration_ms NOT BETWEEN 1 AND 3600000 THEN
+    RAISE EXCEPTION 'p_lease_duration_ms must be between 1 and 3600000'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_limit IS NULL OR p_limit NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'p_limit must be between 1 and 100'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_max_protocol_version IS NULL OR p_max_protocol_version NOT BETWEEN 1 AND 2 THEN
+    RAISE EXCEPTION 'p_max_protocol_version must be between 1 and 2'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH claimable AS (
+    SELECT jobs.job_id
+    FROM content.generated_media_promotion_jobs AS jobs
+    WHERE jobs.protocol_version <= p_max_protocol_version
+      AND (
+        (
+          jobs.state = 'pending'
+          AND jobs.next_attempt_at <= statement_timestamp()
+        )
+        OR (
+          jobs.state = 'leased'
+          AND jobs.lease_expires_at <= statement_timestamp()
+        )
+      )
+    ORDER BY
+      CASE WHEN jobs.state = 'leased' THEN jobs.lease_expires_at
+        ELSE jobs.next_attempt_at END,
+      jobs.created_at,
+      jobs.job_id
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit
+  )
+  UPDATE content.generated_media_promotion_jobs AS jobs
+  SET
+    state = 'leased',
+    lease_token = public.gen_random_uuid(),
+    lease_owner = p_lease_owner,
+    lease_expires_at =
+      statement_timestamp() + (p_lease_duration_ms * interval '1 millisecond'),
+    updated_at = statement_timestamp()
+  FROM claimable
+  WHERE jobs.job_id = claimable.job_id
+  RETURNING jobs.*;
+END;
+$$;
+
+COMMENT ON FUNCTION content.claim_generated_media_promotion_jobs(
+  TEXT, INTEGER, INTEGER, INTEGER
+) IS
+  'Claims generated-media jobs up to an explicit worker protocol version; current workers pass 2.';
+
+REVOKE ALL ON FUNCTION content.claim_generated_media_promotion_jobs(
+  TEXT, INTEGER, INTEGER, INTEGER
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.claim_generated_media_promotion_jobs(
+  TEXT, INTEGER, INTEGER, INTEGER
+) TO backend_app;
+
+CREATE OR REPLACE FUNCTION content.claim_generated_media_promotion_jobs(
+  p_lease_owner TEXT,
+  p_lease_duration_ms INTEGER,
+  p_limit INTEGER
+)
+RETURNS SETOF content.generated_media_promotion_jobs
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT *
+  FROM content.claim_generated_media_promotion_jobs(
+    p_lease_owner,
+    p_lease_duration_ms,
+    p_limit,
+    1
+  );
+$$;
+
+COMMENT ON FUNCTION content.claim_generated_media_promotion_jobs(
+  TEXT, INTEGER, INTEGER
+) IS
+  'Compatibility claim boundary for deployed protocol-v1 workers; lifecycle-marker jobs are excluded.';
+
+REVOKE ALL ON FUNCTION content.claim_generated_media_promotion_jobs(
+  TEXT, INTEGER, INTEGER
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.claim_generated_media_promotion_jobs(
+  TEXT, INTEGER, INTEGER
+) TO backend_app;
+
+CREATE OR REPLACE FUNCTION content.lock_generated_media_promotion_job_after_access_revocation(
+  p_job_id UUID,
+  p_lease_token UUID,
+  p_operation_id UUID,
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_card_id UUID,
+  p_target_side TEXT,
+  p_alt_text TEXT,
+  p_media_asset_id UUID,
+  p_replica_id UUID,
+  p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT,
+  p_sha256 TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT
+)
+RETURNS TABLE(revocation_status TEXT, card_text TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  job_snapshot content.generated_media_promotion_jobs%ROWTYPE;
+  job content.generated_media_promotion_jobs%ROWTYPE;
+  locked_card_text TEXT;
+BEGIN
+  SELECT jobs.*
+  INTO job_snapshot
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(
+      job_snapshot.user_id || ':' || job_snapshot.workspace_id::TEXT,
+      0::BIGINT
+    )
+  );
+
+  INSERT INTO sync.workspace_sync_metadata (
+    workspace_id,
+    min_available_hot_change_id,
+    updated_at
+  )
+  VALUES (job_snapshot.workspace_id, 0, statement_timestamp())
+  ON CONFLICT (workspace_id) DO NOTHING;
+
+  PERFORM 1
+  FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = job_snapshot.workspace_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  PERFORM 1
+  FROM content.media_blob_writer_reservations AS reservations
+  INNER JOIN content.media_blob_lifecycles AS lifecycles
+    ON lifecycles.sha256 = reservations.sha256
+  WHERE reservations.writer_kind = 'generated_promotion'
+    AND reservations.workspace_id = job_snapshot.workspace_id
+    AND reservations.media_asset_id = job_snapshot.media_asset_id
+    AND reservations.operation_id = job_snapshot.operation_id::TEXT
+  FOR UPDATE OF lifecycles, reservations;
+
+  SELECT jobs.*
+  INTO job
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR job.operation_id IS DISTINCT FROM p_operation_id
+    OR job.user_id IS DISTINCT FROM p_user_id
+    OR job.workspace_id IS DISTINCT FROM p_workspace_id
+    OR job.card_id IS DISTINCT FROM p_card_id
+    OR job.target_side IS DISTINCT FROM p_target_side
+    OR job.alt_text IS DISTINCT FROM p_alt_text
+    OR job.media_asset_id IS DISTINCT FROM p_media_asset_id
+    OR job.replica_id IS DISTINCT FROM p_replica_id
+    OR job.staging_storage_key IS DISTINCT FROM p_staging_storage_key
+    OR job.blob_storage_key IS DISTINCT FROM p_blob_storage_key
+    OR job.sha256 IS DISTINCT FROM p_sha256
+    OR job.mime_type IS DISTINCT FROM p_mime_type
+    OR job.size_bytes IS DISTINCT FROM p_size_bytes
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF job.state = 'applied' THEN
+    RETURN QUERY SELECT 'applied'::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF job.state IS DISTINCT FROM 'leased'
+    OR job.lease_token IS DISTINCT FROM p_lease_token
+    OR job.lease_expires_at <= clock_timestamp()
+  THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM org.workspace_memberships AS memberships
+    WHERE memberships.workspace_id = job.workspace_id
+      AND memberships.user_id = job.user_id
+  ) THEN
+    RETURN QUERY SELECT 'access_active'::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF job.target_side NOT IN ('front', 'back') THEN
+    RETURN QUERY SELECT 'stale'::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT CASE job.target_side
+    WHEN 'front' THEN cards.front_text
+    WHEN 'back' THEN cards.back_text
+  END
+  INTO locked_card_text
+  FROM content.cards AS cards
+  WHERE cards.workspace_id = job.workspace_id
+    AND cards.card_id = job.card_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    locked_card_text := NULL;
+  END IF;
+
+  RETURN QUERY SELECT 'access_revoked'::TEXT, locked_card_text;
+END;
+$$;
+
+COMMENT ON FUNCTION content.lock_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT
+) IS
+  'Locks one exact leased generated-media job, its writer state, sync metadata, and tombstone-inclusive card row, then returns the requested card side only after confirming workspace access is revoked.';
+
+REVOKE ALL ON FUNCTION content.lock_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.lock_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT
+) TO backend_app;
+
+CREATE OR REPLACE FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  p_job_id UUID,
+  p_lease_token UUID,
+  p_operation_id UUID,
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_card_id UUID,
+  p_target_side TEXT,
+  p_alt_text TEXT,
+  p_media_asset_id UUID,
+  p_replica_id UUID,
+  p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT,
+  p_sha256 TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  lock_status TEXT;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000 THEN
+    RAISE EXCEPTION 'p_cleanup_delay_ms must be between 1 and 604800000'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT locks.revocation_status
+  INTO lock_status
+  FROM content.lock_generated_media_promotion_job_after_access_revocation(
+    p_job_id,
+    p_lease_token,
+    p_operation_id,
+    p_user_id,
+    p_workspace_id,
+    p_card_id,
+    p_target_side,
+    p_alt_text,
+    p_media_asset_id,
+    p_replica_id,
+    p_staging_storage_key,
+    p_blob_storage_key,
+    p_sha256,
+    p_mime_type,
+    p_size_bytes
+  ) AS locks;
+
+  IF lock_status = 'access_revoked' THEN
+    RETURN 'stale';
+  END IF;
+  RETURN COALESCE(lock_status, 'stale');
+END;
+$$;
+
+COMMENT ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, INTEGER
+) IS
+  'Compatibility fence for workers deployed before parser-safe access-revocation settlement; active access and applied jobs remain observable, while revoked jobs wait for a current worker.';
+
+REVOKE ALL ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, INTEGER
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, INTEGER
+) TO backend_app;
+
+CREATE OR REPLACE FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  p_job_id UUID,
+  p_lease_token UUID,
+  p_operation_id UUID,
+  p_user_id TEXT,
+  p_workspace_id UUID,
+  p_card_id UUID,
+  p_target_side TEXT,
+  p_alt_text TEXT,
+  p_media_asset_id UUID,
+  p_replica_id UUID,
+  p_staging_storage_key TEXT,
+  p_blob_storage_key TEXT,
+  p_sha256 TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_expected_card_text TEXT,
+  p_failed_card_text TEXT,
+  p_error_code TEXT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  lock_status TEXT;
+  locked_card_text TEXT;
+  job content.generated_media_promotion_jobs%ROWTYPE;
+  card content.cards%ROWTYPE;
+  reservation_found BOOLEAN;
+  reservation_token UUID;
+  reservation_sha256 TEXT;
+  reservation_state TEXT;
+  lifecycle_storage_key TEXT;
+  lifecycle_mime_type TEXT;
+  lifecycle_size_bytes BIGINT;
+  lifecycle_normalization_version TEXT;
+  terminalization_status TEXT;
+  pending_destination TEXT;
+  failed_destination TEXT;
+  expected_index INTEGER;
+  failed_index INTEGER;
+  expected_length INTEGER;
+  failed_length INTEGER;
+  transition_count INTEGER := 0;
+  generated_client_updated_at TIMESTAMPTZ;
+BEGIN
+  IF p_cleanup_delay_ms IS NULL OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000 THEN
+    RAISE EXCEPTION 'p_cleanup_delay_ms must be between 1 and 604800000'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_error_code IS NULL
+    OR p_error_code NOT IN (
+      'WORKSPACE_ACCESS_REVOKED',
+      'GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT'
+    )
+  THEN
+    RAISE EXCEPTION 'p_error_code is not an allowed access-revocation settlement outcome'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT locks.revocation_status, locks.card_text
+  INTO lock_status, locked_card_text
+  FROM content.lock_generated_media_promotion_job_after_access_revocation(
+    p_job_id,
+    p_lease_token,
+    p_operation_id,
+    p_user_id,
+    p_workspace_id,
+    p_card_id,
+    p_target_side,
+    p_alt_text,
+    p_media_asset_id,
+    p_replica_id,
+    p_staging_storage_key,
+    p_blob_storage_key,
+    p_sha256,
+    p_mime_type,
+    p_size_bytes
+  ) AS locks;
+
+  IF lock_status IS DISTINCT FROM 'access_revoked' THEN
+    RETURN COALESCE(lock_status, 'stale');
+  END IF;
+
+  IF locked_card_text IS DISTINCT FROM p_expected_card_text THEN
+    RETURN 'stale';
+  END IF;
+  IF p_error_code = 'GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT'
+    AND p_failed_card_text IS DISTINCT FROM p_expected_card_text
+  THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT jobs.*
+  INTO job
+  FROM content.generated_media_promotion_jobs AS jobs
+  WHERE jobs.job_id = p_job_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT
+    reservations.reservation_token,
+    reservations.sha256,
+    reservations.state,
+    lifecycles.storage_key,
+    lifecycles.mime_type,
+    lifecycles.size_bytes,
+    lifecycles.normalization_version
+  INTO
+    reservation_token,
+    reservation_sha256,
+    reservation_state,
+    lifecycle_storage_key,
+    lifecycle_mime_type,
+    lifecycle_size_bytes,
+    lifecycle_normalization_version
+  FROM content.media_blob_writer_reservations AS reservations
+  INNER JOIN content.media_blob_lifecycles AS lifecycles
+    ON lifecycles.sha256 = reservations.sha256
+  WHERE reservations.writer_kind = 'generated_promotion'
+    AND reservations.workspace_id = job.workspace_id
+    AND reservations.media_asset_id = job.media_asset_id
+    AND reservations.operation_id = job.operation_id::TEXT
+  FOR UPDATE OF lifecycles, reservations;
+  reservation_found := FOUND;
+
+  IF reservation_found AND (
+    reservation_sha256 IS DISTINCT FROM job.sha256
+    OR reservation_state NOT IN ('active', 'ambiguous', 'finalized', 'unreferenced')
+    OR lifecycle_storage_key IS DISTINCT FROM job.blob_storage_key
+    OR lifecycle_mime_type IS DISTINCT FROM job.mime_type
+    OR lifecycle_size_bytes IS DISTINCT FROM job.size_bytes
+    OR lifecycle_normalization_version NOT IN ('passthrough-v1', 'image-jpeg-card-v1')
+  ) THEN
+    RETURN 'stale';
+  END IF;
+
+  SELECT cards.*
+  INTO card
+  FROM content.cards AS cards
+  WHERE cards.workspace_id = job.workspace_id
+    AND cards.card_id = job.card_id
+  FOR UPDATE;
+
+  IF FOUND THEN
+    IF p_expected_card_text IS NULL OR p_failed_card_text IS NULL THEN
+      RETURN 'stale';
+    END IF;
+
+    IF p_failed_card_text IS DISTINCT FROM p_expected_card_text THEN
+      pending_destination :=
+        'fcasset:' || lower(job.media_asset_id::TEXT) || '?state=pending';
+      failed_destination :=
+        'fcasset:' || lower(job.media_asset_id::TEXT) || '?state=failed';
+      expected_index := 1;
+      failed_index := 1;
+      expected_length := char_length(p_expected_card_text);
+      failed_length := char_length(p_failed_card_text);
+
+      WHILE expected_index <= expected_length OR failed_index <= failed_length LOOP
+        IF substring(
+          p_expected_card_text FROM expected_index FOR char_length(pending_destination)
+        ) = pending_destination
+          AND substring(
+            p_failed_card_text FROM failed_index FOR char_length(failed_destination)
+          ) = failed_destination
+        THEN
+          expected_index := expected_index + char_length(pending_destination);
+          failed_index := failed_index + char_length(failed_destination);
+          transition_count := transition_count + 1;
+        ELSIF expected_index <= expected_length
+          AND failed_index <= failed_length
+          AND substring(p_expected_card_text FROM expected_index FOR 1)
+            = substring(p_failed_card_text FROM failed_index FOR 1)
+        THEN
+          expected_index := expected_index + 1;
+          failed_index := failed_index + 1;
+        ELSE
+          RETURN 'stale';
+        END IF;
+      END LOOP;
+
+      IF transition_count = 0 THEN
+        RETURN 'stale';
+      END IF;
+    END IF;
+  ELSIF p_expected_card_text IS NOT NULL OR p_failed_card_text IS NOT NULL THEN
+    RETURN 'stale';
+  END IF;
+
+  IF reservation_found THEN
+    terminalization_status := content.terminalize_media_blob_writer_failure(
+      reservation_token,
+      reservation_sha256,
+      lifecycle_storage_key,
+      lifecycle_mime_type,
+      lifecycle_size_bytes,
+      lifecycle_normalization_version,
+      'generated_promotion',
+      job.workspace_id,
+      job.media_asset_id,
+      job.operation_id::TEXT,
+      p_cleanup_delay_ms
+    );
+
+    IF terminalization_status NOT IN ('referenced', 'unreferenced') THEN
+      RAISE EXCEPTION
+        'Generated-media writer terminalization failed after access revocation. job_id=% status=%',
+        job.job_id,
+        terminalization_status
+        USING ERRCODE = '55000';
+    END IF;
+  END IF;
+
+  IF card.card_id IS NOT NULL
+    AND p_failed_card_text IS DISTINCT FROM p_expected_card_text
+  THEN
+    generated_client_updated_at := GREATEST(
+      statement_timestamp(),
+      card.client_updated_at + interval '1 millisecond'
+    );
+
+    IF job.target_side = 'front' THEN
+      UPDATE content.cards AS cards
+      SET
+        front_text = p_failed_card_text,
+        client_updated_at = generated_client_updated_at,
+        last_modified_by_replica_id = job.replica_id,
+        last_operation_id = job.operation_id::TEXT,
+        updated_at = statement_timestamp()
+      WHERE cards.workspace_id = job.workspace_id
+        AND cards.card_id = job.card_id;
+    ELSIF job.target_side = 'back' THEN
+      UPDATE content.cards AS cards
+      SET
+        back_text = p_failed_card_text,
+        client_updated_at = generated_client_updated_at,
+        last_modified_by_replica_id = job.replica_id,
+        last_operation_id = job.operation_id::TEXT,
+        updated_at = statement_timestamp()
+      WHERE cards.workspace_id = job.workspace_id
+        AND cards.card_id = job.card_id;
+    ELSE
+      RAISE EXCEPTION 'Generated-media job target side is invalid. job_id=%', job.job_id
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Locked generated-media card disappeared. job_id=%', job.job_id
+        USING ERRCODE = '55000';
+    END IF;
+
+    INSERT INTO sync.hot_changes (
+      workspace_id,
+      entity_type,
+      entity_id,
+      action,
+      replica_id,
+      operation_id,
+      client_updated_at
+    )
+    VALUES (
+      job.workspace_id,
+      'card',
+      job.card_id::TEXT,
+      'upsert',
+      job.replica_id,
+      job.operation_id::TEXT,
+      generated_client_updated_at
+    );
+  END IF;
+
+  UPDATE content.generated_media_promotion_jobs AS jobs
+  SET
+    state = 'failed',
+    next_attempt_at = NULL,
+    lease_token = NULL,
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_error_code = p_error_code,
+    last_error_message = CASE p_error_code
+      WHEN 'WORKSPACE_ACCESS_REVOKED' THEN
+        'Workspace access was revoked before generated-media promotion completed.'
+      WHEN 'GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT' THEN
+        'Generated image settlement could not inspect the '
+          || job.target_side
+          || ' side because its Markdown exceeds parser complexity limits. Card text was preserved.'
+    END,
+    updated_at = statement_timestamp()
+  WHERE jobs.job_id = job.job_id;
+
+  RETURN 'failed';
+END;
+$$;
+
+COMMENT ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, TEXT, TEXT, TEXT, INTEGER
+) IS
+  'Atomically validates a parser-computed pending-to-failed transition or exact no-change parser-conflict settlement, terminalizes the exact generated writer, preserves card tombstones, emits hot sync state only for text changes, and fails the current job lease after workspace access revocation.';
+
+REVOKE ALL ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, TEXT, TEXT, TEXT, INTEGER
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.fail_generated_media_promotion_job_after_access_revocation(
+  UUID, UUID, UUID, TEXT, UUID, UUID, TEXT, TEXT, UUID, UUID, TEXT, TEXT,
+  TEXT, TEXT, BIGINT, TEXT, TEXT, TEXT, INTEGER
+) TO backend_app;
+
+CREATE OR REPLACE FUNCTION content.generated_media_promotion_protocol_v2_active()
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+SET search_path = pg_catalog
+AS $$
+  SELECT TRUE;
+$$;
+
+COMMENT ON FUNCTION content.generated_media_promotion_protocol_v2_active() IS
+  'Migration-completion marker that activates admission for protocol-v2 lifecycle-marker jobs.';
+
+REVOKE ALL ON FUNCTION content.generated_media_promotion_protocol_v2_active()
+  FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+
+GRANT EXECUTE ON FUNCTION content.generated_media_promotion_protocol_v2_active()
+  TO backend_app;

--- a/docs/managed-media-cross-client-smoke.md
+++ b/docs/managed-media-cross-client-smoke.md
@@ -75,6 +75,28 @@ If any path fails, capture:
 
 After this change is merged and deployed, make the next permitted real image request from a signed-in production chat:
 
-- Explicitly request one teaching-relevant image, confirm the assistant inspects the card first, names the card and side, and attaches exactly one canonical managed-media reference to that side; sync Web, iOS, and Android and confirm it renders everywhere without front-side answer leakage.
-- Do not make additional real image requests for cap, retry, replay, cancellation, claim-loss, or guest checks. Use the deployed automated test results and structured logs to confirm those paths, including that guest chat stays SQL-only.
+- Explicitly request one teaching-relevant image and confirm the assistant
+  inspects the card first and names the card and side.
+- While background promotion is outstanding, inspect the requested side and
+  confirm it contains exactly one pending marker:
+  `![<alt>](fcasset:<mediaAssetId>?state=pending)`. Ordinary card text on both
+  sides must remain unchanged.
+- After promotion completes, sync Web, iOS, and Android. Confirm the same
+  marker becomes `![<alt>](fcasset:<mediaAssetId>)`, the image renders
+  everywhere, and no answer-revealing content appears on the front.
+- Confirm the pending and ready writes each appear as card hot-sync changes
+  with the generated operation metadata. The media asset registration and
+  query-free card marker must become durable in the same promotion
+  transaction.
+- Do not make additional real image requests for cap, retry, replay,
+  cancellation, claim-loss, guest, or terminal-failure checks. Use the
+  deployed automated Postgres integration result and structured promotion-job
+  logs to confirm that retries retain `?state=pending`, terminal failures
+  change a still-present marker to `?state=failed`, access revocation performs
+  the same transition, and guest chat stays SQL-only.
+- For failure evidence without another paid image request, use the automated
+  fixture's deterministic staged bytes and correlate the promotion `jobId`,
+  `workspaceId`, terminal `errorCode`, and outcome in structured logs. Confirm
+  the corresponding card hot-change record and failed marker; do not inject a
+  production failure or replay a provider request.
 - Record only model/status/request ID/duration and card/media IDs, never prompts, alt text, image bytes/base64, signed URLs, storage keys, or tool output.

--- a/docs/review-markdown-rendering.md
+++ b/docs/review-markdown-rendering.md
@@ -45,6 +45,23 @@ Managed media persists in card text as one of these forms:
 [label](fcasset:<mediaAssetId>)
 ```
 
+Generated images use an image-only lifecycle reference on the exact requested
+card side:
+
+```text
+pending = ![label](fcasset:<mediaAssetId>?state=pending)
+ready   = ![label](fcasset:<mediaAssetId>)
+failed  = ![label](fcasset:<mediaAssetId>?state=failed)
+```
+
+The pending marker is written atomically with durable background-promotion
+admission. Successful promotion removes the query state; terminal failure
+changes `state=pending` to `state=failed`. Card text never contains a localized
+status sentence, staging URL, or image payload. Each client owns localized
+pending and failed presentation and extracts the media asset ID before the query
+parameters. Pending and failed references are not exportable or publishable
+managed media.
+
 Outside fenced code, clients render these references with their existing
 managed-media UI. An `fcasset:` URL must never be sent to a generic network
 image loader. Inside fenced code, the same text is literal code and must not

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -94,7 +94,7 @@ test("shared worker has exact permanent-prefix access and no public route", () =
   );
 });
 
-test("release disables cleanup until migration 0103 is confirmed", () => {
+test("release disables cleanup until migration 0104 is confirmed", () => {
   for (const relativePath of [
     "../../.github/workflows/aws-web-release.yml",
     "../../scripts/deploy/bootstrap.sh",
@@ -107,7 +107,7 @@ test("release disables cleanup until migration 0103 is confirmed", () => {
       "mediaBlobCleanupEnabled=false",
     );
     const migration = source.indexOf(
-      "--require-migration 0103_ai_chat_initiating_auth_classification.sql",
+      "--require-migration 0104_generated_image_placeholder_terminal_state.sql",
     );
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",
@@ -137,6 +137,72 @@ test("release disables cleanup until migration 0103 is confirmed", () => {
   assert.match(
     verificationScript,
     /check_schedule "GeneratedMediaPromotionScheduleName"/u,
+  );
+});
+
+test("lifecycle promotion rollout is fenced by durable database protocol activation", () => {
+  const migrationSource = readSource(
+    "../../db/migrations/0104_generated_image_placeholder_terminal_state.sql",
+  );
+  const admissionSource = readSource(
+    "../../apps/backend/src/chat/cardImages/promotionJobs.ts",
+  );
+  const processorSource = readSource(
+    "../../apps/backend/src/chat/cardImages/promotionProcessor.ts",
+  );
+
+  const activationDrop = migrationSource.indexOf(
+    "DROP FUNCTION IF EXISTS content.generated_media_promotion_protocol_v2_active()",
+  );
+  const protocolColumn = migrationSource.indexOf(
+    "ADD COLUMN IF NOT EXISTS protocol_version INTEGER NOT NULL DEFAULT 1",
+  );
+  const currentClaim = migrationSource.indexOf(
+    "p_max_protocol_version INTEGER",
+  );
+  const legacyClaim = migrationSource.indexOf(
+    "p_limit,\n    1\n  );",
+  );
+  const activationCreate = migrationSource.indexOf(
+    "CREATE OR REPLACE FUNCTION content.generated_media_promotion_protocol_v2_active()",
+  );
+  assert.equal(activationDrop >= 0, true);
+  assert.equal(protocolColumn > activationDrop, true);
+  assert.equal(currentClaim > protocolColumn, true);
+  assert.equal(legacyClaim > currentClaim, true);
+  assert.equal(activationCreate > legacyClaim, true);
+  assert.match(
+    migrationSource,
+    /jobs\.protocol_version <= p_max_protocol_version/u,
+  );
+  assert.match(
+    migrationSource,
+    /p_error_code = 'GENERATED_IMAGE_MARKDOWN_COMPLEXITY_CONFLICT'\s+AND p_failed_card_text IS DISTINCT FROM p_expected_card_text/u,
+  );
+  assert.equal(
+    migrationSource.slice(activationCreate).trimEnd().endsWith("TO backend_app;"),
+    true,
+  );
+
+  assert.match(
+    admissionSource,
+    /assertGeneratedMediaPromotionLifecycleProtocolActiveInExecutor/u,
+  );
+  assert.match(
+    admissionSource,
+    /sha256, mime_type, size_bytes, protocol_version/u,
+  );
+  assert.match(
+    admissionSource,
+    /claim_generated_media_promotion_jobs\(\$1, \$2, \$3, \$4\)/u,
+  );
+  assert.match(
+    processorSource,
+    /protocolVersion === 1[\s\S]*appendManagedImageToCardSideInExecutor/u,
+  );
+  assert.match(
+    processorSource,
+    /markPendingManagedImageReadyOnCardSideInExecutor/u,
   );
 });
 

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0103_ai_chat_initiating_auth_classification.sql",
+    "--require-migration 0104_generated_image_placeholder_terminal_state.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -246,7 +246,7 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0103_ai_chat_initiating_auth_classification.sql",
+    "--require-migration 0104_generated_image_placeholder_terminal_state.sql",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -150,7 +150,7 @@ npx cdk deploy --all --require-approval never \
 echo "=== Run database migrations ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0103_ai_chat_initiating_auth_classification.sql
+  --require-migration 0104_generated_image_placeholder_terminal_state.sql
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \


### PR DESCRIPTION
## Summary

- atomically persist generated-image pending markers with durable promotion jobs
- settle pending markers to ready or failed with tombstone, lease, parser, and sync-order safety
- add protocol-version rollout fencing, export/catalog validation, migration gates, and lifecycle documentation

## Validation

- backend TypeScript lint/typecheck passed
- targeted lifecycle/export/catalog suite passed (99/99)
- bootstrap and PostgreSQL runner syntax passed
- infra TypeScript syntax and migration/workflow/source-order checks passed
- git diff/scope/ancestry/hygiene checks passed
- real PostgreSQL integration cases compile/typecheck; execution was unavailable because POSTGRES_INTEGRATION_ADMIN_URL was not configured

Client lifecycle support is already present on main across Web, Android, and iOS.