### PR TITLE
Seed the demo card only for a new user, not for every new workspace

### DIFF
--- a/apps/web/src/appData/context/provider.tsx
+++ b/apps/web/src/appData/context/provider.tsx
@@ -141,6 +141,7 @@ export function AppDataProvider(props: Props): ReactElement {
     sessionVerificationState,
     session,
     activeWorkspace,
+    availableWorkspaces,
     setWorkspaceSettings,
     setCloudSettings,
     setLocalReadVersion,

--- a/apps/web/src/appData/sync/engine/useSyncEngine.mediaUploadLifecycle.test.tsx
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.mediaUploadLifecycle.test.tsx
@@ -105,6 +105,7 @@ function renderSyncEngineHarness(): Readonly<{
       sessionVerificationState: "verified",
       session,
       activeWorkspace: workspace,
+      availableWorkspaces: [workspace],
       setWorkspaceSettings,
       setCloudSettings,
       setLocalReadVersion,

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -88,6 +88,7 @@ type UseSyncEngineParams = Readonly<{
   sessionVerificationState: SessionVerificationState;
   session: SessionInfo | null;
   activeWorkspace: WorkspaceSummary | null;
+  availableWorkspaces: ReadonlyArray<WorkspaceSummary>;
   setWorkspaceSettings: Dispatch<SetStateAction<WorkspaceSchedulerSettings | null>>;
   setCloudSettings: Dispatch<SetStateAction<CloudSettings | null>>;
   setLocalReadVersion: Dispatch<SetStateAction<number>>;
@@ -153,6 +154,17 @@ function calculateMediaUploadRetryTimerDelayMs(nextAttemptAt: string, nowMs: num
   return delayMs > maximumMediaUploadRetryTimerDelayMs ? null : delayMs;
 }
 
+// A brand-new user owns exactly one workspace, the one created for the account at sign-up.
+// Creating a further workspace never removes the earlier ones, so an account that still has
+// a single workspace is the only user-scoped signal remote sync needs to tell a new user
+// apart from an existing user who deliberately created another empty workspace.
+function isOnlyWorkspaceOfAccount(
+  availableWorkspaces: ReadonlyArray<WorkspaceSummary>,
+  workspaceId: string,
+): boolean {
+  return availableWorkspaces.length === 1 && availableWorkspaces[0].workspaceId === workspaceId;
+}
+
 function isBrowserOnline(): boolean {
   return typeof navigator === "undefined" || navigator.onLine !== false;
 }
@@ -192,6 +204,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     sessionVerificationState,
     session,
     activeWorkspace,
+    availableWorkspaces,
     setWorkspaceSettings,
     setCloudSettings,
     setLocalReadVersion,
@@ -200,6 +213,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     setTechnicalError,
   } = params;
   const activeWorkspaceRef = useRef<WorkspaceSummary | null>(activeWorkspace);
+  const availableWorkspacesRef = useRef<ReadonlyArray<WorkspaceSummary>>(availableWorkspaces);
   const syncPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
   const localReadPromisesRef = useRef<Set<Promise<unknown>>>(new Set());
   const localMutationPromisesRef = useRef<Set<Promise<unknown>>>(new Set());
@@ -220,6 +234,10 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   const isDiscardingAllSyncWorkRef = useRef<boolean>(false);
   const discardAllSyncWorkPromiseRef = useRef<Promise<void> | null>(null);
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
+  // Mirrored during render, not in an effect: workspace activation publishes the new
+  // workspace list and starts the sync run for the new workspace in the same tick, and the
+  // run must not decide "only workspace of the account" from the pre-creation list.
+  availableWorkspacesRef.current = availableWorkspaces;
 
   useEffect(() => {
     sessionLoadStateRef.current = sessionLoadState;
@@ -635,6 +653,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           workspaceId,
           installationId,
           syncRunId,
+          isOnlyWorkspaceForUser: isOnlyWorkspaceOfAccount(availableWorkspacesRef.current, workspaceId),
           requireWorkspaceSyncNotDiscarded: requireCurrentWorkspaceSync,
           publishWorkspaceSettings: publishCurrentWorkspaceSettings,
           refreshWorkspaceView: refreshCurrentWorkspaceView,

--- a/apps/web/src/appData/sync/local/demoCard.ts
+++ b/apps/web/src/appData/sync/local/demoCard.ts
@@ -38,6 +38,7 @@ export type SeedDemoCardInput = Readonly<{
   userId: string;
   workspaceId: string;
   installationId: string;
+  isOnlyWorkspaceForUser: boolean;
   remoteIsEmpty: boolean | null;
   localCardCount: number;
 }>;
@@ -73,17 +74,29 @@ function buildDemoCardText(): DemoCardText {
 // it goes through createCardLocally, so it lands in IndexedDB and in the outbox and is
 // pushed by the normal sync path. Nothing else in the app special-cases it.
 //
+// This is a new-user card, not a new-workspace card. An empty workspace is not by itself
+// a new account: an existing user who deliberately creates a second workspace is handed an
+// empty one too, and would otherwise be onboarded again. isOnlyWorkspaceForUser carries
+// that user-scoped signal, decided by the caller from the account's workspace list.
+//
 // The backend never seeds this card, because a server-side seed would make a new
 // workspace non-empty and push mobile cloud linking into the replace_local_shell branch,
 // discarding a new user's offline work. Deduplication is therefore purely local: each
 // client seeds only at its own new-user moment, and only into a workspace that holds no
 // cards at all.
 //
+// Every condition is decided by the caller and passed in, so this stays a pure guard over
+// its input and never re-reads workspace state.
+//
 // Failing to seed must never fail a sync run, so a seed failure is reported and swallowed.
 export async function seedDemoCardForNewWorkspace(
   input: SeedDemoCardInput,
 ): Promise<LocalCardMutationResult | null> {
-  if (input.remoteIsEmpty !== true || input.localCardCount !== 0) {
+  if (
+    input.isOnlyWorkspaceForUser !== true
+    || input.remoteIsEmpty !== true
+    || input.localCardCount !== 0
+  ) {
     return null;
   }
 

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -79,6 +79,7 @@ function createRemoteSyncInput(): WorkspaceRemoteSyncInput {
     workspaceId: "workspace-1",
     installationId: "installation-1",
     syncRunId: "sync-run-1",
+    isOnlyWorkspaceForUser: true,
     requireWorkspaceSyncNotDiscarded: (_workspaceId: string): void => {},
     publishWorkspaceSettings: (_workspaceId, _settings): void => {},
     refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {},

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -388,18 +388,21 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
       }
     }
 
-    // Brand-new user: the first successful bootstrap of a workspace that is empty on the
-    // backend and holds no local cards. isLocalDbRecovery excludes a re-hydration of an
-    // evicted local cache, which is by definition a workspace this browser already
-    // bootstrapped once. The seed runs after the observations above so it cannot change
-    // localCardCountAfter, and after the restore-history write so both keep describing the
-    // bootstrap result itself.
+    // Brand-new user: the first successful bootstrap of the account's only workspace, when
+    // that workspace is empty on the backend and holds no local cards. isOnlyWorkspaceForUser
+    // is what makes this a new-user rule rather than a new-workspace rule, so an existing
+    // user who deliberately creates another empty workspace is not onboarded again.
+    // isLocalDbRecovery excludes a re-hydration of an evicted local cache, which is by
+    // definition a workspace this browser already bootstrapped once. The seed runs after the
+    // observations above so it cannot change localCardCountAfter, and after the
+    // restore-history write so both keep describing the bootstrap result itself.
     if (isLocalDbRecovery === false) {
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       const demoCardSeedResult = await seedDemoCardForNewWorkspace({
         userId: input.userId,
         workspaceId: input.workspaceId,
         installationId: input.installationId,
+        isOnlyWorkspaceForUser: input.isOnlyWorkspaceForUser,
         remoteIsEmpty,
         localCardCount: localCardCountAfter,
       });

--- a/apps/web/src/appData/sync/remote/types.ts
+++ b/apps/web/src/appData/sync/remote/types.ts
@@ -17,6 +17,10 @@ export type WorkspaceRemoteSyncInput = Readonly<{
   workspaceId: string;
   installationId: string;
   syncRunId: string;
+  // True when this workspace is the only one the account owns, which is the user-scoped
+  // signal for a brand-new user. Resolved by the sync engine from the account's workspace
+  // list, because remote sync itself only ever sees one workspace.
+  isOnlyWorkspaceForUser: boolean;
   requireWorkspaceSyncNotDiscarded: (workspaceId: string) => void;
   publishWorkspaceSettings: (workspaceId: string, settings: WorkspaceSchedulerSettings) => void;
   refreshWorkspaceView: (workspaceId: string) => Promise<void>;


### PR DESCRIPTION
Cumulative promotion review found the web seed gate was per-workspace, so any empty workspace an existing user creates got an onboarding card. Adds a user-scoped condition derived at the sync-engine call site.

Follow-up fix on `integration-demo-card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)