### PR TITLE
Fix public catalog test collection fixture

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -411,7 +411,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0106_catalog_install_idempotency.sql
+            --require-migration 0107_catalog_test_collection.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,9 +71,10 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
-    migrationFileName: "0106_catalog_install_idempotency.sql",
-    expectedMigrationCount: 108,
+    migrationFileName: "0107_catalog_test_collection.sql",
+    expectedMigrationCount: 109,
     testFiles: Object.freeze([
+      "src/catalog/distribution/public.postgres.integration.ts",
       "src/catalog/distribution/install.postgres.integration.ts",
       "src/catalog/authoring/lockOrder.postgres.integration.ts",
       "src/cards/generatedImageAppend.postgres.integration.ts",

--- a/apps/backend/src/catalog/distribution/public.postgres.integration.ts
+++ b/apps/backend/src/catalog/distribution/public.postgres.integration.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import { loadPublicCatalogSnapshotInExecutor } from "./public";
+
+const fixtureAuthorId = "00000000-0000-4000-a105-000000000001";
+const fixturePackageId = "00000000-0000-4000-a105-000000000002";
+const fixturePackageVersionId = "00000000-0000-4000-a105-000000000003";
+const fixtureCardIds = [
+  "00000000-0000-4000-a105-000000000004",
+  "00000000-0000-4000-a105-000000000005",
+] as const;
+const fixtureCollectionId = "00000000-0000-4000-a107-000000000001";
+
+type CollectionFixtureRow = Readonly<{
+  collection_id: string;
+  package_id: string;
+  ordinal: number;
+}>;
+
+function requireTestDatabaseAdminUrl(): string {
+  const databaseUrl = process.env.TEST_DATABASE_ADMIN_URL?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error("TEST_DATABASE_ADMIN_URL is required for the public catalog snapshot integration test.");
+  }
+
+  return databaseUrl;
+}
+
+function createPoolExecutor(pool: pg.Pool): DatabaseExecutor {
+  return {
+    query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      return pool.query<Row>(text, [...params]);
+    },
+  };
+}
+
+test("latest migrations expose the deterministic collection through the public catalog snapshot", async () => {
+  const pool = new pg.Pool({
+    connectionString: requireTestDatabaseAdminUrl(),
+    application_name: "public-catalog-snapshot-integration",
+  });
+
+  try {
+    const fixtureResult = await pool.query<CollectionFixtureRow>(
+      `SELECT
+         collections.collection_id::text AS collection_id,
+         memberships.package_id::text AS package_id,
+         memberships.ordinal
+       FROM catalog.collections AS collections
+       INNER JOIN catalog.collection_packages AS memberships
+         ON memberships.collection_id = collections.collection_id
+       WHERE collections.collection_id = $1
+         AND collections.status = 'published'
+         AND collections.delisted_at IS NULL`,
+      [fixtureCollectionId],
+    );
+    assert.deepEqual(fixtureResult.rows, [{
+      collection_id: fixtureCollectionId,
+      package_id: fixturePackageId,
+      ordinal: 1,
+    }]);
+
+    const snapshot = await loadPublicCatalogSnapshotInExecutor(createPoolExecutor(pool), {
+      publicApiBaseUrl: "https://api.flashcards-open-source-app.com/v1",
+      publicAppBaseUrl: "https://flashcards-open-source-app.com",
+      generatedAt: "2026-08-03T00:02:00.000Z",
+    });
+
+    const author = snapshot.authors.find((candidate) => candidate.authorId === fixtureAuthorId);
+    const catalogPackage = snapshot.packages.find((candidate) => candidate.packageId === fixturePackageId);
+    const packageVersion = snapshot.packageVersions.find(
+      (candidate) => candidate.packageVersionId === fixturePackageVersionId,
+    );
+    const cards = snapshot.cards.filter(
+      (candidate) => candidate.packageVersionId === fixturePackageVersionId,
+    );
+    const collection = snapshot.collections.find(
+      (candidate) => candidate.collectionId === fixtureCollectionId,
+    );
+    const collectionPackage = snapshot.collectionPackages.find(
+      (candidate) => candidate.collectionId === fixtureCollectionId,
+    );
+
+    assert.equal(snapshot.schemaVersion, 1);
+    assert.equal(author?.authorId, fixtureAuthorId);
+    assert.equal(catalogPackage?.authorId, fixtureAuthorId);
+    assert.equal(catalogPackage?.latestPackageVersionId, fixturePackageVersionId);
+    assert.equal(packageVersion?.packageId, fixturePackageId);
+    assert.equal(
+      packageVersion?.installUrl,
+      `https://flashcards-open-source-app.com/catalog/import/${fixturePackageVersionId}`,
+    );
+    assert.deepEqual(cards.map((card) => card.packageCardId), fixtureCardIds);
+    assert.deepEqual(cards.map((card) => card.ordinal), [1, 2]);
+    assert.equal(collection?.coverPackageId, fixturePackageId);
+    assert.deepEqual(collectionPackage, {
+      collectionId: fixtureCollectionId,
+      packageId: fixturePackageId,
+      ordinal: 1,
+    });
+  } finally {
+    await pool.end();
+  }
+});

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0106_catalog_install_idempotency.sql",
+      RequiredMigration: "0107_catalog_test_collection.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0106_catalog_install_idempotency.sql",
+    requiredMigration: "0107_catalog_test_collection.sql",
   });
 });
 

--- a/db/migrations/0107_catalog_test_collection.sql
+++ b/db/migrations/0107_catalog_test_collection.sql
@@ -1,0 +1,95 @@
+-- Migration status: Current / additive.
+-- Introduces: deterministic public catalog collection content for end-to-end testing.
+-- Schemas touched/read explicitly: catalog, pg_catalog.
+
+DO $migration$
+DECLARE
+  fixture_collection_id CONSTANT UUID := '00000000-0000-4000-a107-000000000001';
+  fixture_package_id CONSTANT UUID := '00000000-0000-4000-a105-000000000002';
+  fixture_created_at CONSTANT TIMESTAMPTZ := '2026-08-03 00:00:00+00';
+  fixture_published_at CONSTANT TIMESTAMPTZ := '2026-08-03 00:01:00+00';
+BEGIN
+  INSERT INTO catalog.collections (
+    collection_id,
+    slug,
+    title,
+    summary,
+    description,
+    language_tags,
+    topic_tags,
+    cover_package_id,
+    status,
+    created_at,
+    updated_at,
+    published_at,
+    delisted_at
+  )
+  VALUES (
+    fixture_collection_id,
+    'test',
+    'тест',
+    'Minimal collection for catalog testing.',
+    'Test-only public catalog collection for verifying ordered package membership.',
+    ARRAY['und']::TEXT[],
+    ARRAY['test']::TEXT[],
+    fixture_package_id,
+    'published',
+    fixture_created_at,
+    fixture_published_at,
+    fixture_published_at,
+    NULL
+  )
+  ON CONFLICT DO NOTHING;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM catalog.collections AS collections
+    WHERE collections.collection_id = fixture_collection_id
+      AND collections.slug = 'test'
+      AND collections.title = 'тест'
+      AND collections.summary = 'Minimal collection for catalog testing.'
+      AND collections.description = 'Test-only public catalog collection for verifying ordered package membership.'
+      AND collections.language_tags = ARRAY['und']::TEXT[]
+      AND collections.topic_tags = ARRAY['test']::TEXT[]
+      AND collections.cover_package_id = fixture_package_id
+      AND collections.status = 'published'
+      AND collections.created_at = fixture_created_at
+      AND collections.updated_at = fixture_published_at
+      AND collections.published_at = fixture_published_at
+      AND collections.delisted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Catalog test collection identity conflicts with incompatible pre-existing content'
+      USING ERRCODE = '23505';
+  END IF;
+
+  INSERT INTO catalog.collection_packages (
+    collection_id,
+    package_id,
+    ordinal,
+    created_at
+  )
+  VALUES (
+    fixture_collection_id,
+    fixture_package_id,
+    1,
+    fixture_created_at
+  )
+  ON CONFLICT DO NOTHING;
+
+  IF (
+    SELECT pg_catalog.count(*)
+    FROM catalog.collection_packages AS collection_packages
+    WHERE collection_packages.collection_id = fixture_collection_id
+  ) <> 1 OR NOT EXISTS (
+    SELECT 1
+    FROM catalog.collection_packages AS collection_packages
+    WHERE collection_packages.collection_id = fixture_collection_id
+      AND collection_packages.package_id = fixture_package_id
+      AND collection_packages.ordinal = 1
+      AND collection_packages.created_at = fixture_created_at
+  ) THEN
+    RAISE EXCEPTION 'Catalog test collection packages conflict with incompatible pre-existing content'
+      USING ERRCODE = '23505';
+  END IF;
+END;
+$migration$;

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0106_catalog_install_idempotency.sql",
+    "0107_catalog_test_collection.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0106_catalog_install_idempotency.sql"
+    && resource.Properties?.RequiredMigration === "0107_catalog_test_collection.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -107,7 +107,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
       "mediaBlobCleanupEnabled=false",
     );
     const migration = source.indexOf(
-      "--require-migration 0106_catalog_install_idempotency.sql",
+      "--require-migration 0107_catalog_test_collection.sql",
     );
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0106_catalog_install_idempotency.sql",
+    "--require-migration 0107_catalog_test_collection.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -235,7 +235,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0106_catalog_install_idempotency\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0107_catalog_test_collection\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");
@@ -260,7 +260,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0106_catalog_install_idempotency.sql",
+    "--require-migration 0107_catalog_test_collection.sql",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -340,7 +340,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0106_catalog_install_idempotency.sql",
+      "0107_catalog_test_collection.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -150,7 +150,7 @@ npx cdk deploy --all --require-approval never \
 echo "=== Verify required database migration ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0106_catalog_install_idempotency.sql
+  --require-migration 0107_catalog_test_collection.sql
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \


### PR DESCRIPTION
## Summary
- seed one deterministic published catalog test collection in additive migration 0107
- link the existing deterministic test package at ordinal 1
- advance canonical migration gates and add real PostgreSQL snapshot boundary coverage

## Validation
- backend focused tests: 79 passed
- backend full tests: 1181 passed
- backend lint and build passed
- infrastructure tests: 95 passed
- OpenAPI lint and bundle passed
- repository static checks passed

## Local limitation
- PostgreSQL 18 boundary suite is registered but was not runnable locally because no server/admin URL or Docker daemon was available