### PR TITLE
Carry guest media assets through the Android workspace fork using the media upload path

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
@@ -3,12 +3,16 @@ package com.flashcardsopensourceapp.data.local.cloud.sync
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.identity.forkedCardId
 import com.flashcardsopensourceapp.data.local.cloud.identity.forkedDeckId
+import com.flashcardsopensourceapp.data.local.cloud.identity.forkedMediaAssetId
 import com.flashcardsopensourceapp.data.local.cloud.identity.forkedReviewEventId
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaBlobCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaTransferQueueEntity
+import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
@@ -16,6 +20,10 @@ import com.flashcardsopensourceapp.data.local.model.cards.defaultCardType
 import com.flashcardsopensourceapp.data.local.model.cards.encodeDefaultCardMetadataJson
 import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferKind
+import com.flashcardsopensourceapp.data.local.model.media.MediaTransferStatus
+import com.flashcardsopensourceapp.data.local.model.media.buildMediaBlobCacheRelativePath
+import com.flashcardsopensourceapp.data.local.model.media.managedImageMarkdownReference
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
@@ -230,85 +238,308 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
     }
 
     @Test
-    fun forkWorkspaceIdentityBlocksWhenWorkspaceHasMediaAssets(): Unit = runBlocking {
+    fun forkWorkspaceIdentityForksRegisteredMediaAssetsAndRewritesCardReferences(): Unit = runBlocking {
         insertSyncContractWorkspaceShell(
             database = database,
             workspaceId = syncLocalStoreContractWorkspaceId
         )
-        database.mediaAssetDao().insertMediaAsset(
-            createMediaAssetEntity(
-                mediaAssetId = "media-1",
-                workspaceId = syncLocalStoreContractWorkspaceId
+        val activeMediaAsset = createMediaAssetEntity(
+            mediaAssetId = "media-1",
+            workspaceId = syncLocalStoreContractWorkspaceId,
+            sha256 = firstContractMediaSha256,
+            deletedAtMillis = null
+        )
+        val tombstonedMediaAsset = createMediaAssetEntity(
+            mediaAssetId = "media-2",
+            workspaceId = syncLocalStoreContractWorkspaceId,
+            sha256 = secondContractMediaSha256,
+            deletedAtMillis = 42L
+        )
+        database.mediaAssetDao().insertMediaAssets(
+            mediaAssets = listOf(activeMediaAsset, tombstonedMediaAsset)
+        )
+        val originalCard = createContractCardEntity(
+            cardId = "card-1",
+            workspaceId = syncLocalStoreContractWorkspaceId,
+            frontText = "Front " + managedImageMarkdownReference(
+                mediaAssetId = activeMediaAsset.mediaAssetId,
+                altText = "Diagram"
+            ),
+            backText = "Back " + managedImageMarkdownReference(
+                mediaAssetId = tombstonedMediaAsset.mediaAssetId,
+                altText = "Answer"
+            )
+        )
+        database.cardDao().insertCard(originalCard)
+        syncLocalStore.enqueueCardUpsert(
+            card = originalCard,
+            tags = emptyList(),
+            affectsReviewSchedule = false
+        )
+
+        syncLocalStore.forkWorkspaceIdentity(
+            currentLocalWorkspaceId = syncLocalStoreContractWorkspaceId,
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspace = CloudWorkspaceSummary(
+                workspaceId = "workspace-2",
+                name = "Forked",
+                createdAtMillis = 2_000L,
+                isSelected = true
             )
         )
 
-        try {
-            syncLocalStore.forkWorkspaceIdentity(
-                currentLocalWorkspaceId = syncLocalStoreContractWorkspaceId,
-                sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
-                destinationWorkspace = CloudWorkspaceSummary(
-                    workspaceId = "workspace-2",
-                    name = "Forked",
-                    createdAtMillis = 2_000L,
-                    isSelected = true
-                )
-            )
-            throw AssertionError("Expected registered media asset rows to block workspace identity fork.")
-        } catch (error: IllegalArgumentException) {
-            assertEquals(
-                "Cannot fork workspace identity from workspace '$syncLocalStoreContractWorkspaceId' to " +
-                    "'workspace-2' because the source workspace has 1 registered media asset row(s). " +
-                    "Android can only reassign pending media uploads.",
-                error.message
-            )
-        }
+        val expectedForkedActiveMediaAssetId = forkedMediaAssetId(
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceMediaAssetId = activeMediaAsset.mediaAssetId
+        )
+        val expectedForkedTombstonedMediaAssetId = forkedMediaAssetId(
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceMediaAssetId = tombstonedMediaAsset.mediaAssetId
+        )
+        val expectedForkedCardId = forkedCardId(
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceCardId = originalCard.cardId
+        )
+        val forkedActiveMediaAsset = requireNotNull(
+            database.mediaAssetDao().loadMediaAsset(mediaAssetId = expectedForkedActiveMediaAssetId)
+        )
+        val forkedTombstonedMediaAsset = requireNotNull(
+            database.mediaAssetDao().loadMediaAsset(mediaAssetId = expectedForkedTombstonedMediaAssetId)
+        )
+        val forkedCard = requireNotNull(database.cardDao().loadCard(expectedForkedCardId))
+        val forkedCardPayload = (
+            syncLocalStore.loadOutboxEntries(workspaceId = "workspace-2")
+                .single { entry -> entry.operation.entityType == SyncEntityType.CARD }
+                .operation.payload as SyncOperationPayload.Card
+            ).payload
 
-        assertEquals(syncLocalStoreContractWorkspaceId, database.workspaceDao().loadAnyWorkspace()?.workspaceId)
-        assertNotNull(database.mediaAssetDao().loadMediaAsset(mediaAssetId = "media-1"))
-        assertNull(database.workspaceDao().loadWorkspaceById(workspaceId = "workspace-2"))
+        assertNull(database.mediaAssetDao().loadMediaAsset(mediaAssetId = activeMediaAsset.mediaAssetId))
+        assertNull(database.mediaAssetDao().loadMediaAsset(mediaAssetId = tombstonedMediaAsset.mediaAssetId))
+        assertEquals("workspace-2", forkedActiveMediaAsset.workspaceId)
+        assertEquals(activeMediaAsset.sha256, forkedActiveMediaAsset.sha256)
+        assertEquals(activeMediaAsset.mimeType, forkedActiveMediaAsset.mimeType)
+        assertEquals(activeMediaAsset.sizeBytes, forkedActiveMediaAsset.sizeBytes)
+        assertEquals(activeMediaAsset.lastModifiedByReplicaId, forkedActiveMediaAsset.lastModifiedByReplicaId)
+        assertEquals(activeMediaAsset.clientUpdatedAtMillis, forkedActiveMediaAsset.clientUpdatedAtMillis)
+        assertNull(forkedActiveMediaAsset.deletedAtMillis)
+        assertEquals("workspace-2", forkedTombstonedMediaAsset.workspaceId)
+        assertEquals(tombstonedMediaAsset.sha256, forkedTombstonedMediaAsset.sha256)
+        assertEquals(tombstonedMediaAsset.deletedAtMillis, forkedTombstonedMediaAsset.deletedAtMillis)
+        assertEquals(
+            "Front " + managedImageMarkdownReference(
+                mediaAssetId = expectedForkedActiveMediaAssetId,
+                altText = "Diagram"
+            ),
+            forkedCard.frontText
+        )
+        assertEquals(
+            "Back " + managedImageMarkdownReference(
+                mediaAssetId = expectedForkedTombstonedMediaAssetId,
+                altText = "Answer"
+            ),
+            forkedCard.backText
+        )
+        assertEquals(expectedForkedCardId, forkedCardPayload.cardId)
+        assertEquals(forkedCard.frontText, forkedCardPayload.frontText)
+        assertEquals(forkedCard.backText, forkedCardPayload.backText)
     }
 
     @Test
-    fun forkWorkspaceIdentityBlocksWhenDestinationWorkspaceHasMediaAssets(): Unit = runBlocking {
+    fun bootstrapAfterForkQueuesMediaUploadsInsteadOfReplicatingMediaAssets(): Unit = runBlocking {
         insertSyncContractWorkspaceShell(
             database = database,
             workspaceId = syncLocalStoreContractWorkspaceId
         )
-        insertSyncContractWorkspaceShell(
-            database = database,
-            workspaceId = "workspace-2"
+        val cachedMediaAsset = createMediaAssetEntity(
+            mediaAssetId = "media-1",
+            workspaceId = syncLocalStoreContractWorkspaceId,
+            sha256 = firstContractMediaSha256,
+            deletedAtMillis = null
         )
-        database.mediaAssetDao().insertMediaAsset(
-            createMediaAssetEntity(
-                mediaAssetId = "media-destination-1",
-                workspaceId = "workspace-2"
+        val uncachedMediaAsset = createMediaAssetEntity(
+            mediaAssetId = "media-2",
+            workspaceId = syncLocalStoreContractWorkspaceId,
+            sha256 = secondContractMediaSha256,
+            deletedAtMillis = null
+        )
+        database.mediaAssetDao().insertMediaAssets(
+            mediaAssets = listOf(cachedMediaAsset, uncachedMediaAsset)
+        )
+        database.mediaTransferDao().upsertMediaBlobCache(
+            mediaBlobCache = MediaBlobCacheEntity(
+                sha256 = cachedMediaAsset.sha256,
+                mimeType = cachedMediaAsset.mimeType,
+                sizeBytes = cachedMediaAsset.sizeBytes,
+                localRelativePath = buildMediaBlobCacheRelativePath(sha256 = cachedMediaAsset.sha256),
+                createdAtMillis = 1L,
+                lastAccessedAtMillis = 1L,
+                sourceMediaAssetId = cachedMediaAsset.mediaAssetId
             )
         )
-
-        try {
-            syncLocalStore.forkWorkspaceIdentity(
-                currentLocalWorkspaceId = syncLocalStoreContractWorkspaceId,
-                sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
-                destinationWorkspace = CloudWorkspaceSummary(
-                    workspaceId = "workspace-2",
-                    name = "Forked",
-                    createdAtMillis = 2_000L,
-                    isSelected = true
+        // The guest already uploaded this image under the source workspace, so the
+        // fork carries a succeeded upload onto the forked asset id. That upload says
+        // nothing about the destination workspace and must not suppress the new one.
+        database.mediaTransferDao().upsertMediaTransfer(
+            mediaTransfer = MediaTransferQueueEntity(
+                transferId = "transfer-succeeded-1",
+                workspaceId = syncLocalStoreContractWorkspaceId,
+                mediaAssetId = cachedMediaAsset.mediaAssetId,
+                kind = MediaTransferKind.UPLOAD.wireKey,
+                status = MediaTransferStatus.SUCCEEDED.wireKey,
+                sha256 = cachedMediaAsset.sha256,
+                mimeType = cachedMediaAsset.mimeType,
+                sizeBytes = cachedMediaAsset.sizeBytes,
+                localRelativePath = buildMediaBlobCacheRelativePath(sha256 = cachedMediaAsset.sha256),
+                attemptCount = 1,
+                nextAttemptAtMillis = 5L,
+                lastError = null,
+                createdAtMillis = 1L,
+                updatedAtMillis = 2L
+            )
+        )
+        database.cardDao().insertCard(
+            createContractCardEntity(
+                cardId = "card-1",
+                workspaceId = syncLocalStoreContractWorkspaceId,
+                frontText = "Front " + managedImageMarkdownReference(
+                    mediaAssetId = cachedMediaAsset.mediaAssetId,
+                    altText = "Diagram"
+                ),
+                backText = "Back " + managedImageMarkdownReference(
+                    mediaAssetId = uncachedMediaAsset.mediaAssetId,
+                    altText = "Answer"
                 )
             )
-            throw AssertionError("Expected destination media asset registry rows to block workspace identity fork.")
-        } catch (error: IllegalArgumentException) {
-            assertEquals(
-                "Cannot fork workspace identity from workspace '$syncLocalStoreContractWorkspaceId' to " +
-                    "'workspace-2' because the destination workspace has 1 media asset registry row(s). " +
-                    "Android cannot delete or reassign managed media assets in this sync/storage split.",
-                error.message
-            )
-        }
+        )
 
-        assertNotNull(database.workspaceDao().loadWorkspaceById(workspaceId = syncLocalStoreContractWorkspaceId))
-        assertNotNull(database.workspaceDao().loadWorkspaceById(workspaceId = "workspace-2"))
-        assertNotNull(database.mediaAssetDao().loadMediaAsset(mediaAssetId = "media-destination-1"))
+        syncLocalStore.forkWorkspaceIdentity(
+            currentLocalWorkspaceId = syncLocalStoreContractWorkspaceId,
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspace = CloudWorkspaceSummary(
+                workspaceId = "workspace-2",
+                name = "Forked",
+                createdAtMillis = 2_000L,
+                isSelected = true
+            )
+        )
+        syncLocalStore.prepareReferencedMediaAssetUploads(workspaceId = "workspace-2")
+
+        val expectedForkedCachedMediaAssetId = forkedMediaAssetId(
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceMediaAssetId = cachedMediaAsset.mediaAssetId
+        )
+        val bootstrapEntries = syncLocalStore.buildBootstrapEntries(workspaceId = "workspace-2")
+        val bootstrapEntityTypes: List<String> = (0 until bootstrapEntries.length()).map { index ->
+            bootstrapEntries.getJSONObject(index).getString("entityType")
+        }
+        val workspaceMediaTransfers = database.mediaTransferDao()
+            .loadMediaTransfersForWorkspace(workspaceId = "workspace-2")
+        val forkedUploadTransfer = workspaceMediaTransfers.single { mediaTransfer ->
+            mediaTransfer.status == MediaTransferStatus.QUEUED.wireKey
+        }
+        val carriedSucceededTransfer = requireNotNull(
+            database.mediaTransferDao().loadMediaTransfer(transferId = "transfer-succeeded-1")
+        )
+
+        assertEquals(false, bootstrapEntityTypes.contains("media_asset"))
+        assertEquals(listOf("card", "workspace_scheduler_settings"), bootstrapEntityTypes)
+        assertEquals(2, workspaceMediaTransfers.size)
+        assertEquals(expectedForkedCachedMediaAssetId, forkedUploadTransfer.mediaAssetId)
+        assertEquals("workspace-2", forkedUploadTransfer.workspaceId)
+        assertEquals(MediaTransferKind.UPLOAD.wireKey, forkedUploadTransfer.kind)
+        assertEquals(MediaTransferStatus.QUEUED.wireKey, forkedUploadTransfer.status)
+        assertEquals(cachedMediaAsset.sha256, forkedUploadTransfer.sha256)
+        assertEquals(
+            buildMediaBlobCacheRelativePath(sha256 = cachedMediaAsset.sha256),
+            forkedUploadTransfer.localRelativePath
+        )
+        assertEquals("workspace-2", carriedSucceededTransfer.workspaceId)
+        assertEquals(expectedForkedCachedMediaAssetId, carriedSucceededTransfer.mediaAssetId)
+        assertEquals(MediaTransferStatus.SUCCEEDED.wireKey, carriedSucceededTransfer.status)
+    }
+
+    @Test
+    fun forkWorkspaceIdentityCarriesPendingMediaUploadOntoForkedAsset(): Unit = runBlocking {
+        insertSyncContractWorkspaceShell(
+            database = database,
+            workspaceId = syncLocalStoreContractWorkspaceId
+        )
+        val pendingMediaAsset = createMediaAssetEntity(
+            mediaAssetId = "media-1",
+            workspaceId = syncLocalStoreContractWorkspaceId,
+            sha256 = firstContractMediaSha256,
+            deletedAtMillis = null
+        )
+        database.mediaAssetDao().insertMediaAsset(pendingMediaAsset)
+        database.mediaTransferDao().upsertMediaTransfer(
+            mediaTransfer = MediaTransferQueueEntity(
+                transferId = "transfer-1",
+                workspaceId = syncLocalStoreContractWorkspaceId,
+                mediaAssetId = pendingMediaAsset.mediaAssetId,
+                kind = MediaTransferKind.UPLOAD.wireKey,
+                status = MediaTransferStatus.QUEUED.wireKey,
+                sha256 = pendingMediaAsset.sha256,
+                mimeType = pendingMediaAsset.mimeType,
+                sizeBytes = pendingMediaAsset.sizeBytes,
+                localRelativePath = buildMediaBlobCacheRelativePath(sha256 = pendingMediaAsset.sha256),
+                attemptCount = 1,
+                nextAttemptAtMillis = 5L,
+                lastError = null,
+                createdAtMillis = 1L,
+                updatedAtMillis = 2L
+            )
+        )
+        database.outboxDao().insertOutboxEntry(
+            entry = createMediaAssetOutboxEntry(mediaAsset = pendingMediaAsset)
+        )
+
+        syncLocalStore.forkWorkspaceIdentity(
+            currentLocalWorkspaceId = syncLocalStoreContractWorkspaceId,
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspace = CloudWorkspaceSummary(
+                workspaceId = "workspace-2",
+                name = "Forked",
+                createdAtMillis = 2_000L,
+                isSelected = true
+            )
+        )
+
+        val expectedForkedMediaAssetId = forkedMediaAssetId(
+            sourceWorkspaceId = syncLocalStoreContractWorkspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceMediaAssetId = pendingMediaAsset.mediaAssetId
+        )
+        val forkedMediaAsset = requireNotNull(
+            database.mediaAssetDao().loadMediaAsset(mediaAssetId = expectedForkedMediaAssetId)
+        )
+        val forkedTransfer = requireNotNull(
+            database.mediaTransferDao().loadMediaTransfer(transferId = "transfer-1")
+        )
+        val forkedMediaAssetEntry = syncLocalStore.loadOutboxEntries(workspaceId = "workspace-2")
+            .single { entry -> entry.operation.entityType == SyncEntityType.MEDIA_ASSET }
+        val forkedMediaAssetPayload =
+            (forkedMediaAssetEntry.operation.payload as SyncOperationPayload.MediaAsset).payload
+
+        assertEquals("workspace-2", forkedMediaAsset.workspaceId)
+        assertEquals(pendingMediaAsset.sha256, forkedMediaAsset.sha256)
+        assertEquals("workspace-2", forkedTransfer.workspaceId)
+        assertEquals(expectedForkedMediaAssetId, forkedTransfer.mediaAssetId)
+        assertEquals(pendingMediaAsset.sha256, forkedTransfer.sha256)
+        assertEquals(
+            buildMediaBlobCacheRelativePath(sha256 = pendingMediaAsset.sha256),
+            forkedTransfer.localRelativePath
+        )
+        assertEquals(MediaTransferKind.UPLOAD.wireKey, forkedTransfer.kind)
+        assertEquals(MediaTransferStatus.QUEUED.wireKey, forkedTransfer.status)
+        assertEquals(expectedForkedMediaAssetId, forkedMediaAssetEntry.operation.entityId)
+        assertEquals("workspace-2", forkedMediaAssetEntry.workspaceId)
+        assertEquals(expectedForkedMediaAssetId, forkedMediaAssetPayload.mediaAssetId)
+        assertEquals("workspace-2", forkedMediaAssetPayload.workspaceId)
+        assertEquals(pendingMediaAsset.sha256, forkedMediaAssetPayload.sha256)
     }
 
     @Test
@@ -317,10 +548,19 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             database = database,
             workspaceId = syncLocalStoreContractWorkspaceId
         )
+        val originalMediaAsset = createMediaAssetEntity(
+            mediaAssetId = "media-1",
+            workspaceId = syncLocalStoreContractWorkspaceId,
+            sha256 = firstContractMediaSha256,
+            deletedAtMillis = null
+        )
         val originalCard = CardEntity(
             cardId = "card-1",
             workspaceId = syncLocalStoreContractWorkspaceId,
-            frontText = "Front",
+            frontText = "Front " + managedImageMarkdownReference(
+                mediaAssetId = originalMediaAsset.mediaAssetId,
+                altText = "Diagram"
+            ),
             backText = "Back",
             cardType = defaultCardType,
             metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
@@ -348,6 +588,7 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             reviewedAtServerIso = "2026-03-27T19:05:00Z",
             reviewedTimeZone = null
         )
+        database.mediaAssetDao().insertMediaAsset(originalMediaAsset)
         database.cardDao().insertCard(originalCard)
         database.reviewLogDao().insertReviewLog(originalReviewLog)
         database.syncStateDao().insertSyncState(
@@ -387,12 +628,30 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             destinationWorkspaceId = syncLocalStoreContractWorkspaceId,
             sourceReviewEventId = originalReviewLog.reviewLogId
         )
+        val expectedForkedMediaAssetId = forkedMediaAssetId(
+            sourceWorkspaceId = "workspace-conflict-source",
+            destinationWorkspaceId = syncLocalStoreContractWorkspaceId,
+            sourceMediaAssetId = originalMediaAsset.mediaAssetId
+        )
         val forkedReviewLog = database.reviewLogDao().loadReviewLogs().single()
         val forkedOutboxEntries = syncLocalStore.loadOutboxEntries(workspaceId = syncLocalStoreContractWorkspaceId)
+        val forkedMediaAsset = requireNotNull(
+            database.mediaAssetDao().loadMediaAsset(mediaAssetId = expectedForkedMediaAssetId)
+        )
+        val forkedCard = requireNotNull(database.cardDao().loadCard(expectedForkedCardId))
 
         assertEquals(syncLocalStoreContractWorkspaceId, database.workspaceDao().loadAnyWorkspace()?.workspaceId)
         assertNull(database.cardDao().loadCard(originalCard.cardId))
-        assertNotNull(database.cardDao().loadCard(expectedForkedCardId))
+        assertNull(database.mediaAssetDao().loadMediaAsset(mediaAssetId = originalMediaAsset.mediaAssetId))
+        assertEquals(syncLocalStoreContractWorkspaceId, forkedMediaAsset.workspaceId)
+        assertEquals(originalMediaAsset.sha256, forkedMediaAsset.sha256)
+        assertEquals(
+            "Front " + managedImageMarkdownReference(
+                mediaAssetId = expectedForkedMediaAssetId,
+                altText = "Diagram"
+            ),
+            forkedCard.frontText
+        )
         assertEquals(expectedForkedReviewEventId, forkedReviewLog.reviewLogId)
         assertEquals(expectedForkedCardId, forkedReviewLog.cardId)
         assertEquals(
@@ -492,11 +751,45 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
     }
 }
 
+private const val firstContractMediaSha256: String =
+    "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+private const val secondContractMediaSha256: String =
+    "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+
+private fun createContractCardEntity(
+    cardId: String,
+    workspaceId: String,
+    frontText: String,
+    backText: String
+): CardEntity {
+    return CardEntity(
+        cardId = cardId,
+        workspaceId = workspaceId,
+        frontText = frontText,
+        backText = backText,
+        cardType = defaultCardType,
+        metadataJson = encodeDefaultCardMetadataJson(createdAt = formatIsoTimestamp(1L)),
+        dueAtMillis = null,
+        createdAtMillis = 1L,
+        updatedAtMillis = 2L,
+        reps = 0,
+        lapses = 0,
+        fsrsCardState = FsrsCardState.NEW,
+        fsrsStepIndex = null,
+        fsrsStability = null,
+        fsrsDifficulty = null,
+        fsrsLastReviewedAtMillis = null,
+        fsrsScheduledDays = null,
+        deletedAtMillis = null
+    )
+}
+
 private fun createMediaAssetEntity(
     mediaAssetId: String,
-    workspaceId: String
+    workspaceId: String,
+    sha256: String,
+    deletedAtMillis: Long?
 ): MediaAssetEntity {
-    val sha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
     return MediaAssetEntity(
         mediaAssetId = mediaAssetId,
         workspaceId = workspaceId,
@@ -509,6 +802,32 @@ private fun createMediaAssetEntity(
         lastModifiedByReplicaId = "replica-1",
         lastOperationId = "operation-1",
         updatedAtMillis = 3L,
-        deletedAtMillis = null
+        deletedAtMillis = deletedAtMillis
+    )
+}
+
+private fun createMediaAssetOutboxEntry(mediaAsset: MediaAssetEntity): OutboxEntryEntity {
+    return OutboxEntryEntity(
+        outboxEntryId = "outbox-media-asset-1",
+        workspaceId = mediaAsset.workspaceId,
+        installationId = "installation-1",
+        entityType = "media_asset",
+        entityId = mediaAsset.mediaAssetId,
+        operationType = "upsert",
+        payloadJson = JSONObject()
+            .put("mediaAssetId", mediaAsset.mediaAssetId)
+            .put("workspaceId", mediaAsset.workspaceId)
+            .put("mimeType", mediaAsset.mimeType)
+            .put("sizeBytes", mediaAsset.sizeBytes)
+            .put("sha256", mediaAsset.sha256)
+            .put("sourceUrl", JSONObject.NULL)
+            .put("createdAt", formatIsoTimestamp(mediaAsset.createdAtMillis))
+            .put("deletedAt", JSONObject.NULL)
+            .toString(),
+        clientUpdatedAtIso = formatIsoTimestamp(mediaAsset.clientUpdatedAtMillis),
+        createdAtMillis = mediaAsset.createdAtMillis,
+        affectsReviewSchedule = false,
+        attemptCount = 0,
+        lastError = null
     )
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityFork.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityFork.kt
@@ -2,10 +2,12 @@ package com.flashcardsopensourceapp.data.local.cloud.identity
 
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.cloud.wire.parseSyncEntityType
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
+import com.flashcardsopensourceapp.data.local.model.media.rewriteManagedMediaAssetReferences
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import org.json.JSONObject
 import java.nio.ByteBuffer
@@ -16,13 +18,15 @@ import java.util.UUID
 private val cardIdentityForkNamespace: UUID = UUID.fromString("5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1")
 private val deckIdentityForkNamespace: UUID = UUID.fromString("98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4")
 private val reviewEventIdentityForkNamespace: UUID = UUID.fromString("3a214a3e-9c89-426d-a21f-11a5f5c1d6e8")
+private val mediaAssetIdentityForkNamespace: UUID = UUID.fromString("b6f4d0a1-9c3e-4d58-8f21-7a6c5e0b3d94")
 
 internal const val syncWorkspaceForkRequiredErrorCode: String = "SYNC_WORKSPACE_FORK_REQUIRED"
 
 internal data class WorkspaceForkIdMappings(
     val cardIdsBySourceId: Map<String, String>,
     val deckIdsBySourceId: Map<String, String>,
-    val reviewEventIdsBySourceId: Map<String, String>
+    val reviewEventIdsBySourceId: Map<String, String>,
+    val mediaAssetIdsBySourceId: Map<String, String>
 )
 
 internal fun forkedCardId(
@@ -64,6 +68,25 @@ internal fun forkedReviewEventId(
     )
 }
 
+/**
+ * A forked media asset cannot keep its id because the backend registry keys
+ * `content.media_assets` by a bare media asset id, so the same id cannot exist
+ * in two workspaces. The blob itself is shared, because storage is keyed by
+ * `sha256`, so forking is a registry-row copy under a derived id.
+ */
+internal fun forkedMediaAssetId(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceMediaAssetId: String
+): String {
+    return forkedWorkspaceEntityId(
+        namespace = mediaAssetIdentityForkNamespace,
+        sourceWorkspaceId = sourceWorkspaceId,
+        destinationWorkspaceId = destinationWorkspaceId,
+        sourceEntityId = sourceMediaAssetId
+    )
+}
+
 private fun forkedWorkspaceEntityId(
     namespace: UUID,
     sourceWorkspaceId: String,
@@ -102,7 +125,8 @@ internal fun buildWorkspaceForkIdMappings(
     destinationWorkspaceId: String,
     cards: List<CardEntity>,
     decks: List<DeckEntity>,
-    reviewLogs: List<ReviewLogEntity>
+    reviewLogs: List<ReviewLogEntity>,
+    mediaAssets: List<MediaAssetEntity>
 ): WorkspaceForkIdMappings {
     return WorkspaceForkIdMappings(
         cardIdsBySourceId = cards.associate { card ->
@@ -124,6 +148,13 @@ internal fun buildWorkspaceForkIdMappings(
                 sourceWorkspaceId = sourceWorkspaceId,
                 destinationWorkspaceId = destinationWorkspaceId,
                 sourceReviewEventId = reviewLog.reviewLogId
+            )
+        },
+        mediaAssetIdsBySourceId = mediaAssets.associate { mediaAsset ->
+            mediaAsset.mediaAssetId to forkedMediaAssetId(
+                sourceWorkspaceId = sourceWorkspaceId,
+                destinationWorkspaceId = destinationWorkspaceId,
+                sourceMediaAssetId = mediaAsset.mediaAssetId
             )
         }
     )
@@ -154,8 +185,9 @@ internal fun rewriteOutboxEntryForFork(
             sourceId = entry.entityId
         )
 
-        SyncEntityType.MEDIA_ASSET -> throw IllegalArgumentException(
-            "Cannot rewrite media_asset outbox entry '${entry.outboxEntryId}' during workspace identity fork."
+        SyncEntityType.MEDIA_ASSET -> forkMappings.mediaAssetIdsBySourceId.requireMappedId(
+            entityType = "media_asset",
+            sourceId = entry.entityId
         )
     }
     when (entityType) {
@@ -165,6 +197,20 @@ internal fun rewriteOutboxEntryForFork(
                 forkMappings.cardIdsBySourceId.requireMappedId(
                     entityType = "card",
                     sourceId = payloadJson.requireCloudString("cardId", "fork.outbox.card.cardId")
+                )
+            )
+            payloadJson.put(
+                "frontText",
+                rewriteManagedMediaAssetReferences(
+                    markdown = payloadJson.requireCloudString("frontText", "fork.outbox.card.frontText"),
+                    mediaAssetIdsBySourceId = forkMappings.mediaAssetIdsBySourceId
+                )
+            )
+            payloadJson.put(
+                "backText",
+                rewriteManagedMediaAssetReferences(
+                    markdown = payloadJson.requireCloudString("backText", "fork.outbox.card.backText"),
+                    mediaAssetIdsBySourceId = forkMappings.mediaAssetIdsBySourceId
                 )
             )
         }
@@ -201,9 +247,16 @@ internal fun rewriteOutboxEntryForFork(
             )
         }
 
-        SyncEntityType.MEDIA_ASSET -> throw IllegalArgumentException(
-            "Cannot rewrite media_asset outbox entry '${entry.outboxEntryId}' during workspace identity fork."
-        )
+        SyncEntityType.MEDIA_ASSET -> {
+            payloadJson.put(
+                "mediaAssetId",
+                forkMappings.mediaAssetIdsBySourceId.requireMappedId(
+                    entityType = "media_asset",
+                    sourceId = payloadJson.requireCloudString("mediaAssetId", "fork.outbox.mediaAsset.mediaAssetId")
+                )
+            )
+            payloadJson.put("workspaceId", destinationWorkspaceId)
+        }
     }
     return entry.copy(
         workspaceId = destinationWorkspaceId,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
@@ -6,6 +6,8 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaTransferQueueEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
@@ -17,12 +19,10 @@ import com.flashcardsopensourceapp.data.local.cloud.sync.ReviewHistoryChangedEve
 import com.flashcardsopensourceapp.data.local.cloud.sync.emptySyncStateEntity
 import com.flashcardsopensourceapp.data.local.cloud.wire.toRemoteValue
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
-import com.flashcardsopensourceapp.data.local.model.media.MediaTransferKind
-import com.flashcardsopensourceapp.data.local.model.media.MediaTransferStatus
+import com.flashcardsopensourceapp.data.local.model.media.rewriteManagedMediaAssetReferences
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.scheduling.encodeSchedulerStepListJson
 import com.flashcardsopensourceapp.data.local.model.scheduling.makeDefaultWorkspaceSchedulerSettings
-import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.buildClientWorkspaceReplicaId
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.loadCurrentWorkspaceOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
@@ -36,6 +36,8 @@ private data class WorkspaceForkSnapshot(
     val tags: List<TagEntity>,
     val cardTags: List<CardTagEntity>,
     val reviewLogs: List<ReviewLogEntity>,
+    val mediaAssets: List<MediaAssetEntity>,
+    val mediaTransfers: List<MediaTransferQueueEntity>,
     val outboxEntries: List<OutboxEntryEntity>,
     val schedulerSettings: WorkspaceSchedulerSettingsEntity?
 )
@@ -293,35 +295,16 @@ internal class WorkspaceIdentityLocalStore(
         ) {
             "Cannot fork workspace identity because current local workspace '$currentLocalWorkspaceId' does not exist."
         }
-        val registeredMediaAssetCount = database.mediaAssetDao().countMediaAssetsExcludingPendingUploads(
-            workspaceId = currentLocalWorkspaceId,
-            uploadKind = MediaTransferKind.UPLOAD.wireKey,
-            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey
-        )
-        require(registeredMediaAssetCount == 0) {
-            "Cannot fork workspace identity from workspace '$currentLocalWorkspaceId' to " +
-                "'${destinationWorkspace.workspaceId}' because the source workspace has $registeredMediaAssetCount " +
-                "registered media asset row(s). Android can only reassign pending media uploads."
-        }
         val snapshot = loadWorkspaceForkSnapshot(workspaceId = currentLocalWorkspaceId)
         val forkMappings = buildWorkspaceForkIdMappings(
             sourceWorkspaceId = sourceWorkspaceId,
             destinationWorkspaceId = destinationWorkspace.workspaceId,
             cards = snapshot.cards,
             decks = snapshot.decks,
-            reviewLogs = snapshot.reviewLogs
+            reviewLogs = snapshot.reviewLogs,
+            mediaAssets = snapshot.mediaAssets
         )
         val destinationMatchesCurrentWorkspace = currentLocalWorkspaceId == destinationWorkspace.workspaceId
-        if (destinationMatchesCurrentWorkspace.not()) {
-            val destinationMediaAssetCount = database.mediaAssetDao()
-                .countMediaAssets(workspaceId = destinationWorkspace.workspaceId)
-            require(destinationMediaAssetCount == 0) {
-                "Cannot fork workspace identity from workspace '$currentLocalWorkspaceId' to " +
-                    "'${destinationWorkspace.workspaceId}' because the destination workspace has " +
-                    "$destinationMediaAssetCount media asset registry row(s). Android cannot delete or reassign " +
-                    "managed media assets in this sync/storage split."
-            }
-        }
 
         if (destinationMatchesCurrentWorkspace) {
             database.workspaceDao().updateWorkspace(
@@ -354,10 +337,6 @@ internal class WorkspaceIdentityLocalStore(
                     newWorkspaceId = destinationWorkspace.workspaceId
                 )
             }
-            reassignPendingMediaUploadsForWorkspaceFork(
-                oldWorkspaceId = currentLocalWorkspaceId,
-                newWorkspaceId = destinationWorkspace.workspaceId
-            )
             localProgressCacheStore.reassignWorkspaceInTransaction(
                 oldWorkspaceId = currentLocalWorkspaceId,
                 newWorkspaceId = destinationWorkspace.workspaceId
@@ -375,7 +354,15 @@ internal class WorkspaceIdentityLocalStore(
                 }
                 card.copy(
                     cardId = rewrittenCardId,
-                    workspaceId = destinationWorkspace.workspaceId
+                    workspaceId = destinationWorkspace.workspaceId,
+                    frontText = rewriteManagedMediaAssetReferences(
+                        markdown = card.frontText,
+                        mediaAssetIdsBySourceId = forkMappings.mediaAssetIdsBySourceId
+                    ),
+                    backText = rewriteManagedMediaAssetReferences(
+                        markdown = card.backText,
+                        mediaAssetIdsBySourceId = forkMappings.mediaAssetIdsBySourceId
+                    )
                 )
             }
             if (cardsToInsert.isNotEmpty()) {
@@ -437,6 +424,49 @@ internal class WorkspaceIdentityLocalStore(
                 database.reviewLogDao().insertReviewLogs(reviewLogs = reviewLogsToInsert)
             }
         }
+        if (snapshot.mediaAssets.isNotEmpty()) {
+            val mediaAssetsToInsert = snapshot.mediaAssets.mapNotNull { mediaAsset ->
+                val rewrittenMediaAssetId = forkMappings.mediaAssetIdsBySourceId.requireMappedId(
+                    entityType = "media_asset",
+                    sourceId = mediaAsset.mediaAssetId
+                )
+                if (destinationMatchesCurrentWorkspace && rewrittenMediaAssetId == mediaAsset.mediaAssetId) {
+                    return@mapNotNull null
+                }
+                mediaAsset.copy(
+                    mediaAssetId = rewrittenMediaAssetId,
+                    workspaceId = destinationWorkspace.workspaceId
+                )
+            }
+            if (mediaAssetsToInsert.isNotEmpty()) {
+                database.mediaAssetDao().insertMediaAssets(mediaAssets = mediaAssetsToInsert)
+            }
+        }
+        if (snapshot.mediaTransfers.isNotEmpty()) {
+            // Transfers carry no foreign key to the registry, so derive the forked
+            // asset id directly instead of failing on a transfer that outlived its
+            // media asset row.
+            val mediaTransfersToUpsert = snapshot.mediaTransfers.mapNotNull { mediaTransfer ->
+                val rewrittenMediaAssetId = forkedMediaAssetId(
+                    sourceWorkspaceId = sourceWorkspaceId,
+                    destinationWorkspaceId = destinationWorkspace.workspaceId,
+                    sourceMediaAssetId = mediaTransfer.mediaAssetId
+                )
+                if (
+                    rewrittenMediaAssetId == mediaTransfer.mediaAssetId &&
+                    mediaTransfer.workspaceId == destinationWorkspace.workspaceId
+                ) {
+                    return@mapNotNull null
+                }
+                mediaTransfer.copy(
+                    mediaAssetId = rewrittenMediaAssetId,
+                    workspaceId = destinationWorkspace.workspaceId
+                )
+            }
+            if (mediaTransfersToUpsert.isNotEmpty()) {
+                database.mediaTransferDao().upsertMediaTransfers(mediaTransfers = mediaTransfersToUpsert)
+            }
+        }
         if (snapshot.outboxEntries.isNotEmpty()) {
             val outboxEntriesToInsert = snapshot.outboxEntries.mapNotNull { entry ->
                 val rewrittenEntry = rewriteOutboxEntryForFork(
@@ -480,6 +510,16 @@ internal class WorkspaceIdentityLocalStore(
                     ) != card.cardId
                 }
                 .forEach { card -> database.cardDao().deleteCard(cardId = card.cardId) }
+            snapshot.mediaAssets
+                .filter { mediaAsset ->
+                    forkMappings.mediaAssetIdsBySourceId.requireMappedId(
+                        entityType = "media_asset",
+                        sourceId = mediaAsset.mediaAssetId
+                    ) != mediaAsset.mediaAssetId
+                }
+                .forEach { mediaAsset ->
+                    database.mediaAssetDao().deleteMediaAsset(mediaAssetId = mediaAsset.mediaAssetId)
+                }
             if (didRewriteLocalEntityIds) {
                 resetVolatileWorkspaceSelectionsAfterLocalEntityReId(workspaceId = destinationWorkspace.workspaceId)
             }
@@ -491,32 +531,6 @@ internal class WorkspaceIdentityLocalStore(
         replaceSyncStateWithEmptyProgress(workspaceId = destinationWorkspace.workspaceId)
     }
 
-    private suspend fun reassignPendingMediaUploadsForWorkspaceFork(
-        oldWorkspaceId: String,
-        newWorkspaceId: String
-    ) {
-        val updatedAtMillis: Long = System.currentTimeMillis()
-        val lastModifiedByReplicaId: String = buildClientWorkspaceReplicaId(
-            workspaceId = newWorkspaceId,
-            installationId = preferencesStore.currentCloudSettings().installationId
-        )
-        database.mediaAssetDao().reassignPendingUploadMediaAssets(
-            oldWorkspaceId = oldWorkspaceId,
-            newWorkspaceId = newWorkspaceId,
-            uploadKind = MediaTransferKind.UPLOAD.wireKey,
-            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey,
-            lastModifiedByReplicaId = lastModifiedByReplicaId,
-            updatedAtMillis = updatedAtMillis
-        )
-        database.mediaTransferDao().reassignPendingUploadMediaTransfers(
-            oldWorkspaceId = oldWorkspaceId,
-            newWorkspaceId = newWorkspaceId,
-            uploadKind = MediaTransferKind.UPLOAD.wireKey,
-            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey,
-            updatedAtMillis = updatedAtMillis
-        )
-    }
-
     private suspend fun loadWorkspaceForkSnapshot(workspaceId: String): WorkspaceForkSnapshot {
         val cards = database.cardDao().loadCards(workspaceId = workspaceId)
         return WorkspaceForkSnapshot(
@@ -525,6 +539,8 @@ internal class WorkspaceIdentityLocalStore(
             tags = database.tagDao().loadTags(workspaceId = workspaceId),
             cardTags = database.tagDao().loadCardTags(workspaceId = workspaceId),
             reviewLogs = database.reviewLogDao().loadReviewLogs(workspaceId = workspaceId),
+            mediaAssets = database.mediaAssetDao().loadMediaAssets(workspaceId = workspaceId),
+            mediaTransfers = database.mediaTransferDao().loadMediaTransfersForWorkspace(workspaceId = workspaceId),
             outboxEntries = database.outboxDao().loadAllOutboxEntries(workspaceId = workspaceId),
             schedulerSettings = database.workspaceSchedulerSettingsDao()
                 .loadWorkspaceSchedulerSettings(workspaceId = workspaceId)
@@ -707,6 +723,11 @@ private fun hasWorkspaceForkEntityIdRewrites(
             entityType = "review_event",
             sourceId = reviewLog.reviewLogId
         ) != reviewLog.reviewLogId
+    } || snapshot.mediaAssets.any { mediaAsset ->
+        forkMappings.mediaAssetIdsBySourceId.requireMappedId(
+            entityType = "media_asset",
+            sourceId = mediaAsset.mediaAssetId
+        ) != mediaAsset.mediaAssetId
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
@@ -1,20 +1,41 @@
 package com.flashcardsopensourceapp.data.local.cloud.sync
 
+import android.util.Log
 import androidx.room.withTransaction
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
+import com.flashcardsopensourceapp.data.local.database.entities.MediaAssetEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaBlobCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.MediaTransferQueueEntity
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapEntry
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildCardBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildDeckBootstrapEntryJson
-import com.flashcardsopensourceapp.data.local.cloud.wire.buildMediaAssetBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildReviewHistoryImportEventJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildWorkspaceSchedulerSettingsBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.toCardSummary
 import com.flashcardsopensourceapp.data.local.model.media.MediaTransferKind
 import com.flashcardsopensourceapp.data.local.model.media.MediaTransferStatus
+import com.flashcardsopensourceapp.data.local.model.media.managedMediaAssetIdsReferencedByCardText
+import com.flashcardsopensourceapp.data.local.model.media.normalizeMediaSha256
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
+import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
 import kotlinx.coroutines.flow.first
 import org.json.JSONArray
 import java.util.UUID
+
+private const val bootstrapMediaUploadLogTag: String = "FlashcardsBootstrapMedia"
+
+/**
+ * Only an upload that has not finished yet makes a new bootstrap upload
+ * redundant. A `succeeded` row deliberately does not count: after a workspace
+ * fork it describes an upload made under the source workspace and source media
+ * asset id, so the destination workspace still has to register the asset.
+ * Mirrors the iOS `.pendingOnly` policy in
+ * `apps/ios/Flashcards/Flashcards/Database/MediaTransferStore/MediaTransferStore.swift`.
+ */
+private val pendingUploadMediaTransferStatuses: List<String> = listOf(
+    MediaTransferStatus.QUEUED.wireKey,
+    MediaTransferStatus.IN_PROGRESS.wireKey
+)
 
 internal data class PendingLocalHotEntityKey(
     val entityType: SyncEntityType,
@@ -29,8 +50,16 @@ internal data class BootstrapApplyResult(
 internal class SyncBootstrapLocalStore(
     private val database: AppDatabase,
     private val outboxLocalStore: SyncOutboxLocalStore,
-    private val hotStateLocalStore: SyncHotStateLocalStore
+    private val hotStateLocalStore: SyncHotStateLocalStore,
+    private val timeProvider: TimeProvider
 ) {
+    /**
+     * Media assets are registered remotely only through the media-assets upload
+     * API, and sync replication rejects `media_asset` writes outright, so the
+     * bootstrap entries here stay limited to cards, decks and workspace
+     * scheduler settings. Mirrors `loadHotBootstrapEntries` in
+     * `apps/ios/Flashcards/Flashcards/Database/LocalDatabase/Sync/LocalDatabase+Sync.swift`.
+     */
     suspend fun buildBootstrapEntries(workspaceId: String): JSONArray {
         val entries = JSONArray()
         database.cardDao().observeCardsWithRelations().first()
@@ -56,20 +85,6 @@ internal class SyncBootstrapLocalStore(
                 )
             }
 
-        database.mediaAssetDao().loadMediaAssetsExcludingPendingUploads(
-            workspaceId = workspaceId,
-            uploadKind = MediaTransferKind.UPLOAD.wireKey,
-            succeededStatus = MediaTransferStatus.SUCCEEDED.wireKey
-        )
-            .forEach { mediaAsset ->
-                entries.put(
-                    buildMediaAssetBootstrapEntryJson(
-                        mediaAsset = mediaAsset,
-                        lastOperationId = mediaAsset.lastOperationId
-                    )
-                )
-            }
-
         val settings = database.workspaceSchedulerSettingsDao().loadWorkspaceSchedulerSettings(workspaceId = workspaceId)
         if (settings != null) {
             entries.put(
@@ -82,6 +97,98 @@ internal class SyncBootstrapLocalStore(
         }
 
         return entries
+    }
+
+    /**
+     * Queues a media-assets upload for every asset the workspace's active cards
+     * still reference, so a workspace bootstrapped into an empty remote — most
+     * notably one forked from a guest workspace at sign-in — registers its
+     * images through the upload API that the bootstrap entries cannot carry.
+     * Mirrors `prepareReferencedMediaAssetUploadsForHotBootstrap` in
+     * `apps/ios/Flashcards/Flashcards/Database/LocalDatabase/Sync/LocalDatabase+Sync.swift`.
+     */
+    suspend fun prepareReferencedMediaAssetUploads(workspaceId: String) {
+        val referencedMediaAssetIds: List<String> = database.cardDao().loadCards(workspaceId = workspaceId)
+            .filter { card -> card.deletedAtMillis == null }
+            .flatMapTo(destination = mutableSetOf()) { card ->
+                managedMediaAssetIdsReferencedByCardText(
+                    frontText = card.frontText,
+                    backText = card.backText
+                )
+            }
+            .sorted()
+        if (referencedMediaAssetIds.isEmpty()) {
+            return
+        }
+
+        database.withTransaction {
+            val mediaAssetsById: Map<String, MediaAssetEntity> = database.mediaAssetDao()
+                .loadMediaAssets(workspaceId = workspaceId)
+                .associateBy { mediaAsset -> mediaAsset.mediaAssetId }
+            referencedMediaAssetIds.forEach { mediaAssetId ->
+                enqueueReferencedMediaAssetUpload(
+                    workspaceId = workspaceId,
+                    mediaAssetId = mediaAssetId,
+                    mediaAsset = mediaAssetsById[mediaAssetId]
+                )
+            }
+        }
+    }
+
+    private suspend fun enqueueReferencedMediaAssetUpload(
+        workspaceId: String,
+        mediaAssetId: String,
+        mediaAsset: MediaAssetEntity?
+    ) {
+        if (mediaAsset == null || mediaAsset.deletedAtMillis != null) {
+            logSkippedReferencedMediaAssetUpload(
+                workspaceId = workspaceId,
+                mediaAssetId = mediaAssetId,
+                reason = if (mediaAsset == null) "missingLocalMediaAsset" else "deletedMediaAsset"
+            )
+            return
+        }
+
+        val sha256: String = normalizeMediaSha256(rawSha256 = mediaAsset.sha256)
+        val mediaBlobCache: MediaBlobCacheEntity? = database.mediaTransferDao().loadMediaBlobCache(sha256 = sha256)
+        if (mediaBlobCache == null) {
+            logSkippedReferencedMediaAssetUpload(
+                workspaceId = workspaceId,
+                mediaAssetId = mediaAssetId,
+                reason = "missingLocalMediaBlob"
+            )
+            return
+        }
+        val hasPendingUpload: Boolean = database.mediaTransferDao().hasMediaTransferForMediaAsset(
+            workspaceId = workspaceId,
+            mediaAssetId = mediaAssetId,
+            sha256 = sha256,
+            kind = MediaTransferKind.UPLOAD.wireKey,
+            statuses = pendingUploadMediaTransferStatuses
+        )
+        if (hasPendingUpload) {
+            return
+        }
+
+        val nowMillis: Long = timeProvider.currentTimeMillis()
+        database.mediaTransferDao().upsertMediaTransfer(
+            mediaTransfer = MediaTransferQueueEntity(
+                transferId = UUID.randomUUID().toString(),
+                workspaceId = workspaceId,
+                mediaAssetId = mediaAssetId,
+                kind = MediaTransferKind.UPLOAD.wireKey,
+                status = MediaTransferStatus.QUEUED.wireKey,
+                sha256 = sha256,
+                mimeType = mediaAsset.mimeType,
+                sizeBytes = mediaAsset.sizeBytes,
+                localRelativePath = mediaBlobCache.localRelativePath,
+                attemptCount = 0,
+                nextAttemptAtMillis = nowMillis,
+                lastError = null,
+                createdAtMillis = nowMillis,
+                updatedAtMillis = nowMillis
+            )
+        )
     }
 
     suspend fun buildReviewHistoryImportEvents(workspaceId: String): JSONArray {
@@ -137,6 +244,18 @@ internal class SyncBootstrapLocalStore(
                 .any { pendingHotEntityKey -> pendingHotEntityKey in appliedHotEntityKeys }
         }
     }
+}
+
+private fun logSkippedReferencedMediaAssetUpload(
+    workspaceId: String,
+    mediaAssetId: String,
+    reason: String
+) {
+    Log.w(
+        bootstrapMediaUploadLogTag,
+        "outcome=skippedReferencedMediaAssetUpload workspaceId=$workspaceId " +
+            "mediaAssetId=$mediaAssetId reason=$reason"
+    )
 }
 
 private fun RemoteBootstrapEntry.toPendingLocalHotEntityKey(): PendingLocalHotEntityKey? {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStore.kt
@@ -46,7 +46,8 @@ class SyncLocalStore(
     private val bootstrapLocalStore = SyncBootstrapLocalStore(
         database = database,
         outboxLocalStore = outboxLocalStore,
-        hotStateLocalStore = hotStateLocalStore
+        hotStateLocalStore = hotStateLocalStore,
+        timeProvider = timeProvider
     )
     private val reviewHistoryLocalStore = SyncReviewHistoryLocalStore(
         database = database,
@@ -220,6 +221,10 @@ class SyncLocalStore(
 
     suspend fun bindGuestUpgradeToLinkedWorkspace(workspace: CloudWorkspaceSummary): WorkspaceEntity {
         return workspaceIdentityLocalStore.bindGuestUpgradeToLinkedWorkspace(workspace = workspace)
+    }
+
+    suspend fun prepareReferencedMediaAssetUploads(workspaceId: String) {
+        bootstrapLocalStore.prepareReferencedMediaAssetUploads(workspaceId = workspaceId)
     }
 
     suspend fun buildBootstrapEntries(workspaceId: String): JSONArray {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
@@ -210,23 +210,6 @@ internal fun buildWorkspaceSchedulerSettingsBootstrapEntryJson(
         )
 }
 
-internal fun buildMediaAssetBootstrapEntryJson(
-    mediaAsset: MediaAssetEntity,
-    lastOperationId: String
-): JSONObject {
-    return JSONObject()
-        .put("entityType", "media_asset")
-        .put("entityId", mediaAsset.mediaAssetId)
-        .put("action", "upsert")
-        .put(
-            "payload",
-            buildMediaAssetBootstrapPayloadJson(
-                mediaAsset = mediaAsset,
-                lastOperationId = lastOperationId
-            )
-        )
-}
-
 internal fun buildReviewHistoryImportEventJson(reviewLog: ReviewLogEntity): JSONObject {
     return JSONObject()
         .put("reviewEventId", reviewLog.reviewLogId)
@@ -539,15 +522,4 @@ internal fun toCardSummary(card: CardWithRelations): CardSummary {
         fsrsScheduledDays = card.card.fsrsScheduledDays,
         deletedAtMillis = card.card.deletedAtMillis
     )
-}
-
-private fun buildMediaAssetBootstrapPayloadJson(
-    mediaAsset: MediaAssetEntity,
-    lastOperationId: String
-): JSONObject {
-    return buildMediaAssetOutboxPayloadJson(mediaAsset = mediaAsset)
-        .put("clientUpdatedAt", formatIsoTimestamp(mediaAsset.clientUpdatedAtMillis))
-        .put("lastModifiedByReplicaId", mediaAsset.lastModifiedByReplicaId)
-        .put("lastOperationId", lastOperationId)
-        .put("updatedAt", formatIsoTimestamp(mediaAsset.updatedAtMillis))
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaAssetDao.kt
@@ -26,31 +26,17 @@ interface MediaAssetDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMediaAsset(mediaAsset: MediaAssetEntity)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMediaAssets(mediaAssets: List<MediaAssetEntity>)
+
+    @Query("DELETE FROM media_assets WHERE mediaAssetId = :mediaAssetId")
+    suspend fun deleteMediaAsset(mediaAssetId: String)
+
     @Query("SELECT * FROM media_assets WHERE mediaAssetId = :mediaAssetId LIMIT 1")
     suspend fun loadMediaAsset(mediaAssetId: String): MediaAssetEntity?
 
     @Query("SELECT * FROM media_assets WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, mediaAssetId ASC")
     suspend fun loadMediaAssets(workspaceId: String): List<MediaAssetEntity>
-
-    @Query(
-        """
-        SELECT * FROM media_assets
-        WHERE workspaceId = :workspaceId
-            AND NOT EXISTS (
-                SELECT 1 FROM media_transfer_queue
-                WHERE media_transfer_queue.workspaceId = media_assets.workspaceId
-                    AND media_transfer_queue.mediaAssetId = media_assets.mediaAssetId
-                    AND media_transfer_queue.kind = :uploadKind
-                    AND media_transfer_queue.status != :succeededStatus
-            )
-        ORDER BY createdAtMillis ASC, mediaAssetId ASC
-        """
-    )
-    suspend fun loadMediaAssetsExcludingPendingUploads(
-        workspaceId: String,
-        uploadKind: String,
-        succeededStatus: String
-    ): List<MediaAssetEntity>
 
     @Query("SELECT * FROM media_assets WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, mediaAssetId ASC")
     fun observeMediaAssets(workspaceId: String): Flow<List<MediaAssetEntity>>
@@ -111,52 +97,4 @@ interface MediaAssetDao {
         workspaceId: String,
         limit: Int
     ): Flow<List<LocalSyncDiagnosticsMissingMediaBlobRow>>
-
-    @Query("SELECT COUNT(*) FROM media_assets WHERE workspaceId = :workspaceId")
-    suspend fun countMediaAssets(workspaceId: String): Int
-
-    @Query(
-        """
-        SELECT COUNT(*) FROM media_assets
-        WHERE workspaceId = :workspaceId
-            AND NOT EXISTS (
-                SELECT 1 FROM media_transfer_queue
-                WHERE media_transfer_queue.workspaceId = media_assets.workspaceId
-                    AND media_transfer_queue.mediaAssetId = media_assets.mediaAssetId
-                    AND media_transfer_queue.kind = :uploadKind
-                    AND media_transfer_queue.status != :succeededStatus
-            )
-        """
-    )
-    suspend fun countMediaAssetsExcludingPendingUploads(
-        workspaceId: String,
-        uploadKind: String,
-        succeededStatus: String
-    ): Int
-
-    @Query(
-        """
-        UPDATE media_assets
-        SET workspaceId = :newWorkspaceId,
-            clientUpdatedAtMillis = :updatedAtMillis,
-            lastModifiedByReplicaId = :lastModifiedByReplicaId,
-            updatedAtMillis = :updatedAtMillis
-        WHERE workspaceId = :oldWorkspaceId
-            AND EXISTS (
-                SELECT 1 FROM media_transfer_queue
-                WHERE media_transfer_queue.workspaceId = media_assets.workspaceId
-                    AND media_transfer_queue.mediaAssetId = media_assets.mediaAssetId
-                    AND media_transfer_queue.kind = :uploadKind
-                    AND media_transfer_queue.status != :succeededStatus
-            )
-        """
-    )
-    suspend fun reassignPendingUploadMediaAssets(
-        oldWorkspaceId: String,
-        newWorkspaceId: String,
-        uploadKind: String,
-        succeededStatus: String,
-        lastModifiedByReplicaId: String,
-        updatedAtMillis: Long
-    )
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/media/MediaTransferDao.kt
@@ -86,6 +86,26 @@ interface MediaTransferDao {
 
     @Query(
         """
+        SELECT EXISTS(
+            SELECT 1 FROM media_transfer_queue
+            WHERE workspaceId = :workspaceId
+                AND mediaAssetId = :mediaAssetId
+                AND sha256 = :sha256
+                AND kind = :kind
+                AND status IN (:statuses)
+        )
+        """
+    )
+    suspend fun hasMediaTransferForMediaAsset(
+        workspaceId: String,
+        mediaAssetId: String,
+        sha256: String,
+        kind: String,
+        statuses: List<String>
+    ): Boolean
+
+    @Query(
+        """
         SELECT
             COUNT(
                 CASE
@@ -309,21 +329,12 @@ interface MediaTransferDao {
 
     @Query(
         """
-        UPDATE media_transfer_queue
-        SET workspaceId = :newWorkspaceId,
-            updatedAtMillis = :updatedAtMillis
-        WHERE workspaceId = :oldWorkspaceId
-            AND kind = :uploadKind
-            AND status != :succeededStatus
+        SELECT * FROM media_transfer_queue
+        WHERE workspaceId = :workspaceId
+        ORDER BY createdAtMillis ASC, transferId ASC
         """
     )
-    suspend fun reassignPendingUploadMediaTransfers(
-        oldWorkspaceId: String,
-        newWorkspaceId: String,
-        uploadKind: String,
-        succeededStatus: String,
-        updatedAtMillis: Long
-    )
+    suspend fun loadMediaTransfersForWorkspace(workspaceId: String): List<MediaTransferQueueEntity>
 
     @Query("DELETE FROM media_transfer_queue WHERE workspaceId = :workspaceId")
     suspend fun deleteMediaTransfersForWorkspace(workspaceId: String)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/media/ManagedMediaMarkdown.kt
@@ -33,6 +33,49 @@ fun extractManagedMediaAssetReferences(markdown: String): Set<String> {
         .toSet()
 }
 
+/**
+ * A card can reference managed media from either face, so every flow that needs
+ * the assets a card depends on — sync bootstrap upload preparation and local
+ * sync diagnostics — reads them through this one helper instead of repeating the
+ * `fcasset:` scan.
+ */
+fun managedMediaAssetIdsReferencedByCardText(
+    frontText: String,
+    backText: String
+): Set<String> {
+    return extractManagedMediaAssetReferences(markdown = frontText) +
+        extractManagedMediaAssetReferences(markdown = backText)
+}
+
+/**
+ * Card text points at managed media through `fcasset:` links, so any flow that
+ * re-identifies media assets, such as the workspace identity fork, must carry
+ * the card bodies onto the new asset ids. References without a mapping are left
+ * untouched.
+ */
+fun rewriteManagedMediaAssetReferences(
+    markdown: String,
+    mediaAssetIdsBySourceId: Map<String, String>
+): String {
+    if (mediaAssetIdsBySourceId.isEmpty()) {
+        return markdown
+    }
+
+    return managedMediaAssetReferenceRegex.replace(input = markdown) { matchResult ->
+        val rawReference: String = matchResult.groupValues[1]
+        val mediaAssetId: String? = parseManagedMediaReference(reference = matchResult.value)?.mediaAssetId
+        val rewrittenMediaAssetId: String? = mediaAssetId?.let(mediaAssetIdsBySourceId::get)
+        if (mediaAssetId == null || rewrittenMediaAssetId == null) {
+            matchResult.value
+        } else {
+            managedMediaAssetSchemePrefix + rawReference.replaceFirst(
+                oldValue = mediaAssetId,
+                newValue = rewrittenMediaAssetId
+            )
+        }
+    }
+}
+
 fun parseManagedMediaReference(reference: String): ManagedMediaReference? {
     val normalizedReference: String = reference.trim()
     if (normalizedReference.startsWith(prefix = managedMediaAssetSchemePrefix, ignoreCase = true).not()) {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
@@ -263,6 +263,9 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
             )
 
             if (bootstrapResponse.remoteIsEmpty) {
+                // Bootstrap entries never carry media assets, so queue the
+                // media-assets uploads the local cards still reference first.
+                syncLocalStore.prepareReferencedMediaAssetUploads(workspaceId = workspaceId)
                 val bootstrapEntries = syncLocalStore.buildBootstrapEntries(workspaceId)
                 if (bootstrapEntries.length() > 0) {
                     try {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/workspace/LocalWorkspaceRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/workspace/LocalWorkspaceRepository.kt
@@ -18,7 +18,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.sync.DeviceDiagnosticsSummary
 import com.flashcardsopensourceapp.data.local.model.media.MediaTransferKind
 import com.flashcardsopensourceapp.data.local.model.media.MediaTransferStatus
-import com.flashcardsopensourceapp.data.local.model.media.extractManagedMediaAssetReferences
+import com.flashcardsopensourceapp.data.local.model.media.managedMediaAssetIdsReferencedByCardText
 import com.flashcardsopensourceapp.data.local.model.sync.LocalSyncDiagnosticsCardOutboxProblem
 import com.flashcardsopensourceapp.data.local.model.sync.LocalSyncDiagnosticsCardsSync
 import com.flashcardsopensourceapp.data.local.model.sync.LocalSyncDiagnosticsManagedMediaSync
@@ -361,8 +361,9 @@ class LocalWorkspaceRepository(
                 .map(LocalSyncDiagnosticsMediaAssetIdRow::mediaAssetId)
                 .toSet()
             val referencedMediaAssetIds: Set<String> = cardMarkdownRows
-                .flatMap(::extractManagedMediaReferences)
-                .toSet()
+                .flatMapTo(destination = mutableSetOf()) { row ->
+                    managedMediaAssetIdsReferencedByCardText(frontText = row.frontText, backText = row.backText)
+                }
             val missingMediaReferences: List<LocalSyncDiagnosticsMissingMediaReferenceProblem> =
                 makeMissingMediaReferenceProblems(
                     cardMarkdownRows = cardMarkdownRows,
@@ -416,17 +417,12 @@ class LocalWorkspaceRepository(
     }
 }
 
-private fun extractManagedMediaReferences(row: LocalSyncDiagnosticsCardMarkdownRow): Set<String> {
-    return extractManagedMediaAssetReferences(markdown = row.frontText) +
-        extractManagedMediaAssetReferences(markdown = row.backText)
-}
-
 private fun makeMissingMediaReferenceProblems(
     cardMarkdownRows: List<LocalSyncDiagnosticsCardMarkdownRow>,
     activeMediaAssetIds: Set<String>
 ): List<LocalSyncDiagnosticsMissingMediaReferenceProblem> {
     return cardMarkdownRows.flatMap { row ->
-        extractManagedMediaReferences(row = row)
+        managedMediaAssetIdsReferencedByCardText(frontText = row.frontText, backText = row.backText)
             .filter { mediaAssetId -> activeMediaAssetIds.contains(mediaAssetId).not() }
             .map { mediaAssetId ->
                 LocalSyncDiagnosticsMissingMediaReferenceProblem(


### PR DESCRIPTION
## Goal

A guest who attached images keeps them after signing in on Android, matching shipped iOS behaviour: forked media assets reach the server through the media-assets REST upload path and never through sync replication (Sentry FLASHCARDS-ANDROID-14).

## Problem

Signing in forks the guest workspace into the account workspace. Two things broke media on that path:

- `rewriteOutboxEntryForFork` threw `IllegalArgumentException` on any `media_asset` outbox entry, so a guest with pending image uploads could not fork at all.
- The sync bootstrap emitted `media_asset` entries, which sync replication rejects — media assets are registered remotely only through the media-assets upload API.

Card bodies also kept pointing at the source workspace's `fcasset:` ids, so even a successful fork would reference assets that do not exist in the destination workspace.

## Change

- `WorkspaceIdentityFork.kt`: derive forked media asset ids under a dedicated UUID namespace, include them in `WorkspaceForkIdMappings`, rewrite `media_asset` outbox entries instead of throwing, and rewrite the `fcasset:` references embedded in forked card `frontText`/`backText`. The blob itself is shared because storage is keyed by `sha256`, so a fork is a registry-row copy under a derived id.
- `ManagedMediaMarkdown.kt`: add `rewriteManagedMediaAssetReferences` and `managedMediaAssetIdsReferencedByCardText` so the `fcasset:` scan lives in one place.
- `SyncBootstrapLocalStore.kt`: stop emitting `media_asset` bootstrap entries, and add `prepareReferencedMediaAssetUploads`, which queues a media-assets upload for every asset the workspace's live cards still reference. A `succeeded` transfer deliberately does not suppress the new upload, because after a fork it describes an upload made under the source workspace and source asset id.
- `SyncWirePayloads.kt`: drop the now-unused `media_asset` bootstrap payload builders.
- `CloudSyncRunner.kt`, `SyncLocalStore.kt`, `WorkspaceIdentityLocalStore.kt`, `LocalWorkspaceRepository.kt`, `MediaAssetDao.kt`, `MediaTransferDao.kt`: wire the new upload preparation into the bootstrap run and replace the old "exclude succeeded uploads" query with the pending-only lookup.

Each new piece names the iOS function it mirrors in a doc comment.

## Testing

Extended `SyncLocalStoreWorkspaceIdentityForkContractTest` (Android instrumentation, `data:local`) to cover forking media assets, rewritten card references, and the queued uploads. Project checks were not run locally per the delivery instructions; the `Android PR` workflow runs the emulator instrumentation suite.
