### PR TITLE
Fix Android reference Markdown routing

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentParser.kt
@@ -65,22 +65,24 @@ internal fun prepareReviewContent(
     text: String,
     mediaAssetsById: Map<String, MediaAsset>
 ): PreparedReviewContent {
-    val mathBlocks: List<ReviewMathBlock> = extractReviewMathBlocks(markdown = text)
+    val mathExtraction: ReviewMathBlockExtraction = extractReviewMathBlocks(markdown = text)
     val renderedContent: ReviewRenderedContent = makeReviewRenderedContent(
         text = text,
         mediaAssetsById = mediaAssetsById,
-        mathBlocks = mathBlocks
+        mathBlocks = mathExtraction.blocks,
+        requiresMarkdownRendering = mathExtraction.requiresMarkdownRendering
     )
     return PreparedReviewContent(
         renderedContent = renderedContent,
-        speakableText = makeReviewSpeakableText(mathBlocks = mathBlocks)
+        speakableText = makeReviewSpeakableText(mathBlocks = mathExtraction.blocks)
     )
 }
 
 private fun makeReviewRenderedContent(
     text: String,
     mediaAssetsById: Map<String, MediaAsset>,
-    mathBlocks: List<ReviewMathBlock>
+    mathBlocks: List<ReviewMathBlock>,
+    requiresMarkdownRendering: Boolean
 ): ReviewRenderedContent {
     if (mathBlocks.any { block -> block is ReviewMathBlock.Formula }) {
         return makeReviewMathMarkdownContent(
@@ -94,7 +96,11 @@ private fun makeReviewRenderedContent(
         mediaAssetsById = mediaAssetsById
     )
     if (managedMarkdown != null) {
+        // Managed media keeps the segmented renderer authoritative; V1 does not rebuild document-wide reference context.
         return managedMarkdown
+    }
+    if (requiresMarkdownRendering) {
+        return ReviewRenderedContent.Markdown(markdown = text)
     }
 
     val plainText: String = (mathBlocks.single() as ReviewMathBlock.Markdown).normalizedMarkdown

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
@@ -12,6 +12,11 @@ internal sealed interface ReviewMathBlock {
     ) : ReviewMathBlock
 }
 
+internal data class ReviewMathBlockExtraction(
+    val blocks: List<ReviewMathBlock>,
+    val requiresMarkdownRendering: Boolean
+)
+
 private data class ReviewMathLine(
     val startOffset: Int,
     val contentEndOffset: Int,
@@ -60,7 +65,7 @@ private val reviewExplicitLinkRegex: Regex = Regex(
     pattern = """!?\[[^]\r\n]*]\s*(?:\([^)]*\)|\[[^]\r\n]*])"""
 )
 
-internal fun extractReviewMathBlocks(markdown: String): List<ReviewMathBlock> {
+internal fun extractReviewMathBlocks(markdown: String): ReviewMathBlockExtraction {
     val lines: List<ReviewMathLine> = makeReviewMathLines(markdown = markdown)
     val extraction: ReviewMathExtraction = extractReviewMathCandidates(
         markdown = markdown,
@@ -78,10 +83,13 @@ internal fun extractReviewMathBlocks(markdown: String): List<ReviewMathBlock> {
         extraction.candidates.sortedBy { candidate -> candidate.startOffset }
     }
 
-    return makeReviewMathBlocks(
-        markdown = markdown,
-        candidates = candidates,
-        escapedDollarOffsets = extraction.escapedDollarOffsets
+    return ReviewMathBlockExtraction(
+        blocks = makeReviewMathBlocks(
+            markdown = markdown,
+            candidates = candidates,
+            escapedDollarOffsets = extraction.escapedDollarOffsets
+        ),
+        requiresMarkdownRendering = hasReferenceDefinition
     )
 }
 


### PR DESCRIPTION
## Summary
- preserve whole-side math suppression when reference definitions guard Android review content
- route non-managed guarded sides through the existing MikePenz Markdown renderer so reference links resolve while dollar-delimited formulas remain literal
- keep ordinary plain and managed-media routing unchanged

## Intentional limitation
The existing managed-media renderer remains segmented and authoritative. Reference uses and definitions separated by managed-media fragment boundaries remain the pre-existing limitation and are outside this card-math V1 change.

## Validation
- not run locally, per repository workflow and reviewed-patch instructions