### PR TITLE
Improve Android repetition accessibility

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewContent.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -372,6 +374,15 @@ private fun ReviewRepetitionPill(
     formattedReps: String
 ) {
     val isNew = reps == 0
+    val displayedReps = if (isNew) {
+        stringResource(id = R.string.review_due_new)
+    } else {
+        formattedReps
+    }
+    val repetitionContentDescription = stringResource(
+        id = R.string.review_repetition_content_description,
+        displayedReps
+    )
     Surface(
         shape = RoundedCornerShape(percent = 50),
         color = if (isNew) {
@@ -383,6 +394,9 @@ private fun ReviewRepetitionPill(
             MaterialTheme.colorScheme.onPrimary
         } else {
             MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        modifier = Modifier.clearAndSetSemantics {
+            contentDescription = repetitionContentDescription
         }
     ) {
         Row(
@@ -396,11 +410,7 @@ private fun ReviewRepetitionPill(
                 modifier = Modifier.size(reviewMetadataIconSize)
             )
             Text(
-                text = if (isNew) {
-                    stringResource(id = R.string.review_due_new)
-                } else {
-                    formattedReps
-                },
+                text = displayedReps,
                 style = MaterialTheme.typography.bodyMedium
             )
         }

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="review_loading">Loading...</string>
     <string name="review_no_tags_label">No tags</string>
     <string name="review_due_new">New</string>
+    <string name="review_repetition_content_description">Repetitions: %1$s</string>
     <string name="review_interval_now">now</string>
     <string name="review_interval_less_than_one_minute">in less than a minute</string>
     <plurals name="review_interval_minutes">


### PR DESCRIPTION
## Summary
- expose the repetition pill as one meaningful TalkBack label
- localize the semantic description while preserving the displayed repetition value
- avoid duplicate child announcements without changing pill visuals or behavior

## Validation
- Not run locally, per repository delivery instructions.