### PR TITLE
fix(web): stack invite-page sections in one centred column

### DIFF
--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -2,7 +2,10 @@
   min-height: 100vh;
   max-height: 100vh;
   display: grid;
-  place-items: center;
+  grid-template-columns: min(100%, 560px);
+  justify-content: center;
+  align-content: safe center;
+  gap: 16px;
   overflow-y: auto;
   padding: 24px;
 }
@@ -209,7 +212,7 @@
 @media (max-width: 640px) {
   .invite-page {
     padding: 16px;
-    align-items: start;
+    align-content: start;
   }
 
   .invite-link-grid {


### PR DESCRIPTION
Layer 0 of the catalog import flow redesign.

`.invite-page` used `place-items: center` on a grid whose rows stretch, so a page with two cards rendered each one floating in the centre of its own half of the viewport — the large empty gap on the signed-out catalog import screen. The grid also had no `gap`, and only `.invite-panel` carried the 560px width, so the `settings-group` section on the authenticated screen rendered wider than its siblings and touched them vertically.

One explicit 560px column, `align-content: safe center`, and a 16px gap fix all three symptoms. CSS only.

Base is the integration branch `integration-catalog-import-flow`; promotion to `main` happens once all four items land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)