### PR TITLE
Dismiss the review filter popover by element instead of a screen coordinate

### DIFF
--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
@@ -125,7 +125,7 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
         }
 
         try self.step("dismiss the empty review filter menu with an outside tap") {
-            self.dismissReviewFilterPopoverWithOutsideTap()
+            try self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -171,7 +171,7 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
         }
 
         try self.step("verify the tagged card returns after dismissing the menu") {
-            self.dismissReviewFilterPopoverWithOutsideTap()
+            try self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: tagToggleIdentifier,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -205,7 +205,7 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
         }
 
         try self.step("verify the all cards review returns after dismissing the menu") {
-            self.dismissReviewFilterPopoverWithOutsideTap()
+            try self.dismissReviewFilterPopoverWithOutsideTap()
             try self.assertElementDoesNotExist(
                 identifier: LiveSmokeIdentifier.reviewFilterAllCardsToggle,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -293,10 +293,16 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
     }
 
     @MainActor
-    private func dismissReviewFilterPopoverWithOutsideTap() {
-        let reviewScreen = self.app.descendants(matching: .any)
-            .matching(identifier: LiveSmokeIdentifier.reviewScreen)
-            .firstMatch
-        reviewScreen.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+    private func dismissReviewFilterPopoverWithOutsideTap() throws {
+        let dismissRegion = self.app.otherElements[LiveSmokeIdentifier.popoverDismissRegion].firstMatch
+        guard dismissRegion.waitForExistence(timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds) else {
+            throw LiveSmokeFailure.unexpectedReviewState(
+                message: "The review filter popover dismiss region was not present, so the popover could not be dismissed.",
+                screen: self.currentScreenSummary(),
+                step: self.currentStepTitle
+            )
+        }
+
+        dismissRegion.tap()
     }
 }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -22,6 +22,10 @@ enum LiveSmokeIdentifier {
     static let reviewFilterScrollSurface: String = "review.filter.scrollSurface"
     static let reviewFilterAllCardsToggle: String = "review.filter.allCards"
     static let reviewFilterTagTogglePrefix: String = "review.filter.tag."
+    // UIKit exposes the transparent tap-catching region behind a presented popover under this
+    // fixed accessibility identifier. Tapping it is the deterministic way to dismiss a popover,
+    // instead of guessing a screen coordinate that happens to fall outside it.
+    static let popoverDismissRegion: String = "PopoverDismissRegion"
     static let aiScreen: String = "ai.screen"
     static let progressScreen: String = "progress.screen"
     static let progressStreakSection: String = "progress.streakSection"


### PR DESCRIPTION
## Problem

`testLiveSmokeReviewFilterMenuSupportsEmptyTagAndAllCardsStates` dismissed the review filter popover by tapping a hardcoded normalized coordinate (`dx: 0.95, dy: 0.5`) on the review screen. Whether that tap actually dismissed the popover depended on what happened to be rendered behind it at that moment, so the step was non-deterministic and could leave the popover on screen, stalling the test before it ran to completion.

## Change

Dismiss the popover through UIKit's own popover dismiss region instead of guessing a screen coordinate:

- Added `LiveSmokeIdentifier.popoverDismissRegion = "PopoverDismissRegion"`, the fixed accessibility identifier UIKit gives the transparent tap-catching region behind a presented popover.
- Rewrote `dismissReviewFilterPopoverWithOutsideTap()` as a throwing helper that resolves `app.otherElements[popoverDismissRegion].firstMatch` and taps it.
- When the region is absent, the helper throws `LiveSmokeFailure.unexpectedReviewState` with the current screen summary and step, so the failure is explicit and diagnosable.
- No fallback, retry, or coordinate tap remains. The three call sites now use `try`; all were already inside throwing `self.step` closures.

Test-target files only. No app-target file was touched.

## Verification

Verification is the Xcode Cloud `Test - iOS` action on the merged `main` SHA, because iOS builds and tests do not run in GitHub Actions. The check is that `testLiveSmokeReviewFilterMenuSupportsEmptyTagAndAllCardsStates` runs to completion, with all three "dismiss the menu" steps passing.

Nothing was run locally: per repository policy no `xcodebuild`, simulator run, or validation script was executed for this change.

Note on risk: `PopoverDismissRegion` is supplied by UIKit rather than owned by the app. If it is not exposed for the `.presentationCompactAdaptation(.popover)` presentation, the test now fails fast with an explicit message rather than silently mis-tapping — that outcome should prompt a different dismissal approach, not a reintroduced coordinate tap.
