### PR TITLE
Fix iOS card editor closure type inference

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
@@ -691,7 +691,7 @@ private func cardEditorTextByReconcilingMediaLifecycle(
         grouping: cardEditorManagedImageMatches(text: text),
         by: { Array($0.mediaAssetId.utf8) }
     )
-    let replacements = transitions.compactMap { transition in
+    let replacements = transitions.compactMap { transition -> CardEditorTextReplacement? in
         guard let draftMatches = draftMatchesByMediaAssetIdUTF8[transition.mediaAssetIdUTF8],
               draftMatches.count == 1,
               let draftMatch = draftMatches.first,


### PR DESCRIPTION
## Problem

Xcode Cloud build 544 fails to compile the iOS **app target**. Two errors, both in `CardEditorScreen.swift`:

- `Generic parameter 'ElementOfResult' could not be inferred` — line 694
- `Generic parameter 'Bound' could not be inferred` — line 707

## Root cause

These are one bug, not two. The multi-statement `compactMap` closure at line 694 returns bare `nil` from a `guard` in one branch and `CardEditorTextReplacement(...)` in the other, so Swift cannot infer `ElementOfResult`. The element type of `replacements` is then unknown, so the chained `.sorted` at line 707 cannot resolve `first.range.lowerBound` — that second error is a cascade.

Reproduced in a standalone snippet on Apple Swift 6.3.3: both diagnostics appear verbatim, and adding an explicit closure result type clears both.

## Fix

Annotate the closure result type. One line, behaviour unchanged.

## Notes

The affected file is in the app target, not a test target, so this broke every Xcode Cloud action that builds the app — not only the deliberately non-required `Test - iOS`.

A repo-wide scan found ~25 other multi-statement closures in `apps/ios`; they compile today because their result type is inferable from context, so they are deliberately left alone rather than churned.

The durable fix is a pre-merge iOS compile gate, which `apps/ios/**` currently lacks entirely — that follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)