### PR TITLE
Add Android multi-tag review filters

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -4,8 +4,11 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToNodeAction
@@ -22,6 +25,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
+import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
@@ -41,6 +45,9 @@ import com.flashcardsopensourceapp.feature.review.reviewEditCardButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewEmptyStateContentTag
 import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag
 import com.flashcardsopensourceapp.feature.review.reviewFilterButtonTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterAllCardsOptionTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterSheetTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterTagOptionTag
 import com.flashcardsopensourceapp.feature.review.reviewRateGoodButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewQueueButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewShowAnswerButtonTag
@@ -509,6 +516,68 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
         composeRule.onNodeWithText("Review scope").fetchSemanticsNode()
         composeRule.onNodeWithText("Review the full local queue").performClick()
+    }
+
+    @Test
+    fun reviewFilterChecklistAppliesImmediatelyStaysOpenPersistsAndRestoresAllCards() {
+        waitForCardsEmptyState()
+        createCard(frontText = "Alpha review", backText = "Alpha answer", tags = listOf("Alpha"))
+        createCard(frontText = "Beta review", backText = "Beta answer", tags = listOf("Beta"))
+        createCard(frontText = "Gamma review", backText = "Gamma answer", tags = listOf("Gamma"))
+
+        openReviewTab()
+        waitForTagToExist(tag = reviewFilterButtonTag)
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        waitForTagToExist(tag = reviewFilterSheetTag)
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn().performClick()
+
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 2 cards.")
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).performClick()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("Beta").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("No tags").fetchSemanticsNodes().isNotEmpty()
+                && composeRule.onAllNodesWithTag(reviewEmptyStateTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 0 cards.")
+
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn()
+
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).performClick()
+        pressBack()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
+        }
+        openCardsTab()
+        openReviewTab()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
     }
 
     @Test

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
@@ -38,6 +38,7 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                 ReviewPreviewRoute(
                     uiState = ReviewUiState(
                         isLoading = false,
+                        requestedFilter = ReviewFilter.AllCards,
                         selectedFilter = ReviewFilter.AllCards,
                         selectedFilterTitle = "All cards",
                         remainingCount = 0,
@@ -104,6 +105,7 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                 ReviewPreviewRoute(
                     uiState = ReviewUiState(
                         isLoading = false,
+                        requestedFilter = ReviewFilter.AllCards,
                         selectedFilter = ReviewFilter.AllCards,
                         selectedFilterTitle = "All cards",
                         remainingCount = 0,
@@ -156,6 +158,7 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                 ReviewPreviewRoute(
                     uiState = ReviewUiState(
                         isLoading = false,
+                        requestedFilter = ReviewFilter.AllCards,
                         selectedFilter = ReviewFilter.AllCards,
                         selectedFilterTitle = "All cards",
                         remainingCount = 0,

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -75,6 +75,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                 ReviewRoute(
                     uiState = ReviewUiState(
                         isLoading = false,
+                        requestedFilter = ReviewFilter.AllCards,
                         selectedFilter = ReviewFilter.AllCards,
                         selectedFilterTitle = "All cards",
                         remainingCount = 4,

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
@@ -94,6 +94,7 @@ class RtlLayoutTest : FirebaseAppInstrumentationTimeoutTest() {
             ReviewPreviewRoute(
                 uiState = ReviewUiState(
                     isLoading = false,
+                    requestedFilter = ReviewFilter.AllCards,
                     selectedFilter = ReviewFilter.AllCards,
                     selectedFilterTitle = previewTitle,
                     remainingCount = 1,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
 import com.flashcardsopensourceapp.feature.settings.deck.DeckDetailRoute
 import com.flashcardsopensourceapp.feature.settings.deck.DeckEditorSaveResult
 import com.flashcardsopensourceapp.feature.settings.deck.DeckEditorRoute
@@ -289,7 +290,7 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
             onSearchQueryChange = workspaceTagsViewModel::updateSearchQuery,
             onOpenTagReview = { tag ->
                 appGraph.appHandoffCoordinator.requestReviewFilter(
-                    reviewFilter = ReviewFilter.Tag(tag = tag)
+                    reviewFilter = makeReviewTagFilter(tagNames = listOf(tag))
                 )
             },
             onBack = {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationDiagnostics.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationDiagnostics.kt
@@ -203,7 +203,8 @@ private fun PersistedReviewFilter.toNotificationDiagnosticsUiState(): Notificati
     return NotificationDiagnosticsReviewFilterUiState(
         kind = kind,
         deckId = deckId,
-        tag = tag
+        tag = tag,
+        tags = tags
     )
 }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationsManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationsManager.kt
@@ -33,9 +33,11 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.review.loadTopActiveReviewCard
 import com.flashcardsopensourceapp.data.local.model.cards.DeckFilterDefinition
-import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.cards.decodeDeckFilterDefinitionJson
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTagKey
+import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
+import com.flashcardsopensourceapp.data.local.model.review.resolveReviewTagFilter
 import com.flashcardsopensourceapp.data.local.notifications.CurrentReviewNotificationCard
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationMode
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
@@ -385,8 +387,8 @@ class ReviewNotificationsManager(
             workspaceId = workspaceId,
             selectedReviewFilter = selectedReviewFilter
         )
-        val resolvedReviewFilter = when (reviewNotificationFilterPlan) {
-            is ReviewNotificationFilterPlan.Schedule -> reviewNotificationFilterPlan.reviewFilter
+        val scheduledFilterPlan = when (reviewNotificationFilterPlan) {
+            is ReviewNotificationFilterPlan.Schedule -> reviewNotificationFilterPlan
             ReviewNotificationFilterPlan.SuppressScheduledPayloads -> {
                 saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(
                     stage = "filter_suppressed",
@@ -401,12 +403,15 @@ class ReviewNotificationsManager(
                 return
             }
         }
+        val persistedPayloadReviewFilter = makePersistedReviewFilter(
+            reviewFilter = scheduledFilterPlan.payloadReviewFilter
+        )
 
         val currentCard = loadCurrentReviewNotificationCard(
             workspaceId = workspaceId,
-            reviewFilter = resolvedReviewFilter,
+            reviewFilter = scheduledFilterPlan.queryReviewFilter,
             nowMillis = nowMillis
-        )
+        )?.copy(reviewFilter = persistedPayloadReviewFilter)
 
         val zoneId = ZoneId.systemDefault()
         val payloads = if (currentCard != null) {
@@ -444,12 +449,11 @@ class ReviewNotificationsManager(
                 }
             }
         } else {
-            val persistedReviewFilter = makePersistedReviewFilter(reviewFilter = resolvedReviewFilter)
             val fallbackFrontText = reviewTextProvider(context = context).notificationFallbackFrontText
             when (settings.selectedMode) {
                 ReviewNotificationMode.DAILY -> buildFallbackDailyReminderPayloads(
                     workspaceId = workspaceId,
-                    reviewFilter = persistedReviewFilter,
+                    reviewFilter = persistedPayloadReviewFilter,
                     fallbackFrontText = fallbackFrontText,
                     nowMillis = nowMillis,
                     zoneId = zoneId,
@@ -471,7 +475,7 @@ class ReviewNotificationsManager(
                         )
                     buildFallbackInactivityReminderPayloads(
                         workspaceId = workspaceId,
-                        reviewFilter = persistedReviewFilter,
+                        reviewFilter = persistedPayloadReviewFilter,
                         fallbackFrontText = fallbackFrontText,
                         nowMillis = nowMillis,
                         lastActiveAtMillis = lastActiveAtMillis,
@@ -751,9 +755,9 @@ class ReviewNotificationsManager(
                 nowMillis = nowMillis
             )
 
-            is ReviewFilter.Tag -> loadCurrentTagReviewNotificationCard(
+            is ReviewFilter.Tags -> loadCurrentTagsReviewNotificationCard(
                 workspaceId = workspaceId,
-                tag = reviewFilter.tag,
+                tags = reviewFilter.tags,
                 nowMillis = nowMillis
             )
         }
@@ -770,7 +774,7 @@ class ReviewNotificationsManager(
             )
 
             ReviewFilter.AllCards,
-            is ReviewFilter.Tag -> null
+            is ReviewFilter.Tags -> null
         }
 
         return resolveReviewNotificationFilterPlan(
@@ -837,20 +841,17 @@ class ReviewNotificationsManager(
         )
     }
 
-    private suspend fun loadCurrentTagReviewNotificationCard(
+    private suspend fun loadCurrentTagsReviewNotificationCard(
         workspaceId: String,
-        tag: String,
+        tags: List<String>,
         nowMillis: Long
     ): CurrentReviewNotificationCard? {
         val exactTagNames = loadExactStoredReviewTagNames(
             workspaceId = workspaceId,
-            requestedTagNames = listOf(tag)
+            requestedTagNames = tags
         )
         if (exactTagNames.isEmpty()) {
-            return loadCurrentAllCardsReviewNotificationCard(
-                workspaceId = workspaceId,
-                nowMillis = nowMillis
-            )
+            return null
         }
 
         val card = loadTopActiveReviewCard(
@@ -861,7 +862,9 @@ class ReviewNotificationsManager(
         ) ?: return null
 
         return CurrentReviewNotificationCard(
-            reviewFilter = makePersistedReviewFilter(reviewFilter = ReviewFilter.Tag(tag = tag)),
+            reviewFilter = makePersistedReviewFilter(
+                reviewFilter = makeReviewTagFilter(tagNames = exactTagNames)
+            ),
             cardId = card.cardId,
             frontText = card.frontText
         )
@@ -906,7 +909,8 @@ class ReviewNotificationsManager(
 
 internal sealed interface ReviewNotificationFilterPlan {
     data class Schedule(
-        val reviewFilter: ReviewFilter
+        val queryReviewFilter: ReviewFilter,
+        val payloadReviewFilter: ReviewFilter
     ) : ReviewNotificationFilterPlan
 
     data object SuppressScheduledPayloads : ReviewNotificationFilterPlan
@@ -918,22 +922,40 @@ internal fun resolveReviewNotificationFilterPlan(
     selectedDeckFilterDefinition: DeckFilterDefinition?
 ): ReviewNotificationFilterPlan {
     return when (selectedReviewFilter) {
-        ReviewFilter.AllCards -> ReviewNotificationFilterPlan.Schedule(reviewFilter = ReviewFilter.AllCards)
-        is ReviewFilter.Tag -> {
-            val exactTagName = resolveExactStoredReviewTagNames(
-                requestedTagNames = listOf(selectedReviewFilter.tag),
-                storedTagNames = activeReviewTagNames
-            ).firstOrNull()
-            val resolvedReviewFilter = exactTagName?.let { tagName ->
-                ReviewFilter.Tag(tag = tagName)
-            } ?: ReviewFilter.AllCards
+        ReviewFilter.AllCards -> ReviewNotificationFilterPlan.Schedule(
+            queryReviewFilter = ReviewFilter.AllCards,
+            payloadReviewFilter = ReviewFilter.AllCards
+        )
+        is ReviewFilter.Tags -> {
+            when (
+                val resolvedReviewFilter = resolveReviewTagFilter(
+                    selectedTagNames = selectedReviewFilter.tags,
+                    availableTagNames = activeReviewTagNames
+                )
+            ) {
+                is ReviewFilter.Tags -> if (resolvedReviewFilter.tags.isEmpty()) {
+                    ReviewNotificationFilterPlan.SuppressScheduledPayloads
+                } else {
+                    ReviewNotificationFilterPlan.Schedule(
+                        queryReviewFilter = resolvedReviewFilter,
+                        payloadReviewFilter = selectedReviewFilter
+                    )
+                }
 
-            ReviewNotificationFilterPlan.Schedule(reviewFilter = resolvedReviewFilter)
+                ReviewFilter.AllCards -> ReviewNotificationFilterPlan.Schedule(
+                    queryReviewFilter = ReviewFilter.AllCards,
+                    payloadReviewFilter = ReviewFilter.AllCards
+                )
+                is ReviewFilter.Deck -> error("Tag filter resolution cannot produce a deck filter.")
+            }
         }
 
         is ReviewFilter.Deck -> {
             if (selectedDeckFilterDefinition == null) {
-                return ReviewNotificationFilterPlan.Schedule(reviewFilter = ReviewFilter.AllCards)
+                return ReviewNotificationFilterPlan.Schedule(
+                    queryReviewFilter = ReviewFilter.AllCards,
+                    payloadReviewFilter = ReviewFilter.AllCards
+                )
             }
 
             if (hasImpossibleStoredTagDeckPredicate(
@@ -943,7 +965,10 @@ internal fun resolveReviewNotificationFilterPlan(
             ) {
                 ReviewNotificationFilterPlan.SuppressScheduledPayloads
             } else {
-                ReviewNotificationFilterPlan.Schedule(reviewFilter = selectedReviewFilter)
+                ReviewNotificationFilterPlan.Schedule(
+                    queryReviewFilter = selectedReviewFilter,
+                    payloadReviewFilter = selectedReviewFilter
+                )
             }
         }
     }

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManagerTest.kt
@@ -7,6 +7,7 @@ import com.flashcardsopensourceapp.app.notifications.review.reviewReminderNotifi
 import com.flashcardsopensourceapp.app.notifications.strict.strictReminderNotificationTag
 import com.flashcardsopensourceapp.data.local.model.cards.DeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -92,30 +93,71 @@ class ReviewNotificationsManagerTest {
     }
 
     @Test
-    fun directMissingTagFilterSchedulesAllCardsPlan() {
+    fun directMissingTagFilterSuppressesScheduledPayloads() {
         val plan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
-            selectedReviewFilter = ReviewFilter.Tag(tag = "missing-tag"),
+            selectedReviewFilter = ReviewFilter.Tags(tags = listOf("missing-tag")),
             activeReviewTagNames = listOf("Éclair", "Plain"),
             selectedDeckFilterDefinition = null
         )
 
         assertEquals(
-            ReviewNotificationFilterPlan.Schedule(reviewFilter = ReviewFilter.AllCards),
+            ReviewNotificationFilterPlan.SuppressScheduledPayloads,
             plan
         )
     }
 
     @Test
-    fun directDeletedOnlyTagFilterSchedulesAllCardsFromActiveReviewTagSource() {
+    fun directDeletedOnlyTagFilterSuppressesScheduledPayloads() {
         val plan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
-            selectedReviewFilter = ReviewFilter.Tag(tag = "stale"),
+            selectedReviewFilter = ReviewFilter.Tags(tags = listOf("stale")),
             activeReviewTagNames = listOf("Visible"),
             selectedDeckFilterDefinition = null
         )
 
         assertEquals(
-            ReviewNotificationFilterPlan.Schedule(reviewFilter = ReviewFilter.AllCards),
+            ReviewNotificationFilterPlan.SuppressScheduledPayloads,
             plan
+        )
+    }
+
+    @Test
+    fun multiTagFilterDropsMissingTagsAndCanonicalizesEveryCurrentTagToAllCards() {
+        val partialPlan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
+            selectedReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "missing")),
+            activeReviewTagNames = listOf("Éclair", "Plain"),
+            selectedDeckFilterDefinition = null
+        )
+        val allTagsPlan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
+            selectedReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "Plain")),
+            activeReviewTagNames = listOf("Éclair", "Plain"),
+            selectedDeckFilterDefinition = null
+        )
+        val missingPlusEveryRemainingTagPlan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
+            selectedReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "missing")),
+            activeReviewTagNames = listOf("Éclair"),
+            selectedDeckFilterDefinition = null
+        )
+
+        assertEquals(
+            ReviewNotificationFilterPlan.Schedule(
+                queryReviewFilter = ReviewFilter.Tags(tags = listOf("Éclair")),
+                payloadReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "missing"))
+            ),
+            partialPlan
+        )
+        assertEquals(
+            ReviewNotificationFilterPlan.Schedule(
+                queryReviewFilter = ReviewFilter.AllCards,
+                payloadReviewFilter = ReviewFilter.AllCards
+            ),
+            allTagsPlan
+        )
+        assertEquals(
+            ReviewNotificationFilterPlan.Schedule(
+                queryReviewFilter = ReviewFilter.Tags(tags = listOf("Éclair")),
+                payloadReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "missing"))
+            ),
+            missingPlusEveryRemainingTagPlan
         )
     }
 
@@ -145,7 +187,10 @@ class ReviewNotificationsManagerTest {
         )
 
         assertEquals(
-            ReviewNotificationFilterPlan.Schedule(reviewFilter = ReviewFilter.AllCards),
+            ReviewNotificationFilterPlan.Schedule(
+                queryReviewFilter = ReviewFilter.AllCards,
+                payloadReviewFilter = ReviewFilter.AllCards
+            ),
             plan
         )
     }
@@ -153,7 +198,7 @@ class ReviewNotificationsManagerTest {
     @Test
     fun validUnicodeCaseNormalizedTagAndDeckFiltersRemainSchedulable() {
         val tagPlan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
-            selectedReviewFilter = ReviewFilter.Tag(tag = "éclair"),
+            selectedReviewFilter = ReviewFilter.Tags(tags = listOf("éclair")),
             activeReviewTagNames = listOf("Éclair", "Привет"),
             selectedDeckFilterDefinition = null
         )
@@ -167,11 +212,17 @@ class ReviewNotificationsManagerTest {
         )
 
         assertEquals(
-            ReviewNotificationFilterPlan.Schedule(reviewFilter = ReviewFilter.Tag(tag = "Éclair")),
+            ReviewNotificationFilterPlan.Schedule(
+                queryReviewFilter = ReviewFilter.Tags(tags = listOf("Éclair")),
+                payloadReviewFilter = ReviewFilter.Tags(tags = listOf("éclair"))
+            ),
             tagPlan
         )
         assertEquals(
-            ReviewNotificationFilterPlan.Schedule(reviewFilter = ReviewFilter.Deck(deckId = "deck-1")),
+            ReviewNotificationFilterPlan.Schedule(
+                queryReviewFilter = ReviewFilter.Deck(deckId = "deck-1"),
+                payloadReviewFilter = ReviewFilter.Deck(deckId = "deck-1")
+            ),
             deckPlan
         )
     }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreForkReidentificationContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreForkReidentificationContractTest.kt
@@ -102,7 +102,7 @@ class SyncLocalStoreForkReidentificationContractTest {
         database.reviewLogDao().insertReviewLog(originalReviewLog)
         reviewPreferencesStore.saveSelectedReviewFilter(
             workspaceId = syncLocalStoreContractWorkspaceId,
-            reviewFilter = ReviewFilter.Tag(tag = "android")
+            reviewFilter = ReviewFilter.Tags(tags = listOf("android"))
         )
         syncLocalStore.enqueueCardUpsert(
             card = originalCard,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewFilterContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewFilterContractTest.kt
@@ -1,14 +1,19 @@
 package com.flashcardsopensourceapp.data.local.review
 
+import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
+import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
-import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.notifications.ScheduledReviewNotificationPayload
+import com.flashcardsopensourceapp.data.local.notifications.SharedPreferencesReviewNotificationsStore
+import com.flashcardsopensourceapp.data.local.notifications.decodePersistedReviewFilter
+import com.flashcardsopensourceapp.data.local.notifications.makePersistedReviewFilter
 import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
 import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
 import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
@@ -45,7 +50,7 @@ class LocalReviewFilterContractTest {
     }
 
     @Test
-    fun reviewRepositoryResolvesDeletedOnlyDirectTagFromActiveReviewTagsAsAllCards(): Unit = runBlocking {
+    fun reviewRepositoryDropsDeletedOnlyTagWithoutBroadeningTheSelection(): Unit = runBlocking {
         val nowMillis = System.currentTimeMillis()
         val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = nowMillis)
         val reviewRepository = createTestReviewRepository(runtime = runtime)
@@ -88,25 +93,37 @@ class LocalReviewFilterContractTest {
 
         val activeReviewTagNames = database.tagDao().loadReviewTagNames(workspaceId = workspaceId)
         val sessionSnapshot = reviewRepository.observeReviewSession(
-            selectedFilter = ReviewFilter.Tag(tag = "stale"),
+            selectedFilter = ReviewFilter.Tags(tags = listOf("stale")),
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
+        ).first()
+        val partiallyResolvedSnapshot = reviewRepository.observeReviewSession(
+            selectedFilter = ReviewFilter.Tags(tags = listOf("stale", "Visible")),
             pendingReviewedCards = emptySet(),
             presentedCardId = null
         ).first()
         val timelinePage = reviewRepository.loadReviewTimelinePage(
-            selectedFilter = ReviewFilter.Tag(tag = "stale"),
+            selectedFilter = ReviewFilter.Tags(tags = listOf("stale")),
             pendingReviewedCards = emptySet(),
             offset = 0,
             limit = 10
         )
 
         assertEquals(listOf("Visible"), activeReviewTagNames)
-        assertEquals(ReviewFilter.AllCards, sessionSnapshot.selectedFilter)
-        assertEquals(listOf("visible-card"), sessionSnapshot.cards.map { card -> card.cardId })
-        assertEquals("visible-card", sessionSnapshot.presentedCard?.cardId)
-        assertEquals(1, sessionSnapshot.dueCount)
-        assertEquals(1, sessionSnapshot.totalCount)
-        assertEquals(listOf("visible-card"), timelinePage.cards.map { card -> card.cardId })
+        assertEquals(ReviewFilter.Tags(tags = emptyList()), sessionSnapshot.selectedFilter)
+        assertTrue(sessionSnapshot.cards.isEmpty())
+        assertEquals(null, sessionSnapshot.presentedCard)
+        assertEquals(0, sessionSnapshot.dueCount)
+        assertEquals(0, sessionSnapshot.totalCount)
+        assertTrue(timelinePage.cards.isEmpty())
         assertFalse(timelinePage.hasMoreCards)
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Visible")),
+            partiallyResolvedSnapshot.selectedFilter
+        )
+        assertEquals(listOf("visible-card"), partiallyResolvedSnapshot.cards.map { card -> card.cardId })
+        assertEquals(1, partiallyResolvedSnapshot.dueCount)
+        assertEquals(1, partiallyResolvedSnapshot.totalCount)
     }
 
     @Test
@@ -200,6 +217,156 @@ class LocalReviewFilterContractTest {
     }
 
     @Test
+    fun reviewRepositoryMatchesAnySelectedTagAndTreatsEmptySelectionAsMatchNone(): Unit = runBlocking {
+        val nowMillis = 12 * 60 * 60 * 1_000L
+        val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = nowMillis)
+        val reviewRepository = createTestReviewRepository(runtime = runtime)
+        val alphaTag = TagEntity(tagId = "tag-alpha", workspaceId = workspaceId, name = "Alpha")
+        val betaTag = TagEntity(tagId = "tag-beta", workspaceId = workspaceId, name = "Beta")
+        val gammaTag = TagEntity(tagId = "tag-gamma", workspaceId = workspaceId, name = "Gamma")
+        val cardsById = listOf(
+            "alpha-card",
+            "beta-card",
+            "both-card",
+            "gamma-card",
+            "untagged-card"
+        ).mapIndexed { index, cardId ->
+            makeNewReviewOrderingCardEntity(
+                cardId = cardId,
+                workspaceId = workspaceId,
+                createdAtMillis = index.toLong(),
+                updatedAtMillis = index.toLong()
+            )
+        }.associateBy { card ->
+            card.cardId
+        }
+
+        database.cardDao().insertCards(cards = cardsById.values.toList())
+        database.tagDao().insertTags(tags = listOf(alphaTag, betaTag, gammaTag))
+        database.tagDao().insertCardTags(
+            cardTags = listOf(
+                CardTagEntity(cardId = "alpha-card", tagId = alphaTag.tagId),
+                CardTagEntity(cardId = "beta-card", tagId = betaTag.tagId),
+                CardTagEntity(cardId = "both-card", tagId = alphaTag.tagId),
+                CardTagEntity(cardId = "both-card", tagId = betaTag.tagId),
+                CardTagEntity(cardId = "gamma-card", tagId = gammaTag.tagId)
+            )
+        )
+
+        val orSnapshot = reviewRepository.observeReviewSession(
+            selectedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "Beta")),
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
+        ).first()
+        val emptySnapshot = reviewRepository.observeReviewSession(
+            selectedFilter = ReviewFilter.Tags(tags = emptyList()),
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
+        ).first()
+        val allTagsSnapshot = reviewRepository.observeReviewSession(
+            selectedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "Beta", "Gamma")),
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
+        ).first()
+
+        assertEquals(setOf("alpha-card", "beta-card", "both-card"), orSnapshot.cards.map { it.cardId }.toSet())
+        assertEquals(3, orSnapshot.dueCount)
+        assertEquals(3, orSnapshot.totalCount)
+        assertEquals(ReviewFilter.Tags(tags = emptyList()), emptySnapshot.selectedFilter)
+        assertTrue(emptySnapshot.cards.isEmpty())
+        assertEquals(0, emptySnapshot.dueCount)
+        assertEquals(0, emptySnapshot.totalCount)
+        assertEquals(ReviewFilter.AllCards, allTagsSnapshot.selectedFilter)
+        assertEquals(cardsById.keys, allTagsSnapshot.cards.map { it.cardId }.toSet())
+    }
+
+    @Test
+    fun reviewPreferencesPersistMultiTagSelectionPerWorkspaceAndDecodeLegacyValues() {
+        val store = SharedPreferencesReviewPreferencesStore(context = runtime.context)
+        val firstWorkspaceFilter = ReviewFilter.Tags(tags = listOf("Alpha", "Beta"))
+        val secondWorkspaceFilter = ReviewFilter.Tags(tags = emptyList())
+        val missingTagFilter = ReviewFilter.Tags(tags = listOf("Alpha", "missing"))
+        store.saveSelectedReviewFilter(workspaceId = "workspace-a", reviewFilter = firstWorkspaceFilter)
+        store.saveSelectedReviewFilter(workspaceId = "workspace-b", reviewFilter = secondWorkspaceFilter)
+        store.saveSelectedReviewFilter(workspaceId = "workspace-missing", reviewFilter = missingTagFilter)
+
+        val preferences = runtime.context.getSharedPreferences(
+            "flashcards-review-preferences",
+            Context.MODE_PRIVATE
+        )
+        check(
+            preferences.edit()
+                .putString("selected-review-filter::legacy-tag", "{\"kind\":\"tag\",\"tag\":\"Legacy\"}")
+                .putString("selected-review-filter::legacy-deck", "{\"kind\":\"deck\",\"deckId\":\"deck-1\"}")
+                .putString("selected-review-filter::legacy-effort", "{\"kind\":\"effort\",\"effortLevel\":\"MEDIUM\"}")
+                .commit()
+        ) {
+            "Could not seed legacy review preferences."
+        }
+
+        assertEquals(firstWorkspaceFilter, store.loadSelectedReviewFilter(workspaceId = "workspace-a"))
+        assertEquals(secondWorkspaceFilter, store.loadSelectedReviewFilter(workspaceId = "workspace-b"))
+        assertEquals(missingTagFilter, store.loadSelectedReviewFilter(workspaceId = "workspace-missing"))
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Legacy")),
+            store.loadSelectedReviewFilter(workspaceId = "legacy-tag")
+        )
+        assertEquals(
+            ReviewFilter.Deck(deckId = "deck-1"),
+            store.loadSelectedReviewFilter(workspaceId = "legacy-deck")
+        )
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("medium")),
+            store.loadSelectedReviewFilter(workspaceId = "legacy-effort")
+        )
+    }
+
+    @Test
+    fun scheduledNotificationPayloadCodecPreservesMultiTagAndLegacySingleTagFilters() {
+        runtime.context.deleteSharedPreferences("flashcards-review-notifications")
+        val store = SharedPreferencesReviewNotificationsStore(context = runtime.context)
+        val selectedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "Beta"))
+        store.saveScheduledPayloads(
+            payloads = listOf(
+                ScheduledReviewNotificationPayload(
+                    workspaceId = "workspace-a",
+                    reviewFilter = makePersistedReviewFilter(reviewFilter = selectedFilter),
+                    cardId = "card-1",
+                    frontText = "Front",
+                    scheduledAtMillis = 1_000L,
+                    requestId = "request-1"
+                )
+            )
+        )
+
+        assertEquals(
+            selectedFilter,
+            decodePersistedReviewFilter(filter = store.loadScheduledPayloads().single().reviewFilter)
+        )
+
+        val preferences = runtime.context.getSharedPreferences(
+            "flashcards-review-notifications",
+            Context.MODE_PRIVATE
+        )
+        check(
+            preferences.edit().putString(
+                "review-notifications-scheduled-payloads",
+                "[{\"workspaceId\":\"workspace-a\",\"reviewFilter\":{\"kind\":\"tag\",\"tag\":\"Legacy\"}," +
+                    "\"cardId\":\"card-1\",\"frontText\":\"Front\",\"scheduledAtMillis\":1000," +
+                    "\"requestId\":\"request-legacy\"}]"
+            ).commit()
+        ) {
+            "Could not seed legacy scheduled review notification payload."
+        }
+
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Legacy")),
+            decodePersistedReviewFilter(filter = store.loadScheduledPayloads().single().reviewFilter)
+        )
+        assertTrue(runtime.context.deleteSharedPreferences("flashcards-review-notifications"))
+    }
+
+    @Test
     fun reviewRepositoryMatchesUnicodeTagFilterInBoundedQueueAndCounts(): Unit = runBlocking {
         val nowMillis = 12 * 60 * 60 * 1_000L
         val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = nowMillis)
@@ -240,7 +407,7 @@ class LocalReviewFilterContractTest {
         )
 
         val sessionSnapshot = reviewRepository.observeReviewSession(
-            selectedFilter = ReviewFilter.Tag(tag = "éclair"),
+            selectedFilter = ReviewFilter.Tags(tags = listOf("éclair")),
             pendingReviewedCards = emptySet(),
             presentedCardId = null
         ).first()
@@ -261,7 +428,7 @@ class LocalReviewFilterContractTest {
             tagNames = listOf("Éclair")
         ).first()
 
-        assertEquals(ReviewFilter.Tag(tag = "Éclair"), sessionSnapshot.selectedFilter)
+        assertEquals(ReviewFilter.Tags(tags = listOf("Éclair")), sessionSnapshot.selectedFilter)
         assertEquals(listOf("unicode-tag-card"), sessionSnapshot.cards.map { card -> card.cardId })
         assertEquals("unicode-tag-card", sessionSnapshot.presentedCard?.cardId)
         assertEquals(1, sessionSnapshot.dueCount)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewQueueContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewQueueContractTest.kt
@@ -104,7 +104,7 @@ class LocalReviewQueueContractTest {
             presentedCardId = null
         ).first()
         val tagSnapshot = reviewRepository.observeReviewSession(
-            selectedFilter = ReviewFilter.Tag(tag = "ui"),
+            selectedFilter = ReviewFilter.Tags(tags = listOf("ui")),
             pendingReviewedCards = emptySet(),
             presentedCardId = null
         ).first()

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewRollbackContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewRollbackContractTest.kt
@@ -73,6 +73,44 @@ class LocalReviewRollbackContractTest {
     }
 
     @Test
+    fun reviewRepositoryLoadsRollbackForPartiallyResolvedMissingTagFilter(): Unit = runBlocking {
+        val nowMillis = System.currentTimeMillis()
+        val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = nowMillis)
+        val reviewRepository = createTestReviewRepository(runtime = runtime)
+        val alphaTag = TagEntity(
+            tagId = "rollback-partial-alpha-tag",
+            workspaceId = workspaceId,
+            name = "Alpha"
+        )
+        val submittedCard = makeNewReviewOrderingCardEntity(
+            cardId = "rollback-partial-alpha-card",
+            workspaceId = workspaceId,
+            createdAtMillis = nowMillis,
+            updatedAtMillis = nowMillis
+        )
+        database.cardDao().insertCard(card = submittedCard)
+        database.tagDao().insertTags(tags = listOf(alphaTag))
+        database.tagDao().insertCardTags(
+            cardTags = listOf(
+                CardTagEntity(cardId = submittedCard.cardId, tagId = alphaTag.tagId)
+            )
+        )
+
+        val sessionSnapshot = reviewRepository.observeReviewSession(
+            selectedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "missing")),
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
+        ).first()
+        val rollbackCard = reviewRepository.loadReviewCardForRollback(
+            selectedFilter = sessionSnapshot.selectedFilter,
+            cardId = submittedCard.cardId
+        )
+
+        assertEquals(ReviewFilter.Tags(tags = listOf("Alpha")), sessionSnapshot.selectedFilter)
+        assertEquals(submittedCard.cardId, rollbackCard?.cardId)
+    }
+
+    @Test
     fun reviewRepositoryRejectsRollbackForNonCurrentOrInactiveCards(): Unit = runBlocking {
         val nowMillis = System.currentTimeMillis()
         val oneDayMillis = 86_400_000L
@@ -211,7 +249,7 @@ class LocalReviewRollbackContractTest {
 
         val activeReviewTagNames = database.tagDao().loadReviewTagNames(workspaceId = workspaceId)
         val missingTagRollbackCard = reviewRepository.loadReviewCardForRollback(
-            selectedFilter = ReviewFilter.Tag(tag = "Stale"),
+            selectedFilter = ReviewFilter.Tags(tags = listOf("Stale")),
             cardId = visibleCard.cardId
         )
         val missingDeckRollbackCard = reviewRepository.loadReviewCardForRollback(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewModels.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.data.local.model.review
 
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeTagKey
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 
 enum class ReviewRating {
@@ -16,9 +17,38 @@ sealed interface ReviewFilter {
         val deckId: String
     ) : ReviewFilter
 
-    data class Tag(
-        val tag: String
-    ) : ReviewFilter
+    data class Tags(
+        val tags: List<String>
+    ) : ReviewFilter {
+        init {
+            require(tags == normalizeReviewTagNames(tagNames = tags)) {
+                "Review tag selection must be normalized, deduplicated, and deterministically ordered."
+            }
+        }
+    }
+}
+
+fun normalizeReviewTagNames(tagNames: List<String>): List<String> {
+    return tagNames.map(String::trim)
+        .filter(String::isNotEmpty)
+        .groupBy { tagName ->
+            normalizeTagKey(tag = tagName)
+        }
+        .values
+        .map { equivalentTagNames ->
+            equivalentTagNames.minOrNull() ?: error("Normalized review tag group cannot be empty.")
+        }
+        .sortedWith(
+            compareBy<String> { tagName ->
+                normalizeTagKey(tag = tagName)
+            }.thenBy { tagName ->
+                tagName
+            }
+        )
+}
+
+fun makeReviewTagFilter(tagNames: List<String>): ReviewFilter.Tags {
+    return ReviewFilter.Tags(tags = normalizeReviewTagNames(tagNames = tagNames))
 }
 
 data class ReviewCard(
@@ -67,7 +97,8 @@ data class ReviewAnswerOption(
 data class ReviewDeckFilterOption(
     val deckId: String,
     val title: String,
-    val totalCount: Int
+    val totalCount: Int,
+    val tags: List<String>
 )
 
 data class ReviewTagFilterOption(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt
@@ -64,10 +64,12 @@ fun matchesReviewFilter(filter: ReviewFilter, decks: List<DeckSummary>, card: Ca
             )
         }
 
-        is ReviewFilter.Tag -> {
-            val requestedTagKey = normalizeTagKey(tag = filter.tag)
+        is ReviewFilter.Tags -> {
+            val requestedTagKeys: Set<String> = filter.tags.map { tag ->
+                normalizeTagKey(tag = tag)
+            }.toSet()
             card.tags.any { tag ->
-                normalizeTagKey(tag = tag) == requestedTagKey
+                requestedTagKeys.contains(normalizeTagKey(tag = tag))
             }
         }
     }
@@ -106,17 +108,38 @@ fun resolveReviewFilterFromTagNames(
             }
         }
 
-        is ReviewFilter.Tag -> {
-            val matchingTag = tagNames.firstOrNull { tag ->
-                normalizeTagKey(tag = tag) == normalizeTagKey(tag = selectedFilter.tag)
-            }
+        is ReviewFilter.Tags -> resolveReviewTagFilter(
+            selectedTagNames = selectedFilter.tags,
+            availableTagNames = tagNames
+        )
+    }
+}
 
-            if (matchingTag == null) {
-                ReviewFilter.AllCards
-            } else {
-                ReviewFilter.Tag(tag = matchingTag)
-            }
+fun resolveReviewTagFilter(
+    selectedTagNames: List<String>,
+    availableTagNames: List<String>
+): ReviewFilter {
+    val normalizedSelectedTagNames: List<String> = normalizeReviewTagNames(tagNames = selectedTagNames)
+    val selectedTagKeys: Set<String> = normalizedSelectedTagNames.map { tagName ->
+        normalizeTagKey(tag = tagName)
+    }.toSet()
+    val resolvedTagNames: List<String> = normalizeReviewTagNames(
+        tagNames = availableTagNames.filter { availableTagName ->
+            selectedTagKeys.contains(normalizeTagKey(tag = availableTagName))
         }
+    )
+    val normalizedAvailableTagNames: List<String> = normalizeReviewTagNames(tagNames = availableTagNames)
+    val resolvedTagKeys: Set<String> = resolvedTagNames.map(::normalizeTagKey).toSet()
+    val availableTagKeys: Set<String> = normalizedAvailableTagNames.map(::normalizeTagKey).toSet()
+
+    return if (
+        normalizedAvailableTagNames.isNotEmpty() &&
+        resolvedTagKeys == selectedTagKeys &&
+        resolvedTagKeys == availableTagKeys
+    ) {
+        ReviewFilter.AllCards
+    } else {
+        makeReviewTagFilter(tagNames = resolvedTagNames)
     }
 }
 
@@ -130,7 +153,11 @@ fun reviewFilterTitle(
             deck.deckId == selectedFilter.deckId
         }?.name ?: "All cards"
 
-        is ReviewFilter.Tag -> selectedFilter.tag
+        is ReviewFilter.Tags -> when (selectedFilter.tags.size) {
+            0 -> "No tags"
+            1 -> selectedFilter.tags.single()
+            else -> "${selectedFilter.tags.size} tags"
+        }
     }
 }
 
@@ -185,7 +212,8 @@ fun buildReviewDeckFilterOptions(decks: List<DeckSummary>): List<ReviewDeckFilte
         ReviewDeckFilterOption(
             deckId = deck.deckId,
             title = deck.name,
-            totalCount = deck.dueCards
+            totalCount = deck.dueCards,
+            tags = normalizeReviewTagNames(tagNames = deck.filterDefinition.tags)
         )
     }.sortedWith(
         compareBy<ReviewDeckFilterOption> { option ->

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
@@ -3,6 +3,7 @@ package com.flashcardsopensourceapp.data.local.notifications
 import android.content.Context
 import androidx.core.content.edit
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -38,10 +39,12 @@ private const val reviewFilterKindKey: String = "kind"
 private const val reviewFilterDeckIdKey: String = "deckId"
 private const val reviewFilterEffortLevelKey: String = "effortLevel"
 private const val reviewFilterTagKey: String = "tag"
+private const val reviewFilterTagsKey: String = "tags"
 private const val reviewFilterAllCardsKind: String = "allCards"
 private const val reviewFilterDeckKind: String = "deck"
 private const val reviewFilterEffortKind: String = "effort"
 private const val reviewFilterTagKind: String = "tag"
+private const val reviewFilterTagsKind: String = "tags"
 
 enum class ReviewNotificationMode {
     DAILY,
@@ -79,7 +82,8 @@ data class PersistedReviewFilter(
     val kind: String,
     val deckId: String?,
     val effortLevel: String?,
-    val tag: String?
+    val tag: String?,
+    val tags: List<String>?
 )
 
 data class ScheduledReviewNotificationPayload(
@@ -418,21 +422,24 @@ fun makePersistedReviewFilter(reviewFilter: ReviewFilter): PersistedReviewFilter
             kind = reviewFilterAllCardsKind,
             deckId = null,
             effortLevel = null,
-            tag = null
+            tag = null,
+            tags = null
         )
 
         is ReviewFilter.Deck -> PersistedReviewFilter(
             kind = reviewFilterDeckKind,
             deckId = reviewFilter.deckId,
             effortLevel = null,
-            tag = null
+            tag = null,
+            tags = null
         )
 
-        is ReviewFilter.Tag -> PersistedReviewFilter(
-            kind = reviewFilterTagKind,
+        is ReviewFilter.Tags -> PersistedReviewFilter(
+            kind = reviewFilterTagsKind,
             deckId = null,
             effortLevel = null,
-            tag = reviewFilter.tag
+            tag = null,
+            tags = reviewFilter.tags
         )
     }
 }
@@ -453,8 +460,14 @@ fun decodePersistedReviewFilter(filter: PersistedReviewFilter): ReviewFilter {
             val tag = requireNotNull(filter.tag) {
                 "Persisted review filter is missing tag."
             }
-            ReviewFilter.Tag(tag = tag)
+            makeReviewTagFilter(tagNames = listOf(tag))
         }
+
+        reviewFilterTagsKind -> makeReviewTagFilter(
+            tagNames = requireNotNull(filter.tags) {
+                "Persisted review filter is missing tags."
+            }
+        )
 
         else -> {
             throw IllegalArgumentException("Persisted review filter has an unsupported kind.")
@@ -953,6 +966,9 @@ private fun encodePersistedReviewFilter(filter: PersistedReviewFilter): JSONObje
         if (filter.tag != null) {
             put(reviewFilterTagKey, filter.tag)
         }
+        if (filter.tags != null) {
+            put(reviewFilterTagsKey, JSONArray(filter.tags))
+        }
     }
 }
 
@@ -961,7 +977,12 @@ private fun decodePersistedReviewFilterPayload(payload: JSONObject): PersistedRe
         kind = payload.getString(reviewFilterKindKey),
         deckId = payload.optString(reviewFilterDeckIdKey).takeIf { it.isNotBlank() },
         effortLevel = payload.optString(reviewFilterEffortLevelKey).takeIf { it.isNotBlank() },
-        tag = payload.optString(reviewFilterTagKey).takeIf { it.isNotBlank() }
+        tag = payload.optString(reviewFilterTagKey).takeIf { it.isNotBlank() },
+        tags = payload.optJSONArray(reviewFilterTagsKey)?.let { tagsPayload ->
+            (0 until tagsPayload.length()).map { index ->
+                tagsPayload.getString(index)
+            }
+        }
     )
 
     return normalizeLegacyPersistedReviewFilter(filter = filter)
@@ -981,8 +1002,8 @@ private fun decodeLegacyPersistedEffortFilter(filter: PersistedReviewFilter): Re
     }
     return when (effortLevel.trim().lowercase()) {
         "fast" -> ReviewFilter.AllCards
-        "medium" -> ReviewFilter.Tag(tag = "medium")
-        "long" -> ReviewFilter.Tag(tag = "long")
+        "medium" -> makeReviewTagFilter(tagNames = listOf("medium"))
+        "long" -> makeReviewTagFilter(tagNames = listOf("long"))
         else -> throw IllegalArgumentException("Persisted review filter has an unsupported effortLevel.")
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
@@ -221,7 +221,12 @@ class LocalReviewRepository(
                         workspaceId = queryBase.workspaceId,
                         nowMillis = queryBase.nowMillis
                     )
-                        .map(::buildReviewTagFilterOptionsFromRows)
+                        .map { rows ->
+                            buildReviewTagFilterOptionsFromRows(
+                                rows = rows,
+                                storedTagNames = queryBase.storedTagNames
+                            )
+                        }
 
                 combine(queueStateFlow, tagFiltersFlow) { queueState, tagFilters ->
                     val deckSummaries: List<DeckSummary> = loadReviewDeckSummaries(
@@ -548,16 +553,23 @@ class LocalReviewRepository(
                 dueCards = 0
             )
         }
-        val resolvedFilter: ReviewFilter = resolveReviewFilterFromTagNames(
-            selectedFilter = selectedFilter,
-            decks = decksForResolution,
-            tagNames = storedTagNames
-        )
-        if (resolvedFilter != selectedFilter) {
-            return null
+        val executableFilter: ReviewFilter = when (selectedFilter) {
+            is ReviewFilter.Tags -> selectedFilter
+            ReviewFilter.AllCards,
+            is ReviewFilter.Deck -> {
+                val resolvedFilter: ReviewFilter = resolveReviewFilterFromTagNames(
+                    selectedFilter = selectedFilter,
+                    decks = decksForResolution,
+                    tagNames = storedTagNames
+                )
+                if (resolvedFilter != selectedFilter) {
+                    return null
+                }
+                resolvedFilter
+            }
         }
         if (matchesReviewFilter(
-                filter = resolvedFilter,
+                filter = executableFilter,
                 decks = decksForResolution,
                 card = cardSummary
             ).not()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupport.kt
@@ -31,7 +31,7 @@ internal const val reviewSessionQueueLookaheadSize: Int = 1
 internal sealed interface ReviewTagPredicate {
     data object None : ReviewTagPredicate
 
-    data object Impossible : ReviewTagPredicate
+    data object MatchNone : ReviewTagPredicate
 
     data class ExactTagNames(
         val tagNames: List<String>
@@ -110,10 +110,11 @@ internal fun makeReviewQueuePredicate(
             )
         }
 
-        is ReviewFilter.Tag -> ReviewQueuePredicate(
+        is ReviewFilter.Tags -> ReviewQueuePredicate(
             tagPredicate = makeReviewTagPredicate(
-                requestedTagNames = listOf(selectedFilter.tag),
-                storedTagNames = storedTagNames
+                requestedTagNames = selectedFilter.tags,
+                storedTagNames = storedTagNames,
+                emptySelectionMatchesNone = true
             )
         )
     }
@@ -126,14 +127,16 @@ internal fun makeReviewQueuePredicate(
     return ReviewQueuePredicate(
         tagPredicate = makeReviewTagPredicate(
             requestedTagNames = filterDefinition.tags,
-            storedTagNames = storedTagNames
+            storedTagNames = storedTagNames,
+            emptySelectionMatchesNone = false
         )
     )
 }
 
 private fun makeReviewTagPredicate(
     requestedTagNames: List<String>,
-    storedTagNames: List<String>
+    storedTagNames: List<String>,
+    emptySelectionMatchesNone: Boolean
 ): ReviewTagPredicate {
     val requestedTagKeys: List<String> = requestedTagNames.map { tagName ->
         normalizeTagKey(tag = tagName)
@@ -141,7 +144,11 @@ private fun makeReviewTagPredicate(
         tagKey.isNotEmpty()
     }.distinct()
     if (requestedTagKeys.isEmpty()) {
-        return ReviewTagPredicate.None
+        return if (emptySelectionMatchesNone) {
+            ReviewTagPredicate.MatchNone
+        } else {
+            ReviewTagPredicate.None
+        }
     }
 
     val requestedTagKeySet: Set<String> = requestedTagKeys.toSet()
@@ -150,7 +157,7 @@ private fun makeReviewTagPredicate(
     }.distinct()
 
     return if (exactTagNames.isEmpty()) {
-        ReviewTagPredicate.Impossible
+        ReviewTagPredicate.MatchNone
     } else {
         ReviewTagPredicate.ExactTagNames(tagNames = exactTagNames)
     }
@@ -169,7 +176,7 @@ internal fun observeActiveReviewQueue(
 
     val cutoffMillis = nowMillis - activeReviewRecentPriorityWindowMillis
     return when (val tagPredicate: ReviewTagPredicate = predicate.tagPredicate) {
-        ReviewTagPredicate.Impossible -> flowOf(emptyList<CardWithRelations>())
+        ReviewTagPredicate.MatchNone -> flowOf(emptyList<CardWithRelations>())
         ReviewTagPredicate.None -> database.reviewQueueDao().observeBucketedActiveReviewQueue(
             workspaceId = workspaceId,
             cutoffMillis = cutoffMillis,
@@ -194,7 +201,7 @@ internal fun observeReviewDueCount(
     predicate: ReviewQueuePredicate
 ): Flow<Int> {
     return when (val tagPredicate: ReviewTagPredicate = predicate.tagPredicate) {
-        ReviewTagPredicate.Impossible -> flowOf(0)
+        ReviewTagPredicate.MatchNone -> flowOf(0)
         ReviewTagPredicate.None -> database.reviewCountDao().observeReviewDueCount(
             workspaceId = workspaceId,
             nowMillis = nowMillis
@@ -214,7 +221,7 @@ internal fun observeReviewTotalCount(
     predicate: ReviewQueuePredicate
 ): Flow<Int> {
     return when (val tagPredicate: ReviewTagPredicate = predicate.tagPredicate) {
-        ReviewTagPredicate.Impossible -> flowOf(0)
+        ReviewTagPredicate.MatchNone -> flowOf(0)
         ReviewTagPredicate.None -> database.reviewCountDao().observeReviewTotalCount(workspaceId = workspaceId)
 
         is ReviewTagPredicate.ExactTagNames -> database.reviewCountDao().observeReviewTotalCountByAnyTags(
@@ -342,12 +349,18 @@ private fun isPreservablePresentedCard(
 }
 
 internal fun buildReviewTagFilterOptionsFromRows(
-    rows: List<ReviewTagCountRow>
+    rows: List<ReviewTagCountRow>,
+    storedTagNames: List<String>
 ): List<ReviewTagFilterOption> {
-    return rows.map { row ->
+    val countsByTagKey: Map<String, Int> = rows.associate { row ->
+        normalizeTagKey(tag = row.tag) to row.totalCount
+    }
+    return storedTagNames.distinctBy { tagName ->
+        normalizeTagKey(tag = tagName)
+    }.map { tagName ->
         ReviewTagFilterOption(
-            tag = row.tag,
-            totalCount = row.totalCount
+            tag = tagName,
+            totalCount = countsByTagKey[normalizeTagKey(tag = tagName)] ?: 0
         )
     }.sortedWith(
         compareBy<ReviewTagFilterOption> { option ->
@@ -399,7 +412,7 @@ internal suspend fun countReviewDueCards(
     predicate: ReviewQueuePredicate
 ): Int {
     return when (val tagPredicate: ReviewTagPredicate = predicate.tagPredicate) {
-        ReviewTagPredicate.Impossible -> 0
+        ReviewTagPredicate.MatchNone -> 0
         ReviewTagPredicate.None -> database.reviewCountDao().countReviewDueCards(
             workspaceId = workspaceId,
             nowMillis = nowMillis

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/review/ReviewPreferencesStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/review/ReviewPreferencesStore.kt
@@ -3,6 +3,8 @@ package com.flashcardsopensourceapp.data.local.review
 import android.content.Context
 import androidx.core.content.edit
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
+import org.json.JSONArray
 import org.json.JSONObject
 
 private const val reviewPreferencesName: String = "flashcards-review-preferences"
@@ -12,10 +14,12 @@ private const val persistedReviewFilterKindKey: String = "kind"
 private const val persistedReviewFilterDeckIdKey: String = "deckId"
 private const val persistedReviewFilterEffortLevelKey: String = "effortLevel"
 private const val persistedReviewFilterTagKey: String = "tag"
+private const val persistedReviewFilterTagsKey: String = "tags"
 private const val persistedReviewFilterAllCardsKind: String = "allCards"
 private const val persistedReviewFilterDeckKind: String = "deck"
 private const val persistedReviewFilterEffortKind: String = "effort"
 private const val persistedReviewFilterTagKind: String = "tag"
+private const val persistedReviewFilterTagsKind: String = "tags"
 
 interface ReviewPreferencesStore {
     /** Loads the selected review filter for a workspace. */
@@ -99,9 +103,9 @@ private fun encodePersistedReviewFilter(reviewFilter: ReviewFilter): String {
             payload.put(persistedReviewFilterDeckIdKey, reviewFilter.deckId)
         }
 
-        is ReviewFilter.Tag -> {
-            payload.put(persistedReviewFilterKindKey, persistedReviewFilterTagKind)
-            payload.put(persistedReviewFilterTagKey, reviewFilter.tag)
+        is ReviewFilter.Tags -> {
+            payload.put(persistedReviewFilterKindKey, persistedReviewFilterTagsKind)
+            payload.put(persistedReviewFilterTagsKey, JSONArray(reviewFilter.tags))
         }
     }
 
@@ -133,7 +137,16 @@ private fun decodePersistedReviewFilter(rawValue: String): ReviewFilter {
             require(tag.isNotEmpty()) {
                 "Persisted review filter is missing tag."
             }
-            ReviewFilter.Tag(tag = tag)
+            makeReviewTagFilter(tagNames = listOf(tag))
+        }
+
+        persistedReviewFilterTagsKind -> {
+            val tagsPayload = payload.getJSONArray(persistedReviewFilterTagsKey)
+            makeReviewTagFilter(
+                tagNames = (0 until tagsPayload.length()).map { index ->
+                    tagsPayload.getString(index)
+                }
+            )
         }
 
         else -> {
@@ -145,8 +158,8 @@ private fun decodePersistedReviewFilter(rawValue: String): ReviewFilter {
 private fun decodeLegacyEffortReviewFilter(rawValue: String): ReviewFilter {
     return when (rawValue.trim().lowercase()) {
         "fast" -> ReviewFilter.AllCards
-        "medium" -> ReviewFilter.Tag(tag = "medium")
-        "long" -> ReviewFilter.Tag(tag = "long")
+        "medium" -> makeReviewTagFilter(tagNames = listOf("medium"))
+        "long" -> makeReviewTagFilter(tagNames = listOf("long"))
         else -> throw IllegalArgumentException("Persisted review filter has an unsupported effortLevel.")
     }
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStoreTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStoreTest.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.data.local.notifications
 
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -56,7 +57,8 @@ class ReviewNotificationsStoreTest {
                 kind = "deck",
                 deckId = "deck-1",
                 effortLevel = null,
-                tag = null
+                tag = null,
+                tags = null
             ),
             fallbackFrontText = fallbackFrontText,
             nowMillis = parseTimestampMillis(value = "2026-04-03T09:00:00Z"),
@@ -173,7 +175,8 @@ class ReviewNotificationsStoreTest {
                 kind = "tag",
                 deckId = null,
                 effortLevel = null,
-                tag = "biology"
+                tag = "biology",
+                tags = null
             ),
             fallbackFrontText = fallbackFrontText,
             nowMillis = parseTimestampMillis(value = "2026-04-03T10:16:00Z"),
@@ -297,15 +300,54 @@ class ReviewNotificationsStoreTest {
             kind = "effort",
             deckId = null,
             effortLevel = "MEDIUM",
-            tag = null
+            tag = null,
+            tags = null
         )
 
         assertEquals(
-            ReviewFilter.Tag(tag = "medium"),
+            ReviewFilter.Tags(tags = listOf("medium")),
             decodePersistedReviewFilter(filter = persistedFilter)
         )
         assertEquals("effort", persistedFilter.kind)
         assertEquals("MEDIUM", persistedFilter.effortLevel)
+    }
+
+    @Test
+    fun multiTagReviewFilterPersistsEmptyAndOrSelectionsWhileLegacyTagRemainsReadable() {
+        val selectedTags = ReviewFilter.Tags(tags = listOf("biology", "science"))
+        val emptyTags = ReviewFilter.Tags(tags = emptyList())
+        val legacyTag = PersistedReviewFilter(
+            kind = "tag",
+            deckId = null,
+            effortLevel = null,
+            tag = "legacy",
+            tags = null
+        )
+
+        assertEquals(
+            selectedTags,
+            decodePersistedReviewFilter(
+                filter = makePersistedReviewFilter(reviewFilter = selectedTags)
+            )
+        )
+        assertEquals(
+            emptyTags,
+            decodePersistedReviewFilter(
+                filter = makePersistedReviewFilter(reviewFilter = emptyTags)
+            )
+        )
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("legacy")),
+            decodePersistedReviewFilter(filter = legacyTag)
+        )
+    }
+
+    @Test
+    fun multiTagReviewFilterNormalizesDeduplicatesAndOrdersTags() {
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Biology", "science")),
+            makeReviewTagFilter(tagNames = listOf(" science ", "biology", "Biology"))
+        )
     }
 
     @Test
@@ -460,7 +502,8 @@ private fun makeCurrentCard(cardId: String, frontText: String): CurrentReviewNot
             kind = "allCards",
             deckId = null,
             effortLevel = null,
-            tag = null
+            tag = null,
+            tags = null
         ),
         cardId = cardId,
         frontText = frontText

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewDraftState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewDraftState.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.review
 
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeTagKey
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewDeckFilterOption
@@ -129,6 +130,29 @@ internal fun applyResolvedReviewFilter(
         isNotificationPermissionPromptVisible = false,
         isHardAnswerReminderVisible = false
     )
+}
+
+internal fun reviewFilterResolutionToApply(
+    requestedFilter: ReviewFilter,
+    resolvedFilter: ReviewFilter,
+    availableTagFilters: List<ReviewTagFilterOption>
+): ReviewFilter? {
+    if (requestedFilter == resolvedFilter) {
+        return null
+    }
+    if (requestedFilter is ReviewFilter.Tags) {
+        val availableTagKeys: Set<String> = availableTagFilters.map { tagFilter ->
+            normalizeTagKey(tag = tagFilter.tag)
+        }.toSet()
+        val hasMissingRequestedTag: Boolean = requestedFilter.tags.any { tagName ->
+            availableTagKeys.contains(normalizeTagKey(tag = tagName)).not()
+        }
+        if (hasMissingRequestedTag) {
+            return null
+        }
+    }
+
+    return resolvedFilter
 }
 
 internal fun nextReviewFilterGenerationAfterSelection(

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -76,6 +76,7 @@ fun ReviewRoute(
     onScreenVisible: () -> Unit
 ) {
     var isFilterSheetVisible by remember { mutableStateOf(value = false) }
+    var filterSheetSelection by remember { mutableStateOf<ReviewFilter?>(value = null) }
     var speechErrorMessage by remember { mutableStateOf(value = "") }
     var activeReviewReactionEvents by remember {
         mutableStateOf<List<ReviewReactionEvent>>(value = emptyList())
@@ -201,6 +202,7 @@ fun ReviewRoute(
                 reviewProgressBadge = uiState.reviewProgressBadge,
                 selectedFilterTitle = uiState.selectedFilterTitle,
                 onOpenFilter = {
+                    filterSheetSelection = uiState.requestedFilter
                     isFilterSheetVisible = true
                 },
                 onOpenPreview = onOpenPreview,
@@ -300,18 +302,30 @@ fun ReviewRoute(
 
     if (isFilterSheetVisible) {
         ReviewFilterSheet(
-            selectedFilter = uiState.selectedFilter,
+            selectedFilter = filterSheetSelection ?: uiState.requestedFilter,
             availableDeckFilters = uiState.availableDeckFilters,
             availableTagFilters = uiState.availableTagFilters,
             onDismiss = {
                 isFilterSheetVisible = false
+                filterSheetSelection = null
             },
             onSelectFilter = { nextFilter ->
+                filterSheetSelection = nextFilter
                 onSelectFilter(nextFilter)
-                isFilterSheetVisible = false
+            },
+            onToggleTag = { tagName ->
+                val nextFilter = toggleReviewTagFilter(
+                    selectedFilter = filterSheetSelection ?: uiState.requestedFilter,
+                    toggledTagName = tagName,
+                    availableDeckFilters = uiState.availableDeckFilters,
+                    availableTagFilters = uiState.availableTagFilters
+                )
+                filterSheetSelection = nextFilter
+                onSelectFilter(nextFilter)
             },
             onManageDecks = {
                 isFilterSheetVisible = false
+                filterSheetSelection = null
                 onOpenDeckManagement()
             }
         )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewScreenTags.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewScreenTags.kt
@@ -16,3 +16,9 @@ const val reviewCurrentCardFrontContentTag: String = "review_current_card_front_
 const val reviewProgressBadgeTag: String = "review_progress_badge"
 const val reviewLeaderboardShortcutTag: String = "review_leaderboard_shortcut"
 const val reviewQueueButtonTag: String = "review_queue_button"
+const val reviewFilterSheetTag: String = "review_filter_sheet"
+const val reviewFilterAllCardsOptionTag: String = "review_filter_all_cards_option"
+
+fun reviewFilterDeckOptionTag(deckId: String): String = "review_filter_deck_option::$deckId"
+
+fun reviewFilterTagOptionTag(tag: String): String = "review_filter_tag_option::$tag"

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewStrings.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewStrings.kt
@@ -119,7 +119,15 @@ class ReviewTextProvider(
                 deck.deckId == selectedFilter.deckId
             }?.title ?: allCardsTitle()
 
-            is ReviewFilter.Tag -> selectedFilter.tag
+            is ReviewFilter.Tags -> when (selectedFilter.tags.size) {
+                0 -> resources.getString(R.string.review_no_tags_label)
+                1 -> selectedFilter.tags.single()
+                else -> resources.getQuantityString(
+                    R.plurals.review_filter_tag_count,
+                    selectedFilter.tags.size,
+                    selectedFilter.tags.size
+                )
+            }
         }
     }
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
@@ -25,6 +25,7 @@ enum class ReviewEmptyState {
 
 data class ReviewUiState(
     val isLoading: Boolean,
+    val requestedFilter: ReviewFilter,
     val selectedFilter: ReviewFilter,
     val selectedFilterTitle: String,
     val remainingCount: Int,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiStateMapping.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiStateMapping.kt
@@ -25,6 +25,7 @@ internal fun initialReviewAppMetadataSummary(textProvider: ReviewTextProvider): 
 internal fun initialReviewUiState(textProvider: ReviewTextProvider): ReviewUiState {
     return ReviewUiState(
         isLoading = true,
+        requestedFilter = ReviewFilter.AllCards,
         selectedFilter = ReviewFilter.AllCards,
         selectedFilterTitle = textProvider.allCardsTitle(),
         remainingCount = 0,
@@ -123,6 +124,7 @@ internal fun mapToReviewUiState(
 
     return ReviewUiState(
         isLoading = sessionSnapshot.isLoading,
+        requestedFilter = state.requestedFilter,
         selectedFilter = sessionSnapshot.selectedFilter,
         selectedFilterTitle = textProvider.filterTitle(
             selectedFilter = sessionSnapshot.selectedFilter,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -624,9 +624,11 @@ class ReviewViewModel(
                 if (reviewSessionState.requestedFilter != requestedFilter) {
                     return@collect
                 }
-                if (requestedFilter == sessionSnapshot.selectedFilter) {
-                    return@collect
-                }
+                val resolvedFilterToApply = reviewFilterResolutionToApply(
+                    requestedFilter = requestedFilter,
+                    resolvedFilter = sessionSnapshot.selectedFilter,
+                    availableTagFilters = sessionSnapshot.availableTagFilters
+                ) ?: return@collect
 
                 reviewFilterGeneration += 1L
                 lastObservedReviewSessionSignature = null
@@ -634,12 +636,12 @@ class ReviewViewModel(
                 draftState.update { state ->
                     applyResolvedReviewFilter(
                         state = state,
-                        reviewFilter = sessionSnapshot.selectedFilter
+                        reviewFilter = resolvedFilterToApply
                     )
                 }
                 reviewPreferencesStore.saveSelectedReviewFilter(
                     workspaceId = workspaceId,
-                    reviewFilter = sessionSnapshot.selectedFilter
+                    reviewFilter = resolvedFilterToApply
                 )
             }
         }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
@@ -1,29 +1,34 @@
 package com.flashcardsopensourceapp.feature.review
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.core.ui.bidiWrap
 import com.flashcardsopensourceapp.core.ui.currentResourceLocale
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeTagKey
 import com.flashcardsopensourceapp.data.local.model.review.ReviewDeckFilterOption
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
+import com.flashcardsopensourceapp.data.local.model.review.resolveReviewTagFilter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,16 +38,27 @@ internal fun ReviewFilterSheet(
     availableTagFilters: List<ReviewTagFilterOption>,
     onDismiss: () -> Unit,
     onSelectFilter: (ReviewFilter) -> Unit,
+    onToggleTag: (String) -> Unit,
     onManageDecks: () -> Unit
 ) {
     val context = LocalContext.current
     val locale = currentResourceLocale(resources = context.resources)
+    val selectedTagNames = selectedReviewTagNames(
+        selectedFilter = selectedFilter,
+        availableDeckFilters = availableDeckFilters,
+        availableTagFilters = availableTagFilters
+    )
+    val selectedTagKeys: Set<String> = selectedTagNames.map { tagName ->
+        normalizeTagKey(tag = tagName)
+    }.toSet()
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
         LazyColumn(
             contentPadding = PaddingValues(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(reviewFilterSheetTag)
         ) {
             item {
                 Text(
@@ -57,6 +73,7 @@ internal fun ReviewFilterSheet(
                     title = stringResource(id = R.string.review_all_cards),
                     subtitle = stringResource(id = R.string.review_scope_subtitle_all_cards),
                     selected = selectedFilter == ReviewFilter.AllCards,
+                    testTag = reviewFilterAllCardsOptionTag,
                     onClick = {
                         onSelectFilter(ReviewFilter.AllCards)
                     }
@@ -85,6 +102,7 @@ internal fun ReviewFilterSheet(
                         ),
                         subtitle = stringResource(id = R.string.review_filtered_deck_subtitle),
                         selected = selectedFilter == ReviewFilter.Deck(deckId = deck.deckId),
+                        testTag = reviewFilterDeckOptionTag(deckId = deck.deckId),
                         onClick = {
                             onSelectFilter(ReviewFilter.Deck(deckId = deck.deckId))
                         }
@@ -113,9 +131,10 @@ internal fun ReviewFilterSheet(
                             tag.totalCount
                         ),
                         subtitle = stringResource(id = R.string.review_workspace_tag_subtitle),
-                        selected = selectedFilter == ReviewFilter.Tag(tag = tag.tag),
+                        selected = selectedTagKeys.contains(normalizeTagKey(tag = tag.tag)),
+                        testTag = reviewFilterTagOptionTag(tag = tag.tag),
                         onClick = {
-                            onSelectFilter(ReviewFilter.Tag(tag = tag.tag))
+                            onToggleTag(tag.tag)
                         }
                     )
                 }
@@ -142,6 +161,7 @@ private fun ReviewFilterOptionRow(
     title: String,
     subtitle: String,
     selected: Boolean,
+    testTag: String,
     onClick: () -> Unit
 ) {
     ListItem(
@@ -152,11 +172,86 @@ private fun ReviewFilterOptionRow(
             Text(subtitle)
         },
         leadingContent = {
-            RadioButton(
-                selected = selected,
-                onClick = null
+            Checkbox(
+                checked = selected,
+                onCheckedChange = null
             )
         },
-        modifier = Modifier.clickable(onClick = onClick)
+        modifier = Modifier
+            .testTag(testTag)
+            .toggleable(
+                value = selected,
+                role = Role.Checkbox,
+                onValueChange = {
+                    onClick()
+                }
+            )
     )
+}
+
+internal fun selectedReviewTagNames(
+    selectedFilter: ReviewFilter,
+    availableDeckFilters: List<ReviewDeckFilterOption>,
+    availableTagFilters: List<ReviewTagFilterOption>
+): List<String> {
+    val availableTagNames: List<String> = availableTagFilters.map(ReviewTagFilterOption::tag)
+    val requestedTagNames: List<String> = when (selectedFilter) {
+        ReviewFilter.AllCards -> availableTagNames
+        is ReviewFilter.Deck -> availableDeckFilters.firstOrNull { deck ->
+            deck.deckId == selectedFilter.deckId
+        }?.let { deck ->
+            if (deck.tags.isEmpty()) {
+                availableTagNames
+            } else {
+                deck.tags
+            }
+        } ?: emptyList()
+        is ReviewFilter.Tags -> selectedFilter.tags
+    }
+    val requestedTagKeys: Set<String> = requestedTagNames.map { tagName ->
+        normalizeTagKey(tag = tagName)
+    }.toSet()
+
+    return availableTagNames.filter { availableTagName ->
+        requestedTagKeys.contains(normalizeTagKey(tag = availableTagName))
+    }
+}
+
+internal fun toggleReviewTagFilter(
+    selectedFilter: ReviewFilter,
+    toggledTagName: String,
+    availableDeckFilters: List<ReviewDeckFilterOption>,
+    availableTagFilters: List<ReviewTagFilterOption>
+): ReviewFilter {
+    val availableTagNames: List<String> = availableTagFilters.map(ReviewTagFilterOption::tag)
+    val currentTagNames: List<String> = if (selectedFilter is ReviewFilter.Tags) {
+        selectedFilter.tags
+    } else {
+        selectedReviewTagNames(
+            selectedFilter = selectedFilter,
+            availableDeckFilters = availableDeckFilters,
+            availableTagFilters = availableTagFilters
+        )
+    }
+    val toggledTagKey: String = normalizeTagKey(tag = toggledTagName)
+    val currentTagKeys: Set<String> = currentTagNames.map { tagName ->
+        normalizeTagKey(tag = tagName)
+    }.toSet()
+    val nextTagNames: List<String> = if (currentTagKeys.contains(toggledTagKey)) {
+        currentTagNames.filter { tagName ->
+            normalizeTagKey(tag = tagName) != toggledTagKey
+        }
+    } else {
+        currentTagNames + toggledTagName
+    }
+
+    val resolvedFilter = resolveReviewTagFilter(
+        selectedTagNames = nextTagNames,
+        availableTagNames = availableTagNames
+    )
+    return if (resolvedFilter == ReviewFilter.AllCards) {
+        ReviewFilter.AllCards
+    } else {
+        makeReviewTagFilter(tagNames = nextTagNames)
+    }
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reconciliation/ReviewSubmissionReconciliation.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reconciliation/ReviewSubmissionReconciliation.kt
@@ -289,6 +289,7 @@ private fun hasOwnedDeckFilterOptionChange(
         val nextOption = nextOptionsByDeckId[previousOption.deckId] ?: return false
         val countDelta = previousOption.totalCount - nextOption.totalCount
         nextOption.title == previousOption.title &&
+            nextOption.tags == previousOption.tags &&
             countDelta >= 0 &&
             countDelta <= committedReviewedCards.size
     }
@@ -322,11 +323,7 @@ private fun hasOwnedTagFilterOptionChange(
         }
         val expectedCount = previousOption.totalCount - expectedDelta
         val nextOption = nextOptionsByTag[previousOption.tag]
-        if (expectedCount <= 0) {
-            nextOption == null
-        } else {
-            nextOption?.totalCount == expectedCount
-        }
+        nextOption?.totalCount == maxOf(0, expectedCount)
     }
 }
 

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -101,4 +101,8 @@
         <item quantity="one">Review queue %d card.</item>
         <item quantity="other">Review queue %d cards.</item>
     </plurals>
+    <plurals name="review_filter_tag_count">
+        <item quantity="one">%d tag</item>
+        <item quantity="other">%d tags</item>
+    </plurals>
 </resources>

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewFilterAndSessionGenerationTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewFilterAndSessionGenerationTest.kt
@@ -387,9 +387,172 @@ class ReviewFilterAndSessionGenerationTest {
     }
 
     @Test
+    fun rapidOwnedReviewConsumesMatchingMarkerWhenTagRowsReachZero() {
+        val firstSubmittedCard = makePinnedReviewCard(
+            cardId = "rapid-zero-first-card",
+            tags = listOf("other"),
+            updatedAtMillis = 50L
+        )
+        val secondSubmittedCard = makePinnedReviewCard(
+            cardId = "rapid-zero-second-card",
+            tags = listOf("exhausted", "fast"),
+            updatedAtMillis = 51L
+        )
+        val nextCard = makePinnedReviewCard(
+            cardId = "rapid-zero-next-card",
+            tags = emptyList(),
+            updatedAtMillis = 52L
+        )
+        val firstPendingCard = PendingReviewedCard(
+            cardId = firstSubmittedCard.cardId,
+            updatedAtMillis = firstSubmittedCard.updatedAtMillis
+        )
+        val secondPendingCard = PendingReviewedCard(
+            cardId = secondSubmittedCard.cardId,
+            updatedAtMillis = secondSubmittedCard.updatedAtMillis
+        )
+        val previousSignature = createObservedReviewSessionSignature(
+            reviewCards = listOf(nextCard),
+            presentedCard = nextCard,
+            dueCount = 1,
+            remainingCount = 1,
+            totalCount = 2,
+            availableTagFilters = listOf(
+                ReviewTagFilterOption(tag = "exhausted", totalCount = 1),
+                ReviewTagFilterOption(tag = "fast", totalCount = 1),
+                ReviewTagFilterOption(tag = "other", totalCount = 0)
+            )
+        )
+        val nextSignature = createObservedReviewSessionSignature(
+            reviewCards = listOf(nextCard),
+            presentedCard = nextCard,
+            dueCount = 0,
+            remainingCount = 0,
+            totalCount = 2,
+            availableTagFilters = listOf(
+                ReviewTagFilterOption(tag = "exhausted", totalCount = 0),
+                ReviewTagFilterOption(tag = "fast", totalCount = 0),
+                ReviewTagFilterOption(tag = "other", totalCount = 0)
+            )
+        )
+        val state = makePinnedReviewDraftState(
+            requestedFilter = ReviewFilter.AllCards,
+            presentedCard = nextCard,
+            reviewedInSessionCount = 0,
+            pendingReviewedCards = setOf(firstPendingCard, secondPendingCard),
+            optimisticPreparedCurrentCard = makePreparedReviewCardPresentation(card = nextCard),
+            errorMessage = ""
+        )
+        val ownedReviewSubmissions = mapOf(
+            firstPendingCard to makeOwnedReviewSubmission(
+                pendingReviewedCard = firstPendingCard,
+                reviewedCard = firstSubmittedCard,
+                presentedCard = nextCard,
+                observationState = OwnedReviewSubmissionObservationState.COMMIT_PENDING_OBSERVATION
+            ),
+            secondPendingCard to makeOwnedReviewSubmission(
+                pendingReviewedCard = secondPendingCard,
+                reviewedCard = secondSubmittedCard,
+                presentedCard = nextCard,
+                observationState = OwnedReviewSubmissionObservationState.COMMIT_PENDING_OBSERVATION
+            )
+        )
+        val suppression = requireNotNull(
+            findOwnedReviewSessionObservationSuppression(
+                previousSignature = previousSignature,
+                nextSignature = nextSignature,
+                state = state,
+                ownedReviewSubmissions = ownedReviewSubmissions
+            )
+        )
+
+        assertFalse(
+            shouldAdvanceReviewSessionGeneration(
+                previousSignature = previousSignature,
+                nextSignature = nextSignature,
+                state = state,
+                ownedReviewSubmissions = ownedReviewSubmissions
+            )
+        )
+        assertEquals(setOf(secondPendingCard), suppression.consumedPendingReviewedCards)
+    }
+
+    @Test
+    fun concurrentDeckTagChangeAdvancesGenerationDuringOwnedReview() {
+        val submittedCard = makePinnedReviewCard(
+            cardId = "deck-definition-change-card",
+            tags = listOf("fast"),
+            updatedAtMillis = 53L
+        )
+        val pendingReviewedCard = PendingReviewedCard(
+            cardId = submittedCard.cardId,
+            updatedAtMillis = submittedCard.updatedAtMillis
+        )
+        val previousSignature = createObservedReviewSessionSignature(
+            reviewCards = emptyList(),
+            presentedCard = null,
+            dueCount = 1,
+            remainingCount = 1,
+            totalCount = 1,
+            availableTagFilters = listOf(ReviewTagFilterOption(tag = "fast", totalCount = 1))
+        )
+        val nextSignature = createObservedReviewSessionSignature(
+            reviewCards = emptyList(),
+            presentedCard = null,
+            dueCount = 0,
+            remainingCount = 0,
+            totalCount = 1,
+            availableTagFilters = listOf(ReviewTagFilterOption(tag = "fast", totalCount = 0))
+        ).copy(
+            availableDeckFilters = listOf(
+                ReviewDeckFilterOption(
+                    deckId = "all-fast",
+                    title = "All fast",
+                    totalCount = 0,
+                    tags = listOf("changed")
+                )
+            )
+        )
+        val state = makePinnedReviewDraftState(
+            requestedFilter = ReviewFilter.AllCards,
+            presentedCard = null,
+            reviewedInSessionCount = 0,
+            pendingReviewedCards = setOf(pendingReviewedCard),
+            optimisticPreparedCurrentCard = null,
+            errorMessage = ""
+        )
+        val ownedReviewSubmissions = mapOf(
+            pendingReviewedCard to makeOwnedReviewSubmission(
+                pendingReviewedCard = pendingReviewedCard,
+                reviewedCard = submittedCard,
+                presentedCard = null,
+                observationState = OwnedReviewSubmissionObservationState.COMMIT_PENDING_OBSERVATION
+            )
+        )
+
+        assertEquals(
+            null,
+            findOwnedReviewSessionObservationSuppression(
+                previousSignature = previousSignature,
+                nextSignature = nextSignature,
+                state = state,
+                ownedReviewSubmissions = ownedReviewSubmissions
+            )
+        )
+        assertTrue(
+            shouldAdvanceReviewSessionGeneration(
+                previousSignature = previousSignature,
+                nextSignature = nextSignature,
+                state = state,
+                ownedReviewSubmissions = ownedReviewSubmissions
+            )
+        )
+    }
+
+    @Test
     fun sameFilterSelectionDoesNotAdvanceFilterGeneration() {
         val currentGeneration = 7L
-        val activeFilter = ReviewFilter.Tag(tag = "active")
+        val activeFilter = ReviewFilter.Tags(tags = listOf("active"))
 
         assertEquals(
             currentGeneration,
@@ -406,6 +569,146 @@ class ReviewFilterAndSessionGenerationTest {
                 selectedFilter = ReviewFilter.AllCards,
                 currentFilterGeneration = currentGeneration
             )
+        )
+    }
+
+    @Test
+    fun missingRequestedTagsStayUnchangedAcrossRepeatedFilterResolutions() {
+        val requestedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "missing"))
+        val resolvedQueryFilter = ReviewFilter.Tags(tags = listOf("Alpha"))
+        val availableTagFilters = listOf(
+            ReviewTagFilterOption(tag = "Alpha", totalCount = 1)
+        )
+
+        repeat(times = 2) {
+            assertEquals(
+                null,
+                reviewFilterResolutionToApply(
+                    requestedFilter = requestedFilter,
+                    resolvedFilter = resolvedQueryFilter,
+                    availableTagFilters = availableTagFilters
+                )
+            )
+        }
+        assertEquals(
+            ReviewFilter.AllCards,
+            reviewFilterResolutionToApply(
+                requestedFilter = ReviewFilter.Tags(tags = listOf("Alpha")),
+                resolvedFilter = ReviewFilter.AllCards,
+                availableTagFilters = availableTagFilters
+            )
+        )
+    }
+
+    @Test
+    fun checklistMaterializesDeckPresetSupportsEmptySelectionAndCanonicalizesAllTags() {
+        val deckFilters = listOf(
+            ReviewDeckFilterOption(
+                deckId = "deck-1",
+                title = "Deck 1",
+                totalCount = 2,
+                tags = listOf("Alpha", "Beta")
+            ),
+            ReviewDeckFilterOption(
+                deckId = "all-cards-deck",
+                title = "All cards deck",
+                totalCount = 3,
+                tags = emptyList()
+            )
+        )
+        val tagFilters = listOf("Alpha", "Beta", "Gamma").map { tagName ->
+            ReviewTagFilterOption(tag = tagName, totalCount = 1)
+        }
+
+        assertEquals(
+            listOf("Alpha", "Beta", "Gamma"),
+            selectedReviewTagNames(
+                selectedFilter = ReviewFilter.AllCards,
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        )
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Alpha")),
+            toggleReviewTagFilter(
+                selectedFilter = ReviewFilter.Deck(deckId = "deck-1"),
+                toggledTagName = "Beta",
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        )
+        assertEquals(
+            listOf("Alpha", "Beta", "Gamma"),
+            selectedReviewTagNames(
+                selectedFilter = ReviewFilter.Deck(deckId = "all-cards-deck"),
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        )
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Beta", "Gamma")),
+            toggleReviewTagFilter(
+                selectedFilter = ReviewFilter.Deck(deckId = "all-cards-deck"),
+                toggledTagName = "Alpha",
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        )
+        val allCardsMinusAlpha = toggleReviewTagFilter(
+            selectedFilter = ReviewFilter.AllCards,
+            toggledTagName = "Alpha",
+            availableDeckFilters = deckFilters,
+            availableTagFilters = tagFilters
+        )
+        assertEquals(ReviewFilter.Tags(tags = listOf("Beta", "Gamma")), allCardsMinusAlpha)
+        assertEquals(
+            ReviewFilter.AllCards,
+            toggleReviewTagFilter(
+                selectedFilter = allCardsMinusAlpha,
+                toggledTagName = "Alpha",
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        )
+        assertEquals(
+            ReviewFilter.Tags(tags = emptyList()),
+            toggleReviewTagFilter(
+                selectedFilter = ReviewFilter.AllCards,
+                toggledTagName = "Alpha",
+                availableDeckFilters = emptyList(),
+                availableTagFilters = listOf(ReviewTagFilterOption(tag = "Alpha", totalCount = 1))
+            )
+        )
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Alpha", "Beta", "missing")),
+            toggleReviewTagFilter(
+                selectedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "missing")),
+                toggledTagName = "Beta",
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        )
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("missing")),
+            toggleReviewTagFilter(
+                selectedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "missing")),
+                toggledTagName = "Alpha",
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        )
+        var immediateSelection: ReviewFilter = ReviewFilter.AllCards
+        listOf("Alpha", "Beta").forEach { tagName ->
+            immediateSelection = toggleReviewTagFilter(
+                selectedFilter = immediateSelection,
+                toggledTagName = tagName,
+                availableDeckFilters = deckFilters,
+                availableTagFilters = tagFilters
+            )
+        }
+        assertEquals(
+            ReviewFilter.Tags(tags = listOf("Gamma")),
+            immediateSelection
         )
     }
 }
@@ -432,7 +735,8 @@ private fun createObservedReviewSessionSignature(
             ReviewDeckFilterOption(
                 deckId = "all-fast",
                 title = "All fast",
-                totalCount = dueCount
+                totalCount = dueCount,
+                tags = listOf("fast")
             )
         ),
         availableTagFilters = availableTagFilters

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewSubmissionRollbackTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewSubmissionRollbackTest.kt
@@ -18,7 +18,7 @@ class ReviewSubmissionRollbackTest {
             cardId = submittedCard.cardId,
             updatedAtMillis = submittedCard.updatedAtMillis
         )
-        val currentFilter = ReviewFilter.Tag(tag = "current")
+        val currentFilter = ReviewFilter.Tags(tags = listOf("current"))
         val state = makePinnedReviewDraftState(
             requestedFilter = currentFilter,
             presentedCard = null,
@@ -45,6 +45,66 @@ class ReviewSubmissionRollbackTest {
     }
 
     @Test
+    fun partiallyResolvedMissingTagFailureRestoresSubmittedCard(): Unit = runBlocking {
+        val submittedCard = makePinnedReviewCard(
+            cardId = "submitted-partial-tag-card",
+            tags = listOf("Alpha"),
+            updatedAtMillis = 221L
+        )
+        val optimisticNextCard = makePinnedReviewCard(
+            cardId = "optimistic-partial-tag-next-card",
+            tags = listOf("Alpha"),
+            updatedAtMillis = 222L
+        )
+        val pendingReviewedCard = PendingReviewedCard(
+            cardId = submittedCard.cardId,
+            updatedAtMillis = submittedCard.updatedAtMillis
+        )
+        val requestedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "missing"))
+        val executableFilter = ReviewFilter.Tags(tags = listOf("Alpha"))
+        val context = ReviewSubmissionSessionContext(
+            requestedFilter = requestedFilter,
+            observedRequestedFilter = requestedFilter,
+            selectedFilter = executableFilter,
+            sessionGeneration = 2L,
+            filterGeneration = 3L
+        )
+        val state = makePinnedReviewDraftState(
+            requestedFilter = requestedFilter,
+            presentedCard = optimisticNextCard,
+            reviewedInSessionCount = 1,
+            pendingReviewedCards = setOf(pendingReviewedCard),
+            optimisticPreparedCurrentCard = makePreparedReviewCardPresentation(card = optimisticNextCard),
+            errorMessage = ""
+        )
+
+        val rollbackLookup = resolveFailedReviewSubmissionRollback(
+            submittedContext = context,
+            currentContextBeforeLookup = context,
+            cardId = submittedCard.cardId,
+            loadRollbackCard = { selectedFilter: ReviewFilter, cardId: String ->
+                assertEquals(executableFilter, selectedFilter)
+                assertEquals(submittedCard.cardId, cardId)
+                submittedCard
+            },
+            captureCurrentContext = { context }
+        )
+        val result = applyFailedReviewSubmission(
+            state = state,
+            submittedContext = context,
+            currentContext = rollbackLookup.currentContext,
+            rollbackCard = rollbackLookup.rollbackCard,
+            pendingReviewedCard = pendingReviewedCard,
+            errorMessage = "Review save failed"
+        )
+
+        assertEquals(submittedCard, result.presentedCard)
+        assertEquals(null, result.optimisticPreparedCurrentCard)
+        assertEquals(emptySet<PendingReviewedCard>(), result.pendingReviewedCards)
+        assertEquals("Review save failed", result.errorMessage)
+    }
+
+    @Test
     fun currentFailedReviewWithInvalidRollbackCardPreservesPresentationAndSetsError() {
         val submittedCard = makePinnedReviewCard(
             cardId = "submitted-invalid-rollback-card",
@@ -61,7 +121,7 @@ class ReviewSubmissionRollbackTest {
             updatedAtMillis = 24L
         )
         val optimisticPreparedCurrentCard = makePreparedReviewCardPresentation(card = presentedCard)
-        val currentFilter = ReviewFilter.Tag(tag = "current")
+        val currentFilter = ReviewFilter.Tags(tags = listOf("current"))
         val state = makePinnedReviewDraftState(
             requestedFilter = currentFilter,
             presentedCard = presentedCard,
@@ -109,7 +169,7 @@ class ReviewSubmissionRollbackTest {
             filterGeneration = 3L
         )
         val staleContext = makeReviewSubmissionSessionContextWithGenerations(
-            reviewFilter = ReviewFilter.Tag(tag = "new"),
+            reviewFilter = ReviewFilter.Tags(tags = listOf("new")),
             sessionGeneration = 8L,
             filterGeneration = 4L
         )
@@ -128,7 +188,7 @@ class ReviewSubmissionRollbackTest {
             captureCurrentContext = { currentContext }
         )
         val state = makePinnedReviewDraftState(
-            requestedFilter = ReviewFilter.Tag(tag = "new"),
+            requestedFilter = ReviewFilter.Tags(tags = listOf("new")),
             presentedCard = null,
             reviewedInSessionCount = 9,
             pendingReviewedCards = setOf(submittedPendingCard, retainedOtherCard),

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewSubmissionStalenessTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewSubmissionStalenessTest.kt
@@ -26,7 +26,7 @@ class ReviewSubmissionStalenessTest {
             cardId = "other-pending-card",
             updatedAtMillis = 20L
         )
-        val newFilter = ReviewFilter.Tag(tag = "new")
+        val newFilter = ReviewFilter.Tags(tags = listOf("new"))
         val state = makePinnedReviewDraftState(
             requestedFilter = newFilter,
             presentedCard = null,
@@ -43,7 +43,7 @@ class ReviewSubmissionStalenessTest {
         val result = applyFailedReviewSubmission(
             state = state,
             submittedContext = makeReviewSubmissionSessionContext(
-                reviewFilter = ReviewFilter.Tag(tag = "old")
+                reviewFilter = ReviewFilter.Tags(tags = listOf("old"))
             ),
             currentContext = makeReviewSubmissionSessionContext(
                 reviewFilter = newFilter
@@ -123,7 +123,7 @@ class ReviewSubmissionStalenessTest {
             cardId = "other-pending-card",
             updatedAtMillis = 24L
         )
-        val newFilter = ReviewFilter.Tag(tag = "new")
+        val newFilter = ReviewFilter.Tags(tags = listOf("new"))
         val state = makePinnedReviewDraftState(
             requestedFilter = newFilter,
             presentedCard = null,
@@ -136,7 +136,7 @@ class ReviewSubmissionStalenessTest {
         val result = applySuccessfulReviewSubmission(
             state = state,
             submittedContext = makeReviewSubmissionSessionContext(
-                reviewFilter = ReviewFilter.Tag(tag = "old")
+                reviewFilter = ReviewFilter.Tags(tags = listOf("old"))
             ),
             currentContext = makeReviewSubmissionSessionContext(
                 reviewFilter = newFilter

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/notifications/NotificationDiagnosticsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/notifications/NotificationDiagnosticsRoute.kt
@@ -367,6 +367,14 @@ private fun NotificationDiagnosticsReviewPayloadCard(
                     label = stringResource(R.string.settings_notification_diagnostics_filter_tag_label),
                     value = tag
                 )
+            },
+            payload.reviewFilter.tags?.let { tags ->
+                NotificationDiagnosticsInfoRow(
+                    label = stringResource(R.string.settings_notification_diagnostics_filter_tags_label),
+                    value = tags.joinToString(separator = ", ").ifEmpty {
+                        context.getString(R.string.settings_none)
+                    }
+                )
             }
         )
     )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/notifications/NotificationDiagnosticsUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/notifications/NotificationDiagnosticsUiState.kt
@@ -103,7 +103,8 @@ data class NotificationDiagnosticsReviewPayloadUiState(
 data class NotificationDiagnosticsReviewFilterUiState(
     val kind: String,
     val deckId: String?,
-    val tag: String?
+    val tag: String?,
+    val tags: List<String>?
 )
 
 data class NotificationDiagnosticsStrictReminderPayloadUiState(

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -239,6 +239,7 @@
     <string name="settings_notification_diagnostics_filter_kind_label">Filter kind</string>
     <string name="settings_notification_diagnostics_filter_deck_label">Filter deck</string>
     <string name="settings_notification_diagnostics_filter_tag_label">Filter tag</string>
+    <string name="settings_notification_diagnostics_filter_tags_label">Filter tags</string>
     <string name="settings_notification_diagnostics_time_offset_label">Time offset</string>
 
     <string name="settings_cloud_status_disconnected">Disconnected</string>


### PR DESCRIPTION
## Summary
- add native Material 3 multi-tag Review filtering on Android
- preserve workspace and notification filter compatibility
- cover OR, empty, deck preset, rapid-toggle, reconciliation, and rollback behavior

## Validation
- node scripts/checks/pr/run-all.mjs
- git diff --check

Gradle and emulator tests were not run locally because permission was not granted; Android PR CI provides those gates.