### PR TITLE
Extract shared web import presentation

### DIFF
--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportPresentation.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportPresentation.tsx
@@ -1,0 +1,214 @@
+import { Fragment, type ReactElement } from "react";
+import type {
+  WorkspaceImportOptions,
+  WorkspaceImportPresentationCopy,
+  WorkspaceImportPreviewModel,
+} from "./workspaceImportPresentationModel";
+
+type WorkspaceImportPresentationProps = Readonly<{
+  copy: WorkspaceImportPresentationCopy;
+  preview: WorkspaceImportPreviewModel | null;
+  options: WorkspaceImportOptions;
+  isControlDisabled: boolean;
+  canConfirm: boolean;
+  isConfirming: boolean;
+  unavailableMessage: string | null;
+  errorMessage: string;
+  successMessage: string;
+  onSelect: () => void;
+  onOptionsChange: (options: WorkspaceImportOptions) => void;
+  onConfirm: (options: WorkspaceImportOptions) => void;
+}>;
+
+type WorkspaceImportPreviewProps = Readonly<{
+  copy: WorkspaceImportPresentationCopy;
+  preview: WorkspaceImportPreviewModel;
+  options: WorkspaceImportOptions;
+  isControlDisabled: boolean;
+  onOptionsChange: (options: WorkspaceImportOptions) => void;
+}>;
+
+function updateImportTagEnabled(
+  options: WorkspaceImportOptions,
+  suggestedImportTag: string | null,
+  addImportTag: boolean,
+): WorkspaceImportOptions {
+  return {
+    ...options,
+    addImportTag,
+    importTag: addImportTag && options.importTag.trim() === "" && suggestedImportTag !== null
+      ? suggestedImportTag
+      : options.importTag,
+  };
+}
+
+function updateImportTag(options: WorkspaceImportOptions, importTag: string): WorkspaceImportOptions {
+  return {
+    ...options,
+    importTag,
+  };
+}
+
+function toggleRemovedTag(options: WorkspaceImportOptions, tag: string): WorkspaceImportOptions {
+  return {
+    ...options,
+    removeTags: options.removeTags.includes(tag)
+      ? options.removeTags.filter((removedTag) => removedTag !== tag)
+      : [...options.removeTags, tag],
+  };
+}
+
+function WorkspaceImportPreview(props: WorkspaceImportPreviewProps): ReactElement {
+  const { copy, preview, options, isControlDisabled, onOptionsChange } = props;
+
+  return (
+    <section className="workspace-import-preview" data-testid="workspace-package-import-preview">
+      <div className="workspace-import-preview-stats">
+        {preview.statistics.map((statistic) => (
+          <div key={statistic.id} className="workspace-import-preview-stat">
+            <span className="subtitle">{statistic.label}</span>
+            <strong data-testid={statistic.testId}>{statistic.value}</strong>
+          </div>
+        ))}
+      </div>
+      {options.addImportTag ? (
+        <label className="workspace-import-tag-field" htmlFor="workspace-package-import-tag-input">
+          <span>{copy.importTagValueLabel}</span>
+          <input
+            id="workspace-package-import-tag-input"
+            type="text"
+            value={options.importTag}
+            disabled={isControlDisabled}
+            data-testid="workspace-package-import-tag-input"
+            onChange={(event) => onOptionsChange(updateImportTag(options, event.currentTarget.value))}
+          />
+        </label>
+      ) : null}
+      {preview.metadataRows.length === 0 ? null : (
+        <dl className="workspace-import-preview-metadata" data-testid="workspace-package-import-preview-metadata">
+          {preview.metadataRows.map((row) => (
+            <div key={row.id} className="workspace-import-preview-metadata-row">
+              <dt>{row.label}</dt>
+              <dd>
+                {row.href === null ? row.value : (
+                  <a href={row.href} target="_blank" rel="noreferrer">{row.value}</a>
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {preview.warnings.length === 0 ? null : (
+        <div className="workspace-import-preview-warnings" data-testid="workspace-package-import-preview-warnings">
+          <strong>{copy.warningsTitle}</strong>
+          <ul>
+            {preview.warnings.map((warning) => <li key={warning.id}>{warning.message}</li>)}
+          </ul>
+        </div>
+      )}
+      {preview.tags.length === 0 ? null : (
+        <div className="workspace-import-preview-tags">
+          <strong>{copy.tagsTitle}</strong>
+          <div className="workspace-import-preview-tag-list">
+            {preview.tags.map((tagOption) => (
+              <label key={tagOption.tag} className="workspace-import-preview-tag-control">
+                <input
+                  type="checkbox"
+                  checked={options.removeTags.includes(tagOption.tag)}
+                  disabled={isControlDisabled}
+                  data-testid="workspace-package-remove-tag-checkbox"
+                  data-tag={tagOption.tag}
+                  onChange={() => onOptionsChange(toggleRemovedTag(options, tagOption.tag))}
+                />
+                <span>{tagOption.removalLabel}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function WorkspaceImportPresentation(props: WorkspaceImportPresentationProps): ReactElement {
+  const {
+    copy,
+    preview,
+    options,
+    isControlDisabled,
+    canConfirm,
+    isConfirming,
+    unavailableMessage,
+    errorMessage,
+    successMessage,
+    onSelect,
+    onOptionsChange,
+    onConfirm,
+  } = props;
+
+  return (
+    <Fragment>
+      <article className="content-card workspace-export-format-card">
+        <div className="settings-nav-card-copy">
+          <strong className="panel-subtitle">{copy.title}</strong>
+          <p className="subtitle">{copy.description}</p>
+        </div>
+        <label className="workspace-import-tag-control">
+          <input
+            type="checkbox"
+            checked={options.addImportTag}
+            disabled={isControlDisabled}
+            data-testid="workspace-package-import-tag-checkbox"
+            onChange={(event) => onOptionsChange(updateImportTagEnabled(
+              options,
+              preview?.suggestedImportTag ?? null,
+              event.currentTarget.checked,
+            ))}
+          />
+          <span className="workspace-import-tag-copy">
+            <span>{copy.importTagLabel}</span>
+            <span className="subtitle">{copy.importTagDescription}</span>
+          </span>
+        </label>
+        {preview === null ? null : (
+          <WorkspaceImportPreview
+            copy={copy}
+            preview={preview}
+            options={options}
+            isControlDisabled={isControlDisabled}
+            onOptionsChange={onOptionsChange}
+          />
+        )}
+        <div className="workspace-export-actions">
+          <button
+            className="primary-btn"
+            type="button"
+            disabled={isControlDisabled}
+            data-testid="workspace-package-import-button"
+            onClick={onSelect}
+          >
+            {copy.selectionActionLabel}
+          </button>
+          <button
+            className="primary-btn"
+            type="button"
+            disabled={!canConfirm}
+            data-testid="workspace-package-import-confirm-button"
+            onClick={() => onConfirm(options)}
+          >
+            {isConfirming ? copy.confirmingActionLabel : copy.confirmActionLabel}
+          </button>
+        </div>
+        {unavailableMessage === null ? null : (
+          <p className="subtitle" data-testid="workspace-package-import-unavailable">{unavailableMessage}</p>
+        )}
+      </article>
+      {errorMessage === "" ? null : (
+        <p className="error-banner" role="alert" data-testid="workspace-import-error">{errorMessage}</p>
+      )}
+      {successMessage === "" ? null : (
+        <p className="subtitle" data-testid="workspace-import-success">{successMessage}</p>
+      )}
+    </Fragment>
+  );
+}

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
@@ -7,19 +7,19 @@ import {
 import { useAppData } from "../../../../appData";
 import { requireCloudInstallationId } from "../../../../appData/sync/local/syncCloudSettings";
 import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
-import { type TranslationKey, useI18n } from "../../../../i18n";
+import { type TranslationKey, type TranslationValues, useI18n } from "../../../../i18n";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type {
   WorkspacePackageImportConfirmOptions,
   WorkspacePackageImportPreviewResponse,
 } from "../../../../types";
 import { SettingsShell } from "../../SettingsShared";
-
-type PackageMetadataRow = Readonly<{
-  label: string;
-  value: string;
-  href: string | null;
-}>;
+import { WorkspaceImportPresentation } from "./WorkspaceImportPresentation";
+import type {
+  WorkspaceImportOptions,
+  WorkspaceImportPreviewMetadataRow,
+  WorkspaceImportPreviewModel,
+} from "./workspaceImportPresentationModel";
 
 type PackageImportPreviewIdentity = Readonly<{
   workspaceId: string;
@@ -69,6 +69,93 @@ function formatPackageMetadataCreatedAt(
   return formatDateTimeValue(dateValue);
 }
 
+function buildWorkspaceImportPreviewModel(
+  preview: WorkspacePackageImportPreviewResponse,
+  t: (key: TranslationKey, values?: TranslationValues) => string,
+  formatDateTimeValue: (dateValue: Date) => string,
+  formatNumberValue: (value: number) => string,
+): WorkspaceImportPreviewModel {
+  const metadataRows: ReadonlyArray<WorkspaceImportPreviewMetadataRow> = [
+    preview.packageMetadata.label === null ? null : {
+      id: "label",
+      label: t("workspaceImport.previewMetadataLabel"),
+      value: preview.packageMetadata.label,
+      href: null,
+    },
+    preview.packageMetadata.author === null ? null : {
+      id: "author",
+      label: t("workspaceImport.previewMetadataAuthor"),
+      value: preview.packageMetadata.author,
+      href: null,
+    },
+    preview.packageMetadata.comment === null ? null : {
+      id: "comment",
+      label: t("workspaceImport.previewMetadataComment"),
+      value: preview.packageMetadata.comment,
+      href: null,
+    },
+    preview.packageMetadata.createdAt === null ? null : {
+      id: "created-at",
+      label: t("workspaceImport.previewMetadataCreatedAt"),
+      value: formatPackageMetadataCreatedAt(preview.packageMetadata.createdAt, formatDateTimeValue),
+      href: null,
+    },
+    preview.packageMetadata.sourceUrl === null ? null : {
+      id: "source-url",
+      label: t("workspaceImport.previewMetadataSourceUrl"),
+      value: preview.packageMetadata.sourceUrl,
+      href: buildSafeMetadataHttpUrl(preview.packageMetadata.sourceUrl),
+    },
+  ].filter((row): row is WorkspaceImportPreviewMetadataRow => row !== null);
+
+  return {
+    statistics: [
+      {
+        id: "source",
+        label: t("workspaceImport.previewSourceLabel"),
+        value: t("workspaceImport.previewSourceZip"),
+        testId: "workspace-package-import-preview-source",
+      },
+      {
+        id: "cards",
+        label: t("workspaceImport.previewCardsLabel"),
+        value: formatNumberValue(preview.cardCount),
+        testId: "workspace-package-import-preview-card-count",
+      },
+      {
+        id: "referenced-media",
+        label: t("workspaceImport.previewReferencedMediaLabel"),
+        value: formatNumberValue(preview.referencedMediaCount),
+        testId: "workspace-package-import-preview-referenced-media-count",
+      },
+      {
+        id: "package-media",
+        label: t("workspaceImport.previewPackageMediaLabel"),
+        value: formatNumberValue(preview.packageMediaFileCount),
+        testId: "workspace-package-import-preview-package-media-count",
+      },
+    ],
+    metadataRows,
+    warnings: preview.warnings.map((warning) => ({
+      id: `${warning.code}:${warning.mediaPath}:${warning.message}`,
+      message: warning.mediaPath === ""
+        ? warning.message
+        : t("workspaceImport.previewWarningWithPath", {
+          message: warning.message,
+          path: warning.mediaPath,
+        }),
+    })),
+    tags: preview.tagCounts.map((tagCount) => ({
+      tag: tagCount.tag,
+      removalLabel: t("workspaceImport.previewRemoveTagLabel", {
+        tag: tagCount.tag,
+        count: tagCount.cardsCount,
+      }),
+    })),
+    suggestedImportTag: preview.defaultOptions.suggestedImportTag,
+  };
+}
+
 export function WorkspaceImportScreen(): ReactElement {
   const { activeWorkspace, cloudSettings, isSessionVerified, refreshLocalData, session } = useAppData();
   const { showCapturedTechnicalError } = useAppErrorDialog();
@@ -76,12 +163,14 @@ export function WorkspaceImportScreen(): ReactElement {
   const packageImportInputRef = useRef<HTMLInputElement | null>(null);
   const [isPackagePreviewing, setIsPackagePreviewing] = useState<boolean>(false);
   const [isPackageImporting, setIsPackageImporting] = useState<boolean>(false);
-  const [shouldTagPackageImport, setShouldTagPackageImport] = useState<boolean>(true);
   const [packageImportFile, setPackageImportFile] = useState<File | null>(null);
   const [packageImportPreview, setPackageImportPreview] = useState<WorkspacePackageImportPreviewResponse | null>(null);
   const [packageImportPreviewIdentity, setPackageImportPreviewIdentity] = useState<PackageImportPreviewIdentity | null>(null);
-  const [packageImportTag, setPackageImportTag] = useState<string>("");
-  const [packageImportRemoveTags, setPackageImportRemoveTags] = useState<ReadonlyArray<string>>([]);
+  const [packageImportOptions, setPackageImportOptions] = useState<WorkspaceImportOptions>({
+    addImportTag: true,
+    importTag: "",
+    removeTags: [],
+  });
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [successMessage, setSuccessMessage] = useState<string>("");
   const technicalErrorMessage = t("appError.technicalError.message");
@@ -98,35 +187,9 @@ export function WorkspaceImportScreen(): ReactElement {
     && packageImportPreviewIdentity.workspaceId === activeWorkspaceId
     && packageImportPreviewIdentity.installationId === currentInstallationId;
   const isPackageImportControlDisabled = !isPackageImportAvailable || isPackageImportBusy;
-  const packageImportMetadataRows: ReadonlyArray<PackageMetadataRow> = packageImportPreview === null
-    ? []
-    : [
-      packageImportPreview.packageMetadata.label === null ? null : {
-        label: t("workspaceImport.previewMetadataLabel"),
-        value: packageImportPreview.packageMetadata.label,
-        href: null,
-      },
-      packageImportPreview.packageMetadata.author === null ? null : {
-        label: t("workspaceImport.previewMetadataAuthor"),
-        value: packageImportPreview.packageMetadata.author,
-        href: null,
-      },
-      packageImportPreview.packageMetadata.comment === null ? null : {
-        label: t("workspaceImport.previewMetadataComment"),
-        value: packageImportPreview.packageMetadata.comment,
-        href: null,
-      },
-      packageImportPreview.packageMetadata.createdAt === null ? null : {
-        label: t("workspaceImport.previewMetadataCreatedAt"),
-        value: formatPackageMetadataCreatedAt(packageImportPreview.packageMetadata.createdAt, formatDateTime),
-        href: null,
-      },
-      packageImportPreview.packageMetadata.sourceUrl === null ? null : {
-        label: t("workspaceImport.previewMetadataSourceUrl"),
-        value: packageImportPreview.packageMetadata.sourceUrl,
-        href: buildSafeMetadataHttpUrl(packageImportPreview.packageMetadata.sourceUrl),
-      },
-    ].filter((row): row is PackageMetadataRow => row !== null);
+  const packageImportPreviewModel = packageImportPreview === null
+    ? null
+    : buildWorkspaceImportPreviewModel(packageImportPreview, t, formatDateTime, formatNumber);
 
   function captureWorkspaceImportError(error: unknown): boolean {
     return captureAppOperationError(error, {
@@ -143,8 +206,11 @@ export function WorkspaceImportScreen(): ReactElement {
     setPackageImportFile(null);
     setPackageImportPreview(null);
     setPackageImportPreviewIdentity(null);
-    setPackageImportTag("");
-    setPackageImportRemoveTags([]);
+    setPackageImportOptions({
+      addImportTag: true,
+      importTag: "",
+      removeTags: [],
+    });
   }
 
   useEffect(() => {
@@ -180,9 +246,11 @@ export function WorkspaceImportScreen(): ReactElement {
         workspaceId: activeWorkspace.workspaceId,
         installationId: currentInstallationId,
       });
-      setShouldTagPackageImport(preview.defaultOptions.addImportTag);
-      setPackageImportTag(preview.defaultOptions.suggestedImportTag);
-      setPackageImportRemoveTags([...preview.defaultOptions.removedTags]);
+      setPackageImportOptions({
+        addImportTag: preview.defaultOptions.addImportTag,
+        importTag: preview.defaultOptions.suggestedImportTag,
+        removeTags: [...preview.defaultOptions.removedTags],
+      });
     } catch (error) {
       const validationErrorMessage = getWorkspacePackageValidationErrorMessage(error, t);
       if (validationErrorMessage !== null) {
@@ -204,7 +272,7 @@ export function WorkspaceImportScreen(): ReactElement {
     }
   }
 
-  async function confirmPackageImport(): Promise<void> {
+  async function confirmPackageImport(importOptions: WorkspaceImportOptions): Promise<void> {
     if (!isPackageImportAvailable) {
       resetPackageImportPreview();
       setErrorMessage(t("workspaceImport.workspaceUnavailable"));
@@ -219,8 +287,8 @@ export function WorkspaceImportScreen(): ReactElement {
       return;
     }
 
-    const confirmedPackageImportTag = packageImportTag.trim();
-    if (shouldTagPackageImport && confirmedPackageImportTag === "") {
+    const confirmedPackageImportTag = importOptions.importTag.trim();
+    if (importOptions.addImportTag && confirmedPackageImportTag === "") {
       setErrorMessage(t("workspaceImport.importTagRequired"));
       setSuccessMessage("");
       return;
@@ -234,9 +302,9 @@ export function WorkspaceImportScreen(): ReactElement {
       const importId = crypto.randomUUID().toLowerCase();
       const importedAt = new Date().toISOString();
       const options: WorkspacePackageImportConfirmOptions = {
-        addImportTag: shouldTagPackageImport,
+        addImportTag: importOptions.addImportTag,
         importTag: confirmedPackageImportTag,
-        removeTags: packageImportRemoveTags,
+        removeTags: importOptions.removeTags,
         importedAt,
         importId,
         clientUpdatedAt: importedAt,
@@ -280,22 +348,6 @@ export function WorkspaceImportScreen(): ReactElement {
     void previewPackageImportFile(file);
   }
 
-  function updateShouldTagPackageImport(shouldTagImport: boolean): void {
-    if (shouldTagImport && packageImportTag.trim() === "" && packageImportPreview !== null) {
-      setPackageImportTag(packageImportPreview.defaultOptions.suggestedImportTag);
-    }
-
-    setShouldTagPackageImport(shouldTagImport);
-  }
-
-  function togglePackageImportRemovedTag(tag: string): void {
-    setPackageImportRemoveTags((currentTags) => (
-      currentTags.includes(tag)
-        ? currentTags.filter((currentTag) => currentTag !== tag)
-        : [...currentTags, tag]
-    ));
-  }
-
   return (
     <SettingsShell
       title={t("workspaceImport.title")}
@@ -303,152 +355,44 @@ export function WorkspaceImportScreen(): ReactElement {
       activeTab="workspace"
     >
       <section className="settings-group">
-        <article className="content-card workspace-export-format-card">
-          <div className="settings-nav-card-copy">
-            <strong className="panel-subtitle">{t("workspaceImport.packageTitle")}</strong>
-            <p className="subtitle">{t("workspaceImport.packageDescription")}</p>
-          </div>
-          <label className="workspace-import-tag-control">
-            <input
-              type="checkbox"
-              checked={shouldTagPackageImport}
-              disabled={isPackageImportControlDisabled}
-              data-testid="workspace-package-import-tag-checkbox"
-              onChange={(event) => updateShouldTagPackageImport(event.currentTarget.checked)}
-            />
-            <span className="workspace-import-tag-copy">
-              <span>{t("workspaceImport.importTagLabel")}</span>
-              <span className="subtitle">{t("workspaceImport.importTagDescription")}</span>
-            </span>
-          </label>
-          <input
-            ref={packageImportInputRef}
-            type="file"
-            accept=".zip,application/zip,application/x-zip-compressed"
-            disabled={isPackageImportControlDisabled}
-            data-testid="workspace-package-import-file-input"
-            style={{ display: "none" }}
-            onChange={handlePackageImportInputChange}
-          />
-          {packageImportPreview === null ? null : (
-            <section className="workspace-import-preview" data-testid="workspace-package-import-preview">
-              <div className="workspace-import-preview-stats">
-                <div className="workspace-import-preview-stat">
-                  <span className="subtitle">{t("workspaceImport.previewSourceLabel")}</span>
-                  <strong data-testid="workspace-package-import-preview-source">
-                    {t("workspaceImport.previewSourceZip")}
-                  </strong>
-                </div>
-                <div className="workspace-import-preview-stat">
-                  <span className="subtitle">{t("workspaceImport.previewCardsLabel")}</span>
-                  <strong data-testid="workspace-package-import-preview-card-count">{formatNumber(packageImportPreview.cardCount)}</strong>
-                </div>
-                <div className="workspace-import-preview-stat">
-                  <span className="subtitle">{t("workspaceImport.previewReferencedMediaLabel")}</span>
-                  <strong data-testid="workspace-package-import-preview-referenced-media-count">{formatNumber(packageImportPreview.referencedMediaCount)}</strong>
-                </div>
-                <div className="workspace-import-preview-stat">
-                  <span className="subtitle">{t("workspaceImport.previewPackageMediaLabel")}</span>
-                  <strong data-testid="workspace-package-import-preview-package-media-count">{formatNumber(packageImportPreview.packageMediaFileCount)}</strong>
-                </div>
-              </div>
-              {shouldTagPackageImport ? (
-                <label className="workspace-import-tag-field" htmlFor="workspace-package-import-tag-input">
-                  <span>{t("workspaceImport.importTagValueLabel")}</span>
-                  <input
-                    id="workspace-package-import-tag-input"
-                    type="text"
-                    value={packageImportTag}
-                    disabled={isPackageImportControlDisabled}
-                    data-testid="workspace-package-import-tag-input"
-                    onChange={(event) => setPackageImportTag(event.currentTarget.value)}
-                  />
-                </label>
-              ) : null}
-              {packageImportMetadataRows.length === 0 ? null : (
-                <dl className="workspace-import-preview-metadata" data-testid="workspace-package-import-preview-metadata">
-                  {packageImportMetadataRows.map((row) => (
-                    <div key={row.label} className="workspace-import-preview-metadata-row">
-                      <dt>{row.label}</dt>
-                      <dd>
-                        {row.href === null ? row.value : (
-                          <a href={row.href} target="_blank" rel="noreferrer">{row.value}</a>
-                        )}
-                      </dd>
-                    </div>
-                  ))}
-                </dl>
-              )}
-              {packageImportPreview.warnings.length === 0 ? null : (
-                <div className="workspace-import-preview-warnings" data-testid="workspace-package-import-preview-warnings">
-                  <strong>{t("workspaceImport.previewWarningsTitle")}</strong>
-                  <ul>
-                    {packageImportPreview.warnings.map((warning) => (
-                      <li key={`${warning.code}:${warning.mediaPath}:${warning.message}`}>
-                        {warning.mediaPath === ""
-                          ? warning.message
-                          : t("workspaceImport.previewWarningWithPath", {
-                            message: warning.message,
-                            path: warning.mediaPath,
-                          })}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {packageImportPreview.tagCounts.length === 0 ? null : (
-                <div className="workspace-import-preview-tags">
-                  <strong>{t("workspaceImport.previewTagsTitle")}</strong>
-                  <div className="workspace-import-preview-tag-list">
-                    {packageImportPreview.tagCounts.map((tagCount) => (
-                      <label key={tagCount.tag} className="workspace-import-preview-tag-control">
-                        <input
-                          type="checkbox"
-                          checked={packageImportRemoveTags.includes(tagCount.tag)}
-                          disabled={isPackageImportControlDisabled}
-                          data-testid="workspace-package-remove-tag-checkbox"
-                          data-tag={tagCount.tag}
-                          onChange={() => togglePackageImportRemovedTag(tagCount.tag)}
-                        />
-                        <span>{t("workspaceImport.previewRemoveTagLabel", {
-                          tag: tagCount.tag,
-                          count: tagCount.cardsCount,
-                        })}</span>
-                      </label>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </section>
-          )}
-          <div className="workspace-export-actions">
-            <button
-              className="primary-btn"
-              type="button"
-              disabled={isPackageImportControlDisabled}
-              data-testid="workspace-package-import-button"
-              onClick={() => packageImportInputRef.current?.click()}
-            >
-              {isPackagePreviewing ? t("workspaceImport.packagePreviewing") : t("workspaceImport.packageImportButton")}
-            </button>
-            <button
-              className="primary-btn"
-              type="button"
-              disabled={!isPackageImportPreviewCurrent || isPackageImportBusy}
-              data-testid="workspace-package-import-confirm-button"
-              onClick={() => void confirmPackageImport()}
-            >
-              {isPackageImporting ? t("workspaceImport.packageImporting") : t("workspaceImport.packageConfirmButton")}
-            </button>
-          </div>
-          {activeWorkspace !== null && !isPackageImportAvailable ? (
-            <p className="subtitle" data-testid="workspace-package-import-unavailable">
-              {isSessionVerified ? t("workspaceImport.workspaceUnavailable") : t("loading.restoringSession")}
-            </p>
-          ) : null}
-        </article>
-        {errorMessage !== "" ? <p className="error-banner" role="alert" data-testid="workspace-import-error">{errorMessage}</p> : null}
-        {successMessage !== "" ? <p className="subtitle" data-testid="workspace-import-success">{successMessage}</p> : null}
+        <input
+          ref={packageImportInputRef}
+          type="file"
+          accept=".zip,application/zip,application/x-zip-compressed"
+          disabled={isPackageImportControlDisabled}
+          data-testid="workspace-package-import-file-input"
+          style={{ display: "none" }}
+          onChange={handlePackageImportInputChange}
+        />
+        <WorkspaceImportPresentation
+          copy={{
+            title: t("workspaceImport.packageTitle"),
+            description: t("workspaceImport.packageDescription"),
+            importTagLabel: t("workspaceImport.importTagLabel"),
+            importTagDescription: t("workspaceImport.importTagDescription"),
+            importTagValueLabel: t("workspaceImport.importTagValueLabel"),
+            warningsTitle: t("workspaceImport.previewWarningsTitle"),
+            tagsTitle: t("workspaceImport.previewTagsTitle"),
+            selectionActionLabel: isPackagePreviewing
+              ? t("workspaceImport.packagePreviewing")
+              : t("workspaceImport.packageImportButton"),
+            confirmActionLabel: t("workspaceImport.packageConfirmButton"),
+            confirmingActionLabel: t("workspaceImport.packageImporting"),
+          }}
+          preview={packageImportPreviewModel}
+          options={packageImportOptions}
+          isControlDisabled={isPackageImportControlDisabled}
+          canConfirm={isPackageImportPreviewCurrent && !isPackageImportBusy}
+          isConfirming={isPackageImporting}
+          unavailableMessage={activeWorkspace !== null && !isPackageImportAvailable
+            ? isSessionVerified ? t("workspaceImport.workspaceUnavailable") : t("loading.restoringSession")
+            : null}
+          errorMessage={errorMessage}
+          successMessage={successMessage}
+          onSelect={() => packageImportInputRef.current?.click()}
+          onOptionsChange={setPackageImportOptions}
+          onConfirm={(options) => void confirmPackageImport(options)}
+        />
       </section>
     </SettingsShell>
   );

--- a/apps/web/src/screens/settings/workspace/packages/workspaceImportPresentationModel.ts
+++ b/apps/web/src/screens/settings/workspace/packages/workspaceImportPresentationModel.ts
@@ -1,0 +1,50 @@
+export type WorkspaceImportPreviewStatistic = Readonly<{
+  id: string;
+  label: string;
+  value: string;
+  testId: string;
+}>;
+
+export type WorkspaceImportPreviewMetadataRow = Readonly<{
+  id: string;
+  label: string;
+  value: string;
+  href: string | null;
+}>;
+
+export type WorkspaceImportPreviewWarning = Readonly<{
+  id: string;
+  message: string;
+}>;
+
+export type WorkspaceImportPreviewTag = Readonly<{
+  tag: string;
+  removalLabel: string;
+}>;
+
+export type WorkspaceImportPreviewModel = Readonly<{
+  statistics: ReadonlyArray<WorkspaceImportPreviewStatistic>;
+  metadataRows: ReadonlyArray<WorkspaceImportPreviewMetadataRow>;
+  warnings: ReadonlyArray<WorkspaceImportPreviewWarning>;
+  tags: ReadonlyArray<WorkspaceImportPreviewTag>;
+  suggestedImportTag: string;
+}>;
+
+export type WorkspaceImportOptions = Readonly<{
+  addImportTag: boolean;
+  importTag: string;
+  removeTags: ReadonlyArray<string>;
+}>;
+
+export type WorkspaceImportPresentationCopy = Readonly<{
+  title: string;
+  description: string;
+  importTagLabel: string;
+  importTagDescription: string;
+  importTagValueLabel: string;
+  warningsTitle: string;
+  tagsTitle: string;
+  selectionActionLabel: string;
+  confirmActionLabel: string;
+  confirmingActionLabel: string;
+}>;


### PR DESCRIPTION
## Summary
- extract reusable typed workspace import presentation and view model
- keep ZIP selection, preview, confirmation, and error capture in the file-source controller
- preserve existing copy, styles, selectors, defaults, and success behavior

## Validation
- focused import flow: 14/14 passed
- full web suite: 79 files, 663 tests passed
- production web build: passed
- git diff --check: passed
- fresh delegated review: no findings, full pass, green light