### PR TITLE
Move iOS bootstrap reads off the main actor

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -279,7 +279,7 @@ extension FlashcardsStore {
             try self.throwIfCloudCredentialRecoveryRequired()
             let failureError: Error
             do {
-                failureError = try self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
+                failureError = try await self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
                     error: error,
                     now: Date()
                 )
@@ -615,7 +615,7 @@ extension FlashcardsStore {
         now: Date,
         trigger: CloudSyncTrigger
     ) async throws {
-        let bootstrapRefreshOutcome = try self.refreshBootstrapSnapshotWithoutReset(now: now)
+        let bootstrapRefreshOutcome = try await self.refreshBootstrapSnapshotWithoutReset(now: now)
         let didResetVolatileReviewSelection = self.resetVolatileReviewSelectionAfterLocalIdRepairIfNeeded(
             syncResult: syncResult,
             now: now
@@ -666,12 +666,12 @@ extension FlashcardsStore {
     private func failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
         error: Error,
         now: Date
-    ) throws -> Error {
+    ) async throws -> Error {
         guard let localIdRepairFailure = error as? CloudSyncLocalIdRepairFailure else {
             return error
         }
 
-        try self.applyLocalIdRepairSideEffectsAfterSyncFailure(
+        try await self.applyLocalIdRepairSideEffectsAfterSyncFailure(
             syncResult: localIdRepairFailure.syncResult,
             now: now
         )
@@ -681,8 +681,8 @@ extension FlashcardsStore {
     private func applyLocalIdRepairSideEffectsAfterSyncFailure(
         syncResult: CloudSyncResult,
         now: Date
-    ) throws {
-        let bootstrapRefreshOutcome = try self.refreshBootstrapSnapshotWithoutReset(now: now)
+    ) async throws {
+        let bootstrapRefreshOutcome = try await self.refreshBootstrapSnapshotWithoutReset(now: now)
         let didResetVolatileReviewSelection = self.resetVolatileReviewSelectionAfterLocalIdRepairIfNeeded(
             syncResult: syncResult,
             now: now
@@ -894,7 +894,7 @@ extension FlashcardsStore {
 
             return try await self.cloudRuntime.runLinkedSync(linkedSession: linkedSession)
         } catch {
-            let failureError = try self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
+            let failureError = try await self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
                 error: error,
                 now: Date()
             )
@@ -933,7 +933,7 @@ extension FlashcardsStore {
 
             return try await self.cloudRuntime.runFreshLinkedSyncAfterActiveSyncSettles(linkedSession: linkedSession)
         } catch {
-            let failureError = try self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
+            let failureError = try await self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
                 error: error,
                 now: Date()
             )

--- a/apps/ios/Flashcards/Flashcards/Database/Core/DatabaseCore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Core/DatabaseCore.swift
@@ -160,7 +160,18 @@ final class DatabaseCore {
     }
 
     func inTransaction<T>(_ body: () throws -> T) throws -> T {
-        let beginResult = sqlite3_exec(connection, "BEGIN IMMEDIATE TRANSACTION", nil, nil, nil)
+        try self.runTransaction(beginStatement: "BEGIN IMMEDIATE TRANSACTION", body)
+    }
+
+    func inReadTransaction<T>(_ body: () throws -> T) throws -> T {
+        try self.runTransaction(beginStatement: "BEGIN DEFERRED TRANSACTION", body)
+    }
+
+    private func runTransaction<T>(
+        beginStatement: String,
+        _ body: () throws -> T
+    ) throws -> T {
+        let beginResult = sqlite3_exec(connection, beginStatement, nil, nil, nil)
         guard beginResult == SQLITE_OK else {
             throw LocalStoreError.database("Failed to begin transaction: \(self.lastErrorMessage())")
         }

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
@@ -550,7 +550,7 @@ extension FlashcardsStore {
 
     func processReviewSubmissionRequest(request: ReviewSubmissionRequest) async {
         guard let reviewSubmissionExecutor = self.dependencies.reviewSubmissionExecutor else {
-            self.handleReviewSubmissionFailure(
+            await self.handleReviewSubmissionFailure(
                 request: request,
                 submissionError: self.reviewRuntime.reviewSubmissionExecutorUnavailableError()
             )
@@ -569,7 +569,7 @@ extension FlashcardsStore {
                 )
             )
         } catch {
-            self.handleReviewSubmissionFailure(request: request, submissionError: error)
+            await self.handleReviewSubmissionFailure(request: request, submissionError: error)
             return
         }
 
@@ -589,7 +589,7 @@ extension FlashcardsStore {
         let bootstrapRefreshOutcome: BootstrapSnapshotRefreshOutcome
         let didReconcileReviewState: Bool
         do {
-            bootstrapRefreshOutcome = try self.refreshBootstrapSnapshotWithoutProgressContextRefresh(now: now)
+            bootstrapRefreshOutcome = try await self.refreshBootstrapSnapshotWithoutProgressContextRefresh(now: now)
             didReconcileReviewState = try await self.reconcileReviewState(
                 now: now,
                 trigger: .localReview
@@ -739,7 +739,7 @@ extension FlashcardsStore {
         self.refreshLocalReadModels(now: now)
     }
 
-    func handleReviewSubmissionFailure(request: ReviewSubmissionRequest, submissionError: Error) {
+    func handleReviewSubmissionFailure(request: ReviewSubmissionRequest, submissionError: Error) async {
         let submissionErrorMessage = Flashcards.errorMessage(error: submissionError)
         let now = Date()
         // Capture the pre-refresh validation context once so the staleness classification
@@ -756,7 +756,7 @@ extension FlashcardsStore {
         }
 
         do {
-            _ = try self.refreshBootstrapSnapshotWithoutReset(now: now)
+            _ = try await self.refreshBootstrapSnapshotWithoutReset(now: now)
             let rollbackValidationContext = self.makeReviewSubmissionRollbackValidationContext(now: now)
             guard self.reviewSubmissionRequestMatchesCurrentContext(
                 request: request,

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/Submission/ReviewSubmissionExecutor.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/Submission/ReviewSubmissionExecutor.swift
@@ -6,17 +6,29 @@ protocol ReviewSubmissionExecuting: Sendable {
     func submitReview(workspaceId: String, submission: ReviewSubmission) async throws -> Card
 }
 
+struct ReviewSubmissionMutationState: Sendable {
+    let revision: Int
+    let activeSubmissionCount: Int
+}
+
+enum ReviewSubmissionProtectedPublication<Result> {
+    case published(Result)
+    case stale(ReviewSubmissionMutationState)
+}
+
 final class ReviewSubmissionOutboxMutationGate: @unchecked Sendable {
     private let lock: NSLock
     private var isBlockedForGuestUpgrade: Bool
     private var activeReviewSubmissionCount: Int
     private var activeReviewSubmissionWaiters: [CheckedContinuation<Void, Never>]
+    private var reviewSubmissionMutationRevision: Int
 
     init() {
         self.lock = NSLock()
         self.isBlockedForGuestUpgrade = false
         self.activeReviewSubmissionCount = 0
         self.activeReviewSubmissionWaiters = []
+        self.reviewSubmissionMutationRevision = 0
     }
 
     func beginReviewSubmission() throws {
@@ -30,6 +42,7 @@ final class ReviewSubmissionOutboxMutationGate: @unchecked Sendable {
         }
 
         self.activeReviewSubmissionCount += 1
+        self.reviewSubmissionMutationRevision += 1
     }
 
     func finishReviewSubmission() {
@@ -42,6 +55,7 @@ final class ReviewSubmissionOutboxMutationGate: @unchecked Sendable {
         }
 
         self.activeReviewSubmissionCount -= 1
+        self.reviewSubmissionMutationRevision += 1
         if self.activeReviewSubmissionCount == 0 {
             waiters = self.activeReviewSubmissionWaiters
             self.activeReviewSubmissionWaiters = []
@@ -74,6 +88,32 @@ final class ReviewSubmissionOutboxMutationGate: @unchecked Sendable {
         self.lock.unlock()
     }
 
+    func currentReviewSubmissionMutationState() -> ReviewSubmissionMutationState {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+        return self.reviewSubmissionMutationState()
+    }
+
+    @MainActor
+    func publishIfReviewSubmissionMutationIsStable<Result>(
+        expectedRevision: Int,
+        publication: () -> Result
+    ) -> ReviewSubmissionProtectedPublication<Result> {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        let mutationState = self.reviewSubmissionMutationState()
+        guard mutationState.revision == expectedRevision,
+            mutationState.activeSubmissionCount == 0 else {
+            return .stale(mutationState)
+        }
+        return .published(publication())
+    }
+
     private func blockNewReviewSubmissions() -> Bool {
         self.lock.lock()
         self.isBlockedForGuestUpgrade = true
@@ -96,6 +136,13 @@ final class ReviewSubmissionOutboxMutationGate: @unchecked Sendable {
 
         self.activeReviewSubmissionWaiters.append(continuation)
         return false
+    }
+
+    private func reviewSubmissionMutationState() -> ReviewSubmissionMutationState {
+        ReviewSubmissionMutationState(
+            revision: self.reviewSubmissionMutationRevision,
+            activeSubmissionCount: self.activeReviewSubmissionCount
+        )
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore+Bootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore+Bootstrap.swift
@@ -7,6 +7,13 @@ private struct LoadedLocalReadModels {
     let homeSnapshot: HomeSnapshot
 }
 
+private struct BootstrapReadExpectation: Sendable {
+    let databaseIdentity: ObjectIdentifier
+    let databaseURL: URL
+    let localReadVersion: Int
+    let reviewSubmissionMutationRevision: Int
+}
+
 private func loadLocalReadModels(
     database: LocalDatabase,
     snapshot: AppBootstrapSnapshot,
@@ -244,29 +251,86 @@ extension FlashcardsStore {
     }
 
     @discardableResult
-    func refreshBootstrapSnapshotWithoutReset(now: Date) throws -> BootstrapSnapshotRefreshOutcome {
-        let outcome = try self.refreshBootstrapSnapshotContentWithoutReset(now: now)
+    func refreshBootstrapSnapshotWithoutReset(now: Date) async throws -> BootstrapSnapshotRefreshOutcome {
+        let outcome = try await self.refreshBootstrapSnapshotContentWithoutReset(now: now)
         self.handleProgressContextDidChange(now: now)
         return outcome
     }
 
     @discardableResult
-    func refreshBootstrapSnapshotWithoutProgressContextRefresh(now: Date) throws -> BootstrapSnapshotRefreshOutcome {
-        try self.refreshBootstrapSnapshotContentWithoutReset(now: now)
+    func refreshBootstrapSnapshotWithoutProgressContextRefresh(now: Date) async throws -> BootstrapSnapshotRefreshOutcome {
+        try await self.refreshBootstrapSnapshotContentWithoutReset(now: now)
     }
 
-    private func refreshBootstrapSnapshotContentWithoutReset(now: Date) throws -> BootstrapSnapshotRefreshOutcome {
-        let database = try requireLocalDatabase(database: self.database)
-        let bootstrapSnapshot = try database.loadBootstrapSnapshot()
-        let localReadModels = try loadLocalReadModels(
-            database: database,
-            snapshot: bootstrapSnapshot,
-            now: now
-        )
-        let nextCards = localReadModels.cards
-        let nextDecks = localReadModels.decks
-        let nextDeckItems = localReadModels.deckItems
-        let resolvedHomeSnapshot = localReadModels.homeSnapshot
+    private func refreshBootstrapSnapshotContentWithoutReset(now: Date) async throws -> BootstrapSnapshotRefreshOutcome {
+        var staleResultCount = 0
+
+        while true {
+            let expectation = try self.currentBootstrapReadExpectation()
+            let loadedSnapshot = try await defaultBootstrapSnapshotLoader(
+                databaseURL: expectation.databaseURL,
+                now: now
+            )
+            let actualDatabase = self.database
+            let actualDatabaseIdentity = actualDatabase.map { ObjectIdentifier($0) }
+            let actualDatabaseURL = actualDatabase?.databaseURL
+            let actualLocalReadVersion = self.localReadVersion
+            let isCurrentDatabaseState = actualDatabaseIdentity == expectation.databaseIdentity
+                && actualDatabaseURL == expectation.databaseURL
+                && actualLocalReadVersion == expectation.localReadVersion
+
+            guard isCurrentDatabaseState else {
+                if staleResultCount == 0 {
+                    staleResultCount += 1
+                    continue
+                }
+                throw self.staleBootstrapSnapshotError(
+                    expectation: expectation,
+                    actualDatabaseIdentity: actualDatabaseIdentity,
+                    actualDatabaseURL: actualDatabaseURL,
+                    actualLocalReadVersion: actualLocalReadVersion,
+                    actualReviewSubmissionMutationState: self.reviewSubmissionOutboxMutationGate
+                        .currentReviewSubmissionMutationState()
+                )
+            }
+
+            let publication = self.reviewSubmissionOutboxMutationGate
+                .publishIfReviewSubmissionMutationIsStable(
+                    expectedRevision: expectation.reviewSubmissionMutationRevision
+                ) {
+                    self.applyRefreshedBootstrapSnapshotContent(
+                        loadedSnapshot: loadedSnapshot,
+                        now: now
+                    )
+                }
+            switch publication {
+            case .published(let outcome):
+                return outcome
+            case .stale(let actualReviewSubmissionMutationState):
+                if staleResultCount == 0 {
+                    staleResultCount += 1
+                    continue
+                }
+                throw self.staleBootstrapSnapshotError(
+                    expectation: expectation,
+                    actualDatabaseIdentity: actualDatabaseIdentity,
+                    actualDatabaseURL: actualDatabaseURL,
+                    actualLocalReadVersion: actualLocalReadVersion,
+                    actualReviewSubmissionMutationState: actualReviewSubmissionMutationState
+                )
+            }
+        }
+    }
+
+    private func applyRefreshedBootstrapSnapshotContent(
+        loadedSnapshot: LoadedBootstrapSnapshot,
+        now: Date
+    ) -> BootstrapSnapshotRefreshOutcome {
+        let bootstrapSnapshot = loadedSnapshot.snapshot
+        let nextCards = loadedSnapshot.cards
+        let nextDecks = loadedSnapshot.decks
+        let nextDeckItems = loadedSnapshot.deckItems
+        let resolvedHomeSnapshot = loadedSnapshot.homeSnapshot
 
         let previousWorkspaceId = self.workspace?.workspaceId
         let didSwitchWorkspace = previousWorkspaceId != bootstrapSnapshot.workspace.workspaceId
@@ -344,6 +408,32 @@ extension FlashcardsStore {
             workspaceChanged: workspaceChanged,
             cardsChanged: cardsChanged,
             homeSnapshotChanged: homeSnapshotChanged
+        )
+    }
+
+    private func currentBootstrapReadExpectation() throws -> BootstrapReadExpectation {
+        let database = try requireLocalDatabase(database: self.database)
+        return BootstrapReadExpectation(
+            databaseIdentity: ObjectIdentifier(database),
+            databaseURL: database.databaseURL,
+            localReadVersion: self.localReadVersion,
+            reviewSubmissionMutationRevision: self.reviewSubmissionOutboxMutationGate
+                .currentReviewSubmissionMutationState()
+                .revision
+        )
+    }
+
+    private func staleBootstrapSnapshotError(
+        expectation: BootstrapReadExpectation,
+        actualDatabaseIdentity: ObjectIdentifier?,
+        actualDatabaseURL: URL?,
+        actualLocalReadVersion: Int,
+        actualReviewSubmissionMutationState: ReviewSubmissionMutationState
+    ) -> LocalStoreError {
+        let actualDatabaseIdentityDescription = actualDatabaseIdentity.map { String(describing: $0) } ?? "none"
+        let actualDatabaseURLDescription = actualDatabaseURL?.path ?? "none"
+        return LocalStoreError.database(
+            "Bootstrap snapshot load produced a stale result twice. Expected database identity \(expectation.databaseIdentity) at \(expectation.databaseURL.path) with local read version \(expectation.localReadVersion) and review submission mutation revision \(expectation.reviewSubmissionMutationRevision), but found identity \(actualDatabaseIdentityDescription) at \(actualDatabaseURLDescription) with local read version \(actualLocalReadVersion), review submission mutation revision \(actualReviewSubmissionMutationState.revision), and \(actualReviewSubmissionMutationState.activeSubmissionCount) active review submissions."
         )
     }
 

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreLoaders.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreLoaders.swift
@@ -45,7 +45,15 @@ typealias ReviewTimelinePageLoader = @Sendable (
 let reviewSeedQueueSize: Int = 8
 let reviewQueueReplenishmentThreshold: Int = 4
 
-private func withTemporaryReviewLoaderDatabase<Result>(
+struct LoadedBootstrapSnapshot: Sendable {
+    let snapshot: AppBootstrapSnapshot
+    let cards: [Card]
+    let decks: [Deck]
+    let deckItems: [DeckListItem]
+    let homeSnapshot: HomeSnapshot
+}
+
+private func withTemporaryLocalLoaderDatabase<Result>(
     databaseURL: URL,
     operation: (LocalDatabase) throws -> Result
 ) throws -> Result {
@@ -59,7 +67,7 @@ private func withTemporaryReviewLoaderDatabase<Result>(
             try database.close()
         } catch {
             throw LocalStoreError.database(
-                "Failed to close temporary review loader database at \(databaseURL.path) after operation error: \(operationError.localizedDescription). Close error: \(error.localizedDescription)"
+                "Failed to close temporary local loader database at \(databaseURL.path) after operation error: \(operationError.localizedDescription). Close error: \(error.localizedDescription)"
             )
         }
         throw operationError
@@ -67,6 +75,40 @@ private func withTemporaryReviewLoaderDatabase<Result>(
 
     try database.close()
     return result
+}
+
+func defaultBootstrapSnapshotLoader(
+    databaseURL: URL,
+    now: Date
+) async throws -> LoadedBootstrapSnapshot {
+    try await Task.detached(priority: .userInitiated) {
+        try Task.checkCancellation()
+        return try withTemporaryLocalLoaderDatabase(databaseURL: databaseURL) { database in
+            try database.core.inReadTransaction {
+                let snapshot = try database.loadBootstrapSnapshot()
+                let cards = try database.loadActiveCards(workspaceId: snapshot.workspace.workspaceId)
+                let decks = try database.loadActiveDecks(workspaceId: snapshot.workspace.workspaceId)
+                let overviewSnapshot = try database.loadWorkspaceOverviewSnapshot(
+                    workspaceId: snapshot.workspace.workspaceId,
+                    workspaceName: snapshot.workspace.name,
+                    now: now
+                )
+                return LoadedBootstrapSnapshot(
+                    snapshot: snapshot,
+                    cards: cards,
+                    decks: decks,
+                    deckItems: makeDeckListItems(decks: decks, cards: cards, now: now),
+                    homeSnapshot: HomeSnapshot(
+                        deckCount: overviewSnapshot.deckCount,
+                        totalCards: overviewSnapshot.totalCards,
+                        dueCount: overviewSnapshot.dueCount,
+                        newCount: overviewSnapshot.newCount,
+                        reviewedCount: overviewSnapshot.reviewedCount
+                    )
+                )
+            }
+        }
+    }.value
 }
 
 func defaultReviewHeadLoader(
@@ -79,7 +121,7 @@ func defaultReviewHeadLoader(
 ) async throws -> ReviewHeadLoadState {
     try await Task.detached(priority: .userInitiated) {
         try Task.checkCancellation()
-        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+        return try withTemporaryLocalLoaderDatabase(databaseURL: databaseURL) { database in
             try database.loadReviewHead(
                 workspaceId: workspaceId,
                 resolvedReviewFilter: resolvedReviewFilter,
@@ -99,7 +141,7 @@ func defaultReviewCountsLoader(
 ) async throws -> ReviewCounts {
     try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+        return try withTemporaryLocalLoaderDatabase(databaseURL: databaseURL) { database in
             try database.loadReviewCounts(
                 workspaceId: workspaceId,
                 reviewQueryDefinition: reviewQueryDefinition,
@@ -119,7 +161,7 @@ func defaultReviewQueueChunkLoader(
 ) async throws -> ReviewQueueChunkLoadState {
     try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+        return try withTemporaryLocalLoaderDatabase(databaseURL: databaseURL) { database in
             try database.loadReviewQueueChunk(
                 workspaceId: workspaceId,
                 reviewQueryDefinition: reviewQueryDefinition,
@@ -140,7 +182,7 @@ func defaultReviewQueueWindowLoader(
 ) async throws -> ReviewQueueWindowLoadState {
     return try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+        return try withTemporaryLocalLoaderDatabase(databaseURL: databaseURL) { database in
             try database.loadReviewQueueWindow(
                 workspaceId: workspaceId,
                 reviewQueryDefinition: reviewQueryDefinition,
@@ -161,7 +203,7 @@ func defaultReviewTimelinePageLoader(
 ) async throws -> ReviewTimelinePage {
     try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+        return try withTemporaryLocalLoaderDatabase(databaseURL: databaseURL) { database in
             try database.loadReviewTimelinePage(
                 workspaceId: workspaceId,
                 reviewQueryDefinition: reviewQueryDefinition,

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressContextChangeTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressContextChangeTests.swift
@@ -196,13 +196,13 @@ final class ProgressContextChangeTests: ProgressStoreTestCase {
             reviewedAtClient: "\(requestRange.to)T09:00:00.000Z"
         )
 
-        _ = try context.store.refreshBootstrapSnapshotWithoutProgressContextRefresh(now: now)
+        _ = try await context.store.refreshBootstrapSnapshotWithoutProgressContextRefresh(now: now)
 
         XCTAssertEqual(makeEmptyReviewProgressBadgeState(), context.store.reviewProgressBadgeState)
         XCTAssertEqual(0, context.cloudSyncService.loadProgressSummaryCallCount)
         XCTAssertEqual(0, context.cloudSyncService.loadProgressSeriesCallCount)
 
-        _ = try context.store.refreshBootstrapSnapshotWithoutReset(now: now)
+        _ = try await context.store.refreshBootstrapSnapshotWithoutReset(now: now)
 
         XCTAssertEqual(
             ReviewProgressBadgeState(

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundIdentityTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundIdentityTests.swift
@@ -358,7 +358,7 @@ final class ReviewBackgroundIdentityTests: ProgressStoreTestCase {
             cardId: nil,
             mediaAssetIdsReadyForUpload: []
         )
-        let refreshOutcome = try store.refreshBootstrapSnapshotWithoutProgressContextRefresh(
+        let refreshOutcome = try await store.refreshBootstrapSnapshotWithoutProgressContextRefresh(
             now: try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T10:01:00.000Z"))
         )
         XCTAssertTrue(refreshOutcome.cardsChanged)
@@ -530,4 +530,3 @@ final class ReviewBackgroundIdentityTests: ProgressStoreTestCase {
         XCTAssertFalse(store.isReviewQueueChunkLoading)
     }
 }
-

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundSubmissionSettlementTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundSubmissionSettlementTests.swift
@@ -477,7 +477,7 @@ final class ReviewBackgroundSubmissionSettlementTests: ProgressStoreTestCase {
     }
 
     @MainActor
-    func testReviewSubmissionFailureReloadFailureDoesNotRestoreStaleRollbackCard() throws {
+    func testReviewSubmissionFailureReloadFailureDoesNotRestoreStaleRollbackCard() async throws {
         let suiteName = "review-submit-reload-failure-\(UUID().uuidString.lowercased())"
         let userDefaults = UserDefaults(suiteName: suiteName)!
         let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
@@ -554,7 +554,7 @@ final class ReviewBackgroundSubmissionSettlementTests: ProgressStoreTestCase {
             reviewedTimeZone: "UTC"
         )
 
-        store.handleReviewSubmissionFailure(
+        await store.handleReviewSubmissionFailure(
             request: request,
             submissionError: LocalStoreError.validation("Submission failed")
         )
@@ -567,7 +567,7 @@ final class ReviewBackgroundSubmissionSettlementTests: ProgressStoreTestCase {
     }
 
     @MainActor
-    func testReviewSubmissionFailureClassifiesStaleContextBeforeRefreshingReviewState() throws {
+    func testReviewSubmissionFailureClassifiesStaleContextBeforeRefreshingReviewState() async throws {
         let database = try self.makeDatabase()
         let suiteName = "review-submit-stale-before-refresh-\(UUID().uuidString.lowercased())"
         let userDefaults = UserDefaults(suiteName: suiteName)!
@@ -651,7 +651,7 @@ final class ReviewBackgroundSubmissionSettlementTests: ProgressStoreTestCase {
             reviewedTimeZone: "UTC"
         )
 
-        store.handleReviewSubmissionFailure(
+        await store.handleReviewSubmissionFailure(
             request: request,
             submissionError: LocalStoreError.validation("Submission failed")
         )


### PR DESCRIPTION
## Summary
- load post-sync and review-settlement bootstrap snapshots on a detached temporary SQLite connection
- make multi-query snapshots transactionally consistent and reject stale publication across local changes and review commits
- propagate the asynchronous refresh contract through cloud sync, review settlement, and affected tests

## Validation
- Local project checks not run; required trunk PR CI owns executable validation.