### PR TITLE
Stop warning on offline streak leaderboard refreshes

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressStreakLeaderboardOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressStreakLeaderboardOrchestration.kt
@@ -4,6 +4,7 @@ import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
+import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIoException
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.findProgressStreakLeaderboardServerBase
@@ -20,6 +21,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.Prog
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressStreakLeaderboardStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.createProgressStreakLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.createProgressStreakLeaderboardStoreState
+import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -130,7 +132,7 @@ internal class ProgressStreakLeaderboardOrchestration(
         } catch (error: Exception) {
             failedRemoteLoadScopeKeyMutable.value = serializedScopeKey
             publishLatestSnapshot()
-            if (shouldSuppressRemoteLoadWarning(refreshStoreState = refreshStoreState)) {
+            if (shouldSuppressRemoteLoadWarning(refreshStoreState = refreshStoreState, error = error)) {
                 return
             }
             logProgressRefreshWarning(
@@ -162,14 +164,21 @@ internal class ProgressStreakLeaderboardOrchestration(
     }
 
     private fun shouldSuppressRemoteLoadWarning(
-        refreshStoreState: ProgressStreakLeaderboardStoreState
+        refreshStoreState: ProgressStreakLeaderboardStoreState,
+        error: Exception
     ): Boolean {
         val latestStoreState = currentStoreState() ?: return true
         if (latestStoreState.scopeKey != refreshStoreState.scopeKey) {
             return true
         }
+        if (latestStoreState.cloudState != CloudAccountState.LINKED) {
+            return true
+        }
 
-        return latestStoreState.cloudState != CloudAccountState.LINKED
+        // A leaderboard refresh that dies on an unreachable network means the device is offline,
+        // not that the product failed: the request already exhausted its transient retry ladder
+        // and the cached snapshot stays on screen.
+        return error is IOException && isLikelyTransientNetworkIoException(error = error)
     }
 
     private fun publishLatestSnapshot() {


### PR DESCRIPTION
## Problem

Sentry [FLASHCARDS-ANDROID-11](https://samo-danni-eood.sentry.io/issues/138987656/) — `progress_streak_leaderboard_remote_load_failed`, warning, `1.17.0+18285162`.

The raw event says the device was simply offline:

- breadcrumbs repeat `Unable to resolve host "api.flashcards-open-source-app.com": No address associated with hostname`
- `device.online = false`, app in background
- four `http_transient_retry` attempts at `stage: io_exception`, all exhausted

Thread stack is `ProgressStreakLeaderboardOrchestration:136 performRefresh` → `logProgressRefreshWarning` → `captureWarning`. Nothing here is actionable, and the cached snapshot stays on screen.

## Fix

`shouldSuppressRemoteLoadWarning` already suppresses scope changes and unlinked accounts. Add the transient-network case, using `isLikelyTransientNetworkIoException` — the same helper this repository already uses for this exact decision in `AiChatObservability` and `AiChatBootstrapRetryPolicy`, following the established `error is IOException && isLikelyTransientNetworkIoException(error = error)` shape.

Non-transient failures (HTTP errors, parse failures, TLS problems) still warn.

## Note for a follow-up

`ProgressLeaderboardOrchestration.kt:171` has an identical private `shouldSuppressRemoteLoadWarning` with the same gap. It has not produced a production issue yet, so I left it out of this diff rather than widening the change — worth aligning separately.

## Validation

Static change; no local Gradle run (repository policy requires explicit approval). `Android PR` CI compiles the module and runs unit tests. No test covered the suppression helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)