### PR TITLE
fix(web): export media upload test mock safely

### DIFF
--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadClaimLifecycle.test.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadClaimLifecycle.test.ts
@@ -1,22 +1,23 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { claimNextDueMediaTransferByKind } from "../../../localDb/mediaTransfers";
+import { primeSessionCsrfToken, setNavigationHandlerForTests } from "../../../api";
+import { createJsonResponse } from "../../../api/ApiTestSupport";
+import {
+  claimNextDueMediaTransferByKind,
+  loadMediaTransferQueueRecord,
+} from "../../../localDb/mediaTransfers";
 import {
   createAbortResponse,
-  createJsonResponse,
   createTestBlob,
   createUploadRequiredResponse,
   createdAt,
   futurePartUrlExpiresAt,
-  loadMediaTransferQueueRecord,
   mediaAssetFixture,
   mediaTransferRenewMock,
-  primeSessionCsrfToken,
   processDueMediaUploadTransfersForWorkspace,
   resetMediaUploadTransferTestState,
   seedQueuedUpload,
-  setNavigationHandlerForTests,
   textMimeType,
   transferId,
   workspaceId,

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.test.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.test.ts
@@ -1,21 +1,23 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { primeSessionCsrfToken } from "../../../api";
+import { createJsonResponse } from "../../../api/ApiTestSupport";
 import { loadMediaAssetRecord } from "../../../localDb/mediaAssets";
-import { enqueueMediaTransferUpload } from "../../../localDb/mediaTransfers";
 import {
-  createJsonResponse,
+  enqueueMediaTransferUpload,
+  loadMediaTransferQueueRecord,
+} from "../../../localDb/mediaTransfers";
+import {
   createTestBlob,
   createUploadRequiredResponse,
   createdAt,
   futurePartUrlExpiresAt,
   helloWorldSha256,
   installationId,
-  loadMediaTransferQueueRecord,
   mediaAssetFixture,
   mediaAssetId,
   parseRequestBody,
-  primeSessionCsrfToken,
   processDueMediaUploadTransfersForWorkspace,
   resetMediaUploadTransferTestState,
   seedQueuedUpload,

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
@@ -13,7 +13,7 @@ import {
 import { putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import type { CloudSettings, MediaAsset } from "../../../types";
 import {
-  processDueMediaUploadTransfersForWorkspace as runDueMediaUploadTransfersForWorkspace,
+  processDueMediaUploadTransfersForWorkspace as runMediaUploadTransferRunner,
 } from "./mediaUploadTransferRunner";
 
 type RenewMediaTransferClaim = (input: RenewInProgressMediaTransferClaimInput) => Promise<MediaTransferQueueRecord>;
@@ -45,10 +45,17 @@ export const textMimeType = "text/plain";
 export const futurePartUrlExpiresAt = "9999-12-31T23:59:59.999Z";
 
 export function processDueMediaUploadTransfersForWorkspace(testWorkspaceId: string): Promise<void> {
-  return runDueMediaUploadTransfersForWorkspace(
+  return runMediaUploadTransferRunner(
     testWorkspaceId,
     new AbortController().signal,
   );
+}
+
+export function runDueMediaUploadTransfersForWorkspace(
+  testWorkspaceId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  return runMediaUploadTransferRunner(testWorkspaceId, signal);
 }
 
 function toTestUuidFromHexDigest(hexDigest: string): string {

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
@@ -29,10 +29,12 @@ export {
 
 type RenewMediaTransferClaim = (input: RenewInProgressMediaTransferClaimInput) => Promise<MediaTransferQueueRecord>;
 
-export const mediaTransferRenewMock = vi.hoisted(() => ({
+const mediaTransferRenewMock = vi.hoisted(() => ({
   defaultRenewInProgressMediaTransferClaim: null as RenewMediaTransferClaim | null,
   renewInProgressMediaTransferClaim: vi.fn<RenewMediaTransferClaim>(),
 }));
+
+export { mediaTransferRenewMock };
 
 vi.mock("../../../localDb/mediaTransfers", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../localDb/mediaTransfers")>();

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
@@ -2,12 +2,10 @@ import { createHash } from "node:crypto";
 import { Blob as NodeBlob } from "node:buffer";
 import { vi } from "vitest";
 import "../../../api/endpoints/endpointsTestSupport";
-import { primeSessionCsrfToken, setNavigationHandlerForTests } from "../../../api";
 import { createJsonResponse } from "../../../api/ApiTestSupport";
 import { clearWebSyncCache } from "../../../localDb/core/cache";
 import {
   enqueueMediaTransferUpload,
-  loadMediaTransferQueueRecord,
   type MediaTransferQueueRecord,
   type RenewInProgressMediaTransferClaimInput,
   writeMediaBlobCacheRecord,
@@ -17,15 +15,6 @@ import type { CloudSettings, MediaAsset } from "../../../types";
 import {
   processDueMediaUploadTransfersForWorkspace as runDueMediaUploadTransfersForWorkspace,
 } from "./mediaUploadTransferRunner";
-
-export {
-  primeSessionCsrfToken,
-  setNavigationHandlerForTests,
-  createJsonResponse,
-  loadMediaTransferQueueRecord,
-  runDueMediaUploadTransfersForWorkspace,
-};
-
 
 type RenewMediaTransferClaim = (input: RenewInProgressMediaTransferClaimInput) => Promise<MediaTransferQueueRecord>;
 

--- a/apps/web/src/appData/sync/mediaUploads/multipartCompletion.test.ts
+++ b/apps/web/src/appData/sync/mediaUploads/multipartCompletion.test.ts
@@ -2,27 +2,30 @@
 
 import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { markMediaTransferSucceeded } from "../../../localDb/mediaTransfers";
+import { primeSessionCsrfToken, setNavigationHandlerForTests } from "../../../api";
+import { createJsonResponse } from "../../../api/ApiTestSupport";
+import {
+  loadMediaTransferQueueRecord,
+  markMediaTransferSucceeded,
+} from "../../../localDb/mediaTransfers";
+import {
+  processDueMediaUploadTransfersForWorkspace as runDueMediaUploadTransfersForWorkspace,
+} from "./mediaUploadTransferRunner";
 import {
   bufferSourceToBytes,
   createAbortResponse,
-  createJsonResponse,
   createTestBlob,
   createUploadRequiredResponse,
   futurePartUrlExpiresAt,
   getAlgorithmName,
   helloWorldSha256,
-  loadMediaTransferQueueRecord,
   mediaAssetFixture,
   mediaAssetId,
   mediaTransferRenewMock,
   parseRequestBody,
-  primeSessionCsrfToken,
   processDueMediaUploadTransfersForWorkspace,
   resetMediaUploadTransferTestState,
-  runDueMediaUploadTransfersForWorkspace,
   seedQueuedUpload,
-  setNavigationHandlerForTests,
   textMimeType,
   toArrayBuffer,
   transferId,

--- a/apps/web/src/appData/sync/mediaUploads/multipartCompletion.test.ts
+++ b/apps/web/src/appData/sync/mediaUploads/multipartCompletion.test.ts
@@ -9,9 +9,6 @@ import {
   markMediaTransferSucceeded,
 } from "../../../localDb/mediaTransfers";
 import {
-  processDueMediaUploadTransfersForWorkspace as runDueMediaUploadTransfersForWorkspace,
-} from "./mediaUploadTransferRunner";
-import {
   bufferSourceToBytes,
   createAbortResponse,
   createTestBlob,
@@ -25,6 +22,7 @@ import {
   parseRequestBody,
   processDueMediaUploadTransfersForWorkspace,
   resetMediaUploadTransferTestState,
+  runDueMediaUploadTransfersForWorkspace,
   seedQueuedUpload,
   textMimeType,
   toArrayBuffer,

--- a/apps/web/src/appData/sync/mediaUploads/signedPartUpload.test.ts
+++ b/apps/web/src/appData/sync/mediaUploads/signedPartUpload.test.ts
@@ -2,21 +2,23 @@
 
 import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { primeSessionCsrfToken } from "../../../api";
+import { createJsonResponse } from "../../../api/ApiTestSupport";
+import { loadMediaTransferQueueRecord } from "../../../localDb/mediaTransfers";
+import {
+  processDueMediaUploadTransfersForWorkspace as runDueMediaUploadTransfersForWorkspace,
+} from "./mediaUploadTransferRunner";
 import {
   createAbortResponse,
-  createJsonResponse,
   createTestBlob,
   createUploadRequiredResponse,
   futurePartUrlExpiresAt,
-  loadMediaTransferQueueRecord,
   mediaAssetFixture,
   mediaAssetId,
   mediaTransferRenewMock,
   parseRequestBody,
-  primeSessionCsrfToken,
   processDueMediaUploadTransfersForWorkspace,
   resetMediaUploadTransferTestState,
-  runDueMediaUploadTransfersForWorkspace,
   seedQueuedUpload,
   textMimeType,
   transferId,

--- a/apps/web/src/appData/sync/mediaUploads/signedPartUpload.test.ts
+++ b/apps/web/src/appData/sync/mediaUploads/signedPartUpload.test.ts
@@ -6,9 +6,6 @@ import { primeSessionCsrfToken } from "../../../api";
 import { createJsonResponse } from "../../../api/ApiTestSupport";
 import { loadMediaTransferQueueRecord } from "../../../localDb/mediaTransfers";
 import {
-  processDueMediaUploadTransfersForWorkspace as runDueMediaUploadTransfersForWorkspace,
-} from "./mediaUploadTransferRunner";
-import {
   createAbortResponse,
   createTestBlob,
   createUploadRequiredResponse,
@@ -19,6 +16,7 @@ import {
   parseRequestBody,
   processDueMediaUploadTransfersForWorkspace,
   resetMediaUploadTransferTestState,
+  runDueMediaUploadTransfersForWorkspace,
   seedQueuedUpload,
   textMimeType,
   transferId,


### PR DESCRIPTION
## Summary
- keep the Vitest hoisted media-transfer mock as a private module binding
- export the binding separately so all four split media-upload suites import successfully
- preserve existing test behavior

## Hosted failure
Fixes the Web test suite import failure from PR #1298: `Cannot export hoisted variable`.

## Validation
- fresh static review: no P0-P4 findings
- hosted CI only; no local project checks were run