### PR TITLE
Fix historical workspace ID compatibility

### DIFF
--- a/api/src/components/schemas/AgentAccountData.yaml
+++ b/api/src/components/schemas/AgentAccountData.yaml
@@ -11,7 +11,7 @@ properties:
     type: string
   selectedWorkspaceId:
     anyOf:
-      - $ref: ./UuidString.yaml
+      - $ref: ./WorkspaceIdString.yaml
       - type: 'null'
   agentWorkspaceReplicaId:
     description: >-

--- a/api/src/components/schemas/CatalogPackageVersion.yaml
+++ b/api/src/components/schemas/CatalogPackageVersion.yaml
@@ -62,7 +62,7 @@ properties:
       - 'null'
   sourceWorkspaceId:
     oneOf:
-      - $ref: ./UuidString.yaml
+      - $ref: ./WorkspaceIdString.yaml
       - type: 'null'
   cardCount:
     type: integer

--- a/api/src/components/schemas/CreateCatalogPackageVersionFromWorkspaceInput.yaml
+++ b/api/src/components/schemas/CreateCatalogPackageVersionFromWorkspaceInput.yaml
@@ -8,7 +8,7 @@ properties:
   packageVersionId:
     $ref: ./UuidString.yaml
   workspaceId:
-    $ref: ./UuidString.yaml
+    $ref: ./WorkspaceIdString.yaml
   cardIds:
     type: array
     minItems: 1

--- a/api/src/components/schemas/MediaAsset.yaml
+++ b/api/src/components/schemas/MediaAsset.yaml
@@ -17,7 +17,7 @@ properties:
   mediaAssetId:
     $ref: ./UuidString.yaml
   workspaceId:
-    $ref: ./UuidString.yaml
+    $ref: ./WorkspaceIdString.yaml
   mimeType:
     type: string
     example: image/png

--- a/api/src/components/schemas/MediaAssetStorageErrorDetails.yaml
+++ b/api/src/components/schemas/MediaAssetStorageErrorDetails.yaml
@@ -7,7 +7,7 @@ required:
   - retryable
 properties:
   workspaceId:
-    $ref: ./UuidString.yaml
+    $ref: ./WorkspaceIdString.yaml
   mediaAssetId:
     $ref: ./UuidString.yaml
   reason:

--- a/api/src/components/schemas/MediaAssetUploadSessionCreateResponse.yaml
+++ b/api/src/components/schemas/MediaAssetUploadSessionCreateResponse.yaml
@@ -12,7 +12,7 @@ required:
   - uploadSession
 properties:
   workspaceId:
-    $ref: ./UuidString.yaml
+    $ref: ./WorkspaceIdString.yaml
   mediaAssetId:
     $ref: ./UuidString.yaml
   status:

--- a/api/src/components/schemas/WorkspaceIdString.yaml
+++ b/api/src/components/schemas/WorkspaceIdString.yaml
@@ -1,0 +1,4 @@
+type: string
+format: uuid
+pattern: '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$'
+description: Canonical PostgreSQL workspace UUID text without UUID version or variant restrictions.

--- a/api/src/components/schemas/WorkspaceSummary.yaml
+++ b/api/src/components/schemas/WorkspaceSummary.yaml
@@ -7,7 +7,7 @@ required:
   - isSelected
 properties:
   workspaceId:
-    $ref: ./UuidString.yaml
+    $ref: ./WorkspaceIdString.yaml
   name:
     type: string
   createdAt:

--- a/api/src/paths/agent_workspaces_{workspaceId}_select.yaml
+++ b/api/src/paths/agent_workspaces_{workspaceId}_select.yaml
@@ -12,7 +12,7 @@ post:
       name: workspaceId
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
   responses:
     '200':
       description: Workspace selected

--- a/api/src/paths/workspaces_{workspaceId}_catalog_package-versions_{packageVersionId}_install.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_catalog_package-versions_{packageVersionId}_install.yaml
@@ -19,7 +19,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: packageVersionId
       in: path
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_catalog_package-versions_{packageVersionId}_install_preview.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_catalog_package-versions_{packageVersionId}_install_preview.yaml
@@ -15,7 +15,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: packageVersionId
       in: path
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_images.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_images.yaml
@@ -15,7 +15,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: x-media-asset-id
       in: header
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions.yaml
@@ -22,7 +22,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
   requestBody:
     required: true
     content:

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_abort.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_abort.yaml
@@ -18,7 +18,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: sessionId
       in: path
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_complete.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_complete.yaml
@@ -18,7 +18,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: sessionId
       in: path
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_parts.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_upload-sessions_{sessionId}_parts.yaml
@@ -14,7 +14,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: sessionId
       in: path
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}.yaml
@@ -12,7 +12,7 @@ get:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: mediaAssetId
       in: path
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_media-assets_{mediaAssetId}_download-url.yaml
@@ -13,7 +13,7 @@ get:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
     - name: mediaAssetId
       in: path
       required: true

--- a/api/src/paths/workspaces_{workspaceId}_packages_export.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_export.yaml
@@ -13,7 +13,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
   requestBody:
     required: true
     content:

--- a/api/src/paths/workspaces_{workspaceId}_packages_export_preview.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_export_preview.yaml
@@ -13,7 +13,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
   requestBody:
     required: true
     content:

--- a/api/src/paths/workspaces_{workspaceId}_packages_import.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_import.yaml
@@ -14,7 +14,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
   requestBody:
     required: true
     content:

--- a/api/src/paths/workspaces_{workspaceId}_packages_import_preview.yaml
+++ b/api/src/paths/workspaces_{workspaceId}_packages_import_preview.yaml
@@ -15,7 +15,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: ../components/schemas/UuidString.yaml
+        $ref: ../components/schemas/WorkspaceIdString.yaml
   requestBody:
     required: true
     content:

--- a/apps/backend/src/chat/http/contract.ts
+++ b/apps/backend/src/chat/http/contract.ts
@@ -11,6 +11,7 @@ import {
   expectNonEmptyString,
   expectRecord,
   expectUuidString,
+  expectWorkspaceIdString,
 } from "../../server/requestParsing";
 
 export const chatMaximumStartRunRequestBytes = 5 * 1024 * 1024;
@@ -269,7 +270,7 @@ function parseOptionalWorkspaceIdField(value: unknown): string | undefined {
     return undefined;
   }
 
-  return expectUuidString(value, "workspaceId");
+  return expectWorkspaceIdString(value, "workspaceId");
 }
 
 /**

--- a/apps/backend/src/chat/tests/routes/contract.test.ts
+++ b/apps/backend/src/chat/tests/routes/contract.test.ts
@@ -11,6 +11,8 @@ import {
   chatRequestTooLargeCode,
   chatRequestTooLargeMessage,
   parseChatRequestBody,
+  parseNewChatRequestBody,
+  parseStopChatRequestBody,
 } from "../../http/contract";
 import {
   chatAttachmentUnsupportedTypeCode,
@@ -19,6 +21,7 @@ import {
 import type { ChatSessionSnapshot, PersistedChatMessageItem } from "../../store";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
+const LEGACY_POSTGRES_WORKSPACE_ID = "35274129-ef97-d366-954c-955b4bb0fbf0";
 const PLAIN_TEXT_BASE64 = "cGxhaW4gdGV4dA==";
 const VALID_PDF_BASE64 = "JVBERi0xLjEKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCAxIDFdID4+CmVuZG9iagp4cmVmCjAgNAowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1Jvb3QgMSAwIFIgL1NpemUgNCA+PgpzdGFydHhyZWYKMTgyCiUlRU9GCg==";
 const TRUNCATED_PDF_BASE64 = "JVBERi0xLjcK";
@@ -167,6 +170,122 @@ function findLog(
 ): StructuredLogRecord | undefined {
   return records.find((record) => record.action === action);
 }
+
+const workspaceRequestBodyCases: ReadonlyArray<Readonly<{
+  name: string;
+  parse: (value: unknown) => Readonly<{ workspaceId?: string }>;
+  body: Readonly<Record<string, unknown>>;
+}>> = [
+  {
+    name: "chat start",
+    parse: parseChatRequestBody,
+    body: {
+      sessionId: SESSION_ONE,
+      clientRequestId: "client-request-1",
+      content: [{ type: "text", text: "hello" }],
+      timezone: "Europe/Madrid",
+    },
+  },
+  {
+    name: "new chat",
+    parse: parseNewChatRequestBody,
+    body: {
+      sessionId: SESSION_ONE,
+    },
+  },
+  {
+    name: "stop chat",
+    parse: parseStopChatRequestBody,
+    body: {
+      sessionId: SESSION_ONE,
+      runId: SESSION_ONE,
+    },
+  },
+];
+
+test("chat request bodies accept and trim legacy PostgreSQL workspace IDs", () => {
+  for (const requestBodyCase of workspaceRequestBodyCases) {
+    assert.equal(
+      requestBodyCase.parse({
+        ...requestBodyCase.body,
+        workspaceId: ` \n${LEGACY_POSTGRES_WORKSPACE_ID}\t`,
+      }).workspaceId,
+      LEGACY_POSTGRES_WORKSPACE_ID,
+      requestBodyCase.name,
+    );
+    assert.equal(
+      requestBodyCase.parse(requestBodyCase.body).workspaceId,
+      undefined,
+      requestBodyCase.name,
+    );
+    assert.equal(
+      requestBodyCase.parse({
+        ...requestBodyCase.body,
+        workspaceId: LEGACY_POSTGRES_WORKSPACE_ID.toUpperCase(),
+      }).workspaceId,
+      LEGACY_POSTGRES_WORKSPACE_ID,
+      requestBodyCase.name,
+    );
+  }
+});
+
+test("chat workspace fields preserve their public validation errors", () => {
+  const invalidWorkspaceIds: ReadonlyArray<Readonly<{
+    value: unknown;
+    message: string;
+  }>> = [
+    { value: 42, message: "workspaceId must be a string" },
+    { value: " \t\n", message: "workspaceId must not be empty" },
+    { value: "not-a-uuid", message: "workspaceId must be a UUID" },
+  ];
+
+  for (const requestBodyCase of workspaceRequestBodyCases) {
+    for (const invalidWorkspaceId of invalidWorkspaceIds) {
+      assert.throws(
+        () => requestBodyCase.parse({
+          ...requestBodyCase.body,
+          workspaceId: invalidWorkspaceId.value,
+        }),
+        (error: unknown) => error instanceof HttpError
+          && error.statusCode === 400
+          && error.code === null
+          && error.message === invalidWorkspaceId.message,
+        `${requestBodyCase.name}: ${invalidWorkspaceId.message}`,
+      );
+    }
+  }
+});
+
+test("chat session and run fields keep strict UUID validation", () => {
+  assert.throws(
+    () => parseChatRequestBody({
+      sessionId: LEGACY_POSTGRES_WORKSPACE_ID,
+      clientRequestId: "client-request-1",
+      content: [{ type: "text", text: "hello" }],
+      timezone: "Europe/Madrid",
+      workspaceId: LEGACY_POSTGRES_WORKSPACE_ID,
+    }),
+    (error: unknown) => error instanceof HttpError
+      && error.message === "sessionId must be a UUID",
+  );
+  assert.throws(
+    () => parseNewChatRequestBody({
+      sessionId: LEGACY_POSTGRES_WORKSPACE_ID,
+      workspaceId: LEGACY_POSTGRES_WORKSPACE_ID,
+    }),
+    (error: unknown) => error instanceof HttpError
+      && error.message === "sessionId must be a UUID",
+  );
+  assert.throws(
+    () => parseStopChatRequestBody({
+      sessionId: SESSION_ONE,
+      runId: LEGACY_POSTGRES_WORKSPACE_ID,
+      workspaceId: LEGACY_POSTGRES_WORKSPACE_ID,
+    }),
+    (error: unknown) => error instanceof HttpError
+      && error.message === "runId must be a UUID",
+  );
+});
 
 test("parseChatRequestBody normalizes supported attachment media type aliases", () => {
   const cases = [

--- a/apps/backend/src/chat/tests/routes/transcriptions.test.ts
+++ b/apps/backend/src/chat/tests/routes/transcriptions.test.ts
@@ -9,6 +9,7 @@ import type { RequestContext } from "../../../server/requestContext";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
 const EXPLICIT_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
+const LEGACY_POSTGRES_WORKSPACE_ID = "35274129-ef97-d366-954c-955b4bb0fbf0";
 const LEGACY_WORKSPACE_ID = "workspace-legacy";
 
 function createRequestContext(): RequestContext {
@@ -95,6 +96,99 @@ test("POST /chat/transcriptions prefers an explicit workspaceId multipart field 
   assert.deepEqual(await response.json(), {
     text: "hello",
     sessionId: SESSION_ONE,
+  });
+});
+
+test("POST /chat/transcriptions accepts and trims a legacy PostgreSQL workspaceId multipart field", async () => {
+  const requestedWorkspaceIds: string[] = [];
+  const app = createChatTranscriptionsRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    getRecoveredChatSessionSnapshotFn: async (_userId, workspaceId, sessionId) => {
+      requestedWorkspaceIds.push(workspaceId);
+      return {
+        sessionId: sessionId ?? SESSION_ONE,
+        runState: "idle",
+        activeRunId: null,
+        updatedAt: 1,
+        activeRunHeartbeatAt: null,
+        composerSuggestions: [],
+        mainContentInvalidationVersion: 0,
+        messages: [],
+      };
+    },
+    transcribeAudioFn: async () => "hello",
+  });
+
+  const formData = new FormData();
+  formData.set("file", new File(["audio"], "note.m4a", { type: "audio/m4a" }));
+  formData.set("source", "web");
+  formData.set("sessionId", SESSION_ONE);
+  formData.set("workspaceId", ` \n${LEGACY_POSTGRES_WORKSPACE_ID}\t`);
+
+  const response = await app.request("http://localhost/chat/transcriptions", {
+    method: "POST",
+    body: formData,
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(requestedWorkspaceIds, [LEGACY_POSTGRES_WORKSPACE_ID]);
+  assert.deepEqual(await response.json(), {
+    text: "hello",
+    sessionId: SESSION_ONE,
+  });
+});
+
+test("POST /chat/transcriptions preserves malformed workspaceId validation", async () => {
+  let sessionRecoveryRequested = false;
+  const routes = createChatTranscriptionsRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    getRecoveredChatSessionSnapshotFn: async () => {
+      sessionRecoveryRequested = true;
+      throw new Error("Malformed workspaceId must stop before session recovery");
+    },
+    transcribeAudioFn: async () => "hello",
+  });
+  const app = new Hono();
+  app.onError((error, context) => {
+    const httpError = toHttpErrorLike(error);
+    if (httpError === null) {
+      throw error;
+    }
+
+    context.status(httpError.statusCode as ContentfulStatusCode);
+    return context.json({
+      error: httpError.message,
+      requestId: null,
+      code: httpError.code,
+    });
+  });
+  app.route("/", routes);
+
+  const formData = new FormData();
+  formData.set("file", new File(["audio"], "note.m4a", { type: "audio/m4a" }));
+  formData.set("source", "web");
+  formData.set("sessionId", SESSION_ONE);
+  formData.set("workspaceId", "not-a-uuid");
+
+  const response = await app.request("http://localhost/chat/transcriptions", {
+    method: "POST",
+    body: formData,
+  });
+
+  assert.equal(sessionRecoveryRequested, false);
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "workspaceId must be a UUID",
+    requestId: null,
+    code: null,
   });
 });
 

--- a/apps/backend/src/chat/transcriptions.ts
+++ b/apps/backend/src/chat/transcriptions.ts
@@ -12,7 +12,7 @@ import {
   getBackendErrorLogDetails,
   type ChatTranscriptionFailureDetails,
 } from "../observability/sentry";
-import { expectUuidString } from "../server/requestParsing";
+import { expectWorkspaceIdString } from "../server/requestParsing";
 import { getObservedOpenAIClient } from "./openai/client";
 import {
   classifyChatTranscriptionFailure,
@@ -139,7 +139,7 @@ export async function parseChatTranscriptionUpload(request: Request): Promise<Ch
   const workspaceValue = formData.get("workspaceId");
   const workspaceId = workspaceValue === null
     ? undefined
-    : expectUuidString(workspaceValue, "workspaceId");
+    : expectWorkspaceIdString(workspaceValue, "workspaceId");
 
   return {
     file: fileValue,

--- a/apps/backend/src/feedback/input.ts
+++ b/apps/backend/src/feedback/input.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { HttpError, type HttpErrorDetails, type ValidationIssueSummary } from "../shared/errors";
 import {
+  isWorkspaceId,
+  normalizeWorkspaceId,
+} from "../workspaces/identity";
+import {
   feedbackMessageMaxCharacters,
   type FeedbackPromptEventInput,
   type FeedbackSubmissionInput,
@@ -8,6 +12,21 @@ import {
 
 const uuidStringSchema = z.string().uuid().transform((value) => value.toLowerCase());
 const nullableUuidStringSchema = uuidStringSchema.nullable();
+const workspaceIdStringSchema = z.string()
+  .transform(normalizeWorkspaceId)
+  .superRefine((value, context) => {
+    if (!isWorkspaceId(value)) {
+      context.addIssue({
+        origin: "string",
+        code: "invalid_format",
+        format: "uuid",
+        input: value,
+        message: "Invalid UUID",
+      });
+    }
+  })
+  .transform((value) => value.toLowerCase());
+const nullableWorkspaceIdStringSchema = workspaceIdStringSchema.nullable();
 const platformSchema = z.enum(["ios", "android", "web"]);
 const promptEventTypeSchema = z.enum(["automatic_prompt_shown", "automatic_prompt_dismissed"]);
 const submissionTriggerSchema = z.enum(["automatic", "settings"]);
@@ -19,7 +38,7 @@ const messageSchema = z.string()
 
 const feedbackPromptEventInputSchema = z.strictObject({
   feedbackPromptEventId: uuidStringSchema,
-  workspaceId: nullableUuidStringSchema,
+  workspaceId: nullableWorkspaceIdStringSchema,
   installationId: nullableUuidStringSchema,
   platform: platformSchema,
   appVersion: requiredNullableTextSchema,
@@ -31,7 +50,7 @@ const feedbackPromptEventInputSchema = z.strictObject({
 
 const feedbackSubmissionInputSchema = z.strictObject({
   feedbackSubmissionId: uuidStringSchema,
-  workspaceId: nullableUuidStringSchema,
+  workspaceId: nullableWorkspaceIdStringSchema,
   installationId: nullableUuidStringSchema,
   platform: platformSchema,
   appVersion: requiredNullableTextSchema,

--- a/apps/backend/src/mcp/server.test.ts
+++ b/apps/backend/src/mcp/server.test.ts
@@ -19,6 +19,7 @@ const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
 const RESOURCE_URL = "https://mcp.flashcards-open-source-app.com/mcp";
 const WEBSITE_URL = "https://flashcards-open-source-app.com";
 const ICON_URL = "https://mcp.flashcards-open-source-app.com/icon.svg";
+const LEGACY_POSTGRES_WORKSPACE_ID = "35274129-ef97-d366-954c-955b4bb0fbf0";
 
 type ResolveWorkspaceCall = Readonly<{
   requestContext: WorkspaceRequestContext;
@@ -134,6 +135,13 @@ function requireTool(tools: ReadonlyArray<ListedTool>, name: string): ListedTool
   return tool;
 }
 
+function readWorkspaceIdInputSchema(tool: ListedTool): JsonObject {
+  const inputSchema: unknown = tool.inputSchema;
+  assert.ok(isJsonObject(inputSchema), `Expected ${tool.name} input schema to be an object`);
+  const properties = readJsonObject(inputSchema, "properties");
+  return readJsonObject(properties, "workspaceId");
+}
+
 function createFakeDependencyCalls(): FakeDependencyCalls {
   return {
     resolveAccessibleMcpWorkspaceIds: [],
@@ -219,7 +227,7 @@ function createFakeDependencies(
 
 test("MCP server exposes workspace and SQL tools through the protocol path", async () => {
   const selectedWorkspaceId = "11111111-1111-4111-8111-111111111111";
-  const requestedWorkspaceId = "22222222-2222-4222-8222-222222222222";
+  const requestedWorkspaceId = LEGACY_POSTGRES_WORKSPACE_ID;
   const connection: AuthenticatedMcpAccessToken = {
     userId: "user-mcp-smoke",
     connectionId: "connection-mcp-smoke",
@@ -279,6 +287,13 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
       destructiveHint: true,
       openWorldHint: false,
     });
+    for (const tool of [sqlQueryTool, sqlExecuteTool]) {
+      const workspaceIdSchema = readWorkspaceIdInputSchema(tool);
+      assert.equal(readJsonString(workspaceIdSchema, "format"), "uuid", tool.name);
+      const workspaceIdPattern = new RegExp(readJsonString(workspaceIdSchema, "pattern"));
+      assert.equal(workspaceIdPattern.test(LEGACY_POSTGRES_WORKSPACE_ID), true, tool.name);
+      assert.equal(workspaceIdPattern.test("not-a-uuid"), false, tool.name);
+    }
 
     const listWorkspacesResult = await client.callTool({
       name: LIST_WORKSPACES_TOOL_NAME,
@@ -299,17 +314,36 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
     assert.notEqual(sqlQueryEnvelope.instructions, "");
     assert.notEqual(sqlQueryEnvelope.docs.openapiUrl, "");
 
+    const executeSql = "UPDATE cards SET back_text = 'Paris' WHERE card_id = 'card-1'";
+    const sqlExecuteResult = await client.callTool({
+      name: SQL_EXECUTE_TOOL_NAME,
+      arguments: { sql: executeSql, workspaceId: requestedWorkspaceId },
+    });
+    const sqlExecuteEnvelope = parseAgentEnvelope(readSingleTextContent(sqlExecuteResult));
+    assert.equal(sqlExecuteEnvelope.data.sql, executeSql);
+    assert.notEqual(sqlExecuteEnvelope.instructions, "");
+    assert.notEqual(sqlExecuteEnvelope.docs.openapiUrl, "");
+
     assert.deepEqual(calls.listWorkspaces, [{
       userId: connection.userId,
       selectedWorkspaceId: connection.selectedWorkspaceId,
     }]);
-    assert.deepEqual(calls.resolveAccessibleMcpWorkspaceIds, [{
-      requestContext: {
-        userId: connection.userId,
-        selectedWorkspaceId: connection.selectedWorkspaceId,
+    assert.deepEqual(calls.resolveAccessibleMcpWorkspaceIds, [
+      {
+        requestContext: {
+          userId: connection.userId,
+          selectedWorkspaceId: connection.selectedWorkspaceId,
+        },
+        explicitWorkspaceId: requestedWorkspaceId,
       },
-      explicitWorkspaceId: requestedWorkspaceId,
-    }]);
+      {
+        requestContext: {
+          userId: connection.userId,
+          selectedWorkspaceId: connection.selectedWorkspaceId,
+        },
+        explicitWorkspaceId: requestedWorkspaceId,
+      },
+    ]);
     assert.deepEqual(calls.sqlQueries, [{
       context: {
         userId: connection.userId,
@@ -319,6 +353,62 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
       },
       sql,
     }]);
+    assert.deepEqual(calls.sqlExecutes, [{
+      context: {
+        userId: connection.userId,
+        workspaceId: requestedWorkspaceId,
+        selectedWorkspaceId: connection.selectedWorkspaceId,
+        connectionId: connection.connectionId,
+      },
+      sql: executeSql,
+    }]);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("MCP SQL tools reject malformed workspace IDs before access resolution", async () => {
+  const selectedWorkspaceId = "11111111-1111-4111-8111-111111111111";
+  const connection: AuthenticatedMcpAccessToken = {
+    userId: "user-mcp-smoke",
+    connectionId: "connection-mcp-smoke",
+    selectedWorkspaceId,
+  };
+  const calls = createFakeDependencyCalls();
+  const server = createMcpServerWithDependencies(
+    connection,
+    RESOURCE_URL,
+    WEBSITE_URL,
+    ICON_URL,
+    createFakeDependencies(calls, []),
+  );
+  const client = new Client({ name: "mcp-protocol-smoke", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    for (const toolCall of [
+      {
+        name: SQL_QUERY_TOOL_NAME,
+        sql: "SELECT * FROM cards LIMIT 1",
+      },
+      {
+        name: SQL_EXECUTE_TOOL_NAME,
+        sql: "DELETE FROM cards WHERE card_id = 'card-1'",
+      },
+    ]) {
+      const result = await client.callTool({
+        name: toolCall.name,
+        arguments: { sql: toolCall.sql, workspaceId: "not-a-uuid" },
+      });
+      assert.equal(result.isError, true, toolCall.name);
+    }
+
+    assert.deepEqual(calls.resolveAccessibleMcpWorkspaceIds, []);
+    assert.deepEqual(calls.sqlQueries, []);
     assert.deepEqual(calls.sqlExecutes, []);
   } finally {
     await client.close();

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -32,6 +32,8 @@ import type { AuthenticatedMcpAccessToken } from "../auth/mcpTokens";
 const SERVER_NAME = "flashcards-open-source-app";
 const SERVER_VERSION = "v1";
 
+const workspaceIdStringSchema = z.string().trim().check(z.guid()).toLowerCase();
+
 /**
  * Descriptions for the split MCP `sql_query` (read-only) and `sql_execute`
  * (write) tools. Reuse the published split tool-call descriptions so the MCP
@@ -393,9 +395,7 @@ export function createMcpServerWithDependencies(
           .describe(
             "One or more read statements in the published Flashcards SQL dialect (SHOW TABLES, DESCRIBE, SHOW COLUMNS, SELECT).",
           ),
-        workspaceId: z
-          .string()
-          .uuid()
+        workspaceId: workspaceIdStringSchema
           .optional()
           .describe(
             "Optional workspace UUID from the list_workspaces tool; omit to use your currently selected default workspace.",
@@ -446,9 +446,7 @@ export function createMcpServerWithDependencies(
           .describe(
             "One or more write statements in the published Flashcards SQL dialect (INSERT, UPDATE, DELETE).",
           ),
-        workspaceId: z
-          .string()
-          .uuid()
+        workspaceId: workspaceIdStringSchema
           .optional()
           .describe(
             "Optional workspace UUID from the list_workspaces tool; omit to use your currently selected default workspace.",

--- a/apps/backend/src/routes/catalogAdmin.test.ts
+++ b/apps/backend/src/routes/catalogAdmin.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AdminRequestContext } from "../admin/authz";
+import type {
+  CatalogPackageVersion,
+  CreateCatalogPackageVersionFromWorkspaceInput,
+} from "../catalog/types";
+import type { AppEnv } from "../server/app";
+import { HttpError } from "../shared/errors";
+import { createCatalogAdminRoutes } from "./catalogAdmin";
+
+const packageId = "11111111-1111-4111-8111-111111111111";
+const packageVersionId = "22222222-2222-4222-8222-222222222222";
+const cardId = "33333333-3333-4333-8333-333333333333";
+const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
+
+function createAdminRequestContext(): AdminRequestContext {
+  return {
+    email: "admin@example.com",
+    transport: "session",
+    userId: "admin-user-1",
+    subjectUserId: "admin-subject-1",
+    requestAuthInputs: {
+      authorizationHeader: undefined,
+      sessionToken: undefined,
+      csrfTokenHeader: undefined,
+      originHeader: undefined,
+      refererHeader: undefined,
+      secFetchSiteHeader: undefined,
+    },
+  };
+}
+
+function createCatalogPackageVersion(sourceWorkspaceId: string): CatalogPackageVersion {
+  const timestamp = "2026-08-02T00:00:00.000Z";
+  return {
+    packageVersionId,
+    packageId,
+    versionNumber: 1,
+    status: "draft",
+    slug: "test-package-v1",
+    title: "Test package",
+    summary: "Test summary",
+    description: "Test description",
+    languageTags: [],
+    topicTags: [],
+    license: "CC-BY-4.0",
+    contentWarning: null,
+    coverPackageMediaKey: null,
+    sourceWorkspaceId,
+    cardCount: 1,
+    createdByAdminEmail: "admin@example.com",
+    reviewedByAdminEmail: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    submittedAt: null,
+    reviewedAt: null,
+    publishedAt: null,
+    delistedAt: null,
+  };
+}
+
+function createCatalogAdminTestApp(
+  createVersion: (
+    receivedPackageId: string,
+    input: CreateCatalogPackageVersionFromWorkspaceInput,
+    adminUserId: string,
+    adminEmail: string,
+  ) => Promise<CatalogPackageVersion>,
+  authorize: () => Promise<AdminRequestContext>,
+): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.onError((error, context) => {
+    if (error instanceof HttpError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({ error: error.message, code: error.code });
+    }
+
+    throw error;
+  });
+  app.route("/", createCatalogAdminRoutes({
+    allowedOrigins: [],
+    requireAdminRequestFn: authorize,
+    createCatalogPackageVersionFromWorkspaceSelectionFn: createVersion,
+  }));
+  return app;
+}
+
+test("POST catalog version from workspace normalizes a legacy PostgreSQL workspace ID", async () => {
+  let authorizationChecks = 0;
+  let processingCalls = 0;
+  const app = createCatalogAdminTestApp(
+    async (receivedPackageId, input, adminUserId, adminEmail) => {
+      processingCalls += 1;
+      assert.equal(receivedPackageId, packageId);
+      assert.deepEqual(input, {
+        packageVersionId,
+        workspaceId: legacyWorkspaceId,
+        cardIds: [cardId],
+      });
+      assert.equal(adminUserId, "admin-user-1");
+      assert.equal(adminEmail, "admin@example.com");
+      return createCatalogPackageVersion(input.workspaceId);
+    },
+    async () => {
+      authorizationChecks += 1;
+      return createAdminRequestContext();
+    },
+  );
+
+  const response = await app.request(
+    `http://localhost/admin/catalog/packages/${packageId}/versions/from-workspace`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        packageVersionId,
+        workspaceId: ` \n${legacyWorkspaceId.toUpperCase()}\t`,
+        cardIds: [cardId],
+      }),
+    },
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(authorizationChecks, 1);
+  assert.equal(processingCalls, 1);
+  const payload = await response.json() as Readonly<{
+    packageVersion: CatalogPackageVersion;
+  }>;
+  assert.equal(payload.packageVersion.sourceWorkspaceId, legacyWorkspaceId);
+});
+
+test("POST catalog version from workspace preserves malformed workspace errors", async () => {
+  let authorizationChecks = 0;
+  let processingCalls = 0;
+  const app = createCatalogAdminTestApp(
+    async () => {
+      processingCalls += 1;
+      return createCatalogPackageVersion(legacyWorkspaceId);
+    },
+    async () => {
+      authorizationChecks += 1;
+      return createAdminRequestContext();
+    },
+  );
+
+  const response = await app.request(
+    `http://localhost/admin/catalog/packages/${packageId}/versions/from-workspace`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        packageVersionId,
+        workspaceId: "not-a-uuid",
+        cardIds: [cardId],
+      }),
+    },
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "workspaceId must be a UUID",
+    code: null,
+  });
+  assert.equal(authorizationChecks, 1);
+  assert.equal(processingCalls, 0);
+});

--- a/apps/backend/src/routes/catalogAdmin.ts
+++ b/apps/backend/src/routes/catalogAdmin.ts
@@ -35,6 +35,7 @@ import {
   expectNonEmptyString,
   expectRecord,
   expectUuidString,
+  expectWorkspaceIdString,
   parseJsonBodyWithByteLimit,
 } from "../server/requestParsing";
 import { HttpError } from "../shared/errors";
@@ -255,7 +256,7 @@ function parseCreatePackageVersionFromWorkspaceInput(
 ): CreateCatalogPackageVersionFromWorkspaceInput {
   return {
     packageVersionId: expectUuidString(record.packageVersionId, "packageVersionId"),
-    workspaceId: expectUuidString(record.workspaceId, "workspaceId"),
+    workspaceId: expectWorkspaceIdString(record.workspaceId, "workspaceId"),
     cardIds: expectStringArray(record.cardIds, "cardIds").map((cardId, index) => (
       expectUuidString(cardId, `cardIds[${index}]`)
     )),

--- a/apps/backend/src/routes/feedback.test.ts
+++ b/apps/backend/src/routes/feedback.test.ts
@@ -45,6 +45,7 @@ type FeedbackTestAppOptions = Readonly<{
 }>;
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
+const legacyPostgresWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
 const promptEventId = "22222222-2222-4222-8222-222222222222";
 const submissionId = "33333333-3333-4333-8333-333333333333";
 const installationId = "44444444-4444-4444-8444-444444444444";
@@ -417,6 +418,69 @@ test("POST /feedback/submissions records submission state and does not duplicate
   assert.equal(state.sentEmails.length, 1);
   assert.equal(state.sentEmails[0]?.message, "Please make review faster.");
   assert.equal(state.submissions.get(submissionId)?.emailNotificationStatus, "sent");
+});
+
+test("POST feedback routes preserve a legacy PostgreSQL workspace ID", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: null,
+  });
+
+  const promptResponse = await postJson(app, "/feedback/prompt-events", {
+    ...createPromptEventBody(),
+    workspaceId: legacyPostgresWorkspaceId,
+  });
+  const submissionResponse = await postJson(app, "/feedback/submissions", {
+    ...createSubmissionBody("Legacy workspace feedback."),
+    workspaceId: ` \n${legacyPostgresWorkspaceId.toUpperCase()}\t`,
+  });
+
+  assert.equal(promptResponse.status, 200);
+  assert.equal(submissionResponse.status, 200);
+  assert.equal(
+    state.promptEvents.get(promptEventId)?.workspaceId,
+    legacyPostgresWorkspaceId,
+  );
+  assert.equal(
+    state.submissions.get(submissionId)?.workspaceId,
+    legacyPostgresWorkspaceId,
+  );
+  assert.equal(state.sentEmails[0]?.workspaceId, legacyPostgresWorkspaceId);
+});
+
+test("POST feedback routes keep non-workspace identities on strict UUID validation", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: null,
+  });
+
+  const promptResponse = await postJson(app, "/feedback/prompt-events", {
+    ...createPromptEventBody(),
+    installationId: legacyPostgresWorkspaceId,
+  });
+  const submissionResponse = await postJson(app, "/feedback/submissions", {
+    ...createSubmissionBody("Strict identity validation."),
+    feedbackSubmissionId: legacyPostgresWorkspaceId,
+  });
+
+  assert.equal(promptResponse.status, 400);
+  assert.equal(submissionResponse.status, 400);
+  assert.deepEqual(await promptResponse.json(), {
+    error: "Feedback request is invalid.",
+    requestId: "request-1",
+    code: "FEEDBACK_INVALID_INPUT",
+  });
+  assert.deepEqual(await submissionResponse.json(), {
+    error: "Feedback request is invalid.",
+    requestId: "request-1",
+    code: "FEEDBACK_INVALID_INPUT",
+  });
+  assert.equal(state.promptEvents.size, 0);
+  assert.equal(state.submissions.size, 0);
 });
 
 test("POST /feedback/submissions rejects empty and too-long messages", async () => {

--- a/apps/backend/src/routes/sync/index.test.ts
+++ b/apps/backend/src/routes/sync/index.test.ts
@@ -10,6 +10,7 @@ import type { GuestSessionPlatform } from "../../guestAuth";
 import { createSyncRoutes } from "./index";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
+const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
 
 function createCodedError(code: string, message: string): Error & Readonly<{ code: string }> {
   const error = new Error(message) as Error & { code: string };
@@ -201,6 +202,68 @@ test("POST /sync/push accepts card payloads without legacy effortLevel", async (
       },
     ],
   });
+  assert.equal(processCalls, 1);
+});
+
+test("POST /sync/bootstrap preserves a legacy PostgreSQL workspace ID", async () => {
+  let accessCheckCalls = 0;
+  let processCalls = 0;
+  const routes = createSyncRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, requestedWorkspaceId) => {
+      accessCheckCalls += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, legacyWorkspaceId);
+    },
+    processSyncBootstrapFn: async (requestedWorkspaceId, userId, input) => {
+      processCalls += 1;
+      assert.equal(requestedWorkspaceId, legacyWorkspaceId);
+      assert.equal(userId, "user-1");
+      assert.equal(input.mode, "pull");
+      return {
+        mode: "pull",
+        entries: [],
+        nextCursor: null,
+        hasMore: false,
+        bootstrapHotChangeId: 0,
+        remoteIsEmpty: true,
+      };
+    },
+  });
+  const app = createSyncTestApp(routes);
+
+  const response = await app.request(
+    `http://localhost/workspaces/${legacyWorkspaceId}/sync/bootstrap`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        mode: "pull",
+        installationId: "install-1",
+        platform: "web",
+        appVersion: "1.0.0",
+        cursor: null,
+        limit: 100,
+      }),
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    mode: "pull",
+    entries: [],
+    nextCursor: null,
+    hasMore: false,
+    bootstrapHotChangeId: 0,
+    remoteIsEmpty: true,
+  });
+  assert.equal(accessCheckCalls, 1);
   assert.equal(processCalls, 1);
 });
 

--- a/apps/backend/src/server/requestContext.test.ts
+++ b/apps/backend/src/server/requestContext.test.ts
@@ -3,7 +3,75 @@ import test from "node:test";
 import { HttpError } from "../shared/errors";
 import {
   loadRequestContextWithAbortSignalAndDependencies,
+  parseOptionalWorkspaceIdParam,
+  parseWorkspaceIdParam,
 } from "./requestContext";
+
+const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
+const versionFourWorkspaceId = "11111111-1111-4111-8111-111111111111";
+
+test("workspace request parameters accept PostgreSQL UUID text", () => {
+  for (const parseWorkspaceId of [
+    parseWorkspaceIdParam,
+    parseOptionalWorkspaceIdParam,
+  ]) {
+    assert.equal(parseWorkspaceId(legacyWorkspaceId), legacyWorkspaceId);
+    assert.equal(parseWorkspaceId(versionFourWorkspaceId), versionFourWorkspaceId);
+    assert.equal(
+      parseWorkspaceId(` \n${legacyWorkspaceId}\t`),
+      legacyWorkspaceId,
+    );
+  }
+
+  assert.equal(parseOptionalWorkspaceIdParam(undefined), undefined);
+});
+
+test("required workspace request parameters preserve missing and invalid error codes", () => {
+  assert.throws(
+    () => parseWorkspaceIdParam(undefined),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.message, "workspaceId is required");
+      assert.equal(error.code, "WORKSPACE_ID_REQUIRED");
+      return true;
+    },
+  );
+
+  const invalidWorkspaceIds: ReadonlyArray<Readonly<{
+    value: string;
+    message: string;
+  }>> = [
+    { value: "", message: "workspaceId must not be empty" },
+    { value: " \t\n", message: "workspaceId must not be empty" },
+    {
+      value: "35274129-ef97-d366-954c-955b4bb0fbf",
+      message: "workspaceId must be a UUID",
+    },
+    {
+      value: "g5274129-ef97-d366-954c-955b4bb0fbf0",
+      message: "workspaceId must be a UUID",
+    },
+  ];
+
+  for (const parseWorkspaceId of [
+    parseWorkspaceIdParam,
+    parseOptionalWorkspaceIdParam,
+  ]) {
+    for (const invalidWorkspaceId of invalidWorkspaceIds) {
+      assert.throws(
+        () => parseWorkspaceId(invalidWorkspaceId.value),
+        (error: unknown) => {
+          assert.ok(error instanceof HttpError);
+          assert.equal(error.statusCode, 400);
+          assert.equal(error.message, invalidWorkspaceId.message);
+          assert.equal(error.code, "WORKSPACE_ID_INVALID");
+          return true;
+        },
+      );
+    }
+  }
+});
 
 test("request context aborts in-flight authentication before profile database work", async () => {
   const controller = new AbortController();

--- a/apps/backend/src/server/requestContext.ts
+++ b/apps/backend/src/server/requestContext.ts
@@ -14,6 +14,10 @@ import {
 } from "../auth/ensureUser";
 import { assertUserHasWorkspaceAccess } from "../workspaces/selection";
 import {
+  isWorkspaceId,
+  normalizeWorkspaceId,
+} from "../workspaces/identity";
+import {
   enforceSessionCsrfProtection,
   enforceSessionCsrfProtectionWithAbortSignal,
   extractRequestAuthInputs,
@@ -244,17 +248,16 @@ export function parseWorkspaceIdParam(value: string | undefined): string {
     throw new HttpError(400, "workspaceId is required", "WORKSPACE_ID_REQUIRED");
   }
 
-  const trimmedValue = value.trim();
-  if (trimmedValue === "") {
+  const normalizedValue = normalizeWorkspaceId(value);
+  if (normalizedValue === "") {
     throw new HttpError(400, "workspaceId must not be empty", "WORKSPACE_ID_INVALID");
   }
 
-  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-  if (!uuidPattern.test(trimmedValue)) {
+  if (!isWorkspaceId(normalizedValue)) {
     throw new HttpError(400, "workspaceId must be a UUID", "WORKSPACE_ID_INVALID");
   }
 
-  return trimmedValue;
+  return normalizedValue;
 }
 
 export function parseOptionalWorkspaceIdParam(value: string | undefined): string | undefined {

--- a/apps/backend/src/server/requestParsing.ts
+++ b/apps/backend/src/server/requestParsing.ts
@@ -1,4 +1,8 @@
 import { HttpError } from "../shared/errors";
+import {
+  isWorkspaceId,
+  normalizeWorkspaceId,
+} from "../workspaces/identity";
 
 export async function parseJsonBody(request: Request): Promise<unknown> {
   try {
@@ -64,6 +68,15 @@ export function expectUuidString(value: unknown, fieldName: string): string {
   }
 
   return trimmedValue.toLowerCase();
+}
+
+export function expectWorkspaceIdString(value: unknown, fieldName: string): string {
+  const normalizedValue = normalizeWorkspaceId(expectNonEmptyString(value, fieldName));
+  if (!isWorkspaceId(normalizedValue)) {
+    throw new HttpError(400, `${fieldName} must be a UUID`);
+  }
+
+  return normalizedValue.toLowerCase();
 }
 
 export function expectNullableNonEmptyString(value: unknown, fieldName: string): string | null {

--- a/apps/backend/src/workspaces/identity.ts
+++ b/apps/backend/src/workspaces/identity.ts
@@ -1,0 +1,10 @@
+const workspaceIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+export function normalizeWorkspaceId(value: string): string {
+  return value.trim();
+}
+
+export function isWorkspaceId(value: string): boolean {
+  return workspaceIdPattern.test(value);
+}


### PR DESCRIPTION
## Summary

- accept canonical PostgreSQL workspace UUID text at external backend boundaries
- retain strict UUID validation for non-workspace identities
- publish a dedicated WorkspaceIdString schema across OpenAPI and align MCP schema/runtime
- add route and protocol regression coverage for the persisted legacy workspace ID

## Validation

- npm run lint --prefix api
- npm run bundle --prefix api
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend (1,077 passed)
- npm run build --prefix apps/backend
- npm run test:mcp --prefix apps/backend
- git diff --check