### PR TITLE
Android review and editor metadata

### DIFF
--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Resources
 import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import java.text.NumberFormat
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -70,6 +71,11 @@ fun formatCardsDueLabel(resources: Resources, dueAtMillis: Long?): String {
         .ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
         .withLocale(locale)
         .format(Instant.ofEpochMilli(dueAtMillis).atZone(ZoneId.systemDefault()))
+}
+
+fun formatCardsCount(resources: Resources, count: Int): String {
+    val locale = resources.configuration.locales[0] ?: Locale.getDefault()
+    return NumberFormat.getIntegerInstance(locale).format(count)
 }
 
 fun formatCardsMetadataSummary(resources: Resources, card: CardSummary): String {

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
@@ -11,8 +11,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.Label
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.Autorenew
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -26,7 +29,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
@@ -37,6 +42,8 @@ import com.flashcardsopensourceapp.feature.cards.cardEditorBackSummaryCardTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorFrontSummaryCardTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorSaveButtonTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorTagsSummaryCardTag
+import com.flashcardsopensourceapp.feature.cards.formatCardsCount
+import com.flashcardsopensourceapp.feature.cards.formatCardsDueLabel
 import com.flashcardsopensourceapp.feature.cards.formatCardsTagSelectionSummary
 import com.flashcardsopensourceapp.feature.cards.formatCardsTextPreview
 
@@ -241,6 +248,42 @@ fun CardEditorRoute(
                 }
             }
 
+            if (uiState.isEditing && uiState.schedulingMetadata != null) {
+                val metadata = uiState.schedulingMetadata
+                item {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        CardEditorMetadataItem(
+                            icon = Icons.Outlined.AccessTime,
+                            label = stringResource(
+                                id = R.string.cards_due_label,
+                                formatCardsDueLabel(
+                                    resources = resources,
+                                    dueAtMillis = metadata.dueAtMillis
+                                )
+                            )
+                        )
+                        CardEditorMetadataItem(
+                            icon = Icons.Outlined.Autorenew,
+                            label = stringResource(
+                                id = R.string.cards_reps_label,
+                                formatCardsCount(resources = resources, count = metadata.reps)
+                            )
+                        )
+                        CardEditorMetadataItem(
+                            icon = Icons.Outlined.WarningAmber,
+                            label = stringResource(
+                                id = R.string.cards_lapses_label,
+                                formatCardsCount(resources = resources, count = metadata.lapses)
+                            )
+                        )
+                    }
+                }
+            }
+
             item {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -278,5 +321,27 @@ fun CardEditorRoute(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun CardEditorMetadataItem(
+    icon: ImageVector,
+    label: String
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
@@ -41,6 +41,12 @@ data class CardEditorManagedImageReference(
     }
 }
 
+data class CardEditorSchedulingMetadata(
+    val dueAtMillis: Long?,
+    val reps: Int,
+    val lapses: Int
+)
+
 data class CardEditorUiState(
     val isLoading: Boolean,
     val title: String,
@@ -53,6 +59,7 @@ data class CardEditorUiState(
     val backManagedImageReferences: List<CardEditorManagedImageReference>,
     val selectedTags: List<String>,
     val availableTagSuggestions: List<WorkspaceTagSummary>,
+    val schedulingMetadata: CardEditorSchedulingMetadata?,
     val frontTextErrorMessage: String,
     val backTextErrorMessage: String,
     val tagsErrorMessage: String,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -137,6 +137,17 @@ class CardEditorViewModel(
                     referenceTags = tagsSummary.tags.map(WorkspaceTagSummary::tag)
                 ),
                 availableTagSuggestions = tagsSummary.tags,
+                schedulingMetadata = if (currentState.hasLoadedInitialValues) {
+                    card?.let { loadedCard ->
+                        CardEditorSchedulingMetadata(
+                            dueAtMillis = loadedCard.dueAtMillis,
+                            reps = loadedCard.reps,
+                            lapses = loadedCard.lapses
+                        )
+                    }
+                } else {
+                    null
+                },
                 frontTextErrorMessage = currentState.frontTextErrorMessage,
                 backTextErrorMessage = currentState.backTextErrorMessage,
                 tagsErrorMessage = currentState.tagsErrorMessage,
@@ -158,6 +169,7 @@ class CardEditorViewModel(
                 backManagedImageReferences = emptyList(),
                 selectedTags = emptyList(),
                 availableTagSuggestions = emptyList(),
+                schedulingMetadata = null,
                 frontTextErrorMessage = "",
                 backTextErrorMessage = "",
                 tagsErrorMessage = "",

--- a/apps/android/feature/cards/src/main/res/values/strings.xml
+++ b/apps/android/feature/cards/src/main/res/values/strings.xml
@@ -30,6 +30,9 @@
     <string name="cards_no_tags_label">No tags</string>
     <string name="cards_tag_with_count">%1$s (%2$d)</string>
     <string name="cards_due_new">New</string>
+    <string name="cards_due_label">Due %1$s</string>
+    <string name="cards_reps_label">Reps %1$s</string>
+    <string name="cards_lapses_label">Lapses %1$s</string>
     <string name="cards_filter_summary_tags">Tags: %1$s</string>
     <string name="cards_updated_on_another_device">Cards updated on another device.</string>
     <string name="cards_new_card_title">New card</string>

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewStrings.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewStrings.kt
@@ -105,10 +105,6 @@ class ReviewTextProvider(
             .format(Instant.ofEpochMilli(dueAtMillis).atZone(ZoneId.systemDefault()))
     }
 
-    fun repsLabel(reps: Int): String = resources.getString(R.string.review_reps_label, reps)
-
-    fun lapsesLabel(lapses: Int): String = resources.getString(R.string.review_lapses_label, lapses)
-
     fun filterTitle(
         selectedFilter: ReviewFilter,
         availableDeckFilters: List<ReviewDeckFilterOption>

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -19,10 +19,8 @@ import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
-import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.Autorenew
 import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.FilledIconButton
@@ -31,6 +29,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -50,6 +49,7 @@ import com.flashcardsopensourceapp.core.ui.bidiWrap
 import com.flashcardsopensourceapp.core.ui.currentResourceLocale
 import com.flashcardsopensourceapp.data.local.model.media.MediaAssetDownloadUrl
 import com.flashcardsopensourceapp.data.local.model.media.ReviewMediaAssetFile
+import java.text.NumberFormat
 
 private val reviewShowAnswerContentBottomPadding = 120.dp
 private val reviewAnswerGridContentBottomPadding = 184.dp
@@ -287,6 +287,10 @@ private fun ReviewCardContent(
                     icon = Icons.AutoMirrored.Outlined.Label,
                     label = currentCard.tagsLabel
                 )
+                ReviewRepetitionPill(
+                    reps = currentCard.card.reps,
+                    formattedReps = NumberFormat.getIntegerInstance(locale).format(currentCard.card.reps)
+                )
             }
 
             Row(
@@ -359,29 +363,45 @@ private fun ReviewCardContent(
                 }
             }
         }
+    }
+}
 
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.fillMaxWidth()
+@Composable
+private fun ReviewRepetitionPill(
+    reps: Int,
+    formattedReps: String
+) {
+    val isNew = reps == 0
+    Surface(
+        shape = RoundedCornerShape(percent = 50),
+        color = if (isNew) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHighest
+        },
+        contentColor = if (isNew) {
+            MaterialTheme.colorScheme.onPrimary
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
         ) {
-            ReviewMetadataItem(
-                icon = Icons.Outlined.AccessTime,
-                label = stringResource(
-                    id = R.string.review_due_label,
-                    bidiWrap(
-                        text = currentCard.dueLabel,
-                        locale = locale
-                    )
-                )
+            Icon(
+                imageVector = Icons.Outlined.Autorenew,
+                contentDescription = null,
+                modifier = Modifier.size(reviewMetadataIconSize)
             )
-            ReviewMetadataItem(
-                icon = Icons.Outlined.Autorenew,
-                label = currentCard.repsLabel
-            )
-            ReviewMetadataItem(
-                icon = Icons.Outlined.WarningAmber,
-                label = currentCard.lapsesLabel
+            Text(
+                text = if (isNew) {
+                    stringResource(id = R.string.review_due_new)
+                } else {
+                    formattedReps
+                },
+                style = MaterialTheme.typography.bodyMedium
             )
         }
     }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewCardPresentationPreparation.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewCardPresentationPreparation.kt
@@ -28,9 +28,6 @@ fun prepareReviewCardPresentation(
     return PreparedReviewCardPresentation(
         card = card,
         tagsLabel = textProvider.tagsLabel(tags = card.tags),
-        dueLabel = textProvider.dueLabel(dueAtMillis = card.dueAtMillis),
-        repsLabel = textProvider.repsLabel(reps = card.reps),
-        lapsesLabel = textProvider.lapsesLabel(lapses = card.lapses),
         frontContent = preparedFrontContent.renderedContent,
         backContent = preparedBackContent.renderedContent,
         frontSpeakableText = preparedFrontContent.speakableText,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/presentation/ReviewContentModels.kt
@@ -65,9 +65,6 @@ data class PreparedReviewAnswerOption(
 data class PreparedReviewCardPresentation(
     val card: ReviewCard,
     val tagsLabel: String,
-    val dueLabel: String,
-    val repsLabel: String,
-    val lapsesLabel: String,
     val frontContent: ReviewRenderedContent,
     val backContent: ReviewRenderedContent,
     val frontSpeakableText: String,

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -34,7 +34,6 @@
     <string name="review_edit_card_content_description">Edit card</string>
     <string name="review_front_label">Front</string>
     <string name="review_back_label">Back</string>
-    <string name="review_due_label">Due %1$s</string>
     <string name="review_stop_speech">Stop %1$s speech</string>
     <string name="review_speak">Speak %1$s</string>
     <string name="review_show_answer">Show answer</string>
@@ -74,8 +73,6 @@
     <string name="review_media_video_label">Video attachment</string>
     <string name="review_math_render_failed">Formula couldn\'t be rendered.</string>
     <string name="review_no_back_text">No back text</string>
-    <string name="review_reps_label">Reps %1$d</string>
-    <string name="review_lapses_label">Lapses %1$d</string>
     <string name="review_later_section">Later</string>
     <string name="review_loading">Loading...</string>
     <string name="review_no_tags_label">No tags</string>

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewSubmissionReconciliationTestSupport.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewSubmissionReconciliationTestSupport.kt
@@ -12,9 +12,6 @@ internal fun makePreparedReviewCardPresentation(card: ReviewCard): PreparedRevie
     return PreparedReviewCardPresentation(
         card = card,
         tagsLabel = card.tags.joinToString(),
-        dueLabel = "Due",
-        repsLabel = "2 reps",
-        lapsesLabel = "0 lapses",
         frontContent = ReviewRenderedContent.ShortPlain(text = card.frontText),
         backContent = ReviewRenderedContent.ShortPlain(text = card.backText),
         frontSpeakableText = card.frontText,


### PR DESCRIPTION
## Summary
- replace the Review scheduling footer with a persistent repetition pill beside tags
- expose loaded scheduling metadata as one optional editor UI-state value
- show immutable Due, Reps, and Lapses metadata in existing-card edit mode

## Validation
- static review gate passed
- project checks not run for this integration PR, as required