### PR TITLE
Fix final native card math parity

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
@@ -380,6 +380,7 @@ private fun extractReviewInlineLine(
     val escapedDollarOffsets: MutableList<Int> = mutableListOf()
     val prose: StringBuilder = StringBuilder()
     var openingDollarOffset: Int? = null
+    var literalDoubleDollarSecondOffset: Int? = null
     var precedingBackslashCount: Int = 0
 
     line.content.forEachIndexed { index, character ->
@@ -400,6 +401,11 @@ private fun extractReviewInlineLine(
             return@forEachIndexed
         }
 
+        if (literalDoubleDollarSecondOffset == index) {
+            literalDoubleDollarSecondOffset = null
+            return@forEachIndexed
+        }
+
         if (isEscaped) {
             escapedDollarOffsets.add(line.startOffset + index - 1)
             if (openingDollarOffset == null) {
@@ -409,7 +415,12 @@ private fun extractReviewInlineLine(
         }
 
         if (line.content.getOrNull(index = index + 1) == '$') {
-            return null
+            if (openingDollarOffset != null) {
+                return null
+            }
+            prose.append("$$")
+            literalDoubleDollarSecondOffset = index + 1
+            return@forEachIndexed
         }
 
         val openingOffset: Int? = openingDollarOffset

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
@@ -31,7 +31,9 @@ private struct ReviewInlineMathLine {
     let containsFormula: Bool
 }
 
-private let reviewMathReferenceDefinitionExpression = makeReviewContentRegularExpression(pattern: #"^ {0,3}\[[^\]]+\]:"#)
+private let reviewMathReferenceDefinitionExpression = makeReviewContentRegularExpression(
+    pattern: #"^ {0,3}\[(?:\\.|[^\\\]])+\]:"#
+)
 private let reviewMathContainerPrefixExpression = makeReviewContentRegularExpression(
     pattern: #"^ {0,3}(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t])"#
 )
@@ -278,6 +280,11 @@ private func reviewMathFence(line: String) -> ReviewMathFence? {
         character == marker
     }).count
     guard markerLength >= 3 else {
+        return nil
+    }
+
+    let info = content.dropFirst(markerLength)
+    if marker == "`", info.contains("`") {
         return nil
     }
 


### PR DESCRIPTION
## Summary
- accept escaped characters in iOS reference-definition labels
- preserve literal paragraph `$$` without invalidating neighboring Android inline formulas
- reject iOS backtick fences whose info string contains a backtick

## Validation
- fresh static review: no P0-P4 findings
- local executable checks intentionally not run