### PR TITLE
Align Web review metadata styling

### DIFF
--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -124,7 +124,7 @@ function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
         <div className="review-pane-head-meta">
           {loadingReviewCurrentCard !== null ? (
             <>
-              <span className="badge">{formatTagSummary(loadingReviewCurrentCard.tags)}</span>
+              <span className="review-pane-tag-label">{formatTagSummary(loadingReviewCurrentCard.tags)}</span>
             </>
           ) : (
             <>
@@ -313,7 +313,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
     <>
       <div className="review-pane-head">
         <div className="review-pane-head-meta">
-          <span className="badge review-pane-tag-badge">{formatTagSummary(selectedCard.tags)}</span>
+          <span className="review-pane-tag-label">{formatTagSummary(selectedCard.tags)}</span>
           <span className={`badge review-repetition-badge${selectedCard.reps === 0 ? " review-repetition-badge-new" : ""}`}>
             <ReviewRepetitionIcon />
             <span aria-hidden="true">{repetitionValue}</span>

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -48,21 +48,30 @@
   min-width: 0;
 }
 
-.review-pane-tag-badge {
+.review-pane-tag-label {
+  display: inline-flex;
+  align-items: center;
   flex: 0 1 auto;
+  min-height: 30px;
   min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
   overflow-wrap: anywhere;
 }
 
 .review-repetition-badge {
   flex: 0 0 auto;
   gap: 6px;
-  min-height: 26px;
+  min-height: 30px;
   padding-inline: 9px;
+  border: 0;
 }
 
 .review-repetition-badge-new {
-  border-color: var(--accent);
   background: var(--accent);
   color: #fff;
 }


### PR DESCRIPTION
## Summary
- render review tags as plain secondary labels in active and loading-card states
- align tag and repetition metadata to a 30 px minimum height
- remove repetition capsule outlines while preserving reviewed and New fills

## Testing
- Not run locally per repository workflow; required trunk CI owns validation.