### PR TITLE
Center responsive card images across clients

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AttachFile
@@ -74,6 +76,7 @@ import java.io.IOException
 
 private val reviewManagedMediaIconSize = 22.dp
 private val reviewManagedMediaActionIconSize = 18.dp
+private val reviewManagedMediaImageMaxWidth = 520.dp
 private const val reviewManagedMediaImagePlaceholderAspectRatio = 4f / 3f
 private val reviewManagedMediaImagePlaceholderHeight = 180.dp
 private val reviewManagedMediaSurfaceCornerRadius = 12.dp
@@ -139,9 +142,9 @@ internal fun ReviewManagedMediaContent(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.PROGRESS,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
             return
         }
@@ -157,9 +160,9 @@ internal fun ReviewManagedMediaContent(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.WARNING,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
             return
         }
@@ -238,9 +241,9 @@ private fun ReviewManagedMediaImageFile(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.PROGRESS,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
         }
 
@@ -255,9 +258,9 @@ private fun ReviewManagedMediaImageFile(
                     supportingText
                 ),
                 style = ReviewManagedMediaImageStateStyle.WARNING,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
             )
         }
 
@@ -336,11 +339,20 @@ private fun ReviewManagedMediaImage(
                     modifier = Modifier.fillMaxSize()
                 )
             },
-            modifier = Modifier
-                .fillMaxWidth()
-                .then(imageSizeModifier)
+            modifier = Modifier.reviewManagedMediaImageFrame(sizeModifier = imageSizeModifier)
         )
     }
+}
+
+private fun Modifier.reviewManagedMediaImageFrame(sizeModifier: Modifier): Modifier {
+    return fillMaxWidth()
+        .wrapContentWidth(
+            align = Alignment.CenterHorizontally,
+            unbounded = false
+        )
+        .widthIn(max = reviewManagedMediaImageMaxWidth)
+        .fillMaxWidth()
+        .then(sizeModifier)
 }
 
 private fun reviewManagedMediaImageMemoryCacheKey(

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewManagedMediaContent.kt
@@ -170,11 +170,28 @@ internal fun ReviewManagedMediaContent(
         ManagedMediaReferenceState.READY -> Unit
     }
     if (isUnavailable) {
-        ReviewManagedMediaPlaceholderRow(
-            label = label,
-            supportingText = stringResource(id = R.string.review_media_unavailable),
-            icon = Icons.Outlined.WarningAmber
-        )
+        val supportingText = stringResource(id = R.string.review_media_unavailable)
+        if (category == ReviewManagedMediaCategory.IMAGE) {
+            ReviewManagedMediaImageState(
+                label = label,
+                supportingText = supportingText,
+                accessibilityLabel = stringResource(
+                    id = R.string.review_media_status_content_description,
+                    label,
+                    supportingText
+                ),
+                style = ReviewManagedMediaImageStateStyle.WARNING,
+                modifier = Modifier.reviewManagedMediaImageFrame(
+                    sizeModifier = Modifier.aspectRatio(ratio = reviewManagedMediaImagePlaceholderAspectRatio)
+                )
+            )
+        } else {
+            ReviewManagedMediaPlaceholderRow(
+                label = label,
+                supportingText = supportingText,
+                icon = Icons.Outlined.WarningAmber
+            )
+        }
         return
     }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/Media/ReviewManagedMediaView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/Media/ReviewManagedMediaView.swift
@@ -4,6 +4,7 @@ import UIKit
 
 private let reviewManagedMediaStringsTableName: String = "ReviewCards"
 private let reviewManagedMediaCornerRadius: CGFloat = reviewContentSurfaceCornerRadius / 2
+private let reviewManagedImagePresentationMaxWidth: CGFloat = 520
 private let reviewManagedImagePlaceholderAspectRatio: CGFloat = 4.0 / 3.0
 private let reviewManagedAudioHeight: CGFloat = 76
 private let reviewManagedVideoMinHeight: CGFloat = 190
@@ -137,6 +138,7 @@ struct ReviewManagedMediaView: View {
         RoundedRectangle(cornerRadius: reviewManagedMediaCornerRadius)
             .fill(mediaBackgroundStyle)
             .aspectRatio(reviewManagedImagePlaceholderAspectRatio, contentMode: .fit)
+            .frame(maxWidth: reviewManagedImagePresentationMaxWidth)
             .frame(maxWidth: .infinity, alignment: .center)
             .overlay {
                 ProgressView(loadingMediaLabel)
@@ -151,6 +153,7 @@ struct ReviewManagedMediaView: View {
         RoundedRectangle(cornerRadius: reviewManagedMediaCornerRadius)
             .fill(mediaBackgroundStyle)
             .aspectRatio(reviewManagedImagePlaceholderAspectRatio, contentMode: .fit)
+            .frame(maxWidth: reviewManagedImagePresentationMaxWidth)
             .frame(maxWidth: .infinity, alignment: .center)
             .overlay {
                 VStack(spacing: 10) {
@@ -172,6 +175,7 @@ struct ReviewManagedMediaView: View {
         RoundedRectangle(cornerRadius: reviewManagedMediaCornerRadius)
             .fill(mediaBackgroundStyle)
             .aspectRatio(reviewManagedImagePlaceholderAspectRatio, contentMode: .fit)
+            .frame(maxWidth: reviewManagedImagePresentationMaxWidth)
             .frame(maxWidth: .infinity, alignment: .center)
             .overlay {
                 VStack(spacing: 8) {
@@ -288,8 +292,9 @@ struct ReviewManagedMediaView: View {
                     .scaledToFit()
             }
         }
-        .frame(maxWidth: .infinity, alignment: .center)
+        .frame(maxWidth: reviewManagedImagePresentationMaxWidth)
         .clipShape(RoundedRectangle(cornerRadius: reviewManagedMediaCornerRadius))
+        .frame(maxWidth: .infinity, alignment: .center)
         .accessibilityLabel(accessibilityLabel)
     }
 

--- a/apps/web/src/styles/features/review/review-markdown.css
+++ b/apps/web/src/styles/features/review/review-markdown.css
@@ -154,7 +154,8 @@
   display: block;
   width: 100%;
   height: auto;
-  max-width: 100%;
+  max-width: 520px;
+  margin-inline: auto;
   border-radius: var(--review-managed-media-image-radius, 8px);
   background: rgba(7, 7, 10, 0.34);
   object-fit: contain;
@@ -168,7 +169,8 @@
 .review-markdown-media-image-loading {
   display: block;
   width: 100%;
-  max-width: 100%;
+  max-width: 520px;
+  margin-inline: auto;
   aspect-ratio: 4 / 3;
   border-radius: var(--review-managed-media-image-radius, 8px);
   background: rgba(7, 7, 10, 0.34);
@@ -179,7 +181,8 @@
   display: flex;
   box-sizing: border-box;
   width: 100%;
-  max-width: 100%;
+  max-width: 520px;
+  margin-inline: auto;
   aspect-ratio: 4 / 3;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary

- cap web, iOS, and Android card image presentation at 520 layout units while keeping narrow images full-width and proportional
- center capped managed image loading, pending, failed, and unavailable states
- preserve Android non-image unavailable media rows while covering missing or deleted image registry records

## Review

- fresh cumulative static review of `origin/main...origin/integration-responsive-card-images`: no P0-P4 issues found
- local project checks were not run; required trunk CI owns executable validation