### PR TITLE
Scroll revealed answers into view across clients

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -153,6 +153,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                             "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"
                         )
                     },
+                    onConsumeRelocationTarget = { _, _ -> null },
                     onScreenVisible = {
                         screenVisibleCalls += 1
                     },
@@ -465,6 +466,7 @@ private fun ReviewRouteTestContent(
                     "ReviewRouteTest does not load managed media. mediaAssetId=$mediaAssetId"
                 )
             },
+            onConsumeRelocationTarget = { _, _ -> null },
             onRevealAnswer = {},
             onRateAgain = {},
             onRateHard = {},

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -180,6 +180,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 },
                 onLoadManagedMediaFile = reviewViewModel::loadManagedMediaFile,
                 onLoadManagedMediaDownloadUrl = reviewViewModel::loadManagedMediaDownloadUrl,
+                onConsumeRelocationTarget = reviewViewModel::consumeReviewRelocationTarget,
                 onRevealAnswer = reviewViewModel::revealAnswer,
                 onRateAgain = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.AGAIN) },
                 onRateHard = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.HARD) },

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -65,6 +65,7 @@ fun ReviewRoute(
     onSwitchToAllCards: () -> Unit,
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
+    onConsumeRelocationTarget: (String?, Boolean) -> ReviewRelocationTarget?,
     onRevealAnswer: () -> Unit,
     onRateAgain: () -> Unit,
     onRateHard: () -> Unit,
@@ -288,6 +289,7 @@ fun ReviewRoute(
                 onSwitchToAllCards = onSwitchToAllCards,
                 onLoadManagedMediaFile = onLoadManagedMediaFile,
                 onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
+                onConsumeRelocationTarget = onConsumeRelocationTarget,
                 onToggleFrontSpeech = {
                     uiState.preparedCurrentCard?.let { currentCard ->
                         reviewSpeechController.toggleSpeech(

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -311,14 +312,18 @@ fun ReviewRoute(
                         )
                     }
                 },
-                contentPadding = PaddingValues(
-                    start = 16.dp,
-                    top = innerPadding.calculateTopPadding() + 16.dp,
-                    end = 16.dp,
+                modifier = Modifier.padding(
+                    top = innerPadding.calculateTopPadding(),
                     bottom = innerPadding.calculateBottomPadding() + reviewContentBottomPadding(
                         hasCurrentCard = uiState.preparedCurrentCard != null,
                         isAnswerVisible = uiState.isAnswerVisible
                     )
+                ),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    top = 16.dp,
+                    end = 16.dp,
+                    bottom = 0.dp
                 )
             )
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
@@ -23,6 +23,11 @@ enum class ReviewEmptyState {
     SESSION_COMPLETE
 }
 
+enum class ReviewRelocationTarget {
+    FRONT,
+    BACK
+}
+
 data class ReviewUiState(
     val isLoading: Boolean,
     val requestedFilter: ReviewFilter,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -135,6 +135,8 @@ class ReviewViewModel(
     private var reviewFilterGeneration: Long = 0L
     private var activeWorkspaceId: String? = null
     private var workspaceGeneration: Long = 0L
+    private var handledPresentedCardId: String? = null
+    private var handledAnswerRevealCardId: String? = null
     /** Fixed-size in-memory review history for the current review session only. */
     private var recentReviewRatings: List<ReviewRating> = emptyList()
     /** Device-level cooldown timestamp for the hard-answer reminder. */
@@ -234,6 +236,28 @@ class ReviewViewModel(
                 errorMessage = ""
             )
         }
+    }
+
+    fun consumeReviewRelocationTarget(
+        presentedCardId: String?,
+        isAnswerVisible: Boolean
+    ): ReviewRelocationTarget? {
+        if (presentedCardId != handledPresentedCardId) {
+            handledPresentedCardId = presentedCardId
+            handledAnswerRevealCardId = if (isAnswerVisible) presentedCardId else null
+            return if (presentedCardId == null) null else ReviewRelocationTarget.FRONT
+        }
+
+        if (isAnswerVisible.not()) {
+            handledAnswerRevealCardId = null
+            return null
+        }
+        if (presentedCardId == null || handledAnswerRevealCardId == presentedCardId) {
+            return null
+        }
+
+        handledAnswerRevealCardId = presentedCardId
+        return ReviewRelocationTarget.BACK
     }
 
     fun dismissErrorMessage() {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -88,11 +88,33 @@ internal fun ReviewContent(
     onSwitchToAllCards: () -> Unit,
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
+    onConsumeRelocationTarget: (String?, Boolean) -> ReviewRelocationTarget?,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit,
     modifier: Modifier,
     contentPadding: PaddingValues
 ) {
+    val presentedCardId: String? = if (uiState.isLoading) {
+        null
+    } else {
+        uiState.preparedCurrentCard?.card?.cardId
+    }
+    val frontBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val backBringIntoViewRequester = remember { BringIntoViewRequester() }
+
+    LaunchedEffect(presentedCardId, uiState.isAnswerVisible) {
+        when (
+            onConsumeRelocationTarget(
+                presentedCardId,
+                uiState.isAnswerVisible
+            )
+        ) {
+            ReviewRelocationTarget.FRONT -> frontBringIntoViewRequester.bringIntoView()
+            ReviewRelocationTarget.BACK -> backBringIntoViewRequester.bringIntoView()
+            null -> Unit
+        }
+    }
+
     if (uiState.isLoading.not() && uiState.preparedCurrentCard == null && uiState.emptyState != null) {
         Box(
             contentAlignment = Alignment.Center,
@@ -143,7 +165,9 @@ internal fun ReviewContent(
                         onLoadManagedMediaFile = onLoadManagedMediaFile,
                         onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
                         onToggleFrontSpeech = onToggleFrontSpeech,
-                        onToggleBackSpeech = onToggleBackSpeech
+                        onToggleBackSpeech = onToggleBackSpeech,
+                        frontBringIntoViewRequester = frontBringIntoViewRequester,
+                        backBringIntoViewRequester = backBringIntoViewRequester
                     )
                 }
 
@@ -238,23 +262,12 @@ private fun ReviewCardContent(
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
-    onToggleBackSpeech: () -> Unit
+    onToggleBackSpeech: () -> Unit,
+    frontBringIntoViewRequester: BringIntoViewRequester,
+    backBringIntoViewRequester: BringIntoViewRequester
 ) {
     val context = LocalContext.current
     val locale = currentResourceLocale(resources = context.resources)
-    val frontBringIntoViewRequester = remember { BringIntoViewRequester() }
-    val backBringIntoViewRequester = remember { BringIntoViewRequester() }
-    val currentCardId: String = currentCard.card.cardId
-
-    LaunchedEffect(currentCardId) {
-        frontBringIntoViewRequester.bringIntoView()
-    }
-
-    LaunchedEffect(currentCardId, isAnswerVisible) {
-        if (isAnswerVisible) {
-            backBringIntoViewRequester.bringIntoView()
-        }
-    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
@@ -32,6 +34,8 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -86,12 +90,13 @@ internal fun ReviewContent(
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
     onToggleFrontSpeech: () -> Unit,
     onToggleBackSpeech: () -> Unit,
+    modifier: Modifier,
     contentPadding: PaddingValues
 ) {
     if (uiState.isLoading.not() && uiState.preparedCurrentCard == null && uiState.emptyState != null) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxSize()
                 .padding(contentPadding)
                 .testTag(reviewEmptyStateTag)
@@ -110,7 +115,7 @@ internal fun ReviewContent(
     LazyColumn(
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
         item {
             when {
@@ -237,6 +242,19 @@ private fun ReviewCardContent(
 ) {
     val context = LocalContext.current
     val locale = currentResourceLocale(resources = context.resources)
+    val frontBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val backBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val currentCardId: String = currentCard.card.cardId
+
+    LaunchedEffect(currentCardId) {
+        frontBringIntoViewRequester.bringIntoView()
+    }
+
+    LaunchedEffect(currentCardId, isAnswerVisible) {
+        if (isAnswerVisible) {
+            backBringIntoViewRequester.bringIntoView()
+        }
+    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -294,6 +312,10 @@ private fun ReviewCardContent(
                 ReviewCardSideSection(
                     label = stringResource(id = R.string.review_front_label),
                     content = currentCard.frontContent,
+                    sectionModifier = Modifier,
+                    labelModifier = Modifier.bringIntoViewRequester(
+                        frontBringIntoViewRequester
+                    ),
                     contentModifier = Modifier.testTag(reviewCurrentCardFrontContentTag),
                     onLoadManagedMediaFile = onLoadManagedMediaFile,
                     onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
@@ -308,6 +330,10 @@ private fun ReviewCardContent(
                     ReviewCardSideSection(
                         label = stringResource(id = R.string.review_back_label),
                         content = currentCard.backContent,
+                        sectionModifier = Modifier.bringIntoViewRequester(
+                            backBringIntoViewRequester
+                        ),
+                        labelModifier = Modifier,
                         contentModifier = Modifier,
                         onLoadManagedMediaFile = onLoadManagedMediaFile,
                         onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl,
@@ -352,6 +378,8 @@ private fun ReviewCardContent(
 private fun ReviewCardSideSection(
     label: String,
     content: ReviewRenderedContent,
+    sectionModifier: Modifier,
+    labelModifier: Modifier,
     contentModifier: Modifier,
     onLoadManagedMediaFile: suspend (String) -> ReviewMediaAssetFile,
     onLoadManagedMediaDownloadUrl: suspend (String) -> MediaAssetDownloadUrl,
@@ -366,12 +394,13 @@ private fun ReviewCardSideSection(
 
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.fillMaxWidth()
+        modifier = sectionModifier.fillMaxWidth()
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = labelModifier
         )
         ReviewRenderedContentView(
             content = content,

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -12,6 +12,11 @@ private let showAnswerButtonMinHeight: CGFloat = 56
 let emptyBackTextPlaceholder: String = String(localized: "No back text", table: reviewCardsStringsTableName)
 private let reviewQueuePreviewPageSize: Int = 50
 
+private enum ReviewCardScrollTarget: Hashable {
+    case front
+    case back
+}
+
 private struct ReviewFilterPresentationContext: Equatable {
     let workspaceId: String?
     let committedFilter: ReviewFilter
@@ -395,13 +400,25 @@ struct ReviewView: View {
     }
 
     private func activeCardView(card: Card, preparedRevealState: PreparedReviewRevealState) -> some View {
-        ScrollView {
-            ReadableContentLayout(
-                maxWidth: flashcardsReadableContentMaxWidth,
-                horizontalPadding: 20
-            ) {
-                activeCardContentView(card: card, preparedRevealState: preparedRevealState)
-                    .padding(.vertical, 20)
+        ScrollViewReader { proxy in
+            ScrollView {
+                ReadableContentLayout(
+                    maxWidth: flashcardsReadableContentMaxWidth,
+                    horizontalPadding: 20
+                ) {
+                    activeCardContentView(card: card, preparedRevealState: preparedRevealState)
+                        .padding(.vertical, 20)
+                }
+            }
+            .onChange(of: isAnswerVisible) { wasVisible, isVisible in
+                guard wasVisible == false, isVisible else {
+                    return
+                }
+
+                proxy.scrollTo(ReviewCardScrollTarget.back, anchor: .top)
+            }
+            .onChange(of: card.cardId) { _, _ in
+                proxy.scrollTo(ReviewCardScrollTarget.front, anchor: .top)
             }
         }
     }
@@ -443,6 +460,7 @@ struct ReviewView: View {
                 onOpenAi: {},
                 surfaceStyle: .front
             )
+            .id(ReviewCardScrollTarget.front)
 
             if isAnswerVisible {
                 ReviewCardSideView(
@@ -459,6 +477,7 @@ struct ReviewView: View {
                     },
                     surfaceStyle: .back
                 )
+                .id(ReviewCardScrollTarget.back)
             }
 
             HStack(spacing: 12) {

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { useLayoutEffect, useRef, type ReactElement } from "react";
 import { Link } from "react-router";
 import type { ReviewRating } from "../../../../../backend/src/scheduling";
 import { useI18n } from "../../../i18n";
@@ -18,6 +18,12 @@ import {
 } from "./reviewScreenTypes";
 
 const REVIEW_BUTTONS_PER_COLUMN = 2;
+const REVIEW_SCROLL_INTO_VIEW_OPTIONS = {
+  behavior: "instant",
+  block: "start",
+  container: "nearest",
+  inline: "nearest",
+} as const satisfies ScrollIntoViewOptions & { container: "nearest" };
 
 export type ReviewPaneProps = Readonly<{
   activeSpeechSide: ReviewSpeechSide | null;
@@ -266,6 +272,27 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
   const backSideLabel = t("reviewScreen.sides.back");
   const leftReviewButtonOptions = reviewButtonOptions.slice(0, REVIEW_BUTTONS_PER_COLUMN);
   const rightReviewButtonOptions = reviewButtonOptions.slice(REVIEW_BUTTONS_PER_COLUMN, REVIEW_BUTTONS_PER_COLUMN * 2);
+  const frontTargetRef = useRef<HTMLDivElement>(null);
+  const backTargetRef = useRef<HTMLDivElement>(null);
+  const previousCardIdRef = useRef<string | null>(null);
+  const wasAnswerVisibleRef = useRef(false);
+
+  useLayoutEffect(() => {
+    const didCardChange = previousCardIdRef.current !== selectedCard.cardId;
+    const didRevealAnswer = !didCardChange && !wasAnswerVisibleRef.current && isAnswerVisible;
+
+    previousCardIdRef.current = selectedCard.cardId;
+    wasAnswerVisibleRef.current = isAnswerVisible;
+
+    if (didCardChange) {
+      frontTargetRef.current?.scrollIntoView(REVIEW_SCROLL_INTO_VIEW_OPTIONS);
+      return;
+    }
+
+    if (didRevealAnswer) {
+      backTargetRef.current?.scrollIntoView(REVIEW_SCROLL_INTO_VIEW_OPTIONS);
+    }
+  }, [isAnswerVisible, selectedCard.cardId]);
 
   return (
     <>
@@ -286,49 +313,53 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
         </div>
       </div>
       <div className="review-card-stack">
-        <ReviewCardSide
-          label={frontSideLabel}
-          aiButtonAriaLabel={null}
-          text={selectedCard.frontText}
-          contentClassName="review-front"
-          isSpeaking={activeSpeechSide === "front"}
-          onOpenAi={null}
-          onToggleSpeech={() => onToggleSpeech("front", selectedCard.frontText)}
-          showAiButton={false}
-          showSpeechButton={selectedFrontSpeakableText !== ""}
-          speechButtonAriaLabel={t(activeSpeechSide === "front" ? "reviewScreen.speakAriaLabel.stop" : "reviewScreen.speakAriaLabel.start", {
-            side: frontSideLabel.toLowerCase(),
-          })}
-          speechButtonDisabled={false}
-          localReadVersion={localReadVersion}
-          surfaceCardId={selectedCard.cardId}
-          surfaceClassName="review-card-surface review-card-surface-front"
-          surfaceFrontText={selectedCard.frontText}
-          surfaceTestId="review-current-front-card"
-          workspaceId={workspaceId}
-        />
-
-        {isAnswerVisible ? (
+        <div className="review-card-scroll-target" ref={frontTargetRef}>
           <ReviewCardSide
-            label={backSideLabel}
-            aiButtonAriaLabel={t("reviewScreen.aiOpenAriaLabel", {
-              side: backSideLabel.toLowerCase(),
-            })}
-            text={selectedCard.backText === "" ? t("common.noBackText") : selectedCard.backText}
-            contentClassName="review-back"
-            isSpeaking={activeSpeechSide === "back"}
-            onOpenAi={() => void onAiHandoff(selectedCard)}
-            onToggleSpeech={() => onToggleSpeech("back", selectedCard.backText)}
-            showAiButton={true}
-            showSpeechButton={selectedBackSpeakableText !== ""}
-            speechButtonAriaLabel={t(activeSpeechSide === "back" ? "reviewScreen.speakAriaLabel.stop" : "reviewScreen.speakAriaLabel.start", {
-              side: backSideLabel.toLowerCase(),
+            label={frontSideLabel}
+            aiButtonAriaLabel={null}
+            text={selectedCard.frontText}
+            contentClassName="review-front"
+            isSpeaking={activeSpeechSide === "front"}
+            onOpenAi={null}
+            onToggleSpeech={() => onToggleSpeech("front", selectedCard.frontText)}
+            showAiButton={false}
+            showSpeechButton={selectedFrontSpeakableText !== ""}
+            speechButtonAriaLabel={t(activeSpeechSide === "front" ? "reviewScreen.speakAriaLabel.stop" : "reviewScreen.speakAriaLabel.start", {
+              side: frontSideLabel.toLowerCase(),
             })}
             speechButtonDisabled={false}
             localReadVersion={localReadVersion}
-            surfaceClassName="review-card-surface review-card-answer"
+            surfaceCardId={selectedCard.cardId}
+            surfaceClassName="review-card-surface review-card-surface-front"
+            surfaceFrontText={selectedCard.frontText}
+            surfaceTestId="review-current-front-card"
             workspaceId={workspaceId}
           />
+        </div>
+
+        {isAnswerVisible ? (
+          <div className="review-card-scroll-target" ref={backTargetRef}>
+            <ReviewCardSide
+              label={backSideLabel}
+              aiButtonAriaLabel={t("reviewScreen.aiOpenAriaLabel", {
+                side: backSideLabel.toLowerCase(),
+              })}
+              text={selectedCard.backText === "" ? t("common.noBackText") : selectedCard.backText}
+              contentClassName="review-back"
+              isSpeaking={activeSpeechSide === "back"}
+              onOpenAi={() => void onAiHandoff(selectedCard)}
+              onToggleSpeech={() => onToggleSpeech("back", selectedCard.backText)}
+              showAiButton={true}
+              showSpeechButton={selectedBackSpeakableText !== ""}
+              speechButtonAriaLabel={t(activeSpeechSide === "back" ? "reviewScreen.speakAriaLabel.stop" : "reviewScreen.speakAriaLabel.start", {
+                side: backSideLabel.toLowerCase(),
+              })}
+              speechButtonDisabled={false}
+              localReadVersion={localReadVersion}
+              surfaceClassName="review-card-surface review-card-answer"
+              workspaceId={workspaceId}
+            />
+          </div>
         ) : null}
       </div>
 

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -592,6 +592,7 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     reviewReactionLottieLoadAnimationMock.mockReset();
     reviewReactionLottieLoadAnimationMock.mockImplementation(() => makeReviewReactionLottieAnimationItemForTest());
     vi.stubGlobal("fetch", vi.fn(fetchReviewReactionLottieAssetForTest));
+    HTMLElement.prototype.scrollIntoView = vi.fn();
 
     state = createDefaultReviewScreenTestState();
     container = document.createElement("div");

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -117,6 +117,11 @@
   gap: 10px;
 }
 
+.review-card-scroll-target {
+  width: 100%;
+  min-width: 0;
+}
+
 .review-card-surface {
   min-height: 112px;
   width: 100%;


### PR DESCRIPTION
## Summary

- scroll the revealed Back into the unobscured review viewport on web, iOS, and Android
- preserve native clamping, manual scrolling, and Front-above-Back flow
- reset genuinely new cards to Front without retriggering on rerenders or Android destination recreation

## Validation

- cumulative static promotion review passed with no P0-P4 findings
- required trunk CI owns executable validation