### PR TITLE
Fix deck refresh barrier ordering

### DIFF
--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -301,7 +301,7 @@ export function DeckFormScreen(): ReactElement {
     })();
   }, [activeWorkspace, deckId, getDeckById, showCapturedTechnicalError, t, technicalErrorMessage]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     void loadScreenData();
     return () => {
       loadRequestSequenceRef.current += 1;


### PR DESCRIPTION
## Summary
- install deck refresh barriers during the layout-effect phase
- close the post-commit window where Save could observe stale form refs

## Validation
- clean fresh static review completed
- local checks not run per repository workflow