### PR TITLE
Restore Android marketing review labels

### DIFF
--- a/apps/android/app/src/marketingScreenshot/res/values-ar/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ar/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">كل البطاقات</string>
     <string name="review_front_label">الوجه الأمامي</string>
     <string name="review_back_label">الوجه الخلفي</string>
+    <string name="review_due_label">الاستحقاق: %1$s</string>
     <string name="review_due_new">جديدة</string>
+    <string name="review_reps_label">مرات %1$d</string>
+    <string name="review_lapses_label">أخطاء %1$d</string>
     <string name="review_show_answer">إظهار الإجابة</string>
     <string name="review_again">مرة أخرى</string>
     <string name="review_hard">صعب</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-b+es+419/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-b+es+419/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">Todas las tarjetas</string>
     <string name="review_front_label">Frente</string>
     <string name="review_back_label">Reverso</string>
+    <string name="review_due_label">Vence: %1$s</string>
     <string name="review_due_new">Nueva</string>
+    <string name="review_reps_label">Repasos %1$d</string>
+    <string name="review_lapses_label">Errores %1$d</string>
     <string name="review_show_answer">Mostrar respuesta</string>
     <string name="review_again">Otra vez</string>
     <string name="review_hard">Difícil</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-de-rDE/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-de-rDE/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">Alle Karten</string>
     <string name="review_front_label">Vorderseite</string>
     <string name="review_back_label">Rückseite</string>
+    <string name="review_due_label">Fällig: %1$s</string>
     <string name="review_due_new">Neu</string>
+    <string name="review_reps_label">Wdh. %1$d</string>
+    <string name="review_lapses_label">Fehler %1$d</string>
     <string name="review_show_answer">Antwort anzeigen</string>
     <string name="review_again">Nochmal</string>
     <string name="review_hard">Schwer</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-es-rES/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-es-rES/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">Todas</string>
     <string name="review_front_label">Anverso</string>
     <string name="review_back_label">Reverso</string>
+    <string name="review_due_label">Vence: %1$s</string>
     <string name="review_due_new">Nueva</string>
+    <string name="review_reps_label">Repasos %1$d</string>
+    <string name="review_lapses_label">Errores %1$d</string>
     <string name="review_show_answer">Mostrar respuesta</string>
     <string name="review_again">Otra vez</string>
     <string name="review_hard">Difícil</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-es-rUS/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-es-rUS/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">Todas las tarjetas</string>
     <string name="review_front_label">Frente</string>
     <string name="review_back_label">Reverso</string>
+    <string name="review_due_label">Vence: %1$s</string>
     <string name="review_due_new">Nueva</string>
+    <string name="review_reps_label">Repasos %1$d</string>
+    <string name="review_lapses_label">Errores %1$d</string>
     <string name="review_show_answer">Mostrar respuesta</string>
     <string name="review_again">Otra vez</string>
     <string name="review_hard">Difícil</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-hi-rIN/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-hi-rIN/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">सभी कार्ड</string>
     <string name="review_front_label">सामने</string>
     <string name="review_back_label">पीछे</string>
+    <string name="review_due_label">देय: %1$s</string>
     <string name="review_due_new">नया</string>
+    <string name="review_reps_label">दोहराव %1$d</string>
+    <string name="review_lapses_label">भूल %1$d</string>
     <string name="review_show_answer">उत्तर दिखाएं</string>
     <string name="review_again">फिर से</string>
     <string name="review_hard">कठिन</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-ja-rJP/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ja-rJP/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">すべてのカード</string>
     <string name="review_front_label">表面</string>
     <string name="review_back_label">裏面</string>
+    <string name="review_due_label">期限: %1$s</string>
     <string name="review_due_new">新規</string>
+    <string name="review_reps_label">復習 %1$d</string>
+    <string name="review_lapses_label">忘れ %1$d</string>
     <string name="review_show_answer">答えを表示</string>
     <string name="review_again">もう一度</string>
     <string name="review_hard">難しい</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-ru-rRU/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ru-rRU/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">Все карточки</string>
     <string name="review_front_label">Лицевая сторона</string>
     <string name="review_back_label">Обратная сторона</string>
+    <string name="review_due_label">Срок: %1$s</string>
     <string name="review_due_new">Новая</string>
+    <string name="review_reps_label">Повторы %1$d</string>
+    <string name="review_lapses_label">Ошибки %1$d</string>
     <string name="review_show_answer">Показать ответ</string>
     <string name="review_again">Снова</string>
     <string name="review_hard">Трудно</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-zh-rCN/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">所有卡片</string>
     <string name="review_front_label">正面</string>
     <string name="review_back_label">背面</string>
+    <string name="review_due_label">到期：%1$s</string>
     <string name="review_due_new">新卡</string>
+    <string name="review_reps_label">次数 %1$d</string>
+    <string name="review_lapses_label">遗忘 %1$d</string>
     <string name="review_show_answer">显示答案</string>
     <string name="review_again">再来一次</string>
     <string name="review_hard">困难</string>

--- a/apps/android/app/src/marketingScreenshot/res/values/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values/strings.xml
@@ -21,7 +21,10 @@
     <string name="review_all_cards">All cards</string>
     <string name="review_front_label">Front</string>
     <string name="review_back_label">Back</string>
+    <string name="review_due_label">Due %1$s</string>
     <string name="review_due_new">New</string>
+    <string name="review_reps_label">Reps %1$d</string>
+    <string name="review_lapses_label">Lapses %1$d</string>
     <string name="review_show_answer">Show answer</string>
     <string name="review_again">Again</string>
     <string name="review_hard">Hard</string>


### PR DESCRIPTION
## Summary
- restore the three review metadata strings removed from each marketing screenshot locale
- preserve the existing localized text and resource ordering
- remove the marketing screenshot subtree from the cumulative integration diff versus main

## Testing
- not run per repository instructions; static review gate completed cleanly