### PR TITLE
Support parenthesized WHERE groups, NOT LIKE, and array comparison in the agent SQL dialect

### DIFF
--- a/api/src/paths/agent_sql_execute.yaml
+++ b/api/src/paths/agent_sql_execute.yaml
@@ -12,7 +12,13 @@ post:
     atomically: all statements succeed or the whole batch fails. INSERT,
     UPDATE, and DELETE may affect at most 100 rows per statement. Array columns
     (e.g. tags) take a parenthesized list such as ('tag1', 'tag2'), or () for
-    empty.
+    empty. UPDATE and DELETE WHERE clauses support parenthesized AND/OR groups
+    where AND binds tighter than OR, LIKE, NOT LIKE, ILIKE, case-insensitive
+    exact string matches via LOWER(column) = 'value', LOWER(column) IN (...),
+    and LOWER(column) NOT IN (...), the LOWER(column) LIKE, LOWER(column) NOT
+    LIKE, and LOWER(column) ILIKE forms, and array comparison against a literal
+    tag list such as tags = ('english', 'slang') or tags = () for rows with no
+    tags.
   security:
     - ApiKeyHeader: []
   requestBody:

--- a/api/src/paths/agent_sql_query.yaml
+++ b/api/src/paths/agent_sql_query.yaml
@@ -9,10 +9,13 @@ post:
     published logical resources only. This endpoint rejects INSERT, UPDATE, and
     DELETE; use POST /agent/sql/execute for writes. Multiple read statements may
     be separated with semicolons in one sql string. SELECT supports projected
-    column lists, LIKE, case-insensitive exact string matches via
+    column lists, parenthesized AND/OR groups in WHERE where AND binds tighter
+    than OR, LIKE, NOT LIKE, ILIKE, case-insensitive exact string matches via
     LOWER(column) = 'value', LOWER(column) IN (...), and LOWER(column) NOT IN
-    (...), aggregates, GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards
-    UNNEST tags AS tag.
+    (...), the LOWER(column) LIKE, LOWER(column) NOT LIKE, and LOWER(column)
+    ILIKE forms, array comparison against a literal tag list such as
+    tags = ('english', 'slang') or tags = () for rows with no tags, aggregates,
+    GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag.
   security:
     - ApiKeyHeader: []
   requestBody:

--- a/apps/backend/src/aiTools/agentSql/batchMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/batchMutation.ts
@@ -78,7 +78,7 @@ function selectMutationRows(
       unnestColumnName: null,
     },
     selectItems: [{ type: "wildcard" }],
-    predicateClauses: statement.predicateClauses,
+    predicate: statement.predicate,
     groupBy: [],
     orderBy: [],
     limit: MAX_SQL_LIMIT,

--- a/apps/backend/src/aiTools/agentSql/singleMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/singleMutation.ts
@@ -37,7 +37,7 @@ function selectTargetRows(
       unnestColumnName: null,
     },
     selectItems: [{ type: "wildcard" }],
-    predicateClauses: statement.predicateClauses,
+    predicate: statement.predicate,
     groupBy: [],
     orderBy: [],
     limit: 100,

--- a/apps/backend/src/aiTools/sqlDialect/mutationParser.ts
+++ b/apps/backend/src/aiTools/sqlDialect/mutationParser.ts
@@ -5,9 +5,9 @@ import {
   splitTopLevel,
 } from "./parserSplitting";
 import {
-  parsePredicateClauses,
   parseSqlLiteral,
   parseStringArrayLiteralList,
+  parseWherePredicate,
 } from "./predicateParser";
 import type {
   SqlDeleteStatement,
@@ -137,7 +137,7 @@ export function parseUpdateStatement(normalizedSql: string): SqlUpdateStatement 
     type: "update",
     resourceName,
     assignments: parseAssignments(resourceName, assignmentsValue),
-    predicateClauses: parsePredicateClauses(source, predicateValue),
+    predicate: parseWherePredicate(source, predicateValue),
     normalizedSql,
   };
 }
@@ -171,7 +171,7 @@ export function parseDeleteStatement(normalizedSql: string): SqlDeleteStatement 
   return {
     type: "delete",
     resourceName,
-    predicateClauses: parsePredicateClauses(source, predicateValue),
+    predicate: parseWherePredicate(source, predicateValue),
     normalizedSql,
   };
 }

--- a/apps/backend/src/aiTools/sqlDialect/parser.ts
+++ b/apps/backend/src/aiTools/sqlDialect/parser.ts
@@ -8,8 +8,8 @@ import {
   parseUpdateStatement,
 } from "./mutationParser";
 import {
-  parsePredicateClauses,
   parseStringLiteral,
+  parseWherePredicate,
 } from "./predicateParser";
 import {
   extractTopLevelClauses,
@@ -236,9 +236,9 @@ function parseSelectStatement(normalizedSql: string): SqlSelectStatement {
     type: "select",
     source,
     selectItems,
-    predicateClauses: extractedClauses.clauseValues.has("where")
-      ? parsePredicateClauses(source, extractedClauses.clauseValues.get("where") ?? "")
-      : [],
+    predicate: extractedClauses.clauseValues.has("where")
+      ? parseWherePredicate(source, extractedClauses.clauseValues.get("where") ?? "")
+      : null,
     groupBy,
     orderBy: extractedClauses.clauseValues.has("orderBy")
       ? parseOrderBy(extractedClauses.clauseValues.get("orderBy") ?? "")

--- a/apps/backend/src/aiTools/sqlDialect/predicateParser.ts
+++ b/apps/backend/src/aiTools/sqlDialect/predicateParser.ts
@@ -1,4 +1,7 @@
-import { ensureSqlSourceColumnExists } from "./schema";
+import {
+  ensureSqlSourceColumnExists,
+  getSqlSourceColumnDescriptors,
+} from "./schema";
 import {
   assert,
   splitTopLevel,
@@ -9,9 +12,15 @@ import type {
   SqlFromSource,
   SqlLiteral,
   SqlPredicate,
-  SqlPredicateClause,
+  SqlPredicateExpression,
   SqlPredicateValue,
 } from "./types";
+
+/**
+ * Parenthesized WHERE groups nest, so recursion needs an explicit terminal
+ * limit instead of relying on the JavaScript stack.
+ */
+const MAXIMUM_PREDICATE_GROUP_DEPTH = 16;
 
 export function parseStringLiteral(value: string): string {
   assert(value.startsWith("'") && value.endsWith("'"), "Expected a quoted string literal");
@@ -151,15 +160,18 @@ function parsePredicate(source: SqlFromSource, value: string): SqlPredicate {
     };
   }
 
-  const loweredLikePredicate = trimmedValue.match(/^LOWER\s*\(\s*([a-z_][a-z0-9_]*)\s*\)\s+LIKE\s+('(?:''|[^'])*')$/i);
+  const loweredLikePredicate = trimmedValue.match(
+    /^LOWER\s*\(\s*([a-z_][a-z0-9_]*)\s*\)\s+(NOT\s+)?I?LIKE\s+('(?:''|[^'])*')$/i,
+  );
   if (loweredLikePredicate !== null) {
     const columnName = (loweredLikePredicate[1] ?? "").toLowerCase();
     ensureSqlSourceColumnExists(source, columnName);
     return {
       type: "like",
       columnName,
-      pattern: parseStringLiteral(loweredLikePredicate[2] ?? ""),
+      pattern: parseStringLiteral(loweredLikePredicate[3] ?? ""),
       caseInsensitive: true,
+      isNegated: loweredLikePredicate[2] !== undefined,
     };
   }
 
@@ -172,6 +184,7 @@ function parsePredicate(source: SqlFromSource, value: string): SqlPredicate {
       columnName,
       pattern: parseStringLiteral(loweredEqualsPredicate[2] ?? ""),
       caseInsensitive: true,
+      isNegated: false,
     };
   }
 
@@ -191,15 +204,18 @@ function parsePredicate(source: SqlFromSource, value: string): SqlPredicate {
     };
   }
 
-  const likePredicate = trimmedValue.match(/^([a-z_][a-z0-9_]*)\s+LIKE\s+('(?:''|[^'])*')$/i);
+  const likePredicate = trimmedValue.match(
+    /^([a-z_][a-z0-9_]*)\s+(NOT\s+)?(I?LIKE)\s+('(?:''|[^'])*')$/i,
+  );
   if (likePredicate !== null) {
     const columnName = (likePredicate[1] ?? "").toLowerCase();
     ensureSqlSourceColumnExists(source, columnName);
     return {
       type: "like",
       columnName,
-      pattern: parseStringLiteral(likePredicate[2] ?? ""),
-      caseInsensitive: false,
+      pattern: parseStringLiteral(likePredicate[4] ?? ""),
+      caseInsensitive: (likePredicate[3] ?? "").toUpperCase() === "ILIKE",
+      isNegated: likePredicate[2] !== undefined,
     };
   }
 
@@ -251,23 +267,140 @@ function parsePredicate(source: SqlFromSource, value: string): SqlPredicate {
   if (comparisonPredicate !== null) {
     const columnName = (comparisonPredicate[1] ?? "").toLowerCase();
     ensureSqlSourceColumnExists(source, columnName);
+    const operator = (comparisonPredicate[2] ?? "=") as SqlComparisonOperator;
+    const rightSideValue = comparisonPredicate[3] ?? "";
+    if (operator === "=" && getSqlSourceColumnDescriptors(source)[columnName]?.type === "string[]") {
+      return {
+        type: "array_equals",
+        columnName,
+        values: parseStringArrayLiteralList(rightSideValue, columnName),
+      };
+    }
+
     return {
       type: "comparison",
       columnName,
-      operator: (comparisonPredicate[2] ?? "=") as SqlComparisonOperator,
-      value: parsePredicateValue(comparisonPredicate[3] ?? ""),
+      operator,
+      value: parsePredicateValue(rightSideValue),
     };
   }
 
   throw new Error(`Unsupported predicate: ${trimmedValue}`);
 }
 
-export function parsePredicateClauses(source: SqlFromSource, value: string): ReadonlyArray<SqlPredicateClause> {
-  const trimmedValue = value.trim();
-  if (trimmedValue === "") {
-    return [];
+/**
+ * A segment is a parenthesized group only when its own wrapping parentheses are
+ * balanced and enclose the whole segment, e.g. `(a = 1 OR b = 2)` but not
+ * `(a = 1) AND (b = 2)`.
+ */
+function isParenthesizedGroup(value: string): boolean {
+  if (value.startsWith("(") === false || value.endsWith(")") === false) {
+    return false;
   }
 
-  return splitTopLevelByKeyword(trimmedValue, "OR").map((clause) =>
-    splitTopLevelByKeyword(clause, "AND").map((predicate) => parsePredicate(source, predicate)));
+  let depth = 0;
+  let inString = false;
+  let inDoubleQuote = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    const nextCharacter = value[index + 1];
+    if (character === "'" && inDoubleQuote === false) {
+      if (inString && nextCharacter === "'") {
+        index += 1;
+        continue;
+      }
+
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) {
+      continue;
+    }
+
+    if (character === '"') {
+      const isEscapedQuote = inDoubleQuote && value[index - 1] === "\\";
+      if (isEscapedQuote === false) {
+        inDoubleQuote = !inDoubleQuote;
+      }
+
+      continue;
+    }
+
+    if (inDoubleQuote) {
+      continue;
+    }
+
+    if (character === "(") {
+      depth += 1;
+      continue;
+    }
+
+    if (character === ")") {
+      depth -= 1;
+      if (depth < 0) {
+        return false;
+      }
+
+      if (depth === 0 && index !== value.length - 1) {
+        return false;
+      }
+    }
+  }
+
+  return depth === 0;
+}
+
+function parsePredicateExpression(
+  source: SqlFromSource,
+  value: string,
+  depth: number,
+): SqlPredicateExpression {
+  if (depth > MAXIMUM_PREDICATE_GROUP_DEPTH) {
+    throw new Error(
+      `WHERE clause nests parenthesized groups deeper than the supported limit of ${MAXIMUM_PREDICATE_GROUP_DEPTH}`,
+    );
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") {
+    throw new Error("WHERE clause contains an empty predicate group");
+  }
+
+  const orSegments = splitTopLevelByKeyword(trimmedValue, "OR");
+  if (orSegments.length > 1) {
+    return {
+      type: "or",
+      operands: orSegments.map((segment) => parsePredicateExpression(source, segment, depth)),
+    };
+  }
+
+  const orSegment = orSegments[0] ?? trimmedValue;
+  const andSegments = splitTopLevelByKeyword(orSegment, "AND");
+  if (andSegments.length > 1) {
+    return {
+      type: "and",
+      operands: andSegments.map((segment) => parsePredicateExpression(source, segment, depth)),
+    };
+  }
+
+  const primarySegment = andSegments[0] ?? orSegment;
+  if (isParenthesizedGroup(primarySegment)) {
+    return parsePredicateExpression(source, primarySegment.slice(1, -1), depth + 1);
+  }
+
+  return {
+    type: "predicate",
+    predicate: parsePredicate(source, primarySegment),
+  };
+}
+
+export function parseWherePredicate(source: SqlFromSource, value: string): SqlPredicateExpression | null {
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") {
+    return null;
+  }
+
+  return parsePredicateExpression(source, trimmedValue, 0);
 }

--- a/apps/backend/src/aiTools/sqlDialect/selectExecutor.ts
+++ b/apps/backend/src/aiTools/sqlDialect/selectExecutor.ts
@@ -2,10 +2,11 @@ import { buildInvalidSqlError } from "../sqlErrors";
 import { getSqlSourceColumnDescriptors } from "./schema";
 import type {
   SqlAggregateFunctionName,
+  SqlColumnType,
   SqlFromSource,
   SqlLiteral,
   SqlPredicate,
-  SqlPredicateClause,
+  SqlPredicateExpression,
   SqlPredicateValue,
   SqlRow,
   SqlRowScalar,
@@ -170,6 +171,32 @@ function rowMatchesInPredicate(columnValue: SqlRowValue | undefined, predicate: 
   return predicate.isNegated ? hasMatch === false : hasMatch;
 }
 
+function rowMatchesArrayEqualsPredicate(
+  columnValue: SqlRowValue | undefined,
+  values: ReadonlyArray<string>,
+): boolean {
+  const normalizedColumnValues = normalizeStringArray(columnValue);
+  if (normalizedColumnValues.length !== values.length) {
+    return false;
+  }
+
+  const sortedColumnValues = [...normalizedColumnValues].sort();
+  const sortedValues = [...values].sort();
+  return sortedColumnValues.every((value, index) => value === sortedValues[index]);
+}
+
+/**
+ * LIKE, NOT LIKE, ILIKE and `LOWER(column) = 'value'` all match a text pattern,
+ * so they only make sense on text-valued columns. Any other column type is
+ * rejected instead of silently evaluating to "no match", which would invert the
+ * answer for the negated form.
+ */
+const LIKE_SUPPORTED_COLUMN_TYPES: ReadonlySet<SqlColumnType> = new Set<SqlColumnType>([
+  "string",
+  "uuid",
+  "datetime",
+]);
+
 function validatePredicate(source: SqlFromSource, predicate: SqlPredicate): void {
   if (predicate.type === "match") {
     if (predicate.query.trim() === "") {
@@ -187,6 +214,10 @@ function validatePredicate(source: SqlFromSource, predicate: SqlPredicate): void
   if (columnDescriptor.filterable === false) {
     throw buildInvalidSqlError(`Column is not filterable: ${predicate.columnName}`);
   }
+
+  if (predicate.type === "like" && LIKE_SUPPORTED_COLUMN_TYPES.has(columnDescriptor.type) === false) {
+    throw buildInvalidSqlError(`LIKE is not supported for column: ${predicate.columnName}`);
+  }
 }
 
 function rowMatchesPredicate(row: SqlRow, predicate: SqlPredicate): boolean {
@@ -201,7 +232,8 @@ function rowMatchesPredicate(row: SqlRow, predicate: SqlPredicate): boolean {
       return false;
     }
 
-    return createLikePatternRegExp(predicate.pattern, predicate.caseInsensitive).test(columnValue);
+    const matchesPattern = createLikePatternRegExp(predicate.pattern, predicate.caseInsensitive).test(columnValue);
+    return predicate.isNegated ? matchesPattern === false : matchesPattern;
   }
 
   const columnValue = row[predicate.columnName];
@@ -243,25 +275,47 @@ function rowMatchesPredicate(row: SqlRow, predicate: SqlPredicate): boolean {
     return columnValue !== null && columnValue !== undefined;
   }
 
+  if (predicate.type === "array_equals") {
+    return rowMatchesArrayEqualsPredicate(columnValue, predicate.values);
+  }
+
   return normalizeStringArray(columnValue).some((value) => predicate.values.includes(value));
 }
 
-function applyPredicateClauses(
-  source: SqlFromSource,
-  rows: ReadonlyArray<SqlRow>,
-  predicateClauses: ReadonlyArray<SqlPredicateClause>,
-): ReadonlyArray<SqlRow> {
-  for (const clause of predicateClauses) {
-    for (const predicate of clause) {
-      validatePredicate(source, predicate);
-    }
+function validatePredicateExpression(source: SqlFromSource, expression: SqlPredicateExpression): void {
+  if (expression.type === "predicate") {
+    validatePredicate(source, expression.predicate);
+    return;
   }
 
-  if (predicateClauses.length === 0) {
+  for (const operand of expression.operands) {
+    validatePredicateExpression(source, operand);
+  }
+}
+
+function rowMatchesPredicateExpression(row: SqlRow, expression: SqlPredicateExpression): boolean {
+  if (expression.type === "predicate") {
+    return rowMatchesPredicate(row, expression.predicate);
+  }
+
+  if (expression.type === "and") {
+    return expression.operands.every((operand) => rowMatchesPredicateExpression(row, operand));
+  }
+
+  return expression.operands.some((operand) => rowMatchesPredicateExpression(row, operand));
+}
+
+function applyPredicateExpression(
+  source: SqlFromSource,
+  rows: ReadonlyArray<SqlRow>,
+  predicate: SqlPredicateExpression | null,
+): ReadonlyArray<SqlRow> {
+  if (predicate === null) {
     return rows;
   }
 
-  return rows.filter((row) => predicateClauses.some((clause) => clause.every((predicate) => rowMatchesPredicate(row, predicate))));
+  validatePredicateExpression(source, predicate);
+  return rows.filter((row) => rowMatchesPredicateExpression(row, predicate));
 }
 
 function applyOrderBy(
@@ -569,7 +623,7 @@ export function executeSqlSelect(
   const limit = normalizeSqlLimit(statement.limit, maximumLimit);
   const offset = normalizeSqlOffset(statement.offset);
   const expandedRows = expandRowsForSource(statement.source, rows);
-  const filteredRows = applyPredicateClauses(statement.source, expandedRows, statement.predicateClauses);
+  const filteredRows = applyPredicateExpression(statement.source, expandedRows, statement.predicate);
   const orderedRows = isWildcardSelect(statement)
     ? (() => {
       validateRowOrderBy(statement.source, statement.orderBy);

--- a/apps/backend/src/aiTools/sqlDialect/types.ts
+++ b/apps/backend/src/aiTools/sqlDialect/types.ts
@@ -58,6 +58,7 @@ export type SqlPredicate =
     columnName: string;
     pattern: string;
     caseInsensitive: boolean;
+    isNegated: boolean;
   }>
   | Readonly<{
     type: "in";
@@ -68,6 +69,11 @@ export type SqlPredicate =
   }>
   | Readonly<{
     type: "overlap";
+    columnName: string;
+    values: ReadonlyArray<string>;
+  }>
+  | Readonly<{
+    type: "array_equals";
     columnName: string;
     values: ReadonlyArray<string>;
   }>
@@ -84,7 +90,19 @@ export type SqlPredicate =
     query: string;
   }>;
 
-export type SqlPredicateClause = ReadonlyArray<SqlPredicate>;
+/**
+ * WHERE clauses are a boolean expression tree so parenthesized AND/OR groups
+ * keep SQL precedence, where AND binds tighter than OR.
+ */
+export type SqlPredicateExpression =
+  | Readonly<{
+    type: "and" | "or";
+    operands: ReadonlyArray<SqlPredicateExpression>;
+  }>
+  | Readonly<{
+    type: "predicate";
+    predicate: SqlPredicate;
+  }>;
 
 export type SqlSelectOrderBy =
   | Readonly<{
@@ -124,7 +142,7 @@ export type SqlSelectStatement = Readonly<{
   type: "select";
   source: SqlFromSource;
   selectItems: ReadonlyArray<SqlSelectItem>;
-  predicateClauses: ReadonlyArray<SqlPredicateClause>;
+  predicate: SqlPredicateExpression | null;
   groupBy: ReadonlyArray<string>;
   orderBy: ReadonlyArray<SqlSelectOrderBy>;
   limit: number | null;
@@ -159,14 +177,14 @@ export type SqlUpdateStatement = Readonly<{
     columnName: string;
     value: SqlLiteral | ReadonlyArray<string>;
   }>>;
-  predicateClauses: ReadonlyArray<SqlPredicateClause>;
+  predicate: SqlPredicateExpression | null;
   normalizedSql: string;
 }>;
 
 export type SqlDeleteStatement = Readonly<{
   type: "delete";
   resourceName: "cards" | "decks";
-  predicateClauses: ReadonlyArray<SqlPredicateClause>;
+  predicate: SqlPredicateExpression | null;
   normalizedSql: string;
 }>;
 

--- a/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
+++ b/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
@@ -36,6 +36,8 @@ export const SQL_QUERY_TOOL_PROMPT_EXAMPLE_LINES = Object.freeze([
   "- sql_query => {\"sql\": \"SELECT * FROM review_events WHERE card_id = '00000000-0000-4000-8000-000000000000' ORDER BY reviewed_at_server DESC LIMIT 20 OFFSET 0\"}",
   "- sql_query => {\"sql\": \"SELECT tag, COUNT(*) AS cards_count FROM cards UNNEST tags AS tag GROUP BY tag ORDER BY cards_count DESC LIMIT 100 OFFSET 0\"}",
   "- sql_query => {\"sql\": \"SELECT * FROM cards WHERE due_at IS NULL OR due_at <= NOW() ORDER BY due_at ASC, created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
+  "- sql_query => {\"sql\": \"SELECT card_id, front_text, back_text, tags FROM cards UNNEST tags AS tag WHERE LOWER(tag) = 'english' AND (LOWER(front_text) LIKE '%example%' OR LOWER(back_text) NOT LIKE '%draft%') ORDER BY created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
+  "- sql_query => {\"sql\": \"SELECT card_id, front_text, back_text, tags FROM cards WHERE tags = () ORDER BY created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
 ]);
 
 /**
@@ -76,6 +78,29 @@ const SQL_DIALECT_DESCRIPTION_LINES = Object.freeze([
 ]);
 
 /**
+ * Shared WHERE-clause grammar fragment. UPDATE and DELETE resolve their target
+ * rows through the same SELECT evaluator, so the read and write surfaces must
+ * advertise exactly the same WHERE forms.
+ */
+const SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION =
+  "parenthesized AND/OR groups in WHERE where AND binds tighter than OR, LIKE, NOT LIKE, ILIKE, LOWER(column) = 'value', LOWER(column) LIKE '...', LOWER(column) NOT LIKE '...', LOWER(column) ILIKE '...', LOWER(column) IN (...), and LOWER(column) NOT IN (...) for case-insensitive exact string matches, array comparison against a literal tag list such as tags = ('english', 'slang') or tags = () for rows with no tags";
+
+/**
+ * Shared supported-forms sentence reused by the split `sql_query` description
+ * and the combined in-app `sql` tool description so both surfaces advertise the
+ * same SELECT grammar.
+ */
+const SQL_SELECT_SUPPORTED_FORMS_DESCRIPTION =
+  `SELECT supports projected column lists, ${SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION}, COUNT(*), SUM, AVG, MIN, MAX, GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag.`;
+
+/**
+ * Write-side mirror of the WHERE grammar for the `sql_execute` surface, matching
+ * the description in `api/src/paths/agent_sql_execute.yaml`.
+ */
+const SQL_MUTATION_WHERE_SUPPORTED_FORMS_DESCRIPTION =
+  `UPDATE and DELETE WHERE clauses support ${SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION}.`;
+
+/**
  * Read-only contract description for the split `sql_query` surface.
  */
 export const SQL_QUERY_TOOL_DESCRIPTION = [
@@ -84,7 +109,7 @@ export const SQL_QUERY_TOOL_DESCRIPTION = [
   "Supported statements: SHOW TABLES, DESCRIBE <resource>, SHOW COLUMNS FROM <resource>, SELECT.",
   "This tool is read-only and rejects INSERT, UPDATE, and DELETE; use sql_execute for writes.",
   `SELECT returns at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
-  "SELECT supports projected column lists, LIKE, LOWER(column) = 'value', LOWER(column) IN (...), and LOWER(column) NOT IN (...) for case-insensitive exact string matches, COUNT(*), SUM, AVG, MIN, MAX, GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag.",
+  SQL_SELECT_SUPPORTED_FORMS_DESCRIPTION,
   "Examples (tool-call JSON):",
   ...SQL_QUERY_TOOL_PROMPT_EXAMPLE_LINES,
 ].join(" ");
@@ -101,6 +126,7 @@ export const SQL_EXECUTE_TOOL_DESCRIPTION = [
   `INSERT, UPDATE, and DELETE may affect at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
   `If you need to create, update, or delete more than ${MAX_SQL_RECORD_LIMIT} records, split the work into multiple batches of at most ${MAX_SQL_RECORD_LIMIT} records across separate SQL statements or separate tool calls.`,
   "Array columns (e.g. tags) take a parenthesized list: ('tag1', 'tag2'), or () for empty.",
+  SQL_MUTATION_WHERE_SUPPORTED_FORMS_DESCRIPTION,
   "Examples (tool-call JSON):",
   ...SQL_EXECUTE_TOOL_PROMPT_EXAMPLE_LINES,
 ].join(" ");
@@ -123,7 +149,7 @@ export const OPENAI_SQL_TOOL: FunctionTool = {
     `SELECT returns at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
     `INSERT, UPDATE, and DELETE may affect at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
     `If you need to create, update, or delete more than ${MAX_SQL_RECORD_LIMIT} records, split the work into multiple batches of at most ${MAX_SQL_RECORD_LIMIT} records across separate SQL statements or separate tool calls.`,
-    "SELECT supports projected column lists, LIKE, LOWER(column) = 'value', LOWER(column) IN (...), and LOWER(column) NOT IN (...) for case-insensitive exact string matches, COUNT(*), SUM, AVG, MIN, MAX, GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag.",
+    SQL_SELECT_SUPPORTED_FORMS_DESCRIPTION,
     "Array columns (e.g. tags) take a parenthesized list: ('tag1', 'tag2'), or () for empty.",
     "Examples (tool-call JSON):",
     ...SQL_TOOL_PROMPT_EXAMPLE_LINES,


### PR DESCRIPTION
## Why

Measured from Langfuse over 2026-07-07 to 2026-08-06: 170 dialect rejections across 2711 `sql` tool calls. Three `WHERE` forms agents keep attempting account for 76 of them:

- parenthesized boolean groups — 58 rejections (34%), almost always "narrow by tag, then a text OR-group"
- `NOT LIKE` — 8
- array comparison such as `tags = ('a','b')` or `tags = ()` — 10

## What changed

- The flat disjunctive-normal-form predicate list becomes a recursive boolean expression, so explicit parentheses parse and evaluate. SQL precedence is preserved: `AND` binds tighter than `OR`.
- `NOT LIKE` and `ILIKE` are accepted, in both the bare and `LOWER(column)` forms.
- Array comparison: `tags = ('a','b')` is exact set equality, `tags = ()` means "no tags".
- `UPDATE` and `DELETE` resolve target rows through the same evaluator, so they gain the new forms without separate work.
- The tool contract and both OpenAPI path descriptions are updated in the same change, as `CLAUDE.md` requires for the machine API.

## Behavior change worth calling out

`LIKE` against a non-text column used to match no rows at all, silently telling the agent that nothing existed. Real agents hit this: `LOWER(tags) LIKE '%english%'` appeared 9 times in the measured window and returned zero rows every time. It now fails with a clear actionable error instead.

The `Column is not filterable` check still runs first, so the exact message asserted by `scripts/checks/check-agent-api-smoke.sh` is unchanged.

## Scope

Deliberately out of scope, landing separately: deck semantics wording, documentation of the already-supported `OVERLAP` and `MATCH` predicates, the rule against batching schema discovery with dependent statements, bulk-write limit arithmetic, and targeted repair hints inside rejection payloads.

`JOIN`, CTEs, subqueries, `HAVING`, `DISTINCT`, `SUM(CASE WHEN …)`, date arithmetic, and `!=`/`<>` stay unsupported. Date arithmetic and `!=`/`<>` had zero real occurrences in the sampled window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)