### PR TITLE
Add web review repetition badge

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -845,6 +845,7 @@ const arCatalog: TranslationCatalog = {
       switchToAllCards: "التبديل إلى مجموعة كل البطاقات",
     },
     aiOpenAriaLabel: "افتح جانب {{side}} من البطاقة في دردشة الذكاء الاصطناعي",
+    repetitionBadgeAriaLabel: "المراجعات: {{value}}",
     empty: {
       noCardsBody: "لم تنشئ أي بطاقات بعد. أضف بطاقتك الأولى لبدء الدراسة.",
       noCardsTitle: "لا توجد بطاقات بعد",
@@ -889,11 +890,6 @@ const arCatalog: TranslationCatalog = {
       loading: "جارٍ تحميل الوسائط...",
       unavailable: "الوسائط غير متاحة",
       videoLabel: "مرفق فيديو",
-    },
-    meta: {
-      due: "مستحق {{value}}",
-      lapses: "الإخفاقات {{count}}",
-      reps: "المراجعات {{count}}",
     },
     queue: {
       cards: "{{count}} بطاقة",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -845,6 +845,7 @@ const deCatalog: TranslationCatalog = {
       switchToAllCards: "zum Alle-Karten-Deck wechseln",
     },
     aiOpenAriaLabel: "{{side}}-Seite der Karte im AI-Chat öffnen",
+    repetitionBadgeAriaLabel: "Wiederholungen: {{value}}",
     empty: {
       noCardsBody: "Du hast noch keine Karten erstellt. Füge deine erste Karte hinzu, um mit dem Lernen zu beginnen.",
       noCardsTitle: "Noch keine Karten",
@@ -889,11 +890,6 @@ const deCatalog: TranslationCatalog = {
       loading: "Medien werden geladen...",
       unavailable: "Medien nicht verfügbar",
       videoLabel: "Videoanhang",
-    },
-    meta: {
-      due: "Fällig {{value}}",
-      lapses: "Fehlversuche {{count}}",
-      reps: "Wiederholungen {{count}}",
     },
     queue: {
       cards: "{{count}} Karten",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -843,6 +843,7 @@ const enCatalog = {
       switchToAllCards: "switch to all cards deck",
     },
     aiOpenAriaLabel: "Open {{side}} card in AI chat",
+    repetitionBadgeAriaLabel: "Repetitions: {{value}}",
     empty: {
       noCardsBody: "You have not created any cards yet. Add your first card to start studying.",
       noCardsTitle: "No Cards Yet",
@@ -887,11 +888,6 @@ const enCatalog = {
       loading: "Loading media...",
       unavailable: "Media unavailable",
       videoLabel: "Video attachment",
-    },
-    meta: {
-      due: "Due {{value}}",
-      lapses: "Lapses {{count}}",
-      reps: "Reps {{count}}",
     },
     queue: {
       cards: "{{count}} cards",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -845,6 +845,7 @@ const esEsCatalog: TranslationCatalog = {
       switchToAllCards: "cambiar al mazo de todas las tarjetas",
     },
     aiOpenAriaLabel: "Abrir la tarjeta del {{side}} en el chat con IA",
+    repetitionBadgeAriaLabel: "Repasos: {{value}}",
     empty: {
       noCardsBody: "Aún no has creado ninguna tarjeta. Añade tu primera tarjeta para empezar a estudiar.",
       noCardsTitle: "Aún no hay tarjetas",
@@ -889,11 +890,6 @@ const esEsCatalog: TranslationCatalog = {
       loading: "Cargando archivo multimedia...",
       unavailable: "Archivo multimedia no disponible",
       videoLabel: "Adjunto de video",
-    },
-    meta: {
-      due: "Pendiente {{value}}",
-      lapses: "Fallos {{count}}",
-      reps: "Repasos {{count}}",
     },
     queue: {
       cards: "{{count}} tarjetas",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -845,6 +845,7 @@ const esMxCatalog: TranslationCatalog = {
       switchToAllCards: "cambiar al mazo de todas las tarjetas",
     },
     aiOpenAriaLabel: "Abrir la tarjeta del {{side}} en el chat con IA",
+    repetitionBadgeAriaLabel: "Repasos: {{value}}",
     empty: {
       noCardsBody: "Todavía no has creado ninguna tarjeta. Añade tu primera tarjeta para empezar a estudiar.",
       noCardsTitle: "Todavía no hay tarjetas",
@@ -889,11 +890,6 @@ const esMxCatalog: TranslationCatalog = {
       loading: "Cargando archivo multimedia...",
       unavailable: "Archivo multimedia no disponible",
       videoLabel: "Adjunto de video",
-    },
-    meta: {
-      due: "Pendiente {{value}}",
-      lapses: "Fallos {{count}}",
-      reps: "Repasos {{count}}",
     },
     queue: {
       cards: "{{count}} tarjetas",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -845,6 +845,7 @@ const hiCatalog: TranslationCatalog = {
       switchToAllCards: "सभी कार्ड डेक पर जाएँ",
     },
     aiOpenAriaLabel: "{{side}} कार्ड को AI चैट में खोलें",
+    repetitionBadgeAriaLabel: "रिव्यू: {{value}}",
     empty: {
       noCardsBody: "आपने अभी तक कोई कार्ड नहीं बनाया है। पढ़ाई शुरू करने के लिए अपना पहला कार्ड जोड़ें।",
       noCardsTitle: "अभी तक कोई कार्ड नहीं",
@@ -889,11 +890,6 @@ const hiCatalog: TranslationCatalog = {
       loading: "मीडिया लोड हो रहा है...",
       unavailable: "मीडिया उपलब्ध नहीं है",
       videoLabel: "वीडियो अटैचमेंट",
-    },
-    meta: {
-      due: "बाकी {{value}}",
-      lapses: "चूक {{count}}",
-      reps: "रिव्यू {{count}}",
     },
     queue: {
       cards: "{{count}} कार्ड",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -845,6 +845,7 @@ export const jaCatalog = {
       switchToAllCards: "すべてのカードデッキに切り替える",
     },
     aiOpenAriaLabel: "{{side}} のカードを AI チャットで開く",
+    repetitionBadgeAriaLabel: "復習回数: {{value}}",
     empty: {
       noCardsBody: "まだカードを作成していません。最初のカードを追加して学習を始めましょう。",
       noCardsTitle: "カードがまだありません",
@@ -889,11 +890,6 @@ export const jaCatalog = {
       loading: "メディアを読み込み中...",
       unavailable: "メディアを利用できません",
       videoLabel: "動画添付",
-    },
-    meta: {
-      due: "期限 {{value}}",
-      lapses: "失敗 {{count}}",
-      reps: "復習回数 {{count}}",
     },
     queue: {
       cards: "{{count}} 枚",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -845,6 +845,7 @@ export const ruCatalog = {
       switchToAllCards: "переключиться на колоду всех карточек",
     },
     aiOpenAriaLabel: "Открыть {{side}} карточки в AI-чате",
+    repetitionBadgeAriaLabel: "Повторы: {{value}}",
     empty: {
       noCardsBody: "Вы еще не создали ни одной карточки. Добавьте первую карточку, чтобы начать учиться.",
       noCardsTitle: "Карточек пока нет",
@@ -889,11 +890,6 @@ export const ruCatalog = {
       loading: "Загрузка медиа...",
       unavailable: "Медиа недоступно",
       videoLabel: "Видеовложение",
-    },
-    meta: {
-      due: "Срок {{value}}",
-      lapses: "Ошибки {{count}}",
-      reps: "Повторы {{count}}",
     },
     queue: {
       cards: "{{count}} карточек",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -845,6 +845,7 @@ export const zhHansCatalog = {
       switchToAllCards: "切换到所有卡片牌组",
     },
     aiOpenAriaLabel: "在 AI 聊天中打开{{side}}卡片",
+    repetitionBadgeAriaLabel: "复习次数：{{value}}",
     empty: {
       noCardsBody: "您还没有创建任何卡片。添加第一张卡片即可开始学习。",
       noCardsTitle: "还没有卡片",
@@ -889,11 +890,6 @@ export const zhHansCatalog = {
       loading: "正在加载媒体...",
       unavailable: "媒体不可用",
       videoLabel: "视频附件",
-    },
-    meta: {
-      due: "到期 {{value}}",
-      lapses: "失误 {{count}}",
-      reps: "复习次数 {{count}}",
     },
     queue: {
       cards: "{{count}} 张卡片",

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -5,7 +5,7 @@ import { useI18n } from "../../../i18n";
 import { cardsRoute, chatRoute } from "../../../routes";
 import type { Card } from "../../../types";
 import type { ReviewLoadingSnapshot } from "../../shared/loadingSnapshots";
-import { formatNullableDateTime, formatTagSummary } from "../../shared/featureFormatting";
+import { formatTagSummary } from "../../shared/featureFormatting";
 import { ReviewCardSide, ReviewCardSpeechButton, ReviewEditIcon } from "./card/ReviewCardSide";
 import type { ReviewButtonOption } from "./reviewRatingOptions";
 import type { ReviewSpeechSide } from "../speech/reviewSpeech";
@@ -89,6 +89,20 @@ type ReviewRatingButtonColumnProps = Readonly<{
 }>;
 
 function handleDisabledSpeechToggle(): void {
+}
+
+function ReviewRepetitionIcon(): ReactElement {
+  return (
+    <svg className="review-repetition-badge-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+      <path
+        d="M21 12A9 9 0 1 1 18.36 5.64L21 8M21 3V8H16"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
 }
 
 function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
@@ -267,9 +281,10 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
     selectedFrontSpeakableText,
     workspaceId,
   } = props;
-  const { t, formatDateTime, formatNumber } = useI18n();
+  const { t, formatNumber } = useI18n();
   const frontSideLabel = t("reviewScreen.sides.front");
   const backSideLabel = t("reviewScreen.sides.back");
+  const repetitionValue = selectedCard.reps === 0 ? t("common.newItem") : formatNumber(selectedCard.reps);
   const leftReviewButtonOptions = reviewButtonOptions.slice(0, REVIEW_BUTTONS_PER_COLUMN);
   const rightReviewButtonOptions = reviewButtonOptions.slice(REVIEW_BUTTONS_PER_COLUMN, REVIEW_BUTTONS_PER_COLUMN * 2);
   const frontTargetRef = useRef<HTMLDivElement>(null);
@@ -298,7 +313,14 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
     <>
       <div className="review-pane-head">
         <div className="review-pane-head-meta">
-          <span className="badge">{formatTagSummary(selectedCard.tags)}</span>
+          <span className="badge review-pane-tag-badge">{formatTagSummary(selectedCard.tags)}</span>
+          <span className={`badge review-repetition-badge${selectedCard.reps === 0 ? " review-repetition-badge-new" : ""}`}>
+            <ReviewRepetitionIcon />
+            <span aria-hidden="true">{repetitionValue}</span>
+            <span className="review-repetition-badge-accessible-label">
+              {t("reviewScreen.repetitionBadgeAriaLabel", { value: repetitionValue })}
+            </span>
+          </span>
         </div>
         <div className="review-pane-head-actions">
           <button
@@ -361,12 +383,6 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
             />
           </div>
         ) : null}
-      </div>
-
-      <div className="review-meta">
-        <span>{t("reviewScreen.meta.due", { value: formatNullableDateTime(selectedCard.dueAt, formatDateTime, t) })}</span>
-        <span>{t("reviewScreen.meta.reps", { count: formatNumber(selectedCard.reps) })}</span>
-        <span>{t("reviewScreen.meta.lapses", { count: formatNumber(selectedCard.lapses) })}</span>
       </div>
 
       <div className="review-actions-dock">

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -42,8 +42,48 @@
 
 .review-pane-head-meta {
   display: flex;
+  flex: 1 1 0;
+  align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.review-pane-tag-badge {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.review-repetition-badge {
+  flex: 0 0 auto;
+  gap: 6px;
+  min-height: 26px;
+  padding-inline: 9px;
+}
+
+.review-repetition-badge-new {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+
+.review-repetition-badge-icon {
+  width: 14px;
+  height: 14px;
+  display: block;
+  flex-shrink: 0;
+}
+
+.review-repetition-badge-accessible-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .review-pane-head-actions {


### PR DESCRIPTION
Adds an accessible, contrast-safe repetition badge beside Review tags, removes the active-card scheduling row while preserving loading status, handles long tags in narrow LTR and RTL layouts, and removes only dead Review metadata translations. Promotion remains deferred on the integration branch.