### PR TITLE
Persist Android review relocation transitions

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -153,6 +153,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                             "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"
                         )
                     },
+                    onConsumeRelocationTarget = { _, _ -> null },
                     onScreenVisible = {
                         screenVisibleCalls += 1
                     },
@@ -465,6 +466,7 @@ private fun ReviewRouteTestContent(
                     "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"
                 )
             },
+            onConsumeRelocationTarget = { _, _ -> null },
             onRevealAnswer = {},
             onRateAgain = {},
             onRateHard = {},

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -180,6 +180,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 },
                 onLoadManagedMediaFile = reviewViewModel::loadManagedMediaFile,
                 onLoadManagedMediaDownloadUrl = reviewViewModel::loadManagedMediaDownloadUrl,
+                onConsumeRelocationTarget = reviewViewModel::consumeReviewRelocationTarget,
                 onRevealAnswer = reviewViewModel::revealAnswer,
                 onRateAgain = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.AGAIN) },
                 onRateHard = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.HARD) },

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -65,6 +65,7 @@ fun ReviewRoute(
     onSwitchToAllCards: () -> Unit,
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
+    onConsumeRelocationTarget: (String?, Boolean) -> ReviewRelocationTarget?,
     onRevealAnswer: () -> Unit,
     onRateAgain: () -> Unit,
     onRateHard: () -> Unit,
@@ -288,6 +289,7 @@ fun ReviewRoute(
                 onSwitchToAllCards = onSwitchToAllCards,
                 onLoadManagedMediaFile = onLoadManagedMediaFile,
                 onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
+                onConsumeRelocationTarget = onConsumeRelocationTarget,
                 onToggleFrontSpeech = {
                     uiState.preparedCurrentCard?.let { currentCard ->
                         reviewSpeechController.toggleSpeech(

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
@@ -23,6 +23,11 @@ enum class ReviewEmptyState {
     SESSION_COMPLETE
 }
 
+enum class ReviewRelocationTarget {
+    FRONT,
+    BACK
+}
+
 data class ReviewUiState(
     val isLoading: Boolean,
     val requestedFilter: ReviewFilter,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -135,6 +135,8 @@ class ReviewViewModel(
     private var reviewFilterGeneration: Long = 0L
     private var activeWorkspaceId: String? = null
     private var workspaceGeneration: Long = 0L
+    private var handledPresentedCardId: String? = null
+    private var handledAnswerRevealCardId: String? = null
     /** Fixed-size in-memory review history for the current review session only. */
     private var recentReviewRatings: List<ReviewRating> = emptyList()
     /** Device-level cooldown timestamp for the hard-answer reminder. */
@@ -234,6 +236,28 @@ class ReviewViewModel(
                 errorMessage = ""
             )
         }
+    }
+
+    fun consumeReviewRelocationTarget(
+        presentedCardId: String?,
+        isAnswerVisible: Boolean
+    ): ReviewRelocationTarget? {
+        if (presentedCardId != handledPresentedCardId) {
+            handledPresentedCardId = presentedCardId
+            handledAnswerRevealCardId = if (isAnswerVisible) presentedCardId else null
+            return if (presentedCardId == null) null else ReviewRelocationTarget.FRONT
+        }
+
+        if (isAnswerVisible.not()) {
+            handledAnswerRevealCardId = null
+            return null
+        }
+        if (presentedCardId == null || handledAnswerRevealCardId == presentedCardId) {
+            return null
+        }
+
+        handledAnswerRevealCardId = presentedCardId
+        return ReviewRelocationTarget.BACK
     }
 
     fun dismissErrorMessage() {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -88,11 +88,33 @@ internal fun ReviewContent(
     onSwitchToAllCards: () -> Unit,
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
+    onConsumeRelocationTarget: (String?, Boolean) -> ReviewRelocationTarget?,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit,
     modifier: Modifier,
     contentPadding: PaddingValues
 ) {
+    val presentedCardId: String? = if (uiState.isLoading) {
+        null
+    } else {
+        uiState.preparedCurrentCard?.card?.cardId
+    }
+    val frontBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val backBringIntoViewRequester = remember { BringIntoViewRequester() }
+
+    LaunchedEffect(presentedCardId, uiState.isAnswerVisible) {
+        when (
+            onConsumeRelocationTarget(
+                presentedCardId,
+                uiState.isAnswerVisible
+            )
+        ) {
+            ReviewRelocationTarget.FRONT -> frontBringIntoViewRequester.bringIntoView()
+            ReviewRelocationTarget.BACK -> backBringIntoViewRequester.bringIntoView()
+            null -> Unit
+        }
+    }
+
     if (uiState.isLoading.not() && uiState.preparedCurrentCard == null && uiState.emptyState != null) {
         Box(
             contentAlignment = Alignment.Center,
@@ -143,7 +165,9 @@ internal fun ReviewContent(
                         onLoadManagedMediaFile = onLoadManagedMediaFile,
                         onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                         onToggleFrontSpeech = onToggleFrontSpeech,
-                        onToggleBackSpeech = onToggleBackSpeech
+                        onToggleBackSpeech = onToggleBackSpeech,
+                        frontBringIntoViewRequester = frontBringIntoViewRequester,
+                        backBringIntoViewRequester = backBringIntoViewRequester
                     )
                 }
 
@@ -238,23 +262,12 @@ private fun ReviewCardContent(
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
-    onToggleBackSpeech: () -> Unit
+    onToggleBackSpeech: () -> Unit,
+    frontBringIntoViewRequester: BringIntoViewRequester,
+    backBringIntoViewRequester: BringIntoViewRequester
 ) {
     val context = LocalContext.current
     val locale = currentResourceLocale(resources = context.resources)
-    val frontBringIntoViewRequester = remember { BringIntoViewRequester() }
-    val backBringIntoViewRequester = remember { BringIntoViewRequester() }
-    val currentCardId: String = currentCard.card.cardId
-
-    LaunchedEffect(currentCardId) {
-        frontBringIntoViewRequester.bringIntoView()
-    }
-
-    LaunchedEffect(currentCardId, isAnswerVisible) {
-        if (isAnswerVisible) {
-            backBringIntoViewRequester.bringIntoView()
-        }
-    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),


### PR DESCRIPTION
## Summary
- retain handled review relocation identities in the ReviewRootGraph-scoped ViewModel
- consume only one native Front or Back relocation for each valid presentation transition
- prevent unchanged Review destination recreation from issuing competing scroll requests

## Validation
- independent static review found no P0-P4 issues
- project checks intentionally deferred to the later promotion PR to main