### PR TITLE
Refactor group catalog distribution workflows

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -81,8 +81,8 @@ export const boundaryDefinitions = Object.freeze([
     migrationFileName: "0107_catalog_test_collection.sql",
     expectedMigrationCount: 109,
     testFiles: Object.freeze([
-      "src/catalog/distribution/public.postgres.integration.ts",
-      "src/catalog/distribution/install.postgres.integration.ts",
+      "src/catalog/distribution/public/public.postgres.integration.ts",
+      "src/catalog/distribution/install/install.postgres.integration.ts",
       "src/catalog/authoring/lockOrder.postgres.integration.ts",
       "src/cards/generatedImageAppend.postgres.integration.ts",
       "src/chat/cardImages/operation.postgres.integration.ts",

--- a/apps/backend/src/catalog/distribution/install/index.ts
+++ b/apps/backend/src/catalog/distribution/install/index.ts
@@ -1,0 +1,8 @@
+export {
+  catalogPackageInstallOperationIdPrefixMaximumLength,
+  installCatalogPackageVersion,
+  installCatalogPackageVersionInExecutor,
+  isValidCatalogPackageInstallOperationIdPrefix,
+  previewCatalogPackageInstall,
+  previewCatalogPackageInstallInExecutor,
+} from "./install";

--- a/apps/backend/src/catalog/distribution/install/install.postgres.integration.ts
+++ b/apps/backend/src/catalog/distribution/install/install.postgres.integration.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
 import test from "node:test";
 import pg from "pg";
-import { HttpError } from "../../shared/errors";
-import type { CatalogPackageInstallConfirmInput } from "../types";
+import { HttpError } from "../../../shared/errors";
+import type { CatalogPackageInstallConfirmInput } from "../../types";
 import { installCatalogPackageVersion } from "./install";
 
 type InstallEffectCounts = Readonly<{

--- a/apps/backend/src/catalog/distribution/install/install.test.ts
+++ b/apps/backend/src/catalog/distribution/install/install.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../../database";
-import { createCatalogInstallRoutes } from "../../routes/catalogInstall";
-import { HttpError } from "../../shared/errors";
+import type { DatabaseExecutor, SqlValue } from "../../../database";
+import { createCatalogInstallRoutes } from "../../../routes/catalogInstall";
+import { HttpError } from "../../../shared/errors";
 import {
   catalogPackageInstallOperationIdPrefixMaximumLength,
   installCatalogPackageVersionInExecutor,
@@ -21,12 +21,12 @@ import {
   testWorkspaceCardId,
   testWorkspaceId,
   testWorkspaceMediaAssetId,
-} from "../testSupport";
+} from "../../testSupport";
 import type {
   CatalogPackageInstallConfirmInput,
   CatalogPackageInstallResult,
   CatalogPackageStatus,
-} from "../types";
+} from "../../types";
 
 const testWorkspaceReplicaId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 const testInstallTimestamp = "2026-04-19T10:30:00.000Z";

--- a/apps/backend/src/catalog/distribution/install/install.ts
+++ b/apps/backend/src/catalog/distribution/install/install.ts
@@ -4,39 +4,39 @@ import {
   transactionWithWorkspaceScope,
   transactionWithWorkspaceScopeReadOnly,
   type DatabaseExecutor,
-} from "../../database";
-import type { CardMetadata, CardSourceMetadata } from "../../cards/types";
-import { normalizeCardMetadata } from "../../cards/shared";
+} from "../../../database";
+import type { CardMetadata, CardSourceMetadata } from "../../../cards/types";
+import { normalizeCardMetadata } from "../../../cards/shared";
 import {
   isValidMediaAssetLastOperationId,
   isValidMediaAssetLastOperationIdPrefix,
   maximumMediaAssetLastOperationIdLength,
-} from "../../mediaAssets/lastOperationId";
-import { assertReplicaBelongsToWorkspaceInExecutor } from "../../mediaAssets/workspaceReplicas";
-import { HttpError } from "../../shared/errors";
+} from "../../../mediaAssets/lastOperationId";
+import { assertReplicaBelongsToWorkspaceInExecutor } from "../../../mediaAssets/workspaceReplicas";
+import { HttpError } from "../../../shared/errors";
 import {
   buildSuggestedCardImportTag,
   normalizeCardImportTagOptions,
   planCardImportTags,
   type CardImportTagPlan,
-} from "../../shared/cardImportTags";
-import { normalizeIsoTimestamp } from "../../sync/conflicts/lww";
+} from "../../../shared/cardImportTags";
+import { normalizeIsoTimestamp } from "../../../sync/conflicts/lww";
 import {
   insertSyncChange,
   lockWorkspaceSyncMetadataForHotChangesInExecutor,
   type HotChangeWriteLock,
-} from "../../sync/replication/changes";
-import { rewriteMarkdownFcAssetUrlsToFcAssets } from "../../workspacePackages";
+} from "../../../sync/replication/changes";
+import { rewriteMarkdownFcAssetUrlsToFcAssets } from "../../../workspacePackages";
 import {
   isLowercaseWorkspaceId,
   normalizeWorkspaceId,
-} from "../../workspaces/identity";
+} from "../../../workspaces/identity";
 import {
   normalizeNonEmptyString,
   toIsoString,
   toOptionalIsoString,
   toSafeNumber,
-} from "../common";
+} from "../../common";
 import type {
   CatalogPackageStatus,
   TimestampValue,
@@ -47,7 +47,7 @@ import type {
   CatalogPackageInstallPackageVersion,
   CatalogInstalledCard,
   CatalogInstalledMediaAsset,
-} from "../types";
+} from "../../types";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 const maximumJavaScriptArrayIndex = 4_294_967_294;

--- a/apps/backend/src/catalog/distribution/public/index.ts
+++ b/apps/backend/src/catalog/distribution/public/index.ts
@@ -1,0 +1,15 @@
+export {
+  listPublicCatalogPackages,
+  listPublicCatalogPackagesInExecutor,
+  loadPublicCatalogPackageDetail,
+  loadPublicCatalogPackageDetailInExecutor,
+  loadPublicCatalogPackageMediaAssetsInExecutor,
+  loadPublicCatalogPackageMediaForDownload,
+  loadPublicCatalogPackageMediaForDownloadInExecutor,
+  loadPublicCatalogPackageVersionCardPreview,
+  loadPublicCatalogPackageVersionCardPreviewInExecutor,
+  loadPublicCatalogSnapshot,
+  loadPublicCatalogSnapshotInExecutor,
+  normalizeCatalogPublicPackageCardPreviewInput,
+  normalizeCatalogPublicPackageListInput,
+} from "./public";

--- a/apps/backend/src/catalog/distribution/public/public.postgres.integration.ts
+++ b/apps/backend/src/catalog/distribution/public/public.postgres.integration.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../../database";
+import type { DatabaseExecutor, SqlValue } from "../../../database";
 import { loadPublicCatalogSnapshotInExecutor } from "./public";
 
 const fixtureAuthorId = "00000000-0000-4000-a105-000000000001";

--- a/apps/backend/src/catalog/distribution/public/public.test.ts
+++ b/apps/backend/src/catalog/distribution/public/public.test.ts
@@ -3,11 +3,11 @@ import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../../database";
-import { createCatalogPublicRoutes } from "../../routes/catalogPublic";
-import type { AppEnv } from "../../server/app";
-import { HttpError } from "../../shared/errors";
-import { maximumPublicCatalogMediaDownloadBytes } from "../publicMediaDelivery";
+import type { DatabaseExecutor, SqlValue } from "../../../database";
+import { createCatalogPublicRoutes } from "../../../routes/catalogPublic";
+import type { AppEnv } from "../../../server/app";
+import { HttpError } from "../../../shared/errors";
+import { maximumPublicCatalogMediaDownloadBytes } from "../../publicMediaDelivery";
 import {
   listPublicCatalogPackagesInExecutor,
   loadPublicCatalogSnapshotInExecutor,
@@ -23,8 +23,8 @@ import {
   testPackageVersionId,
   testTimestamp,
   testWorkspaceMediaAssetId,
-} from "../testSupport";
-import type { CatalogPublicPackageMediaDownloadSource } from "../types";
+} from "../../testSupport";
+import type { CatalogPublicPackageMediaDownloadSource } from "../../types";
 
 const legacyPrivateWorkspacePackageMediaKey = `w-${testWorkspaceMediaAssetId}`;
 const unsafeShaPackageMediaKey = "a".repeat(64);

--- a/apps/backend/src/catalog/distribution/public/public.ts
+++ b/apps/backend/src/catalog/distribution/public/public.ts
@@ -1,6 +1,6 @@
-import type { DatabaseExecutor, SqlValue } from "../../database";
-import { unsafeRepeatableReadReadOnlyTransaction } from "../../database/core";
-import { HttpError } from "../../shared/errors";
+import type { DatabaseExecutor, SqlValue } from "../../../database";
+import { unsafeRepeatableReadReadOnlyTransaction } from "../../../database/core";
+import { HttpError } from "../../../shared/errors";
 import {
   isUnsafePublicPackageMediaKey,
   normalizeNonEmptyString,
@@ -8,17 +8,17 @@ import {
   normalizeSlug,
   toIsoString,
   toSafeNumber,
-} from "../common";
+} from "../../common";
 import {
   getCatalogCardRequiredPackageMediaKeys,
-} from "../cardMedia";
+} from "../../cardMedia";
 import {
   getPublicCatalogAuthorEligibilityIssue,
   getPublicCatalogVersionEligibilityIssue,
   isPublicCatalogCardMarkdownSafe,
   isPublicCatalogTextArraySafe,
   isPublicCatalogTextSafe,
-} from "../publicSafety";
+} from "../../publicSafety";
 import type {
   CatalogPublicAuthor,
   CatalogPublicPackageCardPreview,
@@ -38,8 +38,8 @@ import type {
   CatalogPublicSnapshotPackage,
   CatalogPublicSnapshotPackageVersion,
   TimestampValue,
-} from "../types";
-import { catalogPublicSnapshotSchemaVersion } from "../types";
+} from "../../types";
+import { catalogPublicSnapshotSchemaVersion } from "../../types";
 
 type PublicCatalogQuery = Readonly<{
   text: string;


### PR DESCRIPTION
## Summary

- move public catalog distribution into its own workflow directory
- move catalog installation into its own workflow directory
- preserve catalog exports and PostgreSQL integration boundaries

## Review

The exact snapshot patch was reviewed with no P0-P4 findings. This PR reproduces that reviewed content byte-for-byte on the current integration base.

## Validation

Project checks were not run, per the delegated delivery instructions.