### PR TITLE
feat(ios): stabilize review filter popover

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -22,6 +22,7 @@ enum UITestIdentifier {
     static let rootTabSettingsItem: String = "rootTab.settings.item"
     static let reviewScreen: String = "review.screen"
     static let reviewFilterMenu: String = "review.filter.menu"
+    static let reviewFilterScrollSurface: String = "review.filter.scrollSurface"
     static let reviewFilterAllCardsAction: String = "review.filter.allCards"
     static let reviewFilterDeckActionPrefix: String = "review.filter.deck."
     static let reviewFilterTagTogglePrefix: String = "review.filter.tag."

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
@@ -81,7 +81,21 @@ private enum FlashcardsUITestLaunchScenarioData {
     static let aiReviewCard: FlashcardsUITestFixtureCard = FlashcardsUITestFixtureCard(
         frontText: "Smoke guest AI review question",
         backText: "Smoke guest AI review answer",
-        tags: ["smoke-guest-ai-review"]
+        tags: [
+            "smoke-guest-ai-review",
+            "smoke-overflow-01",
+            "smoke-overflow-02",
+            "smoke-overflow-03",
+            "smoke-overflow-04",
+            "smoke-overflow-05",
+            "smoke-overflow-06",
+            "smoke-overflow-07",
+            "smoke-overflow-08",
+            "smoke-overflow-09",
+            "smoke-overflow-10",
+            "smoke-overflow-11",
+            "smoke-overflow-12"
+        ]
     )
 }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewFilterPopover.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewFilterPopover.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+private let reviewFilterPopoverWidth: CGFloat = 320
+private let reviewFilterPopoverHeight: CGFloat = 420
+private let reviewFilterSelectionColumnWidth: CGFloat = 20
+private let reviewFilterRowHorizontalPadding: CGFloat = 16
+private let reviewFilterRowVerticalPadding: CGFloat = 11
+private let reviewFilterRowSpacing: CGFloat = 12
+
+struct ReviewFilterPopover: View {
+    @Binding var reviewFilter: ReviewFilter
+    let deckSummaries: [DeckSummary]
+    let tagSummaries: [WorkspaceTagSummary]
+    let onEditDecks: () -> Void
+
+    @State private var scrollPosition: ScrollPosition = ScrollPosition(idType: String.self)
+
+    private var storedTagNames: [String] {
+        self.tagSummaries.map(\.tag)
+    }
+
+    private var selectedTagKeys: Set<String> {
+        let selectedTags: [String]
+        switch self.reviewFilter {
+        case .allCards:
+            selectedTags = self.storedTagNames
+        case .deck(let deckId):
+            selectedTags = self.deckSummaries.first(where: { deckSummary in
+                deckSummary.deckId == deckId
+            }).map { deckSummary in
+                selectedReviewDeckTagNames(
+                    deckFilterTagNames: deckSummary.filterDefinition.tags,
+                    storedTagNames: self.storedTagNames
+                )
+            } ?? []
+        case .tags(let tags):
+            selectedTags = resolveExactStoredTagNames(
+                requestedTagNames: tags,
+                storedTagNames: self.storedTagNames
+            )
+        }
+
+        return Set(selectedTags.map(normalizeTagKey))
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                self.allCardsButton
+                    .id("all-cards")
+
+                ForEach(self.deckSummaries, id: \.deckId) { deckSummary in
+                    self.deckButton(deckSummary: deckSummary)
+                        .id("deck:\(deckSummary.deckId)")
+                }
+
+                self.editDecksButton
+                    .id("edit-decks")
+
+                Divider()
+                    .padding(.vertical, 4)
+
+                if self.tagSummaries.isEmpty == false {
+                    ForEach(self.tagSummaries, id: \.tag) { tagSummary in
+                        self.tagButton(tagSummary: tagSummary)
+                            .id("tag:\(normalizeTagKey(tag: tagSummary.tag))")
+                    }
+
+                    Divider()
+                        .padding(.vertical, 4)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollPosition(self.$scrollPosition)
+        .accessibilityIdentifier(UITestIdentifier.reviewFilterScrollSurface)
+        .frame(width: reviewFilterPopoverWidth, height: reviewFilterPopoverHeight)
+    }
+
+    private var allCardsButton: some View {
+        let isSelected = self.reviewFilter == .allCards
+        return self.selectionButton(
+            title: localizedAllCardsLabel(),
+            systemImage: "rectangle.stack",
+            isSelected: isSelected,
+            accessibilityIdentifier: UITestIdentifier.reviewFilterAllCardsAction,
+            action: {
+                self.reviewFilter = isSelected
+                    ? makeReviewTagsFilter(tags: [])
+                    : .allCards
+            }
+        )
+    }
+
+    private func deckButton(deckSummary: DeckSummary) -> some View {
+        let deckFilter = ReviewFilter.deck(deckId: deckSummary.deckId)
+        return self.selectionButton(
+            title: deckSummary.name,
+            systemImage: nil,
+            isSelected: self.reviewFilter == deckFilter,
+            accessibilityIdentifier: UITestIdentifier.reviewFilterDeckActionPrefix + deckSummary.deckId,
+            action: {
+                self.reviewFilter = deckFilter
+            }
+        )
+    }
+
+    private var editDecksButton: some View {
+        Button(action: self.onEditDecks) {
+            HStack(spacing: reviewFilterRowSpacing) {
+                Image(systemName: "square.stack.3d.up")
+                    .frame(width: reviewFilterSelectionColumnWidth)
+                Text(String(localized: "Edit decks", table: "ReviewCards"))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, reviewFilterRowHorizontalPadding)
+            .padding(.vertical, reviewFilterRowVerticalPadding)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func tagButton(tagSummary: WorkspaceTagSummary) -> some View {
+        let tagKey = normalizeTagKey(tag: tagSummary.tag)
+        return self.selectionButton(
+            title: "\(tagSummary.tag) (\(tagSummary.cardsCount.formatted()))",
+            systemImage: nil,
+            isSelected: self.selectedTagKeys.contains(tagKey),
+            accessibilityIdentifier: UITestIdentifier.reviewFilterTagTogglePrefix + tagSummary.tag,
+            action: {
+                self.toggleTag(tag: tagSummary.tag)
+            }
+        )
+    }
+
+    private func selectionButton(
+        title: String,
+        systemImage: String?,
+        isSelected: Bool,
+        accessibilityIdentifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: reviewFilterRowSpacing) {
+                ZStack {
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.body.weight(.semibold))
+                    }
+                }
+                .frame(width: reviewFilterSelectionColumnWidth)
+
+                if let systemImage {
+                    Image(systemName: systemImage)
+                }
+
+                Text(title)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, reviewFilterRowHorizontalPadding)
+            .padding(.vertical, reviewFilterRowVerticalPadding)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "1" : "0")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func toggleTag(tag: String) {
+        let tagFilter: ReviewFilter
+        switch self.reviewFilter {
+        case .deck(let deckId):
+            let deckTags = self.deckSummaries.first(where: { deckSummary in
+                deckSummary.deckId == deckId
+            })?.filterDefinition.tags ?? []
+            tagFilter = makeReviewTagsFilter(
+                tags: selectedReviewDeckTagNames(
+                    deckFilterTagNames: deckTags,
+                    storedTagNames: self.storedTagNames
+                )
+            )
+        case .allCards, .tags:
+            tagFilter = self.reviewFilter
+        }
+
+        self.reviewFilter = reviewFilterByTogglingTag(
+            reviewFilter: tagFilter,
+            tag: tag,
+            decks: [],
+            storedTagNames: self.storedTagNames
+        )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -45,6 +45,9 @@ struct ReviewView: View {
     @State var reviewTagSummaries: [WorkspaceTagSummary] = []
     @State var reviewDeckSummaries: [DeckSummary] = []
     @State var totalCardsCount: Int = 0
+    @State var isReviewFilterPopoverPresented: Bool = false
+    @State var reviewFilterDraft: ReviewFilter = .allCards
+    @State var reviewFilterAtPresentation: ReviewFilter = .allCards
 
     private var availableTagSuggestions: [TagSuggestion] {
         self.reviewTagSummaries.map { tagSummary in
@@ -68,78 +71,8 @@ struct ReviewView: View {
         }
     }
 
-    private var selectedReviewTagKeys: Set<String> {
-        let storedTagNames = self.reviewTagSummaries.map(\.tag)
-        let selectedTags: [String]
-        switch store.selectedReviewFilter {
-        case .allCards:
-            selectedTags = storedTagNames
-        case .deck(let deckId):
-            selectedTags = self.reviewDeckSummaries.first(where: { deckSummary in
-                deckSummary.deckId == deckId
-            }).map { deckSummary in
-                selectedReviewDeckTagNames(
-                    deckFilterTagNames: deckSummary.filterDefinition.tags,
-                    storedTagNames: storedTagNames
-                )
-            } ?? []
-        case .tags(let tags):
-            selectedTags = resolveExactStoredTagNames(
-                requestedTagNames: tags,
-                storedTagNames: storedTagNames
-            )
-        }
-
-        return Set(selectedTags.map(normalizeTagKey))
-    }
-
     var areReviewReactionAnimationsEnabled: Bool {
         store.accountPreferences.reviewReactionAnimationsEnabled && self.isLowPowerModeEnabled == false
-    }
-
-    private func reviewFilterMenuItemLabel(reviewFilter: ReviewFilter) -> String {
-        switch reviewFilter {
-        case .allCards:
-            return localizedAllCardsLabel()
-        case .deck(let deckId):
-            return self.reviewDeckSummaries.first(where: { deckSummary in
-                deckSummary.deckId == deckId
-            })?.name ?? localizedAllCardsLabel()
-        case .tags(let tags):
-            return tags.joined(separator: ", ")
-        }
-    }
-
-    private func selectReviewTag(tag: String) {
-        let storedTagNames = self.reviewTagSummaries.map(\.tag)
-        let nextReviewFilter: ReviewFilter
-        switch store.selectedReviewFilter {
-        case .deck(let deckId):
-            let deckTags = self.reviewDeckSummaries.first(where: { deckSummary in
-                deckSummary.deckId == deckId
-            })?.filterDefinition.tags ?? []
-            let deckTagFilter = makeReviewTagsFilter(
-                tags: selectedReviewDeckTagNames(
-                    deckFilterTagNames: deckTags,
-                    storedTagNames: storedTagNames
-                )
-            )
-            nextReviewFilter = reviewFilterByTogglingTag(
-                reviewFilter: deckTagFilter,
-                tag: tag,
-                decks: [],
-                storedTagNames: storedTagNames
-            )
-        case .allCards, .tags:
-            nextReviewFilter = reviewFilterByTogglingTag(
-                reviewFilter: store.selectedReviewFilter,
-                tag: tag,
-                decks: [],
-                storedTagNames: storedTagNames
-            )
-        }
-
-        store.selectReviewFilter(reviewFilter: nextReviewFilter)
     }
 
     private var currentCard: Card? {
@@ -369,68 +302,10 @@ struct ReviewView: View {
     }
 
     private var reviewFilterMenu: some View {
-        Menu {
-            Toggle(
-                isOn: Binding(
-                    get: {
-                        store.selectedReviewFilter == .allCards
-                    },
-                    set: { isEnabled in
-                        let reviewFilter: ReviewFilter = isEnabled
-                            ? .allCards
-                            : makeReviewTagsFilter(tags: [])
-                        store.selectReviewFilter(reviewFilter: reviewFilter)
-                    }
-                )
-            ) {
-                Text(localizedAllCardsLabel())
-            }
-            .menuActionDismissBehavior(.disabled)
-            .accessibilityIdentifier(UITestIdentifier.reviewFilterAllCardsAction)
-
-            ForEach(self.reviewDeckSummaries, id: \.deckId) { deckSummary in
-                let reviewFilter = ReviewFilter.deck(deckId: deckSummary.deckId)
-                Button {
-                    store.selectReviewFilter(reviewFilter: reviewFilter)
-                } label: {
-                    if store.selectedReviewFilter == reviewFilter {
-                        Label(reviewFilterMenuItemLabel(reviewFilter: reviewFilter), systemImage: "checkmark")
-                    } else {
-                        Text(reviewFilterMenuItemLabel(reviewFilter: reviewFilter))
-                    }
-                }
-                .menuActionDismissBehavior(.disabled)
-                .accessibilityIdentifier(UITestIdentifier.reviewFilterDeckActionPrefix + deckSummary.deckId)
-            }
-
-            Button {
-                navigation.openSettings(destination: .workspaceDecks)
-            } label: {
-                Label(String(localized: "Edit decks", table: reviewCardsStringsTableName), systemImage: "square.stack.3d.up")
-            }
-
-            Divider()
-
-            if reviewTagSummaries.isEmpty == false {
-                ForEach(reviewTagSummaries, id: \.tag) { tagSummary in
-                    Toggle(
-                        isOn: Binding(
-                            get: {
-                                self.selectedReviewTagKeys.contains(normalizeTagKey(tag: tagSummary.tag))
-                            },
-                            set: { _ in
-                                self.selectReviewTag(tag: tagSummary.tag)
-                            }
-                        )
-                    ) {
-                        Text("\(tagSummary.tag) (\(tagSummary.cardsCount.formatted()))")
-                    }
-                    .menuActionDismissBehavior(.disabled)
-                    .accessibilityIdentifier(UITestIdentifier.reviewFilterTagTogglePrefix + tagSummary.tag)
-                }
-
-                Divider()
-            }
+        Button {
+            self.reviewFilterDraft = store.selectedReviewFilter
+            self.reviewFilterAtPresentation = store.selectedReviewFilter
+            self.isReviewFilterPopoverPresented = true
         } label: {
             HStack(spacing: 4) {
                 Text(self.selectedReviewFilterTitle)
@@ -442,6 +317,35 @@ struct ReviewView: View {
             }
         }
         .accessibilityIdentifier(UITestIdentifier.reviewFilterMenu)
+        .popover(isPresented: self.$isReviewFilterPopoverPresented) {
+            ReviewFilterPopover(
+                reviewFilter: self.$reviewFilterDraft,
+                deckSummaries: self.reviewDeckSummaries,
+                tagSummaries: self.reviewTagSummaries,
+                onEditDecks: self.dismissReviewFilterPopoverAndOpenDecks
+            )
+            .presentationCompactAdaptation(.popover)
+        }
+        .onChange(of: self.isReviewFilterPopoverPresented) { _, isPresented in
+            if isPresented == false {
+                self.commitReviewFilterDraft()
+            }
+        }
+    }
+
+    private func commitReviewFilterDraft() {
+        guard self.reviewFilterDraft != self.reviewFilterAtPresentation else {
+            return
+        }
+
+        self.reviewFilterAtPresentation = self.reviewFilterDraft
+        store.selectReviewFilter(reviewFilter: self.reviewFilterDraft)
+    }
+
+    private func dismissReviewFilterPopoverAndOpenDecks() {
+        self.commitReviewFilterDraft()
+        self.isReviewFilterPopoverPresented = false
+        navigation.openSettings(destination: .workspaceDecks)
     }
 
     private var reviewLoadingView: some View {

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
@@ -51,8 +51,9 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
     func testLiveSmokeReviewFilterMenuSupportsEmptyTagAndAllCardsStates() throws {
         try self.launchApplication(launchScenario: .guestAIReviewCard, selectedTab: .review)
         let tagToggleIdentifier = LiveSmokeIdentifier.reviewFilterTagTogglePrefix + "smoke-guest-ai-review"
+        let lowerTagToggleIdentifier = LiveSmokeIdentifier.reviewFilterTagTogglePrefix + "smoke-overflow-12"
 
-        try self.step("clear all review filters without dismissing the menu") {
+        try self.step("keep a lower review filter row visible after changing its draft selection") {
             try self.assertElementExists(
                 identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
                 timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
@@ -61,6 +62,36 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
                 identifier: LiveSmokeIdentifier.reviewFilterMenu,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
+            try self.tapReviewFilterButtonScrollingIntoView(identifier: lowerTagToggleIdentifier)
+            try self.assertReviewFilterToggleValue(
+                identifier: lowerTagToggleIdentifier,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+
+            let lowerTagToggle = self.app.buttons[lowerTagToggleIdentifier].firstMatch
+            guard lowerTagToggle.isHittable else {
+                throw LiveSmokeFailure.unexpectedReviewState(
+                    message: "The toggled lower review filter row moved out of view.",
+                    screen: self.currentScreenSummary(),
+                    step: self.currentStepTitle
+                )
+            }
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+
+            lowerTagToggle.tap()
+            try self.assertReviewFilterToggleValue(
+                identifier: lowerTagToggleIdentifier,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.scrollReviewFilterToTop()
+        }
+
+        try self.step("clear all review filters without dismissing the menu") {
             try self.assertReviewFilterToggleValue(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 expectedValue: .on,
@@ -87,13 +118,14 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
                 expectedValue: .off,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
         }
 
         try self.step("dismiss the empty review filter menu with an outside tap") {
-            self.app.descendants(matching: .any)
-                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
-                .firstMatch
-                .tap()
+            self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -139,10 +171,7 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
         }
 
         try self.step("verify the tagged card returns after dismissing the menu") {
-            self.app.descendants(matching: .any)
-                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
-                .firstMatch
-                .tap()
+            self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: tagToggleIdentifier,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -176,10 +205,7 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
         }
 
         try self.step("verify the all cards review returns after dismissing the menu") {
-            self.app.descendants(matching: .any)
-                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
-                .firstMatch
-                .tap()
+            self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -214,5 +240,63 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
             screen: self.currentScreenSummary(),
             step: self.currentStepTitle
         )
+    }
+
+    @MainActor
+    private func tapReviewFilterButtonScrollingIntoView(identifier: String) throws {
+        let scrollSurface = self.app.scrollViews[LiveSmokeIdentifier.reviewFilterScrollSurface].firstMatch
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.reviewFilterScrollSurface,
+            timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+        )
+
+        let button = self.app.buttons[identifier].firstMatch
+        let deadline = Date().addingTimeInterval(LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        while Date() < deadline {
+            if button.exists && button.isHittable {
+                button.tap()
+                return
+            }
+
+            scrollSurface.swipeUp()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        }
+
+        throw LiveSmokeFailure.missingElement(
+            identifier: identifier,
+            timeoutSeconds: LiveSmokeConfiguration.shortUiTimeoutSeconds,
+            screen: self.currentScreenSummary(),
+            step: self.currentStepTitle
+        )
+    }
+
+    @MainActor
+    private func scrollReviewFilterToTop() throws {
+        let scrollSurface = self.app.scrollViews[LiveSmokeIdentifier.reviewFilterScrollSurface].firstMatch
+        let allCardsButton = self.app.buttons[LiveSmokeIdentifier.reviewFilterAllCardsToggle].firstMatch
+        let deadline = Date().addingTimeInterval(LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        while Date() < deadline {
+            if allCardsButton.exists && allCardsButton.isHittable {
+                return
+            }
+
+            scrollSurface.swipeDown()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        }
+
+        throw LiveSmokeFailure.missingElement(
+            identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+            timeoutSeconds: LiveSmokeConfiguration.shortUiTimeoutSeconds,
+            screen: self.currentScreenSummary(),
+            step: self.currentStepTitle
+        )
+    }
+
+    @MainActor
+    private func dismissReviewFilterPopoverWithOutsideTap() {
+        let reviewScreen = self.app.descendants(matching: .any)
+            .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+            .firstMatch
+        reviewScreen.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
     }
 }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -19,6 +19,7 @@ enum LiveSmokeIdentifier {
     static let rootTabSettingsItem: String = "rootTab.settings.item"
     static let reviewScreen: String = "review.screen"
     static let reviewFilterMenu: String = "review.filter.menu"
+    static let reviewFilterScrollSurface: String = "review.filter.scrollSurface"
     static let reviewFilterAllCardsToggle: String = "review.filter.allCards"
     static let reviewFilterTagTogglePrefix: String = "review.filter.tag."
     static let aiScreen: String = "ai.screen"


### PR DESCRIPTION
## Summary
- replace the long Review filter menu with an anchored native SwiftUI popover
- stage filter selections until dismissal while preserving stable row geometry and scroll position
- extend the real Review live smoke fixture and flow for overflow and deferred application

## Validation
- xcrun swiftc -parse across all six accepted Swift files
- node scripts/checks/pr/run-all.mjs
- git diff --check
- simulator-backed tests not run because explicit permission was not granted