### PR TITLE
ci: run the Android emulator gate on pull requests only for data-layer changes

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -9,6 +9,10 @@ on:
       android_version_code:
         required: true
         type: string
+      run_build:
+        required: false
+        type: boolean
+        default: true
       run_data_local_instrumentation:
         required: false
         type: boolean
@@ -17,6 +21,7 @@ on:
 jobs:
   build:
     name: Android build, unit tests, and lint
+    if: ${{ inputs.run_build }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 

--- a/.github/workflows/android-pr-data-local.yml
+++ b/.github/workflows/android-pr-data-local.yml
@@ -1,28 +1,26 @@
-name: Android PR
+name: Android PR data:local
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - 'apps/android/**'
-      - '!apps/android/README.md'
-      - '!apps/android/docs/**'
-      - 'cloudbuild.android.yaml'
-      - 'scripts/android/run-android-ci.sh'
-      - 'scripts/android/run-android-firebase-test-lab.sh'
-      - 'scripts/android/run-android-release.sh'
-      - 'scripts/android/setup-github-android.sh'
-      - '.github/workflows/android-pr.yml'
+      - 'apps/android/data/**'
+      - 'apps/android/core/observability/**'
+      - 'apps/android/build.gradle.kts'
+      - 'apps/android/settings.gradle.kts'
+      - 'apps/android/gradle.properties'
+      - 'apps/android/gradle/**'
+      - '.github/workflows/android-pr-data-local.yml'
       - '.github/workflows/android-ci-reusable.yml'
 
 permissions:
   contents: read
 
 jobs:
-  android_pr:
-    name: Android PR
+  android_pr_data_local:
+    name: Android PR data:local
     concurrency:
-      group: android-pr-${{ github.event.pull_request.number }}
+      group: android-pr-data-local-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     uses: ./.github/workflows/android-ci-reusable.yml
     with:
@@ -30,5 +28,6 @@ jobs:
       # merge result rather than the branch tip and gates on what will actually land on main.
       target_ref: ${{ github.sha }}
       android_version_code: ${{ github.run_number }}
-      run_data_local_instrumentation: false
+      run_build: false
+      run_data_local_instrumentation: true
     secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ For the optional private analytical DB access path, granted reporting permission
 
 Pushes to `main` use three independent release streams: AWS/web, Android, and iOS.
 Pull-request checks stay deliberately light and fast: do not add heavy mobile build or test jobs to pull-request workflows.
-The `Android PR` build, unit test, lint, and GitHub-hosted `data:local` emulator instrumentation run in `.github/workflows/android-pr.yml` (about 7 minutes) is an accepted exception and stays; the Firebase Test Lab managed-device suite stays out of pull requests.
+Two Android pull-request workflows are an accepted exception and stay: `Android PR` in `.github/workflows/android-pr.yml` runs build, unit tests, and lint for every Android-impacting pull request (about 6 minutes), and `Android PR data:local` in `.github/workflows/android-pr-data-local.yml` adds the GitHub-hosted `data:local` emulator instrumentation only when the Android data layer or shared Android Gradle configuration changes; the Firebase Test Lab managed-device suite stays out of pull requests.
 Nothing compiles iOS before merge by design, though `PR Checks` still runs the static iOS checks.
 Swift builds and tests run in Xcode Cloud, whose workflow definitions live in App Store Connect; its in-repo build inputs are documented in [docs/ios-ci-cd.md](docs/ios-ci-cd.md).
 Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -199,7 +199,7 @@ The repository policy for Android CI/CD is:
 - Firebase Test Lab is the cloud device test runner
 - `cloudbuild.android.yaml` is the Google-native Cloud Build entrypoint
 - Google auth from GitHub must use Workload Identity Federation, not a JSON key
-- Android pull requests and automatic Android CI on `main` both run unit tests, debug builds, lint, and GitHub-hosted `data:local` instrumentation without uploading to Google Play or submitting Firebase Test Lab
+- Android pull requests run unit tests, debug builds, and lint, and add the GitHub-hosted `data:local` instrumentation only when the Android data layer or shared Android Gradle configuration changes; automatic Android CI on `main` always runs both. Neither uploads to Google Play or submits Firebase Test Lab
 - the manual `Android Release` workflow runs the same GitHub-hosted Android gate, submits Firebase Test Lab app instrumentation, then uploads a Google Play production-track draft
 - one shared `ANDROID_VERSION_CODE` is resolved once per release run and reused across Android release artifacts and the Play draft bundle
 - one shared manager-readable release identifier, currently `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`, is reused in the Play release name and Firebase Test Lab result naming so the same release stays traceable across GitHub, Play, and Firebase

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -1,10 +1,11 @@
 # Android CI/CD
 
-This repository uses one reusable Android validation workflow plus three entry workflows: automatic pull request, automatic `push main`, and manual release:
+This repository uses one reusable Android validation workflow plus four entry workflows: two automatic pull-request workflows, automatic `push main`, and manual release:
 
 - GitHub Actions is the primary Android CI/CD entrypoint on `main`
 - `.github/workflows/android-ci-reusable.yml` contains the actual Android CI implementation
-- `.github/workflows/android-pr.yml` is the automatic pull-request Android validation workflow
+- `.github/workflows/android-pr.yml` is the automatic pull-request build, unit test, and lint workflow
+- `.github/workflows/android-pr-data-local.yml` is the automatic pull-request `data:local` emulator instrumentation workflow, scoped to Android data-layer and shared Android Gradle configuration changes
 - `.github/workflows/android-ci.yml` is the automatic `push main` Android validation workflow
 - `.github/workflows/android-release.yml` is the manual Android release workflow
 - Firebase Test Lab runs only from the manual release workflow on Google-managed devices
@@ -65,19 +66,30 @@ Pull-request GitHub Actions workflow: `.github/workflows/android-pr.yml`
 
 - Starts on `pull_request` targeting `main` when Android-impacting files change, excluding `apps/android/README.md` and `apps/android/docs/**`
 - Calls `.github/workflows/android-ci-reusable.yml` for the pull-request merge commit, so the gate covers what will actually land on `main`
-- Runs the GitHub-hosted `data:local` emulator instrumentation gate in parallel with the build/unit/lint job for the same ref, so a failing `data:local` test fails the pull request first; the same suite still runs on `main` after merge
+- Passes `run_data_local_instrumentation: false`, so it is the build, unit test, and lint pull-request gate only
+- Does not upload a Google Play draft
+- Does not submit Firebase Test Lab
+
+Pull-request GitHub Actions workflow: `.github/workflows/android-pr-data-local.yml`
+
+- Starts on `pull_request` targeting `main` only when files that can change the `:data:local` suite result change: `apps/android/data/**`, `apps/android/core/observability/**`, the shared Android Gradle configuration (`apps/android/build.gradle.kts`, `apps/android/settings.gradle.kts`, `apps/android/gradle.properties`, `apps/android/gradle/**`), and the two workflow files themselves
+- Calls `.github/workflows/android-ci-reusable.yml` for the pull-request merge commit with `run_build: false` and `run_data_local_instrumentation: true`, so it runs only the GitHub-hosted `data:local` emulator instrumentation job
+- The narrow filter exists because `:data:local` depends only on `:core:observability`, so `:app`, `:core:ui`, and `:feature:*` changes cannot change that suite result
+- A pull request that skips this workflow is still covered by `android-ci.yml` on `main` after merge, before any manual `Android Release`
 - Does not upload a Google Play draft
 - Does not submit Firebase Test Lab
 
 Automatic GitHub Actions workflow: `.github/workflows/android-ci.yml`
 
 - Starts on `push main` when Android-impacting files change
-- Calls `.github/workflows/android-ci-reusable.yml`
+- Calls `.github/workflows/android-ci-reusable.yml` with both inputs left at their `true` defaults, so the build/unit/lint job and the `data:local` emulator instrumentation job both run
+- Is the post-merge backstop for a pull request that skipped the emulator gate, and it runs before any manual `Android Release`
 - Does not upload a Google Play draft
 - Does not submit Firebase Test Lab
 
 GitHub Actions reusable workflow: `.github/workflows/android-ci-reusable.yml`
 
+- Exposes two boolean inputs that both default to `true`: `run_build` gates the build, unit test, and lint job, and `run_data_local_instrumentation` gates the emulator `data:local` instrumentation job; the two pull-request workflows each turn one of them off, while `android-ci.yml` and `android-release.yml` leave both on
 - Runs `test` for the whole Android Gradle project
 - Builds `:app:assembleDebug`
 - Builds `:app:assembleDebugAndroidTest`
@@ -101,10 +113,12 @@ Top-level release workflow Firebase job: `.github/workflows/android-release.yml`
 
 The pull-request Android flow is:
 
-1. `android-pr.yml` starts on `pull_request` targeting `main` for Android-impacting changes and validates the pull-request merge commit
-2. It runs the same GitHub-hosted gate as `Android CI`: the unit test, debug build, and lint job and the `data:local` emulator instrumentation job run in parallel for the same ref, and the pull request is green only when both pass
-3. The `android-pr-<pull request number>` concurrency group cancels superseded runs, so a new push replaces the in-flight emulator run instead of queueing another one
-4. The workflow stops there: no Firebase Test Lab submission and no Google Play draft upload
+1. `android-pr.yml` starts on `pull_request` targeting `main` for Android-impacting changes and validates the pull-request merge commit with the unit test, debug build, and lint job
+2. `android-pr-data-local.yml` starts on the same pull-request merge commit, but only when the Android data layer, `:core:observability`, or the shared Android Gradle configuration changes, and it runs the `data:local` emulator instrumentation job alone
+3. When both workflows are triggered they run independently and in parallel for the same ref, and the pull request is green only when every triggered job passes
+4. The `android-pr-<pull request number>` and `android-pr-data-local-<pull request number>` concurrency groups cancel superseded runs, so a new push replaces the in-flight runs instead of queueing another one
+5. A pull request that does not touch the data layer skips the emulator gate entirely; `android-ci.yml` on `main` runs it after merge
+6. The workflows stop there: no Firebase Test Lab submission and no Google Play draft upload
 
 The automatic Android CI flow is:
 


### PR DESCRIPTION
The GitHub-hosted emulator instrumentation gate runs exactly one Gradle task, and the module it exercises depends only on `:core:observability`. A pull request that touches only feature or UI modules cannot change that task's result, so running it on every Android pull request spends roughly six minutes of wall clock to re-confirm an outcome that was already determined. This change scopes the emulator gate on pull requests to data-layer changes only.

Coverage moves rather than disappears. The same instrumentation suite still runs on every Android-impacting push to `main`, and it still runs before every manual Android Release, so nothing reaches a release build without having passed it. The only thing that changes is which pull requests pay for it up front.

A typical Android pull request — one that does not touch the data layer — now finishes in about 6 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
