### PR TITLE
Add All Cards review filter toggle

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -532,20 +532,11 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn().performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
 
         composeRule.onNodeWithTag(reviewFilterSheetTag).assertIsDisplayed()
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 2 cards.")
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).performClick()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("Beta").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
@@ -557,12 +548,37 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
             .assertContentDescriptionEquals("Review queue 0 cards.")
 
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).performClick()
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 1 card.")
+
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).performClick()
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 2 cards.")
+
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
         composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("All cards").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 3 cards.")
 
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).performClick()
         pressBack()

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
@@ -75,7 +75,12 @@ internal fun ReviewFilterSheet(
                     selected = selectedFilter == ReviewFilter.AllCards,
                     testTag = reviewFilterAllCardsOptionTag,
                     onClick = {
-                        onSelectFilter(ReviewFilter.AllCards)
+                        val nextFilter: ReviewFilter = if (selectedFilter == ReviewFilter.AllCards) {
+                            makeReviewTagFilter(tagNames = emptyList())
+                        } else {
+                            ReviewFilter.AllCards
+                        }
+                        onSelectFilter(nextFilter)
                     }
                 )
             }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -370,14 +370,20 @@ struct ReviewView: View {
 
     private var reviewFilterMenu: some View {
         Menu {
-            Button {
-                store.selectReviewFilter(reviewFilter: .allCards)
-            } label: {
-                if store.selectedReviewFilter == .allCards {
-                    Label(localizedAllCardsLabel(), systemImage: "checkmark")
-                } else {
-                    Text(localizedAllCardsLabel())
-                }
+            Toggle(
+                isOn: Binding(
+                    get: {
+                        store.selectedReviewFilter == .allCards
+                    },
+                    set: { isEnabled in
+                        let reviewFilter: ReviewFilter = isEnabled
+                            ? .allCards
+                            : makeReviewTagsFilter(tags: [])
+                        store.selectReviewFilter(reviewFilter: reviewFilter)
+                    }
+                )
+            ) {
+                Text(localizedAllCardsLabel())
             }
             .menuActionDismissBehavior(.disabled)
             .accessibilityIdentifier(UITestIdentifier.reviewFilterAllCardsAction)

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
@@ -1,5 +1,10 @@
 import XCTest
 
+private enum ReviewFilterToggleValue: String {
+    case off = "0"
+    case on = "1"
+}
+
 final class LiveSmokeReviewTests: LiveSmokeTestCase {
     @MainActor
     func testLiveSmokeManualCardReviewFlow() throws {
@@ -43,41 +48,171 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
     }
 
     @MainActor
-    func testLiveSmokeReviewTagMenuAppliesImmediatelyAndStaysOpenUntilOutsideTap() throws {
+    func testLiveSmokeReviewFilterMenuSupportsEmptyTagAndAllCardsStates() throws {
         try self.launchApplication(launchScenario: .guestAIReviewCard, selectedTab: .review)
         let tagToggleIdentifier = LiveSmokeIdentifier.reviewFilterTagTogglePrefix + "smoke-guest-ai-review"
 
-        try self.step("toggle the review tag without dismissing the menu") {
+        try self.step("clear all review filters without dismissing the menu") {
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
+            )
             try self.tapButton(
                 identifier: LiveSmokeIdentifier.reviewFilterMenu,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            try self.assertElementExists(
-                identifier: tagToggleIdentifier,
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .on,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            self.app.descendants(matching: .any).matching(identifier: tagToggleIdentifier).firstMatch.tap()
-            try self.assertElementExists(
+            try self.assertReviewFilterToggleValue(
                 identifier: tagToggleIdentifier,
+                expectedValue: .on,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            self.app.descendants(matching: .any).matching(identifier: tagToggleIdentifier).firstMatch.tap()
-            try self.assertElementExists(
+
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle)
+                .firstMatch
+                .tap()
+
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
                 identifier: tagToggleIdentifier,
+                expectedValue: .off,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
         }
 
-        try self.step("dismiss the review tag menu with an outside tap") {
-            self.app.descendants(matching: .any).matching(identifier: LiveSmokeIdentifier.reviewScreen).firstMatch.tap()
+        try self.step("dismiss the empty review filter menu with an outside tap") {
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+                .firstMatch
+                .tap()
+            try self.assertElementDoesNotExist(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
             try self.assertElementDoesNotExist(
                 identifier: tagToggleIdentifier,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
-            try self.assertTextExists(
-                LiveSmokeLaunchFixtureData.aiReviewFrontText,
+            try self.assertElementDoesNotExist(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
                 timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
             )
         }
+
+        try self.step("select one review tag from empty without dismissing the menu") {
+            try self.tapButton(
+                identifier: LiveSmokeIdentifier.reviewFilterMenu,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: tagToggleIdentifier,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+
+            self.app.descendants(matching: .any).matching(identifier: tagToggleIdentifier).firstMatch.tap()
+
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: tagToggleIdentifier,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+        }
+
+        try self.step("verify the tagged card returns after dismissing the menu") {
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+                .firstMatch
+                .tap()
+            try self.assertElementDoesNotExist(
+                identifier: tagToggleIdentifier,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
+            )
+        }
+
+        try self.step("restore all cards without dismissing the menu") {
+            try self.tapButton(
+                identifier: LiveSmokeIdentifier.reviewFilterMenu,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle)
+                .firstMatch
+                .tap()
+
+            try self.assertReviewFilterToggleValue(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertReviewFilterToggleValue(
+                identifier: tagToggleIdentifier,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+        }
+
+        try self.step("verify the all cards review returns after dismissing the menu") {
+            self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+                .firstMatch
+                .tap()
+            try self.assertElementDoesNotExist(
+                identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
+            )
+        }
+    }
+
+    @MainActor
+    private func assertReviewFilterToggleValue(
+        identifier: String,
+        expectedValue: ReviewFilterToggleValue,
+        timeout: TimeInterval
+    ) throws {
+        let toggle = self.app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+        try self.assertElementExists(identifier: identifier, timeout: timeout)
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if self.elementValue(element: toggle) == expectedValue.rawValue {
+                return
+            }
+
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        }
+
+        throw LiveSmokeFailure.unexpectedReviewState(
+            message: "Expected review filter toggle '\(identifier)' to have value '\(expectedValue.rawValue)', found '\(self.elementValue(element: toggle))'.",
+            screen: self.currentScreenSummary(),
+            step: self.currentStepTitle
+        )
     }
 }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -19,6 +19,7 @@ enum LiveSmokeIdentifier {
     static let rootTabSettingsItem: String = "rootTab.settings.item"
     static let reviewScreen: String = "review.screen"
     static let reviewFilterMenu: String = "review.filter.menu"
+    static let reviewFilterAllCardsToggle: String = "review.filter.allCards"
     static let reviewFilterTagTogglePrefix: String = "review.filter.tag."
     static let aiScreen: String = "ai.screen"
     static let progressScreen: String = "progress.screen"

--- a/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
+++ b/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
@@ -82,7 +82,9 @@ function buildReviewDeckFilterMenuItems(
     {
       key: toReviewFilterMenuItemKey(ALL_CARDS_REVIEW_FILTER),
       label: allCardsLabel,
-      reviewFilter: ALL_CARDS_REVIEW_FILTER,
+      reviewFilter: selectedReviewFilter.kind === "allCards"
+        ? makeTagsReviewFilter([])
+        : ALL_CARDS_REVIEW_FILTER,
       subtitle: null,
       isSelected: toReviewFilterMenuItemKey(selectedReviewFilter) === toReviewFilterMenuItemKey(ALL_CARDS_REVIEW_FILTER),
     },

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -323,6 +323,88 @@ describe("ReviewScreen filter controls", () => {
     expect(listbox.querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
     expect(listbox.querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
     expect(listbox.querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("true");
+
+    const selectedAllCardsOption = listbox.querySelector("[data-review-filter-key='allCards']");
+    if (!(selectedAllCardsOption instanceof HTMLElement)) {
+      throw new Error("Selected All Cards review filter option was not found");
+    }
+
+    await clickElementAsync(selectedAllCardsOption);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: [],
+    });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: [],
+    };
+    state.reviewQueue = [];
+    state.reviewTimeline = [];
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-pane-state")).toBe("empty");
+      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-current-card-id")).toBe("");
+    });
+
+    const grammarOptionFromEmpty = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    if (!(grammarOptionFromEmpty instanceof HTMLElement)) {
+      throw new Error("Grammar review filter option was not found after clearing All Cards");
+    }
+
+    await clickElementAsync(grammarOptionFromEmpty);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+      kind: "tags",
+      tags: ["grammar"],
+    });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+
+    state.appData.selectedReviewFilter = {
+      kind: "tags",
+      tags: ["grammar"],
+    };
+    state.reviewQueue = [state.cards[0] as (typeof state.cards)[number]];
+    state.reviewTimeline = state.reviewQueue;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
+    });
+
+    const unselectedAllCardsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
+    if (!(unselectedAllCardsOption instanceof HTMLElement)) {
+      throw new Error("Unselected All Cards review filter option was not found");
+    }
+
+    await clickElementAsync(unselectedAllCardsOption);
+
+    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({ kind: "allCards" });
+    expect(queryReviewFilterMenu()).not.toBeNull();
+
+    state.appData.selectedReviewFilter = { kind: "allCards" };
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+    await rerenderReviewScreen();
+
+    await vi.waitFor(() => {
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
+      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("true");
+    });
+    state.appData.selectReviewFilter.mockClear();
+
     expect(reviewStylesContain(
       ".review-filter-menu",
       "display: flex",


### PR DESCRIPTION
## Summary
- add All Cards toggles to the web, iOS, and Android review filters
- allow an explicit empty tag filter while keeping existing OR-selection semantics
- align the iOS All Cards control with native tag-row toggles

## Validation
- cumulative fresh review: no P0-P4 findings
- web: 82 files / 702 tests passed on definitive retry
- web production build passed (2,190 modules)
- Swift parser checks passed for all changed Swift files
- all four repository PR checks passed
- git diff --check passed

## Runtime gates
- Android PR CI build, unit, lint, and data:local instrumentation
- post-merge Xcode Cloud