### PR TITLE
Tell agents the truth about decks and advertise the SQL predicates they never find

### DIFF
--- a/api/src/paths/agent_sql_execute.yaml
+++ b/api/src/paths/agent_sql_execute.yaml
@@ -7,18 +7,34 @@ post:
     currently selected workspace. This is not full PostgreSQL. Supported
     statements are INSERT, UPDATE, and DELETE across published writable
     resources only. This endpoint rejects SHOW TABLES, DESCRIBE, SHOW COLUMNS,
-    and SELECT; use POST /agent/sql/query for reads. Multiple write statements
-    may be separated with semicolons in one sql string and are executed
-    atomically: all statements succeed or the whole batch fails. INSERT,
-    UPDATE, and DELETE may affect at most 100 rows per statement. Array columns
-    (e.g. tags) take a parenthesized list such as ('tag1', 'tag2'), or () for
-    empty. UPDATE and DELETE WHERE clauses support parenthesized AND/OR groups
-    where AND binds tighter than OR, LIKE, NOT LIKE, ILIKE, case-insensitive
-    exact string matches via LOWER(column) = 'value', LOWER(column) IN (...),
-    and LOWER(column) NOT IN (...), the LOWER(column) LIKE, LOWER(column) NOT
-    LIKE, and LOWER(column) ILIKE forms, and array comparison against a literal
-    tag list such as tags = ('english', 'slang') or tags = () for rows with no
-    tags.
+    and SELECT; use POST /agent/sql/query for reads. Cards have no deck_id column
+    and no deck membership: a deck is a saved tag filter whose tags column
+    defines the filter, so the only association between a card and a deck is
+    matching tags. Decks expose deck_id, name, tags, created_at, updated_at, and
+    deleted_at, and have no description column. Multiple write statements may be
+    separated with semicolons in one sql string and are executed atomically: all
+    statements succeed or the whole batch fails. Send schema discovery to POST
+    /agent/sql/query as its own request, and never in the same
+    semicolon-separated sql string as statements that depend on the result,
+    because the whole batch is composed before any statement runs. Bulk-write
+    split arithmetic: at most 100 rows affected per statement, at most 50
+    statements per batch, and a batch must not mix read and write statements.
+    Split larger work across separate statements or separate requests. Array
+    columns (e.g. tags) take a parenthesized list such as ('tag1', 'tag2'), or ()
+    for empty. UPDATE and DELETE WHERE clauses support parenthesized AND/OR
+    groups where AND binds tighter than OR, LIKE, NOT LIKE, ILIKE,
+    case-insensitive exact string matches via LOWER(column) = 'value',
+    LOWER(column) IN (...), and LOWER(column) NOT IN (...), the LOWER(column)
+    LIKE, LOWER(column) NOT LIKE, and LOWER(column) ILIKE forms, array comparison
+    against a literal tag list such as tags = ('english', 'slang') or tags = ()
+    for rows with no tags, array-column intersection such as
+    tags OVERLAP ('english', 'slang') for rows carrying at least one of the
+    listed values, compared exactly and case-sensitively, so pass tag values as
+    they are stored, MATCH('text') to keep rows where any column of the row contains
+    that text as a case-insensitive substring (it scans every column, including
+    tags and JSON metadata, and there is no tokenization, so prefer one word or an
+    exact phrase). Filter by tag in UPDATE and DELETE with
+    tags OVERLAP ('tag'), because UNNEST is only available in SELECT.
   security:
     - ApiKeyHeader: []
   requestBody:

--- a/api/src/paths/agent_sql_query.yaml
+++ b/api/src/paths/agent_sql_query.yaml
@@ -7,15 +7,29 @@ post:
     the currently selected workspace. This is not full PostgreSQL. Supported
     statements are SHOW TABLES, DESCRIBE, SHOW COLUMNS, and SELECT across
     published logical resources only. This endpoint rejects INSERT, UPDATE, and
-    DELETE; use POST /agent/sql/execute for writes. Multiple read statements may
-    be separated with semicolons in one sql string. SELECT supports projected
-    column lists, parenthesized AND/OR groups in WHERE where AND binds tighter
-    than OR, LIKE, NOT LIKE, ILIKE, case-insensitive exact string matches via
+    DELETE; use POST /agent/sql/execute for writes. Cards have no deck_id column
+    and no deck membership: a deck is a saved tag filter whose tags column
+    defines the filter, so the only association between a card and a deck is
+    matching tags. Decks expose deck_id, name, tags, created_at, updated_at, and
+    deleted_at, and have no description column. Multiple read statements may
+    be separated with semicolons in one sql string. Send SHOW TABLES, DESCRIBE,
+    and SHOW COLUMNS as their own request, and never in the same
+    semicolon-separated sql string as statements that depend on the result,
+    because the whole batch is composed before any statement runs. SELECT
+    supports projected column lists, aggregates, GROUP BY, NOW(), standalone
+    ORDER BY RANDOM(), and cards UNNEST tags AS tag. SELECT WHERE clauses
+    support parenthesized AND/OR groups where AND binds tighter than OR, LIKE,
+    NOT LIKE, ILIKE, case-insensitive exact string matches via
     LOWER(column) = 'value', LOWER(column) IN (...), and LOWER(column) NOT IN
     (...), the LOWER(column) LIKE, LOWER(column) NOT LIKE, and LOWER(column)
     ILIKE forms, array comparison against a literal tag list such as
-    tags = ('english', 'slang') or tags = () for rows with no tags, aggregates,
-    GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag.
+    tags = ('english', 'slang') or tags = () for rows with no tags, array-column
+    intersection such as tags OVERLAP ('english', 'slang') for rows carrying at
+    least one of the listed values, compared exactly and case-sensitively, so
+    pass tag values as they are stored, MATCH('text') to keep rows where any column
+    of the row contains that text as a case-insensitive substring (it scans every
+    column, including tags and JSON metadata, and there is no tokenization, so
+    prefer one word or an exact phrase).
   security:
     - ApiKeyHeader: []
   requestBody:

--- a/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
+++ b/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
@@ -38,6 +38,7 @@ export const SQL_QUERY_TOOL_PROMPT_EXAMPLE_LINES = Object.freeze([
   "- sql_query => {\"sql\": \"SELECT * FROM cards WHERE due_at IS NULL OR due_at <= NOW() ORDER BY due_at ASC, created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
   "- sql_query => {\"sql\": \"SELECT card_id, front_text, back_text, tags FROM cards UNNEST tags AS tag WHERE LOWER(tag) = 'english' AND (LOWER(front_text) LIKE '%example%' OR LOWER(back_text) NOT LIKE '%draft%') ORDER BY created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
   "- sql_query => {\"sql\": \"SELECT card_id, front_text, back_text, tags FROM cards WHERE tags = () ORDER BY created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
+  "- sql_query => {\"sql\": \"SELECT card_id, front_text, back_text, tags FROM cards WHERE tags OVERLAP ('english', 'slang') ORDER BY created_at DESC, card_id ASC LIMIT 20 OFFSET 0\"}",
 ]);
 
 /**
@@ -51,6 +52,7 @@ export const SQL_EXECUTE_TOOL_PROMPT_EXAMPLE_LINES = Object.freeze([
   "- sql_execute => {\"sql\": \"UPDATE cards SET back_text = 'Updated answer' WHERE card_id = '00000000-0000-4000-8000-000000000000'\"}",
   "- sql_execute => {\"sql\": \"UPDATE cards SET back_text = 'First update' WHERE card_id = '00000000-0000-4000-8000-000000000000'; UPDATE cards SET back_text = 'Second update' WHERE card_id = '00000000-0000-4000-8000-000000000001'\"}",
   "- sql_execute => {\"sql\": \"DELETE FROM decks WHERE deck_id IN ('00000000-0000-4000-8000-000000000000')\"}",
+  "- sql_execute => {\"sql\": \"DELETE FROM cards WHERE tags OVERLAP ('some-tag')\"}",
 ]);
 
 /**
@@ -73,17 +75,23 @@ const SQL_DIALECT_DESCRIPTION_LINES = Object.freeze([
   "Use one JSON object: {\"sql\": \"...\"}.",
   "Public docs: https://flashcards-open-source-app.com/docs/mcp-connector/ and https://flashcards-open-source-app.com/docs/api/.",
   "Published resources: workspace, cards, decks, review_events.",
+  "Resource semantics: cards have no deck_id column and no deck membership.",
+  "A deck is a saved tag filter whose tags column defines the filter, so the only association between a card and a deck is matching tags.",
+  "Decks expose deck_id, name, tags, created_at, updated_at, and deleted_at, and have no description column.",
   "Multiple supported statements may be separated with semicolons in one sql string.",
   `A batch may contain at most ${MAX_SQL_BATCH_STATEMENT_COUNT} statements.`,
+  "Schema discovery (SHOW TABLES, DESCRIBE, SHOW COLUMNS) must be its own read call and must never share a semicolon-separated sql string with statements that depend on its result, because the whole batch is composed before any statement runs.",
 ]);
 
 /**
  * Shared WHERE-clause grammar fragment. UPDATE and DELETE resolve their target
  * rows through the same SELECT evaluator, so the read and write surfaces must
- * advertise exactly the same WHERE forms.
+ * advertise exactly the same WHERE forms. The fragment is a bare comma-separated
+ * list of forms with no "WHERE" framing and no trailing conjunction of its own,
+ * so each surface can end its own sentence with it.
  */
 const SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION =
-  "parenthesized AND/OR groups in WHERE where AND binds tighter than OR, LIKE, NOT LIKE, ILIKE, LOWER(column) = 'value', LOWER(column) LIKE '...', LOWER(column) NOT LIKE '...', LOWER(column) ILIKE '...', LOWER(column) IN (...), and LOWER(column) NOT IN (...) for case-insensitive exact string matches, array comparison against a literal tag list such as tags = ('english', 'slang') or tags = () for rows with no tags";
+  "parenthesized AND/OR groups where AND binds tighter than OR, LIKE, NOT LIKE, ILIKE, LOWER(column) = 'value', LOWER(column) LIKE '...', LOWER(column) NOT LIKE '...', LOWER(column) ILIKE '...', LOWER(column) IN (...), and LOWER(column) NOT IN (...) for case-insensitive exact string matches, array comparison against a literal tag list such as tags = ('english', 'slang') or tags = () for rows with no tags, array-column intersection such as tags OVERLAP ('english', 'slang') for rows carrying at least one of the listed values, compared exactly and case-sensitively, so pass tag values as they are stored, MATCH('text') to keep rows where any column of the row contains that text as a case-insensitive substring (it scans every column, including tags and JSON metadata, and there is no tokenization, so prefer one word or an exact phrase)";
 
 /**
  * Shared supported-forms sentence reused by the split `sql_query` description
@@ -91,14 +99,33 @@ const SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION =
  * same SELECT grammar.
  */
 const SQL_SELECT_SUPPORTED_FORMS_DESCRIPTION =
-  `SELECT supports projected column lists, ${SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION}, COUNT(*), SUM, AVG, MIN, MAX, GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag.`;
+  `SELECT supports projected column lists, COUNT(*), SUM, AVG, MIN, MAX, GROUP BY, NOW(), standalone ORDER BY RANDOM(), and cards UNNEST tags AS tag. SELECT WHERE clauses support ${SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION}.`;
+
+/**
+ * Tag filtering on the write side. `UNNEST` only exists in `SELECT`, so `OVERLAP`
+ * is the only way to target rows by tag in `UPDATE` and `DELETE`.
+ */
+const SQL_MUTATION_TAG_FILTER_DESCRIPTION =
+  "Filter by tag in UPDATE and DELETE with tags OVERLAP ('tag'), because UNNEST is only available in SELECT.";
 
 /**
  * Write-side mirror of the WHERE grammar for the `sql_execute` surface, matching
  * the description in `api/src/paths/agent_sql_execute.yaml`.
  */
 const SQL_MUTATION_WHERE_SUPPORTED_FORMS_DESCRIPTION =
-  `UPDATE and DELETE WHERE clauses support ${SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION}.`;
+  `UPDATE and DELETE WHERE clauses support ${SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION}. ${SQL_MUTATION_TAG_FILTER_DESCRIPTION}`;
+
+/**
+ * Self-contained bulk-write split arithmetic for every write surface, so an
+ * agent can size a batch without cross-referencing other description lines.
+ *
+ * Deliberately limited to the three limits the dialect actually enforces on
+ * every write surface. Result-payload budgets differ per surface (the split
+ * `sql_query`/`sql_execute` entrypoints reject an oversized payload, while the
+ * in-app `sql` tool truncates it), so they are not stated here.
+ */
+const SQL_BULK_WRITE_SPLIT_DESCRIPTION =
+  `Bulk-write split arithmetic: at most ${MAX_SQL_RECORD_LIMIT} rows affected per statement, at most ${MAX_SQL_BATCH_STATEMENT_COUNT} statements per batch, and a batch must not mix read and write statements. Split larger work across separate statements or separate tool calls.`;
 
 /**
  * Read-only contract description for the split `sql_query` surface.
@@ -123,8 +150,7 @@ export const SQL_EXECUTE_TOOL_DESCRIPTION = [
   "Supported statements: INSERT, UPDATE, DELETE.",
   "This tool is write-only and rejects SHOW TABLES, DESCRIBE, SHOW COLUMNS, and SELECT; use sql_query for reads.",
   "Mutation batches are applied atomically: all statements succeed or the whole batch fails.",
-  `INSERT, UPDATE, and DELETE may affect at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
-  `If you need to create, update, or delete more than ${MAX_SQL_RECORD_LIMIT} records, split the work into multiple batches of at most ${MAX_SQL_RECORD_LIMIT} records across separate SQL statements or separate tool calls.`,
+  SQL_BULK_WRITE_SPLIT_DESCRIPTION,
   "Array columns (e.g. tags) take a parenthesized list: ('tag1', 'tag2'), or () for empty.",
   SQL_MUTATION_WHERE_SUPPORTED_FORMS_DESCRIPTION,
   "Examples (tool-call JSON):",
@@ -136,20 +162,14 @@ export const OPENAI_SQL_TOOL: FunctionTool = {
   name: SQL_TOOL_NAME,
   description: [
     "Query and mutate the flashcards workspace with the published SQL dialect.",
-    "This is not full PostgreSQL.",
-    "Cards, decks, review_events, and workspace are already scoped to the selected workspace.",
-    "Use one JSON object: {\"sql\": \"...\"}.",
-    "Public docs: https://flashcards-open-source-app.com/docs/mcp-connector/ and https://flashcards-open-source-app.com/docs/api/.",
-    "Published resources: workspace, cards, decks, review_events.",
+    ...SQL_DIALECT_DESCRIPTION_LINES,
     "Supported statements: SHOW TABLES, DESCRIBE <resource>, SHOW COLUMNS FROM <resource>, SELECT, INSERT, UPDATE, DELETE.",
-    "Multiple supported statements may be separated with semicolons in one sql string.",
-    `A batch may contain at most ${MAX_SQL_BATCH_STATEMENT_COUNT} statements.`,
-    "A batch must contain only read statements or only mutation statements.",
     "Mutation batches are applied atomically: all statements succeed or the whole batch fails.",
     `SELECT returns at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
-    `INSERT, UPDATE, and DELETE may affect at most ${MAX_SQL_RECORD_LIMIT} rows per statement.`,
-    `If you need to create, update, or delete more than ${MAX_SQL_RECORD_LIMIT} records, split the work into multiple batches of at most ${MAX_SQL_RECORD_LIMIT} records across separate SQL statements or separate tool calls.`,
+    SQL_BULK_WRITE_SPLIT_DESCRIPTION,
     SQL_SELECT_SUPPORTED_FORMS_DESCRIPTION,
+    "UPDATE and DELETE WHERE clauses support the same forms as SELECT WHERE clauses.",
+    SQL_MUTATION_TAG_FILTER_DESCRIPTION,
     "Array columns (e.g. tags) take a parenthesized list: ('tag1', 'tag2'), or () for empty.",
     "Examples (tool-call JSON):",
     ...SQL_TOOL_PROMPT_EXAMPLE_LINES,

--- a/apps/backend/src/chat/shared.ts
+++ b/apps/backend/src/chat/shared.ts
@@ -19,6 +19,8 @@ function buildWorkspaceSection(): string {
   return joinLines([
     "You work over the synced workspace state managed by the backend.",
     "Use the shared sql tool to inspect workspace data.",
+    "Decks are saved tag filters: a deck row exposes deck_id, name, and tags, and has no description.",
+    "Cards have no deck_id and no deck membership, so a card belongs to a deck only by matching that deck's tags.",
     "You help with card drafting, deck cleanup, review analysis, study planning, and organizing content.",
   ]);
 }
@@ -77,6 +79,7 @@ function buildToolCallRulesSection(): string {
     "Tool-call rules:",
     "- Tool arguments must be exactly one JSON object.",
     "- Use the shared sql tool for workspace reads, writes, and schema discovery.",
+    "- Send SHOW TABLES, DESCRIBE, and SHOW COLUMNS as their own tool call, never in the same sql string as statements that depend on the result.",
     "- Put the whole query in the sql string field and do not invent extra tool arguments.",
     "- SQL pagination uses LIMIT and OFFSET inside the SQL string.",
     "- SELECT returns at most 100 rows per statement.",


### PR DESCRIPTION
## Why

Measured from Langfuse over 2026-07-07 to 2026-08-06, across 2711 `sql` tool calls and 170 dialect rejections:

- **57 rejections (33.5%) request columns that do not exist** — `cards.deck_id` 35 times, `decks.description` 11, bare `tag` outside an `UNNEST` source 4. Agents import the deck model from other flashcard products.
- **Schema discovery does not correct them.** 78 of the 157 discovery calls were batched into the same `sql` string as the statements that depended on the result. A batch is composed before any statement runs, so `SHOW COLUMNS` could never inform them.
- **`OVERLAP` and `MATCH` were implemented but documented nowhere** — each used once in 2711 calls. `OVERLAP` is the only way to filter by tag in `UPDATE` and `DELETE`, where `UNNEST` is unavailable.

## What changed

Documentation and prompt text only. No parser, evaluator, schema, error, or telemetry code.

- The real resource model: decks are saved tag filters (`content.decks.filter_definition`), cards carry no deck membership, and a card belongs to a deck only by matching its tags. Decks have no `description`.
- `tags OVERLAP ('a','b')` and `MATCH('text')` are now advertised, with `OVERLAP` named as the tag filter for writes. `MATCH` is described accurately as an any-column substring scan that also covers `tags` and JSON metadata, with no tokenization.
- Schema discovery must be its own tool call.
- The bulk-write split arithmetic is stated explicitly instead of being discovered by hitting limits.
- The chat system prompt gains the deck model and the discovery rule, kept terse because it ships on every turn.

## Review notes

A first-round review caught a real defect before it shipped: the initial draft published a derived ceiling of `MAX_SQL_RECORD_LIMIT × MAX_SQL_BATCH_STATEMENT_COUNT` = 5000 rows per batch as an end-to-end guarantee, which the independent `MAX_SQL_RESULT_CHARS` limit makes untrue. Removed.

No string asserted by `check-agent-api-smoke.sh` or `check-mcp-smoke.sh` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)