### PR TITLE
Fix restored all-tag review filters

### DIFF
--- a/apps/web/src/localDb/cards/tags/index.ts
+++ b/apps/web/src/localDb/cards/tags/index.ts
@@ -16,6 +16,7 @@ export type TagCardIdsLookup = Readonly<{
 export type ReviewTagFilterLookup = Readonly<{
   cardIds: ReadonlySet<string>;
   canonicalTags: ReadonlyArray<string>;
+  availableTagKeys: ReadonlySet<string>;
 }>;
 
 function putCardTags(cardTagsStore: IDBObjectStore, workspaceId: string, card: Card): void {
@@ -181,15 +182,13 @@ export async function loadReviewTagFilterLookupForTags(
   const allowedCardIds = new Set<string>();
   const requestedTagKeys = new Set(tags.map((tag) => normalizeTagKey(tag)).filter((tagKey) => tagKey !== ""));
   const canonicalTagsByKey = new Map<string, string>();
-  if (requestedTagKeys.size === 0) {
-    return {
-      cardIds: allowedCardIds,
-      canonicalTags: [],
-    };
-  }
-
+  const availableTagKeys = new Set<string>();
   await iterateAllCardTags(database, workspaceId, (record) => {
     const tagKey = normalizeTagKey(record.tag);
+    if (tagKey !== "") {
+      availableTagKeys.add(tagKey);
+    }
+
     if (requestedTagKeys.has(tagKey) === false) {
       return true;
     }
@@ -207,6 +206,7 @@ export async function loadReviewTagFilterLookupForTags(
     canonicalTags: [...canonicalTagsByKey.entries()]
       .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
       .map(([, tag]) => tag),
+    availableTagKeys,
   };
 }
 

--- a/apps/web/src/localDb/reviews/reviews.test.ts
+++ b/apps/web/src/localDb/reviews/reviews.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { replaceCards } from "../cards/cards";
 import { replaceDecks } from "../cards/decks";
 import { loadWorkspaceTagsSummary } from "../cards/workspace";
+import { parsePersistedReviewFilter } from "../../appData/context/reviewFilterPersistence";
 import {
   loadReviewQueueChunk,
   loadReviewQueueSnapshot,
@@ -205,6 +206,75 @@ describe("localDb reviews", () => {
       } finally {
         Date.now = originalNow;
       }
+    });
+
+    it("restores a persisted all-tag selection as All Cards only while it exactly matches the current tag set", async () => {
+      const grammarCard = makeCard({
+        cardId: "grammar-card",
+        frontText: "Grammar",
+        backText: "back",
+        tags: ["Grammar"],
+        dueAt: null,
+        createdAt: "2026-03-10T09:00:00.000Z",
+      });
+      const verbsCard = makeCard({
+        cardId: "verbs-card",
+        frontText: "Verbs",
+        backText: "back",
+        tags: ["verbs"],
+        dueAt: null,
+        createdAt: "2026-03-10T09:01:00.000Z",
+      });
+      const untaggedCard = makeCard({
+        cardId: "untagged-card",
+        frontText: "Untagged",
+        backText: "back",
+        tags: [],
+        dueAt: null,
+        createdAt: "2026-03-10T09:02:00.000Z",
+      });
+      const persistedFilter = parsePersistedReviewFilter(JSON.stringify({
+        kind: "tags",
+        tags: [" VERBS ", "grammar"],
+      }));
+      await replaceCards(workspaceId, [grammarCard, verbsCard, untaggedCard]);
+
+      const restoredAllTagsSnapshot = await loadReviewQueueSnapshot(workspaceId, persistedFilter, 10);
+
+      expect(restoredAllTagsSnapshot.resolvedReviewFilter).toEqual({ kind: "allCards" });
+      expect(restoredAllTagsSnapshot.cards.map((card) => card.cardId)).toEqual([
+        "grammar-card",
+        "verbs-card",
+        "untagged-card",
+      ]);
+
+      const codeCard = makeCard({
+        cardId: "code-card",
+        frontText: "Code",
+        backText: "back",
+        tags: ["code"],
+        dueAt: null,
+        createdAt: "2026-03-10T09:03:00.000Z",
+      });
+      await replaceCards(workspaceId, [grammarCard, verbsCard, untaggedCard, codeCard]);
+
+      const expandedTagSetSnapshot = await loadReviewQueueSnapshot(workspaceId, persistedFilter, 10);
+
+      expect(expandedTagSetSnapshot.resolvedReviewFilter).toEqual({
+        kind: "tags",
+        tags: ["Grammar", "verbs"],
+      });
+      expect(expandedTagSetSnapshot.cards.map((card) => card.cardId)).toEqual(["grammar-card", "verbs-card"]);
+
+      await replaceCards(workspaceId, [grammarCard, untaggedCard]);
+
+      const missingPersistedTagSnapshot = await loadReviewQueueSnapshot(workspaceId, persistedFilter, 10);
+
+      expect(missingPersistedTagSnapshot.resolvedReviewFilter).toEqual({
+        kind: "tags",
+        tags: ["Grammar"],
+      });
+      expect(missingPersistedTagSnapshot.cards.map((card) => card.cardId)).toEqual(["grammar-card"]);
     });
 
     it("resolves selected tag ids and canonical tags in one cardTags transaction", async () => {

--- a/apps/web/src/localDb/reviews/reviews.ts
+++ b/apps/web/src/localDb/reviews/reviews.ts
@@ -11,6 +11,7 @@ import {
   ALL_CARDS_REVIEW_FILTER,
   makeTagsReviewFilter,
   matchesDeckFilterDefinition,
+  normalizeTagKey,
   recentDuePriorityWindow,
 } from "../../appData/domain";
 import { loadReviewTagFilterLookupForTags } from "../cards/tags";
@@ -104,6 +105,19 @@ async function resolveReviewFilterFromIndexedDb(
   }
 
   const tagFilterLookup = await loadReviewTagFilterLookupForTags(database, workspaceId, reviewFilter.tags);
+  const requestedTagKeys = new Set(
+    reviewFilter.tags.map((tag) => normalizeTagKey(tag)).filter((tagKey) => tagKey !== ""),
+  );
+  const includesEveryAvailableTag = requestedTagKeys.size > 0
+    && requestedTagKeys.size === tagFilterLookup.availableTagKeys.size
+    && tagFilterLookup.canonicalTags.length === requestedTagKeys.size;
+  if (includesEveryAvailableTag) {
+    return {
+      resolvedReviewFilter: ALL_CARDS_REVIEW_FILTER,
+      deck: null,
+      allowedTagCardIds: null,
+    };
+  }
 
   return {
     resolvedReviewFilter: makeTagsReviewFilter(tagFilterLookup.canonicalTags),


### PR DESCRIPTION
## Summary
- canonicalize restored exact all-tag selections to All Cards in the web IndexedDB resolver
- preserve explicit empty and missing-tag custom scopes
- cover tagged and untagged cards across persisted restore and tag-set changes

## Validation
- focused web review tests: 16 passed
- full web suite: 82 files, 696 tests passed
- production web build passed
- repository static checks: 4 passed
- git diff --check passed