### PR TITLE
Fix Android Unicode tag identities

### DIFF
--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManagerTest.kt
@@ -122,13 +122,14 @@ class ReviewNotificationsManagerTest {
 
     @Test
     fun multiTagFilterDropsMissingTagsAndCanonicalizesEveryCurrentTagToAllCards() {
+        val decomposedTag = "E\u0301clair"
         val partialPlan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
-            selectedReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "missing")),
+            selectedReviewFilter = makeReviewTagFilter(tagNames = listOf(decomposedTag, "missing")),
             activeReviewTagNames = listOf("Éclair", "Plain"),
             selectedDeckFilterDefinition = null
         )
         val allTagsPlan: ReviewNotificationFilterPlan = resolveReviewNotificationFilterPlan(
-            selectedReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "Plain")),
+            selectedReviewFilter = makeReviewTagFilter(tagNames = listOf(decomposedTag, "Plain")),
             activeReviewTagNames = listOf("Éclair", "Plain"),
             selectedDeckFilterDefinition = null
         )
@@ -141,7 +142,7 @@ class ReviewNotificationsManagerTest {
         assertEquals(
             ReviewNotificationFilterPlan.Schedule(
                 queryReviewFilter = ReviewFilter.Tags(tags = listOf("Éclair")),
-                payloadReviewFilter = makeReviewTagFilter(tagNames = listOf("Éclair", "missing"))
+                payloadReviewFilter = makeReviewTagFilter(tagNames = listOf(decomposedTag, "missing"))
             ),
             partialPlan
         )

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewFilterContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewFilterContractTest.kt
@@ -10,6 +10,8 @@ import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption
+import com.flashcardsopensourceapp.data.local.model.review.makeReviewTagFilter
 import com.flashcardsopensourceapp.data.local.notifications.ScheduledReviewNotificationPayload
 import com.flashcardsopensourceapp.data.local.notifications.SharedPreferencesReviewNotificationsStore
 import com.flashcardsopensourceapp.data.local.notifications.decodePersistedReviewFilter
@@ -283,7 +285,10 @@ class LocalReviewFilterContractTest {
     @Test
     fun reviewPreferencesPersistMultiTagSelectionPerWorkspaceAndDecodeLegacyValues() {
         val store = SharedPreferencesReviewPreferencesStore(context = runtime.context)
-        val firstWorkspaceFilter = ReviewFilter.Tags(tags = listOf("Alpha", "Beta"))
+        val decomposedTag = "E\u0301clair"
+        val firstWorkspaceFilter = makeReviewTagFilter(
+            tagNames = listOf("Alpha", " Éclair ", decomposedTag)
+        )
         val secondWorkspaceFilter = ReviewFilter.Tags(tags = emptyList())
         val missingTagFilter = ReviewFilter.Tags(tags = listOf("Alpha", "missing"))
         store.saveSelectedReviewFilter(workspaceId = "workspace-a", reviewFilter = firstWorkspaceFilter)
@@ -299,6 +304,10 @@ class LocalReviewFilterContractTest {
                 .putString("selected-review-filter::legacy-tag", "{\"kind\":\"tag\",\"tag\":\"Legacy\"}")
                 .putString("selected-review-filter::legacy-deck", "{\"kind\":\"deck\",\"deckId\":\"deck-1\"}")
                 .putString("selected-review-filter::legacy-effort", "{\"kind\":\"effort\",\"effortLevel\":\"MEDIUM\"}")
+                .putString(
+                    "selected-review-filter::unicode-tags",
+                    "{\"kind\":\"tags\",\"tags\":[\" Éclair \",\"$decomposedTag\"]}"
+                )
                 .commit()
         ) {
             "Could not seed legacy review preferences."
@@ -319,13 +328,20 @@ class LocalReviewFilterContractTest {
             ReviewFilter.Tags(tags = listOf("medium")),
             store.loadSelectedReviewFilter(workspaceId = "legacy-effort")
         )
+        assertEquals(
+            makeReviewTagFilter(tagNames = listOf("Éclair", decomposedTag)),
+            store.loadSelectedReviewFilter(workspaceId = "unicode-tags")
+        )
     }
 
     @Test
     fun scheduledNotificationPayloadCodecPreservesMultiTagAndLegacySingleTagFilters() {
         runtime.context.deleteSharedPreferences("flashcards-review-notifications")
         val store = SharedPreferencesReviewNotificationsStore(context = runtime.context)
-        val selectedFilter = ReviewFilter.Tags(tags = listOf("Alpha", "Beta"))
+        val decomposedTag = "E\u0301clair"
+        val selectedFilter = makeReviewTagFilter(
+            tagNames = listOf("Alpha", "Éclair", decomposedTag)
+        )
         store.saveScheduledPayloads(
             payloads = listOf(
                 ScheduledReviewNotificationPayload(
@@ -367,14 +383,20 @@ class LocalReviewFilterContractTest {
     }
 
     @Test
-    fun reviewRepositoryMatchesUnicodeTagFilterInBoundedQueueAndCounts(): Unit = runBlocking {
+    fun reviewRepositoryMatchesCanonicalUnicodeTagIdentityInBoundedQueueAndCounts(): Unit = runBlocking {
         val nowMillis = 12 * 60 * 60 * 1_000L
         val workspaceId = bootstrapTestWorkspace(runtime = runtime, currentTimeMillis = nowMillis)
         val reviewRepository = createTestReviewRepository(runtime = runtime)
-        val unicodeTag = TagEntity(
-            tagId = "tag-eclair",
+        val decomposedTagName = "E\u0301clair"
+        val composedTag = TagEntity(
+            tagId = "tag-eclair-composed",
             workspaceId = workspaceId,
             name = "Éclair"
+        )
+        val decomposedTag = TagEntity(
+            tagId = "tag-eclair-decomposed",
+            workspaceId = workspaceId,
+            name = decomposedTagName
         )
         val plainTag = TagEntity(
             tagId = "tag-plain",
@@ -385,10 +407,16 @@ class LocalReviewFilterContractTest {
         database.cardDao().insertCards(
             listOf(
                 makeNewReviewOrderingCardEntity(
-                    cardId = "unicode-tag-card",
+                    cardId = "composed-tag-card",
                     workspaceId = workspaceId,
                     createdAtMillis = 200L,
                     updatedAtMillis = 200L
+                ),
+                makeNewReviewOrderingCardEntity(
+                    cardId = "decomposed-tag-card",
+                    workspaceId = workspaceId,
+                    createdAtMillis = 150L,
+                    updatedAtMillis = 150L
                 ),
                 makeNewReviewOrderingCardEntity(
                     cardId = "plain-tag-card",
@@ -398,22 +426,29 @@ class LocalReviewFilterContractTest {
                 )
             )
         )
-        database.tagDao().insertTags(tags = listOf(unicodeTag, plainTag))
+        database.tagDao().insertTags(tags = listOf(composedTag, decomposedTag, plainTag))
         database.tagDao().insertCardTags(
             cardTags = listOf(
-                CardTagEntity(cardId = "unicode-tag-card", tagId = unicodeTag.tagId),
+                CardTagEntity(cardId = "composed-tag-card", tagId = composedTag.tagId),
+                CardTagEntity(cardId = "composed-tag-card", tagId = decomposedTag.tagId),
+                CardTagEntity(cardId = "decomposed-tag-card", tagId = decomposedTag.tagId),
                 CardTagEntity(cardId = "plain-tag-card", tagId = plainTag.tagId)
             )
         )
 
         val sessionSnapshot = reviewRepository.observeReviewSession(
-            selectedFilter = ReviewFilter.Tags(tags = listOf("éclair")),
+            selectedFilter = makeReviewTagFilter(tagNames = listOf("éclair", decomposedTagName)),
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
+        ).first()
+        val allTagsSnapshot = reviewRepository.observeReviewSession(
+            selectedFilter = makeReviewTagFilter(tagNames = listOf("ÉCLAIR", decomposedTagName, "plain")),
             pendingReviewedCards = emptySet(),
             presentedCardId = null
         ).first()
         val boundedQueueCardIds = database.reviewQueueDao().observeNewReviewQueueByAnyTags(
             workspaceId = workspaceId,
-            tagNames = listOf("Éclair"),
+            tagNames = listOf("Éclair", decomposedTagName),
             limit = 8
         ).first().map { card ->
             card.card.cardId
@@ -421,25 +456,33 @@ class LocalReviewFilterContractTest {
         val dueCount = database.reviewCountDao().observeReviewDueCountByAnyTags(
             workspaceId = workspaceId,
             nowMillis = nowMillis,
-            tagNames = listOf("Éclair")
+            tagNames = listOf("Éclair", decomposedTagName)
         ).first()
         val totalCount = database.reviewCountDao().observeReviewTotalCountByAnyTags(
             workspaceId = workspaceId,
-            tagNames = listOf("Éclair")
+            tagNames = listOf("Éclair", decomposedTagName)
         ).first()
 
-        assertEquals(ReviewFilter.Tags(tags = listOf("Éclair")), sessionSnapshot.selectedFilter)
-        assertEquals(listOf("unicode-tag-card"), sessionSnapshot.cards.map { card -> card.cardId })
-        assertEquals("unicode-tag-card", sessionSnapshot.presentedCard?.cardId)
-        assertEquals(1, sessionSnapshot.dueCount)
-        assertEquals(1, sessionSnapshot.remainingCount)
-        assertEquals(1, sessionSnapshot.totalCount)
-        assertEquals(listOf("unicode-tag-card"), boundedQueueCardIds)
-        assertEquals(1, dueCount)
-        assertEquals(1, totalCount)
-        assertTrue(sessionSnapshot.availableTagFilters.any { tag ->
-            tag.tag == "Éclair" && tag.totalCount == 1
-        })
+        assertEquals(makeReviewTagFilter(tagNames = listOf(decomposedTagName)), sessionSnapshot.selectedFilter)
+        assertEquals(
+            listOf("decomposed-tag-card", "composed-tag-card"),
+            sessionSnapshot.cards.map { card -> card.cardId }
+        )
+        assertEquals("decomposed-tag-card", sessionSnapshot.presentedCard?.cardId)
+        assertEquals(2, sessionSnapshot.dueCount)
+        assertEquals(2, sessionSnapshot.remainingCount)
+        assertEquals(2, sessionSnapshot.totalCount)
+        assertEquals(listOf("decomposed-tag-card", "composed-tag-card"), boundedQueueCardIds)
+        assertEquals(2, dueCount)
+        assertEquals(2, totalCount)
+        assertEquals(ReviewFilter.AllCards, allTagsSnapshot.selectedFilter)
+        assertEquals(3, allTagsSnapshot.totalCount)
+        assertEquals(
+            listOf(ReviewTagFilterOption(tag = decomposedTagName, totalCount = 2)),
+            sessionSnapshot.availableTagFilters.filter { tag ->
+                tag.tag != "Plain"
+            }
+        )
     }
 
     @Test

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/FilterSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cards/FilterSupport.kt
@@ -1,5 +1,7 @@
 package com.flashcardsopensourceapp.data.local.model.cards
 
+import java.text.Normalizer
+import java.util.Locale
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -30,7 +32,9 @@ fun normalizeTag(rawValue: String): String {
 }
 
 fun normalizeTagKey(tag: String): String {
-    return normalizeTag(rawValue = tag).lowercase()
+    return Normalizer.normalize(tag, Normalizer.Form.NFC)
+        .lowercase(Locale.ROOT)
+        .trim()
 }
 
 fun canonicalTagValue(rawValue: String, referenceTags: List<String>): String? {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/review/ReviewSupport.kt
@@ -228,16 +228,31 @@ fun buildReviewTagFilterOptions(cards: List<CardSummary>, reviewedAtMillis: Long
     val dueCards = cards.filter { card ->
         isCardDue(card = card, nowMillis = reviewedAtMillis)
     }
-    val counts = dueCards.fold(emptyMap<String, Int>()) { result, card ->
-        card.tags.fold(result) { tagResult, tag ->
-            tagResult + (tag to ((tagResult[tag] ?: 0) + 1))
+    val cardIdsByTagKey: Map<String, Set<String>> = dueCards
+        .flatMap { card ->
+            card.tags.map { tag ->
+                normalizeTagKey(tag = tag) to card.cardId
+            }
         }
-    }
+        .groupBy(
+            keySelector = { (tagKey, _) -> tagKey },
+            valueTransform = { (_, cardId) -> cardId }
+        )
+        .mapValues { (_, cardIds) ->
+            cardIds.toSet()
+        }
+    val tagNamesByKey: Map<String, List<String>> = dueCards
+        .flatMap(CardSummary::tags)
+        .groupBy { tag ->
+            normalizeTagKey(tag = tag)
+        }
 
-    return counts.entries.map { entry ->
+    return tagNamesByKey.map { (tagKey, equivalentTagNames) ->
+        val canonicalTagName: String = equivalentTagNames.minOrNull()
+            ?: error("Review tag identity group cannot be empty.")
         ReviewTagFilterOption(
-            tag = entry.key,
-            totalCount = entry.value
+            tag = canonicalTagName,
+            totalCount = cardIdsByTagKey[tagKey]?.size ?: 0
         )
     }.sortedWith(
         compareBy<ReviewTagFilterOption> { option ->

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStoreTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStoreTest.kt
@@ -344,9 +344,13 @@ class ReviewNotificationsStoreTest {
 
     @Test
     fun multiTagReviewFilterNormalizesDeduplicatesAndOrdersTags() {
+        val decomposedTag = "E\u0301clair"
+
         assertEquals(
-            ReviewFilter.Tags(tags = listOf("Biology", "science")),
-            makeReviewTagFilter(tagNames = listOf(" science ", "biology", "Biology"))
+            ReviewFilter.Tags(tags = listOf("Biology", "science", decomposedTag)),
+            makeReviewTagFilter(
+                tagNames = listOf(" science ", "biology", "Biology", " Éclair ", decomposedTag)
+            )
         )
     }
 

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupportTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupportTest.kt
@@ -8,21 +8,23 @@ import org.junit.Test
 class ReviewRepositorySupportTest {
     @Test
     fun tagFilterOptionsAggregateDistinctCardsAcrossEquivalentStoredNames() {
+        val decomposedTag = "E\u0301clair"
         val rows = listOf(
             ReviewTagCardRow(tag = "éCLAIR", cardId = "shared-card"),
             ReviewTagCardRow(tag = "Éclair", cardId = "shared-card"),
+            ReviewTagCardRow(tag = decomposedTag, cardId = "shared-card"),
             ReviewTagCardRow(tag = "éCLAIR", cardId = "second-card"),
-            ReviewTagCardRow(tag = "Éclair", cardId = "third-card")
+            ReviewTagCardRow(tag = decomposedTag, cardId = "third-card")
         )
 
         assertEquals(
             listOf(
                 ReviewTagFilterOption(tag = "Future", totalCount = 0),
-                ReviewTagFilterOption(tag = "Éclair", totalCount = 3)
+                ReviewTagFilterOption(tag = decomposedTag, totalCount = 3)
             ),
             buildReviewTagFilterOptionsFromRows(
                 rows = rows,
-                storedTagNames = listOf("éCLAIR", "Future", "Éclair")
+                storedTagNames = listOf("éCLAIR", "Future", "Éclair", decomposedTag)
             )
         )
     }

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewFilterAndSessionGenerationTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewFilterAndSessionGenerationTest.kt
@@ -222,9 +222,10 @@ class ReviewFilterAndSessionGenerationTest {
 
     @Test
     fun ownedLocalReviewMatchesCommittedTagsByNormalizedKey() {
+        val decomposedTag = "E\u0301clair"
         val submittedCard = makePinnedReviewCard(
             cardId = "normalized-tag-card",
-            tags = listOf("éCLAIR", "Éclair"),
+            tags = listOf("Éclair", decomposedTag),
             updatedAtMillis = 46L
         )
         val pendingReviewedCard = PendingReviewedCard(
@@ -248,7 +249,7 @@ class ReviewFilterAndSessionGenerationTest {
             remainingCount = 0,
             totalCount = 1,
             availableTagFilters = listOf(
-                ReviewTagFilterOption(tag = "éCLAIR", totalCount = 0)
+                ReviewTagFilterOption(tag = decomposedTag, totalCount = 0)
             )
         )
         val state = makePinnedReviewDraftState(


### PR DESCRIPTION
## Summary
- normalize Android tag identity keys to canonical NFC before locale-stable case folding and trimming
- aggregate equivalent tag options by identity and count distinct cards
- cover composed/decomposed variants across review queries, persistence, notifications, reconciliation, and All Cards canonicalization

## Validation
- repository static checks passed
- diff and Android-only scope checks passed
- mandatory fresh review gate found no P0-P4 issues
- Gradle and emulator were not run, as required