### PR TITLE
Finalize Android review filter draft

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -1,30 +1,49 @@
 package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.fetchSemanticsNode
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption
 import com.flashcardsopensourceapp.feature.review.R as ReviewStringResources
 import com.flashcardsopensourceapp.feature.review.ReviewEmptyState
 import com.flashcardsopensourceapp.feature.review.ReviewLeaderboardBadgeState
 import com.flashcardsopensourceapp.feature.review.ReviewProgressBadgeState
 import com.flashcardsopensourceapp.feature.review.ReviewRoute
 import com.flashcardsopensourceapp.feature.review.ReviewUiState
+import com.flashcardsopensourceapp.feature.review.reviewFilterAllCardsOptionTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterButtonTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterSheetTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterTagOptionTag
 import com.flashcardsopensourceapp.feature.review.reviewLeaderboardShortcutTag
+import com.flashcardsopensourceapp.feature.review.reviewManageDecksButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewProgressBadgeTag
 import com.flashcardsopensourceapp.feature.review.reviewQueueButtonTag
 import com.flashcardsopensourceapp.feature.review.reaction.rememberReviewReactionLottieConfigurationStore
@@ -109,7 +128,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     workspaceId = "review-route-test-workspace",
                     reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                     reviewReactionAnimationsEnabled = true,
-                    onSelectFilter = { _, _ -> },
+                    onSelectFilter = { _, _, _ -> },
                     onOpenPreview = {
                         openPreviewCalls += 1
                     },
@@ -197,6 +216,312 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         assertEquals(1, openPreviewCalls)
         assertEquals(1, openProgressCalls)
     }
+
+    @Test
+    fun reviewFilterDraftStaysLocalAndAppliesExactlyOnceOnOutsideDismissal() {
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = false,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { workspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = workspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
+        composeRule.runOnIdle {
+            assertTrue(filterSelections.isEmpty())
+        }
+
+        val filterSheet = composeRule.onNodeWithTag(reviewFilterSheetTag)
+        val filterSheetTop = filterSheet.fetchSemanticsNode().boundsInRoot.top
+        filterSheet.performTouchInput {
+            click(position = Offset(x = center.x, y = -filterSheetTop / 2f))
+        }
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+        composeRule.runOnIdle {
+            assertEquals(
+                listOf(
+                    ReviewFilterSelection(
+                        workspaceId = reviewRouteWorkspaceId,
+                        openingFilter = ReviewFilter.AllCards,
+                        selectedFilter = ReviewFilter.Tags(tags = emptyList())
+                    )
+                ),
+                filterSelections
+            )
+        }
+    }
+
+    @Test
+    fun reviewFilterManageDecksFinalizesDraftBeforeNavigation() {
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+        var openDeckManagementCalls = 0
+
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = false,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { workspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = workspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {
+                    openDeckManagementCalls += 1
+                },
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteFirstTag)).performClick()
+        composeRule.onNodeWithTag(reviewManageDecksButtonTag).performClick()
+
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+        composeRule.runOnIdle {
+            assertEquals(1, openDeckManagementCalls)
+            assertEquals(
+                listOf(
+                    ReviewFilterSelection(
+                        workspaceId = reviewRouteWorkspaceId,
+                        openingFilter = ReviewFilter.AllCards,
+                        selectedFilter = ReviewFilter.Tags(tags = listOf(reviewRouteSecondTag))
+                    )
+                ),
+                filterSelections
+            )
+        }
+    }
+
+    @Test
+    fun reviewFilterDraftIsDiscardedWhenWorkspaceOrCommittedFilterChanges() {
+        var uiState by mutableStateOf(
+            value = reviewRouteUiState(
+                isLoading = false,
+                requestedFilter = ReviewFilter.AllCards
+            )
+        )
+        var workspaceId by mutableStateOf(value = reviewRouteWorkspaceId)
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = uiState,
+                workspaceId = workspaceId,
+                onSelectFilter = { selectedWorkspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = selectedWorkspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
+        composeRule.runOnIdle {
+            workspaceId = "replacement-workspace"
+        }
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
+        composeRule.runOnIdle {
+            uiState = reviewRouteUiState(
+                isLoading = false,
+                requestedFilter = ReviewFilter.Tags(tags = listOf(reviewRouteFirstTag))
+            )
+        }
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+        composeRule.runOnIdle {
+            assertTrue(filterSelections.isEmpty())
+        }
+    }
+
+    @Test
+    fun reviewFilterCannotOpenWhileReviewIsLoading() {
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = true,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { _, _, _ -> },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertIsNotEnabled()
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+    }
+
+    @Test
+    fun reviewFilterDraftRestoresBeforeDismissal() {
+        val stateRestorationTester = StateRestorationTester(composeRule)
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+
+        stateRestorationTester.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = false,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { workspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = workspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteFirstTag)).performClick()
+        stateRestorationTester.emulateSavedInstanceStateRestore()
+
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteFirstTag)).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteSecondTag)).assertIsOn()
+        composeRule.runOnIdle {
+            assertTrue(filterSelections.isEmpty())
+        }
+
+        pressBack()
+        composeRule.runOnIdle {
+            assertEquals(1, filterSelections.size)
+        }
+    }
+}
+
+private const val reviewRouteWorkspaceId = "review-route-test-workspace"
+private const val reviewRouteFirstTag = "Alpha"
+private const val reviewRouteSecondTag = "Beta"
+
+private data class ReviewFilterSelection(
+    val workspaceId: String,
+    val openingFilter: ReviewFilter,
+    val selectedFilter: ReviewFilter
+)
+
+@Composable
+private fun ReviewRouteTestContent(
+    uiState: ReviewUiState,
+    workspaceId: String?,
+    onSelectFilter: (String, ReviewFilter, ReviewFilter) -> Unit,
+    onOpenDeckManagement: () -> Unit,
+    onScreenVisible: () -> Unit
+) {
+    FlashcardsTheme {
+        val reviewReactionLottieConfigurationStore =
+            rememberReviewReactionLottieConfigurationStore(loadLottieCompositions = true)
+        ReviewRoute(
+            uiState = uiState,
+            workspaceId = workspaceId,
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
+            reviewReactionAnimationsEnabled = false,
+            onSelectFilter = onSelectFilter,
+            onOpenPreview = {},
+            onOpenCurrentCard = {},
+            onOpenCurrentCardWithAi = { _, _, _, _ -> },
+            onOpenDeckManagement = onOpenDeckManagement,
+            onCreateCard = {},
+            onCreateCardWithAi = {},
+            onSwitchToAllCards = {},
+            onLoadManagedMediaFile = { mediaAssetId ->
+                throw UnsupportedOperationException(
+                    "ReviewRouteTest does not load managed media files. mediaAssetId=$mediaAssetId"
+                )
+            },
+            onLoadManagedMediaDownloadUrl = { mediaAssetId ->
+                throw UnsupportedOperationException(
+                    "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"
+                )
+            },
+            onRevealAnswer = {},
+            onRateAgain = {},
+            onRateHard = {},
+            onRateGood = {},
+            onRateEasy = {},
+            onDismissHardAnswerReminder = {},
+            onDismissErrorMessage = {},
+            onDismissNotificationPermissionPrompt = {},
+            onContinueNotificationPermissionPrompt = {},
+            onOpenLeaderboard = {},
+            onOpenProgress = {},
+            onScreenVisible = onScreenVisible
+        )
+    }
+}
+
+private fun reviewRouteUiState(
+    isLoading: Boolean,
+    requestedFilter: ReviewFilter
+): ReviewUiState {
+    return ReviewUiState(
+        isLoading = isLoading,
+        requestedFilter = requestedFilter,
+        selectedFilter = requestedFilter,
+        selectedFilterTitle = "Review filter",
+        remainingCount = 0,
+        totalCount = 0,
+        reviewedInSessionCount = 0,
+        isAnswerVisible = false,
+        currentCardIdForEditing = null,
+        preparedCurrentCard = null,
+        preparedNextCard = null,
+        availableDeckFilters = emptyList(),
+        availableTagFilters = listOf(
+            ReviewTagFilterOption(tag = reviewRouteFirstTag, totalCount = 1),
+            ReviewTagFilterOption(tag = reviewRouteSecondTag, totalCount = 1)
+        ),
+        reviewLeaderboardBadge = ReviewLeaderboardBadgeState(
+            rank = null,
+            windowKey = null,
+            isInteractive = false
+        ),
+        reviewProgressBadge = ReviewProgressBadgeState(
+            streakDays = 0,
+            hasReviewedToday = false,
+            isInteractive = false
+        ),
+        isPreviewLoading = false,
+        previewItems = emptyList(),
+        hasMorePreviewCards = false,
+        emptyState = ReviewEmptyState.SESSION_COMPLETE,
+        previewErrorMessage = "",
+        errorMessage = "",
+        isNotificationPermissionPromptVisible = false,
+        isHardAnswerReminderVisible = false
+    )
 }
 
 private fun <T> hasSemanticsValue(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -131,7 +131,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 workspaceId = workspaceId,
                 reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                 reviewReactionAnimationsEnabled = reviewReactionAnimationsEnabledState.value,
-                onSelectFilter = reviewViewModel::selectFilterForWorkspace,
+                onSelectFilter = reviewViewModel::selectFilterForWorkspaceIfUnchanged,
                 onOpenPreview = {
                     reviewViewModel.refreshPreview()
                     navController.navigate(route = ReviewPreviewDestination.route)

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -49,7 +49,7 @@ fun ReviewRoute(
     workspaceId: String?,
     reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
     reviewReactionAnimationsEnabled: Boolean,
-    onSelectFilter: (String, ReviewFilter) -> Unit,
+    onSelectFilter: (String, ReviewFilter, ReviewFilter) -> Unit,
     onOpenPreview: () -> Unit,
     onOpenCurrentCard: (String) -> Unit,
     onOpenCurrentCardWithAi: (
@@ -139,12 +139,13 @@ fun ReviewRoute(
             workspaceId = workspaceId,
             selection = uiState.requestedFilter
         )
-        if (
-            workspaceId != null
-            && transaction.workspaceId == workspaceId
-            && transaction.draftSelection != transaction.openingSelection
-        ) {
-            onSelectFilter(workspaceId, transaction.draftSelection)
+        val openingWorkspaceId: String = transaction.workspaceId ?: return
+        if (transaction.draftSelection != transaction.openingSelection) {
+            onSelectFilter(
+                openingWorkspaceId,
+                transaction.openingSelection,
+                transaction.draftSelection
+            )
         }
     }
     val onRateAgainWithReaction: () -> Unit = {
@@ -179,12 +180,15 @@ fun ReviewRoute(
         }
     }
 
-    LaunchedEffect(workspaceId) {
+    LaunchedEffect(workspaceId, uiState.requestedFilter, uiState.isLoading) {
         val transaction: ReviewFilterSheetTransaction = filterSheetTransaction
         if (
-            workspaceId != null
-            && transaction.isVisible
-            && transaction.workspaceId != workspaceId
+            transaction.isVisible
+            && uiState.isLoading.not()
+            && (
+                transaction.workspaceId != workspaceId
+                    || transaction.openingSelection != uiState.requestedFilter
+                )
         ) {
             filterSheetTransaction = closedReviewFilterSheetTransaction(
                 workspaceId = workspaceId,
@@ -244,7 +248,7 @@ fun ReviewRoute(
                 reviewProgressBadge = uiState.reviewProgressBadge,
                 selectedFilterTitle = uiState.selectedFilterTitle,
                 onOpenFilter = {
-                    if (workspaceId != null) {
+                    if (workspaceId != null && uiState.isLoading.not()) {
                         filterSheetTransaction = openReviewFilterSheetTransaction(
                             workspaceId = workspaceId,
                             selection = uiState.requestedFilter

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewScreenTags.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewScreenTags.kt
@@ -18,6 +18,7 @@ const val reviewLeaderboardShortcutTag: String = "review_leaderboard_shortcut"
 const val reviewQueueButtonTag: String = "review_queue_button"
 const val reviewFilterSheetTag: String = "review_filter_sheet"
 const val reviewFilterAllCardsOptionTag: String = "review_filter_all_cards_option"
+const val reviewManageDecksButtonTag: String = "review_manage_decks_button"
 
 fun reviewFilterDeckOptionTag(deckId: String): String = "review_filter_deck_option::$deckId"
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -192,8 +192,17 @@ class ReviewViewModel(
         onReviewNotificationsChanged(ReviewNotificationsReconcileTrigger.FILTER_CHANGED)
     }
 
-    fun selectFilterForWorkspace(workspaceId: String, reviewFilter: ReviewFilter) {
-        if (workspaceId != activeWorkspaceId) {
+    fun selectFilterForWorkspaceIfUnchanged(
+        workspaceId: String,
+        openingFilter: ReviewFilter,
+        reviewFilter: ReviewFilter
+    ) {
+        if (
+            workspaceId != activeWorkspaceId
+            || draftState.value.requestedFilter != openingFilter
+            || uiState.value.isLoading
+            || reviewFilter == openingFilter
+        ) {
             return
         }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
@@ -152,7 +152,9 @@ internal fun ReviewFilterSheet(
             item {
                 TextButton(
                     onClick = onManageDecks,
-                    modifier = Modifier.padding(horizontal = 24.dp)
+                    modifier = Modifier
+                        .padding(horizontal = 24.dp)
+                        .testTag(reviewManageDecksButtonTag)
                 ) {
                     Text(stringResource(id = R.string.review_manage_filtered_decks))
                 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
@@ -72,6 +72,7 @@ internal fun ReviewTopBar(
         actions = {
             FilterChip(
                 selected = false,
+                enabled = isLoading.not(),
                 onClick = onOpenFilter,
                 label = {
                     Text(


### PR DESCRIPTION
## Summary
- keep review filter edits local until the native sheet closes
- conditionally commit only when the opening workspace and filter still match
- discard stale drafts and preserve them through UI state restoration
- guard filter opening while the review screen is loading
- add focused Android instrumentation coverage

## Validation
- Not run locally per integration queue policy; the patch passed a complete static seven-file review with no P0-P4 findings.