### PR TITLE
Flatten the Progress screen view tree to cut first-render cost

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-private enum ProgressScreenSectionID: Hashable {
+enum ProgressScreenSectionID: Hashable {
     case streak
     case leaderboard
     case streakLeaderboard
@@ -47,118 +47,24 @@ struct ProgressScreen: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 20) {
-                    if self.store.progressErrorMessage.isEmpty == false {
-                        Label {
-                            Text(self.store.progressErrorMessage)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        } icon: {
-                            Image(systemName: "exclamationmark.triangle")
-                                .foregroundStyle(.orange)
-                        }
-                        .modifier(ProgressCardModifier())
-                    }
+                    ProgressErrorBanner(message: self.store.progressErrorMessage)
 
                     if let progressSnapshot = self.store.progressSnapshot {
-                        let presentationCalendar = requiredProgressPresentationCalendar(
-                            timeZoneIdentifier: progressSnapshot.scopeKey.timeZone
-                        )
-                        let streakWeeks = requiredProgressStreakWeeks(
+                        ProgressLoadedSections(
                             progressSnapshot: progressSnapshot,
-                            calendar: presentationCalendar
+                            leaderboardSnapshot: self.store.progressLeaderboardSnapshot,
+                            streakLeaderboardSnapshot: self.store.progressStreakLeaderboardSnapshot,
+                            reviewScheduleSnapshot: self.store.reviewScheduleSnapshot,
+                            isProgressRefreshing: self.store.isProgressRefreshing,
+                            leaderboardRefreshMessage: self.store.progressErrorState.leaderboardRefreshMessage,
+                            streakLeaderboardRefreshMessage: self.store.progressErrorState.streakLeaderboardRefreshMessage,
+                            selectedLeaderboardWindowKey: self.$selectedLeaderboardWindowKey,
+                            onOpenCloudSignIn: self.openCloudSignInFlow,
+                            onOpenFriendInvite: self.openFriendInviteFlow,
+                            onOpenProfile: self.openLeaderboardProfile
                         )
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text(
-                                String(
-                                    localized: "progress.screen.streak.section_title",
-                                    defaultValue: "Streak",
-                                    table: progressStringsTableName,
-                                    comment: "Progress streak section title"
-                                )
-                            )
-                            .font(.headline)
-
-                            ProgressStreakSection(
-                                weeks: streakWeeks,
-                                badgeState: makeReviewProgressBadgeState(summary: progressSnapshot.summary),
-                                streakFreeze: progressSnapshot.summary.streakFreeze,
-                                calendar: presentationCalendar
-                            )
-                        }
-                        .id(ProgressScreenSectionID.streak)
-                        .accessibilityIdentifier(UITestIdentifier.progressStreakSection)
-                        .accessibilityValue(progressSummaryUITestValue(summary: progressSnapshot.summary))
-                        .modifier(ProgressCardModifier())
-
-                        if let leaderboardSnapshot = self.store.progressLeaderboardSnapshot {
-                            VStack(alignment: .leading, spacing: 0) {
-                                ProgressLeaderboardSection(
-                                    snapshot: leaderboardSnapshot,
-                                    isRefreshing: self.store.isProgressRefreshing,
-                                    leaderboardRefreshMessage: self.store.progressErrorState.leaderboardRefreshMessage,
-                                    selectedWindowKey: self.$selectedLeaderboardWindowKey,
-                                    onOpenCloudSignIn: self.openCloudSignInFlow,
-                                    onOpenFriendInvite: self.openFriendInviteFlow,
-                                    onOpenProfile: self.openLeaderboardProfile
-                                )
-                            }
-                            .id(ProgressScreenSectionID.leaderboard)
-                            .accessibilityIdentifier(UITestIdentifier.progressLeaderboardSection)
-                            .modifier(ProgressCardModifier())
-                        }
-
-                        if let streakLeaderboardSnapshot = self.store.progressStreakLeaderboardSnapshot {
-                            VStack(alignment: .leading, spacing: 0) {
-                                ProgressStreakLeaderboardSection(
-                                    snapshot: streakLeaderboardSnapshot,
-                                    isRefreshing: self.store.isProgressRefreshing,
-                                    streakLeaderboardRefreshMessage: self.store.progressErrorState.streakLeaderboardRefreshMessage,
-                                    onOpenProfile: self.openLeaderboardProfile
-                                )
-                            }
-                            .id(ProgressScreenSectionID.streakLeaderboard)
-                            .accessibilityIdentifier(UITestIdentifier.progressStreakLeaderboardSection)
-                            .modifier(ProgressCardModifier())
-                        }
-
-                        VStack(alignment: .leading, spacing: 0) {
-                            ProgressReviewsSection(
-                                chartDays: progressSnapshot.chartData.chartDays,
-                                chartCalendar: presentationCalendar,
-                                selectionResetKey: progressSnapshot.scopeKey.storageKey
-                            )
-                        }
-                        .accessibilityIdentifier(UITestIdentifier.progressReviewsSection)
-                        .modifier(ProgressCardModifier())
-
-                        if let reviewScheduleSnapshot = self.store.reviewScheduleSnapshot {
-                            VStack(alignment: .leading, spacing: 0) {
-                                ProgressReviewScheduleSection(snapshot: reviewScheduleSnapshot)
-                            }
-                            .accessibilityIdentifier(UITestIdentifier.progressReviewScheduleSection)
-                            .modifier(ProgressCardModifier())
-                        }
                     } else if self.store.isProgressRefreshing == false {
-                        VStack(alignment: .leading, spacing: 0) {
-                            ContentUnavailableView(
-                                String(
-                                    localized: "progress.screen.unavailable.title",
-                                    defaultValue: "Progress is unavailable",
-                                    table: progressStringsTableName,
-                                    comment: "Progress unavailable title"
-                                ),
-                                systemImage: "chart.bar.xaxis",
-                                description: Text(
-                                    String(
-                                        localized: "progress.screen.unavailable.description",
-                                        defaultValue: "Open review or reconnect cloud data, then refresh progress.",
-                                        table: progressStringsTableName,
-                                        comment: "Progress unavailable description"
-                                    )
-                                )
-                            )
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .modifier(ProgressCardModifier())
+                        ProgressUnavailableCard()
                     }
                 }
                 .padding(.horizontal, 16)
@@ -254,30 +160,6 @@ struct ProgressScreen: View {
         case .leaderboard:
             return .leaderboard
         }
-    }
-}
-
-private func progressSummaryUITestValue(summary: ProgressSummary) -> String {
-    let components: [String] = [
-        "currentStreakDays=\(summary.currentStreakDays)",
-        "longestStreakDays=\(summary.longestStreakDays)",
-        "hasReviewedToday=\(summary.hasReviewedToday ? "true" : "false")",
-        "activeReviewDays=\(summary.activeReviewDays)",
-        "streakFreezeAvailableCredits=\(summary.streakFreeze.availableCredits)",
-        "streakFreezeCapacity=\(summary.streakFreeze.capacity)"
-    ]
-    return components.joined(separator: ";")
-}
-
-private struct ProgressCardModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color(uiColor: .secondarySystemGroupedBackground))
-            )
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressCardModifier.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressCardModifier.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+// Shared card chrome for every Progress screen section.
+struct ProgressCardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(uiColor: .secondarySystemGroupedBackground))
+            )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressErrorBanner.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressErrorBanner.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ProgressErrorBanner: View {
+    let message: String
+
+    var body: some View {
+        if self.message.isEmpty == false {
+            Label {
+                Text(self.message)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+            }
+            .modifier(ProgressCardModifier())
+        }
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLoadedSections.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLoadedSections.swift
@@ -1,0 +1,192 @@
+import Foundation
+import SwiftUI
+
+// The five loaded Progress cards are siblings at one nesting level so the
+// enclosing lazy container keeps a shallow generic type. Each optional card
+// decides on its own whether it draws, and every value a card needs is passed
+// in explicitly instead of read back from the environment.
+struct ProgressLoadedSections: View {
+    let progressSnapshot: ProgressSnapshot
+    let leaderboardSnapshot: ProgressLeaderboardSnapshot?
+    let streakLeaderboardSnapshot: ProgressStreakLeaderboardSnapshot?
+    let reviewScheduleSnapshot: ReviewScheduleSnapshot?
+    let isProgressRefreshing: Bool
+    let leaderboardRefreshMessage: String
+    let streakLeaderboardRefreshMessage: String
+    @Binding var selectedLeaderboardWindowKey: LeaderboardWindowKey?
+    let onOpenCloudSignIn: () -> Void
+    let onOpenFriendInvite: () -> Void
+    let onOpenProfile: (ProgressLeaderboardSelectedProfile) -> Void
+
+    var body: some View {
+        ProgressStreakCard(progressSnapshot: self.progressSnapshot)
+
+        ProgressLeaderboardCard(
+            snapshot: self.leaderboardSnapshot,
+            isRefreshing: self.isProgressRefreshing,
+            leaderboardRefreshMessage: self.leaderboardRefreshMessage,
+            selectedWindowKey: self.$selectedLeaderboardWindowKey,
+            onOpenCloudSignIn: self.onOpenCloudSignIn,
+            onOpenFriendInvite: self.onOpenFriendInvite,
+            onOpenProfile: self.onOpenProfile
+        )
+
+        ProgressStreakLeaderboardCard(
+            snapshot: self.streakLeaderboardSnapshot,
+            isRefreshing: self.isProgressRefreshing,
+            streakLeaderboardRefreshMessage: self.streakLeaderboardRefreshMessage,
+            onOpenProfile: self.onOpenProfile
+        )
+
+        ProgressReviewsCard(progressSnapshot: self.progressSnapshot)
+
+        ProgressReviewScheduleCard(snapshot: self.reviewScheduleSnapshot)
+    }
+}
+
+private struct ProgressStreakCard: View {
+    private let summary: ProgressSummary
+    private let streakWeeks: [ProgressCalendarWeek]
+    private let presentationCalendar: Calendar
+
+    init(progressSnapshot: ProgressSnapshot) {
+        let presentationCalendar = requiredProgressPresentationCalendar(
+            timeZoneIdentifier: progressSnapshot.scopeKey.timeZone
+        )
+        self.summary = progressSnapshot.summary
+        self.streakWeeks = requiredProgressStreakWeeks(
+            progressSnapshot: progressSnapshot,
+            calendar: presentationCalendar
+        )
+        self.presentationCalendar = presentationCalendar
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(
+                String(
+                    localized: "progress.screen.streak.section_title",
+                    defaultValue: "Streak",
+                    table: progressStringsTableName,
+                    comment: "Progress streak section title"
+                )
+            )
+            .font(.headline)
+
+            ProgressStreakSection(
+                weeks: self.streakWeeks,
+                badgeState: makeReviewProgressBadgeState(summary: self.summary),
+                streakFreeze: self.summary.streakFreeze,
+                calendar: self.presentationCalendar
+            )
+        }
+        .id(ProgressScreenSectionID.streak)
+        .accessibilityIdentifier(UITestIdentifier.progressStreakSection)
+        .accessibilityValue(progressSummaryUITestValue(summary: self.summary))
+        .modifier(ProgressCardModifier())
+    }
+}
+
+private struct ProgressLeaderboardCard: View {
+    let snapshot: ProgressLeaderboardSnapshot?
+    let isRefreshing: Bool
+    let leaderboardRefreshMessage: String
+    @Binding var selectedWindowKey: LeaderboardWindowKey?
+    let onOpenCloudSignIn: () -> Void
+    let onOpenFriendInvite: () -> Void
+    let onOpenProfile: (ProgressLeaderboardSelectedProfile) -> Void
+
+    var body: some View {
+        if let snapshot = self.snapshot {
+            VStack(alignment: .leading, spacing: 0) {
+                ProgressLeaderboardSection(
+                    snapshot: snapshot,
+                    isRefreshing: self.isRefreshing,
+                    leaderboardRefreshMessage: self.leaderboardRefreshMessage,
+                    selectedWindowKey: self.$selectedWindowKey,
+                    onOpenCloudSignIn: self.onOpenCloudSignIn,
+                    onOpenFriendInvite: self.onOpenFriendInvite,
+                    onOpenProfile: self.onOpenProfile
+                )
+            }
+            .id(ProgressScreenSectionID.leaderboard)
+            .accessibilityIdentifier(UITestIdentifier.progressLeaderboardSection)
+            .modifier(ProgressCardModifier())
+        }
+    }
+}
+
+private struct ProgressStreakLeaderboardCard: View {
+    let snapshot: ProgressStreakLeaderboardSnapshot?
+    let isRefreshing: Bool
+    let streakLeaderboardRefreshMessage: String
+    let onOpenProfile: (ProgressLeaderboardSelectedProfile) -> Void
+
+    var body: some View {
+        if let snapshot = self.snapshot {
+            VStack(alignment: .leading, spacing: 0) {
+                ProgressStreakLeaderboardSection(
+                    snapshot: snapshot,
+                    isRefreshing: self.isRefreshing,
+                    streakLeaderboardRefreshMessage: self.streakLeaderboardRefreshMessage,
+                    onOpenProfile: self.onOpenProfile
+                )
+            }
+            .id(ProgressScreenSectionID.streakLeaderboard)
+            .accessibilityIdentifier(UITestIdentifier.progressStreakLeaderboardSection)
+            .modifier(ProgressCardModifier())
+        }
+    }
+}
+
+private struct ProgressReviewsCard: View {
+    private let chartDays: [ProgressChartDay]
+    private let selectionResetKey: String
+    private let presentationCalendar: Calendar
+
+    init(progressSnapshot: ProgressSnapshot) {
+        self.chartDays = progressSnapshot.chartData.chartDays
+        self.selectionResetKey = progressSnapshot.scopeKey.storageKey
+        self.presentationCalendar = requiredProgressPresentationCalendar(
+            timeZoneIdentifier: progressSnapshot.scopeKey.timeZone
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ProgressReviewsSection(
+                chartDays: self.chartDays,
+                chartCalendar: self.presentationCalendar,
+                selectionResetKey: self.selectionResetKey
+            )
+        }
+        .accessibilityIdentifier(UITestIdentifier.progressReviewsSection)
+        .modifier(ProgressCardModifier())
+    }
+}
+
+private struct ProgressReviewScheduleCard: View {
+    let snapshot: ReviewScheduleSnapshot?
+
+    var body: some View {
+        if let snapshot = self.snapshot {
+            VStack(alignment: .leading, spacing: 0) {
+                ProgressReviewScheduleSection(snapshot: snapshot)
+            }
+            .accessibilityIdentifier(UITestIdentifier.progressReviewScheduleSection)
+            .modifier(ProgressCardModifier())
+        }
+    }
+}
+
+private func progressSummaryUITestValue(summary: ProgressSummary) -> String {
+    let components: [String] = [
+        "currentStreakDays=\(summary.currentStreakDays)",
+        "longestStreakDays=\(summary.longestStreakDays)",
+        "hasReviewedToday=\(summary.hasReviewedToday ? "true" : "false")",
+        "activeReviewDays=\(summary.activeReviewDays)",
+        "streakFreezeAvailableCredits=\(summary.streakFreeze.availableCredits)",
+        "streakFreezeCapacity=\(summary.streakFreeze.capacity)"
+    ]
+    return components.joined(separator: ";")
+}

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressUnavailableCard.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressUnavailableCard.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ProgressUnavailableCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ContentUnavailableView(
+                String(
+                    localized: "progress.screen.unavailable.title",
+                    defaultValue: "Progress is unavailable",
+                    table: progressStringsTableName,
+                    comment: "Progress unavailable title"
+                ),
+                systemImage: "chart.bar.xaxis",
+                description: Text(
+                    String(
+                        localized: "progress.screen.unavailable.description",
+                        defaultValue: "Open review or reconnect cloud data, then refresh progress.",
+                        table: progressStringsTableName,
+                        comment: "Progress unavailable description"
+                    )
+                )
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .modifier(ProgressCardModifier())
+    }
+}


### PR DESCRIPTION
## Problem

Sentry [FLASHCARDS-IOS-44](https://samo-danni-eood.sentry.io/issues/131654398/) — `Fatal App Hang Fully Blocked`, the OS watchdog terminating the app after the main thread blocked past its limit. 3 events, 3 users, regressed, currently the only unresolved fatal in production.

Evidence from the raw event:

- The stack is entirely inside SwiftUI list building — `_LazyLayout_Subviews.applyNodes`, `DynamicViewList.WrappedList.applyNodes`, `ResettableListContainer.WrappedList.applyNodes` — ending in `__swift_instantiateGenericMetadata` → `swift_getGenericMetadata` → `LockingConcurrentMap::getOrInsert`. **There is no app frame.**
- Breadcrumbs immediately before the hang: `visible_tab_presentation.start` → `progress_snapshot_prepare` → `progress_refresh.success`, all inside ~30 ms, `card_count: "0"`. So the hang is the render that follows, not data loading.
- Device conditions: `low_power_mode: true`, `free_memory` ≈ 99 MB.

`ProgressScreen.body` built the whole screen inline: one `LazyVStack` containing an error branch, then a large `if let progressSnapshot` block nesting five more optional section branches plus an `else if` empty state. Each nested `if`/`if let` adds a `_ConditionalContent` layer to the container's generic type, and the Swift runtime instantiates that metadata on first display. `requiredProgressPresentationCalendar` and `requiredProgressStreakWeeks` were also evaluated inside the `ViewBuilder`.

## Fix

`ProgressScreen.body` is now a short composition over nominal view types:

```swift
LazyVStack {
    ProgressErrorBanner(...)
    if let snapshot { ProgressLoadedSections(...) } else if !isRefreshing { ProgressUnavailableCard() }
}
```

One conditional layer instead of five nested ones. `ProgressLoadedSections` renders the five cards as siblings at a single nesting level; each optional card takes an optional snapshot and decides internally whether it draws, so the parent gains no conditional layer per section. The calendar and streak-week derivations moved out of the `ViewBuilder` into the card initializers. Cards receive concrete values rather than re-reading the environment, and all store reads stay in `ProgressScreen.body` so Observation tracking is unchanged.

Behavior is preserved verbatim: same `.id(ProgressScreenSectionID.…)` on the same containers used by `handleProgressPresentationRequest(proxy:)`, same `ProgressCardModifier` on the same visual cards, same accessibility identifiers and values, same localization keys and table, same spacing and alignments, unchanged `.task(id:)` and all three `.sheet` modifiers. No caching, memoization, queues or new state.

The `.xcodeproj` uses `PBXFileSystemSynchronizedRootGroup` with no exception sets, so the four new files need no project-file edit.

## Honest caveat

This is a deliberate best-practice structural fix chosen **instead of** profiling first. It removes a concrete, stack-supported cause, but there is no profile proving it is the only one. Verification is the absence of new IOS-44 events on the next iOS release.

## Validation

Static change only. No local build, tests, lint, or simulator run — repository policy requires explicit approval for simulator-backed runs and it was not granted for this work. Xcode Cloud is the compile and test gate after merge.

Accepted residual (P4, not fixed): `requiredProgressPresentationCalendar` is now derived twice per `ProgressLoadedSections` evaluation instead of once, since the streak and reviews cards each build their own. Two `Calendar`/`TimeZone` constructions are negligible next to the generic-metadata cost this removes, so it was not worth another review round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)