### PR TITLE
fix(backend): canonicalize HTTP workspace IDs

### DIFF
--- a/apps/backend/src/routes/directImageIngestion.ts
+++ b/apps/backend/src/routes/directImageIngestion.ts
@@ -38,8 +38,15 @@ import {
   getDirectImageIngestionRequestTiming,
 } from "../server/directImageIngestionRequestTiming";
 
-type DirectImageIngestionRoutesOptions = Readonly<{
+export type DirectImageIngestionRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
+  loadRequestContextFromRequestWithAbortSignalFn?:
+    typeof loadRequestContextFromRequestWithAbortSignal;
+  assertUserHasWorkspaceAccessFn?: typeof assertUserHasWorkspaceAccess;
+  assertImageMediaAssetIngestionPreconditionsForWorkspaceFn?:
+    typeof assertImageMediaAssetIngestionPreconditionsForWorkspace;
+  ingestImageMediaAssetWithRequestDeadlineFn?:
+    typeof ingestImageMediaAssetWithRequestDeadline;
 }>;
 
 function createDirectImageIngestionScope(
@@ -131,6 +138,17 @@ export function createDirectImageIngestionRoutes(
   options: DirectImageIngestionRoutesOptions,
 ): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
+  const loadRequestContextFromRequestWithAbortSignalFn =
+    options.loadRequestContextFromRequestWithAbortSignalFn
+    ?? loadRequestContextFromRequestWithAbortSignal;
+  const assertUserHasWorkspaceAccessFn =
+    options.assertUserHasWorkspaceAccessFn ?? assertUserHasWorkspaceAccess;
+  const assertImageMediaAssetIngestionPreconditionsForWorkspaceFn =
+    options.assertImageMediaAssetIngestionPreconditionsForWorkspaceFn
+    ?? assertImageMediaAssetIngestionPreconditionsForWorkspace;
+  const ingestImageMediaAssetWithRequestDeadlineFn =
+    options.ingestImageMediaAssetWithRequestDeadlineFn
+    ?? ingestImageMediaAssetWithRequestDeadline;
 
   app.post("/workspaces/:workspaceId/media-assets/images", async (context) => {
     let userId: string | null = null;
@@ -145,7 +163,7 @@ export function createDirectImageIngestionRoutes(
       const prepared = await runDatabaseOperationsWithDeadline(
         ingestionDeadline.preprocessingDeadlineAtMs,
         async () => {
-          const loadedContext = await loadRequestContextFromRequestWithAbortSignal(
+          const loadedContext = await loadRequestContextFromRequestWithAbortSignalFn(
             context.req.raw,
             options.allowedOrigins,
             ingestionDeadline.preprocessingSignal,
@@ -154,7 +172,7 @@ export function createDirectImageIngestionRoutes(
           workspaceId = parseWorkspaceIdParam(
             context.req.param("workspaceId"),
           );
-          await assertUserHasWorkspaceAccess(
+          await assertUserHasWorkspaceAccessFn(
             loadedContext.requestContext.userId,
             workspaceId,
           );
@@ -162,7 +180,7 @@ export function createDirectImageIngestionRoutes(
             context.req.raw.headers,
           );
           mediaAssetId = metadata.mediaAssetId;
-          await assertImageMediaAssetIngestionPreconditionsForWorkspace(
+          await assertImageMediaAssetIngestionPreconditionsForWorkspaceFn(
             loadedContext.requestContext.userId,
             workspaceId,
             metadata,
@@ -191,7 +209,7 @@ export function createDirectImageIngestionRoutes(
       );
       const result = await runDatabaseOperationsWithDeadline(
         ingestionDeadline.requestDeadlineAtMs,
-        () => ingestImageMediaAssetWithRequestDeadline({
+        () => ingestImageMediaAssetWithRequestDeadlineFn({
           userId: prepared.loadedContext.requestContext.userId,
           workspaceId: prepared.workspaceId,
           metadata: prepared.metadata,

--- a/apps/backend/src/routes/mediaAssets.test.ts
+++ b/apps/backend/src/routes/mediaAssets.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { RequestAuthInputs } from "../auth/requestSecurity";
 import {
   DatabaseCommitOutcomeUnknownError,
   TransientDatabaseHttpError,
@@ -16,6 +17,7 @@ import type {
 import { createBackendObservationScope } from "../observability/sentry";
 import { HttpError } from "../shared/errors";
 import type { AppEnv } from "../server/appEnv";
+import type { RequestContext } from "../server/requestContext";
 import {
   createMultipartCompletionRequestTiming,
   runWithMultipartCompletionRequestTiming,
@@ -37,7 +39,48 @@ import {
 } from "../mediaAssets/multipart/completionBoundary";
 import { createMediaAssetsRoutes } from "./mediaAssets";
 
-function createMediaAssetsTestApp(): Hono<AppEnv> {
+const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
+const uppercaseLegacyWorkspaceId = legacyWorkspaceId.toUpperCase();
+const testMediaAssetId = "33333333-3333-4333-8333-333333333333";
+const testReplicaId = "44444444-4444-4444-8444-444444444444";
+const testTimestamp = "2026-07-28T10:00:00.000Z";
+
+const requestAuthInputs: RequestAuthInputs = {
+  authorizationHeader: undefined,
+  sessionToken: undefined,
+  csrfTokenHeader: undefined,
+  originHeader: undefined,
+  refererHeader: undefined,
+  secFetchSiteHeader: undefined,
+};
+
+const requestContext: RequestContext = {
+  userId: "user-1",
+  subjectUserId: "subject-1",
+  selectedWorkspaceId: legacyWorkspaceId,
+  email: "user@example.com",
+  locale: "en",
+  userSettingsCreatedAt: testTimestamp,
+  preferences: {
+    reviewReactionAnimationsEnabled: true,
+  },
+  transport: "bearer",
+  connectionId: null,
+  guestSessionId: null,
+  guestPlatform: null,
+};
+
+function createLoadedRequestContext(): Readonly<{
+  requestAuthInputs: RequestAuthInputs;
+  requestContext: RequestContext;
+}> {
+  return {
+    requestAuthInputs,
+    requestContext,
+  };
+}
+
+function createMediaAssetsRouteTestApp(routes: Hono<AppEnv>): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   app.use("*", async (context, next) => {
     context.set("requestId", "request-1");
@@ -54,8 +97,14 @@ function createMediaAssetsTestApp(): Hono<AppEnv> {
     }
     throw error;
   });
-  app.route("/", createMediaAssetsRoutes({ allowedOrigins: [] }));
+  app.route("/", routes);
   return app;
+}
+
+function createMediaAssetsTestApp(): Hono<AppEnv> {
+  return createMediaAssetsRouteTestApp(
+    createMediaAssetsRoutes({ allowedOrigins: [] }),
+  );
 }
 
 function uploadSession(
@@ -194,6 +243,145 @@ function createMultipartCompletionBoundaryTestDependencies(
     resolveCompletionAttemptFailureWithOwnerFn,
   };
 }
+
+test("uppercase historical workspace path reaches direct image ingestion as lowercase", async () => {
+  const forwardedWorkspaceIds: Array<string> = [];
+  const app = createMediaAssetsRouteTestApp(createMediaAssetsRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestWithAbortSignalFn: async () =>
+      createLoadedRequestContext(),
+    assertUserHasWorkspaceAccessFn: async (_userId, workspaceId) => {
+      forwardedWorkspaceIds.push(workspaceId);
+    },
+    assertImageMediaAssetIngestionPreconditionsForWorkspaceFn:
+      async (_userId, workspaceId) => {
+        forwardedWorkspaceIds.push(workspaceId);
+      },
+    ingestImageMediaAssetWithRequestDeadlineFn: async (input) => {
+      forwardedWorkspaceIds.push(input.workspaceId);
+      return {
+        mediaAsset: {
+          mediaAssetId: testMediaAssetId,
+          workspaceId: input.workspaceId,
+          mimeType: "image/jpeg",
+          sizeBytes: 1,
+          sha256: "a".repeat(64),
+          sourceUrl: null,
+          createdAt: testTimestamp,
+          clientUpdatedAt: testTimestamp,
+          lastModifiedByReplicaId: testReplicaId,
+          lastOperationId: "operation-1",
+          updatedAt: testTimestamp,
+          deletedAt: null,
+        },
+        applied: true,
+      };
+    },
+  }));
+
+  const response = await app.request(
+    `http://localhost/workspaces/${uppercaseLegacyWorkspaceId}/media-assets/images`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "image/png",
+        "x-media-asset-id": testMediaAssetId,
+        "x-media-created-at": testTimestamp,
+        "x-media-client-updated-at": testTimestamp,
+        "x-media-last-modified-by-replica-id": testReplicaId,
+        "x-media-last-operation-id": "operation-1",
+      },
+      body: new Uint8Array([1]),
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(forwardedWorkspaceIds, [
+    legacyWorkspaceId,
+    legacyWorkspaceId,
+    legacyWorkspaceId,
+  ]);
+});
+
+test("uppercase historical workspace path reaches multipart create and replay as lowercase", async () => {
+  const forwardedWorkspaceIds: Array<string> = [];
+  const session = uploadSession(
+    "active",
+    new Date(Date.now() + 60_000).toISOString(),
+  );
+  const app = createMediaAssetsRouteTestApp(createMediaAssetsRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => createLoadedRequestContext(),
+    assertUserHasWorkspaceAccessFn: async (_userId, workspaceId) => {
+      assert.equal(workspaceId, legacyWorkspaceId);
+    },
+    multipartUploadSessionCreationApplicationDependencies: {
+      abortMultipartMediaAssetUploadUntilDeadlineFn: async () => {
+        throw new Error("Finalized creation replay must not abort storage.");
+      },
+      acquireCreationClaimFn: async (_userId, workspaceId) => {
+        forwardedWorkspaceIds.push(workspaceId);
+        return {
+          status: "finalized",
+          uploadSessionId: session.sessionId,
+        };
+      },
+      createMediaAssetFromAvailableBlobForWorkspaceFn: async () => {
+        throw new Error("Finalized creation replay must not create media.");
+      },
+      createMultipartMediaAssetUploadFn: async () => {
+        throw new Error("Finalized creation replay must not create storage.");
+      },
+      loadCreationReplayFn: async (_userId, workspaceId) => {
+        forwardedWorkspaceIds.push(workspaceId);
+        return {
+          state: "active",
+          uploadSession: {
+            ...session,
+            workspaceId,
+          },
+        };
+      },
+      recordUploadSessionWithCreationClaimFn: async () => {
+        throw new Error("Finalized creation replay must not record a session.");
+      },
+      releaseCreationClaimFn: async () => {
+        throw new Error("Finalized creation replay must not release its claim.");
+      },
+    },
+  }));
+  const requestBody = JSON.stringify({
+    mediaAssetId: testMediaAssetId,
+    mimeType: "image/png",
+    sizeBytes: 1,
+    sha256: "a".repeat(64),
+    partSizeBytes: 1,
+    partCount: 1,
+    sourceUrl: null,
+    createdAt: testTimestamp,
+    clientUpdatedAt: testTimestamp,
+    lastModifiedByReplicaId: testReplicaId,
+    lastOperationId: "operation-1",
+  });
+  const requestUrl =
+    `http://localhost/workspaces/${uppercaseLegacyWorkspaceId}/media-assets/upload-sessions`;
+
+  const replayResponse = await app.request(requestUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: requestBody,
+  });
+
+  assert.equal(replayResponse.status, 201);
+  const replayResponseBody = await replayResponse.json() as Readonly<{
+    workspaceId: string;
+  }>;
+  assert.equal(replayResponseBody.workspaceId, legacyWorkspaceId);
+  assert.deepEqual(forwardedWorkspaceIds, [
+    legacyWorkspaceId,
+    legacyWorkspaceId,
+  ]);
+});
 
 test("expired multipart completion cleanup resumes only active or aborting sessions", () => {
   const expiredAt = new Date(Date.now() - 60_000).toISOString();

--- a/apps/backend/src/routes/mediaAssets.ts
+++ b/apps/backend/src/routes/mediaAssets.ts
@@ -22,6 +22,7 @@ import {
   createMultipartUploadSessionAtApplicationBoundary,
   multipartUploadSessionCreationApplicationDependencies,
   multipartUploadSessionCreationClaimLeaseDurationMs,
+  type MultipartUploadSessionCreationApplicationDependencies,
 } from "../mediaAssets/multipart/creationBoundary";
 import {
   mapMultipartCompletionDeadlineError,
@@ -65,18 +66,30 @@ import {
 import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
 import type { AppEnv } from "../server/app";
 import { runDatabaseOperationsWithDeadline } from "../database";
-import { createDirectImageIngestionRoutes } from "./directImageIngestion";
+import {
+  createDirectImageIngestionRoutes,
+  type DirectImageIngestionRoutesOptions,
+} from "./directImageIngestion";
 import {
   createStandaloneMultipartCompletionRequestTiming,
   getMultipartCompletionRequestTimingContext,
 } from "../server/multipartCompletionRequestTiming";
 
-type MediaAssetsRoutesOptions = Readonly<{
-  allowedOrigins: ReadonlyArray<string>;
+type MediaAssetsRoutesOptions = DirectImageIngestionRoutesOptions & Readonly<{
+  loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
+  multipartUploadSessionCreationApplicationDependencies?:
+    MultipartUploadSessionCreationApplicationDependencies;
 }>;
 
 export function createMediaAssetsRoutes(options: MediaAssetsRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
+  const loadRequestContextFromRequestFn =
+    options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
+  const assertUserHasWorkspaceAccessFn =
+    options.assertUserHasWorkspaceAccessFn ?? assertUserHasWorkspaceAccess;
+  const multipartUploadSessionCreationDependencies =
+    options.multipartUploadSessionCreationApplicationDependencies
+    ?? multipartUploadSessionCreationApplicationDependencies;
 
   app.route("/", createDirectImageIngestionRoutes(options));
 
@@ -88,10 +101,10 @@ export function createMediaAssetsRoutes(options: MediaAssetsRoutesOptions): Hono
     let sessionId: string | null = null;
 
     try {
-      const loadedContext = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+      const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
       requestContext = loadedContext.requestContext;
       workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
-      await assertUserHasWorkspaceAccess(loadedContext.requestContext.userId, workspaceId);
+      await assertUserHasWorkspaceAccessFn(loadedContext.requestContext.userId, workspaceId);
       const input = parseMediaAssetUploadSessionCreateInput(await parseJsonBody(context.req.raw));
       mediaAssetId = input.mediaAssetId;
       sessionId = randomUUID();
@@ -111,7 +124,7 @@ export function createMediaAssetsRoutes(options: MediaAssetsRoutesOptions): Hono
           scope,
           context.req.raw.signal,
           multipartUploadSessionCreationClaimLeaseDurationMs,
-          multipartUploadSessionCreationApplicationDependencies,
+          multipartUploadSessionCreationDependencies,
         );
       const sessionResult = applicationResult.sessionResult;
       if (sessionResult.status === "already_available") {

--- a/apps/backend/src/server/requestContext.test.ts
+++ b/apps/backend/src/server/requestContext.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./requestContext";
 
 const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
+const uppercaseLegacyWorkspaceId = legacyWorkspaceId.toUpperCase();
 const versionFourWorkspaceId = "11111111-1111-4111-8111-111111111111";
 
 test("workspace request parameters accept PostgreSQL UUID text", () => {
@@ -16,6 +17,7 @@ test("workspace request parameters accept PostgreSQL UUID text", () => {
     parseOptionalWorkspaceIdParam,
   ]) {
     assert.equal(parseWorkspaceId(legacyWorkspaceId), legacyWorkspaceId);
+    assert.equal(parseWorkspaceId(uppercaseLegacyWorkspaceId), legacyWorkspaceId);
     assert.equal(parseWorkspaceId(versionFourWorkspaceId), versionFourWorkspaceId);
     assert.equal(
       parseWorkspaceId(` \n${legacyWorkspaceId}\t`),

--- a/apps/backend/src/server/requestContext.ts
+++ b/apps/backend/src/server/requestContext.ts
@@ -257,7 +257,7 @@ export function parseWorkspaceIdParam(value: string | undefined): string {
     throw new HttpError(400, "workspaceId must be a UUID", "WORKSPACE_ID_INVALID");
   }
 
-  return normalizedValue;
+  return normalizedValue.toLowerCase();
 }
 
 export function parseOptionalWorkspaceIdParam(value: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary
- return accepted HTTP workspace path/query IDs in lowercase canonical form
- preserve strict internal and non-workspace ID validation
- cover uppercase historical IDs through direct ingestion and multipart finalized replay

## Validation
- focused parser/media tests: 18/18
- backend lint
- backend tests: 1081/1081
- backend build
- git diff --check
- fresh review: no P0-P4 findings