### PR TITLE
Add image paste to AI chat

### DIFF
--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -191,6 +191,7 @@ export function ChatPanel(props: Props): ReactElement {
     handleDragLeave,
     handleDragOver,
     handleDrop,
+    handlePaste,
     ingestFiles,
     isDragOver,
     removeAttachment,
@@ -441,6 +442,7 @@ export function ChatPanel(props: Props): ReactElement {
               updateTrackedDraftSelection(event.target);
             }}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             onSelect={(event) => updateTrackedDraftSelection(event.currentTarget)}
             onClick={(event) => updateTrackedDraftSelection(event.currentTarget)}
             onKeyUp={(event) => updateTrackedDraftSelection(event.currentTarget)}

--- a/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
@@ -6,7 +6,10 @@ import {
   createChatPanelDragEnterEvent,
   createChatSnapshot,
   createDropEvent,
+  createImagePasteEvent,
   createNewChatSessionMock,
+  createTextPasteEvent,
+  dispatchChatComposerPasteEvent,
   dispatchChatPanelDragEvent,
   getChatSnapshotMock,
   binaryPendingAttachmentExceedsSizeLimitMock,
@@ -73,6 +76,41 @@ describe("ChatPanel composer controls", () => {
     expect(prepareAttachmentMock.mock.calls[0]?.[0]).toBeInstanceOf(File);
     expect(prepareAttachmentMock.mock.calls[0]?.[0]?.name).toBe("attached.txt");
     expect(getContainer().textContent).toContain("attached.txt");
+  });
+
+  it("prevents image paste and prepares the image through shared file ingestion", async () => {
+    prepareAttachmentMock.mockResolvedValue({
+      type: "binary",
+      fileName: "pasted-image.png",
+      mediaType: "image/png",
+      base64Data: "aW1hZ2U=",
+    });
+
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    const pasteEvent = createImagePasteEvent(new File(["image"], "", { type: "image/png" }));
+    await dispatchChatComposerPasteEvent(getContainer(), pasteEvent);
+    await flushAsync();
+
+    expect(pasteEvent.defaultPrevented).toBe(true);
+    expect(prepareAttachmentMock).toHaveBeenCalledTimes(1);
+    expect(prepareAttachmentMock.mock.calls[0]?.[0]).toBeInstanceOf(File);
+    expect(prepareAttachmentMock.mock.calls[0]?.[0]?.name).toBe("pasted-image.png");
+  });
+
+  it("leaves text-only paste native without preparing an attachment", async () => {
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    const pasteEvent = createTextPasteEvent();
+    await dispatchChatComposerPasteEvent(getContainer(), pasteEvent);
+    await flushAsync();
+
+    expect(pasteEvent.defaultPrevented).toBe(false);
+    expect(prepareAttachmentMock).not.toHaveBeenCalled();
   });
 
   it("includes an explicit sessionId in the first dictation upload", async () => {

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -443,6 +443,46 @@ export function createDropEvent(file: File): DragEvent {
   return dropEvent;
 }
 
+export function createImagePasteEvent(file: File): ClipboardEvent {
+  const pasteEvent = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+  const imageItem = {
+    kind: "file",
+    type: file.type,
+    getAsFile: () => file,
+  } as DataTransferItem;
+  const textItem = {
+    kind: "string",
+    type: "text/plain",
+    getAsFile: () => null,
+  } as DataTransferItem;
+  const htmlItem = {
+    kind: "string",
+    type: "text/html",
+    getAsFile: () => null,
+  } as DataTransferItem;
+  Object.defineProperty(pasteEvent, "clipboardData", {
+    value: {
+      items: [textItem, htmlItem, imageItem],
+    },
+  });
+  return pasteEvent;
+}
+
+export function createTextPasteEvent(): ClipboardEvent {
+  const pasteEvent = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+  const textItem = {
+    kind: "string",
+    type: "text/plain",
+    getAsFile: () => null,
+  } as DataTransferItem;
+  Object.defineProperty(pasteEvent, "clipboardData", {
+    value: {
+      items: [textItem],
+    },
+  });
+  return pasteEvent;
+}
+
 export function createChatPanelDragEnterEvent(file: File): DragEvent {
   const dragEvent = new Event("dragenter", { bubbles: true, cancelable: true }) as DragEvent;
   const dataTransfer: { files: ReadonlyArray<File>; dropEffect: DataTransfer["dropEffect"] } = {
@@ -464,6 +504,19 @@ export async function dispatchChatPanelDragEvent(
 
   await act(async () => {
     chatPanel?.dispatchEvent(dragEvent);
+    await Promise.resolve();
+  });
+}
+
+export async function dispatchChatComposerPasteEvent(
+  container: HTMLDivElement,
+  pasteEvent: ClipboardEvent,
+): Promise<void> {
+  const textarea = queryChatComposerInput(container);
+  expect(textarea).not.toBeNull();
+
+  await act(async () => {
+    textarea?.dispatchEvent(pasteEvent);
     await Promise.resolve();
   });
 }

--- a/apps/web/src/chat/attachments/useChatAttachments.ts
+++ b/apps/web/src/chat/attachments/useChatAttachments.ts
@@ -1,4 +1,10 @@
-import { useRef, useState, type DragEvent, type MutableRefObject } from "react";
+import {
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type DragEvent,
+  type MutableRefObject,
+} from "react";
 import {
   ATTACHMENT_PAYLOAD_LIMIT_BYTES,
   IMAGE_MEDIA_TYPE_PREFIX,
@@ -41,10 +47,37 @@ export type ChatAttachmentControls = Readonly<{
   handleDragLeave: (event: DragEvent<HTMLDivElement>) => void;
   handleDragOver: (event: DragEvent<HTMLDivElement>) => void;
   handleDrop: (event: DragEvent<HTMLDivElement>) => Promise<void>;
+  handlePaste: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
   ingestFiles: (files: ReadonlyArray<File>) => Promise<void>;
   isDragOver: boolean;
   removeAttachment: (index: number) => void;
 }>;
+
+function clipboardImageExtension(mediaType: string): string {
+  const normalizedMediaType = mediaType.split(";")[0]?.trim().toLowerCase() ?? "";
+  const imageSubtype = normalizedMediaType.slice(IMAGE_MEDIA_TYPE_PREFIX.length);
+  const extension = imageSubtype.split("+")[0]?.replace(/[^a-z0-9]/g, "") ?? "";
+  if (extension.length === 0) {
+    throw new Error(`Cannot name pasted image because clipboard MIME type "${mediaType}" has no usable subtype.`);
+  }
+
+  return extension === "jpeg" ? "jpg" : extension;
+}
+
+function ensureClipboardImageFileName(file: File, clipboardMediaType: string): File {
+  if (file.name.trim().length > 0) {
+    return file;
+  }
+
+  return new File(
+    [file],
+    `pasted-image.${clipboardImageExtension(clipboardMediaType)}`,
+    {
+      type: clipboardMediaType,
+      lastModified: file.lastModified,
+    },
+  );
+}
 
 function buildDraftRequestBodyForAttachments(params: Readonly<{
   attachments: ReadonlyArray<PendingAttachment>;
@@ -241,11 +274,44 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
     await ingestFiles(Array.from(event.dataTransfer.files));
   }
 
+  function handlePaste(event: ClipboardEvent<HTMLTextAreaElement>): void {
+    if (!canAttachDraftFiles) {
+      return;
+    }
+
+    const imageItems = Array.from(event.clipboardData.items).filter(
+      (item) => item.kind === "file" && item.type.startsWith(IMAGE_MEDIA_TYPE_PREFIX),
+    );
+    const imageFiles: ReadonlyArray<File> = imageItems.flatMap((item) => {
+      try {
+        const file = item.getAsFile();
+        if (file === null) {
+          throw new Error(
+            `Failed to read pasted image from clipboard item with MIME type "${item.type}".`,
+          );
+        }
+
+        return [ensureClipboardImageFileName(file, item.type)];
+      } catch (error) {
+        onTechnicalError(error);
+        return [];
+      }
+    });
+
+    if (imageFiles.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    void ingestFiles(imageFiles);
+  }
+
   return {
     handleDragEnter,
     handleDragLeave,
     handleDragOver,
     handleDrop,
+    handlePaste,
     ingestFiles,
     isDragOver,
     removeAttachment,


### PR DESCRIPTION
## Summary
- route pasted image files through the shared chat attachment ingestion path
- preserve native text-only paste behavior
- add focused composer paste-event coverage

## Validation
- Not run locally per repository integration-PR policy