### PR TITLE
Fix Android sign-in crash when verify runs without a challenge

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -309,12 +309,24 @@ class CloudSignInViewModel(
     }
 
     suspend fun verifyCode(): Boolean {
-        val challenge = requireNotNull(draftState.value.challenge) {
-            strings.get(R.string.settings_sign_in_request_code_first)
-        }
+        val challenge = draftState.value.challenge
         val authAttemptId = nextAuthAttemptId(draftState.value)
         draftState.update { state ->
             startCloudVerifyCodeAttempt(state = state, authAttemptId = authAttemptId)
+        }
+        if (challenge == null) {
+            draftState.update { state ->
+                failCloudVerifyCode(
+                    state = state,
+                    authAttemptId = authAttemptId,
+                    errorPresentation = CloudSignInErrorPresentation(
+                        message = strings.get(R.string.settings_sign_in_request_code_first),
+                        technicalDetails = null,
+                        technicalDetailsReportId = null
+                    )
+                )
+            }
+            return false
         }
         return try {
             val linkContext = cloudAccountRepository.verifyCode(


### PR DESCRIPTION
## Problem

Sentry [FLASHCARDS-ANDROID-10](https://samo-danni-eood.sentry.io/issues/138324242/) — fatal uncaught `IllegalArgumentException`, production, `1.17.0+18285162`.

`CloudSignInViewModel.verifyCode` resolved the challenge with `requireNotNull` **outside** its `try` block, so a missing challenge terminated the app instead of surfacing a recoverable error.

The raw event JSON shows the actual sequence: `POST /api/send-code` failed with `error_message: "Socket closed"`, the OTP screen still accepted the code, and verification then crashed before reaching `/api/verify-code`.

## Fix

Route the missing challenge through the verify failure path that already exists directly below it (`failCloudVerifyCode` + `CloudSignInErrorPresentation`), so the user gets the already-translated `settings_sign_in_request_code_first` message and can request a new code.

No new strings, no new state, no behavior change when a challenge is present.

## Validation

Static change only; no Gradle run (repository policy requires explicit approval for local Gradle). `Android PR` CI compiles the module and runs unit tests. No existing test asserted the crash behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)