### PR TITLE
Cap Android review images responsively

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AttachFile
@@ -74,6 +76,7 @@ import java.io.IOException
 
 private val reviewManagedMediaIconSize = 22.dp
 private val reviewManagedMediaActionIconSize = 18.dp
+private val reviewManagedMediaImageMaxWidth = 520.dp
 private const val reviewManagedMediaImagePlaceholderAspectRatio = 4f / 3f
 private val reviewManagedMediaImagePlaceholderHeight = 180.dp
 private val reviewManagedMediaSurfaceCornerRadius = 12.dp
@@ -139,9 +142,9 @@ internal fun ReviewManagedMediaContent(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.PROGRESS,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
             return
         }
@@ -157,9 +160,9 @@ internal fun ReviewManagedMediaContent(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.WARNING,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
             return
         }
@@ -238,9 +241,9 @@ private fun ReviewManagedMediaImageFile(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.PROGRESS,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
         }
 
@@ -255,9 +258,9 @@ private fun ReviewManagedMediaImageFile(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.WARNING,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
         }
 
@@ -336,11 +339,20 @@ private fun ReviewManagedMediaImage(
                     modifier = Modifier.fillMaxSize()
                 )
             },
-            modifier = Modifier
-                .fillMaxWidth()
-                .then(imageSizeModifier)
+            modifier = Modifier.reviewManagedMediaImageFrame(sizeModifier = imageSizeModifier)
         )
     }
+}
+
+private fun Modifier.reviewManagedMediaImageFrame(sizeModifier: Modifier): Modifier {
+    return fillMaxWidth()
+        .wrapContentWidth(
+            align = Alignment.CenterHorizontally,
+            unbounded = false
+        )
+        .widthIn(max = reviewManagedMediaImageMaxWidth)
+        .fillMaxWidth()
+        .then(sizeModifier)
 }
 
 private fun reviewManagedMediaImageMemoryCacheKey(


### PR DESCRIPTION
## Summary
- keep managed review images full-width through 520 dp
- cap and center ready and image-shaped loading/error states on wider content
- preserve existing aspect ratios and managed-media behavior

## Validation
- independent static working-tree review completed with no P0-P4 findings
- project checks not run per integration delivery policy