### PR TITLE
Fix catalog CORS and zero-gap rollout

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -359,7 +359,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: CDK deploy with reconciliation schedule disabled
+      - name: CDK deploy with migration-gated runtime and reconciliation schedule disabled
         working-directory: infra/aws
         env:
           AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
@@ -407,7 +407,7 @@ jobs:
             -c mediaBlobCleanupEnabled=false \
             -c multipartCompletionReconciliationScheduleState=DISABLED
 
-      - name: Run database migrations
+      - name: Verify required database migration
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseMigrationInvocation } from "./migrate-lambda";
+
+test("migration Lambda distinguishes direct and CloudFormation invocations", () => {
+  assert.deepEqual(parseMigrationInvocation({}), { kind: "direct" });
+  assert.deepEqual(parseMigrationInvocation({ RequestType: "Delete" }), { kind: "delete" });
+  assert.deepEqual(parseMigrationInvocation({
+    RequestType: "Update",
+    ResourceProperties: {
+      RequiredMigration: "0106_catalog_install_idempotency.sql",
+      UnrelatedProperty: "ignored",
+    },
+  }), {
+    kind: "provision",
+    requiredMigration: "0106_catalog_install_idempotency.sql",
+  });
+});
+
+test("migration Lambda rejects invalid CloudFormation migration requirements", () => {
+  assert.throws(
+    () => parseMigrationInvocation({ RequestType: "Replace" }),
+    /RequestType is invalid/u,
+  );
+  assert.throws(
+    () => parseMigrationInvocation({ RequestType: "Create", ResourceProperties: {} }),
+    /RequiredMigration must be a non-empty string/u,
+  );
+});

--- a/apps/backend/src/entrypoints/migrate-lambda.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.ts
@@ -26,6 +26,21 @@ type MigrationLambdaResult = Readonly<{
   configuredRuntimeRoles: ReadonlyArray<MigrationLambdaRuntimeRoleResult>;
 }>;
 
+type MigrationCustomResourceResult = MigrationLambdaResult & Readonly<{
+  PhysicalResourceId: string;
+}>;
+
+type MigrationCustomResourceDeleteResult = Readonly<{
+  PhysicalResourceId: string;
+}>;
+
+type MigrationInvocation =
+  | Readonly<{ kind: "direct" }>
+  | Readonly<{ kind: "delete" }>
+  | Readonly<{ kind: "provision"; requiredMigration: string }>;
+
+const migrationCustomResourcePhysicalId = "flashcards-database-migrations";
+
 let migrationRuntimePromise: Promise<MigrationRuntime> | null = null;
 
 async function createMigrationRuntime(): Promise<MigrationRuntime> {
@@ -51,11 +66,67 @@ function createMigrationFailureDetails(error: Error): MigrationFailureDetails {
   };
 }
 
-const migrationHandler: Handler<unknown, MigrationLambdaResult> = async (_event, context) => {
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && Array.isArray(value) === false;
+}
+
+export function parseMigrationInvocation(event: unknown): MigrationInvocation {
+  if (!isRecord(event) || !("RequestType" in event)) {
+    return { kind: "direct" };
+  }
+
+  const requestType = event.RequestType;
+  if (requestType === "Delete") {
+    return { kind: "delete" };
+  }
+  if (requestType !== "Create" && requestType !== "Update") {
+    throw new TypeError(`Migration custom resource RequestType is invalid. requestType=${String(requestType)}`);
+  }
+
+  const resourceProperties = event.ResourceProperties;
+  if (!isRecord(resourceProperties)) {
+    throw new TypeError("Migration custom resource ResourceProperties must be an object");
+  }
+  const requiredMigration = resourceProperties.RequiredMigration;
+  if (typeof requiredMigration !== "string" || requiredMigration.trim() === "") {
+    throw new TypeError("Migration custom resource RequiredMigration must be a non-empty string");
+  }
+
+  return { kind: "provision", requiredMigration };
+}
+
+function assertRequiredMigrationInstalled(
+  installedMigrations: ReadonlyArray<string>,
+  requiredMigration: string,
+): void {
+  if (!installedMigrations.includes(requiredMigration)) {
+    throw new Error(`Required migration was not installed. requiredMigration=${requiredMigration}`);
+  }
+}
+
+type MigrationLambdaResponse =
+  | MigrationLambdaResult
+  | MigrationCustomResourceResult
+  | MigrationCustomResourceDeleteResult;
+
+const migrationHandler: Handler<unknown, MigrationLambdaResponse> = async (event, context) => {
   try {
+    const invocation = parseMigrationInvocation(event);
+    if (invocation.kind === "delete") {
+      return { PhysicalResourceId: migrationCustomResourcePhysicalId };
+    }
+
     const runtime = await getMigrationRuntime();
     const result = await runtime.runMigrations();
-    return result;
+    if (invocation.kind === "direct") {
+      return result;
+    }
+
+    assertRequiredMigrationInstalled(result.installedMigrations, invocation.requiredMigration);
+    return {
+      ...result,
+      PhysicalResourceId: migrationCustomResourcePhysicalId,
+    };
   } catch (error) {
     const normalizedError = normalizeCaughtError(error);
     captureBackendException({

--- a/apps/web/src/api/endpoints/catalog.test.ts
+++ b/apps/web/src/api/endpoints/catalog.test.ts
@@ -76,7 +76,7 @@ describe("catalog API endpoints", () => {
       },
     };
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
-      .mockResolvedValueOnce(createJsonResponse({
+      .mockResolvedValueOnce(new Response(JSON.stringify({
         schemaVersion: 1,
         generatedAt: "2026-08-02T10:00:00.000Z",
         authors: [{
@@ -106,6 +106,13 @@ describe("catalog API endpoints", () => {
         mediaAssets: [],
         collections: [],
         collectionPackages: [],
+      }), {
+        status: 200,
+        headers: {
+          "Access-Control-Allow-Origin": "http://localhost:3000",
+          "Content-Type": "application/json",
+          "X-Request-Id": "catalog-request-id",
+        },
       }))
       .mockResolvedValueOnce(createJsonResponse(previewResponse))
       .mockResolvedValueOnce(createJsonResponse(confirmResponse));
@@ -130,12 +137,18 @@ describe("catalog API endpoints", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       "http://localhost:8080/v1/catalog",
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({
+        credentials: "omit",
+        method: "GET",
+      }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       `http://localhost:8080/v1/workspaces/${workspaceId}/catalog/package-versions/${packageVersionId}/install/preview`,
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({
+        credentials: "include",
+        method: "POST",
+      }),
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
@@ -143,6 +156,42 @@ describe("catalog API endpoints", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify(options),
+        credentials: "include",
+      }),
+    );
+  });
+
+  it("preserves public catalog errors and request IDs without auth recovery", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: "Catalog request is invalid.",
+        code: "INVALID_CATALOG_REQUEST",
+        requestId: "body-request-id",
+      }), {
+        status: 400,
+        headers: {
+          "Access-Control-Allow-Origin": "http://localhost:3000",
+          "Content-Type": "application/json",
+          "X-Request-Id": "header-request-id",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadPublicCatalog()).rejects.toMatchObject({
+      code: "INVALID_CATALOG_REQUEST",
+      endpoint: "GET /catalog",
+      message: "Catalog request is invalid.",
+      requestId: "header-request-id",
+      responseBodyKind: "json",
+      statusCode: 400,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/catalog",
+      expect.objectContaining({
+        credentials: "omit",
+        method: "GET",
       }),
     );
   });

--- a/apps/web/src/api/endpoints/catalog.ts
+++ b/apps/web/src/api/endpoints/catalog.ts
@@ -13,7 +13,7 @@ import { parseContractResponse } from "../transport/response";
 import {
   allowAuthRecovery,
   requestJson,
-  skipAuthRecoveryWithTransientNetworkRetry,
+  requestPublicJson,
 } from "../transport/transport";
 
 function encodePathSegment(value: string): string {
@@ -22,7 +22,7 @@ function encodePathSegment(value: string): string {
 
 export async function loadPublicCatalog(): Promise<CatalogPublicSnapshot> {
   return parseContractResponse(
-    await requestJson("/catalog", { method: "GET" }, skipAuthRecoveryWithTransientNetworkRetry),
+    await requestPublicJson("/catalog"),
     "GET /catalog",
     parseCatalogPublicSnapshotResponse,
   );

--- a/apps/web/src/api/transport/transport.ts
+++ b/apps/web/src/api/transport/transport.ts
@@ -274,14 +274,19 @@ function warnApiTransportRetry(error: ApiNetworkError): void {
   });
 }
 
-async function performFetch(pathname: string, init: RequestInit, attemptCount: number): Promise<Response> {
+async function performFetch(
+  pathname: string,
+  init: RequestInit,
+  credentials: RequestCredentials,
+  attemptCount: number,
+): Promise<Response> {
   const config = getAppConfig();
   const headers = createHeaders(init);
 
   try {
     return await fetch(`${config.apiBaseUrl}${pathname}`, {
       ...init,
-      credentials: "include",
+      credentials,
       headers,
     });
   } catch (error) {
@@ -655,7 +660,7 @@ async function requestResponse(
   }
 
   const endpoint = buildSanitizedRequestEndpoint(pathname, init);
-  let response: Response = await performFetch(pathname, init, attemptCount);
+  let response: Response = await performFetch(pathname, init, "include", attemptCount);
   if (options.authRecoveryMode === "skip") {
     return response;
   }
@@ -670,7 +675,7 @@ async function requestResponse(
 
       didRecoverSession = true;
       await recoverSession(options);
-      response = await performFetch(pathname, init, attemptCount);
+      response = await performFetch(pathname, init, "include", attemptCount);
       continue;
     }
 
@@ -684,7 +689,7 @@ async function requestResponse(
     ) {
       didRecoverSessionCsrf = true;
       await recoverSessionCsrf(options);
-      response = await performFetch(pathname, init, attemptCount);
+      response = await performFetch(pathname, init, "include", attemptCount);
       continue;
     }
 
@@ -700,6 +705,27 @@ export async function requestJson(
   const endpoint = buildSanitizedRequestEndpoint(pathname, init);
   return performWithNetworkRetry(endpoint, init, options, async (attemptCount: number) => {
     const response = await requestResponse(pathname, init, options, attemptCount);
+    return parseJsonPayload(
+      response,
+      buildRequestEndpoint(pathname, init),
+      {
+        attemptCount,
+        endpoint,
+      },
+    );
+  });
+}
+
+/**
+ * Loads public JSON without sending browser credentials. Public API routes use
+ * credential-free CORS and intentionally do not participate in auth recovery.
+ */
+export async function requestPublicJson(pathname: string): Promise<ParsedResponsePayload> {
+  const init: RequestInit = { method: "GET" };
+  const options = skipAuthRecoveryWithTransientNetworkRetry;
+  const endpoint = buildSanitizedRequestEndpoint(pathname, init);
+  return performWithNetworkRetry(endpoint, init, options, async (attemptCount: number) => {
+    const response = await performFetch(pathname, init, "omit", attemptCount);
     return parseJsonPayload(
       response,
       buildRequestEndpoint(pathname, init),

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Template } from "aws-cdk-lib/assertions";
+import {
+  addDatabaseMigrationDependency,
+  databaseMigrationGate,
+} from "./migration-runner";
+
+type CloudFormationResource = Readonly<{
+  Type: string;
+  DependsOn?: string | ReadonlyArray<string>;
+  Properties?: Readonly<Record<string, unknown>>;
+}>;
+
+test("database migration gate blocks the dependent backend runtime", () => {
+  const stack = new cdk.Stack();
+  const migrationFn = new lambda.Function(stack, "MigrationHandler", {
+    code: lambda.Code.fromInline("exports.handler = async () => ({ installedMigrations: [] });"),
+    handler: "index.handler",
+    runtime: lambda.Runtime.NODEJS_24_X,
+  });
+  const migrationGate = databaseMigrationGate(
+    stack,
+    migrationFn,
+    "0106_catalog_install_idempotency.sql",
+  );
+  const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
+    code: lambda.Code.fromInline("exports.handler = async () => ({});"),
+    description: "Catalog-dependent backend runtime",
+    handler: "index.handler",
+    runtime: lambda.Runtime.NODEJS_24_X,
+  });
+
+  addDatabaseMigrationDependency(dependentRuntime, migrationGate);
+
+  const template = Template.fromStack(stack).toJSON() as Readonly<{
+    Resources: Readonly<Record<string, CloudFormationResource>>;
+  }>;
+  const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
+    resource.Type === "AWS::CloudFormation::CustomResource"
+    && resource.Properties?.RequiredMigration === "0106_catalog_install_idempotency.sql"
+  ));
+  if (migrationGateEntry === undefined) {
+    throw new Error("Synthesized template is missing the required database migration gate");
+  }
+
+  const dependentRuntimeEntry = Object.entries(template.Resources).find(([, resource]) => (
+    resource.Type === "AWS::Lambda::Function"
+    && resource.Properties?.Description === "Catalog-dependent backend runtime"
+  ));
+  if (dependentRuntimeEntry === undefined) {
+    throw new Error("Synthesized template is missing the catalog-dependent backend runtime");
+  }
+
+  const migrationGateLogicalId = migrationGateEntry[0];
+  const dependentRuntimeResource = dependentRuntimeEntry[1];
+  const dependencies = Array.isArray(dependentRuntimeResource.DependsOn)
+    ? dependentRuntimeResource.DependsOn
+    : [dependentRuntimeResource.DependsOn];
+  assert.ok(dependencies.includes(migrationGateLogicalId));
+});

--- a/infra/aws/lib/migration-runner.ts
+++ b/infra/aws/lib/migration-runner.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as customResources from "aws-cdk-lib/custom-resources";
 import * as rds from "aws-cdk-lib/aws-rds";
 import { Construct } from "constructs";
 import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
@@ -116,4 +117,33 @@ export function migrationRunner(scope: Construct, props: MigrationRunnerProps): 
   addOptionalSentryEnvironment(scope, migrationFn, props);
 
   return migrationFn;
+}
+
+/**
+ * Runs the current migration bundle during the stack deployment. A version
+ * token makes CloudFormation update this resource whenever the bundled
+ * migration Lambda changes.
+ */
+export function databaseMigrationGate(
+  scope: Construct,
+  migrationFn: lambda.Function,
+  requiredMigration: string,
+): cdk.CustomResource {
+  const provider = new customResources.Provider(scope, "DatabaseMigrationProvider", {
+    onEventHandler: migrationFn,
+  });
+  return new cdk.CustomResource(scope, "DatabaseMigrationGate", {
+    serviceToken: provider.serviceToken,
+    properties: {
+      MigrationBundleVersion: migrationFn.currentVersion.version,
+      RequiredMigration: requiredMigration,
+    },
+  });
+}
+
+export function addDatabaseMigrationDependency(
+  dependentRuntime: lambda.IFunction,
+  migrationGate: cdk.CustomResource,
+): void {
+  dependentRuntime.node.addDependency(migrationGate);
 }

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -197,7 +197,7 @@ test("monitoring covers worker errors, staleness, and terminal job failures", ()
   );
 });
 
-test("release deploys the schedule disabled, migrates, then enables and verifies it", () => {
+test("release deploys migration-gated runtime disabled, verifies migrations, then enables schedules", () => {
   const workflow = readLibSource(
     "../../.github/workflows/aws-web-release.yml",
   );
@@ -221,7 +221,21 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
   assert.ok(scheduleVerification > enabledDeploy);
   assert.match(
     workflow,
+    /name: CDK deploy with migration-gated runtime and reconciliation schedule disabled/,
+  );
+  assert.match(
+    workflow,
+    /name: Verify required database migration/,
+  );
+  assert.match(
+    workflow,
     /name: Verify cleanup-capable reconciliation schedules are enabled/,
+  );
+
+  const stackSource = readLibSource("lib/stack.ts");
+  assert.match(
+    stackSource,
+    /databaseMigrationGate\([\s\S]*"0106_catalog_install_idempotency\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");
@@ -258,6 +272,11 @@ test("release deploys the schedule disabled, migrates, then enables and verifies
   assert.ok(bootstrapMigration > bootstrapDisabled);
   assert.ok(bootstrapEnabled > bootstrapMigration);
   assert.ok(bootstrapVerification > bootstrapEnabled);
+  assert.match(
+    bootstrapScript,
+    /CDK deploy with migration-gated runtime and reconciliation schedule disabled/,
+  );
+  assert.match(bootstrapScript, /Verify required database migration/);
 });
 
 test("release verification can read only the exact reconciliation schedule", () => {

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -11,7 +11,11 @@ import { backupPlan } from "./backup";
 import { outputs } from "./outputs";
 import { webApp } from "./web";
 import { adminApp } from "./admin";
-import { migrationRunner } from "./migration-runner";
+import {
+  addDatabaseMigrationDependency,
+  databaseMigrationGate,
+  migrationRunner,
+} from "./migration-runner";
 import { authGateway } from "./gateways/auth-gateway";
 import { mcpGateway } from "./gateways/mcp-gateway";
 import { analyticsAccess, type AnalyticsAccessResult } from "./analytics-access";
@@ -333,6 +337,11 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       adminEmails,
       ...sentryContext,
     });
+    const migrationGate = databaseMigrationGate(
+      this,
+      migrationFn,
+      "0106_catalog_install_idempotency.sql",
+    );
     const api = apiGateway(this, {
       vpc: net.vpc,
       lambdaSg: net.lambdaSg,
@@ -359,6 +368,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       userPoolArn: authResult.userPool.userPoolArn,
       userPoolClientId: authResult.userPoolClient.userPoolClientId,
     });
+    addDatabaseMigrationDependency(api.backendFn, migrationGate);
     const web = webApp(this, {
       baseDomain,
       webCertificateArnUsEast1,

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -141,13 +141,13 @@ echo "=== CDK bootstrap ==="
 cd "$CDK_DIR"
 npx cdk bootstrap --region "$REGION"
 
-echo "=== CDK deploy with reconciliation schedule disabled ==="
+echo "=== CDK deploy with migration-gated runtime and reconciliation schedule disabled ==="
 npx cdk deploy --all --require-approval never \
   -c generatedMediaPromotionScheduleState=DISABLED \
   -c mediaBlobCleanupEnabled=false \
   -c multipartCompletionReconciliationScheduleState=DISABLED
 
-echo "=== Run database migrations ==="
+echo "=== Verify required database migration ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
   --require-migration 0106_catalog_install_idempotency.sql


### PR DESCRIPTION
## Summary
- load the public Web catalog without browser credentials while preserving shared error, retry, and contract handling
- apply and verify migration 0106 through a CloudFormation deployment gate before publishing the dependent backend runtime
- keep first bootstrap and existing-stack release sequencing explicit and covered

## Validation
- focused Web catalog boundary: 2 tests
- focused migration contract: 2 tests
- focused infra/CORS/order: 30 tests
- full Web: 678 tests and build
- full backend: 1181 tests, lint, and build
- full infra: 95 tests and build
- repository static checks, bash syntax, ShellCheck, actionlint, and diff check
- fresh staging-agnostic review: no P0-P4 issues