### PR TITLE
Fix escaped-dollar parity in plain review text

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
@@ -151,9 +151,9 @@ func makeReviewRenderedContent(text: String) -> ReviewRenderedContent {
 
     switch classifyReviewContentPresentation(text: text) {
     case .shortPlain:
-        return .shortPlain(text)
+        return .shortPlain(normalizeReviewPlainTextEscapedDollars(text: text))
     case .paragraphPlain:
-        return .paragraphPlain(text)
+        return .paragraphPlain(normalizeReviewPlainTextEscapedDollars(text: text))
     case .markdown:
         return .markdown(makeReviewMarkdownContent(text: text))
     }
@@ -181,7 +181,13 @@ func makeReviewSpeakableText(text: String) -> String {
         }.filter { segment in
             segment.isEmpty == false
         }.joined(separator: "\n")
-    case .literalMarkdown, .none:
+    case .literalMarkdown:
+        return makeReviewSpeakableTextWithoutMath(text: text)
+    case .none:
+        if classifyReviewContentPresentation(text: text) != .markdown {
+            let plainText = normalizeReviewPlainTextEscapedDollars(text: text)
+            return normalizeReviewSpeakableLines(lines: plainText.components(separatedBy: .newlines))
+        }
         return makeReviewSpeakableTextWithoutMath(text: text)
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
@@ -230,6 +230,28 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
     return .segmented(blocks)
 }
 
+func normalizeReviewPlainTextEscapedDollars(text: String) -> String {
+    var normalizedText = ""
+    var precedingBackslashCount = 0
+
+    for character in text {
+        if character == "\\" {
+            precedingBackslashCount += 1
+            continue
+        }
+
+        let preservedBackslashCount = character == "$" && precedingBackslashCount.isMultiple(of: 2) == false
+            ? precedingBackslashCount - 1
+            : precedingBackslashCount
+        normalizedText += String(repeating: "\\", count: preservedBackslashCount)
+        normalizedText.append(character)
+        precedingBackslashCount = 0
+    }
+
+    normalizedText += String(repeating: "\\", count: precedingBackslashCount)
+    return normalizedText
+}
+
 private func makeReviewMathSourceLines(text: String) -> [ReviewMathSourceLine] {
     let rawLines = text.components(separatedBy: "\n")
     return rawLines.enumerated().map { index, rawLine in

--- a/apps/web/src/screens/review/components/card/ReviewCardSide.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewCardSide.tsx
@@ -16,7 +16,7 @@ import {
   type ManagedMediaReferenceState,
 } from "../../../../media/managedMediaMarkdown";
 import { classifyReviewContentPresentation } from "./reviewContentPresentation";
-import reviewMathBlocks from "./reviewMathBlocks";
+import reviewMathBlocks, { normalizeReviewPlainTextEscapedDollars } from "./reviewMathBlocks";
 import { ReviewMathBlock } from "./ReviewMathBlock";
 
 const REVIEW_MARKDOWN_FENCE_PATTERN = /^\s{0,3}(`{3,}|~{3,})/;
@@ -406,7 +406,7 @@ export function ReviewCardSide(props: ReviewCardSideProps): ReactElement {
           >
             {presentationMode === "markdown" ? (
               <ReviewCardMarkdown localReadVersion={localReadVersion} text={text} workspaceId={workspaceId} />
-            ) : text}
+            ) : normalizeReviewPlainTextEscapedDollars(text)}
           </div>
         </div>
 

--- a/apps/web/src/screens/review/components/card/reviewMathBlocks.ts
+++ b/apps/web/src/screens/review/components/card/reviewMathBlocks.ts
@@ -274,6 +274,27 @@ export function hasEligibleReviewMath(text: string): boolean {
   return collectAcceptedReviewMathSources(reviewMathProcessor.parse(text), text).length > 0;
 }
 
+export function normalizeReviewPlainTextEscapedDollars(text: string): string {
+  const normalizedCharacters: Array<string> = [];
+  let precedingBackslashCount = 0;
+
+  for (const character of text) {
+    if (character === "\\") {
+      precedingBackslashCount += 1;
+      continue;
+    }
+
+    const preservedBackslashCount = character === "$" && precedingBackslashCount % 2 !== 0
+      ? precedingBackslashCount - 1
+      : precedingBackslashCount;
+    normalizedCharacters.push("\\".repeat(preservedBackslashCount), character);
+    precedingBackslashCount = 0;
+  }
+
+  normalizedCharacters.push("\\".repeat(precedingBackslashCount));
+  return normalizedCharacters.join("");
+}
+
 export function splitEligibleReviewMathForSpeech(text: string): ReadonlyArray<ReviewMathSpeechSegment> {
   const sources = [...collectAcceptedReviewMathSources(reviewMathProcessor.parse(text), text)]
     .sort((left, right) => left.startIndex - right.startIndex);

--- a/apps/web/src/screens/review/speech/reviewSpeech.ts
+++ b/apps/web/src/screens/review/speech/reviewSpeech.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Locale } from "../../../i18n/types";
 import { classifyReviewContentPresentation } from "../components/card/reviewContentPresentation";
 import {
+  normalizeReviewPlainTextEscapedDollars,
   splitEligibleReviewMathForSpeech,
   type ReviewMathSpeechSegment,
 } from "../components/card/reviewMathBlocks";
@@ -134,7 +135,8 @@ function normalizeMarkdownSpeakableLine(line: string, startsAtLineBoundary: bool
 
 export function makeReviewSpeakableText(text: string): string {
   if (classifyReviewContentPresentation(text) !== "markdown") {
-    return normalizeSpeakableParagraphs(text.split(/\r?\n+/));
+    const plainText = normalizeReviewPlainTextEscapedDollars(text);
+    return normalizeSpeakableParagraphs(plainText.split(/\r?\n+/));
   }
 
   const segments: ReadonlyArray<ReviewMathSpeechSegment> = text.includes("$")


### PR DESCRIPTION
Normalize odd-backslash escaped dollars for Web and iOS plain display and speech paths while preserving original classification and rich content sources.

Review: fresh gpt-5.6-sol/high reviewer reported no P0-P4 issues.

Checks: not run, per integration delivery instructions.