### PR TITLE
Fix iOS review tag filter identities

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/Tags/TagSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Tags/TagSupport.swift
@@ -29,11 +29,42 @@ func resolveExactStoredTagNames(requestedTagNames: [String], storedTagNames: [St
         guard requestedTagKeySet.contains(normalizeTagKey(tag: storedTagName)) else {
             return
         }
-        guard result.contains(storedTagName) == false else {
+        guard result.contains(where: { resultTagName in
+            resultTagName.unicodeScalars.elementsEqual(storedTagName.unicodeScalars)
+        }) == false else {
             return
         }
 
         result.append(storedTagName)
+    }
+}
+
+private struct WorkspaceTagAccumulator {
+    let tag: String
+    var cardIds: Set<String>
+}
+
+func makeWorkspaceTagSummaries(storedCardTags: [StoredCardTag]) -> [WorkspaceTagSummary] {
+    let accumulators = storedCardTags.reduce(into: [String: WorkspaceTagAccumulator]()) { result, storedCardTag in
+        let tag = normalizeTag(rawValue: storedCardTag.tag)
+        let tagKey = normalizeTagKey(tag: tag)
+        guard tagKey.isEmpty == false else {
+            return
+        }
+
+        if var accumulator = result[tagKey] {
+            accumulator.cardIds.insert(storedCardTag.cardId)
+            result[tagKey] = accumulator
+        } else {
+            result[tagKey] = WorkspaceTagAccumulator(
+                tag: tag,
+                cardIds: [storedCardTag.cardId]
+            )
+        }
+    }
+
+    return accumulators.values.map { accumulator in
+        WorkspaceTagSummary(tag: accumulator.tag, cardsCount: accumulator.cardIds.count)
     }
 }
 
@@ -194,14 +225,12 @@ func makeWorkspaceTagsSummary(cards: [Card]) -> WorkspaceTagsSummary {
     let activeCards = cards.filter { card in
         card.deletedAt == nil
     }
-    let counts = activeCards.reduce(into: [String: Int]()) { result, card in
-        for tag in card.tags {
-            result[tag, default: 0] += 1
+    let storedCardTags = activeCards.flatMap { card in
+        card.tags.map { tag in
+            StoredCardTag(cardId: card.cardId, tag: tag)
         }
     }
-    let tags = counts.map { entry in
-        WorkspaceTagSummary(tag: entry.key, cardsCount: entry.value)
-    }.sorted { leftTag, rightTag in
+    let tags = makeWorkspaceTagSummaries(storedCardTags: storedCardTags).sorted { leftTag, rightTag in
         if leftTag.cardsCount != rightTag.cardsCount {
             return leftTag.cardsCount > rightTag.cardsCount
         }

--- a/apps/ios/Flashcards/Flashcards/Cards/Tags/TagTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Tags/TagTypes.swift
@@ -10,6 +10,11 @@ struct WorkspaceTagsSummary: Codable, Hashable, Sendable {
     let totalCards: Int
 }
 
+struct StoredCardTag: Hashable, Sendable {
+    let cardId: String
+    let tag: String
+}
+
 enum TagSuggestionCount: Hashable, Sendable {
     case loading
     case ready(cardsCount: Int)

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
@@ -490,7 +490,7 @@ extension CardStore {
     ) throws -> CardsListSnapshot {
         let storedTagNames: [String]
         if let filter, filter.tags.isEmpty == false {
-            storedTagNames = try self.loadWorkspaceTagsSummary(workspaceId: workspaceId).tags.map(\.tag)
+            storedTagNames = try self.loadStoredTagNames(workspaceId: workspaceId)
         } else {
             storedTagNames = []
         }
@@ -523,20 +523,27 @@ extension CardStore {
      screens without scanning all card rows in SwiftUI.
      */
     func loadWorkspaceTagsSummary(workspaceId: String) throws -> WorkspaceTagsSummary {
-        let tags = try self.core.query(
+        let storedCardTags = try self.core.query(
             sql: """
-            SELECT tag, COUNT(*) AS cards_count
+            SELECT card_id, tag
             FROM card_tags
             WHERE workspace_id = ?
-            GROUP BY tag
             ORDER BY tag COLLATE NOCASE ASC, tag ASC
             """,
             values: [.text(workspaceId)]
         ) { statement in
-            WorkspaceTagSummary(
-                tag: DatabaseCore.columnText(statement: statement, index: 0),
-                cardsCount: Int(DatabaseCore.columnInt64(statement: statement, index: 1))
+            StoredCardTag(
+                cardId: DatabaseCore.columnText(statement: statement, index: 0),
+                tag: DatabaseCore.columnText(statement: statement, index: 1)
             )
+        }
+        let tags = makeWorkspaceTagSummaries(storedCardTags: storedCardTags).sorted { leftTag, rightTag in
+            let comparison = leftTag.tag.localizedCaseInsensitiveCompare(rightTag.tag)
+            if comparison != .orderedSame {
+                return comparison == .orderedAscending
+            }
+
+            return leftTag.tag < rightTag.tag
         }
         let totalCards = try self.core.scalarInt(
             sql: """
@@ -548,6 +555,20 @@ extension CardStore {
         )
 
         return WorkspaceTagsSummary(tags: tags, totalCards: totalCards)
+    }
+
+    func loadStoredTagNames(workspaceId: String) throws -> [String] {
+        try self.core.query(
+            sql: """
+            SELECT DISTINCT tag
+            FROM card_tags
+            WHERE workspace_id = ?
+            ORDER BY tag COLLATE NOCASE ASC, tag ASC
+            """,
+            values: [.text(workspaceId)]
+        ) { statement in
+            DatabaseCore.columnText(statement: statement, index: 0)
+        }
     }
 
     /**

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Read.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 private func loadStoredTagNames(database: LocalDatabase, workspaceId: String) throws -> [String] {
-    try database.loadWorkspaceTagsSummary(workspaceId: workspaceId).tags.map(\.tag)
+    try database.cardStore.loadStoredTagNames(workspaceId: workspaceId)
 }
 
 extension LocalDatabase {

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/Query/ReviewQuerySupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/Query/ReviewQuerySupport.swift
@@ -411,8 +411,8 @@ func selectedReviewTagNames(
             return []
         }
 
-        return resolveReviewTagNamesPreservingUnmatched(
-            requestedTagNames: deck.filterDefinition.tags,
+        return selectedReviewDeckTagNames(
+            deckFilterTagNames: deck.filterDefinition.tags,
             storedTagNames: storedTagNames
         )
     case .tags(let tags):
@@ -421,6 +421,20 @@ func selectedReviewTagNames(
             storedTagNames: storedTagNames
         )
     }
+}
+
+func selectedReviewDeckTagNames(
+    deckFilterTagNames: [String],
+    storedTagNames: [String]
+) -> [String] {
+    if deckFilterTagNames.isEmpty {
+        return normalizedReviewTagNames(tags: storedTagNames)
+    }
+
+    return resolveReviewTagNamesPreservingUnmatched(
+        requestedTagNames: deckFilterTagNames,
+        storedTagNames: storedTagNames
+    )
 }
 
 func reviewFilterByTogglingTag(

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -78,8 +78,8 @@ struct ReviewView: View {
             selectedTags = self.reviewDeckSummaries.first(where: { deckSummary in
                 deckSummary.deckId == deckId
             }).map { deckSummary in
-                resolveExactStoredTagNames(
-                    requestedTagNames: deckSummary.filterDefinition.tags,
+                selectedReviewDeckTagNames(
+                    deckFilterTagNames: deckSummary.filterDefinition.tags,
                     storedTagNames: storedTagNames
                 )
             } ?? []
@@ -119,8 +119,8 @@ struct ReviewView: View {
                 deckSummary.deckId == deckId
             })?.filterDefinition.tags ?? []
             let deckTagFilter = makeReviewTagsFilter(
-                tags: resolveReviewTagNamesPreservingUnmatched(
-                    requestedTagNames: deckTags,
+                tags: selectedReviewDeckTagNames(
+                    deckFilterTagNames: deckTags,
                     storedTagNames: storedTagNames
                 )
             )

--- a/apps/ios/Flashcards/FlashcardsTests/Review/FSRS/FsrsReviewPresentationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/FSRS/FsrsReviewPresentationTests.swift
@@ -275,6 +275,78 @@ final class FsrsReviewPresentationTests: XCTestCase {
         )
     }
 
+    func testEmptyTagDeckPresetKeepsDeckSelectionUntilTagToggleThenRemovesTagFromMatchAll() {
+        let decks = [
+            FsrsSchedulerTestSupport.makeDeck(
+                deckId: "all-cards-preset",
+                name: "All cards preset",
+                filterDefinition: buildDeckFilterDefinition(tags: [])
+            )
+        ]
+        let storedTagNames = ["Chemistry", "Biology"]
+        let selectedFilter = ReviewFilter.deck(deckId: "all-cards-preset")
+
+        XCTAssertEqual(
+            resolveReviewFilter(
+                reviewFilter: selectedFilter,
+                decks: decks,
+                storedTagNames: storedTagNames
+            ),
+            selectedFilter
+        )
+        XCTAssertEqual(
+            selectedReviewTagNames(
+                reviewFilter: selectedFilter,
+                decks: decks,
+                storedTagNames: storedTagNames
+            ),
+            ["Biology", "Chemistry"]
+        )
+        XCTAssertEqual(
+            reviewFilterByTogglingTag(
+                reviewFilter: selectedFilter,
+                tag: "biology",
+                decks: decks,
+                storedTagNames: storedTagNames
+            ),
+            makeReviewTagsFilter(tags: ["Chemistry"])
+        )
+    }
+
+    func testReviewTagMenuUsesOneNormalizedIdentityAndDistinctCardCount() {
+        let decomposedTag = "E\u{301}clair"
+        let tagSummaries = makeWorkspaceTagSummaries(
+            storedCardTags: [
+                StoredCardTag(cardId: "card-1", tag: "Éclair"),
+                StoredCardTag(cardId: "card-1", tag: "éclair"),
+                StoredCardTag(cardId: "card-2", tag: decomposedTag)
+            ]
+        )
+        let tagSummary = tagSummaries[0]
+        let storedTagNames = tagSummaries.map(\.tag)
+
+        XCTAssertEqual(tagSummaries.count, 1)
+        XCTAssertEqual(tagSummary.cardsCount, 2)
+        XCTAssertEqual(normalizeTagKey(tag: tagSummary.tag), normalizeTagKey(tag: "éclair"))
+        XCTAssertEqual(
+            Set(selectedReviewTagNames(
+                reviewFilter: .allCards,
+                decks: [],
+                storedTagNames: storedTagNames
+            ).map(normalizeTagKey)),
+            Set([normalizeTagKey(tag: tagSummary.tag)])
+        )
+        XCTAssertEqual(
+            reviewFilterByTogglingTag(
+                reviewFilter: .allCards,
+                tag: tagSummary.tag,
+                decks: [],
+                storedTagNames: storedTagNames
+            ),
+            makeReviewTagsFilter(tags: [])
+        )
+    }
+
     func testDeckFilterTagMatchesUnicodeStoredTagByNormalizedKey() throws {
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
         let decks = [

--- a/apps/ios/Flashcards/FlashcardsTests/Review/SQLite/ReviewSQLiteOrderingTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/SQLite/ReviewSQLiteOrderingTests.swift
@@ -236,6 +236,7 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+        let decomposedTag = "E\u{301}clair"
 
         try self.insertCard(
             database: database,
@@ -261,6 +262,22 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
             createdAt: "2026-03-09T07:00:00.000Z",
             tags: ["plain"]
         )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "duplicate-identity-tag-card",
+            dueAt: nil,
+            createdAt: "2026-03-09T07:30:00.000Z",
+            tags: ["Éclair", "éclair"]
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "decomposed-tag-card",
+            dueAt: nil,
+            createdAt: "2026-03-09T07:45:00.000Z",
+            tags: [decomposedTag]
+        )
 
         let resolvedReviewQuery = try database.loadResolvedReviewQuery(
             workspaceId: workspace.workspaceId,
@@ -278,15 +295,37 @@ final class ReviewSQLiteOrderingTests: XCTestCase {
             reviewQueryDefinition: resolvedReviewQuery.queryDefinition,
             now: now
         )
+        let tagSummary = try database.loadWorkspaceTagsSummary(workspaceId: workspace.workspaceId)
+        let matchingTagSummaries = tagSummary.tags.filter { summary in
+            normalizeTagKey(tag: summary.tag) == normalizeTagKey(tag: "éclair")
+        }
 
-        XCTAssertEqual(resolvedReviewQuery.reviewFilter, .tag(tag: "Éclair"))
+        guard case .tags(let resolvedTagNames) = resolvedReviewQuery.reviewFilter else {
+            XCTFail("Expected resolved tag review filter")
+            return
+        }
+        XCTAssertEqual(resolvedTagNames.count, 1)
+        XCTAssertEqual(normalizeTagKey(tag: resolvedTagNames[0]), normalizeTagKey(tag: "éclair"))
         guard case .tag(let exactTagNames) = resolvedReviewQuery.queryDefinition else {
             XCTFail("Expected resolved direct tag query definition")
             return
         }
-        XCTAssertEqual(Set<String>(exactTagNames), Set<String>(["Éclair", "éclair"]))
-        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["lowercase-tag-card", "uppercase-tag-card"])
-        XCTAssertEqual(reviewCounts, ReviewCounts(dueCount: 2, totalCount: 2))
+        XCTAssertEqual(exactTagNames.count, 3)
+        XCTAssertTrue(exactTagNames.contains { tagName in
+            tagName.unicodeScalars.elementsEqual(decomposedTag.unicodeScalars)
+        })
+        XCTAssertEqual(
+            reviewHead.seedReviewQueue.map(\.cardId),
+            [
+                "duplicate-identity-tag-card",
+                "decomposed-tag-card",
+                "lowercase-tag-card",
+                "uppercase-tag-card"
+            ]
+        )
+        XCTAssertEqual(reviewCounts, ReviewCounts(dueCount: 4, totalCount: 4))
+        XCTAssertEqual(matchingTagSummaries.count, 1)
+        XCTAssertEqual(matchingTagSummaries.first?.cardsCount, 4)
     }
 
     func testSQLiteTagReviewFilterMatchesAnySelectedTagAndEmptySelectionMatchesNone() throws {


### PR DESCRIPTION
## Summary
- materialize empty-tag deck presets as all current tags for menu checks and toggles
- aggregate case and Unicode-equivalent stored tags into distinct-card menu identities
- preserve all raw stored spellings for complete SQLite filtering
- add focused preset, menu, database, and query coverage

## Validation
- repository pre-merge checks
- Swift parser for all changed Swift files
- diff and apps/ios-only scope checks
- fresh review gate: clean
- no simulator or Xcode build run (prohibited)