### PR TITLE
fix(web): mirror the catalog import back arrow in RTL and drop the duplicate email

### DIFF
--- a/apps/web/src/screens/catalog/CatalogImportScreen.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.tsx
@@ -854,7 +854,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       ) : null}
       <CatalogImportContextCard
         catalogContext={catalogContext}
-        accountEmail={cloudSettings?.linkedEmail ?? session?.profile.email ?? null}
+        accountEmail={step === "done" ? null : (cloudSettings?.linkedEmail ?? session?.profile.email ?? null)}
       />
       {workspaceErrorMessage === "" ? null : (
         <section className="content-card invite-panel" data-testid="catalog-import-workspace-error">

--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -302,6 +302,12 @@
   height: 20px;
 }
 
+/* The chevron path is hardcoded left-pointing, so RTL locales need it mirrored. Only the icon flips
+   so the button's focus ring geometry stays untouched. */
+[dir="rtl"] .catalog-import-back-icon {
+  transform: scaleX(-1);
+}
+
 .catalog-import-success-header {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);


### PR DESCRIPTION
These are the two P3 findings from the cumulative promotion review of the catalog import polish integration branch, landed before promoting to main.

- The catalog import back control's chevron path is hardcoded left-pointing, so RTL locales now mirror the icon. Only the icon flips, so the button's focus ring geometry stays untouched.
- The header context card no longer repeats the account email on the completed step, where the success panel already shows it.