### PR TITLE
Show API key notice as warning

### DIFF
--- a/apps/web/src/screens/settings/account/AgentConnectionsScreen.tsx
+++ b/apps/web/src/screens/settings/account/AgentConnectionsScreen.tsx
@@ -236,7 +236,7 @@ export function AgentConnectionsScreen(): ReactElement {
         >
           <div className="cell-stack">
             <h2 className="panel-subtitle">{t("agentConnections.keyShownOnceTitle")}</h2>
-            <p className="error-banner settings-delete-warning">{t("agentConnections.keyShownOnceWarning")}</p>
+            <p className="warning-banner">{t("agentConnections.keyShownOnceWarning")}</p>
             <code className="settings-key-value" data-testid="agent-key-generated-value">{generatedApiKey}</code>
           </div>
           <div className="screen-actions">

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -274,14 +274,24 @@
   transform: none;
 }
 
-.error-banner {
+.error-banner,
+.warning-banner {
   margin: 0;
   padding: 11px 14px;
-  border: 1px solid rgba(255, 77, 87, 0.26);
   border-radius: var(--radius-sm);
+  font-size: 14px;
+}
+
+.error-banner {
+  border: 1px solid rgba(255, 77, 87, 0.26);
   background: rgba(112, 20, 28, 0.38);
   color: #ffd6d9;
-  font-size: 14px;
+}
+
+.warning-banner {
+  border: 1px solid #d6a84b;
+  background: #3a2a0a;
+  color: #ffe7b0;
 }
 
 .app-error-dialog-backdrop {


### PR DESCRIPTION
## Summary
- add a semantic dark-theme amber warning banner
- use it only for the one-time generated API-key notice
- keep actual error banners and generated-key behavior unchanged

## Validation
- not run locally, per repository delivery policy
- fresh static review found no P0-P4 issues