### PR TITLE
Recreate Android test graph after logout

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
@@ -47,6 +47,8 @@ internal fun resetAndroidTestAppState() {
             clearTestOnlySharedPreferences(context = context)
             application.recreateAppGraphAndAwaitStartup()
             application.appGraph.cloudAccountRepository.logout()
+            application.closeAppGraph()
+            application.recreateAppGraphAndAwaitStartup()
         }
     }
     NotificationManagerCompat.from(context).cancelAll()


### PR DESCRIPTION
## Summary
- close the Android instrumentation app graph after logout
- recreate and await a fresh graph from post-logout persistent state

## Validation
- `git --no-pager diff --check`
- fresh independent review: no P0-P4 findings
- Gradle and instrumentation intentionally deferred to CI per repository policy