### PR TITLE
refactor(backend): group mediaAssets multipart and blob lifecycle files

### DIFF
--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -93,23 +93,23 @@ const boundaryDefinitions = Object.freeze([
       "src/chat/cardImages/promotionJobs.postgres.integration.ts",
       "src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts",
       "src/database/aiChatInitiatingAuthClassification.postgres.integration.ts",
-      "src/mediaAssets/mediaBlobCleanup.postgres.integration.ts",
+      "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
     migrationFileName: "0101_multipart_foreground_completion_fencing.sql",
     expectedMigrationCount: 103,
     testFiles: Object.freeze([
-      "src/mediaAssets/atomicMultipartWriter.postgres.integration.ts",
-      "src/mediaAssets/multipartForegroundFencing.postgres.integration.ts",
+      "src/mediaAssets/multipart/atomicWriter.postgres.integration.ts",
+      "src/mediaAssets/multipart/foregroundFencing.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
     migrationFileName: "0100_multipart_replacement_creation_claim.sql",
     expectedMigrationCount: 102,
     testFiles: Object.freeze([
-      "src/mediaAssets/multipartReplacementCreationClaim.postgres.integration.ts",
-      "src/mediaAssets/multipartUploadSessionCreation.postgres.integration.ts",
+      "src/mediaAssets/multipart/replacementCreationClaim.postgres.integration.ts",
+      "src/mediaAssets/multipart/uploadSessionCreation.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
@@ -117,10 +117,10 @@ const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 101,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
-      "src/mediaAssets/blobLifecycle.postgres.integration.ts",
-      "src/mediaAssets/directIngestionApply.postgres.integration.ts",
-      "src/mediaAssets/multipartCompletionReconciliation.postgres.integration.ts",
-      "src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts",
+      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
+      "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
+      "src/mediaAssets/multipart/completionReconciliation.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
@@ -128,23 +128,23 @@ const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 100,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
-      "src/mediaAssets/blobLifecycle.postgres.integration.ts",
-      "src/mediaAssets/directIngestionApply.postgres.integration.ts",
-      "src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts",
+      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
+      "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
     migrationFileName: "0097_direct_multipart_writer_attempt_fencing.sql",
     expectedMigrationCount: 99,
     testFiles: Object.freeze([
-      "src/mediaAssets/multipartWriterAbortReplay.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
     migrationFileName: "0096_atomic_multipart_completion_resolution.sql",
     expectedMigrationCount: 98,
     testFiles: Object.freeze([
-      "src/mediaAssets/mediaBlobWriterAttempts.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerAttempts.postgres.integration.ts",
     ]),
   }),
 ]);

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.test.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.test.ts
@@ -6,7 +6,7 @@ import type {
 import {
   MediaBlobCleanupBatchError,
   type MediaBlobCleanupBatchResult,
-} from "../../mediaAssets/blobCleanupProcessor";
+} from "../../mediaAssets/blobLifecycle/cleanupProcessor";
 import { createBackendObservationScope } from "../../observability/sentry";
 import {
   readMediaBlobCleanupEnabled,

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
@@ -7,7 +7,7 @@ import {
   MediaBlobCleanupBatchError,
   runMediaBlobCleanupBatch,
   type MediaBlobCleanupBatchResult,
-} from "../../mediaAssets/blobCleanupProcessor";
+} from "../../mediaAssets/blobLifecycle/cleanupProcessor";
 import {
   addBackendBreadcrumb, captureBackendException, createBackendObservationScope,
   type BackendObservationScope,

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.test.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.test.ts
@@ -6,7 +6,7 @@ import {
   MultipartCompletionReconciliationBatchError,
   type MultipartCompletionFailureReportBatchResult,
   type MultipartCompletionReconciliationBatchResult,
-} from "../../mediaAssets/multipartCompletionReconciliation";
+} from "../../mediaAssets/multipart/completionReconciliation";
 import {
   calculateMultipartCompletionReconciliationDeadlineAtMs,
   getMultipartCompletionReconciliationFailureDetails,

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.ts
@@ -6,7 +6,7 @@ import {
   runMultipartCompletionReconciliationBatch,
   type MultipartCompletionFailureReportBatchResult,
   type MultipartCompletionReconciliationBatchResult,
-} from "../../mediaAssets/multipartCompletionReconciliation";
+} from "../../mediaAssets/multipart/completionReconciliation";
 import { createCloudWatchRecord } from "../../observability/cloudWatch";
 import {
   addBackendSentryBreadcrumb,

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
@@ -5,14 +5,14 @@ import test from "node:test";
 import {
   enqueueGeneratedMediaPromotionJob,
   type EnqueueGeneratedMediaPromotionJobInput,
-} from "../chat/cardImages/promotionJobs";
+} from "../../chat/cardImages/promotionJobs";
 import {
   transactionWithWorkspaceScope,
-} from "../database";
+} from "../../database";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../testSupport/postgresIntegration";
+} from "../../testSupport/postgresIntegration";
 import {
   authorizeMediaBlobCleanup,
   claimNextMediaBlobCleanup,
@@ -20,16 +20,16 @@ import {
   recordMediaBlobCleanupFailure,
   renewMediaBlobCleanupLease,
   type MediaBlobCleanupClaim,
-} from "./blobCleanupRepository";
+} from "./cleanupRepository";
 import {
   MediaBlobLifecycleBusyError,
   reserveMediaBlobWriterInExecutor,
-} from "./blobLifecycle";
+} from "./index";
 import {
   buildMediaBlobStorageKey,
   buildMediaUploadStagingStorageKey,
-} from "./storageKeys";
-import { imageJpegCardMediaBlobNormalizationVersion } from "./types";
+} from "../storageKeys";
+import { imageJpegCardMediaBlobNormalizationVersion } from "../types";
 
 const deadlineOffsetMs = 30_000;
 type RunFixture = Readonly<{

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanupProcessor.test.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanupProcessor.test.ts
@@ -1,19 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { DatabaseDeadlineExceededError } from "../database";
-import { DatabaseCommitOutcomeUnknownError } from "../database/transient";
-import { createBackendObservationScope } from "../observability/sentry";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+import { DatabaseDeadlineExceededError } from "../../database";
+import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
+import { createBackendObservationScope } from "../../observability/sentry";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 import {
   MediaBlobCleanupBatchError,
   runMediaBlobCleanupBatchWithDependencies,
   type MediaBlobCleanupProcessorDependencies,
-} from "./blobCleanupProcessor";
-import type { MediaBlobCleanupClaim } from "./blobCleanupRepository";
+} from "./cleanupProcessor";
+import type { MediaBlobCleanupClaim } from "./cleanupRepository";
 import {
   MediaBlobCleanupStorageAmbiguousDeleteError,
   MediaBlobCleanupStorageTransientError,
-} from "./storage";
+} from "../storage";
 
 const sha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
 const cleanupToken = "77777777-7777-4777-8777-777777777777";

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanupProcessor.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanupProcessor.ts
@@ -1,14 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { setTimeout as wait } from "node:timers/promises";
-import { DatabaseDeadlineExceededError } from "../database";
+import { DatabaseDeadlineExceededError } from "../../database";
 import {
   DatabaseCommitOutcomeUnknownError,
   getDatabaseErrorFields,
   isTransientDatabaseError,
   TransientDatabaseHttpError,
-} from "../database/transient";
-import { addBackendRuntimeBreadcrumb } from "../observability/runtime";
-import type { BackendObservationScope } from "../observability/sentry";
+} from "../../database/transient";
+import { addBackendRuntimeBreadcrumb } from "../../observability/runtime";
+import type { BackendObservationScope } from "../../observability/sentry";
 import {
   authorizeMediaBlobCleanup,
   claimNextMediaBlobCleanup,
@@ -19,7 +19,7 @@ import {
   type MediaBlobCleanupFailureDisposition,
   type MediaBlobCleanupFailurePhase,
   type MediaBlobCleanupLeaseRenewalPhase,
-} from "./blobCleanupRepository";
+} from "./cleanupRepository";
 import {
   deletePermanentMediaBlob,
   MediaBlobCleanupStorageAmbiguousDeleteError,
@@ -27,7 +27,7 @@ import {
   MediaBlobCleanupStorageTerminalError,
   MediaBlobCleanupStorageTransientError,
   type PermanentMediaBlobDeleteOutcome,
-} from "./storage";
+} from "../storage";
 
 const minimumNewCandidateBudgetMs = 1_000;
 const cleanupLeaseFinalizationReserveMs = 1_000;

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanupRepository.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanupRepository.ts
@@ -1,6 +1,6 @@
-import type { DatabaseExecutor } from "../database";
-import { unsafeTransactionWithDeadline } from "../database/unsafe";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+import type { DatabaseExecutor } from "../../database";
+import { unsafeTransactionWithDeadline } from "../../database/unsafe";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 
 const sha256Pattern = /^[0-9a-f]{64}$/u;
 const uuidPattern =

--- a/apps/backend/src/mediaAssets/blobLifecycle/index.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/index.ts
@@ -3,16 +3,16 @@ import {
   transactionWithWorkspaceScope,
   transactionWithWorkspaceScopeDeadline,
   type DatabaseExecutor,
-} from "../database";
-import { unsafeTransaction, unsafeTransactionWithDeadline } from "../database/unsafe";
-import { HttpError } from "../shared/errors";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+} from "../../database";
+import { unsafeTransaction, unsafeTransactionWithDeadline } from "../../database/unsafe";
+import { HttpError } from "../../shared/errors";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 import {
   mediaBlobNormalizationVersions,
   passthroughMediaBlobNormalizationVersion,
   type MediaBlobNormalizationVersion,
   type TimestampValue,
-} from "./types";
+} from "../types";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const sha256Pattern = /^[0-9a-f]{64}$/u;
 const mimeTypePattern = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/u;

--- a/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
@@ -6,9 +6,9 @@ import { setTimeout as wait } from "node:timers/promises";
 import test from "node:test";
 import {
   DatabaseDeadlineExceededError, transactionWithWorkspaceScope, transactionWithWorkspaceScopeDeadline, type DatabaseExecutor,
-} from "../database";
-import { unsafeTransaction } from "../database/unsafe";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+} from "../../database";
+import { unsafeTransaction } from "../../database/unsafe";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
 import {
   assertDirectMediaBlobStorageCapabilityForMutation,
   beginDirectMediaBlobWriterAttemptWithOwner,
@@ -29,10 +29,10 @@ import {
   type DirectMediaBlobWriterApplyExecutor,
   type DirectMediaBlobStorageCapability,
   type MediaBlobWriterReservationInput,
-} from "./blobLifecycle";
-import { createImageNormalizedMediaAssetForWorkspace } from ".";
-import { buildMediaBlobStorageKey } from "./storageKeys";
-import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "./types";
+} from "./index";
+import { createImageNormalizedMediaAssetForWorkspace } from "..";
+import { buildMediaBlobStorageKey } from "../storageKeys";
+import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "../types";
 type LifecycleUpgradeRow = Readonly<{
   storage_key: string; mime_type: string; size_bytes: string; normalization_version: string;
   created_at_matches: boolean; updated_at_matches: boolean; workspace_fence: boolean; catalog_fence: boolean;
@@ -43,10 +43,10 @@ type LifecycleUpgradeRow = Readonly<{
 }>;
 function createUniqueSha256(): string { return createHash("sha256").update(randomUUID()).digest("hex"); }
 const lifecycleMigrationSql = readFileSync(resolve(
-  __dirname, "../../../../db/migrations/0091_durable_media_blob_lifecycle.sql",
+  __dirname, "../../../../../db/migrations/0091_durable_media_blob_lifecycle.sql",
 ), "utf8");
 const writerSupportMigrationSql = readFileSync(resolve(
-  __dirname, "../../../../db/migrations/0092_media_blob_writer_support.sql",
+  __dirname, "../../../../../db/migrations/0092_media_blob_writer_support.sql",
 ), "utf8");
 function input(workspaceId: string, mediaAssetId: string, operationId: string, sha256: string): MediaBlobWriterReservationInput {
   return {

--- a/apps/backend/src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts
@@ -1,26 +1,26 @@
 import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
 import test from "node:test";
-import { DatabaseDeadlineExceededError } from "../database";
-import { HttpError } from "../shared/errors";
+import { DatabaseDeadlineExceededError } from "../../database";
+import { HttpError } from "../../shared/errors";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../testSupport/postgresIntegration";
+} from "../../testSupport/postgresIntegration";
 import {
   applyImageNormalizedMediaAssetWithDirectWriterForWorkspace,
   replayImageNormalizedMediaAssetForWorkspace,
-} from ".";
+} from "..";
 import {
   beginDirectMediaBlobWriterAttemptWithOwner,
   type DirectMediaBlobWriterAttemptExactInput,
   type DirectMediaBlobWriterAttemptInput,
-} from "./blobLifecycle";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+} from "../blobLifecycle";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 import {
   imageJpegCardMediaBlobNormalizationVersion,
   type NormalizedImageMediaAssetInput,
-} from "./types";
+} from "../types";
 
 function createSha256(): string {
   return createHash("sha256").update(randomUUID()).digest("hex");

--- a/apps/backend/src/mediaAssets/multipart/atomicWriter.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/atomicWriter.postgres.integration.ts
@@ -11,18 +11,18 @@ import {
   ListPartsCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
-import { unsafeTransaction } from "../database/unsafe";
+import { unsafeTransaction } from "../../database/unsafe";
 import {
   DatabaseCommitOutcomeUnknownError,
   TransientDatabaseHttpError,
-} from "../database/transient";
-import { createBackendObservationScope } from "../observability/sentry";
-import { HttpError } from "../shared/errors";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+} from "../../database/transient";
+import { createBackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "./storageKeys";
+} from "../storageKeys";
 import {
   acquireMediaAssetUploadSessionCreationClaimForWorkspace,
   beginMediaAssetUploadSessionAbortForWorkspace,
@@ -50,29 +50,29 @@ import {
   type MultipartMediaBlobWriterAttemptExactInput,
   type MultipartMediaBlobWriterAttemptInput,
   type MediaAssetUploadSessionCompletionWithOwnerInput,
-} from "./uploadSessions";
+} from "../uploadSessions";
 import {
   passthroughMediaBlobNormalizationVersion,
   type MediaBlobNormalizationVersion,
-} from "./types";
-import type { CompleteMediaAssetUploadPartInput } from "./types";
+} from "../types";
+import type { CompleteMediaAssetUploadPartInput } from "../types";
 import {
   completeMultipartMediaAssetUploadWithDependencies,
-} from "./storage/multipart";
+} from "../storage/multipart";
 import {
   applyMultipartCompletionReconciliation,
   claimMultipartCompletionReconciliations,
   renewMultipartCompletionReconciliationLease,
   type ClaimedMultipartCompletionReconciliation,
-} from "./multipartCompletionReconciliation";
+} from "./completionReconciliation";
 import {
   reconcileMultipartMediaAssetUploadWithDependencies,
-} from "./storage/multipartReconciliation";
+} from "../storage/multipartReconciliation";
 import {
   createS3Error,
   getTestMediaAssetsStorageConfig,
   getUnexpectedS3CommandName,
-} from "./storage/testHelpers";
+} from "../storage/testHelpers";
 import {
   abortMultipartUploadSessionAtApplicationBoundary,
   completeMultipartUploadSessionAtApplicationBoundary,
@@ -80,16 +80,16 @@ import {
   createMultipartUploadSessionAtApplicationBoundary,
   createMultipartWriterHeartbeat,
   isExpiredMultipartCompletionCleanupRequired,
-} from "../routes/mediaAssets";
+} from "../../routes/mediaAssets";
 import {
   createMultipartCompletionWriterLeaseTargetAtMs,
-} from "../server/multipartCompletionRequestTiming";
+} from "../../server/multipartCompletionRequestTiming";
 
 const migration0094 = readFileSync(resolve(
-  __dirname, "../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql",
+  __dirname, "../../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql",
 ), "utf8");
 const migration0095 = readFileSync(resolve(
-  __dirname, "../../../../db/migrations/0095_atomic_multipart_writer_completion.sql",
+  __dirname, "../../../../../db/migrations/0095_atomic_multipart_writer_completion.sql",
 ), "utf8");
 const closerStart = migration0094.indexOf(
   "CREATE FUNCTION content.close_media_upload_session_blob_writer(",

--- a/apps/backend/src/mediaAssets/multipart/completionReconciliation.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/completionReconciliation.postgres.integration.ts
@@ -5,8 +5,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../testSupport/postgresIntegration";
-import { HttpError } from "../shared/errors";
+} from "../../testSupport/postgresIntegration";
+import { HttpError } from "../../shared/errors";
 import {
   applyMultipartCompletionReconciliation,
   claimMultipartCompletionFailureReports,
@@ -21,8 +21,8 @@ import {
   rescheduleMultipartCompletionReconciliation,
   type ClaimedMultipartCompletionFailureReport,
   type ClaimedMultipartCompletionReconciliation,
-} from "./multipartCompletionReconciliation";
-import { isValidMediaAssetLastOperationId } from "./lastOperationId";
+} from "./completionReconciliation";
+import { isValidMediaAssetLastOperationId } from "../lastOperationId";
 import {
   beginMediaAssetUploadSessionCompletionAttemptWithOwner,
   beginMediaAssetUploadSessionCompletionForWorkspace,
@@ -31,12 +31,12 @@ import {
   markMediaAssetUploadSessionAbortedForWorkspace,
   recordMediaAssetUploadSessionForWorkspace,
   type MultipartMediaBlobWriterAttemptInput,
-} from "./uploadSessions";
-import { passthroughMediaBlobNormalizationVersion } from "./types";
+} from "../uploadSessions";
+import { passthroughMediaBlobNormalizationVersion } from "../types";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "./storageKeys";
+} from "../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;

--- a/apps/backend/src/mediaAssets/multipart/completionReconciliation.test.ts
+++ b/apps/backend/src/mediaAssets/multipart/completionReconciliation.test.ts
@@ -1,17 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { DatabaseDeadlineExceededError } from "../database";
-import { DatabaseCommitOutcomeUnknownError } from "../database/transient";
-import { createBackendObservationScope } from "../observability/sentry";
-import { HttpError } from "../shared/errors";
+import { DatabaseDeadlineExceededError } from "../../database";
+import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
+import { createBackendObservationScope } from "../../observability/sentry";
+import { HttpError } from "../../shared/errors";
 import {
   MultipartCompletionReconciliationStorageTerminalError,
   MultipartCompletionReconciliationStorageTransientError,
-} from "./storage";
+} from "../storage";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "./storageKeys";
+} from "../storageKeys";
 import {
   MultipartCompletionFailureReportBatchError,
   MultipartCompletionFailureReportLeaseLostError,
@@ -29,7 +29,7 @@ import {
   type MultipartCompletionReconciliationBatchInput,
   type MultipartCompletionReconciliationProcessorDependencies,
   type MultipartCompletionReconciliationSafeError,
-} from "./multipartCompletionReconciliation";
+} from "./completionReconciliation";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 const sessionId = "22222222-2222-4222-8222-222222222222";

--- a/apps/backend/src/mediaAssets/multipart/completionReconciliation.ts
+++ b/apps/backend/src/mediaAssets/multipart/completionReconciliation.ts
@@ -1,39 +1,39 @@
 import {
   DatabaseDeadlineExceededError,
   type DatabaseExecutor,
-} from "../database";
+} from "../../database";
 import {
   unsafeQueryWithDeadline,
   unsafeTransactionWithDeadline,
-} from "../database/unsafe";
+} from "../../database/unsafe";
 import {
   DatabaseCommitOutcomeUnknownError,
   isTransientDatabaseError,
   TransientDatabaseHttpError,
-} from "../database/transient";
+} from "../../database/transient";
 import type {
   BackendObservationScope,
   MultipartCompletionReconciliationTerminalFailureDetails,
-} from "../observability/sentry";
-import { mediaBlobCleanupDelayMs } from "./blobLifecycle";
-import { isValidMediaAssetLastOperationId } from "./lastOperationId";
+} from "../../observability/sentry";
+import { mediaBlobCleanupDelayMs } from "../blobLifecycle";
+import { isValidMediaAssetLastOperationId } from "../lastOperationId";
 import {
   upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
-} from "./persistence";
+} from "../persistence";
 import {
   MultipartCompletionReconciliationStorageTerminalError,
   MultipartCompletionReconciliationStorageTransientError,
   reconcileMultipartMediaAssetUpload,
-} from "./storage";
+} from "../storage";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "./storageKeys";
+} from "../storageKeys";
 import {
   mediaBlobNormalizationVersions,
   type MediaAsset,
   type MediaBlobNormalizationVersion,
-} from "./types";
+} from "../types";
 
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;

--- a/apps/backend/src/mediaAssets/multipart/completionResolution.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/completionResolution.postgres.integration.ts
@@ -3,15 +3,15 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 import { beginMediaAssetUploadSessionCompletionWithOwner, fenceMediaAssetUploadSessionCompletionApplyWithOwner,
   fenceMediaAssetUploadSessionCompletionApplyWithOwnerInExecutor, resolveMediaAssetUploadSessionCompletionAfterAccessRevocation,
   resolveMediaAssetUploadSessionCompletionAfterAccessRevocationInExecutor, resolveMediaAssetUploadSessionCompletionFailureWithOwner,
-  type MediaAssetUploadSessionCompletionResolutionInput, type MediaAssetUploadSessionCompletionRevocationInput, type MediaAssetUploadSessionCompletionWithOwnerInput } from "./uploadSessions";
-import { compareLwwMetadata } from "../sync/conflicts/lww";
-import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "./types";
-const migration0096 = readFileSync(resolve(__dirname, "../../../../db/migrations/0096_atomic_multipart_completion_resolution.sql"), "utf8");
+  type MediaAssetUploadSessionCompletionResolutionInput, type MediaAssetUploadSessionCompletionRevocationInput, type MediaAssetUploadSessionCompletionWithOwnerInput } from "../uploadSessions";
+import { compareLwwMetadata } from "../../sync/conflicts/lww";
+import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "../types";
+const migration0096 = readFileSync(resolve(__dirname, "../../../../../db/migrations/0096_atomic_multipart_completion_resolution.sql"), "utf8");
 const signatures = {
   apply: "content.fence_media_upload_session_completion_apply_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,uuid,text,integer)",
   failure: "content.resolve_media_upload_session_completion_failure_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,uuid,text,integer)",

--- a/apps/backend/src/mediaAssets/multipart/foregroundFencing.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/foregroundFencing.postgres.integration.ts
@@ -6,8 +6,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+} from "../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;

--- a/apps/backend/src/mediaAssets/multipart/replacementCreationClaim.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/replacementCreationClaim.postgres.integration.ts
@@ -6,8 +6,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+} from "../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;

--- a/apps/backend/src/mediaAssets/multipart/uploadSessionCreation.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/uploadSessionCreation.postgres.integration.ts
@@ -2,14 +2,14 @@ import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
 import { setTimeout as delay } from "node:timers/promises";
 import test from "node:test";
-import { DatabaseCommitOutcomeUnknownError } from "../database/transient";
-import { HttpError } from "../shared/errors";
-import { getHttpErrorResponseHeaders } from "../server/httpErrorResponseHeaders";
-import { createBackendObservationScope } from "../observability/sentry";
+import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
+import { HttpError } from "../../shared/errors";
+import { getHttpErrorResponseHeaders } from "../../server/httpErrorResponseHeaders";
+import { createBackendObservationScope } from "../../observability/sentry";
 import {
   createMultipartUploadSessionAtApplicationBoundary,
   type MultipartUploadSessionCreationApplicationDependencies,
-} from "../routes/mediaAssets";
+} from "../../routes/mediaAssets";
 import {
   acquireMediaAssetUploadSessionCreationClaimForWorkspace,
   createMediaAssetFromAvailableBlobForWorkspace,
@@ -17,19 +17,19 @@ import {
   recordMediaAssetUploadSessionForWorkspace,
   recordMediaAssetUploadSessionWithCreationClaimForWorkspace,
   releaseMediaAssetUploadSessionCreationClaimForWorkspace,
-} from "./uploadSessions";
+} from "../uploadSessions";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "./storageKeys";
+} from "../storageKeys";
 import type {
   MediaAssetUploadSession,
   MediaAssetUploadSessionCreateInput,
-} from "./types";
+} from "../types";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../testSupport/postgresIntegration";
+} from "../../testSupport/postgresIntegration";
 
 type CountRow = Readonly<{ count: number }>;
 type ClaimStateRow = Readonly<{

--- a/apps/backend/src/mediaAssets/multipart/writerAbandonment.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerAbandonment.postgres.integration.ts
@@ -3,19 +3,19 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
-import { transactionWithWorkspaceScope } from "../database";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
+import { transactionWithWorkspaceScope } from "../../database";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
 import { resolveDirectMediaBlobWriterAfterAccessRevocation, reserveDirectMediaBlobWriterWithOwner,
   reserveMediaBlobWriterInExecutor,
   type DirectMediaBlobWriterReservationInput,
   type DirectMediaBlobWriterResolutionInput,
-  type MediaBlobWriterReservationInput } from "./blobLifecycle";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+  type MediaBlobWriterReservationInput } from "../blobLifecycle";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 import { closeMediaAssetUploadSessionBlobWriter,
   reserveMediaAssetUploadSessionBlobWriterWithOwner,
-  type MediaAssetUploadSessionWriterClosureInput } from "./uploadSessions";
-import { passthroughMediaBlobNormalizationVersion } from "./types";
-const migrationSql = readFileSync(resolve(__dirname, "../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql"), "utf8");
+  type MediaAssetUploadSessionWriterClosureInput } from "../uploadSessions";
+import { passthroughMediaBlobNormalizationVersion } from "../types";
+const migrationSql = readFileSync(resolve(__dirname, "../../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql"), "utf8");
 const signatures = {
   directReserve: "content.reserve_direct_media_blob_writer_with_owner(text,uuid,uuid,text,uuid,text,text,text,bigint,text)",
   multipartReserve: "content.reserve_media_upload_session_blob_writer_with_owner(text,uuid,uuid,text)",

--- a/apps/backend/src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts
@@ -7,8 +7,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+} from "../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;
@@ -61,7 +61,7 @@ type QueryExecutor = Pick<pg.PoolClient | pg.Pool, "query">;
 const cleanupDelayMs = 3_600_000;
 const migration0098 = readFileSync(resolve(
   __dirname,
-  "../../../../db/migrations/0098_multipart_writer_abort_and_terminal_replay.sql",
+  "../../../../../db/migrations/0098_multipart_writer_abort_and_terminal_replay.sql",
 ), "utf8");
 const multipartRow = `ROW(
   $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22

--- a/apps/backend/src/mediaAssets/multipart/writerAttempts.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerAttempts.postgres.integration.ts
@@ -4,8 +4,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 import type pg from "pg";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "./storageKeys";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../storageKeys";
 type DirectPayload = Readonly<{
   userId: string; workspaceId: string; mediaAssetId: string; operationId: string;
   replicaId: string; sha256: string; storageKey: string; mimeType: string;
@@ -31,7 +31,7 @@ type SqlValue = string | number | null;
 type QueryExecutor = Pick<pg.PoolClient, "query">;
 const cleanupDelayMs = 3_600_000;
 const migration0097 = readFileSync(resolve(
-  __dirname, "../../../../db/migrations/0097_direct_multipart_writer_attempt_fencing.sql",
+  __dirname, "../../../../../db/migrations/0097_direct_multipart_writer_attempt_fencing.sql",
 ), "utf8");
 const directRow = `ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
   ::content.direct_media_blob_writer_attempt_payload`;


### PR DESCRIPTION
`apps/backend/src/mediaAssets/` held 25 authored source files and 21,311 lines directly in the package root — the largest flat source directory in the repo — even though `ingestion/`, `persistence/`, `storage/` and `uploadSessions/` already existed.

- 11 multipart writer/completion files → `mediaAssets/multipart/` (13,958 lines)
- 6 blob lifecycle/cleanup files → `mediaAssets/blobLifecycle/` (5,387 lines)
- `directIngestionApply.postgres.integration.ts` → existing `ingestion/`
- 7 core files (`index`, `types`, `validators`, `storageKeys`, `workspaceReplicas`, `lastOperationId`) stay flat

Pure move. `blobLifecycle.ts` became `blobLifecycle/index.ts` so every existing `mediaAssets/blobLifecycle` specifier keeps resolving unchanged. The 21 hardcoded `.postgres.integration.ts` paths in `boundaryDefinitions` were rewritten and all verified to resolve.

Validation: `lint` clean, `npm test --prefix apps/backend` 1064/1064 — identical to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)