### PR TITLE
migrate.sh: run each migration file as a single transaction

### DIFF
--- a/scripts/deploy/migrate.sh
+++ b/scripts/deploy/migrate.sh
@@ -35,7 +35,16 @@ for f in "$ROOT_DIR"/db/migrations/*.sql; do
     continue
   fi
   echo "  Applying $BASENAME"
-  run_psql -v ON_ERROR_STOP=1 -f "$f"
+  # --single-transaction: several migrations rely on being run as one
+  # transaction per file — e.g. db/migrations/0035_sync_installations_and_
+  # workspace_replicas.sql's `ON COMMIT DROP` scratch temp tables (dropped
+  # before the next statement can use them without this), and org.workspaces'
+  # fk_workspaces_fsrs_last_modified_replica, which is DEFERRABLE INITIALLY
+  # DEFERRED specifically so a circular insert order across two tables can
+  # be checked once at commit instead of per statement. Without this flag,
+  # psql autocommits each statement individually and both patterns break on
+  # a from-scratch migrate run.
+  run_psql --single-transaction -v ON_ERROR_STOP=1 -f "$f"
   echo "INSERT INTO schema_migrations (filename) VALUES (:'fname')" | run_psql -v "fname=$BASENAME"
 done
 
@@ -69,7 +78,7 @@ WHERE EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'role_name')
 SQL
 fi
 
-run_psql -v "admin_emails=${ADMIN_EMAILS:-}" <<'SQL'
+run_psql --single-transaction -v "admin_emails=${ADMIN_EMAILS:-}" <<'SQL'
 CREATE TEMP TABLE desired_bootstrap_admins (
   email TEXT PRIMARY KEY
 ) ON COMMIT DROP;


### PR DESCRIPTION
## Summary
- `scripts/deploy/migrate.sh` runs each migration file with plain `psql -f`, which autocommits every statement individually. Two patterns already in the migration set assume the whole file runs as one transaction:
  - `db/migrations/0035_sync_installations_and_workspace_replicas.sql` uses `CREATE TEMP TABLE ... ON COMMIT DROP` as scratch space across several statements in the same file — without a wrapping transaction, the temp table is dropped the moment it's created, so the next statement fails with `relation "..." does not exist`.
  - `org.workspaces`' `fk_workspaces_fsrs_last_modified_replica` (formerly `fsrs_last_modified_by_device_id`) is `DEFERRABLE INITIALLY DEFERRED`, specifically so migration `0018`'s circular workspace↔device/replica insert order can be checked once at commit — that only works if both inserts share a transaction.
- Adds `--single-transaction` to the two `run_psql` call sites that need it (the per-migration-file loop, and the trailing `ADMIN_EMAILS` bootstrap heredoc). No individual migration file is touched.

## How I hit this
Followed `docs/architecture.md`'s local dev entrypoints (not the docker-compose path) against a genuinely empty database — `AUTH_MODE=none`, `MIGRATION_DATABASE_URL` pointed at a fresh `flashcards` db. Both failures above hit before the migration chain could complete; after this fix, all 100+ migrations and views apply cleanly from scratch.

## Test plan
- [x] Dropped and recreated an empty `flashcards` database, ran `bash scripts/deploy/migrate.sh` end to end — completes with no errors, `schema_migrations` shows every file applied.
- [x] Started `apps/backend` + `apps/web` locally against that database (`AUTH_MODE=none`) and confirmed the review flow loads (workspace bootstrap → sync pull → review-history pull all 200).