### PR TITLE
Seed the demo onboarding card on first Android launch

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -34,6 +34,7 @@ import com.flashcardsopensourceapp.app.notifications.review.ReviewReminderAttent
 import com.flashcardsopensourceapp.app.notifications.review.ReviewNotificationsManager
 import com.flashcardsopensourceapp.app.notifications.strict.AndroidStrictRemindersScheduler
 import com.flashcardsopensourceapp.app.notifications.strict.StrictRemindersManager
+import com.flashcardsopensourceapp.app.onboarding.seedDemoCardForNewWorkspace
 import com.flashcardsopensourceapp.data.local.bootstrap.ensureLocalWorkspaceShell
 import com.flashcardsopensourceapp.data.local.ai.remote.AiChatLiveRemoteService
 import com.flashcardsopensourceapp.data.local.ai.store.AiChatHistoryStore
@@ -615,11 +616,19 @@ class AppGraph(
     }
 
     suspend fun ensureLocalWorkspaceShell(currentTimeMillis: Long) {
-        ensureLocalWorkspaceShell(
+        val localWorkspaceShell = ensureLocalWorkspaceShell(
             database = database,
             currentTimeMillis = currentTimeMillis
         )
         cloudPreferencesStore.hydrateCloudSettingsFromDatabase()
+        if (localWorkspaceShell.didCreateWorkspace) {
+            seedDemoCardForNewWorkspace(
+                context = applicationContext,
+                database = database,
+                cardsRepository = cardsRepository,
+                workspaceId = localWorkspaceShell.workspaceId
+            )
+        }
     }
 
     suspend fun ensureGuestCloudSession(workspaceId: String): AppGuestCloudSession {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/onboarding/DemoCardSeed.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/onboarding/DemoCardSeed.kt
@@ -1,0 +1,63 @@
+package com.flashcardsopensourceapp.app.onboarding
+
+import android.content.Context
+import com.flashcardsopensourceapp.app.R
+import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
+import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
+import com.flashcardsopensourceapp.data.local.repository.CardsRepository
+import com.flashcardsopensourceapp.feature.review.R as ReviewR
+
+const val demoCardTag: String = "demo"
+
+private const val demoCardParagraphSeparator: String = "\n\n"
+
+/**
+ * Builds the onboarding demo card from the current app locale. The rating
+ * labels are read from the review feature so the card always names the same
+ * buttons the user sees while reviewing.
+ *
+ * The Markdown lives here rather than in the translatable strings: the back
+ * text carries exactly the bold product name and the inline-code rating
+ * labels. The backticks are load-bearing, not decoration.
+ * `classifyReviewContentPresentation` only switches to Markdown on a backtick
+ * or a block-level cue, and inline emphasis alone never switches the mode
+ * (see docs/review-markdown-rendering.md). Removing the backticks would demote
+ * this multi-paragraph card to plain text and show the `**` literally, so
+ * whoever removes them must also remove the bold.
+ */
+fun buildDemoCardDraft(context: Context): CardDraft {
+    val productName: String = "**${context.getString(R.string.app_name)}**"
+    val againLabel: String = "`${context.getString(ReviewR.string.review_again)}`"
+    val hardLabel: String = "`${context.getString(ReviewR.string.review_hard)}`"
+    val backParagraphs: List<String> = listOf(
+        context.getString(R.string.demo_card_back_1, productName),
+        context.getString(R.string.demo_card_back_2),
+        context.getString(R.string.demo_card_back_3),
+        context.getString(R.string.demo_card_back_4, againLabel, hardLabel),
+        context.getString(R.string.demo_card_back_5, againLabel)
+    )
+    return CardDraft(
+        frontText = context.getString(R.string.demo_card_front),
+        backText = backParagraphs.joinToString(separator = demoCardParagraphSeparator),
+        tags = listOf(demoCardTag)
+    )
+}
+
+/**
+ * Seeds the onboarding demo card offline through the normal card creation
+ * path, so the card entity, its tags, and its outbox row are written exactly
+ * like a user-authored card. Call this only right after the local workspace
+ * shell was newly created; the card-count guard keeps a workspace that already
+ * holds cards untouched.
+ */
+suspend fun seedDemoCardForNewWorkspace(
+    context: Context,
+    database: AppDatabase,
+    cardsRepository: CardsRepository,
+    workspaceId: String
+) {
+    if (database.cardDao().loadCards(workspaceId = workspaceId).isNotEmpty()) {
+        return
+    }
+    cardsRepository.createCard(cardDraft = buildDemoCardDraft(context = context))
+}

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">Flashcards Open Source App</string>
     <string name="top_level_review">Review</string>
     <string name="top_level_ai">AI</string>
@@ -34,6 +34,18 @@
     <string name="feedback_prompt_submit_failed">Feedback could not be sent. Check your connection and try again.</string>
     <string name="feedback_prompt_empty_message">Write a message before sending.</string>
     <string name="feedback_prompt_message_too_long">Feedback must be %1$d characters or fewer.</string>
+    <!-- Question shown on the front of the onboarding demo flashcard seeded for a new install. -->
+    <string name="demo_card_front">What is the best application for studying?</string>
+    <!-- First paragraph on the back of the onboarding demo flashcard. The placeholder is the product name. -->
+    <string name="demo_card_back_1"><xliff:g id="app_name" example="Flashcards Open Source App">%1$s</xliff:g> — the app you are looking at right now.</string>
+    <!-- Second paragraph on the back of the onboarding demo flashcard. -->
+    <string name="demo_card_back_2">Everything here is a flashcard: a question on the front, the answer on the back. You can write cards yourself, or just give the built-in AI chat a topic and it will create a set of cards for you.</string>
+    <!-- Third paragraph on the back of the onboarding demo flashcard. -->
+    <string name="demo_card_back_3">When you review, you try to recall the answer, then rate how it went. Every card schedules itself from there: what you know well comes back in weeks or months, what you keep forgetting comes back today or tomorrow.</string>
+    <!-- Fourth paragraph on the back of the onboarding demo flashcard. The placeholders are the review rating button labels. -->
+    <string name="demo_card_back_4">Rate honestly, this is what makes it work. If you did not know the answer, choose <xliff:g id="again_button" example="Again">%1$s</xliff:g> — including when you had to peek. <xliff:g id="hard_button" example="Hard">%2$s</xliff:g> is only for answers you knew but struggled to recall.</string>
+    <!-- Fifth paragraph on the back of the onboarding demo flashcard. The placeholder is the review rating button label. -->
+    <string name="demo_card_back_5">Try it right now: rate this card <xliff:g id="again_button" example="Again">%1$s</xliff:g>, and it will come back in about a minute — so this answer sticks.</string>
     <string name="review_notification_channel_name">Review reminders</string>
     <string name="review_notification_channel_description">Study reminders with cards from your review queue.</string>
 </resources>

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
@@ -93,7 +93,7 @@ internal suspend fun bootstrapTestWorkspace(
     val workspaceId = ensureLocalWorkspaceShell(
         database = runtime.database,
         currentTimeMillis = currentTimeMillis
-    )
+    ).workspaceId
     runtime.preferencesStore.hydrateCloudSettingsFromDatabase()
     return workspaceId
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/bootstrap/LocalWorkspaceBootstrap.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/bootstrap/LocalWorkspaceBootstrap.kt
@@ -13,10 +13,20 @@ import java.util.UUID
 
 const val localWorkspaceName: String = "Personal"
 
+/**
+ * Result of the local workspace shell bootstrap. [didCreateWorkspace] is true
+ * only for the call that actually inserted the workspace row, which is the
+ * new-user moment callers use for one-time local onboarding work.
+ */
+data class LocalWorkspaceShell(
+    val workspaceId: String,
+    val didCreateWorkspace: Boolean
+)
+
 suspend fun ensureLocalWorkspaceShell(
     database: AppDatabase,
     currentTimeMillis: Long
-): String {
+): LocalWorkspaceShell {
     return database.withTransaction {
         val existingWorkspace = database.workspaceDao().loadAnyWorkspace()
         if (existingWorkspace != null) {
@@ -30,7 +40,10 @@ suspend fun ensureLocalWorkspaceShell(
                 workspaceId = existingWorkspace.workspaceId,
                 currentTimeMillis = currentTimeMillis
             )
-            return@withTransaction existingWorkspace.workspaceId
+            return@withTransaction LocalWorkspaceShell(
+                workspaceId = existingWorkspace.workspaceId,
+                didCreateWorkspace = false
+            )
         }
 
         val workspace = WorkspaceEntity(
@@ -49,7 +62,10 @@ suspend fun ensureLocalWorkspaceShell(
             workspaceId = workspace.workspaceId,
             currentTimeMillis = currentTimeMillis
         )
-        workspace.workspaceId
+        LocalWorkspaceShell(
+            workspaceId = workspace.workspaceId,
+            didCreateWorkspace = true
+        )
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/CloudIdentityResetCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/CloudIdentityResetCoordinator.kt
@@ -45,7 +45,7 @@ class CloudIdentityResetCoordinator(
                 val activeWorkspaceId = ensureLocalWorkspaceShell(
                     database = database,
                     currentTimeMillis = System.currentTimeMillis()
-                )
+                ).workspaceId
                 cloudPreferencesStore.regenerateInstallationId()
                 cloudPreferencesStore.updateCloudSettings(
                     cloudState = CloudAccountState.DISCONNECTED,
@@ -74,7 +74,7 @@ class CloudIdentityResetCoordinator(
                 val activeWorkspaceId = ensureLocalWorkspaceShell(
                     database = database,
                     currentTimeMillis = System.currentTimeMillis()
-                )
+                ).workspaceId
                 cloudPreferencesStore.regenerateInstallationId()
                 cloudPreferencesStore.updateCloudSettings(
                     cloudState = CloudAccountState.DISCONNECTED,
@@ -111,7 +111,7 @@ class CloudIdentityResetCoordinator(
                 val activeWorkspaceId = ensureLocalWorkspaceShell(
                     database = database,
                     currentTimeMillis = System.currentTimeMillis()
-                )
+                ).workspaceId
                 cloudPreferencesStore.updateCloudSettings(
                     cloudState = CloudAccountState.DISCONNECTED,
                     linkedUserId = null,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -577,7 +577,7 @@ class CloudGuestSessionCoordinator(
             ensureLocalWorkspaceShell(
                 database = database,
                 currentTimeMillis = System.currentTimeMillis()
-            )
+            ).workspaceId
         }
         preferencesStore.updateActiveWorkspaceId(activeWorkspaceId = resolvedWorkspaceId)
     }


### PR DESCRIPTION
Seeds one `demo`-tagged flashcard offline at the moment the local workspace shell is first created. English source strings only; translations are Play-managed. Cloud-identity reset paths deliberately do not re-seed.

Part of the demo onboarding card feature. Targets `integration-demo-card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)