### PR TITLE
Add Android review relocation infrastructure

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -311,14 +312,18 @@ fun ReviewRoute(
                         )
                     }
                 },
-                contentPadding = PaddingValues(
-                    start = 16.dp,
-                    top = innerPadding.calculateTopPadding() + 16.dp,
-                    end = 16.dp,
+                modifier = Modifier.padding(
+                    top = innerPadding.calculateTopPadding(),
                     bottom = innerPadding.calculateBottomPadding() + reviewContentBottomPadding(
                         hasCurrentCard = uiState.preparedCurrentCard != null,
                         isAnswerVisible = uiState.isAnswerVisible
                     )
+                ),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    top = 16.dp,
+                    end = 16.dp,
+                    bottom = 0.dp
                 )
             )
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
@@ -32,6 +34,8 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -86,12 +90,13 @@ internal fun ReviewContent(
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit,
+    modifier: Modifier,
     contentPadding: PaddingValues
 ) {
     if (uiState.isLoading.not() && uiState.preparedCurrentCard == null && uiState.emptyState != null) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxSize()
                 .padding(contentPadding)
                 .testTag(reviewEmptyStateTag)
@@ -110,7 +115,7 @@ internal fun ReviewContent(
     LazyColumn(
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
         item {
             when {
@@ -237,6 +242,19 @@ private fun ReviewCardContent(
 ) {
     val context = LocalContext.current
     val locale = currentResourceLocale(resources = context.resources)
+    val frontBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val backBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val currentCardId: String = currentCard.card.cardId
+
+    LaunchedEffect(currentCardId) {
+        frontBringIntoViewRequester.bringIntoView()
+    }
+
+    LaunchedEffect(currentCardId, isAnswerVisible) {
+        if (isAnswerVisible) {
+            backBringIntoViewRequester.bringIntoView()
+        }
+    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -294,6 +312,10 @@ private fun ReviewCardContent(
                 ReviewCardSideSection(
                     label = stringResource(id = R.string.review_front_label),
                     content = currentCard.frontContent,
+                    sectionModifier = Modifier,
+                    labelModifier = Modifier.bringIntoViewRequester(
+                        frontBringIntoViewRequester
+                    ),
                     contentModifier = Modifier.testTag(reviewCurrentCardFrontContentTag),
                     onLoadManagedMediaFile = onLoadManagedMediaFile,
                     onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
@@ -308,6 +330,10 @@ private fun ReviewCardContent(
                     ReviewCardSideSection(
                         label = stringResource(id = R.string.review_back_label),
                         content = currentCard.backContent,
+                        sectionModifier = Modifier.bringIntoViewRequester(
+                            backBringIntoViewRequester
+                        ),
+                        labelModifier = Modifier,
                         contentModifier = Modifier,
                         onLoadManagedMediaFile = onLoadManagedMediaFile,
                         onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
@@ -352,6 +378,8 @@ private fun ReviewCardContent(
 private fun ReviewCardSideSection(
     label: String,
     content: ReviewRenderedContent,
+    sectionModifier: Modifier,
+    labelModifier: Modifier,
     contentModifier: Modifier,
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
@@ -366,12 +394,13 @@ private fun ReviewCardSideSection(
 
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.fillMaxWidth()
+        modifier = sectionModifier.fillMaxWidth()
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = labelModifier
         )
         ReviewRenderedContentView(
             content = content,


### PR DESCRIPTION
## Summary
- add native BringIntoViewRequester targets for review Front and Back content
- constrain the review scroll viewport between the top bar and bottom action overlay
- preserve the existing single-card LazyColumn presentation

## Integration scope
Destination-recreation transition persistence is intentionally deferred to item 04 before promotion. This integration branch must not deploy until that repair lands.

## Checks
Not run locally per repository policy.