### PR TITLE
feat(web): render card math blocks

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -15,11 +15,13 @@
         "micromark": "^4.0.2",
         "micromark-util-decode-string": "^2.0.1",
         "qrcode.react": "^4.2.0",
+        "ratex-wasm": "0.1.14",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
         "react-router": "^8.3.0",
         "remark-gfm": "^4.0.1",
+        "remark-math": "6.0.0",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.0",
         "unist-util-visit": "^5.0.0"
@@ -1474,6 +1476,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2203,6 +2211,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2763,6 +2780,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -3239,6 +3272,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -3555,6 +3607,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -4300,6 +4371,12 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/ratex-wasm": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/ratex-wasm/-/ratex-wasm-0.1.14.tgz",
+      "integrity": "sha512-X/hsdqAA4GEpHgZY7vktrrNjKhHLVXAlFY1du872BLzXQnibYmZzXeQaVeFHarDjMCD5PC75bVxYGD4oinDJjg==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -4380,6 +4457,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -4790,6 +4883,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,11 +19,13 @@
     "micromark": "^4.0.2",
     "micromark-util-decode-string": "^2.0.1",
     "qrcode.react": "^4.2.0",
+    "ratex-wasm": "0.1.14",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
     "react-router": "^8.3.0",
     "remark-gfm": "^4.0.1",
+    "remark-math": "6.0.0",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",
     "unist-util-visit": "^5.0.0"

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -854,6 +854,7 @@ const arCatalog: TranslationCatalog = {
       queue: "لا توجد بطاقات للمراجعة الآن.",
     },
     errors: {
+      mathRenderFailed: "تعذر عرض الصيغة.",
       schedulerUnavailable: "لم يتم تحميل إعدادات جدولة مساحة العمل",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -854,6 +854,7 @@ const deCatalog: TranslationCatalog = {
       queue: "Zurzeit gibt es keine Karten zum Wiederholen.",
     },
     errors: {
+      mathRenderFailed: "Die Formel konnte nicht dargestellt werden.",
       schedulerUnavailable: "Die Planer-Einstellungen des Arbeitsbereichs sind nicht geladen",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -852,6 +852,7 @@ const enCatalog = {
       queue: "No cards to review right now.",
     },
     errors: {
+      mathRenderFailed: "The formula could not be rendered.",
       schedulerUnavailable: "Workspace scheduler settings are not loaded",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -854,6 +854,7 @@ const esEsCatalog: TranslationCatalog = {
       queue: "No hay tarjetas para repasar ahora mismo.",
     },
     errors: {
+      mathRenderFailed: "No se pudo mostrar la fórmula.",
       schedulerUnavailable: "Los ajustes del programador del espacio de trabajo no están cargados",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -854,6 +854,7 @@ const esMxCatalog: TranslationCatalog = {
       queue: "No hay tarjetas para repasar en este momento.",
     },
     errors: {
+      mathRenderFailed: "No se pudo mostrar la fórmula.",
       schedulerUnavailable: "La configuración del programador del espacio de trabajo no está cargada",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -854,6 +854,7 @@ const hiCatalog: TranslationCatalog = {
       queue: "अभी रिव्यू करने के लिए कोई कार्ड नहीं है।",
     },
     errors: {
+      mathRenderFailed: "फ़ॉर्मूला रेंडर नहीं किया जा सका।",
       schedulerUnavailable: "वर्कस्पेस शेड्यूलर सेटिंग्स लोड नहीं हुई हैं",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -854,6 +854,7 @@ export const jaCatalog = {
       queue: "現在、復習するカードはありません。",
     },
     errors: {
+      mathRenderFailed: "数式を表示できませんでした。",
       schedulerUnavailable: "ワークスペースのスケジューラー設定が読み込まれていません",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -854,6 +854,7 @@ export const ruCatalog = {
       queue: "Сейчас нет карточек для повторения.",
     },
     errors: {
+      mathRenderFailed: "Не удалось отобразить формулу.",
       schedulerUnavailable: "Настройки планировщика рабочего пространства не загружены",
     },
     leaderboardShortcut: {

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -854,6 +854,7 @@ export const zhHansCatalog = {
       queue: "当前没有可复习的卡片。",
     },
     errors: {
+      mathRenderFailed: "无法呈现公式。",
       schedulerUnavailable: "工作区调度器设置尚未加载",
     },
     leaderboardShortcut: {

--- a/apps/web/src/screens/review/components/card/ReviewCardSide.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewCardSide.tsx
@@ -5,6 +5,7 @@ import {
 } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 import {
   ManagedMediaReference,
   parseManagedMediaUrlReference,
@@ -15,9 +16,12 @@ import {
   type ManagedMediaReferenceState,
 } from "../../../../media/managedMediaMarkdown";
 import { classifyReviewContentPresentation } from "./reviewContentPresentation";
+import reviewMathBlocks from "./reviewMathBlocks";
+import { ReviewMathBlock } from "./ReviewMathBlock";
 
 const REVIEW_MARKDOWN_FENCE_PATTERN = /^\s{0,3}(`{3,}|~{3,})/;
 const REVIEW_MARKDOWN_SYMBOL_ONLY_LIST_ITEM_PATTERN = /^(\s{0,3}[-*+]\s+)([+*\-#>])(\s*)$/;
+const REVIEW_MARKDOWN_DISPLAY_MATH_DELIMITER_PATTERN = /^[ \t]*\$\$[ \t]*$/;
 
 type MarkdownFenceMarker = "`" | "~";
 type ReviewMarkdownRenderContextValue = Readonly<{
@@ -108,6 +112,7 @@ export function normalizeReviewMarkdownForWeb(text: string): string {
   const lines = text.split("\n");
   const normalizedLines: Array<string> = [];
   let activeFenceMarker: MarkdownFenceMarker | null = null;
+  let isInsideDisplayMath = false;
 
   for (const line of lines) {
     const lineFenceMarker = toMarkdownFenceMarker(line);
@@ -119,6 +124,17 @@ export function normalizeReviewMarkdownForWeb(text: string): string {
         activeFenceMarker = null;
       }
 
+      continue;
+    }
+
+    if (REVIEW_MARKDOWN_DISPLAY_MATH_DELIMITER_PATTERN.test(line)) {
+      isInsideDisplayMath = !isInsideDisplayMath;
+      normalizedLines.push(line);
+      continue;
+    }
+
+    if (isInsideDisplayMath) {
+      normalizedLines.push(line);
       continue;
     }
 
@@ -135,6 +151,18 @@ export function normalizeReviewMarkdownForWeb(text: string): string {
 }
 
 const reviewMarkdownComponents: Components = {
+  div: function ReviewMarkdownDiv({ children, node }) {
+    const formulaSource = node?.properties["data-formula-source"];
+    const delimitedSource = node?.properties["data-delimited-source"];
+    if (typeof formulaSource === "string" && typeof delimitedSource === "string") {
+      return <ReviewMathBlock formulaSource={formulaSource} delimitedSource={delimitedSource} />;
+    }
+    if (formulaSource !== undefined || delimitedSource !== undefined) {
+      throw new Error("Review formula block was missing its source properties");
+    }
+
+    return <div>{children}</div>;
+  },
   a: function ReviewMarkdownAnchor({ children, href, title }) {
     const { localReadVersion, workspaceId } = useReviewMarkdownRenderContext();
     const mediaReference = parseManagedMediaUrlReference(href);
@@ -269,7 +297,9 @@ function ReviewCardMarkdown(props: Readonly<{
       <ReactMarkdown
         urlTransform={reviewMarkdownUrlTransform}
         components={reviewMarkdownComponents}
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={normalizedText.includes("$")
+          ? [remarkGfm, remarkMath, reviewMathBlocks]
+          : [remarkGfm]}
       >
         {normalizedText}
       </ReactMarkdown>

--- a/apps/web/src/screens/review/components/card/ReviewMathBlock.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewMathBlock.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import {
+  initRatex,
+  renderLatexToCanvas,
+} from "ratex-wasm";
+import "ratex-wasm/fonts.css";
+import { useI18n } from "../../../../i18n";
+
+const REVIEW_MATH_FONT_SIZE = 32;
+const REVIEW_MATH_FONT_DESCRIPTORS: ReadonlyArray<string> = [
+  "400 32px KaTeX_AMS",
+  "400 32px KaTeX_Caligraphic",
+  "700 32px KaTeX_Caligraphic",
+  "400 32px KaTeX_Fraktur",
+  "700 32px KaTeX_Fraktur",
+  "400 32px KaTeX_Main",
+  "italic 400 32px KaTeX_Main",
+  "700 32px KaTeX_Main",
+  "italic 700 32px KaTeX_Main",
+  "italic 400 32px KaTeX_Math",
+  "italic 700 32px KaTeX_Math",
+  "400 32px KaTeX_SansSerif",
+  "italic 400 32px KaTeX_SansSerif",
+  "700 32px KaTeX_SansSerif",
+  "400 32px KaTeX_Script",
+  "400 32px KaTeX_Size1",
+  "400 32px KaTeX_Size2",
+  "400 32px KaTeX_Size3",
+  "400 32px KaTeX_Size4",
+  "400 32px KaTeX_Typewriter",
+];
+
+type ReviewMathBlockProps = Readonly<{
+  delimitedSource: string;
+  formulaSource: string;
+}>;
+type ReviewMathRenderState = Readonly<{
+  formulaSource: string;
+  status: "ready" | "failed";
+}> | null;
+
+function readErrorName(error: unknown): string {
+  return error instanceof Error && error.name.trim() !== "" ? error.name : typeof error;
+}
+
+function readErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim() !== "" ? error.message : String(error);
+}
+
+function logReviewMathRenderFailure(formulaSource: string, error: unknown): void {
+  console.error("Review formula rendering failed", {
+    formulaSource,
+    error,
+    errorName: readErrorName(error),
+    errorMessage: readErrorMessage(error),
+  });
+}
+
+async function loadReviewMathFonts(signal: AbortSignal): Promise<void> {
+  await Promise.all(REVIEW_MATH_FONT_DESCRIPTORS.map((descriptor) => document.fonts.load(descriptor)));
+  signal.throwIfAborted();
+}
+
+export function ReviewMathBlock(props: ReviewMathBlockProps): ReactElement {
+  const { delimitedSource, formulaSource } = props;
+  const { t } = useI18n();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [renderState, setRenderState] = useState<ReviewMathRenderState>(null);
+  const renderErrorMessage = t("reviewScreen.errors.mathRenderFailed");
+  const currentRenderStatus = renderState?.formulaSource === formulaSource ? renderState.status : null;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (container === null || canvas === null) {
+      throw new Error("Review formula canvas was unavailable during rendering");
+    }
+
+    const controller = new AbortController();
+    canvas.width = 0;
+    canvas.height = 0;
+
+    async function renderFormula(): Promise<void> {
+      try {
+        await initRatex();
+        controller.signal.throwIfAborted();
+        await loadReviewMathFonts(controller.signal);
+        const color = getComputedStyle(container).getPropertyValue("--text").trim();
+        if (color === "") {
+          throw new Error("Review formula rendering could not resolve the theme text color");
+        }
+        renderLatexToCanvas(
+          formulaSource,
+          canvas,
+          {
+            backgroundColor: "transparent",
+            fontSize: REVIEW_MATH_FONT_SIZE,
+            padding: 8,
+          },
+          {
+            color,
+            displayMode: true,
+          },
+        );
+        controller.signal.throwIfAborted();
+        setRenderState({
+          formulaSource,
+          status: "ready",
+        });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        logReviewMathRenderFailure(formulaSource, error);
+        setRenderState({
+          formulaSource,
+          status: "failed",
+        });
+      }
+    }
+
+    void renderFormula();
+    return () => controller.abort();
+  }, [formulaSource]);
+
+  return (
+    <div ref={containerRef} className="review-math-block" data-render-status={currentRenderStatus ?? "loading"}>
+      <canvas
+        ref={canvasRef}
+        className="review-math-block-canvas"
+        role="img"
+        aria-label={formulaSource}
+        hidden={currentRenderStatus !== "ready"}
+      />
+      {currentRenderStatus === "failed" ? (
+        <div
+          className="review-math-block-error"
+          role="alert"
+          aria-label={`${formulaSource}. ${renderErrorMessage}`}
+        >
+          <code className="review-math-block-source">{delimitedSource}</code>
+          <span>{renderErrorMessage}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/screens/review/components/card/reviewContentPresentation.ts
+++ b/apps/web/src/screens/review/components/card/reviewContentPresentation.ts
@@ -1,3 +1,5 @@
+import { hasEligibleReviewMath } from "./reviewMathBlocks";
+
 /**
  * Keep review content presentation heuristics aligned with:
  * - apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
@@ -11,6 +13,8 @@ const markdownUnorderedListPattern = /^\s{0,3}[-*+]\s+\S/m;
 const markdownOrderedListPattern = /^\s{0,3}\d+\.\s+\S/m;
 const markdownFencedCodePattern = /^\s{0,3}(?:```|~~~)/m;
 const markdownLinkOrMediaPattern = /!?\[[^\]]*]\([^)]+\)/;
+const markdownReferenceLinkOrMediaPattern = /!?\[[^\]]+]\[[^\]]*]/;
+const markdownReferenceDefinitionPattern = /^\s{0,3}\[[^\]]+]:\s+\S/m;
 const markdownThematicBreakPattern = /^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/m;
 const markdownTableSeparatorPattern = /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$/m;
 const newlinePattern = /[\r\n]/;
@@ -25,6 +29,8 @@ function hasStrongMarkdownCue(text: string): boolean {
     || markdownOrderedListPattern.test(text)
     || markdownFencedCodePattern.test(text)
     || markdownLinkOrMediaPattern.test(text)
+    || markdownReferenceLinkOrMediaPattern.test(text)
+    || markdownReferenceDefinitionPattern.test(text)
     || markdownThematicBreakPattern.test(text)
     || markdownTableSeparatorPattern.test(text);
 }
@@ -37,6 +43,10 @@ export function classifyReviewContentPresentation(text: string): ReviewContentPr
   }
 
   if (hasStrongMarkdownCue(trimmedText)) {
+    return "markdown";
+  }
+
+  if (text.includes("$") && hasEligibleReviewMath(text)) {
     return "markdown";
   }
 

--- a/apps/web/src/screens/review/components/card/reviewMathBlocks.ts
+++ b/apps/web/src/screens/review/components/card/reviewMathBlocks.ts
@@ -1,0 +1,313 @@
+import type { Nodes, Parents, Paragraph, Root, RootContent } from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import remarkParse from "remark-parse";
+import type { Plugin } from "unified";
+import { unified } from "unified";
+import { EXIT, SKIP, visit } from "unist-util-visit";
+
+const DISPLAY_MATH_OPEN_PATTERN = /^[ \t]*\$\$[ \t]*(?:\r\n|\r|\n)/;
+const DISPLAY_MATH_CLOSE_PATTERN = /(?:\r\n|\r|\n)[ \t]*\$\$[ \t]*$/;
+
+type ReviewMathSource = Readonly<{
+  delimitedSource: string;
+  endIndex: number;
+  formulaSource: string;
+  startIndex: number;
+}>;
+export type ReviewMathSpeechSegment =
+  | Readonly<{
+    kind: "formula";
+    value: string;
+  }>
+  | Readonly<{
+    kind: "prose";
+    startsAtLineBoundary: boolean;
+    value: string;
+  }>;
+
+function requireNodeSource(text: string, node: Nodes): ReviewMathSource {
+  const startIndex = node.position?.start.offset;
+  const endIndex = node.position?.end.offset;
+  if (startIndex === undefined || endIndex === undefined) {
+    throw new Error(`Review math parser returned a ${node.type} node without source offsets`);
+  }
+
+  return {
+    delimitedSource: text.slice(startIndex, endIndex),
+    endIndex,
+    formulaSource: node.type === "math" || node.type === "inlineMath" ? node.value : "",
+    startIndex,
+  };
+}
+
+function readInlineMathSource(text: string, node: Nodes): ReviewMathSource | null {
+  const source = requireNodeSource(text, node);
+  const delimitedSource = source.delimitedSource;
+  if (
+    delimitedSource.length < 2
+    || delimitedSource.startsWith("$$")
+    || delimitedSource.endsWith("$$")
+    || /[\r\n]/.test(delimitedSource)
+  ) {
+    return null;
+  }
+
+  let precedingBackslashCount = 0;
+  for (let index = delimitedSource.length - 2; index >= 0 && delimitedSource[index] === "\\"; index -= 1) {
+    precedingBackslashCount += 1;
+  }
+  if (precedingBackslashCount % 2 !== 0) {
+    return null;
+  }
+
+  return {
+    ...source,
+    formulaSource: delimitedSource.slice(1, -1),
+  };
+}
+
+function readDisplayMathSource(text: string, node: Nodes): ReviewMathSource | null {
+  const source = requireNodeSource(text, node);
+  const openMatch = DISPLAY_MATH_OPEN_PATTERN.exec(source.delimitedSource);
+  const closeMatch = DISPLAY_MATH_CLOSE_PATTERN.exec(source.delimitedSource);
+  if (openMatch === null || closeMatch === null || openMatch[0].length > closeMatch.index) {
+    return null;
+  }
+
+  return {
+    ...source,
+    formulaSource: source.delimitedSource.slice(openMatch[0].length, closeMatch.index),
+  };
+}
+
+function sourceKey(source: ReviewMathSource): string {
+  return `${source.startIndex}:${source.endIndex}`;
+}
+
+function nodeSourceKey(node: Nodes): string {
+  const startIndex = node.position?.start.offset;
+  const endIndex = node.position?.end.offset;
+  if (startIndex === undefined || endIndex === undefined) {
+    throw new Error(`Review math parser returned a ${node.type} node without source offsets`);
+  }
+
+  return `${startIndex}:${endIndex}`;
+}
+
+function containsReferenceDefinition(tree: Root): boolean {
+  let containsDefinition = false;
+  visit(tree, "definition", () => {
+    containsDefinition = true;
+    return EXIT;
+  });
+  return containsDefinition;
+}
+
+function collectAcceptedReviewMathSources(tree: Root, text: string): ReadonlyArray<ReviewMathSource> {
+  if (containsReferenceDefinition(tree)) {
+    return [];
+  }
+
+  const sources: Array<ReviewMathSource> = [];
+  for (const child of tree.children) {
+    if (child.type === "math") {
+      const source = readDisplayMathSource(text, child);
+      if (source !== null) {
+        sources.push(source);
+      }
+      continue;
+    }
+
+    if (
+      child.type !== "paragraph"
+      || child.children.every((paragraphChild) => (
+        paragraphChild.type === "text" || paragraphChild.type === "inlineMath"
+      )) === false
+    ) {
+      continue;
+    }
+
+    for (const paragraphChild of child.children) {
+      if (paragraphChild.type !== "inlineMath") {
+        continue;
+      }
+      const source = readInlineMathSource(text, paragraphChild);
+      if (source !== null) {
+        sources.push(source);
+      }
+    }
+  }
+
+  return sources;
+}
+
+function replaceParentChild(parent: Parents | undefined, index: number | undefined, replacement: Nodes): void {
+  if (parent === undefined || index === undefined) {
+    throw new Error("Review math guard could not replace a node without its parent and index");
+  }
+
+  const children = parent.children as Array<Nodes>;
+  children[index] = replacement;
+}
+
+function createContainerMathLiteral(node: Extract<Nodes, { type: "math" }>): string {
+  const openingDelimiter = node.meta === null || node.meta === undefined ? "$$" : `$$${node.meta}`;
+  return `${openingDelimiter}\n${node.value}\n$$`;
+}
+
+function markAcceptedMath(node: Extract<Nodes, { type: "math" }>, source: ReviewMathSource): void {
+  node.value = source.formulaSource;
+  node.meta = null;
+  node.data = {
+    hName: "div",
+    hProperties: {
+      className: ["review-math-block"],
+      "data-formula-source": source.formulaSource,
+      "data-delimited-source": source.delimitedSource,
+    },
+    hChildren: [],
+  };
+}
+
+function createAcceptedInlineMathBlock(
+  node: Extract<Nodes, { type: "inlineMath" }>,
+  source: ReviewMathSource,
+): Extract<RootContent, { type: "math" }> {
+  const mathNode: Extract<RootContent, { type: "math" }> = {
+    type: "math",
+    value: source.formulaSource,
+    meta: null,
+    position: node.position,
+  };
+  markAcceptedMath(mathNode, source);
+  return mathNode;
+}
+
+function splitAcceptedMathParagraph(
+  paragraph: Paragraph,
+  acceptedSourcesByKey: ReadonlyMap<string, ReviewMathSource>,
+): ReadonlyArray<RootContent> {
+  const blocks: Array<RootContent> = [];
+  let textChildren: Paragraph["children"] = [];
+
+  function flushTextChildren(): void {
+    if (textChildren.length === 0) {
+      return;
+    }
+    blocks.push({
+      type: "paragraph",
+      children: textChildren,
+    });
+    textChildren = [];
+  }
+
+  for (const child of paragraph.children) {
+    if (child.type === "inlineMath") {
+      const source = acceptedSourcesByKey.get(nodeSourceKey(child));
+      if (source === undefined) {
+        throw new Error("Review math guard lost an accepted inline formula during paragraph splitting");
+      }
+      flushTextChildren();
+      blocks.push(createAcceptedInlineMathBlock(child, source));
+      continue;
+    }
+
+    textChildren.push(child);
+  }
+  flushTextChildren();
+
+  return blocks;
+}
+
+export function transformReviewMathBlocks(tree: Root, text: string): Root {
+  const transformedTree = structuredClone(tree);
+  const acceptedSources = collectAcceptedReviewMathSources(transformedTree, text);
+  const acceptedSourcesByKey = new Map(acceptedSources.map((source) => [sourceKey(source), source]));
+
+  // This guard is the intentional V1 cross-client boundary for eligible formula topology.
+  visit(transformedTree, "inlineMath", (node, index, parent) => {
+    const source = requireNodeSource(text, node);
+    if (acceptedSourcesByKey.has(sourceKey(source))) {
+      return;
+    }
+    replaceParentChild(parent, index, {
+      type: "text",
+      value: source.delimitedSource,
+      position: node.position,
+    });
+    return SKIP;
+  });
+
+  visit(transformedTree, "math", (node, index, parent) => {
+    const source = requireNodeSource(text, node);
+    const acceptedSource = acceptedSourcesByKey.get(sourceKey(source));
+    if (acceptedSource !== undefined) {
+      markAcceptedMath(node, acceptedSource);
+      return;
+    }
+    replaceParentChild(parent, index, {
+      type: "paragraph",
+      children: [{
+        type: "text",
+        value: parent?.type === "root" ? source.delimitedSource : createContainerMathLiteral(node),
+        position: node.position,
+      }],
+      position: node.position,
+    });
+    return SKIP;
+  });
+
+  transformedTree.children = transformedTree.children.flatMap((child) => {
+    if (child.type !== "paragraph" || child.children.some((paragraphChild) => paragraphChild.type === "inlineMath") === false) {
+      return [child];
+    }
+    return splitAcceptedMathParagraph(child, acceptedSourcesByKey);
+  });
+
+  return transformedTree;
+}
+
+const reviewMathProcessor = unified().use(remarkParse).use(remarkGfm).use(remarkMath);
+
+export function hasEligibleReviewMath(text: string): boolean {
+  return collectAcceptedReviewMathSources(reviewMathProcessor.parse(text), text).length > 0;
+}
+
+export function splitEligibleReviewMathForSpeech(text: string): ReadonlyArray<ReviewMathSpeechSegment> {
+  const sources = [...collectAcceptedReviewMathSources(reviewMathProcessor.parse(text), text)]
+    .sort((left, right) => left.startIndex - right.startIndex);
+  const segments: Array<ReviewMathSpeechSegment> = [];
+  let sourceCursor = 0;
+
+  for (const source of sources) {
+    if (source.startIndex > sourceCursor) {
+      segments.push({
+        kind: "prose",
+        startsAtLineBoundary: sourceCursor === 0 || /[\r\n]/.test(text[sourceCursor - 1] ?? ""),
+        value: text.slice(sourceCursor, source.startIndex),
+      });
+    }
+    segments.push({
+      kind: "formula",
+      value: source.formulaSource,
+    });
+    sourceCursor = source.endIndex;
+  }
+
+  if (sourceCursor < text.length || segments.length === 0) {
+    segments.push({
+      kind: "prose",
+      startsAtLineBoundary: sourceCursor === 0 || /[\r\n]/.test(text[sourceCursor - 1] ?? ""),
+      value: text.slice(sourceCursor),
+    });
+  }
+
+  return segments;
+}
+
+const reviewMathBlocks: Plugin<[], Root> = function reviewMathBlocksPlugin() {
+  return (tree, file) => transformReviewMathBlocks(tree, String(file));
+};
+
+export default reviewMathBlocks;

--- a/apps/web/src/screens/review/speech/reviewSpeech.ts
+++ b/apps/web/src/screens/review/speech/reviewSpeech.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Locale } from "../../../i18n/types";
 import { classifyReviewContentPresentation } from "../components/card/reviewContentPresentation";
+import {
+  splitEligibleReviewMathForSpeech,
+  type ReviewMathSpeechSegment,
+} from "../components/card/reviewMathBlocks";
 
 export type ReviewSpeechSide = "front" | "back";
 
@@ -105,11 +109,15 @@ function fenceMarkerForLine(line: string): string | null {
   return match[1] ?? null;
 }
 
-function normalizeMarkdownSpeakableLine(line: string): string {
+function normalizeMarkdownSpeakableLine(line: string, startsAtLineBoundary: boolean): string {
   const trimmedLine = line.trim();
 
   if (trimmedLine === "") {
     return "";
+  }
+
+  if (startsAtLineBoundary === false) {
+    return normalizeSpeakableInlineText(line);
   }
 
   if (REVIEW_THEMATIC_BREAK_PATTERN.test(trimmedLine) || REVIEW_TABLE_SEPARATOR_PATTERN.test(trimmedLine)) {
@@ -129,33 +137,45 @@ export function makeReviewSpeakableText(text: string): string {
     return normalizeSpeakableParagraphs(text.split(/\r?\n+/));
   }
 
+  const segments: ReadonlyArray<ReviewMathSpeechSegment> = text.includes("$")
+    ? splitEligibleReviewMathForSpeech(text)
+    : [{ kind: "prose", startsAtLineBoundary: true, value: text }];
   const speakableLines: Array<string> = [];
-  const lines = text.split(/\r?\n/);
   let activeFenceMarker: string | null = null;
 
-  for (const line of lines) {
-    const marker = fenceMarkerForLine(line);
+  for (const segment of segments) {
+    if (segment.kind === "formula") {
+      if (segment.value !== "") {
+        speakableLines.push(segment.value);
+      }
+      continue;
+    }
 
-    if (activeFenceMarker !== null) {
-      if (marker === activeFenceMarker) {
-        activeFenceMarker = null;
+    const lines = segment.value.split(/\r?\n/);
+    for (const [lineIndex, line] of lines.entries()) {
+      const startsAtLineBoundary = segment.startsAtLineBoundary || lineIndex > 0;
+      const marker = startsAtLineBoundary ? fenceMarkerForLine(line) : null;
+
+      if (activeFenceMarker !== null) {
+        if (marker === activeFenceMarker) {
+          activeFenceMarker = null;
+        }
+        continue;
       }
 
-      continue;
-    }
+      if (marker !== null) {
+        activeFenceMarker = marker;
+        continue;
+      }
 
-    if (marker !== null) {
-      activeFenceMarker = marker;
-      continue;
-    }
-
-    const normalizedLine = normalizeMarkdownSpeakableLine(line);
-    if (normalizedLine !== "") {
-      speakableLines.push(normalizedLine);
+      const normalizedLine = normalizeMarkdownSpeakableLine(line, startsAtLineBoundary);
+      if (normalizedLine !== "") {
+        speakableLines.push(normalizedLine);
+      }
     }
   }
 
-  return normalizeSpeakableParagraphs(speakableLines);
+  return speakableLines.join("\n");
 }
 
 function scoreLanguageHeuristic(text: string, heuristic: LanguageHeuristic): number {

--- a/apps/web/src/styles/features/review/review-markdown.css
+++ b/apps/web/src/styles/features/review/review-markdown.css
@@ -36,8 +36,38 @@
 .review-markdown-blockquote,
 .review-markdown-pre,
 .review-markdown-table,
-.review-markdown-managed-media {
+.review-markdown-managed-media,
+.review-math-block {
   margin: 0 0 0.75em;
+}
+
+.review-math-block {
+  max-width: 100%;
+  color: var(--text);
+  overflow-x: auto;
+}
+
+.review-math-block-canvas {
+  display: block;
+  width: auto;
+  max-width: none;
+  height: auto;
+}
+
+.review-math-block-canvas[hidden] {
+  display: none;
+}
+
+.review-math-block-error {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--danger);
+}
+
+.review-math-block-source {
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .review-markdown-a {


### PR DESCRIPTION
## Summary
- parse V1-eligible card formulas with official remark-math
- render accepted formulas as standalone RaTeX canvas blocks
- preserve ordinary Markdown, managed media, speech, localization, and visible error behavior

## Validation
- Not run locally per repository and delivery instructions

## Accepted V1 residuals
- cross-line malformed inline math may leave a later formula literal
- rejected nested flow math may normalize literal fence shape or closure
- speech may add boundaries around inline formula chunks
- ambiguous escaped-dollar formulas remain literal