### PR TITLE
Fix review math ref narrowing

### DIFF
--- a/apps/web/src/screens/review/components/card/ReviewMathBlock.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewMathBlock.tsx
@@ -76,6 +76,8 @@ export function ReviewMathBlock(props: ReviewMathBlockProps): ReactElement {
     if (container === null || canvas === null) {
       throw new Error("Review formula canvas was unavailable during rendering");
     }
+    const renderContainer = container;
+    const renderCanvas = canvas;
 
     const controller = new AbortController();
     canvas.width = 0;
@@ -86,13 +88,13 @@ export function ReviewMathBlock(props: ReviewMathBlockProps): ReactElement {
         await initRatex();
         controller.signal.throwIfAborted();
         await loadReviewMathFonts(controller.signal);
-        const color = getComputedStyle(container).getPropertyValue("--text").trim();
+        const color = getComputedStyle(renderContainer).getPropertyValue("--text").trim();
         if (color === "") {
           throw new Error("Review formula rendering could not resolve the theme text color");
         }
         renderLatexToCanvas(
           formulaSource,
-          canvas,
+          renderCanvas,
           {
             backgroundColor: "transparent",
             fontSize: REVIEW_MATH_FONT_SIZE,


### PR DESCRIPTION
## Summary

- Preserve the guarded non-null container and canvas element types in immutable bindings before the async render closure.
- Keep review-math rendering, cancellation, lifecycle, and error behavior unchanged.

## PR #1352 CI blocker

This fixes the deterministic Type checks and builds failure blocking PR #1352:

- `src/screens/review/components/card/ReviewMathBlock.tsx(89,40): error TS2345: Argument of type 'HTMLDivElement | null' is not assignable to parameter of type 'Element'.`
  `Type 'null' is not assignable to type 'Element'.`
- `src/screens/review/components/card/ReviewMathBlock.tsx(95,11): error TS2345: Argument of type 'HTMLCanvasElement | null' is not assignable to parameter of type 'HTMLCanvasElement'.`
  `Type 'null' is not assignable to type 'HTMLCanvasElement'.`

## Validation

- Fresh static review: no P0-P4 issues.
- Local checks were not run; applicable GitHub checks own executable validation.