### PR TITLE
feat(web): add settings feedback links

### DIFF
--- a/apps/web/e2e/live-smoke/flows/settings-ia.ts
+++ b/apps/web/e2e/live-smoke/flows/settings-ia.ts
@@ -81,6 +81,8 @@ const settingsDetailTargets: ReadonlyArray<SettingsDetailTarget> = [
 ];
 
 const rootRowTestIds: ReadonlyArray<string> = [
+  "settings-row-review-app-store",
+  "settings-row-private-feedback",
   "settings-row-account-status",
   "settings-row-current-workspace",
   "settings-row-review-reminders",
@@ -117,7 +119,7 @@ async function assertSettingsRootTree(session: LiveSmokeSession): Promise<void> 
   const { page, diagnostics } = session;
   await openSettingsRoot(session, "open Settings for IA verification");
 
-  for (const groupLabel of ["Account", "General", "Support", "Advanced"]) {
+  for (const groupLabel of ["Feedback", "Account", "General", "Support", "Advanced"]) {
     await trackedExpectVisible(
       diagnostics,
       `confirm Settings group ${groupLabel} is visible`,

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -386,6 +386,7 @@ const arCatalog: TranslationCatalog = {
     },
     groups: {
       share: "مشاركة",
+      feedback: "الملاحظات",
       account: "الحساب",
       general: "عام",
       support: "الدعم",
@@ -399,6 +400,14 @@ const arCatalog: TranslationCatalog = {
       shareText: "افتح Flashcards على iOS أو Android أو الويب.",
       shared: "تم فتح نافذة المشاركة.",
       shareUnavailable: "المشاركة غير متاحة في هذا المتصفح.",
+    },
+    reviewAppStore: {
+      title: "قيّم في App Store",
+      description: "قيّم Flashcards في صفحة التطبيق على App Store.",
+    },
+    privateFeedback: {
+      title: "شارك ملاحظاتك بشكل خاص",
+      description: "أرسل ملاحظاتك مباشرةً إلى فريق Flashcards.",
     },
     currentWorkspace: {
       title: "مساحة العمل",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -386,6 +386,7 @@ const deCatalog: TranslationCatalog = {
     },
     groups: {
       share: "Teilen",
+      feedback: "Feedback",
       account: "Konto",
       general: "Allgemein",
       support: "Support",
@@ -399,6 +400,14 @@ const deCatalog: TranslationCatalog = {
       shareText: "Öffne Flashcards auf iOS, Android oder im Web.",
       shared: "Teilen-Dialog geöffnet.",
       shareUnavailable: "Teilen ist in diesem Browser nicht verfügbar.",
+    },
+    reviewAppStore: {
+      title: "Im App Store bewerten",
+      description: "Bewerte Flashcards auf der Produktseite im App Store.",
+    },
+    privateFeedback: {
+      title: "Privates Feedback teilen",
+      description: "Sende Feedback direkt an das Flashcards-Team.",
     },
     currentWorkspace: {
       title: "Arbeitsbereich",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -384,6 +384,7 @@ const enCatalog = {
     },
     groups: {
       share: "Share",
+      feedback: "Feedback",
       account: "Account",
       general: "General",
       support: "Support",
@@ -397,6 +398,14 @@ const enCatalog = {
       shareText: "Open Flashcards on iOS, Android, or the web.",
       shared: "Share sheet opened.",
       shareUnavailable: "Sharing is not available in this browser.",
+    },
+    reviewAppStore: {
+      title: "Review in App Store",
+      description: "Rate Flashcards on its App Store listing.",
+    },
+    privateFeedback: {
+      title: "Share private feedback",
+      description: "Send feedback directly to the Flashcards team.",
     },
     currentWorkspace: {
       title: "Workspace",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -386,6 +386,7 @@ const esEsCatalog: TranslationCatalog = {
     },
     groups: {
       share: "Compartir",
+      feedback: "Comentarios",
       account: "Cuenta",
       general: "General",
       support: "Soporte",
@@ -399,6 +400,14 @@ const esEsCatalog: TranslationCatalog = {
       shareText: "Abre Flashcards en iOS, Android o la web.",
       shared: "Hoja para compartir abierta.",
       shareUnavailable: "La opción de compartir no está disponible en este navegador.",
+    },
+    reviewAppStore: {
+      title: "Valorar en App Store",
+      description: "Valora Flashcards en su ficha de App Store.",
+    },
+    privateFeedback: {
+      title: "Compartir comentarios en privado",
+      description: "Envía tus comentarios directamente al equipo de Flashcards.",
     },
     currentWorkspace: {
       title: "Espacio de trabajo",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -386,6 +386,7 @@ const esMxCatalog: TranslationCatalog = {
     },
     groups: {
       share: "Compartir",
+      feedback: "Comentarios",
       account: "Cuenta",
       general: "General",
       support: "Soporte",
@@ -399,6 +400,14 @@ const esMxCatalog: TranslationCatalog = {
       shareText: "Abre Flashcards en iOS, Android o la web.",
       shared: "Se abrió la hoja para compartir.",
       shareUnavailable: "Compartir no está disponible en este navegador.",
+    },
+    reviewAppStore: {
+      title: "Calificar en App Store",
+      description: "Califica Flashcards en su ficha de App Store.",
+    },
+    privateFeedback: {
+      title: "Compartir comentarios privados",
+      description: "Envía tus comentarios directamente al equipo de Flashcards.",
     },
     currentWorkspace: {
       title: "Espacio de trabajo",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -386,6 +386,7 @@ const hiCatalog: TranslationCatalog = {
     },
     groups: {
       share: "शेयर करें",
+      feedback: "फ़ीडबैक",
       account: "खाता",
       general: "सामान्य",
       support: "सहायता",
@@ -399,6 +400,14 @@ const hiCatalog: TranslationCatalog = {
       shareText: "Flashcards को iOS, Android या वेब पर खोलें।",
       shared: "शेयर शीट खुल गई।",
       shareUnavailable: "इस ब्राउज़र में शेयरिंग उपलब्ध नहीं है।",
+    },
+    reviewAppStore: {
+      title: "App Store पर रिव्यू करें",
+      description: "App Store लिस्टिंग पर Flashcards को रेट करें।",
+    },
+    privateFeedback: {
+      title: "निजी फ़ीडबैक साझा करें",
+      description: "Flashcards टीम को सीधे फ़ीडबैक भेजें।",
     },
     currentWorkspace: {
       title: "वर्कस्पेस",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -386,6 +386,7 @@ export const jaCatalog = {
     },
     groups: {
       share: "共有",
+      feedback: "フィードバック",
       account: "アカウント",
       general: "一般",
       support: "サポート",
@@ -399,6 +400,14 @@ export const jaCatalog = {
       shareText: "Flashcards を iOS、Android、または Web で開きます。",
       shared: "共有シートを開きました。",
       shareUnavailable: "このブラウザでは共有を利用できません。",
+    },
+    reviewAppStore: {
+      title: "App Store でレビューする",
+      description: "App Store の製品ページで Flashcards を評価します。",
+    },
+    privateFeedback: {
+      title: "非公開のフィードバックを共有",
+      description: "Flashcards チームにフィードバックを直接送信します。",
     },
     currentWorkspace: {
       title: "ワークスペース",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -386,6 +386,7 @@ export const ruCatalog = {
     },
     groups: {
       share: "Поделиться",
+      feedback: "Обратная связь",
       account: "Аккаунт",
       general: "Общие",
       support: "Поддержка",
@@ -399,6 +400,14 @@ export const ruCatalog = {
       shareText: "Откройте Flashcards на iOS, Android или в вебе.",
       shared: "Окно отправки открыто.",
       shareUnavailable: "Отправка недоступна в этом браузере.",
+    },
+    reviewAppStore: {
+      title: "Оценить в App Store",
+      description: "Оцените Flashcards на странице приложения в App Store.",
+    },
+    privateFeedback: {
+      title: "Отправить личный отзыв",
+      description: "Отправьте отзыв напрямую команде Flashcards.",
     },
     currentWorkspace: {
       title: "Рабочее пространство",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -386,6 +386,7 @@ export const zhHansCatalog = {
     },
     groups: {
       share: "分享",
+      feedback: "反馈",
       account: "账户",
       general: "通用",
       support: "支持",
@@ -399,6 +400,14 @@ export const zhHansCatalog = {
       shareText: "在 iOS、Android 或网页版打开 Flashcards。",
       shared: "分享面板已打开。",
       shareUnavailable: "此浏览器不支持分享。",
+    },
+    reviewAppStore: {
+      title: "在 App Store 中评价",
+      description: "在 App Store 产品页为 Flashcards 评分。",
+    },
+    privateFeedback: {
+      title: "分享私密反馈",
+      description: "直接向 Flashcards 团队发送反馈。",
     },
     currentWorkspace: {
       title: "工作区",

--- a/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
@@ -329,11 +329,13 @@ describe("SettingsScreen navigation", () => {
 
     expect(textContent()).toContain("Account");
     expect(textContent()).toContain("Share");
+    expect(textContent()).toContain("Feedback");
     expect(textContent()).toContain("General");
     expect(textContent()).toContain("Support");
     expect(textContent()).toContain("Advanced");
     expectGroupLabelNotClickable("Account");
     expectGroupLabelNotClickable("Share");
+    expectGroupLabelNotClickable("Feedback");
     expectGroupLabelNotClickable("General");
     expectGroupLabelNotClickable("Support");
     expectGroupLabelNotClickable("Advanced");
@@ -362,13 +364,18 @@ describe("SettingsScreen navigation", () => {
       "settings-row-reset-study-progress",
       "settings-row-delete-current-workspace",
       "settings-row-delete-account",
+      "settings-row-review-app-store",
+      "settings-row-private-feedback",
     ].forEach(expectRowVisible);
     expectRowVisible("settings-invite-open");
     expectRowVisible("settings-share-app-open");
     expect(getContainer().querySelector("[data-testid='settings-invite-open']")?.textContent).toBe("Invite friend");
     expect(rowIndex("settings-invite-open")).toBeLessThan(rowIndex("settings-row-account-status"));
     expect(rowIndex("settings-invite-open")).toBeLessThan(rowIndex("settings-share-app-open"));
-    expect(rowIndex("settings-share-app-open")).toBeLessThan(rowIndex("settings-row-account-status"));
+    expect(rowIndex("settings-share-app-open")).toBeLessThan(rowIndex("settings-group-feedback"));
+    expect(rowIndex("settings-group-feedback")).toBeLessThan(rowIndex("settings-row-review-app-store"));
+    expect(rowIndex("settings-row-review-app-store")).toBeLessThan(rowIndex("settings-row-private-feedback"));
+    expect(rowIndex("settings-row-private-feedback")).toBeLessThan(rowIndex("settings-row-account-status"));
     expect(rowIndex("settings-row-review-reminders")).toBeLessThan(rowIndex("settings-row-review-animations"));
     expect(rowIndex("settings-row-review-animations")).toBeLessThan(rowIndex("settings-row-ai-chat-suggestions"));
     expect(rowIndex("settings-row-ai-chat-suggestions")).toBeLessThan(rowIndex("settings-row-leaderboard-participation"));
@@ -475,10 +482,24 @@ describe("SettingsScreen navigation", () => {
     expect(currentPathname()).toBe(accountDangerZoneRoute);
   });
 
-  it("navigates the Send feedback row to the feedback settings screen", async () => {
+  it("navigates both feedback rows to the feedback settings screen", async () => {
     await renderSettingsScreen();
+
+    await clickRow("settings-row-private-feedback");
+    expect(currentPathname()).toBe(settingsFeedbackRoute);
+
     await clickRow("settings-row-feedback");
 
     expect(currentPathname()).toBe(settingsFeedbackRoute);
+  });
+
+  it("opens the locale-neutral App Store listing externally", async () => {
+    await renderSettingsScreen();
+
+    const reviewLink = getContainer().querySelector("[data-testid='settings-row-review-app-store']");
+    expect(reviewLink).toBeInstanceOf(HTMLAnchorElement);
+    expect(reviewLink?.getAttribute("href")).toBe("https://apps.apple.com/app/id6760538964");
+    expect(reviewLink?.getAttribute("target")).toBe("_blank");
+    expect(reviewLink?.getAttribute("rel")).toBe("noreferrer");
   });
 });

--- a/apps/web/src/screens/settings/SettingsScreen.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.tsx
@@ -42,10 +42,13 @@ import { useTestMode } from "../../testMode";
 import { FriendInviteCreateDialog } from "../friends/FriendInviteCreateDialog";
 import {
   SettingsActionCard,
+  SettingsExternalLinkCard,
   SettingsGroup,
   SettingsNavigationCard,
   SettingsShell,
 } from "./SettingsShared";
+
+const appStoreListingUrl = "https://apps.apple.com/app/id6760538964";
 
 type LocaleNameTranslationKey = `locale.names.${Locale}`;
 
@@ -182,6 +185,24 @@ export function SettingsScreen(): ReactElement {
             {shareErrorMessage}
           </p>
         )}
+      </SettingsGroup>
+
+      <SettingsGroup title={t("settingsHome.groups.feedback")} testId="settings-group-feedback">
+        <div className="settings-nav-list">
+          <SettingsExternalLinkCard
+            title={t("settingsHome.reviewAppStore.title")}
+            description={t("settingsHome.reviewAppStore.description")}
+            href={appStoreListingUrl}
+            testId="settings-row-review-app-store"
+          />
+          <SettingsNavigationCard
+            title={t("settingsHome.privateFeedback.title")}
+            description={t("settingsHome.privateFeedback.description")}
+            value={null}
+            to={settingsFeedbackRoute}
+            testId="settings-row-private-feedback"
+          />
+        </div>
       </SettingsGroup>
 
       <SettingsGroup title={t("settingsHome.groups.account")}>

--- a/apps/web/src/screens/settings/SettingsShared.tsx
+++ b/apps/web/src/screens/settings/SettingsShared.tsx
@@ -30,9 +30,17 @@ type SettingsActionCardProps = Readonly<{
   workspaceManagementState?: "locked" | "ready";
 }>;
 
+type SettingsExternalLinkCardProps = Readonly<{
+  title: string;
+  description: string;
+  href: string;
+  testId: string;
+}>;
+
 type SettingsGroupProps = Readonly<{
   title?: string;
   children: ReactNode;
+  testId?: string;
 }>;
 
 export function SettingsShell(props: SettingsShellProps): ReactElement {
@@ -93,11 +101,30 @@ export function SettingsActionCard(props: SettingsActionCardProps): ReactElement
   );
 }
 
-export function SettingsGroup(props: SettingsGroupProps): ReactElement {
-  const { title, children } = props;
+export function SettingsExternalLinkCard(props: SettingsExternalLinkCardProps): ReactElement {
+  const { title, description, href, testId } = props;
 
   return (
-    <section className="settings-group">
+    <a
+      className="settings-nav-card content-card"
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      data-testid={testId}
+    >
+      <div className="settings-nav-card-copy">
+        <strong className="panel-subtitle">{title}</strong>
+        <p className="subtitle">{description}</p>
+      </div>
+    </a>
+  );
+}
+
+export function SettingsGroup(props: SettingsGroupProps): ReactElement {
+  const { title, children, testId } = props;
+
+  return (
+    <section className="settings-group" data-testid={testId}>
       {title === undefined ? null : <h2 className="panel-subtitle">{title}</h2>}
       {children}
     </section>


### PR DESCRIPTION
## Summary
- add a Feedback section directly after Share in web Settings
- link to the locale-neutral App Store listing and reuse the private feedback route
- localize all supported web catalogs and update navigation/live-smoke coverage

## Validation
- `npx vitest run src/screens/settings/SettingsScreen.navigation.test.tsx` (9/9 passed)
- `npm run build`
- `git diff --check`

## Review
- fresh independent review: no P0-P4 findings; green light

## Note
- validation ran under Node 25.6.1 while the package declares Node 24.x; npm emitted an engine warning, but tests and build passed.