### PR TITLE
Emit one structured agent_sql record on every SQL surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Nothing compiles iOS before merge by design, though `PR Checks` still runs the s
 Swift builds and tests run in Xcode Cloud, whose workflow definitions live in App Store Connect; its in-repo build inputs are documented in [docs/ios-ci-cd.md](docs/ios-ci-cd.md).
 Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.
 Details, rollback rules, and live smoke references: [docs/release-gates.md](docs/release-gates.md).
+Agent SQL executions emit one structured CloudWatch record per run on every surface; the record fields and the failure-rate queries live in [docs/agent-sql-telemetry.md](docs/agent-sql-telemetry.md).
 
 ## Repository Strategy
 

--- a/apps/backend/src/aiTools/agentSql.ts
+++ b/apps/backend/src/aiTools/agentSql.ts
@@ -1,4 +1,6 @@
+import { createHash } from "node:crypto";
 import { HttpError } from "../shared/errors";
+import { logAgentSqlEvent } from "../server/logging";
 import {
   DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
   type AgentToolOperationDependencies,
@@ -15,6 +17,8 @@ import {
   isSqlReadStatement,
   type AgentSqlContext,
   type AgentSqlExecutionResult,
+  type AgentSqlPayload,
+  type AgentSqlSinglePayload,
 } from "./agentSql/shared";
 import { executeSqlMutationStatement } from "./agentSql/singleMutation";
 import { buildInvalidSqlError } from "./sqlErrors";
@@ -104,31 +108,160 @@ function assertSqlResultWithinSizeBudget<T extends AgentSqlExecutionResult>(resu
   return result;
 }
 
+function getAgentSqlFingerprint(sql: string): string {
+  return createHash("sha256")
+    .update(sql)
+    .digest("hex");
+}
+
+function getSingleStatementRowOrAffectedCount(payload: AgentSqlSinglePayload): number {
+  return "rowCount" in payload ? payload.rowCount : payload.affectedCount;
+}
+
+function getAgentSqlRowOrAffectedCount(payload: AgentSqlPayload): number {
+  if (payload.statementType === "batch") {
+    return payload.statements.reduce(
+      (total, statement) => total + getSingleStatementRowOrAffectedCount(statement),
+      0,
+    );
+  }
+
+  return getSingleStatementRowOrAffectedCount(payload);
+}
+
+function getAgentSqlStatementCount(payload: AgentSqlPayload): number {
+  return payload.statementType === "batch" ? payload.statementCount : 1;
+}
+
+function getAgentSqlErrorCode(error: unknown): string | null {
+  return error instanceof HttpError ? error.code : null;
+}
+
+/**
+ * Reads the dialect's reason for a rejection defensively: the first validation
+ * issue code carried by the failure, treated as an opaque value. The dialect
+ * owns that vocabulary (today it is one constant everywhere, later it will be
+ * specific), so nothing here may depend on which values appear.
+ */
+function getAgentSqlDialectReason(error: unknown): string | null {
+  if (error instanceof HttpError) {
+    const validationIssues = error.details?.validationIssues ?? [];
+    return validationIssues.length === 0 ? null : validationIssues[0].code;
+  }
+
+  return null;
+}
+
+/**
+ * Reads the same minification-safe `error.name` that `getBackendErrorLogDetails`
+ * records. The constructor binding is not usable here: backend Lambdas are
+ * bundled with esbuild `minify: true` and no `keepNames`, so `constructor.name`
+ * would be a mangled label that changes between deploys.
+ */
+function getAgentSqlErrorClass(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+/**
+ * Emits exactly one structured `agent_sql` record per execution, on success and
+ * on failure alike, so the failure ratio of the agent SQL surface is computable
+ * per surface and per caller instead of being invisible.
+ *
+ * It must stay wrapped around the executor bodies below, i.e. *inside*
+ * `executeAgentSql` / `runSqlQuery` / `runSqlExecute`. The MCP tool handlers in
+ * `apps/backend/src/mcp/server.ts` catch their own errors and answer with a
+ * `CallToolResult`, so nothing above them ever reaches `app.onError`; anything
+ * recorded higher up would leave every MCP dialect rejection unobserved, which
+ * is the blind spot this exists to close.
+ *
+ * The record carries no error message on purpose. Dialect and batch errors quote
+ * the offending SQL fragment verbatim, so the text carries flashcard content,
+ * and no delimiter heuristic can strip it reliably: an unquoted or typographic
+ * operand (`... WHERE front_text = Paris`) has no delimiter to find. Only the
+ * low-cardinality dimensions below are recorded, and unexpected failures still
+ * reach Sentry with their full message and stack through
+ * `captureBackendException`, so nothing debuggable is lost.
+ *
+ * Instrumentation only: the caller's result is returned and the caller's error
+ * is rethrown untouched.
+ */
+async function withAgentSqlTelemetry<Result extends AgentSqlExecutionResult>(
+  context: AgentSqlContext,
+  sql: string,
+  execute: () => Promise<Result>,
+): Promise<Result> {
+  const startedAt = Date.now();
+  const executionDetails = {
+    userId: context.userId,
+    workspaceId: context.workspaceId,
+    surface: context.surface,
+    caller: context.caller ?? null,
+    connectionId: context.connectionId,
+    sqlLength: sql.length,
+    sqlFingerprint: getAgentSqlFingerprint(sql),
+  };
+
+  try {
+    const result = await execute();
+    logAgentSqlEvent({
+      ...executionDetails,
+      succeeded: true,
+      statementType: result.data.statementType,
+      resource: result.data.resource,
+      statementCount: getAgentSqlStatementCount(result.data),
+      rowOrAffectedCount: getAgentSqlRowOrAffectedCount(result.data),
+      durationMs: Date.now() - startedAt,
+      errorCode: null,
+      dialectReason: null,
+      errorClass: null,
+    });
+
+    return result;
+  } catch (error) {
+    logAgentSqlEvent({
+      ...executionDetails,
+      succeeded: false,
+      statementType: null,
+      resource: null,
+      statementCount: null,
+      rowOrAffectedCount: null,
+      durationMs: Date.now() - startedAt,
+      errorCode: getAgentSqlErrorCode(error),
+      dialectReason: getAgentSqlDialectReason(error),
+      errorClass: getAgentSqlErrorClass(error),
+    });
+
+    throw error;
+  }
+}
+
 export async function executeAgentSql(
   context: AgentSqlContext,
   sql: string,
   dependencies: AgentToolOperationDependencies = DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
 ) {
-  const statements = parseSqlBatch(sql);
-  const statementSqls = toStatementSqls(sql, statements);
+  return withAgentSqlTelemetry(context, sql, async () => {
+    const statements = parseSqlBatch(sql);
+    const statementSqls = toStatementSqls(sql, statements);
 
-  if (statements.every(isSqlReadStatement)) {
-    if (statements.length === 1) {
-      return executeSqlReadStatement(dependencies, context, sql, statements[0]);
+    if (statements.every(isSqlReadStatement)) {
+      if (statements.length === 1) {
+        return executeSqlReadStatement(dependencies, context, sql, statements[0]);
+      }
+
+      return executeSqlReadBatch(dependencies, context, sql, statements, statementSqls);
     }
 
-    return executeSqlReadBatch(dependencies, context, sql, statements, statementSqls);
-  }
+    if (statements.every(isSqlMutationStatement)) {
+      if (statements.length === 1) {
+        return executeSqlMutationStatement(dependencies, context, sql, statements[0]);
+      }
 
-  if (statements.every(isSqlMutationStatement)) {
-    if (statements.length === 1) {
-      return executeSqlMutationStatement(dependencies, context, sql, statements[0]);
+      return executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls);
     }
 
-    return executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls);
-  }
-
-  throw buildInvalidSqlError("SQL batch must contain only read statements or only mutation statements");
+    throw buildInvalidSqlError("SQL batch must contain only read statements or only mutation statements");
+  });
 }
 
 /**
@@ -148,24 +281,26 @@ export async function runSqlQuery(
   sql: string,
   dependencies: AgentToolOperationDependencies = DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
 ) {
-  const statements = parseSqlBatch(sql);
-  const statementSqls = toStatementSqls(sql, statements);
+  return withAgentSqlTelemetry(context, sql, async () => {
+    const statements = parseSqlBatch(sql);
+    const statementSqls = toStatementSqls(sql, statements);
 
-  if (statements.every(isSqlReadStatement)) {
-    if (statements.length === 1) {
+    if (statements.every(isSqlReadStatement)) {
+      if (statements.length === 1) {
+        return assertSqlResultWithinSizeBudget(
+          await executeSqlReadStatement(dependencies, context, sql, statements[0]),
+        );
+      }
+
       return assertSqlResultWithinSizeBudget(
-        await executeSqlReadStatement(dependencies, context, sql, statements[0]),
+        await executeSqlReadBatch(dependencies, context, sql, statements, statementSqls),
       );
     }
 
-    return assertSqlResultWithinSizeBudget(
-      await executeSqlReadBatch(dependencies, context, sql, statements, statementSqls),
+    throw buildInvalidSqlError(
+      "sql_query is read-only and accepts only SHOW TABLES, DESCRIBE, SHOW COLUMNS, and SELECT statements. Use sql_execute for INSERT, UPDATE, and DELETE.",
     );
-  }
-
-  throw buildInvalidSqlError(
-    "sql_query is read-only and accepts only SHOW TABLES, DESCRIBE, SHOW COLUMNS, and SELECT statements. Use sql_execute for INSERT, UPDATE, and DELETE.",
-  );
+  });
 }
 
 /**
@@ -179,22 +314,24 @@ export async function runSqlExecute(
   sql: string,
   dependencies: AgentToolOperationDependencies = DEFAULT_AGENT_TOOL_OPERATION_DEPENDENCIES,
 ) {
-  const statements = parseSqlBatch(sql);
-  const statementSqls = toStatementSqls(sql, statements);
+  return withAgentSqlTelemetry(context, sql, async () => {
+    const statements = parseSqlBatch(sql);
+    const statementSqls = toStatementSqls(sql, statements);
 
-  if (statements.every(isSqlMutationStatement)) {
-    if (statements.length === 1) {
+    if (statements.every(isSqlMutationStatement)) {
+      if (statements.length === 1) {
+        return assertSqlResultWithinSizeBudget(
+          await executeSqlMutationStatement(dependencies, context, sql, statements[0]),
+        );
+      }
+
       return assertSqlResultWithinSizeBudget(
-        await executeSqlMutationStatement(dependencies, context, sql, statements[0]),
+        await executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls),
       );
     }
 
-    return assertSqlResultWithinSizeBudget(
-      await executeSqlMutationBatch(dependencies, context, sql, statements, statementSqls),
+    throw buildInvalidSqlError(
+      "sql_execute is write-only and accepts only INSERT, UPDATE, and DELETE statements. Use sql_query for SHOW TABLES, DESCRIBE, SHOW COLUMNS, and SELECT.",
     );
-  }
-
-  throw buildInvalidSqlError(
-    "sql_execute is write-only and accepts only INSERT, UPDATE, and DELETE statements. Use sql_query for SHOW TABLES, DESCRIBE, SHOW COLUMNS, and SELECT.",
-  );
+  });
 }

--- a/apps/backend/src/aiTools/agentSql/batchMutation.test.ts
+++ b/apps/backend/src/aiTools/agentSql/batchMutation.test.ts
@@ -262,6 +262,7 @@ test("executeSqlMutationBatch appends legacy deck effort tags after final tags a
       userId: "user-1",
       selectedWorkspaceId: null,
       connectionId: "connection-1",
+      surface: "agent-rest",
     };
 
     await executeSqlMutationBatch(

--- a/apps/backend/src/aiTools/agentSql/shared.ts
+++ b/apps/backend/src/aiTools/agentSql/shared.ts
@@ -11,11 +11,25 @@ import type {
 } from "../sqlDialect";
 import { MAX_SQL_RECORD_LIMIT } from "../toolContract/sqlToolLimits";
 
+/**
+ * Entrypoint that executed the SQL. Kept as a closed union and required on
+ * `AgentSqlContext` so a future surface cannot reach the shared executors
+ * silently untagged in telemetry.
+ */
+export type AgentSqlSurface = "chat-tool" | "agent-rest" | "mcp";
+
 export type AgentSqlContext = Readonly<{
   userId: string;
   workspaceId: string;
   selectedWorkspaceId: string | null;
   connectionId: string;
+  surface: AgentSqlSurface;
+  /**
+   * Best-effort label of the foreign client behind the surface, recorded so the
+   * SQL failure rate can be split per client. Only the MCP surface can observe
+   * one today (see `apps/backend/src/mcp/server.ts`), so it stays optional.
+   */
+  caller?: string | null;
 }>;
 
 export type AgentSqlReadPayload = Readonly<{

--- a/apps/backend/src/chat/openai/tools/tools.ts
+++ b/apps/backend/src/chat/openai/tools/tools.ts
@@ -540,6 +540,7 @@ export async function executeChatToolCallWithDependencies(
         workspaceId: context.workspaceId,
         selectedWorkspaceId: context.workspaceId,
         connectionId: "chat-v2",
+        surface: "chat-tool",
       },
       parsed.sql,
       dependencies.createToolDependencies(context),

--- a/apps/backend/src/entrypoints/lambda-mcp.ts
+++ b/apps/backend/src/entrypoints/lambda-mcp.ts
@@ -145,6 +145,11 @@ function extractBearerToken(authorization: string | undefined): string | null {
  * custom-domain Host to the Lambda); the non-canonical execute-api host is not
  * used by real clients because issued tokens bind to the custom-domain
  * `resource` and would 401 on any other host.
+ *
+ * The request `User-Agent` is handed to the server as the caller label for SQL
+ * telemetry. Because the transport is stateless, a `tools/call` never carries
+ * the client's `initialize` clientInfo, so the header is the only caller signal
+ * available here (see `resolveMcpCaller` in apps/backend/src/mcp/server.ts).
  */
 async function handleMcpTransportRequest(
   request: Request,
@@ -156,6 +161,7 @@ async function handleMcpTransportRequest(
     getResourceUrl(baseDomain),
     getWebsiteUrl(baseDomain),
     getIconUrl(baseDomain),
+    request.headers.get("user-agent"),
   );
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,

--- a/apps/backend/src/mcp/server.test.ts
+++ b/apps/backend/src/mcp/server.test.ts
@@ -19,6 +19,7 @@ const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
 const RESOURCE_URL = "https://mcp.flashcards-open-source-app.com/mcp";
 const WEBSITE_URL = "https://flashcards-open-source-app.com";
 const ICON_URL = "https://mcp.flashcards-open-source-app.com/icon.svg";
+const CALLER_USER_AGENT = "mcp-protocol-smoke/1.0.0";
 const LEGACY_POSTGRES_WORKSPACE_ID = "35274129-ef97-d366-954c-955b4bb0fbf0";
 
 type ResolveWorkspaceCall = Readonly<{
@@ -254,6 +255,7 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
     RESOURCE_URL,
     WEBSITE_URL,
     ICON_URL,
+    CALLER_USER_AGENT,
     createFakeDependencies(calls, workspaces),
   );
   const client = new Client({ name: "mcp-protocol-smoke", version: "1.0.0" });
@@ -350,6 +352,8 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
         workspaceId: requestedWorkspaceId,
         selectedWorkspaceId: connection.selectedWorkspaceId,
         connectionId: connection.connectionId,
+        surface: "mcp",
+        caller: CALLER_USER_AGENT,
       },
       sql,
     }]);
@@ -359,6 +363,8 @@ test("MCP server exposes workspace and SQL tools through the protocol path", asy
         workspaceId: requestedWorkspaceId,
         selectedWorkspaceId: connection.selectedWorkspaceId,
         connectionId: connection.connectionId,
+        surface: "mcp",
+        caller: CALLER_USER_AGENT,
       },
       sql: executeSql,
     }]);
@@ -381,6 +387,7 @@ test("MCP SQL tools reject malformed workspace IDs before access resolution", as
     RESOURCE_URL,
     WEBSITE_URL,
     ICON_URL,
+    CALLER_USER_AGENT,
     createFakeDependencies(calls, []),
   );
   const client = new Client({ name: "mcp-protocol-smoke", version: "1.0.0" });

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -72,6 +72,36 @@ const DEFAULT_MCP_SERVER_DEPENDENCIES: McpServerDependencies = {
   listUserWorkspacesWithStatsForSelectedWorkspace,
 };
 
+const MAX_MCP_CALLER_CHARS = 120;
+
+/**
+ * Caller label recorded on the agent SQL telemetry record so the dialect
+ * failure rate can be split per MCP client.
+ *
+ * The `initialize` clientInfo is not reachable here: the MCP Lambda runs the
+ * transport statelessly (`sessionIdGenerator: undefined` in
+ * apps/backend/src/entrypoints/lambda-mcp.ts), so a `tools/call` arrives as its
+ * own HTTP request on a freshly built server that never saw the client's
+ * `initialize`. The request `User-Agent` is the one caller signal that is
+ * observable without restructuring the entrypoint, so it is what gets recorded,
+ * trimmed and capped. Clients that send no `User-Agent` are recorded as null
+ * rather than guessed at.
+ */
+function resolveMcpCaller(callerUserAgent: string | null): string | null {
+  if (callerUserAgent === null) {
+    return null;
+  }
+
+  const trimmedCaller = callerUserAgent.trim();
+  if (trimmedCaller === "") {
+    return null;
+  }
+
+  return trimmedCaller.length <= MAX_MCP_CALLER_CHARS
+    ? trimmedCaller
+    : trimmedCaller.slice(0, MAX_MCP_CALLER_CHARS);
+}
+
 function buildToolResultText(payload: unknown): string {
   return JSON.stringify(payload, null, 2);
 }
@@ -336,18 +366,22 @@ const LIST_WORKSPACES_RESULT_INSTRUCTIONS =
  * `iconUrl` is the absolute https URL of the served branded SVG icon
  * (`/icon.svg`), advertised as the server `icons` entry so spec-current MCP
  * clients and auto-ingesting catalogs can render the brand.
+ * `callerUserAgent` is the request `User-Agent` (see `resolveMcpCaller`), used
+ * only to label the SQL telemetry record with the calling client.
  */
 export function createMcpServer(
   connection: AuthenticatedMcpAccessToken,
   resourceUrl: string,
   websiteUrl: string,
   iconUrl: string,
+  callerUserAgent: string | null,
 ): McpServer {
   return createMcpServerWithDependencies(
     connection,
     resourceUrl,
     websiteUrl,
     iconUrl,
+    callerUserAgent,
     DEFAULT_MCP_SERVER_DEPENDENCIES,
   );
 }
@@ -357,8 +391,10 @@ export function createMcpServerWithDependencies(
   resourceUrl: string,
   websiteUrl: string,
   iconUrl: string,
+  callerUserAgent: string | null,
   dependencies: McpServerDependencies,
 ): McpServer {
+  const caller = resolveMcpCaller(callerUserAgent);
   const server = new McpServer(
     {
       name: SERVER_NAME,
@@ -416,6 +452,8 @@ export function createMcpServerWithDependencies(
           workspaceId,
           selectedWorkspaceId: connection.selectedWorkspaceId,
           connectionId: connection.connectionId,
+          surface: "mcp",
+          caller,
         }, sql);
 
         return buildToolResult(
@@ -465,6 +503,8 @@ export function createMcpServerWithDependencies(
           workspaceId,
           selectedWorkspaceId: connection.selectedWorkspaceId,
           connectionId: connection.connectionId,
+          surface: "mcp",
+          caller,
         }, sql);
 
         return buildToolResult(

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -1,3 +1,4 @@
+import type { AgentSqlSurface } from "../../aiTools/agentSql/shared";
 import type { MediaAssetStorageErrorDetails } from "../../shared/errors";
 
 export type BackendService =
@@ -87,6 +88,39 @@ export type AdminQueryDetails = Readonly<{
   durationMs: number;
   success: boolean;
   sqlFingerprint: string;
+}>;
+
+/**
+ * One record per agent SQL execution, emitted on success and on failure by
+ * every surface (`chat-tool`, `agent-rest`, `mcp`). `succeeded` is the
+ * denominator the failure ratio is computed from, and `errorCode` /
+ * `dialectReason` are the aggregable causes. `dialectReason` is the first
+ * validation-issue code carried by the failure, recorded as an opaque value:
+ * the dialect owns that vocabulary and may change it.
+ *
+ * Raw SQL text is deliberately absent; `sqlFingerprint` plus `sqlLength` are
+ * what make repeated failures groupable, matching `AdminQueryDetails`.
+ *
+ * The error message is deliberately absent too: dialect errors quote the
+ * offending SQL fragment verbatim, so the message carries flashcard content that
+ * no delimiter heuristic can strip reliably. Unexpected failures still reach
+ * Sentry with their full message and stack through `captureBackendException`.
+ */
+export type AgentSqlDetails = Readonly<{
+  surface: AgentSqlSurface;
+  caller: string | null;
+  connectionId: string;
+  succeeded: boolean;
+  statementType: string | null;
+  resource: string | null;
+  statementCount: number | null;
+  rowOrAffectedCount: number | null;
+  durationMs: number;
+  sqlLength: number;
+  sqlFingerprint: string;
+  errorCode: string | null;
+  dialectReason: string | null;
+  errorClass: string | null;
 }>;
 
 export type SyncPushDetails = Readonly<{
@@ -897,6 +931,7 @@ type SyncConflictFailureDetailsFor<Details> = FailureDetailsFor<Details> & Backe
 
 export type BackendBreadcrumbEvent =
   | EventByAction<"admin_query", AdminQueryDetails>
+  | EventByAction<"agent_sql", AgentSqlDetails>
   | EventByAction<"request_error", RequestErrorDetails>
   | EventByAction<"global_metrics_snapshot_generated", GlobalMetricsSnapshotGeneratedDetails>
   | EventByAction<"community_leaderboard_snapshot_generated", CommunityLeaderboardSnapshotGeneratedDetails>

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -129,6 +129,7 @@ export function createAgentRoutes(options: AgentRoutesOptions): Hono<AppEnv> {
       workspaceId,
       selectedWorkspaceId: requestContext.selectedWorkspaceId,
       connectionId,
+      surface: "agent-rest",
     }, body.sql);
 
     return context.json(createAgentEnvelope(context.req.url, result.data, result.instructions));
@@ -143,6 +144,7 @@ export function createAgentRoutes(options: AgentRoutesOptions): Hono<AppEnv> {
       workspaceId,
       selectedWorkspaceId: requestContext.selectedWorkspaceId,
       connectionId,
+      surface: "agent-rest",
     }, body.sql);
 
     return context.json(createAgentEnvelope(context.req.url, result.data, result.instructions));

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -7,7 +7,9 @@ import {
   createBackendObservationScope,
   getBackendErrorLogDetails,
   type AdminQueryDetails,
+  type AgentSqlDetails,
   type BackendObservationScope,
+  type BackendService,
   type BackendErrorLogDetails,
   type BackendFailureDetails,
   type RequestErrorDetails,
@@ -26,6 +28,11 @@ type AdminQueryLogPayload = Readonly<{
 type CloudWatchAdminQueryDetails = Omit<AdminQueryDetails, "adminEmail"> & Readonly<{
   adminEmail: string;
 }>;
+
+type AgentSqlLogPayload = Readonly<{
+  userId: string;
+  workspaceId: string;
+}> & AgentSqlDetails;
 
 export function getErrorLogContext(error: unknown): ErrorLogContext {
   return getBackendErrorLogDetails(error);
@@ -224,6 +231,65 @@ export function logAdminQueryEvent(
 
   addBackendSentryBreadcrumb({
     action: "admin_query",
+    scope,
+    details,
+  });
+}
+
+/**
+ * The shared agent SQL executor runs in two Lambdas: the chat tool executes
+ * inside the chat worker, while the REST agent routes and the MCP transport
+ * execute inside the backend API. Map the surface onto the emitting service so
+ * the record's `service` matches the log group it lands in.
+ */
+function getAgentSqlService(surface: AgentSqlDetails["surface"]): BackendService {
+  return surface === "chat-tool" ? "chat-worker" : "backend-api";
+}
+
+/**
+ * Emits the single structured record for one agent SQL execution, following the
+ * `logAdminQueryEvent` convention above (fingerprint + statement count +
+ * duration + outcome, never the raw SQL). Unlike the admin variant nothing here
+ * needs a CloudWatch-specific redaction, so this goes through the shared
+ * `addBackendBreadcrumb` helper that writes the sanitized CloudWatch record and
+ * the Sentry breadcrumb in one call.
+ *
+ * The route is synthetic (`agent-sql/<surface>`) because the same executor is
+ * reached from an MCP tool call, a REST route, and the in-app chat tool.
+ */
+export function logAgentSqlEvent(payload: AgentSqlLogPayload): void {
+  const scope: BackendObservationScope = createBackendObservationScope(
+    getAgentSqlService(payload.surface),
+    null,
+    `agent-sql/${payload.surface}`,
+    "POST",
+    payload.userId,
+    payload.workspaceId,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+  const details: AgentSqlDetails = {
+    surface: payload.surface,
+    caller: payload.caller,
+    connectionId: payload.connectionId,
+    succeeded: payload.succeeded,
+    statementType: payload.statementType,
+    resource: payload.resource,
+    statementCount: payload.statementCount,
+    rowOrAffectedCount: payload.rowOrAffectedCount,
+    durationMs: payload.durationMs,
+    sqlLength: payload.sqlLength,
+    sqlFingerprint: payload.sqlFingerprint,
+    errorCode: payload.errorCode,
+    dialectReason: payload.dialectReason,
+    errorClass: payload.errorClass,
+  };
+
+  addBackendBreadcrumb({
+    action: "agent_sql",
     scope,
     details,
   });

--- a/docs/agent-sql-telemetry.md
+++ b/docs/agent-sql-telemetry.md
@@ -1,0 +1,99 @@
+# Agent SQL Telemetry
+
+Every agent SQL execution emits exactly one structured CloudWatch record, on
+success and on failure alike, so the failure rate of foreign models against our
+SQL dialect is measurable.
+
+The record is emitted by `withAgentSqlTelemetry` in
+`apps/backend/src/aiTools/agentSql.ts`, which wraps `executeAgentSql`,
+`runSqlQuery`, and `runSqlExecute`. It sits below the MCP tool handlers' own
+`catch`, which answers with a `CallToolResult` and therefore never reaches
+`app.onError`: without this record an MCP dialect rejection produces no
+CloudWatch event, no Sentry event, and no Langfuse trace.
+
+## Where the records are
+
+- `action = "agent_sql"`, `domain = "backend"`
+- surface `agent-rest`: backend API Lambda log group
+  (`/aws/lambda/<BackendFunctionName>`, `service = "backend-api"`)
+- surface `mcp`: MCP Lambda log group (`/aws/lambda/<McpFunctionName>`,
+  `service = "backend-api"`)
+- surface `chat-tool`: chat worker Lambda log group
+  (`/aws/lambda/<ChatWorkerFunctionName>`, `service = "chat-worker"`)
+
+The function names are the `BackendFunctionName`, `McpFunctionName`, and
+`ChatWorkerFunctionName` CDK stack outputs. Query the three log groups together
+to compare surfaces.
+
+## Record fields
+
+| Field | Meaning |
+| --- | --- |
+| `surface` | `chat-tool`, `agent-rest`, or `mcp` |
+| `caller` | Calling client label; `null` on every surface except MCP |
+| `connectionId` | Agent connection the execution ran under |
+| `succeeded` | Outcome; the denominator for any failure ratio |
+| `statementType` | `select`, `insert`, `batch`, and so on; `null` on failure |
+| `resource` | `cards`, `decks`, and so on; `null` for batches and on failure |
+| `statementCount` | Statements in the submitted SQL; `null` on failure |
+| `rowOrAffectedCount` | Rows read or records affected; `null` on failure |
+| `durationMs` | Wall-clock duration of the execution |
+| `sqlLength` | Character length of the submitted SQL |
+| `sqlFingerprint` | SHA-256 hex digest of the submitted SQL |
+| `errorCode` | `HttpError` code on failure, else `null` |
+| `dialectReason` | First validation-issue code on failure, else `null` |
+| `errorClass` | `error.name` on failure, else `null`; coarse by design, so group failures by `errorCode` and `dialectReason` |
+
+`userId`, `workspaceId`, and the synthetic route `agent-sql/<surface>` come from
+the shared observation scope on every record.
+
+Raw SQL text is never logged. `sqlFingerprint` plus `errorCode` and
+`dialectReason` are what make repeated failures groupable, the same choice the
+admin reporting query records already make.
+
+The error message is not recorded either. Dialect and batch errors quote the
+offending SQL fragment verbatim, so the message carries flashcard content that
+no delimiter heuristic can strip reliably. Unexpected failures still reach
+Sentry with their full message and stack, so use Sentry when a specific failure
+needs to be read rather than counted.
+
+`dialectReason` is recorded as an opaque value. The SQL dialect owns that
+vocabulary and will make it more specific over time; nothing in this record
+depends on which values appear.
+
+## The MCP caller label
+
+On the MCP surface `caller` is the request `User-Agent`, trimmed and capped at
+120 characters, and `null` when the client sends no `User-Agent`.
+
+The `initialize` clientInfo is not used because it is not reachable: the MCP
+Lambda runs the transport statelessly (`sessionIdGenerator: undefined` in
+`apps/backend/src/entrypoints/lambda-mcp.ts`), so a `tools/call` arrives as its
+own HTTP request on a freshly built server that never saw the client's
+`initialize`. Reaching clientInfo would mean restructuring the entrypoint into a
+session-bearing transport.
+
+## Failure share by surface
+
+```
+filter domain = "backend" and action = "agent_sql"
+| stats count(*) as executions,
+        sum(succeeded = 0) as failures,
+        sum(succeeded = 0) * 100 / count(*) as failureSharePct
+  by surface
+| sort failureSharePct desc
+```
+
+Add `, caller` to the `by` clause to split the MCP surface per client.
+
+## Top failure causes
+
+```
+filter domain = "backend" and action = "agent_sql" and succeeded = 0
+| stats count(*) as failures by surface, errorCode, dialectReason, caller
+| sort failures desc
+| limit 20
+```
+
+If a log group renders `succeeded` as `true`/`false` instead of `1`/`0`, use
+`succeeded = "false"` in both queries.


### PR DESCRIPTION
## Problem

The MCP connector and `POST /v1/agent/sql/*` were not observable at all for the failures that matter there.

- **MCP: total blind spot.** The tool handlers in `mcp/server.ts` catch their own errors and return a `CallToolResult`, so nothing ever reaches `app.onError`, and `buildToolErrorResult` reports to Sentry only when `statusCode >= 500`. Every 4xx — i.e. every dialect rejection — produced no CloudWatch record, no Sentry event and no trace.
- **REST: half a signal.** Errors reach `app.onError`, but `shouldLogRequestErrorAtErrorLevel` sends 4xx down the breadcrumb path, which does write a CloudWatch record. So the numerator exists. No surface logged successes, so the denominator did not exist anywhere and no ratio was computable.

Foreign models reach these two surfaces through Claude.ai and ChatGPT, so how they cope with our SQL dialect was unknowable in principle.

## Change

- `withAgentSqlTelemetry` wraps `executeAgentSql` / `runSqlQuery` / `runSqlExecute` — deliberately **inside** the executors, below the MCP handlers' own catch. Placed any higher, the MCP blind spot would survive the change.
- One `agent_sql` record per execution, success and failure alike, modeled on the existing `logAdminQueryEvent` convention rather than a second one.
- `surface` dimension (`chat-tool` / `agent-rest` / `mcp`) plus an MCP caller label, so the failure rate of foreign clients can be compared against our own chat tool.
- `docs/agent-sql-telemetry.md` with the record fields and two Logs Insights queries: failure share by surface, and top failure causes.

## Deliberately not recorded

No raw SQL text, and **no error message**. `errorMessage` sits on `cloudWatchActionableExceptionTextFieldNames`, so the repo's content redaction intentionally preserves it verbatim — and a delimiter heuristic cannot strip caller values reliably (`WHERE front_text = Paris`, unquoted or typographically quoted, gives it nothing to find), which is exactly the mistake class this feature exists to measure. `errorCode` + `dialectReason` + `errorClass` carry the aggregation signal with no user content; unexpected failures still reach Sentry with full message and stack.

`dialectReason` reads `validationIssues[0].code` as an opaque value, so this keeps working before and after the separate dialect-reason-code change lands.

## Known residuals

- The record carries no `requestId`, so CloudWatch→Sentry drill-down joins on Lambda `@requestId` within an invocation, or `userId` + timestamp. Aggregate measurement — the goal here — is unaffected. Threading a correlation id through all three surfaces is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)