### PR TITLE
Lint shell scripts and workflows before merge

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -522,6 +522,8 @@ jobs:
 
           printf '127.0.0.1 app.flashcards-open-source-app.com\n' | sudo tee -a /etc/hosts >/dev/null
 
+          # The log redirect is meant to stay unprivileged; RUNNER_TEMP is runner-writable.
+          # shellcheck disable=SC2024
           sudo env PATH="${PATH}" node scripts/serve-dist-https.mjs \
             --host 0.0.0.0 \
             --port 443 \

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -280,3 +280,52 @@ jobs:
         env:
           PR_BASE_REF: ${{ github.base_ref }}
         run: node scripts/checks/pr/run-all.mjs
+
+  lint_scripts:
+    name: Shell and workflow lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check shell script syntax
+        run: |
+          set -euo pipefail
+
+          git ls-files -z '*.sh' | xargs -0 -r -n1 bash -n
+
+      - name: Run shellcheck
+        run: |
+          set -euo pipefail
+
+          shellcheck --version
+
+          git ls-files -z '*.sh' | xargs -0 -r shellcheck --severity=warning
+
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+
+          install_dir="${RUNNER_TEMP}/actionlint"
+          archive_path="${install_dir}/actionlint.tar.gz"
+          archive_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+
+          mkdir -p "${install_dir}"
+
+          # Retry transient release-CDN failures instead of turning an unrelated PR red.
+          # --show-error reports every failed attempt, and the last error still fails the step.
+          curl --silent --show-error --fail --location \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            --output "${archive_path}" \
+            "${archive_url}"
+
+          printf '%s  %s\n' "${ACTIONLINT_SHA256}" "${archive_path}" | sha256sum --check --strict -
+
+          tar -xzf "${archive_path}" -C "${install_dir}" actionlint
+
+          "${install_dir}/actionlint" --version
+          "${install_dir}/actionlint"

--- a/apps/ios/Flashcards/ci_scripts/ci_post_clone.sh
+++ b/apps/ios/Flashcards/ci_scripts/ci_post_clone.sh
@@ -106,6 +106,8 @@ load_local_env_file() {
 
         escaped_value=$(printf "%s" "${value}" | sed "s/'/'\\\\''/g")
         eval "${key}='${escaped_value}'"
+        # key holds a variable name, so exporting its expansion is intended.
+        # shellcheck disable=SC2163
         export "${key}"
         ;;
     esac

--- a/apps/ios/Flashcards/ci_scripts/ci_post_xcodebuild.sh
+++ b/apps/ios/Flashcards/ci_scripts/ci_post_xcodebuild.sh
@@ -162,6 +162,8 @@ load_local_env_file() {
 
         escaped_value=$(printf "%s" "${value}" | sed "s/'/'\\\\''/g")
         eval "${key}='${escaped_value}'"
+        # key holds a variable name, so exporting its expansion is intended.
+        # shellcheck disable=SC2163
         export "${key}"
         ;;
     esac

--- a/scripts/cloudflare/setup-admin-domain.sh
+++ b/scripts/cloudflare/setup-admin-domain.sh
@@ -45,7 +45,7 @@ echo "Certificate ARN: ${CERT_ARN}"
 echo "Waiting for ACM to generate validation DNS record..."
 
 VALIDATION_JSON=""
-for i in $(seq 1 24); do
+for _ in $(seq 1 24); do
   VALIDATION_JSON=$(aws acm describe-certificate \
     --region "$REGION" \
     --certificate-arn "$CERT_ARN" \

--- a/scripts/cloudflare/setup-apex-redirect-domain.sh
+++ b/scripts/cloudflare/setup-apex-redirect-domain.sh
@@ -41,7 +41,7 @@ echo "Certificate ARN: ${CERT_ARN}"
 echo "Waiting for ACM to generate validation DNS record..."
 
 VALIDATION_JSON=""
-for i in $(seq 1 24); do
+for _ in $(seq 1 24); do
   VALIDATION_JSON=$(aws acm describe-certificate \
     --region "$REGION" \
     --certificate-arn "$CERT_ARN" \

--- a/scripts/cloudflare/setup-api-domain.sh
+++ b/scripts/cloudflare/setup-api-domain.sh
@@ -56,7 +56,7 @@ echo "Certificate ARN: ${CERT_ARN}"
 echo "Waiting for ACM to generate validation DNS record..."
 
 VALIDATION_JSON=""
-for i in $(seq 1 24); do
+for _ in $(seq 1 24); do
   VALIDATION_JSON=$(aws acm describe-certificate \
     --region "$REGION" \
     --certificate-arn "$CERT_ARN" \

--- a/scripts/cloudflare/setup-certificate.sh
+++ b/scripts/cloudflare/setup-certificate.sh
@@ -47,8 +47,6 @@ openssl req -new -newkey rsa:2048 -nodes \
   -out "$CSR_FILE" \
   -subj "/CN=${DOMAIN}" 2>/dev/null
 
-CSR_PEM=$(cat "$CSR_FILE")
-
 # --- Create Origin Certificate via Cloudflare API ---
 CERT_RESPONSE=$(curl -s -X POST "https://api.cloudflare.com/client/v4/certificates" \
   -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \

--- a/scripts/cloudflare/setup-web-domain.sh
+++ b/scripts/cloudflare/setup-web-domain.sh
@@ -52,7 +52,7 @@ echo "Certificate ARN: ${CERT_ARN}"
 echo "Waiting for ACM to generate validation DNS record..."
 
 VALIDATION_JSON=""
-for i in $(seq 1 24); do
+for _ in $(seq 1 24); do
   VALIDATION_JSON=$(aws acm describe-certificate \
     --region "$REGION" \
     --certificate-arn "$CERT_ARN" \

--- a/scripts/lib/deploy-config.sh
+++ b/scripts/lib/deploy-config.sh
@@ -4,7 +4,10 @@ DEPLOY_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${DEPLOY_CONFIG_LIB_DIR}/root-env.sh"
 
+# The tag key/value pair is consumed by scripts that source this library, not here.
+# shellcheck disable=SC2034
 DEPLOY_CONFIG_PROJECT_TAG_KEY="flashcards:project"
+# shellcheck disable=SC2034
 DEPLOY_CONFIG_PROJECT_TAG_VALUE="flashcards-open-source-app"
 DEPLOY_CONFIG_PURPOSE_TAG_KEY="flashcards:purpose"
 


### PR DESCRIPTION
A quoting or syntax mistake in `scripts/checks/*.sh` or `scripts/deploy/*.sh` previously surfaced **mid-deploy**, and a mistake in the workflow YAML surfaced as a broken run on `main`.

Adds a `lint_scripts` job to PR Checks:
- `bash -n` over all 50 tracked shell scripts;
- `shellcheck --severity=warning` (verified green against both 0.11.0 and the 0.9.0 that `ubuntu-24.04` actually ships);
- `actionlint` 1.7.12 over all 9 workflows, **pinned and SHA256-verified**, so a bad or missing download fails loudly rather than silently skipping the lint.

Also includes the **nine pre-existing shellcheck findings** this surfaced, 1:1 with what `shellcheck` reports on the unmodified files — no gratuitous cleanup. Dead assignments removed, unused loop variables replaced with `_` (matching existing repo style), and targeted `# shellcheck disable=` comments with reasons where the pattern is intentional.

**One change lands outside PR Checks:** a single `# shellcheck disable=SC2024` comment in `aws-web-release.yml`, required because actionlint runs shellcheck over `run:` bodies. No behavioural effect. Verified load-bearing — removing it makes actionlint fail.

The gate was verified non-hollow: injecting `runs-on: ubunut-24.04` into the new job is caught, confirming it lints the job it lives in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)