### PR TITLE
Fix cross-client card math parity

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
@@ -28,8 +28,14 @@ private data class ReviewMathCandidate(
     val startOffset: Int,
     val endOffset: Int,
     val source: String,
-    val delimitedSource: String
+    val delimitedSource: String,
+    val kind: ReviewMathCandidateKind
 )
+
+private enum class ReviewMathCandidateKind {
+    INLINE,
+    DISPLAY
+}
 
 private data class ReviewMathExtraction(
     val candidates: List<ReviewMathCandidate>,
@@ -61,19 +67,16 @@ private val reviewBareLinkRegex: Regex = Regex(
 private val reviewBareEmailRegex: Regex = Regex(
     pattern = """[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"""
 )
-private val reviewExplicitLinkRegex: Regex = Regex(
-    pattern = """!?\[[^]\r\n]*]\s*(?:\([^)]*\)|\[[^]\r\n]*])"""
-)
-
 internal fun extractReviewMathBlocks(markdown: String): ReviewMathBlockExtraction {
     val lines: List<ReviewMathLine> = makeReviewMathLines(markdown = markdown)
     val extraction: ReviewMathExtraction = extractReviewMathCandidates(
         markdown = markdown,
         lines = lines
     )
-    val hasReferenceDefinition: Boolean = lines.any { line ->
-        reviewReferenceDefinitionRegex.containsMatchIn(line.content)
-    }
+    val hasReferenceDefinition: Boolean = hasReviewReferenceDefinitionOutsideDisplayMath(
+        lines = lines,
+        candidates = extraction.candidates
+    )
     // This conservative boundary is intentional cross-client V1 behavior.
     val candidates: List<ReviewMathCandidate> = if (
         hasReferenceDefinition || extraction.hasAmbiguousDisplayDelimiter
@@ -91,6 +94,22 @@ internal fun extractReviewMathBlocks(markdown: String): ReviewMathBlockExtractio
         ),
         requiresMarkdownRendering = hasReferenceDefinition
     )
+}
+
+private fun hasReviewReferenceDefinitionOutsideDisplayMath(
+    lines: List<ReviewMathLine>,
+    candidates: List<ReviewMathCandidate>
+): Boolean {
+    val displayCandidates: List<ReviewMathCandidate> = candidates.filter { candidate ->
+        candidate.kind == ReviewMathCandidateKind.DISPLAY
+    }
+    return lines.any { line ->
+        reviewReferenceDefinitionRegex.containsMatchIn(line.content) &&
+            displayCandidates.none { candidate ->
+                line.startOffset >= candidate.startOffset &&
+                    line.contentEndOffset <= candidate.endOffset
+            }
+    }
 }
 
 private fun extractReviewMathCandidates(
@@ -282,7 +301,8 @@ private fun makeReviewDisplayCandidate(
         delimitedSource = markdown.substring(
             startIndex = openingLine.startOffset,
             endIndex = closingLine.contentEndOffset
-        )
+        ),
+        kind = ReviewMathCandidateKind.DISPLAY
     )
 }
 
@@ -301,6 +321,9 @@ private fun extractReviewInlineParagraph(
     markdown: String,
     lines: List<ReviewMathLine>
 ): ReviewInlineMathExtraction? {
+    if (lines.dropLast(n = 1).any { line -> hasReviewMarkdownHardBreak(line = line.content) }) {
+        return null
+    }
     val candidates: MutableList<ReviewMathCandidate> = mutableListOf()
     val escapedDollarOffsets: MutableList<Int> = mutableListOf()
     lines.forEach { line ->
@@ -321,9 +344,8 @@ private fun extractReviewInlineLine(
     markdown: String,
     line: ReviewMathLine
 ): ReviewInlineMathExtraction? {
-    if (line.content.firstOrNull()?.isWhitespace() == true ||
-        reviewExplicitLinkRegex.containsMatchIn(line.content)
-    ) {
+    val leadingWhitespace: String = line.content.takeWhile { character -> character.isWhitespace() }
+    if (leadingWhitespace.any { character -> character != ' ' } || leadingWhitespace.length > 3) {
         return null
     }
     val candidates: MutableList<ReviewMathCandidate> = mutableListOf()
@@ -381,7 +403,8 @@ private fun extractReviewInlineLine(
                     delimitedSource = markdown.substring(
                         startIndex = line.startOffset + openingOffset,
                         endIndex = line.startOffset + index + 1
-                    )
+                    ),
+                    kind = ReviewMathCandidateKind.INLINE
                 )
             )
             openingDollarOffset = null
@@ -398,9 +421,29 @@ private fun extractReviewInlineLine(
 }
 
 private fun containsReviewProtectedProse(source: String): Boolean {
-    return source.any { character -> reviewProtectedProseCharacters.contains(character) } ||
+    return source.indices.any { index ->
+        reviewProtectedProseCharacters.contains(source[index]) &&
+            isReviewCharacterUnescaped(source = source, index = index)
+    } ||
         reviewBareLinkRegex.containsMatchIn(source) ||
         reviewBareEmailRegex.containsMatchIn(source)
+}
+
+private fun isReviewCharacterUnescaped(source: String, index: Int): Boolean {
+    var precedingBackslashCount: Int = 0
+    var cursor: Int = index - 1
+    while (cursor >= 0 && source[cursor] == '\\') {
+        precedingBackslashCount += 1
+        cursor -= 1
+    }
+    return precedingBackslashCount % 2 == 0
+}
+
+private fun hasReviewMarkdownHardBreak(line: String): Boolean {
+    if (line.takeLastWhile { character -> character == ' ' }.length >= 2) {
+        return true
+    }
+    return line.takeLastWhile { character -> character == '\\' }.length % 2 == 1
 }
 
 private fun isReviewParagraphBoundary(line: String): Boolean {
@@ -447,12 +490,14 @@ private fun makeReviewMathBlocks(
                 markdown = markdown,
                 startOffset = 0,
                 endOffset = markdown.length,
-                escapedDollarOffsets = escapedDollarOffsets
+                escapedDollarOffsets = escapedDollarOffsets,
+                continuesInlineParagraph = false
             )
         )
     }
 
     var currentOffset: Int = 0
+    var continuesInlineParagraph: Boolean = false
     return buildList {
         candidates.forEach { candidate ->
             if (currentOffset < candidate.startOffset) {
@@ -461,7 +506,8 @@ private fun makeReviewMathBlocks(
                         markdown = markdown,
                         startOffset = currentOffset,
                         endOffset = candidate.startOffset,
-                        escapedDollarOffsets = escapedDollarOffsets
+                        escapedDollarOffsets = escapedDollarOffsets,
+                        continuesInlineParagraph = continuesInlineParagraph
                     )
                 )
             }
@@ -472,6 +518,7 @@ private fun makeReviewMathBlocks(
                 )
             )
             currentOffset = candidate.endOffset
+            continuesInlineParagraph = candidate.kind == ReviewMathCandidateKind.INLINE
         }
         if (currentOffset < markdown.length) {
             add(
@@ -479,7 +526,8 @@ private fun makeReviewMathBlocks(
                     markdown = markdown,
                     startOffset = currentOffset,
                     endOffset = markdown.length,
-                    escapedDollarOffsets = escapedDollarOffsets
+                    escapedDollarOffsets = escapedDollarOffsets,
+                    continuesInlineParagraph = continuesInlineParagraph
                 )
             )
         }
@@ -490,7 +538,8 @@ private fun makeReviewMarkdownBlock(
     markdown: String,
     startOffset: Int,
     endOffset: Int,
-    escapedDollarOffsets: List<Int>
+    escapedDollarOffsets: List<Int>,
+    continuesInlineParagraph: Boolean
 ): ReviewMathBlock.Markdown {
     val rawMarkdown: String = markdown.substring(startIndex = startOffset, endIndex = endOffset)
     val removedOffsets: Set<Int> = escapedDollarOffsets.filter { offset ->
@@ -504,7 +553,33 @@ private fun makeReviewMarkdownBlock(
         }
     }
     return ReviewMathBlock.Markdown(
-        markdown = rawMarkdown,
+        markdown = if (continuesInlineParagraph) {
+            normalizeReviewInlineMathParagraphContinuation(markdown = rawMarkdown)
+        } else {
+            rawMarkdown
+        },
         normalizedMarkdown = normalizedMarkdown
     )
+}
+
+private fun normalizeReviewInlineMathParagraphContinuation(markdown: String): String {
+    if (markdown.isEmpty() || markdown.first() == '\r' || markdown.first() == '\n') {
+        return markdown
+    }
+    // A mid-paragraph fragment must not acquire document-level block syntax after splitting.
+    val leadingWhitespaceLength: Int = markdown.takeWhile { character ->
+        character == ' ' || character == '\t'
+    }.length
+    val content: String = markdown.drop(n = leadingWhitespaceLength)
+    val normalizedPrefix: String = if (leadingWhitespaceLength == 0) "" else " "
+    val escapedContent: String = when {
+        Regex(pattern = """^#{1,6}(?:[ \t]+|$)""").containsMatchIn(content) -> "\\$content"
+        Regex(pattern = """^[-+*](?:[ \t]+|$)""").containsMatchIn(content) -> "\\$content"
+        Regex(pattern = """^(?:-[ \t]*){3,}(?:\r?\n|$)""").containsMatchIn(content) -> "\\$content"
+        else -> Regex(pattern = """^(\d{1,9})([.)])(?=[ \t]+|\r\n|\r|\n|$)""").replaceFirst(
+            input = content,
+            replacement = "$1\\\\$2"
+        )
+    }
+    return normalizedPrefix + escapedContent
 }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
@@ -41,10 +41,12 @@ enum ReviewManagedMarkdownBlock {
 struct ReviewFormulaContent {
     let originalSource: String
     let latex: String
+    let continuesParagraph: Bool
 
-    init(originalSource: String, latex: String) {
+    init(originalSource: String, latex: String, continuesParagraph: Bool) {
         self.originalSource = originalSource
         self.latex = latex
+        self.continuesParagraph = continuesParagraph
     }
 }
 
@@ -229,17 +231,23 @@ private func makeReviewSegmentedMarkdownContent(
     mathBlocks: [ReviewMathBlock]
 ) -> ReviewManagedMarkdownContent {
     var blocks: [ReviewManagedMarkdownBlock] = []
+    var normalizesNextMarkdownFragment = false
 
     for mathBlock in mathBlocks {
         switch mathBlock {
         case .markdown(let text):
-            if let managedMarkdownContent = makeReviewManagedMarkdownContent(text: text) {
+            let renderedText = normalizesNextMarkdownFragment
+                ? normalizeReviewInlineMathParagraphContinuation(markdown: text)
+                : text
+            if let managedMarkdownContent = makeReviewManagedMarkdownContent(text: renderedText) {
                 blocks.append(contentsOf: managedMarkdownContent.blocks)
             } else {
-                appendReviewMarkdownBlock(text: text, blocks: &blocks)
+                appendReviewMarkdownBlock(text: renderedText, blocks: &blocks)
             }
+            normalizesNextMarkdownFragment = false
         case .formula(let formula):
             blocks.append(.formula(formula))
+            normalizesNextMarkdownFragment = formula.continuesParagraph
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
@@ -42,7 +42,7 @@ private let reviewMathThematicBreakExpression = makeReviewContentRegularExpressi
 private let reviewMathSetextHeadingExpression = makeReviewContentRegularExpression(pattern: #"^ {0,3}(?:=+[ \t]*|-+[ \t]*)$"#)
 private let reviewMathTableSeparatorExpression = makeReviewContentRegularExpression(pattern: #"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$"#)
 private let reviewMathHTMLExpression = makeReviewContentRegularExpression(pattern: #"^ {0,3}<"#)
-private let reviewMathUnsupportedInlineExpression = makeReviewContentRegularExpression(pattern: #"[`*_~\[\]<>]"#)
+private let reviewMathUnsupportedInlineCharacters = "[]`|<>*_~"
 private let reviewMathBareURLExpression = makeReviewContentRegularExpression(pattern: #"(?i)\b(?:https?://|www\.)"#)
 private let reviewMathBareEmailExpression = makeReviewContentRegularExpression(
     pattern: #"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"#
@@ -120,7 +120,8 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
                 .formula(
                     ReviewFormulaContent(
                         originalSource: originalSource,
-                        latex: latex
+                        latex: latex,
+                        continuesParagraph: false
                     )
                 )
             )
@@ -422,6 +423,11 @@ private func splitReviewMathParagraph(lines: [ReviewMathSourceLine]) -> [ReviewM
     }) {
         return nil
     }
+    if lines.dropLast().contains(where: { line in
+        reviewMathLineHasHardBreak(line: line.content)
+    }) {
+        return nil
+    }
 
     var parsedLines: [ReviewInlineMathLine] = []
     for line in lines {
@@ -470,7 +476,7 @@ private func reviewMathParagraphIsEligible(lines: [ReviewInlineMathLine]) -> Boo
         line.parts.allSatisfy { part in
             switch part {
             case .text(let text):
-                return reviewMathUnsupportedInlineExpression.matches(text) == false
+                return reviewMathContainsUnsupportedInlineSyntax(text: text) == false
                     && reviewMathBareURLExpression.matches(text) == false
                     && reviewMathBareEmailExpression.matches(text) == false
             case .formula:
@@ -487,7 +493,7 @@ private func splitReviewInlineMathLine(line: String) -> ReviewInlineMathLine? {
     var didFindFormula = false
 
     while index < line.endIndex {
-        guard line[index] == "$", reviewMathDollarIsUnescaped(line: line, index: index) else {
+        guard line[index] == "$", reviewMathCharacterIsUnescaped(text: line, index: index) else {
             index = line.index(after: index)
             continue
         }
@@ -512,7 +518,8 @@ private func splitReviewInlineMathLine(line: String) -> ReviewInlineMathLine? {
             .formula(
                 ReviewFormulaContent(
                     originalSource: String(line[index..<afterClosing]),
-                    latex: String(line[latexStart..<closingIndex])
+                    latex: String(line[latexStart..<closingIndex]),
+                    continuesParagraph: true
                 )
             )
         )
@@ -535,7 +542,7 @@ private func reviewInlineMathClosingIndex(line: String, openingIndex: String.Ind
     var index = line.index(after: openingIndex)
 
     while index < line.endIndex {
-        guard line[index] == "$", reviewMathDollarIsUnescaped(line: line, index: index) else {
+        guard line[index] == "$", reviewMathCharacterIsUnescaped(text: line, index: index) else {
             index = line.index(after: index)
             continue
         }
@@ -551,13 +558,20 @@ private func reviewInlineMathClosingIndex(line: String, openingIndex: String.Ind
     return nil
 }
 
-private func reviewMathDollarIsUnescaped(line: String, index: String.Index) -> Bool {
+private func reviewMathContainsUnsupportedInlineSyntax(text: String) -> Bool {
+    text.indices.contains { index in
+        reviewMathUnsupportedInlineCharacters.contains(text[index])
+            && reviewMathCharacterIsUnescaped(text: text, index: index)
+    }
+}
+
+private func reviewMathCharacterIsUnescaped(text: String, index: String.Index) -> Bool {
     var backslashCount = 0
     var cursor = index
 
-    while cursor > line.startIndex {
-        let previousIndex = line.index(before: cursor)
-        guard line[previousIndex] == "\\" else {
+    while cursor > text.startIndex {
+        let previousIndex = text.index(before: cursor)
+        guard text[previousIndex] == "\\" else {
             break
         }
         backslashCount += 1
@@ -565,6 +579,56 @@ private func reviewMathDollarIsUnescaped(line: String, index: String.Index) -> B
     }
 
     return backslashCount.isMultiple(of: 2)
+}
+
+private func reviewMathLineHasHardBreak(line: String) -> Bool {
+    if line.reversed().prefix(while: { character in character == " " }).count >= 2 {
+        return true
+    }
+    return line.reversed().prefix(while: { character in character == "\\" }).count.isMultiple(of: 2) == false
+}
+
+func normalizeReviewInlineMathParagraphContinuation(markdown: String) -> String {
+    guard let firstCharacter = markdown.first, firstCharacter != "\r", firstCharacter != "\n" else {
+        return markdown
+    }
+
+    // A mid-paragraph fragment must not acquire document-level block syntax after splitting.
+    let leadingWhitespaceCount = markdown.prefix(while: { character in
+        character == " " || character == "\t"
+    }).count
+    let content = String(markdown.dropFirst(leadingWhitespaceCount))
+    let normalizedPrefix = leadingWhitespaceCount == 0 ? "" : " "
+    let startsHeading = makeReviewContentRegularExpression(
+        pattern: #"^#{1,6}(?:[ \t]+|$)"#
+    ).matches(content)
+    let startsUnorderedList = makeReviewContentRegularExpression(
+        pattern: #"^[-+*](?:[ \t]+|$)"#
+    ).matches(content)
+    let startsThematicBreak = makeReviewContentRegularExpression(
+        pattern: #"^(?:-[ \t]*){3,}(?:\r?\n|$)"#
+    ).matches(content)
+    if startsHeading || startsUnorderedList || startsThematicBreak {
+        return normalizedPrefix + "\\" + content
+    }
+
+    let digitCount = content.prefix(while: { character in
+        "0123456789".contains(character)
+    }).count
+    guard digitCount > 0, digitCount <= 9, digitCount < content.count else {
+        return normalizedPrefix + content
+    }
+    let punctuationIndex = content.index(content.startIndex, offsetBy: digitCount)
+    let afterPunctuationIndex = content.index(after: punctuationIndex)
+    guard (content[punctuationIndex] == "." || content[punctuationIndex] == ")"),
+          afterPunctuationIndex == content.endIndex
+            || " \t\r\n".contains(content[afterPunctuationIndex]) else {
+        return normalizedPrefix + content
+    }
+
+    var escapedContent = content
+    escapedContent.insert("\\", at: punctuationIndex)
+    return normalizedPrefix + escapedContent
 }
 
 private func reviewMathSource(lines: [ReviewMathSourceLine]) -> String {


### PR DESCRIPTION
## Summary
- preserve prose paragraph semantics after inline formulas without changing stored source or speech
- allow Android inline-math paragraphs with 1–3 leading spaces while keeping indented root display delimiters literal
- keep hard-break paragraphs literal on Android and iOS
- ignore reference-like content inside accepted Android display formulas while guarding real definitions elsewhere
- accept odd-backslash escaped Markdown punctuation while rejecting real Markdown constructs
- keep empty ordered markers such as `1.` and `1)` as prose after formula segmentation

## Validation
- passed the required fresh static post-fix review with no P0–P4 findings
- local tests and validation were intentionally not run per repository workflow