### PR TITLE
Fix iOS review fence closer parity

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
@@ -198,22 +198,20 @@ private func makeReviewSpeakableTextWithoutMath(text: String) -> String {
         return normalizeReviewSpeakableLines(lines: text.components(separatedBy: .newlines))
     }
 
-    var activeFenceMarker: String? = nil
+    var activeFence: ReviewMathFence? = nil
     var speakableLines: [String] = []
 
     for line in text.components(separatedBy: .newlines) {
-        let fenceMarker = reviewFenceMarker(line: line)
-
-        if let currentFenceMarker = activeFenceMarker {
-            if fenceMarker == currentFenceMarker {
-                activeFenceMarker = nil
+        if let openingFence = activeFence {
+            if reviewMathFenceCloses(line: line, openingFence: openingFence) {
+                activeFence = nil
             }
 
             continue
         }
 
-        if let fenceMarker {
-            activeFenceMarker = fenceMarker
+        if let openingFence = reviewMathFence(line: line) {
+            activeFence = openingFence
             continue
         }
 
@@ -260,14 +258,6 @@ private func hasStrongMarkdownCue(text: String) -> Bool {
     }
 }
 
-private func reviewFenceMarker(line: String) -> String? {
-    guard let fence = reviewMathFence(line: line) else {
-        return nil
-    }
-
-    return String(repeating: fence.marker, count: fence.minimumLength)
-}
-
 private func normalizeReviewSpeakableMarkdownLine(line: String) -> String {
     let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
     if trimmedLine.isEmpty {
@@ -303,24 +293,22 @@ private func normalizeReviewSpeakableInlineText(text: String) -> String {
 }
 
 private func makeReviewManagedMarkdownContent(text: String) -> ReviewManagedMarkdownContent? {
-    var activeFenceMarker: String? = nil
+    var activeFence: ReviewMathFence? = nil
     var pendingMarkdownLines: [String] = []
     var blocks: [ReviewManagedMarkdownBlock] = []
     var didFindManagedMedia = false
 
     for line in text.components(separatedBy: .newlines) {
-        let fenceMarker = reviewFenceMarker(line: line)
-
-        if let currentFenceMarker = activeFenceMarker {
+        if let openingFence = activeFence {
             pendingMarkdownLines.append(line)
-            if fenceMarker == currentFenceMarker {
-                activeFenceMarker = nil
+            if reviewMathFenceCloses(line: line, openingFence: openingFence) {
+                activeFence = nil
             }
             continue
         }
 
-        if let fenceMarker {
-            activeFenceMarker = fenceMarker
+        if let openingFence = reviewMathFence(line: line) {
+            activeFence = openingFence
             pendingMarkdownLines.append(line)
             continue
         }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewMathBlocks.swift
@@ -76,7 +76,7 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
                 pendingMarkdown += fencedLine.content + fencedLine.separator
                 lineIndex += 1
 
-                if reviewMathFenceCloses(line: fencedLine.content, fence: fence) {
+                if reviewMathFenceCloses(line: fencedLine.content, openingFence: fence) {
                     break
                 }
             }
@@ -146,7 +146,7 @@ func extractReviewMathBlocks(text: String) -> ReviewMathBlockExtraction {
                     if detectsContainerReferences {
                         let containerContent = reviewMathContainerContent(line: containerLine.content)
                         if let fence = containerFence {
-                            if reviewMathFenceCloses(line: containerContent, fence: fence) {
+                            if reviewMathFenceCloses(line: containerContent, openingFence: fence) {
                                 containerFence = nil
                             }
                         } else if reviewMathLineIsIndentedCode(line: containerContent) == false {
@@ -291,12 +291,12 @@ func reviewMathFence(line: String) -> ReviewMathFence? {
     return ReviewMathFence(marker: marker, minimumLength: markerLength)
 }
 
-private func reviewMathFenceCloses(line: String, fence: ReviewMathFence) -> Bool {
+func reviewMathFenceCloses(line: String, openingFence: ReviewMathFence) -> Bool {
     let content = line.dropFirst(min(reviewMathLeadingSpaceCount(line: line), 3))
     let markerLength = content.prefix(while: { character in
-        character == fence.marker
+        character == openingFence.marker
     }).count
-    guard markerLength >= fence.minimumLength else {
+    guard markerLength >= openingFence.minimumLength else {
         return false
     }
 


### PR DESCRIPTION
## Summary
- retain full review fence openers in speech and managed-media presentation loops
- reuse the shared fence closer predicate for same-marker minimum-length behavior
- preserve existing review Markdown and math routing semantics

## Validation
- fresh static review completed with no P0-P4 findings
- local project checks intentionally not run