### PR TITLE
Check pull requests before merge

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,282 @@
+name: PR Checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-24.04
+    outputs:
+      api_changed: ${{ steps.detect.outputs.api_changed }}
+      auth_changed: ${{ steps.detect.outputs.auth_changed }}
+      backend_changed: ${{ steps.detect.outputs.backend_changed }}
+      web_changed: ${{ steps.detect.outputs.web_changed }}
+      admin_changed: ${{ steps.detect.outputs.admin_changed }}
+      infra_changed: ${{ steps.detect.outputs.infra_changed }}
+      node_changed: ${{ steps.detect.outputs.node_changed }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: detect
+        run: |
+          set -euo pipefail
+
+          changed_files_path="${RUNNER_TEMP}/changed-files.txt"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            printf '%s\n' 'workflow_dispatch (forced full PR checks)' > "${changed_files_path}"
+          else
+            git fetch --no-tags origin "${GITHUB_BASE_REF}"
+            git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" > "${changed_files_path}"
+          fi
+
+          api_changed=false
+          auth_changed=false
+          backend_changed=false
+          web_changed=false
+          admin_changed=false
+          infra_changed=false
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            api_changed=true
+            auth_changed=true
+            backend_changed=true
+            web_changed=true
+            admin_changed=true
+            infra_changed=true
+          else
+            if grep -Eq '^(api/|\.github/workflows/pr-checks\.yml$)' "${changed_files_path}"; then
+              api_changed=true
+            fi
+
+            if grep -Eq '^(apps/auth/|\.github/workflows/pr-checks\.yml$)' "${changed_files_path}"; then
+              auth_changed=true
+            fi
+
+            # The backend is contract-coupled to the spec: its contract tests bundle
+            # api/src/openapi.yaml and assert the handlers still agree with it.
+            if grep -Eq '^(apps/backend/|api/|\.github/workflows/pr-checks\.yml$)' "${changed_files_path}"; then
+              backend_changed=true
+            fi
+
+            if grep -Eq '^(apps/web/|apps/backend/src/scheduling/|\.github/workflows/pr-checks\.yml$)' "${changed_files_path}"; then
+              web_changed=true
+            fi
+
+            if grep -Eq '^(apps/admin/|\.github/workflows/pr-checks\.yml$)' "${changed_files_path}"; then
+              admin_changed=true
+            fi
+
+            if grep -Eq '^(infra/|\.github/workflows/pr-checks\.yml$)' "${changed_files_path}"; then
+              infra_changed=true
+            fi
+          fi
+
+          node_changed=false
+          if [[ "${api_changed}" == "true" || "${auth_changed}" == "true" || "${backend_changed}" == "true" \
+             || "${web_changed}" == "true" || "${admin_changed}" == "true" || "${infra_changed}" == "true" ]]; then
+            node_changed=true
+          fi
+
+          {
+            echo "api_changed=${api_changed}"
+            echo "auth_changed=${auth_changed}"
+            echo "backend_changed=${backend_changed}"
+            echo "web_changed=${web_changed}"
+            echo "admin_changed=${admin_changed}"
+            echo "infra_changed=${infra_changed}"
+            echo "node_changed=${node_changed}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Summarize changed areas
+        env:
+          API_CHANGED: ${{ steps.detect.outputs.api_changed }}
+          AUTH_CHANGED: ${{ steps.detect.outputs.auth_changed }}
+          BACKEND_CHANGED: ${{ steps.detect.outputs.backend_changed }}
+          WEB_CHANGED: ${{ steps.detect.outputs.web_changed }}
+          ADMIN_CHANGED: ${{ steps.detect.outputs.admin_changed }}
+          INFRA_CHANGED: ${{ steps.detect.outputs.infra_changed }}
+        run: |
+          set -euo pipefail
+
+          changed_files_path="${RUNNER_TEMP}/changed-files.txt"
+
+          {
+            echo "## PR check scope"
+            echo ""
+            echo "- API changed: \`${API_CHANGED}\`"
+            echo "- Auth changed: \`${AUTH_CHANGED}\`"
+            echo "- Backend changed: \`${BACKEND_CHANGED}\`"
+            echo "- Web changed: \`${WEB_CHANGED}\`"
+            echo "- Admin changed: \`${ADMIN_CHANGED}\`"
+            echo "- Infra changed: \`${INFRA_CHANGED}\`"
+            echo ""
+            echo "### Changed files"
+            echo ""
+            if [[ -s "${changed_files_path}" ]]; then
+              cat "${changed_files_path}"
+            else
+              echo "No changed files detected."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  checks:
+    name: Type checks and builds
+    needs: changes
+    if: ${{ needs.changes.outputs.node_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            api/package-lock.json
+            apps/auth/package-lock.json
+            apps/backend/package-lock.json
+            apps/web/package-lock.json
+            apps/admin/package-lock.json
+            infra/aws/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefix api
+          npm ci --prefix apps/auth
+          npm ci --prefix apps/backend
+          npm ci --prefix apps/web
+          npm ci --prefix apps/admin
+          npm ci --prefix infra/aws
+
+      - name: Lint OpenAPI spec
+        if: ${{ needs.changes.outputs.api_changed == 'true' }}
+        run: npm run lint --prefix api
+
+      - name: Bundle OpenAPI spec
+        run: npm run bundle --prefix api
+
+      - name: Build auth app
+        if: ${{ needs.changes.outputs.auth_changed == 'true' }}
+        run: npm run build --prefix apps/auth
+
+      - name: Test auth app
+        if: ${{ needs.changes.outputs.auth_changed == 'true' }}
+        run: npm run test --prefix apps/auth
+
+      - name: Lint backend
+        if: ${{ needs.changes.outputs.backend_changed == 'true' }}
+        run: npm run lint --prefix apps/backend
+
+      - name: Build backend
+        if: ${{ needs.changes.outputs.backend_changed == 'true' }}
+        run: npm run build --prefix apps/backend
+
+      - name: Build web app
+        if: ${{ needs.changes.outputs.web_changed == 'true' }}
+        run: npm run build --prefix apps/web
+
+      - name: Build admin app
+        if: ${{ needs.changes.outputs.admin_changed == 'true' }}
+        run: npm run build --prefix apps/admin
+
+      - name: Build infra
+        if: ${{ needs.changes.outputs.infra_changed == 'true' }}
+        run: npm run build --prefix infra/aws
+
+      - name: Test infra
+        if: ${{ needs.changes.outputs.infra_changed == 'true' }}
+        run: npm run test --prefix infra/aws
+
+  backend_tests:
+    name: Backend test suites
+    needs: changes
+    if: ${{ needs.changes.outputs.backend_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            api/package-lock.json
+            apps/backend/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefix api
+          npm ci --prefix apps/backend
+
+      - name: Test backend
+        run: npm test --prefix apps/backend
+
+  web_tests:
+    name: Web test suite
+    needs: changes
+    if: ${{ needs.changes.outputs.web_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefix apps/web
+
+      - name: Test web app
+        run: npm test --prefix apps/web
+
+  static_checks:
+    name: Repository static checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Fetch base ref
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+            git fetch --no-tags origin "${GITHUB_BASE_REF}"
+          else
+            echo "No base ref to fetch for event ${GITHUB_EVENT_NAME}."
+          fi
+
+      - name: Run repository static checks
+        env:
+          PR_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/checks/pr/run-all.mjs

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -114,6 +114,8 @@ export default defineConfig(({ command }) => {
       sourcemap: shouldUploadSentrySourceMaps,
     },
     test: {
+      // Progress fixtures hardcode this zone, so the suite must run in it until they become zone-independent.
+      env: { TZ: "Europe/Madrid" },
       environment: "jsdom",
       environmentOptions: {
         jsdom: {

--- a/scripts/checks/pr/README.md
+++ b/scripts/checks/pr/README.md
@@ -1,0 +1,21 @@
+# Pre-merge static checks
+
+Repository-wide consistency checks that run on every pull request through the
+`static_checks` job of [`.github/workflows/pr-checks.yml`](../../../.github/workflows/pr-checks.yml).
+
+`run-all.mjs` discovers every `check-*.mjs` file in this directory, runs them in
+sorted order from the repository root, and exits non-zero when any of them fails.
+Adding a check means adding one file here; the workflow never needs to change.
+
+## Convention for a check
+
+- One standalone `check-*.mjs` file per check, plain ESM with no dependencies.
+- Runnable directly: `node scripts/checks/pr/check-<name>.mjs` from the repository root.
+- Offline and service-free: no network calls, no database, no AWS credentials.
+- Fast: finishes in seconds, so it never becomes the slow part of a pull request.
+- Exits `0` when the repository is consistent.
+- Exits non-zero with an actionable message that names the exact files that
+  disagree and what has to change to make them agree.
+
+`PR_BASE_REF` is set in the workflow environment, so a check that needs the pull
+request merge base can resolve it as `origin/${PR_BASE_REF}`.

--- a/scripts/checks/pr/run-all.mjs
+++ b/scripts/checks/pr/run-all.mjs
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..", "..");
+const CHECK_FILE_PATTERN = /^check-.*\.mjs$/;
+
+const checkFileNames = readdirSync(SCRIPT_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && CHECK_FILE_PATTERN.test(entry.name))
+  .map((entry) => entry.name)
+  .sort();
+
+if (checkFileNames.length === 0) {
+  console.log("No pre-merge checks are registered in scripts/checks/pr yet.");
+  process.exit(0);
+}
+
+const failedCheckNames = [];
+
+for (const checkFileName of checkFileNames) {
+  console.log(`[pr-checks] running ${checkFileName}`);
+
+  const checkProcess = spawnSync(process.execPath, [join(SCRIPT_DIR, checkFileName)], {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+    shell: false,
+  });
+
+  if (checkProcess.error !== undefined) {
+    console.error("Pre-merge check failed to start.", {
+      checkFileName,
+      repoRoot: REPO_ROOT,
+      errorMessage: checkProcess.error.message,
+    });
+    throw checkProcess.error;
+  }
+
+  if (checkProcess.signal !== null) {
+    console.error("Pre-merge check terminated by signal.", {
+      checkFileName,
+      signal: checkProcess.signal,
+    });
+    failedCheckNames.push(checkFileName);
+    continue;
+  }
+
+  if (checkProcess.status !== 0) {
+    failedCheckNames.push(checkFileName);
+  }
+}
+
+if (failedCheckNames.length > 0) {
+  console.error("Pre-merge checks failed.", {
+    failedChecks: failedCheckNames,
+    totalChecks: checkFileNames.length,
+  });
+  process.exit(1);
+}
+
+console.log(`All ${checkFileNames.length} pre-merge checks passed.`);


### PR DESCRIPTION
The repository had no real `pull_request` CI. `aws-web-release.yml` and `android-ci.yml` both trigger on `push: [main]`, so a type error or build break was only caught *after* the merge had already started a production deploy. The only `pull_request` workflow was `mcp-registry-validate.yml`, which checks `server.json` alone.

This adds **PR Checks**, running the fast subset of `pre_deploy_checks`, path-filtered from the PR merge base.

### Jobs
| Job | Runs when |
|---|---|
| `changes` | always — detects changed areas |
| `checks` | any Node area changed — OpenAPI lint, auth/backend/web/admin/infra builds, backend `tsc --noEmit`, auth + infra tests |
| `backend_tests` | `apps/backend/` or `api/` changed |
| `web_tests` | `apps/web/` changed |
| `static_checks` | always — runs `scripts/checks/pr/run-all.mjs` |

Deliberately **excluded**: the Postgres service container and the Docker/QEMU CDK synth. They are the two slow parts of `pre_deploy_checks` and stay post-merge. `aws-web-release.yml` is untouched, so nothing is lost if these checks turn out wrong.

### Two suites that had never run in CI
`npm test --prefix apps/backend` (1064 tests, offline) and `npm test --prefix apps/web` (663 tests) were invoked by no workflow at all.

Wiring up the web suite required pinning the vitest timezone. The progress fixtures hardcode `Europe/Madrid` while `progressDates.ts` reads the ambient zone via `Intl.DateTimeFormat().resolvedOptions().timeZone`, so on a UTC runner 14 tests in 2 files fail:

```
TZ=Europe/Madrid → 79 files, 663 tests pass
TZ=UTC           → 2 files failed, 14 tests failed
```

The pin is in `vite.config.ts` rather than the workflow step so local and CI behave identically. **Follow-up:** make `progressSourceTestSupport.tsx` zone-independent and drop the pin — until then the suite cannot catch timezone bugs.

### Extensible static checks
`scripts/checks/pr/run-all.mjs` discovers sibling `check-*.mjs` files, so planned follow-ups (OpenAPI/agent-smoke contract drift, migration hygiene, version alignment, iOS localization parity) each land as one new file with no workflow edit and no conflicts between them. It exits 0 while the directory is empty, which is why none ship here.

### Security
This repo is public and takes outside PRs, so: changed filenames are never routed through `GITHUB_OUTPUT` (a fixed `EOF` heredoc delimiter plus attacker-controlled filenames lets a fork PR terminate it early and forge step outputs), and every step output reaches a `run:` body through `env:` rather than `${{ }}` interpolation. Note `aws-web-release.yml` still has the heredoc pattern; it is far lower risk there (`push: [main]`, so filenames come from merged code) and is left for a separate change.

### Review
Implementation review → 5-lens adversarial verification (8 findings confirmed, 10 refuted) → two fix rounds → clean re-review. The verification pass is what caught the timezone failure, the `GITHUB_OUTPUT` injection, and the missing job-level gate.

### Known gaps, recorded deliberately
- An **infra-only** PR skips the backend tests that regex-assert `infra/aws/lib/gateways/api-gateway.ts`. Low likelihood — CLAUDE.md already requires that file to change alongside backend routes — and adding `infra/` would make every infra PR pay a full backend test job.
- If `changes` fails, the jobs depending on it report **skipped**, which branch protection counts as satisfied. Mark `changes` required too if these are ever made required.

This PR triggers the workflow on itself, so the run here is the first real validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)