### PR TITLE
Stabilize Android editor metadata snapshots

### DIFF
--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
@@ -18,7 +18,8 @@ data class CardsTextProvider(
     val enterTagBeforeAdding: String,
     val frontTextRequired: String,
     val backTextRequired: String,
-    val imageReferenceMissing: String
+    val imageReferenceMissing: String,
+    val cardUnavailable: String
 )
 
 fun cardsTextProvider(context: Context): CardsTextProvider {
@@ -29,7 +30,8 @@ fun cardsTextProvider(context: Context): CardsTextProvider {
         enterTagBeforeAdding = context.getString(R.string.cards_enter_tag_before_adding),
         frontTextRequired = context.getString(R.string.cards_front_text_required),
         backTextRequired = context.getString(R.string.cards_back_text_required),
-        imageReferenceMissing = context.getString(R.string.cards_editor_image_reference_missing)
+        imageReferenceMissing = context.getString(R.string.cards_editor_image_reference_missing),
+        cardUnavailable = context.getString(R.string.cards_editor_card_unavailable)
     )
 }
 

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
@@ -1,6 +1,8 @@
 package com.flashcardsopensourceapp.feature.cards.editor
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -18,6 +20,7 @@ import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -78,6 +81,46 @@ fun CardEditorRoute(
             )
         }
     ) { innerPadding ->
+        if (uiState.isLoading) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+
+        if (uiState.isCardUnavailable) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp)
+            ) {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = uiState.errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(20.dp)
+                    )
+                }
+                OutlinedButton(
+                    onClick = onBack,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                ) {
+                    Text(stringResource(id = R.string.cards_editor_back_content_description))
+                }
+            }
+            return@Scaffold
+        }
+
         LazyColumn(
             contentPadding = PaddingValues(
                 start = 16.dp,
@@ -248,8 +291,10 @@ fun CardEditorRoute(
                 }
             }
 
-            if (uiState.isEditing && uiState.schedulingMetadata != null) {
-                val metadata = uiState.schedulingMetadata
+            if (uiState.isEditing) {
+                val metadata = requireNotNull(uiState.schedulingMetadata) {
+                    "Scheduling metadata must be available before rendering an edit card."
+                }
                 item {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
@@ -49,6 +49,7 @@ data class CardEditorSchedulingMetadata(
 
 data class CardEditorUiState(
     val isLoading: Boolean,
+    val isCardUnavailable: Boolean,
     val title: String,
     val isEditing: Boolean,
     val frontText: String,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -12,12 +12,10 @@ import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummar
 import com.flashcardsopensourceapp.data.local.repository.CardsRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.feature.cards.CardsTextProvider
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -33,7 +31,9 @@ private data class CardEditorDraftState(
     val tagsErrorMessage: String,
     val errorMessage: String,
     val isDirty: Boolean,
-    val hasLoadedInitialValues: Boolean
+    val hasLoadedInitialValues: Boolean,
+    val isCardUnavailable: Boolean,
+    val schedulingMetadata: CardEditorSchedulingMetadata?
 )
 
 class CardEditorViewModel(
@@ -54,70 +54,84 @@ class CardEditorViewModel(
             tagsErrorMessage = "",
             errorMessage = "",
             isDirty = false,
-            hasLoadedInitialValues = editingCardId == null
+            hasLoadedInitialValues = editingCardId == null,
+            isCardUnavailable = false,
+            schedulingMetadata = null
         )
     )
 
     val uiState: StateFlow<CardEditorUiState>
 
     init {
-        val cardFlow: Flow<CardSummary?> = if (editingCardId == null) {
-            flowOf(null)
-        } else {
-            cardsRepository.observeCard(cardId = editingCardId)
-        }
-        var previousObservedCard: CardSummary? = null
-
-        viewModelScope.launch {
-            cardFlow.collect { card ->
-                if (card == null) {
-                    return@collect
-                }
-
-                val previousCard: CardSummary? = previousObservedCard
-                inputState.update { state ->
-                    if (state.hasLoadedInitialValues && previousCard != null) {
-                        val refreshedFrontText = refreshManagedImageReferenceStates(
-                            text = state.frontText,
-                            selection = state.frontTextSelection,
-                            previousObservedText = previousCard.frontText,
-                            observedText = card.frontText
-                        )
-                        val refreshedBackText = refreshManagedImageReferenceStates(
-                            text = state.backText,
-                            selection = state.backTextSelection,
-                            previousObservedText = previousCard.backText,
-                            observedText = card.backText
-                        )
-                        return@update state.copy(
-                            frontText = refreshedFrontText.text,
-                            backText = refreshedBackText.text,
-                            frontTextSelection = refreshedFrontText.selection,
-                            backTextSelection = refreshedBackText.selection
-                        )
-                    }
-                    if (state.hasLoadedInitialValues) {
-                        return@update state
+        if (editingCardId != null) {
+            viewModelScope.launch {
+                var previousObservedCard: CardSummary? = null
+                cardsRepository.observeCard(cardId = editingCardId).collect { card ->
+                    if (card == null) {
+                        inputState.update { state ->
+                            if (state.hasLoadedInitialValues) {
+                                state
+                            } else {
+                                state.copy(
+                                    errorMessage = textProvider.cardUnavailable,
+                                    hasLoadedInitialValues = true,
+                                    isCardUnavailable = true
+                                )
+                            }
+                        }
+                        return@collect
                     }
 
-                    state.copy(
-                        frontText = card.frontText,
-                        backText = card.backText,
-                        selectedTags = card.tags,
-                        hasLoadedInitialValues = true
-                    )
+                    val previousCard: CardSummary? = previousObservedCard
+                    inputState.update { state ->
+                        if (state.hasLoadedInitialValues && previousCard != null) {
+                            val refreshedFrontText = refreshManagedImageReferenceStates(
+                                text = state.frontText,
+                                selection = state.frontTextSelection,
+                                previousObservedText = previousCard.frontText,
+                                observedText = card.frontText
+                            )
+                            val refreshedBackText = refreshManagedImageReferenceStates(
+                                text = state.backText,
+                                selection = state.backTextSelection,
+                                previousObservedText = previousCard.backText,
+                                observedText = card.backText
+                            )
+                            return@update state.copy(
+                                frontText = refreshedFrontText.text,
+                                backText = refreshedBackText.text,
+                                frontTextSelection = refreshedFrontText.selection,
+                                backTextSelection = refreshedBackText.selection
+                            )
+                        }
+                        if (state.hasLoadedInitialValues) {
+                            return@update state
+                        }
+
+                        state.copy(
+                            frontText = card.frontText,
+                            backText = card.backText,
+                            selectedTags = card.tags,
+                            hasLoadedInitialValues = true,
+                            schedulingMetadata = CardEditorSchedulingMetadata(
+                                dueAtMillis = card.dueAtMillis,
+                                reps = card.reps,
+                                lapses = card.lapses
+                            )
+                        )
+                    }
+                    previousObservedCard = card
                 }
-                previousObservedCard = card
             }
         }
 
         uiState = combine(
-            cardFlow,
             workspaceRepository.observeWorkspaceTagsSummary(),
             inputState
-        ) { card, tagsSummary, currentState ->
+        ) { tagsSummary, currentState ->
             CardEditorUiState(
-                isLoading = editingCardId != null && card != null && currentState.hasLoadedInitialValues.not(),
+                isLoading = currentState.hasLoadedInitialValues.not(),
+                isCardUnavailable = currentState.isCardUnavailable,
                 title = if (editingCardId == null) textProvider.newCardTitle else textProvider.editCardTitle,
                 isEditing = editingCardId != null,
                 frontText = currentState.frontText,
@@ -137,17 +151,7 @@ class CardEditorViewModel(
                     referenceTags = tagsSummary.tags.map(WorkspaceTagSummary::tag)
                 ),
                 availableTagSuggestions = tagsSummary.tags,
-                schedulingMetadata = if (currentState.hasLoadedInitialValues) {
-                    card?.let { loadedCard ->
-                        CardEditorSchedulingMetadata(
-                            dueAtMillis = loadedCard.dueAtMillis,
-                            reps = loadedCard.reps,
-                            lapses = loadedCard.lapses
-                        )
-                    }
-                } else {
-                    null
-                },
+                schedulingMetadata = currentState.schedulingMetadata,
                 frontTextErrorMessage = currentState.frontTextErrorMessage,
                 backTextErrorMessage = currentState.backTextErrorMessage,
                 tagsErrorMessage = currentState.tagsErrorMessage,
@@ -158,7 +162,8 @@ class CardEditorViewModel(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
             initialValue = CardEditorUiState(
-                isLoading = true,
+                isLoading = editingCardId != null,
+                isCardUnavailable = false,
                 title = if (editingCardId == null) textProvider.newCardTitle else textProvider.editCardTitle,
                 isEditing = editingCardId != null,
                 frontText = "",

--- a/apps/android/feature/cards/src/main/res/values/strings.xml
+++ b/apps/android/feature/cards/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="cards_editor_image_unavailable">Image unavailable</string>
     <string name="cards_editor_remove_image">Remove</string>
     <string name="cards_editor_image_reference_missing">The image reference is no longer in this card text.</string>
+    <string name="cards_editor_card_unavailable">This card is no longer available. Go back and choose another card.</string>
     <string name="cards_editor_add_image_failed">Could not add image: %1$s</string>
     <string name="cards_editor_add_image_unknown_error">Unknown import error.</string>
     <string name="cards_editor_guidance">Front text stays the review prompt. Back text stays the answer. Both can be long-form and are edited on dedicated Android surfaces.</string>


### PR DESCRIPTION
## Summary
- wait for the initial local card before rendering Android edit mode
- capture scheduling metadata once per editor session
- preserve image lifecycle reconciliation without refreshing scheduling metadata
- show a localized unavailable state when the card is missing

## Validation
- static staging-agnostic review completed with no P0-P4 findings
- project checks not run locally per repository policy

Integration PR; promotion to main is deferred.