### PR TITLE
Report real SQL tool outcomes in chat Langfuse traces

### DIFF
--- a/apps/backend/src/chat/openai/loop/loop.providerEvents.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.providerEvents.test.ts
@@ -314,6 +314,7 @@ test("startOpenAILoopWithDeps retries a callIndex > 1 overflow once with the red
         shouldInvalidateMainContent: false,
         stopReason: null,
         generatedImageTelemetry: null,
+        sqlTelemetry: null,
       };
     },
   };

--- a/apps/backend/src/chat/openai/loop/loop.testSupport.ts
+++ b/apps/backend/src/chat/openai/loop/loop.testSupport.ts
@@ -13,6 +13,7 @@ type TestToolCallResult = Readonly<{
   shouldInvalidateMainContent?: boolean;
   stopReason?: "deadline_reached" | "run_inactive" | null;
   generatedImageTelemetry?: null;
+  sqlTelemetry?: null;
 }>;
 export type OpenAIResponseStream = AsyncIterable<OpenAI.Responses.ResponseStreamEvent> & Readonly<{
   finalResponse?: () => Promise<OpenAI.Responses.Response>;
@@ -337,6 +338,7 @@ export function createDependencies(
           ?? (result.succeeded && result.isMutating),
         stopReason: result.stopReason ?? null,
         generatedImageTelemetry: result.generatedImageTelemetry ?? null,
+        sqlTelemetry: result.sqlTelemetry ?? null,
       };
     },
   };

--- a/apps/backend/src/chat/openai/tools/toolExecutor.ts
+++ b/apps/backend/src/chat/openai/tools/toolExecutor.ts
@@ -1,11 +1,20 @@
 import type OpenAI from "openai";
-import type { LangfuseObservation } from "@langfuse/tracing";
-import { createBackendObservationScope } from "../../../observability/sentry";
+import type { LangfuseObservation, ObservationLevel } from "@langfuse/tracing";
+import {
+  createBackendObservationScope,
+  getBackendErrorLogDetails,
+} from "../../../observability/sentry";
 import {
   executeChatToolCall,
   type ExecutedChatToolCall,
 } from "./tools";
 import type { ChatRunClaimToken } from "../../runs";
+
+/**
+ * A tool that returned an error envelope to the model and a tool that threw are different
+ * operator situations, so the exported outcome keeps them apart instead of one boolean.
+ */
+type ToolCallOutcome = "success" | "tool_error" | "thrown";
 
 type ToolTelemetryMetadata = Readonly<{
   toolName: string;
@@ -14,12 +23,21 @@ type ToolTelemetryMetadata = Readonly<{
   hasArguments: boolean;
   durationMs: number | null;
   outputLength: number | null;
-  ok: boolean | null;
+  outcome: ToolCallOutcome | null;
   errorClass: string | null;
   errorMessage: string | null;
+  errorCode: string | null;
+  dialectReason: string | null;
   generatedImageAttempt: number | null;
   generatedImageStatus: string | null;
+  sqlStatementType: string | null;
+  sqlStatementCount: number | null;
+  sqlRowOrAffectedCount: number | null;
+  sqlDurationMs: number | null;
 }>;
+
+/** Upper bound for one exported error message so a long provider error cannot flood the span. */
+const MAX_TELEMETRY_ERROR_MESSAGE_CHARS = 300 as const;
 
 function getToolArgumentLength(argumentsJson: string): number {
   return argumentsJson.length;
@@ -33,16 +51,14 @@ function getErrorClass(error: unknown): string {
   return error instanceof Error ? error.name : "NonErrorThrow";
 }
 
-function getSafeErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim() !== "") {
-    return "tool execution failed";
-  }
-
-  if (error instanceof Error) {
-    return "tool execution failed without message";
-  }
-
-  return "tool execution failed with non-error throw";
+/**
+ * Exports the real cause of a thrown tool call as one short line.
+ * The Langfuse span processor masks the exported value with `sanitizeTelemetryValue`, and the
+ * repository sanitizer already strips internal error text before it reaches this point.
+ */
+function getSanitizedErrorMessage(error: unknown): string | null {
+  const firstLine = getBackendErrorLogDetails(error).errorMessage.split("\n", 1)[0]?.trim() ?? "";
+  return firstLine === "" ? null : firstLine.slice(0, MAX_TELEMETRY_ERROR_MESSAGE_CHARS);
 }
 
 function buildToolTelemetryMetadata(
@@ -52,13 +68,14 @@ function buildToolTelemetryMetadata(
     argumentsJson: string;
     durationMs: number | null;
     outputLength: number | null;
-    ok: boolean | null;
+    outcome: ToolCallOutcome | null;
     errorClass: string | null;
     errorMessage: string | null;
     result: ExecutedChatToolCall | null;
   }>,
 ): ToolTelemetryMetadata {
   const generatedImage = params.result?.generatedImageTelemetry ?? null;
+  const sql = params.result?.sqlTelemetry ?? null;
   return {
     toolName: params.toolName,
     toolCallId: params.toolCallId,
@@ -66,12 +83,54 @@ function buildToolTelemetryMetadata(
     hasArguments: hasToolArguments(params.argumentsJson),
     durationMs: params.durationMs,
     outputLength: params.outputLength,
-    ok: params.ok,
+    outcome: params.outcome,
     errorClass: params.errorClass,
     errorMessage: params.errorMessage,
+    errorCode: sql?.errorCode ?? null,
+    dialectReason: sql?.dialectReason ?? null,
     generatedImageAttempt: generatedImage?.attempt ?? null,
     generatedImageStatus: generatedImage?.status ?? null,
+    sqlStatementType: sql?.statementType ?? null,
+    sqlStatementCount: sql?.statementCount ?? null,
+    sqlRowOrAffectedCount: sql?.rowOrAffectedCount ?? null,
+    sqlDurationMs: sql?.durationMs ?? null,
   };
+}
+
+/**
+ * Builds the Langfuse `statusMessage` of a failed tool observation from the identifying
+ * fields already exported as metadata, so the built-in error view names the cause.
+ */
+function buildToolStatusMessage(metadata: ToolTelemetryMetadata): string {
+  const details = [
+    metadata.errorClass,
+    metadata.errorCode,
+    metadata.dialectReason,
+    metadata.errorMessage,
+  ].filter((detail): detail is string => detail !== null && detail !== "");
+  const outcome = metadata.outcome ?? "thrown";
+  return details.length === 0 ? outcome : `${outcome}: ${details.join(" | ")}`;
+}
+
+/**
+ * Marks a failed tool observation with Langfuse own error semantics so operators can filter
+ * failed tool calls in the UI instead of parsing full generations.
+ *
+ * A tool call that threw always qualifies. A tool call that returned an error envelope only
+ * qualifies when it carries SQL telemetry, because a SQL envelope always reports a real failure,
+ * while the generated-image tool reports expected product outcomes such as `limit_reached` the
+ * same way and its genuine provider failures already own the provider observation. Both keep
+ * exporting `outcome` as metadata either way.
+ */
+function buildFailureObservationAttributes(
+  metadata: ToolTelemetryMetadata,
+  result: ExecutedChatToolCall | null,
+): Readonly<{ level?: ObservationLevel; statusMessage?: string }> {
+  const failed = metadata.outcome === "thrown"
+    || (metadata.outcome === "tool_error" && (result?.sqlTelemetry ?? null) !== null);
+  return failed
+    ? { level: "ERROR", statusMessage: buildToolStatusMessage(metadata) }
+    : {};
 }
 
 /**
@@ -106,7 +165,7 @@ export async function runOneToolCall(
         argumentsJson: params.item.arguments,
         durationMs: null,
         outputLength: null,
-        ok: null,
+        outcome: null,
         errorClass: null,
         errorMessage: null,
         result: null,
@@ -143,41 +202,46 @@ export async function runOneToolCall(
       },
     );
 
+    const outcome: ToolCallOutcome = result.succeeded ? "success" : "tool_error";
+    const metadata = buildToolTelemetryMetadata({
+      toolName: params.item.name,
+      toolCallId: params.item.call_id,
+      argumentsJson: params.item.arguments,
+      durationMs: Date.now() - startedAt,
+      outputLength: result.output.length,
+      outcome,
+      errorClass: result.sqlTelemetry?.errorClass ?? null,
+      errorMessage: null,
+      result,
+    });
     toolObservation?.updateOtelSpanAttributes({
       output: {
-        ok: true,
+        outcome,
         outputLength: result.output.length,
       },
-      metadata: buildToolTelemetryMetadata({
-        toolName: params.item.name,
-        toolCallId: params.item.call_id,
-        argumentsJson: params.item.arguments,
-        durationMs: Date.now() - startedAt,
-        outputLength: result.output.length,
-        ok: true,
-        errorClass: null,
-        errorMessage: null,
-        result,
-      }),
+      metadata,
+      ...buildFailureObservationAttributes(metadata, result),
     });
     toolObservation?.end();
     return result;
   } catch (error) {
+    const metadata = buildToolTelemetryMetadata({
+      toolName: params.item.name,
+      toolCallId: params.item.call_id,
+      argumentsJson: params.item.arguments,
+      durationMs: Date.now() - startedAt,
+      outputLength: null,
+      outcome: "thrown",
+      errorClass: getErrorClass(error),
+      errorMessage: getSanitizedErrorMessage(error),
+      result: null,
+    });
     toolObservation?.updateOtelSpanAttributes({
       output: {
-        ok: false,
+        outcome: "thrown",
       },
-      metadata: buildToolTelemetryMetadata({
-        toolName: params.item.name,
-        toolCallId: params.item.call_id,
-        argumentsJson: params.item.arguments,
-        durationMs: Date.now() - startedAt,
-        outputLength: null,
-        ok: false,
-        errorClass: getErrorClass(error),
-        errorMessage: getSafeErrorMessage(error),
-        result: null,
-      }),
+      metadata,
+      ...buildFailureObservationAttributes(metadata, null),
     });
     toolObservation?.end();
     throw error;

--- a/apps/backend/src/chat/openai/tools/tools.ts
+++ b/apps/backend/src/chat/openai/tools/tools.ts
@@ -20,7 +20,7 @@ import {
   type AgentToolOperationDependencies,
 } from "../../../aiTools/agentSql/operations";
 import { parseSqlStatement, splitSqlStatements } from "../../../aiTools/sqlDialect";
-import { isSqlMutationStatement } from "../../../aiTools/agentSql/shared";
+import { isSqlMutationStatement, type AgentSqlPayload } from "../../../aiTools/agentSql/shared";
 import {
   OPENAI_SQL_TOOL,
   SQL_TOOL_ARGUMENT_VALIDATOR,
@@ -67,6 +67,23 @@ export type GeneratedImageToolTelemetry = Readonly<{
   status: string;
 }>;
 
+/**
+ * Structured outcome of one SQL tool call, exported to Langfuse by the tool executor.
+ * A failed SQL call returns an error envelope to the model instead of throwing, so this
+ * is the only signal that tells the failure apart from a successful call.
+ * `dialectReason` is read as an opaque value: the dialect owns its vocabulary of codes.
+ */
+export type SqlToolTelemetry = Readonly<{
+  succeeded: boolean;
+  errorCode: string | null;
+  errorClass: string | null;
+  dialectReason: string | null;
+  statementType: string | null;
+  statementCount: number | null;
+  rowOrAffectedCount: number | null;
+  durationMs: number;
+}>;
+
 export type ExecutedChatToolCall = Readonly<{
   output: string;
   isMutating: boolean;
@@ -74,6 +91,7 @@ export type ExecutedChatToolCall = Readonly<{
   shouldInvalidateMainContent: boolean;
   stopReason: "deadline_reached" | "run_inactive" | null;
   generatedImageTelemetry: GeneratedImageToolTelemetry | null;
+  sqlTelemetry: SqlToolTelemetry | null;
 }>;
 
 export type OpenAIToolDependencies = Readonly<{
@@ -234,6 +252,33 @@ function getIsMutatingSql(sql: string | null): boolean {
   }
 }
 
+function getSqlStatementCount(payload: AgentSqlPayload): number {
+  return payload.statementType === "batch" ? payload.statementCount : 1;
+}
+
+function getSqlRowOrAffectedCount(payload: AgentSqlPayload): number | null {
+  switch (payload.statementType) {
+    case "batch":
+      return payload.affectedCountTotal;
+    case "insert":
+    case "update":
+    case "delete":
+      return payload.affectedCount;
+    default:
+      return payload.rowCount;
+  }
+}
+
+/**
+ * Reads the dialect reason of a failed SQL tool call without depending on the dialect vocabulary.
+ * The value is whatever the dialect reports today and stays valid when those codes change.
+ */
+function getSqlDialectReason(error: unknown): string | null {
+  return error instanceof HttpError
+    ? error.details?.validationIssues?.[0]?.code ?? null
+    : null;
+}
+
 export const OPENAI_CHAT_TOOLS: ReadonlyArray<OpenAI.Responses.FunctionTool> = [OPENAI_SQL_TOOL];
 
 const DEFAULT_OPENAI_TOOL_DEPENDENCIES: OpenAIToolDependencies = {
@@ -255,7 +300,7 @@ export function buildOpenAIChatTools(
 }
 
 type GeneratedImageExecutionState =
-  Omit<ExecutedChatToolCall, "output" | "generatedImageTelemetry"> & Readonly<{
+  Omit<ExecutedChatToolCall, "output" | "generatedImageTelemetry" | "sqlTelemetry"> & Readonly<{
     attempt: number | null;
     status: string;
   }>;
@@ -269,6 +314,7 @@ function createGeneratedImageResult(
     output: JSON.stringify({ tool: GENERATED_IMAGE_TOOL_NAME, ...payload }),
     ...executionResult,
     generatedImageTelemetry: { attempt, status },
+    sqlTelemetry: null,
   };
 }
 
@@ -531,6 +577,7 @@ export async function executeChatToolCallWithDependencies(
 
   const sql = getSqlFromRawArguments(rawArguments);
   const isMutating = getIsMutatingSql(sql);
+  const startedAt = Date.now();
 
   try {
     const parsed = SQL_TOOL_ARGUMENT_VALIDATOR.parse(JSON.parse(rawArguments));
@@ -556,6 +603,16 @@ export async function executeChatToolCallWithDependencies(
       shouldInvalidateMainContent: isMutating,
       stopReason: null,
       generatedImageTelemetry: null,
+      sqlTelemetry: {
+        succeeded: true,
+        errorCode: null,
+        errorClass: null,
+        dialectReason: null,
+        statementType: result.data.statementType,
+        statementCount: getSqlStatementCount(result.data),
+        rowOrAffectedCount: getSqlRowOrAffectedCount(result.data),
+        durationMs: Date.now() - startedAt,
+      },
     };
   } catch (error) {
     const payload: ToolErrorPayload = error instanceof HttpError
@@ -577,6 +634,16 @@ export async function executeChatToolCallWithDependencies(
       shouldInvalidateMainContent: false,
       stopReason: null,
       generatedImageTelemetry: null,
+      sqlTelemetry: {
+        succeeded: false,
+        errorCode: error instanceof HttpError ? error.code : null,
+        errorClass: serializeToolError(error).name,
+        dialectReason: getSqlDialectReason(error),
+        statementType: null,
+        statementCount: null,
+        rowOrAffectedCount: null,
+        durationMs: Date.now() - startedAt,
+      },
     };
   }
 }

--- a/docs/langfuse-operations.md
+++ b/docs/langfuse-operations.md
@@ -29,6 +29,37 @@ For each backend-owned `/chat` turn, expect:
 
 If the turn uses tools, expect nested tool observations under the same trace.
 
+### Tool observation shape
+
+Each nested tool observation carries metadata describing how the call ended:
+
+- `outcome` is `success`, `tool_error`, or `thrown`. A failed SQL call returns an error envelope
+  to the model instead of throwing, so it is `tool_error`, not `thrown`.
+- `errorClass`, `errorCode`, and `dialectReason` identify the failure. `dialectReason` is the
+  first `validationIssues` code reported by the SQL dialect and is read as an opaque value.
+- `errorMessage` carries the sanitized first line of a thrown error.
+- `sqlStatementType`, `sqlStatementCount`, `sqlRowOrAffectedCount`, and `sqlDurationMs` describe
+  the SQL call itself.
+- `generatedImageAttempt` and `generatedImageStatus` describe the generated-image call.
+
+An observation is exported with level `ERROR` and a `statusMessage` naming the cause, so the
+built-in Langfuse error filter finds it, when the call threw or when a SQL call returned an error
+envelope. A generated-image `tool_error` stays at the default level because that tool reports
+expected product outcomes such as `limit_reached` the same way; read its `outcome` and
+`generatedImageStatus` metadata instead, and its provider failures under the provider observation.
+
+### Failed SQL share
+
+In the Langfuse UI, filter observations by `name = sql`:
+
+- failed calls: `metadata.outcome` is not `success` (for `name = sql` this is the same set as
+  level `ERROR`)
+- share of failed SQL calls: that count divided by all `name = sql` observations in the same
+  time range
+
+Group the failed set by `metadata.dialectReason` or `metadata.errorCode` to see which failures
+dominate.
+
 ## Expected transcription trace shape
 
 For each `/chat/transcriptions` request, expect:


### PR DESCRIPTION
## Problem

The SQL tool does not throw on a dialect or validation failure — `executeChatToolCallWithDependencies` catches it and returns an error envelope with `succeeded: false` (`tools.ts:560-581`). But `runOneToolCall` hardcoded `ok: true`, `errorClass: null` and `errorMessage: null` in its success branch and never read `result.succeeded` (`toolExecutor.ts:146-162`).

So for the SQL tool the exported `ok` was **always** true and `errorClass` **always** null — not merely often. `getSafeErrorMessage` compounded it by returning one of three constants and never the real message, and it only ran in the catch branch that SQL failures never reach.

Net effect: the share of failed SQL tool calls could not be computed from telemetry at all, which is why answering that question meant parsing full generations.

## Change

- `sqlTelemetry` on `ExecutedChatToolCall`, populated where the error is still in hand — mirrors the existing `generatedImageTelemetry` pattern that already threads structured tool telemetry through the same executor.
- Explicit `outcome`: `success` / `tool_error` / `thrown`. A tool that returned an error envelope to the model and a tool that threw are different operator situations.
- Real error message via the existing `getBackendErrorLogDetails` sanitizer, first line, length-capped. The Langfuse span processor already applies `mask: sanitizeTelemetryValue` on export.
- Langfuse `level: "ERROR"` + `statusMessage` so the built-in error filter works, scoped to thrown calls and SQL error envelopes — the generated-image envelope is overloaded with expected product outcomes (`limit_reached`, `sign_in_required`) that are not failures.
- `docs/langfuse-operations.md` documents the observation shape and the filter that computes the failed-SQL share.

## Notes

- Dialect reason is read as an opaque `validationIssues[0].code`, so this keeps working before and after the separate dialect-reason-code change lands.
- Langfuse numeric scores deliberately left out: the JS SDK has no in-context `observation.score()` and would need a separate client package and credential path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)