### PR TITLE
Open iOS AI chat at transcript bottom

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -120,7 +120,7 @@ struct AIChatView: View {
         self.selectedPhotoItem = nil
         self.isAutoFollowEnabled = true
         self.hasActiveUserScrollGesture = false
-        self.scrollPosition = ScrollPosition(idType: String.self)
+        self.scrollPosition = ScrollPosition(idType: String.self, edge: .bottom)
         self.autoScrollTask = nil
         self.deferredBottomSyncTask = nil
         self.composerSelection = nil
@@ -856,12 +856,12 @@ struct AIChatView: View {
             return
         }
 
+        self.resetScrollPositionForTabEntry()
         self.syncChatSurface(refreshConsent: true)
         self.handleAIChatPresentationRequest(
             request: self.deferredPresentationRequest,
             source: .selectedAITab
         )
-        self.scheduleDeferredBottomSyncIfNeeded()
     }
 
     func handleDictationStateViewChange(nextState: AIChatDictationState) {

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
@@ -70,6 +70,18 @@ func aiChatMessageListUpdateChangesExistingTail(
 }
 
 extension AIChatView {
+    func resetScrollPositionForTabEntry() {
+        self.cancelDeferredBottomSync()
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            self.isAutoFollowEnabled = true
+            self.hasActiveUserScrollGesture = false
+            self.scrollPosition = ScrollPosition(idType: String.self, edge: .bottom)
+        }
+    }
+
     func detachAutoFollow() {
         self.isAutoFollowEnabled = false
         self.cancelDeferredBottomSync()


### PR DESCRIPTION
## Summary
- initialize the iOS AI transcript at its bottom edge
- replace preserved cross-tab scroll state synchronously on AI-tab entry
- disable tab-entry scroll animations while preserving same-visit manual scrolling

## Validation
- not run locally; required CI owns executable validation