### PR TITLE
fix(web): wrap the catalog import account email and drop the nav landmark

### DIFF
--- a/apps/web/src/screens/catalog/CatalogImportScreen.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.tsx
@@ -148,7 +148,7 @@ function CatalogImportContextCard(props: Readonly<{
         {t("catalogImport.author", { author: catalogContext.author.displayName })}
       </p>
       {accountEmail === null ? null : (
-        <p className="subtitle" data-testid="catalog-import-account-email">
+        <p className="subtitle catalog-import-account-email" data-testid="catalog-import-account-email">
           {t("catalogImport.accountEmail", { email: accountEmail })}
         </p>
       )}
@@ -161,7 +161,7 @@ function CatalogImportBackNav(props: Readonly<{ isDisabled: boolean; onBack: () 
   const { t } = useI18n();
 
   return (
-    <nav className="catalog-import-back-nav">
+    <div className="catalog-import-back-nav">
       <button
         className="ghost-btn catalog-import-back-button"
         type="button"
@@ -183,7 +183,7 @@ function CatalogImportBackNav(props: Readonly<{ isDisabled: boolean; onBack: () 
           <path d="M15 5l-7 7 7 7" />
         </svg>
       </button>
-    </nav>
+    </div>
   );
 }
 

--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -214,6 +214,11 @@
   line-height: 1.35;
 }
 
+/* An email address is one unbreakable token, so it has to wrap inside the fixed-width card. */
+.catalog-import-account-email {
+  overflow-wrap: anywhere;
+}
+
 .catalog-import-workspace-option-active {
   background: var(--accent-soft);
   color: var(--accent-strong);


### PR DESCRIPTION
These are the two findings from the second cumulative promotion review of the catalog import polish integration branch, landed before promoting to `main`.

- A long account email is a single unbreakable token and overflowed the fixed-width catalog import header card, so it now carries the same `overflow-wrap` treatment as the existing account row.
- The single back button no longer sits in an unnamed `nav` landmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)