### PR TITLE
Fix web draft promotion TypeScript CI

### DIFF
--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -334,10 +334,12 @@ export function DeckFormScreen(): ReactElement {
       return formStateRef.current;
     }
 
-    while (
-      isMountedRef.current
-      && areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity)
-    ) {
+    const isSubmitEditorCurrent = function isSubmitEditorCurrent(): boolean {
+      return isMountedRef.current
+        && areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity);
+    };
+
+    while (isSubmitEditorCurrent()) {
       const refreshBarrier = latestRelevantRefreshRef.current;
       if (
         refreshBarrier === null
@@ -347,10 +349,7 @@ export function DeckFormScreen(): ReactElement {
       }
 
       const refreshOutcome = await refreshBarrier.promise;
-      if (
-        isMountedRef.current === false
-        || areDeckEditorIdentitiesEqual(renderedEditorIdentityRef.current, submitEditorIdentity) === false
-      ) {
+      if (isSubmitEditorCurrent() === false) {
         return null;
       }
 


### PR DESCRIPTION
## Summary

- preserve the post-refresh mounted and editor-identity guard
- avoid TypeScript carrying a literal narrowing across the refresh barrier await

## Validation

No local checks were run. The existing promotion PR #1331 will validate the updated integration head.