### PR TITLE
Stage Android review filters until dismissal

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToNodeAction
@@ -519,7 +520,7 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     @Test
-    fun reviewFilterChecklistAppliesImmediatelyStaysOpenPersistsAndRestoresAllCards() {
+    fun reviewFilterChecklistStagesUntilDismissPersistsAndRestoresAllCards() {
         waitForCardsEmptyState()
         createCard(frontText = "Alpha review", backText = "Alpha answer", tags = listOf("Alpha"))
         createCard(frontText = "Beta review", backText = "Beta answer", tags = listOf("Beta"))
@@ -540,12 +541,26 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("All cards")
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 3 cards.")
+
+        pressBack()
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("No tags").fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
                 && composeRule.onAllNodesWithTag(reviewEmptyStateTag).fetchSemanticsNodes().isNotEmpty()
         }
-        composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 0 cards.")
+        waitForReviewFilterState(
+            filterTitle = "No tags",
+            queueContentDescription = "Review queue 0 cards."
+        )
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        waitForTagToExist(tag = reviewFilterSheetTag)
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
 
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).performClick()
         composeRule.onNodeWithTag(reviewFilterSheetTag).assertIsDisplayed()
@@ -553,47 +568,83 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
-        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("No tags")
         composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 1 card.")
+            .assertContentDescriptionEquals("Review queue 0 cards.")
 
+        recreateActivity()
+        waitForTagToExist(tag = reviewFilterSheetTag)
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("No tags")
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 0 cards.")
+
+        pressBack()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
+        }
+        waitForReviewFilterState(
+            filterTitle = "Alpha",
+            queueContentDescription = "Review queue 1 card."
+        )
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        waitForTagToExist(tag = reviewFilterSheetTag)
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).performClick()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
-        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("Alpha")
         composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 2 cards.")
+            .assertContentDescriptionEquals("Review queue 1 card.")
 
+        pressBack()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
+        }
+        waitForReviewFilterState(
+            filterTitle = "2 tags",
+            queueContentDescription = "Review queue 2 cards."
+        )
+
+        openCardsTab()
+        openReviewTab()
+        waitForReviewFilterState(
+            filterTitle = "2 tags",
+            queueContentDescription = "Review queue 2 cards."
+        )
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        waitForTagToExist(tag = reviewFilterSheetTag)
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
         composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("All cards").fetchSemanticsNodes().isNotEmpty()
-        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("2 tags")
         composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 3 cards.")
+            .assertContentDescriptionEquals("Review queue 2 cards.")
 
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).performClick()
         pressBack()
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
         }
-        openCardsTab()
-        openReviewTab()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
-        }
+        waitForReviewFilterState(
+            filterTitle = "All cards",
+            queueContentDescription = "Review queue 3 cards."
+        )
+
         composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn()
     }
 
     @Test
@@ -918,6 +969,25 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             countNodesWithTagInAnySemanticsTree(tag = tag) > 0
         }
+    }
+
+    private fun waitForReviewFilterState(
+        filterTitle: String,
+        queueContentDescription: String
+    ) {
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodes(
+                matcher = hasTestTag(reviewFilterButtonTag).and(other = hasText(filterTitle))
+            ).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodes(
+                    matcher = hasTestTag(reviewQueueButtonTag).and(
+                        other = hasContentDescription(queueContentDescription)
+                    )
+                ).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals(filterTitle)
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals(queueContentDescription)
     }
 
     private fun aiString(@StringRes resId: Int): String {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -106,9 +106,10 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isNotificationPermissionPromptVisible = false,
                         isHardAnswerReminderVisible = false
                     ),
+                    workspaceId = "review-route-test-workspace",
                     reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                     reviewReactionAnimationsEnabled = true,
-                    onSelectFilter = {},
+                    onSelectFilter = { _, _ -> },
                     onOpenPreview = {
                         openPreviewCalls += 1
                     },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -115,6 +115,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 )
             )
             val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
+            val workspaceId by reviewViewModel.workspaceId.collectAsStateWithLifecycle()
             val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
 
             LaunchedEffect(reviewFilterRequest?.requestId, uiState) {
@@ -127,9 +128,10 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
 
             ReviewRoute(
                 uiState = uiState,
+                workspaceId = workspaceId,
                 reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                 reviewReactionAnimationsEnabled = reviewReactionAnimationsEnabledState.value,
-                onSelectFilter = reviewViewModel::selectFilter,
+                onSelectFilter = reviewViewModel::selectFilterForWorkspace,
                 onOpenPreview = {
                     reviewViewModel.refreshPreview()
                     navController.navigate(route = ReviewPreviewDestination.route)

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewFilterSheetTransaction.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewFilterSheetTransaction.kt
@@ -1,0 +1,120 @@
+package com.flashcardsopensourceapp.feature.review
+
+import android.os.Bundle
+import androidx.compose.runtime.saveable.Saver
+import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+
+private const val reviewFilterSheetVisibleKey = "visible"
+private const val reviewFilterSheetWorkspaceIdKey = "workspace_id"
+private const val reviewFilterSheetOpeningSelectionKey = "opening_selection"
+private const val reviewFilterSheetDraftSelectionKey = "draft_selection"
+private const val reviewFilterAllCardsType = "all_cards"
+private const val reviewFilterDeckType = "deck"
+private const val reviewFilterTagsType = "tags"
+
+internal data class ReviewFilterSheetTransaction(
+    val isVisible: Boolean,
+    val workspaceId: String?,
+    val openingSelection: ReviewFilter,
+    val draftSelection: ReviewFilter
+)
+
+internal val reviewFilterSheetTransactionSaver: Saver<ReviewFilterSheetTransaction, Bundle> = Saver(
+    save = { transaction ->
+        Bundle().apply {
+            putBoolean(reviewFilterSheetVisibleKey, transaction.isVisible)
+            putString(reviewFilterSheetWorkspaceIdKey, transaction.workspaceId)
+            putStringArrayList(
+                reviewFilterSheetOpeningSelectionKey,
+                ArrayList(serializeReviewFilter(reviewFilter = transaction.openingSelection))
+            )
+            putStringArrayList(
+                reviewFilterSheetDraftSelectionKey,
+                ArrayList(serializeReviewFilter(reviewFilter = transaction.draftSelection))
+            )
+        }
+    },
+    restore = { savedState ->
+        require(savedState.containsKey(reviewFilterSheetVisibleKey)) {
+            "Saved review filter sheet transaction is missing its visibility state."
+        }
+        require(savedState.containsKey(reviewFilterSheetWorkspaceIdKey)) {
+            "Saved review filter sheet transaction is missing its workspace context."
+        }
+
+        ReviewFilterSheetTransaction(
+            isVisible = savedState.getBoolean(reviewFilterSheetVisibleKey),
+            workspaceId = savedState.getString(reviewFilterSheetWorkspaceIdKey),
+            openingSelection = deserializeReviewFilter(
+                savedFilter = requireSavedReviewFilter(
+                    savedState = savedState,
+                    key = reviewFilterSheetOpeningSelectionKey
+                )
+            ),
+            draftSelection = deserializeReviewFilter(
+                savedFilter = requireSavedReviewFilter(
+                    savedState = savedState,
+                    key = reviewFilterSheetDraftSelectionKey
+                )
+            )
+        )
+    }
+)
+
+internal fun closedReviewFilterSheetTransaction(
+    workspaceId: String?,
+    selection: ReviewFilter
+): ReviewFilterSheetTransaction {
+    return ReviewFilterSheetTransaction(
+        isVisible = false,
+        workspaceId = workspaceId,
+        openingSelection = selection,
+        draftSelection = selection
+    )
+}
+
+internal fun openReviewFilterSheetTransaction(
+    workspaceId: String,
+    selection: ReviewFilter
+): ReviewFilterSheetTransaction {
+    return ReviewFilterSheetTransaction(
+        isVisible = true,
+        workspaceId = workspaceId,
+        openingSelection = selection,
+        draftSelection = selection
+    )
+}
+
+private fun serializeReviewFilter(reviewFilter: ReviewFilter): List<String> {
+    return when (reviewFilter) {
+        ReviewFilter.AllCards -> listOf(reviewFilterAllCardsType)
+        is ReviewFilter.Deck -> listOf(reviewFilterDeckType, reviewFilter.deckId)
+        is ReviewFilter.Tags -> listOf(reviewFilterTagsType) + reviewFilter.tags
+    }
+}
+
+private fun deserializeReviewFilter(savedFilter: List<String>): ReviewFilter {
+    val filterType: String = savedFilter.firstOrNull()
+        ?: throw IllegalStateException("Saved review filter is empty.")
+    return when (filterType) {
+        reviewFilterAllCardsType -> {
+            require(savedFilter.size == 1) {
+                "Saved All cards review filter must not contain values."
+            }
+            ReviewFilter.AllCards
+        }
+        reviewFilterDeckType -> {
+            require(savedFilter.size == 2 && savedFilter[1].isNotEmpty()) {
+                "Saved deck review filter must contain exactly one non-empty deck ID."
+            }
+            ReviewFilter.Deck(deckId = savedFilter[1])
+        }
+        reviewFilterTagsType -> ReviewFilter.Tags(tags = savedFilter.drop(1))
+        else -> throw IllegalStateException("Saved review filter has unsupported type '$filterType'.")
+    }
+}
+
+private fun requireSavedReviewFilter(savedState: Bundle, key: String): List<String> {
+    return savedState.getStringArrayList(key)
+        ?: throw IllegalStateException("Saved review filter sheet transaction is missing '$key'.")
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -45,9 +46,10 @@ import java.util.Locale
 @Composable
 fun ReviewRoute(
     uiState: ReviewUiState,
+    workspaceId: String?,
     reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
     reviewReactionAnimationsEnabled: Boolean,
-    onSelectFilter: (ReviewFilter) -> Unit,
+    onSelectFilter: (String, ReviewFilter) -> Unit,
     onOpenPreview: () -> Unit,
     onOpenCurrentCard: (String) -> Unit,
     onOpenCurrentCardWithAi: (
@@ -75,8 +77,16 @@ fun ReviewRoute(
     onOpenProgress: () -> Unit,
     onScreenVisible: () -> Unit
 ) {
-    var isFilterSheetVisible by remember { mutableStateOf(value = false) }
-    var filterSheetSelection by remember { mutableStateOf<ReviewFilter?>(value = null) }
+    var filterSheetTransaction by rememberSaveable(
+        stateSaver = reviewFilterSheetTransactionSaver
+    ) {
+        mutableStateOf(
+            value = closedReviewFilterSheetTransaction(
+                workspaceId = workspaceId,
+                selection = uiState.requestedFilter
+            )
+        )
+    }
     var speechErrorMessage by remember { mutableStateOf(value = "") }
     var activeReviewReactionEvents by remember {
         mutableStateOf<List<ReviewReactionEvent>>(value = emptyList())
@@ -119,6 +129,24 @@ fun ReviewRoute(
             maximumActiveEvents = reviewReactionMaximumActiveEvents
         )
     }
+    fun finalizeFilterSheetSelection(): Unit {
+        val transaction: ReviewFilterSheetTransaction = filterSheetTransaction
+        if (transaction.isVisible.not()) {
+            return
+        }
+
+        filterSheetTransaction = closedReviewFilterSheetTransaction(
+            workspaceId = workspaceId,
+            selection = uiState.requestedFilter
+        )
+        if (
+            workspaceId != null
+            && transaction.workspaceId == workspaceId
+            && transaction.draftSelection != transaction.openingSelection
+        ) {
+            onSelectFilter(workspaceId, transaction.draftSelection)
+        }
+    }
     val onRateAgainWithReaction: () -> Unit = {
         emitReviewReaction(rating = ReviewRating.AGAIN)
         onRateAgain()
@@ -148,6 +176,20 @@ fun ReviewRoute(
     LaunchedEffect(reviewReactionAnimationsEnabled) {
         if (reviewReactionAnimationsEnabled.not()) {
             activeReviewReactionEvents = emptyList()
+        }
+    }
+
+    LaunchedEffect(workspaceId) {
+        val transaction: ReviewFilterSheetTransaction = filterSheetTransaction
+        if (
+            workspaceId != null
+            && transaction.isVisible
+            && transaction.workspaceId != workspaceId
+        ) {
+            filterSheetTransaction = closedReviewFilterSheetTransaction(
+                workspaceId = workspaceId,
+                selection = uiState.requestedFilter
+            )
         }
     }
 
@@ -202,8 +244,12 @@ fun ReviewRoute(
                 reviewProgressBadge = uiState.reviewProgressBadge,
                 selectedFilterTitle = uiState.selectedFilterTitle,
                 onOpenFilter = {
-                    filterSheetSelection = uiState.requestedFilter
-                    isFilterSheetVisible = true
+                    if (workspaceId != null) {
+                        filterSheetTransaction = openReviewFilterSheetTransaction(
+                            workspaceId = workspaceId,
+                            selection = uiState.requestedFilter
+                        )
+                    }
                 },
                 onOpenPreview = onOpenPreview,
                 onOpenLeaderboard = onOpenLeaderboard,
@@ -300,32 +346,34 @@ fun ReviewRoute(
         }
     }
 
-    if (isFilterSheetVisible) {
+    if (
+        workspaceId != null
+        && filterSheetTransaction.isVisible
+        && filterSheetTransaction.workspaceId == workspaceId
+    ) {
         ReviewFilterSheet(
-            selectedFilter = filterSheetSelection ?: uiState.requestedFilter,
+            selectedFilter = filterSheetTransaction.draftSelection,
             availableDeckFilters = uiState.availableDeckFilters,
             availableTagFilters = uiState.availableTagFilters,
-            onDismiss = {
-                isFilterSheetVisible = false
-                filterSheetSelection = null
-            },
+            onDismiss = ::finalizeFilterSheetSelection,
             onSelectFilter = { nextFilter ->
-                filterSheetSelection = nextFilter
-                onSelectFilter(nextFilter)
+                filterSheetTransaction = filterSheetTransaction.copy(
+                    draftSelection = nextFilter
+                )
             },
             onToggleTag = { tagName ->
                 val nextFilter = toggleReviewTagFilter(
-                    selectedFilter = filterSheetSelection ?: uiState.requestedFilter,
+                    selectedFilter = filterSheetTransaction.draftSelection,
                     toggledTagName = tagName,
                     availableDeckFilters = uiState.availableDeckFilters,
                     availableTagFilters = uiState.availableTagFilters
                 )
-                filterSheetSelection = nextFilter
-                onSelectFilter(nextFilter)
+                filterSheetTransaction = filterSheetTransaction.copy(
+                    draftSelection = nextFilter
+                )
             },
             onManageDecks = {
-                isFilterSheetVisible = false
-                filterSheetSelection = null
+                finalizeFilterSheetSelection()
                 onOpenDeckManagement()
             }
         )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -98,6 +98,13 @@ class ReviewViewModel(
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
         initialValue = null
     )
+    val workspaceId: StateFlow<String?> = workspaceState.map { workspace ->
+        workspace?.workspaceId
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = null
+    )
     private val appMetadataState = workspaceRepository.observeAppMetadata().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
@@ -183,6 +190,14 @@ class ReviewViewModel(
         }
         persistSelectedReviewFilter(reviewFilter = reviewFilter)
         onReviewNotificationsChanged(ReviewNotificationsReconcileTrigger.FILTER_CHANGED)
+    }
+
+    fun selectFilterForWorkspace(workspaceId: String, reviewFilter: ReviewFilter) {
+        if (workspaceId != activeWorkspaceId) {
+            return
+        }
+
+        selectFilter(reviewFilter = reviewFilter)
     }
 
     fun selectFilterForHandoff(reviewFilter: ReviewFilter): Boolean {


### PR DESCRIPTION
## Summary
- keep review filter checkbox changes local to the open Material bottom sheet
- commit the final changed draft once on dismissal or before Manage decks navigation
- preserve the workspace-keyed draft across Activity recreation and reject stale workspace commits
- update Compose instrumentation coverage for staged application and asynchronous queue state

## Validation
- `node scripts/checks/pr/run-all.mjs`
- `git diff --check`
- Gradle/instrumentation not run locally because repository policy requires explicit permission and none was granted

Promotion to `main` is deferred to the cumulative integration PR.