### PR TITLE
Add catalog image normalization primitives

### DIFF
--- a/apps/backend/src/mediaAssets/ingestion/imageNormalization.test.ts
+++ b/apps/backend/src/mediaAssets/ingestion/imageNormalization.test.ts
@@ -9,10 +9,12 @@ import test from "node:test";
 import sharp from "sharp";
 import { HttpError } from "../../shared/errors";
 import {
+  imageJpegCatalogCoverMaxSidePixels,
   imageJpegCardMaxSidePixels,
   imageJpegCardTransparentPixelLightCardGray,
   normalizeImageBytesForCard,
   normalizeImageBytesForCardUntilDeadline,
+  normalizeImageBytesForCatalogCover,
   runImageNormalizationWorker,
   type ImageNormalizationProcessDependencies,
 } from "./imageNormalization";
@@ -45,6 +47,21 @@ async function createLargeJpeg(): Promise<Buffer> {
     create: {
       width: 1_600,
       height: 800,
+      channels: 3,
+      background: {
+        r: 20,
+        g: 30,
+        b: 40,
+      },
+    },
+  }).jpeg().toBuffer();
+}
+
+async function createCatalogCoverJpeg(): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: 3_000,
+      height: 1_500,
       channels: 3,
       background: {
         r: 20,
@@ -101,6 +118,47 @@ test("normalizeImageBytesForCard constrains the longest side", async () => {
 
   assert.equal(metadata.width, imageJpegCardMaxSidePixels);
   assert.equal(metadata.height, 600);
+});
+
+test("normalizeImageBytesForCard preserves the workspace card transform profile", async () => {
+  const inputBytes = await createLargeJpeg();
+  const expectedBytes = await sharp(inputBytes, {
+    animated: false,
+    failOn: "warning",
+    limitInputPixels: 24_000_000,
+  })
+    .rotate()
+    .resize({
+      width: 1_200,
+      height: 1_200,
+      fit: "inside",
+      withoutEnlargement: true,
+    })
+    .flatten({ background: { r: 241, g: 243, b: 244 } })
+    .toColorspace("srgb")
+    .jpeg({
+      quality: 82,
+      progressive: false,
+      mozjpeg: false,
+    })
+    .toBuffer();
+
+  const result = await normalizeImageBytesForCard(inputBytes);
+
+  assert.deepEqual(result.bytes, expectedBytes);
+});
+
+test("normalizeImageBytesForCatalogCover is deterministic and constrains the longest side", async () => {
+  const inputBytes = await createCatalogCoverJpeg();
+
+  const firstResult = await normalizeImageBytesForCatalogCover(inputBytes);
+  const secondResult = await normalizeImageBytesForCatalogCover(inputBytes);
+  const metadata = await sharp(firstResult.bytes).metadata();
+
+  assert.deepEqual(firstResult.bytes, secondResult.bytes);
+  assert.equal(firstResult.mimeType, imageJpegCardMediaBlobMimeType);
+  assert.equal(metadata.width, imageJpegCatalogCoverMaxSidePixels);
+  assert.equal(metadata.height, 1_200);
 });
 
 test("normalizeImageBytesForCard rejects GIF input", async () => {

--- a/apps/backend/src/mediaAssets/ingestion/imageNormalization.ts
+++ b/apps/backend/src/mediaAssets/ingestion/imageNormalization.ts
@@ -8,6 +8,8 @@ import { imageJpegCardMediaBlobMimeType } from "../types";
 
 export const imageJpegCardMaxSidePixels = 1_200;
 export const imageJpegCardJpegQuality = 82;
+export const imageJpegCatalogCoverMaxSidePixels = 2_400;
+export const imageJpegCatalogCoverJpegQuality = 90;
 export const imageJpegCardMaximumDecodedPixels = 24_000_000;
 export const imageJpegCardTransparentPixelLightCardGray = {
   r: 241,
@@ -56,7 +58,11 @@ type ImageNormalizationWorkerError = Readonly<{
   detail: string;
 }>;
 
-const imageNormalizationWorkerScript = String.raw`
+function createImageNormalizationWorkerScript(
+  maximumSidePixels: number,
+  jpegQuality: number,
+): string {
+  return String.raw`
 "use strict";
 const sharp = require(process.argv[1]);
 const maximumDecodedPixels = ${imageJpegCardMaximumDecodedPixels};
@@ -120,15 +126,15 @@ async function main() {
   })
     .rotate()
     .resize({
-      width: ${imageJpegCardMaxSidePixels},
-      height: ${imageJpegCardMaxSidePixels},
+      width: ${maximumSidePixels},
+      height: ${maximumSidePixels},
       fit: "inside",
       withoutEnlargement: true,
     })
     .flatten({ background })
     .toColorspace("srgb")
     .jpeg({
-      quality: ${imageJpegCardJpegQuality},
+      quality: ${jpegQuality},
       progressive: false,
       mozjpeg: false,
     })
@@ -137,9 +143,21 @@ async function main() {
 }
 main().catch(writeFailure);
 `;
+}
 
-const productionImageNormalizationWorker = Object.freeze({
-  script: imageNormalizationWorkerScript,
+const productionCardImageNormalizationWorker = Object.freeze({
+  script: createImageNormalizationWorkerScript(
+    imageJpegCardMaxSidePixels,
+    imageJpegCardJpegQuality,
+  ),
+  arguments: [require.resolve("sharp")],
+});
+
+const productionCatalogCoverImageNormalizationWorker = Object.freeze({
+  script: createImageNormalizationWorkerScript(
+    imageJpegCatalogCoverMaxSidePixels,
+    imageJpegCatalogCoverJpegQuality,
+  ),
   arguments: [require.resolve("sharp")],
 });
 
@@ -512,6 +530,7 @@ async function normalizeImageBytes(
   inputBytes: Buffer,
   deadlineAtMs: number,
   abortSignal: AbortSignal,
+  worker: ImageNormalizationWorker,
 ): Promise<NormalizedImageBytes> {
   const unsupportedContainerFormat = detectUnsupportedContainerFormat(inputBytes);
   if (unsupportedContainerFormat !== null) {
@@ -521,7 +540,7 @@ async function normalizeImageBytes(
     inputBytes,
     deadlineAtMs,
     abortSignal,
-    productionImageNormalizationWorker,
+    worker,
     productionImageNormalizationProcessDependencies,
   );
   return {
@@ -537,6 +556,7 @@ export async function normalizeImageBytesForCard(inputBytes: Buffer): Promise<No
     inputBytes,
     Date.now() + standaloneImageNormalizationBudgetMs,
     controller.signal,
+    productionCardImageNormalizationWorker,
   );
 }
 
@@ -545,5 +565,35 @@ export async function normalizeImageBytesForCardUntilDeadline(
   deadlineAtMs: number,
   abortSignal: AbortSignal,
 ): Promise<NormalizedImageBytes> {
-  return normalizeImageBytes(inputBytes, deadlineAtMs, abortSignal);
+  return normalizeImageBytes(
+    inputBytes,
+    deadlineAtMs,
+    abortSignal,
+    productionCardImageNormalizationWorker,
+  );
+}
+
+export async function normalizeImageBytesForCatalogCover(
+  inputBytes: Buffer,
+): Promise<NormalizedImageBytes> {
+  const controller = new AbortController();
+  return normalizeImageBytes(
+    inputBytes,
+    Date.now() + standaloneImageNormalizationBudgetMs,
+    controller.signal,
+    productionCatalogCoverImageNormalizationWorker,
+  );
+}
+
+export async function normalizeImageBytesForCatalogCoverUntilDeadline(
+  inputBytes: Buffer,
+  deadlineAtMs: number,
+  abortSignal: AbortSignal,
+): Promise<NormalizedImageBytes> {
+  return normalizeImageBytes(
+    inputBytes,
+    deadlineAtMs,
+    abortSignal,
+    productionCatalogCoverImageNormalizationWorker,
+  );
 }

--- a/apps/backend/src/mediaAssets/storage/contracts.ts
+++ b/apps/backend/src/mediaAssets/storage/contracts.ts
@@ -14,11 +14,16 @@ import type {
 } from "../uploadSessions";
 import type { getMediaAssetsStorageConfig } from "./config";
 
-export type MediaAssetStorageContext = Readonly<{
-  workspaceId: string;
-  mediaAssetId: string;
+export type MediaBlobStorageContext = Readonly<{
+  workspaceId: string | null;
+  mediaAssetId: string | null;
   storageKey: string;
   observationScope: BackendObservationScope;
+}>;
+
+export type MediaAssetStorageContext = MediaBlobStorageContext & Readonly<{
+  workspaceId: string;
+  mediaAssetId: string;
 }>;
 
 export type DeletePermanentMediaBlobInput = Readonly<{
@@ -79,6 +84,16 @@ export type StoreMediaAssetBlobBytesInput = Readonly<{
   mimeType: string;
   sha256: string;
   lastOperationId: string;
+  bytes: Buffer;
+  observationScope: BackendObservationScope;
+}>;
+
+export type StoreCatalogImageBlobBytesInput = Readonly<{
+  signal: AbortSignal;
+  storageKey: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
   bytes: Buffer;
   observationScope: BackendObservationScope;
 }>;

--- a/apps/backend/src/mediaAssets/storage/direct.ts
+++ b/apps/backend/src/mediaAssets/storage/direct.ts
@@ -1,11 +1,26 @@
 import { getMediaAssetsS3Client, getMediaAssetsStorageConfig } from "./config";
-import type { StoreMediaAssetBlobBytesInput } from "./contracts";
-import { storeMediaAssetBlobBytesIfAbsentWithDependencies } from "./promotion/promotion";
+import type {
+  StoreCatalogImageBlobBytesInput,
+  StoreMediaAssetBlobBytesInput,
+} from "./contracts";
+import {
+  storeCatalogImageBlobBytesIfAbsentWithDependencies,
+  storeMediaAssetBlobBytesIfAbsentWithDependencies,
+} from "./promotion/promotion";
 
 export function storeMediaAssetBlobBytesIfAbsent(
   input: StoreMediaAssetBlobBytesInput,
 ): Promise<void> {
   return storeMediaAssetBlobBytesIfAbsentWithDependencies(input, {
+    s3Client: getMediaAssetsS3Client(),
+    getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
+  });
+}
+
+export function storeCatalogImageBlobBytesIfAbsent(
+  input: StoreCatalogImageBlobBytesInput,
+): Promise<void> {
+  return storeCatalogImageBlobBytesIfAbsentWithDependencies(input, {
     s3Client: getMediaAssetsS3Client(),
     getMediaAssetsStorageConfigFn: getMediaAssetsStorageConfig,
   });

--- a/apps/backend/src/mediaAssets/storage/errors.ts
+++ b/apps/backend/src/mediaAssets/storage/errors.ts
@@ -3,6 +3,7 @@ import {
 } from "../../observability/runtime";
 import { HttpError, type MediaAssetStorageErrorDetails } from "../../shared/errors";
 import type {
+  MediaBlobStorageContext,
   MediaAssetStorageContext,
   MediaAssetStorageOperation,
 } from "./contracts";
@@ -124,7 +125,7 @@ function isUploadNotAvailableStorageError(operation: MediaAssetStorageOperation,
 }
 
 export async function runMediaAssetStorageOperationWithRetries<Result>(
-  context: MediaAssetStorageContext,
+  context: MediaBlobStorageContext,
   operation: MediaAssetStorageOperation,
   run: () => Promise<Result>,
 ): Promise<Result> {
@@ -137,7 +138,7 @@ export async function runMediaAssetStorageOperationWithRetries<Result>(
 }
 
 async function runMediaAssetStorageOperationWithRetriesAndOptionalAbortSignal<Result>(
-  context: MediaAssetStorageContext,
+  context: MediaBlobStorageContext,
   operation: MediaAssetStorageOperation,
   signal: AbortSignal | null,
   run: () => Promise<Result>,
@@ -181,7 +182,7 @@ async function runMediaAssetStorageOperationWithRetriesAndOptionalAbortSignal<Re
 }
 
 export function runMediaAssetStorageOperationWithRetriesAndAbortSignal<Result>(
-  context: MediaAssetStorageContext,
+  context: MediaBlobStorageContext,
   operation: MediaAssetStorageOperation,
   signal: AbortSignal,
   run: () => Promise<Result>,

--- a/apps/backend/src/mediaAssets/storage/promotion/promotion.test.ts
+++ b/apps/backend/src/mediaAssets/storage/promotion/promotion.test.ts
@@ -23,6 +23,7 @@ import {
 } from "..";
 import {
   promoteMediaAssetUploadToBlobWithCapabilityVerifier,
+  storeCatalogImageBlobBytesIfAbsentWithDependencies,
   storeMediaAssetBlobBytesIfAbsentWithCapabilityVerifier,
 } from "./promotion";
 import {
@@ -200,6 +201,59 @@ test("storeMediaAssetBlobBytesIfAbsentWithDependencies verifies an existing cond
     `head:${testBlobStorageKey}`,
   ]);
   assert.equal(capabilityChecks, 3);
+});
+
+test("catalog image storage reuses the conditional write and checksum winner verification path", async () => {
+  const sentCommands: Array<string> = [];
+  const signal = AbortSignal.timeout(10_000);
+  const client = createTestS3Client();
+  client.send = (async (
+    command: unknown,
+    options: Readonly<{ abortSignal?: AbortSignal }>,
+  ) => {
+    assert.equal(options.abortSignal, signal);
+    if (command instanceof PutObjectCommand) {
+      sentCommands.push(`put:${String(command.input.Key)}`);
+      assert.equal(command.input.IfNoneMatch, "*");
+      assert.equal(
+        command.input.ChecksumSHA256,
+        Buffer.from(testSha256, "hex").toString("base64"),
+      );
+      throw createS3Error(412, "PreconditionFailed", "Object already exists");
+    }
+    if (command instanceof HeadObjectCommand) {
+      sentCommands.push(`head:${String(command.input.Key)}`);
+      return createHeadObjectResponse({
+        sizeBytes: testObjectBytes.byteLength,
+        mimeType: "image/jpeg",
+        sha256: testSha256,
+      });
+    }
+    throw new Error(
+      `Unexpected S3 command ${getUnexpectedS3CommandName(command)}`,
+    );
+  }) as S3Client["send"];
+
+  await storeCatalogImageBlobBytesIfAbsentWithDependencies(
+    {
+      signal,
+      storageKey: testBlobStorageKey,
+      mimeType: "image/jpeg",
+      sizeBytes: testObjectBytes.byteLength,
+      sha256: testSha256,
+      bytes: testObjectBytes,
+      observationScope: testObservationScope,
+    },
+    {
+      s3Client: client,
+      getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+    },
+  );
+
+  assert.deepEqual(sentCommands, [
+    `put:${testBlobStorageKey}`,
+    `head:${testBlobStorageKey}`,
+  ]);
 });
 
 test("direct conditional PutObject retries 409 without verification and succeeds on retry", async () => {

--- a/apps/backend/src/mediaAssets/storage/promotion/promotion.ts
+++ b/apps/backend/src/mediaAssets/storage/promotion/promotion.ts
@@ -20,9 +20,11 @@ import type { BackendObservationScope } from "../../../observability/sentry/even
 import { HttpError } from "../../../shared/errors";
 import type {
   AssertMediaAssetObjectInput,
+  MediaBlobStorageContext,
   MediaAssetStorageContext,
   MediaAssetStorageDependencies,
   PromoteMediaAssetUploadInput,
+  StoreCatalogImageBlobBytesInput,
   StoreMediaAssetBlobBytesInput,
 } from "../contracts";
 import {
@@ -206,51 +208,68 @@ function rethrowDirectStorageAbortReason(
   }
 }
 
-async function assertStoredMediaAssetBlobObjectContentMatchesWithDependencies(
-  input: StoreMediaAssetBlobBytesInput,
+type StoreContentAddressedMediaBlobBytesInput = Readonly<{
+  signal: AbortSignal;
+  storageKey: string;
+  mimeType: string;
+  sha256: string;
+  bytes: Buffer;
+  observationScope: BackendObservationScope;
+}>;
+
+async function storeContentAddressedMediaBlobBytesIfAbsentWithDependencies(
+  input: StoreContentAddressedMediaBlobBytesInput,
+  context: MediaBlobStorageContext,
   dependencies: MediaAssetStorageDependencies,
-  verifyCapability: DirectMediaBlobStorageCapabilityVerifier,
+  assertMutationAuthorized: () => void,
+  assertWinnerMatches: (response: HeadObjectCommandOutput) => void,
 ): Promise<void> {
-  const blobObjectInput: AssertMediaAssetObjectInput = {
-    workspaceId: input.workspaceId,
-    mediaAssetId: input.mediaAssetId,
-    storageKey: input.storageKey,
-    mimeType: input.mimeType,
-    sizeBytes: input.bytes.byteLength,
-    sha256: input.sha256,
-    lastOperationId: input.lastOperationId,
-    observationScope: input.observationScope,
-  };
   const config = dependencies.getMediaAssetsStorageConfigFn();
-  const context = { ...blobObjectInput, storageKey: input.storageKey };
-  let response: HeadObjectCommandOutput;
-  try {
-    response = await runMediaAssetStorageOperationWithRetries(
-      context,
-      "head_object",
-      () => {
-        assertDirectStorageMutationAuthorized(input, verifyCapability);
-        return dependencies.s3Client.send(new HeadObjectCommand({
+  const checksumSha256 = toBase64Sha256Digest(input.sha256);
+  const stored = await runMediaAssetStorageOperationWithRetries(
+    context,
+    "put_object",
+    async () => {
+      assertMutationAuthorized();
+      try {
+        await dependencies.s3Client.send(new PutObjectCommand({
           Bucket: config.bucketName,
           Key: input.storageKey,
-          ChecksumMode: "ENABLED",
+          Body: input.bytes,
+          ContentType: input.mimeType,
+          ChecksumSHA256: checksumSha256,
+          IfNoneMatch: "*",
+          Metadata: {
+            [uploadProofSha256Key]: input.sha256,
+          },
         }), { abortSignal: input.signal });
-      },
-    );
-  } catch (error) {
-    rethrowDirectStorageAbortReason(input.signal, error);
-    if (error instanceof MediaBlobWriterFenceError) throw error;
-    throw createMediaAssetStorageError(context, "put_object", error);
-  }
-  assertMediaAssetObjectContentMatches(blobObjectInput, {
-    sizeBytes: response.ContentLength ?? null, mimeType: response.ContentType ?? null,
-    eTag: response.ETag ?? null,
-    checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
-    checksumType: response.ChecksumType ?? null,
-    uploadProof: {
-      workspaceId: null, mediaAssetId: null, lastOperationIdSha256: null, sha256: null,
+        return true;
+      } catch (error) {
+        if (getS3ErrorStatusCode(error) === 412) {
+          return false;
+        }
+        throw error;
+      }
     },
-  });
+  );
+
+  if (stored) {
+    return;
+  }
+
+  const response = await runMediaAssetStorageOperationWithRetries(
+    context,
+    "head_object",
+    () => {
+      assertMutationAuthorized();
+      return dependencies.s3Client.send(new HeadObjectCommand({
+        Bucket: config.bucketName,
+        Key: input.storageKey,
+        ChecksumMode: "ENABLED",
+      }), { abortSignal: input.signal });
+    },
+  );
+  assertWinnerMatches(response);
 }
 
 export async function storeMediaAssetBlobBytesIfAbsentWithDependencies(
@@ -269,53 +288,48 @@ export async function storeMediaAssetBlobBytesIfAbsentWithCapabilityVerifier(
   dependencies: MediaAssetStorageDependencies,
   verifyCapability: DirectMediaBlobStorageCapabilityVerifier,
 ): Promise<void> {
-  assertDirectStorageMutationAuthorized(input, verifyCapability);
-  const config = dependencies.getMediaAssetsStorageConfigFn();
+  const assertMutationAuthorized = (): void => {
+    assertDirectStorageMutationAuthorized(input, verifyCapability);
+  };
+  assertMutationAuthorized();
   const context: MediaAssetStorageContext = {
     workspaceId: input.workspaceId,
     mediaAssetId: input.mediaAssetId,
     storageKey: input.storageKey,
     observationScope: input.observationScope,
   };
-  const checksumSha256 = toBase64Sha256Digest(input.sha256);
 
   try {
-    const stored = await runMediaAssetStorageOperationWithRetries(
-      context,
-      "put_object",
-      async () => {
-        assertDirectStorageMutationAuthorized(input, verifyCapability);
-        try {
-          await dependencies.s3Client.send(new PutObjectCommand({
-            Bucket: config.bucketName,
-            Key: input.storageKey,
-            Body: input.bytes,
-            ContentType: input.mimeType,
-            ChecksumSHA256: checksumSha256,
-            IfNoneMatch: "*",
-            Metadata: {
-              [uploadProofSha256Key]: input.sha256,
-            },
-          }), { abortSignal: input.signal });
-          return true;
-        } catch (error) {
-          if (getS3ErrorStatusCode(error) === 412) {
-            return false;
-          }
-
-          throw error;
-        }
-      },
-    );
-
-    if (stored) {
-      return;
-    }
-
-    await assertStoredMediaAssetBlobObjectContentMatchesWithDependencies(
+    await storeContentAddressedMediaBlobBytesIfAbsentWithDependencies(
       input,
+      context,
       dependencies,
-      verifyCapability,
+      assertMutationAuthorized,
+      (response) => assertMediaAssetObjectContentMatches(
+        {
+          workspaceId: input.workspaceId,
+          mediaAssetId: input.mediaAssetId,
+          storageKey: input.storageKey,
+          mimeType: input.mimeType,
+          sizeBytes: input.bytes.byteLength,
+          sha256: input.sha256,
+          lastOperationId: input.lastOperationId,
+          observationScope: input.observationScope,
+        },
+        {
+          sizeBytes: response.ContentLength ?? null,
+          mimeType: response.ContentType ?? null,
+          eTag: response.ETag ?? null,
+          checksumSha256: toHexSha256Digest(response.ChecksumSHA256),
+          checksumType: response.ChecksumType ?? null,
+          uploadProof: {
+            workspaceId: null,
+            mediaAssetId: null,
+            lastOperationIdSha256: null,
+            sha256: null,
+          },
+        },
+      ),
     );
   } catch (error) {
     rethrowDirectStorageAbortReason(input.signal, error);
@@ -324,6 +338,95 @@ export async function storeMediaAssetBlobBytesIfAbsentWithCapabilityVerifier(
     }
 
     throw createMediaAssetStorageError(context, "put_object", error);
+  }
+}
+
+function assertCatalogImageBlobStorageInput(
+  input: StoreCatalogImageBlobBytesInput,
+): void {
+  const actualSha256 = createHash("sha256").update(input.bytes).digest("hex");
+  if (
+    input.storageKey !== `media/blobs/sha256/${input.sha256.slice(0, 2)}/${input.sha256.slice(2, 4)}/${input.sha256}`
+    || input.mimeType !== "image/jpeg"
+    || input.sizeBytes !== input.bytes.byteLength
+    || actualSha256 !== input.sha256
+  ) {
+    throw new TypeError("Catalog image blob storage input does not match its normalized bytes.");
+  }
+}
+
+function createCatalogImageBlobObjectMismatchError(
+  input: StoreCatalogImageBlobBytesInput,
+  response: HeadObjectCommandOutput,
+): HttpError {
+  const checksumSha256 = toHexSha256Digest(response.ChecksumSHA256);
+  const mismatchedFields = [
+    ...(response.ContentLength === input.sizeBytes ? [] : ["sizeBytes"]),
+    ...(response.ContentType === input.mimeType ? [] : ["mimeType"]),
+    ...(response.ChecksumType === "FULL_OBJECT" ? [] : ["checksumType"]),
+    ...(checksumSha256 === input.sha256 ? [] : ["sha256"]),
+  ];
+  return new HttpError(
+    409,
+    `Catalog image blob conflicts with stored object bytes. sha256=${input.sha256} mismatchedFields=${mismatchedFields.join(",")}`,
+    "CATALOG_IMAGE_BLOB_OBJECT_MISMATCH",
+  );
+}
+
+function createCatalogImageBlobStorageError(
+  input: StoreCatalogImageBlobBytesInput,
+  error: unknown,
+): HttpError {
+  return new HttpError(
+    503,
+    [
+      "Catalog image blob storage is temporarily unavailable.",
+      `sha256=${input.sha256}`,
+      `storageKey=${input.storageKey}`,
+      `s3StatusCode=${String(getS3ErrorStatusCode(error))}`,
+      `s3ErrorClass=${error instanceof Error ? error.name : "UnknownError"}`,
+    ].join(" "),
+    "CATALOG_IMAGE_BLOB_STORAGE_UNAVAILABLE",
+  );
+}
+
+export async function storeCatalogImageBlobBytesIfAbsentWithDependencies(
+  input: StoreCatalogImageBlobBytesInput,
+  dependencies: MediaAssetStorageDependencies,
+): Promise<void> {
+  assertCatalogImageBlobStorageInput(input);
+  const context: MediaBlobStorageContext = {
+    workspaceId: null,
+    mediaAssetId: null,
+    storageKey: input.storageKey,
+    observationScope: input.observationScope,
+  };
+  const assertMutationAuthorized = (): void => {
+    input.signal.throwIfAborted();
+  };
+  try {
+    await storeContentAddressedMediaBlobBytesIfAbsentWithDependencies(
+      input,
+      context,
+      dependencies,
+      assertMutationAuthorized,
+      (response) => {
+        if (
+          response.ContentLength !== input.sizeBytes
+          || response.ContentType !== input.mimeType
+          || response.ChecksumType !== "FULL_OBJECT"
+          || toHexSha256Digest(response.ChecksumSHA256) !== input.sha256
+        ) {
+          throw createCatalogImageBlobObjectMismatchError(input, response);
+        }
+      },
+    );
+  } catch (error) {
+    rethrowDirectStorageAbortReason(input.signal, error);
+    if (error instanceof HttpError) {
+      throw error;
+    }
+    throw createCatalogImageBlobStorageError(input, error);
   }
 }
 

--- a/apps/backend/src/mediaAssets/types.ts
+++ b/apps/backend/src/mediaAssets/types.ts
@@ -3,10 +3,13 @@ export type TimestampValue = Date | string;
 export const imageJpegCardMediaBlobMimeType = "image/jpeg";
 export const passthroughMediaBlobNormalizationVersion = "passthrough-v1";
 export const imageJpegCardMediaBlobNormalizationVersion = "image-jpeg-card-v1";
+export const imageJpegCatalogCoverMediaBlobNormalizationVersion =
+  "image-jpeg-catalog-cover-v1";
 
 export const mediaBlobNormalizationVersions = [
   passthroughMediaBlobNormalizationVersion,
   imageJpegCardMediaBlobNormalizationVersion,
+  imageJpegCatalogCoverMediaBlobNormalizationVersion,
 ] as const;
 
 export type MediaBlobNormalizationVersion = typeof mediaBlobNormalizationVersions[number];

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -881,8 +881,8 @@ export type MediaAssetStorageRetryDetails = Readonly<{
     | "put_object";
   attempt: number;
   maxAttempts: number;
-  workspaceId: string;
-  mediaAssetId: string;
+  workspaceId: string | null;
+  mediaAssetId: string | null;
   statusCode: number | null;
   errorClass: string;
 }>;


### PR DESCRIPTION
Summary:
- add the deterministic catalog-cover image normalizer while preserving the card profile
- extract the conditional content-addressed S3 storage primitive for catalog reuse
- cover normalization and concurrent object-winner verification boundaries

Testing:
- not run locally per repository workflow