### PR TITLE
Add iOS settings feedback links

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -48,6 +48,8 @@ enum UITestIdentifier {
     static let settingsScreen: String = "settings.screen"
     static let settingsInviteFriendButton: String = "settings.inviteFriendButton"
     static let settingsShareAppRow: String = "settings.shareAppRow"
+    static let settingsReviewInAppStoreRow: String = "settings.reviewInAppStoreRow"
+    static let settingsPrivateFeedbackRow: String = "settings.privateFeedbackRow"
     static let settingsAccountStatusRow: String = "settings.accountStatusRow"
     static let settingsCurrentWorkspaceRow: String = "settings.currentWorkspaceRow"
     static let settingsReviewRemindersRow: String = "settings.reviewRemindersRow"

--- a/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
@@ -48,6 +48,13 @@ let flashcardsAppShareUrl: URL = {
     }
     return url
 }()
+let flashcardsAppStoreUrl: URL = {
+    let urlString: String = "https://apps.apple.com/app/id6760538964"
+    guard let url = URL(string: urlString) else {
+        preconditionFailure("Flashcards App Store URL is invalid: \(urlString)")
+    }
+    return url
+}()
 
 var flashcardsPrivacyPolicyUrl: String {
     flashcardsLegalSupportConfiguration.privacyPolicyUrl

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -64,6 +64,28 @@ struct SettingsView: View {
                 .accessibilityIdentifier(UITestIdentifier.settingsShareAppRow)
             }
 
+            Section(aiSettingsLocalized("settings.section.feedback", "Feedback")) {
+                Link(destination: flashcardsAppStoreUrl) {
+                    SettingsNavigationRow(
+                        title: aiSettingsLocalized("settings.row.reviewInAppStore", "Review in App Store"),
+                        value: nil,
+                        systemImage: "star",
+                        attentionCount: nil
+                    )
+                }
+                .accessibilityIdentifier(UITestIdentifier.settingsReviewInAppStoreRow)
+
+                NavigationLink(value: SettingsNavigationDestination.feedback) {
+                    SettingsNavigationRow(
+                        title: aiSettingsLocalized("settings.row.sharePrivateFeedback", "Share private feedback"),
+                        value: nil,
+                        systemImage: "text.bubble",
+                        attentionCount: nil
+                    )
+                }
+                .accessibilityIdentifier(UITestIdentifier.settingsPrivateFeedbackRow)
+            }
+
             Section(aiSettingsLocalized("settings.section.account", "Account")) {
                 NavigationLink(value: SettingsNavigationDestination.accountStatus) {
                     SettingsNavigationRow(

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "دعوة صديق";
 "settings.section.share" = "مشاركة";
 "settings.row.shareApp" = "مشاركة Flashcards";
+"settings.section.feedback" = "الملاحظات";
+"settings.row.reviewInAppStore" = "قيّم التطبيق في App Store";
+"settings.row.sharePrivateFeedback" = "شارك ملاحظاتك بشكل خاص";
 "settings.section.account" = "الحساب";
 "settings.section.general" = "عام";
 "settings.section.support" = "الدعم";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "Freund einladen";
 "settings.section.share" = "Teilen";
 "settings.row.shareApp" = "Flashcards teilen";
+"settings.section.feedback" = "Feedback";
+"settings.row.reviewInAppStore" = "Im App Store bewerten";
+"settings.row.sharePrivateFeedback" = "Privates Feedback teilen";
 "settings.section.account" = "Konto";
 "settings.section.general" = "Allgemein";
 "settings.section.support" = "Support";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "Invitar amigo";
 "settings.section.share" = "Compartir";
 "settings.row.shareApp" = "Compartir Flashcards";
+"settings.section.feedback" = "Comentarios";
+"settings.row.reviewInAppStore" = "Valorar en App Store";
+"settings.row.sharePrivateFeedback" = "Compartir comentarios en privado";
 "settings.section.account" = "Cuenta";
 "settings.section.general" = "General";
 "settings.section.support" = "Soporte";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "Invitar amigo";
 "settings.section.share" = "Compartir";
 "settings.row.shareApp" = "Compartir Flashcards";
+"settings.section.feedback" = "Comentarios";
+"settings.row.reviewInAppStore" = "Calificar en App Store";
+"settings.row.sharePrivateFeedback" = "Compartir comentarios en privado";
 "settings.section.account" = "Cuenta";
 "settings.section.general" = "General";
 "settings.section.support" = "Soporte";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "दोस्त को आमंत्रित करें";
 "settings.section.share" = "साझा करें";
 "settings.row.shareApp" = "Flashcards साझा करें";
+"settings.section.feedback" = "प्रतिक्रिया";
+"settings.row.reviewInAppStore" = "App Store पर समीक्षा करें";
+"settings.row.sharePrivateFeedback" = "निजी प्रतिक्रिया साझा करें";
 "settings.section.account" = "खाता";
 "settings.section.general" = "सामान्य";
 "settings.section.support" = "सहायता";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "友達を招待";
 "settings.section.share" = "共有";
 "settings.row.shareApp" = "Flashcardsを共有";
+"settings.section.feedback" = "フィードバック";
+"settings.row.reviewInAppStore" = "App Storeでレビューする";
+"settings.row.sharePrivateFeedback" = "非公開のフィードバックを共有";
 "settings.section.account" = "アカウント";
 "settings.section.general" = "一般";
 "settings.section.support" = "サポート";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "Пригласить друга";
 "settings.section.share" = "Поделиться";
 "settings.row.shareApp" = "Поделиться Flashcards";
+"settings.section.feedback" = "Обратная связь";
+"settings.row.reviewInAppStore" = "Оставить отзыв в App Store";
+"settings.row.sharePrivateFeedback" = "Отправить личный отзыв";
 "settings.section.account" = "Аккаунт";
 "settings.section.general" = "Общие";
 "settings.section.support" = "Поддержка";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -132,6 +132,9 @@
 "settings.inviteFriend.button" = "邀请朋友";
 "settings.section.share" = "分享";
 "settings.row.shareApp" = "分享 Flashcards";
+"settings.section.feedback" = "反馈";
+"settings.row.reviewInAppStore" = "在 App Store 中评价";
+"settings.row.sharePrivateFeedback" = "私下分享反馈";
 "settings.section.account" = "账户";
 "settings.section.general" = "通用";
 "settings.section.support" = "支持";

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSettingsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSettingsTests.swift
@@ -29,7 +29,17 @@ final class LiveSmokeSettingsTests: LiveSmokeTestCase {
 
     @MainActor
     private func verifySettingsInformationArchitecture() throws {
-        try self.assertTextExists("Account", timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        try self.assertTextExists("Feedback", timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.settingsReviewInAppStoreRow,
+            timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+        )
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.settingsPrivateFeedbackRow,
+            timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+        )
+
+        try self.assertTextExistsScrollingIntoView("Account", timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
         try self.openSettingsRootRow(identifier: LiveSmokeIdentifier.settingsAccountStatusRow)
         try self.assertElementExists(
             identifier: LiveSmokeIdentifier.accountStatusSignInButton,

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -25,6 +25,8 @@ enum LiveSmokeIdentifier {
     static let progressLeaderboardSection: String = "progress.leaderboardSection"
     static let cardsScreen: String = "cards.screen"
     static let settingsScreen: String = "settings.screen"
+    static let settingsReviewInAppStoreRow: String = "settings.reviewInAppStoreRow"
+    static let settingsPrivateFeedbackRow: String = "settings.privateFeedbackRow"
     static let settingsAccountStatusRow: String = "settings.accountStatusRow"
     static let settingsCurrentWorkspaceRow: String = "settings.currentWorkspaceRow"
     static let settingsReviewRemindersRow: String = "settings.reviewRemindersRow"


### PR DESCRIPTION
## Summary
- add a Feedback section after Share in iOS Settings
- link to the App Store listing and reuse the private feedback flow
- localize the new rows and align UI smoke identifiers

## Validation
- localization `plutil -lint` for all eight supported non-English locales
- localization key presence audit
- `git diff --check`
- independent review: no P0-P4 findings

Simulator-backed tests were not run because permission was not granted.