### PR TITLE
Stabilize iOS review filter popover rows

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewFilterPopover.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewFilterPopover.swift
@@ -60,14 +60,9 @@ struct ReviewFilterPopover: View {
                 Divider()
                     .padding(.vertical, 4)
 
-                if self.tagSummaries.isEmpty == false {
-                    ForEach(self.tagSummaries, id: \.tag) { tagSummary in
-                        self.tagButton(tagSummary: tagSummary)
-                            .id("tag:\(normalizeTagKey(tag: tagSummary.tag))")
-                    }
-
-                    Divider()
-                        .padding(.vertical, 4)
+                ForEach(self.tagSummaries, id: \.tag) { tagSummary in
+                    self.tagButton(tagSummary: tagSummary)
+                        .id("tag:\(normalizeTagKey(tag: tagSummary.tag))")
                 }
             }
             .scrollTargetLayout()
@@ -81,7 +76,6 @@ struct ReviewFilterPopover: View {
         let isSelected = self.reviewFilter == .allCards
         return self.selectionButton(
             title: localizedAllCardsLabel(),
-            systemImage: "rectangle.stack",
             isSelected: isSelected,
             accessibilityIdentifier: UITestIdentifier.reviewFilterAllCardsAction,
             action: {
@@ -96,7 +90,6 @@ struct ReviewFilterPopover: View {
         let deckFilter = ReviewFilter.deck(deckId: deckSummary.deckId)
         return self.selectionButton(
             title: deckSummary.name,
-            systemImage: nil,
             isSelected: self.reviewFilter == deckFilter,
             accessibilityIdentifier: UITestIdentifier.reviewFilterDeckActionPrefix + deckSummary.deckId,
             action: {
@@ -126,7 +119,6 @@ struct ReviewFilterPopover: View {
         let tagKey = normalizeTagKey(tag: tagSummary.tag)
         return self.selectionButton(
             title: "\(tagSummary.tag) (\(tagSummary.cardsCount.formatted()))",
-            systemImage: nil,
             isSelected: self.selectedTagKeys.contains(tagKey),
             accessibilityIdentifier: UITestIdentifier.reviewFilterTagTogglePrefix + tagSummary.tag,
             action: {
@@ -137,24 +129,17 @@ struct ReviewFilterPopover: View {
 
     private func selectionButton(
         title: String,
-        systemImage: String?,
         isSelected: Bool,
         accessibilityIdentifier: String,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
             HStack(spacing: reviewFilterRowSpacing) {
-                ZStack {
-                    if isSelected {
-                        Image(systemName: "checkmark")
-                            .font(.body.weight(.semibold))
-                    }
-                }
-                .frame(width: reviewFilterSelectionColumnWidth)
-
-                if let systemImage {
-                    Image(systemName: systemImage)
-                }
+                // Always rendered so the row height does not depend on selection.
+                Image(systemName: "checkmark")
+                    .font(.body.weight(.semibold))
+                    .opacity(isSelected ? 1 : 0)
+                    .frame(width: reviewFilterSelectionColumnWidth)
 
                 Text(title)
                     .lineLimit(1)


### PR DESCRIPTION
Polish the iOS review filter popover so its rows stay visually stable while the user changes the filter.

## Fixes

- **Constant row height regardless of checkmark state.** The checkmark is now always rendered in the leading selection column and only its opacity changes, so selecting or deselecting a row no longer changes that row's height.
- **All Cards leading icon removed.** The `rectangle.stack` image was the only leading icon among the selectable rows, which pushed its title out of line with deck and tag rows. Removing it (and the now-unused `systemImage` parameter of `selectionButton`) makes every selectable row share the same alignment.
- **Trailing divider after the tag list removed.** The tag section no longer appends a divider after the last tag, so the popover does not end with a dangling separator. The tag `ForEach` no longer needs the surrounding emptiness check.

## Testing

Static change only, no project checks, simulator runs, or Gradle runs were executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)