### PR TITLE
feat(android): render review math blocks

### DIFF
--- a/apps/android/feature/review/build.gradle.kts
+++ b/apps/android/feature/review/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.markdown.renderer)
     implementation(libs.markdown.renderer.m3)
     implementation(libs.markdown.renderer.coil3)
+    implementation(libs.ratex.android)
 
     testImplementation(libs.junit4)
 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -294,7 +294,7 @@ fun ReviewRoute(
                     uiState.preparedCurrentCard?.let { currentCard ->
                         reviewSpeechController.toggleSpeech(
                             side = ReviewSpeechSide.FRONT,
-                            sourceText = currentCard.card.frontText,
+                            speakableText = currentCard.frontSpeakableText,
                             fallbackLanguageTag = reviewSpeechFallbackLanguageTag,
                             onError = { message ->
                                 speechErrorMessage = message
@@ -306,7 +306,7 @@ fun ReviewRoute(
                     uiState.preparedCurrentCard?.let { currentCard ->
                         reviewSpeechController.toggleSpeech(
                             side = ReviewSpeechSide.BACK,
-                            sourceText = currentCard.card.backText,
+                            speakableText = currentCard.backSpeakableText,
                             fallbackLanguageTag = reviewSpeechFallbackLanguageTag,
                             onError = { message ->
                                 speechErrorMessage = message

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewCardPresentationPreparation.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewCardPresentationPreparation.kt
@@ -16,6 +16,14 @@ fun prepareReviewCardPresentation(
     } else {
         card.backText
     }
+    val preparedFrontContent: PreparedReviewContent = prepareReviewContent(
+        text = card.frontText,
+        mediaAssetsById = mediaAssetsById
+    )
+    val preparedBackContent: PreparedReviewContent = prepareReviewContent(
+        text = normalizedBackText,
+        mediaAssetsById = mediaAssetsById
+    )
 
     return PreparedReviewCardPresentation(
         card = card,
@@ -23,16 +31,14 @@ fun prepareReviewCardPresentation(
         dueLabel = textProvider.dueLabel(dueAtMillis = card.dueAtMillis),
         repsLabel = textProvider.repsLabel(reps = card.reps),
         lapsesLabel = textProvider.lapsesLabel(lapses = card.lapses),
-        frontContent = makeReviewRenderedContent(
-            text = card.frontText,
-            mediaAssetsById = mediaAssetsById
-        ),
-        backContent = makeReviewRenderedContent(
-            text = normalizedBackText,
-            mediaAssetsById = mediaAssetsById
-        ),
-        frontSpeakableText = makeReviewSpeakableText(text = card.frontText),
-        backSpeakableText = makeReviewSpeakableText(text = card.backText),
+        frontContent = preparedFrontContent.renderedContent,
+        backContent = preparedBackContent.renderedContent,
+        frontSpeakableText = preparedFrontContent.speakableText,
+        backSpeakableText = if (card.backText.trim().isEmpty()) {
+            ""
+        } else {
+            preparedBackContent.speakableText
+        },
         answerOptions = answerOptions.map { option ->
             PreparedReviewAnswerOption(
                 rating = option.rating,
@@ -55,18 +61,24 @@ fun refreshPreparedReviewCardPresentationMedia(
     } else {
         card.backText
     }
+    val preparedFrontContent: PreparedReviewContent = prepareReviewContent(
+        text = card.frontText,
+        mediaAssetsById = mediaAssetsById
+    )
+    val preparedBackContent: PreparedReviewContent = prepareReviewContent(
+        text = normalizedBackText,
+        mediaAssetsById = mediaAssetsById
+    )
 
     return presentation.copy(
-        frontContent = makeReviewRenderedContent(
-            text = card.frontText,
-            mediaAssetsById = mediaAssetsById
-        ),
-        backContent = makeReviewRenderedContent(
-            text = normalizedBackText,
-            mediaAssetsById = mediaAssetsById
-        ),
-        frontSpeakableText = makeReviewSpeakableText(text = card.frontText),
-        backSpeakableText = makeReviewSpeakableText(text = card.backText)
+        frontContent = preparedFrontContent.renderedContent,
+        backContent = preparedBackContent.renderedContent,
+        frontSpeakableText = preparedFrontContent.speakableText,
+        backSpeakableText = if (card.backText.trim().isEmpty()) {
+            ""
+        } else {
+            preparedBackContent.speakableText
+        }
     )
 }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
@@ -37,7 +37,17 @@ sealed interface ReviewManagedMarkdownBlock {
     data class ManagedMedia(
         val reference: ReviewManagedMediaReference
     ) : ReviewManagedMarkdownBlock
+
+    data class Formula(
+        val source: String,
+        val delimitedSource: String
+    ) : ReviewManagedMarkdownBlock
 }
+
+internal data class PreparedReviewContent(
+    val renderedContent: ReviewRenderedContent,
+    val speakableText: String
+)
 
 data class ReviewManagedMediaReference(
     val mediaAssetId: String,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
@@ -61,10 +61,34 @@ fun classifyReviewContentPresentation(text: String): ReviewContentPresentationMo
     return ReviewContentPresentationMode.SHORT_PLAIN
 }
 
-fun makeReviewRenderedContent(
+internal fun prepareReviewContent(
     text: String,
     mediaAssetsById: Map<String, MediaAsset>
+): PreparedReviewContent {
+    val mathBlocks: List<ReviewMathBlock> = extractReviewMathBlocks(markdown = text)
+    val renderedContent: ReviewRenderedContent = makeReviewRenderedContent(
+        text = text,
+        mediaAssetsById = mediaAssetsById,
+        mathBlocks = mathBlocks
+    )
+    return PreparedReviewContent(
+        renderedContent = renderedContent,
+        speakableText = makeReviewSpeakableText(mathBlocks = mathBlocks)
+    )
+}
+
+private fun makeReviewRenderedContent(
+    text: String,
+    mediaAssetsById: Map<String, MediaAsset>,
+    mathBlocks: List<ReviewMathBlock>
 ): ReviewRenderedContent {
+    if (mathBlocks.any { block -> block is ReviewMathBlock.Formula }) {
+        return makeReviewMathMarkdownContent(
+            mathBlocks = mathBlocks,
+            mediaAssetsById = mediaAssetsById
+        )
+    }
+
     val managedMarkdown: ReviewRenderedContent.ManagedMarkdown? = makeReviewManagedMarkdownContent(
         text = text,
         mediaAssetsById = mediaAssetsById
@@ -73,10 +97,57 @@ fun makeReviewRenderedContent(
         return managedMarkdown
     }
 
+    val plainText: String = (mathBlocks.single() as ReviewMathBlock.Markdown).normalizedMarkdown
     return when (classifyReviewContentPresentation(text = text)) {
-        ReviewContentPresentationMode.SHORT_PLAIN -> ReviewRenderedContent.ShortPlain(text = text)
-        ReviewContentPresentationMode.PARAGRAPH_PLAIN -> ReviewRenderedContent.ParagraphPlain(text = text)
+        ReviewContentPresentationMode.SHORT_PLAIN -> ReviewRenderedContent.ShortPlain(text = plainText)
+        ReviewContentPresentationMode.PARAGRAPH_PLAIN -> {
+            ReviewRenderedContent.ParagraphPlain(text = plainText)
+        }
         ReviewContentPresentationMode.RICH -> ReviewRenderedContent.Markdown(markdown = text)
+    }
+}
+
+private fun makeReviewMathMarkdownContent(
+    mathBlocks: List<ReviewMathBlock>,
+    mediaAssetsById: Map<String, MediaAsset>
+): ReviewRenderedContent.ManagedMarkdown {
+    val renderedBlocks: List<ReviewManagedMarkdownBlock> = buildList {
+        mathBlocks.forEach { block ->
+            when (block) {
+                is ReviewMathBlock.Markdown -> addAll(
+                    reviewManagedMarkdownBlocks(
+                        text = block.markdown,
+                        mediaAssetsById = mediaAssetsById
+                    )
+                )
+
+                is ReviewMathBlock.Formula -> add(
+                    ReviewManagedMarkdownBlock.Formula(
+                        source = block.source,
+                        delimitedSource = block.delimitedSource
+                    )
+                )
+            }
+        }
+    }
+    return ReviewRenderedContent.ManagedMarkdown(blocks = renderedBlocks)
+}
+
+private fun reviewManagedMarkdownBlocks(
+    text: String,
+    mediaAssetsById: Map<String, MediaAsset>
+): List<ReviewManagedMarkdownBlock> {
+    val managedContent: ReviewRenderedContent.ManagedMarkdown? = makeReviewManagedMarkdownContent(
+        text = text,
+        mediaAssetsById = mediaAssetsById
+    )
+    if (managedContent != null) {
+        return managedContent.blocks
+    }
+    return if (text.isBlank()) {
+        emptyList()
+    } else {
+        listOf(ReviewManagedMarkdownBlock.Markdown(markdown = text))
     }
 }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
@@ -1,0 +1,502 @@
+package com.flashcardsopensourceapp.feature.review
+
+internal sealed interface ReviewMathBlock {
+    data class Markdown(
+        val markdown: String,
+        val normalizedMarkdown: String
+    ) : ReviewMathBlock
+
+    data class Formula(
+        val source: String,
+        val delimitedSource: String
+    ) : ReviewMathBlock
+}
+
+private data class ReviewMathLine(
+    val startOffset: Int,
+    val contentEndOffset: Int,
+    val endOffset: Int,
+    val content: String
+)
+
+private data class ReviewMathCandidate(
+    val startOffset: Int,
+    val endOffset: Int,
+    val source: String,
+    val delimitedSource: String
+)
+
+private data class ReviewMathExtraction(
+    val candidates: List<ReviewMathCandidate>,
+    val escapedDollarOffsets: List<Int>,
+    val hasAmbiguousDisplayDelimiter: Boolean
+)
+
+private data class ReviewInlineMathExtraction(
+    val candidates: List<ReviewMathCandidate>,
+    val escapedDollarOffsets: List<Int>
+)
+
+private const val reviewProtectedProseCharacters: String = "[]`|<>*_~"
+private val reviewReferenceDefinitionRegex: Regex = Regex(
+    pattern = """^\s*(?:(?:>\s*)|(?:[-+*]\s+)|(?:\d+[.)]\s+))*\[(?:\\.|[^]])+]:"""
+)
+private val reviewContainerRegex: Regex = Regex(
+    pattern = """^\s{0,3}(?:>\s*|[-+*]\s+|\d+[.)]\s+)"""
+)
+private val reviewAtxHeadingRegex: Regex = Regex(
+    pattern = """^\s{0,3}#{1,6}(?:\s+|$)"""
+)
+private val reviewSetextBoundaryRegex: Regex = Regex(
+    pattern = """^\s{0,3}(?:=+|-+)\s*$"""
+)
+private val reviewBareLinkRegex: Regex = Regex(
+    pattern = """(?i)(?:https?://|www\.)"""
+)
+private val reviewBareEmailRegex: Regex = Regex(
+    pattern = """[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"""
+)
+private val reviewExplicitLinkRegex: Regex = Regex(
+    pattern = """!?\[[^]\r\n]*]\s*(?:\([^)]*\)|\[[^]\r\n]*])"""
+)
+
+internal fun extractReviewMathBlocks(markdown: String): List<ReviewMathBlock> {
+    val lines: List<ReviewMathLine> = makeReviewMathLines(markdown = markdown)
+    val extraction: ReviewMathExtraction = extractReviewMathCandidates(
+        markdown = markdown,
+        lines = lines
+    )
+    val hasReferenceDefinition: Boolean = lines.any { line ->
+        reviewReferenceDefinitionRegex.containsMatchIn(line.content)
+    }
+    // This conservative boundary is intentional cross-client V1 behavior.
+    val candidates: List<ReviewMathCandidate> = if (
+        hasReferenceDefinition || extraction.hasAmbiguousDisplayDelimiter
+    ) {
+        emptyList()
+    } else {
+        extraction.candidates.sortedBy { candidate -> candidate.startOffset }
+    }
+
+    return makeReviewMathBlocks(
+        markdown = markdown,
+        candidates = candidates,
+        escapedDollarOffsets = extraction.escapedDollarOffsets
+    )
+}
+
+private fun extractReviewMathCandidates(
+    markdown: String,
+    lines: List<ReviewMathLine>
+): ReviewMathExtraction {
+    val candidates: MutableList<ReviewMathCandidate> = mutableListOf()
+    val escapedDollarOffsets: MutableList<Int> = mutableListOf()
+    var hasAmbiguousDisplayDelimiter: Boolean = false
+    var lineIndex: Int = 0
+
+    while (lineIndex < lines.size) {
+        val line: ReviewMathLine = lines[lineIndex]
+        val fenceMarker: String? = reviewFenceMarker(line = line.content)
+        when {
+            line.content.isBlank() -> lineIndex += 1
+
+            fenceMarker != null -> {
+                lineIndex = reviewLineIndexAfterFence(
+                    lines = lines,
+                    openingLineIndex = lineIndex,
+                    marker = fenceMarker
+                )
+            }
+
+            isReviewIndentedCodeLine(line = line.content) -> lineIndex += 1
+
+            reviewReferenceDefinitionRegex.containsMatchIn(line.content) -> {
+                lineIndex = reviewLineIndexAfterLiteralBlock(
+                    lines = lines,
+                    startLineIndex = lineIndex
+                )
+            }
+
+            isReviewDisplayDelimiterLine(line = line.content) -> {
+                val closingLineIndex: Int? = findReviewDisplayClosingLine(
+                    lines = lines,
+                    openingLineIndex = lineIndex
+                )
+                if (closingLineIndex == null) {
+                    hasAmbiguousDisplayDelimiter = true
+                    lineIndex = reviewLineIndexAfterLiteralBlock(
+                        lines = lines,
+                        startLineIndex = lineIndex
+                    )
+                } else {
+                    makeReviewDisplayCandidate(
+                        markdown = markdown,
+                        openingLine = line,
+                        closingLine = lines[closingLineIndex]
+                    )?.let(candidates::add)
+                    lineIndex = closingLineIndex + 1
+                }
+            }
+
+            isReviewContainerLine(line = line.content) || isReviewRawHtmlLine(line = line.content) -> {
+                lineIndex = reviewLineIndexAfterLiteralBlock(
+                    lines = lines,
+                    startLineIndex = lineIndex
+                )
+            }
+
+            isReviewSingleLineBoundary(line = line.content) -> lineIndex += 1
+
+            else -> {
+                val paragraphEndIndex: Int = findReviewParagraphEndIndex(
+                    lines = lines,
+                    startLineIndex = lineIndex
+                )
+                val nextLine: ReviewMathLine? = lines.getOrNull(index = paragraphEndIndex)
+                val isSetextOrTable: Boolean = nextLine != null && (
+                    reviewSetextBoundaryRegex.matches(nextLine.content) ||
+                        reviewTableDelimiterRegex.matches(nextLine.content)
+                    )
+                if (isSetextOrTable.not()) {
+                    val paragraphExtraction: ReviewInlineMathExtraction? = extractReviewInlineParagraph(
+                        markdown = markdown,
+                        lines = lines.subList(
+                            fromIndex = lineIndex,
+                            toIndex = paragraphEndIndex
+                        )
+                    )
+                    if (paragraphExtraction != null) {
+                        candidates.addAll(paragraphExtraction.candidates)
+                        escapedDollarOffsets.addAll(paragraphExtraction.escapedDollarOffsets)
+                    }
+                }
+                lineIndex = paragraphEndIndex
+            }
+        }
+    }
+
+    return ReviewMathExtraction(
+        candidates = candidates,
+        escapedDollarOffsets = escapedDollarOffsets,
+        hasAmbiguousDisplayDelimiter = hasAmbiguousDisplayDelimiter
+    )
+}
+
+private fun makeReviewMathLines(markdown: String): List<ReviewMathLine> {
+    val lines: MutableList<ReviewMathLine> = mutableListOf()
+    var lineStart: Int = 0
+    while (lineStart < markdown.length) {
+        var contentEnd: Int = lineStart
+        while (contentEnd < markdown.length &&
+            markdown[contentEnd] != '\r' &&
+            markdown[contentEnd] != '\n'
+        ) {
+            contentEnd += 1
+        }
+        var lineEnd: Int = contentEnd
+        if (lineEnd < markdown.length && markdown[lineEnd] == '\r') {
+            lineEnd += 1
+        }
+        if (lineEnd < markdown.length && markdown[lineEnd] == '\n') {
+            lineEnd += 1
+        }
+        lines.add(
+            ReviewMathLine(
+                startOffset = lineStart,
+                contentEndOffset = contentEnd,
+                endOffset = lineEnd,
+                content = markdown.substring(startIndex = lineStart, endIndex = contentEnd)
+            )
+        )
+        lineStart = lineEnd
+    }
+    return lines
+}
+
+private fun reviewLineIndexAfterFence(
+    lines: List<ReviewMathLine>,
+    openingLineIndex: Int,
+    marker: String
+): Int {
+    var lineIndex: Int = openingLineIndex + 1
+    while (lineIndex < lines.size) {
+        if (isReviewFenceClosingLine(line = lines[lineIndex].content, openingMarker = marker)) {
+            return lineIndex + 1
+        }
+        lineIndex += 1
+    }
+    return lines.size
+}
+
+private fun reviewLineIndexAfterLiteralBlock(
+    lines: List<ReviewMathLine>,
+    startLineIndex: Int
+): Int {
+    var lineIndex: Int = startLineIndex + 1
+    while (lineIndex < lines.size && lines[lineIndex].content.isNotBlank()) {
+        lineIndex += 1
+    }
+    return lineIndex
+}
+
+private fun findReviewDisplayClosingLine(
+    lines: List<ReviewMathLine>,
+    openingLineIndex: Int
+): Int? {
+    var lineIndex: Int = openingLineIndex + 1
+    while (lineIndex < lines.size) {
+        if (isReviewDisplayDelimiterLine(line = lines[lineIndex].content)) {
+            return lineIndex
+        }
+        lineIndex += 1
+    }
+    return null
+}
+
+private fun makeReviewDisplayCandidate(
+    markdown: String,
+    openingLine: ReviewMathLine,
+    closingLine: ReviewMathLine
+): ReviewMathCandidate? {
+    val source: String = markdown.substring(
+        startIndex = openingLine.endOffset,
+        endIndex = closingLine.startOffset
+    ).removeSuffix(suffix = "\r\n")
+        .removeSuffix(suffix = "\n")
+        .removeSuffix(suffix = "\r")
+    if (source.isBlank()) {
+        return null
+    }
+    return ReviewMathCandidate(
+        startOffset = openingLine.startOffset,
+        endOffset = closingLine.contentEndOffset,
+        source = source,
+        delimitedSource = markdown.substring(
+            startIndex = openingLine.startOffset,
+            endIndex = closingLine.contentEndOffset
+        )
+    )
+}
+
+private fun findReviewParagraphEndIndex(
+    lines: List<ReviewMathLine>,
+    startLineIndex: Int
+): Int {
+    var lineIndex: Int = startLineIndex
+    while (lineIndex < lines.size && isReviewParagraphBoundary(line = lines[lineIndex].content).not()) {
+        lineIndex += 1
+    }
+    return lineIndex
+}
+
+private fun extractReviewInlineParagraph(
+    markdown: String,
+    lines: List<ReviewMathLine>
+): ReviewInlineMathExtraction? {
+    val candidates: MutableList<ReviewMathCandidate> = mutableListOf()
+    val escapedDollarOffsets: MutableList<Int> = mutableListOf()
+    lines.forEach { line ->
+        val lineExtraction: ReviewInlineMathExtraction = extractReviewInlineLine(
+            markdown = markdown,
+            line = line
+        ) ?: return null
+        candidates.addAll(lineExtraction.candidates)
+        escapedDollarOffsets.addAll(lineExtraction.escapedDollarOffsets)
+    }
+    return ReviewInlineMathExtraction(
+        candidates = candidates,
+        escapedDollarOffsets = escapedDollarOffsets
+    )
+}
+
+private fun extractReviewInlineLine(
+    markdown: String,
+    line: ReviewMathLine
+): ReviewInlineMathExtraction? {
+    if (line.content.firstOrNull()?.isWhitespace() == true ||
+        reviewExplicitLinkRegex.containsMatchIn(line.content)
+    ) {
+        return null
+    }
+    val candidates: MutableList<ReviewMathCandidate> = mutableListOf()
+    val escapedDollarOffsets: MutableList<Int> = mutableListOf()
+    val prose: StringBuilder = StringBuilder()
+    var openingDollarOffset: Int? = null
+    var precedingBackslashCount: Int = 0
+
+    line.content.forEachIndexed { index, character ->
+        if (character == '\\') {
+            precedingBackslashCount += 1
+            if (openingDollarOffset == null) {
+                prose.append(character)
+            }
+            return@forEachIndexed
+        }
+
+        val isEscaped: Boolean = precedingBackslashCount % 2 == 1
+        precedingBackslashCount = 0
+        if (character != '$') {
+            if (openingDollarOffset == null) {
+                prose.append(character)
+            }
+            return@forEachIndexed
+        }
+
+        if (isEscaped) {
+            if (openingDollarOffset == null) {
+                escapedDollarOffsets.add(line.startOffset + index - 1)
+                prose.append(character)
+            }
+            return@forEachIndexed
+        }
+
+        if (line.content.getOrNull(index = index + 1) == '$') {
+            return null
+        }
+
+        val openingOffset: Int? = openingDollarOffset
+        if (openingOffset == null) {
+            openingDollarOffset = index
+        } else {
+            val source: String = line.content.substring(
+                startIndex = openingOffset + 1,
+                endIndex = index
+            )
+            if (source.isBlank()) {
+                return null
+            }
+            candidates.add(
+                ReviewMathCandidate(
+                    startOffset = line.startOffset + openingOffset,
+                    endOffset = line.startOffset + index + 1,
+                    source = source,
+                    delimitedSource = markdown.substring(
+                        startIndex = line.startOffset + openingOffset,
+                        endIndex = line.startOffset + index + 1
+                    )
+                )
+            )
+            openingDollarOffset = null
+        }
+    }
+
+    if (openingDollarOffset != null || containsReviewProtectedProse(source = prose.toString())) {
+        return null
+    }
+    return ReviewInlineMathExtraction(
+        candidates = candidates,
+        escapedDollarOffsets = escapedDollarOffsets
+    )
+}
+
+private fun containsReviewProtectedProse(source: String): Boolean {
+    return source.any { character -> reviewProtectedProseCharacters.contains(character) } ||
+        reviewBareLinkRegex.containsMatchIn(source) ||
+        reviewBareEmailRegex.containsMatchIn(source)
+}
+
+private fun isReviewParagraphBoundary(line: String): Boolean {
+    return line.isBlank() ||
+        reviewFenceMarker(line = line) != null ||
+        isReviewIndentedCodeLine(line = line) ||
+        isReviewDisplayDelimiterLine(line = line) ||
+        isReviewContainerLine(line = line) ||
+        isReviewRawHtmlLine(line = line) ||
+        isReviewSingleLineBoundary(line = line)
+}
+
+private fun isReviewSingleLineBoundary(line: String): Boolean {
+    return reviewAtxHeadingRegex.containsMatchIn(line) ||
+        reviewSetextBoundaryRegex.matches(line) ||
+        reviewHorizontalRuleRegex.matches(line) ||
+        reviewTableDelimiterRegex.matches(line)
+}
+
+private fun isReviewContainerLine(line: String): Boolean {
+    return reviewContainerRegex.containsMatchIn(line)
+}
+
+private fun isReviewRawHtmlLine(line: String): Boolean {
+    return line.trimStart().startsWith(prefix = "<")
+}
+
+private fun isReviewIndentedCodeLine(line: String): Boolean {
+    return line.startsWith(prefix = "\t") || line.startsWith(prefix = "    ")
+}
+
+private fun isReviewDisplayDelimiterLine(line: String): Boolean {
+    return line.trimEnd(chars = charArrayOf(' ', '\t')) == "$$"
+}
+
+private fun makeReviewMathBlocks(
+    markdown: String,
+    candidates: List<ReviewMathCandidate>,
+    escapedDollarOffsets: List<Int>
+): List<ReviewMathBlock> {
+    if (candidates.isEmpty()) {
+        return listOf(
+            makeReviewMarkdownBlock(
+                markdown = markdown,
+                startOffset = 0,
+                endOffset = markdown.length,
+                escapedDollarOffsets = escapedDollarOffsets
+            )
+        )
+    }
+
+    var currentOffset: Int = 0
+    return buildList {
+        candidates.forEach { candidate ->
+            if (currentOffset < candidate.startOffset) {
+                add(
+                    makeReviewMarkdownBlock(
+                        markdown = markdown,
+                        startOffset = currentOffset,
+                        endOffset = candidate.startOffset,
+                        escapedDollarOffsets = escapedDollarOffsets
+                    )
+                )
+            }
+            add(
+                ReviewMathBlock.Formula(
+                    source = candidate.source,
+                    delimitedSource = candidate.delimitedSource
+                )
+            )
+            currentOffset = candidate.endOffset
+        }
+        if (currentOffset < markdown.length) {
+            add(
+                makeReviewMarkdownBlock(
+                    markdown = markdown,
+                    startOffset = currentOffset,
+                    endOffset = markdown.length,
+                    escapedDollarOffsets = escapedDollarOffsets
+                )
+            )
+        }
+    }
+}
+
+private fun makeReviewMarkdownBlock(
+    markdown: String,
+    startOffset: Int,
+    endOffset: Int,
+    escapedDollarOffsets: List<Int>
+): ReviewMathBlock.Markdown {
+    val rawMarkdown: String = markdown.substring(startIndex = startOffset, endIndex = endOffset)
+    val removedOffsets: Set<Int> = escapedDollarOffsets.filter { offset ->
+        offset >= startOffset && offset < endOffset
+    }.toSet()
+    val normalizedMarkdown: String = buildString(capacity = rawMarkdown.length) {
+        rawMarkdown.forEachIndexed { index, character ->
+            if (startOffset + index !in removedOffsets) {
+                append(character)
+            }
+        }
+    }
+    return ReviewMathBlock.Markdown(
+        markdown = rawMarkdown,
+        normalizedMarkdown = normalizedMarkdown
+    )
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathFormulaBlock.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathFormulaBlock.kt
@@ -1,0 +1,130 @@
+package com.flashcardsopensourceapp.feature.review
+
+import android.util.Log
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import io.ratex.RaTeXException
+import io.ratex.RaTeXView
+
+private const val reviewMathLogTag: String = "ReviewMath"
+private val reviewMathBlockCornerRadius = 12.dp
+private val reviewMathMinimumHeight = 48.dp
+
+@Composable
+internal fun ReviewMathFormulaBlock(
+    source: String,
+    delimitedSource: String,
+    modifier: Modifier
+) {
+    var renderError: RaTeXException? by remember(source) {
+        mutableStateOf<RaTeXException?>(value = null)
+    }
+    val errorMessage: String = stringResource(id = R.string.review_math_render_failed)
+    val formulaColor: Int = MaterialTheme.colorScheme.onSurface.toArgb()
+    val formulaFontSize: TextUnit = MaterialTheme.typography.titleLarge.fontSize
+    val localDensity: Density = LocalDensity.current
+    val formulaFontSizeDp: Float = with(localDensity) {
+        formulaFontSize.toPx() / density
+    }
+    val onRenderError: (RaTeXException) -> Unit = { error ->
+        Log.e(reviewMathLogTag, "RaTeX formula rendering failed.", error)
+        renderError = error
+    }
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(reviewMathBlockCornerRadius),
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clearAndSetSemantics {
+                    contentDescription = source
+                    if (renderError != null) {
+                        stateDescription = errorMessage
+                    }
+                }
+        ) {
+            if (renderError != null) {
+                ReviewMathRenderError(
+                    delimitedSource = delimitedSource,
+                    errorMessage = errorMessage
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(state = rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                ) {
+                    AndroidView(
+                        factory = { context -> RaTeXView(context) },
+                        update = { view ->
+                            view.displayMode = true
+                            view.fontSize = formulaFontSizeDp
+                            view.color = formulaColor
+                            view.onError = onRenderError
+                            view.latex = source
+                        },
+                        modifier = Modifier
+                            .heightIn(min = reviewMathMinimumHeight)
+                            .wrapContentSize()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewMathRenderError(
+    delimitedSource: String,
+    errorMessage: String
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(state = rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(
+            text = delimitedSource,
+            style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Monospace)
+        )
+        Text(
+            text = errorMessage,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewRenderedContentView.kt
@@ -61,6 +61,12 @@ fun ReviewRenderedContentView(
                                 onLoadManagedMediaFile = onLoadManagedMediaFile,
                                 onLoadManagedMediaDownloadUrl = onLoadManagedMediaDownloadUrl
                             )
+
+                            is ReviewManagedMarkdownBlock.Formula -> ReviewMathFormulaBlock(
+                                source = block.source,
+                                delimitedSource = block.delimitedSource,
+                                modifier = Modifier.fillMaxWidth()
+                            )
                         }
                     }
                 }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewSpeakableText.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewSpeakableText.kt
@@ -1,6 +1,24 @@
 package com.flashcardsopensourceapp.feature.review
 
-fun makeReviewSpeakableText(text: String): String {
+internal fun makeReviewSpeakableText(
+    mathBlocks: List<ReviewMathBlock>
+): String {
+    if (mathBlocks.any { block -> block is ReviewMathBlock.Formula }) {
+        return mathBlocks.mapNotNull { block ->
+            when (block) {
+                is ReviewMathBlock.Formula -> block.source
+                is ReviewMathBlock.Markdown -> makeReviewSpeakableTextWithoutMath(
+                    text = block.normalizedMarkdown
+                ).ifEmpty { null }
+            }
+        }.joinToString(separator = "\n")
+    }
+
+    val markdownBlock: ReviewMathBlock.Markdown = mathBlocks.single() as ReviewMathBlock.Markdown
+    return makeReviewSpeakableTextWithoutMath(text = markdownBlock.normalizedMarkdown)
+}
+
+private fun makeReviewSpeakableTextWithoutMath(text: String): String {
     if (text.trim().isEmpty()) {
         return ""
     }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/speech/ReviewSpeechSupport.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/speech/ReviewSpeechSupport.kt
@@ -81,11 +81,10 @@ class ReviewSpeechController(
 
     fun toggleSpeech(
         side: ReviewSpeechSide,
-        sourceText: String,
+        speakableText: String,
         fallbackLanguageTag: String,
         onError: (String) -> Unit
     ) {
-        val speakableText = makeReviewSpeakableText(text = sourceText)
         if (speakableText.isEmpty()) {
             return
         }

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="review_media_status_content_description">%1$s. %2$s</string>
     <string name="review_media_unavailable">Media unavailable</string>
     <string name="review_media_video_label">Video attachment</string>
+    <string name="review_math_render_failed">Formula couldn\'t be rendered.</string>
     <string name="review_no_back_text">No back text</string>
     <string name="review_reps_label">Reps %1$d</string>
     <string name="review_lapses_label">Lapses %1$d</string>

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ lottieCompose = "6.7.1"
 coil = "3.5.0"
 # Android 14: pin for ArrayList.removeLast() incompatibility; upgrade once the renderer uses org.jetbrains:markdown 0.7.9+: https://github.com/JetBrains/markdown/issues/197
 markdownRenderer = "0.41.0"
+ratex = "0.1.14"
 room = "2.8.4"
 work = "2.11.2"
 adaptive = "1.2.0"
@@ -57,6 +58,7 @@ coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp"
 markdown-renderer = { group = "com.mikepenz", name = "multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
 markdown-renderer-m3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 markdown-renderer-coil3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-coil3", version.ref = "markdownRenderer" }
+ratex-android = { group = "io.github.erweixin", name = "ratex-android", version.ref = "ratex" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary
- extract conservative standalone review math blocks without changing review state
- render formulas with RaTeX while preserving Markdown, managed media, speech, and error paths
- keep the Android 14-safe MikePenz Markdown pin and avoid direct JetBrains parser APIs

## Validation
- Not run per repository and task instructions; integration PR does not require a CI wait.