### PR TITLE
Simplify Android demo card copy

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/onboarding/DemoCardSeed.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/onboarding/DemoCardSeed.kt
@@ -19,13 +19,13 @@ private const val demoCardParagraphSeparator: String = "\n\n"
 private const val demoCardProductName: String = "Flashcards Open Source App"
 
 /**
- * Builds the onboarding demo card from the current app locale. The rating
- * labels are read from the review feature so the card always names the same
- * buttons the user sees while reviewing.
+ * Builds the onboarding demo card from the current app locale. The three back
+ * paragraphs use the review feature's Again label so the card names the same
+ * button the user sees while reviewing.
  *
  * The Markdown lives here rather than in the translatable strings: the back
  * text carries exactly the bold product name and the inline-code rating
- * labels. The backticks are load-bearing, not decoration.
+ * label. The backticks are load-bearing, not decoration.
  * `classifyReviewContentPresentation` only switches to Markdown on a backtick
  * or a block-level cue, and inline emphasis alone never switches the mode
  * (see docs/review-markdown-rendering.md). Removing the backticks would demote
@@ -35,13 +35,10 @@ private const val demoCardProductName: String = "Flashcards Open Source App"
 fun buildDemoCardDraft(context: Context): CardDraft {
     val productName: String = "**$demoCardProductName**"
     val againLabel: String = "`${context.getString(ReviewR.string.review_again)}`"
-    val hardLabel: String = "`${context.getString(ReviewR.string.review_hard)}`"
     val backParagraphs: List<String> = listOf(
         context.getString(R.string.demo_card_back_1, productName),
         context.getString(R.string.demo_card_back_2),
-        context.getString(R.string.demo_card_back_3),
-        context.getString(R.string.demo_card_back_4, againLabel, hardLabel),
-        context.getString(R.string.demo_card_back_5, againLabel)
+        context.getString(R.string.demo_card_back_3, againLabel)
     )
     return CardDraft(
         frontText = context.getString(R.string.demo_card_front),

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -37,15 +37,11 @@
     <!-- Question shown on the front of the onboarding demo flashcard seeded for a new install. -->
     <string name="demo_card_front">What is the best application for studying?</string>
     <!-- First paragraph on the back of the onboarding demo flashcard. The placeholder is the product name. -->
-    <string name="demo_card_back_1"><xliff:g id="app_name" example="Flashcards Open Source App">%1$s</xliff:g> — the app you are looking at right now.</string>
+    <string name="demo_card_back_1"><xliff:g id="app_name" example="Flashcards Open Source App">%1$s</xliff:g> — the app you are looking at right now. Everything here is a flashcard: a question on the front, the answer on the back.</string>
     <!-- Second paragraph on the back of the onboarding demo flashcard. -->
-    <string name="demo_card_back_2">Everything here is a flashcard: a question on the front, the answer on the back. You can write cards yourself, or just give the built-in AI chat a topic and it will create a set of cards for you.</string>
-    <!-- Third paragraph on the back of the onboarding demo flashcard. -->
-    <string name="demo_card_back_3">When you review, you try to recall the answer, then rate how it went. Every card schedules itself from there: what you know well comes back in weeks or months, what you keep forgetting comes back today or tomorrow.</string>
-    <!-- Fourth paragraph on the back of the onboarding demo flashcard. The placeholders are the review rating button labels. -->
-    <string name="demo_card_back_4">Rate honestly, this is what makes it work. If you did not know the answer, choose <xliff:g id="again_button" example="Again">%1$s</xliff:g> — including when you had to peek. <xliff:g id="hard_button" example="Hard">%2$s</xliff:g> is only for answers you knew but struggled to recall.</string>
-    <!-- Fifth paragraph on the back of the onboarding demo flashcard. The placeholder is the review rating button label. -->
-    <string name="demo_card_back_5">Try it right now: rate this card <xliff:g id="again_button" example="Again">%1$s</xliff:g>, and it will come back in about a minute — so this answer sticks.</string>
+    <string name="demo_card_back_2">Give the built-in AI chat a topic and it will create a set of cards for you.</string>
+    <!-- Third paragraph on the back of the onboarding demo flashcard. The placeholder is the review rating button label. -->
+    <string name="demo_card_back_3">Try it right now: rate this card <xliff:g id="again_button" example="Again">%1$s</xliff:g>, and it will come back in about a minute — so this answer sticks.</string>
     <string name="review_notification_channel_name">Review reminders</string>
     <string name="review_notification_channel_description">Study reminders with cards from your review queue.</string>
 </resources>


### PR DESCRIPTION
## Summary
- simplify the Android onboarding demo card to the approved three-paragraph answer
- retain the localized Again label and remove obsolete Hard and paragraph resources
- keep Android localization Play-first with base English resources only

## Validation
- static review passed with no P0-P4 findings
- project checks not run per repository workflow