### PR TITLE
Stabilize review filter multiselect finalization

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToNodeAction
@@ -519,7 +520,7 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     @Test
-    fun reviewFilterChecklistAppliesImmediatelyStaysOpenPersistsAndRestoresAllCards() {
+    fun reviewFilterChecklistStagesUntilDismissPersistsAndRestoresAllCards() {
         waitForCardsEmptyState()
         createCard(frontText = "Alpha review", backText = "Alpha answer", tags = listOf("Alpha"))
         createCard(frontText = "Beta review", backText = "Beta answer", tags = listOf("Beta"))
@@ -540,12 +541,26 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("All cards")
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 3 cards.")
+
+        pressBack()
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("No tags").fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
                 && composeRule.onAllNodesWithTag(reviewEmptyStateTag).fetchSemanticsNodes().isNotEmpty()
         }
-        composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 0 cards.")
+        waitForReviewFilterState(
+            filterTitle = "No tags",
+            queueContentDescription = "Review queue 0 cards."
+        )
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        waitForTagToExist(tag = reviewFilterSheetTag)
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
 
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).performClick()
         composeRule.onNodeWithTag(reviewFilterSheetTag).assertIsDisplayed()
@@ -553,47 +568,83 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
-        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("No tags")
         composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 1 card.")
+            .assertContentDescriptionEquals("Review queue 0 cards.")
 
+        recreateActivity()
+        waitForTagToExist(tag = reviewFilterSheetTag)
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("No tags")
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals("Review queue 0 cards.")
+
+        pressBack()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
+        }
+        waitForReviewFilterState(
+            filterTitle = "Alpha",
+            queueContentDescription = "Review queue 1 card."
+        )
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        waitForTagToExist(tag = reviewFilterSheetTag)
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).performClick()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
-        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("Alpha")
         composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 2 cards.")
+            .assertContentDescriptionEquals("Review queue 1 card.")
 
+        pressBack()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
+        }
+        waitForReviewFilterState(
+            filterTitle = "2 tags",
+            queueContentDescription = "Review queue 2 cards."
+        )
+
+        openCardsTab()
+        openReviewTab()
+        waitForReviewFilterState(
+            filterTitle = "2 tags",
+            queueContentDescription = "Review queue 2 cards."
+        )
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        waitForTagToExist(tag = reviewFilterSheetTag)
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
         composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
         composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("All cards").fetchSemanticsNodes().isNotEmpty()
-        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals("2 tags")
         composeRule.onNodeWithTag(reviewQueueButtonTag)
-            .assertContentDescriptionEquals("Review queue 3 cards.")
+            .assertContentDescriptionEquals("Review queue 2 cards.")
 
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).performClick()
         pressBack()
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             composeRule.onAllNodesWithTag(reviewFilterSheetTag).fetchSemanticsNodes().isEmpty()
         }
-        openCardsTab()
-        openReviewTab()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithText("2 tags").fetchSemanticsNodes().isNotEmpty()
-        }
+        waitForReviewFilterState(
+            filterTitle = "All cards",
+            queueContentDescription = "Review queue 3 cards."
+        )
+
         composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Alpha")).assertIsOn()
         composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Beta")).assertIsOn()
-        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = "Gamma")).assertIsOn()
     }
 
     @Test
@@ -918,6 +969,25 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             countNodesWithTagInAnySemanticsTree(tag = tag) > 0
         }
+    }
+
+    private fun waitForReviewFilterState(
+        filterTitle: String,
+        queueContentDescription: String
+    ) {
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodes(
+                matcher = hasTestTag(reviewFilterButtonTag).and(other = hasText(filterTitle))
+            ).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodes(
+                    matcher = hasTestTag(reviewQueueButtonTag).and(
+                        other = hasContentDescription(queueContentDescription)
+                    )
+                ).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertTextEquals(filterTitle)
+        composeRule.onNodeWithTag(reviewQueueButtonTag)
+            .assertContentDescriptionEquals(queueContentDescription)
     }
 
     private fun aiString(@StringRes resId: Int): String {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -1,30 +1,49 @@
 package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.fetchSemanticsNode
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption
 import com.flashcardsopensourceapp.feature.review.R as ReviewStringResources
 import com.flashcardsopensourceapp.feature.review.ReviewEmptyState
 import com.flashcardsopensourceapp.feature.review.ReviewLeaderboardBadgeState
 import com.flashcardsopensourceapp.feature.review.ReviewProgressBadgeState
 import com.flashcardsopensourceapp.feature.review.ReviewRoute
 import com.flashcardsopensourceapp.feature.review.ReviewUiState
+import com.flashcardsopensourceapp.feature.review.reviewFilterAllCardsOptionTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterButtonTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterSheetTag
+import com.flashcardsopensourceapp.feature.review.reviewFilterTagOptionTag
 import com.flashcardsopensourceapp.feature.review.reviewLeaderboardShortcutTag
+import com.flashcardsopensourceapp.feature.review.reviewManageDecksButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewProgressBadgeTag
 import com.flashcardsopensourceapp.feature.review.reviewQueueButtonTag
 import com.flashcardsopensourceapp.feature.review.reaction.rememberReviewReactionLottieConfigurationStore
@@ -109,7 +128,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     workspaceId = "review-route-test-workspace",
                     reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                     reviewReactionAnimationsEnabled = true,
-                    onSelectFilter = { _, _ -> },
+                    onSelectFilter = { _, _, _ -> },
                     onOpenPreview = {
                         openPreviewCalls += 1
                     },
@@ -197,6 +216,312 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         assertEquals(1, openPreviewCalls)
         assertEquals(1, openProgressCalls)
     }
+
+    @Test
+    fun reviewFilterDraftStaysLocalAndAppliesExactlyOnceOnOutsideDismissal() {
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = false,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { workspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = workspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).assertIsOff()
+        composeRule.runOnIdle {
+            assertTrue(filterSelections.isEmpty())
+        }
+
+        val filterSheet = composeRule.onNodeWithTag(reviewFilterSheetTag)
+        val filterSheetTop = filterSheet.fetchSemanticsNode().boundsInRoot.top
+        filterSheet.performTouchInput {
+            click(position = Offset(x = center.x, y = -filterSheetTop / 2f))
+        }
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+        composeRule.runOnIdle {
+            assertEquals(
+                listOf(
+                    ReviewFilterSelection(
+                        workspaceId = reviewRouteWorkspaceId,
+                        openingFilter = ReviewFilter.AllCards,
+                        selectedFilter = ReviewFilter.Tags(tags = emptyList())
+                    )
+                ),
+                filterSelections
+            )
+        }
+    }
+
+    @Test
+    fun reviewFilterManageDecksFinalizesDraftBeforeNavigation() {
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+        var openDeckManagementCalls = 0
+
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = false,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { workspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = workspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {
+                    openDeckManagementCalls += 1
+                },
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteFirstTag)).performClick()
+        composeRule.onNodeWithTag(reviewManageDecksButtonTag).performClick()
+
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+        composeRule.runOnIdle {
+            assertEquals(1, openDeckManagementCalls)
+            assertEquals(
+                listOf(
+                    ReviewFilterSelection(
+                        workspaceId = reviewRouteWorkspaceId,
+                        openingFilter = ReviewFilter.AllCards,
+                        selectedFilter = ReviewFilter.Tags(tags = listOf(reviewRouteSecondTag))
+                    )
+                ),
+                filterSelections
+            )
+        }
+    }
+
+    @Test
+    fun reviewFilterDraftIsDiscardedWhenWorkspaceOrCommittedFilterChanges() {
+        var uiState by mutableStateOf(
+            value = reviewRouteUiState(
+                isLoading = false,
+                requestedFilter = ReviewFilter.AllCards
+            )
+        )
+        var workspaceId by mutableStateOf(value = reviewRouteWorkspaceId)
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = uiState,
+                workspaceId = workspaceId,
+                onSelectFilter = { selectedWorkspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = selectedWorkspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
+        composeRule.runOnIdle {
+            workspaceId = "replacement-workspace"
+        }
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterAllCardsOptionTag).performClick()
+        composeRule.runOnIdle {
+            uiState = reviewRouteUiState(
+                isLoading = false,
+                requestedFilter = ReviewFilter.Tags(tags = listOf(reviewRouteFirstTag))
+            )
+        }
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+        composeRule.runOnIdle {
+            assertTrue(filterSelections.isEmpty())
+        }
+    }
+
+    @Test
+    fun reviewFilterCannotOpenWhileReviewIsLoading() {
+        composeRule.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = true,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { _, _, _ -> },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).assertIsNotEnabled()
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertDoesNotExist()
+    }
+
+    @Test
+    fun reviewFilterDraftRestoresBeforeDismissal() {
+        val stateRestorationTester = StateRestorationTester(composeRule)
+        val filterSelections = mutableListOf<ReviewFilterSelection>()
+
+        stateRestorationTester.setContent {
+            ReviewRouteTestContent(
+                uiState = reviewRouteUiState(
+                    isLoading = false,
+                    requestedFilter = ReviewFilter.AllCards
+                ),
+                workspaceId = reviewRouteWorkspaceId,
+                onSelectFilter = { workspaceId, openingFilter, selectedFilter ->
+                    filterSelections += ReviewFilterSelection(
+                        workspaceId = workspaceId,
+                        openingFilter = openingFilter,
+                        selectedFilter = selectedFilter
+                    )
+                },
+                onOpenDeckManagement = {},
+                onScreenVisible = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(reviewFilterButtonTag).performClick()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteFirstTag)).performClick()
+        stateRestorationTester.emulateSavedInstanceStateRestore()
+
+        composeRule.onNodeWithTag(reviewFilterSheetTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteFirstTag)).assertIsOff()
+        composeRule.onNodeWithTag(reviewFilterTagOptionTag(tag = reviewRouteSecondTag)).assertIsOn()
+        composeRule.runOnIdle {
+            assertTrue(filterSelections.isEmpty())
+        }
+
+        pressBack()
+        composeRule.runOnIdle {
+            assertEquals(1, filterSelections.size)
+        }
+    }
+}
+
+private const val reviewRouteWorkspaceId = "review-route-test-workspace"
+private const val reviewRouteFirstTag = "Alpha"
+private const val reviewRouteSecondTag = "Beta"
+
+private data class ReviewFilterSelection(
+    val workspaceId: String,
+    val openingFilter: ReviewFilter,
+    val selectedFilter: ReviewFilter
+)
+
+@Composable
+private fun ReviewRouteTestContent(
+    uiState: ReviewUiState,
+    workspaceId: String?,
+    onSelectFilter: (String, ReviewFilter, ReviewFilter) -> Unit,
+    onOpenDeckManagement: () -> Unit,
+    onScreenVisible: () -> Unit
+) {
+    FlashcardsTheme {
+        val reviewReactionLottieConfigurationStore =
+            rememberReviewReactionLottieConfigurationStore(loadLottieCompositions = true)
+        ReviewRoute(
+            uiState = uiState,
+            workspaceId = workspaceId,
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
+            reviewReactionAnimationsEnabled = false,
+            onSelectFilter = onSelectFilter,
+            onOpenPreview = {},
+            onOpenCurrentCard = {},
+            onOpenCurrentCardWithAi = { _, _, _, _ -> },
+            onOpenDeckManagement = onOpenDeckManagement,
+            onCreateCard = {},
+            onCreateCardWithAi = {},
+            onSwitchToAllCards = {},
+            onLoadManagedMediaFile = { mediaAssetId ->
+                throw UnsupportedOperationException(
+                    "ReviewRouteTest does not load managed media files. mediaAssetId=$mediaAssetId"
+                )
+            },
+            onLoadManagedMediaDownloadUrl = { mediaAssetId ->
+                throw UnsupportedOperationException(
+                    "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"
+                )
+            },
+            onRevealAnswer = {},
+            onRateAgain = {},
+            onRateHard = {},
+            onRateGood = {},
+            onRateEasy = {},
+            onDismissHardAnswerReminder = {},
+            onDismissErrorMessage = {},
+            onDismissNotificationPermissionPrompt = {},
+            onContinueNotificationPermissionPrompt = {},
+            onOpenLeaderboard = {},
+            onOpenProgress = {},
+            onScreenVisible = onScreenVisible
+        )
+    }
+}
+
+private fun reviewRouteUiState(
+    isLoading: Boolean,
+    requestedFilter: ReviewFilter
+): ReviewUiState {
+    return ReviewUiState(
+        isLoading = isLoading,
+        requestedFilter = requestedFilter,
+        selectedFilter = requestedFilter,
+        selectedFilterTitle = "Review filter",
+        remainingCount = 0,
+        totalCount = 0,
+        reviewedInSessionCount = 0,
+        isAnswerVisible = false,
+        currentCardIdForEditing = null,
+        preparedCurrentCard = null,
+        preparedNextCard = null,
+        availableDeckFilters = emptyList(),
+        availableTagFilters = listOf(
+            ReviewTagFilterOption(tag = reviewRouteFirstTag, totalCount = 1),
+            ReviewTagFilterOption(tag = reviewRouteSecondTag, totalCount = 1)
+        ),
+        reviewLeaderboardBadge = ReviewLeaderboardBadgeState(
+            rank = null,
+            windowKey = null,
+            isInteractive = false
+        ),
+        reviewProgressBadge = ReviewProgressBadgeState(
+            streakDays = 0,
+            hasReviewedToday = false,
+            isInteractive = false
+        ),
+        isPreviewLoading = false,
+        previewItems = emptyList(),
+        hasMorePreviewCards = false,
+        emptyState = ReviewEmptyState.SESSION_COMPLETE,
+        previewErrorMessage = "",
+        errorMessage = "",
+        isNotificationPermissionPromptVisible = false,
+        isHardAnswerReminderVisible = false
+    )
 }
 
 private fun <T> hasSemanticsValue(

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -12,12 +12,11 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
-import androidx.compose.ui.test.fetchSemanticsNode
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -106,9 +106,10 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isNotificationPermissionPromptVisible = false,
                         isHardAnswerReminderVisible = false
                     ),
+                    workspaceId = "review-route-test-workspace",
                     reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                     reviewReactionAnimationsEnabled = true,
-                    onSelectFilter = {},
+                    onSelectFilter = { _, _ -> },
                     onOpenPreview = {
                         openPreviewCalls += 1
                     },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -115,6 +115,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 )
             )
             val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
+            val workspaceId by reviewViewModel.workspaceId.collectAsStateWithLifecycle()
             val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
 
             LaunchedEffect(reviewFilterRequest?.requestId, uiState) {
@@ -127,9 +128,10 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
 
             ReviewRoute(
                 uiState = uiState,
+                workspaceId = workspaceId,
                 reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                 reviewReactionAnimationsEnabled = reviewReactionAnimationsEnabledState.value,
-                onSelectFilter = reviewViewModel::selectFilter,
+                onSelectFilter = reviewViewModel::selectFilterForWorkspace,
                 onOpenPreview = {
                     reviewViewModel.refreshPreview()
                     navController.navigate(route = ReviewPreviewDestination.route)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -131,7 +131,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 workspaceId = workspaceId,
                 reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                 reviewReactionAnimationsEnabled = reviewReactionAnimationsEnabledState.value,
-                onSelectFilter = reviewViewModel::selectFilterForWorkspace,
+                onSelectFilter = reviewViewModel::selectFilterForWorkspaceIfUnchanged,
                 onOpenPreview = {
                     reviewViewModel.refreshPreview()
                     navController.navigate(route = ReviewPreviewDestination.route)

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewFilterSheetTransaction.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewFilterSheetTransaction.kt
@@ -1,0 +1,120 @@
+package com.flashcardsopensourceapp.feature.review
+
+import android.os.Bundle
+import androidx.compose.runtime.saveable.Saver
+import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
+
+private const val reviewFilterSheetVisibleKey = "visible"
+private const val reviewFilterSheetWorkspaceIdKey = "workspace_id"
+private const val reviewFilterSheetOpeningSelectionKey = "opening_selection"
+private const val reviewFilterSheetDraftSelectionKey = "draft_selection"
+private const val reviewFilterAllCardsType = "all_cards"
+private const val reviewFilterDeckType = "deck"
+private const val reviewFilterTagsType = "tags"
+
+internal data class ReviewFilterSheetTransaction(
+    val isVisible: Boolean,
+    val workspaceId: String?,
+    val openingSelection: ReviewFilter,
+    val draftSelection: ReviewFilter
+)
+
+internal val reviewFilterSheetTransactionSaver: Saver<ReviewFilterSheetTransaction, Bundle> = Saver(
+    save = { transaction ->
+        Bundle().apply {
+            putBoolean(reviewFilterSheetVisibleKey, transaction.isVisible)
+            putString(reviewFilterSheetWorkspaceIdKey, transaction.workspaceId)
+            putStringArrayList(
+                reviewFilterSheetOpeningSelectionKey,
+                ArrayList(serializeReviewFilter(reviewFilter = transaction.openingSelection))
+            )
+            putStringArrayList(
+                reviewFilterSheetDraftSelectionKey,
+                ArrayList(serializeReviewFilter(reviewFilter = transaction.draftSelection))
+            )
+        }
+    },
+    restore = { savedState ->
+        require(savedState.containsKey(reviewFilterSheetVisibleKey)) {
+            "Saved review filter sheet transaction is missing its visibility state."
+        }
+        require(savedState.containsKey(reviewFilterSheetWorkspaceIdKey)) {
+            "Saved review filter sheet transaction is missing its workspace context."
+        }
+
+        ReviewFilterSheetTransaction(
+            isVisible = savedState.getBoolean(reviewFilterSheetVisibleKey),
+            workspaceId = savedState.getString(reviewFilterSheetWorkspaceIdKey),
+            openingSelection = deserializeReviewFilter(
+                savedFilter = requireSavedReviewFilter(
+                    savedState = savedState,
+                    key = reviewFilterSheetOpeningSelectionKey
+                )
+            ),
+            draftSelection = deserializeReviewFilter(
+                savedFilter = requireSavedReviewFilter(
+                    savedState = savedState,
+                    key = reviewFilterSheetDraftSelectionKey
+                )
+            )
+        )
+    }
+)
+
+internal fun closedReviewFilterSheetTransaction(
+    workspaceId: String?,
+    selection: ReviewFilter
+): ReviewFilterSheetTransaction {
+    return ReviewFilterSheetTransaction(
+        isVisible = false,
+        workspaceId = workspaceId,
+        openingSelection = selection,
+        draftSelection = selection
+    )
+}
+
+internal fun openReviewFilterSheetTransaction(
+    workspaceId: String,
+    selection: ReviewFilter
+): ReviewFilterSheetTransaction {
+    return ReviewFilterSheetTransaction(
+        isVisible = true,
+        workspaceId = workspaceId,
+        openingSelection = selection,
+        draftSelection = selection
+    )
+}
+
+private fun serializeReviewFilter(reviewFilter: ReviewFilter): List<String> {
+    return when (reviewFilter) {
+        ReviewFilter.AllCards -> listOf(reviewFilterAllCardsType)
+        is ReviewFilter.Deck -> listOf(reviewFilterDeckType, reviewFilter.deckId)
+        is ReviewFilter.Tags -> listOf(reviewFilterTagsType) + reviewFilter.tags
+    }
+}
+
+private fun deserializeReviewFilter(savedFilter: List<String>): ReviewFilter {
+    val filterType: String = savedFilter.firstOrNull()
+        ?: throw IllegalStateException("Saved review filter is empty.")
+    return when (filterType) {
+        reviewFilterAllCardsType -> {
+            require(savedFilter.size == 1) {
+                "Saved All cards review filter must not contain values."
+            }
+            ReviewFilter.AllCards
+        }
+        reviewFilterDeckType -> {
+            require(savedFilter.size == 2 && savedFilter[1].isNotEmpty()) {
+                "Saved deck review filter must contain exactly one non-empty deck ID."
+            }
+            ReviewFilter.Deck(deckId = savedFilter[1])
+        }
+        reviewFilterTagsType -> ReviewFilter.Tags(tags = savedFilter.drop(1))
+        else -> throw IllegalStateException("Saved review filter has unsupported type '$filterType'.")
+    }
+}
+
+private fun requireSavedReviewFilter(savedState: Bundle, key: String): List<String> {
+    return savedState.getStringArrayList(key)
+        ?: throw IllegalStateException("Saved review filter sheet transaction is missing '$key'.")
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -49,7 +49,7 @@ fun ReviewRoute(
     workspaceId: String?,
     reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
     reviewReactionAnimationsEnabled: Boolean,
-    onSelectFilter: (String, ReviewFilter) -> Unit,
+    onSelectFilter: (String, ReviewFilter, ReviewFilter) -> Unit,
     onOpenPreview: () -> Unit,
     onOpenCurrentCard: (String) -> Unit,
     onOpenCurrentCardWithAi: (
@@ -139,12 +139,13 @@ fun ReviewRoute(
             workspaceId = workspaceId,
             selection = uiState.requestedFilter
         )
-        if (
-            workspaceId != null
-            && transaction.workspaceId == workspaceId
-            && transaction.draftSelection != transaction.openingSelection
-        ) {
-            onSelectFilter(workspaceId, transaction.draftSelection)
+        val openingWorkspaceId: String = transaction.workspaceId ?: return
+        if (transaction.draftSelection != transaction.openingSelection) {
+            onSelectFilter(
+                openingWorkspaceId,
+                transaction.openingSelection,
+                transaction.draftSelection
+            )
         }
     }
     val onRateAgainWithReaction: () -> Unit = {
@@ -179,12 +180,15 @@ fun ReviewRoute(
         }
     }
 
-    LaunchedEffect(workspaceId) {
+    LaunchedEffect(workspaceId, uiState.requestedFilter, uiState.isLoading) {
         val transaction: ReviewFilterSheetTransaction = filterSheetTransaction
         if (
-            workspaceId != null
-            && transaction.isVisible
-            && transaction.workspaceId != workspaceId
+            transaction.isVisible
+            && uiState.isLoading.not()
+            && (
+                transaction.workspaceId != workspaceId
+                    || transaction.openingSelection != uiState.requestedFilter
+                )
         ) {
             filterSheetTransaction = closedReviewFilterSheetTransaction(
                 workspaceId = workspaceId,
@@ -244,7 +248,7 @@ fun ReviewRoute(
                 reviewProgressBadge = uiState.reviewProgressBadge,
                 selectedFilterTitle = uiState.selectedFilterTitle,
                 onOpenFilter = {
-                    if (workspaceId != null) {
+                    if (workspaceId != null && uiState.isLoading.not()) {
                         filterSheetTransaction = openReviewFilterSheetTransaction(
                             workspaceId = workspaceId,
                             selection = uiState.requestedFilter

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -45,9 +46,10 @@ import java.util.Locale
 @Composable
 fun ReviewRoute(
     uiState: ReviewUiState,
+    workspaceId: String?,
     reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
     reviewReactionAnimationsEnabled: Boolean,
-    onSelectFilter: (ReviewFilter) -> Unit,
+    onSelectFilter: (String, ReviewFilter) -> Unit,
     onOpenPreview: () -> Unit,
     onOpenCurrentCard: (String) -> Unit,
     onOpenCurrentCardWithAi: (
@@ -75,8 +77,16 @@ fun ReviewRoute(
     onOpenProgress: () -> Unit,
     onScreenVisible: () -> Unit
 ) {
-    var isFilterSheetVisible by remember { mutableStateOf(value = false) }
-    var filterSheetSelection by remember { mutableStateOf<ReviewFilter?>(value = null) }
+    var filterSheetTransaction by rememberSaveable(
+        stateSaver = reviewFilterSheetTransactionSaver
+    ) {
+        mutableStateOf(
+            value = closedReviewFilterSheetTransaction(
+                workspaceId = workspaceId,
+                selection = uiState.requestedFilter
+            )
+        )
+    }
     var speechErrorMessage by remember { mutableStateOf(value = "") }
     var activeReviewReactionEvents by remember {
         mutableStateOf<List<ReviewReactionEvent>>(value = emptyList())
@@ -119,6 +129,24 @@ fun ReviewRoute(
             maximumActiveEvents = reviewReactionMaximumActiveEvents
         )
     }
+    fun finalizeFilterSheetSelection(): Unit {
+        val transaction: ReviewFilterSheetTransaction = filterSheetTransaction
+        if (transaction.isVisible.not()) {
+            return
+        }
+
+        filterSheetTransaction = closedReviewFilterSheetTransaction(
+            workspaceId = workspaceId,
+            selection = uiState.requestedFilter
+        )
+        if (
+            workspaceId != null
+            && transaction.workspaceId == workspaceId
+            && transaction.draftSelection != transaction.openingSelection
+        ) {
+            onSelectFilter(workspaceId, transaction.draftSelection)
+        }
+    }
     val onRateAgainWithReaction: () -> Unit = {
         emitReviewReaction(rating = ReviewRating.AGAIN)
         onRateAgain()
@@ -148,6 +176,20 @@ fun ReviewRoute(
     LaunchedEffect(reviewReactionAnimationsEnabled) {
         if (reviewReactionAnimationsEnabled.not()) {
             activeReviewReactionEvents = emptyList()
+        }
+    }
+
+    LaunchedEffect(workspaceId) {
+        val transaction: ReviewFilterSheetTransaction = filterSheetTransaction
+        if (
+            workspaceId != null
+            && transaction.isVisible
+            && transaction.workspaceId != workspaceId
+        ) {
+            filterSheetTransaction = closedReviewFilterSheetTransaction(
+                workspaceId = workspaceId,
+                selection = uiState.requestedFilter
+            )
         }
     }
 
@@ -202,8 +244,12 @@ fun ReviewRoute(
                 reviewProgressBadge = uiState.reviewProgressBadge,
                 selectedFilterTitle = uiState.selectedFilterTitle,
                 onOpenFilter = {
-                    filterSheetSelection = uiState.requestedFilter
-                    isFilterSheetVisible = true
+                    if (workspaceId != null) {
+                        filterSheetTransaction = openReviewFilterSheetTransaction(
+                            workspaceId = workspaceId,
+                            selection = uiState.requestedFilter
+                        )
+                    }
                 },
                 onOpenPreview = onOpenPreview,
                 onOpenLeaderboard = onOpenLeaderboard,
@@ -300,32 +346,34 @@ fun ReviewRoute(
         }
     }
 
-    if (isFilterSheetVisible) {
+    if (
+        workspaceId != null
+        && filterSheetTransaction.isVisible
+        && filterSheetTransaction.workspaceId == workspaceId
+    ) {
         ReviewFilterSheet(
-            selectedFilter = filterSheetSelection ?: uiState.requestedFilter,
+            selectedFilter = filterSheetTransaction.draftSelection,
             availableDeckFilters = uiState.availableDeckFilters,
             availableTagFilters = uiState.availableTagFilters,
-            onDismiss = {
-                isFilterSheetVisible = false
-                filterSheetSelection = null
-            },
+            onDismiss = ::finalizeFilterSheetSelection,
             onSelectFilter = { nextFilter ->
-                filterSheetSelection = nextFilter
-                onSelectFilter(nextFilter)
+                filterSheetTransaction = filterSheetTransaction.copy(
+                    draftSelection = nextFilter
+                )
             },
             onToggleTag = { tagName ->
                 val nextFilter = toggleReviewTagFilter(
-                    selectedFilter = filterSheetSelection ?: uiState.requestedFilter,
+                    selectedFilter = filterSheetTransaction.draftSelection,
                     toggledTagName = tagName,
                     availableDeckFilters = uiState.availableDeckFilters,
                     availableTagFilters = uiState.availableTagFilters
                 )
-                filterSheetSelection = nextFilter
-                onSelectFilter(nextFilter)
+                filterSheetTransaction = filterSheetTransaction.copy(
+                    draftSelection = nextFilter
+                )
             },
             onManageDecks = {
-                isFilterSheetVisible = false
-                filterSheetSelection = null
+                finalizeFilterSheetSelection()
                 onOpenDeckManagement()
             }
         )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewScreenTags.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewScreenTags.kt
@@ -18,6 +18,7 @@ const val reviewLeaderboardShortcutTag: String = "review_leaderboard_shortcut"
 const val reviewQueueButtonTag: String = "review_queue_button"
 const val reviewFilterSheetTag: String = "review_filter_sheet"
 const val reviewFilterAllCardsOptionTag: String = "review_filter_all_cards_option"
+const val reviewManageDecksButtonTag: String = "review_manage_decks_button"
 
 fun reviewFilterDeckOptionTag(deckId: String): String = "review_filter_deck_option::$deckId"
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -98,6 +98,13 @@ class ReviewViewModel(
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
         initialValue = null
     )
+    val workspaceId: StateFlow<String?> = workspaceState.map { workspace ->
+        workspace?.workspaceId
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = null
+    )
     private val appMetadataState = workspaceRepository.observeAppMetadata().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
@@ -183,6 +190,14 @@ class ReviewViewModel(
         }
         persistSelectedReviewFilter(reviewFilter = reviewFilter)
         onReviewNotificationsChanged(ReviewNotificationsReconcileTrigger.FILTER_CHANGED)
+    }
+
+    fun selectFilterForWorkspace(workspaceId: String, reviewFilter: ReviewFilter) {
+        if (workspaceId != activeWorkspaceId) {
+            return
+        }
+
+        selectFilter(reviewFilter = reviewFilter)
     }
 
     fun selectFilterForHandoff(reviewFilter: ReviewFilter): Boolean {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -192,8 +192,17 @@ class ReviewViewModel(
         onReviewNotificationsChanged(ReviewNotificationsReconcileTrigger.FILTER_CHANGED)
     }
 
-    fun selectFilterForWorkspace(workspaceId: String, reviewFilter: ReviewFilter) {
-        if (workspaceId != activeWorkspaceId) {
+    fun selectFilterForWorkspaceIfUnchanged(
+        workspaceId: String,
+        openingFilter: ReviewFilter,
+        reviewFilter: ReviewFilter
+    ) {
+        if (
+            workspaceId != activeWorkspaceId
+            || draftState.value.requestedFilter != openingFilter
+            || uiState.value.isLoading
+            || reviewFilter == openingFilter
+        ) {
             return
         }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
@@ -152,7 +152,9 @@ internal fun ReviewFilterSheet(
             item {
                 TextButton(
                     onClick = onManageDecks,
-                    modifier = Modifier.padding(horizontal = 24.dp)
+                    modifier = Modifier
+                        .padding(horizontal = 24.dp)
+                        .testTag(reviewManageDecksButtonTag)
                 ) {
                     Text(stringResource(id = R.string.review_manage_filtered_decks))
                 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
@@ -72,6 +72,7 @@ internal fun ReviewTopBar(
         actions = {
             FilterChip(
                 selected = false,
+                enabled = isLoading.not(),
                 onClick = onOpenFilter,
                 label = {
                     Text(

--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -22,6 +22,7 @@ enum UITestIdentifier {
     static let rootTabSettingsItem: String = "rootTab.settings.item"
     static let reviewScreen: String = "review.screen"
     static let reviewFilterMenu: String = "review.filter.menu"
+    static let reviewFilterScrollSurface: String = "review.filter.scrollSurface"
     static let reviewFilterAllCardsAction: String = "review.filter.allCards"
     static let reviewFilterDeckActionPrefix: String = "review.filter.deck."
     static let reviewFilterTagTogglePrefix: String = "review.filter.tag."

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
@@ -81,7 +81,21 @@ private enum FlashcardsUITestLaunchScenarioData {
     static let aiReviewCard: FlashcardsUITestFixtureCard = FlashcardsUITestFixtureCard(
         frontText: "Smoke guest AI review question",
         backText: "Smoke guest AI review answer",
-        tags: ["smoke-guest-ai-review"]
+        tags: [
+            "smoke-guest-ai-review",
+            "smoke-overflow-01",
+            "smoke-overflow-02",
+            "smoke-overflow-03",
+            "smoke-overflow-04",
+            "smoke-overflow-05",
+            "smoke-overflow-06",
+            "smoke-overflow-07",
+            "smoke-overflow-08",
+            "smoke-overflow-09",
+            "smoke-overflow-10",
+            "smoke-overflow-11",
+            "smoke-overflow-12"
+        ]
     )
 }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewFilterPopover.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewFilterPopover.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+private let reviewFilterPopoverWidth: CGFloat = 320
+private let reviewFilterPopoverHeight: CGFloat = 420
+private let reviewFilterSelectionColumnWidth: CGFloat = 20
+private let reviewFilterRowHorizontalPadding: CGFloat = 16
+private let reviewFilterRowVerticalPadding: CGFloat = 11
+private let reviewFilterRowSpacing: CGFloat = 12
+
+struct ReviewFilterPopover: View {
+    @Binding var reviewFilter: ReviewFilter
+    let deckSummaries: [DeckSummary]
+    let tagSummaries: [WorkspaceTagSummary]
+    let onEditDecks: () -> Void
+
+    @State private var scrollPosition: ScrollPosition = ScrollPosition(idType: String.self)
+
+    private var storedTagNames: [String] {
+        self.tagSummaries.map(\.tag)
+    }
+
+    private var selectedTagKeys: Set<String> {
+        let selectedTags: [String]
+        switch self.reviewFilter {
+        case .allCards:
+            selectedTags = self.storedTagNames
+        case .deck(let deckId):
+            selectedTags = self.deckSummaries.first(where: { deckSummary in
+                deckSummary.deckId == deckId
+            }).map { deckSummary in
+                selectedReviewDeckTagNames(
+                    deckFilterTagNames: deckSummary.filterDefinition.tags,
+                    storedTagNames: self.storedTagNames
+                )
+            } ?? []
+        case .tags(let tags):
+            selectedTags = resolveExactStoredTagNames(
+                requestedTagNames: tags,
+                storedTagNames: self.storedTagNames
+            )
+        }
+
+        return Set(selectedTags.map(normalizeTagKey))
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                self.allCardsButton
+                    .id("all-cards")
+
+                ForEach(self.deckSummaries, id: \.deckId) { deckSummary in
+                    self.deckButton(deckSummary: deckSummary)
+                        .id("deck:\(deckSummary.deckId)")
+                }
+
+                self.editDecksButton
+                    .id("edit-decks")
+
+                Divider()
+                    .padding(.vertical, 4)
+
+                if self.tagSummaries.isEmpty == false {
+                    ForEach(self.tagSummaries, id: \.tag) { tagSummary in
+                        self.tagButton(tagSummary: tagSummary)
+                            .id("tag:\(normalizeTagKey(tag: tagSummary.tag))")
+                    }
+
+                    Divider()
+                        .padding(.vertical, 4)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollPosition(self.$scrollPosition)
+        .accessibilityIdentifier(UITestIdentifier.reviewFilterScrollSurface)
+        .frame(width: reviewFilterPopoverWidth, height: reviewFilterPopoverHeight)
+    }
+
+    private var allCardsButton: some View {
+        let isSelected = self.reviewFilter == .allCards
+        return self.selectionButton(
+            title: localizedAllCardsLabel(),
+            systemImage: "rectangle.stack",
+            isSelected: isSelected,
+            accessibilityIdentifier: UITestIdentifier.reviewFilterAllCardsAction,
+            action: {
+                self.reviewFilter = isSelected
+                    ? makeReviewTagsFilter(tags: [])
+                    : .allCards
+            }
+        )
+    }
+
+    private func deckButton(deckSummary: DeckSummary) -> some View {
+        let deckFilter = ReviewFilter.deck(deckId: deckSummary.deckId)
+        return self.selectionButton(
+            title: deckSummary.name,
+            systemImage: nil,
+            isSelected: self.reviewFilter == deckFilter,
+            accessibilityIdentifier: UITestIdentifier.reviewFilterDeckActionPrefix + deckSummary.deckId,
+            action: {
+                self.reviewFilter = deckFilter
+            }
+        )
+    }
+
+    private var editDecksButton: some View {
+        Button(action: self.onEditDecks) {
+            HStack(spacing: reviewFilterRowSpacing) {
+                Image(systemName: "square.stack.3d.up")
+                    .frame(width: reviewFilterSelectionColumnWidth)
+                Text(String(localized: "Edit decks", table: "ReviewCards"))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, reviewFilterRowHorizontalPadding)
+            .padding(.vertical, reviewFilterRowVerticalPadding)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func tagButton(tagSummary: WorkspaceTagSummary) -> some View {
+        let tagKey = normalizeTagKey(tag: tagSummary.tag)
+        return self.selectionButton(
+            title: "\(tagSummary.tag) (\(tagSummary.cardsCount.formatted()))",
+            systemImage: nil,
+            isSelected: self.selectedTagKeys.contains(tagKey),
+            accessibilityIdentifier: UITestIdentifier.reviewFilterTagTogglePrefix + tagSummary.tag,
+            action: {
+                self.toggleTag(tag: tagSummary.tag)
+            }
+        )
+    }
+
+    private func selectionButton(
+        title: String,
+        systemImage: String?,
+        isSelected: Bool,
+        accessibilityIdentifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: reviewFilterRowSpacing) {
+                ZStack {
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.body.weight(.semibold))
+                    }
+                }
+                .frame(width: reviewFilterSelectionColumnWidth)
+
+                if let systemImage {
+                    Image(systemName: systemImage)
+                }
+
+                Text(title)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, reviewFilterRowHorizontalPadding)
+            .padding(.vertical, reviewFilterRowVerticalPadding)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "1" : "0")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func toggleTag(tag: String) {
+        let tagFilter: ReviewFilter
+        switch self.reviewFilter {
+        case .deck(let deckId):
+            let deckTags = self.deckSummaries.first(where: { deckSummary in
+                deckSummary.deckId == deckId
+            })?.filterDefinition.tags ?? []
+            tagFilter = makeReviewTagsFilter(
+                tags: selectedReviewDeckTagNames(
+                    deckFilterTagNames: deckTags,
+                    storedTagNames: self.storedTagNames
+                )
+            )
+        case .allCards, .tags:
+            tagFilter = self.reviewFilter
+        }
+
+        self.reviewFilter = reviewFilterByTogglingTag(
+            reviewFilter: tagFilter,
+            tag: tag,
+            decks: [],
+            storedTagNames: self.storedTagNames
+        )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -45,6 +45,9 @@ struct ReviewView: View {
     @State var reviewTagSummaries: [WorkspaceTagSummary] = []
     @State var reviewDeckSummaries: [DeckSummary] = []
     @State var totalCardsCount: Int = 0
+    @State var isReviewFilterPopoverPresented: Bool = false
+    @State var reviewFilterDraft: ReviewFilter = .allCards
+    @State var reviewFilterAtPresentation: ReviewFilter = .allCards
 
     private var availableTagSuggestions: [TagSuggestion] {
         self.reviewTagSummaries.map { tagSummary in
@@ -68,78 +71,8 @@ struct ReviewView: View {
         }
     }
 
-    private var selectedReviewTagKeys: Set<String> {
-        let storedTagNames = self.reviewTagSummaries.map(\.tag)
-        let selectedTags: [String]
-        switch store.selectedReviewFilter {
-        case .allCards:
-            selectedTags = storedTagNames
-        case .deck(let deckId):
-            selectedTags = self.reviewDeckSummaries.first(where: { deckSummary in
-                deckSummary.deckId == deckId
-            }).map { deckSummary in
-                selectedReviewDeckTagNames(
-                    deckFilterTagNames: deckSummary.filterDefinition.tags,
-                    storedTagNames: storedTagNames
-                )
-            } ?? []
-        case .tags(let tags):
-            selectedTags = resolveExactStoredTagNames(
-                requestedTagNames: tags,
-                storedTagNames: storedTagNames
-            )
-        }
-
-        return Set(selectedTags.map(normalizeTagKey))
-    }
-
     var areReviewReactionAnimationsEnabled: Bool {
         store.accountPreferences.reviewReactionAnimationsEnabled && self.isLowPowerModeEnabled == false
-    }
-
-    private func reviewFilterMenuItemLabel(reviewFilter: ReviewFilter) -> String {
-        switch reviewFilter {
-        case .allCards:
-            return localizedAllCardsLabel()
-        case .deck(let deckId):
-            return self.reviewDeckSummaries.first(where: { deckSummary in
-                deckSummary.deckId == deckId
-            })?.name ?? localizedAllCardsLabel()
-        case .tags(let tags):
-            return tags.joined(separator: ", ")
-        }
-    }
-
-    private func selectReviewTag(tag: String) {
-        let storedTagNames = self.reviewTagSummaries.map(\.tag)
-        let nextReviewFilter: ReviewFilter
-        switch store.selectedReviewFilter {
-        case .deck(let deckId):
-            let deckTags = self.reviewDeckSummaries.first(where: { deckSummary in
-                deckSummary.deckId == deckId
-            })?.filterDefinition.tags ?? []
-            let deckTagFilter = makeReviewTagsFilter(
-                tags: selectedReviewDeckTagNames(
-                    deckFilterTagNames: deckTags,
-                    storedTagNames: storedTagNames
-                )
-            )
-            nextReviewFilter = reviewFilterByTogglingTag(
-                reviewFilter: deckTagFilter,
-                tag: tag,
-                decks: [],
-                storedTagNames: storedTagNames
-            )
-        case .allCards, .tags:
-            nextReviewFilter = reviewFilterByTogglingTag(
-                reviewFilter: store.selectedReviewFilter,
-                tag: tag,
-                decks: [],
-                storedTagNames: storedTagNames
-            )
-        }
-
-        store.selectReviewFilter(reviewFilter: nextReviewFilter)
     }
 
     private var currentCard: Card? {
@@ -369,68 +302,10 @@ struct ReviewView: View {
     }
 
     private var reviewFilterMenu: some View {
-        Menu {
-            Toggle(
-                isOn: Binding(
-                    get: {
-                        store.selectedReviewFilter == .allCards
-                    },
-                    set: { isEnabled in
-                        let reviewFilter: ReviewFilter = isEnabled
-                            ? .allCards
-                            : makeReviewTagsFilter(tags: [])
-                        store.selectReviewFilter(reviewFilter: reviewFilter)
-                    }
-                )
-            ) {
-                Text(localizedAllCardsLabel())
-            }
-            .menuActionDismissBehavior(.disabled)
-            .accessibilityIdentifier(UITestIdentifier.reviewFilterAllCardsAction)
-
-            ForEach(self.reviewDeckSummaries, id: \.deckId) { deckSummary in
-                let reviewFilter = ReviewFilter.deck(deckId: deckSummary.deckId)
-                Button {
-                    store.selectReviewFilter(reviewFilter: reviewFilter)
-                } label: {
-                    if store.selectedReviewFilter == reviewFilter {
-                        Label(reviewFilterMenuItemLabel(reviewFilter: reviewFilter), systemImage: "checkmark")
-                    } else {
-                        Text(reviewFilterMenuItemLabel(reviewFilter: reviewFilter))
-                    }
-                }
-                .menuActionDismissBehavior(.disabled)
-                .accessibilityIdentifier(UITestIdentifier.reviewFilterDeckActionPrefix + deckSummary.deckId)
-            }
-
-            Button {
-                navigation.openSettings(destination: .workspaceDecks)
-            } label: {
-                Label(String(localized: "Edit decks", table: reviewCardsStringsTableName), systemImage: "square.stack.3d.up")
-            }
-
-            Divider()
-
-            if reviewTagSummaries.isEmpty == false {
-                ForEach(reviewTagSummaries, id: \.tag) { tagSummary in
-                    Toggle(
-                        isOn: Binding(
-                            get: {
-                                self.selectedReviewTagKeys.contains(normalizeTagKey(tag: tagSummary.tag))
-                            },
-                            set: { _ in
-                                self.selectReviewTag(tag: tagSummary.tag)
-                            }
-                        )
-                    ) {
-                        Text("\(tagSummary.tag) (\(tagSummary.cardsCount.formatted()))")
-                    }
-                    .menuActionDismissBehavior(.disabled)
-                    .accessibilityIdentifier(UITestIdentifier.reviewFilterTagTogglePrefix + tagSummary.tag)
-                }
-
-                Divider()
-            }
+        Button {
+            self.reviewFilterDraft = store.selectedReviewFilter
+            self.reviewFilterAtPresentation = store.selectedReviewFilter
+            self.isReviewFilterPopoverPresented = true
         } label: {
             HStack(spacing: 4) {
                 Text(self.selectedReviewFilterTitle)
@@ -442,6 +317,35 @@ struct ReviewView: View {
             }
         }
         .accessibilityIdentifier(UITestIdentifier.reviewFilterMenu)
+        .popover(isPresented: self.$isReviewFilterPopoverPresented) {
+            ReviewFilterPopover(
+                reviewFilter: self.$reviewFilterDraft,
+                deckSummaries: self.reviewDeckSummaries,
+                tagSummaries: self.reviewTagSummaries,
+                onEditDecks: self.dismissReviewFilterPopoverAndOpenDecks
+            )
+            .presentationCompactAdaptation(.popover)
+        }
+        .onChange(of: self.isReviewFilterPopoverPresented) { _, isPresented in
+            if isPresented == false {
+                self.commitReviewFilterDraft()
+            }
+        }
+    }
+
+    private func commitReviewFilterDraft() {
+        guard self.reviewFilterDraft != self.reviewFilterAtPresentation else {
+            return
+        }
+
+        self.reviewFilterAtPresentation = self.reviewFilterDraft
+        store.selectReviewFilter(reviewFilter: self.reviewFilterDraft)
+    }
+
+    private func dismissReviewFilterPopoverAndOpenDecks() {
+        self.commitReviewFilterDraft()
+        self.isReviewFilterPopoverPresented = false
+        navigation.openSettings(destination: .workspaceDecks)
     }
 
     private var reviewLoadingView: some View {

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -12,6 +12,11 @@ private let showAnswerButtonMinHeight: CGFloat = 56
 let emptyBackTextPlaceholder: String = String(localized: "No back text", table: reviewCardsStringsTableName)
 private let reviewQueuePreviewPageSize: Int = 50
 
+private struct ReviewFilterPresentationContext: Equatable {
+    let workspaceId: String?
+    let committedFilter: ReviewFilter
+}
+
 struct ReviewView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.isLowPowerModeEnabled) var isLowPowerModeEnabled: Bool
@@ -47,7 +52,7 @@ struct ReviewView: View {
     @State var totalCardsCount: Int = 0
     @State var isReviewFilterPopoverPresented: Bool = false
     @State var reviewFilterDraft: ReviewFilter = .allCards
-    @State var reviewFilterAtPresentation: ReviewFilter = .allCards
+    @State private var reviewFilterPresentationContext: ReviewFilterPresentationContext? = nil
 
     private var availableTagSuggestions: [TagSuggestion] {
         self.reviewTagSummaries.map { tagSummary in
@@ -303,8 +308,12 @@ struct ReviewView: View {
 
     private var reviewFilterMenu: some View {
         Button {
-            self.reviewFilterDraft = store.selectedReviewFilter
-            self.reviewFilterAtPresentation = store.selectedReviewFilter
+            let committedFilter = store.selectedReviewFilter
+            self.reviewFilterDraft = committedFilter
+            self.reviewFilterPresentationContext = ReviewFilterPresentationContext(
+                workspaceId: store.workspace?.workspaceId,
+                committedFilter: committedFilter
+            )
             self.isReviewFilterPopoverPresented = true
         } label: {
             HStack(spacing: 4) {
@@ -328,22 +337,46 @@ struct ReviewView: View {
         }
         .onChange(of: self.isReviewFilterPopoverPresented) { _, isPresented in
             if isPresented == false {
-                self.commitReviewFilterDraft()
+                self.finalizeReviewFilterDraft()
             }
+        }
+        .onChange(of: store.workspace?.workspaceId) { _, _ in
+            self.dismissReviewFilterPopoverIfContextDiverged()
+        }
+        .onChange(of: store.selectedReviewFilter) { _, _ in
+            self.dismissReviewFilterPopoverIfContextDiverged()
         }
     }
 
-    private func commitReviewFilterDraft() {
-        guard self.reviewFilterDraft != self.reviewFilterAtPresentation else {
+    private func finalizeReviewFilterDraft() {
+        guard let presentationContext = self.reviewFilterPresentationContext else {
+            return
+        }
+        self.reviewFilterPresentationContext = nil
+
+        guard presentationContext.workspaceId == store.workspace?.workspaceId,
+              presentationContext.committedFilter == store.selectedReviewFilter,
+              presentationContext.committedFilter != self.reviewFilterDraft else {
             return
         }
 
-        self.reviewFilterAtPresentation = self.reviewFilterDraft
         store.selectReviewFilter(reviewFilter: self.reviewFilterDraft)
     }
 
+    private func dismissReviewFilterPopoverIfContextDiverged() {
+        guard self.isReviewFilterPopoverPresented,
+              let presentationContext = self.reviewFilterPresentationContext,
+              presentationContext.workspaceId != store.workspace?.workspaceId
+                || presentationContext.committedFilter != store.selectedReviewFilter else {
+            return
+        }
+
+        self.finalizeReviewFilterDraft()
+        self.isReviewFilterPopoverPresented = false
+    }
+
     private func dismissReviewFilterPopoverAndOpenDecks() {
-        self.commitReviewFilterDraft()
+        self.finalizeReviewFilterDraft()
         self.isReviewFilterPopoverPresented = false
         navigation.openSettings(destination: .workspaceDecks)
     }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
@@ -51,8 +51,9 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
     func testLiveSmokeReviewFilterMenuSupportsEmptyTagAndAllCardsStates() throws {
         try self.launchApplication(launchScenario: .guestAIReviewCard, selectedTab: .review)
         let tagToggleIdentifier = LiveSmokeIdentifier.reviewFilterTagTogglePrefix + "smoke-guest-ai-review"
+        let lowerTagToggleIdentifier = LiveSmokeIdentifier.reviewFilterTagTogglePrefix + "smoke-overflow-12"
 
-        try self.step("clear all review filters without dismissing the menu") {
+        try self.step("keep a lower review filter row visible after changing its draft selection") {
             try self.assertElementExists(
                 identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
                 timeout: LiveSmokeConfiguration.reviewInitialProbeTimeoutSeconds
@@ -61,6 +62,36 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
                 identifier: LiveSmokeIdentifier.reviewFilterMenu,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
+            try self.tapReviewFilterButtonScrollingIntoView(identifier: lowerTagToggleIdentifier)
+            try self.assertReviewFilterToggleValue(
+                identifier: lowerTagToggleIdentifier,
+                expectedValue: .off,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+
+            let lowerTagToggle = self.app.buttons[lowerTagToggleIdentifier].firstMatch
+            guard lowerTagToggle.isHittable else {
+                throw LiveSmokeFailure.unexpectedReviewState(
+                    message: "The toggled lower review filter row moved out of view.",
+                    screen: self.currentScreenSummary(),
+                    step: self.currentStepTitle
+                )
+            }
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+
+            lowerTagToggle.tap()
+            try self.assertReviewFilterToggleValue(
+                identifier: lowerTagToggleIdentifier,
+                expectedValue: .on,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
+            try self.scrollReviewFilterToTop()
+        }
+
+        try self.step("clear all review filters without dismissing the menu") {
             try self.assertReviewFilterToggleValue(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 expectedValue: .on,
@@ -87,13 +118,14 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
                 expectedValue: .off,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
+            try self.assertElementExists(
+                identifier: LiveSmokeIdentifier.reviewShowAnswerButton,
+                timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+            )
         }
 
         try self.step("dismiss the empty review filter menu with an outside tap") {
-            self.app.descendants(matching: .any)
-                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
-                .firstMatch
-                .tap()
+            self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -139,10 +171,7 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
         }
 
         try self.step("verify the tagged card returns after dismissing the menu") {
-            self.app.descendants(matching: .any)
-                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
-                .firstMatch
-                .tap()
+            self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: tagToggleIdentifier,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -176,10 +205,7 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
         }
 
         try self.step("verify the all cards review returns after dismissing the menu") {
-            self.app.descendants(matching: .any)
-                .matching(identifier: LiveSmokeIdentifier.reviewScreen)
-                .firstMatch
-                .tap()
+            self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -214,5 +240,63 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
             screen: self.currentScreenSummary(),
             step: self.currentStepTitle
         )
+    }
+
+    @MainActor
+    private func tapReviewFilterButtonScrollingIntoView(identifier: String) throws {
+        let scrollSurface = self.app.scrollViews[LiveSmokeIdentifier.reviewFilterScrollSurface].firstMatch
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.reviewFilterScrollSurface,
+            timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
+        )
+
+        let button = self.app.buttons[identifier].firstMatch
+        let deadline = Date().addingTimeInterval(LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        while Date() < deadline {
+            if button.exists && button.isHittable {
+                button.tap()
+                return
+            }
+
+            scrollSurface.swipeUp()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        }
+
+        throw LiveSmokeFailure.missingElement(
+            identifier: identifier,
+            timeoutSeconds: LiveSmokeConfiguration.shortUiTimeoutSeconds,
+            screen: self.currentScreenSummary(),
+            step: self.currentStepTitle
+        )
+    }
+
+    @MainActor
+    private func scrollReviewFilterToTop() throws {
+        let scrollSurface = self.app.scrollViews[LiveSmokeIdentifier.reviewFilterScrollSurface].firstMatch
+        let allCardsButton = self.app.buttons[LiveSmokeIdentifier.reviewFilterAllCardsToggle].firstMatch
+        let deadline = Date().addingTimeInterval(LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        while Date() < deadline {
+            if allCardsButton.exists && allCardsButton.isHittable {
+                return
+            }
+
+            scrollSurface.swipeDown()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        }
+
+        throw LiveSmokeFailure.missingElement(
+            identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
+            timeoutSeconds: LiveSmokeConfiguration.shortUiTimeoutSeconds,
+            screen: self.currentScreenSummary(),
+            step: self.currentStepTitle
+        )
+    }
+
+    @MainActor
+    private func dismissReviewFilterPopoverWithOutsideTap() {
+        let reviewScreen = self.app.descendants(matching: .any)
+            .matching(identifier: LiveSmokeIdentifier.reviewScreen)
+            .firstMatch
+        reviewScreen.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
     }
 }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -19,6 +19,7 @@ enum LiveSmokeIdentifier {
     static let rootTabSettingsItem: String = "rootTab.settings.item"
     static let reviewScreen: String = "review.screen"
     static let reviewFilterMenu: String = "review.filter.menu"
+    static let reviewFilterScrollSurface: String = "review.filter.scrollSurface"
     static let reviewFilterAllCardsToggle: String = "review.filter.allCards"
     static let reviewFilterTagTogglePrefix: String = "review.filter.tag."
     static let aiScreen: String = "ai.screen"

--- a/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
+++ b/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   ALL_CARDS_REVIEW_FILTER,
+  isReviewFilterEqual,
   makeTagsReviewFilter,
   normalizeReviewFilterTags,
   normalizeTagKey,
@@ -247,22 +248,28 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   } = params;
   const { t } = useI18n();
   const [isReviewFilterMenuOpen, setIsReviewFilterMenuOpen] = useState<boolean>(false);
+  const [reviewFilterDraft, setReviewFilterDraft] = useState<ReviewFilter | null>(null);
   const [reviewDeckSearchText, setReviewDeckSearchText] = useState<string>("");
   const [activeReviewFilterOptionKey, setActiveReviewFilterOptionKey] = useState<string | null>(null);
+  const openingReviewFilterRef = useRef<ReviewFilter | null>(null);
+  const reviewFilterDraftRef = useRef<ReviewFilter | null>(null);
   const reviewFilterTriggerRef = useRef<HTMLButtonElement | null>(null);
   const reviewFilterMenuRef = useRef<HTMLDivElement | null>(null);
   const reviewDeckSearchInputRef = useRef<HTMLInputElement | null>(null);
   const reviewFilterListboxRef = useRef<HTMLDivElement | null>(null);
+  const displayedReviewFilter = isReviewFilterMenuOpen && reviewFilterDraft !== null
+    ? reviewFilterDraft
+    : selectedReviewFilter;
   const reviewDeckFilterMenuItems = buildReviewDeckFilterMenuItems(
     deckSummaries,
-    selectedReviewFilter,
+    displayedReviewFilter,
     t("filters.allCards"),
     t("reviewFilterMenu.deckSmartFilterLabel"),
   );
   const reviewTagFilterMenuItems = buildReviewTagFilterMenuItems(
     deckSummaries,
     reviewTagSummaries,
-    selectedReviewFilter,
+    displayedReviewFilter,
   );
   const reviewFilterMenuItems = buildReviewFilterMenuItems(t("reviewFilterMenu.editDecks"));
   const totalReviewFilterChoicesCount = reviewDeckFilterMenuItems.length
@@ -351,8 +358,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
 
     function handleKeyDown(event: KeyboardEvent): void {
       if (event.key === "Escape") {
-        setIsReviewFilterMenuOpen(false);
-        reviewFilterTriggerRef.current?.focus();
+        closeReviewFilterMenuAndFocusTrigger();
       }
     }
 
@@ -361,26 +367,42 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }, [isReviewFilterMenuOpen]);
 
   function handleCloseMenu(): void {
+    const openingReviewFilter = openingReviewFilterRef.current;
+    const finalReviewFilterDraft = reviewFilterDraftRef.current;
+    openingReviewFilterRef.current = null;
+    reviewFilterDraftRef.current = null;
+    setReviewFilterDraft(null);
     setReviewDeckSearchText("");
     setActiveReviewFilterOptionKey(null);
     setIsReviewFilterMenuOpen(false);
+
+    if (
+      openingReviewFilter !== null
+      && finalReviewFilterDraft !== null
+      && isReviewFilterEqual(openingReviewFilter, finalReviewFilterDraft) === false
+    ) {
+      onSelectReviewFilter(finalReviewFilterDraft);
+    }
   }
 
   function handleReviewFilterMenuToggle(): void {
     setReviewDeckSearchText("");
     if (isReviewFilterMenuOpen) {
-      setActiveReviewFilterOptionKey(null);
-      setIsReviewFilterMenuOpen(false);
+      handleCloseMenu();
       return;
     }
 
+    openingReviewFilterRef.current = selectedReviewFilter;
+    reviewFilterDraftRef.current = selectedReviewFilter;
+    setReviewFilterDraft(selectedReviewFilter);
     setActiveReviewFilterOptionKey(findDefaultReviewFilterOptionKey(visibleReviewFilterChoiceMenuItems));
     setIsReviewFilterMenuOpen(true);
   }
 
   function handleReviewFilterSelect(optionKey: string, reviewFilter: ReviewFilter): void {
     setActiveReviewFilterOptionKey(optionKey);
-    onSelectReviewFilter(reviewFilter);
+    reviewFilterDraftRef.current = reviewFilter;
+    setReviewFilterDraft(reviewFilter);
   }
 
   function preventReviewFilterHandledKeyDown(event: ReactKeyboardEvent<HTMLInputElement | HTMLDivElement>): void {
@@ -389,9 +411,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }
 
   function closeReviewFilterMenuAndFocusTrigger(): void {
-    setReviewDeckSearchText("");
-    setActiveReviewFilterOptionKey(null);
-    setIsReviewFilterMenuOpen(false);
+    handleCloseMenu();
     reviewFilterTriggerRef.current?.focus();
   }
 
@@ -410,7 +430,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
       activeReviewFilterOptionKey,
     );
     if (activeReviewFilterOption !== null) {
-      onSelectReviewFilter(activeReviewFilterOption.reviewFilter);
+      handleReviewFilterSelect(activeReviewFilterOption.key, activeReviewFilterOption.reviewFilter);
     }
   }
 

--- a/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
+++ b/apps/web/src/screens/review/filters/useReviewFilterMenu.ts
@@ -35,6 +35,12 @@ type UseReviewFilterMenuParams = Readonly<{
   onSelectReviewFilter: (reviewFilter: ReviewFilter) => void;
   reviewTagSummaries: ReadonlyArray<WorkspaceTagSummary>;
   selectedReviewFilter: ReviewFilter;
+  workspaceId: string | null;
+}>;
+
+type ReviewFilterMenuContext = Readonly<{
+  reviewFilter: ReviewFilter;
+  workspaceId: string | null;
 }>;
 
 export type UseReviewFilterMenuResult = Readonly<{
@@ -239,24 +245,41 @@ function isReviewFilterComboboxComposing(event: ReactKeyboardEvent<HTMLInputElem
   return event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229;
 }
 
+function isReviewFilterMenuContextEqual(
+  leftContext: ReviewFilterMenuContext,
+  rightContext: ReviewFilterMenuContext,
+): boolean {
+  return leftContext.workspaceId === rightContext.workspaceId
+    && isReviewFilterEqual(leftContext.reviewFilter, rightContext.reviewFilter);
+}
+
 export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseReviewFilterMenuResult {
   const {
     deckSummaries,
     onSelectReviewFilter,
     reviewTagSummaries,
     selectedReviewFilter,
+    workspaceId,
   } = params;
   const { t } = useI18n();
   const [isReviewFilterMenuOpen, setIsReviewFilterMenuOpen] = useState<boolean>(false);
   const [reviewFilterDraft, setReviewFilterDraft] = useState<ReviewFilter | null>(null);
   const [reviewDeckSearchText, setReviewDeckSearchText] = useState<string>("");
   const [activeReviewFilterOptionKey, setActiveReviewFilterOptionKey] = useState<string | null>(null);
-  const openingReviewFilterRef = useRef<ReviewFilter | null>(null);
+  const currentReviewFilterMenuContextRef = useRef<ReviewFilterMenuContext>({
+    reviewFilter: selectedReviewFilter,
+    workspaceId,
+  });
+  const openingReviewFilterMenuContextRef = useRef<ReviewFilterMenuContext | null>(null);
   const reviewFilterDraftRef = useRef<ReviewFilter | null>(null);
   const reviewFilterTriggerRef = useRef<HTMLButtonElement | null>(null);
   const reviewFilterMenuRef = useRef<HTMLDivElement | null>(null);
   const reviewDeckSearchInputRef = useRef<HTMLInputElement | null>(null);
   const reviewFilterListboxRef = useRef<HTMLDivElement | null>(null);
+  currentReviewFilterMenuContextRef.current = {
+    reviewFilter: selectedReviewFilter,
+    workspaceId,
+  };
   const displayedReviewFilter = isReviewFilterMenuOpen && reviewFilterDraft !== null
     ? reviewFilterDraft
     : selectedReviewFilter;
@@ -352,6 +375,19 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }, [isReviewFilterMenuOpen, shouldShowReviewDeckSearch]);
 
   useEffect(() => {
+    const openingContext = openingReviewFilterMenuContextRef.current;
+    if (
+      !isReviewFilterMenuOpen
+      || openingContext === null
+      || isReviewFilterMenuContextEqual(openingContext, currentReviewFilterMenuContextRef.current)
+    ) {
+      return;
+    }
+
+    handleCloseMenu();
+  }, [isReviewFilterMenuOpen, selectedReviewFilter, workspaceId]);
+
+  useEffect(() => {
     if (!isReviewFilterMenuOpen) {
       return;
     }
@@ -367,9 +403,9 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
   }, [isReviewFilterMenuOpen]);
 
   function handleCloseMenu(): void {
-    const openingReviewFilter = openingReviewFilterRef.current;
+    const openingContext = openingReviewFilterMenuContextRef.current;
     const finalReviewFilterDraft = reviewFilterDraftRef.current;
-    openingReviewFilterRef.current = null;
+    openingReviewFilterMenuContextRef.current = null;
     reviewFilterDraftRef.current = null;
     setReviewFilterDraft(null);
     setReviewDeckSearchText("");
@@ -377,9 +413,10 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
     setIsReviewFilterMenuOpen(false);
 
     if (
-      openingReviewFilter !== null
+      openingContext !== null
       && finalReviewFilterDraft !== null
-      && isReviewFilterEqual(openingReviewFilter, finalReviewFilterDraft) === false
+      && isReviewFilterMenuContextEqual(openingContext, currentReviewFilterMenuContextRef.current)
+      && isReviewFilterEqual(openingContext.reviewFilter, finalReviewFilterDraft) === false
     ) {
       onSelectReviewFilter(finalReviewFilterDraft);
     }
@@ -392,7 +429,7 @@ export function useReviewFilterMenu(params: UseReviewFilterMenuParams): UseRevie
       return;
     }
 
-    openingReviewFilterRef.current = selectedReviewFilter;
+    openingReviewFilterMenuContextRef.current = currentReviewFilterMenuContextRef.current;
     reviewFilterDraftRef.current = selectedReviewFilter;
     setReviewFilterDraft(selectedReviewFilter);
     setActiveReviewFilterOptionKey(findDefaultReviewFilterOptionKey(visibleReviewFilterChoiceMenuItems));

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -500,6 +500,98 @@ describe("ReviewScreen filter controls", () => {
     expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-4" });
   });
 
+  it("discards a draft after a keyboard workspace switch and applies a reopened draft once", async () => {
+    const state = getState();
+    state.decks = createDecks(["Grammar"]);
+    state.cards = [
+      createCard({ cardId: "workspace-switch-grammar", tags: ["grammar"] }),
+      createCard({ cardId: "workspace-switch-verbs", tags: ["verbs"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const grammarOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    if (!(grammarOption instanceof HTMLElement)) {
+      throw new Error("Grammar review filter option was not found before the workspace switch");
+    }
+
+    await clickElementAsync(grammarOption);
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "2") {
+        return;
+      }
+
+      state.appData.activeWorkspace = {
+        workspaceId: "workspace-2",
+        name: "Secondary",
+        createdAt: "2026-03-11T00:00:00.000Z",
+        isSelected: true,
+      };
+      state.appData.selectedReviewFilter = { kind: "tags", tags: ["verbs"] };
+    }, { once: true });
+
+    await dispatchDocumentKeydown("2");
+    await rerenderReviewScreen();
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+
+    await openReviewFilterMenu();
+    expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
+    const deckOption = getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-1']");
+    const trigger = getContainer().querySelector("[data-testid='review-filter-trigger']");
+    if (!(deckOption instanceof HTMLElement) || !(trigger instanceof HTMLButtonElement)) {
+      throw new Error("Reopened review filter controls were not found after the workspace switch");
+    }
+
+    await clickElementAsync(deckOption);
+    await clickElementAsync(trigger);
+    await dispatchDocumentKeydown("Escape");
+    await pointerDownElementAsync(document.body);
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-1" });
+  });
+
+  it("discards a draft when the committed filter changes in the same workspace", async () => {
+    const state = getState();
+    state.decks = createDecks(["Grammar"]);
+    state.cards = [
+      createCard({ cardId: "external-filter-grammar", tags: ["grammar"] }),
+      createCard({ cardId: "external-filter-verbs", tags: ["verbs"] }),
+    ];
+    state.reviewQueue = state.cards;
+    state.reviewTimeline = state.cards;
+
+    await renderReviewScreen();
+    await openReviewFilterMenu();
+
+    const grammarOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
+    if (!(grammarOption instanceof HTMLElement)) {
+      throw new Error("Grammar review filter option was not found before the committed filter changed");
+    }
+
+    await clickElementAsync(grammarOption);
+    state.appData.selectedReviewFilter = { kind: "deck", deckId: "deck-1" };
+    await rerenderReviewScreen();
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+
+    await openReviewFilterMenu();
+    expect(getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-1']")?.getAttribute("aria-selected")).toBe("true");
+    await dispatchDocumentKeydown("Escape");
+
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+  });
+
   it("selects items by keyboard when the review filter menu has no search field", async () => {
     const state = getState();
     state.decks = createDecks(["Alpha", "Beta"]);

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.filter.test.tsx
@@ -287,7 +287,7 @@ describe("ReviewScreen filter controls", () => {
     expect(getContainer().querySelector("#review-queue-panel")).toBeNull();
   });
 
-  it("filters, dismisses externally, and applies selections without closing the review filter menu", async () => {
+  it("stages accessible multi-select changes and applies the final filter once on dismissal", async () => {
     const state = getState();
     state.decks = createDecks(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta"]);
     state.cards = [
@@ -331,28 +331,14 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(selectedAllCardsOption);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: [],
-    });
+    expect(selectedAllCardsOption.getAttribute("aria-selected")).toBe("false");
+    expect(listbox.querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("false");
+    expect(listbox.querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
+    expect(listbox.querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-pane-state")).toBe("card");
+    expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-current-card-id")).toBe("tag-1");
     expect(queryReviewFilterMenu()).not.toBeNull();
-
-    state.appData.selectedReviewFilter = {
-      kind: "tags",
-      tags: [],
-    };
-    state.reviewQueue = [];
-    state.reviewTimeline = [];
-    await rerenderReviewScreen();
-
-    await vi.waitFor(() => {
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-pane-state")).toBe("empty");
-      expect(getContainer().querySelector("[data-testid='review-pane']")?.getAttribute("data-review-current-card-id")).toBe("");
-    });
 
     const grammarOptionFromEmpty = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
     if (!(grammarOptionFromEmpty instanceof HTMLElement)) {
@@ -361,49 +347,76 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(grammarOptionFromEmpty);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: ["grammar"],
-    });
+    expect(grammarOptionFromEmpty.getAttribute("aria-selected")).toBe("true");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
 
-    state.appData.selectedReviewFilter = {
-      kind: "tags",
-      tags: ["grammar"],
-    };
-    state.reviewQueue = [state.cards[0] as (typeof state.cards)[number]];
-    state.reviewTimeline = state.reviewQueue;
+    await pointerDownElementAsync(document.body);
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["grammar"] });
+
+    state.appData.selectedReviewFilter = { kind: "tags", tags: ["grammar"] };
     await rerenderReviewScreen();
-
-    await vi.waitFor(() => {
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("false");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("false");
-    });
-
-    const unselectedAllCardsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
-    if (!(unselectedAllCardsOption instanceof HTMLElement)) {
-      throw new Error("Unselected All Cards review filter option was not found");
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const verbsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
+    if (!(verbsOption instanceof HTMLElement)) {
+      throw new Error("Verbs review filter option was not found");
     }
+    await clickElementAsync(verbsOption);
+    expect(verbsOption.getAttribute("aria-selected")).toBe("true");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await dispatchDocumentKeydown("Escape");
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["grammar", "verbs"] });
 
-    await clickElementAsync(unselectedAllCardsOption);
-
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({ kind: "allCards" });
-    expect(queryReviewFilterMenu()).not.toBeNull();
+    state.appData.selectedReviewFilter = { kind: "tags", tags: ["grammar", "verbs"] };
+    await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const allCardsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
+    const trigger = getContainer().querySelector(".review-filter-trigger");
+    if (!(allCardsOption instanceof HTMLElement) || !(trigger instanceof HTMLButtonElement)) {
+      throw new Error("All Cards option or review filter trigger was not found");
+    }
+    await clickElementAsync(allCardsOption);
+    expect(allCardsOption.getAttribute("aria-selected")).toBe("true");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await clickElementAsync(trigger);
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "allCards" });
 
     state.appData.selectedReviewFilter = { kind: "allCards" };
-    state.reviewQueue = state.cards;
-    state.reviewTimeline = state.cards;
     await rerenderReviewScreen();
-
-    await vi.waitFor(() => {
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']")?.getAttribute("aria-selected")).toBe("true");
-      expect(getReviewFilterMenu().querySelector("[data-review-filter-key='tag:medium']")?.getAttribute("aria-selected")).toBe("true");
-    });
     state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const selectedAllCardsForEditDecks = getReviewFilterMenu().querySelector("[data-review-filter-key='allCards']");
+    const editDecksLink = getReviewFilterMenu().querySelector(".review-filter-menu-entry-action");
+    if (!(selectedAllCardsForEditDecks instanceof HTMLElement) || !(editDecksLink instanceof HTMLAnchorElement)) {
+      throw new Error("All Cards option or Edit decks link was not found");
+    }
+    await clickElementAsync(selectedAllCardsForEditDecks);
+    expect(selectedAllCardsForEditDecks.getAttribute("aria-selected")).toBe("false");
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await clickElementAsync(editDecksLink);
+    expect(queryReviewFilterMenu()).toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: [] });
+
+    state.appData.selectedReviewFilter = { kind: "allCards" };
+    await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
+    const searchableFilterMenu = getReviewFilterMenu();
+    const searchableListbox = searchableFilterMenu.querySelector("[role='listbox']");
+    const searchableInput = searchableFilterMenu.querySelector(".review-filter-search-input");
+    if (!(searchableListbox instanceof HTMLElement) || !(searchableInput instanceof HTMLInputElement)) {
+      throw new Error("Searchable review filter controls were not found after reopening");
+    }
+    searchableListbox.scrollTop = 24;
 
     expect(reviewStylesContain(
       ".review-filter-menu",
@@ -415,68 +428,64 @@ describe("ReviewScreen filter controls", () => {
       "overflow-y: auto",
     )).toBe(true);
 
-    const editDecksLink = filterMenu.querySelector(".review-filter-menu-entry-action");
-    if (!(editDecksLink instanceof HTMLAnchorElement)) {
-      throw new Error("Review filter edit decks link was not found");
+    const searchableEditDecksLink = searchableFilterMenu.querySelector(".review-filter-menu-entry-action");
+    if (!(searchableEditDecksLink instanceof HTMLAnchorElement)) {
+      throw new Error("Review filter Edit decks link was not found after reopening");
     }
+    expect(searchableEditDecksLink.getAttribute("role")).not.toBe("option");
+    expect(searchableEditDecksLink.getAttribute("data-review-filter-key")).toBeNull();
+    expect(searchableListbox.contains(searchableEditDecksLink)).toBe(false);
 
-    expect(editDecksLink.getAttribute("role")).not.toBe("option");
-    expect(editDecksLink.getAttribute("data-review-filter-key")).toBeNull();
-    expect(listbox.contains(editDecksLink)).toBe(false);
+    await setTextFieldValueAsync(searchableInput, "med");
 
-    await setTextFieldValueAsync(searchInput, "med");
-
-    expect([...listbox.querySelectorAll("[role='option']")].map((option) => (
+    expect([...searchableListbox.querySelectorAll("[role='option']")].map((option) => (
       option.getAttribute("data-review-filter-key")
     ))).toEqual(["tag:medium"]);
-    expect(listbox.querySelector(".review-filter-menu-divider")).toBeNull();
+    expect(searchableListbox.querySelector(".review-filter-menu-divider")).toBeNull();
 
-    await setTextFieldValueAsync(searchInput, "ta");
+    await setTextFieldValueAsync(searchableInput, "ta");
 
     expect(getReviewFilterMenu().textContent).toContain("Beta");
     expect(getReviewFilterMenu().textContent).toContain("Delta");
     expect(getReviewFilterMenu().textContent).not.toContain("Alpha");
-    expect([...listbox.querySelectorAll("[role='option']")].map((option) => (
+    expect([...searchableListbox.querySelectorAll("[role='option']")].map((option) => (
       option.getAttribute("data-review-filter-key")
     ))).toEqual(["deck:deck-2", "deck:deck-4", "deck:deck-6", "deck:deck-7"]);
 
     await vi.waitFor(() => {
-      expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
+      expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
     });
-    expect(getActiveReviewFilterOption(searchInput).classList.contains("review-filter-menu-entry-keyboard-active")).toBe(true);
+    expect(getActiveReviewFilterOption(searchableInput).classList.contains("review-filter-menu-entry-keyboard-active")).toBe(true);
 
-    await composingKeydownElementAsync(searchInput, "ArrowDown");
-    await composingKeydownElementAsync(searchInput, "Enter");
+    await composingKeydownElementAsync(searchableInput, "ArrowDown");
+    await composingKeydownElementAsync(searchableInput, "Enter");
 
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
     expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
 
-    await keydownElementAsync(searchInput, "ArrowDown");
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
+    await keydownElementAsync(searchableInput, "ArrowDown");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
 
-    await keydownElementAsync(searchInput, "ArrowLeft");
-    await keydownElementAsync(searchInput, "ArrowRight");
-    await keydownElementAsync(searchInput, " ");
+    await keydownElementAsync(searchableInput, "ArrowLeft");
+    await keydownElementAsync(searchableInput, "ArrowRight");
+    await keydownElementAsync(searchableInput, " ");
 
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-4");
     expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
 
-    await keydownElementAsync(searchInput, "ArrowUp");
-    expect(getActiveReviewFilterOption(searchInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
+    await keydownElementAsync(searchableInput, "ArrowUp");
+    expect(getActiveReviewFilterOption(searchableInput).getAttribute("data-review-filter-key")).toBe("deck:deck-2");
 
-    await keydownElementAsync(searchInput, "ArrowDown");
-    await keydownElementAsync(searchInput, "Enter");
+    await keydownElementAsync(searchableInput, "ArrowDown");
+    await keydownElementAsync(searchableInput, "Enter");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-4",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
-    expect(document.activeElement).toBe(searchInput);
+    expect(document.activeElement).toBe(searchableInput);
+    expect(searchableListbox.scrollTop).toBe(24);
 
-    state.appData.selectReviewFilter.mockClear();
     const triggerAfterSearchKeyboardSelect = getContainer().querySelector(".review-filter-trigger");
     if (!(triggerAfterSearchKeyboardSelect instanceof HTMLButtonElement)) {
       throw new Error("Review filter trigger was not found after search keyboard selection");
@@ -487,25 +496,8 @@ describe("ReviewScreen filter controls", () => {
     expect(queryReviewFilterMenu()).not.toBeNull();
     await pointerDownElementAsync(document.body);
     expect(queryReviewFilterMenu()).toBeNull();
-
-    await openReviewFilterMenu();
-    await dispatchDocumentKeydown("Escape");
-    expect(queryReviewFilterMenu()).toBeNull();
-
-    await openReviewFilterMenu();
-    const mediumOption = [...getReviewFilterMenu().querySelectorAll("[data-review-filter-key]")]
-      .find((element) => element.getAttribute("data-review-filter-key") === "tag:medium");
-    if (!(mediumOption instanceof HTMLElement)) {
-      throw new Error("Medium review filter option was not found");
-    }
-
-    await clickElementAsync(mediumOption);
-
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "tags",
-      tags: ["grammar", "verbs"],
-    });
-    expect(queryReviewFilterMenu()).not.toBeNull();
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-4" });
   });
 
   it("selects items by keyboard when the review filter menu has no search field", async () => {
@@ -552,16 +544,17 @@ describe("ReviewScreen filter controls", () => {
 
     await keydownElementAsync(listbox, " ");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-2",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(getReviewFilterMenu().querySelector("[data-review-filter-key='deck:deck-2']")?.getAttribute("aria-selected")).toBe("true");
     expect(queryReviewFilterMenu()).not.toBeNull();
     const triggerAfterListboxKeyboardSelect = getContainer().querySelector(".review-filter-trigger");
     if (!(triggerAfterListboxKeyboardSelect instanceof HTMLButtonElement)) {
       throw new Error("Review filter trigger was not found after listbox keyboard selection");
     }
     expect(document.activeElement).toBe(listbox);
+    await clickElementAsync(triggerAfterListboxKeyboardSelect);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-2" });
   });
 
   it("uses the pointer-selected option for the next keyboard selection", async () => {
@@ -589,20 +582,15 @@ describe("ReviewScreen filter controls", () => {
 
     expect(getActiveReviewFilterOption(listbox)).toBe(deckOption);
     expect(listbox.getAttribute("aria-activedescendant")).toBe(deckOption.id);
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "deck",
-      deckId: "deck-1",
-    });
-    state.appData.selectReviewFilter.mockClear();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
 
     await keydownElementAsync(listbox, " ");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-1",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-1" });
   });
 
   it("keeps searchable pointer selection owned by the combobox for keyboard activation", async () => {
@@ -633,17 +621,16 @@ describe("ReviewScreen filter controls", () => {
     expect(document.activeElement).toBe(searchInput);
     expect(getActiveReviewFilterOption(searchInput)).toBe(deckOption);
     expect(searchInput.getAttribute("aria-activedescendant")).toBe(deckOption.id);
-    state.appData.selectReviewFilter.mockClear();
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
 
     await keydownElementAsync(searchInput, "Enter");
 
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
-    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
-      kind: "deck",
-      deckId: "deck-4",
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(searchInput);
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await dispatchDocumentKeydown("Escape");
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "deck", deckId: "deck-4" });
   });
 
   it("shows the resolved tag count after StrictMode replays the initial load effect", async () => {
@@ -832,17 +819,20 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(grammarOption);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: ["verbs"],
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(grammarOption.getAttribute("aria-selected")).toBe("false");
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["verbs"] });
 
     state.appData.selectedReviewFilter = {
       kind: "tags",
       tags: ["grammar"],
     };
     await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
     const verbsOption = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
     if (!(verbsOption instanceof HTMLElement)) {
       throw new Error("Verbs review filter option was not found");
@@ -850,8 +840,12 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(verbsOption);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({ kind: "allCards" });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    expect(verbsOption.getAttribute("aria-selected")).toBe("true");
     expect(queryReviewFilterMenu()).not.toBeNull();
+    await dispatchDocumentKeydown("Escape");
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledTimes(1);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "allCards" });
   });
 
   it("retains missing custom and preset tags while toggling visible tags", async () => {
@@ -885,7 +879,9 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(verbsFromConfiguredDeck);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
       kind: "tags",
       tags: ["grammar", "missing", "verbs"],
     });
@@ -895,6 +891,8 @@ describe("ReviewScreen filter controls", () => {
       tags: ["grammar", "missing"],
     };
     await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
     const verbsFromCustomSelection = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
     if (!(verbsFromCustomSelection instanceof HTMLElement)) {
       throw new Error("Verbs option was not found for the custom selection");
@@ -902,7 +900,9 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(verbsFromCustomSelection);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
+    await pointerDownElementAsync(document.body);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({
       kind: "tags",
       tags: ["grammar", "missing", "verbs"],
     });
@@ -912,6 +912,8 @@ describe("ReviewScreen filter controls", () => {
       deckId: "deck-2",
     };
     await rerenderReviewScreen();
+    state.appData.selectReviewFilter.mockClear();
+    await openReviewFilterMenu();
     const grammarFromAllTagsDeck = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:grammar']");
     const verbsFromAllTagsDeck = getReviewFilterMenu().querySelector("[data-review-filter-key='tag:verbs']");
     if (!(grammarFromAllTagsDeck instanceof HTMLElement) || !(verbsFromAllTagsDeck instanceof HTMLElement)) {
@@ -922,11 +924,14 @@ describe("ReviewScreen filter controls", () => {
 
     await clickElementAsync(grammarFromAllTagsDeck);
 
-    expect(state.appData.selectReviewFilter).toHaveBeenLastCalledWith({
-      kind: "tags",
-      tags: ["verbs"],
-    });
+    expect(state.appData.selectReviewFilter).not.toHaveBeenCalled();
     expect(queryReviewFilterMenu()).not.toBeNull();
+    const reviewFilterTrigger = getContainer().querySelector(".review-filter-trigger");
+    if (!(reviewFilterTrigger instanceof HTMLButtonElement)) {
+      throw new Error("Review filter trigger was not found");
+    }
+    await clickElementAsync(reviewFilterTrigger);
+    expect(state.appData.selectReviewFilter).toHaveBeenCalledWith({ kind: "tags", tags: ["verbs"] });
   });
 
   it("keeps review filter option ids unique for similar tag text", async () => {

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -248,6 +248,7 @@ export function useReviewScreenController(
     onSelectReviewFilter: selectReviewFilter,
     reviewTagSummaries,
     selectedReviewFilter,
+    workspaceId: activeWorkspace?.workspaceId ?? null,
   });
   const {
     captureEditorPresentationToken,


### PR DESCRIPTION
## Summary

- keep the review filter chooser open for native multi-selection across iOS, Web, and Android, with immediate draft feedback and one committed queue update on dismissal
- support All cards → empty → one or multiple tag/deck choices → All cards restoration while preserving stable selection columns and scroll position
- finalize idempotently for outside dismissal, trigger close, and Edit/Manage decks, while discarding drafts after workspace or committed-filter divergence
- preserve the anchored SwiftUI popover on iOS, ARIA/focus/search/keyboard behavior on Web, and the Material 3 ModalBottomSheet with local rememberSaveable draft state on Android

## Promotion gate

- cumulative `origin/main...integration-review-filter-chooser-stability` review covered the complete non-empty 18-file patch
- promotion review reported no P0-P4 findings
- required GitHub checks on this main-targeting PR are the executable validation gate
