### PR TITLE
Reject over-limit UPDATE and DELETE instead of silently writing the first 100 rows

### DIFF
--- a/api/src/paths/agent_sql_execute.yaml
+++ b/api/src/paths/agent_sql_execute.yaml
@@ -24,10 +24,12 @@ post:
     Split larger work across separate statements or separate requests. Array
     columns (e.g. tags) take a parenthesized list such as ('tag1', 'tag2'), or ()
     for empty. UPDATE and DELETE WHERE clauses support parenthesized AND/OR
-    groups where AND binds tighter than OR; LIKE, NOT LIKE, ILIKE,
+    groups where AND binds tighter than OR; scalar comparison with =, <, <=, >,
+    and >=; IS NULL and IS NOT NULL; LIKE, NOT LIKE, ILIKE,
     LOWER(column) LIKE, LOWER(column) NOT LIKE, LOWER(column) ILIKE, and
     LOWER(column) = 'value', which is a case-insensitive whole-string LIKE
     match, so % and _ in the value are wildcards rather than literal characters;
+    exact value matches via column IN (...);
     case-insensitive exact string matches via LOWER(column) IN (...) and
     LOWER(column) NOT IN (...); array comparison against a literal tag list such as
     tags = ('english', 'slang'), which is exact set equality, meaning the row
@@ -47,9 +49,14 @@ post:
     LOWER(column) = 'value' apply only to text-valued columns, meaning the
     string, uuid, and datetime column types; on array columns such as
     tags they are rejected with a clear error.
-    LOWER(column) IN (...) and LOWER(column) NOT IN (...) compare text values
-    only: on an array column such as tags they are not rejected, but both match
-    no rows. Match tags with tags OVERLAP ('english')
+    LOWER(column) IN (...) and LOWER(column) NOT IN (...)
+    compare text values only; plain column IN (...) compares the column value
+    exactly, so pass integer and boolean literals unquoted. On an array column
+    such as tags none of these IN forms are rejected, but they all match no
+    rows. The negated form exists only as
+    LOWER(column) NOT IN (...); a plain column NOT IN (...) is rejected as an
+    unsupported predicate for every column type.
+    Match tags with tags OVERLAP ('english')
     or tags = ('english', 'slang') instead. metadata is neither filterable nor
     sortable, so it can never appear in a WHERE clause.
     Filter by tag in UPDATE and DELETE with

--- a/api/src/paths/agent_sql_query.yaml
+++ b/api/src/paths/agent_sql_query.yaml
@@ -20,11 +20,13 @@ post:
     because the whole batch is composed before any statement runs. SELECT
     supports projected column lists, aggregates, GROUP BY, NOW(), standalone
     ORDER BY RANDOM(), and cards UNNEST tags AS tag. SELECT WHERE clauses
-    support parenthesized AND/OR groups where AND binds tighter than OR; LIKE,
+    support parenthesized AND/OR groups where AND binds tighter than OR; scalar
+    comparison with =, <, <=, >, and >=; IS NULL and IS NOT NULL; LIKE,
     NOT LIKE, ILIKE, LOWER(column) LIKE, LOWER(column) NOT LIKE,
     LOWER(column) ILIKE, and LOWER(column) = 'value', which is a
     case-insensitive whole-string LIKE match, so % and _ in the value are
-    wildcards rather than literal characters; case-insensitive exact string
+    wildcards rather than literal characters; exact value matches via
+    column IN (...); case-insensitive exact string
     matches via LOWER(column) IN (...) and LOWER(column) NOT IN (...); array
     comparison against a
     literal tag list such as tags = ('english', 'slang'), which is exact set
@@ -44,8 +46,12 @@ post:
     text-valued columns, meaning the string, uuid, and datetime column types; on
     array columns such as tags they are rejected with a
     clear error. LOWER(column) IN (...) and LOWER(column) NOT IN (...) compare
-    text values only: on an array column such as tags they are not rejected, but
-    both match no rows. Match tags
+    text values only; plain column IN (...) compares the column value exactly,
+    so pass integer and boolean literals unquoted. On an array column such as
+    tags none of these IN forms are rejected, but they all match no rows. The
+    negated form exists
+    only as LOWER(column) NOT IN (...); a plain column NOT IN (...) is rejected
+    as an unsupported predicate for every column type. Match tags
     with tags OVERLAP ('english') or tags = ('english', 'slang') instead, or
     with LOWER(tag) IN (...) over cards UNNEST tags AS tag. metadata is neither
     filterable nor sortable, so it can never appear in WHERE or in ORDER BY.

--- a/apps/backend/src/aiTools/agentSql/batchMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/batchMutation.ts
@@ -62,6 +62,11 @@ function buildMutationMetadata(
   };
 }
 
+/**
+ * Resolves target rows one row past the per-statement write limit so a broader
+ * match set reaches `assertSqlMutationRecordLimit` and fails the whole batch,
+ * instead of being truncated to the first `MAX_SQL_LIMIT` rows and written.
+ */
 function selectMutationRows(
   statement: Extract<AgentSqlMutationStatement, Readonly<{ type: "update" | "delete" }>>,
   state: MutationBatchState,
@@ -81,7 +86,7 @@ function selectMutationRows(
     predicate: statement.predicate,
     groupBy: [],
     orderBy: [],
-    limit: MAX_SQL_LIMIT,
+    limit: MAX_SQL_LIMIT + 1,
     offset: 0,
     normalizedSql: statement.normalizedSql,
   }, currentRows, Number.MAX_SAFE_INTEGER).rows;

--- a/apps/backend/src/aiTools/agentSql/singleMutation.ts
+++ b/apps/backend/src/aiTools/agentSql/singleMutation.ts
@@ -9,6 +9,7 @@ import {
 } from "./operations";
 import { executeSqlSelect, type SqlRow } from "../sqlDialect";
 import {
+  MAX_SQL_LIMIT,
   assertSqlMutationRecordLimit,
   buildCardUpdateInput,
   buildCreateCardInput,
@@ -25,6 +26,11 @@ import {
 import { loadSelectRows } from "./readExecution";
 import { HttpError } from "../../shared/errors";
 
+/**
+ * Resolves target rows one row past the per-statement write limit so a broader
+ * match set reaches `assertSqlMutationRecordLimit` and is rejected, instead of
+ * being truncated to the first `MAX_SQL_LIMIT` rows and written as a success.
+ */
 function selectTargetRows(
   statement: Extract<AgentSqlMutationStatement, Readonly<{ type: "update" | "delete" }>>,
   rows: ReadonlyArray<SqlRow>,
@@ -40,7 +46,7 @@ function selectTargetRows(
     predicate: statement.predicate,
     groupBy: [],
     orderBy: [],
-    limit: 100,
+    limit: MAX_SQL_LIMIT + 1,
     offset: 0,
     normalizedSql: statement.normalizedSql,
   }, rows, Number.MAX_SAFE_INTEGER).rows;

--- a/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
+++ b/apps/backend/src/aiTools/toolContract/sqlToolContract.ts
@@ -94,7 +94,7 @@ const SQL_DIALECT_DESCRIPTION_LINES = Object.freeze([
  * explanations of their own.
  */
 const SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION =
-  "parenthesized AND/OR groups where AND binds tighter than OR; LIKE, NOT LIKE, ILIKE, LOWER(column) LIKE '...', LOWER(column) NOT LIKE '...', LOWER(column) ILIKE '...', and LOWER(column) = 'value', which is a case-insensitive whole-string LIKE match, so % and _ in the value are wildcards rather than literal characters; case-insensitive exact string matches via LOWER(column) IN (...) and LOWER(column) NOT IN (...); array comparison against a literal tag list such as tags = ('english', 'slang'), which is exact set equality, meaning the row array must equal exactly the listed values, order-independent and case-sensitive, so a card carrying any additional tag does not match; tags = () for rows with no tags; array-column intersection such as tags OVERLAP ('english', 'slang') for rows carrying at least one of the listed values, compared exactly and case-sensitively, so pass tag values as they are stored; for cards carrying all of several tags, combine intersections such as tags OVERLAP ('english') AND tags OVERLAP ('slang'); MATCH('text') to keep rows where any column of the row contains that text as a case-insensitive substring (it scans every column, including tags and JSON metadata, and there is no tokenization, so prefer one word or an exact phrase)";
+  "parenthesized AND/OR groups where AND binds tighter than OR; scalar comparison with =, <, <=, >, and >=; IS NULL and IS NOT NULL; LIKE, NOT LIKE, ILIKE, LOWER(column) LIKE '...', LOWER(column) NOT LIKE '...', LOWER(column) ILIKE '...', and LOWER(column) = 'value', which is a case-insensitive whole-string LIKE match, so % and _ in the value are wildcards rather than literal characters; exact value matches via column IN (...); case-insensitive exact string matches via LOWER(column) IN (...) and LOWER(column) NOT IN (...); array comparison against a literal tag list such as tags = ('english', 'slang'), which is exact set equality, meaning the row array must equal exactly the listed values, order-independent and case-sensitive, so a card carrying any additional tag does not match; tags = () for rows with no tags; array-column intersection such as tags OVERLAP ('english', 'slang') for rows carrying at least one of the listed values, compared exactly and case-sensitively, so pass tag values as they are stored; for cards carrying all of several tags, combine intersections such as tags OVERLAP ('english') AND tags OVERLAP ('slang'); MATCH('text') to keep rows where any column of the row contains that text as a case-insensitive substring (it scans every column, including tags and JSON metadata, and there is no tokenization, so prefer one word or an exact phrase)";
 
 /**
  * Text-only WHERE forms. The pattern family (LIKE, NOT LIKE, ILIKE and
@@ -102,19 +102,26 @@ const SQL_WHERE_SUPPORTED_FORMS_DESCRIPTION =
  * predicate, so `%` and `_` stay wildcards there too) is gated by
  * `LIKE_SUPPORTED_COLUMN_TYPES` in
  * `apps/backend/src/aiTools/sqlDialect/selectExecutor.ts` and rejects non-text
- * columns. `LOWER(column) IN (...)` is a separate `in` predicate that the same
- * gate does not cover, so the dialect accepts it on a filterable array column
- * such as `tags`; `rowMatchesInPredicate` then returns `false` for the
- * non-string column value before negation is applied, so the plain and the
- * negated form both match no rows. `metadata` reaches neither gate because the
- * dialect schema marks it `filterable: false`.
+ * columns. `column IN (...)` and `LOWER(column) IN (...)` are separate `in`
+ * predicates that the same gate does not cover, so the dialect accepts them on a
+ * filterable array column such as `tags`; `rowMatchesInPredicate` then returns
+ * `false` for the array column value before negation is applied, so the plain,
+ * the lowered, and the negated lowered form all match no rows. Only the lowered
+ * forms are text-only: `parseLoweredStringLiteralList` accepts string literals
+ * alone, while the plain form parses its literals with `parseSqlLiteral` and
+ * `valuesEqual` compares them strictly, so `column IN (1, 2)` and
+ * `column IN (true)` do compare and do match. The negation exists only as
+ * `LOWER(column) NOT IN (...)`: `predicateParser.ts` has no plain
+ * `column NOT IN (...)` branch, so that spelling reaches the
+ * unsupported-predicate error for every column type. `metadata` reaches neither
+ * gate because the dialect schema marks it `filterable: false`.
  *
  * Every outcome claim here is read out of the evaluator. Do not add an intuited
  * one: it would ship a wrong mental model into the in-app prompt, the MCP tool
  * descriptions, and the published spec.
  */
 const SQL_TEXT_COLUMN_FORMS_DESCRIPTION =
-  "LIKE, NOT LIKE, ILIKE, their LOWER(column) variants, and LOWER(column) = 'value' apply only to text-valued columns, meaning the string, uuid, and datetime column types; on array columns such as tags they are rejected with a clear error. LOWER(column) IN (...) and LOWER(column) NOT IN (...) compare text values only: on an array column such as tags they are not rejected, but both match no rows. Match tags with tags OVERLAP ('english') or tags = ('english', 'slang') instead. metadata is neither filterable nor sortable, so it can never appear in WHERE or ORDER BY.";
+  "LIKE, NOT LIKE, ILIKE, their LOWER(column) variants, and LOWER(column) = 'value' apply only to text-valued columns, meaning the string, uuid, and datetime column types; on array columns such as tags they are rejected with a clear error. LOWER(column) IN (...) and LOWER(column) NOT IN (...) compare text values only; plain column IN (...) compares the column value exactly, so pass integer and boolean literals unquoted. On an array column such as tags none of these IN forms are rejected, but they all match no rows. The negated form exists only as LOWER(column) NOT IN (...); a plain column NOT IN (...) is rejected as an unsupported predicate for every column type. Match tags with tags OVERLAP ('english') or tags = ('english', 'slang') instead. metadata is neither filterable nor sortable, so it can never appear in WHERE or ORDER BY.";
 
 /**
  * Shared supported-forms sentence reused by the split `sql_query` description


### PR DESCRIPTION
## Why

Found by the cumulative promotion review of this feature, not by per-item review — because the defect only exists as a combination of two items.

Broad mutations resolved their target rows with `limit: 100`, so `paginateRows` truncated the match set to exactly 100 and dropped `hasMore`. The following `assertSqlMutationRecordLimit` therefore saw 100 and never fired. A `DELETE` matching 250 rows deleted 100, reported `affectedCount: 100`, and returned a success envelope — while every published surface states "at most 100 rows affected per statement" and tells the agent to split larger work, which reads as a rejection contract, not silent partial application.

The truncation predates this feature. What this feature changed is reachability: the earlier commits advertise `DELETE FROM cards WHERE tags OVERLAP ('some-tag')` as an example, instruct agents to filter writes by tag with `OVERLAP`, and allow parenthesized groups in mutation `WHERE` clauses. Filtering a mutation by tag went from undocumented and awkward to the recommended path, so a latent data-loss path became the happy path.

## What changed

Runtime, two lines: resolve target rows with `MAX_SQL_LIMIT + 1` at both mutation call sites, so a 101st match reaches the existing assertion and the caller gets the documented rejection instead of a partial write. No new logic, no retries, no partial-success reporting — behavior now matches the contract that was already published.

Documentation: the `WHERE` grammar enumeration now names scalar comparisons and `IS NULL` / `IS NOT NULL`, which the parser has always supported but the new "WHERE clauses support …" list read as excluding.

## Corrected en route

The task instruction for this item claimed a plain `column IN (...)` is text-only like the `LOWER` forms. Review verified against the evaluator that this is false: `parseSqlLiteral` accepts numbers, booleans, and `null`, and the strict `valuesEqual` branch really compares them, so `reps IN (1, 2)` and `enable_fuzz IN (true)` work. Only the lowered forms are text-only, because `parseLoweredStringLiteralList` throws on any non-string literal. The documentation states the verified behavior, not the instruction.

## CI note

GitHub Actions is in a partial outage, so this branch may not get a green run. `apps/backend` lint is `tsc --noEmit`; the change adds one import and edits two numeric arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)