### PR TITLE
Fix iOS AI chat empty state clipping

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
@@ -118,14 +118,7 @@ extension AIChatView {
     var chatScrollContent: some View {
         // The transcript must use a native virtualized container and stable row IDs.
         List {
-            if self.chatStore.messages.isEmpty {
-                self.emptyChatState
-                    .frame(maxWidth: .infinity)
-                    .containerRelativeFrame(.vertical, alignment: .center)
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-            } else {
+            if self.chatStore.messages.isEmpty == false {
                 let tailMessageId: String? = self.chatStore.messages.last?.id
 
                 ForEach(self.chatStore.messages) { message in
@@ -149,5 +142,10 @@ extension AIChatView {
         .listStyle(.plain)
         .listRowSpacing(12)
         .scrollContentBackground(.hidden)
+        .overlay {
+            if self.chatStore.messages.isEmpty {
+                self.emptyChatState
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- keep the AI transcript List alive when there are no messages
- present the existing empty state as a conditional List overlay
- remove the clipped list-row and container-relative sizing

## Validation
- not run locally, per repository policy
- uncommitted patch passed a fresh static review with no P0-P4 findings