### PR TITLE
Stop paging on expected chat provider terminals and name quota exhaustion

### DIFF
--- a/apps/backend/src/chat/runtime/lifecycleLogs.ts
+++ b/apps/backend/src/chat/runtime/lifecycleLogs.ts
@@ -8,6 +8,7 @@ import {
 } from "../worker/logging";
 import {
   createSafeProviderErrorDetails,
+  isChatAttachmentRejectedError,
   isContextLengthExceededError,
   isHandledProviderFailure,
 } from "./providerErrors";
@@ -134,15 +135,19 @@ export function logTerminalStatePersisted(
     return;
   }
 
-  // Demote context_length_exceeded to a breadcrumb instead of a Sentry warning:
-  // it is an expected, user-actionable terminal already surfaced to the user with a
-  // clean "start a new chat" message, and the root cause is mitigated in the OpenAI loop,
-  // so it should not page as a warning. The payload (including providerErrorCode) is
-  // unchanged, so the event stays fully searchable in CloudWatch.
+  // Demote expected, user-actionable terminals to breadcrumbs instead of Sentry warnings.
+  // context_length_exceeded already carries a clean "start a new chat" message and its root
+  // cause is mitigated in the OpenAI loop; a rejected attachment is the user picking a file
+  // the provider cannot read, and it is surfaced with the attachment guidance message. Neither
+  // is actionable for us, so neither should page as a warning. Provider-side and infrastructure
+  // failures stay warnings. The payload (including providerErrorCode) is unchanged, so the
+  // events stay fully searchable in CloudWatch.
+  const isExpectedUserTerminal = isContextLengthExceededError(error)
+    || isChatAttachmentRejectedError(error);
   logChatWorkerLifecycleEvent(
     "chat_worker_terminal_state_persisted",
     context,
     payload,
-    runStatus === "failed" && !isContextLengthExceededError(error),
+    runStatus === "failed" && !isExpectedUserTerminal,
   );
 }

--- a/apps/backend/src/chat/runtime/providerErrors.ts
+++ b/apps/backend/src/chat/runtime/providerErrors.ts
@@ -166,12 +166,16 @@ export function createPublicTerminalErrorMessage(error: unknown): string {
   const category = classifyProviderErrorCategory(error, providerMetadata.upstreamStatus);
   const providerErrorCode = readErrorRecordStringField(error, "code");
 
-  if (isChatAttachmentUnsupportedTypeError(error) || providerErrorCode === "invalid_file") {
+  if (isChatAttachmentRejectedError(error)) {
     return chatAttachmentUnsupportedTypeMessage;
   }
 
   if (providerErrorCode === "context_length_exceeded") {
     return PROVIDER_CONTEXT_LENGTH_ERROR_MESSAGE;
+  }
+
+  if (isProviderQuotaExhaustedError(error)) {
+    return PROVIDER_UNAVAILABLE_ERROR_MESSAGE;
   }
 
   if (category === "provider_auth") {
@@ -216,4 +220,14 @@ export function isUserAbortError(error: unknown): boolean {
 
 export function isContextLengthExceededError(error: unknown): boolean {
   return readErrorRecordStringField(error, "code") === "context_length_exceeded";
+}
+
+export function isChatAttachmentRejectedError(error: unknown): boolean {
+  return isChatAttachmentUnsupportedTypeError(error)
+    || readErrorRecordStringField(error, "code") === "invalid_file";
+}
+
+export function isProviderQuotaExhaustedError(error: unknown): boolean {
+  return readErrorRecordStringField(error, "code") === "credit_balance_exhausted"
+    || normalizeProviderErrorType(readErrorRecordStringField(error, "type")) === "insufficient_quota";
 }

--- a/apps/backend/src/chat/tests/runtime/providerErrors.test.ts
+++ b/apps/backend/src/chat/tests/runtime/providerErrors.test.ts
@@ -118,7 +118,7 @@ test("runPersistedChatSessionWithDeps maps provider invalid_file failures to att
     chatAttachmentUnsupportedTypeMessage,
   );
   const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
-  assert.equal(terminalLog?.consoleMethod, "warn");
+  assert.equal(terminalLog?.consoleMethod, "log");
   assert.equal(terminalLog?.providerErrorClass, "BadRequestError");
   assert.equal(terminalLog?.providerErrorMessage, null);
   assert.equal(terminalLog?.providerErrorStatus, 400);
@@ -165,7 +165,7 @@ test("runPersistedChatSessionWithDeps maps local attachment validation failures 
     chatAttachmentUnsupportedTypeMessage,
   );
   const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
-  assert.equal(terminalLog?.consoleMethod, "warn");
+  assert.equal(terminalLog?.consoleMethod, "log");
   assert.equal(terminalLog?.providerErrorMessage, null);
   assert.equal(terminalLog?.providerErrorType, null);
   assert.equal(terminalLog?.providerErrorParam, null);


### PR DESCRIPTION
## Problem

Two unresolved production warning groups, both emitted from `chat_worker_terminal_state_persisted`, neither of which is a backend defect:

- [FLASHCARDS-BACKEND-K](https://samo-danni-eood.sentry.io/issues/138987765/) — provider `invalid_file` / `invalid_request_error`, HTTP 400 on `POST /v1/responses`. 5 events from one user in 4 minutes. The user picked a file the provider cannot read.
- [FLASHCARDS-BACKEND-J](https://samo-danni-eood.sentry.io/issues/138803580/) — `credit_balance_exhausted` / `insufficient_quota`, 9 events across 4 users. Provider returned 200 and the quota error arrived inside the stream.

They share one Sentry fingerprint family and one emission site, and the fix for both is the same classification decision.

## Fix

**K** is expected and user-actionable, and already surfaces as the attachment guidance message — the same shape as `context_length_exceeded`, which this repo deliberately demotes to a breadcrumb. Demote rejected attachments through that same path.

**J** had no branch of its own and fell through to the generic *"could not complete the response. Please try again."* Retrying cannot help when the credit balance is gone, so it now returns the temporarily-unavailable message. It stays a Sentry warning on purpose: unlike K, it is operator-actionable and you want to see it.

Log payloads are untouched, so `providerErrorCode` and friends stay searchable in CloudWatch either way.

## Validation

`npm test` in `apps/backend` — 1181 passed, 0 failed.

Two existing assertions in `providerErrors.test.ts` asserted `consoleMethod === "warn"` for the attachment paths; they now assert `"log"`, which is the behavior this change intends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)