### PR TITLE
Fix iOS AI chat scroll restoration

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -103,7 +103,6 @@ struct AIChatView: View {
     @State var isPhotoPickerPresented: Bool
     @State var selectedPhotoItem: PhotosPickerItem?
     @State var isAutoFollowEnabled: Bool
-    @State var currentScrollState: AIChatScrollState?
     @State var hasActiveUserScrollGesture: Bool
     @State var scrollPosition: ScrollPosition
     @State var autoScrollTask: Task<Void, Never>?
@@ -120,7 +119,6 @@ struct AIChatView: View {
         self.isPhotoPickerPresented = false
         self.selectedPhotoItem = nil
         self.isAutoFollowEnabled = true
-        self.currentScrollState = nil
         self.hasActiveUserScrollGesture = false
         self.scrollPosition = ScrollPosition(idType: String.self)
         self.autoScrollTask = nil
@@ -800,6 +798,7 @@ struct AIChatView: View {
             return
         }
 
+        self.scheduleDeferredBottomSyncIfNeeded()
         self.handleAIChatPresentationRequest(
             request: self.deferredPresentationRequest,
             source: .bootstrapReady

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
@@ -32,20 +32,6 @@ func aiChatScrollState(
     )
 }
 
-func aiChatScrollStateAllowsDeferredBottomSync(
-    scrollState: AIChatScrollState?,
-    messages: [AIChatMessage]
-) -> Bool {
-    guard messages.isEmpty == false else {
-        return true
-    }
-    guard let scrollState else {
-        return false
-    }
-
-    return scrollState.isNearBottom
-}
-
 func aiChatMessageListUpdateAppendsTail(
     previousMessages: [AIChatMessage],
     nextMessages: [AIChatMessage]
@@ -106,12 +92,6 @@ extension AIChatView {
         guard self.isAutoFollowEnabled else {
             return
         }
-        guard aiChatScrollStateAllowsDeferredBottomSync(
-            scrollState: self.currentScrollState,
-            messages: self.chatStore.messages
-        ) else {
-            return
-        }
 
         self.cancelDeferredBottomSync()
         self.deferredBottomSyncTask = Task { @MainActor in
@@ -133,13 +113,6 @@ extension AIChatView {
                 return
             }
             guard self.isAutoFollowEnabled else {
-                self.deferredBottomSyncTask = nil
-                return
-            }
-            guard aiChatScrollStateAllowsDeferredBottomSync(
-                scrollState: self.currentScrollState,
-                messages: self.chatStore.messages
-            ) else {
                 self.deferredBottomSyncTask = nil
                 return
             }

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
@@ -26,7 +26,6 @@ extension AIChatView {
                 scrollGeometry: context.geometry,
                 bottomThreshold: aiChatAutoScrollBottomThreshold
             )
-            self.currentScrollState = nextScrollState
 
             // Only user-driven scrolls can detach auto-follow. Animated scrolls are
             // app-driven and should not flip the latch while assistant content grows.
@@ -56,9 +55,8 @@ extension AIChatView {
             }
         }
         .onAppear {
-            // Keep the one-shot deferred sync only when the previous geometry already
-            // proved the reader was at the bottom, so tab return cannot override a
-            // deliberate manual scroll-away.
+            // Keep the one-shot deferred sync behind the auto-follow latch so tab
+            // return cannot override a deliberate manual scroll-away.
             self.scheduleDeferredBottomSyncIfNeeded()
             if self.chatStore.isStreaming {
                 self.startAutoScrollTask()
@@ -71,7 +69,6 @@ extension AIChatView {
         .onChange(of: self.chatStore.messages) { previousMessages, messages in
             guard messages.isEmpty == false else {
                 self.isAutoFollowEnabled = true
-                self.currentScrollState = nil
                 self.hasActiveUserScrollGesture = false
                 self.scrollToBottom(isAnimated: false)
                 return


### PR DESCRIPTION
## Summary
- retry the existing deferred bottom alignment when AI chat bootstrap becomes ready
- use the auto-follow latch as the single source of transcript attachment state
- preserve detached history position across AI tab changes

## Validation
- required PR CI (no local project checks per repository policy)