### PR TITLE
Accept backend-permitted mixed-scope progress streak days on iOS

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
@@ -652,7 +652,13 @@ private func makeProgressTimeline(
         guard let streakState = streakStatesByLocalDate[localDate] else {
             throw ProgressPresentationError.missingStreakDay(localDate)
         }
-        guard (reviewCount > 0) == (streakState == .reviewed) else {
+        // Progress is temporarily mixed-scope: daily review bars still reflect the current
+        // legacy review-event scope, while streak days are user-wide. A user-wide reviewed
+        // streak day can therefore have zero reviews in the daily series, and the backend
+        // permits exactly that combination when it builds the series. Only the reverse —
+        // reviews recorded on a day the streak does not consider reviewed — is a real
+        // inconsistency worth refusing to present.
+        guard reviewCount == 0 || streakState == .reviewed else {
             throw ProgressPresentationError.inconsistentStreakDay(
                 localDate: localDate,
                 reviewCount: reviewCount,

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
@@ -461,7 +461,7 @@ final class ProgressSnapshotValidationTests: XCTestCase {
         }
     }
 
-    func testProgressSnapshotRejectsReviewedStreakStateWithoutReviewCount() throws {
+    func testProgressSnapshotAcceptsReviewedStreakStateWithoutReviewCount() throws {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
         let scopeKey = makeProgressScopeKeyForTests(
@@ -491,28 +491,17 @@ final class ProgressSnapshotValidationTests: XCTestCase {
             reviewHistoryWatermarks: []
         )
 
-        XCTAssertThrowsError(
-            try makeProgressSnapshot(
-                summary: makeEmptyProgressSummaryForTests(),
-                series: series,
-                scopeKey: scopeKey,
-                summarySourceState: .serverBase,
-                seriesSourceState: .serverBase,
-                calendar: calendar
-            )
-        ) { error in
-            guard case ProgressPresentationError.inconsistentStreakDay(
-                localDate: let localDate,
-                reviewCount: let reviewCount,
-                streakState: let state
-            ) = error else {
-                XCTFail("Expected ProgressPresentationError.inconsistentStreakDay, received \(error)")
-                return
-            }
+        let snapshot = try makeProgressSnapshot(
+            summary: makeEmptyProgressSummaryForTests(),
+            series: series,
+            scopeKey: scopeKey,
+            summarySourceState: .serverBase,
+            seriesSourceState: .serverBase,
+            calendar: calendar
+        )
 
-            XCTAssertEqual("2026-02-03", localDate)
-            XCTAssertEqual(0, reviewCount)
-            XCTAssertEqual(.reviewed, state)
-        }
+        let day = try XCTUnwrap(snapshot.chartData.chartDays.first { $0.localDate == "2026-02-03" })
+        XCTAssertEqual(0, day.reviewCount)
+        XCTAssertEqual(.reviewed, day.streakState)
     }
 }


### PR DESCRIPTION
## Problem

Sentry [FLASHCARDS-IOS-43](https://samo-danni-eood.sentry.io/issues/131558042/) — `Flashcards.ProgressPresentationError: Code: 3`, high priority, 8 events, iOS `1.17.0` (546). Code 3 is `inconsistentStreakDay`.

The backend and iOS disagree about one specific day shape, and the backend disagrees **on purpose**:

```ts
// apps/backend/src/progress/reports/index.ts
// Progress is temporarily mixed-scope: daily review bars still reflect the
// current legacy review-event scope, while streak days are user-wide. …
if (dailyReview.reviewCount === 0 && streakState === "reviewed") {
  continue;
}
```

iOS applied the strict invariant `(reviewCount > 0) == (streakState == .reviewed)` and threw on that same combination. The captured event shows `GET` progress series returning **200** — this is a contract rejection on the client, not a network failure, and the user got a technical error instead of the Progress screen.

## Fix

Mirror the documented backend tolerance in `ProgressSnapshotFactory`, and keep rejecting the direction that really is broken: reviews recorded on a day the streak does not consider reviewed.

Checked Android and web — neither enforces this invariant, so no other client needs the change.

## Validation

Static change; no simulator run (repository policy requires explicit approval for local iOS simulator runs). Xcode Cloud runs the Swift tests.

`testProgressSnapshotRejectsReviewedStreakStateWithoutReviewCount` asserted the old behavior and is now `…Accepts…`, checking the day is presented with `reviewCount 0` and `streakState .reviewed`. The sibling test for the opposite direction (`reviewCount 1` with `.frozen`) is untouched and still expects a throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)