### PR TITLE
Stage web review filter until dismissal

### DIFF
--- a/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
+++ b/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   ALL_CARDS_REVIEW_FILTER,
+  isReviewFilterEqual,
   makeTagsReviewFilter,
   normalizeReviewFilterTags,
   normalizeTagKey,
@@ -247,22 +248,28 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   } = params;
   const { t } = useI18n();
   const [isReviewFilterMenuOpen, setIsReviewFilterMenuOpen] = useState<boolean>(false);
+  const [reviewFilterDraft, setReviewFilterDraft] = useState<ReviewFilter | null>(null);
   const [reviewDeckSearchText, setReviewDeckSearchText] = useState<string>("");
   const [activeReviewFilterOptionKey, setActiveReviewFilterOptionKey] = useState<string | null>(null);
+  const openingReviewFilterRef = useRef<ReviewFilter | null>(null);
+  const reviewFilterDraftRef = useRef<ReviewFilter | null>(null);
   const reviewFilterTriggerRef = useRef<HTMLButtonElement | null>(null);
   const reviewFilterMenuRef = useRef<HTMLDivElement | null>(null);
   const reviewDeckSearchInputRef = useRef<HTMLInputElement | null>(null);
   const reviewFilterListboxRef = useRef<HTMLDivElement | null>(null);
+  const displayedReviewFilter = isReviewFilterMenuOpen && reviewFilterDraft !== null
+    ? reviewFilterDraft
+    : selectedReviewFilter;
   const reviewDeckFilterMenuItems = buildReviewDeckFilterMenuItems(
     deckSummaries,
-    selectedReviewFilter,
+    displayedReviewFilter,
     t("filters.allCards"),
     t("reviewFilterMenu.deckSmartFilterLabel"),
   );
   const reviewTagFilterMenuItems = buildReviewTagFilterMenuItems(
     deckSummaries,
     reviewTagSummaries,
-    selectedReviewFilter,
+    displayedReviewFilter,
   );
   const reviewFilterMenuItems = buildReviewFilterMenuItems(t("reviewFilterMenu.editDecks"));
   const totalReviewFilterChoicesCount = reviewDeckFilterMenuItems.length
@@ -351,8 +358,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
 
     function handleKeyDown(event: KeyboardEvent): void {
       if (event.key === "Escape") {
-        setIsReviewFilterMenuOpen(false);
-        reviewFilterTriggerRef.current?.focus();
+        closeReviewFilterMenuAndFocusTrigger();
       }
     }
 
@@ -361,26 +367,42 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }, [isReviewFilterMenuOpen]);
 
   function handleCloseMenu(): void {
+    const openingReviewFilter = openingReviewFilterRef.current;
+    const finalReviewFilterDraft = reviewFilterDraftRef.current;
+    openingReviewFilterRef.current = null;
+    reviewFilterDraftRef.current = null;
+    setReviewFilterDraft(null);
     setReviewDeckSearchText("");
     setActiveReviewFilterOptionKey(null);
     setIsReviewFilterMenuOpen(false);
+
+    if (
+      openingReviewFilter !== null
+      && finalReviewFilterDraft !== null
+      && isReviewFilterEqual(openingReviewFilter, finalReviewFilterDraft) === false
+    ) {
+      onSelectReviewFilter(finalReviewFilterDraft);
+    }
   }
 
   function handleReviewFilterMenuToggle(): void {
     setReviewDeckSearchText("");
     if (isReviewFilterMenuOpen) {
-      setActiveReviewFilterOptionKey(null);
-      setIsReviewFilterMenuOpen(false);
+      handleCloseMenu();
       return;
     }
 
+    openingReviewFilterRef.current = selectedReviewFilter;
+    reviewFilterDraftRef.current = selectedReviewFilter;
+    setReviewFilterDraft(selectedReviewFilter);
     setActiveReviewFilterOptionKey(findDefaultReviewFilterOptionKey(visibleReviewFilterChoiceMenuItems));
     setIsReviewFilterMenuOpen(true);
   }
 
   function handleReviewFilterSelect(optionKey: string, reviewFilter: ReviewFilter): void {
     setActiveReviewFilterOptionKey(optionKey);
-    onSelectReviewFilter(reviewFilter);
+    reviewFilterDraftRef.current = reviewFilter;
+    setReviewFilterDraft(reviewFilter);
   }
 
   function preventReviewFilterHandledKeyDown(event: ReactKeyboardEvent<HTMLInputElement | HTMLDivElement>): void {
@@ -389,9 +411,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }
 
   function closeReviewFilterMenuAndFocusTrigger(): void {
-    setReviewDeckSearchText("");
-    setActiveReviewFilterOptionKey(null);
-    setIsReviewFilterMenuOpen(false);
+    handleCloseMenu();
     reviewFilterTriggerRef.current?.focus();
   }
 
@@ -410,7 +430,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
       activeReviewFilterOptionKey,
     );
     if (activeReviewFilterOption !== null) {
-      onSelectReviewFilter(activeReviewFilterOption.reviewFilter);
+      handleReviewFilterSelect(activeReviewFilterOption.key, activeReviewFilterOption.reviewFilter);
     }
   }
 

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -287,7 +287,7 @@ describe("ReviewScreen filter controls", () => {
     expect(getContainer().querySelector("#review-queue-panel")).toBeNull();
   });
 
-  it("filters, dismisses externally, and applies selections without closing the review filter menu", async () => {
+  it("stages accessible multi-select changes and applies the final filter once on dismissal", async () => {
     const state = getState();
     state.decks = createDecks(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta"]);
     state.cards = [
@@ -331,28 +331,14 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(selectedAllCardsOption);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: [],
-    });
+    expect(selectedAllCardsOption.getAttribute("aria-selected")).toBe("false");
+    expect(listbox.querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("false");
+    expect(listbox.querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
+    expect(listbox.querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-pane-state")).toBe("card");
+    expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-current-card-id")).toBe("tag-1");
     expect(queryReviewFilterMenu()).not.toBeNull();
-
-    state.appData.selectedReviewFilter = {
-      kind: "tags",
-      tags: [],
-    };
-    state.reviewQueue = [];
-    state.reviewTimeline = [];
-    await rerenderReviewScreen();
-
-    await vi.waitFor(() => {
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-pane-state")).toBe("empty");
-      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-current-card-id")).toBe("");
-    });
 
     const grammarOptionFromEmpty = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
     if (!(grammarOptionFromEmpty instanceof HTMLElement)) {
@@ -361,49 +347,76 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(grammarOptionFromEmpty);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: ["grammar"],
-    });
+    expect(grammarOptionFromEmpty.getAttribute("aria-selected")).toBe("true");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
 
-    state.appData.selectedReviewFilter = {
-      kind: "tags",
-      tags: ["grammar"],
-    };
-    state.reviewQueue = [state.cards[0] as (typeof state.cards)[number]];
-    state.reviewTimeline = state.reviewQueue;
+    await pointerDownElementAsync(document.body);
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["grammar"] });
+
+    state.appData.selectedReviewFilter = { kind: "tags", tags: ["grammar"] };
     await rerenderReviewScreen();
-
-    await vi.waitFor(() => {
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
-    });
-
-    const unselectedAllCardsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
-    if (!(unselectedAllCardsOption instanceof HTMLElement)) {
-      throw new Error("Unselected All Cards review filter option was not found");
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const verbsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
+    if (!(verbsOption instanceof HTMLElement)) {
+      throw new Error("Verbs review filter option was not found");
     }
+    await clickElementAsync(verbsOption);
+    expect(verbsOption.getAttribute("aria-selected")).toBe("true");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await dispatchDocumentKeydown("Escape");
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["grammar", "verbs"] });
 
-    await clickElementAsync(unselectedAllCardsOption);
-
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({ kind: "allCards" });
-    expect(queryReviewFilterMenu()).not.toBeNull();
+    state.appData.selectedReviewFilter = { kind: "tags", tags: ["grammar", "verbs"] };
+    await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const allCardsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
+    const trigger = getContainer().querySelector(".review-filter-trigger");
+    if (!(allCardsOption instanceof HTMLElement) || !(trigger instanceof HTMLButtonElement)) {
+      throw new Error("All Cards option or review filter trigger was not found");
+    }
+    await clickElementAsync(allCardsOption);
+    expect(allCardsOption.getAttribute("aria-selected")).toBe("true");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await clickElementAsync(trigger);
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "allCards" });
 
     state.appData.selectedReviewFilter = { kind: "allCards" };
-    state.reviewQueue = state.cards;
-    state.reviewTimeline = state.cards;
     await rerenderReviewScreen();
-
-    await vi.waitFor(() => {
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("true");
-    });
     state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const selectedAllCardsForEditDecks = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
+    const editDecksLink = getReviewFilterMenu().querySelector(".review-filter-menu-entry-action");
+    if (!(selectedAllCardsForEditDecks instanceof HTMLElement) || !(editDecksLink instanceof HTMLAnchorElement)) {
+      throw new Error("All Cards option or Edit decks link was not found");
+    }
+    await clickElementAsync(selectedAllCardsForEditDecks);
+    expect(selectedAllCardsForEditDecks.getAttribute("aria-selected")).toBe("false");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await clickElementAsync(editDecksLink);
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: [] });
+
+    state.appData.selectedReviewFilter = { kind: "allCards" };
+    await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const searchableFilterMenu = getReviewFilterMenu();
+    const searchableListbox = searchableFilterMenu.querySelector("[role='listbox']");
+    const searchableInput = searchableFilterMenu.querySelector(".review-filter-search-input");
+    if (!(searchableListbox instanceof HTMLElement) || !(searchableInput instanceof HTMLInputElement)) {
+      throw new Error("Searchable review filter controls were not found after reopening");
+    }
+    searchableListbox.scrollTop = 24;
 
     expect(reviewStylesContain(
       ".review-filter-menu",
@@ -415,68 +428,64 @@ describe("ReviewScreen filter controls", () => {
       "overflow-y: auto",
     )).toBe(true);
 
-    const editDecksLink = filterMenu.querySelector(".review-filter-menu-entry-action");
-    if (!(editDecksLink instanceof HTMLAnchorElement)) {
-      throw new Error("Review filter edit decks link was not found");
+    const searchableEditDecksLink = searchableFilterMenu.querySelector(".review-filter-menu-entry-action");
+    if (!(searchableEditDecksLink instanceof HTMLAnchorElement)) {
+      throw new Error("Review filter Edit decks link was not found after reopening");
     }
+    expect(searchableEditDecksLink.getAttribute("role")).not.toBe("option");
+    expect(searchableEditDecksLink.getAttribute("data-review-filter-key")).toBeNull();
+    expect(searchableListbox.contains(searchableEditDecksLink)).toBe(false);
 
-    expect(editDecksLink.getAttribute("role")).not.toBe("option");
-    expect(editDecksLink.getAttribute("data-review-filter-key")).toBeNull();
-    expect(listbox.contains(editDecksLink)).toBe(false);
+    await setTextFieldValueAsync(searchableInput, "med");
 
-    await setTextFieldValueAsync(searchInput, "med");
-
-    expect([...listbox.querySelectorAll("[role='option']")].map((option) => (
+    expect([...searchableListbox.querySelectorAll("[role='option']")].map((option) => (
       option.getAttribute("data-review-filter-key")
     ))).toEqual(["tag:medium"]);
-    expect(listbox.querySelector(".review-filter-menu-divider")).toBeNull();
+    expect(searchableListbox.querySelector(".review-filter-menu-divider")).toBeNull();
 
-    await setTextFieldValueAsync(searchInput, "ta");
+    await setTextFieldValueAsync(searchableInput, "ta");
 
     expect(getReviewFilterMenu().textContent).toContain("Beta");
     expect(getReviewFilterMenu().textContent).toContain("Delta");
     expect(getReviewFilterMenu().textContent).not.toContain("Alpha");
-    expect([...listbox.querySelectorAll("[role='option']")].map((option) => (
+    expect([...searchableListbox.querySelectorAll("[role='option']")].map((option) => (
       option.getAttribute("data-review-filter-key")
     ))).toEqual(["deck:deck-2", "deck:deck-4", "deck:deck-6", "deck:deck-7"]);
 
     await vi.waitFor(() => {
-      expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
+      expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
     });
-    expect(getActiveReviewFilterOption(searchInput).classList.contains("review-filter-menu-entry-keyboard-active")).toBe(true);
+    expect(getActiveReviewFilterOption(searchableInput).classList.contains("review-filter-menu-entry-keyboard-active")).toBe(true);
 
-    await composingKeydownElementAsync(searchInput, "ArrowDown");
-    await composingKeydownElementAsync(searchInput, "Enter");
+    await composingKeydownElementAsync(searchableInput, "ArrowDown");
+    await composingKeydownElementAsync(searchableInput, "Enter");
 
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
     expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
 
-    await keydownElementAsync(searchInput, "ArrowDown");
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
+    await keydownElementAsync(searchableInput, "ArrowDown");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
 
-    await keydownElementAsync(searchInput, "ArrowLeft");
-    await keydownElementAsync(searchInput, "ArrowRight");
-    await keydownElementAsync(searchInput, " ");
+    await keydownElementAsync(searchableInput, "ArrowLeft");
+    await keydownElementAsync(searchableInput, "ArrowRight");
+    await keydownElementAsync(searchableInput, " ");
 
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
     expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
 
-    await keydownElementAsync(searchInput, "ArrowUp");
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
+    await keydownElementAsync(searchableInput, "ArrowUp");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
 
-    await keydownElementAsync(searchInput, "ArrowDown");
-    await keydownElementAsync(searchInput, "Enter");
+    await keydownElementAsync(searchableInput, "ArrowDown");
+    await keydownElementAsync(searchableInput, "Enter");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-4",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
-    expect(document.activeElement).toBe(searchInput);
+    expect(document.activeElement).toBe(searchableInput);
+    expect(searchableListbox.scrollTop).toBe(24);
 
-    state.appData.selectReviewFilter.mockClear();
     const triggerAfterSearchKeyboardSelect = getContainer().querySelector(".review-filter-trigger");
     if (!(triggerAfterSearchKeyboardSelect instanceof HTMLButtonElement)) {
       throw new Error("Review filter trigger was not found after search keyboard selection");
@@ -487,25 +496,8 @@ describe("ReviewScreen filter controls", () => {
     expect(queryReviewFilterMenu()).not.toBeNull();
     await pointerDownElementAsync(document.body);
     expect(queryReviewFilterMenu()).toBeNull();
-
-    await openReviewFilterMenu();
-    await dispatchDocumentKeydown("Escape");
-    expect(queryReviewFilterMenu()).toBeNull();
-
-    await openReviewFilterMenu();
-    const mediumOption = [...getReviewFilterMenu().querySelectorAll("[data-review-filter-key]")]
-      .find((element) => element.getAttribute("data-review-filter-key") === "tag:medium");
-    if (!(mediumOption instanceof HTMLElement)) {
-      throw new Error("Medium review filter option was not found");
-    }
-
-    await clickElementAsync(mediumOption);
-
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "tags",
-      tags: ["grammar", "verbs"],
-    });
-    expect(queryReviewFilterMenu()).not.toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-4" });
   });
 
   it("selects items by keyboard when the review filter menu has no search field", async () => {
@@ -552,16 +544,17 @@ describe("ReviewScreen filter controls", () => {
 
     await keydownElementAsync(listbox, " ");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-2",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-2']")?.getAttribute("aria-selected")).toBe("true");
     expect(queryReviewFilterMenu()).not.toBeNull();
     const triggerAfterListboxKeyboardSelect = getContainer().querySelector(".review-filter-trigger");
     if (!(triggerAfterListboxKeyboardSelect instanceof HTMLButtonElement)) {
       throw new Error("Review filter trigger was not found after listbox keyboard selection");
     }
     expect(document.activeElement).toBe(listbox);
+    await clickElementAsync(triggerAfterListboxKeyboardSelect);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-2" });
   });
 
   it("uses the pointer-selected option for the next keyboard selection", async () => {
@@ -589,20 +582,15 @@ describe("ReviewScreen filter controls", () => {
 
     expect(getActiveReviewFilterOption(listbox)).toBe(deckOption);
     expect(listbox.getAttribute("aria-activedescendant")).toBe(deckOption.id);
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "deck",
-      deckId: "deck-1",
-    });
-    state.appData.selectReviewFilter.mockClear();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
 
     await keydownElementAsync(listbox, " ");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-1",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-1" });
   });
 
   it("keeps searchable pointer selection owned by the combobox for keyboard activation", async () => {
@@ -633,17 +621,16 @@ describe("ReviewScreen filter controls", () => {
     expect(document.activeElement).toBe(searchInput);
     expect(getActiveReviewFilterOption(searchInput)).toBe(deckOption);
     expect(searchInput.getAttribute("aria-activedescendant")).toBe(deckOption.id);
-    state.appData.selectReviewFilter.mockClear();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
 
     await keydownElementAsync(searchInput, "Enter");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-4",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(searchInput);
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await dispatchDocumentKeydown("Escape");
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-4" });
   });
 
   it("shows the resolved tag count after StrictMode replays the initial load effect", async () => {
@@ -832,17 +819,20 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(grammarOption);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: ["verbs"],
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(grammarOption.getAttribute("aria-selected")).toBe("false");
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["verbs"] });
 
     state.appData.selectedReviewFilter = {
       kind: "tags",
       tags: ["grammar"],
     };
     await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
     const verbsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
     if (!(verbsOption instanceof HTMLElement)) {
       throw new Error("Verbs review filter option was not found");
@@ -850,8 +840,12 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(verbsOption);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({ kind: "allCards" });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(verbsOption.getAttribute("aria-selected")).toBe("true");
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await dispatchDocumentKeydown("Escape");
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "allCards" });
   });
 
   it("retains missing custom and preset tags while toggling visible tags", async () => {
@@ -885,7 +879,9 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(verbsFromConfiguredDeck);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
       kind: "tags",
       tags: ["grammar", "missing", "verbs"],
     });
@@ -895,6 +891,8 @@ describe("ReviewScreen filter controls", () => {
       tags: ["grammar", "missing"],
     };
     await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
     const verbsFromCustomSelection = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
     if (!(verbsFromCustomSelection instanceof HTMLElement)) {
       throw new Error("Verbs option was not found for the custom selection");
@@ -902,7 +900,9 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(verbsFromCustomSelection);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
       kind: "tags",
       tags: ["grammar", "missing", "verbs"],
     });
@@ -912,6 +912,8 @@ describe("ReviewScreen filter controls", () => {
       deckId: "deck-2",
     };
     await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
     const grammarFromAllTagsDeck = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
     const verbsFromAllTagsDeck = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
     if (!(grammarFromAllTagsDeck instanceof HTMLElement) || !(verbsFromAllTagsDeck instanceof HTMLElement)) {
@@ -922,11 +924,14 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(grammarFromAllTagsDeck);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: ["verbs"],
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
+    const reviewFilterTrigger = getContainer().querySelector(".review-filter-trigger");
+    if (!(reviewFilterTrigger instanceof HTMLButtonElement)) {
+      throw new Error("Review filter trigger was not found");
+    }
+    await clickElementAsync(reviewFilterTrigger);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["verbs"] });
   });
 
   it("keeps review filter option ids unique for similar tag text", async () => {


### PR DESCRIPTION
## Summary
- keep review-filter changes local to the open Web chooser
- apply the final changed draft once when the chooser closes
- preserve anchored menu search, keyboard, focus, scrolling, and ARIA behavior

## Validation
- focused Review filter suite: 16/16 passed
- Web production build passed
- repository static checks: 4/4 passed
- git diff --check passed
- fresh review: no P0-P4 findings