### PR TITLE
ci: run the Android emulator gate in parallel with the build gate

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -74,8 +74,6 @@ jobs:
 
   emulator-data-local-instrumentation:
     name: Android emulator data:local instrumentation
-    needs:
-      - build
     if: ${{ inputs.run_data_local_instrumentation }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ For the optional private analytical DB access path, granted reporting permission
 
 Pushes to `main` use three independent release streams: AWS/web, Android, and iOS.
 Pull-request checks stay deliberately light and fast: do not add heavy mobile build or test jobs to pull-request workflows.
-The `Android PR` build, unit test, lint, and GitHub-hosted `data:local` emulator instrumentation run in `.github/workflows/android-pr.yml` (about 12 minutes) is an accepted exception and stays; the Firebase Test Lab managed-device suite stays out of pull requests.
+The `Android PR` build, unit test, lint, and GitHub-hosted `data:local` emulator instrumentation run in `.github/workflows/android-pr.yml` (about 7 minutes) is an accepted exception and stays; the Firebase Test Lab managed-device suite stays out of pull requests.
 Nothing compiles iOS before merge by design, though `PR Checks` still runs the static iOS checks.
 Swift builds and tests run in Xcode Cloud, whose workflow definitions live in App Store Connect; its in-repo build inputs are documented in [docs/ios-ci-cd.md](docs/ios-ci-cd.md).
 Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -65,7 +65,7 @@ Pull-request GitHub Actions workflow: `.github/workflows/android-pr.yml`
 
 - Starts on `pull_request` targeting `main` when Android-impacting files change, excluding `apps/android/README.md` and `apps/android/docs/**`
 - Calls `.github/workflows/android-ci-reusable.yml` for the pull-request merge commit, so the gate covers what will actually land on `main`
-- Runs the GitHub-hosted `data:local` emulator instrumentation gate, so a failing `data:local` test fails the pull request first; the same suite still runs on `main` after merge
+- Runs the GitHub-hosted `data:local` emulator instrumentation gate in parallel with the build/unit/lint job for the same ref, so a failing `data:local` test fails the pull request first; the same suite still runs on `main` after merge
 - Does not upload a Google Play draft
 - Does not submit Firebase Test Lab
 
@@ -88,6 +88,7 @@ GitHub Actions reusable workflow: `.github/workflows/android-ci-reusable.yml`
 - Boots a headless Android 17 / API 37 emulator in GitHub Actions with `-gpu swiftshader`
 - Runs `:data:local:connectedDebugAndroidTest` on that emulator
 - Uploads `data:local` instrumentation reports from the emulator run when the Gradle task produced them
+- Intentionally does not make the emulator job depend on the build job, because the emulator job does its own checkout and Gradle build, so a failing build no longer prevents or cancels the emulator run
 - Reuses the caller-provided `ANDROID_VERSION_CODE` across Android CI/build artifacts
 - Uses the Sentry release name `com.flashcardsopensourceapp.app@<versionName>+<versionCode>` for Android release artifact correlation; the workflow summary also prints the manager-readable Play release identifier, but runtime Sentry event tags/contexts are controlled by app runtime code
 
@@ -101,7 +102,7 @@ Top-level release workflow Firebase job: `.github/workflows/android-release.yml`
 The pull-request Android flow is:
 
 1. `android-pr.yml` starts on `pull_request` targeting `main` for Android-impacting changes and validates the pull-request merge commit
-2. It runs the same GitHub-hosted gate as `Android CI`: unit tests, debug builds, and lint first, then `data:local` instrumentation on the emulator once the build job succeeds
+2. It runs the same GitHub-hosted gate as `Android CI`: the unit test, debug build, and lint job and the `data:local` emulator instrumentation job run in parallel for the same ref, and the pull request is green only when both pass
 3. The `android-pr-<pull request number>` concurrency group cancels superseded runs, so a new push replaces the in-flight emulator run instead of queueing another one
 4. The workflow stops there: no Firebase Test Lab submission and no Google Play draft upload
 


### PR DESCRIPTION
## What

Remove the `needs: build` dependency from the `emulator-data-local-instrumentation` job in `.github/workflows/android-ci-reusable.yml`, so the emulator gate starts at the same time as the build/unit/lint gate instead of waiting for it.

## Why

The emulator job never consumed any artifact produced by the build job. It does its own checkout and its own Gradle build before running `:data:local:connectedDebugAndroidTest`, so the dependency only serialized two independent jobs.

Dropping it cuts `Android PR` wall clock from about 11-12 minutes to about 6-7 minutes, because the emulator boot and instrumentation run now overlap the build/unit/lint run instead of following it.

## Coverage

Pre-merge coverage is unchanged. Both jobs still run on every Android-impacting pull request and both still have to pass for the pull request to be green. The only difference is that a failing build no longer prevents or cancels the emulator run, so a broken pull request now reports both failures in one run instead of one at a time.

## Follow-up

Path-scoping the emulator job to data-layer pull requests only is a separate follow-up PR and is deliberately not part of this change.

## Docs

`AGENTS.md` and `docs/android-ci-cd.md` are updated to state the new wall clock and the parallel job relationship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
