### PR TITLE
Stabilize iOS review card selection during background refresh

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -625,7 +625,7 @@ extension FlashcardsStore {
         let didRefreshReviewState: Bool
         if shouldRefreshReviewState {
             let reviewRefreshMode: ReviewRefreshMode
-            if trigger.allowsVisibleChangeBanner {
+            if trigger.allowsVisibleChangeBanner || syncResult.appliedPullChanges {
                 reviewRefreshMode = .backgroundReconcileWithVisibleChangeBanner
             } else {
                 reviewRefreshMode = .backgroundReconcileSilently

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore+Bootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore+Bootstrap.swift
@@ -304,7 +304,14 @@ extension FlashcardsStore {
         self.homeSnapshot = resolvedHomeSnapshot
         self.globalErrorMessage = ""
         if shouldRestartActiveReviewLoad {
-            self.startReviewLoad(reviewFilter: self.selectedReviewFilter, now: now)
+            if self.reviewQueue.isEmpty && self.presentedReviewCard == nil {
+                self.startReviewLoad(reviewFilter: self.selectedReviewFilter, now: now)
+            } else {
+                let settledReviewState = self.reviewRuntime.settleInvalidatedReviewLoads(
+                    publishedState: self.currentReviewPublishedState()
+                )
+                self.applyReviewPublishedState(reviewState: settledReviewState)
+            }
         }
         if didTransitionWorkspace {
             self.clearScheduledNotificationStorageForWorkspaceSwitch(

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/PublicSync/ReviewSelectionSyncRecoveryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/PublicSync/ReviewSelectionSyncRecoveryTests.swift
@@ -4,6 +4,178 @@ import XCTest
 
 final class ReviewSelectionSyncRecoveryTests: LocalWorkspaceSyncTestCase {
     @MainActor
+    func testAppliedRemotePullReportsPresentedReviewCardReplacementForSilentTrigger() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let currentCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Current question",
+                backText: "Current answer",
+                tags: [],
+            ),
+            cardId: nil,
+            mediaAssetIdsReadyForUpload: []
+        )
+        let replacementCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Replacement question",
+                backText: "Replacement answer",
+                tags: [],
+            ),
+            cardId: nil,
+            mediaAssetIdsReadyForUpload: []
+        )
+        let suiteName = "review-selection-applied-pull-\(UUID().uuidString.lowercased())"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        defer {
+            try? credentialStore.clearCredentials()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let store = self.makeReviewReconciliationStore(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+
+        store.workspace = workspace
+        store.schedulerSettings = try database.workspaceSettingsStore.loadWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId
+        )
+        store.cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        store.cards = [currentCard, replacementCard]
+        store.applyReviewPublishedState(
+            reviewState: ReviewQueuePublishedState(
+                selectedReviewFilter: .allCards,
+                reviewQueue: [currentCard, replacementCard],
+                presentedReviewCard: currentCard,
+                reviewCounts: ReviewCounts(dueCount: 2, totalCount: 2),
+                isReviewHeadLoading: false,
+                isReviewCountsLoading: false,
+                isReviewQueueChunkLoading: false,
+                pendingReviewCardIds: [],
+                reviewSubmissionFailure: nil
+            )
+        )
+
+        let remoteDeletedAt = "2099-01-01T00:00:00.000Z"
+        let applyResult = try database.applySyncChange(
+            workspaceId: workspace.workspaceId,
+            change: SyncChange(
+                changeId: 1,
+                entityType: .card,
+                entityId: currentCard.cardId,
+                action: .upsert,
+                payload: .card(
+                    self.makeRemoteDeletedCard(
+                        card: currentCard,
+                        deletedAt: remoteDeletedAt
+                    )
+                )
+            )
+        )
+        XCTAssertTrue(applyResult.didApply)
+
+        try await store.applySyncResultWithoutBlockingReset(
+            syncResult: CloudSyncResult(
+                appliedPullChangeCount: 1,
+                reviewScheduleImpactingPullChangeCount: 1,
+                changedEntityTypes: [.card],
+                localIdRepairEntityTypes: [],
+                acknowledgedOperationCount: 0,
+                acknowledgedReviewEventOperationCount: 0,
+                acknowledgedReviewScheduleImpactingOperationCount: 0,
+                cleanedUpOperationCount: 0,
+                cleanedUpReviewEventOperationCount: 0,
+                cleanedUpReviewScheduleImpactingOperationCount: 0
+            ),
+            now: now,
+            trigger: self.makeManualSyncTrigger(now: now)
+        )
+
+        XCTAssertEqual(replacementCard.cardId, store.presentedReviewCard?.cardId)
+        XCTAssertEqual(.reviewUpdatedOnAnotherDevice, store.currentTransientBanner?.kind)
+    }
+
+    @MainActor
+    func testAcknowledgementOnlyResultDoesNotReportReviewReplacementForSilentTrigger() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let currentCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Current question",
+                backText: "Current answer",
+                tags: [],
+            ),
+            cardId: nil,
+            mediaAssetIdsReadyForUpload: []
+        )
+        let suiteName = "review-selection-acknowledgement-\(UUID().uuidString.lowercased())"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        defer {
+            try? credentialStore.clearCredentials()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let store = self.makeReviewReconciliationStore(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+
+        store.workspace = workspace
+        store.schedulerSettings = try database.workspaceSettingsStore.loadWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId
+        )
+        store.cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        store.cards = [currentCard]
+        store.applyReviewPublishedState(
+            reviewState: ReviewQueuePublishedState(
+                selectedReviewFilter: .allCards,
+                reviewQueue: [currentCard],
+                presentedReviewCard: currentCard,
+                reviewCounts: ReviewCounts(dueCount: 1, totalCount: 1),
+                isReviewHeadLoading: false,
+                isReviewCountsLoading: false,
+                isReviewQueueChunkLoading: false,
+                pendingReviewCardIds: [],
+                reviewSubmissionFailure: nil
+            )
+        )
+
+        try await store.applySyncResultWithoutBlockingReset(
+            syncResult: CloudSyncResult(
+                appliedPullChangeCount: 0,
+                reviewScheduleImpactingPullChangeCount: 0,
+                changedEntityTypes: [],
+                localIdRepairEntityTypes: [],
+                acknowledgedOperationCount: 1,
+                acknowledgedReviewEventOperationCount: 0,
+                acknowledgedReviewScheduleImpactingOperationCount: 0,
+                cleanedUpOperationCount: 0,
+                cleanedUpReviewEventOperationCount: 0,
+                cleanedUpReviewScheduleImpactingOperationCount: 0
+            ),
+            now: now,
+            trigger: self.makeManualSyncTrigger(now: now)
+        )
+
+        XCTAssertEqual(currentCard.cardId, store.presentedReviewCard?.cardId)
+        XCTAssertNil(store.currentTransientBanner)
+    }
+
+    @MainActor
     func testApplySyncResultBroadlyResetsReviewSelectionAfterLocalIdRepair() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
@@ -351,6 +523,67 @@ final class ReviewSelectionSyncRecoveryTests: LocalWorkspaceSyncTestCase {
                 decoder: JSONDecoder(),
                 workspaceId: workspace.workspaceId
             )
+        )
+    }
+
+    @MainActor
+    private func makeReviewReconciliationStore(
+        database: LocalDatabase,
+        userDefaults: UserDefaults,
+        credentialStore: CloudCredentialStore
+    ) -> FlashcardsStore {
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-review-reconciliation-guest-\(UUID().uuidString.lowercased())",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let store = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: JSONEncoder(),
+            decoder: JSONDecoder(),
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: nil,
+            credentialStore: credentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        store.updateCurrentVisibleTab(tab: .review)
+        return store
+    }
+
+    private func makeRemoteDeletedCard(card: Card, deletedAt: String) -> Card {
+        Card(
+            cardId: card.cardId,
+            workspaceId: card.workspaceId,
+            frontText: card.frontText,
+            backText: card.backText,
+            cardType: card.cardType,
+            metadata: card.metadata,
+            tags: card.tags,
+            dueAt: card.dueAt,
+            createdAt: card.createdAt,
+            reps: card.reps,
+            lapses: card.lapses,
+            fsrsCardState: card.fsrsCardState,
+            fsrsStepIndex: card.fsrsStepIndex,
+            fsrsStability: card.fsrsStability,
+            fsrsDifficulty: card.fsrsDifficulty,
+            fsrsLastReviewedAt: card.fsrsLastReviewedAt,
+            fsrsScheduledDays: card.fsrsScheduledDays,
+            clientUpdatedAt: deletedAt,
+            lastModifiedByReplicaId: "remote-replica",
+            lastOperationId: "remote-delete-operation",
+            updatedAt: deletedAt,
+            deletedAt: deletedAt
         )
     }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundSubmissionSettlementTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundSubmissionSettlementTests.swift
@@ -128,9 +128,18 @@ final class ReviewBackgroundSubmissionSettlementTests: ProgressStoreTestCase {
         let staleCountsTask = try XCTUnwrap(store.reviewRuntime.state.activeReviewCountsTask)
         await firstHeadLoadGate.waitUntilEntered()
         await firstCountsLoadGate.waitUntilEntered()
+        XCTAssertTrue(store.reviewQueue.isEmpty)
+        XCTAssertNil(store.presentedReviewCard)
+        XCTAssertTrue(store.isReviewHeadLoading)
+        XCTAssertTrue(store.isReviewCountsLoading)
 
         await submissionGate.release()
         await submissionTask.value
+
+        XCTAssertTrue(store.reviewQueue.isEmpty)
+        XCTAssertNil(store.presentedReviewCard)
+        XCTAssertTrue(store.isReviewHeadLoading)
+        XCTAssertTrue(store.isReviewCountsLoading)
 
         await freshHeadLoadGate.waitUntilEntered()
         await freshCountsLoadGate.waitUntilEntered()
@@ -153,6 +162,166 @@ final class ReviewBackgroundSubmissionSettlementTests: ProgressStoreTestCase {
 
         XCTAssertEqual(store.currentReviewPublishedState(), freshState)
     }
+
+    @MainActor
+    func testLocalSubmissionSettlementPreservesPresentedCardAndRebasesNewlyDueCardBehindIt() async throws {
+        let database = try self.makeDatabase()
+        let bootstrapSnapshot = try database.loadBootstrapSnapshot()
+        let workspaceId = bootstrapSnapshot.workspace.workspaceId
+        let now = Date()
+        let cardASeed = try self.addDueReviewScheduleCard(
+            database: database,
+            workspaceId: workspaceId,
+            dueAt: now.addingTimeInterval(-180)
+        )
+        let cardBSeed = try self.addDueReviewScheduleCard(
+            database: database,
+            workspaceId: workspaceId,
+            dueAt: now.addingTimeInterval(-120)
+        )
+        let cardCSeed = try self.addDueReviewScheduleCard(
+            database: database,
+            workspaceId: workspaceId,
+            dueAt: now.addingTimeInterval(3_600)
+        )
+        let initialCards = try database.loadActiveCards(workspaceId: workspaceId)
+        let cardA = try XCTUnwrap(initialCards.first { card in
+            card.cardId == cardASeed.cardId
+        })
+        let cardB = try XCTUnwrap(initialCards.first { card in
+            card.cardId == cardBSeed.cardId
+        })
+        let submissionGate = ReviewReconcileAsyncGate()
+        let staleChunkGate = ReviewReconcileAsyncGate()
+        let freshReadGate = ReviewReconcileAsyncGate()
+        let suiteName = "review-submit-preserve-presented-\(UUID().uuidString.lowercased())"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+        }
+
+        let submissionExecutor = GatedDatabaseReviewSubmissionExecutor(
+            databaseURL: database.databaseURL,
+            gate: submissionGate
+        )
+        let store = self.makeReviewStoreForIdentityTest(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionExecutor: submissionExecutor,
+            reviewHeadLoader: { databaseURL, workspaceId, resolvedReviewFilter, reviewQueryDefinition, now, limit in
+                XCTFail("Local submission settlement must not start a blocking review head load")
+                await freshReadGate.wait()
+                return try await defaultReviewHeadLoader(
+                    databaseURL: databaseURL,
+                    workspaceId: workspaceId,
+                    resolvedReviewFilter: resolvedReviewFilter,
+                    reviewQueryDefinition: reviewQueryDefinition,
+                    now: now,
+                    seedQueueSize: limit
+                )
+            },
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: { databaseURL, workspaceId, reviewQueryDefinition, excludedCardIds, now, limit in
+                await staleChunkGate.wait()
+                try Task.checkCancellation()
+                return try await defaultReviewQueueChunkLoader(
+                    databaseURL: databaseURL,
+                    workspaceId: workspaceId,
+                    reviewQueryDefinition: reviewQueryDefinition,
+                    excludedCardIds: excludedCardIds,
+                    now: now,
+                    chunkSize: limit
+                )
+            },
+            reviewQueueWindowLoader: { databaseURL, workspaceId, reviewQueryDefinition, now, limit in
+                await freshReadGate.wait()
+                return try await defaultReviewQueueWindowLoader(
+                    databaseURL: databaseURL,
+                    workspaceId: workspaceId,
+                    reviewQueryDefinition: reviewQueryDefinition,
+                    now: now,
+                    limit: limit
+                )
+            },
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        store.reviewRuntime.cancelForAccountDeletion()
+        store.workspace = bootstrapSnapshot.workspace
+        store.schedulerSettings = bootstrapSnapshot.schedulerSettings
+        store.cards = initialCards
+        store.decks = []
+        store.applyReviewPublishedState(
+            reviewState: ReviewQueuePublishedState(
+                selectedReviewFilter: .allCards,
+                reviewQueue: [cardA, cardB],
+                presentedReviewCard: cardA,
+                reviewCounts: ReviewCounts(dueCount: 2, totalCount: 3),
+                isReviewHeadLoading: false,
+                isReviewCountsLoading: false,
+                isReviewQueueChunkLoading: false,
+                pendingReviewCardIds: [],
+                reviewSubmissionFailure: nil
+            )
+        )
+        store.reviewRuntime.state.hasMoreReviewQueueCards = true
+
+        try store.enqueueReviewSubmission(cardId: cardA.cardId, rating: .good)
+        let firstSubmissionTask = try XCTUnwrap(store.reviewRuntime.state.activeReviewProcessorTask)
+        let staleChunkTask = try XCTUnwrap(store.reviewRuntime.state.activeReviewQueueChunkTask)
+        await submissionGate.waitUntilEntered()
+        await staleChunkGate.waitUntilEntered()
+        XCTAssertEqual(store.presentedReviewCard?.cardId, cardB.cardId)
+
+        try self.moveReviewScheduleCardDueAt(
+            database: database,
+            workspaceId: workspaceId,
+            cardId: cardCSeed.cardId,
+            dueAt: now.addingTimeInterval(-60)
+        )
+        await submissionGate.release()
+        await freshReadGate.waitUntilEntered()
+
+        XCTAssertEqual(store.presentedReviewCard?.cardId, cardB.cardId)
+        XCTAssertEqual(store.reviewQueue.map(\.cardId), [cardA.cardId, cardB.cardId])
+        XCTAssertEqual(store.reviewCounts, ReviewCounts(dueCount: 2, totalCount: 3))
+        XCTAssertEqual(store.pendingReviewCardIds, [cardA.cardId])
+        XCTAssertNil(store.reviewSubmissionFailure)
+        XCTAssertFalse(store.isReviewQueueChunkLoading)
+
+        await freshReadGate.release()
+        await firstSubmissionTask.value
+
+        XCTAssertEqual(store.presentedReviewCard?.cardId, cardB.cardId)
+        XCTAssertEqual(store.effectiveReviewQueue.map(\.cardId), [cardB.cardId, cardCSeed.cardId])
+        XCTAssertFalse(store.pendingReviewCardIds.contains(cardA.cardId))
+
+        await staleChunkGate.release()
+        await staleChunkTask.value
+        XCTAssertEqual(store.presentedReviewCard?.cardId, cardB.cardId)
+        XCTAssertEqual(store.effectiveReviewQueue.map(\.cardId), [cardB.cardId, cardCSeed.cardId])
+
+        try store.enqueueReviewSubmission(cardId: cardB.cardId, rating: .good)
+        let secondSubmissionTask = try XCTUnwrap(store.reviewRuntime.state.activeReviewProcessorTask)
+        XCTAssertEqual(store.presentedReviewCard?.cardId, cardCSeed.cardId)
+        await secondSubmissionTask.value
+
+        XCTAssertEqual(store.presentedReviewCard?.cardId, cardCSeed.cardId)
+        XCTAssertEqual(store.effectiveReviewQueue.first?.cardId, cardCSeed.cardId)
+    }
+
     @MainActor
     func testSchedulerWriteSnapshotReadFailurePreservesPublishedReviewState() throws {
         let database = try self.makeDatabase()
@@ -710,4 +879,3 @@ private actor GatedDatabaseReviewSubmissionExecutor: ReviewSubmissionExecuting {
         return try await self.executor.submitReview(workspaceId: workspaceId, submission: submission)
     }
 }
-


### PR DESCRIPTION
## Summary
- preserve the already-presented review card while invalidated active loads settle
- allow applied remote pulls to report review-card replacement without banner noise for stable selection or acknowledgement-only syncs
- add real local-database store coverage for settlement, blocking-load preservation, and sync banner semantics

## Review
- cumulative promotion review: no P0-P4 issues found
- no accepted residuals

## Validation
- local project checks were not run; required GitHub CI owns executable validation for promotion to main