### PR TITLE
feat(web): move the catalog import back control to a top-left arrow

### DIFF
--- a/apps/web/src/screens/catalog/CatalogImportConfirmPanel.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportConfirmPanel.tsx
@@ -16,7 +16,6 @@ export type CatalogImportConfirmCopy = Readonly<{
   tagsTitle: string;
   confirmActionLabel: string;
   confirmingActionLabel: string;
-  backActionLabel: string;
   retryPreviewLabel: string;
 }>;
 
@@ -27,7 +26,6 @@ type CatalogImportConfirmPanelProps = Readonly<{
   options: WorkspaceImportOptions;
   isControlDisabled: boolean;
   isPreviewLoading: boolean;
-  isBackDisabled: boolean;
   canConfirm: boolean;
   isConfirming: boolean;
   unavailableMessage: string | null;
@@ -35,7 +33,6 @@ type CatalogImportConfirmPanelProps = Readonly<{
   onOptionsChange: (options: WorkspaceImportOptions) => void;
   onConfirm: (options: WorkspaceImportOptions) => void;
   onRetryPreview: (() => void) | null;
-  onBack: (() => void) | null;
 }>;
 
 type CatalogImportPreviewSummaryProps = Readonly<{
@@ -181,7 +178,6 @@ export function CatalogImportConfirmPanel(props: CatalogImportConfirmPanelProps)
     options,
     isControlDisabled,
     isPreviewLoading,
-    isBackDisabled,
     canConfirm,
     isConfirming,
     unavailableMessage,
@@ -189,7 +185,6 @@ export function CatalogImportConfirmPanel(props: CatalogImportConfirmPanelProps)
     onOptionsChange,
     onConfirm,
     onRetryPreview,
-    onBack,
   } = props;
 
   return (
@@ -223,17 +218,6 @@ export function CatalogImportConfirmPanel(props: CatalogImportConfirmPanelProps)
         >
           {isConfirming ? copy.confirmingActionLabel : copy.confirmActionLabel}
         </button>
-        {onBack === null ? null : (
-          <button
-            className="ghost-btn catalog-import-back-button"
-            type="button"
-            disabled={isBackDisabled}
-            data-testid="catalog-import-back"
-            onClick={onBack}
-          >
-            {copy.backActionLabel}
-          </button>
-        )}
       </div>
       {unavailableMessage === null ? null : (
         <p className="subtitle" data-testid="workspace-package-import-unavailable">{unavailableMessage}</p>

--- a/apps/web/src/screens/catalog/CatalogImportScreen.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.tsx
@@ -148,6 +148,37 @@ function CatalogImportContextCard(props: Readonly<{ catalogContext: CatalogImpor
   );
 }
 
+function CatalogImportBackNav(props: Readonly<{ isDisabled: boolean; onBack: () => void }>): ReactElement {
+  const { isDisabled, onBack } = props;
+  const { t } = useI18n();
+
+  return (
+    <nav className="catalog-import-back-nav">
+      <button
+        className="ghost-btn catalog-import-back-button"
+        type="button"
+        disabled={isDisabled}
+        aria-label={t("catalogImport.back")}
+        data-testid="catalog-import-back"
+        onClick={onBack}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          className="catalog-import-back-icon"
+          aria-hidden="true"
+        >
+          <path d="M15 5l-7 7 7 7" />
+        </svg>
+      </button>
+    </nav>
+  );
+}
+
 function CatalogImportStatePanel(props: Readonly<{
   testId: string;
   title: string;
@@ -807,6 +838,12 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
 
   return (
     <main className="invite-page" data-testid="catalog-import-authenticated">
+      {hasWorkspaceStep && step === "confirm" ? (
+        <CatalogImportBackNav
+          isDisabled={isImportBusy || isWorkspaceSelectionBusy || areImportOptionsLocked}
+          onBack={() => setStep("workspace")}
+        />
+      ) : null}
       <CatalogImportContextCard catalogContext={catalogContext} />
       {workspaceErrorMessage === "" ? null : (
         <section className="content-card invite-panel" data-testid="catalog-import-workspace-error">
@@ -833,7 +870,6 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
             tagsTitle: t("workspaceImport.previewTagsTitle"),
             confirmActionLabel: t("catalogImport.confirm"),
             confirmingActionLabel: t("catalogImport.installing"),
-            backActionLabel: t("catalogImport.back"),
             retryPreviewLabel: t("common.retry"),
           }}
           workspaceName={activeWorkspace.name}
@@ -841,7 +877,6 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
           options={options}
           isControlDisabled={!isImportAvailable || isImportBusy || areImportOptionsLocked}
           isPreviewLoading={isPreviewing}
-          isBackDisabled={isImportBusy || isWorkspaceSelectionBusy || areImportOptionsLocked}
           canConfirm={isPreviewCurrent && !isImportBusy && !isWorkspaceSelectionBusy}
           isConfirming={isInstalling}
           unavailableMessage={isImportAvailable ? null : t("catalogImport.workspaceUnavailable")}
@@ -849,7 +884,6 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
           onOptionsChange={setOptions}
           onConfirm={(nextOptions) => void confirmInstall(nextOptions)}
           onRetryPreview={canRetryPreview ? () => void refreshPreview() : null}
-          onBack={hasWorkspaceStep ? () => setStep("workspace") : null}
         />
       ) : null}
       {step === "done" && completion !== null ? (

--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -272,8 +272,27 @@
   flex: 1 1 auto;
 }
 
+/* Aligns the back arrow with the left edge of the centered cards in the .invite-page grid. */
+.catalog-import-back-nav {
+  width: min(100%, 560px);
+  display: flex;
+  justify-content: flex-start;
+}
+
 .catalog-import-back-button {
-  min-width: 120px;
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  /* .ghost-btn keeps a 46px min-height for text buttons, so the icon button clears it to stay square. */
+  min-height: 0;
+  height: 40px;
+  padding: 0;
+  border-radius: var(--radius-pill);
+}
+
+.catalog-import-back-icon {
+  width: 20px;
+  height: 20px;
 }
 
 .catalog-import-success-header {
@@ -381,8 +400,7 @@
     width: 100%;
   }
 
-  .catalog-import-actions > .primary-btn,
-  .catalog-import-back-button {
+  .catalog-import-actions > .primary-btn {
     width: 100%;
   }
 


### PR DESCRIPTION
## What changed

- The catalog import "Back" text button inside the confirm panel is replaced by a compact back-arrow icon button rendered above the "Import from catalog" card, aligned with the left edge of the centered card column.
- `CatalogImportConfirmPanel` no longer owns the back control: the `backActionLabel` copy field and the `isBackDisabled` / `onBack` props are removed.
- `CatalogImportScreen` renders the new `CatalogImportBackNav` only while the workspace step exists and the confirm step is active, keeping the same disabled conditions as before.
- `invite.css` restyles `.catalog-import-back-button` into a 40x40 pill icon button and drops its full-width mobile rule.

## Why

The text button sat in the action row next to the primary confirm action and competed with it. A top-left arrow is the conventional back affordance, frees the action row for the primary action only, and reads the same on mobile and desktop.

The `data-testid="catalog-import-back"` hook is preserved, and the arrow carries the existing localized `catalogImport.back` string as its `aria-label`, so no translations change.

## Scope

One of three catalog import polish items landing on `integration-catalog-import-polish` before a single promotion PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)