### PR TITLE
Fix AI chat bottom position on tab visits

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+ComposerUIState.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+ComposerUIState.swift
@@ -74,10 +74,6 @@ extension AIChatStore {
             || self.isStreaming
     }
 
-    var hasLocalTranscriptDuringBootstrap: Bool {
-        self.bootstrapPhase == .loading && self.messages.isEmpty == false
-    }
-
     var shouldShowComposerAccessory: Bool {
         self.isChatInteractive || self.bootstrapPhase == .loading
     }

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -106,7 +106,6 @@ struct AIChatView: View {
     @State var hasActiveUserScrollGesture: Bool
     @State var scrollPosition: ScrollPosition
     @State var autoScrollTask: Task<Void, Never>?
-    @State var deferredBottomSyncTask: Task<Void, Never>?
     @State var composerSelection: TextSelection?
     @State var deferredPresentationRequest: AIChatPresentationRequest?
     @FocusState var isComposerFocused: Bool
@@ -120,9 +119,8 @@ struct AIChatView: View {
         self.selectedPhotoItem = nil
         self.isAutoFollowEnabled = true
         self.hasActiveUserScrollGesture = false
-        self.scrollPosition = ScrollPosition(idType: String.self, edge: .bottom)
+        self.scrollPosition = aiChatBottomScrollPosition(messages: chatStore.messages)
         self.autoScrollTask = nil
-        self.deferredBottomSyncTask = nil
         self.composerSelection = nil
         self.deferredPresentationRequest = nil
     }
@@ -351,20 +349,25 @@ struct AIChatView: View {
         }
     }
 
+    @ViewBuilder
     var chatContent: some View {
-        Group {
-            switch self.chatStore.bootstrapPhase {
-            case .loading:
-                if self.chatStore.hasLocalTranscriptDuringBootstrap {
-                    self.chatScrollSurface
-                } else {
-                    self.loadingChatState
-                }
-            case .failed:
-                self.failedChatState
-            case .ready:
-                self.chatScrollSurface
-            }
+        if self.shouldShowChatScrollSurface {
+            self.chatScrollSurface
+        } else if case .failed = self.chatStore.bootstrapPhase {
+            self.failedChatState
+        } else {
+            self.loadingChatState
+        }
+    }
+
+    var shouldShowChatScrollSurface: Bool {
+        switch self.chatStore.bootstrapPhase {
+        case .loading:
+            return self.chatStore.messages.isEmpty == false
+        case .failed:
+            return false
+        case .ready:
+            return true
         }
     }
 
@@ -753,9 +756,7 @@ struct AIChatView: View {
             return
         }
 
-        // Preserve a manual scroll-away, but if the user was still pinned to the
-        // bottom, let the keyboard settle first and then realign the latest chat.
-        self.scheduleDeferredBottomSyncIfNeeded()
+        self.scrollToBottomIfNeeded(isAnimated: false)
     }
 
     func handleViewAppear() {
@@ -798,7 +799,7 @@ struct AIChatView: View {
             return
         }
 
-        self.scheduleDeferredBottomSyncIfNeeded()
+        self.scrollToBottomIfNeeded(isAnimated: false)
         self.handleAIChatPresentationRequest(
             request: self.deferredPresentationRequest,
             source: .bootstrapReady
@@ -851,7 +852,6 @@ struct AIChatView: View {
 
     func handleSelectedTabChange(nextTab: AppTab) {
         guard nextTab == .ai else {
-            self.cancelDeferredBottomSync()
             self.syncChatSurface(refreshConsent: false)
             return
         }

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
@@ -69,62 +69,21 @@ func aiChatMessageListUpdateChangesExistingTail(
         }
 }
 
+func aiChatBottomScrollPosition(messages: [AIChatMessage]) -> ScrollPosition {
+    guard let tailMessageId = messages.last?.id else {
+        return ScrollPosition(idType: String.self, edge: .bottom)
+    }
+
+    return ScrollPosition(id: tailMessageId, anchor: .bottom)
+}
+
 extension AIChatView {
     func detachAutoFollow() {
         self.isAutoFollowEnabled = false
-        self.cancelDeferredBottomSync()
     }
 
     func detachAutoFollowForExpandedContent() {
         self.detachAutoFollow()
-    }
-
-    func scheduleDeferredBottomSyncIfNeeded() {
-        guard self.navigation.selectedTab == .ai else {
-            return
-        }
-        guard self.accessState == .ready else {
-            return
-        }
-        guard self.chatStore.bootstrapPhase == .ready else {
-            return
-        }
-        guard self.isAutoFollowEnabled else {
-            return
-        }
-
-        self.cancelDeferredBottomSync()
-        self.deferredBottomSyncTask = Task { @MainActor in
-            await Task.yield()
-
-            guard Task.isCancelled == false else {
-                return
-            }
-            guard self.navigation.selectedTab == .ai else {
-                self.deferredBottomSyncTask = nil
-                return
-            }
-            guard self.accessState == .ready else {
-                self.deferredBottomSyncTask = nil
-                return
-            }
-            guard self.chatStore.bootstrapPhase == .ready else {
-                self.deferredBottomSyncTask = nil
-                return
-            }
-            guard self.isAutoFollowEnabled else {
-                self.deferredBottomSyncTask = nil
-                return
-            }
-
-            self.scrollToBottomIfNeeded(isAnimated: false)
-            self.deferredBottomSyncTask = nil
-        }
-    }
-
-    func cancelDeferredBottomSync() {
-        self.deferredBottomSyncTask?.cancel()
-        self.deferredBottomSyncTask = nil
     }
 
     func scrollToBottomIfNeeded(isAnimated: Bool) {
@@ -138,7 +97,7 @@ extension AIChatView {
     func scrollToBottom(isAnimated: Bool) {
         if isAnimated {
             withAnimation(.easeOut(duration: aiChatAutoScrollAnimationDurationSeconds)) {
-                self.scrollPosition.scrollTo(edge: .bottom)
+                self.updateScrollPositionToBottom()
             }
             return
         }
@@ -146,8 +105,17 @@ extension AIChatView {
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            self.scrollPosition.scrollTo(edge: .bottom)
+            self.updateScrollPositionToBottom()
         }
+    }
+
+    private func updateScrollPositionToBottom() {
+        guard let tailMessageId = self.chatStore.messages.last?.id else {
+            self.scrollPosition.scrollTo(edge: .bottom)
+            return
+        }
+
+        self.scrollPosition.scrollTo(id: tailMessageId, anchor: .bottom)
     }
 
     func startAutoScrollTask() {

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
@@ -6,12 +6,6 @@ extension AIChatView {
         .accessibilityIdentifier(UITestIdentifier.aiConversationScrollSurface)
         .defaultScrollAnchor(.bottom, for: .initialOffset)
         .defaultScrollAnchor(.bottom, for: .alignment)
-        // Let SwiftUI preserve the visible content while the viewport changes.
-        // We removed the old geometry-height-driven `scrollToBottomIfNeeded` here
-        // because keyboard-open resizes were getting two competing corrections:
-        // `scrollPosition` preserving the current view and our forced bottom jump.
-        // That over-correction was causing the temporary empty gap above the keyboard
-        // until the user nudged the scroll view manually.
         .scrollPosition(self.$scrollPosition, anchor: .bottom)
         .contentMargins(.horizontal, aiChatMessageListHorizontalPadding, for: .scrollContent)
         .contentMargins(.vertical, 12, for: .scrollContent)
@@ -55,15 +49,12 @@ extension AIChatView {
             }
         }
         .onAppear {
-            // Keep the one-shot deferred sync behind the auto-follow latch so tab
-            // return cannot override a deliberate manual scroll-away.
-            self.scheduleDeferredBottomSyncIfNeeded()
+            self.scrollToBottomIfNeeded(isAnimated: false)
             if self.chatStore.isStreaming {
                 self.startAutoScrollTask()
             }
         }
         .onDisappear {
-            self.cancelDeferredBottomSync()
             self.stopAutoScrollTask()
         }
         .onChange(of: self.chatStore.messages) { previousMessages, messages in
@@ -86,7 +77,9 @@ extension AIChatView {
             guard didAppendTail || didChangeStreamingTail else {
                 return
             }
-            self.scrollToBottomIfNeeded(isAnimated: self.chatStore.isStreaming == false)
+            self.scrollToBottomIfNeeded(
+                isAnimated: previousMessages.isEmpty == false && self.chatStore.isStreaming == false
+            )
         }
         .onChange(of: self.chatStore.isStreaming) { _, isStreaming in
             if isStreaming {

--- a/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/Navigation/RootTabView.swift
@@ -557,8 +557,8 @@ struct RootTabView: View {
     private var aiTab: some View {
         NavigationStack {
             AIChatView(chatStore: store.aiChatStore)
-                .id(self.navigation.aiTabVisitID)
         }
+        .id(self.navigation.aiTabVisitID)
         .tabItem {
             Label(
                 String(


### PR DESCRIPTION
## Summary
- initialize AI chat scrolling at the concrete transcript tail
- keep the native List scroll surface stable through bootstrap
- reset the AI NavigationStack for every tab visit and remove deferred bottom-sync races

## Validation
- static review completed with no P0-P4 findings
- no local project checks run; required PR CI owns executable validation