### PR TITLE
Add catalog blob lifecycle migration

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -411,7 +411,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0108_multipart_absolute_lease_target.sql
+            --require-migration 0109_catalog_image_blob_ingestion.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,6 +71,13 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
+    migrationFileName: "0109_catalog_image_blob_ingestion.sql",
+    expectedMigrationCount: 111,
+    testFiles: Object.freeze([
+      "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",
+    ]),
+  }),
+  Object.freeze({
     migrationFileName: "0108_multipart_absolute_lease_target.sql",
     expectedMigrationCount: 110,
     testFiles: Object.freeze([
@@ -93,7 +100,6 @@ export const boundaryDefinitions = Object.freeze([
       "src/chat/cardImages/promotion/jobsRevocation.postgres.integration.ts",
       "src/chat/runs/generatedImageAttemptBudget.postgres.integration.ts",
       "src/database/aiChatInitiatingAuthClassification.postgres.integration.ts",
-      "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",
       "src/sync/freshBootstrap.postgres.integration.ts",
     ]),
   }),

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0108_multipart_absolute_lease_target.sql",
+      RequiredMigration: "0109_catalog_image_blob_ingestion.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0108_multipart_absolute_lease_target.sql",
+    requiredMigration: "0109_catalog_image_blob_ingestion.sql",
   });
 });
 

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
@@ -32,12 +32,19 @@ import {
 import { imageJpegCardMediaBlobNormalizationVersion } from "../types";
 
 const deadlineOffsetMs = 30_000;
+const imageJpegCatalogCoverMediaBlobNormalizationVersion =
+  "image-jpeg-catalog-cover-v1";
 type RunFixture = Readonly<{
   sessionId: string;
   runId: string;
   claimToken: string;
 }>;
 type ClaimTokenRow = Readonly<{ claim_token: string }>;
+type MultipartWriterAttemptRow = Readonly<{
+  attempt_status: string;
+  reservation_token: string | null;
+  normalization_version: string | null;
+}>;
 
 function createSha256(): string {
   return createHash("sha256").update(randomUUID()).digest("hex");
@@ -291,6 +298,345 @@ async function deleteCleanupFixtures(
     [sha256s],
   );
 }
+
+test("catalog image admission is reclaimable until attachment fences cleanup", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const attachedSha256 = createSha256();
+    const abandonedSha256 = createSha256();
+    const sha256s = [attachedSha256, abandonedSha256];
+    const authorId = randomUUID();
+    const packageId = randomUUID();
+    const packageMediaAssetId = randomUUID();
+    const mediaBlobId = randomUUID();
+    const slug = randomUUID();
+    const storageKey = (sha256: string) => buildMediaBlobStorageKey(sha256);
+    try {
+      await fixture.ownerPool.query(
+        "INSERT INTO catalog.authors(author_id,slug,display_name) VALUES($1,$2,'Image integration')",
+        [authorId, `image-author-${slug}`],
+      );
+      await fixture.ownerPool.query(
+        `INSERT INTO catalog.packages(
+           package_id,author_id,slug,title,summary,description,
+           language_tags,topic_tags,license
+         ) VALUES($1,$2,$3,'Images','Summary','Description',ARRAY['en'],ARRAY['test'],'CC-BY-4.0')`,
+        [packageId, authorId, `image-package-${slug}`],
+      );
+      const admissionParams = (
+        sha256: string,
+        normalizationVersion: string,
+      ) => [
+        sha256, storageKey(sha256), "image/jpeg", 42,
+        normalizationVersion, 3_600_000,
+      ];
+      const admitted = await fixture.runtimePool.query<{
+        normalization_version: string;
+      }>(
+        "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+        admissionParams(
+          attachedSha256,
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+        ),
+      );
+      assert.equal(
+        admitted.rows[0]?.normalization_version,
+        imageJpegCatalogCoverMediaBlobNormalizationVersion,
+      );
+      await fixture.runtimePool.query(
+        `INSERT INTO content.media_blobs(
+           media_blob_id,sha256,mime_type,size_bytes,storage_key,
+           normalization_version
+         ) VALUES($1,$2,'image/jpeg',42,$3,$4)`,
+        [mediaBlobId, attachedSha256, storageKey(attachedSha256),
+          imageJpegCatalogCoverMediaBlobNormalizationVersion],
+      );
+      await fixture.runtimePool.query(
+        `INSERT INTO catalog.package_media_assets(
+           package_media_asset_id,package_id,package_version_id,
+           package_media_key,media_blob_id
+         ) VALUES($1,$2,NULL,'cover.jpg',$3)`,
+        [packageMediaAssetId, packageId, mediaBlobId],
+      );
+      assert.equal((await fixture.ownerPool.query<{ fenced: boolean }>(
+        "SELECT cleanup_eligible_at IS NULL AS fenced FROM content.media_blob_lifecycles WHERE sha256=$1",
+        [attachedSha256],
+      )).rows[0]?.fenced, true);
+      assert.equal((await fixture.runtimePool.query<{ scheduled: boolean }>(
+        "SELECT content.schedule_media_blob_cleanup($1,$2) AS scheduled",
+        [mediaBlobId, 1],
+      )).rows[0]?.scheduled, false);
+
+      await fixture.runtimePool.query(
+        "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+        admissionParams(
+          abandonedSha256,
+          imageJpegCardMediaBlobNormalizationVersion,
+        ),
+      );
+      const reusedAdmission = await fixture.runtimePool.query<{
+        normalization_version: string;
+      }>(
+        "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+        admissionParams(
+          abandonedSha256,
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+        ),
+      );
+      assert.equal(
+        reusedAdmission.rows[0]?.normalization_version,
+        imageJpegCardMediaBlobNormalizationVersion,
+      );
+      await assert.rejects(
+        fixture.runtimePool.query(
+          "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+          [abandonedSha256, storageKey(abandonedSha256), "image/jpeg", 43,
+            imageJpegCardMediaBlobNormalizationVersion, 3_600_000],
+        ),
+        (error: unknown) => hasPostgresCode(error, "23514"),
+      );
+      assert.equal((await fixture.ownerPool.query<{ delayed: boolean }>(
+        "SELECT cleanup_eligible_at>clock_timestamp() AS delayed FROM content.media_blob_lifecycles WHERE sha256=$1",
+        [abandonedSha256],
+      )).rows[0]?.delayed, true);
+      await fixture.ownerPool.query(
+        "UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=clock_timestamp()-interval '1 second' WHERE sha256=$1",
+        [abandonedSha256],
+      );
+      assert.equal((await claimCandidate(randomUUID()))?.sha256, abandonedSha256);
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blob_cleanup_attempts WHERE sha256=$1",
+        [abandonedSha256],
+      );
+      await fixture.ownerPool.query(
+        "UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=NULL,cleanup_lease_token=NULL,cleanup_lease_expires_at=NULL WHERE sha256=$1",
+        [abandonedSha256],
+      );
+
+      await fixture.runtimePool.query(
+        "DELETE FROM catalog.package_media_assets WHERE package_media_asset_id=$1",
+        [packageMediaAssetId],
+      );
+      assert.equal((await fixture.runtimePool.query<{ scheduled: boolean }>(
+        "SELECT content.schedule_media_blob_cleanup($1,$2) AS scheduled",
+        [mediaBlobId, 1],
+      )).rows[0]?.scheduled, true);
+      await fixture.ownerPool.query(
+        "UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=clock_timestamp()-interval '1 second' WHERE sha256=$1",
+        [attachedSha256],
+      );
+      assert.equal((await claimCandidate(randomUUID()))?.sha256, attachedSha256);
+      await assert.rejects(
+        fixture.runtimePool.query(
+          "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+          admissionParams(
+            attachedSha256,
+            imageJpegCatalogCoverMediaBlobNormalizationVersion,
+          ),
+        ),
+        (error: unknown) => hasPostgresCode(error, "55P03"),
+      );
+    } finally {
+      await fixture.ownerPool.query("DELETE FROM catalog.packages WHERE package_id=$1", [packageId]);
+      await fixture.ownerPool.query("DELETE FROM catalog.authors WHERE author_id=$1", [authorId]);
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blob_cleanup_attempts WHERE sha256=ANY($1::text[])", [sha256s],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blobs WHERE sha256=ANY($1::text[])", [sha256s],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blob_lifecycles WHERE sha256=ANY($1::text[])", [sha256s],
+      );
+    }
+  });
+});
+
+test("workspace multipart ingestion adopts existing catalog cover provenance", async () => {
+  await withPostgresIntegrationFixture(async (fixture) => {
+    const sha256 = createSha256();
+    const mediaBlobId = randomUUID();
+    const mediaAssetId = randomUUID();
+    const sessionId = randomUUID();
+    const attemptToken = randomUUID();
+    const lastOperationId = randomUUID();
+    const s3UploadId = `upload-${randomUUID()}`;
+    const storageKey = buildMediaBlobStorageKey(sha256);
+    const stagingStorageKey = buildMediaUploadStagingStorageKey(
+      fixture.workspaceId,
+      mediaAssetId,
+      sessionId,
+    );
+    const sessionExpiresAt = new Date(Date.now() + 3_600_000).toISOString();
+    const completedPartsFingerprint = createSha256();
+    const payloadValues = (
+      normalizationVersion: string,
+    ): ReadonlyArray<string | number | null> => [
+      fixture.userId,
+      fixture.workspaceId,
+      sessionId,
+      mediaAssetId,
+      fixture.replicaId,
+      lastOperationId,
+      sha256,
+      stagingStorageKey,
+      storageKey,
+      s3UploadId,
+      "image/jpeg",
+      42,
+      42,
+      1,
+      null,
+      fixture.createdAt,
+      fixture.createdAt,
+      sessionExpiresAt,
+      normalizationVersion,
+      completedPartsFingerprint,
+    ];
+    const beginAttempt = async (
+      token: string,
+      normalizationVersion: string,
+    ): Promise<MultipartWriterAttemptRow> => transactionWithWorkspaceScope(
+      { userId: fixture.userId, workspaceId: fixture.workspaceId },
+      async (executor) => {
+        const result = await executor.query<MultipartWriterAttemptRow>(
+          `SELECT attempt_status,reservation_token,normalization_version
+           FROM content.begin_media_upload_session_completion_attempt_with_owner(
+             $1,$2,
+             ROW(
+               $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
+               $18,$19,$20,$21,$22
+             )::content.multipart_media_blob_writer_attempt_payload
+           )`,
+          [token, 60_000, ...payloadValues(normalizationVersion)],
+        );
+        const row = result.rows[0];
+        if (row === undefined) {
+          throw new Error("PostgreSQL did not return a multipart writer attempt.");
+        }
+        return row;
+      },
+    );
+    try {
+      await fixture.runtimePool.query(
+        "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+        [
+          sha256,
+          storageKey,
+          "image/jpeg",
+          42,
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+          3_600_000,
+        ],
+      );
+      await fixture.runtimePool.query(
+        `INSERT INTO content.media_blobs(
+           media_blob_id,sha256,mime_type,size_bytes,storage_key,
+           normalization_version
+         ) VALUES($1,$2,'image/jpeg',42,$3,$4)`,
+        [
+          mediaBlobId,
+          sha256,
+          storageKey,
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+        ],
+      );
+      await fixture.ownerPool.query(
+        `INSERT INTO content.media_upload_sessions(
+           media_upload_session_id,workspace_id,media_asset_id,
+           media_blob_sha256,staging_storage_key,blob_storage_key,
+           s3_upload_id,mime_type,size_bytes,part_size_bytes,part_count,state,
+           source_url,asset_created_at,client_updated_at,
+           last_modified_by_replica_id,last_operation_id,expires_at
+         ) VALUES(
+           $1,$2,$3,$4,$5,$6,$7,'image/jpeg',42,42,1,'active',NULL,
+           $8,$8,$9,$10,$11
+         )`,
+        [
+          sessionId,
+          fixture.workspaceId,
+          mediaAssetId,
+          sha256,
+          stagingStorageKey,
+          storageKey,
+          s3UploadId,
+          fixture.createdAt,
+          fixture.replicaId,
+          lastOperationId,
+          sessionExpiresAt,
+        ],
+      );
+
+      assert.equal(
+        (await beginAttempt(
+          randomUUID(),
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+        )).attempt_status,
+        "stale",
+      );
+      const begun = await beginAttempt(attemptToken, "passthrough-v1");
+      assert.deepEqual(
+        [begun.attempt_status, begun.normalization_version],
+        ["acquired", imageJpegCatalogCoverMediaBlobNormalizationVersion],
+      );
+      const reservationToken = begun.reservation_token;
+      assert.ok(reservationToken !== null);
+      assert.deepEqual((await fixture.ownerPool.query<Readonly<{
+        requested_normalization_version: string;
+        normalization_version: string;
+      }>>(
+        `SELECT requested_normalization_version,normalization_version
+         FROM content.media_blob_writer_attempts WHERE attempt_token=$1`,
+        [attemptToken],
+      )).rows[0], {
+        requested_normalization_version: "passthrough-v1",
+        normalization_version:
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+      });
+
+      const recoveryStatus = await transactionWithWorkspaceScope(
+        { userId: fixture.userId, workspaceId: fixture.workspaceId },
+        async (executor) => (await executor.query<Readonly<{ status: string }>>(
+          `SELECT content.resolve_media_upload_session_completion_attempt_failure_with_owner(
+             $1,$2,
+             ROW(
+               $3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
+               $18,$19,$20,$21,$22
+             )::content.multipart_media_blob_writer_attempt_payload,
+             $23
+           ) AS status`,
+          [
+            attemptToken,
+            reservationToken,
+            ...payloadValues(imageJpegCatalogCoverMediaBlobNormalizationVersion),
+            3_600_000,
+          ],
+        )).rows[0]?.status,
+      );
+      assert.equal(recoveryStatus, "unreferenced_restored");
+    } finally {
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blob_writer_attempts WHERE sha256=$1",
+        [sha256],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_upload_sessions WHERE media_upload_session_id=$1",
+        [sessionId],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blob_writer_reservations WHERE sha256=$1",
+        [sha256],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blobs WHERE media_blob_id=$1",
+        [mediaBlobId],
+      );
+      await fixture.ownerPool.query(
+        "DELETE FROM content.media_blob_lifecycles WHERE sha256=$1",
+        [sha256],
+      );
+    }
+  });
+});
 
 test("terminal generated failure is cleanable while live promotion states and global references block deletion", async () => {
   await withPostgresIntegrationFixture(async (fixture) => {

--- a/db/migrations/0109_catalog_image_blob_ingestion.sql
+++ b/db/migrations/0109_catalog_image_blob_ingestion.sql
@@ -1,0 +1,497 @@
+-- Current additive migration for workspace-independent catalog image ingestion.
+-- Schemas touched/read explicitly: content, catalog, pg_catalog.
+
+ALTER TABLE content.media_blobs
+  DROP CONSTRAINT IF EXISTS media_blobs_normalization_version_supported,
+  ADD CONSTRAINT media_blobs_normalization_version_supported CHECK (
+    normalization_version IN (
+      'passthrough-v1', 'image-jpeg-card-v1',
+      'image-jpeg-catalog-cover-v1'
+    )
+  );
+ALTER TABLE content.media_blob_lifecycles
+  DROP CONSTRAINT IF EXISTS media_blob_lifecycles_normalization_version_supported,
+  ADD CONSTRAINT media_blob_lifecycles_normalization_version_supported CHECK (
+    normalization_version IN (
+      'passthrough-v1', 'image-jpeg-card-v1',
+      'image-jpeg-catalog-cover-v1'
+    )
+  );
+
+ALTER TABLE content.media_blob_writer_attempts
+  DROP CONSTRAINT IF EXISTS media_blob_writer_attempts_normalization_supported,
+  ADD CONSTRAINT media_blob_writer_attempts_normalization_supported CHECK (
+    requested_normalization_version IN (
+      'passthrough-v1', 'image-jpeg-card-v1'
+    )
+    AND normalization_version IN (
+      'passthrough-v1', 'image-jpeg-card-v1',
+      'image-jpeg-catalog-cover-v1'
+    )
+  );
+
+CREATE FUNCTION
+content.direct_media_blob_writer_attempt_requested_payload_valid_internal(
+  p_payload content.direct_media_blob_writer_attempt_payload
+)
+RETURNS BOOLEAN
+LANGUAGE SQL IMMUTABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+  SELECT p_payload.user_id IS NOT NULL
+    AND p_payload.user_id = pg_catalog.btrim(p_payload.user_id)
+    AND p_payload.user_id <> ''
+    AND p_payload.workspace_id IS NOT NULL
+    AND p_payload.media_asset_id IS NOT NULL
+    AND p_payload.operation_id IS NOT NULL
+    AND p_payload.operation_id = pg_catalog.btrim(p_payload.operation_id)
+    AND pg_catalog.char_length(p_payload.operation_id) BETWEEN 1 AND 1024
+    AND p_payload.replica_id IS NOT NULL
+    AND p_payload.sha256 ~ '^[0-9a-f]{64}$'
+    AND p_payload.storage_key =
+      'media/blobs/sha256/'
+      || pg_catalog.substring(p_payload.sha256, 1, 2)
+      || '/' || pg_catalog.substring(p_payload.sha256, 3, 2)
+      || '/' || p_payload.sha256
+    AND p_payload.mime_type = pg_catalog.lower(pg_catalog.btrim(p_payload.mime_type))
+    AND p_payload.mime_type ~
+      '^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$'
+    AND p_payload.size_bytes >= 0
+    AND p_payload.normalization_version IN (
+      'passthrough-v1', 'image-jpeg-card-v1'
+    )
+    AND p_payload.asset_created_at IS NOT NULL
+    AND p_payload.client_updated_at IS NOT NULL;
+$$;
+
+CREATE FUNCTION
+content.multipart_media_blob_writer_attempt_requested_payload_valid_internal(
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS BOOLEAN
+LANGUAGE SQL IMMUTABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+  SELECT p_payload.user_id IS NOT NULL
+    AND p_payload.user_id = pg_catalog.btrim(p_payload.user_id)
+    AND p_payload.user_id <> ''
+    AND p_payload.workspace_id IS NOT NULL
+    AND p_payload.media_upload_session_id IS NOT NULL
+    AND p_payload.media_asset_id IS NOT NULL
+    AND p_payload.replica_id IS NOT NULL
+    AND p_payload.last_operation_id IS NOT NULL
+    AND p_payload.last_operation_id = pg_catalog.btrim(p_payload.last_operation_id)
+    AND pg_catalog.char_length(p_payload.last_operation_id) BETWEEN 1 AND 1024
+    AND p_payload.sha256 ~ '^[0-9a-f]{64}$'
+    AND p_payload.staging_storage_key =
+      'media/uploads/workspaces/'
+      || pg_catalog.lower(p_payload.workspace_id::TEXT)
+      || '/assets/' || pg_catalog.lower(p_payload.media_asset_id::TEXT)
+      || '/sessions/' || pg_catalog.lower(p_payload.media_upload_session_id::TEXT)
+    AND p_payload.blob_storage_key =
+      'media/blobs/sha256/'
+      || pg_catalog.substring(p_payload.sha256, 1, 2)
+      || '/' || pg_catalog.substring(p_payload.sha256, 3, 2)
+      || '/' || p_payload.sha256
+    AND p_payload.s3_upload_id IS NOT NULL
+    AND p_payload.s3_upload_id = pg_catalog.btrim(p_payload.s3_upload_id)
+    AND p_payload.s3_upload_id <> ''
+    AND p_payload.mime_type = pg_catalog.lower(pg_catalog.btrim(p_payload.mime_type))
+    AND p_payload.mime_type ~
+      '^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$'
+    AND p_payload.size_bytes > 0
+    AND p_payload.part_size_bytes > 0
+    AND p_payload.part_count BETWEEN 1 AND 10000
+    AND p_payload.asset_created_at IS NOT NULL
+    AND p_payload.client_updated_at IS NOT NULL
+    AND p_payload.session_expires_at IS NOT NULL
+    AND p_payload.normalization_version IN (
+      'passthrough-v1', 'image-jpeg-card-v1'
+    )
+    AND p_payload.completed_parts_fingerprint ~ '^[0-9a-f]{64}$';
+$$;
+
+CREATE OR REPLACE FUNCTION content.direct_media_blob_writer_attempt_payload_valid_internal(
+  p_payload content.direct_media_blob_writer_attempt_payload
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql IMMUTABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  requested_payload content.direct_media_blob_writer_attempt_payload := p_payload;
+BEGIN
+  IF p_payload.normalization_version = 'image-jpeg-catalog-cover-v1' THEN
+    requested_payload.normalization_version := 'passthrough-v1';
+  END IF;
+  RETURN p_payload.normalization_version IN (
+    'passthrough-v1', 'image-jpeg-card-v1',
+    'image-jpeg-catalog-cover-v1'
+  ) AND content.direct_media_blob_writer_attempt_requested_payload_valid_internal(
+    requested_payload
+  ) IS TRUE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION content.multipart_media_blob_writer_attempt_payload_valid_internal(
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql IMMUTABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  requested_payload content.multipart_media_blob_writer_attempt_payload := p_payload;
+BEGIN
+  IF p_payload.normalization_version = 'image-jpeg-catalog-cover-v1' THEN
+    requested_payload.normalization_version := 'passthrough-v1';
+  END IF;
+  RETURN p_payload.normalization_version IN (
+    'passthrough-v1', 'image-jpeg-card-v1',
+    'image-jpeg-catalog-cover-v1'
+  ) AND content.multipart_media_blob_writer_attempt_requested_payload_valid_internal(
+    requested_payload
+  ) IS TRUE;
+END;
+$$;
+
+ALTER FUNCTION content.begin_direct_media_blob_writer_attempt_with_owner(
+  UUID, INTEGER, content.direct_media_blob_writer_attempt_payload
+) RENAME TO begin_direct_media_blob_writer_attempt_0109_internal;
+ALTER FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  UUID, INTEGER, content.multipart_media_blob_writer_attempt_payload
+) RENAME TO begin_media_upload_session_completion_attempt_0109_internal;
+ALTER FUNCTION
+content.begin_media_upload_session_completion_attempt_at_lease_target_with_owner(
+  UUID, TIMESTAMPTZ, content.multipart_media_blob_writer_attempt_payload
+) RENAME TO begin_multipart_writer_attempt_at_lease_0109_internal;
+
+CREATE FUNCTION content.begin_direct_media_blob_writer_attempt_with_owner(
+  p_attempt_token UUID,
+  p_lease_duration_ms INTEGER,
+  p_payload content.direct_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF content.direct_media_blob_writer_attempt_requested_payload_valid_internal(
+    p_payload
+  ) IS DISTINCT FROM true
+  THEN
+    RETURN QUERY
+    SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+  RETURN QUERY
+  SELECT * FROM content.begin_direct_media_blob_writer_attempt_0109_internal(
+    p_attempt_token, p_lease_duration_ms, p_payload
+  );
+END;
+$$;
+
+CREATE FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  p_attempt_token UUID,
+  p_lease_duration_ms INTEGER,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF content.multipart_media_blob_writer_attempt_requested_payload_valid_internal(
+    p_payload
+  ) IS DISTINCT FROM true
+  THEN
+    RETURN QUERY
+    SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+  RETURN QUERY
+  SELECT *
+  FROM content.begin_media_upload_session_completion_attempt_0109_internal(
+    p_attempt_token, p_lease_duration_ms, p_payload
+  );
+END;
+$$;
+
+CREATE FUNCTION
+content.begin_media_upload_session_completion_attempt_at_lease_target_with_owner(
+  p_attempt_token UUID,
+  p_lease_expires_at TIMESTAMPTZ,
+  p_payload content.multipart_media_blob_writer_attempt_payload
+)
+RETURNS TABLE (
+  attempt_status TEXT,
+  reservation_token UUID,
+  normalization_version TEXT,
+  lease_expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF content.multipart_media_blob_writer_attempt_requested_payload_valid_internal(
+    p_payload
+  ) IS DISTINCT FROM true
+  THEN
+    RETURN QUERY
+    SELECT 'stale'::TEXT, NULL::UUID, NULL::TEXT, NULL::TIMESTAMPTZ;
+    RETURN;
+  END IF;
+  RETURN QUERY
+  SELECT *
+  FROM content.begin_multipart_writer_attempt_at_lease_0109_internal(
+    p_attempt_token, p_lease_expires_at, p_payload
+  );
+END;
+$$;
+
+CREATE FUNCTION content.media_blob_has_active_reference_internal(p_sha256 TEXT)
+RETURNS BOOLEAN LANGUAGE SQL STABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM content.media_assets AS assets
+    INNER JOIN content.media_blobs AS blobs
+      ON blobs.media_blob_id = assets.media_blob_id
+    WHERE blobs.sha256 = p_sha256 AND assets.deleted_at IS NULL
+  ) OR EXISTS (
+    SELECT 1 FROM catalog.package_media_assets AS assets
+    INNER JOIN content.media_blobs AS blobs
+      ON blobs.media_blob_id = assets.media_blob_id
+    WHERE blobs.sha256 = p_sha256
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION content.media_blob_cleanup_blocked_internal(
+  p_sha256 TEXT
+)
+RETURNS BOOLEAN LANGUAGE SQL STABLE SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+  SELECT content.media_blob_has_active_reference_internal(p_sha256)
+    OR EXISTS (
+      SELECT 1 FROM content.media_blob_writer_reservations AS reservations
+      WHERE reservations.sha256 = p_sha256
+        AND reservations.state IN ('active', 'ambiguous')
+    ) OR EXISTS (
+      SELECT 1 FROM content.media_blob_writer_attempts AS attempts
+      WHERE attempts.sha256 = p_sha256
+        AND (attempts.state = 'leased'
+          OR attempts.reconciliation_state IN ('pending', 'leased'))
+    ) OR EXISTS (
+      SELECT 1 FROM content.generated_media_promotion_jobs AS jobs
+      WHERE jobs.sha256 = p_sha256 AND jobs.state IN ('pending', 'leased')
+    );
+$$;
+
+CREATE FUNCTION content.admit_catalog_image_blob_write(
+  p_sha256 TEXT,
+  p_storage_key TEXT,
+  p_mime_type TEXT,
+  p_size_bytes BIGINT,
+  p_normalization_version TEXT,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS TABLE (normalization_version TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  admitted_at TIMESTAMPTZ;
+  admitted_cleanup_at TIMESTAMPTZ;
+BEGIN
+  IF p_sha256 IS NULL OR p_sha256 !~ '^[0-9a-f]{64}$'
+    OR p_storage_key IS DISTINCT FROM (
+      'media/blobs/sha256/' || pg_catalog.substring(p_sha256, 1, 2)
+      || '/' || pg_catalog.substring(p_sha256, 3, 2) || '/' || p_sha256
+    )
+    OR p_mime_type IS DISTINCT FROM 'image/jpeg'
+    OR p_size_bytes IS NULL OR p_size_bytes < 0
+    OR p_normalization_version NOT IN (
+      'image-jpeg-card-v1', 'image-jpeg-catalog-cover-v1'
+    )
+  THEN
+    RAISE EXCEPTION 'Catalog image blob admission metadata is invalid'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 60000 AND 604800000
+  THEN
+    RAISE EXCEPTION 'p_cleanup_delay_ms must be between 60000 and 604800000'
+      USING ERRCODE = '22023';
+  END IF;
+
+  admitted_at := pg_catalog.clock_timestamp();
+  admitted_cleanup_at :=
+    admitted_at + (p_cleanup_delay_ms * interval '1 millisecond');
+  INSERT INTO content.media_blob_lifecycles (
+    sha256, storage_key, mime_type, size_bytes, normalization_version,
+    cleanup_eligible_at
+  ) VALUES (
+    p_sha256, p_storage_key, p_mime_type, p_size_bytes,
+    p_normalization_version, admitted_cleanup_at
+  ) ON CONFLICT (sha256) DO NOTHING;
+
+  SELECT lifecycles.* INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = p_sha256 FOR UPDATE;
+  IF NOT FOUND OR lifecycle.storage_key IS DISTINCT FROM p_storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM p_mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM p_size_bytes
+  THEN
+    RAISE EXCEPTION 'Catalog image blob conflicts with immutable lifecycle metadata'
+      USING ERRCODE = '23514';
+  END IF;
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > admitted_at
+  THEN
+    RAISE EXCEPTION 'Catalog image blob admission conflicts with an active cleanup claim'
+      USING ERRCODE = '55P03';
+  END IF;
+
+  UPDATE content.media_blob_lifecycles AS lifecycles SET
+    cleanup_eligible_at = GREATEST(
+      COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ),
+      admitted_cleanup_at
+    ),
+    cleanup_lease_token = NULL,
+    cleanup_lease_expires_at = NULL,
+    updated_at = admitted_at
+  WHERE lifecycles.sha256 = p_sha256 RETURNING lifecycles.* INTO lifecycle;
+  RETURN QUERY SELECT lifecycle.normalization_version;
+END;
+$$;
+
+CREATE FUNCTION content.schedule_media_blob_cleanup(
+  p_media_blob_id UUID,
+  p_cleanup_delay_ms INTEGER
+)
+RETURNS BOOLEAN LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog
+AS $$
+DECLARE
+  media_blob content.media_blobs%ROWTYPE;
+  lifecycle content.media_blob_lifecycles%ROWTYPE;
+  scheduled_at TIMESTAMPTZ;
+BEGIN
+  IF p_media_blob_id IS NULL THEN
+    RAISE EXCEPTION 'p_media_blob_id is required' USING ERRCODE = '22023';
+  END IF;
+  IF p_cleanup_delay_ms IS NULL
+    OR p_cleanup_delay_ms NOT BETWEEN 1 AND 604800000
+  THEN
+    RAISE EXCEPTION 'p_cleanup_delay_ms must be between 1 and 604800000'
+      USING ERRCODE = '22023';
+  END IF;
+  SELECT blobs.* INTO media_blob FROM content.media_blobs AS blobs
+  WHERE blobs.media_blob_id = p_media_blob_id FOR SHARE;
+  IF NOT FOUND THEN RETURN false;
+  END IF;
+  SELECT lifecycles.* INTO lifecycle
+  FROM content.media_blob_lifecycles AS lifecycles
+  WHERE lifecycles.sha256 = media_blob.sha256 FOR UPDATE;
+  IF NOT FOUND OR lifecycle.storage_key IS DISTINCT FROM media_blob.storage_key
+    OR lifecycle.mime_type IS DISTINCT FROM media_blob.mime_type
+    OR lifecycle.size_bytes IS DISTINCT FROM media_blob.size_bytes
+    OR lifecycle.normalization_version IS DISTINCT FROM media_blob.normalization_version
+  THEN
+    RAISE EXCEPTION 'Media blob cleanup scheduling conflicts with immutable lifecycle metadata'
+      USING ERRCODE = '23514';
+  END IF;
+
+  scheduled_at := pg_catalog.clock_timestamp();
+  IF lifecycle.cleanup_lease_token IS NOT NULL
+    AND lifecycle.cleanup_lease_expires_at > scheduled_at
+  THEN
+    RAISE EXCEPTION 'Media blob cleanup scheduling conflicts with an active cleanup claim'
+      USING ERRCODE = '55P03';
+  END IF;
+  IF content.media_blob_has_active_reference_internal(media_blob.sha256) THEN
+    UPDATE content.media_blob_lifecycles AS lifecycles SET
+      cleanup_eligible_at = NULL,
+      cleanup_lease_token = NULL,
+      cleanup_lease_expires_at = NULL,
+      updated_at = scheduled_at
+    WHERE lifecycles.sha256 = media_blob.sha256;
+    RETURN false;
+  END IF;
+  UPDATE content.media_blob_lifecycles AS lifecycles SET
+    cleanup_eligible_at = GREATEST(
+      COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ),
+      scheduled_at + (p_cleanup_delay_ms * interval '1 millisecond')
+    ),
+    cleanup_lease_token = NULL,
+    cleanup_lease_expires_at = NULL,
+    updated_at = scheduled_at
+  WHERE lifecycles.sha256 = media_blob.sha256;
+  RETURN true;
+END;
+$$;
+
+COMMENT ON FUNCTION content.admit_catalog_image_blob_write(
+  TEXT, TEXT, TEXT, BIGINT, TEXT, INTEGER
+) IS 'Durably admits a catalog image object write without a workspace asset and leaves an unattached write cleanup-eligible after the bounded admission window.';
+COMMENT ON FUNCTION content.schedule_media_blob_cleanup(UUID, INTEGER) IS
+  'Schedules a replaced, globally unreferenced permanent media blob for delayed cleanup.';
+
+REVOKE ALL ON FUNCTION content.media_blob_has_active_reference_internal(TEXT)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+content.direct_media_blob_writer_attempt_requested_payload_valid_internal(
+  content.direct_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+content.multipart_media_blob_writer_attempt_requested_payload_valid_internal(
+  content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.direct_media_blob_writer_attempt_payload_valid_internal(
+  content.direct_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.multipart_media_blob_writer_attempt_payload_valid_internal(
+  content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.begin_direct_media_blob_writer_attempt_0109_internal(
+  UUID, INTEGER, content.direct_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+content.begin_media_upload_session_completion_attempt_0109_internal(
+  UUID, INTEGER, content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+content.begin_multipart_writer_attempt_at_lease_0109_internal(
+  UUID, TIMESTAMPTZ, content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.begin_direct_media_blob_writer_attempt_with_owner(
+  UUID, INTEGER, content.direct_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  UUID, INTEGER, content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+content.begin_media_upload_session_completion_attempt_at_lease_target_with_owner(
+  UUID, TIMESTAMPTZ, content.multipart_media_blob_writer_attempt_payload
+) FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.admit_catalog_image_blob_write(
+  TEXT, TEXT, TEXT, BIGINT, TEXT, INTEGER
+) FROM PUBLIC, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.schedule_media_blob_cleanup(UUID, INTEGER)
+FROM PUBLIC, auth_app, reporting_readonly;
+GRANT EXECUTE ON FUNCTION content.admit_catalog_image_blob_write(
+  TEXT, TEXT, TEXT, BIGINT, TEXT, INTEGER
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.schedule_media_blob_cleanup(UUID, INTEGER)
+TO backend_app;
+GRANT EXECUTE ON FUNCTION content.begin_direct_media_blob_writer_attempt_with_owner(
+  UUID, INTEGER, content.direct_media_blob_writer_attempt_payload
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION content.begin_media_upload_session_completion_attempt_with_owner(
+  UUID, INTEGER, content.multipart_media_blob_writer_attempt_payload
+) TO backend_app;
+GRANT EXECUTE ON FUNCTION
+content.begin_media_upload_session_completion_attempt_at_lease_target_with_owner(
+  UUID, TIMESTAMPTZ, content.multipart_media_blob_writer_attempt_payload
+) TO backend_app;

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0108_multipart_absolute_lease_target.sql",
+    "0109_catalog_image_blob_ingestion.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0108_multipart_absolute_lease_target.sql"
+    && resource.Properties?.RequiredMigration === "0109_catalog_image_blob_ingestion.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -107,7 +107,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
       "mediaBlobCleanupEnabled=false",
     );
     const migration = source.indexOf(
-      "--require-migration 0108_multipart_absolute_lease_target.sql",
+      "--require-migration 0109_catalog_image_blob_ingestion.sql",
     );
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0108_multipart_absolute_lease_target.sql",
+    "--require-migration 0109_catalog_image_blob_ingestion.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -235,7 +235,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0108_multipart_absolute_lease_target\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0109_catalog_image_blob_ingestion\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");
@@ -260,7 +260,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0108_multipart_absolute_lease_target.sql",
+    "--require-migration 0109_catalog_image_blob_ingestion.sql",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -340,7 +340,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0108_multipart_absolute_lease_target.sql",
+      "0109_catalog_image_blob_ingestion.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -150,7 +150,7 @@ npx cdk deploy --all --require-approval never \
 echo "=== Verify required database migration ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0108_multipart_absolute_lease_target.sql
+  --require-migration 0109_catalog_image_blob_ingestion.sql
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \


### PR DESCRIPTION
## Summary
- add migration 0109 for catalog image blob admission, fencing, cleanup scheduling, and canonical cover provenance
- preserve workspace request-profile restrictions while supporting adopted cover provenance
- advance active migration gates and PostgreSQL boundary coverage to 0109

## Review
- fresh round-2 static review: no P0-P4 issues found
- no local project checks run, per repository workflow