### PR TITLE
Fix web review tag filter restoration

### DIFF
--- a/apps/web/src/appData/domain/index.test.ts
+++ b/apps/web/src/appData/domain/index.test.ts
@@ -14,6 +14,7 @@ import {
   matchesCardFilter,
   matchesDeckFilterDefinition,
   makeTagsReviewFilter,
+  normalizeTag,
   normalizeReviewFilterTags,
   normalizeTagKey,
   recentDuePriorityWindow,
@@ -282,12 +283,15 @@ describe("review order domain", () => {
 });
 
 describe("review tag matching domain", () => {
-  it("normalizes tag keys by trimming and lowercasing Unicode text", () => {
+  it("canonically normalizes tag text before trimming and lowercasing identity keys", () => {
+    expect(normalizeTag(" E\u0301clair ")).toBe("Éclair");
     expect(normalizeTagKey(" Éclair ")).toBe("éclair");
+    expect(normalizeTagKey(" E\u0301CLAIR ")).toBe("éclair");
   });
 
   it("normalizes, deduplicates, and deterministically orders explicit review tags", () => {
-    expect(normalizeReviewFilterTags([" verbs ", "Grammar", "grammar", ""])).toEqual([
+    expect(normalizeReviewFilterTags([" verbs ", "Grammar", "grammar", " E\u0301clair ", "Éclair", ""])).toEqual([
+      "Éclair",
       "Grammar",
       "verbs",
     ]);

--- a/apps/web/src/appData/domain/index.ts
+++ b/apps/web/src/appData/domain/index.ts
@@ -135,17 +135,21 @@ export function isReviewFilterEqual(left: ReviewFilter, right: ReviewFilter): bo
   return false;
 }
 
+export function normalizeTag(tag: string): string {
+  return tag.normalize("NFC").trim();
+}
+
 export function normalizeTagKey(tag: string): string {
-  return tag.trim().toLowerCase();
+  return normalizeTag(tag).toLowerCase();
 }
 
 export function normalizeReviewFilterTags(tags: ReadonlyArray<string>): ReadonlyArray<string> {
   const tagsByKey = new Map<string, string>();
   for (const tag of tags) {
-    const trimmedTag = tag.trim();
-    const tagKey = normalizeTagKey(trimmedTag);
+    const normalizedTag = normalizeTag(tag);
+    const tagKey = normalizeTagKey(normalizedTag);
     if (tagKey !== "" && tagsByKey.has(tagKey) === false) {
-      tagsByKey.set(tagKey, trimmedTag);
+      tagsByKey.set(tagKey, normalizedTag);
     }
   }
 
@@ -220,7 +224,7 @@ export function makeWorkspaceTagsSummary(cards: ReadonlyArray<Card>): WorkspaceT
       const currentTagStats = result.get(tagKey);
       if (currentTagStats === undefined) {
         result.set(tagKey, {
-          tag: tag.trim(),
+          tag: normalizeTag(tag),
           cardIds: new Set([card.cardId]),
         });
       } else {
@@ -257,7 +261,7 @@ function resolveActiveTags(tags: ReadonlyArray<string>, cards: ReadonlyArray<Car
     for (const tag of card.tags) {
       const tagKey = normalizeTagKey(tag);
       if (tagKey !== "" && canonicalTagsByKey.has(tagKey) === false) {
-        canonicalTagsByKey.set(tagKey, tag.trim());
+        canonicalTagsByKey.set(tagKey, normalizeTag(tag));
       }
     }
   }
@@ -590,7 +594,7 @@ export function normalizeRequiredDeckName(value: string): string {
 
 function normalizeDeckFilterDefinition(filterDefinition: DeckFilterDefinition): DeckFilterDefinition {
   const normalizedTags = filterDefinition.tags.reduce<Array<string>>((result, tag) => {
-    const normalizedTag = tag.trim();
+    const normalizedTag = normalizeTag(tag);
     const normalizedTagKey = normalizeTagKey(normalizedTag);
     if (normalizedTag === "" || result.some((existingTag) => normalizeTagKey(existingTag) === normalizedTagKey)) {
       return result;

--- a/apps/web/src/appData/session/useWorkspaceSession.reviewFilterPersistence.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.reviewFilterPersistence.test.tsx
@@ -65,6 +65,13 @@ describe("workspace review filter persistence", () => {
       kind: "deck",
       deckId: "deck-1",
     });
+    expect(parsePersistedReviewFilter(JSON.stringify({
+      kind: "tags",
+      tags: [" E\u0301clair ", "Éclair"],
+    }))).toEqual({
+      kind: "tags",
+      tags: ["Éclair"],
+    });
   });
 
   it("migrates the legacy global selection into only the first activated workspace", () => {
@@ -96,6 +103,21 @@ describe("workspace review filter persistence", () => {
     expect(loadSelectedReviewFilterForWorkspace("workspace-2")).toEqual({
       kind: "deck",
       deckId: "deck-2",
+    });
+  });
+
+  it("stores canonically normalized tag selections while keeping legacy values readable", () => {
+    storeSelectedReviewFilterForWorkspace("workspace-1", {
+      kind: "tags",
+      tags: [" E\u0301clair ", "Éclair"],
+    });
+
+    expect(window.localStorage.getItem(buildSelectedReviewFilterStorageKey("workspace-1"))).toBe(
+      JSON.stringify({ kind: "tags", tags: ["Éclair"] }),
+    );
+    expect(loadSelectedReviewFilterForWorkspace("workspace-1")).toEqual({
+      kind: "tags",
+      tags: ["Éclair"],
     });
   });
 

--- a/apps/web/src/localDb/cards/tags/index.ts
+++ b/apps/web/src/localDb/cards/tags/index.ts
@@ -1,5 +1,5 @@
 import type { Card } from "../../../types";
-import { normalizeTagKey } from "../../../appData/domain";
+import { normalizeTag, normalizeTagKey } from "../../../appData/domain";
 import { describeIndexedDbError } from "../../core/database";
 
 export type CardTagRecord = Readonly<{
@@ -195,7 +195,7 @@ export async function loadReviewTagFilterLookupForTags(
 
     allowedCardIds.add(record.cardId);
     if (canonicalTagsByKey.has(tagKey) === false) {
-      canonicalTagsByKey.set(tagKey, record.tag.trim());
+      canonicalTagsByKey.set(tagKey, normalizeTag(record.tag));
     }
 
     return true;
@@ -231,7 +231,7 @@ export async function loadAllowedCardIdsForTag(
     }
 
     allowedCardIds.add(record.cardId);
-    canonicalTag = canonicalTag ?? record.tag.trim();
+    canonicalTag = canonicalTag ?? normalizeTag(record.tag);
     return true;
   });
 

--- a/apps/web/src/localDb/cards/workspace/index.ts
+++ b/apps/web/src/localDb/cards/workspace/index.ts
@@ -19,7 +19,7 @@ import { putDeckInTransaction } from "../decks";
 import { loadProgressCacheState, markProgressCacheDirtyInTransaction } from "../../progress/progress";
 import { putReviewEventInTransaction } from "../../reviews/reviews";
 import { putMediaAssetInTransaction } from "../../mediaAssets";
-import { normalizeTagKey } from "../../../appData/domain";
+import { normalizeTag, normalizeTagKey } from "../../../appData/domain";
 
 type HotSyncStateUpdate = Readonly<{
   lastAppliedHotChangeId: number;
@@ -163,7 +163,7 @@ export async function loadWorkspaceTagsSummary(workspaceId: string): Promise<Wor
       const currentTagStats = tagStatsByKey.get(tagKey);
       if (currentTagStats === undefined) {
         tagStatsByKey.set(tagKey, {
-          tag: record.tag.trim(),
+          tag: normalizeTag(record.tag),
           cardIds: new Set([record.cardId]),
         });
       } else {

--- a/apps/web/src/localDb/reviews/reviews.test.ts
+++ b/apps/web/src/localDb/reviews/reviews.test.ts
@@ -97,7 +97,7 @@ describe("localDb reviews", () => {
       }
     });
 
-    it("matches local review tag and deck filters by normalized Unicode tag keys", async () => {
+    it("aggregates and matches canonically equivalent Unicode tags with deterministic display text", async () => {
       const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
       const originalNow = Date.now;
       Date.now = () => nowTimestamp;
@@ -107,7 +107,7 @@ describe("localDb reviews", () => {
           cardId: "unicode-tag-card",
           frontText: "Unicode tag",
           backText: "back",
-          tags: ["Éclair"],
+          tags: ["E\u0301clair"],
           dueAt: "2026-03-10T11:00:00.000Z",
           createdAt: "2026-03-10T09:00:00.000Z",
         });
@@ -119,31 +119,57 @@ describe("localDb reviews", () => {
           dueAt: "2026-03-10T11:05:00.000Z",
           createdAt: "2026-03-10T09:05:00.000Z",
         });
+        const equivalentUnicodeTagCard = makeCard({
+          cardId: "equivalent-unicode-tag-card",
+          frontText: "Equivalent Unicode tag",
+          backText: "back",
+          tags: ["Éclair"],
+          dueAt: "2026-03-10T11:02:00.000Z",
+          createdAt: "2026-03-10T09:02:00.000Z",
+        });
         const unicodeDeck = makeDeck({
           deckId: "deck-unicode-tag",
           name: "Unicode tag",
-          tags: ["éclair"],
+          tags: ["e\u0301clair"],
           createdAt: "2026-03-10T08:00:00.000Z",
         });
 
         await replaceDecks(workspaceId, [unicodeDeck]);
-        await replaceCards(workspaceId, [unicodeTagCard, otherCard]);
+        await replaceCards(workspaceId, [unicodeTagCard, equivalentUnicodeTagCard, otherCard]);
 
-        const tagQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "tags", tags: ["éclair"] }, 10);
+        const persistedFilter = parsePersistedReviewFilter(JSON.stringify({
+          kind: "tags",
+          tags: [" E\u0301CLAIR "],
+        }));
+        const tagQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, persistedFilter, 10);
         const deckQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "deck", deckId: unicodeDeck.deckId }, 10);
-        const tagTimelinePage = await loadReviewTimelinePage(workspaceId, { kind: "tags", tags: ["éclair"] }, 10, 0);
+        const tagTimelinePage = await loadReviewTimelinePage(workspaceId, persistedFilter, 10, 0);
+        const tagsSummary = await loadWorkspaceTagsSummary(workspaceId);
 
         expect(tagQueueSnapshot.resolvedReviewFilter).toEqual({
           kind: "tags",
           tags: ["Éclair"],
         });
-        expect(tagQueueSnapshot.cards.map((card) => card.cardId)).toEqual(["unicode-tag-card"]);
+        expect(tagQueueSnapshot.cards.map((card) => card.cardId)).toEqual([
+          "unicode-tag-card",
+          "equivalent-unicode-tag-card",
+        ]);
         expect(tagQueueSnapshot.reviewCounts).toEqual({
-          dueCount: 1,
-          totalCount: 1,
+          dueCount: 2,
+          totalCount: 2,
         });
-        expect(deckQueueSnapshot.cards.map((card) => card.cardId)).toEqual(["unicode-tag-card"]);
-        expect(tagTimelinePage.cards.map((card) => card.cardId)).toEqual(["unicode-tag-card"]);
+        expect(deckQueueSnapshot.cards.map((card) => card.cardId)).toEqual([
+          "unicode-tag-card",
+          "equivalent-unicode-tag-card",
+        ]);
+        expect(tagTimelinePage.cards.map((card) => card.cardId)).toEqual([
+          "unicode-tag-card",
+          "equivalent-unicode-tag-card",
+        ]);
+        expect(tagsSummary.tags).toEqual([
+          { tag: "Éclair", cardsCount: 2 },
+          { tag: "code", cardsCount: 1 },
+        ]);
       } finally {
         Date.now = originalNow;
       }
@@ -247,6 +273,10 @@ describe("localDb reviews", () => {
         "verbs-card",
         "untagged-card",
       ]);
+      const promotedPersistedFilter = parsePersistedReviewFilter(
+        JSON.stringify(restoredAllTagsSnapshot.resolvedReviewFilter),
+      );
+      expect(promotedPersistedFilter).toEqual({ kind: "allCards" });
 
       const codeCard = makeCard({
         cardId: "code-card",
@@ -258,13 +288,19 @@ describe("localDb reviews", () => {
       });
       await replaceCards(workspaceId, [grammarCard, verbsCard, untaggedCard, codeCard]);
 
-      const expandedTagSetSnapshot = await loadReviewQueueSnapshot(workspaceId, persistedFilter, 10);
+      const expandedTagSetSnapshot = await loadReviewQueueSnapshot(
+        workspaceId,
+        promotedPersistedFilter,
+        10,
+      );
 
-      expect(expandedTagSetSnapshot.resolvedReviewFilter).toEqual({
-        kind: "tags",
-        tags: ["Grammar", "verbs"],
-      });
-      expect(expandedTagSetSnapshot.cards.map((card) => card.cardId)).toEqual(["grammar-card", "verbs-card"]);
+      expect(expandedTagSetSnapshot.resolvedReviewFilter).toEqual({ kind: "allCards" });
+      expect(expandedTagSetSnapshot.cards.map((card) => card.cardId)).toEqual([
+        "grammar-card",
+        "verbs-card",
+        "untagged-card",
+        "code-card",
+      ]);
 
       await replaceCards(workspaceId, [grammarCard, untaggedCard]);
 

--- a/apps/web/src/screens/review/data/useReviewScreenData.ts
+++ b/apps/web/src/screens/review/data/useReviewScreenData.ts
@@ -59,6 +59,7 @@ type UseReviewScreenDataParams = Readonly<{
   installationId: string | null;
   isSyncing: boolean;
   localReadVersion: number;
+  selectReviewFilter: (reviewFilter: ReviewFilter) => void;
   selectedReviewFilter: ReviewFilter;
   setErrorMessage: (message: string) => void;
   submitReviewItem: (cardId: string, rating: 0 | 1 | 2 | 3) => Promise<Card>;
@@ -66,6 +67,11 @@ type UseReviewScreenDataParams = Readonly<{
 }>;
 
 type LocalHotStateStatus = "loading" | "hydrated" | "unhydrated";
+
+type CarriedReviewDataContext = Readonly<{
+  contextKey: string;
+  localReadVersion: number;
+}>;
 
 export type ReviewSubmissionOutcome = "saved" | "failed" | "stale";
 
@@ -105,6 +111,7 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     installationId,
     isSyncing,
     localReadVersion,
+    selectReviewFilter,
     selectedReviewFilter,
     setErrorMessage,
     submitReviewItem,
@@ -143,6 +150,7 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const reviewDataContextKey = buildReviewDataContextKey(activeWorkspaceId, selectedReviewFilterKey);
   const reviewDataContextKeyRef = useRef<string>(reviewDataContextKey);
   const loadedReviewDataContextKeyRef = useRef<string | null>(null);
+  const carriedReviewDataContextRef = useRef<CarriedReviewDataContext | null>(null);
   const observationIdentityRef = useRef<Readonly<{
     userId: string | null;
     installationId: string | null;
@@ -257,6 +265,16 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   }
 
   useEffect(() => {
+    const carriedReviewDataContext = carriedReviewDataContextRef.current;
+    if (
+      carriedReviewDataContext?.contextKey === reviewDataContextKey
+      && carriedReviewDataContext.localReadVersion === localReadVersion
+    ) {
+      carriedReviewDataContextRef.current = null;
+      return;
+    }
+    carriedReviewDataContextRef.current = null;
+
     let isCancelled = false;
     const shouldShowBlockingLoader = loadedReviewDataContextKeyRef.current !== reviewDataContextKey;
 
@@ -295,6 +313,17 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           pendingReviewSnapshotsBeforePresentation,
         );
         const nextResolvedReviewFilter = reviewQueueSnapshot.resolvedReviewFilter;
+        const shouldPromoteResolvedReviewFilter = selectedReviewFilter.kind === "tags"
+          && selectedReviewFilter.tags.length > 0
+          && nextResolvedReviewFilter.kind === "allCards";
+        const loadedSelectedReviewFilter = shouldPromoteResolvedReviewFilter
+          ? nextResolvedReviewFilter
+          : selectedReviewFilter;
+        const loadedSelectedReviewFilterKey = serializeReviewFilterKey(loadedSelectedReviewFilter);
+        const loadedReviewDataContextKey = buildReviewDataContextKey(
+          activeWorkspaceId,
+          loadedSelectedReviewFilterKey,
+        );
         const nextSelectedReviewFilterTitle = resolveReviewFilterTitle(
           nextResolvedReviewFilter,
           decksSnapshot.deckSummaries,
@@ -343,7 +372,7 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
         const nextActiveReviewQueue = buildDisplayedReviewQueue(nextCanonicalReviewQueue, nextPresentedCard);
         const nextQueueCards = buildDisplayedReviewTimeline(nextReviewTimelineCards, nextActiveReviewQueue);
         applyFreshReviewSessionSignature(buildReviewSessionSignature(
-          selectedReviewFilterKey,
+          loadedSelectedReviewFilterKey,
           nextActiveReviewQueue,
           nextQueueCards,
         ));
@@ -359,14 +388,14 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
         setLocalWorkspaceCardCount(tagsSummary.totalCards);
         setLocalHotStateStatus(isHotStateHydrated ? "hydrated" : "unhydrated");
         loadedWorkspaceIdRef.current = activeWorkspaceId;
-        loadedReviewDataContextKeyRef.current = reviewDataContextKey;
-        setLoadedReviewDataContextKey(reviewDataContextKey);
+        loadedReviewDataContextKeyRef.current = loadedReviewDataContextKey;
+        setLoadedReviewDataContextKey(loadedReviewDataContextKey);
         setTagSuggestions(toTagSuggestions(tagsSummary.tags));
         setDeckSummariesState(decksSnapshot.deckSummaries);
         writeReviewLoadingSnapshot({
           version: 1,
           workspaceId: activeWorkspaceId,
-          selectedReviewFilterKey: serializeReviewFilterKey(selectedReviewFilter),
+          selectedReviewFilterKey: loadedSelectedReviewFilterKey,
           resolvedReviewFilterTitle: nextSelectedReviewFilterTitle,
           reviewCounts: reviewQueueSnapshot.reviewCounts,
           currentCard: nextActiveReviewQueue[0] === undefined ? null : buildReviewLoadingCardPreview(nextActiveReviewQueue[0]),
@@ -376,6 +405,13 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           savedAt: new Date().toISOString(),
         });
         setHasLoadedReviewData(true);
+        if (shouldPromoteResolvedReviewFilter) {
+          carriedReviewDataContextRef.current = {
+            contextKey: loadedReviewDataContextKey,
+            localReadVersion,
+          };
+          selectReviewFilter(nextResolvedReviewFilter);
+        }
       } catch (error) {
         if (isCancelled) {
           return;
@@ -405,7 +441,7 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspaceId, getCardById, localReadVersion, reviewDataContextKey, selectedReviewFilter]);
+  }, [activeWorkspaceId, getCardById, localReadVersion, reviewDataContextKey, selectReviewFilter, selectedReviewFilter]);
 
   async function handleReview(card: Card, rating: 0 | 1 | 2 | 3): Promise<ReviewSubmissionOutcome> {
     if (loadedReviewDataContextKeyRef.current !== reviewDataContextKeyRef.current) {

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -144,6 +144,30 @@ export type ReviewQueueChunkResult = Readonly<{
   nextCursor: string | null;
 }>;
 
+export function createStorageMock(): Storage {
+  const state = new Map<string, string>();
+  return {
+    get length(): number {
+      return state.size;
+    },
+    clear(): void {
+      state.clear();
+    },
+    getItem(key: string): string | null {
+      return state.get(key) ?? null;
+    },
+    key(index: number): string | null {
+      return [...state.keys()][index] ?? null;
+    },
+    removeItem(key: string): void {
+      state.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      state.set(key, value);
+    },
+  };
+}
+
 type ReviewScreenDataHarnessProps = Readonly<{
   onResult: (result: UseReviewScreenDataResult) => void;
   state: ReviewScreenTestState;
@@ -180,6 +204,7 @@ function ReviewScreenDataHarnessContent(props: ReviewScreenDataHarnessProps): Re
     installationId: state.appData.cloudSettings?.installationId ?? null,
     isSyncing: state.appData.isSyncing,
     localReadVersion: state.appData.localReadVersion,
+    selectReviewFilter: state.appData.selectReviewFilter,
     selectedReviewFilter: state.appData.selectedReviewFilter,
     setErrorMessage: state.appData.setErrorMessage,
     submitReviewItem: state.appData.submitReviewItem,

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -1,13 +1,23 @@
 // @vitest-environment jsdom
+import { useCallback, useEffect, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
+import {
+  buildSelectedReviewFilterStorageKey,
+  loadSelectedReviewFilterForWorkspace,
+  storeSelectedReviewFilterForWorkspace,
+} from "../../../appData/context/reviewFilterPersistence";
+import type { ReviewFilter, ReviewQueueSnapshot } from "../../../types";
 import {
   clickElementAsync,
   createCard,
+  createDeferredPromise,
   createDecks,
+  createStorageMock,
   loadReviewQueueSnapshotMock,
   reviewStylesContain,
   setTextFieldValueAsync,
   setupReviewScreenTest,
+  useAppDataMock,
 } from "../testSupport/ReviewScreenTestSupport";
 import {
   composingKeydownElementAsync,
@@ -593,6 +603,117 @@ describe("ReviewScreen filter controls", () => {
       expect(trigger.textContent).toContain("1 tag");
       expect(trigger.textContent).not.toContain("2 tags");
     });
+  });
+
+  it("carries a restored exact-all snapshot through the stateful persisted All Cards promotion", async () => {
+    const state = getState();
+    const workspaceId = "workspace-1";
+    state.cards = [
+      createCard({ cardId: "grammar-card", tags: ["grammar"] }),
+      createCard({ cardId: "verbs-card", tags: ["verbs"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: ["grammar", "verbs"],
+    };
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+    storeSelectedReviewFilterForWorkspace(workspaceId, state.appData.selectedReviewFilter);
+    const promotedSelections = vi.fn<(reviewFilter: ReviewFilter) => void>();
+    useAppDataMock.mockImplementation(() => {
+      const [selectedReviewFilter, setSelectedReviewFilter] = useState<ReviewFilter>(
+        () => loadSelectedReviewFilterForWorkspace(workspaceId),
+      );
+      useEffect(() => {
+        storeSelectedReviewFilterForWorkspace(workspaceId, selectedReviewFilter);
+      }, [selectedReviewFilter]);
+      const selectReviewFilter = useCallback((reviewFilter: ReviewFilter): void => {
+        promotedSelections(reviewFilter);
+        setSelectedReviewFilter(reviewFilter);
+      }, []);
+
+      return {
+        ...state.appData,
+        selectedReviewFilter,
+        selectReviewFilter,
+      };
+    });
+    const unexpectedSecondLoad = createDeferredPromise<ReviewQueueSnapshot>();
+    loadReviewQueueSnapshotMock.mockResolvedValueOnce({
+      resolvedReviewFilter: { kind: "allCards" },
+      cards: state.reviewQueue,
+      nextCursor: null,
+      reviewCounts: {
+        dueCount: state.reviewQueue.length,
+        totalCount: state.reviewQueue.length,
+      },
+    });
+    loadReviewQueueSnapshotMock.mockImplementation(() => unexpectedSecondLoad.promise);
+
+    await renderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(promotedSelections).toHaveBeenCalledTimes(1);
+      expect(promotedSelections).toHaveBeenCalledWith({ kind: "allCards" });
+      expect(loadSelectedReviewFilterForWorkspace(workspaceId)).toEqual({ kind: "allCards" });
+    });
+
+    await openReviewFilterMenu();
+
+    const allCardsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
+    const grammarOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    const verbsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
+    const trigger = getContainer().querySelector("[data-testid='review-filter-trigger']");
+    const reviewPane = getContainer().querySelector("[data-testid='review-pane']");
+    if (
+      !(allCardsOption instanceof HTMLElement)
+      || !(grammarOption instanceof HTMLElement)
+      || !(verbsOption instanceof HTMLElement)
+      || !(trigger instanceof HTMLButtonElement)
+      || !(reviewPane instanceof HTMLElement)
+    ) {
+      throw new Error("Promoted All Cards filter controls were not found");
+    }
+
+    expect(trigger.textContent).toContain("All cards");
+    expect(allCardsOption.getAttribute("aria-selected")).toBe("true");
+    expect(grammarOption.getAttribute("aria-selected")).toBe("true");
+    expect(verbsOption.getAttribute("aria-selected")).toBe("true");
+    expect(reviewPane.dataset.reviewPaneState).toBe("card");
+    expect(loadReviewQueueSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(buildSelectedReviewFilterStorageKey(workspaceId))).toBe(
+      JSON.stringify({ kind: "allCards" }),
+    );
+  });
+
+  it.each([
+    ["explicit empty", { kind: "tags", tags: [] }, { kind: "tags", tags: [] }],
+    ["missing tag", { kind: "tags", tags: ["grammar", "missing"] }, { kind: "tags", tags: ["grammar"] }],
+    ["subset", { kind: "tags", tags: ["grammar"] }, { kind: "tags", tags: ["grammar"] }],
+  ] as const)("does not promote a %s tag selection", async (_scenario, selectedReviewFilter, resolvedReviewFilter) => {
+    const state = getState();
+    const card = createCard({ cardId: "grammar-card", tags: ["grammar"] });
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+    state.appData.selectedReviewFilter = selectedReviewFilter;
+    loadReviewQueueSnapshotMock.mockResolvedValue({
+      resolvedReviewFilter,
+      cards: resolvedReviewFilter.tags.length === 0 ? [] : [card],
+      nextCursor: null,
+      reviewCounts: {
+        dueCount: resolvedReviewFilter.tags.length === 0 ? 0 : 1,
+        totalCount: resolvedReviewFilter.tags.length === 0 ? 0 : 1,
+      },
+    });
+
+    await renderReviewScreen();
+
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
   });
 
   it("materializes deck tags and canonicalizes a complete custom selection to All Cards", async () => {

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.loading.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.loading.test.tsx
@@ -2,12 +2,18 @@
 import { act } from "react";
 import { describe, expect, it } from "vitest";
 import { ApiError } from "../../../api";
+import { parsePersistedReviewFilter } from "../../../appData/context/reviewFilterPersistence";
 import type { ReviewQueueSnapshot } from "../../../types";
-import { buildReviewLoadingCardPreview, writeReviewLoadingSnapshot } from "../../shared/loadingSnapshots";
+import {
+  buildReviewLoadingCardPreview,
+  serializeReviewFilterKey,
+  writeReviewLoadingSnapshot,
+} from "../../shared/loadingSnapshots";
 import {
   clickElementAsync,
   createCard,
   createDeferredPromise,
+  createStorageMock,
   hasHydratedHotStateMock,
   loadReviewQueueSnapshotMock,
   setupReviewScreenTest,
@@ -91,6 +97,92 @@ describe("ReviewScreen loading controls", () => {
     expect(reviewPane.querySelector(".review-card-answer")).toBeNull();
     expect(frontCard.textContent).toContain("Snapshot front prompt");
     expect(speechButton.disabled).toBe(true);
+
+    await act(async () => {
+      pendingReviewQueueSnapshot.resolve({
+        resolvedReviewFilter: state.appData.selectedReviewFilter,
+        cards: [snapshotCard],
+        nextCursor: null,
+        reviewCounts: {
+          dueCount: 1,
+          totalCount: 1,
+        },
+      });
+      await pendingReviewQueueSnapshot.promise;
+    });
+    await flushReviewScreenPromises();
+  });
+
+  it("restores and migrates a decomposed legacy tag snapshot for a normalized persisted selection", async () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+    const state = getState();
+    const snapshotCard = createCard({
+      cardId: "legacy-unicode-loading-preview",
+      frontText: "Legacy Unicode snapshot prompt",
+      backText: "Snapshot answer",
+      tags: ["E\u0301clair"],
+    });
+    state.cards = [snapshotCard];
+    state.reviewQueue = [snapshotCard];
+    state.reviewTimeline = [snapshotCard];
+    state.appData.selectedReviewFilter = parsePersistedReviewFilter(JSON.stringify({
+      kind: "tags",
+      tags: [" E\u0301CLAIR "],
+    }));
+    const legacySelectedReviewFilterKey = `tags:${encodeURIComponent("e\u0301clair")}`;
+    writeReviewLoadingSnapshot({
+      version: 1,
+      workspaceId: "workspace-1",
+      selectedReviewFilterKey: legacySelectedReviewFilterKey,
+      resolvedReviewFilterTitle: "1 tag",
+      reviewCounts: {
+        dueCount: 1,
+        totalCount: 1,
+      },
+      currentCard: buildReviewLoadingCardPreview(snapshotCard),
+      queuePreview: [buildReviewLoadingCardPreview(snapshotCard)],
+      savedAt: "2026-03-10T12:00:00.000Z",
+    });
+    const legacyStorageKey = window.localStorage.key(0);
+    if (legacyStorageKey === null) {
+      throw new Error("Legacy review loading snapshot storage key was not written");
+    }
+    const pendingReviewQueueSnapshot = createDeferredPromise<ReviewQueueSnapshot>();
+    loadReviewQueueSnapshotMock.mockImplementation(() => pendingReviewQueueSnapshot.promise);
+
+    await renderReviewScreen();
+
+    const reviewPane = getContainer().querySelector("[data-testid='review-pane']");
+    const frontCard = reviewPane?.querySelector("[data-testid='review-current-front-card']");
+    if (!(reviewPane instanceof HTMLElement) || !(frontCard instanceof HTMLElement)) {
+      throw new Error("Migrated Unicode review loading preview was not rendered");
+    }
+    const canonicalSelectedReviewFilterKey = serializeReviewFilterKey(state.appData.selectedReviewFilter);
+    const canonicalStorageKey = window.localStorage.key(0);
+    if (canonicalStorageKey === null) {
+      throw new Error("Canonical review loading snapshot storage key was not written");
+    }
+    const canonicalSnapshotValue = window.localStorage.getItem(canonicalStorageKey);
+    if (canonicalSnapshotValue === null) {
+      throw new Error("Canonical review loading snapshot value was not written");
+    }
+
+    expect(frontCard.textContent).toContain("Legacy Unicode snapshot prompt");
+    expect(reviewPane.querySelector(".review-loading-card-surface")).toBeNull();
+    expect(loadReviewQueueSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.length).toBe(1);
+    expect(window.localStorage.getItem(legacyStorageKey)).toBeNull();
+    expect(canonicalStorageKey.endsWith(`:${canonicalSelectedReviewFilterKey}`)).toBe(true);
+    expect(JSON.parse(canonicalSnapshotValue)).toMatchObject({
+      selectedReviewFilterKey: canonicalSelectedReviewFilterKey,
+      currentCard: {
+        cardId: snapshotCard.cardId,
+        frontText: snapshotCard.frontText,
+      },
+    });
 
     await act(async () => {
       pendingReviewQueueSnapshot.resolve({

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -205,6 +205,7 @@ export function useReviewScreenController(
     installationId: cloudSettings?.installationId ?? null,
     isSyncing,
     localReadVersion,
+    selectReviewFilter,
     selectedReviewFilter,
     setErrorMessage,
     submitReviewItem,

--- a/apps/web/src/screens/shared/loadingSnapshots.ts
+++ b/apps/web/src/screens/shared/loadingSnapshots.ts
@@ -116,6 +116,32 @@ function writeLocalStorageValue(key: string, value: string): void {
   fallbackLocalStorageState.set(key, value);
 }
 
+function removeLocalStorageValue(key: string): void {
+  const storage = window.localStorage as LocalStorageLike;
+  if (typeof storage.removeItem === "function") {
+    storage.removeItem(key);
+    return;
+  }
+
+  fallbackLocalStorageState.delete(key);
+}
+
+function listLocalStorageKeys(): ReadonlyArray<string> {
+  const storage = window.localStorage as LocalStorageLike;
+  if (typeof storage.key === "function" && typeof storage.length === "number") {
+    const keys: Array<string> = [];
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key !== null) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  }
+
+  return [...fallbackLocalStorageState.keys()];
+}
+
 export function clearLoadingSnapshotFallbackStorage(): void {
   fallbackLocalStorageState.clear();
 }
@@ -287,6 +313,40 @@ export function serializeReviewFilterKey(reviewFilter: ReviewFilter): string {
     .join(",")}`;
 }
 
+function canonicalizeStoredTagsReviewFilterKey(storedReviewFilterKey: string): string | null {
+  if (storedReviewFilterKey.startsWith("tags:") === false) {
+    return null;
+  }
+
+  const encodedTags = storedReviewFilterKey.slice("tags:".length);
+  try {
+    const tags = encodedTags === ""
+      ? []
+      : encodedTags.split(",").map((tag) => decodeURIComponent(tag));
+    return serializeReviewFilterKey({ kind: "tags", tags });
+  } catch {
+    return null;
+  }
+}
+
+function listCanonicalLegacyTagsReviewFilterKeys(
+  workspaceId: string,
+  selectedReviewFilterKey: string,
+): ReadonlyArray<string> {
+  const workspaceStorageKeyPrefix = `${REVIEW_LOADING_SNAPSHOT_KEY_PREFIX}:${workspaceId}:`;
+  const tagsStorageKeyPrefix = `${workspaceStorageKeyPrefix}tags:`;
+
+  return listLocalStorageKeys()
+    .filter((storageKey) => storageKey.startsWith(tagsStorageKeyPrefix))
+    .map((storageKey) => storageKey.slice(workspaceStorageKeyPrefix.length))
+    .filter((storedReviewFilterKey) => storedReviewFilterKey !== selectedReviewFilterKey)
+    .filter(
+      (storedReviewFilterKey) => canonicalizeStoredTagsReviewFilterKey(storedReviewFilterKey)
+        === selectedReviewFilterKey,
+    )
+    .sort((leftKey, rightKey) => leftKey.localeCompare(rightKey));
+}
+
 export function buildReviewLoadingCardPreview(card: Card): ReviewLoadingCardPreview {
   return {
     cardId: card.cardId,
@@ -322,6 +382,23 @@ export function readReviewLoadingSnapshot(
 
   if (snapshot !== null) {
     return snapshot;
+  }
+
+  if (reviewFilter.kind === "tags") {
+    const canonicalLegacyReviewFilterKeys = listCanonicalLegacyTagsReviewFilterKeys(
+      workspaceId,
+      selectedReviewFilterKey,
+    );
+    for (const canonicalLegacyReviewFilterKey of canonicalLegacyReviewFilterKeys) {
+      const canonicalLegacySnapshot = readReviewLoadingSnapshotForStoredKey(
+        workspaceId,
+        selectedReviewFilterKey,
+        canonicalLegacyReviewFilterKey,
+      );
+      if (canonicalLegacySnapshot !== null) {
+        return canonicalLegacySnapshot;
+      }
+    }
   }
 
   const legacyTagReviewFilterKey = buildLegacyTagReviewFilterKey(reviewFilter);
@@ -369,10 +446,13 @@ function readReviewLoadingSnapshotForStoredKey(
     return snapshot;
   }
 
-  return {
+  const migratedSnapshot: ReviewLoadingSnapshot = {
     ...snapshot,
     selectedReviewFilterKey,
   };
+  writeReviewLoadingSnapshot(migratedSnapshot);
+  removeLocalStorageValue(storageKey);
+  return migratedSnapshot;
 }
 
 export function writeReviewLoadingSnapshot(snapshot: ReviewLoadingSnapshot): void {


### PR DESCRIPTION
## Summary
- normalize web review tag identities with Unicode NFC across aggregation, matching, persistence, and canonical display
- promote restored exact-all tag selections to persisted All Cards without a redundant blocking reload
- migrate canonically equivalent legacy warm-snapshot keys to canonical storage

## Validation
- focused web regression tests: 76 passed
- full serialized web suite: 702 passed
- production web build
- repository static checks
- diff and apps/web-only scope checks