### PR TITLE
Replace iOS AI chat scrolling with ScrollViewReader

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -104,8 +104,6 @@ struct AIChatView: View {
     @State var selectedPhotoItem: PhotosPickerItem?
     @State var isAutoFollowEnabled: Bool
     @State var hasActiveUserScrollGesture: Bool
-    @State var scrollPosition: ScrollPosition
-    @State var autoScrollTask: Task<Void, Never>?
     @State var composerSelection: TextSelection?
     @State var deferredPresentationRequest: AIChatPresentationRequest?
     @FocusState var isComposerFocused: Bool
@@ -119,8 +117,6 @@ struct AIChatView: View {
         self.selectedPhotoItem = nil
         self.isAutoFollowEnabled = true
         self.hasActiveUserScrollGesture = false
-        self.scrollPosition = aiChatBottomScrollPosition(messages: chatStore.messages)
-        self.autoScrollTask = nil
         self.composerSelection = nil
         self.deferredPresentationRequest = nil
     }
@@ -186,9 +182,6 @@ struct AIChatView: View {
             }
             .onChange(of: self.navigation.selectedTab) { _, nextTab in
                 self.handleSelectedTabChange(nextTab: nextTab)
-            }
-            .onChange(of: self.isComposerFocused) { _, isFocused in
-                self.handleComposerFocusChange(isFocused: isFocused)
             }
             .onChange(of: self.chatStore.dictationState) { _, nextState in
                 self.handleDictationStateViewChange(nextState: nextState)
@@ -751,14 +744,6 @@ struct AIChatView: View {
         )
     }
 
-    func handleComposerFocusChange(isFocused: Bool) {
-        guard isFocused, self.isAutoFollowEnabled else {
-            return
-        }
-
-        self.scrollToBottomIfNeeded(isAnimated: false)
-    }
-
     func handleViewAppear() {
         self.syncChatSurface(refreshConsent: true)
         self.captureAIChatPresentationRequest(
@@ -799,7 +784,6 @@ struct AIChatView: View {
             return
         }
 
-        self.scrollToBottomIfNeeded(isAnimated: false)
         self.handleAIChatPresentationRequest(
             request: self.deferredPresentationRequest,
             source: .bootstrapReady
@@ -930,7 +914,6 @@ let aiChatComposerStatusLaneHeight: CGFloat = 24
 let aiChatComposerStatusLaneSpacing: CGFloat = 8
 let aiChatComposerDictationTextFieldTopPadding: CGFloat = 12 + aiChatComposerStatusLaneHeight + aiChatComposerStatusLaneSpacing
 let aiChatMessageListHorizontalPadding: CGFloat = 16
-let aiChatAutoScrollIntervalSeconds: Double = 2.0
 let aiChatAutoScrollBottomThreshold: CGFloat = 12
 let aiChatAutoScrollAnimationDurationSeconds: Double = 0.25
 let aiChatBubbleMaximumWidth: CGFloat = 720

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Scrolling.swift
@@ -69,14 +69,6 @@ func aiChatMessageListUpdateChangesExistingTail(
         }
 }
 
-func aiChatBottomScrollPosition(messages: [AIChatMessage]) -> ScrollPosition {
-    guard let tailMessageId = messages.last?.id else {
-        return ScrollPosition(idType: String.self, edge: .bottom)
-    }
-
-    return ScrollPosition(id: tailMessageId, anchor: .bottom)
-}
-
 extension AIChatView {
     func detachAutoFollow() {
         self.isAutoFollowEnabled = false
@@ -86,18 +78,22 @@ extension AIChatView {
         self.detachAutoFollow()
     }
 
-    func scrollToBottomIfNeeded(isAnimated: Bool) {
+    func scrollToBottomIfNeeded(proxy: ScrollViewProxy, isAnimated: Bool) {
         guard self.isAutoFollowEnabled else {
             return
         }
 
-        self.scrollToBottom(isAnimated: isAnimated)
+        self.scrollToBottom(proxy: proxy, isAnimated: isAnimated)
     }
 
-    func scrollToBottom(isAnimated: Bool) {
+    func scrollToBottom(proxy: ScrollViewProxy, isAnimated: Bool) {
+        guard let lastMessage = self.chatStore.messages.last else {
+            return
+        }
+
         if isAnimated {
             withAnimation(.easeOut(duration: aiChatAutoScrollAnimationDurationSeconds)) {
-                self.updateScrollPositionToBottom()
+                proxy.scrollTo(lastMessage.id, anchor: .bottom)
             }
             return
         }
@@ -105,40 +101,7 @@ extension AIChatView {
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            self.updateScrollPositionToBottom()
+            proxy.scrollTo(lastMessage.id, anchor: .bottom)
         }
-    }
-
-    private func updateScrollPositionToBottom() {
-        guard let tailMessageId = self.chatStore.messages.last?.id else {
-            self.scrollPosition.scrollTo(edge: .bottom)
-            return
-        }
-
-        self.scrollPosition.scrollTo(id: tailMessageId, anchor: .bottom)
-    }
-
-    func startAutoScrollTask() {
-        self.stopAutoScrollTask()
-        self.autoScrollTask = Task { @MainActor in
-            while Task.isCancelled == false {
-                do {
-                    try await Task.sleep(for: .seconds(aiChatAutoScrollIntervalSeconds))
-                } catch {
-                    break
-                }
-
-                guard self.chatStore.isStreaming else {
-                    continue
-                }
-
-                self.scrollToBottomIfNeeded(isAnimated: true)
-            }
-        }
-    }
-
-    func stopAutoScrollTask() {
-        self.autoScrollTask?.cancel()
-        self.autoScrollTask = nil
     }
 }

--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
@@ -2,93 +2,115 @@ import SwiftUI
 
 extension AIChatView {
     var chatScrollSurface: some View {
-        self.chatScrollContent
-        .accessibilityIdentifier(UITestIdentifier.aiConversationScrollSurface)
-        .defaultScrollAnchor(.bottom, for: .initialOffset)
-        .defaultScrollAnchor(.bottom, for: .alignment)
-        .scrollPosition(self.$scrollPosition, anchor: .bottom)
-        .contentMargins(.horizontal, aiChatMessageListHorizontalPadding, for: .scrollContent)
-        .contentMargins(.vertical, 12, for: .scrollContent)
-        .contentMargins(.horizontal, 0, for: .scrollIndicators)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            self.dismissComposerFocus()
-        }
-        .onScrollPhaseChange { _, nextPhase, context in
-            let nextScrollState: AIChatScrollState = aiChatScrollState(
-                scrollPhase: nextPhase,
-                scrollGeometry: context.geometry,
-                bottomThreshold: aiChatAutoScrollBottomThreshold
-            )
-
-            // Only user-driven scrolls can detach auto-follow. Animated scrolls are
-            // app-driven and should not flip the latch while assistant content grows.
-            if nextScrollState.isUserInitiatedScroll {
-                self.hasActiveUserScrollGesture = true
-                if nextScrollState.isNearBottom == false {
-                    self.detachAutoFollow()
-                    return
+        ScrollViewReader { proxy in
+            self.chatScrollContent
+                .accessibilityIdentifier(UITestIdentifier.aiConversationScrollSurface)
+                .defaultScrollAnchor(.bottom, for: .initialOffset)
+                .defaultScrollAnchor(.bottom, for: .alignment)
+                .contentMargins(.horizontal, aiChatMessageListHorizontalPadding, for: .scrollContent)
+                .contentMargins(.vertical, 12, for: .scrollContent)
+                .contentMargins(.horizontal, 0, for: .scrollIndicators)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    self.dismissComposerFocus()
                 }
-            }
+                .onScrollPhaseChange { _, nextPhase, context in
+                    let nextScrollState: AIChatScrollState = aiChatScrollState(
+                        scrollPhase: nextPhase,
+                        scrollGeometry: context.geometry,
+                        bottomThreshold: aiChatAutoScrollBottomThreshold
+                    )
 
-            if nextPhase == .idle {
-                let didCompleteUserScrollGesture: Bool = self.hasActiveUserScrollGesture
-                self.hasActiveUserScrollGesture = false
-                guard nextScrollState.isNearBottom else {
-                    if didCompleteUserScrollGesture {
-                        self.detachAutoFollow()
+                    // Only user-driven scrolls can detach auto-follow. Animated scrolls are
+                    // app-driven and should not flip the latch while assistant content grows.
+                    if nextScrollState.isUserInitiatedScroll {
+                        self.hasActiveUserScrollGesture = true
+                        if nextScrollState.isNearBottom == false {
+                            self.detachAutoFollow()
+                            return
+                        }
                     }
-                    return
+
+                    if nextPhase == .idle {
+                        let didCompleteUserScrollGesture: Bool = self.hasActiveUserScrollGesture
+                        self.hasActiveUserScrollGesture = false
+                        guard nextScrollState.isNearBottom else {
+                            if didCompleteUserScrollGesture {
+                                self.detachAutoFollow()
+                            }
+                            return
+                        }
+
+                        self.isAutoFollowEnabled = true
+                        if self.chatStore.isStreaming {
+                            self.scrollToBottom(
+                                proxy: proxy,
+                                isAnimated: false
+                            )
+                        }
+                        return
+                    }
                 }
-
-                self.isAutoFollowEnabled = true
-                if self.chatStore.isStreaming {
-                    self.scrollToBottomIfNeeded(isAnimated: false)
+                .onAppear {
+                    self.isAutoFollowEnabled = true
+                    self.hasActiveUserScrollGesture = false
+                    self.scrollToBottom(proxy: proxy, isAnimated: false)
                 }
-                return
-            }
-        }
-        .onAppear {
-            self.scrollToBottomIfNeeded(isAnimated: false)
-            if self.chatStore.isStreaming {
-                self.startAutoScrollTask()
-            }
-        }
-        .onDisappear {
-            self.stopAutoScrollTask()
-        }
-        .onChange(of: self.chatStore.messages) { previousMessages, messages in
-            guard messages.isEmpty == false else {
-                self.isAutoFollowEnabled = true
-                self.hasActiveUserScrollGesture = false
-                self.scrollToBottom(isAnimated: false)
-                return
-            }
+                .onChange(of: self.navigation.selectedTab) { _, nextTab in
+                    guard nextTab == .ai else {
+                        return
+                    }
 
-            let didAppendTail: Bool = aiChatMessageListUpdateAppendsTail(
-                previousMessages: previousMessages,
-                nextMessages: messages
-            )
-            let didChangeStreamingTail: Bool = self.chatStore.isStreaming
-                && aiChatMessageListUpdateChangesExistingTail(
-                    previousMessages: previousMessages,
-                    nextMessages: messages
-                )
-            guard didAppendTail || didChangeStreamingTail else {
-                return
-            }
-            self.scrollToBottomIfNeeded(
-                isAnimated: previousMessages.isEmpty == false && self.chatStore.isStreaming == false
-            )
-        }
-        .onChange(of: self.chatStore.isStreaming) { _, isStreaming in
-            if isStreaming {
-                self.startAutoScrollTask()
-                return
-            }
+                    self.isAutoFollowEnabled = true
+                    self.hasActiveUserScrollGesture = false
+                    self.scrollToBottom(proxy: proxy, isAnimated: false)
+                }
+                .onChange(of: self.chatStore.bootstrapPhase) { _, nextPhase in
+                    guard nextPhase == .ready else {
+                        return
+                    }
 
-            self.stopAutoScrollTask()
-            self.scrollToBottomIfNeeded(isAnimated: true)
+                    self.scrollToBottomIfNeeded(proxy: proxy, isAnimated: false)
+                }
+                .onChange(of: self.isComposerFocused) { _, isFocused in
+                    guard isFocused else {
+                        return
+                    }
+
+                    self.scrollToBottomIfNeeded(proxy: proxy, isAnimated: false)
+                }
+                .onChange(of: self.chatStore.messages) { previousMessages, messages in
+                    guard messages.isEmpty == false else {
+                        self.isAutoFollowEnabled = true
+                        self.hasActiveUserScrollGesture = false
+                        return
+                    }
+
+                    let didAppendTail: Bool = aiChatMessageListUpdateAppendsTail(
+                        previousMessages: previousMessages,
+                        nextMessages: messages
+                    )
+                    let didChangeTailIdentity: Bool = previousMessages.last?.id != messages.last?.id
+                    let didChangeStreamingTail: Bool = self.chatStore.isStreaming
+                        && aiChatMessageListUpdateChangesExistingTail(
+                            previousMessages: previousMessages,
+                            nextMessages: messages
+                        )
+                    guard didAppendTail || didChangeTailIdentity || didChangeStreamingTail else {
+                        return
+                    }
+                    self.scrollToBottomIfNeeded(
+                        proxy: proxy,
+                        isAnimated: previousMessages.isEmpty == false && self.chatStore.isStreaming == false
+                    )
+                }
+                .onChange(of: self.chatStore.isStreaming) { _, isStreaming in
+                    guard isStreaming == false else {
+                        return
+                    }
+
+                    self.scrollToBottomIfNeeded(proxy: proxy, isAnimated: true)
+                }
         }
     }
 


### PR DESCRIPTION
## Summary
- replace ScrollPosition with one reader-scoped ScrollViewProxy authority
- open each AI tab visit at the semantic bottom without visible animation
- preserve native List virtualization and manual auto-follow detach/reattach behavior

## Validation
- static review passed with no P0-P4 findings
- local project checks intentionally not run; required PR CI owns validation