### PR TITLE
feat(ios): add native All Cards filter toggle

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -370,14 +370,20 @@ struct ReviewView: View {
 
     private var reviewFilterMenu: some View {
         Menu {
-            Button {
-                store.selectReviewFilter(reviewFilter: .allCards)
-            } label: {
-                if store.selectedReviewFilter == .allCards {
-                    Label(localizedAllCardsLabel(), systemImage: "checkmark")
-                } else {
-                    Text(localizedAllCardsLabel())
-                }
+            Toggle(
+                isOn: Binding(
+                    get: {
+                        store.selectedReviewFilter == .allCards
+                    },
+                    set: { isEnabled in
+                        let reviewFilter: ReviewFilter = isEnabled
+                            ? .allCards
+                            : makeReviewTagsFilter(tags: [])
+                        store.selectReviewFilter(reviewFilter: reviewFilter)
+                    }
+                )
+            ) {
+                Text(localizedAllCardsLabel())
             }
             .menuActionDismissBehavior(.disabled)
             .accessibilityIdentifier(UITestIdentifier.reviewFilterAllCardsAction)

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
@@ -1,5 +1,10 @@
 import XCTest
 
+private enum ReviewFilterToggleValue: String {
+    case off = "0"
+    case on = "1"
+}
+
 final class LiveSmokeReviewTests: LiveSmokeTestCase {
     @MainActor
     func testLiveSmokeManualCardReviewFlow() throws {
@@ -43,41 +48,171 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
     }
 
     @MainActor
-    func testLiveSmokeReviewTagMenuAppliesImmediatelyAndStaysOpenUntilOutsideTap() throws {
+    func testLiveSmokeReviewFilterMenuSupportsEmptyTagAndAllCardsStates() throws {
         try self.launchApplication(launchScenario: .guestAIReviewCard, selectedTab: .review)
         let tagToggleIdentifier = LiveSmokeIdentifier.reviewFilterTagTogglePrefix + "smoke-guest-ai-review"
 
-        try self.step("toggle the review tag without dismissing the menu") {
+        try self.step("clear all review filters without dismissing the menu") {
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
+            )
             try self.tapButton(
                 identifier: LiveSmokeIdentifier.reviewFilterMenu,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            try self.assertElementExists(
-                identifier: tagToggleIdentifier,
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .on,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            self.app.descendants(matching: .any).matching(identifier: tagToggleIdentifier).firstMatch.tap()
-            try self.assertElementExists(
+            try self.assertReviewFilterToggleValue(
                 identifier: tagToggleIdentifier,
+                expectedValue: .on,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            self.app.descendants(matching: .any).matching(identifier: tagToggleIdentifier).firstMatch.tap()
-            try self.assertElementExists(
+
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle)
+                .firstMatch
+                .tap()
+
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
                 identifier: tagToggleIdentifier,
+                expectedValue: .off,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
         }
 
-        try self.step("dismiss the review tag menu with an outside tap") {
-            self.app.descendants(matching: .any).matching(identifier: LiveSmokeIdentifier.reviewScreen).firstMatch.tap()
+        try self.step("dismiss the empty review filter menu with an outside tap") {
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+                .firstMatch
+                .tap()
+            try self.assertElementDoesNotExist(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
             try self.assertElementDoesNotExist(
                 identifier: tagToggleIdentifier,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            try self.assertTextExists(
-                LiveSmokeLaunchFixtureData.aiReviewFrontText,
+            try self.assertElementDoesNotExist(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
                 timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
             )
         }
+
+        try self.step("select one review tag from empty without dismissing the menu") {
+            try self.tapButton(
+                identifier: LiveSmokeIdentifier.reviewFilterMenu,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: tagToggleIdentifier,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+
+            self.app.descendants(matching: .any).matching(identifier: tagToggleIdentifier).firstMatch.tap()
+
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: tagToggleIdentifier,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+        }
+
+        try self.step("verify the tagged card returns after dismissing the menu") {
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+                .firstMatch
+                .tap()
+            try self.assertElementDoesNotExist(
+                identifier: tagToggleIdentifier,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
+            )
+        }
+
+        try self.step("restore all cards without dismissing the menu") {
+            try self.tapButton(
+                identifier: LiveSmokeIdentifier.reviewFilterMenu,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle)
+                .firstMatch
+                .tap()
+
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: tagToggleIdentifier,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+        }
+
+        try self.step("verify the all cards review returns after dismissing the menu") {
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+                .firstMatch
+                .tap()
+            try self.assertElementDoesNotExist(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
+            )
+        }
+    }
+
+    @MainActor
+    private func assertReviewFilterToggleValue(
+        identifier: String,
+        expectedValue: ReviewFilterToggleValue,
+        timeout: TimeInterval
+    ) throws {
+        let toggle = self.app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+        try self.assertElementExists(identifier: identifier, timeout: timeout)
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if self.elementValue(element: toggle) == expectedValue.rawValue {
+                return
+            }
+
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        }
+
+        throw LiveSmokeFailure.unexpectedReviewState(
+            message: "Expected review filter toggle '\(identifier)' to have value '\(expectedValue.rawValue)', found '\(self.elementValue(element: toggle))'.",
+            screen: self.currentScreenSummary(),
+            step: self.currentStepTitle
+        )
     }
 }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -19,6 +19,7 @@ enum LiveSmokeIdentifier {
     static let rootTabSettingsItem: String = "rootTab.settings.item"
     static let reviewScreen: String = "review.screen"
     static let reviewFilterMenu: String = "review.filter.menu"
+    static let reviewFilterAllCardsToggle: String = "review.filter.allCards"
     static let reviewFilterTagTogglePrefix: String = "review.filter.tag."
     static let aiScreen: String = "ai.screen"
     static let progressScreen: String = "progress.screen"


### PR DESCRIPTION
Summary:
- render All Cards with the same native SwiftUI Toggle model as tag filters
- map the off state to the supported explicit empty tag filter and on to all cards
- extend native smoke coverage across all cards, empty, one tag, and restoration

Validation:
- Swift parser passed for ReviewView and LiveSmokeReviewTests
- node scripts/checks/pr/run-all.mjs passed
- git diff --check passed
- fresh review: no P0-P4 issues found

Runtime validation:
- local simulator-backed XCUITest was not authorized
- Xcode Cloud native smoke remains the rollout gate