### PR TITLE
Harden restored Android editor sessions

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
@@ -27,6 +27,7 @@ import com.flashcardsopensourceapp.feature.cards.R as CardsR
 import com.flashcardsopensourceapp.feature.cards.cardEditorBackTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorFrontTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.createCardEditorViewModelFactory
+import com.flashcardsopensourceapp.feature.cards.editor.CardEditorLoadingOrUnavailableRoute
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorRoute
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorTextField
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorViewModel
@@ -188,6 +189,16 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 )
             )
             val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
+            if (uiState.isLoading || uiState.isCardUnavailable) {
+                CardEditorLoadingOrUnavailableRoute(
+                    uiState = uiState,
+                    onBack = {
+                        navController.popBackStack()
+                    }
+                )
+                return@composable
+            }
+
             val editorTextField = resolveEditorTextField(field = field)
             val context = LocalContext.current
             val managedImageAltText = stringResource(id = CardsR.string.cards_editor_image_label)
@@ -314,6 +325,15 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 )
             )
             val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
+            if (uiState.isLoading || uiState.isCardUnavailable) {
+                CardEditorLoadingOrUnavailableRoute(
+                    uiState = uiState,
+                    onBack = {
+                        navController.popBackStack()
+                    }
+                )
+                return@composable
+            }
 
             CardTagsRoute(
                 uiState = uiState,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
@@ -370,6 +370,30 @@ fun CardEditorRoute(
 }
 
 @Composable
+fun CardEditorLoadingOrUnavailableRoute(
+    uiState: CardEditorUiState,
+    onBack: () -> Unit
+) {
+    require(uiState.isLoading || uiState.isCardUnavailable) {
+        "Loading or unavailable card editor route requires a matching UI state."
+    }
+    val unavailableAction: () -> Unit = {
+        error("Card editor actions are unavailable while the card is loading or unavailable.")
+    }
+    CardEditorRoute(
+        uiState = uiState,
+        onOpenFrontTextEditor = unavailableAction,
+        onOpenBackTextEditor = unavailableAction,
+        onOpenTagsEditor = unavailableAction,
+        onEditWithAi = null,
+        onRemoveTag = { unavailableAction() },
+        onSave = unavailableAction,
+        onDelete = null,
+        onBack = onBack
+    )
+}
+
+@Composable
 private fun CardEditorMetadataItem(
     icon: ImageVector,
     label: String

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -67,7 +67,10 @@ class CardEditorViewModel(
             viewModelScope.launch {
                 var previousObservedCard: CardSummary? = null
                 cardsRepository.observeCard(cardId = editingCardId).collect { card ->
-                    if (card == null) {
+                    if (
+                        card == null ||
+                        (card.deletedAtMillis != null && inputState.value.hasLoadedInitialValues.not())
+                    ) {
                         inputState.update { state ->
                             if (state.hasLoadedInitialValues) {
                                 state


### PR DESCRIPTION
## Summary
- reject an initial soft-deleted card snapshot as unavailable
- reuse the main editor loading and unavailable surface for restored nested destinations
- preserve valid point-in-time editor session behavior

## Validation
- static review completed with no P0-P4 findings
- project checks not run per integration delivery policy