### PR TITLE
Preserve speech prefixes after inline math

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewMathBlocks.kt
@@ -8,7 +8,8 @@ internal sealed interface ReviewMathBlock {
 
     data class Formula(
         val source: String,
-        val delimitedSource: String
+        val delimitedSource: String,
+        val continuesParagraph: Boolean
     ) : ReviewMathBlock
 }
 
@@ -566,7 +567,8 @@ private fun makeReviewMathBlocks(
             add(
                 ReviewMathBlock.Formula(
                     source = candidate.source,
-                    delimitedSource = candidate.delimitedSource
+                    delimitedSource = candidate.delimitedSource,
+                    continuesParagraph = candidate.kind == ReviewMathCandidateKind.INLINE
                 )
             )
             currentOffset = candidate.endOffset

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewSpeakableText.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewSpeakableText.kt
@@ -4,21 +4,41 @@ internal fun makeReviewSpeakableText(
     mathBlocks: List<ReviewMathBlock>
 ): String {
     if (mathBlocks.any { block -> block is ReviewMathBlock.Formula }) {
-        return mathBlocks.mapNotNull { block ->
-            when (block) {
-                is ReviewMathBlock.Formula -> block.source
-                is ReviewMathBlock.Markdown -> makeReviewSpeakableTextWithoutMath(
-                    text = block.normalizedMarkdown
-                ).ifEmpty { null }
+        var preservesNextOpeningBlockPrefix: Boolean = false
+        val speakableSegments: List<String> = buildList {
+            mathBlocks.forEach { block ->
+                when (block) {
+                    is ReviewMathBlock.Formula -> {
+                        add(block.source)
+                        preservesNextOpeningBlockPrefix = block.continuesParagraph
+                    }
+                    is ReviewMathBlock.Markdown -> {
+                        val segment: String = makeReviewSpeakableTextWithoutMath(
+                            text = block.normalizedMarkdown,
+                            preservesOpeningBlockPrefix = preservesNextOpeningBlockPrefix
+                        )
+                        if (segment.isNotEmpty()) {
+                            add(segment)
+                        }
+                        preservesNextOpeningBlockPrefix = false
+                    }
+                }
             }
-        }.joinToString(separator = "\n")
+        }
+        return speakableSegments.joinToString(separator = "\n")
     }
 
     val markdownBlock: ReviewMathBlock.Markdown = mathBlocks.single() as ReviewMathBlock.Markdown
-    return makeReviewSpeakableTextWithoutMath(text = markdownBlock.normalizedMarkdown)
+    return makeReviewSpeakableTextWithoutMath(
+        text = markdownBlock.normalizedMarkdown,
+        preservesOpeningBlockPrefix = false
+    )
 }
 
-private fun makeReviewSpeakableTextWithoutMath(text: String): String {
+private fun makeReviewSpeakableTextWithoutMath(
+    text: String,
+    preservesOpeningBlockPrefix: Boolean
+): String {
     if (text.trim().isEmpty()) {
         return ""
     }
@@ -30,7 +50,7 @@ private fun makeReviewSpeakableTextWithoutMath(text: String): String {
     val speakableLines: List<String> = buildList {
         var activeFenceMarker: String? = null
 
-        text.lines().forEach { line ->
+        text.lines().forEachIndexed { lineIndex, line ->
             val fenceMarker: String? = reviewFenceMarker(line = line)
             val currentFenceMarker: String? = activeFenceMarker
 
@@ -38,15 +58,19 @@ private fun makeReviewSpeakableTextWithoutMath(text: String): String {
                 if (isReviewFenceClosingLine(line = line, openingMarker = currentFenceMarker)) {
                     activeFenceMarker = null
                 }
-                return@forEach
+                return@forEachIndexed
             }
 
             if (fenceMarker != null) {
                 activeFenceMarker = fenceMarker
-                return@forEach
+                return@forEachIndexed
             }
 
-            val normalizedLine: String = normalizeReviewSpeakableMarkdownLine(line = line)
+            val normalizedLine: String = if (preservesOpeningBlockPrefix && lineIndex == 0) {
+                normalizeReviewSpeakableInlineText(text = line)
+            } else {
+                normalizeReviewSpeakableMarkdownLine(line = line)
+            }
             if (normalizedLine.isNotEmpty()) {
                 add(normalizedLine)
             }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewContentPresentation.swift
@@ -172,28 +172,48 @@ func makeReviewSpeakableText(text: String) -> String {
 
     switch extractReviewMathBlocks(text: text) {
     case .segmented(let mathBlocks):
-        return mathBlocks.map { block in
+        var preservesNextOpeningBlockPrefix = false
+        var speakableSegments: [String] = []
+        for block in mathBlocks {
             switch block {
             case .markdown(let source):
-                return makeReviewSpeakableTextWithoutMath(text: source)
+                let segment = makeReviewSpeakableTextWithoutMath(
+                    text: source,
+                    preservesOpeningBlockPrefix: preservesNextOpeningBlockPrefix
+                )
+                if segment.isEmpty == false {
+                    speakableSegments.append(segment)
+                }
+                preservesNextOpeningBlockPrefix = false
             case .formula(let formula):
-                return formula.latex
+                if formula.latex.isEmpty == false {
+                    speakableSegments.append(formula.latex)
+                }
+                preservesNextOpeningBlockPrefix = formula.continuesParagraph
             }
-        }.filter { segment in
-            segment.isEmpty == false
-        }.joined(separator: "\n")
+        }
+        return speakableSegments.joined(separator: "\n")
     case .literalMarkdown:
-        return makeReviewSpeakableTextWithoutMath(text: text)
+        return makeReviewSpeakableTextWithoutMath(
+            text: text,
+            preservesOpeningBlockPrefix: false
+        )
     case .none:
         if classifyReviewContentPresentation(text: text) != .markdown {
             let plainText = normalizeReviewPlainTextEscapedDollars(text: text)
             return normalizeReviewSpeakableLines(lines: plainText.components(separatedBy: .newlines))
         }
-        return makeReviewSpeakableTextWithoutMath(text: text)
+        return makeReviewSpeakableTextWithoutMath(
+            text: text,
+            preservesOpeningBlockPrefix: false
+        )
     }
 }
 
-private func makeReviewSpeakableTextWithoutMath(text: String) -> String {
+private func makeReviewSpeakableTextWithoutMath(
+    text: String,
+    preservesOpeningBlockPrefix: Bool
+) -> String {
     if classifyReviewContentPresentation(text: text) != .markdown {
         return normalizeReviewSpeakableLines(lines: text.components(separatedBy: .newlines))
     }
@@ -201,7 +221,7 @@ private func makeReviewSpeakableTextWithoutMath(text: String) -> String {
     var activeFence: ReviewMathFence? = nil
     var speakableLines: [String] = []
 
-    for line in text.components(separatedBy: .newlines) {
+    for (lineIndex, line) in text.components(separatedBy: .newlines).enumerated() {
         if let openingFence = activeFence {
             if reviewMathFenceCloses(line: line, openingFence: openingFence) {
                 activeFence = nil
@@ -215,7 +235,9 @@ private func makeReviewSpeakableTextWithoutMath(text: String) -> String {
             continue
         }
 
-        let normalizedLine = normalizeReviewSpeakableMarkdownLine(line: line)
+        let normalizedLine = preservesOpeningBlockPrefix && lineIndex == 0
+            ? normalizeReviewSpeakableInlineText(text: line)
+            : normalizeReviewSpeakableMarkdownLine(line: line)
         if normalizedLine.isEmpty == false {
             speakableLines.append(normalizedLine)
         }


### PR DESCRIPTION
## Summary
- carry inline paragraph continuation context into Android speech segmentation
- preserve heading, list, ordered-list, and thematic-looking prefixes on same-paragraph tails
- keep genuine later Markdown blocks and non-math speech cleanup unchanged on Android and iOS

## Validation
- fresh static review passed with no P0-P4 findings
- local project checks were not run per repository policy