### PR TITLE
Snapshot iOS editor metadata at open

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
@@ -30,6 +30,7 @@ private let cardEditorManagedMediaFenceExpression: NSRegularExpression = {
 
 struct CardFormState {
     var editorSessionId: UUID
+    let readOnlyMetadata: CardEditorReadOnlyMetadata?
     var frontText: String
     var backText: String
     var frontTextSelection: TextSelection?
@@ -124,10 +125,8 @@ struct CardEditorScreen: View {
     @State private var isDeleteConfirmationPresented: Bool = false
 
     let title: String
-    let isEditing: Bool
     let errorMessage: String
     let availableTagSuggestions: [TagSuggestion]
-    let readOnlyMetadata: CardEditorReadOnlyMetadata?
     @Binding var formState: CardFormState
     let onEditWithAI: (() -> Void)?
     let onCancel: () -> Void
@@ -203,7 +202,7 @@ struct CardEditorScreen: View {
                         TagsFieldRow(summary: localizedTagSelectionSummary(tags: formState.tags))
                     }
 
-                    if isEditing, let readOnlyMetadata {
+                    if let readOnlyMetadata = formState.readOnlyMetadata {
                         LabeledContent {
                             Text(localizedCardDueValue(dueAt: readOnlyMetadata.dueAt))
                                 .foregroundStyle(.secondary)
@@ -229,7 +228,7 @@ struct CardEditorScreen: View {
                     Text(String(localized: "Metadata", table: reviewCardsStringsTableName))
                 }
 
-                if isEditing {
+                if formState.readOnlyMetadata != nil {
                     Section {
                         Button(String(localized: "Delete card", table: reviewCardsStringsTableName), role: .destructive) {
                             self.isDeleteConfirmationPresented = true

--- a/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
@@ -95,6 +95,7 @@ struct CardsScreen: View {
     @State private var draftFilter: CardFilter? = nil
     @State private var cardFormState: CardFormState = CardFormState(
         editorSessionId: UUID(),
+        readOnlyMetadata: nil,
         frontText: "",
         backText: "",
         frontTextSelection: nil,
@@ -213,10 +214,8 @@ struct CardsScreen: View {
             NavigationStack {
                 CardEditorScreen(
                     title: presentation.title,
-                    isEditing: presentation.isEditing,
                     errorMessage: self.screenErrorMessage,
                     availableTagSuggestions: self.availableTagSuggestions,
-                    readOnlyMetadata: self.editingCard().map(cardEditorReadOnlyMetadata),
                     formState: self.$cardFormState,
                     onEditWithAI: presentation.editingCardId.map { editingCardId in
                         {
@@ -272,6 +271,7 @@ struct CardsScreen: View {
         self.dismissCardsSearch()
         self.cardFormState = CardFormState(
             editorSessionId: UUID(),
+            readOnlyMetadata: nil,
             frontText: "",
             backText: "",
             frontTextSelection: nil,
@@ -289,6 +289,7 @@ struct CardsScreen: View {
         self.dismissCardsSearch()
         self.cardFormState = CardFormState(
             editorSessionId: UUID(),
+            readOnlyMetadata: cardEditorReadOnlyMetadata(card: card),
             frontText: card.frontText,
             backText: card.backText,
             frontTextSelection: nil,

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Editor.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Editor.swift
@@ -82,6 +82,7 @@ extension ReviewView {
         self.editingCardId = card.cardId
         self.cardFormState = CardFormState(
             editorSessionId: UUID(),
+            readOnlyMetadata: cardEditorReadOnlyMetadata(card: card),
             frontText: card.frontText,
             backText: card.backText,
             frontTextSelection: nil,

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -42,6 +42,7 @@ struct ReviewView: View {
     @State var editingCardId: String? = nil
     @State var cardFormState: CardFormState = CardFormState(
         editorSessionId: UUID(),
+        readOnlyMetadata: nil,
         frontText: "",
         backText: "",
         frontTextSelection: nil,
@@ -205,10 +206,8 @@ struct ReviewView: View {
             NavigationStack {
                 CardEditorScreen(
                     title: String(localized: "Edit card", table: reviewCardsStringsTableName),
-                    isEditing: true,
                     errorMessage: screenErrorMessage,
                     availableTagSuggestions: self.availableTagSuggestions,
-                    readOnlyMetadata: self.editingCard().map(cardEditorReadOnlyMetadata),
                     formState: self.$cardFormState,
                     onEditWithAI: {
                         let cardReference: AIChatCardReference?


### PR DESCRIPTION
## Summary
- snapshot readonly card metadata when the iOS editor opens
- derive edit-only metadata rows and delete visibility from session state
- preserve live card lookup for dirty-state and media reconciliation

## Validation
- static review passed with no P0-P4 findings
- project checks intentionally not run for this integration PR