### PR TITLE
fix(web): match the workspace picker to the account menu styling

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -630,7 +630,7 @@ export function AppShell(): ReactElement {
             {availableWorkspaces.map((workspace) => (
               <button
                 key={workspace.workspaceId}
-                className="ghost-btn workspace-choice-btn"
+                className="workspace-choice-btn"
                 type="button"
                 onClick={() => void chooseWorkspace(workspace.workspaceId)}
                 disabled={isChoosingWorkspace}

--- a/apps/web/src/screens/catalog/CatalogImportScreen.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.tsx
@@ -263,7 +263,7 @@ function CatalogImportWorkspaceChooser(props: Readonly<{
           return (
             <button
               key={workspace.workspaceId}
-              className={`ghost-btn workspace-choice-btn${isActiveWorkspace ? " catalog-import-workspace-option-active" : ""}`}
+              className={`workspace-choice-btn${isActiveWorkspace ? " catalog-import-workspace-option-active" : ""}`}
               type="button"
               disabled={isChoosingWorkspace || isSelectionBusy}
               aria-current={isActiveWorkspace ? "true" : undefined}

--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -251,6 +251,10 @@
   cursor: pointer;
 }
 
+.account-menu-item + .account-menu-item {
+  margin-top: 4px;
+}
+
 .account-menu-link {
   text-decoration: none;
 }

--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -213,14 +213,13 @@
 }
 
 .catalog-import-workspace-option-active {
-  border-color: var(--accent);
   background: var(--accent-soft);
-  color: var(--text);
+  color: var(--accent-strong);
 }
 
 .catalog-import-workspace-option-active:hover:not(:disabled) {
-  border-color: var(--accent-strong);
   background: var(--accent-muted);
+  color: var(--accent-strong);
 }
 
 .catalog-import-target {

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -444,28 +444,46 @@
 
 .workspace-choice-list {
   display: grid;
-  gap: 12px;
+  gap: 4px;
 }
 
 .workspace-choice-btn {
+  display: grid;
+  gap: 4px;
   width: 100%;
-  justify-content: flex-start;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 6px;
+  min-height: 44px;
+  padding: 10px 14px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 400;
+  font-family: inherit;
   text-align: start;
+  cursor: pointer;
+  transition:
+    background 140ms ease,
+    color 140ms ease,
+    opacity 140ms ease;
+}
+
+.workspace-choice-btn:hover:not(:disabled) {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.workspace-choice-btn:disabled {
+  cursor: default;
+  opacity: 0.55;
 }
 
 .workspace-choice-name {
-  color: var(--text);
-  font-weight: 600;
-  font-size: 16px;
+  color: inherit;
 }
 
 .workspace-choice-meta {
   color: var(--text-secondary);
-  font-size: 12px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
The web workspace picker used to render each workspace as a bordered ghost button, so a list of workspaces read as a stack of standalone controls rather than as a menu. It now looks like a row in the account menu: no border, transparent background, secondary text color that brightens on hover, a 44px minimum row height with 10px/14px padding, the same subtle hover tint and disabled opacity, and a tight 4px gap between rows instead of 12px. The workspace name and its metadata line now inherit the row's color and type instead of carrying their own bold weight, larger size, and monospace font, which is what made the old rows feel like separate cards.

Two lists share this look now: the catalog import workspace chooser in `apps/web/src/screens/catalog/CatalogImportScreen.tsx` and the full-page `selecting_workspace` picker in `apps/web/src/App.tsx`. Both drop the `ghost-btn` class and rely on `.workspace-choice-btn` alone.

Note that `.workspace-choice-btn` is a shared class, and the full-page `selecting_workspace` state in `App.tsx` uses it too. That surface intentionally moves with the change rather than being pinned to the old styling, so the two workspace pickers stay visually identical.

Two smaller follow-on adjustments: the active catalog-import option now marks itself with the accent-soft background and accent-strong text instead of an accent border, because the rows no longer have a border to tint; and account-menu rows get an explicit 4px vertical gap so their spacing matches the workspace list they are now aligned with.

Generated with [Claude Code](https://claude.com/claude-code)
