### PR TITLE
fix(web): rename catalog import heading to "Import cards from catalog"

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -726,7 +726,7 @@ const arCatalog: TranslationCatalog = {
     previewRemoveTagLabel: "إزالة {{tag}} ({{count}} بطاقة)",
   },
   catalogImport: {
-    title: "الاستيراد من الكتالوج",
+    title: "استيراد البطاقات من الكتالوج",
     loading: "جارٍ تحميل حزمة الكتالوج...",
     packageSummary: "{{title}} — {{count}}",
     author: "بواسطة {{author}}",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -726,7 +726,7 @@ const deCatalog: TranslationCatalog = {
     previewRemoveTagLabel: "{{tag}} entfernen ({{count}} Karten)",
   },
   catalogImport: {
-    title: "Aus Katalog importieren",
+    title: "Karten aus Katalog importieren",
     loading: "Katalogpaket wird geladen...",
     packageSummary: "{{title}} — {{count}}",
     author: "Von {{author}}",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -724,7 +724,7 @@ const enCatalog = {
     previewRemoveTagLabel: "Remove {{tag}} ({{count}} cards)",
   },
   catalogImport: {
-    title: "Import from catalog",
+    title: "Import cards from catalog",
     loading: "Loading catalog package...",
     packageSummary: "{{title}} — {{count}}",
     author: "By {{author}}",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -726,7 +726,7 @@ const esEsCatalog: TranslationCatalog = {
     previewRemoveTagLabel: "Quitar {{tag}} ({{count}} tarjetas)",
   },
   catalogImport: {
-    title: "Importar del catálogo",
+    title: "Importar tarjetas del catálogo",
     loading: "Cargando paquete del catálogo...",
     packageSummary: "{{title}} — {{count}}",
     author: "De {{author}}",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -726,7 +726,7 @@ const esMxCatalog: TranslationCatalog = {
     previewRemoveTagLabel: "Quitar {{tag}} ({{count}} tarjetas)",
   },
   catalogImport: {
-    title: "Importar del catálogo",
+    title: "Importar tarjetas del catálogo",
     loading: "Cargando paquete del catálogo...",
     packageSummary: "{{title}} — {{count}}",
     author: "De {{author}}",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -726,7 +726,7 @@ const hiCatalog: TranslationCatalog = {
     previewRemoveTagLabel: "{{tag}} हटाएँ ({{count}} कार्ड)",
   },
   catalogImport: {
-    title: "कैटलॉग से इम्पोर्ट करें",
+    title: "कैटलॉग से कार्ड इम्पोर्ट करें",
     loading: "कैटलॉग पैकेज लोड हो रहा है...",
     packageSummary: "{{title}} — {{count}}",
     author: "{{author}} द्वारा",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -726,7 +726,7 @@ export const jaCatalog = {
     previewRemoveTagLabel: "{{tag}} を削除 ({{count}}件のカード)",
   },
   catalogImport: {
-    title: "カタログからインポート",
+    title: "カタログからカードをインポート",
     loading: "カタログパッケージを読み込んでいます...",
     packageSummary: "{{title}} — {{count}}",
     author: "作成者: {{author}}",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -726,7 +726,7 @@ export const ruCatalog = {
     previewRemoveTagLabel: "Удалить {{tag}} (карточек: {{count}})",
   },
   catalogImport: {
-    title: "Импорт из каталога",
+    title: "Импорт карточек из каталога",
     loading: "Загрузка пакета из каталога...",
     packageSummary: "{{title}} — {{count}}",
     author: "Автор: {{author}}",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -726,7 +726,7 @@ export const zhHansCatalog = {
     previewRemoveTagLabel: "移除 {{tag}}（{{count}} 张卡片）",
   },
   catalogImport: {
-    title: "从目录导入",
+    title: "从目录导入卡片",
     loading: "正在加载目录包...",
     packageSummary: "{{title}} — {{count}}",
     author: "作者：{{author}}",


### PR DESCRIPTION
Renames the top block heading on the web catalog import page from "Import from catalog" to "Import cards from catalog".

Only the `catalogImport.title` value changes, in all nine `apps/web/src/i18n/catalogs/*.ts` locales. No component, styling, or other i18n key is touched, and iOS/Android are unaffected (this heading exists only in the web catalogs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)