### PR TITLE
Run Android PR gate only for pull requests to main

### DIFF
--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -2,6 +2,7 @@ name: Android PR
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - 'apps/android/**'
       - '!apps/android/README.md'

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -63,7 +63,7 @@ This Android-specific sync is separate from the AWS deploy bootstrap script `bas
 
 Pull-request GitHub Actions workflow: `.github/workflows/android-pr.yml`
 
-- Starts on `pull_request` when Android-impacting files change, excluding `apps/android/README.md` and `apps/android/docs/**`
+- Starts on `pull_request` targeting `main` when Android-impacting files change, excluding `apps/android/README.md` and `apps/android/docs/**`
 - Calls `.github/workflows/android-ci-reusable.yml` for the pull-request merge commit, so the gate covers what will actually land on `main`
 - Runs the GitHub-hosted `data:local` emulator instrumentation gate, so a failing `data:local` test fails the pull request first; the same suite still runs on `main` after merge
 - Does not upload a Google Play draft
@@ -100,7 +100,7 @@ Top-level release workflow Firebase job: `.github/workflows/android-release.yml`
 
 The pull-request Android flow is:
 
-1. `android-pr.yml` starts on `pull_request` for Android-impacting changes and validates the pull-request merge commit
+1. `android-pr.yml` starts on `pull_request` targeting `main` for Android-impacting changes and validates the pull-request merge commit
 2. It runs the same GitHub-hosted gate as `Android CI`: unit tests, debug builds, and lint first, then `data:local` instrumentation on the emulator once the build job succeeds
 3. The `android-pr-<pull request number>` concurrency group cancels superseded runs, so a new push replaces the in-flight emulator run instead of queueing another one
 4. The workflow stops there: no Firebase Test Lab submission and no Google Play draft upload


### PR DESCRIPTION
## Summary

The `Android PR` workflow (~12 minutes: build, unit tests, lint, and the GitHub-hosted `data:local` emulator instrumentation) was already limited to Android-impacting paths, but fired on pull requests into **any** base branch. This adds `branches: [main]` so both conditions must hold.

Intermediate pull requests — stacked branches, or the per-item pull requests in an integration/epic branch queue — get revalidated by the promotion pull request into `main`, so the emulator run there was duplicated work.

The gate that matters is unchanged: every commit still passes a `main`-base pull request before landing, and `Android CI` on `push main` remains the backstop.

## Changes

- `.github/workflows/android-pr.yml`: add `branches: [main]` to the `pull_request` trigger
- `docs/android-ci-cd.md`: document the base-branch condition in both places that describe the trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)