### PR TITLE
Stop warning when an AI chat stop targets a session that is already gone

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/Run/AIChatStore+RunCancellation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Run/AIChatStore+RunCancellation.swift
@@ -92,6 +92,18 @@ func makeAIChatStopFailureMetadata(
     return metadata
 }
 
+/// A stop request the backend answers with 404 means the session it was asked to stop no longer
+/// exists, which is the outcome the stop wanted. This happens routinely when a stale session is
+/// stopped after a workspace switch or a guest-to-linked upgrade, so it is expected cleanup
+/// rather than a failure worth reporting.
+private func isExpectedStaleAIChatStopFailure(error: Error) -> Bool {
+    guard let diagnosticError = error as? any AIChatFailureDiagnosticProviding else {
+        return false
+    }
+
+    return diagnosticError.diagnostics.statusCode == 404
+}
+
 extension AIChatStore {
     func cancelStreaming() {
         guard let stopContext = self.prepareStreamingCancellationForRemoteStop() else {
@@ -295,6 +307,9 @@ extension AIChatStore {
                 self.repairStatus = nil
             }
         } catch {
+            if isExpectedStaleAIChatStopFailure(error: error) {
+                return
+            }
             logAIChatStoreEvent(
                 action: "ai_stop_failed",
                 metadata: makeAIChatStopFailureMetadata(


### PR DESCRIPTION
## Problem

Sentry [FLASHCARDS-IOS-4A](https://samo-danni-eood.sentry.io/issues/138219829/) — `iOS AI chat warning: ai_stop_failed`, iOS `1.17.0` (546).

The raw event shows a stale-session cleanup during a guest-to-linked workspace upgrade:

- `POST /chat/stop` for session `418932aa-9404-4709-b55e-479eb46acb7f` → **404** `Chat session not found`
- backend request id `b9a98cc5-25cf-4e60-86c7-ff44d3577bb7`, client request id `fff1616e-220d-485b-9935-65def26e97dc`
- stack: `AIChatStore.performRemoteAIChatStop` → `logAIChatStoreEvent` → `captureWarning`

A 404 here means the run we asked to stop is already gone — which is exactly what the stop wanted. There is no failure and nothing to act on.

## Fix

Skip the `ai_stop_failed` warning when the stop failed with 404, using the `statusCode` that `AIChatFailureDiagnosticProviding` already exposes and that `makeAIChatStopFailureMetadata` already reads.

Every other stop failure still warns: transport errors, and non-404 backend rejections. The `defer` block that returns the composer to idle and persists state is unaffected.

## Validation

Static change; no simulator run (repository policy requires explicit approval). Xcode Cloud builds and runs the Swift tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)