### PR TITLE
refactor(backend): extract cardImages promotion pipeline into promotion/

### DIFF
--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -90,7 +90,7 @@ const boundaryDefinitions = Object.freeze([
     testFiles: Object.freeze([
       "src/cards/generatedImageAppend.postgres.integration.ts",
       "src/chat/cardImages/operation.postgres.integration.ts",
-      "src/chat/cardImages/promotionJobs.postgres.integration.ts",
+      "src/chat/cardImages/promotion/jobs.postgres.integration.ts",
       "src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts",
       "src/database/aiChatInitiatingAuthClassification.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",

--- a/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/operation.postgres.integration.ts
@@ -29,7 +29,7 @@ import {
   GeneratedCardImageOperationLockAbortedError,
   withGeneratedCardImageOperationLock, type GeneratedCardImageOperationLockInput,
 } from "./operationLock";
-import { enqueueGeneratedMediaPromotionJob } from "./promotionJobs";
+import { enqueueGeneratedMediaPromotionJob } from "./promotion/jobs";
 import {
   GeneratedCardImageProviderOutcomeUnknownError,
 } from "./providerTypes";

--- a/apps/backend/src/chat/cardImages/operation.test.ts
+++ b/apps/backend/src/chat/cardImages/operation.test.ts
@@ -17,7 +17,7 @@ import {
   generateCardImageWithDependencies,
   type GeneratedCardImageOperationDependencies,
 } from "./operation";
-import type { EnqueueGeneratedMediaPromotionJobResult } from "./promotionJobs";
+import type { EnqueueGeneratedMediaPromotionJobResult } from "./promotion/jobs";
 import {
   GeneratedCardImageProviderOutcomeUnknownError,
   GeneratedCardImageStagingOutcomeUnknownError,

--- a/apps/backend/src/chat/cardImages/operation.ts
+++ b/apps/backend/src/chat/cardImages/operation.ts
@@ -30,7 +30,7 @@ import {
 import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
 import { createOpenAIGeneratedCardImageProvider } from "./openaiAdapter";
 import { withGeneratedCardImageOperationLock } from "./operationLock";
-import { enqueueGeneratedMediaPromotionJob, type EnqueueGeneratedMediaPromotionJobResult } from "./promotionJobs";
+import { enqueueGeneratedMediaPromotionJob, type EnqueueGeneratedMediaPromotionJobResult } from "./promotion/jobs";
 import {
   GeneratedCardImageDeadlineExceededError,
   GeneratedCardImageProviderOutcomeUnknownError,

--- a/apps/backend/src/chat/cardImages/promotion/jobs.postgres.integration.ts
+++ b/apps/backend/src/chat/cardImages/promotion/jobs.postgres.integration.ts
@@ -3,20 +3,20 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
-import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../database";
+import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../../../database";
 import {
   MediaBlobWriterFenceError,
   reserveMediaBlobWriterInExecutor,
   type MediaBlobWriterReservation,
-} from "../../mediaAssets/blobLifecycle";
-import { GeneratedMediaPromotionStorageTerminalError } from "../../mediaAssets/storage";
-import { testObservationScope } from "../../mediaAssets/storage/testHelpers";
-import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
-import { imageJpegCardMediaBlobNormalizationVersion } from "../../mediaAssets/types";
-import { processSyncPull } from "../../sync";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
-import { extractMarkdownImageDestinationUrls } from "../../workspacePackages/markdownMedia";
-import { InactiveChatRunClaimError } from "../runs/claimFence";
+} from "../../../mediaAssets/blobLifecycle";
+import { GeneratedMediaPromotionStorageTerminalError } from "../../../mediaAssets/storage";
+import { testObservationScope } from "../../../mediaAssets/storage/testHelpers";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../../mediaAssets/storageKeys";
+import { imageJpegCardMediaBlobNormalizationVersion } from "../../../mediaAssets/types";
+import { processSyncPull } from "../../../sync";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../../testSupport/postgresIntegration";
+import { extractMarkdownImageDestinationUrls } from "../../../workspacePackages/markdownMedia";
+import { InactiveChatRunClaimError } from "../../runs/claimFence";
 import {
   assertGeneratedMediaBlobStorageCapabilityForMutation,
   claimGeneratedMediaPromotionJobs,
@@ -37,13 +37,13 @@ import {
   type ClaimedGeneratedMediaPromotionJob,
   type EnqueueGeneratedMediaPromotionJobInput,
   type GeneratedMediaBlobStorageCapability,
-} from "./promotionJobs";
-import { maximumGeneratedImageAltTextCodePoints } from "./contract";
+} from "./jobs";
+import { maximumGeneratedImageAltTextCodePoints } from "../contract";
 import {
   applyGeneratedMediaPromotionJob, failGeneratedMediaPromotionJob,
   processClaimedGeneratedMediaPromotionJobWithDependencies,
   rescheduleGeneratedMediaPromotionJob,
-} from "./promotionProcessor";
+} from "./processor";
 type RunFixture = Readonly<{ sessionId: string; runId: string; claimToken: string }>;
 type ClaimTokenRow = Readonly<{ claim_token: string }>;
 type JobStateRow = Readonly<{ state: string; retry_count: number;
@@ -80,7 +80,7 @@ type RevocationUpgradeRow = Readonly<{
   protocol_activation_exists: boolean; protocol_activation_backend_execute: boolean;
 }>;
 const placeholderTerminalStateMigrationSql = readFileSync(resolve(
-  __dirname, "../../../../../db/migrations/0104_generated_image_placeholder_terminal_state.sql",
+  __dirname, "../../../../../../db/migrations/0104_generated_image_placeholder_terminal_state.sql",
 ), "utf8");
 async function createRun(fixture: PostgresIntegrationFixture): Promise<RunFixture> {
   const sessionId = randomUUID();

--- a/apps/backend/src/chat/cardImages/promotion/jobs.ts
+++ b/apps/backend/src/chat/cardImages/promotion/jobs.ts
@@ -2,40 +2,40 @@ import {
   appendPendingManagedImageToCardSideInExecutor,
   hasPendingManagedImageOnCardSideInExecutor,
   ManagedImageMarkdownComplexitySettlementConflictError,
-} from "../../cards";
+} from "../../../cards";
 import {
   transactionWithWorkspaceScopeDeadline,
   type DatabaseExecutor,
   type SqlValue,
-} from "../../database";
-import { unsafeQueryWithDeadline, unsafeTransactionWithDeadline } from "../../database/unsafe";
+} from "../../../database";
+import { unsafeQueryWithDeadline, unsafeTransactionWithDeadline } from "../../../database/unsafe";
 import {
   getDatabaseErrorFields,
-} from "../../database/transient";
+} from "../../../database/transient";
 import {
   MediaBlobLifecycleBusyError,
   MediaBlobWriterFenceError,
   reserveMediaBlobWriterInExecutor,
   type MediaBlobWriterReservation,
   type MediaBlobWriterReservationInput,
-} from "../../mediaAssets/blobLifecycle";
-import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+} from "../../../mediaAssets/blobLifecycle";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../../mediaAssets/storageKeys";
 import {
   imageJpegCardMediaBlobNormalizationVersion,
   mediaBlobNormalizationVersions,
   type MediaBlobNormalizationVersion,
-} from "../../mediaAssets/types";
-import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
-import { HttpError } from "../../shared/errors";
+} from "../../../mediaAssets/types";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../../../mediaAssets/workspaceReplicas";
+import { HttpError } from "../../../shared/errors";
 import {
   isMarkdownComplexityLimitError,
   rewriteMarkdownImageDestinationUrl,
-} from "../../workspacePackages/markdownMedia";
-import { assertActiveChatRunClaimWithExecutor, type ChatRunClaimFenceParams } from "../runs/claimFence";
+} from "../../../workspacePackages/markdownMedia";
+import { assertActiveChatRunClaimWithExecutor, type ChatRunClaimFenceParams } from "../../runs/claimFence";
 import {
   hasValidGeneratedImageAltTextCharactersAndLength,
   maximumGeneratedImageAltTextCodePoints,
-} from "./contract";
+} from "../contract";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const sha256Pattern = /^[0-9a-f]{64}$/u;
 const mimeTypePattern = /^[a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*$/u;

--- a/apps/backend/src/chat/cardImages/promotion/processor.test.ts
+++ b/apps/backend/src/chat/cardImages/promotion/processor.test.ts
@@ -3,19 +3,19 @@ import test from "node:test";
 import {
   DatabaseCommitOutcomeUnknownError,
   TransientDatabaseHttpError,
-} from "../../database/transient";
-import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../mediaAssets/storageKeys";
+} from "../../../database/transient";
+import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../../../mediaAssets/storageKeys";
 import {
   testMediaAssetId, testObservationScope, testSha256, testWorkspaceId,
-} from "../../mediaAssets/storage/testHelpers";
-import { imageJpegCardMediaBlobNormalizationVersion } from "../../mediaAssets/types";
+} from "../../../mediaAssets/storage/testHelpers";
+import { imageJpegCardMediaBlobNormalizationVersion } from "../../../mediaAssets/types";
 import {
   GeneratedMediaPromotionJobAccessRevokedError,
   type ClaimedGeneratedMediaPromotionJob,
   type GeneratedMediaBlobStorageCapability,
   type GeneratedMediaBlobWriterReservation,
-} from "./promotionJobs";
-import { processClaimedGeneratedMediaPromotionJobWithDependencies } from "./promotionProcessor";
+} from "./jobs";
+import { processClaimedGeneratedMediaPromotionJobWithDependencies } from "./processor";
 const jobId = "33333333-3333-4333-8333-333333333333";
 const operationId = "44444444-4444-4444-8444-444444444444";
 const timestamp = "2026-07-25T00:00:00.000Z";

--- a/apps/backend/src/chat/cardImages/promotion/processor.ts
+++ b/apps/backend/src/chat/cardImages/promotion/processor.ts
@@ -5,27 +5,27 @@ import {
   markPendingManagedImageFailedOnCardSideInExecutor,
   markPendingManagedImageReadyOnCardSideInExecutor,
   type ManagedImageSettlementConflictError,
-} from "../../cards";
-import { DatabaseDeadlineExceededError, type DatabaseExecutor } from "../../database";
-import { unsafeTransactionWithDeadline } from "../../database/unsafe";
+} from "../../../cards";
+import { DatabaseDeadlineExceededError, type DatabaseExecutor } from "../../../database";
+import { unsafeTransactionWithDeadline } from "../../../database/unsafe";
 import {
   DatabaseCommitOutcomeUnknownError, isTransientDatabaseError, TransientDatabaseHttpError,
-} from "../../database/transient";
+} from "../../../database/transient";
 import {
   findMediaAssetRowForUpdateInExecutor, mapMediaAssetRow,
   upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
-} from "../../mediaAssets/persistence";
+} from "../../../mediaAssets/persistence";
 import {
   finalizeMediaBlobWriterInExecutor,
-} from "../../mediaAssets/blobLifecycle";
+} from "../../../mediaAssets/blobLifecycle";
 import {
   GeneratedMediaPromotionStorageTerminalError, GeneratedMediaPromotionStorageTransientError,
   promoteGeneratedMediaObject,
-} from "../../mediaAssets/storage";
-import type { MediaAsset } from "../../mediaAssets/types";
-import type { BackendObservationScope } from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
-import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../sync/replication/changes";
+} from "../../../mediaAssets/storage";
+import type { MediaAsset } from "../../../mediaAssets/types";
+import type { BackendObservationScope } from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
+import { lockWorkspaceSyncMetadataForHotChangesInExecutor } from "../../../sync/replication/changes";
 import {
   applyGeneratedMediaPromotionJobScopeWithExecutor, claimGeneratedMediaPromotionJobs,
   failGeneratedMediaPromotionJobAfterAccessRevocation,
@@ -39,7 +39,7 @@ import {
   reserveGeneratedMediaBlobWriter,
   type ClaimedGeneratedMediaPromotionJob, type GeneratedMediaBlobWriterReservation,
   type SafeGeneratedMediaPromotionJobError,
-} from "./promotionJobs";
+} from "./jobs";
 const maximumJobAttempts = 5;
 const retryBaseDelayMs = 30_000;
 const retryMaximumDelayMs = 15 * 60_000;

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.test.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type {
   GeneratedMediaPromotionBatchResult,
-} from "../../chat/cardImages/promotionProcessor";
+} from "../../chat/cardImages/promotion/processor";
 import {
   MediaBlobCleanupBatchError,
   type MediaBlobCleanupBatchResult,

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-generated-media-promotion.ts
@@ -2,7 +2,7 @@ import type { Handler } from "aws-lambda";
 import {
   runGeneratedMediaPromotionBatch,
   type GeneratedMediaPromotionBatchResult,
-} from "../../chat/cardImages/promotionProcessor";
+} from "../../chat/cardImages/promotion/processor";
 import {
   MediaBlobCleanupBatchError,
   runMediaBlobCleanupBatch,

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 import {
   enqueueGeneratedMediaPromotionJob,
   type EnqueueGeneratedMediaPromotionJobInput,
-} from "../../chat/cardImages/promotionJobs";
+} from "../../chat/cardImages/promotion/jobs";
 import {
   transactionWithWorkspaceScope,
 } from "../../database";

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.test.ts
@@ -5,7 +5,7 @@ import { CopyObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from
 import type {
   GeneratedMediaBlobStorageCapability,
   GeneratedMediaBlobWriterExactInput,
-} from "../../chat/cardImages/promotionJobs";
+} from "../../chat/cardImages/promotion/jobs";
 import { MediaBlobWriterFenceError } from "../blobLifecycle";
 import { buildMediaBlobStorageKey, buildMediaUploadStagingStorageKey } from "../storageKeys";
 import { imageJpegCardMediaBlobNormalizationVersion } from "../types";

--- a/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
+++ b/apps/backend/src/mediaAssets/storage/generatedPromotion.ts
@@ -6,7 +6,7 @@ import {
   assertGeneratedMediaBlobStorageCapabilityForMutation,
   type GeneratedMediaBlobStorageCapability,
   type GeneratedMediaBlobWriterExactInput,
-} from "../../chat/cardImages/promotionJobs";
+} from "../../chat/cardImages/promotion/jobs";
 import { addBackendBreadcrumb, type BackendObservationScope } from "../../observability/sentry";
 import { MediaBlobWriterFenceError } from "../blobLifecycle";
 import { imageJpegCardMediaBlobMimeType, type MediaAssetObjectMetadata } from "../types";

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -145,10 +145,10 @@ test("lifecycle promotion rollout is fenced by durable database protocol activat
     "../../db/migrations/0104_generated_image_placeholder_terminal_state.sql",
   );
   const admissionSource = readSource(
-    "../../apps/backend/src/chat/cardImages/promotionJobs.ts",
+    "../../apps/backend/src/chat/cardImages/promotion/jobs.ts",
   );
   const processorSource = readSource(
-    "../../apps/backend/src/chat/cardImages/promotionProcessor.ts",
+    "../../apps/backend/src/chat/cardImages/promotion/processor.ts",
   );
 
   const activationDrop = migrationSource.indexOf(


### PR DESCRIPTION
`chat/cardImages/` was 16 files and 7,448 lines flat, mixing two things that run on different triggers.

Moves the four files of the durable background promotion pipeline — driven by its own scheduled Lambda — into `promotion/` (`jobs.ts`, `jobs.postgres.integration.ts`, `processor.ts`, `processor.test.ts`, 3,602 lines).

Everything serving the synchronous chat-tool request path stays flat on purpose: `openaiAdapter`, `operation`, `operationLock`, `providerTypes`, `contract`, `types`, `metadata`, `index`. Splitting those too would be filename mirroring, not structure.

The plan listed six external importers; the real set is nine — the extra three (`operation.test.ts`, `operation.postgres.integration.ts`, and two `readSource` path strings in `infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts`) were found by grep and updated. `grep -rn 'promotionJobs\|promotionProcessor'` now returns zero hits repo-wide.

Validation: `lint` clean, `npm test --prefix apps/backend` 1064/1064; all 21 integration-registry paths resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)