### PR TITLE
refactor: delete dead re-export shims

### DIFF
--- a/apps/backend/src/auth/index.ts
+++ b/apps/backend/src/auth/index.ts
@@ -16,7 +16,7 @@ import { SimpleJwksCache } from "aws-jwt-verify/jwk";
 import { authenticateAgentApiKey } from "../agent/apiKeys";
 import { getAuthConfig } from "./config";
 import { HttpError } from "../shared/errors";
-import { authenticateGuestSession } from "../guestAuth/session";
+import { authenticateGuestSession } from "../guestAuth/session/index";
 import type { GuestSessionPlatform } from "../guestAuth/types";
 import { loadCognitoIdentityMapping } from "./userIdentities";
 

--- a/apps/backend/src/guestAuth/delete.ts
+++ b/apps/backend/src/guestAuth/delete.ts
@@ -1,1 +1,0 @@
-export * from "./delete/index";

--- a/apps/backend/src/guestAuth/merge.ts
+++ b/apps/backend/src/guestAuth/merge.ts
@@ -1,1 +1,0 @@
-export * from "./merge/index";

--- a/apps/backend/src/guestAuth/session.ts
+++ b/apps/backend/src/guestAuth/session.ts
@@ -1,1 +1,0 @@
-export * from "./session/index";

--- a/apps/backend/src/guestAuth/store.ts
+++ b/apps/backend/src/guestAuth/store.ts
@@ -1,1 +1,0 @@
-export * from "./store/index";

--- a/apps/backend/src/guestAuth/tests/cleanup.test.ts
+++ b/apps/backend/src/guestAuth/tests/cleanup.test.ts
@@ -7,7 +7,7 @@ import {
   deleteGuestSessionInExecutor,
   prepareGuestUpgradeInExecutor,
 } from "..";
-import { cleanupGuestSessionSourceInExecutor } from "../delete";
+import { cleanupGuestSessionSourceInExecutor } from "../delete/index";
 import {
   addWorkspaceMembership,
   createGuestUpgradeExecutor,

--- a/apps/backend/src/guestAuth/upgrade.ts
+++ b/apps/backend/src/guestAuth/upgrade.ts
@@ -1,1 +1,0 @@
-export * from "./upgrade/index";

--- a/apps/web/e2e/live-smoke/seedBridge.ts
+++ b/apps/web/e2e/live-smoke/seedBridge.ts
@@ -3,7 +3,7 @@ import { expect, type BrowserContext, type Page } from "@playwright/test";
 import type {
   TestSeedRequest,
   TestSeedResult,
-} from "../../src/appData/sync/testSeedBridge";
+} from "../../src/appData/sync/local/testSeedBridge";
 import type { LiveSmokeDiagnostics } from "../live-smoke.diagnostics";
 import { externalUiTimeoutMs } from "./config";
 

--- a/apps/web/src/appData/context/provider.tsx
+++ b/apps/web/src/appData/context/provider.tsx
@@ -23,8 +23,8 @@ import type {
 import { ALL_CARDS_REVIEW_FILTER, isReviewFilterEqual } from "../domain";
 import type { AppDataContextValue, Props, SessionLoadState } from "./types";
 import { useProgressInvalidationRefresh } from "../progress/invalidation/progressInvalidation";
-import { isTestSeedBridgeEnabled, type AppDataTestSeedBridge } from "../sync/testSeedBridge";
-import { useSyncEngine } from "../sync/useSyncEngine";
+import { isTestSeedBridgeEnabled, type AppDataTestSeedBridge } from "../sync/local/testSeedBridge";
+import { useSyncEngine } from "../sync/engine/useSyncEngine";
 import { useWorkspaceSession } from "../session/useWorkspaceSession";
 import type { SessionVerificationState } from "../session/workspaceSessionTypes";
 import { loadWarmStartSnapshot, storeWarmStartSnapshot } from "../session/activation/warmStart";

--- a/apps/web/src/appData/sync/syncCloudSettings.ts
+++ b/apps/web/src/appData/sync/syncCloudSettings.ts
@@ -1,1 +1,0 @@
-export * from "./local/syncCloudSettings";

--- a/apps/web/src/appData/sync/syncErrorObservation.ts
+++ b/apps/web/src/appData/sync/syncErrorObservation.ts
@@ -1,1 +1,0 @@
-export * from "./observation/syncErrorObservation";

--- a/apps/web/src/appData/sync/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/syncLifecycleObservation.ts
@@ -1,1 +1,0 @@
-export * from "./observation/syncLifecycleObservation";

--- a/apps/web/src/appData/sync/syncLocalMutations.ts
+++ b/apps/web/src/appData/sync/syncLocalMutations.ts
@@ -1,1 +1,0 @@
-export * from "./local/syncLocalMutations";

--- a/apps/web/src/appData/sync/syncRemote.ts
+++ b/apps/web/src/appData/sync/syncRemote.ts
@@ -1,1 +1,0 @@
-export * from "./remote/syncRemote";

--- a/apps/web/src/appData/sync/syncRestoreHistory.ts
+++ b/apps/web/src/appData/sync/syncRestoreHistory.ts
@@ -1,1 +1,0 @@
-export * from "./restore/syncRestoreHistory";

--- a/apps/web/src/appData/sync/syncSeed.ts
+++ b/apps/web/src/appData/sync/syncSeed.ts
@@ -1,1 +1,0 @@
-export * from "./local/syncSeed";

--- a/apps/web/src/appData/sync/testSeedBridge.ts
+++ b/apps/web/src/appData/sync/testSeedBridge.ts
@@ -1,1 +1,0 @@
-export * from "./local/testSeedBridge";

--- a/apps/web/src/appData/sync/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/useSyncEngine.ts
@@ -1,1 +1,0 @@
-export * from "./engine/useSyncEngine";

--- a/docs/fsrs-scheduling-logic.md
+++ b/docs/fsrs-scheduling-logic.md
@@ -21,7 +21,7 @@ Repository implementations:
 - Android scheduler: `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/scheduling/FsrsScheduler.kt`
 - Android local persistence: `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt`
 - web FSRS type mirror: `apps/web/src/types.ts`
-- web local review submit flow: `apps/web/src/appData/sync/syncLocalMutations.ts`
+- web local review submit flow: `apps/web/src/appData/sync/local/syncLocalMutations.ts`
 - iOS settings UI: `apps/ios/Flashcards/Flashcards/SettingsView.swift`
 - Android settings UI: `apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SchedulerSettingsRoute.kt`
 
@@ -42,7 +42,7 @@ Supporting mirrors around the scheduler contract:
 - backend review persistence: `apps/backend/src/cards/reviews.ts`
 - iOS review persistence: `apps/ios/Flashcards/Flashcards/LocalDatabase.swift`
 - Android review persistence: `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt`
-- web local review submit flow reusing backend scheduler: `apps/web/src/appData/sync/syncLocalMutations.ts`
+- web local review submit flow reusing backend scheduler: `apps/web/src/appData/sync/local/syncLocalMutations.ts`
 - backend scheduler settings: `apps/backend/src/scheduling/workspaceSettings.ts`
 - iOS scheduler settings: `apps/ios/Flashcards/Flashcards/LocalDatabase.swift`
 - Android scheduler settings: `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/scheduling/WorkspaceSchedulerSettingsSupport.kt`


### PR DESCRIPTION
14 files were one-line `export * from "./…"` shims left behind by earlier directory extractions, each sitting beside a real directory of the same name.

- 5 backend: `guestAuth/{delete,merge,session,store,upgrade}.ts`
- 9 web: `appData/sync/{syncCloudSettings,syncRemote,useSyncEngine,syncSeed,testSeedBridge,syncErrorObservation,syncLifecycleObservation,syncLocalMutations,syncRestoreHistory}.ts`

The few live importers are repointed at the real paths, plus two stale references in `docs/fsrs-scheduling-logic.md`. On the web side this also matches CLAUDE.md: backward compatibility is not a goal for clients.

Kept deliberately: `index.ts` barrels, and `apps/web/src/localDb/cache.ts` (still has four live importers).

Validation: backend `lint` clean + 1064/1064; web build clean + 663/663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)