### PR TITLE
Refactor multipart lifecycle boundaries

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -99,15 +99,15 @@ export const boundaryDefinitions = Object.freeze([
     migrationFileName: "0101_multipart_foreground_completion_fencing.sql",
     expectedMigrationCount: 103,
     testFiles: Object.freeze([
-      "src/mediaAssets/multipart/foregroundFencing.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerLifecycle/foregroundFencing.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
     migrationFileName: "0100_multipart_replacement_creation_claim.sql",
     expectedMigrationCount: 102,
     testFiles: Object.freeze([
-      "src/mediaAssets/multipart/replacementCreationClaim.postgres.integration.ts",
-      "src/mediaAssets/multipart/uploadSessionCreation.postgres.integration.ts",
+      "src/mediaAssets/multipart/creation/replacementCreationClaim.postgres.integration.ts",
+      "src/mediaAssets/multipart/creation/uploadSessionCreation.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
@@ -117,8 +117,8 @@ export const boundaryDefinitions = Object.freeze([
       "src/database/deadline.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
       "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
-      "src/mediaAssets/multipart/completionReconciliation.postgres.integration.ts",
-      "src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts",
+      "src/mediaAssets/multipart/completion/completionReconciliation.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
@@ -128,21 +128,21 @@ export const boundaryDefinitions = Object.freeze([
       "src/database/deadline.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
       "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
-      "src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
     migrationFileName: "0097_direct_multipart_writer_attempt_fencing.sql",
     expectedMigrationCount: 99,
     testFiles: Object.freeze([
-      "src/mediaAssets/multipart/writerAbortReplay.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
     migrationFileName: "0096_atomic_multipart_completion_resolution.sql",
     expectedMigrationCount: 98,
     testFiles: Object.freeze([
-      "src/mediaAssets/multipart/writerAttempts.postgres.integration.ts",
+      "src/mediaAssets/multipart/writerLifecycle/writerAttempts.postgres.integration.ts",
     ]),
   }),
 ]);

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.test.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.test.ts
@@ -6,7 +6,7 @@ import {
   MultipartCompletionReconciliationBatchError,
   type MultipartCompletionFailureReportBatchResult,
   type MultipartCompletionReconciliationBatchResult,
-} from "../../mediaAssets/multipart/completionReconciliation";
+} from "../../mediaAssets/multipart/completion/completionReconciliation";
 import {
   calculateMultipartCompletionReconciliationDeadlineAtMs,
   getMultipartCompletionReconciliationFailureDetails,

--- a/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.ts
+++ b/apps/backend/src/entrypoints/scheduledJobs/lambda-multipart-completion-reconciliation.ts
@@ -6,7 +6,7 @@ import {
   runMultipartCompletionReconciliationBatch,
   type MultipartCompletionFailureReportBatchResult,
   type MultipartCompletionReconciliationBatchResult,
-} from "../../mediaAssets/multipart/completionReconciliation";
+} from "../../mediaAssets/multipart/completion/completionReconciliation";
 import { createCloudWatchRecord } from "../../observability/cloudWatch";
 import {
   addBackendSentryBreadcrumb,

--- a/apps/backend/src/mediaAssets/multipart/atomicWriter.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/atomicWriter.postgres.integration.ts
@@ -64,7 +64,7 @@ import {
   claimMultipartCompletionReconciliations,
   renewMultipartCompletionReconciliationLease,
   type ClaimedMultipartCompletionReconciliation,
-} from "./completionReconciliation";
+} from "./completion/completionReconciliation";
 import {
   reconcileMultipartMediaAssetUploadWithDependencies,
 } from "../storage/multipart/reconciliation";
@@ -78,15 +78,15 @@ import {
 } from "./requestBoundary";
 import {
   createMultipartUploadSessionAtApplicationBoundary,
-} from "./creationBoundary";
+} from "./creation/creationBoundary";
 import {
   createMultipartWriterHeartbeat,
   isExpiredMultipartCompletionCleanupRequired,
-} from "./writerLease";
+} from "./writerLifecycle/writerLease";
 import {
   abortMultipartUploadSessionAtApplicationBoundary,
   completeMultipartUploadSessionAtApplicationBoundary,
-} from "./completionBoundary";
+} from "./completion/completionBoundary";
 import {
   createMultipartCompletionWriterLeaseTargetAtMs,
 } from "../../server/mediaRequests/multipartCompletionRequestTiming";

--- a/apps/backend/src/mediaAssets/multipart/completion/completionBoundary.ts
+++ b/apps/backend/src/mediaAssets/multipart/completion/completionBoundary.ts
@@ -1,23 +1,23 @@
 import {
   captureBackendWarning,
   type BackendObservationScope,
-} from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
+} from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
 import {
   createMultipartCompletionWriterLeaseTargetAtMs,
-} from "../../server/mediaRequests/multipartCompletionRequestTiming";
+} from "../../../server/mediaRequests/multipartCompletionRequestTiming";
 import {
   MediaBlobLifecycleBusyError,
-} from "../blobLifecycle";
-import { isValidMediaAssetLastOperationId } from "../lastOperationId";
+} from "../../blobLifecycle";
+import { isValidMediaAssetLastOperationId } from "../../lastOperationId";
 import {
   abortMultipartMediaAssetUpload,
   completeMultipartMediaAssetUpload,
-} from "../storage";
+} from "../../storage";
 import type {
   CompleteMediaAssetUploadPartInput,
   MediaAssetUploadSession,
-} from "../types";
+} from "../../types";
 import {
   assertMediaAssetUploadSessionCompletionPartsMatch,
   assertMediaAssetUploadSessionSupportsDurableCompletion,
@@ -34,7 +34,7 @@ import {
   type MultipartMediaBlobWriterAttemptExactInput,
   type MultipartMediaBlobWriterAttemptHandoffStatus,
   type MultipartMediaBlobWriterAttemptInput,
-} from "../uploadSessions";
+} from "../../uploadSessions";
 import {
   createMultipartCompletionHandedOffError,
   createMultipartCompletionInProgressError,
@@ -46,7 +46,7 @@ import {
   toMultipartAttemptInput,
   type MultipartCompletionRequestDeadline,
   type MultipartDatabaseCommitReplay,
-} from "./requestBoundary";
+} from "../requestBoundary";
 import {
   createMultipartAttemptError,
   createMultipartCompletionResolutionError,
@@ -64,7 +64,7 @@ import {
   type MultipartExactResolutionResult,
   type MultipartWriterHeartbeat,
   type MultipartWriterLease,
-} from "./writerLease";
+} from "../writerLifecycle/writerLease";
 
 export async function beginUploadSessionAbort(
   userId: string,

--- a/apps/backend/src/mediaAssets/multipart/completion/completionReconciliation.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/completion/completionReconciliation.postgres.integration.ts
@@ -5,8 +5,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../../testSupport/postgresIntegration";
-import { HttpError } from "../../shared/errors";
+} from "../../../testSupport/postgresIntegration";
+import { HttpError } from "../../../shared/errors";
 import {
   applyMultipartCompletionReconciliation,
   claimMultipartCompletionFailureReports,
@@ -22,7 +22,7 @@ import {
   type ClaimedMultipartCompletionFailureReport,
   type ClaimedMultipartCompletionReconciliation,
 } from "./completionReconciliation";
-import { isValidMediaAssetLastOperationId } from "../lastOperationId";
+import { isValidMediaAssetLastOperationId } from "../../lastOperationId";
 import {
   beginMediaAssetUploadSessionCompletionAttemptWithOwner,
   beginMediaAssetUploadSessionCompletionForWorkspace,
@@ -31,12 +31,12 @@ import {
   markMediaAssetUploadSessionAbortedForWorkspace,
   recordMediaAssetUploadSessionForWorkspace,
   type MultipartMediaBlobWriterAttemptInput,
-} from "../uploadSessions";
-import { passthroughMediaBlobNormalizationVersion } from "../types";
+} from "../../uploadSessions";
+import { passthroughMediaBlobNormalizationVersion } from "../../types";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "../storageKeys";
+} from "../../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;

--- a/apps/backend/src/mediaAssets/multipart/completion/completionReconciliation.test.ts
+++ b/apps/backend/src/mediaAssets/multipart/completion/completionReconciliation.test.ts
@@ -1,17 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { DatabaseDeadlineExceededError } from "../../database";
-import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
-import { createBackendObservationScope } from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
+import { DatabaseDeadlineExceededError } from "../../../database";
+import { DatabaseCommitOutcomeUnknownError } from "../../../database/transient";
+import { createBackendObservationScope } from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
 import {
   MultipartCompletionReconciliationStorageTerminalError,
   MultipartCompletionReconciliationStorageTransientError,
-} from "../storage";
+} from "../../storage";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "../storageKeys";
+} from "../../storageKeys";
 import {
   MultipartCompletionFailureReportBatchError,
   MultipartCompletionFailureReportLeaseLostError,

--- a/apps/backend/src/mediaAssets/multipart/completion/completionReconciliation.ts
+++ b/apps/backend/src/mediaAssets/multipart/completion/completionReconciliation.ts
@@ -1,40 +1,40 @@
 import {
   DatabaseDeadlineExceededError,
   type DatabaseExecutor,
-} from "../../database";
+} from "../../../database";
 import {
   unsafeQueryWithDeadline,
   unsafeTransactionWithDeadline,
-} from "../../database/unsafe";
+} from "../../../database/unsafe";
 import {
   DatabaseCommitOutcomeUnknownError,
   isTransientDatabaseError,
   TransientDatabaseHttpError,
-} from "../../database/transient";
+} from "../../../database/transient";
 import type {
   BackendObservationScope,
   MultipartCompletionReconciliationTerminalFailureDetails,
-} from "../../observability/sentry";
-import { isLowercaseWorkspaceId } from "../../workspaces/identity";
-import { mediaBlobCleanupDelayMs } from "../blobLifecycle";
-import { isValidMediaAssetLastOperationId } from "../lastOperationId";
+} from "../../../observability/sentry";
+import { isLowercaseWorkspaceId } from "../../../workspaces/identity";
+import { mediaBlobCleanupDelayMs } from "../../blobLifecycle";
+import { isValidMediaAssetLastOperationId } from "../../lastOperationId";
 import {
   upsertMediaAssetSnapshotWithBlobNormalizationInExecutor,
-} from "../persistence";
+} from "../../persistence";
 import {
   MultipartCompletionReconciliationStorageTerminalError,
   MultipartCompletionReconciliationStorageTransientError,
   reconcileMultipartMediaAssetUpload,
-} from "../storage";
+} from "../../storage";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "../storageKeys";
+} from "../../storageKeys";
 import {
   mediaBlobNormalizationVersions,
   type MediaAsset,
   type MediaBlobNormalizationVersion,
-} from "../types";
+} from "../../types";
 
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;

--- a/apps/backend/src/mediaAssets/multipart/completion/completionResolution.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/completion/completionResolution.postgres.integration.ts
@@ -3,15 +3,15 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "../storageKeys";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../../storageKeys";
 import { beginMediaAssetUploadSessionCompletionWithOwner, fenceMediaAssetUploadSessionCompletionApplyWithOwner,
   fenceMediaAssetUploadSessionCompletionApplyWithOwnerInExecutor, resolveMediaAssetUploadSessionCompletionAfterAccessRevocation,
   resolveMediaAssetUploadSessionCompletionAfterAccessRevocationInExecutor, resolveMediaAssetUploadSessionCompletionFailureWithOwner,
-  type MediaAssetUploadSessionCompletionResolutionInput, type MediaAssetUploadSessionCompletionRevocationInput, type MediaAssetUploadSessionCompletionWithOwnerInput } from "../uploadSessions";
-import { compareLwwMetadata } from "../../sync/conflicts/lww";
-import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "../types";
-const migration0096 = readFileSync(resolve(__dirname, "../../../../../db/migrations/0096_atomic_multipart_completion_resolution.sql"), "utf8");
+  type MediaAssetUploadSessionCompletionResolutionInput, type MediaAssetUploadSessionCompletionRevocationInput, type MediaAssetUploadSessionCompletionWithOwnerInput } from "../../uploadSessions";
+import { compareLwwMetadata } from "../../../sync/conflicts/lww";
+import { imageJpegCardMediaBlobNormalizationVersion, passthroughMediaBlobNormalizationVersion } from "../../types";
+const migration0096 = readFileSync(resolve(__dirname, "../../../../../../db/migrations/0096_atomic_multipart_completion_resolution.sql"), "utf8");
 const signatures = {
   apply: "content.fence_media_upload_session_completion_apply_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,uuid,text,integer)",
   failure: "content.resolve_media_upload_session_completion_failure_with_owner(text,uuid,uuid,uuid,uuid,text,text,text,text,text,text,bigint,bigint,integer,text,timestamp with time zone,timestamp with time zone,timestamp with time zone,uuid,text,integer)",

--- a/apps/backend/src/mediaAssets/multipart/creation/creationBoundary.ts
+++ b/apps/backend/src/mediaAssets/multipart/creation/creationBoundary.ts
@@ -1,19 +1,19 @@
 import { setTimeout as wait } from "node:timers/promises";
-import { runDatabaseOperationsWithDeadline } from "../../database";
-import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
+import { runDatabaseOperationsWithDeadline } from "../../../database";
+import { DatabaseCommitOutcomeUnknownError } from "../../../database/transient";
 import {
   normalizeCaughtError,
   type BackendObservationScope,
-} from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
+} from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
 import {
   abortMultipartMediaAssetUploadUntilDeadline,
   createMultipartMediaAssetUpload,
-} from "../storage";
+} from "../../storage";
 import type {
   MediaAssetUploadSessionCreateInput,
   MediaAssetUploadSessionCreateResult,
-} from "../types";
+} from "../../types";
 import {
   acquireMediaAssetUploadSessionCreationClaimForWorkspace,
   createMediaAssetFromAvailableBlobForWorkspace,
@@ -22,7 +22,7 @@ import {
   releaseMediaAssetUploadSessionCreationClaimForWorkspace,
   type MediaAssetUploadSessionCreationClaimResult,
   type MediaAssetUploadSessionCreationReplayResult,
-} from "../uploadSessions";
+} from "../../uploadSessions";
 
 export const multipartUploadSessionCreationClaimLeaseDurationMs = 60_000;
 const multipartUploadSessionCreationMaximumOperationReserveMs = 5_000;

--- a/apps/backend/src/mediaAssets/multipart/creation/replacementCreationClaim.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/creation/replacementCreationClaim.postgres.integration.ts
@@ -6,8 +6,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "../storageKeys";
+} from "../../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;

--- a/apps/backend/src/mediaAssets/multipart/creation/uploadSessionCreation.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/creation/uploadSessionCreation.postgres.integration.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
 import { setTimeout as delay } from "node:timers/promises";
 import test from "node:test";
-import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
-import { HttpError } from "../../shared/errors";
-import { getHttpErrorResponseHeaders } from "../../server/httpErrorResponseHeaders";
-import { createBackendObservationScope } from "../../observability/sentry";
+import { DatabaseCommitOutcomeUnknownError } from "../../../database/transient";
+import { HttpError } from "../../../shared/errors";
+import { getHttpErrorResponseHeaders } from "../../../server/httpErrorResponseHeaders";
+import { createBackendObservationScope } from "../../../observability/sentry";
 import {
   createMultipartUploadSessionAtApplicationBoundary,
   type MultipartUploadSessionCreationApplicationDependencies,
@@ -17,19 +17,19 @@ import {
   recordMediaAssetUploadSessionForWorkspace,
   recordMediaAssetUploadSessionWithCreationClaimForWorkspace,
   releaseMediaAssetUploadSessionCreationClaimForWorkspace,
-} from "../uploadSessions";
+} from "../../uploadSessions";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,
-} from "../storageKeys";
+} from "../../storageKeys";
 import type {
   MediaAssetUploadSession,
   MediaAssetUploadSessionCreateInput,
-} from "../types";
+} from "../../types";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../../testSupport/postgresIntegration";
+} from "../../../testSupport/postgresIntegration";
 
 type CountRow = Readonly<{ count: number }>;
 type ClaimStateRow = Readonly<{

--- a/apps/backend/src/mediaAssets/multipart/writerLifecycle/foregroundFencing.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerLifecycle/foregroundFencing.postgres.integration.ts
@@ -6,8 +6,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "../storageKeys";
+} from "../../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;

--- a/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerAbandonment.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerAbandonment.postgres.integration.ts
@@ -3,19 +3,19 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
-import { transactionWithWorkspaceScope } from "../../database";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
+import { transactionWithWorkspaceScope } from "../../../database";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../../testSupport/postgresIntegration";
 import { resolveDirectMediaBlobWriterAfterAccessRevocation, reserveDirectMediaBlobWriterWithOwner,
   reserveMediaBlobWriterInExecutor,
   type DirectMediaBlobWriterReservationInput,
   type DirectMediaBlobWriterResolutionInput,
-  type MediaBlobWriterReservationInput } from "../blobLifecycle";
-import { buildMediaBlobStorageKey } from "../storageKeys";
+  type MediaBlobWriterReservationInput } from "../../blobLifecycle";
+import { buildMediaBlobStorageKey } from "../../storageKeys";
 import { closeMediaAssetUploadSessionBlobWriter,
   reserveMediaAssetUploadSessionBlobWriterWithOwner,
-  type MediaAssetUploadSessionWriterClosureInput } from "../uploadSessions";
-import { passthroughMediaBlobNormalizationVersion } from "../types";
-const migrationSql = readFileSync(resolve(__dirname, "../../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql"), "utf8");
+  type MediaAssetUploadSessionWriterClosureInput } from "../../uploadSessions";
+import { passthroughMediaBlobNormalizationVersion } from "../../types";
+const migrationSql = readFileSync(resolve(__dirname, "../../../../../../db/migrations/0094_direct_multipart_writer_abandonment.sql"), "utf8");
 const signatures = {
   directReserve: "content.reserve_direct_media_blob_writer_with_owner(text,uuid,uuid,text,uuid,text,text,text,bigint,text)",
   multipartReserve: "content.reserve_media_upload_session_blob_writer_with_owner(text,uuid,uuid,text)",

--- a/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts
@@ -7,8 +7,8 @@ import type pg from "pg";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
-} from "../../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "../storageKeys";
+} from "../../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../../storageKeys";
 
 type MultipartPayload = Readonly<{
   userId: string;
@@ -61,7 +61,7 @@ type QueryExecutor = Pick<pg.PoolClient | pg.Pool, "query">;
 const cleanupDelayMs = 3_600_000;
 const migration0098 = readFileSync(resolve(
   __dirname,
-  "../../../../../db/migrations/0098_multipart_writer_abort_and_terminal_replay.sql",
+  "../../../../../../db/migrations/0098_multipart_writer_abort_and_terminal_replay.sql",
 ), "utf8");
 const multipartRow = `ROW(
   $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22

--- a/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerAttempts.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerAttempts.postgres.integration.ts
@@ -4,8 +4,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
 import type pg from "pg";
-import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../testSupport/postgresIntegration";
-import { buildMediaBlobStorageKey } from "../storageKeys";
+import { type PostgresIntegrationFixture, withPostgresIntegrationFixture } from "../../../testSupport/postgresIntegration";
+import { buildMediaBlobStorageKey } from "../../storageKeys";
 type DirectPayload = Readonly<{
   userId: string; workspaceId: string; mediaAssetId: string; operationId: string;
   replicaId: string; sha256: string; storageKey: string; mimeType: string;
@@ -31,7 +31,7 @@ type SqlValue = string | number | null;
 type QueryExecutor = Pick<pg.PoolClient, "query">;
 const cleanupDelayMs = 3_600_000;
 const migration0097 = readFileSync(resolve(
-  __dirname, "../../../../../db/migrations/0097_direct_multipart_writer_attempt_fencing.sql",
+  __dirname, "../../../../../../db/migrations/0097_direct_multipart_writer_attempt_fencing.sql",
 ), "utf8");
 const directRow = `ROW($3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
   ::content.direct_media_blob_writer_attempt_payload`;

--- a/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerLease.ts
+++ b/apps/backend/src/mediaAssets/multipart/writerLifecycle/writerLease.ts
@@ -2,26 +2,26 @@ import { setTimeout as wait } from "node:timers/promises";
 import {
   DatabaseDeadlineExceededError,
   runDatabaseOperationsWithDeadline,
-} from "../../database";
+} from "../../../database";
 import {
   DatabaseCommitOutcomeUnknownError,
   getDatabaseErrorFields,
   isTransientDatabaseError,
   TransientDatabaseHttpError,
-} from "../../database/transient";
+} from "../../../database/transient";
 import {
   captureBackendWarning,
   type BackendObservationScope,
-} from "../../observability/sentry";
-import { HttpError } from "../../shared/errors";
+} from "../../../observability/sentry";
+import { HttpError } from "../../../shared/errors";
 import {
   MediaBlobLifecycleBusyError,
   MediaBlobWriterFenceError,
-} from "../blobLifecycle";
+} from "../../blobLifecycle";
 import type {
   MediaAsset,
   MediaAssetUploadSession,
-} from "../types";
+} from "../../types";
 import {
   beginMediaAssetUploadSessionCompletionAttemptAtLeaseTargetWithOwnerUntilSettled,
   handoffMediaAssetUploadSessionCompletionAttemptAfterAccessRevocation,
@@ -35,7 +35,7 @@ import {
   type MultipartMediaBlobWriterAttemptHandoffStatus,
   type MultipartMediaBlobWriterAttemptInput,
   type MultipartMediaBlobWriterAttemptResult,
-} from "../uploadSessions";
+} from "../../uploadSessions";
 import {
   assertMultipartCompletionRequestActive,
   createMultipartCompletionDeadlineError,
@@ -47,7 +47,7 @@ import {
   multipartWriterLeaseExpiryObservationPaddingMs,
   type MultipartCompletionRequestDeadline,
   type MultipartDatabaseCommitReplay,
-} from "./requestBoundary";
+} from "../requestBoundary";
 
 export function isMultipartCompletionDeadlineFailure(
   error: unknown,

--- a/apps/backend/src/routes/mediaAssets.test.ts
+++ b/apps/backend/src/routes/mediaAssets.test.ts
@@ -32,11 +32,11 @@ import {
   isExpiredMultipartCompletionCleanupRequired,
   replayCompletedMultipartResultWithDependencies,
   resolveMultipartOperationExactlyUntilSafe,
-} from "../mediaAssets/multipart/writerLease";
+} from "../mediaAssets/multipart/writerLifecycle/writerLease";
 import {
   completeMultipartUploadSessionAtApplicationBoundary,
   type MultipartCompletionApplicationDependencies,
-} from "../mediaAssets/multipart/completionBoundary";
+} from "../mediaAssets/multipart/completion/completionBoundary";
 import { createMediaAssetsRoutes } from "./mediaAssets";
 
 const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";

--- a/apps/backend/src/routes/mediaAssets.ts
+++ b/apps/backend/src/routes/mediaAssets.ts
@@ -23,16 +23,16 @@ import {
   multipartUploadSessionCreationApplicationDependencies,
   multipartUploadSessionCreationClaimLeaseDurationMs,
   type MultipartUploadSessionCreationApplicationDependencies,
-} from "../mediaAssets/multipart/creationBoundary";
+} from "../mediaAssets/multipart/creation/creationBoundary";
 import {
   mapMultipartCompletionDeadlineError,
-} from "../mediaAssets/multipart/writerLease";
+} from "../mediaAssets/multipart/writerLifecycle/writerLease";
 import {
   abortMultipartUploadSessionAtApplicationBoundary,
   beginUploadSessionAbort,
   completeMultipartUploadSessionAtApplicationBoundary,
   multipartCompletionApplicationDependencies,
-} from "../mediaAssets/multipart/completionBoundary";
+} from "../mediaAssets/multipart/completion/completionBoundary";
 import {
   buildMediaBlobStorageKey,
   buildMediaMultipartUploadStagingStorageKey,


### PR DESCRIPTION
Summary:
- group multipart creation, completion, and writer-lifecycle files into three coarse directories
- keep requestBoundary.ts and atomicWriter.postgres.integration.ts flat
- update route, scheduled-job, test, and PostgreSQL boundary paths without changing behavior

Review:
- independent fresh review found no P0-P4 issues
- static stale-path, import-target, and registry-target integrity checks passed

Checks:
- not run locally per repository policy