### PR TITLE
Gate Android pull requests on data:local instrumentation

### DIFF
--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -29,5 +29,5 @@ jobs:
       # merge result rather than the branch tip and gates on what will actually land on main.
       target_ref: ${{ github.sha }}
       android_version_code: ${{ github.run_number }}
-      run_data_local_instrumentation: false
+      run_data_local_instrumentation: true
     secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ For the optional private analytical DB access path, granted reporting permission
 
 Pushes to `main` use three independent release streams: AWS/web, Android, and iOS.
 Pull-request checks stay deliberately light and fast: do not add heavy mobile build or test jobs to pull-request workflows.
-The `Android PR` build, unit test, and lint run in `.github/workflows/android-pr.yml` (about 5 minutes) is an accepted exception and stays; the heavier emulator and Firebase Test Lab suites stay out of pull requests.
+The `Android PR` build, unit test, lint, and GitHub-hosted `data:local` emulator instrumentation run in `.github/workflows/android-pr.yml` (about 12 minutes) is an accepted exception and stays; the Firebase Test Lab managed-device suite stays out of pull requests.
 Nothing compiles iOS before merge by design, though `PR Checks` still runs the static iOS checks.
 Swift builds and tests run in Xcode Cloud, whose workflow definitions live in App Store Connect; its in-repo build inputs are documented in [docs/ios-ci-cd.md](docs/ios-ci-cd.md).
 Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -199,7 +199,7 @@ The repository policy for Android CI/CD is:
 - Firebase Test Lab is the cloud device test runner
 - `cloudbuild.android.yaml` is the Google-native Cloud Build entrypoint
 - Google auth from GitHub must use Workload Identity Federation, not a JSON key
-- automatic Android CI on `main` runs unit tests, debug builds, lint, and GitHub-hosted `data:local` instrumentation without uploading to Google Play or submitting Firebase Test Lab
+- Android pull requests and automatic Android CI on `main` both run unit tests, debug builds, lint, and GitHub-hosted `data:local` instrumentation without uploading to Google Play or submitting Firebase Test Lab
 - the manual `Android Release` workflow runs the same GitHub-hosted Android gate, submits Firebase Test Lab app instrumentation, then uploads a Google Play production-track draft
 - one shared `ANDROID_VERSION_CODE` is resolved once per release run and reused across Android release artifacts and the Play draft bundle
 - one shared manager-readable release identifier, currently `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`, is reused in the Play release name and Firebase Test Lab result naming so the same release stays traceable across GitHub, Play, and Firebase

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -1,9 +1,10 @@
 # Android CI/CD
 
-This repository uses one reusable Android validation workflow plus separate automatic CI and manual release entry workflows:
+This repository uses one reusable Android validation workflow plus three entry workflows: automatic pull request, automatic `push main`, and manual release:
 
 - GitHub Actions is the primary Android CI/CD entrypoint on `main`
 - `.github/workflows/android-ci-reusable.yml` contains the actual Android CI implementation
+- `.github/workflows/android-pr.yml` is the automatic pull-request Android validation workflow
 - `.github/workflows/android-ci.yml` is the automatic `push main` Android validation workflow
 - `.github/workflows/android-release.yml` is the manual Android release workflow
 - Firebase Test Lab runs only from the manual release workflow on Google-managed devices
@@ -60,6 +61,14 @@ This Android-specific sync is separate from the AWS deploy bootstrap script `bas
 
 ## What runs
 
+Pull-request GitHub Actions workflow: `.github/workflows/android-pr.yml`
+
+- Starts on `pull_request` when Android-impacting files change, excluding `apps/android/README.md` and `apps/android/docs/**`
+- Calls `.github/workflows/android-ci-reusable.yml` for the pull-request merge commit, so the gate covers what will actually land on `main`
+- Runs the GitHub-hosted `data:local` emulator instrumentation gate, so a failing `data:local` test fails the pull request first; the same suite still runs on `main` after merge
+- Does not upload a Google Play draft
+- Does not submit Firebase Test Lab
+
 Automatic GitHub Actions workflow: `.github/workflows/android-ci.yml`
 
 - Starts on `push main` when Android-impacting files change
@@ -88,6 +97,13 @@ Top-level release workflow Firebase job: `.github/workflows/android-release.yml`
 - Validates Firebase Test Lab configuration, authenticates to Google Cloud, downloads the debug APK artifacts, and submits the full app instrumentation package `com.flashcardsopensourceapp.app`, excluding `com.flashcardsopensourceapp.app.ManualOnlyAndroidTest`
 - Reuses the shared release identifier `vc<versionCode>-r<runId>a<attempt>-s<shortSha>` in Firebase result naming and traces results under `${ANDROID_FTL_RESULTS_DIR}/<releaseIdentifier>`
 - Requires Firebase Test Lab submission before the Play draft upload starts; the submission is asynchronous, so review the Firebase matrix result before publishing from Play Console
+
+The pull-request Android flow is:
+
+1. `android-pr.yml` starts on `pull_request` for Android-impacting changes and validates the pull-request merge commit
+2. It runs the same GitHub-hosted gate as `Android CI`: unit tests, debug builds, and lint first, then `data:local` instrumentation on the emulator once the build job succeeds
+3. The `android-pr-<pull request number>` concurrency group cancels superseded runs, so a new push replaces the in-flight emulator run instead of queueing another one
+4. The workflow stops there: no Firebase Test Lab submission and no Google Play draft upload
 
 The automatic Android CI flow is:
 


### PR DESCRIPTION
## Problem

`.github/workflows/android-pr.yml` passed `run_data_local_instrumentation: false`, so the GitHub-hosted `data:local` emulator suite only ran from `android-ci.yml` (push to `main`) and `android-release.yml`. A test added in a pull request was therefore first executed after merge.

That is how the flaky `LocalMediaUploadTransferRepositoryCompletionRetryTest` case reached `main`: both the PR that added it and the PR that fixed it merged without ever running it. In `android-release.yml`, `firebase_test_lab_submission` requires `needs.android_ci.result == 'success'` and the Play draft upload requires both, so that single test skipped the Play draft upload entirely in run 30619486018.

## Change

- `android-pr.yml` now passes `run_data_local_instrumentation: true`, so the emulator gate runs on Android pull requests against the merge commit.
- `docs/android-ci-cd.md` documents the pull-request workflow and flow alongside the existing `main` and release ones.
- `AGENTS.md` previously stated that the emulator suite stays out of pull requests, which this change makes false; updated. `CLAUDE.md` is a symlink to it.
- `apps/android/README.md` policy bullet updated.

The suite still runs on `main` after merge — this adds a pre-merge gate, it does not move the existing one.

## Cost

Android pull-request feedback grows from about 7 minutes to about 12 minutes, since the emulator job `needs: build`. Deliberate trade.

Deliberately not done: no retries around the instrumentation step, no `continue-on-error`, and no loosening of `android-release.yml`. All three would hide the class of defect this gate exists to surface.

## Validation

This PR edits `.github/workflows/android-pr.yml`, which is in its own trigger path list, so the new `Android PR / Android emulator data:local instrumentation` job runs on this PR and self-validates the change. The race that made that suite flaky was fixed in #1183, already merged, and `Android CI` on `main` is green for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)