### PR TITLE
Clean obsolete OpenAPI guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ The sync approach and the data model changed multiple times during development. 
 
 ## Planned Monorepo Shape
 
-`apps/{backend,ios,android}`, `db/{migrations,views,queries}`, `infra/{docker,aws}`, `api/src/openapi.yaml`, `docs/`, `scripts/`
+`apps/{backend,ios,android}`, `db/{migrations,views,queries}`, `infra/{docker,aws}`, `docs/`, `scripts/`
 
 ## Auth Service (`apps/auth/`)
 
@@ -107,7 +107,7 @@ Details and key files: [docs/auth-service.md](docs/auth-service.md).
 - Use strict typing across services.
 - Keep changes minimal and scoped.
 - Offline-first clients may apply narrow local overlays for pending changes, but complex product/domain rules must stay server-owned unless explicitly required; do not reimplement full backend algorithms in clients.
-- Machine API documentation is intentionally duplicated across the discovery envelope (`actions` and `instructions`) and the published specs (`/v1/openapi.json`, `/v1/swagger.json`, generated from `api/src/openapi.yaml`). When changing the machine API, keep all of these in sync in the same change.
+- The conventional machine API document probes (`GET /v1/openapi.json`, `GET /v1/swagger.json`, `GET /v1/agent/openapi.json`, and `GET /v1/agent/swagger.json`) return concise source-discovery JSON that links to the open-source repository and relevant backend and auth route source files; they do not publish OpenAPI documents.
 - Flashcard side contract is mandatory across all clients and APIs: `frontText` is only a question/review prompt (never the answer), and `backText` contains the answer (optionally with a concrete example, preferably in a fenced markdown code block when helpful).
 - We align the functional contract across iOS and Android, but we do not synchronize the designs between them. The iOS UI should stay maximally native to iOS, and the Android UI should stay maximally native to Android and Material 3.
 - In the iOS app, every user tap should trigger immediate Apple-standard UI feedback, with background loading shown in place or on the next surface, failed actions restoring the previous state, and successful actions clearly exposing the next step.

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
@@ -3,8 +3,7 @@ import Foundation
 private let progressLeaderboardMaximumGapRowCount: Int = 2
 
 // Wire contract for GET /me/progress/leaderboard.
-// Keep aligned with api/src/openapi.yaml and
-// apps/backend/src/community/leaderboard/progress/progressLeaderboard.ts.
+// Keep aligned with apps/backend/src/community/leaderboard/progress/progressLeaderboard.ts.
 enum LeaderboardWindowKey: String, Codable, CaseIterable, Identifiable, Sendable {
     case last24Hours = "last_24_hours"
     case last3Days = "last_3_days"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,6 @@ The apex `<domain>` is an optional CloudFront redirect to `app.<domain>`.
 - `apps/web`: React + Vite web app with IndexedDB local storage
 - `apps/admin`: React + Vite admin app with server-side analytics data loading
 - `apps/ios`: SwiftUI iOS app with SQLite local storage
-- `api`: published OpenAPI source used by the backend and agent docs
 - `db/migrations`: PostgreSQL schema, security, and runtime-role migrations
 - `db/views`: SQL views applied after migrations
 - `infra/aws`: CDK stack for networking, database, auth, API, web hosting, CI/CD, backups, and monitoring
@@ -91,8 +90,8 @@ The apex `<domain>` is an optional CloudFront redirect to `app.<domain>`.
 
 `apps/backend/src/server/app.ts` mounts ten route modules:
 
-- `system`: discovery, health, OpenAPI, session/account inspection, account deletion
-- `agent`: machine-facing discovery, workspace bootstrap, SQL endpoint, and agent OpenAPI documents
+- `system`: runtime discovery, source-discovery probes, health, session/account inspection, and account deletion
+- `agent`: machine-facing source-discovery aliases, workspace bootstrap, and SQL endpoints
 - `workspaces`: list/create/select workspaces, workspace lifecycle actions, and human-session agent API key management
 - `admin`: admin session and report query endpoints
 - `cards`: workspace card query and tag summary endpoints
@@ -267,7 +266,7 @@ The machine-facing API is intentionally narrower than the human app API:
 - workspace listing and bootstrap at `GET/POST /v1/agent/workspaces`
 - workspace selection at `POST /v1/agent/workspaces/{workspaceId}/select`
 - SQL reads at `POST /v1/agent/sql/query` (read-only) and SQL writes at `POST /v1/agent/sql/execute`
-- published docs at `GET /v1/agent/openapi.json` and `GET /v1/agent/swagger.json`
+- conventional document probes at `GET /v1/openapi.json`, `GET /v1/swagger.json`, `GET /v1/agent/openapi.json`, and `GET /v1/agent/swagger.json`; all four return the same concise source-discovery JSON linking to the open-source repository and the relevant backend and auth route source files, not an OpenAPI document
 
 The SQL dialect is not full PostgreSQL. It is a constrained contract implemented in `apps/backend/src/aiTools`.
 

--- a/docs/version-bump.md
+++ b/docs/version-bump.md
@@ -50,7 +50,7 @@ In normal releases, backend, web, Android, and iOS should all move to the same n
 
 A version bump is not complete until the repo-owned version surfaces that participate in that release stay aligned with each other and with each platform's runtime-reported version source.
 
-Do not change `/v1` API paths, OpenAPI `info.version: v1`, or API Gateway stage names as part of an app release bump. Those values describe the public API contract version, not the app release version.
+Do not change `/v1` API paths or API Gateway stage names as part of an app release bump. Those values describe the public API contract version, not the app release version.
 
 ## Source Of Truth By Platform
 
@@ -62,7 +62,6 @@ Update these package manifests together:
 
 - `apps/backend/package.json`
 - `apps/admin/package.json`
-- `api/package.json`
 - `apps/auth/package.json`
 - `infra/aws/package.json`
 


### PR DESCRIPTION
## Summary
- describe the conventional document probes as source-discovery aliases
- remove obsolete OpenAPI package and version-bump guidance
- remove the stale iOS OpenAPI contract comment

## Testing
- Not run locally per repository instructions; required CI owns validation.