### PR TITLE
Document pull request check policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ For the optional private analytical DB access path, granted reporting permission
 ## Release Gates and Monitoring
 
 Pushes to `main` use three independent release streams: AWS/web, Android, and iOS.
+Pull-request checks stay deliberately light and fast: do not add heavy mobile build or test jobs to pull-request workflows.
+The `Android PR` build, unit test, and lint run in `.github/workflows/android-pr.yml` (about 5 minutes) is an accepted exception and stays; the heavier emulator and Firebase Test Lab suites stay out of pull requests.
+Nothing compiles iOS before merge by design, though `PR Checks` still runs the static iOS checks.
+Swift builds and tests run in Xcode Cloud, whose workflow definitions live in App Store Connect; its in-repo build inputs are documented in [docs/ios-ci-cd.md](docs/ios-ci-cd.md).
 Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.
 Details, rollback rules, and live smoke references: [docs/release-gates.md](docs/release-gates.md).
 


### PR DESCRIPTION
## Why

Pull-request checks should stay light and fast, but that was never written down — so nothing stopped a heavy mobile build job from being added to them.

An iOS pre-merge compile gate was prototyped and deliberately rejected: it cost roughly 8–15 minutes of Xcode per iOS PR to catch what Xcode Cloud already catches. This records the decision so it does not get re-proposed.

## What this states

- Pull-request checks stay deliberately light and fast; do not add heavy mobile build or test jobs to them.
- iOS is not compiled before merge by design. Swift builds and tests run in Xcode Cloud, and build breakage surfaces there. `PR Checks` still runs the static iOS checks (localization parity, version alignment).
- The `Android PR` build/unit-test/lint run is an accepted exception and stays; the heavier emulator and Firebase Test Lab suites remain out of pull requests.

The existing rule about keeping the Xcode Cloud `Test - iOS` action non-required is unchanged.

## Note

`CLAUDE.md` is a symlink to `AGENTS.md`, so this one edit covers both.

The iOS wording deliberately scopes the "outside this repository" claim to the Xcode Cloud *workflow definitions*. Real build inputs — `apps/ios/Flashcards/ci_scripts/` and the shared scheme — do live in this repo, and an over-broad claim would lead agents to skip updating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)