### PR TITLE
Preserve inline card editor drafts

### DIFF
--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -8,7 +8,11 @@ import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } fro
 import { useI18n } from "../../../i18n";
 import { CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
 import { getExpectedCardMutationInlineErrorMessage } from "../cardMutationErrors";
-import { EditableCardTagsCell, EditableCardTextCell } from "./CardsTableEditors";
+import {
+  EditableCardTagsCell,
+  EditableCardTextCell,
+  type CardInlineEditorToken,
+} from "./CardsTableEditors";
 import { queryLocalCardsPage } from "../../../localDb/cards/cards";
 import { loadWorkspaceTagsSummary } from "../../../localDb/cards/workspace";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
@@ -32,12 +36,20 @@ type CardsQueryState = Readonly<{
 
 type CardsQueryRequestKind = "reset" | "refresh" | "loadMore";
 
+type CardsQueryWindow = Readonly<{
+  items: ReadonlyArray<Card>;
+  totalCount: number;
+  nextCursor: string | null;
+}>;
+
 type CardsQueryControl = Readonly<{
   queryIdentity: string;
   requestSequence: number;
   acceptedRowCount: number;
   nextCursor: string | null;
   activeRequest: CardsQueryRequestKind | null;
+  authoritativeWindow: CardsQueryWindow;
+  hasPendingPublication: boolean;
 }>;
 
 const cardsPageSize = 50;
@@ -50,6 +62,34 @@ function createInitialCardsQueryState(): CardsQueryState {
     totalCount: 0,
     nextCursor: null,
     hasLoaded: false,
+    isLoading: false,
+    isLoadingMore: false,
+    errorMessage: "",
+  };
+}
+
+function createEmptyCardsQueryWindow(): CardsQueryWindow {
+  return {
+    items: [],
+    totalCount: 0,
+    nextCursor: null,
+  };
+}
+
+function createCardsQueryWindow(nextPage: QueryCardsPage): CardsQueryWindow {
+  return {
+    items: nextPage.cards,
+    totalCount: nextPage.totalCount,
+    nextCursor: nextPage.nextCursor,
+  };
+}
+
+function createPublishedCardsQueryState(queryWindow: CardsQueryWindow): CardsQueryState {
+  return {
+    items: queryWindow.items,
+    totalCount: queryWindow.totalCount,
+    nextCursor: queryWindow.nextCursor,
+    hasLoaded: true,
     isLoading: false,
     isLoadingMore: false,
     errorMessage: "",
@@ -135,19 +175,19 @@ function getSortPriority(
   return index === -1 ? null : index + 1;
 }
 
-function mergeCardsPage(
-  currentState: CardsQueryState,
+function mergeCardsQueryWindow(
+  currentWindow: CardsQueryWindow,
   nextPage: QueryCardsPage,
-): CardsQueryState {
+): CardsQueryWindow {
   return {
-    items: [...currentState.items, ...nextPage.cards],
+    items: [...currentWindow.items, ...nextPage.cards],
     totalCount: nextPage.totalCount,
     nextCursor: nextPage.nextCursor,
-    hasLoaded: true,
-    isLoading: false,
-    isLoadingMore: false,
-    errorMessage: "",
   };
+}
+
+function getCardInlineEditorTokenKey(editorToken: CardInlineEditorToken): string {
+  return `${editorToken.cardId}:${editorToken.field}`;
 }
 
 export function CardsScreen(): ReactElement {
@@ -171,6 +211,7 @@ export function CardsScreen(): ReactElement {
   const [cardsQueryState, setCardsQueryState] = useState<CardsQueryState>(createInitialCardsQueryState);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const loadMoreSentinelRef = useRef<HTMLTableRowElement | null>(null);
+  const loadMoreSentinelIntersectionConsumedRef = useRef<boolean>(false);
   const filterWrapRef = useRef<HTMLDivElement | null>(null);
   const filterPopoverRef = useRef<HTMLDivElement | null>(null);
   const filterTagsInputRef = useRef<CardTagsInputHandle | null>(null);
@@ -187,7 +228,11 @@ export function CardsScreen(): ReactElement {
     acceptedRowCount: 0,
     nextCursor: null,
     activeRequest: null,
+    authoritativeWindow: createEmptyCardsQueryWindow(),
+    hasPendingPublication: false,
   });
+  const activeEditorLifecyclesRef = useRef<Map<string, number>>(new Map());
+  const nextEditorLifecycleRef = useRef<number>(0);
   const observedQueryIdentityRef = useRef<string | null>(null);
   const observedLocalReadVersionRef = useRef<number>(localReadVersion);
   const [tagSuggestions, setTagSuggestions] = useState<ReadonlyArray<TagSuggestion>>([]);
@@ -229,14 +274,85 @@ export function CardsScreen(): ReactElement {
     return () => window.clearTimeout(timeoutId);
   }, [searchText]);
 
+  function acceptCardsQueryWindow(
+    queryIdentity: string,
+    requestSequence: number,
+    queryWindow: CardsQueryWindow,
+  ): void {
+    const shouldDeferPublication = activeEditorLifecyclesRef.current.size > 0;
+    cardsQueryControlRef.current = {
+      queryIdentity,
+      requestSequence,
+      acceptedRowCount: queryWindow.items.length,
+      nextCursor: queryWindow.nextCursor,
+      activeRequest: null,
+      authoritativeWindow: queryWindow,
+      hasPendingPublication: shouldDeferPublication,
+    };
+
+    if (shouldDeferPublication) {
+      setCardsQueryState((currentState) => ({
+        ...currentState,
+        isLoading: false,
+        isLoadingMore: false,
+        errorMessage: "",
+      }));
+      return;
+    }
+
+    loadMoreSentinelIntersectionConsumedRef.current = false;
+    setCardsQueryState(createPublishedCardsQueryState(queryWindow));
+  }
+
+  const handleInlineEditorOpen = useCallback((editorToken: CardInlineEditorToken): number => {
+    const editorLifecycle = nextEditorLifecycleRef.current + 1;
+    nextEditorLifecycleRef.current = editorLifecycle;
+    activeEditorLifecyclesRef.current.set(
+      getCardInlineEditorTokenKey(editorToken),
+      editorLifecycle,
+    );
+    return editorLifecycle;
+  }, []);
+
+  const handleInlineEditorClose = useCallback((
+    editorToken: CardInlineEditorToken,
+    editorLifecycle: number,
+  ): void => {
+    const editorTokenKey = getCardInlineEditorTokenKey(editorToken);
+    if (activeEditorLifecyclesRef.current.get(editorTokenKey) !== editorLifecycle) {
+      return;
+    }
+
+    activeEditorLifecyclesRef.current.delete(editorTokenKey);
+    if (activeEditorLifecyclesRef.current.size > 0) {
+      return;
+    }
+
+    const currentControl = cardsQueryControlRef.current;
+    if (!currentControl.hasPendingPublication) {
+      return;
+    }
+
+    cardsQueryControlRef.current = {
+      ...currentControl,
+      hasPendingPublication: false,
+    };
+    loadMoreSentinelIntersectionConsumedRef.current = false;
+    setCardsQueryState(createPublishedCardsQueryState(currentControl.authoritativeWindow));
+  }, []);
+
   async function resetCardsQuery(queryIdentity: string): Promise<void> {
     const requestSequence = cardsQueryControlRef.current.requestSequence + 1;
+    activeEditorLifecyclesRef.current.clear();
+    loadMoreSentinelIntersectionConsumedRef.current = false;
     cardsQueryControlRef.current = {
       queryIdentity,
       requestSequence,
       acceptedRowCount: 0,
       nextCursor: null,
       activeRequest: activeWorkspace === null ? null : "reset",
+      authoritativeWindow: createEmptyCardsQueryWindow(),
+      hasPendingPublication: false,
     };
 
     if (activeWorkspace === null) {
@@ -266,13 +382,11 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
-      cardsQueryControlRef.current = {
+      acceptCardsQueryWindow(
         queryIdentity,
         requestSequence,
-        acceptedRowCount: nextPage.cards.length,
-        nextCursor: nextPage.nextCursor,
-        activeRequest: null,
-      };
+        createCardsQueryWindow(nextPage),
+      );
 
       setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
         tag: tagSummary.tag,
@@ -285,15 +399,6 @@ export function CardsScreen(): ReactElement {
         totalCount: nextPage.totalCount,
         rows: nextPage.cards.slice(0, 8).map((card) => buildCardsLoadingRowPreview(card)),
         savedAt: new Date().toISOString(),
-      });
-      setCardsQueryState({
-        items: nextPage.cards,
-        totalCount: nextPage.totalCount,
-        nextCursor: nextPage.nextCursor,
-        hasLoaded: true,
-        isLoading: false,
-        isLoadingMore: false,
-        errorMessage: "",
       });
     } catch (error) {
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
@@ -364,13 +469,11 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
-      cardsQueryControlRef.current = {
+      acceptCardsQueryWindow(
         queryIdentity,
         requestSequence,
-        acceptedRowCount: nextPage.cards.length,
-        nextCursor: nextPage.nextCursor,
-        activeRequest: null,
-      };
+        createCardsQueryWindow(nextPage),
+      );
       setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
         tag: tagSummary.tag,
         countState: "ready",
@@ -382,15 +485,6 @@ export function CardsScreen(): ReactElement {
         totalCount: nextPage.totalCount,
         rows: nextPage.cards.slice(0, 8).map((card) => buildCardsLoadingRowPreview(card)),
         savedAt: new Date().toISOString(),
-      });
-      setCardsQueryState({
-        items: nextPage.cards,
-        totalCount: nextPage.totalCount,
-        nextCursor: nextPage.nextCursor,
-        hasLoaded: true,
-        isLoading: false,
-        isLoadingMore: false,
-        errorMessage: "",
       });
     } catch (error) {
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
@@ -457,15 +551,11 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
-      cardsQueryControlRef.current = {
-        queryIdentity: cardsQueryIdentity,
+      acceptCardsQueryWindow(
+        cardsQueryIdentity,
         requestSequence,
-        acceptedRowCount: currentControl.acceptedRowCount + nextPage.cards.length,
-        nextCursor: nextPage.nextCursor,
-        activeRequest: null,
-      };
-
-      setCardsQueryState((currentState) => mergeCardsPage(currentState, nextPage));
+        mergeCardsQueryWindow(currentControl.authoritativeWindow, nextPage),
+      );
     } catch (error) {
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, cardsQueryIdentity, requestSequence)) {
         return;
@@ -542,9 +632,24 @@ export function CardsScreen(): ReactElement {
 
     const observer = new IntersectionObserver((entries) => {
       const firstEntry = entries[0];
-      if (firstEntry?.isIntersecting) {
-        void loadNextPage();
+      if (!firstEntry?.isIntersecting) {
+        loadMoreSentinelIntersectionConsumedRef.current = false;
+        return;
       }
+
+      const currentControl = cardsQueryControlRef.current;
+      if (
+        loadMoreSentinelIntersectionConsumedRef.current
+        || activeWorkspace === null
+        || currentControl.queryIdentity !== cardsQueryIdentity
+        || currentControl.nextCursor === null
+        || currentControl.activeRequest !== null
+      ) {
+        return;
+      }
+
+      loadMoreSentinelIntersectionConsumedRef.current = true;
+      void loadNextPage();
     }, {
       root: scrollContainer,
       rootMargin: "160px 0px",
@@ -817,27 +922,36 @@ export function CardsScreen(): ReactElement {
                       <Link className="row-open-link" to={`/cards/${card.cardId}`}>{t("cardsScreen.table.open")}</Link>
                     </td>
                     <EditableCardTextCell
+                      editorToken={{ cardId: card.cardId, field: "frontText" }}
                       value={card.frontText}
                       displayValue={card.frontText}
                       cellClassName="cards-col-front"
                       multiline={true}
                       saving={isSaving}
                       onCommit={(nextValue) => handleInlineSave(card, { frontText: nextValue })}
+                      onEditorOpen={handleInlineEditorOpen}
+                      onEditorClose={handleInlineEditorClose}
                     />
                     <EditableCardTextCell
+                      editorToken={{ cardId: card.cardId, field: "backText" }}
                       value={card.backText}
                       displayValue={card.backText}
                       cellClassName="cards-col-back"
                       multiline={true}
                       saving={isSaving}
                       onCommit={(nextValue) => handleInlineSave(card, { backText: nextValue })}
+                      onEditorOpen={handleInlineEditorOpen}
+                      onEditorClose={handleInlineEditorClose}
                     />
                     <EditableCardTagsCell
+                      editorToken={{ cardId: card.cardId, field: "tags" }}
                       value={card.tags}
                       suggestions={tagSuggestions}
                       cellClassName="cards-col-tags cards-tag-cell"
                       saving={isSaving}
                       onCommit={(nextValue) => handleInlineSave(card, { tags: nextValue })}
+                      onEditorOpen={handleInlineEditorOpen}
+                      onEditorClose={handleInlineEditorClose}
                     />
                     <td className="txn-cell txn-cell-mono cards-col-due">{formatNullableDateTime(card.dueAt, formatDateTime, t)}</td>
                     <td className="txn-cell txn-cell-mono cards-col-reps">{card.reps}</td>

--- a/apps/web/src/screens/cards/list/CardsTableEditors.tsx
+++ b/apps/web/src/screens/cards/list/CardsTableEditors.tsx
@@ -15,20 +15,31 @@ import type { TagSuggestion } from "../../../types";
 import { areSameTags, CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
 
 type EditableTextCellProps = Readonly<{
+  editorToken: CardInlineEditorToken;
   value: string;
   displayValue: string;
   multiline: boolean;
   saving: boolean;
   onCommit: (nextValue: string) => Promise<void>;
+  onEditorOpen: (editorToken: CardInlineEditorToken) => number;
+  onEditorClose: (editorToken: CardInlineEditorToken, lifecycle: number) => void;
   cellClassName: string;
 }>;
 
 type EditableTagsCellProps = Readonly<{
+  editorToken: CardInlineEditorToken;
   value: ReadonlyArray<string>;
   suggestions: ReadonlyArray<TagSuggestion>;
   saving: boolean;
   onCommit: (nextValue: ReadonlyArray<string>) => Promise<void>;
+  onEditorOpen: (editorToken: CardInlineEditorToken) => number;
+  onEditorClose: (editorToken: CardInlineEditorToken, lifecycle: number) => void;
   cellClassName: string;
+}>;
+
+export type CardInlineEditorToken = Readonly<{
+  cardId: string;
+  field: "frontText" | "backText" | "tags";
 }>;
 
 const floatingEditorViewportPaddingPx = 12;
@@ -40,13 +51,26 @@ const tagsEditorMaximumWidthPx = 420;
 const tagsEditorMaximumHeightPx = 320;
 
 export function EditableCardTextCell(props: EditableTextCellProps): ReactElement {
-  const { value, displayValue, multiline, saving, onCommit, cellClassName } = props;
+  const {
+    editorToken,
+    value,
+    displayValue,
+    multiline,
+    saving,
+    onCommit,
+    onEditorOpen,
+    onEditorClose,
+    cellClassName,
+  } = props;
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [draftValue, setDraftValue] = useState<string>(value);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const stableEditorTokenRef = useRef<CardInlineEditorToken>(editorToken);
+  const openingValueRef = useRef<string>(value);
+  const editorLifecycleRef = useRef<number | null>(null);
 
   useEffect(() => {
     const activeElement = multiline ? textareaRef.current : inputRef.current;
@@ -59,7 +83,14 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
   }, [isEditing, multiline]);
 
   function closeEditor(): void {
+    const editorLifecycle = editorLifecycleRef.current;
+    if (editorLifecycle === null) {
+      return;
+    }
+
+    editorLifecycleRef.current = null;
     setIsEditing(false);
+    onEditorClose(stableEditorTokenRef.current, editorLifecycle);
   }
 
   function startEditing(): void {
@@ -67,7 +98,9 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
       return;
     }
 
+    openingValueRef.current = value;
     setDraftValue(value);
+    editorLifecycleRef.current = onEditorOpen(stableEditorTokenRef.current);
     setIsEditing(true);
   }
 
@@ -85,14 +118,16 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
   }
 
   function commitEdit(): void {
-    const trimmedValue = draftValue.trim();
-    closeEditor();
-
-    if (trimmedValue === value.trim()) {
+    if (editorLifecycleRef.current === null) {
       return;
     }
 
-    void onCommit(trimmedValue);
+    const trimmedValue = draftValue.trim();
+    if (trimmedValue !== openingValueRef.current.trim()) {
+      void onCommit(trimmedValue);
+    }
+
+    closeEditor();
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>): void {
@@ -174,18 +209,37 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
 }
 
 export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement {
-  const { value, suggestions, saving, onCommit, cellClassName } = props;
+  const {
+    editorToken,
+    value,
+    suggestions,
+    saving,
+    onCommit,
+    onEditorOpen,
+    onEditorClose,
+    cellClassName,
+  } = props;
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [draftTags, setDraftTags] = useState<ReadonlyArray<string>>(value);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<CardTagsInputHandle | null>(null);
+  const stableEditorTokenRef = useRef<CardInlineEditorToken>(editorToken);
+  const openingTagsRef = useRef<ReadonlyArray<string>>(value);
+  const editorLifecycleRef = useRef<number | null>(null);
 
   const handleClose = useCallback((): void => {
+    const editorLifecycle = editorLifecycleRef.current;
+    if (editorLifecycle === null) {
+      return;
+    }
+
+    editorLifecycleRef.current = null;
     setIsOpen(false);
-    setDraftTags(value);
-  }, [value]);
+    setDraftTags(openingTagsRef.current);
+    onEditorClose(stableEditorTokenRef.current, editorLifecycle);
+  }, [onEditorClose]);
 
   useAnchoredFloatingOutsidePointerDismiss({
     triggerRef: cellRef,
@@ -210,36 +264,49 @@ export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement
     setDraftTags(value);
   }, [isOpen, value]);
 
-  function handleCellClick(): void {
-    if (saving || cellRef.current === null) {
+  function handleCellPointerDown(event: PointerEvent<HTMLTableCellElement>): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    if (
+      saving
+      || cellRef.current === null
+      || !(event.target instanceof Node)
+      || !cellRef.current.contains(event.target)
+    ) {
       return;
     }
 
     if (isOpen) {
+      event.preventDefault();
       handleCommit();
       return;
     }
 
+    openingTagsRef.current = value;
     setDraftTags(value);
+    editorLifecycleRef.current = onEditorOpen(stableEditorTokenRef.current);
     setIsOpen(true);
   }
 
   function handleCommit(): void {
-    const nextTags = editorRef.current === null ? draftTags : editorRef.current.flushDraft();
-    setIsOpen(false);
-
-    if (areSameTags(nextTags, value)) {
-      setDraftTags(value);
+    if (editorLifecycleRef.current === null) {
       return;
     }
 
-    void onCommit(nextTags);
+    const nextTags = editorRef.current === null ? draftTags : editorRef.current.flushDraft();
+    if (!areSameTags(nextTags, openingTagsRef.current)) {
+      void onCommit(nextTags);
+    }
+
+    handleClose();
   }
 
   const className = `txn-cell ${cellClassName}${saving ? " cards-cell-disabled" : " drilldown-editable"}`;
 
   return (
-    <td ref={cellRef} className={className} onClick={saving ? undefined : handleCellClick}>
+    <td ref={cellRef} className={className} onPointerDown={saving ? undefined : handleCellPointerDown}>
       {value.length === 0 ? <span className="tag-value-empty">—</span> : (
         <span className="tag-value-list">
           {value.map((tag) => (


### PR DESCRIPTION
## Summary
- preserve inline Cards editor drafts during accepted same-query refreshes
- coordinate editor handoffs with lifecycle leases
- keep deferred authoritative pagination coherent

## Validation
- not run locally, per repository instructions
- clean fresh static review completed