### PR TITLE
Stabilize Android AI focus instrumentation tests

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -1,11 +1,9 @@
 package com.flashcardsopensourceapp.app
 
-import android.os.SystemClock
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasClickAction
@@ -33,8 +31,6 @@ import com.flashcardsopensourceapp.app.support.AppStateResetRule
 import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.feature.ai.R as AiFeatureR
-import com.flashcardsopensourceapp.feature.ai.aiComposerMessageFieldTag
-import com.flashcardsopensourceapp.feature.ai.aiConversationLoadingTag
 import com.flashcardsopensourceapp.feature.ai.aiConversationSurfaceTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorBackSummaryCardTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorBackTextFieldTag
@@ -91,8 +87,6 @@ import org.junit.runner.RunWith
 class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     companion object {
         private const val uiTimeoutMillis: Long = 20_000L
-        private const val aiConversationReadyStableMillis: Long = 1_500L
-        private const val aiComposerFocusAttemptMillis: Long = 2_000L
         private const val settingsBackStackPopLimit: Int = 6
         private const val emptyCardsMessage: String = "No cards yet. Tap the add button to create the first card."
     }
@@ -194,26 +188,6 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         openAiTabAndAssertConsentGate()
         acceptAiConsentAndWaitForConversationSurface()
         composeRule.onNodeWithTag(aiConversationSurfaceTag).fetchSemanticsNode()
-    }
-
-    @Test
-    fun aiConversationSurfaceTapClearsComposerFocus() {
-        waitForCardsEmptyState()
-
-        openAiTabAndAssertConsentGate()
-        acceptAiConsentAndWaitForConversationReady()
-
-        focusAiComposerAndWaitUntilFocused()
-        assertTrue(
-            "Expected the AI composer to be focused before dismissing focus.",
-            aiComposerFocusStateOrNull() == true
-        )
-
-        dismissComposerFocusBySurfaceTapAndWaitUntilNotFocused()
-        assertTrue(
-            "Expected tapping the AI conversation surface to clear the composer focus.",
-            aiComposerFocusStateOrNull() == false
-        )
     }
 
     @Test
@@ -595,160 +569,11 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         waitForAiConversationSurface()
     }
 
-    private fun acceptAiConsentAndWaitForConversationReady() {
-        composeRule.onNodeWithText(aiString(AiFeatureR.string.ai_consent_accept)).performClick()
-        waitForAiConversationReady()
-    }
-
     private fun waitForAiConversationSurface() {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             composeRule.onAllNodesWithText(aiString(AiFeatureR.string.ai_consent_title)).fetchSemanticsNodes().isEmpty() &&
                 countNodesWithTagInAnySemanticsTree(tag = aiConversationSurfaceTag) > 0
         }
-    }
-
-    private fun dismissComposerFocusBySurfaceTapAndWaitUntilNotFocused() {
-        val deadlineMillis: Long = SystemClock.elapsedRealtime() + uiTimeoutMillis
-        while (SystemClock.elapsedRealtime() < deadlineMillis) {
-            try {
-                composeRule.onNodeWithTag(aiConversationSurfaceTag).performClick()
-            } catch (_: AssertionError) {
-                // performClick can fail to inject the tap while the soft-keyboard
-                // show/hide animation is still settling on slow managed devices
-                // ("Failed to inject touch input."); retry until the surface is stable.
-            }
-            composeRule.waitForIdle()
-            if (
-                countNodesWithTagInAnySemanticsTree(tag = aiComposerMessageFieldTag) > 0 &&
-                aiComposerFocusStateOrNull() == false
-            ) {
-                return
-            }
-        }
-        throw AssertionError(
-            "Tapping the AI conversation surface did not clear the composer focus."
-        )
-    }
-
-    private fun waitForAiConversationReady() {
-        waitUntilAiConversationReadyIsStable(timeoutMillis = uiTimeoutMillis)
-    }
-
-    private fun focusAiComposerAndWaitUntilFocused() {
-        val deadlineMillis: Long = SystemClock.elapsedRealtime() + uiTimeoutMillis
-        var lastFocusState: Boolean? = null
-
-        while (SystemClock.elapsedRealtime() < deadlineMillis) {
-            waitUntilAiConversationReadyIsStable(timeoutMillis = remainingTimeoutMillis(deadlineMillis = deadlineMillis))
-            composeRule.onNodeWithTag(aiComposerMessageFieldTag).performClick()
-            composeRule.waitForIdle()
-
-            if (
-                waitUntilAiComposerFocusedOrConversationInterrupted(
-                    timeoutMillis = minOf(
-                        aiComposerFocusAttemptMillis,
-                        remainingTimeoutMillis(deadlineMillis = deadlineMillis)
-                    )
-                )
-            ) {
-                return
-            }
-
-            lastFocusState = aiComposerFocusStateOrNull()
-        }
-
-        throw AssertionError(
-            "AI composer did not become focused after retrying while the conversation was ready. " +
-                "LastFocusState=$lastFocusState " +
-                "LoadingNodes=${countNodesWithTagInAnySemanticsTree(tag = aiConversationLoadingTag)} " +
-                "ComposerNodes=${countNodesWithTagInAnySemanticsTree(tag = aiComposerMessageFieldTag)}"
-        )
-    }
-
-    private fun waitUntilAiComposerFocusedOrConversationInterrupted(timeoutMillis: Long): Boolean {
-        if (timeoutMillis <= 0L) {
-            return false
-        }
-
-        var wasInterrupted: Boolean = false
-        return try {
-            composeRule.waitUntil(timeoutMillis = timeoutMillis) {
-                val isFocused: Boolean = aiComposerFocusStateOrNull() == true
-                if (isFocused) {
-                    true
-                } else {
-                    val isInterrupted: Boolean = aiConversationIsReady().not()
-                    wasInterrupted = isInterrupted
-                    isInterrupted
-                }
-            }
-            wasInterrupted.not() && aiComposerFocusStateOrNull() == true
-        } catch (_: ComposeTimeoutException) {
-            false
-        }
-    }
-
-    private fun waitUntilAiConversationReadyIsStable(timeoutMillis: Long) {
-        var readySinceMillis: Long? = null
-        composeRule.waitUntil(timeoutMillis = timeoutMillis) {
-            val nowMillis: Long = SystemClock.elapsedRealtime()
-            if (aiConversationIsReady()) {
-                if (readySinceMillis == null) {
-                    readySinceMillis = nowMillis
-                }
-                nowMillis - checkNotNull(readySinceMillis) >= aiConversationReadyStableMillis
-            } else {
-                readySinceMillis = null
-                false
-            }
-        }
-    }
-
-    private fun aiConversationIsReady(): Boolean {
-        val consentGateIsHidden: Boolean = composeRule
-            .onAllNodesWithText(aiString(AiFeatureR.string.ai_consent_title))
-            .fetchSemanticsNodes()
-            .isEmpty()
-
-        return consentGateIsHidden &&
-            countNodesWithTagInAnySemanticsTree(tag = aiConversationLoadingTag) == 0 &&
-            countNodesWithTagInAnySemanticsTree(tag = aiConversationSurfaceTag) > 0 &&
-            aiComposerIsEditable()
-    }
-
-    private fun aiComposerIsEditable(): Boolean {
-        val mergedNode = composeRule.onAllNodesWithTag(aiComposerMessageFieldTag)
-            .fetchSemanticsNodes()
-            .firstOrNull()
-        if (mergedNode != null) {
-            return mergedNode.config.contains(SemanticsProperties.Disabled).not()
-        }
-
-        val unmergedNode = composeRule.onAllNodesWithTag(aiComposerMessageFieldTag, useUnmergedTree = true)
-            .fetchSemanticsNodes()
-            .firstOrNull()
-        return unmergedNode != null && unmergedNode.config.contains(SemanticsProperties.Disabled).not()
-    }
-
-    private fun remainingTimeoutMillis(deadlineMillis: Long): Long {
-        return deadlineMillis - SystemClock.elapsedRealtime()
-    }
-
-    private fun aiComposerFocusStateOrNull(): Boolean? {
-        val mergedFocusState: Boolean? = composeRule.onAllNodesWithTag(aiComposerMessageFieldTag)
-            .fetchSemanticsNodes()
-            .firstOrNull()
-            ?.config
-            ?.getOrNull(SemanticsProperties.Focused)
-        if (mergedFocusState != null) {
-            return mergedFocusState
-        }
-
-        return composeRule.onAllNodesWithTag(aiComposerMessageFieldTag, useUnmergedTree = true)
-            .fetchSemanticsNodes()
-            .firstOrNull()
-            ?.config
-            ?.getOrNull(SemanticsProperties.Focused)
     }
 
     private fun countNodesWithTagInAnySemanticsTree(tag: String): Int {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsFocused
@@ -399,6 +401,59 @@ class AiRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         )
         composeRule.onNodeWithTag(aiComposerMessageFieldTag).assertIsNotFocused()
         assertTrue(didSend)
+    }
+
+    @Test
+    fun conversationSurfaceTapClearsComposerFocus() {
+        composeRule.setContent {
+            FlashcardsTheme {
+                AiRoute(
+                    uiState = makeAiUiState(),
+                    onAcceptConsent = {},
+                    onDraftMessageChange = {},
+                    onApplyComposerSuggestion = {},
+                    onSendMessage = {},
+                    onCancelStreaming = {},
+                    onNewChat = {},
+                    onOpenAccountStatus = {},
+                    onDismissErrorMessage = {},
+                    onDismissAlert = {},
+                    onAddPendingAttachment = {},
+                    onRemovePendingAttachment = {},
+                    onStartDictationPermissionRequest = {},
+                    onStartDictationRecording = {},
+                    onTranscribeRecordedAudio = { _, _, _ -> },
+                    onCancelDictation = {},
+                    onScreenVisible = {},
+                    onScreenHidden = {},
+                    onWarmUpSessionIfNeeded = {},
+                    onRetryConversationLoad = {},
+                    onShowAlert = {},
+                    onShowErrorMessage = {},
+                    technicalErrorController = NoOpTechnicalErrorController
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(aiComposerMessageFieldTag).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000L) {
+            composeRule.onAllNodesWithTag(aiComposerMessageFieldTag)
+                .fetchSemanticsNodes()
+                .singleOrNull()
+                ?.config
+                ?.getOrNull(SemanticsProperties.Focused) == true
+        }
+        composeRule.onNodeWithTag(aiComposerMessageFieldTag).assertIsFocused()
+
+        composeRule.onNodeWithTag(aiConversationSurfaceTag).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000L) {
+            composeRule.onAllNodesWithTag(aiComposerMessageFieldTag)
+                .fetchSemanticsNodes()
+                .singleOrNull()
+                ?.config
+                ?.getOrNull(SemanticsProperties.Focused) == false
+        }
+        composeRule.onNodeWithTag(aiComposerMessageFieldTag).assertIsNotFocused()
     }
 
     @Test

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
@@ -47,6 +47,8 @@ internal fun resetAndroidTestAppState() {
             clearTestOnlySharedPreferences(context = context)
             application.recreateAppGraphAndAwaitStartup()
             application.appGraph.cloudAccountRepository.logout()
+            application.closeAppGraph()
+            application.recreateAppGraphAndAwaitStartup()
         }
     }
     NotificationManagerCompat.from(context).cancelAll()


### PR DESCRIPTION
## Summary
- recreate the Android instrumentation app graph after logout
- test AI composer focus behavior at the AiRoute boundary
- retain the full-app AI consent and conversation smoke flow

## Validation
- item PR checks passed for #1186 and #1187
- accumulated promotion review passed with no P0-P4 findings
- Android PR CI is the authoritative build, lint, test, and instrumentation gate