### PR TITLE
fix(web): give catalog import inner blocks half the card radius

### DIFF
--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -14,6 +14,8 @@
 }
 
 .invite-panel {
+  /* Inner blocks follow the half-radius rule instead of the padding-derived default. */
+  --content-card-inner-radius: calc(var(--content-card-radius) / 2);
   width: min(100%, 560px);
   display: grid;
   gap: 16px;
@@ -238,7 +240,7 @@
 }
 
 .catalog-import-advanced {
-  border-radius: var(--radius-md);
+  border-radius: var(--content-card-inner-radius, var(--radius-sm));
   background: var(--surface-hover);
   overflow: hidden;
 }


### PR DESCRIPTION
## What changed

`.invite-panel` now sets `--content-card-inner-radius` to `calc(var(--content-card-radius) / 2)`, and `.catalog-import-advanced` consumes that variable instead of a hardcoded `var(--radius-md)`.

## Why

The two inner blocks of the catalog import card disagreed on their corner radius:

- the preview stats block inherited the padding-derived default for `--content-card-inner-radius`, which resolved to **2px**
- the advanced settings block was hardcoded to `var(--radius-md)`, i.e. **14px**

Both blocks sit inside the same card, so they should follow the same half-radius rule. Deriving the value from the card radius on `.invite-panel` fixes both at once and keeps the rule in one place.

## Context

This is one of three catalog import polish items landing on `integration-catalog-import-polish`. The integration branch is promoted to `main` afterwards through a single promotion PR.