### PR TITLE
Fix promotion marker integration setup

### DIFF
--- a/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotionJobs.postgres.integration.ts
@@ -557,7 +557,7 @@ test("promotion jobs enforce enqueue identity, global leasing, fencing, and RLS"
        SET front_text = replace(front_text, $1, '')
        WHERE workspace_id = $2 AND card_id = $3`,
       [
-        `![${concurrentInput.altText}](fcasset:${concurrentInput.mediaAssetId}?state=pending)`,
+        `\n\n![${concurrentInput.altText}](fcasset:${concurrentInput.mediaAssetId}?state=pending)`,
         fixture.workspaceId,
         fixture.cardId,
       ],


### PR DESCRIPTION
## Summary

- remove the complete separator-plus-pending-marker admitted by the promotion lifecycle test setup
- preserve the existing exact front-text behavior assertion

## Failure evidence

- fixes the sole remaining PostgreSQL integration failure in AWS/Web Release run 30603416404, job 91070730904
- the same real PostgreSQL run passed 18/19 tests, including both tests fixed by PR #1160
- production behavior remains unchanged; this PR modifies one test setup line only

## Validation

- Node 24.18.0
- `npm run lint` in `apps/backend` (`tsc --noEmit`)
- Node/tsx syntax and import validation for `promotionJobs.postgres.integration.ts`
- `git diff --check`
- independent fresh review: no P0-P4 findings and green light to commit
- real PostgreSQL integration deferred to CI because `POSTGRES_INTEGRATION_ADMIN_URL` is absent locally; no mocks or fallbacks used