### PR TITLE
Reset iOS AI chat view on tab visits

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -856,7 +856,6 @@ struct AIChatView: View {
             return
         }
 
-        self.resetScrollPositionForTabEntry()
         self.syncChatSurface(refreshConsent: true)
         self.handleAIChatPresentationRequest(
             request: self.deferredPresentationRequest,

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
@@ -70,18 +70,6 @@ func aiChatMessageListUpdateChangesExistingTail(
 }
 
 extension AIChatView {
-    func resetScrollPositionForTabEntry() {
-        self.cancelDeferredBottomSync()
-
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            self.isAutoFollowEnabled = true
-            self.hasActiveUserScrollGesture = false
-            self.scrollPosition = ScrollPosition(idType: String.self, edge: .bottom)
-        }
-    }
-
     func detachAutoFollow() {
         self.isAutoFollowEnabled = false
         self.cancelDeferredBottomSync()

--- a/apps/ios/Flashcards/Flashcards/App/Navigation/AppNavigationModel.swift
+++ b/apps/ios/Flashcards/Flashcards/App/Navigation/AppNavigationModel.swift
@@ -65,7 +65,8 @@ func makeSettingsNavigationPath(destination: SettingsNavigationDestination) -> [
 @MainActor
 @Observable
 final class AppNavigationModel {
-    var selectedTab: AppTab
+    private(set) var selectedTab: AppTab
+    private(set) var aiTabVisitID: UUID
     var settingsPath: [SettingsNavigationDestination]
     var cardsPresentationRequest: CardsPresentationRequest?
     var aiChatPresentationRequest: AIChatPresentationRequest?
@@ -73,6 +74,7 @@ final class AppNavigationModel {
 
     init() {
         self.selectedTab = .review
+        self.aiTabVisitID = UUID()
         self.settingsPath = []
         self.cardsPresentationRequest = nil
         self.aiChatPresentationRequest = nil
@@ -87,6 +89,7 @@ final class AppNavigationModel {
         progressPresentationRequest: ProgressPresentationRequest?
     ) {
         self.selectedTab = selectedTab
+        self.aiTabVisitID = UUID()
         self.settingsPath = settingsPath
         self.cardsPresentationRequest = cardsPresentationRequest
         self.aiChatPresentationRequest = aiChatPresentationRequest
@@ -94,26 +97,30 @@ final class AppNavigationModel {
     }
 
     func selectTab(_ tab: AppTab) {
+        if self.selectedTab != .ai, tab == .ai {
+            self.aiTabVisitID = UUID()
+        }
+
         self.selectedTab = tab
     }
 
     func openCardCreation() {
-        self.selectedTab = .cards
+        self.selectTab(.cards)
         self.cardsPresentationRequest = .createCard
     }
 
     func openAICardCreation() {
-        self.selectedTab = .ai
+        self.selectTab(.ai)
         self.aiChatPresentationRequest = .createCard
     }
 
     func openAICardHandoff(card: AIChatCardReference) {
-        self.selectedTab = .ai
+        self.selectTab(.ai)
         self.aiChatPresentationRequest = .attachCard(card)
     }
 
     func openProgress(target: ProgressPresentationTarget) {
-        self.selectedTab = .progress
+        self.selectTab(.progress)
         self.progressPresentationRequest = ProgressPresentationRequest(
             id: UUID(),
             target: target
@@ -121,7 +128,7 @@ final class AppNavigationModel {
     }
 
     func openSettings(destination: SettingsNavigationDestination) {
-        self.selectedTab = .settings
+        self.selectTab(.settings)
         self.settingsPath = makeSettingsNavigationPath(destination: destination)
     }
 

--- a/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
@@ -340,7 +340,7 @@ struct RootTabView: View {
                     isRecoveryGateActive: self.store.cloudCredentialRecoveryState != nil,
                     now: Date()
                 )
-                navigation.selectedTab = nextTab
+                navigation.selectTab(nextTab)
             }
         )
 
@@ -557,6 +557,7 @@ struct RootTabView: View {
     private var aiTab: some View {
         NavigationStack {
             AIChatView(chatStore: store.aiChatStore)
+                .id(self.navigation.aiTabVisitID)
         }
         .tabItem {
             Label(


### PR DESCRIPTION
## Summary
- recreate the transient AI chat view lifetime for each new AI-tab visit
- keep persistent chat and composer state in the long-lived AIChatStore
- centralize tab selection so AI visit identity advances before presentation

## Validation
- not run locally; required trunk CI owns validation