### PR TITLE
Fix generated-image lifecycle PostgreSQL integration tests

### DIFF
--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -765,7 +765,15 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
        WHERE workspace_id = $1 AND card_id = $2`,
       [fixture.workspaceId, fixture.cardId],
     );
-    assert.equal(appliedCard.rows[0]?.back_text, "Original answer");
+    assert.equal(
+      appliedCard.rows[0]?.back_text,
+      [
+        "Original answer",
+        ...inputs.slice(1).map((input) => (
+          `![${input.altText}](fcasset:${input.mediaAssetId}?state=pending)`
+        )),
+      ].join("\n\n"),
+    );
     assert.equal(
       appliedCard.rows[0]?.front_text.match(new RegExp(`fcasset:${applied.mediaAssetId}`, "gu"))?.length,
       1,
@@ -1317,7 +1325,7 @@ test("ready promotion sync pages the media asset before the ready card", async (
     const job = byJobId(await claim("sync-order-worker", 1), input.jobId);
     const writer = await reserveGeneratedMediaBlobWriter(job, Date.now() + 10_000);
     await applyGeneratedMediaPromotionJob(writer, Date.now() + 10_000);
-    const installationId = `sync-order-${randomUUID()}`;
+    const installationId = randomUUID();
 
     const firstPage = await processSyncPull(
       fixture.workspaceId,


### PR DESCRIPTION
## Summary

- assert the parser-visible pending markers admitted for back-side generated-image jobs
- use a valid UUID installation identity in the sync-order integration

## Failure evidence

- fixes AWS/Web Release run 30602939814, PostgreSQL integration job 91069315232
- production behavior remains unchanged; this PR modifies one integration-test file only

## Validation

- Node 24.18.0
- `npm run lint` in `apps/backend` (`tsc --noEmit`)
- Node/tsx syntax and import validation for `promotionJobs.postgres.integration.ts`
- `git diff --check`
- independent review: no P0-P4 findings and green light to commit
- real PostgreSQL integration deferred to CI because `POSTGRES_INTEGRATION_ADMIN_URL` is absent locally; no mocks or fallbacks used