### PR TITLE
docs(iOS): explain AI chat layout invariants

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/Transcript/AIChatView+Transcript.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 extension AIChatView {
     var chatScrollSurface: some View {
+        // Keep programmatic navigation tied to stable native List row IDs through
+        // ScrollViewReader; ScrollPosition reopened physical-iPhone transcripts at
+        // the top instead of resolving the tail.
         ScrollViewReader { proxy in
             self.chatScrollContent
                 .accessibilityIdentifier(UITestIdentifier.aiConversationScrollSurface)
@@ -143,6 +146,9 @@ extension AIChatView {
         .listRowSpacing(12)
         .scrollContentBackground(.hidden)
         .overlay {
+            // Keep ContentUnavailableView out of List rows: vertical containerRelativeFrame
+            // row sizing clipped its description on a physical iPhone. This overlay receives
+            // the full List viewport while keeping the List mounted.
             if self.chatStore.messages.isEmpty {
                 self.emptyChatState
             }


### PR DESCRIPTION
Documents why AI chat navigation must continue using ScrollViewReader with stable List row IDs and why the empty state remains a List overlay. Local project checks were not run per repository policy; required pull-request CI owns validation.