### PR TITLE
fix(web): localize new review badge

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -846,6 +846,7 @@ const arCatalog: TranslationCatalog = {
     },
     aiOpenAriaLabel: "افتح جانب {{side}} من البطاقة في دردشة الذكاء الاصطناعي",
     repetitionBadgeAriaLabel: "المراجعات: {{value}}",
+    repetitionBadgeNew: "جديدة",
     empty: {
       noCardsBody: "لم تنشئ أي بطاقات بعد. أضف بطاقتك الأولى لبدء الدراسة.",
       noCardsTitle: "لا توجد بطاقات بعد",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -846,6 +846,7 @@ const deCatalog: TranslationCatalog = {
     },
     aiOpenAriaLabel: "{{side}}-Seite der Karte im AI-Chat öffnen",
     repetitionBadgeAriaLabel: "Wiederholungen: {{value}}",
+    repetitionBadgeNew: "Neu",
     empty: {
       noCardsBody: "Du hast noch keine Karten erstellt. Füge deine erste Karte hinzu, um mit dem Lernen zu beginnen.",
       noCardsTitle: "Noch keine Karten",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -844,6 +844,7 @@ const enCatalog = {
     },
     aiOpenAriaLabel: "Open {{side}} card in AI chat",
     repetitionBadgeAriaLabel: "Repetitions: {{value}}",
+    repetitionBadgeNew: "New",
     empty: {
       noCardsBody: "You have not created any cards yet. Add your first card to start studying.",
       noCardsTitle: "No Cards Yet",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -846,6 +846,7 @@ const esEsCatalog: TranslationCatalog = {
     },
     aiOpenAriaLabel: "Abrir la tarjeta del {{side}} en el chat con IA",
     repetitionBadgeAriaLabel: "Repasos: {{value}}",
+    repetitionBadgeNew: "Nueva",
     empty: {
       noCardsBody: "Aún no has creado ninguna tarjeta. Añade tu primera tarjeta para empezar a estudiar.",
       noCardsTitle: "Aún no hay tarjetas",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -846,6 +846,7 @@ const esMxCatalog: TranslationCatalog = {
     },
     aiOpenAriaLabel: "Abrir la tarjeta del {{side}} en el chat con IA",
     repetitionBadgeAriaLabel: "Repasos: {{value}}",
+    repetitionBadgeNew: "Nueva",
     empty: {
       noCardsBody: "Todavía no has creado ninguna tarjeta. Añade tu primera tarjeta para empezar a estudiar.",
       noCardsTitle: "Todavía no hay tarjetas",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -846,6 +846,7 @@ const hiCatalog: TranslationCatalog = {
     },
     aiOpenAriaLabel: "{{side}} कार्ड को AI चैट में खोलें",
     repetitionBadgeAriaLabel: "रिव्यू: {{value}}",
+    repetitionBadgeNew: "नया",
     empty: {
       noCardsBody: "आपने अभी तक कोई कार्ड नहीं बनाया है। पढ़ाई शुरू करने के लिए अपना पहला कार्ड जोड़ें।",
       noCardsTitle: "अभी तक कोई कार्ड नहीं",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -846,6 +846,7 @@ export const jaCatalog = {
     },
     aiOpenAriaLabel: "{{side}} のカードを AI チャットで開く",
     repetitionBadgeAriaLabel: "復習回数: {{value}}",
+    repetitionBadgeNew: "新規",
     empty: {
       noCardsBody: "まだカードを作成していません。最初のカードを追加して学習を始めましょう。",
       noCardsTitle: "カードがまだありません",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -846,6 +846,7 @@ export const ruCatalog = {
     },
     aiOpenAriaLabel: "Открыть {{side}} карточки в AI-чате",
     repetitionBadgeAriaLabel: "Повторы: {{value}}",
+    repetitionBadgeNew: "Новая",
     empty: {
       noCardsBody: "Вы еще не создали ни одной карточки. Добавьте первую карточку, чтобы начать учиться.",
       noCardsTitle: "Карточек пока нет",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -846,6 +846,7 @@ export const zhHansCatalog = {
     },
     aiOpenAriaLabel: "在 AI 聊天中打开{{side}}卡片",
     repetitionBadgeAriaLabel: "复习次数：{{value}}",
+    repetitionBadgeNew: "新卡",
     empty: {
       noCardsBody: "您还没有创建任何卡片。添加第一张卡片即可开始学习。",
       noCardsTitle: "还没有卡片",

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -284,7 +284,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
   const { t, formatNumber } = useI18n();
   const frontSideLabel = t("reviewScreen.sides.front");
   const backSideLabel = t("reviewScreen.sides.back");
-  const repetitionValue = selectedCard.reps === 0 ? t("common.newItem") : formatNumber(selectedCard.reps);
+  const repetitionValue = selectedCard.reps === 0 ? t("reviewScreen.repetitionBadgeNew") : formatNumber(selectedCard.reps);
   const leftReviewButtonOptions = reviewButtonOptions.slice(0, REVIEW_BUTTONS_PER_COLUMN);
   const rightReviewButtonOptions = reviewButtonOptions.slice(REVIEW_BUTTONS_PER_COLUMN, REVIEW_BUTTONS_PER_COLUMN * 2);
   const frontTargetRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- add a review-specific card-context New translation to all Web catalogs
- use the localized value for the zero-repetition pill and its accessibility text
- preserve non-zero repetition behavior and presentation

## Validation
- not run per repository workflow; fresh static review reported no P0-P4 findings

Promotion to main is deferred.