### PR TITLE
Cap unavailable Android review images

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
@@ -170,11 +170,28 @@ internal fun ReviewManagedMediaContent(
         ManagedMediaReferenceState.READY -> Unit
     }
     if (isUnavailable) {
-        ReviewManagedMediaPlaceholderRow(
-            label = label,
-            supportingText = stringResource(id = R.string.review_media_unavailable),
-            icon = Icons.Outlined.WarningAmber
-        )
+        val supportingText = stringResource(id = R.string.review_media_unavailable)
+        if (category == ReviewManagedMediaCategory.IMAGE) {
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = supportingText,
+                accessibilityLabel = stringResource(
+                    id = R.string.review_media_status_content_description,
+                    label,
+                    supportingText
+                ),
+                style = ReviewManagedMediaImageStateStyle.WARNING,
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
+            )
+        } else {
+            ReviewManagedMediaPlaceholderRow(
+                label = label,
+                supportingText = supportingText,
+                icon = Icons.Outlined.WarningAmber
+            )
+        }
         return
     }
 


### PR DESCRIPTION
## Summary
- render missing or deleted managed images with the existing responsive warning image state
- preserve the compact unavailable row for non-image media
- keep the 520 dp centered image cap consistent across unavailable paths

## Validation
- independent static working-tree review completed with no P0-P4 findings
- project checks not run per integration delivery policy