### PR TITLE
Refactor backend catalog route boundary

### DIFF
--- a/apps/backend/src/catalog/distribution/install/index.test.ts
+++ b/apps/backend/src/catalog/distribution/install/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createCatalogInstallRoutes } from "../../../routes/catalogInstall";
+import { createCatalogInstallRoutes } from "../../../routes/catalog/install";
 import { HttpError } from "../../../shared/errors";
 import {
   testInstallTimestamp,

--- a/apps/backend/src/catalog/distribution/public/media.test.ts
+++ b/apps/backend/src/catalog/distribution/public/media.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
 import type { DatabaseExecutor, SqlValue } from "../../../database";
-import { createCatalogPublicRoutes } from "../../../routes/catalogPublic";
+import { createCatalogPublicRoutes } from "../../../routes/catalog/public";
 import { HttpError } from "../../../shared/errors";
 import {
   loadPublicCatalogPackageMediaForDownloadInExecutor,

--- a/apps/backend/src/catalog/distribution/public/snapshot.test.ts
+++ b/apps/backend/src/catalog/distribution/public/snapshot.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
 import type { DatabaseExecutor, SqlValue } from "../../../database";
-import { createCatalogPublicRoutes } from "../../../routes/catalogPublic";
+import { createCatalogPublicRoutes } from "../../../routes/catalog/public";
 import { maximumPublicCatalogMediaDownloadBytes } from "../../publicMediaDelivery";
 import { loadPublicCatalogSnapshotInExecutor } from "./index";
 import {

--- a/apps/backend/src/routes/catalog/admin.test.ts
+++ b/apps/backend/src/routes/catalog/admin.test.ts
@@ -2,14 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import type { AdminRequestContext } from "../admin/authz";
+import type { AdminRequestContext } from "../../admin/authz";
 import type {
   CatalogPackageVersion,
   CreateCatalogPackageVersionFromWorkspaceInput,
-} from "../catalog/types";
-import type { AppEnv } from "../server/app";
-import { HttpError } from "../shared/errors";
-import { createCatalogAdminRoutes } from "./catalogAdmin";
+} from "../../catalog/types";
+import type { AppEnv } from "../../server/app";
+import { HttpError } from "../../shared/errors";
+import { createCatalogAdminRoutes } from "./admin";
 
 const packageId = "11111111-1111-4111-8111-111111111111";
 const packageVersionId = "22222222-2222-4222-8222-222222222222";

--- a/apps/backend/src/routes/catalog/admin.ts
+++ b/apps/backend/src/routes/catalog/admin.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
-import { requireAdminRequest, type AdminRequestContext } from "../admin/authz";
-import { normalizeCardMetadata } from "../cards/shared";
+import { requireAdminRequest, type AdminRequestContext } from "../../admin/authz";
+import { normalizeCardMetadata } from "../../cards/shared";
 import {
   attachCatalogPackageDraftMediaAsset,
   createCatalogAuthor,
@@ -13,7 +13,7 @@ import {
   updateCatalogAuthor,
   updateCatalogPackageDraft,
   updateCatalogPackageVersionReviewStatus,
-} from "../catalog";
+} from "../../catalog";
 import {
   catalogPackageStatuses,
   type AttachCatalogPackageMediaAssetInput,
@@ -30,16 +30,16 @@ import {
   type UpdateCatalogPackageDraftInput,
   type UpdateCatalogPackageVersionStatusInput,
   type UpsertCatalogAuthorInput,
-} from "../catalog/types";
+} from "../../catalog/types";
 import {
   expectNonEmptyString,
   expectRecord,
   expectUuidString,
   expectWorkspaceIdString,
   parseJsonBodyWithByteLimit,
-} from "../server/requestParsing";
-import { HttpError } from "../shared/errors";
-import type { AppEnv } from "../server/app";
+} from "../../server/requestParsing";
+import { HttpError } from "../../shared/errors";
+import type { AppEnv } from "../../server/app";
 
 type CatalogAdminRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;

--- a/apps/backend/src/routes/catalog/install.ts
+++ b/apps/backend/src/routes/catalog/install.ts
@@ -1,30 +1,30 @@
 import { Hono } from "hono";
-import { listWorkspaceTagsSummary } from "../cards";
+import { listWorkspaceTagsSummary } from "../../cards";
 import {
   catalogPackageInstallOperationIdPrefixMaximumLength,
   installCatalogPackageVersion,
   isValidCatalogPackageInstallOperationIdPrefix,
   previewCatalogPackageInstall,
-} from "../catalog";
+} from "../../catalog";
 import type {
   CatalogPackageInstallConfirmInput,
   CatalogPackageInstallPreview,
   CatalogPackageInstallResult,
-} from "../catalog/types";
-import { assertUserHasWorkspaceAccess } from "../workspaces";
-import type { AppEnv } from "../server/app";
+} from "../../catalog/types";
+import { assertUserHasWorkspaceAccess } from "../../workspaces";
+import type { AppEnv } from "../../server/app";
 import {
   loadRequestContextFromRequest,
   parseWorkspaceIdParam,
-} from "../server/requestContext";
+} from "../../server/requestContext";
 import {
   expectNonEmptyString,
   expectBoolean,
   expectRecord,
   expectUuidString,
   parseJsonBody,
-} from "../server/requestParsing";
-import { HttpError } from "../shared/errors";
+} from "../../server/requestParsing";
+import { HttpError } from "../../shared/errors";
 
 export type CatalogInstallRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;

--- a/apps/backend/src/routes/catalog/public.ts
+++ b/apps/backend/src/routes/catalog/public.ts
@@ -5,16 +5,16 @@ import {
   loadPublicCatalogPackageDetail,
   loadPublicCatalogPackageMediaForDownload,
   loadPublicCatalogPackageVersionCardPreview,
-} from "../catalog";
+} from "../../catalog";
 import {
   isUnsafePublicPackageMediaKey,
   normalizePackageMediaKey,
   normalizeSlug,
-} from "../catalog/common";
+} from "../../catalog/common";
 import {
   getPublicCatalogMediaDeliveryIssue,
   maximumPublicCatalogMediaDownloadBytes,
-} from "../catalog/publicMediaDelivery";
+} from "../../catalog/publicMediaDelivery";
 import type {
   CatalogPublicPackageCardPreview,
   CatalogPublicPackageDetail,
@@ -22,23 +22,23 @@ import type {
   CatalogPublicPackageMediaDownloadSource,
   CatalogPublicPackageSummary,
   CatalogPublicSnapshot,
-} from "../catalog/types";
+} from "../../catalog/types";
 import {
   loadMediaAssetObjectBytes,
   type LoadedMediaAssetObjectBytes,
   type LoadMediaAssetObjectBytesInput,
-} from "../mediaAssets/storage";
+} from "../../mediaAssets/storage";
 import {
   createBackendObservationScope,
   type BackendObservationScope,
-} from "../observability/sentry";
-import type { AppEnv } from "../server/app";
-import { expectUuidString } from "../server/requestParsing";
-import { HttpError } from "../shared/errors";
+} from "../../observability/sentry";
+import type { AppEnv } from "../../server/app";
+import { expectUuidString } from "../../server/requestParsing";
+import { HttpError } from "../../shared/errors";
 import {
   getPublicApiBaseUrl,
   getPublicAppBaseUrl,
-} from "../shared/publicUrls";
+} from "../../shared/publicUrls";
 
 type CatalogPublicRoutesOptions = Readonly<{
   loadPublicCatalogSnapshotFn?: (

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -24,9 +24,9 @@ import { createWorkspacePackageRoutes } from "../routes/workspacePackages";
 import { createSyncRoutes } from "../routes/sync/index";
 import { createSystemRoutes } from "../routes/system";
 import { createAdminRoutes } from "../routes/admin";
-import { createCatalogAdminRoutes } from "../routes/catalogAdmin";
-import { createCatalogPublicRoutes } from "../routes/catalogPublic";
-import { createCatalogInstallRoutes } from "../routes/catalogInstall";
+import { createCatalogAdminRoutes } from "../routes/catalog/admin";
+import { createCatalogPublicRoutes } from "../routes/catalog/public";
+import { createCatalogInstallRoutes } from "../routes/catalog/install";
 import { createGuestAuthRoutes } from "../routes/guestAuth";
 import { createWorkspaceRoutes } from "../routes/workspaces/index";
 import {


### PR DESCRIPTION
## Summary
- group catalog admin, public, and install routes under `routes/catalog/`
- update server registration and catalog distribution test imports
- preserve HTTP routes and route behavior

## Validation
- independent static review: no P0-P4 issues found
- local project checks not run per repository workflow