### PR TITLE
Add web All Cards toggle

### DIFF
--- a/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
+++ b/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
@@ -82,7 +82,9 @@ function buildReviewDeckFilterMenuItems(
     {
       key: toReviewFilterMenuItemKey(ALL_CARDS_REVIEW_FILTER),
       label: allCardsLabel,
-      reviewFilter: ALL_CARDS_REVIEW_FILTER,
+      reviewFilter: selectedReviewFilter.kind === "allCards"
+        ? makeTagsReviewFilter([])
+        : ALL_CARDS_REVIEW_FILTER,
       subtitle: null,
       isSelected: toReviewFilterMenuItemKey(selectedReviewFilter) === toReviewFilterMenuItemKey(ALL_CARDS_REVIEW_FILTER),
     },

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -323,6 +323,88 @@ describe("ReviewScreen filter controls", () => {
     expect(listbox.querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
     expect(listbox.querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
     expect(listbox.querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("true");
+
+    const selectedAllCardsOption = listbox.querySelector("[data-review-filter-key='allCards']");
+    if (!(selectedAllCardsOption instanceof HTMLElement)) {
+      throw new Error("Selected All Cards review filter option was not found");
+    }
+
+    await clickElementAsync(selectedAllCardsOption);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: [],
+    });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: [],
+    };
+    state.reviewQueue = [];
+    state.reviewTimeline = [];
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-pane-state")).toBe("empty");
+      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-current-card-id")).toBe("");
+    });
+
+    const grammarOptionFromEmpty = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    if (!(grammarOptionFromEmpty instanceof HTMLElement)) {
+      throw new Error("Grammar review filter option was not found after clearing All Cards");
+    }
+
+    await clickElementAsync(grammarOptionFromEmpty);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: ["grammar"],
+    });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: ["grammar"],
+    };
+    state.reviewQueue = [state.cards[0] as (typeof state.cards)[number]];
+    state.reviewTimeline = state.reviewQueue;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
+    });
+
+    const unselectedAllCardsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
+    if (!(unselectedAllCardsOption instanceof HTMLElement)) {
+      throw new Error("Unselected All Cards review filter option was not found");
+    }
+
+    await clickElementAsync(unselectedAllCardsOption);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({ kind: "allCards" });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+
+    state.appData.selectedReviewFilter = { kind: "allCards" };
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("true");
+    });
+    state.appData.selectReviewFilter.mockClear();
+
     expect(reviewStylesContain(
       ".review-filter-menu",
       "display: flex",


### PR DESCRIPTION
## Summary
- toggle selected All Cards to the supported explicit empty-tags filter
- keep the review filter chooser open while clearing, selecting tags, and restoring All Cards
- cover empty results, tag recovery, and canonical All Cards restoration in the web interaction test

## Validation
- `npx vitest run src/screens/review/tests/ReviewScreen.controls.filter.test.tsx` (16 tests)
- `npm test --prefix apps/web` (82 files, 702 tests)
- `npm run build --prefix apps/web`
- `node scripts/checks/pr/run-all.mjs`
- `git diff --check`

## Review
- Fresh reviewer: no P0-P4 issues found; no additional notes.