### PR TITLE
Centralize chat file ingestion

### DIFF
--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -187,11 +187,11 @@ export function ChatPanel(props: Props): ReactElement {
     sendPhase,
   });
   const {
-    handleAttach,
     handleDragEnter,
     handleDragLeave,
     handleDragOver,
     handleDrop,
+    ingestFiles,
     isDragOver,
     removeAttachment,
   } = useChatAttachments({
@@ -451,10 +451,7 @@ export function ChatPanel(props: Props): ReactElement {
         <div className="chat-controls">
           <div className="chat-controls-right">
             <FileAttachment
-              onAttach={handleAttach}
-              onTechnicalError={(error) => {
-                showChatTechnicalError(error, "chat_attachment_prepare");
-              }}
+              onFiles={ingestFiles}
               disabled={!canAttachDraftFiles}
             />
             <button

--- a/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
@@ -30,6 +30,7 @@ import { createVerifiedWorkspaceAppDataMock } from "./support/ChatPanelTestFixtu
 import { getChatComposerCapabilities } from "../../composer/chatComposerState";
 
 const {
+  clickAddAttachment,
   clickMicrophone,
   clickStop,
   flushAsync,
@@ -53,6 +54,27 @@ function createChatConfigWithAttachmentsEnabled(
 }
 
 describe("ChatPanel composer controls", () => {
+  it("prepares picker files through the shared file ingestion boundary", async () => {
+    prepareAttachmentMock.mockResolvedValue({
+      type: "binary",
+      fileName: "attached.txt",
+      mediaType: "text/plain",
+      base64Data: "YXR0YWNoZWQ=",
+    });
+
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    await clickAddAttachment();
+    await flushAsync();
+
+    expect(prepareAttachmentMock).toHaveBeenCalledTimes(1);
+    expect(prepareAttachmentMock.mock.calls[0]?.[0]).toBeInstanceOf(File);
+    expect(prepareAttachmentMock.mock.calls[0]?.[0]?.name).toBe("attached.txt");
+    expect(getContainer().textContent).toContain("attached.txt");
+  });
+
   it("includes an explicit sessionId in the first dictation upload", async () => {
     await renderChatPanel();
     await flushAsync();

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -242,13 +242,9 @@ vi.mock("../../../attachments/FileAttachment", () => ({
     maxSidePixels: 1_280,
     quality: 0.55,
   },
-  FileAttachment: ({ disabled, onAttach }: Readonly<{
+  FileAttachment: ({ disabled, onFiles }: Readonly<{
     disabled?: boolean;
-    onAttach: (attachment: {
-      fileName: string;
-      mediaType: string;
-      base64Data: string;
-    }) => Promise<void> | void;
+    onFiles: (files: ReadonlyArray<File>) => Promise<void> | void;
   }>) => createElement(
     "button",
     {
@@ -258,12 +254,7 @@ vi.mock("../../../attachments/FileAttachment", () => ({
       title: "Add attachment",
       disabled: disabled === true,
       onClick: () => {
-        void onAttach({
-          type: "binary",
-          fileName: "attached.txt",
-          mediaType: "text/plain",
-          base64Data: "YXR0YWNoZWQ=",
-        });
+        void onFiles([new File(["attached"], "attached.txt", { type: "text/plain" })]);
       },
     },
     createElement(
@@ -754,9 +745,10 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
     listOutboxRecordsMock.mockResolvedValue([]);
     checkFileSizeMock.mockReturnValue(null);
     prepareAttachmentMock.mockResolvedValue({
-      fileName: "test-file.txt",
-      mediaType: "application/pdf",
-      base64Data: "dGVzdA==",
+      type: "binary",
+      fileName: "attached.txt",
+      mediaType: "text/plain",
+      base64Data: "YXR0YWNoZWQ=",
     });
     recompressImageAttachmentMock.mockResolvedValue({
       fileName: "test-image.jpg",

--- a/apps/web/src/chat/attachments/FileAttachment.tsx
+++ b/apps/web/src/chat/attachments/FileAttachment.tsx
@@ -13,10 +13,7 @@ import {
   isImageMediaType,
   type ImageCompressionOptions,
 } from "../../media/imagePreparation";
-import {
-  isChatAttachmentUnsupportedTypeError,
-  normalizeChatAttachmentFileMediaType,
-} from "./attachmentMediaTypes";
+import { normalizeChatAttachmentFileMediaType } from "./attachmentMediaTypes";
 
 export type { ImageCompressionOptions } from "../../media/imagePreparation";
 
@@ -39,8 +36,7 @@ export type CardPendingAttachment = Readonly<{
 export type PendingAttachment = BinaryPendingAttachment | CardPendingAttachment;
 
 type Props = Readonly<{
-  onAttach: (attachment: PendingAttachment) => Promise<void> | void;
-  onTechnicalError: (error: unknown) => void;
+  onFiles: (files: ReadonlyArray<File>) => Promise<void> | void;
   disabled?: boolean;
 }>;
 
@@ -228,12 +224,10 @@ export async function prepareAttachment(file: File): Promise<PendingAttachment> 
 }
 
 export function FileAttachment(props: Props): ReactElement {
-  const { onAttach, onTechnicalError } = props;
+  const { onFiles } = props;
   const { t } = useI18n();
   const disabled = props.disabled === true;
   const inputRef = useRef<HTMLInputElement>(null);
-  const attachmentLimitMessage = t("chatPanel.alerts.attachmentLimit");
-  const attachmentUnsupportedMessage = t("chatPanel.alerts.attachmentUnsupported");
 
   async function handleChange(): Promise<void> {
     const files = inputRef.current?.files;
@@ -241,35 +235,7 @@ export function FileAttachment(props: Props): ReactElement {
       return;
     }
 
-    for (let index = 0; index < files.length; index++) {
-      const file = files[index];
-      const sizeError = checkFileSize(file);
-      if (sizeError !== null) {
-        window.alert(attachmentLimitMessage);
-        continue;
-      }
-
-      try {
-        await onAttach(await prepareAttachment(file));
-      } catch (error) {
-        if (isChatAttachmentTooLargeError(error)) {
-          window.alert(attachmentLimitMessage);
-          continue;
-        }
-
-        if (isChatAttachmentUnsupportedTypeError(error)) {
-          window.alert(attachmentUnsupportedMessage);
-          continue;
-        }
-
-        if (isExpectedImageAttachmentPreparationError(error)) {
-          window.alert(attachmentUnsupportedMessage);
-          continue;
-        }
-
-        onTechnicalError(error);
-      }
-    }
+    await onFiles(Array.from(files));
 
     if (inputRef.current !== null) {
       inputRef.current.value = "";

--- a/apps/web/src/chat/attachments/useChatAttachments.ts
+++ b/apps/web/src/chat/attachments/useChatAttachments.ts
@@ -37,11 +37,11 @@ type UseChatAttachmentsParams = Readonly<{
 }>;
 
 export type ChatAttachmentControls = Readonly<{
-  handleAttach: (attachment: PendingAttachment) => Promise<void>;
   handleDragEnter: (event: DragEvent<HTMLDivElement>) => void;
   handleDragLeave: (event: DragEvent<HTMLDivElement>) => void;
   handleDragOver: (event: DragEvent<HTMLDivElement>) => void;
   handleDrop: (event: DragEvent<HTMLDivElement>) => Promise<void>;
+  ingestFiles: (files: ReadonlyArray<File>) => Promise<void>;
   isDragOver: boolean;
   removeAttachment: (index: number) => void;
 }>;
@@ -156,6 +156,37 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
     setPendingAttachmentsState(candidateAttachments);
   }
 
+  async function ingestFiles(files: ReadonlyArray<File>): Promise<void> {
+    for (const file of files) {
+      const sizeError = checkFileSize(file);
+      if (sizeError !== null) {
+        window.alert(attachmentLimitMessage);
+        continue;
+      }
+
+      try {
+        await handleAttach(await prepareAttachment(file));
+      } catch (error) {
+        if (isChatAttachmentTooLargeError(error)) {
+          window.alert(attachmentLimitMessage);
+          continue;
+        }
+
+        if (isChatAttachmentUnsupportedTypeError(error)) {
+          window.alert(attachmentUnsupportedMessage);
+          continue;
+        }
+
+        if (isExpectedImageAttachmentPreparationError(error)) {
+          window.alert(attachmentUnsupportedMessage);
+          continue;
+        }
+
+        onTechnicalError(error);
+      }
+    }
+  }
+
   function removeAttachment(index: number): void {
     const currentAttachments = pendingAttachmentsRef.current;
     setPendingAttachmentsState([
@@ -207,44 +238,15 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
       return;
     }
 
-    const files = event.dataTransfer.files;
-    for (let index = 0; index < files.length; index += 1) {
-      const file = files[index];
-      const sizeError = checkFileSize(file);
-      if (sizeError !== null) {
-        window.alert(attachmentLimitMessage);
-        continue;
-      }
-
-      try {
-        await handleAttach(await prepareAttachment(file));
-      } catch (error) {
-        if (isChatAttachmentTooLargeError(error)) {
-          window.alert(attachmentLimitMessage);
-          continue;
-        }
-
-        if (isChatAttachmentUnsupportedTypeError(error)) {
-          window.alert(attachmentUnsupportedMessage);
-          continue;
-        }
-
-        if (isExpectedImageAttachmentPreparationError(error)) {
-          window.alert(attachmentUnsupportedMessage);
-          continue;
-        }
-
-        onTechnicalError(error);
-      }
-    }
+    await ingestFiles(Array.from(event.dataTransfer.files));
   }
 
   return {
-    handleAttach,
     handleDragEnter,
     handleDragLeave,
     handleDragOver,
     handleDrop,
+    ingestFiles,
     isDragOver,
     removeAttachment,
   };


### PR DESCRIPTION
## Summary
- send picker and drop files through one raw-file ingestion path
- keep attachment preparation, compression, limits, errors, and composer locking unchanged
- update focused ChatPanel attachment test support and coverage

## Validation
- not run locally per repository policy