### PR TITLE
Stabilize card editor metadata snapshots

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
@@ -27,6 +27,7 @@ import com.flashcardsopensourceapp.feature.cards.R as CardsR
 import com.flashcardsopensourceapp.feature.cards.cardEditorBackTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorFrontTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.createCardEditorViewModelFactory
+import com.flashcardsopensourceapp.feature.cards.editor.CardEditorLoadingOrUnavailableRoute
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorRoute
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorTextField
 import com.flashcardsopensourceapp.feature.cards.editor.CardEditorViewModel
@@ -188,6 +189,16 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 )
             )
             val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
+            if (uiState.isLoading || uiState.isCardUnavailable) {
+                CardEditorLoadingOrUnavailableRoute(
+                    uiState = uiState,
+                    onBack = {
+                        navController.popBackStack()
+                    }
+                )
+                return@composable
+            }
+
             val editorTextField = resolveEditorTextField(field = field)
             val context = LocalContext.current
             val managedImageAltText = stringResource(id = CardsR.string.cards_editor_image_label)
@@ -314,6 +325,15 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 )
             )
             val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
+            if (uiState.isLoading || uiState.isCardUnavailable) {
+                CardEditorLoadingOrUnavailableRoute(
+                    uiState = uiState,
+                    onBack = {
+                        navController.popBackStack()
+                    }
+                )
+                return@composable
+            }
 
             CardTagsRoute(
                 uiState = uiState,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsStrings.kt
@@ -18,7 +18,8 @@ data class CardsTextProvider(
     val enterTagBeforeAdding: String,
     val frontTextRequired: String,
     val backTextRequired: String,
-    val imageReferenceMissing: String
+    val imageReferenceMissing: String,
+    val cardUnavailable: String
 )
 
 fun cardsTextProvider(context: Context): CardsTextProvider {
@@ -29,7 +30,8 @@ fun cardsTextProvider(context: Context): CardsTextProvider {
         enterTagBeforeAdding = context.getString(R.string.cards_enter_tag_before_adding),
         frontTextRequired = context.getString(R.string.cards_front_text_required),
         backTextRequired = context.getString(R.string.cards_back_text_required),
-        imageReferenceMissing = context.getString(R.string.cards_editor_image_reference_missing)
+        imageReferenceMissing = context.getString(R.string.cards_editor_image_reference_missing),
+        cardUnavailable = context.getString(R.string.cards_editor_card_unavailable)
     )
 }
 

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
@@ -370,6 +370,30 @@ fun CardEditorRoute(
 }
 
 @Composable
+fun CardEditorLoadingOrUnavailableRoute(
+    uiState: CardEditorUiState,
+    onBack: () -> Unit
+) {
+    require(uiState.isLoading || uiState.isCardUnavailable) {
+        "Loading or unavailable card editor route requires a matching UI state."
+    }
+    val unavailableAction: () -> Unit = {
+        error("Card editor actions are unavailable while the card is loading or unavailable.")
+    }
+    CardEditorRoute(
+        uiState = uiState,
+        onOpenFrontTextEditor = unavailableAction,
+        onOpenBackTextEditor = unavailableAction,
+        onOpenTagsEditor = unavailableAction,
+        onEditWithAi = null,
+        onRemoveTag = { unavailableAction() },
+        onSave = unavailableAction,
+        onDelete = null,
+        onBack = onBack
+    )
+}
+
+@Composable
 private fun CardEditorMetadataItem(
     icon: ImageVector,
     label: String

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
@@ -1,6 +1,8 @@
 package com.flashcardsopensourceapp.feature.cards.editor
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -18,6 +20,7 @@ import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -78,6 +81,46 @@ fun CardEditorRoute(
             )
         }
     ) { innerPadding ->
+        if (uiState.isLoading) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+
+        if (uiState.isCardUnavailable) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp)
+            ) {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = uiState.errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(20.dp)
+                    )
+                }
+                OutlinedButton(
+                    onClick = onBack,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                ) {
+                    Text(stringResource(id = R.string.cards_editor_back_content_description))
+                }
+            }
+            return@Scaffold
+        }
+
         LazyColumn(
             contentPadding = PaddingValues(
                 start = 16.dp,
@@ -248,8 +291,10 @@ fun CardEditorRoute(
                 }
             }
 
-            if (uiState.isEditing && uiState.schedulingMetadata != null) {
-                val metadata = uiState.schedulingMetadata
+            if (uiState.isEditing) {
+                val metadata = requireNotNull(uiState.schedulingMetadata) {
+                    "Scheduling metadata must be available before rendering an edit card."
+                }
                 item {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
@@ -49,6 +49,7 @@ data class CardEditorSchedulingMetadata(
 
 data class CardEditorUiState(
     val isLoading: Boolean,
+    val isCardUnavailable: Boolean,
     val title: String,
     val isEditing: Boolean,
     val frontText: String,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -67,7 +67,10 @@ class CardEditorViewModel(
             viewModelScope.launch {
                 var previousObservedCard: CardSummary? = null
                 cardsRepository.observeCard(cardId = editingCardId).collect { card ->
-                    if (card == null) {
+                    if (
+                        card == null ||
+                        (card.deletedAtMillis != null && inputState.value.hasLoadedInitialValues.not())
+                    ) {
                         inputState.update { state ->
                             if (state.hasLoadedInitialValues) {
                                 state

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -12,12 +12,10 @@ import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummar
 import com.flashcardsopensourceapp.data.local.repository.CardsRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.feature.cards.CardsTextProvider
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -33,7 +31,9 @@ private data class CardEditorDraftState(
     val tagsErrorMessage: String,
     val errorMessage: String,
     val isDirty: Boolean,
-    val hasLoadedInitialValues: Boolean
+    val hasLoadedInitialValues: Boolean,
+    val isCardUnavailable: Boolean,
+    val schedulingMetadata: CardEditorSchedulingMetadata?
 )
 
 class CardEditorViewModel(
@@ -54,70 +54,84 @@ class CardEditorViewModel(
             tagsErrorMessage = "",
             errorMessage = "",
             isDirty = false,
-            hasLoadedInitialValues = editingCardId == null
+            hasLoadedInitialValues = editingCardId == null,
+            isCardUnavailable = false,
+            schedulingMetadata = null
         )
     )
 
     val uiState: StateFlow<CardEditorUiState>
 
     init {
-        val cardFlow: Flow<CardSummary?> = if (editingCardId == null) {
-            flowOf(null)
-        } else {
-            cardsRepository.observeCard(cardId = editingCardId)
-        }
-        var previousObservedCard: CardSummary? = null
-
-        viewModelScope.launch {
-            cardFlow.collect { card ->
-                if (card == null) {
-                    return@collect
-                }
-
-                val previousCard: CardSummary? = previousObservedCard
-                inputState.update { state ->
-                    if (state.hasLoadedInitialValues && previousCard != null) {
-                        val refreshedFrontText = refreshManagedImageReferenceStates(
-                            text = state.frontText,
-                            selection = state.frontTextSelection,
-                            previousObservedText = previousCard.frontText,
-                            observedText = card.frontText
-                        )
-                        val refreshedBackText = refreshManagedImageReferenceStates(
-                            text = state.backText,
-                            selection = state.backTextSelection,
-                            previousObservedText = previousCard.backText,
-                            observedText = card.backText
-                        )
-                        return@update state.copy(
-                            frontText = refreshedFrontText.text,
-                            backText = refreshedBackText.text,
-                            frontTextSelection = refreshedFrontText.selection,
-                            backTextSelection = refreshedBackText.selection
-                        )
-                    }
-                    if (state.hasLoadedInitialValues) {
-                        return@update state
+        if (editingCardId != null) {
+            viewModelScope.launch {
+                var previousObservedCard: CardSummary? = null
+                cardsRepository.observeCard(cardId = editingCardId).collect { card ->
+                    if (card == null) {
+                        inputState.update { state ->
+                            if (state.hasLoadedInitialValues) {
+                                state
+                            } else {
+                                state.copy(
+                                    errorMessage = textProvider.cardUnavailable,
+                                    hasLoadedInitialValues = true,
+                                    isCardUnavailable = true
+                                )
+                            }
+                        }
+                        return@collect
                     }
 
-                    state.copy(
-                        frontText = card.frontText,
-                        backText = card.backText,
-                        selectedTags = card.tags,
-                        hasLoadedInitialValues = true
-                    )
+                    val previousCard: CardSummary? = previousObservedCard
+                    inputState.update { state ->
+                        if (state.hasLoadedInitialValues && previousCard != null) {
+                            val refreshedFrontText = refreshManagedImageReferenceStates(
+                                text = state.frontText,
+                                selection = state.frontTextSelection,
+                                previousObservedText = previousCard.frontText,
+                                observedText = card.frontText
+                            )
+                            val refreshedBackText = refreshManagedImageReferenceStates(
+                                text = state.backText,
+                                selection = state.backTextSelection,
+                                previousObservedText = previousCard.backText,
+                                observedText = card.backText
+                            )
+                            return@update state.copy(
+                                frontText = refreshedFrontText.text,
+                                backText = refreshedBackText.text,
+                                frontTextSelection = refreshedFrontText.selection,
+                                backTextSelection = refreshedBackText.selection
+                            )
+                        }
+                        if (state.hasLoadedInitialValues) {
+                            return@update state
+                        }
+
+                        state.copy(
+                            frontText = card.frontText,
+                            backText = card.backText,
+                            selectedTags = card.tags,
+                            hasLoadedInitialValues = true,
+                            schedulingMetadata = CardEditorSchedulingMetadata(
+                                dueAtMillis = card.dueAtMillis,
+                                reps = card.reps,
+                                lapses = card.lapses
+                            )
+                        )
+                    }
+                    previousObservedCard = card
                 }
-                previousObservedCard = card
             }
         }
 
         uiState = combine(
-            cardFlow,
             workspaceRepository.observeWorkspaceTagsSummary(),
             inputState
-        ) { card, tagsSummary, currentState ->
+        ) { tagsSummary, currentState ->
             CardEditorUiState(
-                isLoading = editingCardId != null && card != null && currentState.hasLoadedInitialValues.not(),
+                isLoading = currentState.hasLoadedInitialValues.not(),
+                isCardUnavailable = currentState.isCardUnavailable,
                 title = if (editingCardId == null) textProvider.newCardTitle else textProvider.editCardTitle,
                 isEditing = editingCardId != null,
                 frontText = currentState.frontText,
@@ -137,17 +151,7 @@ class CardEditorViewModel(
                     referenceTags = tagsSummary.tags.map(WorkspaceTagSummary::tag)
                 ),
                 availableTagSuggestions = tagsSummary.tags,
-                schedulingMetadata = if (currentState.hasLoadedInitialValues) {
-                    card?.let { loadedCard ->
-                        CardEditorSchedulingMetadata(
-                            dueAtMillis = loadedCard.dueAtMillis,
-                            reps = loadedCard.reps,
-                            lapses = loadedCard.lapses
-                        )
-                    }
-                } else {
-                    null
-                },
+                schedulingMetadata = currentState.schedulingMetadata,
                 frontTextErrorMessage = currentState.frontTextErrorMessage,
                 backTextErrorMessage = currentState.backTextErrorMessage,
                 tagsErrorMessage = currentState.tagsErrorMessage,
@@ -158,7 +162,8 @@ class CardEditorViewModel(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
             initialValue = CardEditorUiState(
-                isLoading = true,
+                isLoading = editingCardId != null,
+                isCardUnavailable = false,
                 title = if (editingCardId == null) textProvider.newCardTitle else textProvider.editCardTitle,
                 isEditing = editingCardId != null,
                 frontText = "",

--- a/apps/android/feature/cards/src/main/res/values/strings.xml
+++ b/apps/android/feature/cards/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="cards_editor_image_unavailable">Image unavailable</string>
     <string name="cards_editor_remove_image">Remove</string>
     <string name="cards_editor_image_reference_missing">The image reference is no longer in this card text.</string>
+    <string name="cards_editor_card_unavailable">This card is no longer available. Go back and choose another card.</string>
     <string name="cards_editor_add_image_failed">Could not add image: %1$s</string>
     <string name="cards_editor_add_image_unknown_error">Unknown import error.</string>
     <string name="cards_editor_guidance">Front text stays the review prompt. Back text stays the answer. Both can be long-form and are edited on dedicated Android surfaces.</string>

--- a/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/CardEditorScreen.swift
@@ -30,6 +30,7 @@ private let cardEditorManagedMediaFenceExpression: NSRegularExpression = {
 
 struct CardFormState {
     var editorSessionId: UUID
+    let readOnlyMetadata: CardEditorReadOnlyMetadata?
     var frontText: String
     var backText: String
     var frontTextSelection: TextSelection?
@@ -124,10 +125,8 @@ struct CardEditorScreen: View {
     @State private var isDeleteConfirmationPresented: Bool = false
 
     let title: String
-    let isEditing: Bool
     let errorMessage: String
     let availableTagSuggestions: [TagSuggestion]
-    let readOnlyMetadata: CardEditorReadOnlyMetadata?
     @Binding var formState: CardFormState
     let onEditWithAI: (() -> Void)?
     let onCancel: () -> Void
@@ -203,7 +202,7 @@ struct CardEditorScreen: View {
                         TagsFieldRow(summary: localizedTagSelectionSummary(tags: formState.tags))
                     }
 
-                    if isEditing, let readOnlyMetadata {
+                    if let readOnlyMetadata = formState.readOnlyMetadata {
                         LabeledContent {
                             Text(localizedCardDueValue(dueAt: readOnlyMetadata.dueAt))
                                 .foregroundStyle(.secondary)
@@ -229,7 +228,7 @@ struct CardEditorScreen: View {
                     Text(String(localized: "Metadata", table: reviewCardsStringsTableName))
                 }
 
-                if isEditing {
+                if formState.readOnlyMetadata != nil {
                     Section {
                         Button(String(localized: "Delete card", table: reviewCardsStringsTableName), role: .destructive) {
                             self.isDeleteConfirmationPresented = true

--- a/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
@@ -95,6 +95,7 @@ struct CardsScreen: View {
     @State private var draftFilter: CardFilter? = nil
     @State private var cardFormState: CardFormState = CardFormState(
         editorSessionId: UUID(),
+        readOnlyMetadata: nil,
         frontText: "",
         backText: "",
         frontTextSelection: nil,
@@ -213,10 +214,8 @@ struct CardsScreen: View {
             NavigationStack {
                 CardEditorScreen(
                     title: presentation.title,
-                    isEditing: presentation.isEditing,
                     errorMessage: self.screenErrorMessage,
                     availableTagSuggestions: self.availableTagSuggestions,
-                    readOnlyMetadata: self.editingCard().map(cardEditorReadOnlyMetadata),
                     formState: self.$cardFormState,
                     onEditWithAI: presentation.editingCardId.map { editingCardId in
                         {
@@ -272,6 +271,7 @@ struct CardsScreen: View {
         self.dismissCardsSearch()
         self.cardFormState = CardFormState(
             editorSessionId: UUID(),
+            readOnlyMetadata: nil,
             frontText: "",
             backText: "",
             frontTextSelection: nil,
@@ -289,6 +289,7 @@ struct CardsScreen: View {
         self.dismissCardsSearch()
         self.cardFormState = CardFormState(
             editorSessionId: UUID(),
+            readOnlyMetadata: cardEditorReadOnlyMetadata(card: card),
             frontText: card.frontText,
             backText: card.backText,
             frontTextSelection: nil,

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Editor.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Editor.swift
@@ -82,6 +82,7 @@ extension ReviewView {
         self.editingCardId = card.cardId
         self.cardFormState = CardFormState(
             editorSessionId: UUID(),
+            readOnlyMetadata: cardEditorReadOnlyMetadata(card: card),
             frontText: card.frontText,
             backText: card.backText,
             frontTextSelection: nil,

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -42,6 +42,7 @@ struct ReviewView: View {
     @State var editingCardId: String? = nil
     @State var cardFormState: CardFormState = CardFormState(
         editorSessionId: UUID(),
+        readOnlyMetadata: nil,
         frontText: "",
         backText: "",
         frontTextSelection: nil,
@@ -205,10 +206,8 @@ struct ReviewView: View {
             NavigationStack {
                 CardEditorScreen(
                     title: String(localized: "Edit card", table: reviewCardsStringsTableName),
-                    isEditing: true,
                     errorMessage: screenErrorMessage,
                     availableTagSuggestions: self.availableTagSuggestions,
-                    readOnlyMetadata: self.editingCard().map(cardEditorReadOnlyMetadata),
                     formState: self.$cardFormState,
                     onEditWithAI: {
                         let cardReference: AIChatCardReference?


### PR DESCRIPTION
## Summary
- snapshot iOS card editor metadata from the initiating card
- gate Android edit sessions on the first complete active Room card
- preserve session metadata and user edits across later Android emissions

## Review
- item reviews: no P0-P4 issues
- final cumulative review: no P0-P4 issues and no additional notes
- cumulative scope: 10 files, 175 insertions, 74 deletions

## Validation
- local project checks intentionally not run; required trunk CI is the validation gate