### PR TITLE
Make Xcode Cloud release steps human-operated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,13 +47,13 @@ For the optional private analytical DB access path, granted reporting permission
 
 ## Release Gates and Monitoring
 
-Pushes to `main` use three independent release streams: AWS/web, Android, and iOS.
+Release and check workflows use independent AWS/web, Android, and iOS streams.
 Pull-request checks stay deliberately light and fast: do not add heavy mobile build or test jobs to pull-request workflows.
 Two Android pull-request workflows are an accepted exception and stay: `Android PR` in `.github/workflows/android-pr.yml` runs build, unit tests, and lint for every Android-impacting pull request (about 6 minutes), and `Android PR data:local` in `.github/workflows/android-pr-data-local.yml` adds the GitHub-hosted `data:local` emulator instrumentation only when the Android data layer or shared Android Gradle configuration changes; the Firebase Test Lab managed-device suite stays out of pull requests.
 Nothing compiles iOS before merge by design, though `PR Checks` still runs the static iOS checks.
 Swift builds and tests run in Xcode Cloud, whose workflow definitions live in App Store Connect; its in-repo build inputs are documented in [docs/ios-ci-cd.md](docs/ios-ci-cd.md).
 Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.
-Do not trigger Xcode Cloud iOS tests or releases, `Android Release`, or `MCP Registry Publish` unless the user explicitly authorizes that exact action. These actions are human-operated by default; agents may monitor and fix automatically triggered GitHub Actions.
+Xcode Cloud iOS test and build workflows are manually started and monitored by a human. Do not trigger or monitor them unless the user explicitly authorizes that exact action. Do not trigger `Android Release` or `MCP Registry Publish` unless the user explicitly authorizes that exact action; agents may monitor and fix automatically triggered GitHub Actions.
 Details, rollback rules, and live smoke references: [docs/release-gates.md](docs/release-gates.md).
 Agent SQL executions emit one structured CloudWatch record per run on every surface; the record fields and the failure-rate queries live in [docs/agent-sql-telemetry.md](docs/agent-sql-telemetry.md).
 iOS `WatchdogTermination` events carry no stack trace by design; the memory fields carried on the app's own breadcrumbs and the decision tree for reading such an event live in [docs/ios-memory-diagnostics.md](docs/ios-memory-diagnostics.md).

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -135,12 +135,12 @@ Use that document when you need to regenerate localized App Store screenshots or
 iOS CI/CD is documented in [`docs/ios-ci-cd.md`](../../docs/ios-ci-cd.md).
 App Store release-note drafting guidance is documented in [`docs/version-bump.md`](../../docs/version-bump.md#app-store-release-notes).
 
-The expected release gate is:
+The human-operated release gate is:
 
 1. Native XCUITest grouped live smoke
 2. Xcode Cloud archive and distribution
 
-When a change lands on `main`, follow the Xcode Cloud workflow until the release either completes or fails with a concrete error. Do not assume the iOS release finished just because the GitHub-side AWS/Web release workflow is green.
+Xcode Cloud test and build workflows are manually started and monitored by a human. Agents must not trigger or monitor them unless the user explicitly requests that exact action.
 
 ## Respect Existing Code
 

--- a/docs/ios-ci-cd.md
+++ b/docs/ios-ci-cd.md
@@ -1,6 +1,6 @@
 # iOS CI/CD
 
-This repository uses Xcode Cloud as the native iOS release gate and distribution path. The GitHub-side AWS/Web release workflow does not wait for Xcode Cloud on `main`.
+This repository uses Xcode Cloud as the human-operated native iOS release gate and distribution path. The GitHub-side AWS/Web release workflow does not start or wait for Xcode Cloud on `main`.
 We do not aim for exhaustive iOS test coverage in this pipeline. The most trusted automated signal is the native simulator-backed live smoke because it exercises the real app closest to production behavior, while any non-smoke tests should stay targeted to important native contracts.
 
 ## Native release gate
@@ -68,9 +68,9 @@ This keeps the login smoke path pinned to the intended review account instead of
 
 `FLASHCARDS_LIVE_REVIEW_EMAIL` remains optional.
 
-## Monitoring expectations
+## Human operation
 
-After pushing to `main`, watch Xcode Cloud separately through the full archive and distribution path. Do not assume the iOS release completed just because the GitHub-side AWS/Web release workflow is green.
+The Xcode Cloud test and build workflows are manually started and monitored by a human. Agents must not trigger or monitor them unless the user explicitly requests that exact action.
 
 ### Sentry environments
 

--- a/docs/ios-local-setup.md
+++ b/docs/ios-local-setup.md
@@ -82,7 +82,7 @@ Xcode Cloud builds now fail in `ci_post_clone.sh` before `xcodebuild` starts if 
 
 `SENTRY_CLI_EXPECTED_SHA256` is an optional non-secret override for the pinned `sentry-cli` binary checksum. Set it only when intentionally bumping the pinned CLI version.
 
-The iOS release-gate and monitoring expectations are documented in [`docs/ios-ci-cd.md`](ios-ci-cd.md).
+The human-operated iOS release gate is documented in [`docs/ios-ci-cd.md`](ios-ci-cd.md).
 
 If Xcode Cloud should pin the live smoke flow to the standard review account explicitly, also set:
 

--- a/docs/manual-production-release.md
+++ b/docs/manual-production-release.md
@@ -10,6 +10,8 @@ platform actions that a person must start, inspect, or finish.
 
 ## iOS
 
+Start and monitor each Xcode Cloud workflow manually.
+
 1. Run the Xcode Cloud test workflow manually for the release SHA.
 2. Fix every red result, and investigate yellow or warning states until they are
    understood before continuing.

--- a/docs/release-gates.md
+++ b/docs/release-gates.md
@@ -8,7 +8,7 @@ Pushes to `main` use independent release and check streams:
 - migration-bearing AWS failures are explicit fix-forward cases; the next push must still be allowed to run
 - when Android-impacting files changed, `.github/workflows/android-ci.yml` runs independently and enforces the fast GitHub-hosted Android gate without uploading to Google Play or submitting Firebase Test Lab
 - Android production draft upload is manual-only through `.github/workflows/android-release.yml`; that workflow also requires Firebase Test Lab submission before the Play draft upload starts
-- when iOS changed, Xcode Cloud runs independently for the same `main` SHA
+- for an iOS release, a human manually starts and monitors the Xcode Cloud test and build workflows for the selected SHA
 
 The MCP endpoint smoke in `AWS/Web Release` verifies the deployed MCP HTTP
 contract. MCP Registry validation is a separate automatic check for
@@ -19,10 +19,10 @@ previously unpublished `server.json.version`.
 Human-operated production release actions for iOS, Android, web, and MCP are
 tracked in [docs/manual-production-release.md](./manual-production-release.md).
 
-When a change lands on `main`, monitor `AWS/Web Release` for backend/web outcome when AWS-impacting files changed, including the Web, Agent API, and MCP post-deploy smoke jobs, monitor `Android CI` when Android-impacting files changed, and monitor Xcode Cloud separately when iOS changed.
+When a change lands on `main`, monitor `AWS/Web Release` for backend/web outcome when AWS-impacting files changed, including the Web, Agent API, and MCP post-deploy smoke jobs, and monitor `Android CI` when Android-impacting files changed. Xcode Cloud test and build workflows are manually started and monitored by a human; agents must not trigger or monitor them unless the user explicitly requests that exact action.
 For Android, a green `Android CI` run always means the GitHub-hosted Android gate passed for that SHA. It does not mean Firebase Test Lab was submitted, a Google Play draft was uploaded, or a release is already live. Run the manual `Android Release` workflow when the Android SHA is ready for release. A green manual `Android Release` run means the GitHub-hosted Android gate passed, Firebase Test Lab submission succeeded, and CI uploaded a production-track Play draft; Firebase Test Lab is submitted asynchronously, so review its matrix result before publishing from Play Console. A non-green `Android Release` run means one of the required release stages failed or was skipped by a failed dependency. Translation review and final publication still happen later in Play Console.
 To trace the exact Android release, open the GitHub Actions run summary for the manual `Android Release` run, note the shared `ANDROID_VERSION_CODE`, the shared release identifier `vc<versionCode>-r<runId>a<attempt>-s<shortSha>`, the Play draft release name `main-draft-<releaseIdentifier>`, and the Firebase results path for that same release identifier. Correlate the run by release name, results path, GitHub run id and attempt, and SHA; Firebase matrix IDs are Google-assigned lookup values, not the shared release identifier.
-If you need to inspect Xcode Cloud directly instead of relying only on the web UI, use `docs/xcode-cloud-data-access.md`. It documents the local `.env` secrets, App Store Connect API flow, example commands, returned data formats, artifact types, and how to extract timing/debugging insights from cloud test runs.
+For explicitly requested Xcode Cloud inspection, use `docs/xcode-cloud-data-access.md`. It documents the local `.env` secrets, App Store Connect API flow, example commands, returned data formats, artifact types, and how to extract timing/debugging insights from cloud test runs.
 
 Cross-client live smoke references:
 


### PR DESCRIPTION
## Summary

- mark Xcode Cloud test and build workflows as manually started and monitored by a human
- prevent agents from triggering or monitoring Xcode Cloud without an explicit request
- align the iOS release and CI/CD documentation with the manual workflow

## Validation

- Not run (documentation-only change; project checks are owned by CI)