### PR TITLE
Recover multipart completion renewal fences

### DIFF
--- a/apps/backend/src/mediaAssets/atomicMultipartWriter.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/atomicMultipartWriter.postgres.integration.ts
@@ -27,6 +27,7 @@ import {
   acquireMediaAssetUploadSessionCreationClaimForWorkspace,
   beginMediaAssetUploadSessionAbortForWorkspace,
   beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwner,
+  beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled,
   beginMediaAssetUploadSessionCompletionAttemptWithOwner,
   beginMediaAssetUploadSessionCompletionAttemptWithOwnerUntilSettled,
   beginMediaAssetUploadSessionCompletionWithOwner,
@@ -212,8 +213,12 @@ function createApplicationDeadlines(
 }
 
 const applicationAttemptResolutionDependencies = Object.freeze({
+  beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn:
+    beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled,
   handoffCompletionAttemptAfterAccessRevocationFn:
     handoffMediaAssetUploadSessionCompletionAttemptAfterAccessRevocation,
+  loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn:
+    loadMediaAssetForCompletedUploadSessionReplayForWorkspace,
   resolveCompletionAttemptFailureWithOwnerFn:
     resolveMediaAssetUploadSessionCompletionAttemptFailureWithOwner,
 });

--- a/apps/backend/src/mediaAssets/multipartForegroundFencing.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipartForegroundFencing.postgres.integration.ts
@@ -1417,6 +1417,69 @@ test("migration 0101 serializes abort, heartbeat, handoff, and access removal", 
   });
 });
 
+test("migration 0101 exposes a handoff that wins the foreground renewal race as already pending", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const payload = createPayload(fixture, randomUUID());
+    const attempt = await createAttempt(fixture, payload);
+    const blocker = await fixture.ownerPool.connect();
+    const handoffClient = await fixture.runtimePool.connect();
+    const renewalClient = await fixture.runtimePool.connect();
+    const clients = [blocker, handoffClient, renewalClient];
+    let raceError: Error | null = null;
+    try {
+      await blocker.query("BEGIN");
+      await lockMediaAsset(blocker, payload);
+      await handoffClient.query("BEGIN");
+      await beginScopedTransaction(
+        renewalClient,
+        fixture.userId,
+        fixture.workspaceId,
+      );
+      const blockerPid = await backendPid(blocker);
+      const handoffPid = await backendPid(handoffClient);
+      const renewalPid = await backendPid(renewalClient);
+      const handoffPromise = handoffAfterAccessRevocation(
+        handoffClient,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        payload,
+      );
+      await waitUntilBlockedBy(blocker, handoffPid, blockerPid);
+      const renewalPromise = beginAttempt(
+        renewalClient,
+        attempt.attemptToken,
+        payload,
+      );
+      await waitUntilBlockedBy(blocker, renewalPid, handoffPid);
+
+      await blocker.query("COMMIT");
+      assert.equal(await handoffPromise, "handed_off");
+      await handoffClient.query("COMMIT");
+      assert.equal((await renewalPromise).attempt_status, "stale_attempt");
+      await renewalClient.query("COMMIT");
+    } catch (error) {
+      raceError = error instanceof Error ? error : new Error(String(error));
+      throw raceError;
+    } finally {
+      await releaseClients(clients, raceError);
+    }
+
+    assert.equal(
+      await handoffAfterAccessRevocation(
+        fixture.runtimePool,
+        attempt.attemptToken,
+        attempt.reservationToken,
+        payload,
+      ),
+      "already_pending",
+    );
+    const state = await readBoundaryState(fixture, attempt.attemptToken);
+    assert.equal(state.attempt_state, "expired");
+    assert.equal(state.attempt_outcome, "stale_attempt");
+    assert.equal(state.reconciliation_state, "pending");
+  });
+});
+
 test("migration 0101 uses one asset fence for cross-member abort and reconciliation", async () => {
   await withPostgresIntegrationFixture(async (fixture) => {
     const payload = createPayload(fixture, randomUUID());

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -301,6 +301,12 @@ export type MultipartCompletionResolutionRetryDetails = Readonly<{
   errorMessage: string;
 }>;
 
+export type MultipartCompletionRenewalRejectedDetails = Readonly<{
+  mediaAssetId: string;
+  sessionId: string;
+  durableOutcome: string;
+}>;
+
 export type GuestUpgradeCompleteDetails = Readonly<{
   statusCode: number;
   selectionType: string;
@@ -1004,6 +1010,10 @@ export type BackendWarningEvent =
   | EventByAction<
     "media_asset_upload_session_completion_resolution_retry",
     MultipartCompletionResolutionRetryDetails
+  >
+  | EventByAction<
+    "media_asset_upload_session_completion_renewal_rejected",
+    MultipartCompletionRenewalRejectedDetails
   >
   | EventByAction<"feedback_notification_email_retry", FeedbackEmailRetryDetails>
   | EventByAction<"feedback_notification_email_failed", FeedbackEmailFailureDetails>

--- a/apps/backend/src/routes/mediaAssets.test.ts
+++ b/apps/backend/src/routes/mediaAssets.test.ts
@@ -21,6 +21,7 @@ import {
   runWithMultipartCompletionRequestTiming,
 } from "../server/multipartCompletionRequestTiming";
 import {
+  completeMultipartUploadSessionAtApplicationBoundary,
   createMediaAssetsRoutes,
   createMultipartCompletionRequestDeadline,
   createMultipartCompletionResolutionError,
@@ -29,6 +30,7 @@ import {
   replayCompletedMultipartResultWithDependencies,
   replayMultipartDatabaseCommitUnknownUntilDeadline,
   resolveMultipartOperationExactlyUntilSafe,
+  type MultipartCompletionApplicationDependencies,
 } from "./mediaAssets";
 
 function createMediaAssetsTestApp(): Hono<AppEnv> {
@@ -95,6 +97,98 @@ function multipartResolutionTestScope() {
     null,
     null,
   );
+}
+
+type MultipartCompletionBoundaryTestContext = Readonly<{
+  timing: ReturnType<typeof createMultipartCompletionRequestTiming>;
+  operationDeadline: ReturnType<
+    typeof createMultipartCompletionRequestDeadline
+  >;
+  requestDeadline: ReturnType<
+    typeof createMultipartCompletionRequestDeadline
+  >;
+  storageCapability: MultipartMediaBlobStorageCapability;
+  run: (
+    dependencies: MultipartCompletionApplicationDependencies,
+  ) => ReturnType<typeof completeMultipartUploadSessionAtApplicationBoundary>;
+  dispose: () => void;
+}>;
+
+function createMultipartCompletionBoundaryTestContext():
+MultipartCompletionBoundaryTestContext {
+  const observedAtMs = Date.now();
+  const timing = createMultipartCompletionRequestTiming(
+    observedAtMs,
+    observedAtMs,
+    60_000,
+  );
+  const operationDeadline = createMultipartCompletionRequestDeadline(
+    timing.operationDeadlineAtMs,
+  );
+  const requestDeadline = createMultipartCompletionRequestDeadline(
+    timing.requestDeadlineAtMs,
+  );
+  const session = uploadSession(
+    "active",
+    new Date(observedAtMs + 60_000).toISOString(),
+  );
+  return {
+    timing,
+    operationDeadline,
+    requestDeadline,
+    storageCapability: {} as MultipartMediaBlobStorageCapability,
+    run: (dependencies) =>
+      completeMultipartUploadSessionAtApplicationBoundary(
+        "user-1",
+        session,
+        [{ partNumber: 1, eTag: "etag-1", sha256: "b".repeat(64) }],
+        "66666666-6666-4666-8666-666666666666",
+        multipartResolutionTestScope(),
+        operationDeadline,
+        timing.writerLeaseTargetAtMs,
+        requestDeadline,
+        dependencies,
+      ),
+    dispose: () => {
+      operationDeadline.dispose();
+      requestDeadline.dispose();
+    },
+  };
+}
+
+function createMultipartCompletionBoundaryTestDependencies(
+  beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn:
+    MultipartCompletionApplicationDependencies[
+      "beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn"
+    ],
+  completeMultipartMediaAssetUploadFn:
+    MultipartCompletionApplicationDependencies[
+      "completeMultipartMediaAssetUploadFn"
+    ],
+  handoffCompletionAttemptAfterAccessRevocationFn:
+    MultipartCompletionApplicationDependencies[
+      "handoffCompletionAttemptAfterAccessRevocationFn"
+    ],
+  resolveCompletionAttemptFailureWithOwnerFn:
+    MultipartCompletionApplicationDependencies[
+      "resolveCompletionAttemptFailureWithOwnerFn"
+    ],
+): MultipartCompletionApplicationDependencies {
+  return {
+    abortMultipartMediaAssetUploadFn: async () => {
+      throw new Error("Completion recovery must not abort storage.");
+    },
+    beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn,
+    completeMultipartMediaAssetUploadFn,
+    completeMediaAssetUploadSessionForWorkspaceFn: async () => {
+      throw new Error("Completion test must not enter database apply.");
+    },
+    handoffCompletionAttemptAfterAccessRevocationFn,
+    loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn: async () => {
+      throw new Error("Completion test must not replay a completed asset.");
+    },
+    resolveCompletionAttemptFailureWithOwnerFn,
+  };
 }
 
 test("expired multipart completion cleanup resumes only active or aborting sessions", () => {
@@ -446,4 +540,209 @@ test("multipart resolution preserves an actionable HTTP response and diagnostic 
   assert.deepEqual(error.details, resolutionError.details);
   assert.ok(error.cause instanceof AggregateError);
   assert.deepEqual(error.cause.errors, [completionError, resolutionError]);
+});
+
+test("multipart renewal hands a durable reconciliation race back to the existing retryable response", async () => {
+  const context = createMultipartCompletionBoundaryTestContext();
+  const reservationToken = "55555555-5555-4555-8555-555555555555";
+  let beginCalls = 0;
+  let handoffCalls = 0;
+  const dependencies = createMultipartCompletionBoundaryTestDependencies(
+    async () => {
+      beginCalls += 1;
+      if (beginCalls === 1) {
+        return {
+          status: "acquired",
+          reservationToken,
+          normalizationVersion: "passthrough-v1",
+          leaseExpiresAt:
+            new Date(
+              context.timing.writerLeaseTargetAtMs - 1_000,
+            ).toISOString(),
+          storageCapability: context.storageCapability,
+        };
+      }
+      return { status: "stale_attempt" };
+    },
+    async () => {
+      throw new Error("Rejected renewal must not enter storage.");
+    },
+    async () => {
+      handoffCalls += 1;
+      return "already_pending";
+    },
+    async () => {
+      throw new Error(
+        "Renewal ownership loss must use exact handoff resolution.",
+      );
+    },
+  );
+
+  try {
+    await assert.rejects(
+      context.run(dependencies),
+      (error: unknown): boolean => {
+        assert.ok(error instanceof HttpError);
+        assert.equal(error.statusCode, 503);
+        assert.equal(
+          error.code,
+          "MEDIA_ASSET_UPLOAD_SESSION_COMPLETION_IN_PROGRESS",
+        );
+        assert.equal(error.details?.retryAfterSeconds, 1);
+        return true;
+      },
+    );
+    assert.equal(beginCalls, 2);
+    assert.equal(handoffCalls, 1);
+  } finally {
+    context.dispose();
+  }
+});
+
+test("multipart renewal writer mismatch becomes the existing stale conflict instead of an internal fence error", async () => {
+  const context = createMultipartCompletionBoundaryTestContext();
+  let beginCalls = 0;
+  const dependencies = createMultipartCompletionBoundaryTestDependencies(
+    async () => {
+      beginCalls += 1;
+      return {
+        status: beginCalls === 1 ? "acquired" : "replayed",
+        reservationToken: beginCalls === 1
+          ? "55555555-5555-4555-8555-555555555555"
+          : "77777777-7777-4777-8777-777777777777",
+        normalizationVersion: "passthrough-v1",
+        leaseExpiresAt:
+          new Date(
+            context.timing.writerLeaseTargetAtMs - 1_000,
+          ).toISOString(),
+        storageCapability: context.storageCapability,
+      };
+    },
+    async () => {
+      throw new Error("Rejected renewal must not enter storage.");
+    },
+    async () => "stale_attempt",
+    async () => {
+      throw new Error(
+        "Renewal ownership loss must use exact handoff resolution.",
+      );
+    },
+  );
+
+  try {
+    await assert.rejects(
+      context.run(dependencies),
+      (error: unknown): boolean => {
+        assert.ok(error instanceof HttpError);
+        assert.equal(error.statusCode, 409);
+        assert.equal(
+          error.code,
+          "MEDIA_ASSET_UPLOAD_SESSION_STATE_CONFLICT",
+        );
+        assert.match(error.message, /status=stale_attempt/u);
+        return true;
+      },
+    );
+    assert.equal(beginCalls, 2);
+  } finally {
+    context.dispose();
+  }
+});
+
+test("multipart renewal replays an already applied durable result without handoff", async () => {
+  const context = createMultipartCompletionBoundaryTestContext();
+  const mediaAsset: MediaAsset = {
+    mediaAssetId: "33333333-3333-4333-8333-333333333333",
+    workspaceId: "22222222-2222-4222-8222-222222222222",
+    mimeType: "image/png",
+    sizeBytes: 42,
+    sha256: "a".repeat(64),
+    sourceUrl: null,
+    createdAt: "2026-07-28T10:00:00.000Z",
+    clientUpdatedAt: "2026-07-28T10:00:00.000Z",
+    lastModifiedByReplicaId: "44444444-4444-4444-8444-444444444444",
+    lastOperationId: "operation-1",
+    updatedAt: "2026-07-28T10:00:00.000Z",
+    deletedAt: null,
+  };
+  let beginCalls = 0;
+  const dependencies = {
+    ...createMultipartCompletionBoundaryTestDependencies(
+      async () => {
+        beginCalls += 1;
+        if (beginCalls === 1) {
+          return {
+            status: "acquired" as const,
+            reservationToken: "55555555-5555-4555-8555-555555555555",
+            normalizationVersion: "passthrough-v1" as const,
+            leaseExpiresAt:
+              new Date(
+                context.timing.writerLeaseTargetAtMs - 1_000,
+              ).toISOString(),
+            storageCapability: context.storageCapability,
+          };
+        }
+        return { status: "already_applied" as const };
+      },
+      async () => {
+        throw new Error("Applied renewal must not enter storage.");
+      },
+      async () => {
+        throw new Error("Applied renewal must not be handed off.");
+      },
+      async () => {
+        throw new Error("Applied renewal must not enter failure recovery.");
+      },
+    ),
+    loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn: async () =>
+      mediaAsset,
+  };
+
+  try {
+    assert.deepEqual(
+      await context.run(dependencies),
+      { mediaAsset, applied: false },
+    );
+    assert.equal(beginCalls, 2);
+  } finally {
+    context.dispose();
+  }
+});
+
+test("multipart storage failure remains authoritative after the exact writer is restored", async () => {
+  const context = createMultipartCompletionBoundaryTestContext();
+  const storageError = new Error("Multipart storage failed.");
+  let beginCalls = 0;
+  const dependencies = createMultipartCompletionBoundaryTestDependencies(
+    async () => {
+      beginCalls += 1;
+      return {
+        status: beginCalls === 1 ? "acquired" : "replayed",
+        reservationToken: "55555555-5555-4555-8555-555555555555",
+        normalizationVersion: "passthrough-v1",
+        leaseExpiresAt:
+          new Date(
+            context.timing.writerLeaseTargetAtMs - 1_000,
+          ).toISOString(),
+        storageCapability: context.storageCapability,
+      };
+    },
+    async () => {
+      throw storageError;
+    },
+    async () => {
+      throw new Error("Restorable storage failure must not be handed off.");
+    },
+    async () => "unreferenced_restored",
+  );
+
+  try {
+    await assert.rejects(
+      context.run(dependencies),
+      (error: unknown): boolean => error === storageError,
+    );
+    assert.equal(beginCalls, 2);
+  } finally {
+    context.dispose();
+  }
 });

--- a/apps/backend/src/routes/mediaAssets.ts
+++ b/apps/backend/src/routes/mediaAssets.ts
@@ -34,6 +34,7 @@ import {
   type MultipartMediaBlobWriterAttemptFailureStatus,
   type MultipartMediaBlobWriterAttemptHandoffStatus,
   type MultipartMediaBlobWriterAttemptInput,
+  type MultipartMediaBlobWriterAttemptResult,
 } from "../mediaAssets/uploadSessions";
 import {
   buildMediaBlobStorageKey,
@@ -1164,12 +1165,14 @@ async function replayCompletedMultipartResult(
   userId: string,
   session: MediaAssetUploadSession,
   replayDatabaseCommit: MultipartDatabaseCommitReplay,
+  loadMediaAssetForReplay:
+    typeof loadMediaAssetForCompletedUploadSessionReplayForWorkspace,
 ): Promise<Readonly<{ mediaAsset: MediaAsset; applied: false }>> {
   return replayCompletedMultipartResultWithDependencies(
     userId,
     session,
     replayDatabaseCommit,
-    loadMediaAssetForCompletedUploadSessionReplayForWorkspace,
+    loadMediaAssetForReplay,
   );
 }
 
@@ -1363,16 +1366,76 @@ type MultipartWriterLease = Readonly<{
   leaseExpiresAt: string;
 }>;
 
+type MultipartWriterLeaseRenewalOutcome =
+  | MultipartMediaBlobWriterAttemptBeginStatus
+  | "completion_pending"
+  | "acquired"
+  | "expired_takeover"
+  | "replayed_reservation_mismatch"
+  | "replayed_normalization_mismatch"
+  | "replayed_writer_mismatch";
+
+class MultipartWriterLeaseRenewalRejectedError extends Error {
+  readonly durableOutcome: MultipartWriterLeaseRenewalOutcome;
+  readonly fallbackError: Error;
+
+  constructor(
+    durableOutcome: MultipartWriterLeaseRenewalOutcome,
+    fallbackError: Error,
+  ) {
+    super(
+      `Multipart writer lease renewal no longer matched the exact foreground writer. durableOutcome=${durableOutcome}`,
+    );
+    this.name = "MultipartWriterLeaseRenewalRejectedError";
+    this.durableOutcome = durableOutcome;
+    this.fallbackError = fallbackError;
+  }
+}
+
+function createMultipartWriterLeaseRenewalFenceFallback(): Error {
+  const fenceError =
+    new MediaBlobWriterFenceError("multipart_attempt_renewal");
+  const fallbackError = createMultipartAttemptError("stale_attempt", null);
+  Object.defineProperty(fallbackError, "cause", {
+    value: fenceError,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return fallbackError;
+}
+
+function classifyMultipartWriterLeaseRenewalMismatch(
+  renewal: Extract<
+    MultipartMediaBlobWriterAttemptResult,
+    Readonly<{ reservationToken: string }>
+  >,
+  writer: MultipartMediaBlobWriterAttemptExactInput,
+): MultipartWriterLeaseRenewalOutcome {
+  if (renewal.status !== "replayed") return renewal.status;
+  const reservationMatches =
+    renewal.reservationToken === writer.reservationToken;
+  const normalizationMatches =
+    renewal.normalizationVersion === writer.normalizationVersion;
+  if (!reservationMatches && !normalizationMatches) {
+    return "replayed_writer_mismatch";
+  }
+  if (!reservationMatches) return "replayed_reservation_mismatch";
+  return "replayed_normalization_mismatch";
+}
+
 async function renewMultipartWriterLease(
   input: MultipartMediaBlobWriterAttemptInput,
   writer: MultipartMediaBlobWriterAttemptExactInput,
   writerLeaseTargetAtMs: number,
   operationDeadline: MultipartCompletionRequestDeadline,
   replayDatabaseCommit: MultipartDatabaseCommitReplay,
+  beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettled:
+    typeof beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled,
 ): Promise<MultipartWriterLease> {
   const renewal = await replayDatabaseCommit(
     () =>
-      beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled(
+      beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettled(
         input,
         writerLeaseTargetAtMs,
         operationDeadline.deadlineAtMs,
@@ -1380,12 +1443,15 @@ async function renewMultipartWriterLease(
       ),
   );
   if (!("reservationToken" in renewal)) {
-    if (renewal.status === "completion_pending") {
-      throw createMultipartCompletionHandedOffError();
-    }
-    throw createMultipartAttemptError(
+    const fallbackError = renewal.status === "completion_pending"
+      ? createMultipartCompletionHandedOffError()
+      : createMultipartAttemptError(
+        renewal.status,
+        "leaseExpiresAt" in renewal ? renewal.leaseExpiresAt : null,
+      );
+    throw new MultipartWriterLeaseRenewalRejectedError(
       renewal.status,
-      "leaseExpiresAt" in renewal ? renewal.leaseExpiresAt : null,
+      fallbackError,
     );
   }
   if (
@@ -1393,7 +1459,14 @@ async function renewMultipartWriterLease(
     || renewal.reservationToken !== writer.reservationToken
     || renewal.normalizationVersion !== writer.normalizationVersion
   ) {
-    throw new MediaBlobWriterFenceError("multipart_attempt_renewal");
+    const durableOutcome = classifyMultipartWriterLeaseRenewalMismatch(
+      renewal,
+      writer,
+    );
+    throw new MultipartWriterLeaseRenewalRejectedError(
+      durableOutcome,
+      createMultipartWriterLeaseRenewalFenceFallback(),
+    );
   }
   return {
     storageCapability: renewal.storageCapability,
@@ -1706,12 +1779,16 @@ export async function abortMultipartUploadSessionAtApplicationBoundary(
 
 export type MultipartCompletionApplicationDependencies = Readonly<{
   abortMultipartMediaAssetUploadFn: typeof abortMultipartMediaAssetUpload;
+  beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn:
+    typeof beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled;
   completeMultipartMediaAssetUploadFn:
     typeof completeMultipartMediaAssetUpload;
   completeMediaAssetUploadSessionForWorkspaceFn:
     typeof completeMediaAssetUploadSessionForWorkspace;
   handoffCompletionAttemptAfterAccessRevocationFn:
     typeof handoffMediaAssetUploadSessionCompletionAttemptAfterAccessRevocation;
+  loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn:
+    typeof loadMediaAssetForCompletedUploadSessionReplayForWorkspace;
   resolveCompletionAttemptFailureWithOwnerFn:
     typeof resolveMediaAssetUploadSessionCompletionAttemptFailureWithOwner;
 }>;
@@ -1719,11 +1796,15 @@ export type MultipartCompletionApplicationDependencies = Readonly<{
 const multipartCompletionApplicationDependencies:
 MultipartCompletionApplicationDependencies = Object.freeze({
   abortMultipartMediaAssetUploadFn: abortMultipartMediaAssetUpload,
+  beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn:
+    beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled,
   completeMultipartMediaAssetUploadFn: completeMultipartMediaAssetUpload,
   completeMediaAssetUploadSessionForWorkspaceFn:
     completeMediaAssetUploadSessionForWorkspace,
   handoffCompletionAttemptAfterAccessRevocationFn:
     handoffMediaAssetUploadSessionCompletionAttemptAfterAccessRevocation,
+  loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn:
+    loadMediaAssetForCompletedUploadSessionReplayForWorkspace,
   resolveCompletionAttemptFailureWithOwnerFn:
     resolveMediaAssetUploadSessionCompletionAttemptFailureWithOwner,
 });
@@ -1775,7 +1856,7 @@ async function handoffAcceptedMultipartAttempt(
   observationScope: BackendObservationScope,
   requestDeadline: MultipartCompletionRequestDeadline,
   replayDatabaseCommit: MultipartDatabaseCommitReplay,
-  dependencies: MultipartAttemptResolutionDependencies,
+  dependencies: MultipartCompletionApplicationDependencies,
 ): Promise<MultipartCompletionApplicationResult> {
   let resolution:
     MultipartExactResolutionResult<MultipartMediaBlobWriterAttemptHandoffStatus>;
@@ -1819,6 +1900,8 @@ async function handoffAcceptedMultipartAttempt(
       userId,
       session,
       replayDatabaseCommit,
+      dependencies
+        .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
     );
   }
   if (
@@ -1841,7 +1924,7 @@ async function resolveRecoveredMultipartAttempt(
   observationScope: BackendObservationScope,
   requestDeadline: MultipartCompletionRequestDeadline,
   replayDatabaseCommit: MultipartDatabaseCommitReplay,
-  dependencies: MultipartAttemptResolutionDependencies,
+  dependencies: MultipartCompletionApplicationDependencies,
 ): Promise<MultipartCompletionApplicationResult> {
   let recovery:
     MultipartExactResolutionResult<Awaited<
@@ -1852,7 +1935,7 @@ async function resolveRecoveredMultipartAttempt(
   try {
     recovery = await resolveMultipartOperationExactlyUntilSafe(
       () =>
-        beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled(
+        dependencies.beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn(
           attemptInput,
           writerLeaseTargetAtMs,
           writerLeaseTargetAtMs,
@@ -1890,6 +1973,8 @@ async function resolveRecoveredMultipartAttempt(
         userId,
         session,
         replayDatabaseCommit,
+        dependencies
+          .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
       );
     }
     throw completionError;
@@ -1951,6 +2036,8 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
       userId,
       session,
       replayResolutionDatabaseCommit,
+      dependencies
+        .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
     );
   }
   if (
@@ -1991,6 +2078,8 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
         userId,
         completedSession,
         replayResolutionDatabaseCommit,
+        dependencies
+          .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
       );
     }
   }
@@ -2032,7 +2121,7 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
   try {
     attempt = await replayOperationDatabaseCommit(
       () =>
-        beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled(
+        dependencies.beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn(
           attemptInput,
           writerLeaseTargetAtMs,
           operationDeadline.deadlineAtMs,
@@ -2074,6 +2163,8 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
         userId,
         session,
         replayResolutionDatabaseCommit,
+        dependencies
+          .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
       );
     }
     if (
@@ -2084,6 +2175,8 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
         userId,
         session,
         replayResolutionDatabaseCommit,
+        dependencies
+          .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
       );
     }
     if (
@@ -2127,6 +2220,8 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
           writerLeaseTargetAtMs,
           operationDeadline,
           replayOperationDatabaseCommit,
+          dependencies
+            .beginCompletionAttemptAtLeaseTargetWithOwnerUntilSettledFn,
         );
         return renewal;
       },
@@ -2195,6 +2290,47 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
         dependencies,
       );
     }
+    if (
+      completionError instanceof MultipartWriterLeaseRenewalRejectedError
+    ) {
+      try {
+        captureBackendWarning({
+          action: "media_asset_upload_session_completion_renewal_rejected",
+          scope: observationScope,
+          details: {
+            mediaAssetId: session.mediaAssetId,
+            sessionId: session.sessionId,
+            durableOutcome: completionError.durableOutcome,
+          },
+        });
+      } catch {
+        // Observability must not interrupt exact multipart attempt resolution.
+      }
+      if (
+        completionError.durableOutcome === "already_applied"
+        || completionError.durableOutcome === "live_applied"
+        || completionError.durableOutcome === "referenced"
+      ) {
+        return replayCompletedMultipartResult(
+          userId,
+          session,
+          replayResolutionDatabaseCommit,
+          dependencies
+            .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
+        );
+      }
+      return handoffAcceptedMultipartAttempt(
+        completionError.fallbackError,
+        userId,
+        session,
+        exactWriter,
+        lastConfirmedLeaseExpiresAtMs,
+        observationScope,
+        requestDeadline,
+        replayResolutionDatabaseCommit,
+        dependencies,
+      );
+    }
     let exactResolution:
       MultipartExactResolutionResult<MultipartMediaBlobWriterAttemptHandoffStatus>;
     try {
@@ -2230,6 +2366,8 @@ export async function completeMultipartUploadSessionAtApplicationBoundary(
         userId,
         session,
         replayResolutionDatabaseCommit,
+        dependencies
+          .loadMediaAssetForCompletedUploadSessionReplayForWorkspaceFn,
       );
     }
     if (resolution === "handed_off" || resolution === "already_pending") {


### PR DESCRIPTION
## Summary
- classify durable multipart renewal outcomes without weakening writer fencing
- preserve existing success, retryable handoff, stale conflict, and storage-error behavior
- add module-boundary and PostgreSQL concurrency coverage

## Validation
- `npm run lint --prefix apps/backend`
- focused media-assets route tests: 13/13 passed
- full backend suite: 1064/1064 passed
- `git diff --check`
- real PostgreSQL integration requires `POSTGRES_INTEGRATION_ADMIN_URL` and remains a CI gate