### PR TITLE
fix(android): normalize review tag counts

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewCountDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewCountDao.kt
@@ -4,9 +4,9 @@ import androidx.room.Dao
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
-data class ReviewTagCountRow(
+data class ReviewTagCardRow(
     val tag: String,
-    val totalCount: Int
+    val cardId: String
 )
 
 @Dao
@@ -106,7 +106,7 @@ interface ReviewCountDao {
 
     @Query(
         """
-        SELECT tags.name AS tag, COUNT(DISTINCT cards.cardId) AS totalCount
+        SELECT DISTINCT tags.name AS tag, cards.cardId AS cardId
         FROM cards
         INNER JOIN card_tags ON card_tags.cardId = cards.cardId
         INNER JOIN tags ON tags.tagId = card_tags.tagId
@@ -114,8 +114,7 @@ interface ReviewCountDao {
             AND tags.workspaceId = cards.workspaceId
             AND cards.deletedAtMillis IS NULL
             AND (cards.dueAtMillis IS NULL OR cards.dueAtMillis <= :nowMillis)
-        GROUP BY tags.name
         """
     )
-    fun observeReviewTagDueCounts(workspaceId: String, nowMillis: Long): Flow<List<ReviewTagCountRow>>
+    fun observeReviewTagDueCards(workspaceId: String, nowMillis: Long): Flow<List<ReviewTagCardRow>>
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
@@ -217,7 +217,7 @@ class LocalReviewRepository(
                     )
                 }
                 val tagFiltersFlow: Flow<List<com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption>> =
-                    database.reviewCountDao().observeReviewTagDueCounts(
+                    database.reviewCountDao().observeReviewTagDueCards(
                         workspaceId = queryBase.workspaceId,
                         nowMillis = queryBase.nowMillis
                     )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupport.kt
@@ -3,7 +3,7 @@ package com.flashcardsopensourceapp.data.local.repository.review
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardWithRelations
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
-import com.flashcardsopensourceapp.data.local.database.review.ReviewTagCountRow
+import com.flashcardsopensourceapp.data.local.database.review.ReviewTagCardRow
 import com.flashcardsopensourceapp.data.local.database.review.activeReviewRecentPriorityWindowMillis
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.data.local.model.cards.DeckFilterDefinition
@@ -349,18 +349,27 @@ private fun isPreservablePresentedCard(
 }
 
 internal fun buildReviewTagFilterOptionsFromRows(
-    rows: List<ReviewTagCountRow>,
+    rows: List<ReviewTagCardRow>,
     storedTagNames: List<String>
 ): List<ReviewTagFilterOption> {
-    val countsByTagKey: Map<String, Int> = rows.associate { row ->
-        normalizeTagKey(tag = row.tag) to row.totalCount
+    val cardIdsByTagKey: Map<String, Set<String>> = rows.groupBy { row ->
+        normalizeTagKey(tag = row.tag)
+    }.mapValues { (_, tagRows) ->
+        tagRows.map(ReviewTagCardRow::cardId).toSet()
     }
-    return storedTagNames.distinctBy { tagName ->
+    return storedTagNames.groupBy { tagName ->
         normalizeTagKey(tag = tagName)
-    }.map { tagName ->
+    }.map { (tagKey, equivalentTagNames) ->
+        val canonicalTagName: String = equivalentTagNames.minWith(
+            compareBy<String> { tagName ->
+                tagName.lowercase()
+            }.thenBy { tagName ->
+                tagName
+            }
+        )
         ReviewTagFilterOption(
-            tag = tagName,
-            totalCount = countsByTagKey[normalizeTagKey(tag = tagName)] ?: 0
+            tag = canonicalTagName,
+            totalCount = cardIdsByTagKey[tagKey]?.size ?: 0
         )
     }.sortedWith(
         compareBy<ReviewTagFilterOption> { option ->

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupportTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupportTest.kt
@@ -1,0 +1,29 @@
+package com.flashcardsopensourceapp.data.local.repository.review
+
+import com.flashcardsopensourceapp.data.local.database.review.ReviewTagCardRow
+import com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReviewRepositorySupportTest {
+    @Test
+    fun tagFilterOptionsAggregateDistinctCardsAcrossEquivalentStoredNames() {
+        val rows = listOf(
+            ReviewTagCardRow(tag = "éCLAIR", cardId = "shared-card"),
+            ReviewTagCardRow(tag = "Éclair", cardId = "shared-card"),
+            ReviewTagCardRow(tag = "éCLAIR", cardId = "second-card"),
+            ReviewTagCardRow(tag = "Éclair", cardId = "third-card")
+        )
+
+        assertEquals(
+            listOf(
+                ReviewTagFilterOption(tag = "Future", totalCount = 0),
+                ReviewTagFilterOption(tag = "Éclair", totalCount = 3)
+            ),
+            buildReviewTagFilterOptionsFromRows(
+                rows = rows,
+                storedTagNames = listOf("éCLAIR", "Future", "Éclair")
+            )
+        )
+    }
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reconciliation/ReviewSubmissionReconciliation.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reconciliation/ReviewSubmissionReconciliation.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.review
 
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeTagKey
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewDeckFilterOption
@@ -300,29 +301,32 @@ private fun hasOwnedTagFilterOptionChange(
     nextOptions: List<ReviewTagFilterOption>,
     committedReviewedCards: List<ReviewCard>
 ): Boolean {
-    val previousOptionsByTag = previousOptions.associateBy { option ->
-        option.tag
+    val previousOptionsByTagKey = previousOptions.associateBy { option ->
+        normalizeTagKey(tag = option.tag)
     }
-    val nextOptionsByTag = nextOptions.associateBy { option ->
-        option.tag
+    val nextOptionsByTagKey = nextOptions.associateBy { option ->
+        normalizeTagKey(tag = option.tag)
     }
     if (
-        nextOptionsByTag.keys.any { tag ->
-            previousOptionsByTag.containsKey(tag).not()
+        nextOptionsByTagKey.keys.any { tagKey ->
+            previousOptionsByTagKey.containsKey(tagKey).not()
         }
     ) {
         return false
     }
-    val committedReviewTags = committedReviewedCards.flatMap { reviewedCard ->
-        reviewedCard.tags
+    val committedReviewTagKeysByCard: List<Set<String>> = committedReviewedCards.map { reviewedCard ->
+        reviewedCard.tags.map { tag ->
+            normalizeTagKey(tag = tag)
+        }.toSet()
     }
 
     return previousOptions.all { previousOption ->
-        val expectedDelta = committedReviewTags.count { tag ->
-            tag == previousOption.tag
+        val tagKey: String = normalizeTagKey(tag = previousOption.tag)
+        val expectedDelta: Int = committedReviewTagKeysByCard.count { committedReviewTagKeys ->
+            committedReviewTagKeys.contains(tagKey)
         }
         val expectedCount = previousOption.totalCount - expectedDelta
-        val nextOption = nextOptionsByTag[previousOption.tag]
+        val nextOption = nextOptionsByTagKey[tagKey]
         nextOption?.totalCount == maxOf(0, expectedCount)
     }
 }

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewFilterAndSessionGenerationTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewFilterAndSessionGenerationTest.kt
@@ -221,6 +221,66 @@ class ReviewFilterAndSessionGenerationTest {
     }
 
     @Test
+    fun ownedLocalReviewMatchesCommittedTagsByNormalizedKey() {
+        val submittedCard = makePinnedReviewCard(
+            cardId = "normalized-tag-card",
+            tags = listOf("éCLAIR", "Éclair"),
+            updatedAtMillis = 46L
+        )
+        val pendingReviewedCard = PendingReviewedCard(
+            cardId = submittedCard.cardId,
+            updatedAtMillis = submittedCard.updatedAtMillis
+        )
+        val previousSignature = createObservedReviewSessionSignature(
+            reviewCards = emptyList(),
+            presentedCard = null,
+            dueCount = 1,
+            remainingCount = 1,
+            totalCount = 1,
+            availableTagFilters = listOf(
+                ReviewTagFilterOption(tag = "Éclair", totalCount = 1)
+            )
+        )
+        val nextSignature = createObservedReviewSessionSignature(
+            reviewCards = emptyList(),
+            presentedCard = null,
+            dueCount = 0,
+            remainingCount = 0,
+            totalCount = 1,
+            availableTagFilters = listOf(
+                ReviewTagFilterOption(tag = "éCLAIR", totalCount = 0)
+            )
+        )
+        val state = makePinnedReviewDraftState(
+            requestedFilter = ReviewFilter.AllCards,
+            presentedCard = null,
+            reviewedInSessionCount = 0,
+            pendingReviewedCards = setOf(pendingReviewedCard),
+            optimisticPreparedCurrentCard = null,
+            errorMessage = ""
+        )
+        val ownedReviewSubmissions = mapOf(
+            pendingReviewedCard to makeOwnedReviewSubmission(
+                pendingReviewedCard = pendingReviewedCard,
+                reviewedCard = submittedCard,
+                presentedCard = null,
+                observationState = OwnedReviewSubmissionObservationState.COMMIT_PENDING_OBSERVATION
+            )
+        )
+
+        val suppression = requireNotNull(
+            findOwnedReviewSessionObservationSuppression(
+                previousSignature = previousSignature,
+                nextSignature = nextSignature,
+                state = state,
+                ownedReviewSubmissions = ownedReviewSubmissions
+            )
+        )
+
+        assertEquals(setOf(pendingReviewedCard), suppression.consumedPendingReviewedCards)
+    }
+
+    @Test
     fun localWritePendingMarkerDoesNotSuppressExternalDueDropWithUnchangedQueue() {
         val submittedCard = makePinnedReviewCard(
             cardId = "local-write-pending-card",


### PR DESCRIPTION
## Summary
- aggregate due review tag counts by normalized identity and distinct card ID
- select deterministic canonical stored display names
- reconcile committed review tags by normalized key
- add focused aggregation and reconciliation coverage

## Validation
- repository static checks passed
- fresh review gate: no P0-P4 issues found
- local Gradle and emulator runs intentionally not run per task constraint