### PR TITLE
test: cover fresh PostgreSQL bootstrap

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -80,6 +80,7 @@ export const boundaryDefinitions = Object.freeze([
       "src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts",
       "src/database/aiChatInitiatingAuthClassification.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",
+      "src/sync/freshBootstrap.postgres.integration.ts",
     ]),
   }),
   Object.freeze({

--- a/apps/backend/scripts/run-postgres-integrations.mjs
+++ b/apps/backend/scripts/run-postgres-integrations.mjs
@@ -797,9 +797,6 @@ async function assertHistoricalSeedBoundary(client) {
       `Historical migration 0018 test boundary has unexpected scratch data. state=${JSON.stringify(state)}`,
     );
   }
-  await client.query(
-    "DELETE FROM org.user_settings WHERE user_id = 'local'",
-  );
 }
 
 async function seedMigration0099LegacyInvalidMediaAsset(client) {
@@ -1256,9 +1253,9 @@ async function applySingleMigration(
           fileName
           === "0018_auto_provision_workspaces_and_scheduler_seed.sql"
         ) {
-          // The historical 0001 scratch seed has no device. Migration 0018
-          // inserts its workspace before its device and cannot satisfy that old
-          // fixture's FK. Production data never used this scratch seed.
+          // The 0001 local-development seed exercises migration 0018's
+          // workspace/device cycle. Its deferred FK is satisfied when the
+          // migration transaction inserts the corresponding device.
           await assertHistoricalSeedBoundary(client);
         }
         // Every migration gets its own production-like session and transaction.

--- a/apps/backend/src/sync/freshBootstrap.postgres.integration.ts
+++ b/apps/backend/src/sync/freshBootstrap.postgres.integration.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import { Hono } from "hono";
+import pg from "pg";
+import { createSyncRoutes } from "../routes/sync";
+import type { AppEnv } from "../server/app";
+import type { RequestContext } from "../server/requestContext";
+
+const localUserId = "local";
+const localWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
+
+type LocalWorkspaceRow = Readonly<{
+  role: string;
+  selected_workspace_id: string;
+  user_id: string;
+  workspace_id: string;
+}>;
+
+type BootstrapReplicaRow = Readonly<{
+  installation_id: string;
+  platform: string;
+  user_id: string;
+  workspace_id: string;
+}>;
+
+function requireOwnerDatabaseUrl(): string {
+  const databaseUrl = process.env.TEST_DATABASE_ADMIN_URL?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error(
+      "TEST_DATABASE_ADMIN_URL is required for the fresh PostgreSQL bootstrap integration test.",
+    );
+  }
+
+  return databaseUrl;
+}
+
+function createLocalRequestContext(): RequestContext {
+  return {
+    userId: localUserId,
+    subjectUserId: localUserId,
+    selectedWorkspaceId: localWorkspaceId,
+    email: null,
+    locale: "en",
+    userSettingsCreatedAt: "2026-01-01T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
+    transport: "bearer",
+    connectionId: null,
+    guestSessionId: null,
+    guestPlatform: null,
+  };
+}
+
+function createFreshBootstrapApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", randomUUID());
+    context.set("clientAppVersion", null);
+    context.set("clientPlatform", null);
+    await next();
+  });
+  app.route("/", createSyncRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {
+        authorizationHeader: undefined,
+        sessionToken: undefined,
+        csrfTokenHeader: undefined,
+        originHeader: undefined,
+        refererHeader: undefined,
+        secFetchSiteHeader: undefined,
+      },
+      requestContext: createLocalRequestContext(),
+    }),
+  }));
+  return app;
+}
+
+test("a fresh PostgreSQL database bootstraps the migration-0018 local workspace", async () => {
+  const ownerPool = new pg.Pool({
+    connectionString: requireOwnerDatabaseUrl(),
+    application_name: "fresh-bootstrap-integration-owner",
+  });
+  const installationId = randomUUID();
+
+  try {
+    const localWorkspace = await ownerPool.query<LocalWorkspaceRow>(
+      `SELECT
+         user_settings.user_id,
+         user_settings.workspace_id::text AS selected_workspace_id,
+         workspaces.workspace_id::text AS workspace_id,
+         memberships.role
+       FROM org.user_settings AS user_settings
+       INNER JOIN org.workspaces AS workspaces
+         ON workspaces.workspace_id = user_settings.workspace_id
+       INNER JOIN org.workspace_memberships AS memberships
+         ON memberships.workspace_id = workspaces.workspace_id
+        AND memberships.user_id = user_settings.user_id
+       WHERE user_settings.user_id = $1`,
+      [localUserId],
+    );
+    assert.deepEqual(localWorkspace.rows, [{
+      user_id: localUserId,
+      selected_workspace_id: localWorkspaceId,
+      workspace_id: localWorkspaceId,
+      role: "owner",
+    }]);
+
+    const response = await createFreshBootstrapApp().request(
+      `http://localhost/workspaces/${localWorkspaceId}/sync/bootstrap`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          mode: "pull",
+          installationId,
+          platform: "web",
+          cursor: null,
+          limit: 2,
+        }),
+      },
+    );
+    const responseBody = await response.text();
+    assert.equal(response.status, 200, responseBody);
+
+    const replica = await ownerPool.query<BootstrapReplicaRow>(
+      `SELECT
+         installation_id::text AS installation_id,
+         platform,
+         user_id,
+         workspace_id::text AS workspace_id
+       FROM sync.workspace_replicas
+       WHERE workspace_id = $1
+         AND installation_id = $2`,
+      [localWorkspaceId, installationId],
+    );
+    assert.deepEqual(replica.rows, [{
+      installation_id: installationId,
+      platform: "web",
+      user_id: localUserId,
+      workspace_id: localWorkspaceId,
+    }]);
+  } finally {
+    await ownerPool.end();
+  }
+});


### PR DESCRIPTION
## Summary
- preserve the migration 0001 local seed through migration 0018
- add a real PostgreSQL bootstrap HTTP smoke at the latest integration boundary
- verify the deterministic local workspace and resulting web installation replica

## Validation
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend (1,077/1,077)
- npm run build --prefix apps/backend
- git diff --check
- PostgreSQL 18 latest boundary and boundaries 0100, 0099, 0098, 0097, 0096 passed

## Accepted residual
Existing timing-sensitive boundary 0101 reached 15/16 on three runs with different unrelated multipart deadline/fencing assertions. No fixture or production behavior was weakened, and independent review found no P0-P4 issues.