### PR TITLE
Localize empty tag summaries on web

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -39,6 +39,7 @@ const arCatalog: TranslationCatalog = {
     never: "أبدًا",
     newItem: "جديد",
     noBackText: "لا يوجد نص خلفي",
+    noTags: "لا توجد وسوم",
     notRevoked: "غير ملغى",
     ok: "موافق",
     off: "إيقاف",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -39,6 +39,7 @@ const deCatalog: TranslationCatalog = {
     never: "Nie",
     newItem: "neu",
     noBackText: "Kein Rückseitentext",
+    noTags: "Keine Tags",
     notRevoked: "Nicht widerrufen",
     ok: "OK",
     off: "Aus",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -37,6 +37,7 @@ const enCatalog = {
     never: "Never",
     newItem: "new",
     noBackText: "No back text",
+    noTags: "No tags",
     notRevoked: "Not revoked",
     ok: "OK",
     off: "Off",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -39,6 +39,7 @@ const esEsCatalog: TranslationCatalog = {
     never: "Nunca",
     newItem: "nuevo",
     noBackText: "Sin texto en el reverso",
+    noTags: "Sin etiquetas",
     notRevoked: "Sin revocar",
     ok: "OK",
     off: "Desactivado",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -39,6 +39,7 @@ const esMxCatalog: TranslationCatalog = {
     never: "Nunca",
     newItem: "nuevo",
     noBackText: "Sin texto en el reverso",
+    noTags: "Sin etiquetas",
     notRevoked: "Sin revocar",
     ok: "OK",
     off: "Desactivado",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -39,6 +39,7 @@ const hiCatalog: TranslationCatalog = {
     never: "कभी नहीं",
     newItem: "नया",
     noBackText: "कोई बैक टेक्स्ट नहीं",
+    noTags: "कोई टैग नहीं",
     notRevoked: "निरस्त नहीं",
     ok: "ठीक है",
     off: "बंद",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -39,6 +39,7 @@ export const jaCatalog = {
     never: "なし",
     newItem: "新規",
     noBackText: "裏面テキストなし",
+    noTags: "タグなし",
     notRevoked: "取り消されていません",
     ok: "OK",
     off: "オフ",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -39,6 +39,7 @@ export const ruCatalog = {
     never: "Никогда",
     newItem: "новое",
     noBackText: "Нет текста на обратной стороне",
+    noTags: "Нет тегов",
     notRevoked: "Не отозвано",
     ok: "OK",
     off: "Выкл.",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -39,6 +39,7 @@ export const zhHansCatalog = {
     never: "从不",
     newItem: "新建",
     noBackText: "无背面文本",
+    noTags: "无标签",
     notRevoked: "未撤销",
     ok: "确定",
     off: "关",

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -911,7 +911,7 @@ export function CardsScreen(): ReactElement {
                         <span className="cards-loading-cell-text">{card.backText === "" ? t("common.noBackText") : card.backText}</span>
                       </td>
                       <td className="txn-cell cards-col-tags">
-                        <span className="cards-loading-cell-text">{formatTagSummary(card.tags)}</span>
+                        <span className="cards-loading-cell-text">{formatTagSummary(card.tags, t)}</span>
                       </td>
                       <td className="txn-cell txn-cell-mono cards-col-due">{formatNullableDateTime(card.dueAt, formatDateTime, t)}</td>
                       <td className="txn-cell txn-cell-mono cards-col-reps">{card.reps}</td>

--- a/apps/web/src/screens/review/components/ReviewPane.tsx
+++ b/apps/web/src/screens/review/components/ReviewPane.tsx
@@ -124,7 +124,7 @@ function ReviewLoadingPane(props: ReviewLoadingPaneProps): ReactElement {
         <div className="review-pane-head-meta">
           {loadingReviewCurrentCard !== null ? (
             <>
-              <span className="review-pane-tag-label">{formatTagSummary(loadingReviewCurrentCard.tags)}</span>
+              <span className="review-pane-tag-label">{formatTagSummary(loadingReviewCurrentCard.tags, t)}</span>
             </>
           ) : (
             <>
@@ -313,7 +313,7 @@ function ReviewActiveCardPane(props: ReviewActiveCardPaneProps): ReactElement {
     <>
       <div className="review-pane-head">
         <div className="review-pane-head-meta">
-          <span className="review-pane-tag-label">{formatTagSummary(selectedCard.tags)}</span>
+          <span className="review-pane-tag-label">{formatTagSummary(selectedCard.tags, t)}</span>
           <span className={`badge review-repetition-badge${selectedCard.reps === 0 ? " review-repetition-badge-new" : ""}`}>
             <ReviewRepetitionIcon />
             <span aria-hidden="true">{repetitionValue}</span>

--- a/apps/web/src/screens/review/components/ReviewQueuePanel.tsx
+++ b/apps/web/src/screens/review/components/ReviewQueuePanel.tsx
@@ -84,7 +84,7 @@ export function ReviewQueuePanel(props: ReviewQueuePanelProps): ReactElement {
                   data-card-id={card.cardId}
                 >
                   <span className="review-queue-card-title">{card.frontText}</span>
-                  <span className="review-queue-card-tags">{formatTagSummary(card.tags)}</span>
+                  <span className="review-queue-card-tags">{formatTagSummary(card.tags, t)}</span>
                   <span className="review-queue-card-meta">
                     <span>{formatNullableDateTime(card.dueAt, formatDateTime, t)}</span>
                     {isDue ? null : <span>{t("reviewScreen.queue.upcoming")}</span>}
@@ -121,7 +121,7 @@ export function ReviewQueuePanel(props: ReviewQueuePanelProps): ReactElement {
                 data-card-id={card.cardId}
               >
                 <span className="review-queue-card-title">{card.frontText}</span>
-                <span className="review-queue-card-tags">{formatTagSummary(card.tags)}</span>
+                <span className="review-queue-card-tags">{formatTagSummary(card.tags, t)}</span>
                 <span className="review-queue-card-meta">
                   <span>{formatNullableDateTime(card.dueAt, formatDateTime, t)}</span>
                   {isDue ? null : <span>{t("reviewScreen.queue.upcoming")}</span>}

--- a/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
@@ -332,7 +332,7 @@ export function DeckDetailScreen(): ReactElement {
                   {detailState.cards.map((card) => (
                     <article key={card.cardId} className="content-card deck-detail-card">
                       <div className="deck-detail-card-head">
-                        <span className="badge">{formatTagSummary(card.tags)}</span>
+                        <span className="badge">{formatTagSummary(card.tags, t)}</span>
                       </div>
                       <h3 className="panel-subtitle">{card.frontText}</h3>
                       <p className="subtitle">{card.backText === "" ? t("common.noBackText") : card.backText}</p>

--- a/apps/web/src/screens/shared/featureFormatting.ts
+++ b/apps/web/src/screens/shared/featureFormatting.ts
@@ -5,8 +5,6 @@ import type { CardFilter, DeckFilterDefinition } from "../../types";
 type Translate = (key: TranslationKey, values?: TranslationValues) => string;
 type FormatDateTime = (value: DateTimeValue, options?: Readonly<Intl.DateTimeFormatOptions>) => string;
 
-const EMPTY_LIST_PLACEHOLDER = "\u2014";
-
 function joinFilterSummaryParts(parts: ReadonlyArray<string>, t: Translate): string {
   if (parts.length === 0) {
     return t("filters.none");
@@ -27,9 +25,9 @@ export function formatNullableDateTime(
   return formatDateTime(value);
 }
 
-export function formatTagSummary(tags: ReadonlyArray<string>): string {
+export function formatTagSummary(tags: ReadonlyArray<string>, t: Translate): string {
   if (tags.length === 0) {
-    return EMPTY_LIST_PLACEHOLDER;
+    return t("common.noTags");
   }
 
   return tags.join(", ");


### PR DESCRIPTION
## Summary
- add localized common empty-tag labels to all supported Web catalogs
- make the shared tag formatter use the typed translator for empty lists
- pass the existing translator through every current formatter consumer

## Validation
- Fresh static review: no P0-P4 issues found
- Local project checks were not run; required trunk CI owns executable validation