### PR TITLE
Refactor OpenAI loop boundaries

### DIFF
--- a/apps/backend/src/chat/openai/loop/loop.ts
+++ b/apps/backend/src/chat/openai/loop/loop.ts
@@ -1,18 +1,9 @@
 /**
  * OpenAI model loop for backend-owned chat runs.
- * The loop replays persisted history, streams provider events, executes tool calls, and returns replay items for the next recovery point.
+ * The loop replays persisted history, sequences model and tool steps, and returns replay items for the next recovery point.
  */
 import OpenAI from "openai";
 import type { LangfuseObservation } from "@langfuse/tracing";
-import {
-  applyFunctionCallArgumentsDelta,
-  applyFunctionCallArgumentsDone,
-  applyToolCallOutput,
-  applyToolCallStarted,
-  createToolCallStateMap,
-  type FunctionToolCallRawItem,
-  type ToolCallPosition,
-} from "../tools/toolCalls";
 import {
   buildChatCompletionInput,
   buildChatCompletionInputWithBudget,
@@ -21,58 +12,57 @@ import {
 import { getObservedOpenAIClient } from "../client";
 import { isContextLengthExceededError } from "../../runtime/providerErrors";
 import { runOneToolCall as runObservedToolCall } from "../tools/toolExecutor";
-import {
-  toOpenAIResponseInputItem,
-  toStoredOpenAIReplayItem,
-  type ServerChatMessage,
-  type StoredOpenAIReplayItem,
-  type StoredOpenAIReplayMessage,
+import type {
+  ServerChatMessage,
+  StoredOpenAIReplayItem,
 } from "../replayItems";
-import {
-  buildOpenAIChatTools,
-  type ExecutedChatToolCall,
-} from "../tools/tools";
-import { buildOpenAISafetyIdentifier } from "../safetyIdentifier";
-import type { ChatStreamEvent, ContentPart } from "../../types";
-import {
-  createProviderTerminalEventError,
-  type ChatProviderStreamDiagnostics,
-} from "../../providerFailure";
+import { buildOpenAIChatTools, type ExecutedChatToolCall } from "../tools/tools";
+import type { ContentPart } from "../../types";
 import {
   CHAT_HISTORY_REPLAY_TOKEN_BUDGET,
   CHAT_MAX_OUTPUT_TOKENS,
   CHAT_MODEL_CONTEXT_WINDOW_TOKENS,
-  CHAT_MODEL_REASONING_SUMMARY,
   type ChatRuntimeModelId,
   type ChatRuntimeReasoningEffort,
 } from "../../config";
 import type { ChatRunClaimToken } from "../../runs";
-import { createGeneratedImageOperationKey } from "../../generatedImageOperationIdentity";
-import { GENERATED_IMAGE_TOOL_NAME } from "../tools/generatedImageToolContract";
+import {
+  buildOpenAIResponsesRequest,
+  buildPromptCacheKey,
+  buildToolLimitSummaryInstruction,
+  CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS,
+  completeToolLimitSummaryTurn,
+  executeToolCalls,
+  pruneUnpairedToolReplayItems,
+  runOneModelCallWithPhase,
+  type OpenAIResponsesRequest,
+  type RunOneToolCall,
+} from "./modelCall";
+import {
+  isOpenAIAbortError,
+  type ModelCallResult,
+  type OpenAILoopEventSink,
+} from "./responseStream";
 
-export const CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS = 30;
-const MAX_REASONING_ITEMS = 8;
-const TOOL_LIMIT_FALLBACK_ITEM_ID = "tool-limit-summary";
+export {
+  buildPromptCacheKey,
+  CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS,
+};
+export type { OpenAILoopEventSink };
 
 /**
  * Maximum estimated tokens of within-run continuation growth (model output plus
  * tool-call replay items accumulated across tool rounds) before the loop diverts
  * into the tool-limit summary turn instead of scheduling another tool-enabled
- * call. Reserves the history-replay budget for the base input and the
- * `max_output_tokens` headroom for the response, so the loop diverts into the
- * summary turn before `base input + continuation + reserved output` can exceed
- * the model context window even when the character-based estimate under-counts
- * dense content.
+ * call.
  */
 const MAX_WITHIN_RUN_REPLAY_TOKENS = CHAT_MODEL_CONTEXT_WINDOW_TOKENS
   - CHAT_HISTORY_REPLAY_TOKEN_BUDGET
   - CHAT_MAX_OUTPUT_TOKENS;
 
 /**
- * Tighter history-replay budget used to rebuild the base input when the first
- * model call overflows the context window before anything streamed. Halving the
- * default budget drops more of the oldest history while always preserving the
- * current turn, which is reserved separately and never truncated.
+ * Tighter history-replay budget used to rebuild the base input when a model
+ * call overflows the context window.
  */
 const REDUCED_HISTORY_REPLAY_TOKEN_BUDGET = Math.floor(CHAT_HISTORY_REPLAY_TOKEN_BUDGET / 2);
 
@@ -80,64 +70,12 @@ type OpenAILoopDependencies = Readonly<{
   buildChatCompletionInput: typeof buildChatCompletionInput;
   buildChatCompletionInputWithBudget: typeof buildChatCompletionInputWithBudget;
   getObservedOpenAIClient: typeof getObservedOpenAIClient;
-  runOneToolCall: (params: Readonly<{
-    item: OpenAI.Responses.ResponseFunctionToolCall;
-    requestId: string;
-    runId: string;
-    sessionId: string;
-    operationKey: string;
-    generatedImageEligible: boolean;
-    claimToken: ChatRunClaimToken;
-    userId: string;
-    workspaceId: string;
-    signal: AbortSignal | null;
-    generatedImageOperationDeadlineMs: number;
-    rootObservation: LangfuseObservation | null;
-  }>) => Promise<ExecutedChatToolCall>;
+  runOneToolCall: RunOneToolCall;
 }>;
 
 export type OpenAILoopCompletion = Readonly<{
   openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
   terminationReason: "completed" | "stopped_before_next_step" | "run_inactive";
-}>;
-
-export type OpenAILoopEventSink = (
-  event: ChatStreamEvent,
-) => Promise<void> | void;
-
-type ParsedFunctionToolCall = OpenAI.Responses.ResponseFunctionToolCall & Readonly<{
-  parsed_arguments?: unknown;
-}>;
-
-type ResponseStreamWithOptionalFinalResponse = AsyncIterable<OpenAI.Responses.ResponseStreamEvent> & Readonly<{
-  finalResponse?: () => Promise<OpenAI.Responses.Response>;
-}>;
-
-type OpenAIResponsesRequest = Readonly<{
-  model: ChatRuntimeModelId;
-  store: false;
-  include: ["reasoning.encrypted_content"];
-  tools: Array<OpenAI.Responses.Tool>;
-  input: Array<OpenAI.Responses.ResponseInputItem>;
-  max_output_tokens: number;
-  reasoning: Readonly<{
-    effort: ChatRuntimeReasoningEffort;
-    summary: typeof CHAT_MODEL_REASONING_SUMMARY;
-  }>;
-  prompt_cache_key: string;
-  safety_identifier: string;
-  parallel_tool_calls?: false;
-}>;
-
-type BuildOpenAIResponsesRequestParams = Readonly<{
-  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
-  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>;
-  userId: string;
-  sessionId: string;
-  modelId: ChatRuntimeModelId;
-  reasoningEffort: ChatRuntimeReasoningEffort;
-  extraInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
-  tools: ReadonlyArray<OpenAI.Responses.Tool>;
 }>;
 
 export type StartOpenAILoopParams = Readonly<{
@@ -159,245 +97,6 @@ export type StartOpenAILoopParams = Readonly<{
   onExecutionPhaseChanged?: (phase: "idle" | "model" | "tool") => void;
   shouldStopBeforeNextStep?: () => boolean;
 }>;
-
-type ModelCallResult = Readonly<{
-  finalResponse: OpenAI.Responses.Response;
-  functionCalls: ReadonlyArray<ParsedFunctionToolCall>;
-  replayItems: ReadonlyArray<StoredOpenAIReplayItem>;
-  streamedText: string;
-  toolStates: ReturnType<typeof createToolCallStateMap>;
-  // True when the response was capped at `max_output_tokens` after streaming a
-  // partial answer. The loop must finish with that partial text and never run
-  // any (possibly truncated) function call carried in the same output.
-  forceComplete: boolean;
-}>;
-
-function createToolCallPosition(
-  event: OpenAI.Responses.ResponseOutputItemAddedEvent,
-  responseIndex: number,
-): ToolCallPosition {
-  return {
-    itemId: typeof event.item.id === "string" && event.item.id.length > 0
-      ? event.item.id
-      : `response-output-${String(event.output_index)}`,
-    responseIndex,
-    outputIndex: event.output_index,
-    sequenceNumber: event.sequence_number,
-  };
-}
-
-function toFunctionToolCallRawItem(
-  item: OpenAI.Responses.ResponseFunctionToolCall,
-): FunctionToolCallRawItem {
-  return {
-    type: "function_call",
-    callId: item.call_id,
-    id: item.id,
-    name: item.name,
-    arguments: item.arguments,
-    status: item.status ?? undefined,
-  };
-}
-
-function toFunctionCallOutputInputItem(
-  callId: string,
-  output: string,
-): OpenAI.Responses.ResponseInputItem.FunctionCallOutput {
-  return {
-    type: "function_call_output",
-    call_id: callId,
-    output,
-  };
-}
-
-function isReasoningSummaryDelta(
-  event: OpenAI.Responses.ResponseStreamEvent,
-): event is OpenAI.Responses.ResponseReasoningSummaryTextDeltaEvent {
-  return event.type === "response.reasoning_summary_text.delta";
-}
-
-function isReasoningSummaryStarted(
-  event: OpenAI.Responses.ResponseStreamEvent,
-): event is OpenAI.Responses.ResponseReasoningSummaryPartAddedEvent {
-  return event.type === "response.reasoning_summary_part.added";
-}
-
-function isOutputTextDelta(
-  event: OpenAI.Responses.ResponseStreamEvent,
-): event is OpenAI.Responses.ResponseTextDeltaEvent {
-  return event.type === "response.output_text.delta";
-}
-
-function isResponseCompletedEvent(
-  event: OpenAI.Responses.ResponseStreamEvent,
-): event is OpenAI.Responses.ResponseCompletedEvent {
-  return event.type === "response.completed";
-}
-
-function isResponseFailedEvent(
-  event: OpenAI.Responses.ResponseStreamEvent,
-): event is OpenAI.Responses.ResponseFailedEvent {
-  return event.type === "response.failed";
-}
-
-function isResponseIncompleteEvent(
-  event: OpenAI.Responses.ResponseStreamEvent,
-): event is OpenAI.Responses.ResponseIncompleteEvent {
-  return event.type === "response.incomplete";
-}
-
-function isResponseErrorEvent(
-  event: OpenAI.Responses.ResponseStreamEvent,
-): event is OpenAI.Responses.ResponseErrorEvent {
-  return event.type === "error";
-}
-
-const OPENAI_STREAM_ABORT_ERROR_MESSAGE = "OpenAI response stream was aborted before a final response";
-
-class OpenAIStreamAbortError extends Error {
-  constructor() {
-    super(OPENAI_STREAM_ABORT_ERROR_MESSAGE);
-    this.name = "AbortError";
-  }
-}
-
-function createOpenAIStreamAbortError(): OpenAIStreamAbortError {
-  return new OpenAIStreamAbortError();
-}
-
-function isOpenAIAbortError(error: unknown): boolean {
-  return error instanceof OpenAI.APIUserAbortError
-    || error instanceof OpenAIStreamAbortError;
-}
-
-/**
- * Cheap running description of the provider event stream, accumulated while the
- * loop iterates so a stream that dies without a response stays diagnosable.
- * Only counts and enum-like values are kept, never event payload text.
- */
-type ResponseStreamCounters = Readonly<{
-  responseId: string | null;
-  eventCount: number;
-  lastEventType: string | null;
-  sawIncompleteEvent: boolean;
-  sawFailedEvent: boolean;
-}>;
-
-const EMPTY_RESPONSE_STREAM_COUNTERS: ResponseStreamCounters = {
-  responseId: null,
-  eventCount: 0,
-  lastEventType: null,
-  sawIncompleteEvent: false,
-  sawFailedEvent: false,
-};
-
-function accumulateResponseStreamCounters(
-  counters: ResponseStreamCounters,
-  event: OpenAI.Responses.ResponseStreamEvent,
-): ResponseStreamCounters {
-  return {
-    responseId: event.type === "response.created" ? event.response.id : counters.responseId,
-    eventCount: counters.eventCount + 1,
-    lastEventType: event.type,
-    sawIncompleteEvent: counters.sawIncompleteEvent || isResponseIncompleteEvent(event),
-    sawFailedEvent: counters.sawFailedEvent || isResponseFailedEvent(event),
-  };
-}
-
-function toStreamDiagnostics(
-  counters: ResponseStreamCounters,
-  streamedTextLength: number,
-): ChatProviderStreamDiagnostics {
-  return {
-    streamResponseId: counters.responseId,
-    streamEventCount: counters.eventCount,
-    streamLastEventType: counters.lastEventType,
-    streamSawIncompleteEvent: counters.sawIncompleteEvent,
-    streamSawFailedEvent: counters.sawFailedEvent,
-    streamedTextLength,
-  };
-}
-
-function hasProviderErrorCode(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return false;
-  }
-
-  const code = (error as Readonly<Record<string, unknown>>).code;
-  return typeof code === "string" && code.trim() !== "";
-}
-
-/**
- * Tags a rejected `finalResponse()` with the shape of the stream that produced
- * it, and with a code that fingerprints this terminal branch on its own when the
- * rejection carries none.
- *
- * The rejection is annotated and rethrown rather than replaced: its class and
- * any existing `code` are what the abort handling, the history-overflow retry
- * and `createPublicTerminalErrorMessage` classify on, so wrapping it would
- * change behavior that this diagnostics-only path must leave alone.
- */
-function markFinalResponseRejection(
-  error: unknown,
-  streamDiagnostics: ChatProviderStreamDiagnostics,
-): unknown {
-  if (typeof error !== "object" || error === null) {
-    return error;
-  }
-
-  if (hasProviderErrorCode(error)) {
-    return Object.assign(error, { streamDiagnostics });
-  }
-
-  return Object.assign(error, {
-    streamDiagnostics,
-    code: "stream_final_response_rejected",
-  });
-}
-
-/**
- * Resolves the response the loop must return once the event stream ended.
- *
- * The terminal branches carry distinct provider error codes because
- * `createChatTerminalWarningFingerprint` fingerprints Sentry groups by
- * `providerErrorCode`, so "the stream exposed no final response accessor" and
- * "the final response could not be resolved" become separate, separately
- * diagnosable groups instead of one shared code.
- */
-async function getFinalResponseFromStream(
-  stream: ResponseStreamWithOptionalFinalResponse,
-  completedResponse: OpenAI.Responses.Response | null,
-  signal: AbortSignal | undefined,
-  streamDiagnostics: ChatProviderStreamDiagnostics,
-): Promise<OpenAI.Responses.Response> {
-  if (completedResponse !== null) {
-    return completedResponse;
-  }
-
-  if (typeof stream.finalResponse === "function") {
-    try {
-      return await stream.finalResponse();
-    } catch (error) {
-      // An aborted run keeps its rejection untouched: the loop recognizes that
-      // error to finish as `stopped_before_next_step` rather than as a failure.
-      if (isOpenAIAbortError(error) || signal?.aborted === true) {
-        throw error;
-      }
-
-      throw markFinalResponseRejection(error, streamDiagnostics);
-    }
-  }
-
-  if (signal?.aborted === true) {
-    throw createOpenAIStreamAbortError();
-  }
-
-  throw createProviderTerminalEventError({
-    code: "stream_closed_without_final_response_accessor",
-    message: "OpenAI response stream completed without a final response and exposed no final response accessor",
-    streamDiagnostics,
-  });
-}
 
 async function runOneToolCall(
   params: Readonly<{
@@ -425,159 +124,6 @@ const DEFAULT_OPENAI_LOOP_DEPENDENCIES: OpenAILoopDependencies = {
   runOneToolCall,
 };
 
-function createInputTextMessage(
-  role: "system" | "user",
-  text: string,
-): OpenAI.Responses.ResponseInputItem.Message {
-  return {
-    type: "message",
-    role,
-    content: [{
-      type: "input_text",
-      text,
-    }],
-  };
-}
-
-function buildToolLimitSummaryInstruction(toolEnabledModelCallLimit: number): OpenAI.Responses.ResponseInputItem.Message {
-  return createInputTextMessage(
-    "system",
-    [
-      `The tool-enabled model call limit for this turn (${String(toolEnabledModelCallLimit)}) has been reached.`,
-      "Do not call any tools in this response.",
-      "Briefly summarize what you already completed.",
-      "Briefly state what remains unfinished.",
-      "Ask the user to send another message such as continue if they want you to keep going from the same chat session.",
-    ].join(" "),
-  );
-}
-
-function buildToolLimitFallbackText(): string {
-  return `I reached the tool-call limit for this turn (${String(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)}). Send another message such as continue and I will resume from the same chat session.`;
-}
-
-/**
- * Drops the replay items that a `max_output_tokens`-capped response cannot persist
- * safely alongside its partial streamed answer.
- *
- * The loop finishes with the partial text and never executes the truncated
- * `function_call` items, so persisting them would leave orphan `function_call`
- * items with no paired `function_call_output`. Dropping a trailing `function_call`
- * can in turn orphan a `reasoning` item that immediately preceded it: a reasoning
- * item replayed with no following same-turn output item is the same orphan class
- * and the Responses API rejects it on the next turn. So a `reasoning` item is kept
- * only when a later item in the same response output survives this filter; trailing
- * reasoning items left unpaired by the dropped calls are dropped too. The
- * user-visible answer is preserved via the streamed deltas regardless.
- */
-function pruneUnpairedToolReplayItems(
-  items: ReadonlyArray<StoredOpenAIReplayItem>,
-): ReadonlyArray<StoredOpenAIReplayItem> {
-  const functionCallIds = new Set(
-    items.filter((item) => item.type === "function_call").map((item) => item.call_id),
-  );
-  const outputCallIds = new Set(
-    items.filter((item) => item.type === "function_call_output").map((item) => item.call_id),
-  );
-  const pairedItems = items.filter((item) => {
-    if (item.type === "function_call") {
-      return outputCallIds.has(item.call_id);
-    }
-    if (item.type === "function_call_output") {
-      return functionCallIds.has(item.call_id);
-    }
-    return true;
-  });
-  const kept: Array<StoredOpenAIReplayItem> = [];
-
-  let hasFollowingKeptItem = false;
-  for (let index = pairedItems.length - 1; index >= 0; index -= 1) {
-    const item = pairedItems[index];
-    if (item.type === "reasoning" && !hasFollowingKeptItem) {
-      continue;
-    }
-
-    kept.push(item);
-    hasFollowingKeptItem = true;
-  }
-
-  return kept.reverse();
-}
-
-function createAssistantReplayMessage(text: string): StoredOpenAIReplayMessage {
-  return {
-    type: "message",
-    role: "assistant",
-    status: "completed",
-    phase: "final_answer",
-    content: [{
-      type: "output_text",
-      text,
-      annotations: [],
-    }],
-  };
-}
-
-async function emitSyntheticAssistantDelta(
-  onEvent: OpenAILoopEventSink,
-  text: string,
-  responseIndex: number,
-): Promise<void> {
-  if (text.trim().length === 0) {
-    return;
-  }
-
-  await onEvent({
-    type: "delta",
-    text,
-    itemId: TOOL_LIMIT_FALLBACK_ITEM_ID,
-    responseIndex,
-    outputIndex: 0,
-    contentIndex: 0,
-    sequenceNumber: 0,
-  });
-}
-
-function buildOpenAIInput(
-  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>,
-  extraInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-): Array<OpenAI.Responses.ResponseInputItem> {
-  return [
-    ...baseInput,
-    ...continuationItems.map(toOpenAIResponseInputItem),
-    ...extraInput,
-  ];
-}
-
-/**
- * Returns the stable prompt cache key used for all model calls within one chat session.
- */
-export function buildPromptCacheKey(sessionId: string): string {
-  return sessionId;
-}
-
-function buildOpenAIResponsesRequest(params: BuildOpenAIResponsesRequestParams): OpenAIResponsesRequest {
-  return {
-    model: params.modelId,
-    store: false,
-    include: ["reasoning.encrypted_content"],
-    tools: [...params.tools],
-    input: buildOpenAIInput(params.baseInput, params.continuationItems, params.extraInput),
-    max_output_tokens: CHAT_MAX_OUTPUT_TOKENS,
-    reasoning: {
-      effort: params.reasoningEffort,
-      summary: CHAT_MODEL_REASONING_SUMMARY,
-    },
-    prompt_cache_key: buildPromptCacheKey(params.sessionId),
-    safety_identifier: buildOpenAISafetyIdentifier(params.userId),
-    ...(params.tools.some((tool) => tool.type === "function"
-      && tool.name === "add_generated_image_to_card")
-      ? { parallel_tool_calls: false as const }
-      : {}),
-  };
-}
-
 function setExecutionPhase(
   params: StartOpenAILoopParams,
   phase: "idle" | "model" | "tool",
@@ -602,222 +148,74 @@ function createStoppedBeforeNextStepCompletion(
   };
 }
 
-async function runOneModelCall(
+type ModelCallWithOverflowRetryResult = Readonly<{
+  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
+  modelCall: ModelCallResult;
+}>;
+
+type BuildModelCallRequest = (
+  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
+) => OpenAIResponsesRequest;
+
+/**
+ * Runs exactly one model call and, on a `context_length_exceeded` overflow,
+ * rebuilds only the history base input with a tighter history-replay budget and
+ * retries the same call once.
+ */
+async function runModelCallWithOverflowRetry(
   client: OpenAI,
   params: StartOpenAILoopParams,
   onEvent: OpenAILoopEventSink,
-  request: OpenAIResponsesRequest,
+  dependencies: OpenAILoopDependencies,
+  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
+  buildRequest: BuildModelCallRequest,
   callIndex: number,
-): Promise<ModelCallResult> {
-  const stream: ResponseStreamWithOptionalFinalResponse = client.responses.stream(request, {
-    signal: params.signal,
-  });
-
-  const reasoningSummaries = new Map<string, string>();
-  const reasoningOrder: Array<string> = [];
-  let toolStates = createToolCallStateMap();
-  let completedResponse: OpenAI.Responses.Response | null = null;
-  let streamedText = "";
-  let forceComplete = false;
-  let streamCounters = EMPTY_RESPONSE_STREAM_COUNTERS;
-
-  for await (const event of stream) {
-    streamCounters = accumulateResponseStreamCounters(streamCounters, event);
-
-    if (isResponseCompletedEvent(event)) {
-      completedResponse = event.response;
-      continue;
+): Promise<ModelCallWithOverflowRetryResult> {
+  try {
+    return {
+      baseInput,
+      modelCall: await runOneModelCallWithPhase({
+        client,
+        signal: params.signal,
+        onExecutionPhaseChanged: params.onExecutionPhaseChanged,
+        onEvent,
+        request: buildRequest(baseInput),
+        callIndex,
+      }),
+    };
+  } catch (error) {
+    if (!isContextLengthExceededError(error)) {
+      throw error;
     }
 
-    if (isResponseFailedEvent(event)) {
-      throw createProviderTerminalEventError({
-        code: event.response.error?.code ?? null,
-        message: event.response.error?.message ?? null,
-        streamDiagnostics: toStreamDiagnostics(streamCounters, streamedText.length),
-      });
-    }
-
-    if (isResponseIncompleteEvent(event)) {
-      // A `max_output_tokens` incomplete response means the model hit the
-      // reserved output cap after streaming a partial answer. Treat it as a
-      // normal completion so the loop returns the partial text and emits `done`
-      // instead of failing the run, and mark it `forceComplete` so the loop
-      // finishes with that partial text and never runs a truncated function
-      // call that may also appear in the capped output. All other incomplete
-      // reasons (e.g. `content_filter`) still throw. An empty partial answer is
-      // never returned silently: it falls through to the stream-without-response
-      // throw below.
-      if (
-        event.response.incomplete_details?.reason === "max_output_tokens"
-        && streamedText.length > 0
-      ) {
-        completedResponse = event.response;
-        forceComplete = true;
-        continue;
-      }
-
-      throw createProviderTerminalEventError({
-        code: event.response.incomplete_details?.reason ?? null,
-        message: null,
-        streamDiagnostics: toStreamDiagnostics(streamCounters, streamedText.length),
-      });
-    }
-
-    if (isResponseErrorEvent(event)) {
-      throw createProviderTerminalEventError({
-        code: event.code ?? null,
-        message: event.message,
-        streamDiagnostics: toStreamDiagnostics(streamCounters, streamedText.length),
-      });
-    }
-
-    if (isOutputTextDelta(event)) {
-      streamedText = `${streamedText}${event.delta}`;
-      await onEvent({
-        type: "delta",
-        text: event.delta,
-        itemId: event.item_id,
-        responseIndex: callIndex - 1,
-        outputIndex: event.output_index,
-        contentIndex: event.content_index,
-        sequenceNumber: event.sequence_number,
-      });
-      continue;
-    }
-
-    if (event.type === "response.output_item.added" && event.item.type === "function_call") {
-      const update = applyToolCallStarted(
-        toolStates,
-        toFunctionToolCallRawItem(event.item),
-        createToolCallPosition(event, callIndex - 1),
-        Date.now(),
-      );
-      toolStates = update.toolStates;
-      if (update.event !== null) {
-        await onEvent(update.event);
-      }
-      continue;
-    }
-
-    if (event.type === "response.function_call_arguments.delta") {
-      const update = applyFunctionCallArgumentsDelta(toolStates, {
-        itemId: event.item_id,
-        outputIndex: event.output_index,
-        sequenceNumber: event.sequence_number,
-        delta: event.delta,
-      });
-      toolStates = update.toolStates;
-      if (update.event !== null) {
-        await onEvent(update.event);
-      }
-      continue;
-    }
-
-    if (event.type === "response.function_call_arguments.done") {
-      const update = applyFunctionCallArgumentsDone(toolStates, {
-        itemId: event.item_id,
-        outputIndex: event.output_index,
-        sequenceNumber: event.sequence_number,
-        arguments: event.arguments,
-      });
-      toolStates = update.toolStates;
-      if (update.event !== null) {
-        await onEvent(update.event);
-      }
-      continue;
-    }
-
-    if (isReasoningSummaryStarted(event)) {
-      if (!reasoningSummaries.has(event.item_id)) {
-        reasoningOrder.push(event.item_id);
-        if (reasoningOrder.length > MAX_REASONING_ITEMS) {
-          const removedItemId = reasoningOrder.shift();
-          if (removedItemId !== undefined) {
-            reasoningSummaries.delete(removedItemId);
-          }
-        }
-      }
-
-      reasoningSummaries.set(event.item_id, reasoningSummaries.get(event.item_id) ?? "");
-      await onEvent({
-        type: "reasoning_summary",
-        itemId: event.item_id,
-        responseIndex: callIndex - 1,
-        outputIndex: event.output_index,
-        sequenceNumber: event.sequence_number,
-        summary: reasoningSummaries.get(event.item_id) ?? "",
-      });
-      continue;
-    }
-
-    if (isReasoningSummaryDelta(event)) {
-      if (!reasoningSummaries.has(event.item_id)) {
-        reasoningOrder.push(event.item_id);
-        if (reasoningOrder.length > MAX_REASONING_ITEMS) {
-          const removedItemId = reasoningOrder.shift();
-          if (removedItemId !== undefined) {
-            reasoningSummaries.delete(removedItemId);
-          }
-        }
-      }
-
-      const nextSummary = `${reasoningSummaries.get(event.item_id) ?? ""}${event.delta}`;
-      reasoningSummaries.set(event.item_id, nextSummary);
-      await onEvent({
-        type: "reasoning_summary",
-        itemId: event.item_id,
-        responseIndex: callIndex - 1,
-        outputIndex: event.output_index,
-        sequenceNumber: event.sequence_number,
-        summary: nextSummary,
-      });
-    }
+    const reducedBaseInput = await dependencies.buildChatCompletionInputWithBudget(
+      params.localMessages,
+      params.turnInput,
+      params.timezone,
+      params.generatedImageEligible,
+      REDUCED_HISTORY_REPLAY_TOKEN_BUDGET,
+    );
+    return {
+      baseInput: reducedBaseInput,
+      modelCall: await runOneModelCallWithPhase({
+        client,
+        signal: params.signal,
+        onExecutionPhaseChanged: params.onExecutionPhaseChanged,
+        onEvent,
+        request: buildRequest(reducedBaseInput),
+        callIndex,
+      }),
+    };
   }
-
-  const finalResponse = await getFinalResponseFromStream(
-    stream,
-    completedResponse,
-    params.signal,
-    toStreamDiagnostics(streamCounters, streamedText.length),
-  );
-  return {
-    finalResponse,
-    functionCalls: finalResponse.output
-      .filter((item) => item.type === "function_call")
-      .map((item) => item as ParsedFunctionToolCall),
-    replayItems: finalResponse.output.map(toStoredOpenAIReplayItem),
-    streamedText,
-    toolStates,
-    forceComplete,
-  };
 }
 
-async function runOneModelCallWithPhase(
-  client: OpenAI,
-  params: StartOpenAILoopParams,
-  onEvent: OpenAILoopEventSink,
-  request: OpenAIResponsesRequest,
-  callIndex: number,
-): Promise<ModelCallResult> {
-  setExecutionPhase(params, "model");
-  return runOneModelCall(
-    client,
-    params,
-    onEvent,
-    request,
-    callIndex,
-  ).finally(() => {
-    setExecutionPhase(params, "idle");
-  });
-}
-
-async function completeToolLimitSummaryTurn(
+async function runToolLimitSummaryTurn(
   params: StartOpenAILoopParams,
   onEvent: OpenAILoopEventSink,
   dependencies: OpenAILoopDependencies,
   client: OpenAI,
   baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-  continuationItems: Array<StoredOpenAIReplayItem>,
+  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>,
 ): Promise<OpenAILoopCompletion> {
   const summaryCallIndex = CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1;
   let summaryCall: ModelCallResult;
@@ -849,104 +247,10 @@ async function completeToolLimitSummaryTurn(
     throw error;
   }
 
-  const finalResponseText = summaryCall.finalResponse.output_text.trim();
-  const finalAssistantText = finalResponseText.length > 0
-    ? finalResponseText
-    : summaryCall.streamedText.trim();
-
-  // A `max_output_tokens`-capped summary turn (`forceComplete`) keeps its
-  // partial answer even if the truncated output also carries a function call,
-  // so the user sees the real summary instead of the generic fallback text. The
-  // truncated call is dropped so it is never persisted as an orphan replay item.
-  if ((summaryCall.forceComplete || summaryCall.functionCalls.length === 0) && finalAssistantText.length > 0) {
-    continuationItems.push(...(summaryCall.forceComplete
-      ? pruneUnpairedToolReplayItems(summaryCall.replayItems)
-      : summaryCall.replayItems));
-    if (summaryCall.streamedText.length === 0) {
-      await emitSyntheticAssistantDelta(onEvent, finalAssistantText, summaryCallIndex - 1);
-    }
-    await onEvent({ type: "done" });
-    return {
-      openaiItems: continuationItems,
-      terminationReason: "completed",
-    };
-  }
-
-  const fallbackText = buildToolLimitFallbackText();
-  continuationItems.push(createAssistantReplayMessage(fallbackText));
-  if (summaryCall.streamedText.length === 0) {
-    await emitSyntheticAssistantDelta(onEvent, fallbackText, summaryCallIndex - 1);
-  }
-  await onEvent({ type: "done" });
   return {
-    openaiItems: continuationItems,
+    openaiItems: await completeToolLimitSummaryTurn(summaryCall, onEvent, continuationItems),
     terminationReason: "completed",
   };
-}
-
-type ModelCallWithOverflowRetryResult = Readonly<{
-  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
-  modelCall: ModelCallResult;
-}>;
-
-type BuildModelCallRequest = (
-  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-) => OpenAIResponsesRequest;
-
-/**
- * Runs exactly one model call and, on a `context_length_exceeded` overflow,
- * rebuilds only the history base input with a tighter history-replay budget and
- * retries the same call once. Any other failure, or a second overflow,
- * propagates to the existing graceful terminal handling.
- *
- * The retry only shrinks the replayed history: the caller's already-accumulated
- * continuation items are carried by `buildRequest` and are never dropped. The
- * returned `baseInput` is the input actually sent (reduced when the retry fired),
- * so later calls reuse the smaller history.
- */
-async function runModelCallWithOverflowRetry(
-  client: OpenAI,
-  params: StartOpenAILoopParams,
-  onEvent: OpenAILoopEventSink,
-  dependencies: OpenAILoopDependencies,
-  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-  buildRequest: BuildModelCallRequest,
-  callIndex: number,
-): Promise<ModelCallWithOverflowRetryResult> {
-  try {
-    return {
-      baseInput,
-      modelCall: await runOneModelCallWithPhase(
-        client,
-        params,
-        onEvent,
-        buildRequest(baseInput),
-        callIndex,
-      ),
-    };
-  } catch (error) {
-    if (!isContextLengthExceededError(error)) {
-      throw error;
-    }
-
-    const reducedBaseInput = await dependencies.buildChatCompletionInputWithBudget(
-      params.localMessages,
-      params.turnInput,
-      params.timezone,
-      params.generatedImageEligible,
-      REDUCED_HISTORY_REPLAY_TOKEN_BUDGET,
-    );
-    return {
-      baseInput: reducedBaseInput,
-      modelCall: await runOneModelCallWithPhase(
-        client,
-        params,
-        onEvent,
-        buildRequest(reducedBaseInput),
-        callIndex,
-      ),
-    };
-  }
 }
 
 async function runLoopWithDeps(
@@ -1000,12 +304,6 @@ async function runLoopWithDeps(
       throw error;
     }
 
-    // `forceComplete` wins over any function call: a `max_output_tokens`-capped
-    // response may carry a truncated function_call alongside the partial answer,
-    // and the loop must finish with that partial text instead of executing it.
-    // That unexecuted call, plus any reasoning item it orphans, is dropped here
-    // so neither is persisted as an unpaired replay item that the Responses API
-    // would reject on a later turn.
     if (modelCall.forceComplete) {
       continuationItems.push(...pruneUnpairedToolReplayItems(modelCall.replayItems));
       await onEvent({ type: "done" });
@@ -1029,76 +327,39 @@ async function runLoopWithDeps(
       return createStoppedBeforeNextStepCompletion(continuationItems);
     }
 
-    let toolStates = modelCall.toolStates;
-    for (
-      let functionCallIndex = 0;
-      functionCallIndex < modelCall.functionCalls.length;
-      functionCallIndex += 1
-    ) {
-      const functionCall = modelCall.functionCalls[functionCallIndex];
-      const operationKey = functionCall.name === GENERATED_IMAGE_TOOL_NAME
-        ? createGeneratedImageOperationKey(++generatedImageOperationCount)
-        : "not-generated-image";
-      if (shouldStopBeforeNextStep(params)) {
-        return createStoppedBeforeNextStepCompletion(continuationItems);
-      }
-
-      setExecutionPhase(params, "tool");
-      try {
-        const output = await dependencies.runOneToolCall({
-          item: functionCall,
-          requestId: params.requestId,
-          runId: params.runId,
-          sessionId: params.sessionId,
-          operationKey,
-          generatedImageEligible: params.generatedImageEligible,
-          claimToken: params.claimToken,
-          userId: params.userId,
-          workspaceId: params.workspaceId,
-          signal: params.signal ?? null,
-          generatedImageOperationDeadlineMs: params.generatedImageOperationDeadlineMs,
-          rootObservation: params.rootObservation,
-        });
-        if (output.stopReason !== null) {
-          return {
-            openaiItems: pruneUnpairedToolReplayItems(continuationItems),
-            terminationReason: output.stopReason === "run_inactive"
-              ? "run_inactive" : "stopped_before_next_step",
-          };
-        }
-        const update = applyToolCallOutput(
-          toolStates,
-          {
-            type: "function_call_output",
-            callId: functionCall.call_id,
-            id: functionCall.id,
-            name: functionCall.name,
-          },
-          output.output,
-          Date.now(),
-          output.shouldInvalidateMainContent,
-        );
-        toolStates = update.toolStates;
-        if (update.event !== null) {
-          await onEvent(update.event);
-        }
-        continuationItems.push(toStoredOpenAIReplayItem(
-          toFunctionCallOutputInputItem(functionCall.call_id, output.output),
-        ));
-      } finally {
-        setExecutionPhase(params, "idle");
-      }
-
-      if (shouldStopBeforeNextStep(params)) {
-        return createStoppedBeforeNextStepCompletion(continuationItems);
-      }
+    const toolCalls = await executeToolCalls({
+      functionCalls: modelCall.functionCalls,
+      toolStates: modelCall.toolStates,
+      generatedImageOperationCount,
+      requestId: params.requestId,
+      runId: params.runId,
+      sessionId: params.sessionId,
+      generatedImageEligible: params.generatedImageEligible,
+      claimToken: params.claimToken,
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+      signal: params.signal,
+      generatedImageOperationDeadlineMs: params.generatedImageOperationDeadlineMs,
+      rootObservation: params.rootObservation,
+      onExecutionPhaseChanged: params.onExecutionPhaseChanged,
+      shouldStopBeforeNextStep: params.shouldStopBeforeNextStep,
+      onEvent,
+      runOneToolCall: dependencies.runOneToolCall,
+    });
+    continuationItems.push(...toolCalls.replayItems);
+    generatedImageOperationCount = toolCalls.generatedImageOperationCount;
+    if (toolCalls.terminationReason !== null) {
+      return {
+        openaiItems: pruneUnpairedToolReplayItems(continuationItems),
+        terminationReason: toolCalls.terminationReason,
+      };
     }
 
     const reachedToolCallLimit = callIndex === CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS;
     const exceededWithinRunReplayBudget = estimateStoredReplayItemsTokens(continuationItems)
       > MAX_WITHIN_RUN_REPLAY_TOKENS;
     if (reachedToolCallLimit || exceededWithinRunReplayBudget) {
-      return completeToolLimitSummaryTurn(
+      return runToolLimitSummaryTurn(
         params,
         onEvent,
         dependencies,

--- a/apps/backend/src/chat/openai/loop/modelCall.ts
+++ b/apps/backend/src/chat/openai/loop/modelCall.ts
@@ -1,0 +1,396 @@
+import OpenAI from "openai";
+import type { LangfuseObservation } from "@langfuse/tracing";
+import { applyToolCallOutput, type ToolCallStateMap } from "../tools/toolCalls";
+import {
+  toOpenAIResponseInputItem,
+  toStoredOpenAIReplayItem,
+  type StoredOpenAIReplayItem,
+  type StoredOpenAIReplayMessage,
+} from "../replayItems";
+import type { ExecutedChatToolCall } from "../tools/tools";
+import { buildOpenAISafetyIdentifier } from "../safetyIdentifier";
+import {
+  CHAT_MAX_OUTPUT_TOKENS,
+  CHAT_MODEL_REASONING_SUMMARY,
+  type ChatRuntimeModelId,
+  type ChatRuntimeReasoningEffort,
+} from "../../config";
+import type { ChatRunClaimToken } from "../../runs";
+import { createGeneratedImageOperationKey } from "../../generatedImageOperationIdentity";
+import { GENERATED_IMAGE_TOOL_NAME } from "../tools/generatedImageToolContract";
+import {
+  collectResponseStream,
+  type ModelCallResult,
+  type OpenAILoopEventSink,
+  type ParsedFunctionToolCall,
+  type ResponseStreamWithOptionalFinalResponse,
+} from "./responseStream";
+
+export const CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS = 30;
+const TOOL_LIMIT_FALLBACK_ITEM_ID = "tool-limit-summary";
+
+export type OpenAIResponsesRequest = Readonly<{
+  model: ChatRuntimeModelId;
+  store: false;
+  include: ["reasoning.encrypted_content"];
+  tools: Array<OpenAI.Responses.Tool>;
+  input: Array<OpenAI.Responses.ResponseInputItem>;
+  max_output_tokens: number;
+  reasoning: Readonly<{
+    effort: ChatRuntimeReasoningEffort;
+    summary: typeof CHAT_MODEL_REASONING_SUMMARY;
+  }>;
+  prompt_cache_key: string;
+  safety_identifier: string;
+  parallel_tool_calls?: false;
+}>;
+
+type BuildOpenAIResponsesRequestParams = Readonly<{
+  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
+  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>;
+  userId: string;
+  sessionId: string;
+  modelId: ChatRuntimeModelId;
+  reasoningEffort: ChatRuntimeReasoningEffort;
+  extraInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
+  tools: ReadonlyArray<OpenAI.Responses.Tool>;
+}>;
+
+type RunOneModelCallParams = Readonly<{
+  client: OpenAI;
+  signal: AbortSignal | undefined;
+  onExecutionPhaseChanged: ((phase: "idle" | "model" | "tool") => void) | undefined;
+  onEvent: OpenAILoopEventSink;
+  request: OpenAIResponsesRequest;
+  callIndex: number;
+}>;
+
+export type RunOneToolCall = (params: Readonly<{
+  item: OpenAI.Responses.ResponseFunctionToolCall;
+  requestId: string;
+  runId: string;
+  sessionId: string;
+  operationKey: string;
+  generatedImageEligible: boolean;
+  claimToken: ChatRunClaimToken;
+  userId: string;
+  workspaceId: string;
+  signal: AbortSignal | null;
+  generatedImageOperationDeadlineMs: number;
+  rootObservation: LangfuseObservation | null;
+}>) => Promise<ExecutedChatToolCall>;
+
+type ExecuteToolCallsParams = Readonly<{
+  functionCalls: ReadonlyArray<ParsedFunctionToolCall>;
+  toolStates: ToolCallStateMap;
+  generatedImageOperationCount: number;
+  requestId: string;
+  runId: string;
+  sessionId: string;
+  generatedImageEligible: boolean;
+  claimToken: ChatRunClaimToken;
+  userId: string;
+  workspaceId: string;
+  signal: AbortSignal | undefined;
+  generatedImageOperationDeadlineMs: number;
+  rootObservation: LangfuseObservation | null;
+  onExecutionPhaseChanged: ((phase: "idle" | "model" | "tool") => void) | undefined;
+  shouldStopBeforeNextStep: (() => boolean) | undefined;
+  onEvent: OpenAILoopEventSink;
+  runOneToolCall: RunOneToolCall;
+}>;
+
+export type ExecuteToolCallsResult = Readonly<{
+  replayItems: ReadonlyArray<StoredOpenAIReplayItem>;
+  generatedImageOperationCount: number;
+  terminationReason: "stopped_before_next_step" | "run_inactive" | null;
+}>;
+
+function createInputTextMessage(
+  role: "system" | "user",
+  text: string,
+): OpenAI.Responses.ResponseInputItem.Message {
+  return {
+    type: "message",
+    role,
+    content: [{
+      type: "input_text",
+      text,
+    }],
+  };
+}
+
+export function buildToolLimitSummaryInstruction(
+  toolEnabledModelCallLimit: number,
+): OpenAI.Responses.ResponseInputItem.Message {
+  return createInputTextMessage(
+    "system",
+    [
+      `The tool-enabled model call limit for this turn (${String(toolEnabledModelCallLimit)}) has been reached.`,
+      "Do not call any tools in this response.",
+      "Briefly summarize what you already completed.",
+      "Briefly state what remains unfinished.",
+      "Ask the user to send another message such as continue if they want you to keep going from the same chat session.",
+    ].join(" "),
+  );
+}
+
+function buildToolLimitFallbackText(): string {
+  return `I reached the tool-call limit for this turn (${String(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)}). Send another message such as continue and I will resume from the same chat session.`;
+}
+
+function createAssistantReplayMessage(text: string): StoredOpenAIReplayMessage {
+  return {
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    phase: "final_answer",
+    content: [{
+      type: "output_text",
+      text,
+      annotations: [],
+    }],
+  };
+}
+
+async function emitSyntheticAssistantDelta(
+  onEvent: OpenAILoopEventSink,
+  text: string,
+  responseIndex: number,
+): Promise<void> {
+  if (text.trim().length === 0) {
+    return;
+  }
+
+  await onEvent({
+    type: "delta",
+    text,
+    itemId: TOOL_LIMIT_FALLBACK_ITEM_ID,
+    responseIndex,
+    outputIndex: 0,
+    contentIndex: 0,
+    sequenceNumber: 0,
+  });
+}
+
+function buildOpenAIInput(
+  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
+  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>,
+  extraInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
+): Array<OpenAI.Responses.ResponseInputItem> {
+  return [
+    ...baseInput,
+    ...continuationItems.map(toOpenAIResponseInputItem),
+    ...extraInput,
+  ];
+}
+
+export function buildPromptCacheKey(sessionId: string): string {
+  return sessionId;
+}
+
+export function buildOpenAIResponsesRequest(
+  params: BuildOpenAIResponsesRequestParams,
+): OpenAIResponsesRequest {
+  return {
+    model: params.modelId,
+    store: false,
+    include: ["reasoning.encrypted_content"],
+    tools: [...params.tools],
+    input: buildOpenAIInput(params.baseInput, params.continuationItems, params.extraInput),
+    max_output_tokens: CHAT_MAX_OUTPUT_TOKENS,
+    reasoning: {
+      effort: params.reasoningEffort,
+      summary: CHAT_MODEL_REASONING_SUMMARY,
+    },
+    prompt_cache_key: buildPromptCacheKey(params.sessionId),
+    safety_identifier: buildOpenAISafetyIdentifier(params.userId),
+    ...(params.tools.some((tool) => tool.type === "function"
+      && tool.name === "add_generated_image_to_card")
+      ? { parallel_tool_calls: false as const }
+      : {}),
+  };
+}
+
+export async function runOneModelCallWithPhase(
+  params: RunOneModelCallParams,
+): Promise<ModelCallResult> {
+  params.onExecutionPhaseChanged?.("model");
+  try {
+    const stream: ResponseStreamWithOptionalFinalResponse = params.client.responses.stream(
+      params.request,
+      { signal: params.signal },
+    );
+    return await collectResponseStream({
+      stream,
+      signal: params.signal,
+      onEvent: params.onEvent,
+      callIndex: params.callIndex,
+    });
+  } finally {
+    params.onExecutionPhaseChanged?.("idle");
+  }
+}
+
+function toFunctionCallOutputInputItem(
+  callId: string,
+  output: string,
+): OpenAI.Responses.ResponseInputItem.FunctionCallOutput {
+  return {
+    type: "function_call_output",
+    call_id: callId,
+    output,
+  };
+}
+
+function shouldStopBeforeNextStep(
+  callback: (() => boolean) | undefined,
+): boolean {
+  return callback?.() === true;
+}
+
+export async function executeToolCalls(
+  params: ExecuteToolCallsParams,
+): Promise<ExecuteToolCallsResult> {
+  const replayItems: Array<StoredOpenAIReplayItem> = [];
+  let toolStates = params.toolStates;
+  let generatedImageOperationCount = params.generatedImageOperationCount;
+
+  for (const functionCall of params.functionCalls) {
+    const operationKey = functionCall.name === GENERATED_IMAGE_TOOL_NAME
+      ? createGeneratedImageOperationKey(++generatedImageOperationCount)
+      : "not-generated-image";
+    if (shouldStopBeforeNextStep(params.shouldStopBeforeNextStep)) {
+      return {
+        replayItems,
+        generatedImageOperationCount,
+        terminationReason: "stopped_before_next_step",
+      };
+    }
+
+    params.onExecutionPhaseChanged?.("tool");
+    try {
+      const output = await params.runOneToolCall({
+        item: functionCall,
+        requestId: params.requestId,
+        runId: params.runId,
+        sessionId: params.sessionId,
+        operationKey,
+        generatedImageEligible: params.generatedImageEligible,
+        claimToken: params.claimToken,
+        userId: params.userId,
+        workspaceId: params.workspaceId,
+        signal: params.signal ?? null,
+        generatedImageOperationDeadlineMs: params.generatedImageOperationDeadlineMs,
+        rootObservation: params.rootObservation,
+      });
+      if (output.stopReason !== null) {
+        return {
+          replayItems,
+          generatedImageOperationCount,
+          terminationReason: output.stopReason === "run_inactive"
+            ? "run_inactive" : "stopped_before_next_step",
+        };
+      }
+      const update = applyToolCallOutput(
+        toolStates,
+        {
+          type: "function_call_output",
+          callId: functionCall.call_id,
+          id: functionCall.id,
+          name: functionCall.name,
+        },
+        output.output,
+        Date.now(),
+        output.shouldInvalidateMainContent,
+      );
+      toolStates = update.toolStates;
+      if (update.event !== null) {
+        await params.onEvent(update.event);
+      }
+      replayItems.push(toStoredOpenAIReplayItem(
+        toFunctionCallOutputInputItem(functionCall.call_id, output.output),
+      ));
+    } finally {
+      params.onExecutionPhaseChanged?.("idle");
+    }
+
+    if (shouldStopBeforeNextStep(params.shouldStopBeforeNextStep)) {
+      return {
+        replayItems,
+        generatedImageOperationCount,
+        terminationReason: "stopped_before_next_step",
+      };
+    }
+  }
+
+  return {
+    replayItems,
+    generatedImageOperationCount,
+    terminationReason: null,
+  };
+}
+
+export function pruneUnpairedToolReplayItems(
+  items: ReadonlyArray<StoredOpenAIReplayItem>,
+): ReadonlyArray<StoredOpenAIReplayItem> {
+  const functionCallIds = new Set(
+    items.filter((item) => item.type === "function_call").map((item) => item.call_id),
+  );
+  const outputCallIds = new Set(
+    items.filter((item) => item.type === "function_call_output").map((item) => item.call_id),
+  );
+  const pairedItems = items.filter((item) => {
+    if (item.type === "function_call") {
+      return outputCallIds.has(item.call_id);
+    }
+    if (item.type === "function_call_output") {
+      return functionCallIds.has(item.call_id);
+    }
+    return true;
+  });
+  const kept: Array<StoredOpenAIReplayItem> = [];
+
+  let hasFollowingKeptItem = false;
+  for (let index = pairedItems.length - 1; index >= 0; index -= 1) {
+    const item = pairedItems[index];
+    if (item.type === "reasoning" && !hasFollowingKeptItem) {
+      continue;
+    }
+
+    kept.push(item);
+    hasFollowingKeptItem = true;
+  }
+
+  return kept.reverse();
+}
+
+export async function completeToolLimitSummaryTurn(
+  summaryCall: ModelCallResult,
+  onEvent: OpenAILoopEventSink,
+  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>,
+): Promise<ReadonlyArray<StoredOpenAIReplayItem>> {
+  const summaryCallIndex = CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1;
+  const finalResponseText = summaryCall.finalResponse.output_text.trim();
+  const finalAssistantText = finalResponseText.length > 0
+    ? finalResponseText
+    : summaryCall.streamedText.trim();
+
+  if ((summaryCall.forceComplete || summaryCall.functionCalls.length === 0) && finalAssistantText.length > 0) {
+    const summaryReplayItems = summaryCall.forceComplete
+      ? pruneUnpairedToolReplayItems(summaryCall.replayItems)
+      : summaryCall.replayItems;
+    if (summaryCall.streamedText.length === 0) {
+      await emitSyntheticAssistantDelta(onEvent, finalAssistantText, summaryCallIndex - 1);
+    }
+    await onEvent({ type: "done" });
+    return [...continuationItems, ...summaryReplayItems];
+  }
+
+  const fallbackText = buildToolLimitFallbackText();
+  if (summaryCall.streamedText.length === 0) {
+    await emitSyntheticAssistantDelta(onEvent, fallbackText, summaryCallIndex - 1);
+  }
+  await onEvent({ type: "done" });
+  return [...continuationItems, createAssistantReplayMessage(fallbackText)];
+}

--- a/apps/backend/src/chat/openai/loop/responseStream.ts
+++ b/apps/backend/src/chat/openai/loop/responseStream.ts
@@ -1,0 +1,410 @@
+import OpenAI from "openai";
+import {
+  applyFunctionCallArgumentsDelta,
+  applyFunctionCallArgumentsDone,
+  applyToolCallStarted,
+  createToolCallStateMap,
+  type FunctionToolCallRawItem,
+  type ToolCallPosition,
+} from "../tools/toolCalls";
+import { toStoredOpenAIReplayItem, type StoredOpenAIReplayItem } from "../replayItems";
+import type { ChatStreamEvent } from "../../types";
+import {
+  createProviderTerminalEventError,
+  type ChatProviderStreamDiagnostics,
+} from "../../providerFailure";
+
+const MAX_REASONING_ITEMS = 8;
+const OPENAI_STREAM_ABORT_ERROR_MESSAGE = "OpenAI response stream was aborted before a final response";
+
+export type OpenAILoopEventSink = (
+  event: ChatStreamEvent,
+) => Promise<void> | void;
+
+export type ParsedFunctionToolCall = OpenAI.Responses.ResponseFunctionToolCall & Readonly<{
+  parsed_arguments?: unknown;
+}>;
+
+export type ResponseStreamWithOptionalFinalResponse = AsyncIterable<OpenAI.Responses.ResponseStreamEvent> & Readonly<{
+  finalResponse?: () => Promise<OpenAI.Responses.Response>;
+}>;
+
+export type ModelCallResult = Readonly<{
+  finalResponse: OpenAI.Responses.Response;
+  functionCalls: ReadonlyArray<ParsedFunctionToolCall>;
+  replayItems: ReadonlyArray<StoredOpenAIReplayItem>;
+  streamedText: string;
+  toolStates: ReturnType<typeof createToolCallStateMap>;
+  // True when the response was capped at `max_output_tokens` after streaming a
+  // partial answer. The loop must finish with that partial text and never run
+  // any (possibly truncated) function call carried in the same output.
+  forceComplete: boolean;
+}>;
+
+type CollectResponseStreamParams = Readonly<{
+  stream: ResponseStreamWithOptionalFinalResponse;
+  signal: AbortSignal | undefined;
+  onEvent: OpenAILoopEventSink;
+  callIndex: number;
+}>;
+
+type ResponseStreamCounters = Readonly<{
+  responseId: string | null;
+  eventCount: number;
+  lastEventType: string | null;
+  sawIncompleteEvent: boolean;
+  sawFailedEvent: boolean;
+}>;
+
+const EMPTY_RESPONSE_STREAM_COUNTERS: ResponseStreamCounters = {
+  responseId: null,
+  eventCount: 0,
+  lastEventType: null,
+  sawIncompleteEvent: false,
+  sawFailedEvent: false,
+};
+
+function createToolCallPosition(
+  event: OpenAI.Responses.ResponseOutputItemAddedEvent,
+  responseIndex: number,
+): ToolCallPosition {
+  return {
+    itemId: typeof event.item.id === "string" && event.item.id.length > 0
+      ? event.item.id
+      : `response-output-${String(event.output_index)}`,
+    responseIndex,
+    outputIndex: event.output_index,
+    sequenceNumber: event.sequence_number,
+  };
+}
+
+function toFunctionToolCallRawItem(
+  item: OpenAI.Responses.ResponseFunctionToolCall,
+): FunctionToolCallRawItem {
+  return {
+    type: "function_call",
+    callId: item.call_id,
+    id: item.id,
+    name: item.name,
+    arguments: item.arguments,
+    status: item.status ?? undefined,
+  };
+}
+
+function isReasoningSummaryDelta(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseReasoningSummaryTextDeltaEvent {
+  return event.type === "response.reasoning_summary_text.delta";
+}
+
+function isReasoningSummaryStarted(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseReasoningSummaryPartAddedEvent {
+  return event.type === "response.reasoning_summary_part.added";
+}
+
+function isOutputTextDelta(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseTextDeltaEvent {
+  return event.type === "response.output_text.delta";
+}
+
+function isResponseCompletedEvent(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseCompletedEvent {
+  return event.type === "response.completed";
+}
+
+function isResponseFailedEvent(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseFailedEvent {
+  return event.type === "response.failed";
+}
+
+function isResponseIncompleteEvent(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseIncompleteEvent {
+  return event.type === "response.incomplete";
+}
+
+function isResponseErrorEvent(
+  event: OpenAI.Responses.ResponseStreamEvent,
+): event is OpenAI.Responses.ResponseErrorEvent {
+  return event.type === "error";
+}
+
+class OpenAIStreamAbortError extends Error {
+  constructor() {
+    super(OPENAI_STREAM_ABORT_ERROR_MESSAGE);
+    this.name = "AbortError";
+  }
+}
+
+function createOpenAIStreamAbortError(): OpenAIStreamAbortError {
+  return new OpenAIStreamAbortError();
+}
+
+export function isOpenAIAbortError(error: unknown): boolean {
+  return error instanceof OpenAI.APIUserAbortError
+    || error instanceof OpenAIStreamAbortError;
+}
+
+function accumulateResponseStreamCounters(
+  counters: ResponseStreamCounters,
+  event: OpenAI.Responses.ResponseStreamEvent,
+): ResponseStreamCounters {
+  return {
+    responseId: event.type === "response.created" ? event.response.id : counters.responseId,
+    eventCount: counters.eventCount + 1,
+    lastEventType: event.type,
+    sawIncompleteEvent: counters.sawIncompleteEvent || isResponseIncompleteEvent(event),
+    sawFailedEvent: counters.sawFailedEvent || isResponseFailedEvent(event),
+  };
+}
+
+function toStreamDiagnostics(
+  counters: ResponseStreamCounters,
+  streamedTextLength: number,
+): ChatProviderStreamDiagnostics {
+  return {
+    streamResponseId: counters.responseId,
+    streamEventCount: counters.eventCount,
+    streamLastEventType: counters.lastEventType,
+    streamSawIncompleteEvent: counters.sawIncompleteEvent,
+    streamSawFailedEvent: counters.sawFailedEvent,
+    streamedTextLength,
+  };
+}
+
+function hasProviderErrorCode(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const code = (error as Readonly<Record<string, unknown>>).code;
+  return typeof code === "string" && code.trim() !== "";
+}
+
+function markFinalResponseRejection(
+  error: unknown,
+  streamDiagnostics: ChatProviderStreamDiagnostics,
+): unknown {
+  if (typeof error !== "object" || error === null) {
+    return error;
+  }
+
+  if (hasProviderErrorCode(error)) {
+    return Object.assign(error, { streamDiagnostics });
+  }
+
+  return Object.assign(error, {
+    streamDiagnostics,
+    code: "stream_final_response_rejected",
+  });
+}
+
+async function getFinalResponseFromStream(
+  stream: ResponseStreamWithOptionalFinalResponse,
+  completedResponse: OpenAI.Responses.Response | null,
+  signal: AbortSignal | undefined,
+  streamDiagnostics: ChatProviderStreamDiagnostics,
+): Promise<OpenAI.Responses.Response> {
+  if (completedResponse !== null) {
+    return completedResponse;
+  }
+
+  if (typeof stream.finalResponse === "function") {
+    try {
+      return await stream.finalResponse();
+    } catch (error) {
+      if (isOpenAIAbortError(error) || signal?.aborted === true) {
+        throw error;
+      }
+
+      throw markFinalResponseRejection(error, streamDiagnostics);
+    }
+  }
+
+  if (signal?.aborted === true) {
+    throw createOpenAIStreamAbortError();
+  }
+
+  throw createProviderTerminalEventError({
+    code: "stream_closed_without_final_response_accessor",
+    message: "OpenAI response stream completed without a final response and exposed no final response accessor",
+    streamDiagnostics,
+  });
+}
+
+export async function collectResponseStream(
+  params: CollectResponseStreamParams,
+): Promise<ModelCallResult> {
+  const reasoningSummaries = new Map<string, string>();
+  const reasoningOrder: Array<string> = [];
+  let toolStates = createToolCallStateMap();
+  let completedResponse: OpenAI.Responses.Response | null = null;
+  let streamedText = "";
+  let forceComplete = false;
+  let streamCounters = EMPTY_RESPONSE_STREAM_COUNTERS;
+
+  for await (const event of params.stream) {
+    streamCounters = accumulateResponseStreamCounters(streamCounters, event);
+
+    if (isResponseCompletedEvent(event)) {
+      completedResponse = event.response;
+      continue;
+    }
+
+    if (isResponseFailedEvent(event)) {
+      throw createProviderTerminalEventError({
+        code: event.response.error?.code ?? null,
+        message: event.response.error?.message ?? null,
+        streamDiagnostics: toStreamDiagnostics(streamCounters, streamedText.length),
+      });
+    }
+
+    if (isResponseIncompleteEvent(event)) {
+      if (
+        event.response.incomplete_details?.reason === "max_output_tokens"
+        && streamedText.length > 0
+      ) {
+        completedResponse = event.response;
+        forceComplete = true;
+        continue;
+      }
+
+      throw createProviderTerminalEventError({
+        code: event.response.incomplete_details?.reason ?? null,
+        message: null,
+        streamDiagnostics: toStreamDiagnostics(streamCounters, streamedText.length),
+      });
+    }
+
+    if (isResponseErrorEvent(event)) {
+      throw createProviderTerminalEventError({
+        code: event.code ?? null,
+        message: event.message,
+        streamDiagnostics: toStreamDiagnostics(streamCounters, streamedText.length),
+      });
+    }
+
+    if (isOutputTextDelta(event)) {
+      streamedText = `${streamedText}${event.delta}`;
+      await params.onEvent({
+        type: "delta",
+        text: event.delta,
+        itemId: event.item_id,
+        responseIndex: params.callIndex - 1,
+        outputIndex: event.output_index,
+        contentIndex: event.content_index,
+        sequenceNumber: event.sequence_number,
+      });
+      continue;
+    }
+
+    if (event.type === "response.output_item.added" && event.item.type === "function_call") {
+      const update = applyToolCallStarted(
+        toolStates,
+        toFunctionToolCallRawItem(event.item),
+        createToolCallPosition(event, params.callIndex - 1),
+        Date.now(),
+      );
+      toolStates = update.toolStates;
+      if (update.event !== null) {
+        await params.onEvent(update.event);
+      }
+      continue;
+    }
+
+    if (event.type === "response.function_call_arguments.delta") {
+      const update = applyFunctionCallArgumentsDelta(toolStates, {
+        itemId: event.item_id,
+        outputIndex: event.output_index,
+        sequenceNumber: event.sequence_number,
+        delta: event.delta,
+      });
+      toolStates = update.toolStates;
+      if (update.event !== null) {
+        await params.onEvent(update.event);
+      }
+      continue;
+    }
+
+    if (event.type === "response.function_call_arguments.done") {
+      const update = applyFunctionCallArgumentsDone(toolStates, {
+        itemId: event.item_id,
+        outputIndex: event.output_index,
+        sequenceNumber: event.sequence_number,
+        arguments: event.arguments,
+      });
+      toolStates = update.toolStates;
+      if (update.event !== null) {
+        await params.onEvent(update.event);
+      }
+      continue;
+    }
+
+    if (isReasoningSummaryStarted(event)) {
+      if (!reasoningSummaries.has(event.item_id)) {
+        reasoningOrder.push(event.item_id);
+        if (reasoningOrder.length > MAX_REASONING_ITEMS) {
+          const removedItemId = reasoningOrder.shift();
+          if (removedItemId !== undefined) {
+            reasoningSummaries.delete(removedItemId);
+          }
+        }
+      }
+
+      reasoningSummaries.set(event.item_id, reasoningSummaries.get(event.item_id) ?? "");
+      await params.onEvent({
+        type: "reasoning_summary",
+        itemId: event.item_id,
+        responseIndex: params.callIndex - 1,
+        outputIndex: event.output_index,
+        sequenceNumber: event.sequence_number,
+        summary: reasoningSummaries.get(event.item_id) ?? "",
+      });
+      continue;
+    }
+
+    if (isReasoningSummaryDelta(event)) {
+      if (!reasoningSummaries.has(event.item_id)) {
+        reasoningOrder.push(event.item_id);
+        if (reasoningOrder.length > MAX_REASONING_ITEMS) {
+          const removedItemId = reasoningOrder.shift();
+          if (removedItemId !== undefined) {
+            reasoningSummaries.delete(removedItemId);
+          }
+        }
+      }
+
+      const nextSummary = `${reasoningSummaries.get(event.item_id) ?? ""}${event.delta}`;
+      reasoningSummaries.set(event.item_id, nextSummary);
+      await params.onEvent({
+        type: "reasoning_summary",
+        itemId: event.item_id,
+        responseIndex: params.callIndex - 1,
+        outputIndex: event.output_index,
+        sequenceNumber: event.sequence_number,
+        summary: nextSummary,
+      });
+    }
+  }
+
+  const finalResponse = await getFinalResponseFromStream(
+    params.stream,
+    completedResponse,
+    params.signal,
+    toStreamDiagnostics(streamCounters, streamedText.length),
+  );
+  return {
+    finalResponse,
+    functionCalls: finalResponse.output
+      .filter((item) => item.type === "function_call")
+      .map((item) => item as ParsedFunctionToolCall),
+    replayItems: finalResponse.output.map(toStoredOpenAIReplayItem),
+    streamedText,
+    toolStates,
+    forceComplete,
+  };
+}


### PR DESCRIPTION
## Summary
- extract provider response-stream collection and diagnostics
- extract one-model-call request, tool execution, and tool-limit completion
- keep overflow retry, stop handling, and public orchestration in loop.ts

## Validation
- independent fresh static review: no P0-P4 findings
- local project checks intentionally not run for this integration PR