### PR TITLE
Compile Android on pull requests

### DIFF
--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -1,0 +1,33 @@
+name: Android PR
+
+on:
+  pull_request:
+    paths:
+      - 'apps/android/**'
+      - '!apps/android/README.md'
+      - '!apps/android/docs/**'
+      - 'cloudbuild.android.yaml'
+      - 'scripts/android/run-android-ci.sh'
+      - 'scripts/android/run-android-firebase-test-lab.sh'
+      - 'scripts/android/run-android-release.sh'
+      - 'scripts/android/setup-github-android.sh'
+      - '.github/workflows/android-pr.yml'
+      - '.github/workflows/android-ci-reusable.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  android_pr:
+    name: Android PR
+    concurrency:
+      group: android-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/android-ci-reusable.yml
+    with:
+      # On pull_request, github.sha is the refs/pull/N/merge commit, so this builds the PR
+      # merge result rather than the branch tip and gates on what will actually land on main.
+      target_ref: ${{ github.sha }}
+      android_version_code: ${{ github.run_number }}
+      run_data_local_instrumentation: false
+    secrets: inherit


### PR DESCRIPTION
Android code currently compiles for the first time only *after* merge: `android-ci.yml` triggers on `push: [main]`. A wrong Kotlin or Android API usage turns the Android release stream red instead of failing the PR.

This adds a `pull_request` caller for the existing `android-ci-reusable.yml`, path-filtered to the same Android sources as `android-ci.yml`.

- `run_data_local_instrumentation: false` — the emulator job is already guarded by that input, so the PR gate is build + unit tests + lint only. No Firebase Test Lab (it lives in `android-release.yml`, which is `workflow_dispatch`-only).
- `target_ref: ${{ github.sha }}` — on `pull_request` this is the `refs/pull/N/merge` commit, so the gate builds the PR **merge result** rather than the branch tip. A PR on a stale base can otherwise be green here while `main` + PR fails to compile, which is the exact failure class this workflow exists to prevent.

This PR triggers the new workflow on itself (the paths filter includes the file), so the run on this PR is the first real validation.

Reviewed through an implementation review plus a 5-lens adversarial verification pass. The `target_ref` change came out of that pass. `secrets: inherit` was examined by two lenses and confirmed harmless — the reusable workflow references no secrets — and is kept for consistency with `android-ci.yml`.

Known, unchanged behaviour worth noting before any branch-protection change: this workflow is path-filtered, so on non-Android PRs it never starts and its check never appears. If it is ever marked as a *required* status check, non-Android PRs would sit permanently pending. `android-ci.yml` has the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)