### PR TITLE
Simplify card math rendering contract

### DIFF
--- a/docs/review-markdown-rendering.md
+++ b/docs/review-markdown-rendering.md
@@ -16,8 +16,9 @@ An ordinary Markdown link or image is a Markdown presentation cue on every
 client. Inline emphasis by itself does not change presentation selection. For
 example, `A **short** answer` remains subject to the existing plain-text
 selection policy unless the same content contains another Markdown cue.
-Recognized inline or display math is also a Markdown presentation cue. Escaped
-or unbalanced dollar signs and dollar signs inside code are not math cues.
+Eligible inline-source or display math is also a Markdown presentation cue.
+Literal math forms described below, escaped or unbalanced dollar signs, and
+dollar signs inside code are not math cues.
 
 ## Markdown subset
 
@@ -34,7 +35,7 @@ GFM subset:
 - links
 - tables
 - images
-- inline and display math
+- inline-source and display math rendered as standalone blocks
 
 Raw HTML is unsupported. Full TeX documents, custom packages, DOM commands, and
 platform-specific syntax are also unsupported. Card content must not depend on
@@ -42,9 +43,10 @@ those forms being interpreted.
 
 ## Math syntax
 
-Outside code, an unescaped single dollar sign opens inline math and the next
-unescaped single dollar sign on the same line closes it. The content between the
-delimiters is the LaTeX source. Inline math cannot span lines.
+Outside code, an unescaped single dollar sign opens inline-source math and the
+next unescaped single dollar sign on the same logical line closes it. The
+content between the delimiters is the LaTeX source. Inline-source math cannot
+span lines.
 
 Display math opens and closes with separate delimiter lines. Each delimiter line
 contains only optional spaces or tabs and exactly `$$`; the body between them may
@@ -52,28 +54,40 @@ span lines. A `$$` token anywhere else is literal text.
 
 Outside code, `\$` produces a literal dollar sign and cannot open or close math.
 Currency dollar signs therefore need escaping, for example `\$5` and `\$10`.
-Any inline or display delimiter without a matching close remains literal,
-including its opening delimiter.
+Any inline-source or display delimiter without a matching close remains
+literal, including its opening delimiter.
 
-Fenced code blocks and inline code spans take precedence over math and are never
-scanned for math delimiters. Math recognition applies only to Markdown text
-content, not link or image destinations, so it does not reinterpret `fcasset:`
-managed-media URLs. Existing managed-media parsing and rendering behavior is
-unchanged.
+Fenced and indented code blocks and inline code spans take precedence over math
+and are never scanned for math delimiters. Inline-source math is eligible only
+in a top-level plain paragraph whose children are ordinary text or formula
+spans. Display math is eligible only as a direct top-level document block.
+
+Math nested inside links, images or managed-media labels, emphasis, strong,
+strikethrough, headings, lists, blockquotes, tables, code, autolinks, or raw HTML
+remains literal. If a card side contains any reference-style link or image
+definition, V1 performs no math segmentation anywhere on that side and all
+dollar-delimited source remains literal. Ineligible or unbalanced delimiters
+also remain literal. These outcomes are deliberate V1 product behavior, not
+cases for clients to recover by reconstructing the full CommonMark source.
+
+Math recognition does not reinterpret link or image destinations, including
+`fcasset:` managed-media URLs. Stored card data, APIs, sync, and existing
+managed-media parsing and rendering behavior are unchanged.
 
 Applications maintain no LaTeX command allowlist. Every expression that RaTeX
-accepts is eligible to render. This does not extend support to full TeX
-documents, custom packages, DOM commands, or platform-specific syntax that
-RaTeX does not accept.
+0.1.14 accepts is eligible to render. This does not extend support to full TeX
+documents or commands and syntax that RaTeX does not support.
 
 ## Math rendering and accessibility
 
-Inline formulas participate in the surrounding text flow. Display formulas are
-top-level blocks with horizontal scrolling so wide formulas do not resize or
-clip the card.
+Every accepted formula renders in display style as a standalone horizontally
+scrollable block so wide formulas do not resize or clip the card. Eligible
+inline-source math splits its top-level paragraph into ordered Markdown and
+formula segments. For example, `Before $x$ after` renders as Markdown `Before`,
+a formula block for `x`, and Markdown `after`.
 
 When RaTeX rejects a recognized formula, the formula remains visibly
-represented by its original delimited source, the UI exposes an explicit render
+represented by its original delimited source, the UI exposes a localized render
 error, and the client logs the underlying RaTeX error. A rejected formula must
 not disappear or degrade to an empty placeholder.
 
@@ -82,32 +96,57 @@ delimiters, without the opening or closing dollar signs.
 
 ## Compact math parity fixture
 
-For a runnable fixture, replace `<mediaAssetId>` with an asset ID inserted
-through the app's image action; do not type or invent an asset ID.
+Treat each numbered source below as a separate card side. For the managed-media
+case, replace `<mediaAssetId>` through the app's image action; do not type or
+invent an asset ID.
 
-````markdown
-Inline math: $E = mc^2$ and currency: \$5.
+1. `Before $x$ after` becomes Markdown `Before`, a display-style block for `x`,
+   and Markdown `after`.
+2. A top-level display block renders as one horizontally scrollable formula:
 
-Inline code keeps dollars literal: `$not_math$`.
+   ```markdown
+   $$
+   \int_0^1 x^2\,dx = \frac{1}{3}
+   $$
+   ```
 
-$$
-\int_0^1 x^2\,dx = \frac{1}{3}
-$$
+3. `Price: \$5` keeps the escaped dollar literal.
+4. Inline, fenced, and indented code keep dollar-delimited text literal:
 
-```text
-$also_not_math$ and $$
-```
+   ````markdown
+   `$inline_code$`
 
-![Managed image](fcasset:<mediaAssetId>)
+   ```text
+   $fenced_code$
+   ```
 
-Invalid recognized formula: $\frac{1}{$
-````
+       $indented_code$
+   ````
 
-Every client must produce equivalent semantics: the inline and display formulas
-render in their respective layouts; the escaped dollar and code examples stay
-literal; the managed image uses the existing native managed-media path; and the
-invalid formula remains visible with an explicit render error while its
-underlying RaTeX error is logged.
+5. `[$link_label$](https://flashcards-open-source-app.com)` keeps the link-label
+   math literal.
+6. `**$strong$**` keeps the strong math literal.
+7. `- $list_item$` keeps the list math literal.
+8. `![Managed $label$](fcasset:<mediaAssetId>)` uses the existing managed-media
+   path and does not render label math.
+9. This complete side contains a reference-style definition, so it performs no
+   math segmentation and keeps `$x$` literal:
+
+   ```markdown
+   Reference side with $x$ and [documentation][docs].
+
+   [docs]: https://flashcards-open-source-app.com
+   ```
+
+10. `Unbalanced $x` remains literal.
+11. `Invalid $\frac{1}{$` is a recognized formula; it remains visible with its
+    delimiters, a localized render error, and a logged underlying RaTeX error.
+
+Speech and accessibility expose `x`, `\int_0^1 x^2\,dx = \frac{1}{3}`, and
+other recognized formula sources without delimiters. Client rendering work is
+handled by `02-web-block-math`, `03-android-block-math`, and
+`04-ios-block-math`; AI authoring wording remains deferred to
+`05-ai-card-math-authoring` after release.
 
 ## Managed media
 


### PR DESCRIPTION
## Summary
- narrow the unreleased cross-client math contract to deterministic block-only rendering
- document literal nested, container, code, malformed, and reference-definition cases
- update the compact parity fixture and deferred client/AI work

## Validation
- not run (documentation-only integration PR; per repository instructions)