### PR TITLE
Fix the iOS test main-actor isolation build break

### DIFF
--- a/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/ReviewNotificationPayloadTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/ReviewNotificationPayloadTests.swift
@@ -282,6 +282,7 @@ final class ReviewNotificationPayloadTests: ReviewNotificationsTestCase {
         XCTAssertEqual(try makeReviewFilter(persistedReviewFilter: decodedMultiTagFilter), multiTagFilter)
     }
 
+    @MainActor
     func testSelectedMultipleTagFilterPersistsPerWorkspace() throws {
         let suiteName = "ReviewFilterPersistenceTests-\(UUID().uuidString)"
         guard let userDefaults = UserDefaults(suiteName: suiteName) else {


### PR DESCRIPTION
## Problem

The Xcode Cloud `Test - iOS` action fails to compile `FlashcardsTests`. `testSelectedMultipleTagFilterPersistsPerWorkspace` is a `nonisolated` synchronous test method, but it calls the main-actor isolated `FlashcardsStore.loadSelectedReviewFilter`, which Swift's strict concurrency checking rejects.

Two error lines, both in `apps/ios/Flashcards/FlashcardsTests/Review/Notifications/ReviewNotificationPayloadTests.swift`:

- line 301: `FlashcardsStore.loadSelectedReviewFilter(` — call to main actor-isolated static method in a synchronous nonisolated context
- line 309: `FlashcardsStore.loadSelectedReviewFilter(` — same error at the second call site

## Fix

Annotate `testSelectedMultipleTagFilterPersistsPerWorkspace` with `@MainActor` so both call sites execute on the main actor. This matches how the other main-actor-touching tests in the suite are declared and keeps the test body unchanged.

## Verification

iOS-only changes trigger no GitHub release workflow — the release workflows are path-filtered and none of them cover `apps/ios`. Verification is therefore the Xcode Cloud build for the merged SHA: the `Test - iOS` action must compile `FlashcardsTests` and run the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)