### PR TITLE
Update Android add-friend copy and Settings order

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/settings/SettingsRootRouteTest.kt
@@ -127,10 +127,12 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         }
         assertRootItemsInOrder(
             itemTags = listOf(
-                settingsShareAppRowTag,
                 settingsFeedbackSectionTag,
                 settingsReviewAppRowTag,
                 settingsPrivateFeedbackRowTag,
+                settingsShareSectionTag,
+                settingsInviteFriendButtonTag,
+                settingsShareAppRowTag,
                 settingsAccountSectionTag
             )
         )

--- a/apps/android/feature/friendinvite/src/main/res/values/strings.xml
+++ b/apps/android/feature/friendinvite/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="friend_invite_button">Invite friend</string>
-    <string name="friend_invite_dialog_title">Invite a friend</string>
+    <string name="friend_invite_button">Add friend</string>
+    <string name="friend_invite_dialog_title">Add a friend</string>
     <string name="friend_invite_dialog_body">Create a private friend link for the leaderboard.</string>
     <string name="friend_invite_display_name_label">Friend name on your leaderboard</string>
     <string name="friend_invite_expiry_note">Only you see this name on your leaderboard. Your friend chooses what to call you when accepting. Invite links expire in 2 days.</string>

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -129,30 +129,6 @@ fun SettingsRoute(
         ) {
             item {
                 SettingsRootSectionTitle(
-                    title = stringResource(R.string.settings_section_share),
-                    testTag = settingsShareSectionTag
-                )
-            }
-
-            item {
-                SettingsInviteFriendButton(
-                    isEnabled = uiState.friendInviteAvailability != SettingsFriendInviteAvailability.LOADING,
-                    onClick = onOpenFriendInvite
-                )
-            }
-
-            item {
-                SettingsRootRow(
-                    title = stringResource(R.string.settings_share_app_title),
-                    summary = stringResource(R.string.settings_share_app_summary),
-                    attentionCount = null,
-                    testTag = settingsShareAppRowTag,
-                    onClick = onShareApp
-                )
-            }
-
-            item {
-                SettingsRootSectionTitle(
                     title = stringResource(R.string.settings_section_feedback),
                     testTag = settingsFeedbackSectionTag
                 )
@@ -175,6 +151,30 @@ fun SettingsRoute(
                     attentionCount = null,
                     testTag = settingsPrivateFeedbackRowTag,
                     onClick = onOpenFeedback
+                )
+            }
+
+            item {
+                SettingsRootSectionTitle(
+                    title = stringResource(R.string.settings_section_share),
+                    testTag = settingsShareSectionTag
+                )
+            }
+
+            item {
+                SettingsInviteFriendButton(
+                    isEnabled = uiState.friendInviteAvailability != SettingsFriendInviteAvailability.LOADING,
+                    onClick = onOpenFriendInvite
+                )
+            }
+
+            item {
+                SettingsRootRow(
+                    title = stringResource(R.string.settings_share_app_title),
+                    summary = stringResource(R.string.settings_share_app_summary),
+                    attentionCount = null,
+                    testTag = settingsShareAppRowTag,
+                    onClick = onShareApp
                 )
             }
 


### PR DESCRIPTION
## Summary
- update the shared Android friend CTA and dialog title to Add friend / Add a friend
- place the complete Feedback group before Share in Settings
- update the existing tag-based instrumentation order assertion

## Testing
- Not run locally, per repository workflow; integration PRs rely on the later trunk CI gate.