### PR TITLE
Update iOS add friend wording and Settings order

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressFriendInviteSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressFriendInviteSheet.swift
@@ -169,7 +169,7 @@ struct ProgressFriendInviteSheet: View {
             .navigationTitle(
                 String(
                     localized: "progress.friend_invite.title",
-                    defaultValue: "Invite Friend",
+                    defaultValue: "Add Friend",
                     table: progressStringsTableName,
                     comment: "Navigation title for the friend invite creation sheet"
                 )

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressLeaderboardSection.swift
@@ -106,7 +106,7 @@ struct ProgressLeaderboardSection: View {
                 Text(
                     String(
                         localized: "progress.screen.leaderboard.invite.button",
-                        defaultValue: "Invite Friend",
+                        defaultValue: "Add Friend",
                         table: progressStringsTableName,
                         comment: "Button title for creating a leaderboard friend invite link"
                     )
@@ -119,7 +119,7 @@ struct ProgressLeaderboardSection: View {
         .accessibilityLabel(
             String(
                 localized: "progress.screen.leaderboard.invite.accessibility_label",
-                defaultValue: "Invite a friend",
+                defaultValue: "Add a friend",
                 table: progressStringsTableName,
                 comment: "Accessibility label for the leaderboard friend invite button"
             )

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -3252,55 +3252,55 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "دعوة صديق"
+            "value" : "إضافة صديق"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Freund einladen"
+            "value" : "Freund hinzufügen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invite Friend"
+            "value" : "Add Friend"
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invitar amigo"
+            "value" : "Añadir amigo"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invitar amigo"
+            "value" : "Agregar amigo"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "दोस्त को आमंत्रित करें"
+            "value" : "दोस्त जोड़ें"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "友達を招待"
+            "value" : "友達を追加"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пригласить друга"
+            "value" : "Добавить друга"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "邀请朋友"
+            "value" : "添加好友"
           }
         }
       }
@@ -5140,55 +5140,55 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "دعوة صديق"
+            "value" : "إضافة صديق"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Freund einladen"
+            "value" : "Freund hinzufügen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invite Friend"
+            "value" : "Add Friend"
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invitar amigo"
+            "value" : "Añadir amigo"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invitar amigo"
+            "value" : "Agregar amigo"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "दोस्त को आमंत्रित करें"
+            "value" : "दोस्त जोड़ें"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "友達を招待"
+            "value" : "友達を追加"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пригласить друга"
+            "value" : "Добавить друга"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "邀请朋友"
+            "value" : "添加好友"
           }
         }
       }
@@ -5199,55 +5199,55 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "دعوة صديق"
+            "value" : "إضافة صديق"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Freund einladen"
+            "value" : "Freund hinzufügen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invite a friend"
+            "value" : "Add a friend"
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invitar a un amigo"
+            "value" : "Añadir amigo"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invitar a un amigo"
+            "value" : "Agregar amigo"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "दोस्त को आमंत्रित करें"
+            "value" : "दोस्त जोड़ें"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "友達を招待"
+            "value" : "友達を追加"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пригласить друга"
+            "value" : "Добавить друга"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "邀请朋友"
+            "value" : "添加好友"
           }
         }
       }

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -50,20 +50,6 @@ struct SettingsView: View {
 
     var body: some View {
         List {
-            Section(aiSettingsLocalized("settings.section.share", "Share")) {
-                self.friendInviteButton
-
-                ShareLink(item: flashcardsAppShareUrl) {
-                    SettingsNavigationRow(
-                        title: aiSettingsLocalized("settings.row.shareApp", "Share Flashcards"),
-                        value: nil,
-                        systemImage: "square.and.arrow.up",
-                        attentionCount: nil
-                    )
-                }
-                .accessibilityIdentifier(UITestIdentifier.settingsShareAppRow)
-            }
-
             Section(aiSettingsLocalized("settings.section.feedback", "Feedback")) {
                 Link(destination: flashcardsAppStoreUrl) {
                     SettingsNavigationRow(
@@ -84,6 +70,20 @@ struct SettingsView: View {
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsPrivateFeedbackRow)
+            }
+
+            Section(aiSettingsLocalized("settings.section.share", "Share")) {
+                self.friendInviteButton
+
+                ShareLink(item: flashcardsAppShareUrl) {
+                    SettingsNavigationRow(
+                        title: aiSettingsLocalized("settings.row.shareApp", "Share Flashcards"),
+                        value: nil,
+                        systemImage: "square.and.arrow.up",
+                        attentionCount: nil
+                    )
+                }
+                .accessibilityIdentifier(UITestIdentifier.settingsShareAppRow)
             }
 
             Section(aiSettingsLocalized("settings.section.account", "Account")) {
@@ -359,14 +359,14 @@ struct SettingsView: View {
             self.openFriendInviteFlow()
         } label: {
             SettingsNavigationRow(
-                title: aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"),
+                title: aiSettingsLocalized("settings.inviteFriend.button", "Add Friend"),
                 value: nil,
                 systemImage: "person.crop.circle.badge.plus",
                 attentionCount: nil
             )
         }
         .accessibilityIdentifier(UITestIdentifier.settingsInviteFriendButton)
-        .accessibilityLabel(aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"))
+        .accessibilityLabel(aiSettingsLocalized("settings.inviteFriend.button", "Add Friend"))
     }
 
     private func openFriendInviteFlow() {

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "غير متاح";
 
 "settings.title" = "الإعدادات";
-"settings.inviteFriend.button" = "دعوة صديق";
+"settings.inviteFriend.button" = "إضافة صديق";
 "settings.section.share" = "مشاركة";
 "settings.row.shareApp" = "مشاركة Flashcards";
 "settings.section.feedback" = "الملاحظات";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "Nicht verfügbar";
 
 "settings.title" = "Einstellungen";
-"settings.inviteFriend.button" = "Freund einladen";
+"settings.inviteFriend.button" = "Freund hinzufügen";
 "settings.section.share" = "Teilen";
 "settings.row.shareApp" = "Flashcards teilen";
 "settings.section.feedback" = "Feedback";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "No disponible";
 
 "settings.title" = "Ajustes";
-"settings.inviteFriend.button" = "Invitar amigo";
+"settings.inviteFriend.button" = "Añadir amigo";
 "settings.section.share" = "Compartir";
 "settings.row.shareApp" = "Compartir Flashcards";
 "settings.section.feedback" = "Comentarios";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "No disponible";
 
 "settings.title" = "Ajustes";
-"settings.inviteFriend.button" = "Invitar amigo";
+"settings.inviteFriend.button" = "Agregar amigo";
 "settings.section.share" = "Compartir";
 "settings.row.shareApp" = "Compartir Flashcards";
 "settings.section.feedback" = "Comentarios";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "उपलब्ध नहीं है";
 
 "settings.title" = "सेटिंग्स";
-"settings.inviteFriend.button" = "दोस्त को आमंत्रित करें";
+"settings.inviteFriend.button" = "दोस्त जोड़ें";
 "settings.section.share" = "साझा करें";
 "settings.row.shareApp" = "Flashcards साझा करें";
 "settings.section.feedback" = "प्रतिक्रिया";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "利用できません";
 
 "settings.title" = "設定";
-"settings.inviteFriend.button" = "友達を招待";
+"settings.inviteFriend.button" = "友達を追加";
 "settings.section.share" = "共有";
 "settings.row.shareApp" = "Flashcardsを共有";
 "settings.section.feedback" = "フィードバック";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "Недоступно";
 
 "settings.title" = "Настройки";
-"settings.inviteFriend.button" = "Пригласить друга";
+"settings.inviteFriend.button" = "Добавить друга";
 "settings.section.share" = "Поделиться";
 "settings.row.shareApp" = "Поделиться Flashcards";
 "settings.section.feedback" = "Обратная связь";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -129,7 +129,7 @@
 "common.unavailable" = "不可用";
 
 "settings.title" = "设置";
-"settings.inviteFriend.button" = "邀请朋友";
+"settings.inviteFriend.button" = "添加好友";
 "settings.section.share" = "分享";
 "settings.row.shareApp" = "分享 Flashcards";
 "settings.section.feedback" = "反馈";


### PR DESCRIPTION
## Summary
- use add-friend wording across iOS Settings, leaderboard, accessibility, and the friend-link sheet
- update all nine supported iOS locales
- place Feedback before Share in Settings

## Validation
- static review completed with no P0-P4 findings
- project checks not run per repository workflow