### PR TITLE
Keep cancelled media uploads that already succeeded

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
@@ -269,16 +269,36 @@ interface MediaTransferDao {
         """
         UPDATE media_transfer_queue
         SET status = :status,
+            lastError = :lastError,
+            updatedAtMillis = :updatedAtMillis
+        WHERE transferId = :transferId
+            AND status != :succeededStatus
+        """
+    )
+    suspend fun markMediaTransferPermanentlyFailed(
+        transferId: String,
+        status: String,
+        succeededStatus: String,
+        lastError: String,
+        updatedAtMillis: Long
+    )
+
+    @Query(
+        """
+        UPDATE media_transfer_queue
+        SET status = :status,
             attemptCount = attemptCount + 1,
             nextAttemptAtMillis = :nextAttemptAtMillis,
             lastError = :lastError,
             updatedAtMillis = :updatedAtMillis
         WHERE transferId = :transferId
+            AND status != :succeededStatus
         """
     )
     suspend fun markMediaTransferAttemptFailed(
         transferId: String,
         status: String,
+        succeededStatus: String,
         nextAttemptAtMillis: Long,
         lastError: String,
         updatedAtMillis: Long

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/LocalMediaUploadTransferRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/media/LocalMediaUploadTransferRepository.kt
@@ -386,9 +386,10 @@ class LocalMediaUploadTransferRepository(
         val nowMillis: Long = timeProvider.currentTimeMillis()
         val errorMessage: String = renderMediaUploadError(error = error)
         if (isPermanentMediaUploadFailure(error = error)) {
-            database.mediaTransferDao().updateMediaTransferStatus(
+            database.mediaTransferDao().markMediaTransferPermanentlyFailed(
                 transferId = transferEntity.transferId,
                 status = MediaTransferStatus.FAILED.wireKey,
+                succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey,
                 lastError = errorMessage,
                 updatedAtMillis = nowMillis
             )
@@ -398,6 +399,7 @@ class LocalMediaUploadTransferRepository(
         database.mediaTransferDao().markMediaTransferAttemptFailed(
             transferId = transferEntity.transferId,
             status = MediaTransferStatus.QUEUED.wireKey,
+            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey,
             nextAttemptAtMillis = nowMillis + calculateRetryDelayMillis(attemptCount = transferEntity.attemptCount),
             lastError = errorMessage,
             updatedAtMillis = nowMillis
@@ -597,6 +599,10 @@ internal suspend fun retryMediaUploadSessionCompletion(
 ): MediaUploadCompletionReplayResult {
     var attemptNumber = 1
     var lastRetryableCompletionError: CloudRemoteException? = null
+    // Set only after the replay success reached its durable local disposition. NonCancellable
+    // protects the replay body but not the resume boundary, so a cancelled run can still surface
+    // a throw here after the transfer row already committed as succeeded.
+    var durablyPersistedCompletion: MediaAssetUploadCompletion? = null
     while (true) {
         try {
             currentCoroutineContext().ensureActive()
@@ -617,6 +623,7 @@ internal suspend fun retryMediaUploadSessionCompletion(
                 withContext(context = NonCancellable) {
                     val replayCompletion: MediaAssetUploadCompletion = complete()
                     persistReplaySuccess(replayCompletion)
+                    durablyPersistedCompletion = replayCompletion
                     replayCompletion
                 }
             }
@@ -626,7 +633,7 @@ internal suspend fun retryMediaUploadSessionCompletion(
             )
         } catch (error: CancellationException) {
             val completionError = lastRetryableCompletionError
-            if (completionError != null) {
+            if (completionError != null && durablyPersistedCompletion == null) {
                 throw MediaUploadCompletionTerminalException(
                     reason = MediaUploadCompletionTerminalReason.INTERRUPTED,
                     completionCause = completionError,
@@ -674,7 +681,7 @@ internal suspend fun retryMediaUploadSessionCompletion(
             attemptNumber += 1
         } catch (error: Exception) {
             val completionError = lastRetryableCompletionError
-            if (completionError != null) {
+            if (completionError != null && durablyPersistedCompletion == null) {
                 throw MediaUploadCompletionTerminalException(
                     reason = MediaUploadCompletionTerminalReason.INTERRUPTED,
                     completionCause = completionError,


### PR DESCRIPTION
## Problem

`Android CI / Android emulator data:local instrumentation` fails intermittently on `LocalMediaUploadTransferRepositoryCompletionRetryTest.repositoryPersistsReplaySuccessWhenCancellationArrivesBeforeLocalDisposition` with `expected:<succeeded> but was:<failed>`. It passed 3 of the last 4 emulator runs, so it is a race rather than a broken test, and it blocked the Play draft upload in run 30619486018.

`withContext(NonCancellable)` in `retryMediaUploadSessionCompletion` protects the replay body but not the resume boundary: when the block suspends and the outer job is cancelled meanwhile, the resumption of `withContext` can itself throw `CancellationException`. That throw was converted into `MediaUploadCompletionTerminalException(INTERRUPTED)`, `processClaimedUpload` called `recordUploadFailure`, and the DAO rewrote the row to `failed` on top of the `succeeded` that had already been committed.

This is not only a test problem: an upload worker cancelled just after a durable completion marked a successfully uploaded asset as failed.

## Change

- Track the durable local disposition in `retryMediaUploadSessionCompletion` and rethrow cancellation unchanged once it is committed, instead of wrapping it in a terminal failure. `processClaimedUpload` then unwinds without recording a failure and without aborting the session.
- Guard both failure-recording queries in `MediaTransferDao` with `AND status != :succeededStatus`, so a failure write can never move a `succeeded` transfer back to `failed` or `queued`. This also covers the sibling race where the cancellation surfaces inside Room's own resume boundary after the transaction committed.

`updateMediaTransferStatus` stays unguarded; `persistSuccessfulUpload` is its only caller and it writes the success itself.

## Validation

No local Gradle or emulator run: that is resource-heavy and gated on explicit permission in this repository. Compile and unit-test validation come from `Android PR`; the emulator suite still runs post-merge on `Android CI`.

No test changes and no new unit tests. The existing instrumentation test encodes the contract and the production code now satisfies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)