### PR TITLE
Preserve web drafts across background sync

### DIFF
--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -8,7 +8,11 @@ import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } fro
 import { useI18n } from "../../../i18n";
 import { CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
 import { getExpectedCardMutationInlineErrorMessage } from "../cardMutationErrors";
-import { EditableCardTagsCell, EditableCardTextCell } from "./CardsTableEditors";
+import {
+  EditableCardTagsCell,
+  EditableCardTextCell,
+  type CardInlineEditorToken,
+} from "./CardsTableEditors";
 import { queryLocalCardsPage } from "../../../localDb/cards/cards";
 import { loadWorkspaceTagsSummary } from "../../../localDb/cards/workspace";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
@@ -32,12 +36,20 @@ type CardsQueryState = Readonly<{
 
 type CardsQueryRequestKind = "reset" | "refresh" | "loadMore";
 
+type CardsQueryWindow = Readonly<{
+  items: ReadonlyArray<Card>;
+  totalCount: number;
+  nextCursor: string | null;
+}>;
+
 type CardsQueryControl = Readonly<{
   queryIdentity: string;
   requestSequence: number;
   acceptedRowCount: number;
   nextCursor: string | null;
   activeRequest: CardsQueryRequestKind | null;
+  authoritativeWindow: CardsQueryWindow;
+  hasPendingPublication: boolean;
 }>;
 
 const cardsPageSize = 50;
@@ -50,6 +62,34 @@ function createInitialCardsQueryState(): CardsQueryState {
     totalCount: 0,
     nextCursor: null,
     hasLoaded: false,
+    isLoading: false,
+    isLoadingMore: false,
+    errorMessage: "",
+  };
+}
+
+function createEmptyCardsQueryWindow(): CardsQueryWindow {
+  return {
+    items: [],
+    totalCount: 0,
+    nextCursor: null,
+  };
+}
+
+function createCardsQueryWindow(nextPage: QueryCardsPage): CardsQueryWindow {
+  return {
+    items: nextPage.cards,
+    totalCount: nextPage.totalCount,
+    nextCursor: nextPage.nextCursor,
+  };
+}
+
+function createPublishedCardsQueryState(queryWindow: CardsQueryWindow): CardsQueryState {
+  return {
+    items: queryWindow.items,
+    totalCount: queryWindow.totalCount,
+    nextCursor: queryWindow.nextCursor,
+    hasLoaded: true,
     isLoading: false,
     isLoadingMore: false,
     errorMessage: "",
@@ -135,19 +175,19 @@ function getSortPriority(
   return index === -1 ? null : index + 1;
 }
 
-function mergeCardsPage(
-  currentState: CardsQueryState,
+function mergeCardsQueryWindow(
+  currentWindow: CardsQueryWindow,
   nextPage: QueryCardsPage,
-): CardsQueryState {
+): CardsQueryWindow {
   return {
-    items: [...currentState.items, ...nextPage.cards],
+    items: [...currentWindow.items, ...nextPage.cards],
     totalCount: nextPage.totalCount,
     nextCursor: nextPage.nextCursor,
-    hasLoaded: true,
-    isLoading: false,
-    isLoadingMore: false,
-    errorMessage: "",
   };
+}
+
+function getCardInlineEditorTokenKey(editorToken: CardInlineEditorToken): string {
+  return `${editorToken.cardId}:${editorToken.field}`;
 }
 
 export function CardsScreen(): ReactElement {
@@ -171,6 +211,7 @@ export function CardsScreen(): ReactElement {
   const [cardsQueryState, setCardsQueryState] = useState<CardsQueryState>(createInitialCardsQueryState);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const loadMoreSentinelRef = useRef<HTMLTableRowElement | null>(null);
+  const loadMoreSentinelIntersectionConsumedRef = useRef<boolean>(false);
   const filterWrapRef = useRef<HTMLDivElement | null>(null);
   const filterPopoverRef = useRef<HTMLDivElement | null>(null);
   const filterTagsInputRef = useRef<CardTagsInputHandle | null>(null);
@@ -187,7 +228,11 @@ export function CardsScreen(): ReactElement {
     acceptedRowCount: 0,
     nextCursor: null,
     activeRequest: null,
+    authoritativeWindow: createEmptyCardsQueryWindow(),
+    hasPendingPublication: false,
   });
+  const activeEditorLifecyclesRef = useRef<Map<string, number>>(new Map());
+  const nextEditorLifecycleRef = useRef<number>(0);
   const observedQueryIdentityRef = useRef<string | null>(null);
   const observedLocalReadVersionRef = useRef<number>(localReadVersion);
   const [tagSuggestions, setTagSuggestions] = useState<ReadonlyArray<TagSuggestion>>([]);
@@ -229,14 +274,85 @@ export function CardsScreen(): ReactElement {
     return () => window.clearTimeout(timeoutId);
   }, [searchText]);
 
+  function acceptCardsQueryWindow(
+    queryIdentity: string,
+    requestSequence: number,
+    queryWindow: CardsQueryWindow,
+  ): void {
+    const shouldDeferPublication = activeEditorLifecyclesRef.current.size > 0;
+    cardsQueryControlRef.current = {
+      queryIdentity,
+      requestSequence,
+      acceptedRowCount: queryWindow.items.length,
+      nextCursor: queryWindow.nextCursor,
+      activeRequest: null,
+      authoritativeWindow: queryWindow,
+      hasPendingPublication: shouldDeferPublication,
+    };
+
+    if (shouldDeferPublication) {
+      setCardsQueryState((currentState) => ({
+        ...currentState,
+        isLoading: false,
+        isLoadingMore: false,
+        errorMessage: "",
+      }));
+      return;
+    }
+
+    loadMoreSentinelIntersectionConsumedRef.current = false;
+    setCardsQueryState(createPublishedCardsQueryState(queryWindow));
+  }
+
+  const handleInlineEditorOpen = useCallback((editorToken: CardInlineEditorToken): number => {
+    const editorLifecycle = nextEditorLifecycleRef.current + 1;
+    nextEditorLifecycleRef.current = editorLifecycle;
+    activeEditorLifecyclesRef.current.set(
+      getCardInlineEditorTokenKey(editorToken),
+      editorLifecycle,
+    );
+    return editorLifecycle;
+  }, []);
+
+  const handleInlineEditorClose = useCallback((
+    editorToken: CardInlineEditorToken,
+    editorLifecycle: number,
+  ): void => {
+    const editorTokenKey = getCardInlineEditorTokenKey(editorToken);
+    if (activeEditorLifecyclesRef.current.get(editorTokenKey) !== editorLifecycle) {
+      return;
+    }
+
+    activeEditorLifecyclesRef.current.delete(editorTokenKey);
+    if (activeEditorLifecyclesRef.current.size > 0) {
+      return;
+    }
+
+    const currentControl = cardsQueryControlRef.current;
+    if (!currentControl.hasPendingPublication) {
+      return;
+    }
+
+    cardsQueryControlRef.current = {
+      ...currentControl,
+      hasPendingPublication: false,
+    };
+    loadMoreSentinelIntersectionConsumedRef.current = false;
+    setCardsQueryState(createPublishedCardsQueryState(currentControl.authoritativeWindow));
+  }, []);
+
   async function resetCardsQuery(queryIdentity: string): Promise<void> {
     const requestSequence = cardsQueryControlRef.current.requestSequence + 1;
+    activeEditorLifecyclesRef.current.clear();
+    loadMoreSentinelIntersectionConsumedRef.current = false;
     cardsQueryControlRef.current = {
       queryIdentity,
       requestSequence,
       acceptedRowCount: 0,
       nextCursor: null,
       activeRequest: activeWorkspace === null ? null : "reset",
+      authoritativeWindow: createEmptyCardsQueryWindow(),
+      hasPendingPublication: false,
     };
 
     if (activeWorkspace === null) {
@@ -266,13 +382,11 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
-      cardsQueryControlRef.current = {
+      acceptCardsQueryWindow(
         queryIdentity,
         requestSequence,
-        acceptedRowCount: nextPage.cards.length,
-        nextCursor: nextPage.nextCursor,
-        activeRequest: null,
-      };
+        createCardsQueryWindow(nextPage),
+      );
 
       setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
         tag: tagSummary.tag,
@@ -285,15 +399,6 @@ export function CardsScreen(): ReactElement {
         totalCount: nextPage.totalCount,
         rows: nextPage.cards.slice(0, 8).map((card) => buildCardsLoadingRowPreview(card)),
         savedAt: new Date().toISOString(),
-      });
-      setCardsQueryState({
-        items: nextPage.cards,
-        totalCount: nextPage.totalCount,
-        nextCursor: nextPage.nextCursor,
-        hasLoaded: true,
-        isLoading: false,
-        isLoadingMore: false,
-        errorMessage: "",
       });
     } catch (error) {
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
@@ -364,13 +469,11 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
-      cardsQueryControlRef.current = {
+      acceptCardsQueryWindow(
         queryIdentity,
         requestSequence,
-        acceptedRowCount: nextPage.cards.length,
-        nextCursor: nextPage.nextCursor,
-        activeRequest: null,
-      };
+        createCardsQueryWindow(nextPage),
+      );
       setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
         tag: tagSummary.tag,
         countState: "ready",
@@ -382,15 +485,6 @@ export function CardsScreen(): ReactElement {
         totalCount: nextPage.totalCount,
         rows: nextPage.cards.slice(0, 8).map((card) => buildCardsLoadingRowPreview(card)),
         savedAt: new Date().toISOString(),
-      });
-      setCardsQueryState({
-        items: nextPage.cards,
-        totalCount: nextPage.totalCount,
-        nextCursor: nextPage.nextCursor,
-        hasLoaded: true,
-        isLoading: false,
-        isLoadingMore: false,
-        errorMessage: "",
       });
     } catch (error) {
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
@@ -457,15 +551,11 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
-      cardsQueryControlRef.current = {
-        queryIdentity: cardsQueryIdentity,
+      acceptCardsQueryWindow(
+        cardsQueryIdentity,
         requestSequence,
-        acceptedRowCount: currentControl.acceptedRowCount + nextPage.cards.length,
-        nextCursor: nextPage.nextCursor,
-        activeRequest: null,
-      };
-
-      setCardsQueryState((currentState) => mergeCardsPage(currentState, nextPage));
+        mergeCardsQueryWindow(currentControl.authoritativeWindow, nextPage),
+      );
     } catch (error) {
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, cardsQueryIdentity, requestSequence)) {
         return;
@@ -542,9 +632,24 @@ export function CardsScreen(): ReactElement {
 
     const observer = new IntersectionObserver((entries) => {
       const firstEntry = entries[0];
-      if (firstEntry?.isIntersecting) {
-        void loadNextPage();
+      if (!firstEntry?.isIntersecting) {
+        loadMoreSentinelIntersectionConsumedRef.current = false;
+        return;
       }
+
+      const currentControl = cardsQueryControlRef.current;
+      if (
+        loadMoreSentinelIntersectionConsumedRef.current
+        || activeWorkspace === null
+        || currentControl.queryIdentity !== cardsQueryIdentity
+        || currentControl.nextCursor === null
+        || currentControl.activeRequest !== null
+      ) {
+        return;
+      }
+
+      loadMoreSentinelIntersectionConsumedRef.current = true;
+      void loadNextPage();
     }, {
       root: scrollContainer,
       rootMargin: "160px 0px",
@@ -817,27 +922,36 @@ export function CardsScreen(): ReactElement {
                       <Link className="row-open-link" to={`/cards/${card.cardId}`}>{t("cardsScreen.table.open")}</Link>
                     </td>
                     <EditableCardTextCell
+                      editorToken={{ cardId: card.cardId, field: "frontText" }}
                       value={card.frontText}
                       displayValue={card.frontText}
                       cellClassName="cards-col-front"
                       multiline={true}
                       saving={isSaving}
                       onCommit={(nextValue) => handleInlineSave(card, { frontText: nextValue })}
+                      onEditorOpen={handleInlineEditorOpen}
+                      onEditorClose={handleInlineEditorClose}
                     />
                     <EditableCardTextCell
+                      editorToken={{ cardId: card.cardId, field: "backText" }}
                       value={card.backText}
                       displayValue={card.backText}
                       cellClassName="cards-col-back"
                       multiline={true}
                       saving={isSaving}
                       onCommit={(nextValue) => handleInlineSave(card, { backText: nextValue })}
+                      onEditorOpen={handleInlineEditorOpen}
+                      onEditorClose={handleInlineEditorClose}
                     />
                     <EditableCardTagsCell
+                      editorToken={{ cardId: card.cardId, field: "tags" }}
                       value={card.tags}
                       suggestions={tagSuggestions}
                       cellClassName="cards-col-tags cards-tag-cell"
                       saving={isSaving}
                       onCommit={(nextValue) => handleInlineSave(card, { tags: nextValue })}
+                      onEditorOpen={handleInlineEditorOpen}
+                      onEditorClose={handleInlineEditorClose}
                     />
                     <td className="txn-cell txn-cell-mono cards-col-due">{formatNullableDateTime(card.dueAt, formatDateTime, t)}</td>
                     <td className="txn-cell txn-cell-mono cards-col-reps">{card.reps}</td>

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link } from "react-router";
 import { useAppData } from "../../../appData";
+import { normalizeTagKey } from "../../../appData/domain";
 import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 import { getCardFilterActiveDimensionCount, normalizeCardFilter } from "../../../cardFilters";
 import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } from "../../../floating";
@@ -29,6 +30,16 @@ type CardsQueryState = Readonly<{
   errorMessage: string;
 }>;
 
+type CardsQueryRequestKind = "reset" | "refresh" | "loadMore";
+
+type CardsQueryControl = Readonly<{
+  queryIdentity: string;
+  requestSequence: number;
+  acceptedRowCount: number;
+  nextCursor: string | null;
+  activeRequest: CardsQueryRequestKind | null;
+}>;
+
 const cardsPageSize = 50;
 const cardsSearchDebounceMs = 300;
 const maximumUserSortCount = 3;
@@ -48,6 +59,34 @@ function createInitialCardsQueryState(): CardsQueryState {
 function normalizeCardsSearchText(searchText: string): string | null {
   const normalizedSearchText = searchText.trim();
   return normalizedSearchText === "" ? null : normalizedSearchText;
+}
+
+function buildCardsQueryIdentity(
+  workspaceId: string | null,
+  searchText: string | null,
+  filter: CardFilter | null,
+  sorts: ReadonlyArray<CardQuerySort>,
+): string {
+  const normalizedTagKeys = filter === null
+    ? null
+    : [...new Set(filter.tags.map((tag) => normalizeTagKey(tag)))]
+      .sort((leftTag, rightTag) => leftTag.localeCompare(rightTag));
+
+  return JSON.stringify([
+    workspaceId,
+    searchText?.toLowerCase() ?? null,
+    normalizedTagKeys,
+    sorts.map((sort) => [sort.key, sort.direction]),
+  ]);
+}
+
+function ownsCardsQueryRequest(
+  control: CardsQueryControl,
+  queryIdentity: string,
+  requestSequence: number,
+): boolean {
+  return control.queryIdentity === queryIdentity
+    && control.requestSequence === requestSequence;
 }
 
 function createEmptyCardFilter(): CardFilter {
@@ -142,10 +181,24 @@ export function CardsScreen(): ReactElement {
     userId: null,
     installationId: null,
   });
-  const requestSequenceRef = useRef<number>(0);
+  const cardsQueryControlRef = useRef<CardsQueryControl>({
+    queryIdentity: "",
+    requestSequence: 0,
+    acceptedRowCount: 0,
+    nextCursor: null,
+    activeRequest: null,
+  });
+  const observedQueryIdentityRef = useRef<string | null>(null);
+  const observedLocalReadVersionRef = useRef<number>(localReadVersion);
   const [tagSuggestions, setTagSuggestions] = useState<ReadonlyArray<TagSuggestion>>([]);
 
   const normalizedSearchText = normalizeCardsSearchText(debouncedSearchText);
+  const cardsQueryIdentity = buildCardsQueryIdentity(
+    activeWorkspace?.workspaceId ?? null,
+    normalizedSearchText,
+    cardFilter,
+    sorts,
+  );
   const activeFilterDimensionCount = getCardFilterActiveDimensionCount(cardFilter);
   const hasActiveSearchOrFilter = normalizedSearchText !== null || cardFilter !== null;
   const draftFilterValue = draftCardFilter ?? createEmptyCardFilter();
@@ -176,20 +229,26 @@ export function CardsScreen(): ReactElement {
     return () => window.clearTimeout(timeoutId);
   }, [searchText]);
 
-  async function loadFirstPage(): Promise<void> {
+  async function resetCardsQuery(queryIdentity: string): Promise<void> {
+    const requestSequence = cardsQueryControlRef.current.requestSequence + 1;
+    cardsQueryControlRef.current = {
+      queryIdentity,
+      requestSequence,
+      acceptedRowCount: 0,
+      nextCursor: null,
+      activeRequest: activeWorkspace === null ? null : "reset",
+    };
+
     if (activeWorkspace === null) {
       setCardsQueryState(createInitialCardsQueryState());
+      setTagSuggestions([]);
       return;
     }
 
-    const requestSequence = requestSequenceRef.current + 1;
-    requestSequenceRef.current = requestSequence;
-    setCardsQueryState((currentState) => ({
-      ...currentState,
+    setCardsQueryState({
+      ...createInitialCardsQueryState(),
       isLoading: true,
-      isLoadingMore: false,
-      errorMessage: "",
-    }));
+    });
 
     try {
       const [nextPage, tagsSummary] = await Promise.all([
@@ -203,9 +262,17 @@ export function CardsScreen(): ReactElement {
         loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
       ]);
 
-      if (requestSequenceRef.current !== requestSequence) {
+      if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
         return;
       }
+
+      cardsQueryControlRef.current = {
+        queryIdentity,
+        requestSequence,
+        acceptedRowCount: nextPage.cards.length,
+        nextCursor: nextPage.nextCursor,
+        activeRequest: null,
+      };
 
       setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
         tag: tagSummary.tag,
@@ -229,9 +296,14 @@ export function CardsScreen(): ReactElement {
         errorMessage: "",
       });
     } catch (error) {
-      if (requestSequenceRef.current !== requestSequence) {
+      if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
         return;
       }
+
+      cardsQueryControlRef.current = {
+        ...cardsQueryControlRef.current,
+        activeRequest: null,
+      };
 
       const observationIdentity = observationIdentityRef.current;
       captureAppOperationError(error, {
@@ -253,19 +325,119 @@ export function CardsScreen(): ReactElement {
     }
   }
 
-  async function loadNextPage(): Promise<void> {
+  async function refreshCardsQuery(queryIdentity: string): Promise<void> {
     if (
       activeWorkspace === null
-      || cardsQueryState.nextCursor === null
-      || cardsQueryState.isLoading
-      || cardsQueryState.isLoadingMore
+      || cardsQueryControlRef.current.queryIdentity !== queryIdentity
     ) {
       return;
     }
 
-    const requestSequence = requestSequenceRef.current + 1;
-    requestSequenceRef.current = requestSequence;
-    const currentCursor = cardsQueryState.nextCursor;
+    const currentControl = cardsQueryControlRef.current;
+    const requestSequence = currentControl.requestSequence + 1;
+    const refreshLimit = Math.max(cardsPageSize, currentControl.acceptedRowCount);
+    cardsQueryControlRef.current = {
+      ...currentControl,
+      requestSequence,
+      activeRequest: "refresh",
+    };
+    setCardsQueryState((currentState) => ({
+      ...currentState,
+      isLoading: true,
+      isLoadingMore: false,
+      errorMessage: "",
+    }));
+
+    try {
+      const [nextPage, tagsSummary] = await Promise.all([
+        queryLocalCardsPage(activeWorkspace.workspaceId, {
+          searchText: normalizedSearchText,
+          cursor: null,
+          limit: refreshLimit,
+          sorts,
+          filter: cardFilter,
+        }),
+        loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
+      ]);
+
+      if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
+        return;
+      }
+
+      cardsQueryControlRef.current = {
+        queryIdentity,
+        requestSequence,
+        acceptedRowCount: nextPage.cards.length,
+        nextCursor: nextPage.nextCursor,
+        activeRequest: null,
+      };
+      setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
+        tag: tagSummary.tag,
+        countState: "ready",
+        cardsCount: tagSummary.cardsCount,
+      })));
+      writeCardsLoadingSnapshot({
+        version: 1,
+        workspaceId: activeWorkspace.workspaceId,
+        totalCount: nextPage.totalCount,
+        rows: nextPage.cards.slice(0, 8).map((card) => buildCardsLoadingRowPreview(card)),
+        savedAt: new Date().toISOString(),
+      });
+      setCardsQueryState({
+        items: nextPage.cards,
+        totalCount: nextPage.totalCount,
+        nextCursor: nextPage.nextCursor,
+        hasLoaded: true,
+        isLoading: false,
+        isLoadingMore: false,
+        errorMessage: "",
+      });
+    } catch (error) {
+      if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
+        return;
+      }
+
+      cardsQueryControlRef.current = {
+        ...cardsQueryControlRef.current,
+        activeRequest: null,
+      };
+      const observationIdentity = observationIdentityRef.current;
+      captureAppOperationError(error, {
+        feature: "cards",
+        operation: "cards_list_load",
+        userId: observationIdentity.userId,
+        workspaceId: activeWorkspace.workspaceId,
+        installationId: observationIdentity.installationId,
+        entityId: null,
+      });
+      showCapturedTechnicalError(error);
+      setCardsQueryState((currentState) => ({
+        ...currentState,
+        isLoading: false,
+        isLoadingMore: false,
+        errorMessage: t("appError.technicalError.message"),
+      }));
+    }
+  }
+
+  async function loadNextPage(): Promise<void> {
+    const currentControl = cardsQueryControlRef.current;
+    if (
+      activeWorkspace === null
+      || currentControl.queryIdentity !== cardsQueryIdentity
+      || currentControl.nextCursor === null
+      || currentControl.activeRequest !== null
+    ) {
+      return;
+    }
+
+    const requestSequence = currentControl.requestSequence + 1;
+    const currentCursor = currentControl.nextCursor;
+    cardsQueryControlRef.current = {
+      ...currentControl,
+      requestSequence,
+      activeRequest: "loadMore",
+    };
     setCardsQueryState((currentState) => ({
       ...currentState,
       isLoadingMore: true,
@@ -281,15 +453,28 @@ export function CardsScreen(): ReactElement {
         filter: cardFilter,
       });
 
-      if (requestSequenceRef.current !== requestSequence) {
+      if (!ownsCardsQueryRequest(cardsQueryControlRef.current, cardsQueryIdentity, requestSequence)) {
         return;
       }
 
+      cardsQueryControlRef.current = {
+        queryIdentity: cardsQueryIdentity,
+        requestSequence,
+        acceptedRowCount: currentControl.acceptedRowCount + nextPage.cards.length,
+        nextCursor: nextPage.nextCursor,
+        activeRequest: null,
+      };
+
       setCardsQueryState((currentState) => mergeCardsPage(currentState, nextPage));
     } catch (error) {
-      if (requestSequenceRef.current !== requestSequence) {
+      if (!ownsCardsQueryRequest(cardsQueryControlRef.current, cardsQueryIdentity, requestSequence)) {
         return;
       }
+
+      cardsQueryControlRef.current = {
+        ...cardsQueryControlRef.current,
+        activeRequest: null,
+      };
 
       const observationIdentity = observationIdentityRef.current;
       captureAppOperationError(error, {
@@ -310,8 +495,18 @@ export function CardsScreen(): ReactElement {
   }
 
   useEffect(() => {
-    void loadFirstPage();
-  }, [activeWorkspace, cardFilter, localReadVersion, normalizedSearchText, sorts]);
+    if (observedQueryIdentityRef.current !== cardsQueryIdentity) {
+      observedQueryIdentityRef.current = cardsQueryIdentity;
+      observedLocalReadVersionRef.current = localReadVersion;
+      void resetCardsQuery(cardsQueryIdentity);
+      return;
+    }
+
+    if (observedLocalReadVersionRef.current !== localReadVersion) {
+      observedLocalReadVersionRef.current = localReadVersion;
+      void refreshCardsQuery(cardsQueryIdentity);
+    }
+  }, [cardsQueryIdentity, localReadVersion]);
 
   useEffect(() => {
     if (!isFilterPopoverOpen) {
@@ -388,7 +583,7 @@ export function CardsScreen(): ReactElement {
       }
 
       try {
-        await loadFirstPage();
+        await refreshCardsQuery(cardsQueryIdentity);
       } catch (error) {
         showCapturedTechnicalError(error);
         setErrorMessage(t("appError.technicalError.message"));
@@ -472,7 +667,7 @@ export function CardsScreen(): ReactElement {
       <section className="panel cards-panel">
         {cardsQueryState.errorMessage !== "" ? <p className="error-banner">{cardsQueryState.errorMessage}</p> : null}
         {cardsQueryState.errorMessage !== "" && cardsQueryState.hasLoaded === false ? (
-          <button className="primary-btn cards-loading-retry-btn" type="button" onClick={() => void loadFirstPage()}>
+          <button className="primary-btn cards-loading-retry-btn" type="button" onClick={() => void resetCardsQuery(cardsQueryIdentity)}>
             {t("common.retry")}
           </button>
         ) : null}

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -207,7 +207,7 @@ export function CardsScreen(): ReactElement {
   const [cardFilter, setCardFilter] = useState<CardFilter | null>(null);
   const [draftCardFilter, setDraftCardFilter] = useState<CardFilter | null>(null);
   const [isFilterPopoverOpen, setIsFilterPopoverOpen] = useState<boolean>(false);
-  const [savingCardId, setSavingCardId] = useState<string>("");
+  const [savingCardIds, setSavingCardIds] = useState<ReadonlySet<string>>(new Set<string>());
   const [cardsQueryState, setCardsQueryState] = useState<CardsQueryState>(createInitialCardsQueryState);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const loadMoreSentinelRef = useRef<HTMLTableRowElement | null>(null);
@@ -233,6 +233,7 @@ export function CardsScreen(): ReactElement {
   });
   const activeEditorLifecyclesRef = useRef<Map<string, number>>(new Map());
   const nextEditorLifecycleRef = useRef<number>(0);
+  const inlineSaveTailsRef = useRef<Map<string, Promise<void>>>(new Map());
   const observedQueryIdentityRef = useRef<string | null>(null);
   const observedLocalReadVersionRef = useRef<number>(localReadVersion);
   const [tagSuggestions, setTagSuggestions] = useState<ReadonlyArray<TagSuggestion>>([]);
@@ -659,18 +660,19 @@ export function CardsScreen(): ReactElement {
     return () => observer.disconnect();
   }, [cardsQueryState.nextCursor, loadNextPage]);
 
-  async function handleInlineSave(card: Card, patch: UpdateCardInput): Promise<void> {
-    setSavingCardId(card.cardId);
+  function handleInlineSave(card: Card, patch: UpdateCardInput): Promise<void> {
+    setSavingCardIds((currentCardIds) => new Set([...currentCardIds, card.cardId]));
     setErrorMessage("");
 
-    try {
+    const previousTail = inlineSaveTailsRef.current.get(card.cardId) ?? Promise.resolve();
+    const savePromise = previousTail.then(async () => {
       try {
         await updateCardItem(card.cardId, patch);
       } catch (error) {
         const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("cardForm.errors.cardNotFound"));
         if (expectedErrorMessage !== null) {
           setErrorMessage(expectedErrorMessage);
-          return;
+          throw error;
         }
 
         const observationIdentity = observationIdentityRef.current;
@@ -684,7 +686,7 @@ export function CardsScreen(): ReactElement {
         });
         showCapturedTechnicalError(error);
         setErrorMessage(t("appError.technicalError.message"));
-        return;
+        throw error;
       }
 
       try {
@@ -693,9 +695,27 @@ export function CardsScreen(): ReactElement {
         showCapturedTechnicalError(error);
         setErrorMessage(t("appError.technicalError.message"));
       }
-    } finally {
-      setSavingCardId("");
-    }
+    });
+    const nextTail = savePromise.then(
+      () => undefined,
+      () => undefined,
+    );
+    inlineSaveTailsRef.current.set(card.cardId, nextTail);
+
+    void nextTail.then(() => {
+      if (inlineSaveTailsRef.current.get(card.cardId) !== nextTail) {
+        return;
+      }
+
+      inlineSaveTailsRef.current.delete(card.cardId);
+      setSavingCardIds((currentCardIds) => {
+        const nextCardIds = new Set(currentCardIds);
+        nextCardIds.delete(card.cardId);
+        return nextCardIds;
+      });
+    });
+
+    return savePromise;
   }
 
   function handleSortChange(sortKey: CardQuerySortKey): void {
@@ -909,7 +929,7 @@ export function CardsScreen(): ReactElement {
                   ))
                 )
               ) : cardsQueryState.items.map((card) => {
-                const isSaving = savingCardId === card.cardId;
+                const isSaving = savingCardIds.has(card.cardId);
                 return (
                   <tr
                     key={card.cardId}

--- a/apps/web/src/screens/cards/list/CardsTableEditors.tsx
+++ b/apps/web/src/screens/cards/list/CardsTableEditors.tsx
@@ -15,20 +15,31 @@ import type { TagSuggestion } from "../../../types";
 import { areSameTags, CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
 
 type EditableTextCellProps = Readonly<{
+  editorToken: CardInlineEditorToken;
   value: string;
   displayValue: string;
   multiline: boolean;
   saving: boolean;
   onCommit: (nextValue: string) => Promise<void>;
+  onEditorOpen: (editorToken: CardInlineEditorToken) => number;
+  onEditorClose: (editorToken: CardInlineEditorToken, lifecycle: number) => void;
   cellClassName: string;
 }>;
 
 type EditableTagsCellProps = Readonly<{
+  editorToken: CardInlineEditorToken;
   value: ReadonlyArray<string>;
   suggestions: ReadonlyArray<TagSuggestion>;
   saving: boolean;
   onCommit: (nextValue: ReadonlyArray<string>) => Promise<void>;
+  onEditorOpen: (editorToken: CardInlineEditorToken) => number;
+  onEditorClose: (editorToken: CardInlineEditorToken, lifecycle: number) => void;
   cellClassName: string;
+}>;
+
+export type CardInlineEditorToken = Readonly<{
+  cardId: string;
+  field: "frontText" | "backText" | "tags";
 }>;
 
 const floatingEditorViewportPaddingPx = 12;
@@ -40,13 +51,26 @@ const tagsEditorMaximumWidthPx = 420;
 const tagsEditorMaximumHeightPx = 320;
 
 export function EditableCardTextCell(props: EditableTextCellProps): ReactElement {
-  const { value, displayValue, multiline, saving, onCommit, cellClassName } = props;
+  const {
+    editorToken,
+    value,
+    displayValue,
+    multiline,
+    saving,
+    onCommit,
+    onEditorOpen,
+    onEditorClose,
+    cellClassName,
+  } = props;
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [draftValue, setDraftValue] = useState<string>(value);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const stableEditorTokenRef = useRef<CardInlineEditorToken>(editorToken);
+  const openingValueRef = useRef<string>(value);
+  const editorLifecycleRef = useRef<number | null>(null);
 
   useEffect(() => {
     const activeElement = multiline ? textareaRef.current : inputRef.current;
@@ -59,7 +83,14 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
   }, [isEditing, multiline]);
 
   function closeEditor(): void {
+    const editorLifecycle = editorLifecycleRef.current;
+    if (editorLifecycle === null) {
+      return;
+    }
+
+    editorLifecycleRef.current = null;
     setIsEditing(false);
+    onEditorClose(stableEditorTokenRef.current, editorLifecycle);
   }
 
   function startEditing(): void {
@@ -67,7 +98,9 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
       return;
     }
 
+    openingValueRef.current = value;
     setDraftValue(value);
+    editorLifecycleRef.current = onEditorOpen(stableEditorTokenRef.current);
     setIsEditing(true);
   }
 
@@ -85,14 +118,16 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
   }
 
   function commitEdit(): void {
-    const trimmedValue = draftValue.trim();
-    closeEditor();
-
-    if (trimmedValue === value.trim()) {
+    if (editorLifecycleRef.current === null) {
       return;
     }
 
-    void onCommit(trimmedValue);
+    const trimmedValue = draftValue.trim();
+    if (trimmedValue !== openingValueRef.current.trim()) {
+      void onCommit(trimmedValue);
+    }
+
+    closeEditor();
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>): void {
@@ -174,18 +209,37 @@ export function EditableCardTextCell(props: EditableTextCellProps): ReactElement
 }
 
 export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement {
-  const { value, suggestions, saving, onCommit, cellClassName } = props;
+  const {
+    editorToken,
+    value,
+    suggestions,
+    saving,
+    onCommit,
+    onEditorOpen,
+    onEditorClose,
+    cellClassName,
+  } = props;
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [draftTags, setDraftTags] = useState<ReadonlyArray<string>>(value);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<CardTagsInputHandle | null>(null);
+  const stableEditorTokenRef = useRef<CardInlineEditorToken>(editorToken);
+  const openingTagsRef = useRef<ReadonlyArray<string>>(value);
+  const editorLifecycleRef = useRef<number | null>(null);
 
   const handleClose = useCallback((): void => {
+    const editorLifecycle = editorLifecycleRef.current;
+    if (editorLifecycle === null) {
+      return;
+    }
+
+    editorLifecycleRef.current = null;
     setIsOpen(false);
-    setDraftTags(value);
-  }, [value]);
+    setDraftTags(openingTagsRef.current);
+    onEditorClose(stableEditorTokenRef.current, editorLifecycle);
+  }, [onEditorClose]);
 
   useAnchoredFloatingOutsidePointerDismiss({
     triggerRef: cellRef,
@@ -210,36 +264,49 @@ export function EditableCardTagsCell(props: EditableTagsCellProps): ReactElement
     setDraftTags(value);
   }, [isOpen, value]);
 
-  function handleCellClick(): void {
-    if (saving || cellRef.current === null) {
+  function handleCellPointerDown(event: PointerEvent<HTMLTableCellElement>): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    if (
+      saving
+      || cellRef.current === null
+      || !(event.target instanceof Node)
+      || !cellRef.current.contains(event.target)
+    ) {
       return;
     }
 
     if (isOpen) {
+      event.preventDefault();
       handleCommit();
       return;
     }
 
+    openingTagsRef.current = value;
     setDraftTags(value);
+    editorLifecycleRef.current = onEditorOpen(stableEditorTokenRef.current);
     setIsOpen(true);
   }
 
   function handleCommit(): void {
-    const nextTags = editorRef.current === null ? draftTags : editorRef.current.flushDraft();
-    setIsOpen(false);
-
-    if (areSameTags(nextTags, value)) {
-      setDraftTags(value);
+    if (editorLifecycleRef.current === null) {
       return;
     }
 
-    void onCommit(nextTags);
+    const nextTags = editorRef.current === null ? draftTags : editorRef.current.flushDraft();
+    if (!areSameTags(nextTags, openingTagsRef.current)) {
+      void onCommit(nextTags);
+    }
+
+    handleClose();
   }
 
   const className = `txn-cell ${cellClassName}${saving ? " cards-cell-disabled" : " drilldown-editable"}`;
 
   return (
-    <td ref={cellRef} className={className} onClick={saving ? undefined : handleCellClick}>
+    <td ref={cellRef} className={className} onPointerDown={saving ? undefined : handleCellPointerDown}>
       {value.length === 0 ? <span className="tag-value-empty">—</span> : (
         <span className="tag-value-list">
           {value.map((tag) => (

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -301,7 +301,7 @@ export function DeckFormScreen(): ReactElement {
     })();
   }, [activeWorkspace, deckId, getDeckById, showCapturedTechnicalError, t, technicalErrorMessage]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     void loadScreenData();
     return () => {
       loadRequestSequenceRef.current += 1;

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -22,6 +22,15 @@ type DeckEditorIdentity = Readonly<{
   workspaceId: string;
 }>;
 
+type RefreshOutcome = "accepted" | "failed" | "stale";
+
+type RefreshBarrier = Readonly<{
+  editorIdentity: DeckEditorIdentity;
+  generation: number;
+  promise: Promise<RefreshOutcome>;
+  settle: (outcome: RefreshOutcome) => void;
+}>;
+
 function createInitialFormState(): FormState {
   return {
     name: "",
@@ -59,6 +68,26 @@ function areDeckEditorIdentitiesEqual(
     && left.workspaceId === right.workspaceId;
 }
 
+function createRefreshBarrier(
+  editorIdentity: DeckEditorIdentity,
+  generation: number,
+): RefreshBarrier {
+  let settlePromise: ((outcome: RefreshOutcome) => void) | undefined;
+  const promise = new Promise<RefreshOutcome>((resolve) => {
+    settlePromise = resolve;
+  });
+  if (settlePromise === undefined) {
+    throw new Error("Refresh barrier initialization failed");
+  }
+
+  return {
+    editorIdentity,
+    generation,
+    promise,
+    settle: settlePromise,
+  };
+}
+
 export function DeckFormScreen(): ReactElement {
   const { deckId } = useParams();
   const navigate = useNavigate();
@@ -83,9 +112,12 @@ export function DeckFormScreen(): ReactElement {
   const [formErrorMessage, setFormErrorMessage] = useState<string>("");
   const formStateRef = useRef<FormState>(formState);
   const authoritativeFormStateRef = useRef<FormState>(formState);
+  const isMountedRef = useRef<boolean>(true);
+  const isSavingRef = useRef<boolean>(false);
   const editorIdentityRef = useRef<DeckEditorIdentity | null>(null);
   const renderedEditorIdentityRef = useRef<DeckEditorIdentity | null>(null);
   const loadRequestSequenceRef = useRef<number>(0);
+  const latestRelevantRefreshRef = useRef<RefreshBarrier | null>(null);
   const observationIdentityRef = useRef<Readonly<{
     userId: string | null;
     installationId: string | null;
@@ -130,6 +162,8 @@ export function DeckFormScreen(): ReactElement {
     }
 
     previousRenderedEditorIdentityRef.current = nextEditorIdentity;
+    latestRelevantRefreshRef.current?.settle("stale");
+    latestRelevantRefreshRef.current = null;
     editorIdentityRef.current = null;
     loadRequestSequenceRef.current += 1;
     const initialFormState = createInitialFormState();
@@ -143,7 +177,7 @@ export function DeckFormScreen(): ReactElement {
     setFormErrorMessage("");
   }, [activeWorkspace?.workspaceId, deckId, isCreateMode]);
 
-  const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
+  const loadScreenData = useCallback(function loadScreenData(): Promise<void> {
     const requestSequence = loadRequestSequenceRef.current + 1;
     loadRequestSequenceRef.current = requestSequence;
     const requestEditorIdentity = renderedEditorIdentityRef.current;
@@ -162,6 +196,15 @@ export function DeckFormScreen(): ReactElement {
       editorIdentityRef.current,
       requestEditorIdentity,
     );
+    const refreshBarrier = isBackgroundRefresh
+      && requestEditorIdentity !== null
+      && requestEditorIdentity.mode === "edit"
+      ? createRefreshBarrier(requestEditorIdentity, requestSequence)
+      : null;
+    if (refreshBarrier !== null) {
+      latestRelevantRefreshRef.current?.settle("stale");
+      latestRelevantRefreshRef.current = refreshBarrier;
+    }
     if (isBackgroundRefresh === false) {
       setIsLoading(true);
       setScreenErrorMessage("");
@@ -169,87 +212,93 @@ export function DeckFormScreen(): ReactElement {
       setFormErrorMessage("");
     }
 
-    try {
-      if (activeWorkspace === null || requestEditorIdentity === null) {
-        throw new Error("Workspace is unavailable");
-      }
+    return (async function performScreenDataLoad(): Promise<void> {
+      let refreshOutcome: RefreshOutcome = "stale";
+      try {
+        if (activeWorkspace === null || requestEditorIdentity === null) {
+          throw new Error("Workspace is unavailable");
+        }
 
-      const [tagsSummary, loadedDeck] = await Promise.all([
-        loadWorkspaceTagsSummary(requestEditorIdentity.workspaceId),
-        deckId === undefined
-          ? Promise.resolve(null)
-          : deckId === ALL_CARDS_DECK_SLUG
-            ? Promise.reject(new Error(t("deckForm.systemDeckReadonly")))
-            : getDeckById(deckId),
-      ]);
-      if (isCurrentLoadRequest() === false) {
-        return;
-      }
+        const [tagsSummary, loadedDeck] = await Promise.all([
+          loadWorkspaceTagsSummary(requestEditorIdentity.workspaceId),
+          deckId === undefined
+            ? Promise.resolve(null)
+            : deckId === ALL_CARDS_DECK_SLUG
+              ? Promise.reject(new Error(t("deckForm.systemDeckReadonly")))
+              : getDeckById(deckId),
+        ]);
+        if (isCurrentLoadRequest() === false) {
+          return;
+        }
 
-      setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
-        tag: tagSummary.tag,
-        countState: "ready",
-        cardsCount: tagSummary.cardsCount,
-      })));
-      setRefreshErrorMessage("");
-      const authoritativeFormState = loadedDeck === null
-        ? createInitialFormState()
-        : {
-          name: loadedDeck.name,
-          tags: loadedDeck.filterDefinition.tags,
-        };
-      if (isBackgroundRefresh === false) {
-        editorIdentityRef.current = requestEditorIdentity;
-        formStateRef.current = authoritativeFormState;
-        authoritativeFormStateRef.current = authoritativeFormState;
-        setFormState(authoritativeFormState);
-      } else {
-        const nextFormState = applyAuthoritativeFormState(
-          formStateRef.current,
-          authoritativeFormStateRef.current,
-          authoritativeFormState,
-        );
-        formStateRef.current = nextFormState;
-        authoritativeFormStateRef.current = authoritativeFormState;
-        setFormState(nextFormState);
-      }
-    } catch (error) {
-      if (isCurrentLoadRequest() === false) {
-        return;
-      }
+        setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
+          tag: tagSummary.tag,
+          countState: "ready",
+          cardsCount: tagSummary.cardsCount,
+        })));
+        setRefreshErrorMessage("");
+        const authoritativeFormState = loadedDeck === null
+          ? createInitialFormState()
+          : {
+            name: loadedDeck.name,
+            tags: loadedDeck.filterDefinition.tags,
+          };
+        if (isBackgroundRefresh === false) {
+          editorIdentityRef.current = requestEditorIdentity;
+          formStateRef.current = authoritativeFormState;
+          authoritativeFormStateRef.current = authoritativeFormState;
+          setFormState(authoritativeFormState);
+        } else {
+          const nextFormState = applyAuthoritativeFormState(
+            formStateRef.current,
+            authoritativeFormStateRef.current,
+            authoritativeFormState,
+          );
+          formStateRef.current = nextFormState;
+          authoritativeFormStateRef.current = authoritativeFormState;
+          setFormState(nextFormState);
+        }
+        refreshOutcome = "accepted";
+      } catch (error) {
+        if (isCurrentLoadRequest() === false) {
+          return;
+        }
 
-      let errorMessage: string;
-      if (activeWorkspace !== null && deckId !== ALL_CARDS_DECK_SLUG) {
-        const observationIdentity = observationIdentityRef.current;
-        const wasCaptured = captureAppOperationError(error, {
-          feature: "settings",
-          operation: "deck_detail_load",
-          userId: observationIdentity.userId,
-          workspaceId: activeWorkspace.workspaceId,
-          installationId: observationIdentity.installationId,
-          entityId: deckId ?? null,
-        });
-        if (wasCaptured) {
-          if (isBackgroundRefresh === false) {
-            showCapturedTechnicalError(error);
+        refreshOutcome = "failed";
+        let errorMessage: string;
+        if (activeWorkspace !== null && deckId !== ALL_CARDS_DECK_SLUG) {
+          const observationIdentity = observationIdentityRef.current;
+          const wasCaptured = captureAppOperationError(error, {
+            feature: "settings",
+            operation: "deck_detail_load",
+            userId: observationIdentity.userId,
+            workspaceId: activeWorkspace.workspaceId,
+            installationId: observationIdentity.installationId,
+            entityId: deckId ?? null,
+          });
+          if (wasCaptured) {
+            if (isBackgroundRefresh === false) {
+              showCapturedTechnicalError(error);
+            }
+            errorMessage = technicalErrorMessage;
+          } else {
+            errorMessage = error instanceof Error ? error.message : String(error);
           }
-          errorMessage = technicalErrorMessage;
         } else {
           errorMessage = error instanceof Error ? error.message : String(error);
         }
-      } else {
-        errorMessage = error instanceof Error ? error.message : String(error);
+        if (isBackgroundRefresh) {
+          setRefreshErrorMessage(errorMessage);
+        } else {
+          setScreenErrorMessage(errorMessage);
+        }
+      } finally {
+        if (isCurrentLoadRequest()) {
+          setIsLoading(false);
+        }
+        refreshBarrier?.settle(refreshOutcome);
       }
-      if (isBackgroundRefresh) {
-        setRefreshErrorMessage(errorMessage);
-      } else {
-        setScreenErrorMessage(errorMessage);
-      }
-    } finally {
-      if (isCurrentLoadRequest()) {
-        setIsLoading(false);
-      }
-    }
+    })();
   }, [activeWorkspace, deckId, getDeckById, showCapturedTechnicalError, t, technicalErrorMessage]);
 
   useEffect(() => {
@@ -258,6 +307,15 @@ export function DeckFormScreen(): ReactElement {
       loadRequestSequenceRef.current += 1;
     };
   }, [loadScreenData, localReadVersion]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      latestRelevantRefreshRef.current?.settle("stale");
+      latestRelevantRefreshRef.current = null;
+    };
+  }, []);
 
   function updateField<Key extends keyof FormState>(key: Key, value: FormState[Key]): void {
     setFormErrorMessage("");
@@ -269,19 +327,78 @@ export function DeckFormScreen(): ReactElement {
     setFormState(nextFormState);
   }
 
-  async function handleSubmit(): Promise<void> {
-    setErrorMessage("");
-    setFormErrorMessage("");
+  async function readFormStateAfterLatestRefresh(
+    submitEditorIdentity: DeckEditorIdentity,
+  ): Promise<FormState | null> {
+    if (submitEditorIdentity.mode === "create") {
+      return formStateRef.current;
+    }
 
-    const latestFormState = formStateRef.current;
-    if (hasDeckRules(latestFormState) === false) {
-      setFormErrorMessage(t("deckForm.errors.emptyRules"));
+    while (
+      isMountedRef.current
+      && areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity)
+    ) {
+      const refreshBarrier = latestRelevantRefreshRef.current;
+      if (
+        refreshBarrier === null
+        || areDeckEditorIdentitiesEqual(refreshBarrier.editorIdentity, submitEditorIdentity) === false
+      ) {
+        return formStateRef.current;
+      }
+
+      const refreshOutcome = await refreshBarrier.promise;
+      if (
+        isMountedRef.current === false
+        || areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity) === false
+      ) {
+        return null;
+      }
+
+      const latestRefreshBarrier = latestRelevantRefreshRef.current;
+      if (
+        latestRefreshBarrier !== null
+        && areDeckEditorIdentitiesEqual(latestRefreshBarrier.editorIdentity, submitEditorIdentity)
+        && latestRefreshBarrier.generation !== refreshBarrier.generation
+      ) {
+        continue;
+      }
+      if (refreshOutcome !== "accepted") {
+        return null;
+      }
+
+      return formStateRef.current;
+    }
+
+    return null;
+  }
+
+  async function handleSubmit(): Promise<void> {
+    if (isSavingRef.current) {
       return;
     }
 
+    isSavingRef.current = true;
     setIsSaving(true);
+    setErrorMessage("");
+    setFormErrorMessage("");
 
     try {
+      const submitEditorIdentity = renderedEditorIdentityRef.current;
+      if (submitEditorIdentity === null) {
+        throw new Error("Deck editor is unavailable");
+      }
+      const latestFormState = await readFormStateAfterLatestRefresh(submitEditorIdentity);
+      if (latestFormState === null) {
+        return;
+      }
+      if (areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity) === false) {
+        return;
+      }
+      if (hasDeckRules(latestFormState) === false) {
+        setFormErrorMessage(t("deckForm.errors.emptyRules"));
+        return;
+      }
+
       const payload: UpdateDeckInput = {
         name: latestFormState.name,
         filterDefinition: buildDeckFilterDefinition(latestFormState.tags),
@@ -310,6 +427,7 @@ export function DeckFormScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
+      isSavingRef.current = false;
       setIsSaving(false);
     }
   }

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -334,10 +334,12 @@ export function DeckFormScreen(): ReactElement {
       return formStateRef.current;
     }
 
-    while (
-      isMountedRef.current
-      && areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity)
-    ) {
+    const isSubmitEditorCurrent = function isSubmitEditorCurrent(): boolean {
+      return isMountedRef.current
+        && areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity);
+    };
+
+    while (isSubmitEditorCurrent()) {
       const refreshBarrier = latestRelevantRefreshRef.current;
       if (
         refreshBarrier === null
@@ -347,10 +349,7 @@ export function DeckFormScreen(): ReactElement {
       }
 
       const refreshOutcome = await refreshBarrier.promise;
-      if (
-        isMountedRef.current === false
-        || areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity) === false
-      ) {
+      if (isSubmitEditorCurrent() === false) {
         return null;
       }
 

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -33,6 +33,21 @@ function hasDeckRules(formState: FormState): boolean {
   return formState.tags.length > 0;
 }
 
+function areTagsEqual(left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean {
+  return left.length === right.length && left.every((tag, index) => tag === right[index]);
+}
+
+function applyAuthoritativeFormState(
+  draft: FormState,
+  previousBaseline: FormState,
+  authoritativeState: FormState,
+): FormState {
+  return {
+    name: draft.name === previousBaseline.name ? authoritativeState.name : draft.name,
+    tags: areTagsEqual(draft.tags, previousBaseline.tags) ? authoritativeState.tags : draft.tags,
+  };
+}
+
 function areDeckEditorIdentitiesEqual(
   left: DeckEditorIdentity | null,
   right: DeckEditorIdentity | null,
@@ -66,6 +81,8 @@ export function DeckFormScreen(): ReactElement {
   const [screenErrorMessage, setScreenErrorMessage] = useState<string>("");
   const [refreshErrorMessage, setRefreshErrorMessage] = useState<string>("");
   const [formErrorMessage, setFormErrorMessage] = useState<string>("");
+  const formStateRef = useRef<FormState>(formState);
+  const authoritativeFormStateRef = useRef<FormState>(formState);
   const editorIdentityRef = useRef<DeckEditorIdentity | null>(null);
   const renderedEditorIdentityRef = useRef<DeckEditorIdentity | null>(null);
   const loadRequestSequenceRef = useRef<number>(0);
@@ -115,7 +132,10 @@ export function DeckFormScreen(): ReactElement {
     previousRenderedEditorIdentityRef.current = nextEditorIdentity;
     editorIdentityRef.current = null;
     loadRequestSequenceRef.current += 1;
-    setFormState(createInitialFormState());
+    const initialFormState = createInitialFormState();
+    formStateRef.current = initialFormState;
+    authoritativeFormStateRef.current = initialFormState;
+    setFormState(initialFormState);
     setTagSuggestions([]);
     setIsLoading(true);
     setScreenErrorMessage("");
@@ -172,14 +192,26 @@ export function DeckFormScreen(): ReactElement {
         cardsCount: tagSummary.cardsCount,
       })));
       setRefreshErrorMessage("");
+      const authoritativeFormState = loadedDeck === null
+        ? createInitialFormState()
+        : {
+          name: loadedDeck.name,
+          tags: loadedDeck.filterDefinition.tags,
+        };
       if (isBackgroundRefresh === false) {
         editorIdentityRef.current = requestEditorIdentity;
-        setFormState(loadedDeck === null
-          ? createInitialFormState()
-          : {
-            name: loadedDeck.name,
-            tags: loadedDeck.filterDefinition.tags,
-          });
+        formStateRef.current = authoritativeFormState;
+        authoritativeFormStateRef.current = authoritativeFormState;
+        setFormState(authoritativeFormState);
+      } else {
+        const nextFormState = applyAuthoritativeFormState(
+          formStateRef.current,
+          authoritativeFormStateRef.current,
+          authoritativeFormState,
+        );
+        formStateRef.current = nextFormState;
+        authoritativeFormStateRef.current = authoritativeFormState;
+        setFormState(nextFormState);
       }
     } catch (error) {
       if (isCurrentLoadRequest() === false) {
@@ -229,17 +261,20 @@ export function DeckFormScreen(): ReactElement {
 
   function updateField<Key extends keyof FormState>(key: Key, value: FormState[Key]): void {
     setFormErrorMessage("");
-    setFormState((currentFormState) => ({
-      ...currentFormState,
+    const nextFormState = {
+      ...formStateRef.current,
       [key]: value,
-    }));
+    };
+    formStateRef.current = nextFormState;
+    setFormState(nextFormState);
   }
 
   async function handleSubmit(): Promise<void> {
     setErrorMessage("");
     setFormErrorMessage("");
 
-    if (hasDeckRules(formState) === false) {
+    const latestFormState = formStateRef.current;
+    if (hasDeckRules(latestFormState) === false) {
       setFormErrorMessage(t("deckForm.errors.emptyRules"));
       return;
     }
@@ -248,8 +283,8 @@ export function DeckFormScreen(): ReactElement {
 
     try {
       const payload: UpdateDeckInput = {
-        name: formState.name,
-        filterDefinition,
+        name: latestFormState.name,
+        filterDefinition: buildDeckFilterDefinition(latestFormState.tags),
       };
 
       if (isCreateMode) {

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ChangeEvent, type ReactElement } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useAppData } from "../../../../appData";
 import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
@@ -16,6 +16,12 @@ type FormState = Readonly<{
   tags: ReadonlyArray<string>;
 }>;
 
+type DeckEditorIdentity = Readonly<{
+  deckId: string | null;
+  mode: "create" | "edit";
+  workspaceId: string;
+}>;
+
 function createInitialFormState(): FormState {
   return {
     name: "",
@@ -25,6 +31,17 @@ function createInitialFormState(): FormState {
 
 function hasDeckRules(formState: FormState): boolean {
   return formState.tags.length > 0;
+}
+
+function areDeckEditorIdentitiesEqual(
+  left: DeckEditorIdentity | null,
+  right: DeckEditorIdentity | null,
+): boolean {
+  return left !== null
+    && right !== null
+    && left.deckId === right.deckId
+    && left.mode === right.mode
+    && left.workspaceId === right.workspaceId;
 }
 
 export function DeckFormScreen(): ReactElement {
@@ -47,7 +64,11 @@ export function DeckFormScreen(): ReactElement {
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [screenErrorMessage, setScreenErrorMessage] = useState<string>("");
+  const [refreshErrorMessage, setRefreshErrorMessage] = useState<string>("");
   const [formErrorMessage, setFormErrorMessage] = useState<string>("");
+  const editorIdentityRef = useRef<DeckEditorIdentity | null>(null);
+  const renderedEditorIdentityRef = useRef<DeckEditorIdentity | null>(null);
+  const loadRequestSequenceRef = useRef<number>(0);
   const observationIdentityRef = useRef<Readonly<{
     userId: string | null;
     installationId: string | null;
@@ -66,40 +87,106 @@ export function DeckFormScreen(): ReactElement {
     userId: session?.userId ?? null,
     installationId: cloudSettings?.installationId ?? null,
   };
+  renderedEditorIdentityRef.current = activeWorkspace === null
+    ? null
+    : {
+      deckId: deckId ?? null,
+      mode: isCreateMode ? "create" : "edit",
+      workspaceId: activeWorkspace.workspaceId,
+    };
+  const previousRenderedEditorIdentityRef = useRef<DeckEditorIdentity | null>(
+    renderedEditorIdentityRef.current,
+  );
+  const isEditorInitialized = areDeckEditorIdentitiesEqual(
+    editorIdentityRef.current,
+    renderedEditorIdentityRef.current,
+  );
 
-  const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
+  useLayoutEffect(() => {
+    const previousEditorIdentity = previousRenderedEditorIdentityRef.current;
+    const nextEditorIdentity = renderedEditorIdentityRef.current;
+    const isSameEditorIdentity = previousEditorIdentity === null
+      ? nextEditorIdentity === null
+      : areDeckEditorIdentitiesEqual(previousEditorIdentity, nextEditorIdentity);
+    if (isSameEditorIdentity) {
+      return;
+    }
+
+    previousRenderedEditorIdentityRef.current = nextEditorIdentity;
+    editorIdentityRef.current = null;
+    loadRequestSequenceRef.current += 1;
+    setFormState(createInitialFormState());
+    setTagSuggestions([]);
     setIsLoading(true);
     setScreenErrorMessage("");
+    setRefreshErrorMessage("");
     setFormErrorMessage("");
+  }, [activeWorkspace?.workspaceId, deckId, isCreateMode]);
+
+  const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
+    const requestSequence = loadRequestSequenceRef.current + 1;
+    loadRequestSequenceRef.current = requestSequence;
+    const requestEditorIdentity = renderedEditorIdentityRef.current;
+    const isCurrentLoadRequest = function isCurrentLoadRequest(): boolean {
+      return loadRequestSequenceRef.current === requestSequence
+        && (
+          requestEditorIdentity === null
+            ? renderedEditorIdentityRef.current === null
+            : areDeckEditorIdentitiesEqual(
+              renderedEditorIdentityRef.current,
+              requestEditorIdentity,
+            )
+        );
+    };
+    const isBackgroundRefresh = areDeckEditorIdentitiesEqual(
+      editorIdentityRef.current,
+      requestEditorIdentity,
+    );
+    if (isBackgroundRefresh === false) {
+      setIsLoading(true);
+      setScreenErrorMessage("");
+      setRefreshErrorMessage("");
+      setFormErrorMessage("");
+    }
 
     try {
-      if (activeWorkspace === null) {
+      if (activeWorkspace === null || requestEditorIdentity === null) {
         throw new Error("Workspace is unavailable");
       }
 
       const [tagsSummary, loadedDeck] = await Promise.all([
-        loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
+        loadWorkspaceTagsSummary(requestEditorIdentity.workspaceId),
         deckId === undefined
           ? Promise.resolve(null)
           : deckId === ALL_CARDS_DECK_SLUG
             ? Promise.reject(new Error(t("deckForm.systemDeckReadonly")))
             : getDeckById(deckId),
       ]);
+      if (isCurrentLoadRequest() === false) {
+        return;
+      }
 
       setTagSuggestions(tagsSummary.tags.map((tagSummary) => ({
         tag: tagSummary.tag,
         countState: "ready",
         cardsCount: tagSummary.cardsCount,
       })));
-      if (loadedDeck === null) {
-        setFormState(createInitialFormState());
-      } else {
-        setFormState({
-          name: loadedDeck.name,
-          tags: loadedDeck.filterDefinition.tags,
-        });
+      setRefreshErrorMessage("");
+      if (isBackgroundRefresh === false) {
+        editorIdentityRef.current = requestEditorIdentity;
+        setFormState(loadedDeck === null
+          ? createInitialFormState()
+          : {
+            name: loadedDeck.name,
+            tags: loadedDeck.filterDefinition.tags,
+          });
       }
     } catch (error) {
+      if (isCurrentLoadRequest() === false) {
+        return;
+      }
+
+      let errorMessage: string;
       if (activeWorkspace !== null && deckId !== ALL_CARDS_DECK_SLUG) {
         const observationIdentity = observationIdentityRef.current;
         const wasCaptured = captureAppOperationError(error, {
@@ -111,19 +198,33 @@ export function DeckFormScreen(): ReactElement {
           entityId: deckId ?? null,
         });
         if (wasCaptured) {
-          showCapturedTechnicalError(error);
-          setScreenErrorMessage(technicalErrorMessage);
-          return;
+          if (isBackgroundRefresh === false) {
+            showCapturedTechnicalError(error);
+          }
+          errorMessage = technicalErrorMessage;
+        } else {
+          errorMessage = error instanceof Error ? error.message : String(error);
         }
+      } else {
+        errorMessage = error instanceof Error ? error.message : String(error);
       }
-      setScreenErrorMessage(error instanceof Error ? error.message : String(error));
+      if (isBackgroundRefresh) {
+        setRefreshErrorMessage(errorMessage);
+      } else {
+        setScreenErrorMessage(errorMessage);
+      }
     } finally {
-      setIsLoading(false);
+      if (isCurrentLoadRequest()) {
+        setIsLoading(false);
+      }
     }
-  }, [activeWorkspace, deckId, getDeckById, t]);
+  }, [activeWorkspace, deckId, getDeckById, showCapturedTechnicalError, t, technicalErrorMessage]);
 
   useEffect(() => {
     void loadScreenData();
+    return () => {
+      loadRequestSequenceRef.current += 1;
+    };
   }, [loadScreenData, localReadVersion]);
 
   function updateField<Key extends keyof FormState>(key: Key, value: FormState[Key]): void {
@@ -178,7 +279,7 @@ export function DeckFormScreen(): ReactElement {
     }
   }
 
-  if (isLoading) {
+  if (isLoading || (screenErrorMessage === "" && isEditorInitialized === false)) {
     return (
       <main className="container">
         <section className="panel">
@@ -206,6 +307,14 @@ export function DeckFormScreen(): ReactElement {
   return (
     <main className="container">
       <section className="panel">
+        {refreshErrorMessage !== "" ? (
+          <>
+            <p className="error-banner" role="alert">{refreshErrorMessage}</p>
+            <button className="ghost-btn" type="button" onClick={() => void loadScreenData()}>
+              {t("common.retry")}
+            </button>
+          </>
+        ) : null}
         <div className="screen-head">
           <div>
             <h1 className="title">{screenTitle}</h1>


### PR DESCRIPTION
## Summary

- preserve deck name and tag drafts while rebasing untouched fields onto the latest authoritative workspace data
- coordinate refresh barriers with Save so submitted payloads use current field baselines across sync, route, and unmount races
- preserve card editor drafts through field and tag-overlay handoffs with stable leases and per-card commit serialization
- defer and publish authoritative card windows coherently without pagination collapse, cascading load-more, or pinned-row contamination

## Validation

No local checks were run. Required GitHub checks must pass before server-side promotion to main.