### PR TITLE
Template the upload-session id in Android observability endpoint names

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudHttpObservability.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudHttpObservability.kt
@@ -16,6 +16,7 @@ private const val cloudApiGatewayRequestIdHeaderName: String = "X-Amz-Apigw-Id"
 private const val cloudHealthValidationPath: String = "/health"
 private const val officialCloudApiHost: String = "api.flashcards-open-source-app.com"
 private const val officialCloudAuthHost: String = "auth.flashcards-open-source-app.com"
+private val cloudObservationRouteLiteralSegments: Set<String> = setOf("upload-sessions")
 
 internal data class CloudHttpObservationVersions(
     val appVersion: String?,
@@ -199,14 +200,26 @@ internal fun cloudObservationEndpointName(path: String): String {
     }
 
     val normalizedSegments = segments.mapIndexed { index, segment ->
+        val previousSegment = segments.getOrNull(index = index - 1)
         when {
-            index > 0 && segments[index - 1] == "workspaces" -> "{workspaceId}"
-            index > 0 && segments[index - 1] == "media-assets" -> "{mediaAssetId}"
-            index > 0 && segments[index - 1] == "agent-api-keys" -> "{connectionId}"
+            !isCloudObservationIdentifierSegment(segment = segment) -> segment
+            previousSegment == "workspaces" -> "{workspaceId}"
+            previousSegment == "upload-sessions" -> "{uploadSessionId}"
+            previousSegment == "media-assets" -> "{mediaAssetId}"
+            previousSegment == "agent-api-keys" -> "{connectionId}"
             else -> segment
         }
     }
     return "/" + normalizedSegments.joinToString(separator = "/")
+}
+
+/**
+ * Route templating replaces a segment only when it can carry an opaque identifier.
+ * Identifier shapes vary across clients and eras, so literal route segments that follow an
+ * identifier-bearing prefix are listed explicitly instead of being inferred from the segment value.
+ */
+private fun isCloudObservationIdentifierSegment(segment: String): Boolean {
+    return segment !in cloudObservationRouteLiteralSegments
 }
 
 private fun cloudObservationFeature(request: Request): AndroidObservationFeature {


### PR DESCRIPTION
## Problem

Android media upload traffic produced unbounded endpoint names in observability. Every multipart upload reported its own distinct endpoint label because the real upload session id was embedded in the name, so upload failures and latency could not be grouped or alerted on as a single route. At the same time the endpoint name showed `{mediaAssetId}` where the route actually has a fixed literal segment, which made the reported route look like something that does not exist in the API.

## Root cause

`cloudObservationEndpointName` in `apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudHttpObservability.kt` templated a segment purely by looking at the previous segment, assuming anything after a known prefix is an identifier.

Media upload routes are shaped like `/workspaces/{workspaceId}/media-assets/upload-sessions/{uploadSessionId}/parts`. Here the segment following `media-assets` is the literal `upload-sessions`, not an id, so it was rewritten to `{mediaAssetId}`, while the genuine upload session id followed `upload-sessions` — a prefix the normalizer did not know about — and was left in the endpoint name verbatim.

## What this PR changes

- Templates the segment after `upload-sessions` as `{uploadSessionId}`, so upload session ids no longer leak into endpoint names.
- Guards the normalizer so it only rewrites segments that can actually carry an opaque identifier, keeping the literal `upload-sessions` segment intact instead of masking it as `{mediaAssetId}`.
- Keeps known literal route segments in an explicit list rather than guessing from segment shape, because identifier formats vary across clients and eras.

Result: media upload requests now report the stable route `/workspaces/{workspaceId}/media-assets/upload-sessions/{uploadSessionId}/parts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)