### PR TITLE
Make the review filter draft discard explicit instead of a no-op finalize

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -371,7 +371,10 @@ struct ReviewView: View {
             return
         }
 
-        self.finalizeReviewFilterDraft()
+        // The committed filter moved underneath the open popover, so the draft is built on a stale
+        // snapshot and is discarded instead of applied; reopening the menu re-seeds it. Clearing the
+        // context first also keeps the finalize on popover dismissal a no-op.
+        self.reviewFilterPresentationContext = nil
         self.isReviewFilterPopoverPresented = false
     }
 


### PR DESCRIPTION
## Problem

In `apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift`, `dismissReviewFilterPopoverIfContextDiverged()` called `finalizeReviewFilterDraft()` right before closing the popover. That reads as if the user's uncommitted filter draft is being saved on the way out.

It never was. The enclosing guard already established that the presentation context is non-nil and that the committed filter diverged from the snapshot the popover was opened against, which means `finalizeReviewFilterDraft()` always fell through its own equality guard. Its only remaining effect was setting `reviewFilterPresentationContext = nil`. So the code said "save the draft" while the guaranteed runtime behavior was "throw the draft away".

## Change

Replace the misleading call with the effect it actually had — an explicit `self.reviewFilterPresentationContext = nil` — plus a short comment stating why: the committed filter moved underneath the popover, so the draft is built on a stale snapshot and is deliberately discarded rather than applied, and clearing the context first keeps the finalize triggered by the dismissal itself a no-op.

Single file, four lines. Zero behavior delta:

- The subsequent `isReviewFilterPopoverPresented = false` is unchanged.
- The `.onChange` finalize on dismissal now early-returns on a nil context, exactly as it did before.
- `reviewFilterDraft` still needs no reset, because it is re-seeded from the committed filter every time the menu button opens the popover.

No draft preservation, re-anchoring, retry, or new state was added, and no UI test files were touched. User-visible behavior is intentionally identical.

## Verification

iOS does not build in GitHub Actions, so the trunk PR checks here only cover the static iOS checks — they cannot compile this change. Real verification is the Xcode Cloud `Test - iOS` action running against the merged `main` SHA, which must stay as green as it was before this commit. Per repository policy, no `xcodebuild`, simulator run, or validation script was run locally.

Since the change is a pure restatement of an existing guaranteed-no-op path, code review of the diff against `dismissReviewFilterPopoverIfContextDiverged()` and `finalizeReviewFilterDraft()` is the substantive correctness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)