### PR TITLE
Carry guest media assets through the iOS workspace fork instead of cascade-deleting them

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/Model/MediaAssetTypes.swift
@@ -220,28 +220,45 @@ func managedMediaAssetReferenceState(reference: String) -> ManagedMediaAssetRefe
 }
 
 func managedMediaAssetIdsReferencedInMarkdown(text: String) -> Set<String> {
-    var activeFenceMarker: String?
     var mediaAssetIds = Set<String>()
 
-    for line in text.components(separatedBy: .newlines) {
-        let fenceMarker = managedMediaFenceMarker(line: line)
-
-        if let currentFenceMarker = activeFenceMarker {
-            if fenceMarker == currentFenceMarker {
-                activeFenceMarker = nil
-            }
-            continue
-        }
-
-        if let fenceMarker {
-            activeFenceMarker = fenceMarker
-            continue
-        }
-
-        mediaAssetIds.formUnion(managedMediaAssetIdsReferencedInLine(line: line))
+    for line in managedMediaMarkdownLines(text: text) where line.isInsideFencedBlock == false {
+        mediaAssetIds.formUnion(managedMediaAssetIdsReferencedInLine(line: String(line.content)))
     }
 
     return mediaAssetIds
+}
+
+/// Rewrites managed media references to the mapped media asset ids.
+///
+/// Workspace identity forks give every media asset a new id, so card text that
+/// was copied into the destination workspace must point at the forked ids.
+/// References whose id has no mapping are left untouched because they already
+/// pointed at a media asset that does not exist in the source registry.
+func markdownByRewritingManagedMediaAssetIds(
+    text: String,
+    mediaAssetIdsBySourceId: [String: String]
+) -> String {
+    guard mediaAssetIdsBySourceId.isEmpty == false else {
+        return text
+    }
+
+    var rewrittenText = ""
+    for line in managedMediaMarkdownLines(text: text) {
+        if line.isInsideFencedBlock {
+            rewrittenText.append(contentsOf: line.content)
+        } else {
+            rewrittenText.append(
+                managedMediaAssetLineByRewritingIds(
+                    line: String(line.content),
+                    mediaAssetIdsBySourceId: mediaAssetIdsBySourceId
+                )
+            )
+        }
+        rewrittenText.append(contentsOf: line.terminator)
+    }
+
+    return rewrittenText
 }
 
 private func parserSafeManagedImageMarkdownAltText(altText: String) -> String {
@@ -251,6 +268,105 @@ private func parserSafeManagedImageMarkdownAltText(altText: String) -> String {
         .replacingOccurrences(of: "\n", with: " ")
         .replacingOccurrences(of: "[", with: " ")
         .replacingOccurrences(of: "]", with: " ")
+}
+
+private struct ManagedMediaMarkdownLine {
+    let content: Substring
+    let terminator: Substring
+    let isInsideFencedBlock: Bool
+}
+
+/// Splits Markdown into lines that keep their original terminators and know
+/// whether they belong to a fenced block, so reference reads and reference
+/// rewrites always agree on which references are live media links.
+private func managedMediaMarkdownLines(text: String) -> [ManagedMediaMarkdownLine] {
+    var lines: [ManagedMediaMarkdownLine] = []
+    var activeFenceMarker: String?
+    var lineStart = text.startIndex
+
+    while lineStart < text.endIndex {
+        let lineEnd = text[lineStart...].firstIndex { character in
+            character.isNewline
+        } ?? text.endIndex
+        let content = text[lineStart..<lineEnd]
+        let terminator = lineEnd < text.endIndex ? text[lineEnd..<text.index(after: lineEnd)] : text[lineEnd..<lineEnd]
+        let fenceMarker = managedMediaFenceMarker(line: String(content))
+        var isInsideFencedBlock = true
+
+        if let currentFenceMarker = activeFenceMarker {
+            if fenceMarker == currentFenceMarker {
+                activeFenceMarker = nil
+            }
+        } else if let fenceMarker {
+            activeFenceMarker = fenceMarker
+        } else {
+            isInsideFencedBlock = false
+        }
+
+        lines.append(
+            ManagedMediaMarkdownLine(
+                content: content,
+                terminator: terminator,
+                isInsideFencedBlock: isInsideFencedBlock
+            )
+        )
+        lineStart = terminator.isEmpty ? lineEnd : text.index(after: lineEnd)
+    }
+
+    return lines
+}
+
+private func managedMediaAssetLineByRewritingIds(
+    line: String,
+    mediaAssetIdsBySourceId: [String: String]
+) -> String {
+    let fullRange = NSRange(line.startIndex..<line.endIndex, in: line)
+    let matches = managedMediaAssetReferenceExpression.matches(in: line, options: [], range: fullRange)
+    var rewrittenLine = ""
+    var segmentStart = line.startIndex
+
+    for match in matches {
+        guard let destinationRange = Range(match.range(at: 3), in: line) else {
+            continue
+        }
+
+        let destination = String(line[destinationRange])
+        guard let sourceMediaAssetId = managedMediaAssetId(reference: destination),
+              let destinationMediaAssetId = mediaAssetIdsBySourceId[sourceMediaAssetId],
+              let rewrittenDestination = managedMediaAssetReferenceByReplacingId(
+                  reference: destination,
+                  mediaAssetId: destinationMediaAssetId
+              ) else {
+            continue
+        }
+
+        rewrittenLine.append(contentsOf: line[segmentStart..<destinationRange.lowerBound])
+        rewrittenLine.append(rewrittenDestination)
+        segmentStart = destinationRange.upperBound
+    }
+
+    rewrittenLine.append(contentsOf: line[segmentStart...])
+    return rewrittenLine
+}
+
+private func managedMediaAssetReferenceByReplacingId(reference: String, mediaAssetId: String) -> String? {
+    guard reference.lowercased().hasPrefix(managedMediaAssetReferenceSchemePrefix) else {
+        return nil
+    }
+
+    var mediaAssetIdStart = reference.index(
+        reference.startIndex,
+        offsetBy: managedMediaAssetReferenceSchemePrefix.count
+    )
+    while mediaAssetIdStart < reference.endIndex, reference[mediaAssetIdStart] == "/" {
+        mediaAssetIdStart = reference.index(after: mediaAssetIdStart)
+    }
+
+    let queryOrFragmentStart = reference[mediaAssetIdStart...].firstIndex { character in
+        character == "?" || character == "#"
+    } ?? reference.endIndex
+
+    return String(reference[..<mediaAssetIdStart]) + mediaAssetId + String(reference[queryOrFragmentStart...])
 }
 
 private func managedMediaAssetIdsReferencedInLine(line: String) -> Set<String> {

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/Sync/LocalDatabase+WorkspaceLinking.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/Sync/LocalDatabase+WorkspaceLinking.swift
@@ -197,6 +197,7 @@ extension LocalDatabase {
             core: self.core,
             workspaceSettingsStore: self.workspaceSettingsStore,
             shellStore: shellStore,
+            mediaTransferStore: self.mediaTransferStore,
             outboxRewriter: self.makeWorkspaceOutboxRewriter()
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift
@@ -275,6 +275,53 @@ struct MediaTransferStore {
         return try self.loadTransfer(transferId: transferId)
     }
 
+    /// Moves queued byte transfers onto the forked workspace and asset ids.
+    ///
+    /// Transfer rows cascade away with the source workspace, so an interrupted
+    /// upload would otherwise be lost during a workspace identity fork. Queue
+    /// timestamps stay untouched because the fork changes only identity, not
+    /// the transfer attempt state or its retry position.
+    func rewriteTransfersForWorkspaceFork(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String,
+        mediaAssetIdsBySourceId: [String: String]
+    ) throws {
+        let transferRows = try self.core.query(
+            sql: """
+            SELECT transfer_id, media_asset_id
+            FROM media_transfer_queue
+            WHERE workspace_id = ?
+            ORDER BY transfer_id ASC
+            """,
+            values: [.text(sourceWorkspaceId)]
+        ) { statement in
+            (
+                DatabaseCore.columnText(statement: statement, index: 0),
+                DatabaseCore.columnText(statement: statement, index: 1)
+            )
+        }
+
+        for (transferId, sourceMediaAssetId) in transferRows {
+            try self.core.execute(
+                sql: """
+                UPDATE media_transfer_queue
+                SET workspace_id = ?, media_asset_id = ?
+                WHERE transfer_id = ?
+                """,
+                values: [
+                    .text(destinationWorkspaceId),
+                    .text(
+                        try mediaAssetIdsBySourceId.requireMappedId(
+                            entityType: "media_asset",
+                            sourceId: sourceMediaAssetId
+                        )
+                    ),
+                    .text(transferId)
+                ]
+            )
+        }
+    }
+
     func claimDueTransfers(
         now: String,
         staleClaimedBefore: String,

--- a/apps/ios/Flashcards/Flashcards/Database/Sync/WorkspaceOutboxRewriter.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Sync/WorkspaceOutboxRewriter.swift
@@ -87,6 +87,7 @@ struct WorkspaceOutboxRewriter {
             )
             let rewrittenPayloadJson = try self.rewrittenWorkspaceForkOutboxPayloadJson(
                 row: row,
+                destinationWorkspaceId: destinationWorkspaceId,
                 forkMappings: forkMappings
             )
             try self.core.execute(
@@ -203,8 +204,9 @@ struct WorkspaceOutboxRewriter {
         case .deck:
             return try forkMappings.deckIdsBySourceId.requireMappedId(entityType: "deck", sourceId: row.entityId)
         case .mediaAsset:
-            throw LocalStoreError.database(
-                "Workspace identity fork cannot rewrite pending media_asset operation \(row.operationId)"
+            return try forkMappings.mediaAssetIdsBySourceId.requireMappedId(
+                entityType: "media_asset",
+                sourceId: row.entityId
             )
         case .workspaceSchedulerSettings:
             return destinationWorkspaceId
@@ -218,6 +220,7 @@ struct WorkspaceOutboxRewriter {
 
     private func rewrittenWorkspaceForkOutboxPayloadJson(
         row: WorkspaceForkOutboxRow,
+        destinationWorkspaceId: String,
         forkMappings: WorkspaceForkIdMappings
     ) throws -> String {
         var payload = try self.core.decoder.decode(
@@ -231,15 +234,39 @@ struct WorkspaceOutboxRewriter {
             payload["cardId"] = .string(
                 try forkMappings.cardIdsBySourceId.requireMappedId(entityType: "card", sourceId: sourceCardId)
             )
+            // The pending card body still carries the source asset ids, so it
+            // has to follow the same rewrite the forked card row received.
+            if forkMappings.mediaAssetIdsBySourceId.isEmpty == false {
+                payload["frontText"] = .string(
+                    markdownByRewritingManagedMediaAssetIds(
+                        text: try payload.requireString(fieldName: "frontText", context: "fork.outbox.card.frontText"),
+                        mediaAssetIdsBySourceId: forkMappings.mediaAssetIdsBySourceId
+                    )
+                )
+                payload["backText"] = .string(
+                    markdownByRewritingManagedMediaAssetIds(
+                        text: try payload.requireString(fieldName: "backText", context: "fork.outbox.card.backText"),
+                        mediaAssetIdsBySourceId: forkMappings.mediaAssetIdsBySourceId
+                    )
+                )
+            }
         case .deck:
             let sourceDeckId = try payload.requireString(fieldName: "deckId", context: "fork.outbox.deck.deckId")
             payload["deckId"] = .string(
                 try forkMappings.deckIdsBySourceId.requireMappedId(entityType: "deck", sourceId: sourceDeckId)
             )
         case .mediaAsset:
-            throw LocalStoreError.database(
-                "Workspace identity fork cannot rewrite pending media_asset operation \(row.operationId)"
+            let sourceMediaAssetId = try payload.requireString(
+                fieldName: "mediaAssetId",
+                context: "fork.outbox.mediaAsset.mediaAssetId"
             )
+            payload["mediaAssetId"] = .string(
+                try forkMappings.mediaAssetIdsBySourceId.requireMappedId(
+                    entityType: "media_asset",
+                    sourceId: sourceMediaAssetId
+                )
+            )
+            payload["workspaceId"] = .string(destinationWorkspaceId)
         case .workspaceSchedulerSettings:
             break
         case .reviewEvent:

--- a/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceForker.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceForker.swift
@@ -2,6 +2,12 @@ import Foundation
 
 private let workspaceForkReviewEventSelectBatchSize: Int = 500
 
+private struct WorkspaceForkCardTextRow {
+    let cardId: String
+    let frontText: String
+    let backText: String
+}
+
 private struct WorkspaceForkReviewEventRow {
     let sourceReviewEventId: String
     let sourceCardId: String
@@ -17,6 +23,7 @@ struct WorkspaceForker {
     let core: DatabaseCore
     let workspaceSettingsStore: WorkspaceSettingsStore
     let shellStore: WorkspaceShellStore
+    let mediaTransferStore: MediaTransferStore
     let outboxRewriter: WorkspaceOutboxRewriter
 
     func preserveLocalDataForEmptyRemoteWorkspace(
@@ -42,6 +49,20 @@ struct WorkspaceForker {
             sourceWorkspaceId: sourceWorkspaceId,
             destinationWorkspaceId: destinationWorkspaceId,
             forkMappings: forkMappings
+        )
+        try self.insertForkedMediaAssets(
+            sourceWorkspaceId: sourceWorkspaceId,
+            destinationWorkspaceId: destinationWorkspaceId,
+            forkMappings: forkMappings
+        )
+        try self.rewriteForkedCardMediaAssetReferences(
+            destinationWorkspaceId: destinationWorkspaceId,
+            forkMappings: forkMappings
+        )
+        try self.mediaTransferStore.rewriteTransfersForWorkspaceFork(
+            sourceWorkspaceId: sourceWorkspaceId,
+            destinationWorkspaceId: destinationWorkspaceId,
+            mediaAssetIdsBySourceId: forkMappings.mediaAssetIdsBySourceId
         )
         try self.insertForkedDecks(
             sourceWorkspaceId: sourceWorkspaceId,
@@ -104,6 +125,12 @@ struct WorkspaceForker {
             sql: "SELECT review_event_id FROM review_events WHERE workspace_id = ? ORDER BY review_event_id ASC",
             workspaceId: sourceWorkspaceId
         )
+        // Tombstoned media assets are mapped too so forked cards, forked
+        // registry rows, and pending operations keep referencing one id space.
+        let mediaAssetIds = try self.loadEntityIds(
+            sql: "SELECT media_asset_id FROM media_assets WHERE workspace_id = ? ORDER BY media_asset_id ASC",
+            workspaceId: sourceWorkspaceId
+        )
 
         return WorkspaceForkIdMappings(
             cardIdsBySourceId: Dictionary(uniqueKeysWithValues: cardIds.map { cardId in
@@ -123,6 +150,16 @@ struct WorkspaceForker {
                         sourceWorkspaceId: sourceWorkspaceId,
                         destinationWorkspaceId: destinationWorkspaceId,
                         sourceDeckId: deckId
+                    )
+                )
+            }),
+            mediaAssetIdsBySourceId: Dictionary(uniqueKeysWithValues: mediaAssetIds.map { mediaAssetId in
+                (
+                    mediaAssetId,
+                    forkedMediaAssetIdForWorkspace(
+                        sourceWorkspaceId: sourceWorkspaceId,
+                        destinationWorkspaceId: destinationWorkspaceId,
+                        sourceMediaAssetId: mediaAssetId
                     )
                 )
             }),
@@ -259,6 +296,115 @@ struct WorkspaceForker {
                     .text(destinationWorkspaceId),
                     .text(sourceWorkspaceId),
                     .text(sourceDeckId)
+                ]
+            )
+        }
+    }
+
+    private func insertForkedMediaAssets(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws {
+        for (sourceMediaAssetId, destinationMediaAssetId) in forkMappings.mediaAssetIdsBySourceId {
+            try self.core.execute(
+                sql: """
+                INSERT INTO media_assets (
+                    media_asset_id,
+                    workspace_id,
+                    mime_type,
+                    size_bytes,
+                    sha256,
+                    source_url,
+                    created_at,
+                    client_updated_at,
+                    last_modified_by_replica_id,
+                    last_operation_id,
+                    updated_at,
+                    deleted_at
+                )
+                SELECT
+                    ?,
+                    ?,
+                    mime_type,
+                    size_bytes,
+                    sha256,
+                    source_url,
+                    created_at,
+                    client_updated_at,
+                    last_modified_by_replica_id,
+                    last_operation_id,
+                    updated_at,
+                    deleted_at
+                FROM media_assets
+                WHERE workspace_id = ? AND media_asset_id = ?
+                """,
+                values: [
+                    .text(destinationMediaAssetId),
+                    .text(destinationWorkspaceId),
+                    .text(sourceWorkspaceId),
+                    .text(sourceMediaAssetId)
+                ]
+            )
+        }
+    }
+
+    /// Repoints `fcasset:` links in forked card text at the forked asset ids.
+    ///
+    /// Media bytes stay addressed by `sha256` in the workspace-independent blob
+    /// cache, so only the registry ids inside the card bodies have to move.
+    private func rewriteForkedCardMediaAssetReferences(
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws {
+        guard forkMappings.mediaAssetIdsBySourceId.isEmpty == false else {
+            return
+        }
+
+        let cardTextRows: [WorkspaceForkCardTextRow] = try self.core.query(
+            sql: """
+            SELECT card_id, front_text, back_text
+            FROM cards
+            WHERE workspace_id = ? AND (front_text LIKE ? OR back_text LIKE ?)
+            ORDER BY card_id ASC
+            """,
+            values: [
+                .text(destinationWorkspaceId),
+                .text("%\(managedMediaAssetReferenceSchemePrefix)%"),
+                .text("%\(managedMediaAssetReferenceSchemePrefix)%")
+            ]
+        ) { statement in
+            WorkspaceForkCardTextRow(
+                cardId: DatabaseCore.columnText(statement: statement, index: 0),
+                frontText: DatabaseCore.columnText(statement: statement, index: 1),
+                backText: DatabaseCore.columnText(statement: statement, index: 2)
+            )
+        }
+
+        for cardTextRow in cardTextRows {
+            let frontText: String = markdownByRewritingManagedMediaAssetIds(
+                text: cardTextRow.frontText,
+                mediaAssetIdsBySourceId: forkMappings.mediaAssetIdsBySourceId
+            )
+            let backText: String = markdownByRewritingManagedMediaAssetIds(
+                text: cardTextRow.backText,
+                mediaAssetIdsBySourceId: forkMappings.mediaAssetIdsBySourceId
+            )
+            guard frontText != cardTextRow.frontText || backText != cardTextRow.backText else {
+                continue
+            }
+
+            try self.core.execute(
+                sql: """
+                UPDATE cards
+                SET front_text = ?, back_text = ?
+                WHERE workspace_id = ? AND card_id = ?
+                """,
+                values: [
+                    .text(frontText),
+                    .text(backText),
+                    .text(destinationWorkspaceId),
+                    .text(cardTextRow.cardId)
                 ]
             )
         }

--- a/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceIdentityForking.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceIdentityForking.swift
@@ -4,10 +4,12 @@ import Foundation
 private let cardIdentityForkNamespace: UUID = UUID(uuidString: "5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1")!
 private let deckIdentityForkNamespace: UUID = UUID(uuidString: "98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4")!
 private let reviewEventIdentityForkNamespace: UUID = UUID(uuidString: "3a214a3e-9c89-426d-a21f-11a5f5c1d6e8")!
+private let mediaAssetIdentityForkNamespace: UUID = UUID(uuidString: "c1f3a5d7-8b62-4e9a-9f14-7d3c6a2b58e0")!
 
 struct WorkspaceForkIdMappings {
     let cardIdsBySourceId: [String: String]
     let deckIdsBySourceId: [String: String]
+    let mediaAssetIdsBySourceId: [String: String]
     let reviewEventIdsBySourceId: [String: String]
 }
 
@@ -34,6 +36,19 @@ func forkedDeckIdForWorkspace(
         sourceWorkspaceId: sourceWorkspaceId,
         destinationWorkspaceId: destinationWorkspaceId,
         sourceEntityId: sourceDeckId
+    )
+}
+
+func forkedMediaAssetIdForWorkspace(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceMediaAssetId: String
+) -> String {
+    forkedWorkspaceEntityId(
+        namespace: mediaAssetIdentityForkNamespace,
+        sourceWorkspaceId: sourceWorkspaceId,
+        destinationWorkspaceId: destinationWorkspaceId,
+        sourceEntityId: sourceMediaAssetId
     )
 }
 

--- a/docs/sync-identity-model.md
+++ b/docs/sync-identity-model.md
@@ -66,7 +66,10 @@ True workspace copy/fork flows create a separate copy of the data and must deter
 - Fork card ids with UUID v5 namespace `5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1`
 - Fork deck ids with UUID v5 namespace `98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4`
 - Fork review event ids with UUID v5 namespace `3a214a3e-9c89-426d-a21f-11a5f5c1d6e8`
+- Fork media asset ids with UUID v5 namespace `c1f3a5d7-8b62-4e9a-9f14-7d3c6a2b58e0`
 
 When review events are copied into another workspace, their `cardId` references must be rewritten to the forked card ids from the same copy operation.
+
+Media assets must be forked with the cards that reference them, including tombstoned registry rows, because the registry row belongs to the workspace while the bytes stay deduplicated by `sha256`. Copied card text and pending card operations carry `fcasset:` links, so those references must be rewritten to the forked media asset ids from the same copy operation. Queued media byte transfers must move to the forked workspace and asset ids so an interrupted upload still completes after the copy.
 
 If guest upgrade encounters an impossible conflict where a guest entity id belongs to a third workspace, the backend may drop the conflicting guest entity only for clients that send request capability `supportsDroppedEntities`; otherwise it rejects completion. When a guest card does not merge, the backend also drops dependent guest review events for that card, even if the review event ids do not conflict. `droppedEntities` is durable replay, audit, and reconciliation metadata that lets capable clients understand exceptional server-side drops. Current Android and iOS merge-required recovery discards or switches away from the local guest workspace shell, then hydrates the target workspace from remote state instead of requiring per-row deletion of matching local rows. Because completion requires an empty local guest outbox, `droppedEntities` is not a pending-outbox migration path.


### PR DESCRIPTION
## Goal

A guest who attached images keeps them after signing in on iOS. The workspace fork now carries `media_assets`, so deleting the source workspace stops silently destroying the registry behind live `fcasset:` links.

## Problem

Guest upgrade forks the guest workspace into the signed-in workspace and then deletes the source. Card text was copied with its `fcasset:` links intact, but the `media_assets` registry rows were not — they stayed in the source workspace and went away with it. The links survived; the registry rows they resolve through did not.

## Changes

- Fork `media_assets` rows alongside cards, including tombstoned rows, under deterministic UUID v5 ids (`c1f3a5d7-8b62-4e9a-9f14-7d3c6a2b58e0` namespace). The registry row belongs to the workspace; the bytes stay deduplicated by `sha256`.
- Rewrite `fcasset:` references in copied card text and in pending card operations to the forked media asset ids from the same copy operation.
- Move queued media byte transfers to the forked workspace and asset ids, so an upload interrupted by the upgrade still completes after the copy.
- Document the fork namespace and the reference-rewriting rules in `docs/sync-identity-model.md`.

## Scope

iOS client only, plus the shared identity-model doc. No backend, migration, or API-contract change.

## Testing

Per repository policy, no simulator-backed run was made. Manual check: as a guest, attach an image to a card, sign in to trigger the upgrade, then confirm the image still renders in the signed-in workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)