### PR TITLE
Keep an Android demo card seed failure off startup and untranslate its product name

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -622,12 +622,34 @@ class AppGraph(
         )
         cloudPreferencesStore.hydrateCloudSettingsFromDatabase()
         if (localWorkspaceShell.didCreateWorkspace) {
-            seedDemoCardForNewWorkspace(
-                context = applicationContext,
-                database = database,
-                cardsRepository = cardsRepository,
-                workspaceId = localWorkspaceShell.workspaceId
-            )
+            // The demo card is onboarding decoration, so a seed failure is reported and
+            // swallowed instead of failing startup, exactly like the web client does.
+            try {
+                seedDemoCardForNewWorkspace(
+                    context = applicationContext,
+                    database = database,
+                    cardsRepository = cardsRepository,
+                    workspaceId = localWorkspaceShell.workspaceId
+                )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                observability.captureException(
+                    event = AndroidExceptionIssueEvent.AppStartupException(
+                        throwable = error,
+                        startupPhase = "demo_card_seed",
+                        appVersion = appPackageInfo.versionName,
+                        clientVersion = appPackageInfo.versionName,
+                        versionCode = appPackageInfo.longVersionCode.toInt()
+                    )
+                )
+                Log.w(
+                    appGraphLogTag,
+                    "event=demo_card_seed_failed " +
+                        "workspace_id=${localWorkspaceShell.workspaceId} " +
+                        renderSanitizedThrowableLogFields(error = error)
+                )
+            }
         }
     }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/onboarding/DemoCardSeed.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/onboarding/DemoCardSeed.kt
@@ -12,6 +12,13 @@ const val demoCardTag: String = "demo"
 private const val demoCardParagraphSeparator: String = "\n\n"
 
 /**
+ * The product name is a brand and is never translated, so it is a literal here
+ * instead of `R.string.app_name`, which Play may translate. Web and iOS carry
+ * the same literal.
+ */
+private const val demoCardProductName: String = "Flashcards Open Source App"
+
+/**
  * Builds the onboarding demo card from the current app locale. The rating
  * labels are read from the review feature so the card always names the same
  * buttons the user sees while reviewing.
@@ -26,7 +33,7 @@ private const val demoCardParagraphSeparator: String = "\n\n"
  * whoever removes them must also remove the bold.
  */
 fun buildDemoCardDraft(context: Context): CardDraft {
-    val productName: String = "**${context.getString(R.string.app_name)}**"
+    val productName: String = "**$demoCardProductName**"
     val againLabel: String = "`${context.getString(ReviewR.string.review_again)}`"
     val hardLabel: String = "`${context.getString(ReviewR.string.review_hard)}`"
     val backParagraphs: List<String> = listOf(


### PR DESCRIPTION
A seed failure no longer lands in `AppStartupState.Failed`; it is reported and startup continues. The product name is the untranslated literal instead of the translatable `app_name`.

Follow-up fix on `integration-demo-card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)