### PR TITLE
fix(android): align review tag option order test

### DIFF
--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupportTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/review/ReviewRepositorySupportTest.kt
@@ -19,8 +19,8 @@ class ReviewRepositorySupportTest {
 
         assertEquals(
             listOf(
-                ReviewTagFilterOption(tag = "Future", totalCount = 0),
-                ReviewTagFilterOption(tag = decomposedTag, totalCount = 3)
+                ReviewTagFilterOption(tag = decomposedTag, totalCount = 3),
+                ReviewTagFilterOption(tag = "Future", totalCount = 0)
             ),
             buildReviewTagFilterOptionsFromRows(
                 rows = rows,


### PR DESCRIPTION
## Summary
- align the review tag filter expectation with the deterministic production comparator
- keep production behavior unchanged

## Validation
- repository static checks passed
- git diff checks passed
- fresh review found no P0-P4 issues
- Gradle and emulator intentionally not run