### PR TITLE
Fix card filter apply first click

### DIFF
--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -869,7 +869,14 @@ export function CardsScreen(): ReactElement {
               <div className="cards-filter-actions">
                 <button type="button" className="ghost-btn" onClick={handleFilterClear}>{t("cardsScreen.filters.actions.clear")}</button>
                 <button type="button" className="ghost-btn" onClick={handleFilterCancel}>{t("common.cancel")}</button>
-                <button type="button" className="primary-btn" onClick={handleFilterApply}>{t("cardsScreen.filters.actions.apply")}</button>
+                <button
+                  type="button"
+                  className="primary-btn"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={handleFilterApply}
+                >
+                  {t("cardsScreen.filters.actions.apply")}
+                </button>
               </div>
             </AnchoredFloatingOverlay>
           </div>


### PR DESCRIPTION
## Summary
- preserve tag input focus when pressing Apply in the Cards filter
- keep the existing filter apply handler as the sole commit path

## Testing
- Not run locally; required CI owns executable validation.