### PR TITLE
Carry memory, thermal state, and uptime on every iOS Sentry breadcrumb

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -242,6 +242,18 @@ struct FlashcardsApp: App {
                     self.store.reloadReviewReminderAttentionState()
                     self.store.reconcileReviewReminderAttentionAfterReviewLogs(now: now)
                 }
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didReceiveMemoryWarningNotification)) { _ in
+                    logAppLifecycleBreadcrumb(
+                        action: .memoryWarningReceived,
+                        store: self.store,
+                        stage: "memory_warning",
+                        scenePhase: self.scenePhase,
+                        selectedTab: self.navigation.selectedTab,
+                        isStartupReady: self.isStartupReadyForBackgroundWork,
+                        isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                        messageSummary: nil
+                    )
+                }
                 .task(id: self.isAppNotificationTapConsumptionReady) {
                     await self.consumePendingAppNotificationTapIfNeeded()
                 }

--- a/apps/ios/Flashcards/Flashcards/Observability/FlashcardsObservability.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/FlashcardsObservability.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum FlashcardsObservability {
     static func configure(bundle: Bundle, processInfo: ProcessInfo) {
+        startAppUptimeReference(processInfo: processInfo)
         SentryObservabilityAdapter.configure(bundle: bundle, processInfo: processInfo)
     }
 

--- a/apps/ios/Flashcards/Flashcards/Observability/MemoryDiagnostics.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/MemoryDiagnostics.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// Process diagnostics sampled on every Sentry breadcrumb.
+//
+// The Sentry Cocoa SDK deliberately skips frequently changing context such as
+// free memory when it writes a watchdog termination event, but it does replay
+// the persisted breadcrumb ring buffer onto that event. Carrying these values
+// on our own breadcrumbs is therefore the only way a later
+// `WatchdogTermination` can answer whether the OS killed the app for running
+// out of memory. Everything here runs on every breadcrumb, so it must stay
+// allocation-free, must not log, and must not touch Sentry.
+
+private final class AppUptimeReferenceStorage: @unchecked Sendable {
+    private let lock: NSLock
+    private var referenceSystemUptime: TimeInterval?
+
+    init() {
+        self.lock = NSLock()
+        self.referenceSystemUptime = nil
+    }
+
+    func store(systemUptime: TimeInterval) {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        self.referenceSystemUptime = systemUptime
+    }
+
+    func read() -> TimeInterval? {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        return self.referenceSystemUptime
+    }
+}
+
+private let appUptimeReferenceStorage: AppUptimeReferenceStorage = AppUptimeReferenceStorage()
+
+/// Bytes the process currently occupies, as reported by `phys_footprint`. This
+/// is the number the Xcode memory gauge shows and the number the OS jetsam
+/// limit is applied to, which is why `resident_size` is not used here.
+func currentMemoryFootprintBytes() -> UInt64? {
+    var info: task_vm_info_data_t = task_vm_info_data_t()
+    var count: mach_msg_type_number_t = mach_msg_type_number_t(
+        MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size
+    )
+    let capacity: Int = Int(count)
+    let result: kern_return_t = withUnsafeMutablePointer(to: &info) { infoPointer in
+        infoPointer.withMemoryRebound(to: integer_t.self, capacity: capacity) { integerPointer in
+            task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), integerPointer, &count)
+        }
+    }
+    guard result == KERN_SUCCESS else {
+        return nil
+    }
+
+    return info.phys_footprint
+}
+
+/// Bytes the process may still allocate before it hits its dirty memory limit
+/// and the OS terminates it. `os_proc_available_memory` documents `0` as a real
+/// reading meaning the process is already over its memory limit — the single
+/// strongest signal that a termination was an out-of-memory kill — so `0` is
+/// reported as-is and never mapped to a missing value. (The header's other `0`
+/// case, "the calling process is not an app", cannot apply to this binary.)
+func availableMemoryBytes() -> UInt64 {
+    return UInt64(os_proc_available_memory())
+}
+
+func currentThermalStateName(processInfo: ProcessInfo) -> String {
+    switch processInfo.thermalState {
+    case .nominal:
+        return "nominal"
+    case .fair:
+        return "fair"
+    case .serious:
+        return "serious"
+    case .critical:
+        return "critical"
+    @unknown default:
+        return "unknown"
+    }
+}
+
+/// Captures the launch reference read back by `appUptimeSeconds(processInfo:)`.
+func startAppUptimeReference(processInfo: ProcessInfo) {
+    appUptimeReferenceStorage.store(systemUptime: processInfo.systemUptime)
+}
+
+/// Whole seconds since `startAppUptimeReference(processInfo:)` ran, or `nil`
+/// before it ran. Whole seconds are enough to separate a process that has been
+/// running for hours from one that just launched.
+func appUptimeSeconds(processInfo: ProcessInfo) -> Int? {
+    guard let referenceSystemUptime: TimeInterval = appUptimeReferenceStorage.read() else {
+        return nil
+    }
+
+    return Int((processInfo.systemUptime - referenceSystemUptime).rounded(.down))
+}

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -85,6 +85,7 @@ enum AppLifecycleAction: String, Sendable, Hashable {
     case progressContextRefresh = "progress_context_refresh"
     case launchCloudSyncTriggered = "launch_cloud_sync_triggered"
     case launchNotificationReconcileTriggered = "launch_notification_reconcile_triggered"
+    case memoryWarningReceived = "memory_warning_received"
 }
 
 struct AppLifecycleObservation: Sendable, Hashable {

--- a/apps/ios/Flashcards/Flashcards/Observability/Sentry/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/Sentry/SentryCaptureMapping.swift
@@ -178,8 +178,25 @@ extension SentryObservabilityAdapter {
         let breadcrumb: Breadcrumb = Breadcrumb(level: level, category: category)
         breadcrumb.type = "default"
         breadcrumb.message = message
-        breadcrumb.data = sanitizedDictionary(data) ?? [:]
+        breadcrumb.data = sanitizedDictionary(self.dataWithProcessDiagnostics(data)) ?? [:]
         SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    /// Sentry never puts memory data on a watchdog termination event, but it
+    /// does replay breadcrumbs onto it, so every breadcrumb carries the current
+    /// process state. A caller-supplied key of the same name wins.
+    private static func dataWithProcessDiagnostics(_ data: [String: Any]) -> [String: Any] {
+        let processInfo: ProcessInfo = ProcessInfo.processInfo
+        var enrichedData: [String: Any] = [
+            "app_memory_footprint_bytes": currentMemoryFootprintBytes().map { footprintBytes in String(footprintBytes) } ?? "",
+            "app_memory_available_bytes": String(availableMemoryBytes()),
+            "thermal_state": currentThermalStateName(processInfo: processInfo),
+            "app_uptime_seconds": appUptimeSeconds(processInfo: processInfo).map { uptimeSeconds in String(uptimeSeconds) } ?? ""
+        ]
+        for (key, value) in data {
+            enrichedData[key] = value
+        }
+        return enrichedData
     }
 
     private static func applyScope(_ scope: Scope, payload: ObservationPayload) {


### PR DESCRIPTION
Sentry `FLASHCARDS-IOS-3Q` is a fatal `WatchdogTermination`: the OS kills the process, so the event has no stack trace and never will. The Sentry Cocoa SDK also [omits memory data from watchdog events by design](https://docs.sentry.io/platforms/apple/guides/ios/configuration/watchdog-terminations/), skipping frequently changing context to minimise disk I/O. That is why the captured event has the static `memory_size` and `usable_memory` but no `free_memory` and no `contexts.app.app_memory`.

The SDK *does* replay the breadcrumb ring buffer onto those events — the 2026-08-06 event arrived with 100 breadcrumbs covering its last 30.3 seconds. So putting the process state on our own breadcrumbs is the only way a future watchdog event can answer whether it was an out-of-memory kill.

## What this adds

- `MemoryDiagnostics.swift`: `phys_footprint`, `os_proc_available_memory()`, thermal state, and app uptime. Allocation-free, no logging, no Sentry access.
- Four fields merged into `addSentryBreadcrumb`, the single funnel every breadcrumb category already passes through: `app_memory_footprint_bytes`, `app_memory_available_bytes`, `thermal_state`, `app_uptime_seconds`. A caller-supplied key of the same name wins.
- `memory_warning_received` breadcrumb on `UIApplication.didReceiveMemoryWarningNotification`.
- The uptime reference starts in `FlashcardsObservability.configure`, the first thing `FlashcardsApp.init` runs.

`app_memory_available_bytes` reports a literal `0` rather than an empty value: per the SDK header, `0` means the process is already over its dirty memory limit, which is the single strongest signal this instrumentation exists to capture.

## Deliberately not here

No memory-pressure `DispatchSource`, no rolling scope tags, no scene-transition duration field (Sentry already timestamps breadcrumbs, so the gap between consecutive `scene_phase_changed` entries reads directly), no change to `SentryConfiguration.swift`, and no reaction to memory pressure — this is observation only.

The operator document is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)