### PR TITLE
Add web multi-tag review filters

### DIFF
--- a/apps/web/src/accountDeletion.test.ts
+++ b/apps/web/src/accountDeletion.test.ts
@@ -72,6 +72,11 @@ function seedLocalBrowserState(): void {
     version: 1,
     entries: [],
   }));
+  window.localStorage.setItem("selected-review-filter", JSON.stringify({ kind: "allCards" }));
+  window.localStorage.setItem("selected-review-filter:workspace-1", JSON.stringify({
+    kind: "tags",
+    tags: ["grammar"],
+  }));
   window.localStorage.setItem("flashcards-auth-reset-required", "1");
   markBrowserReauthRequired();
 }
@@ -81,6 +86,8 @@ function expectLocalBrowserStateCleared(): void {
   expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
   expect(window.localStorage.getItem(SYNC_RESTORE_HISTORY_STORAGE_KEY)).toBeNull();
   expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBeNull();
+  expect(window.localStorage.getItem("selected-review-filter")).toBeNull();
+  expect(window.localStorage.getItem("selected-review-filter:workspace-1")).toBeNull();
   expect(isBrowserReauthRequired()).toBe(false);
   expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
   expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");

--- a/apps/web/src/accountDeletion.ts
+++ b/apps/web/src/accountDeletion.ts
@@ -22,6 +22,9 @@ const APP_LOCAL_STORAGE_PREFIX = "flashcards-";
 const APP_LOCAL_STORAGE_KEYS: ReadonlyArray<string> = [
   "selected-review-filter",
 ];
+const APP_LOCAL_STORAGE_KEY_PREFIXES: ReadonlyArray<string> = [
+  "selected-review-filter:",
+];
 const PRESERVED_BROWSER_LOCAL_STORAGE_KEYS: ReadonlyArray<string> = [
   INSTALLATION_ID_STORAGE_KEY,
   LOCALE_PREFERENCE_STORAGE_KEY,
@@ -196,7 +199,9 @@ function shouldRemoveAppLocalStorageKey(storageKey: string): boolean {
     return false;
   }
 
-  return storageKey.startsWith(APP_LOCAL_STORAGE_PREFIX) || APP_LOCAL_STORAGE_KEYS.includes(storageKey);
+  return storageKey.startsWith(APP_LOCAL_STORAGE_PREFIX)
+    || APP_LOCAL_STORAGE_KEYS.includes(storageKey)
+    || APP_LOCAL_STORAGE_KEY_PREFIXES.some((prefix) => storageKey.startsWith(prefix));
 }
 
 function isReauthMarkerStorageKey(storageKey: string): boolean {

--- a/apps/web/src/appData/context/provider.tsx
+++ b/apps/web/src/appData/context/provider.tsx
@@ -20,7 +20,7 @@ import type {
   WorkspaceSchedulerSettings,
   WorkspaceSummary,
 } from "../../types";
-import { ALL_CARDS_REVIEW_FILTER, isReviewFilterEqual } from "../domain";
+import { ALL_CARDS_REVIEW_FILTER, isReviewFilterEqual, normalizeReviewFilter } from "../domain";
 import type { AppDataContextValue, Props, SessionLoadState } from "./types";
 import { useProgressInvalidationRefresh } from "../progress/invalidation/progressInvalidation";
 import { isTestSeedBridgeEnabled, type AppDataTestSeedBridge } from "../sync/local/testSeedBridge";
@@ -28,75 +28,14 @@ import { useSyncEngine } from "../sync/engine/useSyncEngine";
 import { useWorkspaceSession } from "../session/useWorkspaceSession";
 import type { SessionVerificationState } from "../session/workspaceSessionTypes";
 import { loadWarmStartSnapshot, storeWarmStartSnapshot } from "../session/activation/warmStart";
+import {
+  activateWorkspaceReviewFilterState,
+  loadSelectedReviewFilterForWorkspace,
+  storeSelectedReviewFilterForWorkspace,
+  type WorkspaceReviewFilterState,
+} from "./reviewFilterPersistence";
 
 const AppDataContext = createContext<AppDataContextValue | null>(null);
-const SELECTED_REVIEW_FILTER_STORAGE_KEY = "selected-review-filter";
-
-function parsePersistedReviewFilter(value: string | null): ReviewFilter {
-  if (value === null) {
-    return ALL_CARDS_REVIEW_FILTER;
-  }
-
-  try {
-    const parsedValue = JSON.parse(value) as unknown;
-    if (
-      typeof parsedValue === "object"
-      && parsedValue !== null
-      && "kind" in parsedValue
-      && parsedValue.kind === "tag"
-      && "tag" in parsedValue
-      && typeof parsedValue.tag === "string"
-      && parsedValue.tag !== ""
-    ) {
-      return {
-        kind: "tag",
-        tag: parsedValue.tag,
-      };
-    }
-
-    if (
-      typeof parsedValue === "object"
-      && parsedValue !== null
-      && "kind" in parsedValue
-      && parsedValue.kind === "effort"
-      && "effortLevel" in parsedValue
-    ) {
-      if (parsedValue.effortLevel === "medium" || parsedValue.effortLevel === "long") {
-        return {
-          kind: "tag",
-          tag: parsedValue.effortLevel,
-        };
-      }
-
-      return {
-        kind: "allCards",
-      };
-    }
-
-    if (
-      typeof parsedValue === "object"
-      && parsedValue !== null
-      && "kind" in parsedValue
-      && parsedValue.kind === "deck"
-      && "deckId" in parsedValue
-      && typeof parsedValue.deckId === "string"
-      && parsedValue.deckId !== ""
-    ) {
-      return {
-        kind: "deck",
-        deckId: parsedValue.deckId,
-      };
-    }
-  } catch {
-    return ALL_CARDS_REVIEW_FILTER;
-  }
-
-  return ALL_CARDS_REVIEW_FILTER;
-}
-
-function loadSelectedReviewFilter(): ReviewFilter {
-  return parsePersistedReviewFilter(window.localStorage.getItem(SELECTED_REVIEW_FILTER_STORAGE_KEY));
-}
 
 function replaceSessionAccountPreferences(
   session: SessionInfo,
@@ -149,7 +88,31 @@ export function AppDataProvider(props: Props): ReactElement {
   const [sessionErrorMessage, setSessionErrorMessageState] = useState<string>("");
   const [sessionTechnicalError, setSessionTechnicalError] = useState<Error | null>(null);
   const [session, setSession] = useState<SessionInfo | null>(warmStartSnapshot?.session ?? null);
-  const [activeWorkspace, setActiveWorkspace] = useState<WorkspaceSummary | null>(warmStartSnapshot?.activeWorkspace ?? null);
+  const [workspaceReviewFilterState, setWorkspaceReviewFilterState] = useState<WorkspaceReviewFilterState>(() => {
+    const activeWorkspace = warmStartSnapshot?.activeWorkspace ?? null;
+    const workspaceId = activeWorkspace?.workspaceId ?? null;
+    return {
+      activeWorkspace,
+      selection: {
+        workspaceId,
+        reviewFilter: loadSelectedReviewFilterForWorkspace(workspaceId),
+      },
+    };
+  });
+  const workspaceReviewFilterStateRef = useRef<WorkspaceReviewFilterState>(workspaceReviewFilterState);
+  workspaceReviewFilterStateRef.current = workspaceReviewFilterState;
+  const activeWorkspace = workspaceReviewFilterState.activeWorkspace;
+  const setActiveWorkspace = useCallback(function setActiveWorkspace(
+    nextActiveWorkspace: WorkspaceSummary | null,
+  ): void {
+    const nextState = activateWorkspaceReviewFilterState(
+      workspaceReviewFilterStateRef.current,
+      nextActiveWorkspace,
+      loadSelectedReviewFilterForWorkspace,
+    );
+    workspaceReviewFilterStateRef.current = nextState;
+    setWorkspaceReviewFilterState(nextState);
+  }, []);
   const [availableWorkspaces, setAvailableWorkspaces] = useState<ReadonlyArray<WorkspaceSummary>>(
     warmStartSnapshot?.availableWorkspaces ?? [],
   );
@@ -161,8 +124,6 @@ export function AppDataProvider(props: Props): ReactElement {
   const [isSyncing, setIsSyncing] = useState<boolean>(false);
   const [errorMessage, setErrorMessageState] = useState<string>("");
   const [technicalError, setTechnicalError] = useState<Error | null>(null);
-  const [selectedReviewFilterState, setSelectedReviewFilterState] = useState<ReviewFilter>(loadSelectedReviewFilter);
-  const shouldSkipSelectedReviewFilterPersistRef = useRef<boolean>(false);
   const accountPreferencesMutationVersionRef = useRef<number>(0);
 
   const setSessionErrorMessage = useCallback<Dispatch<SetStateAction<string>>>((nextMessageAction): void => {
@@ -188,14 +149,19 @@ export function AppDataProvider(props: Props): ReactElement {
     setTechnicalError,
   });
 
+  const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
+  const selectedReviewFilterState = workspaceReviewFilterState.selection.reviewFilter;
+
   useEffect(() => {
-    if (shouldSkipSelectedReviewFilterPersistRef.current) {
-      shouldSkipSelectedReviewFilterPersistRef.current = false;
+    if (workspaceReviewFilterState.selection.workspaceId === null) {
       return;
     }
 
-    window.localStorage.setItem(SELECTED_REVIEW_FILTER_STORAGE_KEY, JSON.stringify(selectedReviewFilterState));
-  }, [selectedReviewFilterState]);
+    storeSelectedReviewFilterForWorkspace(
+      workspaceReviewFilterState.selection.workspaceId,
+      workspaceReviewFilterState.selection.reviewFilter,
+    );
+  }, [workspaceReviewFilterState.selection]);
 
   useEffect(() => {
     if (
@@ -273,28 +239,46 @@ export function AppDataProvider(props: Props): ReactElement {
   ]);
 
   const selectReviewFilter = useCallback(function selectReviewFilter(reviewFilter: ReviewFilter): void {
-    if (isReviewFilterEqual(selectedReviewFilterState, reviewFilter)) {
+    if (activeWorkspaceId === null || isReviewFilterEqual(selectedReviewFilterState, reviewFilter)) {
       return;
     }
 
-    setSelectedReviewFilterState(reviewFilter);
-  }, [selectedReviewFilterState]);
+    setWorkspaceReviewFilterState((currentState): WorkspaceReviewFilterState => ({
+      ...currentState,
+      selection: {
+        workspaceId: activeWorkspaceId,
+        reviewFilter: normalizeReviewFilter(reviewFilter),
+      },
+    }));
+  }, [activeWorkspaceId, selectedReviewFilterState]);
 
   const resetUserScopedUiState = useCallback(function resetUserScopedUiState(): void {
-    if (isReviewFilterEqual(selectedReviewFilterState, ALL_CARDS_REVIEW_FILTER) === false) {
-      shouldSkipSelectedReviewFilterPersistRef.current = true;
-    }
-
-    setSelectedReviewFilterState(ALL_CARDS_REVIEW_FILTER);
+    setWorkspaceReviewFilterState((currentState): WorkspaceReviewFilterState => ({
+      ...currentState,
+      selection: {
+        workspaceId: currentState.activeWorkspace?.workspaceId ?? null,
+        reviewFilter: ALL_CARDS_REVIEW_FILTER,
+      },
+    }));
     setWorkspaceSettings(null);
     setLocalReadVersion(0);
     setLocalCardCount(0);
     setIsSyncing(false);
-  }, [selectedReviewFilterState]);
+  }, []);
 
   const openReview = useCallback(function openReview(reviewFilter: ReviewFilter): void {
-    setSelectedReviewFilterState(reviewFilter);
-  }, []);
+    if (activeWorkspaceId === null) {
+      return;
+    }
+
+    setWorkspaceReviewFilterState((currentState): WorkspaceReviewFilterState => ({
+      ...currentState,
+      selection: {
+        workspaceId: activeWorkspaceId,
+        reviewFilter: normalizeReviewFilter(reviewFilter),
+      },
+    }));
+  }, [activeWorkspaceId]);
 
   const setAccountPreferences = useCallback(function setAccountPreferences(
     userId: string,

--- a/apps/web/src/appData/context/reviewFilterPersistence.ts
+++ b/apps/web/src/appData/context/reviewFilterPersistence.ts
@@ -1,0 +1,130 @@
+import type { ReviewFilter, WorkspaceSummary } from "../../types";
+import {
+  ALL_CARDS_REVIEW_FILTER,
+  makeTagsReviewFilter,
+  normalizeReviewFilter,
+} from "../domain";
+
+export const LEGACY_SELECTED_REVIEW_FILTER_STORAGE_KEY = "selected-review-filter";
+export const SELECTED_REVIEW_FILTER_STORAGE_KEY_PREFIX = "selected-review-filter:";
+
+export type WorkspaceReviewFilterState = Readonly<{
+  activeWorkspace: WorkspaceSummary | null;
+  selection: Readonly<{
+    workspaceId: string | null;
+    reviewFilter: ReviewFilter;
+  }>;
+}>;
+
+export function buildSelectedReviewFilterStorageKey(workspaceId: string): string {
+  return `${SELECTED_REVIEW_FILTER_STORAGE_KEY_PREFIX}${workspaceId}`;
+}
+
+export function parsePersistedReviewFilter(value: string | null): ReviewFilter {
+  if (value === null) {
+    return ALL_CARDS_REVIEW_FILTER;
+  }
+
+  try {
+    const parsedValue = JSON.parse(value) as unknown;
+    if (typeof parsedValue !== "object" || parsedValue === null || !("kind" in parsedValue)) {
+      return ALL_CARDS_REVIEW_FILTER;
+    }
+
+    if (parsedValue.kind === "allCards") {
+      return ALL_CARDS_REVIEW_FILTER;
+    }
+
+    if (
+      parsedValue.kind === "tags"
+      && "tags" in parsedValue
+      && Array.isArray(parsedValue.tags)
+      && parsedValue.tags.every((tag) => typeof tag === "string")
+    ) {
+      return makeTagsReviewFilter(parsedValue.tags);
+    }
+
+    if (
+      parsedValue.kind === "tag"
+      && "tag" in parsedValue
+      && typeof parsedValue.tag === "string"
+      && parsedValue.tag.trim() !== ""
+    ) {
+      return makeTagsReviewFilter([parsedValue.tag]);
+    }
+
+    if (parsedValue.kind === "effort" && "effortLevel" in parsedValue) {
+      return parsedValue.effortLevel === "medium" || parsedValue.effortLevel === "long"
+        ? makeTagsReviewFilter([parsedValue.effortLevel])
+        : ALL_CARDS_REVIEW_FILTER;
+    }
+
+    if (
+      parsedValue.kind === "deck"
+      && "deckId" in parsedValue
+      && typeof parsedValue.deckId === "string"
+      && parsedValue.deckId !== ""
+    ) {
+      return {
+        kind: "deck",
+        deckId: parsedValue.deckId,
+      };
+    }
+  } catch {
+    return ALL_CARDS_REVIEW_FILTER;
+  }
+
+  return ALL_CARDS_REVIEW_FILTER;
+}
+
+export function loadSelectedReviewFilterForWorkspace(workspaceId: string | null): ReviewFilter {
+  if (workspaceId === null) {
+    return ALL_CARDS_REVIEW_FILTER;
+  }
+
+  const workspaceStorageKey = buildSelectedReviewFilterStorageKey(workspaceId);
+  const workspaceValue = window.localStorage.getItem(workspaceStorageKey);
+  if (workspaceValue !== null) {
+    return parsePersistedReviewFilter(workspaceValue);
+  }
+
+  const legacyValue = window.localStorage.getItem(LEGACY_SELECTED_REVIEW_FILTER_STORAGE_KEY);
+  if (legacyValue === null) {
+    return ALL_CARDS_REVIEW_FILTER;
+  }
+
+  const migratedReviewFilter = parsePersistedReviewFilter(legacyValue);
+  window.localStorage.setItem(workspaceStorageKey, JSON.stringify(migratedReviewFilter));
+  window.localStorage.removeItem(LEGACY_SELECTED_REVIEW_FILTER_STORAGE_KEY);
+  return migratedReviewFilter;
+}
+
+export function storeSelectedReviewFilterForWorkspace(workspaceId: string, reviewFilter: ReviewFilter): void {
+  window.localStorage.setItem(
+    buildSelectedReviewFilterStorageKey(workspaceId),
+    JSON.stringify(normalizeReviewFilter(reviewFilter)),
+  );
+}
+
+export function activateWorkspaceReviewFilterState(
+  currentState: WorkspaceReviewFilterState,
+  activeWorkspace: WorkspaceSummary | null,
+  loadReviewFilter: (workspaceId: string | null) => ReviewFilter,
+): WorkspaceReviewFilterState {
+  const currentWorkspaceId = currentState.activeWorkspace?.workspaceId ?? null;
+  const nextWorkspaceId = activeWorkspace?.workspaceId ?? null;
+  if (currentWorkspaceId === nextWorkspaceId) {
+    return {
+      ...currentState,
+      activeWorkspace,
+    };
+  }
+
+  return {
+    activeWorkspace,
+    selection: {
+      workspaceId: nextWorkspaceId,
+      reviewFilter: loadReviewFilter(nextWorkspaceId),
+    },
+  };
+}

--- a/apps/web/src/appData/domain/index.test.ts
+++ b/apps/web/src/appData/domain/index.test.ts
@@ -13,6 +13,8 @@ import {
   doesCardMutationAffectReviewSchedule,
   matchesCardFilter,
   matchesDeckFilterDefinition,
+  makeTagsReviewFilter,
+  normalizeReviewFilterTags,
   normalizeTagKey,
   recentDuePriorityWindow,
   resolveReviewFilter,
@@ -284,6 +286,17 @@ describe("review tag matching domain", () => {
     expect(normalizeTagKey(" Éclair ")).toBe("éclair");
   });
 
+  it("normalizes, deduplicates, and deterministically orders explicit review tags", () => {
+    expect(normalizeReviewFilterTags([" verbs ", "Grammar", "grammar", ""])).toEqual([
+      "Grammar",
+      "verbs",
+    ]);
+    expect(makeTagsReviewFilter([])).toEqual({
+      kind: "tags",
+      tags: [],
+    });
+  });
+
   it("matches review tag filters by normalized key while preserving canonical stored tag text", () => {
     const matchingCard = {
       ...makeReviewOrderCard("unicode-tag", null, "2026-03-10T09:00:00.000Z", null),
@@ -294,13 +307,13 @@ describe("review tag matching domain", () => {
       tags: ["code"],
     };
     const reviewFilter = {
-      kind: "tag",
-      tag: "éclair",
+      kind: "tags",
+      tags: ["éclair"],
     } as const;
 
     expect(resolveReviewFilter(reviewFilter, [], [matchingCard, otherCard])).toEqual({
-      kind: "tag",
-      tag: "Éclair",
+      kind: "tags",
+      tags: ["Éclair"],
     });
     expect(cardsMatchingReviewFilter(reviewFilter, [], [matchingCard, otherCard]).map((card) => card.cardId)).toEqual([
       "unicode-tag",
@@ -317,6 +330,58 @@ describe("review tag matching domain", () => {
       version: 2,
       tags: ["éclair"],
     }, card)).toBe(true);
+  });
+
+  it("matches explicit review tags with OR semantics and keeps an empty selection match-none", () => {
+    const grammarCard = {
+      ...makeReviewOrderCard("grammar", null, "2026-03-10T09:00:00.000Z", null),
+      tags: ["grammar"],
+    };
+    const verbsCard = {
+      ...makeReviewOrderCard("verbs", null, "2026-03-10T09:01:00.000Z", null),
+      tags: ["verbs"],
+    };
+    const untaggedCard = makeReviewOrderCard("untagged", null, "2026-03-10T09:02:00.000Z", null);
+
+    expect(cardsMatchingReviewFilter(
+      { kind: "tags", tags: ["verbs", "grammar"] },
+      [],
+      [grammarCard, verbsCard, untaggedCard],
+    ).map((card) => card.cardId)).toEqual(["grammar", "verbs"]);
+    expect(cardsMatchingReviewFilter(
+      { kind: "tags", tags: [] },
+      [],
+      [grammarCard, verbsCard, untaggedCard],
+    )).toEqual([]);
+    expect(cardsMatchingReviewFilter(
+      { kind: "allCards" },
+      [],
+      [grammarCard, verbsCard, untaggedCard],
+    ).map((card) => card.cardId)).toEqual(["grammar", "verbs", "untagged"]);
+  });
+
+  it("removes missing requested tags without widening the filter to All Cards", () => {
+    const grammarCard = {
+      ...makeReviewOrderCard("grammar", null, "2026-03-10T09:00:00.000Z", null),
+      tags: ["Grammar"],
+    };
+
+    expect(resolveReviewFilter(
+      { kind: "tags", tags: ["missing", "grammar"] },
+      [],
+      [grammarCard],
+    )).toEqual({
+      kind: "tags",
+      tags: ["Grammar"],
+    });
+    expect(resolveReviewFilter(
+      { kind: "tags", tags: ["missing"] },
+      [],
+      [grammarCard],
+    )).toEqual({
+      kind: "tags",
+      tags: [],
+    });
   });
 
   it("matches card filter tags by normalized key", () => {

--- a/apps/web/src/appData/domain/index.ts
+++ b/apps/web/src/appData/domain/index.ts
@@ -125,8 +125,11 @@ export function isReviewFilterEqual(left: ReviewFilter, right: ReviewFilter): bo
     return left.deckId === right.deckId;
   }
 
-  if (left.kind === "tag" && right.kind === "tag") {
-    return left.tag === right.tag;
+  if (left.kind === "tags" && right.kind === "tags") {
+    const leftTags = normalizeReviewFilterTags(left.tags);
+    const rightTags = normalizeReviewFilterTags(right.tags);
+    return leftTags.length === rightTags.length
+      && leftTags.every((tag, index) => normalizeTagKey(tag) === normalizeTagKey(rightTags[index] ?? ""));
   }
 
   return false;
@@ -136,14 +139,39 @@ export function normalizeTagKey(tag: string): string {
   return tag.trim().toLowerCase();
 }
 
-function hasMatchingTag(tags: ReadonlyArray<string>, requestedTag: string): boolean {
-  const requestedTagKey = normalizeTagKey(requestedTag);
-  return tags.some((tag) => normalizeTagKey(tag) === requestedTagKey);
+export function normalizeReviewFilterTags(tags: ReadonlyArray<string>): ReadonlyArray<string> {
+  const tagsByKey = new Map<string, string>();
+  for (const tag of tags) {
+    const trimmedTag = tag.trim();
+    const tagKey = normalizeTagKey(trimmedTag);
+    if (tagKey !== "" && tagsByKey.has(tagKey) === false) {
+      tagsByKey.set(tagKey, trimmedTag);
+    }
+  }
+
+  return [...tagsByKey.entries()]
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([, tag]) => tag);
 }
 
-function findMatchingTag(tags: ReadonlyArray<string>, requestedTag: string): string | null {
-  const requestedTagKey = normalizeTagKey(requestedTag);
-  return tags.find((tag) => normalizeTagKey(tag) === requestedTagKey)?.trim() ?? null;
+export function makeTagsReviewFilter(tags: ReadonlyArray<string>): ReviewFilter {
+  return {
+    kind: "tags",
+    tags: normalizeReviewFilterTags(tags),
+  };
+}
+
+export function normalizeReviewFilter(reviewFilter: ReviewFilter): ReviewFilter {
+  if (reviewFilter.kind === "tags") {
+    return makeTagsReviewFilter(reviewFilter.tags);
+  }
+
+  return reviewFilter;
+}
+
+function hasMatchingTags(tags: ReadonlyArray<string>, requestedTags: ReadonlyArray<string>): boolean {
+  const requestedTagKeys = new Set(requestedTags.map((tag) => normalizeTagKey(tag)));
+  return tags.some((tag) => requestedTagKeys.has(normalizeTagKey(tag)));
 }
 
 /** Keep deck matching semantics aligned with apps/ios/Flashcards/Flashcards/Cards/List/CardFilterSupport.swift and apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/FilterSupport.kt: tags match on any overlap. */
@@ -182,18 +210,31 @@ export function makeDeckCardStats(cards: ReadonlyArray<Card>, nowTimestamp: numb
 
 export function makeWorkspaceTagsSummary(cards: ReadonlyArray<Card>): WorkspaceTagsSummary {
   const activeCards = deriveActiveCards(cards);
-  const counts = activeCards.reduce((result, card) => {
+  const tagStatsByKey = activeCards.reduce((result, card) => {
     for (const tag of card.tags) {
-      result.set(tag, (result.get(tag) ?? 0) + 1);
+      const tagKey = normalizeTagKey(tag);
+      if (tagKey === "") {
+        continue;
+      }
+
+      const currentTagStats = result.get(tagKey);
+      if (currentTagStats === undefined) {
+        result.set(tagKey, {
+          tag: tag.trim(),
+          cardIds: new Set([card.cardId]),
+        });
+      } else {
+        currentTagStats.cardIds.add(card.cardId);
+      }
     }
 
     return result;
-  }, new Map<string, number>());
+  }, new Map<string, Readonly<{ tag: string; cardIds: Set<string> }>>());
 
-  const tags: ReadonlyArray<WorkspaceTagSummary> = [...counts.entries()]
-    .map(([tag, cardsCount]) => ({
-      tag,
-      cardsCount,
+  const tags: ReadonlyArray<WorkspaceTagSummary> = [...tagStatsByKey.values()]
+    .map((tagStats) => ({
+      tag: tagStats.tag,
+      cardsCount: tagStats.cardIds.size,
     }))
     .sort((leftTag, rightTag) => {
       if (leftTag.cardsCount !== rightTag.cardsCount) {
@@ -209,15 +250,21 @@ export function makeWorkspaceTagsSummary(cards: ReadonlyArray<Card>): WorkspaceT
   };
 }
 
-function findActiveTag(tag: string, cards: ReadonlyArray<Card>): string | null {
-  for (const card of deriveActiveCards(cards)) {
-    const matchingTag = findMatchingTag(card.tags, tag);
-    if (matchingTag !== null) {
-      return matchingTag;
+function resolveActiveTags(tags: ReadonlyArray<string>, cards: ReadonlyArray<Card>): ReadonlyArray<string> {
+  const activeCards = deriveActiveCards(cards);
+  const canonicalTagsByKey = new Map<string, string>();
+  for (const card of activeCards) {
+    for (const tag of card.tags) {
+      const tagKey = normalizeTagKey(tag);
+      if (tagKey !== "" && canonicalTagsByKey.has(tagKey) === false) {
+        canonicalTagsByKey.set(tagKey, tag.trim());
+      }
     }
   }
 
-  return null;
+  return normalizeReviewFilterTags(tags)
+    .map((tag) => canonicalTagsByKey.get(normalizeTagKey(tag)) ?? null)
+    .filter((tag): tag is string => tag !== null);
 }
 
 export function resolveReviewFilter(
@@ -238,15 +285,7 @@ export function resolveReviewFilter(
     return reviewFilter;
   }
 
-  const matchingTag = findActiveTag(reviewFilter.tag, cards);
-  if (matchingTag === null) {
-    return ALL_CARDS_REVIEW_FILTER;
-  }
-
-  return {
-    kind: "tag",
-    tag: matchingTag,
-  };
+  return makeTagsReviewFilter(resolveActiveTags(reviewFilter.tags, cards));
 }
 
 export function cardsMatchingReviewFilter(
@@ -268,7 +307,7 @@ export function cardsMatchingReviewFilter(
     return cardsMatchingDeck(deck, cards);
   }
 
-  return deriveActiveCards(cards).filter((card) => hasMatchingTag(card.tags, resolvedReviewFilter.tag));
+  return deriveActiveCards(cards).filter((card) => hasMatchingTags(card.tags, resolvedReviewFilter.tags));
 }
 
 export function reviewFilterTitle(
@@ -286,7 +325,7 @@ export function reviewFilterTitle(
     return deck?.name ?? ALL_CARDS_DECK_LABEL;
   }
 
-  return resolvedReviewFilter.tag;
+  return resolvedReviewFilter.tags.join(", ");
 }
 
 export function shouldShowSwitchToAllCardsReviewAction(

--- a/apps/web/src/appData/session/useWorkspaceSession.reviewFilterPersistence.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.reviewFilterPersistence.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  activateWorkspaceReviewFilterState,
+  buildSelectedReviewFilterStorageKey,
+  LEGACY_SELECTED_REVIEW_FILTER_STORAGE_KEY,
+  loadSelectedReviewFilterForWorkspace,
+  parsePersistedReviewFilter,
+  storeSelectedReviewFilterForWorkspace,
+} from "../context/reviewFilterPersistence";
+
+function createStorageMock(): Storage {
+  const state = new Map<string, string>();
+  return {
+    get length(): number {
+      return state.size;
+    },
+    clear(): void {
+      state.clear();
+    },
+    getItem(key: string): string | null {
+      return state.get(key) ?? null;
+    },
+    key(index: number): string | null {
+      return [...state.keys()][index] ?? null;
+    },
+    removeItem(key: string): void {
+      state.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      state.set(key, value);
+    },
+  };
+}
+
+describe("workspace review filter persistence", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+  });
+
+  it("decodes normalized multi-tag values and legacy single-tag, effort, and deck values", () => {
+    expect(parsePersistedReviewFilter(JSON.stringify({
+      kind: "tags",
+      tags: [" verbs ", "Grammar", "grammar"],
+    }))).toEqual({
+      kind: "tags",
+      tags: ["Grammar", "verbs"],
+    });
+    expect(parsePersistedReviewFilter(JSON.stringify({ kind: "tag", tag: "grammar" }))).toEqual({
+      kind: "tags",
+      tags: ["grammar"],
+    });
+    expect(parsePersistedReviewFilter(JSON.stringify({ kind: "effort", effortLevel: "long" }))).toEqual({
+      kind: "tags",
+      tags: ["long"],
+    });
+    expect(parsePersistedReviewFilter(JSON.stringify({ kind: "effort", effortLevel: "short" }))).toEqual({
+      kind: "allCards",
+    });
+    expect(parsePersistedReviewFilter(JSON.stringify({ kind: "deck", deckId: "deck-1" }))).toEqual({
+      kind: "deck",
+      deckId: "deck-1",
+    });
+  });
+
+  it("migrates the legacy global selection into only the first activated workspace", () => {
+    window.localStorage.setItem(
+      LEGACY_SELECTED_REVIEW_FILTER_STORAGE_KEY,
+      JSON.stringify({ kind: "tag", tag: "grammar" }),
+    );
+
+    expect(loadSelectedReviewFilterForWorkspace("workspace-1")).toEqual({
+      kind: "tags",
+      tags: ["grammar"],
+    });
+    expect(window.localStorage.getItem(LEGACY_SELECTED_REVIEW_FILTER_STORAGE_KEY)).toBeNull();
+    expect(JSON.parse(window.localStorage.getItem(buildSelectedReviewFilterStorageKey("workspace-1")) ?? "null")).toEqual({
+      kind: "tags",
+      tags: ["grammar"],
+    });
+    expect(loadSelectedReviewFilterForWorkspace("workspace-2")).toEqual({ kind: "allCards" });
+  });
+
+  it("stores and restores independent selections for each workspace, including an empty tag set", () => {
+    storeSelectedReviewFilterForWorkspace("workspace-1", { kind: "tags", tags: [] });
+    storeSelectedReviewFilterForWorkspace("workspace-2", { kind: "deck", deckId: "deck-2" });
+
+    expect(loadSelectedReviewFilterForWorkspace("workspace-1")).toEqual({
+      kind: "tags",
+      tags: [],
+    });
+    expect(loadSelectedReviewFilterForWorkspace("workspace-2")).toEqual({
+      kind: "deck",
+      deckId: "deck-2",
+    });
+  });
+
+  it("activates a workspace and its persisted filter as one state transition", () => {
+    storeSelectedReviewFilterForWorkspace("workspace-2", { kind: "tags", tags: [] });
+    const currentState = {
+      activeWorkspace: {
+        workspaceId: "workspace-1",
+        name: "First",
+        createdAt: "2026-03-10T00:00:00.000Z",
+        isSelected: true,
+      },
+      selection: {
+        workspaceId: "workspace-1",
+        reviewFilter: { kind: "allCards" },
+      },
+    } as const;
+    const nextWorkspace = {
+      workspaceId: "workspace-2",
+      name: "Second",
+      createdAt: "2026-03-11T00:00:00.000Z",
+      isSelected: true,
+    } as const;
+
+    expect(activateWorkspaceReviewFilterState(
+      currentState,
+      nextWorkspace,
+      loadSelectedReviewFilterForWorkspace,
+    )).toEqual({
+      activeWorkspace: nextWorkspace,
+      selection: {
+        workspaceId: "workspace-2",
+        reviewFilter: { kind: "tags", tags: [] },
+      },
+    });
+  });
+});

--- a/apps/web/src/appData/session/workspaceSessionTypes.ts
+++ b/apps/web/src/appData/session/workspaceSessionTypes.ts
@@ -27,7 +27,7 @@ export type WorkspaceSessionSetters = Readonly<{
   setSessionErrorMessage: Dispatch<SetStateAction<string>>;
   setSessionTechnicalError: Dispatch<SetStateAction<Error | null>>;
   setSession: Dispatch<SetStateAction<SessionInfo | null>>;
-  setActiveWorkspace: Dispatch<SetStateAction<WorkspaceSummary | null>>;
+  setActiveWorkspace: (activeWorkspace: WorkspaceSummary | null) => void;
   setAvailableWorkspaces: Dispatch<SetStateAction<ReadonlyArray<WorkspaceSummary>>>;
   setIsChoosingWorkspace: Dispatch<SetStateAction<boolean>>;
   setErrorMessage: Dispatch<SetStateAction<string>>;

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -818,6 +818,7 @@ const arCatalog: TranslationCatalog = {
     editDecks: "حرّر المجموعات",
     empty: "لم يتم العثور على فلاتر",
     menuAriaLabel: "فلتر المراجعة",
+    noTags: "بدون وسوم",
     openAriaLabel: "افتح فلتر المراجعة",
     queueBadgeDue: "{{due}} مستحقة",
     queueBadgeDueUpcoming: "{{due}} مستحقة | {{upcoming}} قادمة",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -818,6 +818,7 @@ const deCatalog: TranslationCatalog = {
     editDecks: "Decks bearbeiten",
     empty: "Keine Filter gefunden",
     menuAriaLabel: "Wiederholungsfilter",
+    noTags: "Keine Tags",
     openAriaLabel: "Wiederholungsfilter öffnen",
     queueBadgeDue: "{{due}} fällig",
     queueBadgeDueUpcoming: "{{due}} fällig | {{upcoming}} anstehend",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -816,6 +816,7 @@ const enCatalog = {
     editDecks: "Edit decks",
     empty: "No filters found",
     menuAriaLabel: "Review filter",
+    noTags: "No tags",
     openAriaLabel: "Open review filter",
     queueBadgeDue: "{{due}} due",
     queueBadgeDueUpcoming: "{{due}} due | {{upcoming}} upcoming",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -818,6 +818,7 @@ const esEsCatalog: TranslationCatalog = {
     editDecks: "Editar mazos",
     empty: "No se han encontrado filtros",
     menuAriaLabel: "Filtro de repaso",
+    noTags: "Sin etiquetas",
     openAriaLabel: "Abrir filtro de repaso",
     queueBadgeDue: "{{due}} pendientes",
     queueBadgeDueUpcoming: "{{due}} pendientes | {{upcoming}} próximas",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -818,6 +818,7 @@ const esMxCatalog: TranslationCatalog = {
     editDecks: "Editar mazos",
     empty: "No se encontraron filtros",
     menuAriaLabel: "Filtro de repaso",
+    noTags: "Sin etiquetas",
     openAriaLabel: "Abrir filtro de repaso",
     queueBadgeDue: "{{due}} pendientes",
     queueBadgeDueUpcoming: "{{due}} pendientes | {{upcoming}} próximas",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -818,6 +818,7 @@ const hiCatalog: TranslationCatalog = {
     editDecks: "डेक संपादित करें",
     empty: "कोई फ़िल्टर नहीं मिला",
     menuAriaLabel: "रिव्यू फ़िल्टर",
+    noTags: "कोई टैग नहीं",
     openAriaLabel: "रिव्यू फ़िल्टर खोलें",
     queueBadgeDue: "{{due}} बाकी",
     queueBadgeDueUpcoming: "{{due}} बाकी | {{upcoming}} आने वाले",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -818,6 +818,7 @@ export const jaCatalog = {
     editDecks: "デッキを編集",
     empty: "フィルターが見つかりません",
     menuAriaLabel: "復習フィルター",
+    noTags: "タグなし",
     openAriaLabel: "復習フィルターを開く",
     queueBadgeDue: "{{due}} 件期限あり",
     queueBadgeDueUpcoming: "{{due}} 件期限あり | {{upcoming}} 件予定",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -818,6 +818,7 @@ export const ruCatalog = {
     editDecks: "Редактировать колоды",
     empty: "Фильтры не найдены",
     menuAriaLabel: "Фильтр повторения",
+    noTags: "Нет тегов",
     openAriaLabel: "Открыть фильтр повторения",
     queueBadgeDue: "{{due}} к повторению",
     queueBadgeDueUpcoming: "{{due}} к повторению | {{upcoming}} впереди",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -818,6 +818,7 @@ export const zhHansCatalog = {
     editDecks: "编辑牌组",
     empty: "未找到筛选条件",
     menuAriaLabel: "复习筛选器",
+    noTags: "无标签",
     openAriaLabel: "打开复习筛选器",
     queueBadgeDue: "{{due}} 到期",
     queueBadgeDueUpcoming: "{{due}} 到期 | {{upcoming}} 即将到期",

--- a/apps/web/src/localDb/cards/tags/index.ts
+++ b/apps/web/src/localDb/cards/tags/index.ts
@@ -13,6 +13,11 @@ export type TagCardIdsLookup = Readonly<{
   canonicalTag: string | null;
 }>;
 
+export type ReviewTagFilterLookup = Readonly<{
+  cardIds: ReadonlySet<string>;
+  canonicalTags: ReadonlyArray<string>;
+}>;
+
 function putCardTags(cardTagsStore: IDBObjectStore, workspaceId: string, card: Card): void {
   if (card.deletedAt !== null) {
     return;
@@ -165,21 +170,44 @@ export async function loadAllowedCardIdsForTags(
   workspaceId: string,
   tags: ReadonlyArray<string>,
 ): Promise<ReadonlySet<string>> {
+  return (await loadReviewTagFilterLookupForTags(database, workspaceId, tags)).cardIds;
+}
+
+export async function loadReviewTagFilterLookupForTags(
+  database: IDBDatabase,
+  workspaceId: string,
+  tags: ReadonlyArray<string>,
+): Promise<ReviewTagFilterLookup> {
   const allowedCardIds = new Set<string>();
   const requestedTagKeys = new Set(tags.map((tag) => normalizeTagKey(tag)).filter((tagKey) => tagKey !== ""));
+  const canonicalTagsByKey = new Map<string, string>();
   if (requestedTagKeys.size === 0) {
-    return allowedCardIds;
+    return {
+      cardIds: allowedCardIds,
+      canonicalTags: [],
+    };
   }
 
   await iterateAllCardTags(database, workspaceId, (record) => {
-    if (requestedTagKeys.has(normalizeTagKey(record.tag))) {
-      allowedCardIds.add(record.cardId);
+    const tagKey = normalizeTagKey(record.tag);
+    if (requestedTagKeys.has(tagKey) === false) {
+      return true;
+    }
+
+    allowedCardIds.add(record.cardId);
+    if (canonicalTagsByKey.has(tagKey) === false) {
+      canonicalTagsByKey.set(tagKey, record.tag.trim());
     }
 
     return true;
   });
 
-  return allowedCardIds;
+  return {
+    cardIds: allowedCardIds,
+    canonicalTags: [...canonicalTagsByKey.entries()]
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+      .map(([, tag]) => tag),
+  };
 }
 
 export async function loadAllowedCardIdsForTag(

--- a/apps/web/src/localDb/cards/workspace/index.ts
+++ b/apps/web/src/localDb/cards/workspace/index.ts
@@ -19,6 +19,7 @@ import { putDeckInTransaction } from "../decks";
 import { loadProgressCacheState, markProgressCacheDirtyInTransaction } from "../../progress/progress";
 import { putReviewEventInTransaction } from "../../reviews/reviews";
 import { putMediaAssetInTransaction } from "../../mediaAssets";
+import { normalizeTagKey } from "../../../appData/domain";
 
 type HotSyncStateUpdate = Readonly<{
   lastAppliedHotChangeId: number;
@@ -149,17 +150,33 @@ export async function hasHydratedReviewHistory(workspaceId: string): Promise<boo
 
 export async function loadWorkspaceTagsSummary(workspaceId: string): Promise<WorkspaceTagsSummary> {
   return closeDatabaseAfter(async (database) => {
-    const counts = new Map<string, number>();
+    const tagStatsByKey = new Map<string, Readonly<{
+      tag: string;
+      cardIds: Set<string>;
+    }>>();
     await iterateAllCardTags(database, workspaceId, (record) => {
-      counts.set(record.tag, (counts.get(record.tag) ?? 0) + 1);
+      const tagKey = normalizeTagKey(record.tag);
+      if (tagKey === "") {
+        return true;
+      }
+
+      const currentTagStats = tagStatsByKey.get(tagKey);
+      if (currentTagStats === undefined) {
+        tagStatsByKey.set(tagKey, {
+          tag: record.tag.trim(),
+          cardIds: new Set([record.cardId]),
+        });
+      } else {
+        currentTagStats.cardIds.add(record.cardId);
+      }
       return true;
     });
 
     return {
-      tags: [...counts.entries()]
-        .map(([tag, cardsCount]) => ({
-          tag,
-          cardsCount,
+      tags: [...tagStatsByKey.values()]
+        .map((tagStats) => ({
+          tag: tagStats.tag,
+          cardsCount: tagStats.cardIds.size,
         }))
         .sort(compareTagSummaries),
       totalCards: await loadActiveCardCountWithDatabase(database, workspaceId),

--- a/apps/web/src/localDb/core/testSupport.ts
+++ b/apps/web/src/localDb/core/testSupport.ts
@@ -182,14 +182,15 @@ function resolveLegacyReviewFilter(
       : { kind: "allCards" };
   }
 
-  const requestedTagKey = normalizeTagKey(reviewFilter.tag);
-  const matchingTag = cards
-    .flatMap((card) => card.tags)
-    .find((tag) => normalizeTagKey(tag) === requestedTagKey);
-
-  return matchingTag !== undefined
-    ? { kind: "tag", tag: matchingTag }
-    : { kind: "allCards" };
+  const canonicalTagsByKey = new Map(
+    cards.flatMap((card) => card.tags).map((tag) => [normalizeTagKey(tag), tag] as const),
+  );
+  return {
+    kind: "tags",
+    tags: reviewFilter.tags
+      .map((tag) => canonicalTagsByKey.get(normalizeTagKey(tag)) ?? null)
+      .filter((tag): tag is string => tag !== null),
+  };
 }
 
 export function resolveLegacyReviewFilterForTest(
@@ -217,8 +218,8 @@ export function legacyReviewCards(
         return deck === undefined ? true : matchesDeckFilterDefinition(deck.filterDefinition, card);
       })
       : activeCards.filter((card) => {
-        const requestedTagKey = normalizeTagKey(resolvedReviewFilter.tag);
-        return card.tags.some((tag) => normalizeTagKey(tag) === requestedTagKey);
+        const requestedTagKeys = new Set(resolvedReviewFilter.tags.map((tag) => normalizeTagKey(tag)));
+        return card.tags.some((tag) => requestedTagKeys.has(normalizeTagKey(tag)));
       });
 
   return [...matchingCards].sort((leftCard, rightCard) => compareCardsForReviewOrder(leftCard, rightCard, nowTimestamp));

--- a/apps/web/src/localDb/reviews/reviews.test.ts
+++ b/apps/web/src/localDb/reviews/reviews.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
 import "fake-indexeddb/auto";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { replaceCards } from "../cards/cards";
 import { replaceDecks } from "../cards/decks";
+import { loadWorkspaceTagsSummary } from "../cards/workspace";
 import {
   loadReviewQueueChunk,
   loadReviewQueueSnapshot,
@@ -37,8 +38,8 @@ describe("localDb reviews", () => {
         for (const reviewFilter of [
           { kind: "allCards" } as const,
           { kind: "deck", deckId: deckLongCode.deckId } as const,
-          { kind: "tag", tag: "medium" } as const,
-          { kind: "tag", tag: "grammar" } as const,
+          { kind: "tags", tags: ["medium"] } as const,
+          { kind: "tags", tags: ["grammar"] } as const,
         ]) {
           const result = await loadReviewQueueSnapshot(workspaceId, reviewFilter, 8);
           const legacyCards = legacyReviewCards(reviewFilter, sampleCards, [deckFastGrammar, deckLongCode], nowTimestamp);
@@ -127,13 +128,13 @@ describe("localDb reviews", () => {
         await replaceDecks(workspaceId, [unicodeDeck]);
         await replaceCards(workspaceId, [unicodeTagCard, otherCard]);
 
-        const tagQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "tag", tag: "éclair" }, 10);
+        const tagQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "tags", tags: ["éclair"] }, 10);
         const deckQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "deck", deckId: unicodeDeck.deckId }, 10);
-        const tagTimelinePage = await loadReviewTimelinePage(workspaceId, { kind: "tag", tag: "éclair" }, 10, 0);
+        const tagTimelinePage = await loadReviewTimelinePage(workspaceId, { kind: "tags", tags: ["éclair"] }, 10, 0);
 
         expect(tagQueueSnapshot.resolvedReviewFilter).toEqual({
-          kind: "tag",
-          tag: "Éclair",
+          kind: "tags",
+          tags: ["Éclair"],
         });
         expect(tagQueueSnapshot.cards.map((card) => card.cardId)).toEqual(["unicode-tag-card"]);
         expect(tagQueueSnapshot.reviewCounts).toEqual({
@@ -145,6 +146,106 @@ describe("localDb reviews", () => {
       } finally {
         Date.now = originalNow;
       }
+    });
+
+    it("matches multiple tags with OR semantics and preserves an explicit empty match-none filter", async () => {
+      const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+      const originalNow = Date.now;
+      Date.now = () => nowTimestamp;
+
+      try {
+        const grammarCard = makeCard({
+          cardId: "grammar-card",
+          frontText: "Grammar",
+          backText: "back",
+          tags: ["grammar"],
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        });
+        const verbsCard = makeCard({
+          cardId: "verbs-card",
+          frontText: "Verbs",
+          backText: "back",
+          tags: ["verbs"],
+          dueAt: null,
+          createdAt: "2026-03-10T09:01:00.000Z",
+        });
+        const untaggedCard = makeCard({
+          cardId: "untagged-card",
+          frontText: "Untagged",
+          backText: "back",
+          tags: [],
+          dueAt: null,
+          createdAt: "2026-03-10T09:02:00.000Z",
+        });
+        await replaceCards(workspaceId, [grammarCard, verbsCard, untaggedCard]);
+
+        const multipleTagsSnapshot = await loadReviewQueueSnapshot(
+          workspaceId,
+          { kind: "tags", tags: ["missing", "verbs", "grammar"] },
+          10,
+        );
+        const emptyTagsSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "tags", tags: [] }, 10);
+        const allCardsSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 10);
+
+        expect(multipleTagsSnapshot.resolvedReviewFilter).toEqual({
+          kind: "tags",
+          tags: ["grammar", "verbs"],
+        });
+        expect(multipleTagsSnapshot.cards.map((card) => card.cardId)).toEqual(["grammar-card", "verbs-card"]);
+        expect(multipleTagsSnapshot.reviewCounts).toEqual({ dueCount: 2, totalCount: 2 });
+        expect(emptyTagsSnapshot.resolvedReviewFilter).toEqual({ kind: "tags", tags: [] });
+        expect(emptyTagsSnapshot.cards).toEqual([]);
+        expect(emptyTagsSnapshot.reviewCounts).toEqual({ dueCount: 0, totalCount: 0 });
+        expect(allCardsSnapshot.cards.map((card) => card.cardId)).toEqual([
+          "grammar-card",
+          "verbs-card",
+          "untagged-card",
+        ]);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
+    it("resolves selected tag ids and canonical tags in one cardTags transaction", async () => {
+      const transactionSpy = vi.spyOn(IDBDatabase.prototype, "transaction");
+      try {
+        await loadReviewQueueSnapshot(workspaceId, { kind: "tags", tags: ["grammar", "medium"] }, 10);
+
+        const cardTagsTransactions = transactionSpy.mock.calls.filter(([storeNames]) => {
+          const names = typeof storeNames === "string" ? [storeNames] : [...storeNames];
+          return names.includes("cardTags");
+        });
+        expect(cardTagsTransactions).toHaveLength(1);
+      } finally {
+        transactionSpy.mockRestore();
+      }
+    });
+
+    it("counts each card once when workspace tags differ only by case", async () => {
+      await replaceCards(workspaceId, [
+        makeCard({
+          cardId: "case-variant-card",
+          frontText: "Case variants",
+          backText: "back",
+          tags: ["Grammar", "grammar"],
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "lowercase-card",
+          frontText: "Lowercase",
+          backText: "back",
+          tags: ["grammar"],
+          dueAt: null,
+          createdAt: "2026-03-10T09:01:00.000Z",
+        }),
+      ]);
+
+      await expect(loadWorkspaceTagsSummary(workspaceId)).resolves.toEqual({
+        tags: [{ tag: "Grammar", cardsCount: 2 }],
+        totalCards: 2,
+      });
     });
   });
 
@@ -322,7 +423,7 @@ describe("localDb reviews", () => {
 
         const queueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 10);
         const timelinePage = await loadReviewTimelinePage(workspaceId, { kind: "allCards" }, 10, 0);
-        const grammarQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "tag", tag: "grammar" }, 10);
+        const grammarQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "tags", tags: ["grammar"] }, 10);
 
         expect(queueSnapshot.cards.map((card) => card.cardId)).toEqual([
           "recent-1115",

--- a/apps/web/src/localDb/reviews/reviews.ts
+++ b/apps/web/src/localDb/reviews/reviews.ts
@@ -9,10 +9,11 @@ import type {
 } from "../../types";
 import {
   ALL_CARDS_REVIEW_FILTER,
+  makeTagsReviewFilter,
   matchesDeckFilterDefinition,
   recentDuePriorityWindow,
 } from "../../appData/domain";
-import { loadAllowedCardIdsForTag } from "../cards/tags";
+import { loadReviewTagFilterLookupForTags } from "../cards/tags";
 import {
   iterateLocalStoredCardsByCreatedAtAsc,
   iterateLocalStoredCardsByCreatedAtDesc,
@@ -102,22 +103,12 @@ async function resolveReviewFilterFromIndexedDb(
     };
   }
 
-  const tagCardIdsLookup = await loadAllowedCardIdsForTag(database, workspaceId, reviewFilter.tag);
-  if (tagCardIdsLookup.cardIds.size === 0 || tagCardIdsLookup.canonicalTag === null) {
-    return {
-      resolvedReviewFilter: ALL_CARDS_REVIEW_FILTER,
-      deck: null,
-      allowedTagCardIds: null,
-    };
-  }
+  const tagFilterLookup = await loadReviewTagFilterLookupForTags(database, workspaceId, reviewFilter.tags);
 
   return {
-    resolvedReviewFilter: {
-      kind: "tag",
-      tag: tagCardIdsLookup.canonicalTag,
-    },
+    resolvedReviewFilter: makeTagsReviewFilter(tagFilterLookup.canonicalTags),
     deck: null,
-    allowedTagCardIds: tagCardIdsLookup.cardIds,
+    allowedTagCardIds: tagFilterLookup.cardIds,
   };
 }
 

--- a/apps/web/src/screens/review/data/reviewScreenDataState.ts
+++ b/apps/web/src/screens/review/data/reviewScreenDataState.ts
@@ -56,13 +56,15 @@ export function resolveReviewFilterTitle(
   reviewFilter: ReviewFilter,
   deckSummaries: ReadonlyArray<DeckSummary>,
   allCardsLabel: string,
+  noTagsLabel: string,
+  selectedTagsCountLabel: string,
 ): string {
   if (reviewFilter.kind === "allCards") {
     return allCardsLabel;
   }
 
-  if (reviewFilter.kind === "tag") {
-    return reviewFilter.tag;
+  if (reviewFilter.kind === "tags") {
+    return reviewFilter.tags.length === 0 ? noTagsLabel : selectedTagsCountLabel;
   }
 
   return deckSummaries.find((deck) => deck.deckId === reviewFilter.deckId)?.name ?? allCardsLabel;
@@ -125,8 +127,8 @@ function matchesResolvedReviewFilterForPreservation(
     return deckSummary === undefined ? false : matchesDeckFilterDefinition(deckSummary.filterDefinition, card);
   }
 
-  const requestedTagKey = normalizeTagKey(resolvedReviewFilter.tag);
-  return card.tags.some((tag) => normalizeTagKey(tag) === requestedTagKey);
+  const requestedTagKeys = new Set(resolvedReviewFilter.tags.map((tag) => normalizeTagKey(tag)));
+  return card.tags.some((tag) => requestedTagKeys.has(normalizeTagKey(tag)));
 }
 
 export function isPreservablePresentedCard(

--- a/apps/web/src/screens/review/data/useReviewScreenData.submit.test.tsx
+++ b/apps/web/src/screens/review/data/useReviewScreenData.submit.test.tsx
@@ -229,8 +229,8 @@ describe("useReviewScreenData submit", () => {
   it("does not mutate queue, presented card, or timeline after a stale workspace submit failure", async () => {
     const state = getState();
     state.appData.selectedReviewFilter = {
-      kind: "tag",
-      tag: "grammar",
+      kind: "tags",
+      tags: ["grammar"],
     };
     const submittedCard = createCard({
       cardId: "card-stale-failure-submit",
@@ -275,6 +275,7 @@ describe("useReviewScreenData submit", () => {
       dueAt: "2026-03-10T11:59:00.000Z",
     });
     const submitReviewPromise = createDeferredPromise<Card>();
+    const nextWorkspaceSnapshotPromise = createDeferredPromise<ReviewQueueSnapshot>();
     let latestResult: UseReviewScreenDataResult | null = null;
     let reviewPromise: Promise<ReviewSubmissionOutcome> | null = null;
     const hookContainer = document.createElement("div");
@@ -329,6 +330,9 @@ describe("useReviewScreenData submit", () => {
       state.reviewQueue = [newCanonicalHead, newCanonicalNext];
       state.reviewTimeline = [newCanonicalHead, newCanonicalNext, newTimelineTail];
       state.appData.localReadVersion = 1;
+      loadReviewQueueSnapshotMock.mockImplementation(
+        async (): Promise<ReviewQueueSnapshot> => nextWorkspaceSnapshotPromise.promise,
+      );
 
       await act(async () => {
         hookRoot.render(
@@ -345,19 +349,37 @@ describe("useReviewScreenData submit", () => {
         await Promise.resolve();
       });
 
+      expect(latestResult?.activeReviewQueue).toEqual([]);
+      expect(latestResult?.queueCards).toEqual([]);
+      expect(latestResult?.isInitialReviewLoad).toBe(true);
+      expect(await latestResult?.handleReview(oldNextCard, 2)).toBe("stale");
+      expect(state.appData.submitReviewItem).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        nextWorkspaceSnapshotPromise.resolve({
+          resolvedReviewFilter: state.appData.selectedReviewFilter,
+          cards: [newCanonicalHead, newCanonicalNext],
+          nextCursor: null,
+          reviewCounts: {
+            dueCount: 2,
+            totalCount: 2,
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
       const expectedActiveQueueCardIds = [
-        newPresentedCard.cardId,
         newCanonicalHead.cardId,
         newCanonicalNext.cardId,
       ];
       const expectedTimelineCardIds = [
-        newPresentedCard.cardId,
         newCanonicalHead.cardId,
         newCanonicalNext.cardId,
         newTimelineTail.cardId,
       ];
 
-      expect(state.appData.getCardById).toHaveBeenCalledWith(oldNextCard.cardId);
+      expect(state.appData.getCardById).not.toHaveBeenCalledWith(oldNextCard.cardId);
       expect(latestResult?.activeReviewQueue.map((queueCard) => queueCard.cardId)).toEqual(expectedActiveQueueCardIds);
       expect(latestResult?.queueCards.map((queueCard) => queueCard.cardId)).toEqual(expectedTimelineCardIds);
 
@@ -388,8 +410,8 @@ describe("useReviewScreenData submit", () => {
   it("does not rollback into a synchronously changed selected filter while the new review snapshot is loading", async () => {
     const state = getState();
     state.appData.selectedReviewFilter = {
-      kind: "tag",
-      tag: "grammar",
+      kind: "tags",
+      tags: ["grammar"],
     };
     const submittedCard = createCard({
       cardId: "card-stale-selected-filter-submit",
@@ -469,8 +491,8 @@ describe("useReviewScreenData submit", () => {
 
       loadReviewQueueSnapshotMock.mockImplementation(async (): Promise<ReviewQueueSnapshot> => nextSnapshotPromise.promise);
       state.appData.selectedReviewFilter = {
-        kind: "tag",
-        tag: "code",
+        kind: "tags",
+        tags: ["code"],
       };
       state.cards = [newFilterHead, newFilterNext];
       state.reviewQueue = [newFilterHead, newFilterNext];
@@ -492,6 +514,16 @@ describe("useReviewScreenData submit", () => {
         await Promise.resolve();
       });
 
+      expect(latestResult?.activeReviewQueue).toEqual([]);
+      expect(latestResult?.queueCards).toEqual([]);
+      expect(latestResult?.reviewCounts).toEqual({
+        dueCount: 0,
+        totalCount: 0,
+      });
+      expect(latestResult?.isInitialReviewLoad).toBe(true);
+      expect(await latestResult?.handleReview(oldNextCard, 2)).toBe("stale");
+      expect(state.appData.submitReviewItem).toHaveBeenCalledTimes(1);
+
       await act(async () => {
         submitReviewPromise.reject(new Error("Review submit failed"));
         const didReview = await reviewPromise;
@@ -506,7 +538,7 @@ describe("useReviewScreenData submit", () => {
       expect(state.appData.setErrorMessage).not.toHaveBeenCalledWith(technicalErrorMessage);
       expect(queryTechnicalErrorDialog()).toBeNull();
       expect(state.appData.getCardById).not.toHaveBeenCalledWith(submittedCard.cardId);
-      expect(latestResult?.activeReviewQueue.map((queueCard) => queueCard.cardId)).toEqual([oldNextCard.cardId]);
+      expect(latestResult?.activeReviewQueue).toEqual([]);
 
       await act(async () => {
         nextSnapshotPromise.resolve({
@@ -526,6 +558,84 @@ describe("useReviewScreenData submit", () => {
         newFilterHead.cardId,
         newFilterNext.cardId,
       ]);
+    } finally {
+      await act(async () => {
+        hookRoot.unmount();
+      });
+      hookContainer.remove();
+    }
+  });
+
+  it("immediately exposes an explicit empty tag selection as no actionable cards", async () => {
+    const state = getState();
+    const oldCard = createCard({
+      cardId: "card-before-empty-filter",
+      frontText: "Card before empty filter",
+      backText: "Answer before empty filter",
+      tags: ["grammar"],
+    });
+    const emptySnapshotPromise = createDeferredPromise<ReviewQueueSnapshot>();
+    let latestResult: UseReviewScreenDataResult | null = null;
+    const hookContainer = document.createElement("div");
+    const hookRoot = ReactDOM.createRoot(hookContainer);
+    state.cards = [oldCard];
+    state.reviewQueue = [oldCard];
+    state.reviewTimeline = [oldCard];
+    document.body.appendChild(hookContainer);
+
+    try {
+      await act(async () => {
+        hookRoot.render(
+          <I18nProvider>
+            <ReviewScreenDataHarness
+              onResult={(result) => {
+                latestResult = result;
+              }}
+              state={state}
+            />
+          </I18nProvider>,
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      loadReviewQueueSnapshotMock.mockImplementation(
+        async (): Promise<ReviewQueueSnapshot> => emptySnapshotPromise.promise,
+      );
+      state.appData.selectedReviewFilter = {
+        kind: "tags",
+        tags: [],
+      };
+      state.appData.localReadVersion = 1;
+
+      await act(async () => {
+        hookRoot.render(
+          <I18nProvider>
+            <ReviewScreenDataHarness
+              onResult={(result) => {
+                latestResult = result;
+              }}
+              state={state}
+            />
+          </I18nProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      expect(latestResult?.activeReviewQueue).toEqual([]);
+      expect(latestResult?.queueCards).toEqual([]);
+      expect(latestResult?.reviewCounts).toEqual({
+        dueCount: 0,
+        totalCount: 0,
+      });
+      expect(latestResult?.resolvedReviewFilter).toEqual({
+        kind: "tags",
+        tags: [],
+      });
+      expect(latestResult?.selectedReviewFilterTitle).toBe("No tags");
+      expect(latestResult?.isInitialReviewLoad).toBe(false);
+      expect(await latestResult?.handleReview(oldCard, 2)).toBe("stale");
+      expect(state.appData.submitReviewItem).not.toHaveBeenCalled();
     } finally {
       await act(async () => {
         hookRoot.unmount();
@@ -671,8 +781,8 @@ describe("useReviewScreenData submit", () => {
   it("keeps the canonical head after a same-context submit failure when the fresh card no longer matches the filter", async () => {
     const state = getState();
     state.appData.selectedReviewFilter = {
-      kind: "tag",
-      tag: "grammar",
+      kind: "tags",
+      tags: ["grammar"],
     };
     const submittedCard = createCard({
       cardId: "card-filter-mismatch-submit",

--- a/apps/web/src/screens/review/data/useReviewScreenData.ts
+++ b/apps/web/src/screens/review/data/useReviewScreenData.ts
@@ -1,8 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import {
-  ALL_CARDS_REVIEW_FILTER,
-  isReviewFilterEqual,
-} from "../../../appData/domain";
+import { ALL_CARDS_REVIEW_FILTER } from "../../../appData/domain";
 import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import { loadDecksListSnapshot } from "../../../localDb/cards/decks";
@@ -78,6 +75,10 @@ function isWorkspaceUnavailableError(error: unknown): boolean {
   return error instanceof Error && error.message === workspaceUnavailableErrorMessage;
 }
 
+function buildReviewDataContextKey(workspaceId: string | null, reviewFilterKey: string): string {
+  return JSON.stringify([workspaceId, reviewFilterKey]);
+}
+
 export type UseReviewScreenDataResult = Readonly<{
   activeReviewQueue: ReadonlyArray<Card>;
   deckSummaries: ReadonlyArray<DeckSummary>;
@@ -109,7 +110,7 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     submitReviewItem,
     userId,
   } = params;
-  const { t } = useI18n();
+  const { formatCount, messages, t } = useI18n();
   const { showCapturedTechnicalError } = useAppErrorDialog();
   const [canonicalReviewQueue, setCanonicalReviewQueue] = useState<ReadonlyArray<Card>>([]);
   const [queueCards, setQueueCards] = useState<ReadonlyArray<Card>>([]);
@@ -120,15 +121,14 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const [deckSummaries, setDeckSummaries] = useState<ReadonlyArray<DeckSummary>>([]);
   const [resolvedReviewFilter, setResolvedReviewFilter] = useState<ReviewFilter>(ALL_CARDS_REVIEW_FILTER);
   const [selectedReviewFilterTitle, setSelectedReviewFilterTitle] = useState<string>(t("filters.allCards"));
-  const [isReviewLoading, setIsReviewLoading] = useState<boolean>(true);
   const [localHotStateStatus, setLocalHotStateStatus] = useState<LocalHotStateStatus>("loading");
   const [localWorkspaceCardCount, setLocalWorkspaceCardCount] = useState<number>(0);
   const [reviewLoadErrorMessage, setReviewLoadErrorMessage] = useState<string>("");
   const [hasLoadedReviewData, setHasLoadedReviewData] = useState<boolean>(false);
+  const [loadedReviewDataContextKey, setLoadedReviewDataContextKey] = useState<string | null>(null);
   const [presentedCard, setPresentedCard] = useState<Card | null>(null);
   const activeWorkspaceIdRef = useRef<string | null>(activeWorkspaceId);
   const loadedWorkspaceIdRef = useRef<string | null>(null);
-  const previousReviewFilterRef = useRef<ReviewFilter | null>(null);
   const canonicalReviewQueueRef = useRef<ReadonlyArray<Card>>([]);
   const deckSummariesRef = useRef<ReadonlyArray<DeckSummary>>([]);
   const pendingReviewSnapshotsRef = useRef<ReadonlyMap<string, PendingReviewSnapshot>>(new Map());
@@ -140,6 +140,9 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const reviewSessionSignatureRef = useRef<ReviewSessionSignature | null>(null);
   const selectedReviewFilterKey = serializeReviewFilterKey(selectedReviewFilter);
   const selectedReviewFilterKeyRef = useRef<string>(selectedReviewFilterKey);
+  const reviewDataContextKey = buildReviewDataContextKey(activeWorkspaceId, selectedReviewFilterKey);
+  const reviewDataContextKeyRef = useRef<string>(reviewDataContextKey);
+  const loadedReviewDataContextKeyRef = useRef<string | null>(null);
   const observationIdentityRef = useRef<Readonly<{
     userId: string | null;
     installationId: string | null;
@@ -150,17 +153,46 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const reviewLoadingSnapshot = activeWorkspaceId === null
     ? null
     : readReviewLoadingSnapshot(activeWorkspaceId, selectedReviewFilter);
-  const hasColdEmptyLocalHotState = localHotStateStatus !== "hydrated" && localWorkspaceCardCount === 0;
+  const isCurrentReviewDataContextLoaded = loadedReviewDataContextKey === reviewDataContextKey;
+  const isCurrentWorkspaceLoaded = loadedWorkspaceIdRef.current === activeWorkspaceId;
+  const isExplicitEmptyTagsFilter = selectedReviewFilter.kind === "tags" && selectedReviewFilter.tags.length === 0;
+  const visibleLocalWorkspaceCardCount = isCurrentWorkspaceLoaded ? localWorkspaceCardCount : 0;
+  const hasColdEmptyLocalHotState = localHotStateStatus !== "hydrated" && visibleLocalWorkspaceCardCount === 0;
   const hasColdEmptyRestoreFailure = hasColdEmptyLocalHotState && isSyncing === false && appErrorMessage !== "";
-  const visibleHasLoadedReviewData = hasColdEmptyRestoreFailure ? false : hasLoadedReviewData;
+  const visibleHasLoadedReviewData = hasColdEmptyRestoreFailure
+    ? false
+    : isCurrentReviewDataContextLoaded
+      ? hasLoadedReviewData
+      : isExplicitEmptyTagsFilter;
   const visibleReviewLoadErrorMessage = reviewLoadErrorMessage !== ""
     ? reviewLoadErrorMessage
     : hasColdEmptyRestoreFailure
       ? t("appError.technicalError.message")
       : "";
   const isLocalEmptyHotStateRestoring = hasColdEmptyLocalHotState && hasColdEmptyRestoreFailure === false;
-  const isInitialReviewLoad = (isReviewLoading && visibleHasLoadedReviewData === false) || isLocalEmptyHotStateRestoring;
-  const activeReviewQueue = buildDisplayedReviewQueue(canonicalReviewQueue, presentedCard);
+  const isInitialReviewLoad = isExplicitEmptyTagsFilter
+    ? false
+    : isCurrentReviewDataContextLoaded === false
+      || isLocalEmptyHotStateRestoring;
+  const activeReviewQueue = isCurrentReviewDataContextLoaded
+    ? buildDisplayedReviewQueue(canonicalReviewQueue, presentedCard)
+    : [];
+  const visibleDeckSummaries = isCurrentWorkspaceLoaded ? deckSummaries : [];
+  const visibleSelectedReviewFilterTitle = isCurrentReviewDataContextLoaded
+    ? selectedReviewFilterTitle
+    : resolveReviewFilterTitle(
+      selectedReviewFilter,
+      visibleDeckSummaries,
+      t("filters.allCards"),
+      t("reviewFilterMenu.noTags"),
+      formatCount(
+        selectedReviewFilter.kind === "tags" ? selectedReviewFilter.tags.length : 0,
+        messages.common.countLabels.tag,
+      ),
+    );
+  activeWorkspaceIdRef.current = activeWorkspaceId;
+  selectedReviewFilterKeyRef.current = selectedReviewFilterKey;
+  reviewDataContextKeyRef.current = reviewDataContextKey;
   observationIdentityRef.current = {
     userId,
     installationId,
@@ -196,11 +228,6 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     setReviewQueueCursor(nextReviewQueueCursor);
   }
 
-  useEffect((): void => {
-    activeWorkspaceIdRef.current = activeWorkspaceId;
-    selectedReviewFilterKeyRef.current = selectedReviewFilterKey;
-  }, [activeWorkspaceId, selectedReviewFilterKey]);
-
   function applyFreshReviewSessionSignature(nextReviewSessionSignature: ReviewSessionSignature): void {
     const previousReviewSessionSignature = reviewSessionSignatureRef.current;
     if (
@@ -231,15 +258,9 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
 
   useEffect(() => {
     let isCancelled = false;
-    const previousReviewFilter = previousReviewFilterRef.current;
-    const shouldShowBlockingLoader = previousReviewFilter === null
-      || isReviewFilterEqual(previousReviewFilter, selectedReviewFilter) === false;
-    previousReviewFilterRef.current = selectedReviewFilter;
+    const shouldShowBlockingLoader = loadedReviewDataContextKeyRef.current !== reviewDataContextKey;
 
     async function loadReviewData(): Promise<void> {
-      if (shouldShowBlockingLoader) {
-        setIsReviewLoading(true);
-      }
       if (loadedWorkspaceIdRef.current !== activeWorkspaceId) {
         setLocalHotStateStatus("loading");
         setLocalWorkspaceCardCount(0);
@@ -278,6 +299,11 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           nextResolvedReviewFilter,
           decksSnapshot.deckSummaries,
           t("filters.allCards"),
+          t("reviewFilterMenu.noTags"),
+          formatCount(
+            nextResolvedReviewFilter.kind === "tags" ? nextResolvedReviewFilter.tags.length : 0,
+            messages.common.countLabels.tag,
+          ),
         );
         const previousPresentedCard = shouldShowBlockingLoader ? null : presentedCardRef.current;
         const resolvedPresentedCard = await resolvePresentedCard(
@@ -333,6 +359,8 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
         setLocalWorkspaceCardCount(tagsSummary.totalCards);
         setLocalHotStateStatus(isHotStateHydrated ? "hydrated" : "unhydrated");
         loadedWorkspaceIdRef.current = activeWorkspaceId;
+        loadedReviewDataContextKeyRef.current = reviewDataContextKey;
+        setLoadedReviewDataContextKey(reviewDataContextKey);
         setTagSuggestions(toTagSuggestions(tagsSummary.tags));
         setDeckSummariesState(decksSnapshot.deckSummaries);
         writeReviewLoadingSnapshot({
@@ -369,10 +397,6 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
         });
         showCapturedTechnicalError(error);
         setReviewLoadErrorMessage(t("appError.technicalError.message"));
-      } finally {
-        if (!isCancelled && shouldShowBlockingLoader) {
-          setIsReviewLoading(false);
-        }
       }
     }
 
@@ -381,9 +405,13 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspaceId, getCardById, localReadVersion, selectedReviewFilter]);
+  }, [activeWorkspaceId, getCardById, localReadVersion, reviewDataContextKey, selectedReviewFilter]);
 
   async function handleReview(card: Card, rating: 0 | 1 | 2 | 3): Promise<ReviewSubmissionOutcome> {
+    if (loadedReviewDataContextKeyRef.current !== reviewDataContextKeyRef.current) {
+      return "stale";
+    }
+
     const submissionContext: ReviewSubmissionContext = {
       cardId: card.cardId,
       deckSummaries: deckSummariesRef.current,
@@ -637,19 +665,19 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
 
   return {
     activeReviewQueue,
-    deckSummaries,
+    deckSummaries: visibleDeckSummaries,
     handleReview,
     hasLoadedReviewData: visibleHasLoadedReviewData,
     isInitialReviewLoad,
-    isReviewLoading,
-    localWorkspaceCardCount,
-    queueCards,
-    resolvedReviewFilter,
-    reviewCounts,
+    isReviewLoading: isExplicitEmptyTagsFilter === false && isCurrentReviewDataContextLoaded === false,
+    localWorkspaceCardCount: visibleLocalWorkspaceCardCount,
+    queueCards: isCurrentReviewDataContextLoaded ? queueCards : [],
+    resolvedReviewFilter: isCurrentReviewDataContextLoaded ? resolvedReviewFilter : selectedReviewFilter,
+    reviewCounts: isCurrentReviewDataContextLoaded ? reviewCounts : createEmptyReviewCounts(),
     reviewLoadErrorMessage: visibleReviewLoadErrorMessage,
     reviewLoadingSnapshot,
-    reviewTagSummaries,
-    selectedReviewFilterTitle,
-    tagSuggestions,
+    reviewTagSummaries: isCurrentWorkspaceLoaded ? reviewTagSummaries : [],
+    selectedReviewFilterTitle: visibleSelectedReviewFilterTitle,
+    tagSuggestions: isCurrentWorkspaceLoaded ? tagSuggestions : [],
   };
 }

--- a/apps/web/src/screens/review/filters/ReviewFilterMenu.tsx
+++ b/apps/web/src/screens/review/filters/ReviewFilterMenu.tsx
@@ -19,7 +19,7 @@ type ReviewFilterMenuProps = Readonly<{
   handleReviewFilterComboboxKeyDown: React.KeyboardEventHandler<HTMLInputElement>;
   handleReviewFilterListboxKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
   handleReviewFilterMenuToggle: () => void;
-  handleReviewFilterSelect: (reviewFilter: ReviewFilter) => void;
+  handleReviewFilterSelect: (optionKey: string, reviewFilter: ReviewFilter) => void;
   hasVisibleReviewFilterChoices: boolean;
   isReviewFilterMenuOpen: boolean;
   reviewDeckSearchInputRef: React.RefObject<HTMLInputElement | null>;
@@ -89,6 +89,10 @@ function reviewFilterChoiceClassName(item: ReviewFilterChoiceMenuItem, activeRev
   }
 
   return classNames.join(" ");
+}
+
+function preventReviewFilterOptionPointerFocus(event: React.PointerEvent<HTMLDivElement>): void {
+  event.preventDefault();
 }
 
 export function ReviewFilterMenu(props: ReviewFilterMenuProps): ReactElement {
@@ -182,6 +186,7 @@ export function ReviewFilterMenu(props: ReviewFilterMenuProps): ReactElement {
           id={reviewFilterListboxId}
           className="review-filter-listbox"
           role="listbox"
+          aria-multiselectable="true"
           tabIndex={shouldShowReviewDeckSearch ? undefined : 0}
           aria-label={t("reviewFilterMenu.menuAriaLabel")}
           aria-activedescendant={shouldShowReviewDeckSearch ? undefined : activeReviewFilterOptionId ?? undefined}
@@ -196,7 +201,8 @@ export function ReviewFilterMenu(props: ReviewFilterMenuProps): ReactElement {
               aria-selected={item.isSelected}
               aria-label={item.subtitle === null ? undefined : `${item.label}. ${item.subtitle}`}
               data-review-filter-key={item.key}
-              onClick={() => handleReviewFilterSelect(item.reviewFilter)}
+              onPointerDown={preventReviewFilterOptionPointerFocus}
+              onClick={() => handleReviewFilterSelect(item.key, item.reviewFilter)}
             >
               <span className="review-filter-menu-item-slot" aria-hidden="true">
                 <span className={`review-filter-menu-item-check${item.isSelected ? " review-filter-menu-item-check-visible" : ""}`}>
@@ -225,7 +231,8 @@ export function ReviewFilterMenu(props: ReviewFilterMenuProps): ReactElement {
               role="option"
               aria-selected={tagItem.isSelected}
               data-review-filter-key={tagItem.key}
-              onClick={() => handleReviewFilterSelect(tagItem.reviewFilter)}
+              onPointerDown={preventReviewFilterOptionPointerFocus}
+              onClick={() => handleReviewFilterSelect(tagItem.key, tagItem.reviewFilter)}
             >
               <span className="review-filter-menu-item-slot" aria-hidden="true">
                 <span className={`review-filter-menu-item-check${tagItem.isSelected ? " review-filter-menu-item-check-visible" : ""}`}>

--- a/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
+++ b/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { ALL_CARDS_REVIEW_FILTER } from "../../../appData/domain";
+import {
+  ALL_CARDS_REVIEW_FILTER,
+  makeTagsReviewFilter,
+  normalizeReviewFilterTags,
+  normalizeTagKey,
+} from "../../../appData/domain";
 import { useAnchoredFloatingOutsidePointerDismiss } from "../../../floating";
 import { useI18n } from "../../../i18n";
 import { settingsDecksRoute } from "../../../routes";
@@ -39,7 +44,7 @@ export type UseReviewFilterMenuResult = Readonly<{
   handleReviewFilterComboboxKeyDown: (event: ReactKeyboardEvent<HTMLInputElement>) => void;
   handleReviewFilterListboxKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
   handleReviewFilterMenuToggle: () => void;
-  handleReviewFilterSelect: (reviewFilter: ReviewFilter) => void;
+  handleReviewFilterSelect: (optionKey: string, reviewFilter: ReviewFilter) => void;
   hasVisibleReviewFilterChoices: boolean;
   isReviewFilterMenuOpen: boolean;
   reviewDeckSearchInputRef: React.RefObject<HTMLInputElement | null>;
@@ -64,7 +69,7 @@ function toReviewFilterMenuItemKey(reviewFilter: ReviewFilter): string {
     return `${REVIEW_FILTER_DECK_PREFIX}${reviewFilter.deckId}`;
   }
 
-  return `${REVIEW_FILTER_TAG_PREFIX}${reviewFilter.tag}`;
+  return `${REVIEW_FILTER_TAG_PREFIX}${reviewFilter.tags.map((tag) => encodeURIComponent(tag)).join(",")}`;
 }
 
 function buildReviewDeckFilterMenuItems(
@@ -99,23 +104,63 @@ function buildReviewDeckFilterMenuItems(
 }
 
 function buildReviewTagFilterMenuItems(
+  deckSummaries: ReadonlyArray<DeckSummary>,
   reviewTagSummaries: ReadonlyArray<WorkspaceTagSummary>,
   selectedReviewFilter: ReviewFilter,
 ): Array<ReviewFilterChoiceMenuItem> {
+  const availableTags = reviewTagSummaries.map((tagSummary) => tagSummary.tag);
+  const materializedTags = resolveMaterializedTags(selectedReviewFilter, deckSummaries, availableTags);
+  const selectedTagKeys = new Set(materializedTags.map((tag) => normalizeTagKey(tag)));
+  const availableTagKeys = new Set(availableTags.map((tag) => normalizeTagKey(tag)));
+
   return reviewTagSummaries.map((tagSummary) => {
-    const reviewFilter: ReviewFilter = {
-      kind: "tag",
-      tag: tagSummary.tag,
-    };
+    const tagKey = normalizeTagKey(tagSummary.tag);
+    const nextSelectedTags = selectedTagKeys.has(tagKey)
+      ? materializedTags.filter((tag) => normalizeTagKey(tag) !== tagKey)
+      : [...materializedTags, tagSummary.tag];
+    const normalizedNextSelectedTags = normalizeReviewFilterTags(nextSelectedTags);
+    const hasMissingSelectedTag = normalizedNextSelectedTags.some(
+      (tag) => availableTagKeys.has(normalizeTagKey(tag)) === false,
+    );
+    const isEveryAvailableTagSelected = normalizedNextSelectedTags.length === availableTagKeys.size
+      && normalizedNextSelectedTags.every((tag) => availableTagKeys.has(normalizeTagKey(tag)));
+    const reviewFilter = isEveryAvailableTagSelected && hasMissingSelectedTag === false
+      ? ALL_CARDS_REVIEW_FILTER
+      : makeTagsReviewFilter(normalizedNextSelectedTags);
 
     return {
-      key: toReviewFilterMenuItemKey(reviewFilter),
+      key: `${REVIEW_FILTER_TAG_PREFIX}${tagKey}`,
       label: `${tagSummary.tag} (${tagSummary.cardsCount})`,
       reviewFilter,
       subtitle: null,
-      isSelected: toReviewFilterMenuItemKey(selectedReviewFilter) === toReviewFilterMenuItemKey(reviewFilter),
+      isSelected: selectedTagKeys.has(tagKey),
     };
   });
+}
+
+function resolveMaterializedTags(
+  selectedReviewFilter: ReviewFilter,
+  deckSummaries: ReadonlyArray<DeckSummary>,
+  availableTags: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  if (selectedReviewFilter.kind === "allCards") {
+    return normalizeReviewFilterTags(availableTags);
+  }
+
+  if (selectedReviewFilter.kind === "tags") {
+    return normalizeReviewFilterTags(selectedReviewFilter.tags);
+  }
+
+  const selectedDeck = deckSummaries.find(
+    (deck) => deck.deckId === selectedReviewFilter.deckId,
+  );
+  if (selectedDeck === undefined) {
+    return [];
+  }
+
+  return selectedDeck.filterDefinition.tags.length === 0
+    ? normalizeReviewFilterTags(availableTags)
+    : normalizeReviewFilterTags(selectedDeck.filterDefinition.tags);
 }
 
 function buildReviewFilterMenuItems(label: string): Array<ReviewFilterMenuItem> {
@@ -212,7 +257,11 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
     t("filters.allCards"),
     t("reviewFilterMenu.deckSmartFilterLabel"),
   );
-  const reviewTagFilterMenuItems = buildReviewTagFilterMenuItems(reviewTagSummaries, selectedReviewFilter);
+  const reviewTagFilterMenuItems = buildReviewTagFilterMenuItems(
+    deckSummaries,
+    reviewTagSummaries,
+    selectedReviewFilter,
+  );
   const reviewFilterMenuItems = buildReviewFilterMenuItems(t("reviewFilterMenu.editDecks"));
   const totalReviewFilterChoicesCount = reviewDeckFilterMenuItems.length
     + reviewTagFilterMenuItems.length;
@@ -327,9 +376,9 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
     setIsReviewFilterMenuOpen(true);
   }
 
-  function handleReviewFilterSelect(reviewFilter: ReviewFilter): void {
+  function handleReviewFilterSelect(optionKey: string, reviewFilter: ReviewFilter): void {
+    setActiveReviewFilterOptionKey(optionKey);
     onSelectReviewFilter(reviewFilter);
-    handleCloseMenu();
   }
 
   function preventReviewFilterHandledKeyDown(event: ReactKeyboardEvent<HTMLInputElement | HTMLDivElement>): void {
@@ -360,7 +409,6 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
     );
     if (activeReviewFilterOption !== null) {
       onSelectReviewFilter(activeReviewFilterOption.reviewFilter);
-      closeReviewFilterMenuAndFocusTrigger();
     }
   }
 

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { act, useEffect, type ReactElement } from "react";
+import { act, StrictMode, useEffect, type ReactElement } from "react";
 import ReactDOM from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, vi } from "vitest";
@@ -128,6 +128,7 @@ type ReviewScreenTestHarness = Readonly<{
   openReviewQueue: () => Promise<void>;
   openReviewFilterMenu: () => Promise<void>;
   renderReviewScreen: () => Promise<void>;
+  renderReviewScreenStrictMode: () => Promise<void>;
   rerenderReviewScreen: () => Promise<void>;
   revealAnswer: () => Promise<void>;
 }>;
@@ -347,15 +348,27 @@ function createDecksSnapshot(state: ReviewScreenTestState): DecksListSnapshot {
 }
 
 function createTagsSummary(state: ReviewScreenTestState): WorkspaceTagsSummary {
-  const counts = new Map<string, number>();
+  const tagStatsByKey = new Map<string, Readonly<{ tag: string; cardIds: Set<string> }>>();
   for (const card of state.cards) {
     for (const tag of card.tags) {
-      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      const tagKey = tag.trim().toLowerCase();
+      const currentTagStats = tagStatsByKey.get(tagKey);
+      if (currentTagStats === undefined) {
+        tagStatsByKey.set(tagKey, {
+          tag: tag.trim(),
+          cardIds: new Set([card.cardId]),
+        });
+      } else {
+        currentTagStats.cardIds.add(card.cardId);
+      }
     }
   }
 
   return {
-    tags: [...counts.entries()].map(([tag, cardsCount]) => ({ tag, cardsCount })),
+    tags: [...tagStatsByKey.values()].map((tagStats) => ({
+      tag: tagStats.tag,
+      cardsCount: tagStats.cardIds.size,
+    })),
     totalCards: state.cards.length,
   };
 }
@@ -634,6 +647,27 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     });
   }
 
+  async function renderReviewScreenStrictMode(): Promise<void> {
+    const currentRoot = root;
+    if (currentRoot === null) {
+      throw new Error("ReviewScreen test root is not ready");
+    }
+
+    await act(async () => {
+      currentRoot.render(
+        <StrictMode>
+          <I18nProvider>
+            <AppErrorDialogProvider>
+              <MemoryRouter>
+                <ReviewScreen />
+              </MemoryRouter>
+            </AppErrorDialogProvider>
+          </I18nProvider>
+        </StrictMode>,
+      );
+    });
+  }
+
   async function openReviewFilterMenu(): Promise<void> {
     const trigger = getContainer().querySelector(".review-filter-trigger");
     if (!(trigger instanceof HTMLButtonElement)) {
@@ -684,6 +718,7 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     openReviewQueue,
     openReviewFilterMenu,
     renderReviewScreen,
+    renderReviewScreenStrictMode,
     rerenderReviewScreen: renderReviewScreen,
     revealAnswer,
   };

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -4,6 +4,7 @@ import {
   clickElementAsync,
   createCard,
   createDecks,
+  loadReviewQueueSnapshotMock,
   reviewStylesContain,
   setTextFieldValueAsync,
   setupReviewScreenTest,
@@ -13,6 +14,7 @@ import {
   flushReviewScreenPromises,
   getActiveReviewFilterOption,
   keydownElementAsync,
+  pointerDownAndClickElementAsync,
   pointerDownElementAsync,
 } from "./ReviewScreen.controlsTestSupport";
 
@@ -22,6 +24,7 @@ const {
   getState,
   openReviewFilterMenu,
   renderReviewScreen,
+  renderReviewScreenStrictMode,
   rerenderReviewScreen,
 } = setupReviewScreenTest();
 
@@ -235,8 +238,8 @@ describe("ReviewScreen filter controls", () => {
     state.reviewQueue = [];
     state.reviewTimeline = [];
     state.appData.selectedReviewFilter = {
-      kind: "tag",
-      tag: "empty",
+      kind: "tags",
+      tags: [],
     };
     state.appData.localReadVersion = 1;
 
@@ -274,7 +277,7 @@ describe("ReviewScreen filter controls", () => {
     expect(getContainer().querySelector("#review-queue-panel")).toBeNull();
   });
 
-  it("filters, closes, and selects items in the review filter menu", async () => {
+  it("filters, dismisses externally, and applies selections without closing the review filter menu", async () => {
     const state = getState();
     state.decks = createDecks(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta"]);
     state.cards = [
@@ -304,7 +307,12 @@ describe("ReviewScreen filter controls", () => {
     }
 
     expect(listbox.classList.contains("review-filter-listbox")).toBe(true);
+    expect(listbox.getAttribute("aria-multiselectable")).toBe("true");
     expect(searchInput.getAttribute("aria-controls")).toBe(listbox.id);
+    expect(listbox.querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("true");
+    expect(listbox.querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
+    expect(listbox.querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
+    expect(listbox.querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("true");
     expect(reviewStylesContain(
       ".review-filter-menu",
       "display: flex",
@@ -373,15 +381,14 @@ describe("ReviewScreen filter controls", () => {
       kind: "deck",
       deckId: "deck-4",
     });
-    expect(queryReviewFilterMenu()).toBeNull();
+    expect(queryReviewFilterMenu()).not.toBeNull();
+    expect(document.activeElement).toBe(searchInput);
+
+    state.appData.selectReviewFilter.mockClear();
     const triggerAfterSearchKeyboardSelect = getContainer().querySelector(".review-filter-trigger");
     if (!(triggerAfterSearchKeyboardSelect instanceof HTMLButtonElement)) {
       throw new Error("Review filter trigger was not found after search keyboard selection");
     }
-    expect(document.activeElement).toBe(triggerAfterSearchKeyboardSelect);
-
-    state.appData.selectReviewFilter.mockClear();
-    await openReviewFilterMenu();
     await pointerDownElementAsync(triggerAfterSearchKeyboardSelect);
     expect(queryReviewFilterMenu()).not.toBeNull();
     await pointerDownElementAsync(getReviewFilterMenu());
@@ -403,9 +410,10 @@ describe("ReviewScreen filter controls", () => {
     await clickElementAsync(mediumOption);
 
     expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "tag",
-      tag: "medium",
+      kind: "tags",
+      tags: ["grammar", "verbs"],
     });
+    expect(queryReviewFilterMenu()).not.toBeNull();
   });
 
   it("selects items by keyboard when the review filter menu has no search field", async () => {
@@ -456,12 +464,266 @@ describe("ReviewScreen filter controls", () => {
       kind: "deck",
       deckId: "deck-2",
     });
-    expect(queryReviewFilterMenu()).toBeNull();
+    expect(queryReviewFilterMenu()).not.toBeNull();
     const triggerAfterListboxKeyboardSelect = getContainer().querySelector(".review-filter-trigger");
     if (!(triggerAfterListboxKeyboardSelect instanceof HTMLButtonElement)) {
       throw new Error("Review filter trigger was not found after listbox keyboard selection");
     }
-    expect(document.activeElement).toBe(triggerAfterListboxKeyboardSelect);
+    expect(document.activeElement).toBe(listbox);
+  });
+
+  it("uses the pointer-selected option for the next keyboard selection", async () => {
+    const state = getState();
+    state.decks = createDecks(["Pointer deck"]);
+    const card = createCard({
+      cardId: "card-pointer-keyboard-filter",
+      frontText: "Front",
+      backText: "Back",
+    });
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const listbox = getReviewFilterMenu().querySelector("[role='listbox']");
+    const deckOption = getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-1']");
+    if (!(listbox instanceof HTMLElement) || !(deckOption instanceof HTMLElement)) {
+      throw new Error("Pointer-keyboard review filter controls were not found");
+    }
+
+    await clickElementAsync(deckOption);
+
+    expect(getActiveReviewFilterOption(listbox)).toBe(deckOption);
+    expect(listbox.getAttribute("aria-activedescendant")).toBe(deckOption.id);
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "deck",
+      deckId: "deck-1",
+    });
+    state.appData.selectReviewFilter.mockClear();
+
+    await keydownElementAsync(listbox, " ");
+
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
+      kind: "deck",
+      deckId: "deck-1",
+    });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+  });
+
+  it("keeps searchable pointer selection owned by the combobox for keyboard activation", async () => {
+    const state = getState();
+    state.decks = createDecks(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta"]);
+    const card = createCard({
+      cardId: "card-search-pointer-keyboard-filter",
+      frontText: "Front",
+      backText: "Back",
+    });
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const searchInput = getReviewFilterMenu().querySelector(".review-filter-search-input");
+    const deckOption = getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-4']");
+    if (!(searchInput instanceof HTMLInputElement) || !(deckOption instanceof HTMLElement)) {
+      throw new Error("Searchable pointer-keyboard review filter controls were not found");
+    }
+    expect(document.activeElement).toBe(searchInput);
+
+    const wasPointerDownPrevented = await pointerDownAndClickElementAsync(deckOption);
+
+    expect(wasPointerDownPrevented).toBe(true);
+    expect(document.activeElement).toBe(searchInput);
+    expect(getActiveReviewFilterOption(searchInput)).toBe(deckOption);
+    expect(searchInput.getAttribute("aria-activedescendant")).toBe(deckOption.id);
+    state.appData.selectReviewFilter.mockClear();
+
+    await keydownElementAsync(searchInput, "Enter");
+
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
+      kind: "deck",
+      deckId: "deck-4",
+    });
+    expect(document.activeElement).toBe(searchInput);
+    expect(queryReviewFilterMenu()).not.toBeNull();
+  });
+
+  it("shows the resolved tag count after StrictMode replays the initial load effect", async () => {
+    const state = getState();
+    const card = createCard({
+      cardId: "strict-mode-resolved-filter-card",
+      frontText: "Front",
+      backText: "Back",
+      tags: ["grammar"],
+    });
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: ["grammar", "missing"],
+    };
+    loadReviewQueueSnapshotMock.mockResolvedValue({
+      resolvedReviewFilter: {
+        kind: "tags",
+        tags: ["grammar"],
+      },
+      cards: [card],
+      nextCursor: null,
+      reviewCounts: {
+        dueCount: 1,
+        totalCount: 1,
+      },
+    });
+
+    await renderReviewScreenStrictMode();
+
+    await vi.waitFor(() => {
+      const trigger = getContainer().querySelector("[data-testid='review-filter-trigger']");
+      if (!(trigger instanceof HTMLButtonElement)) {
+        throw new Error("Review filter trigger was not found after StrictMode loading");
+      }
+
+      expect(trigger.textContent).toContain("1 tag");
+      expect(trigger.textContent).not.toContain("2 tags");
+    });
+  });
+
+  it("materializes deck tags and canonicalizes a complete custom selection to All Cards", async () => {
+    const state = getState();
+    state.decks = [
+      ...createDecks(["Grammar and verbs"]),
+    ].map((deck) => ({
+      ...deck,
+      filterDefinition: {
+        version: 2,
+        tags: ["grammar", "verbs"],
+      },
+    }));
+    state.cards = [
+      createCard({ cardId: "grammar-card", tags: ["grammar"] }),
+      createCard({ cardId: "verbs-card", tags: ["verbs"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+    state.appData.selectedReviewFilter = {
+      kind: "deck",
+      deckId: "deck-1",
+    };
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const grammarOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    if (!(grammarOption instanceof HTMLElement)) {
+      throw new Error("Grammar review filter option was not found");
+    }
+    expect(grammarOption.getAttribute("aria-selected")).toBe("true");
+    expect(getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-1']")?.getAttribute("aria-selected")).toBe("true");
+
+    await clickElementAsync(grammarOption);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: ["verbs"],
+    });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: ["grammar"],
+    };
+    await rerenderReviewScreen();
+    const verbsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
+    if (!(verbsOption instanceof HTMLElement)) {
+      throw new Error("Verbs review filter option was not found");
+    }
+
+    await clickElementAsync(verbsOption);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({ kind: "allCards" });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+  });
+
+  it("retains missing custom and preset tags while toggling visible tags", async () => {
+    const state = getState();
+    state.decks = createDecks(["Configured deck", "All tags deck"]).map((deck) => ({
+      ...deck,
+      filterDefinition: {
+        version: 2,
+        tags: deck.deckId === "deck-1" ? ["grammar", "missing"] : [],
+      },
+    }));
+    state.cards = [
+      createCard({ cardId: "visible-grammar-card", tags: ["grammar"] }),
+      createCard({ cardId: "visible-verbs-card", tags: ["verbs"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+    state.appData.selectedReviewFilter = {
+      kind: "deck",
+      deckId: "deck-1",
+    };
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const verbsFromConfiguredDeck = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
+    if (!(verbsFromConfiguredDeck instanceof HTMLElement)) {
+      throw new Error("Verbs option was not found for the configured deck");
+    }
+    expect(verbsFromConfiguredDeck.getAttribute("aria-selected")).toBe("false");
+
+    await clickElementAsync(verbsFromConfiguredDeck);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: ["grammar", "missing", "verbs"],
+    });
+
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: ["grammar", "missing"],
+    };
+    await rerenderReviewScreen();
+    const verbsFromCustomSelection = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
+    if (!(verbsFromCustomSelection instanceof HTMLElement)) {
+      throw new Error("Verbs option was not found for the custom selection");
+    }
+
+    await clickElementAsync(verbsFromCustomSelection);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: ["grammar", "missing", "verbs"],
+    });
+
+    state.appData.selectedReviewFilter = {
+      kind: "deck",
+      deckId: "deck-2",
+    };
+    await rerenderReviewScreen();
+    const grammarFromAllTagsDeck = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    const verbsFromAllTagsDeck = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
+    if (!(grammarFromAllTagsDeck instanceof HTMLElement) || !(verbsFromAllTagsDeck instanceof HTMLElement)) {
+      throw new Error("Visible tag options were not found for the all-tags deck");
+    }
+    expect(grammarFromAllTagsDeck.getAttribute("aria-selected")).toBe("true");
+    expect(verbsFromAllTagsDeck.getAttribute("aria-selected")).toBe("true");
+
+    await clickElementAsync(grammarFromAllTagsDeck);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: ["verbs"],
+    });
+    expect(queryReviewFilterMenu()).not.toBeNull();
   });
 
   it("keeps review filter option ids unique for similar tag text", async () => {
@@ -488,5 +750,22 @@ describe("ReviewScreen filter controls", () => {
     expect(slashTagOption.id).not.toBe(escapedTagOption.id);
     expect(document.getElementById(slashTagOption.id)).toBe(slashTagOption);
     expect(document.getElementById(escapedTagOption.id)).toBe(escapedTagOption);
+  });
+
+  it("shows one unique-card count for case-insensitive tag variants", async () => {
+    const state = getState();
+    state.cards = [
+      createCard({ cardId: "case-variant-card", tags: ["Grammar", "grammar"] }),
+      createCard({ cardId: "lowercase-card", tags: ["grammar"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const tagOptions = getReviewFilterMenu().querySelectorAll("[data-review-filter-key='tag:grammar']");
+    expect(tagOptions).toHaveLength(1);
+    expect(tagOptions[0]?.textContent).toContain("Grammar (2)");
   });
 });

--- a/apps/web/src/screens/review/tests/ReviewScreen.controlsTestSupport.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controlsTestSupport.tsx
@@ -21,11 +21,16 @@ export async function pointerDownElementAsync(element: Element): Promise<void> {
   });
 }
 
-export async function pointerDownAndClickElementAsync(element: Element): Promise<void> {
+export async function pointerDownAndClickElementAsync(element: Element): Promise<boolean> {
+  let wasPointerDownPrevented = false;
   await act(async () => {
-    dispatchPointerDown(element);
+    const pointerDownEvent = new Event("pointerdown", { bubbles: true, cancelable: true });
+    element.dispatchEvent(pointerDownEvent);
+    wasPointerDownPrevented = pointerDownEvent.defaultPrevented;
     clickElement(element);
   });
+
+  return wasPointerDownPrevented;
 }
 
 export async function keydownElementAsync(element: HTMLElement, key: string): Promise<void> {

--- a/apps/web/src/screens/review/tests/ReviewScreen.presented-card.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.presented-card.test.tsx
@@ -100,8 +100,8 @@ describe("ReviewScreen presented card preservation", () => {
   it("does not preserve an omitted presented card after it stops matching the selected filter", async () => {
     const state = getState();
     state.appData.selectedReviewFilter = {
-      kind: "tag",
-      tag: "grammar",
+      kind: "tags",
+      tags: ["grammar"],
     };
     const currentCard = createCard({
       cardId: "card-current-filter",

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -54,6 +54,7 @@ import { buildReviewButtonOptions, type ReviewButtonOption } from "./components/
 import { type LastSubmittedReview, type ReviewSubmitState } from "./components/reviewScreenTypes";
 import { useReviewCardEditor } from "./components/card/useReviewCardEditor";
 import { useReviewScreenData, type ReviewSubmissionOutcome } from "./data/useReviewScreenData";
+import { resolveReviewFilterTitle } from "./data/reviewScreenDataState";
 import { useReviewFilterMenu } from "./filters/useReviewFilterMenu";
 import type { ReviewHardReminderDialogProps } from "./hardReminder/ReviewHardReminderDialog";
 import {
@@ -141,7 +142,7 @@ export function useReviewScreenController(
   } = useAppData();
   const reviewLeaderboardBadge = useReviewLeaderboardBadge();
   const reviewProgressBadge = useReviewProgressBadge();
-  const { locale, t, formatCount } = useI18n();
+  const { formatCount, locale, messages, t } = useI18n();
   const { showCapturedTechnicalError } = useAppErrorDialog();
   const [isAnswerVisible, setIsAnswerVisible] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -187,6 +188,7 @@ export function useReviewScreenController(
     handleReview: handleReviewData,
     hasLoadedReviewData,
     isInitialReviewLoad,
+    isReviewLoading,
     localWorkspaceCardCount,
     queueCards,
     resolvedReviewFilter,
@@ -244,7 +246,7 @@ export function useReviewScreenController(
     deckSummaries,
     onSelectReviewFilter: selectReviewFilter,
     reviewTagSummaries,
-    selectedReviewFilter: resolvedReviewFilter,
+    selectedReviewFilter,
   });
   const {
     captureEditorPresentationToken,
@@ -309,9 +311,21 @@ export function useReviewScreenController(
     };
   }
   const loadingReviewCurrentCard = reviewLoadingSnapshot?.currentCard ?? reviewLoadingSnapshot?.queuePreview[0] ?? null;
+  const requestedReviewFilterTitle = resolveReviewFilterTitle(
+    selectedReviewFilter,
+    deckSummaries,
+    t("filters.allCards"),
+    t("reviewFilterMenu.noTags"),
+    formatCount(
+      selectedReviewFilter.kind === "tags" ? selectedReviewFilter.tags.length : 0,
+      messages.common.countLabels.tag,
+    ),
+  );
   const visibleSelectedReviewFilterTitle = isInitialReviewLoad && reviewLoadingSnapshot !== null
     ? reviewLoadingSnapshot.resolvedReviewFilterTitle
-    : selectedReviewFilterTitle;
+    : isReviewLoading
+      ? requestedReviewFilterTitle
+      : selectedReviewFilterTitle;
   const visibleQueueCardsCount = isInitialReviewLoad && reviewLoadingSnapshot !== null
     ? reviewLoadingSnapshot.queuePreview.length
     : queueCards.length;

--- a/apps/web/src/screens/settings/workspace/TagsScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/TagsScreen.tsx
@@ -91,8 +91,8 @@ export function TagsScreen(): ReactElement {
 
   function handleOpenTagReview(tag: string): void {
     const reviewFilter: ReviewFilter = {
-      kind: "tag",
-      tag,
+      kind: "tags",
+      tags: [tag],
     };
 
     openReview(reviewFilter);

--- a/apps/web/src/screens/shared/loadingSnapshots.ts
+++ b/apps/web/src/screens/shared/loadingSnapshots.ts
@@ -1,6 +1,7 @@
 import type { Card, ReviewCounts, ReviewFilter } from "../../types";
 import type { LegacyEffortLevel } from "../../types/sync";
 import { appendLegacyEffortTag } from "../../legacyEffort";
+import { normalizeReviewFilterTags, normalizeTagKey } from "../../appData/domain";
 
 const SNAPSHOT_VERSION = 1;
 const REVIEW_LOADING_SNAPSHOT_KEY_PREFIX = "flashcards-review-loading-snapshot";
@@ -62,11 +63,22 @@ function buildCardsLoadingSnapshotStorageKey(workspaceId: string): string {
 }
 
 function buildLegacyEffortReviewFilterKey(reviewFilter: ReviewFilter): string | null {
-  if (reviewFilter.kind !== "tag" || (reviewFilter.tag !== "medium" && reviewFilter.tag !== "long")) {
+  const tag = reviewFilter.kind === "tags" && reviewFilter.tags.length === 1
+    ? reviewFilter.tags[0] ?? null
+    : null;
+  if (tag !== "medium" && tag !== "long") {
     return null;
   }
 
-  return `effort:${reviewFilter.tag}`;
+  return `effort:${tag}`;
+}
+
+function buildLegacyTagReviewFilterKey(reviewFilter: ReviewFilter): string | null {
+  if (reviewFilter.kind !== "tags" || reviewFilter.tags.length !== 1) {
+    return null;
+  }
+
+  return `tag:${reviewFilter.tags[0] ?? ""}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -270,7 +282,9 @@ export function serializeReviewFilterKey(reviewFilter: ReviewFilter): string {
     return `deck:${reviewFilter.deckId}`;
   }
 
-  return `tag:${reviewFilter.tag}`;
+  return `tags:${normalizeReviewFilterTags(reviewFilter.tags)
+    .map((tag) => encodeURIComponent(normalizeTagKey(tag)))
+    .join(",")}`;
 }
 
 export function buildReviewLoadingCardPreview(card: Card): ReviewLoadingCardPreview {
@@ -308,6 +322,18 @@ export function readReviewLoadingSnapshot(
 
   if (snapshot !== null) {
     return snapshot;
+  }
+
+  const legacyTagReviewFilterKey = buildLegacyTagReviewFilterKey(reviewFilter);
+  if (legacyTagReviewFilterKey !== null) {
+    const legacyTagSnapshot = readReviewLoadingSnapshotForStoredKey(
+      workspaceId,
+      selectedReviewFilterKey,
+      legacyTagReviewFilterKey,
+    );
+    if (legacyTagSnapshot !== null) {
+      return legacyTagSnapshot;
+    }
   }
 
   const legacyEffortReviewFilterKey = buildLegacyEffortReviewFilterKey(reviewFilter);

--- a/apps/web/src/types/study.ts
+++ b/apps/web/src/types/study.ts
@@ -220,8 +220,8 @@ export type ReviewFilter =
     deckId: string;
   }>
   | Readonly<{
-    kind: "tag";
-    tag: string;
+    kind: "tags";
+    tags: ReadonlyArray<string>;
   }>;
 
 export type ReviewEvent = Readonly<{


### PR DESCRIPTION
## Summary
- add explicit multi-tag review filters with OR and empty-selection semantics
- persist review scope per workspace with legacy compatibility
- add accessible immediate-update review filter controls and focused coverage

## Validation
- npm test --prefix apps/web (82 files, 695 tests)
- npm run build --prefix apps/web
- node scripts/checks/pr/run-all.mjs
- git diff --check