### PR TITLE
Fix Android managed media split argument

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
@@ -59,7 +59,7 @@ fun parseManagedMediaReference(reference: String): ManagedMediaReference? {
 
 private fun parseManagedMediaReferenceState(query: String): ManagedMediaReferenceState {
     val stateValues: List<String> = query
-        .split(separator = "&")
+        .split("&")
         .mapNotNull { queryPart ->
             val parameterName: String = queryPart.substringBefore(delimiter = "=")
             if (parameterName != "state") {


### PR DESCRIPTION
`parseManagedMediaReferenceState` calls `String.split` with a named argument `separator`:

```kotlin
.split(separator = "&")
```

`kotlin.text.split` declares `vararg delimiters: String`, not `separator`, so this does not compile:

```
ManagedMediaMarkdown.kt:62:16  No parameter with name 'separator' found.
                               No value passed for parameter 'delimiter'.
```

**`apps/android` has not compiled since #1154 (`025e6da90`) introduced this line** — `android-ci.yml` on `main` has been failing across six subsequent merges. It went unnoticed because, until #1170, nothing compiled Android before merge.

Passing the delimiter positionally matches every other `.split(` call in the Android sources, including `AiChatRemoteTestFixtures.kt:33`, which performs the identical operation as `rawQuery.split("&")`. Runtime behaviour is unchanged: literal `"&"` delimiter, `ignoreCase = false`, `limit = 0`.

The neighbouring `substringBefore(delimiter = ...)` / `substringAfter(delimiter = ...)` calls are deliberately left alone — those functions genuinely do declare a `delimiter` parameter. (`joinToString(separator = ...)` in `CollectionsKt` really does take `separator`, which is the likely origin of the mistake.)

Verified by decompiling the pinned `kotlin-stdlib` (2.4.10) rather than from memory: `separator` appears zero times in `StringsKt__StringsKt`'s metadata, while `delimiter`, `delimiters`, `ignoreCase` and `limit` all do.

Gradle was not run locally, per CLAUDE.md. **The Android PR gate on this PR is the validation** — its first genuine use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)