### PR TITLE
Run media cleanup integrations after lifecycle activation

### DIFF
--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -93,12 +93,6 @@ const boundaryDefinitions = Object.freeze([
       "src/chat/cardImages/promotionJobs.postgres.integration.ts",
       "src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts",
       "src/database/aiChatInitiatingAuthClassification.postgres.integration.ts",
-    ]),
-  }),
-  Object.freeze({
-    migrationFileName: "0102_media_blob_cleanup_reconciler.sql",
-    expectedMigrationCount: 104,
-    testFiles: Object.freeze([
       "src/mediaAssets/mediaBlobCleanup.postgres.integration.ts",
     ]),
   }),


### PR DESCRIPTION
## Summary

- run the media cleanup integration suite at the existing migration 0104 boundary
- remove the obsolete duplicate execution at migration 0102, where current v2 admission is intentionally inactive

## Failure evidence

- fixes the sole remaining failure in AWS/Web Release run 30603663884, job 91071462095
- the 0104 generated-image suite passed 19/19 before the runner later failed the cleanup admission test at 0102 with `GENERATED_MEDIA_PROMOTION_PROTOCOL_INACTIVE`
- production behavior remains unchanged; this PR modifies one PostgreSQL integration runner file only

## Validation

- Node 24.18.0
- `npm run lint` in `apps/backend` (`tsc --noEmit`)
- `node --check scripts/run-postgres-integrations.mjs`
- `git diff --check`
- independent fresh review: no P0-P4 findings and green light to commit
- real PostgreSQL integration deferred to CI because `POSTGRES_INTEGRATION_ADMIN_URL` is absent locally; no mocks or fallbacks used