### PR TITLE
Refactor: group card image provider

### DIFF
--- a/apps/backend/src/chat/cardImages/index.ts
+++ b/apps/backend/src/chat/cardImages/index.ts
@@ -2,6 +2,6 @@ export { generateCardImage } from "./operation";
 export {
   generatedCardImageModel, generatedCardImageOutputFormat,
   generatedCardImageQuality, generatedCardImageSize,
-} from "./openaiAdapter";
+} from "./provider/openaiAdapter";
 export type { GeneratedCardImageInput, GeneratedCardImageResult } from "./types";
 export type { GeneratedCardImageObservationContext } from "./providerTypes";

--- a/apps/backend/src/chat/cardImages/operation.ts
+++ b/apps/backend/src/chat/cardImages/operation.ts
@@ -33,15 +33,17 @@ import {
   type MarkGeneratedCardImageProviderStartedResult,
 } from "../openai/tools/generatedImageAttemptBudget";
 import { deriveGeneratedCardImageOperationMetadata } from "./metadata";
-import { createOpenAIGeneratedCardImageProvider } from "./openaiAdapter";
+import { createOpenAIGeneratedCardImageProvider } from "./provider/openaiAdapter";
 import { withGeneratedCardImageOperationLock } from "./operationLock";
 import { enqueueGeneratedMediaPromotionJob, type EnqueueGeneratedMediaPromotionJobResult } from "./promotion/jobs";
+import {
+  type GeneratedProviderImage,
+  type OpenAIImageGenerationInput,
+} from "./provider/providerTypes";
 import {
   GeneratedCardImageDeadlineExceededError,
   GeneratedCardImageProviderOutcomeUnknownError,
   GeneratedCardImageStagingOutcomeUnknownError,
-  type GeneratedProviderImage,
-  type OpenAIImageGenerationInput,
 } from "./providerTypes";
 import type {
   GeneratedCardImageInput,

--- a/apps/backend/src/chat/cardImages/provider/openaiAdapter.test.ts
+++ b/apps/backend/src/chat/cardImages/provider/openaiAdapter.test.ts
@@ -10,14 +10,14 @@ import test from "node:test";
 import type { LangfuseObservation } from "@langfuse/tracing";
 import * as Sentry from "@sentry/aws-serverless";
 import OpenAI from "openai";
-import { maximumImageIngestionOriginalBytes } from "../../mediaAssets/validators";
+import { maximumImageIngestionOriginalBytes } from "../../../mediaAssets/validators";
 import {
   createBackendObservationScope,
-} from "../../observability/sentry";
+} from "../../../observability/sentry";
 import {
   sentryModule,
-} from "../../observability/sentry/testHelpers";
-import { buildOpenAISafetyIdentifier } from "../openai/safetyIdentifier";
+} from "../../../observability/sentry/testHelpers";
+import { buildOpenAISafetyIdentifier } from "../../openai/safetyIdentifier";
 import {
   decodeGeneratedCardImageBase64,
   generatedCardImageModel,
@@ -31,7 +31,7 @@ import {
 import type {
   OpenAIImageGenerationInput,
 } from "./providerTypes";
-import { GeneratedCardImageDeadlineExceededError } from "./providerTypes";
+import { GeneratedCardImageDeadlineExceededError } from "../providerTypes";
 
 type CapturedProviderRequest = Readonly<{
   method: string | null;

--- a/apps/backend/src/chat/cardImages/provider/openaiAdapter.ts
+++ b/apps/backend/src/chat/cardImages/provider/openaiAdapter.ts
@@ -1,14 +1,14 @@
 import OpenAI from "openai";
-import { buildOpenAISafetyIdentifier } from "../openai/safetyIdentifier";
-import { getOpenAIClient } from "../openai/client";
+import { buildOpenAISafetyIdentifier } from "../../openai/safetyIdentifier";
+import { getOpenAIClient } from "../../openai/client";
 import {
   addBackendBreadcrumb,
   captureBackendWarning,
   type GeneratedCardImageProviderDetails,
-} from "../../observability/sentry";
-import { maximumImageIngestionOriginalBytes } from "../../mediaAssets/validators";
+} from "../../../observability/sentry";
+import { maximumImageIngestionOriginalBytes } from "../../../mediaAssets/validators";
+import { GeneratedCardImageDeadlineExceededError } from "../providerTypes";
 import {
-  GeneratedCardImageDeadlineExceededError,
   type GeneratedProviderImage,
   type OpenAIImageGenerationInput,
 } from "./providerTypes";

--- a/apps/backend/src/chat/cardImages/provider/providerTypes.ts
+++ b/apps/backend/src/chat/cardImages/provider/providerTypes.ts
@@ -1,0 +1,14 @@
+import type { GeneratedCardImageObservationContext } from "../providerTypes";
+
+export type GeneratedProviderImage = Readonly<{
+  bytes: Buffer;
+  providerRequestId: string | null;
+}>;
+
+export type OpenAIImageGenerationInput = Readonly<{
+  userId: string;
+  imagePrompt: string;
+  observationContext: GeneratedCardImageObservationContext;
+  signal: AbortSignal;
+  operationDeadlineMs: number;
+}>;

--- a/apps/backend/src/chat/cardImages/providerTypes.ts
+++ b/apps/backend/src/chat/cardImages/providerTypes.ts
@@ -6,19 +6,6 @@ export type GeneratedCardImageObservationContext = Readonly<{
   rootObservation: LangfuseObservation | null;
 }>;
 
-export type GeneratedProviderImage = Readonly<{
-  bytes: Buffer;
-  providerRequestId: string | null;
-}>;
-
-export type OpenAIImageGenerationInput = Readonly<{
-  userId: string;
-  imagePrompt: string;
-  observationContext: GeneratedCardImageObservationContext;
-  signal: AbortSignal;
-  operationDeadlineMs: number;
-}>;
-
 export class GeneratedCardImageDeadlineExceededError extends Error {
   readonly code = "GENERATED_CARD_IMAGE_DEADLINE_EXCEEDED";
 

--- a/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
+++ b/apps/backend/src/chat/openai/loop/loop.stopReplay.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../cardImages/operation";
 import {
   OpenAIImageGenerationResponseError,
-} from "../../cardImages/openaiAdapter";
+} from "../../cardImages/provider/openaiAdapter";
 import {
   GeneratedCardImageProviderOutcomeUnknownError,
   GeneratedCardImageStagingOutcomeUnknownError,

--- a/apps/backend/src/chat/openai/tools/tools.test.ts
+++ b/apps/backend/src/chat/openai/tools/tools.test.ts
@@ -37,7 +37,7 @@ import {
 import {
   OpenAIGeneratedCardImageProvider,
   OpenAIImageGenerationResponseError,
-} from "../../cardImages/openaiAdapter";
+} from "../../cardImages/provider/openaiAdapter";
 import {
   GeneratedCardImageDeadlineExceededError,
   GeneratedCardImageProviderOutcomeUnknownError,

--- a/apps/backend/src/chat/openai/tools/tools.ts
+++ b/apps/backend/src/chat/openai/tools/tools.ts
@@ -27,7 +27,7 @@ import {
   SQL_TOOL_NAME,
 } from "../../../aiTools/toolContract/sqlToolContract";
 import { generateCardImage, type GeneratedCardImageObservationContext } from "../../cardImages";
-import { isOpenAIImageGenerationProviderError } from "../../cardImages/openaiAdapter";
+import { isOpenAIImageGenerationProviderError } from "../../cardImages/provider/openaiAdapter";
 import {
   GeneratedCardImageDeadlineExceededError,
   GeneratedCardImageProviderOutcomeUnknownError,


### PR DESCRIPTION
## Summary

- group the OpenAI card-image adapter and contract tests under the provider boundary
- move provider-only contract types into the provider directory
- update imports and facade exports without behavior changes

## Validation

- exact reviewed snapshot patch reproduced on the current integration base
- staged file set and all destination blobs verified against the reviewed snapshot
- no local project checks run, per repository integration-PR policy