### PR TITLE
Discard stale web review filter drafts

### DIFF
--- a/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
+++ b/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
@@ -35,6 +35,12 @@ type UseReviewFilterMenuParams = Readonly<{
   onSelectReviewFilter: (reviewFilter: ReviewFilter) => void;
   reviewTagSummaries: ReadonlyArray<WorkspaceTagSummary>;
   selectedReviewFilter: ReviewFilter;
+  workspaceId: string | null;
+}>;
+
+type ReviewFilterMenuContext = Readonly<{
+  reviewFilter: ReviewFilter;
+  workspaceId: string | null;
 }>;
 
 export type UseReviewFilterMenuResult = Readonly<{
@@ -239,24 +245,41 @@ function isReviewFilterComboboxComposing(event: ReactKeyboardEvent<HTMLInputElem
   return event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229;
 }
 
+function isReviewFilterMenuContextEqual(
+  leftContext: ReviewFilterMenuContext,
+  rightContext: ReviewFilterMenuContext,
+): boolean {
+  return leftContext.workspaceId === rightContext.workspaceId
+    && isReviewFilterEqual(leftContext.reviewFilter, rightContext.reviewFilter);
+}
+
 export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseReviewFilterMenuResult {
   const {
     deckSummaries,
     onSelectReviewFilter,
     reviewTagSummaries,
     selectedReviewFilter,
+    workspaceId,
   } = params;
   const { t } = useI18n();
   const [isReviewFilterMenuOpen, setIsReviewFilterMenuOpen] = useState<boolean>(false);
   const [reviewFilterDraft, setReviewFilterDraft] = useState<ReviewFilter | null>(null);
   const [reviewDeckSearchText, setReviewDeckSearchText] = useState<string>("");
   const [activeReviewFilterOptionKey, setActiveReviewFilterOptionKey] = useState<string | null>(null);
-  const openingReviewFilterRef = useRef<ReviewFilter | null>(null);
+  const currentReviewFilterMenuContextRef = useRef<ReviewFilterMenuContext>({
+    reviewFilter: selectedReviewFilter,
+    workspaceId,
+  });
+  const openingReviewFilterMenuContextRef = useRef<ReviewFilterMenuContext | null>(null);
   const reviewFilterDraftRef = useRef<ReviewFilter | null>(null);
   const reviewFilterTriggerRef = useRef<HTMLButtonElement | null>(null);
   const reviewFilterMenuRef = useRef<HTMLDivElement | null>(null);
   const reviewDeckSearchInputRef = useRef<HTMLInputElement | null>(null);
   const reviewFilterListboxRef = useRef<HTMLDivElement | null>(null);
+  currentReviewFilterMenuContextRef.current = {
+    reviewFilter: selectedReviewFilter,
+    workspaceId,
+  };
   const displayedReviewFilter = isReviewFilterMenuOpen && reviewFilterDraft !== null
     ? reviewFilterDraft
     : selectedReviewFilter;
@@ -352,6 +375,19 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }, [isReviewFilterMenuOpen, shouldShowReviewDeckSearch]);
 
   useEffect(() => {
+    const openingContext = openingReviewFilterMenuContextRef.current;
+    if (
+      !isReviewFilterMenuOpen
+      || openingContext === null
+      || isReviewFilterMenuContextEqual(openingContext, currentReviewFilterMenuContextRef.current)
+    ) {
+      return;
+    }
+
+    handleCloseMenu();
+  }, [isReviewFilterMenuOpen, selectedReviewFilter, workspaceId]);
+
+  useEffect(() => {
     if (!isReviewFilterMenuOpen) {
       return;
     }
@@ -367,9 +403,9 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }, [isReviewFilterMenuOpen]);
 
   function handleCloseMenu(): void {
-    const openingReviewFilter = openingReviewFilterRef.current;
+    const openingContext = openingReviewFilterMenuContextRef.current;
     const finalReviewFilterDraft = reviewFilterDraftRef.current;
-    openingReviewFilterRef.current = null;
+    openingReviewFilterMenuContextRef.current = null;
     reviewFilterDraftRef.current = null;
     setReviewFilterDraft(null);
     setReviewDeckSearchText("");
@@ -377,9 +413,10 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
     setIsReviewFilterMenuOpen(false);
 
     if (
-      openingReviewFilter !== null
+      openingContext !== null
       && finalReviewFilterDraft !== null
-      && isReviewFilterEqual(openingReviewFilter, finalReviewFilterDraft) === false
+      && isReviewFilterMenuContextEqual(openingContext, currentReviewFilterMenuContextRef.current)
+      && isReviewFilterEqual(openingContext.reviewFilter, finalReviewFilterDraft) === false
     ) {
       onSelectReviewFilter(finalReviewFilterDraft);
     }
@@ -392,7 +429,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
       return;
     }
 
-    openingReviewFilterRef.current = selectedReviewFilter;
+    openingReviewFilterMenuContextRef.current = currentReviewFilterMenuContextRef.current;
     reviewFilterDraftRef.current = selectedReviewFilter;
     setReviewFilterDraft(selectedReviewFilter);
     setActiveReviewFilterOptionKey(findDefaultReviewFilterOptionKey(visibleReviewFilterChoiceMenuItems));

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -500,6 +500,98 @@ describe("ReviewScreen filter controls", () => {
     expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-4" });
   });
 
+  it("discards a draft after a keyboard workspace switch and applies a reopened draft once", async () => {
+    const state = getState();
+    state.decks = createDecks(["Grammar"]);
+    state.cards = [
+      createCard({ cardId: "workspace-switch-grammar", tags: ["grammar"] }),
+      createCard({ cardId: "workspace-switch-verbs", tags: ["verbs"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const grammarOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    if (!(grammarOption instanceof HTMLElement)) {
+      throw new Error("Grammar review filter option was not found before the workspace switch");
+    }
+
+    await clickElementAsync(grammarOption);
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "2") {
+        return;
+      }
+
+      state.appData.activeWorkspace = {
+        workspaceId: "workspace-2",
+        name: "Secondary",
+        createdAt: "2026-03-11T00:00:00.000Z",
+        isSelected: true,
+      };
+      state.appData.selectedReviewFilter = { kind: "tags", tags: ["verbs"] };
+    }, { once: true });
+
+    await dispatchDocumentKeydown("2");
+    await rerenderReviewScreen();
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+
+    await openReviewFilterMenu();
+    expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
+    const deckOption = getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-1']");
+    const trigger = getContainer().querySelector("[data-testid='review-filter-trigger']");
+    if (!(deckOption instanceof HTMLElement) || !(trigger instanceof HTMLButtonElement)) {
+      throw new Error("Reopened review filter controls were not found after the workspace switch");
+    }
+
+    await clickElementAsync(deckOption);
+    await clickElementAsync(trigger);
+    await dispatchDocumentKeydown("Escape");
+    await pointerDownElementAsync(document.body);
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-1" });
+  });
+
+  it("discards a draft when the committed filter changes in the same workspace", async () => {
+    const state = getState();
+    state.decks = createDecks(["Grammar"]);
+    state.cards = [
+      createCard({ cardId: "external-filter-grammar", tags: ["grammar"] }),
+      createCard({ cardId: "external-filter-verbs", tags: ["verbs"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const grammarOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    if (!(grammarOption instanceof HTMLElement)) {
+      throw new Error("Grammar review filter option was not found before the committed filter changed");
+    }
+
+    await clickElementAsync(grammarOption);
+    state.appData.selectedReviewFilter = { kind: "deck", deckId: "deck-1" };
+    await rerenderReviewScreen();
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+
+    await openReviewFilterMenu();
+    expect(getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-1']")?.getAttribute("aria-selected")).toBe("true");
+    await dispatchDocumentKeydown("Escape");
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+  });
+
   it("selects items by keyboard when the review filter menu has no search field", async () => {
     const state = getState();
     state.decks = createDecks(["Alpha", "Beta"]);

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -248,6 +248,7 @@ export function useReviewScreenController(
     onSelectReviewFilter: selectReviewFilter,
     reviewTagSummaries,
     selectedReviewFilter,
+    workspaceId: activeWorkspace?.workspaceId ?? null,
   });
   const {
     captureEditorPresentationToken,


### PR DESCRIPTION
## Summary
- bind review-filter drafts to their opening workspace and committed filter
- discard stale drafts when either context changes
- preserve the anchored accessible chooser and cover cancellation and exact-once close behavior

## Validation
- Not run locally per integration queue policy