### PR TITLE
feat: add catalog package image uploads

### DIFF
--- a/apps/backend/src/catalog/authoring/authorsDrafts.test.ts
+++ b/apps/backend/src/catalog/authoring/authorsDrafts.test.ts
@@ -23,7 +23,11 @@ import {
   unsafePublicCatalogStorageReference,
 } from "./authoringTestSupport";
 import { createCatalogAuthorInExecutor, updateCatalogAuthorInExecutor } from "./authors";
-import { attachCatalogPackageDraftMediaAssetInExecutor } from "./draftMedia";
+import {
+  attachCatalogPackageDraftMediaAssetInExecutor,
+  createOrReplayCatalogPackageDraftCardImageInExecutor,
+  replaceCatalogPackageDraftCoverInExecutor,
+} from "./draftMedia";
 import { createCatalogPackageDraftInExecutor, updateCatalogPackageDraftInExecutor } from "./drafts";
 
 function createAuthorRow(websiteUrl: string | null): CatalogAuthorRow {
@@ -463,4 +467,98 @@ test("catalog package media assets attach through content.media_blobs", async ()
   assert.equal(mediaAsset.mediaBlobId, testMediaBlobId);
   assert.equal(mediaAsset.packageMediaKey, "cover");
   assert.equal(queries.length, 2);
+});
+
+test("catalog package image authoring replays card bytes and safely replaces cover bytes", async () => {
+  const replacementBlobId = "66666666-6666-4666-8666-666666666666";
+  const cardMediaAssetId = "77777777-7777-4777-8777-777777777777";
+  let cardRow: CatalogPackageMediaAssetRow | null = null;
+  let coverRow: CatalogPackageMediaAssetRow = {
+    package_media_asset_id: testPackageMediaAssetId,
+    package_id: testPackageId,
+    package_version_id: null,
+    package_media_key: "cover",
+    media_blob_id: testMediaBlobId,
+    alt_text: null,
+    credit: null,
+    license: null,
+    created_at: testTimestamp,
+    updated_at: testTimestamp,
+  };
+  const cleanupParams: Array<ReadonlyArray<SqlValue>> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("FROM catalog.packages") && text.includes("FOR UPDATE")) {
+        return createQueryResult([createPackageRow() as unknown as Row]);
+      }
+      if (text.includes("FROM catalog.package_media_assets") && text.includes("FOR UPDATE")) {
+        const row = params[1] === "cover" ? coverRow : cardRow;
+        return createQueryResult(row === null ? [] : [row as unknown as Row]);
+      }
+      if (text.includes("INSERT INTO catalog.package_media_assets")) {
+        cardRow = {
+          ...coverRow,
+          package_media_asset_id: cardMediaAssetId,
+          package_media_key: String(params[1]),
+          media_blob_id: String(params[2]),
+        };
+        assert.match(text, /gen_random_uuid\(\)/u);
+        return createQueryResult([cardRow as unknown as Row]);
+      }
+      if (text.includes("UPDATE catalog.package_media_assets")) {
+        coverRow = { ...coverRow, media_blob_id: String(params[2]) };
+        return createQueryResult([coverRow as unknown as Row]);
+      }
+      if (text.includes("UPDATE catalog.packages")) {
+        assert.deepEqual(params, [testPackageId, "cover"]);
+        return createQueryResult([]);
+      }
+      if (text.includes("schedule_media_blob_cleanup")) {
+        cleanupParams.push(params);
+        return createQueryResult([]);
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const created = await createOrReplayCatalogPackageDraftCardImageInExecutor(
+    executor,
+    testPackageId,
+    " Diagram ",
+    testMediaBlobId,
+  );
+  const replayed = await createOrReplayCatalogPackageDraftCardImageInExecutor(
+    executor,
+    testPackageId,
+    "diagram",
+    testMediaBlobId,
+  );
+  assert.equal(created.applied, true);
+  assert.equal(replayed.applied, false);
+  assert.equal(replayed.mediaAsset.packageMediaAssetId, cardMediaAssetId);
+  await assert.rejects(
+    createOrReplayCatalogPackageDraftCardImageInExecutor(
+      executor,
+      testPackageId,
+      "diagram",
+      replacementBlobId,
+    ),
+    (error: unknown) => error instanceof HttpError
+      && error.statusCode === 409
+      && error.code === "CATALOG_PACKAGE_MEDIA_KEY_CONTENT_CONFLICT",
+  );
+
+  const replaced = await replaceCatalogPackageDraftCoverInExecutor(
+    executor,
+    testPackageId,
+    replacementBlobId,
+  );
+  assert.equal(replaced.applied, true);
+  assert.equal(replaced.mediaAsset.packageMediaKey, "cover");
+  assert.equal(replaced.mediaAsset.mediaBlobId, replacementBlobId);
+  assert.equal(cleanupParams.length, 1);
+  assert.equal(cleanupParams[0]?.[0], testMediaBlobId);
 });

--- a/apps/backend/src/catalog/authoring/draftMedia.ts
+++ b/apps/backend/src/catalog/authoring/draftMedia.ts
@@ -1,5 +1,11 @@
 import type { DatabaseExecutor } from "../../database";
+import { getDatabaseErrorFields } from "../../database/transient";
 import { unsafeTransaction } from "../../database/core";
+import {
+  mediaBlobCleanupDelayMs,
+  MediaBlobLifecycleBusyError,
+  MediaBlobLifecycleConflictError,
+} from "../../mediaAssets/blobLifecycle";
 import { HttpError } from "../../shared/errors";
 import {
   normalizeNullableString,
@@ -15,10 +21,219 @@ import type {
   AttachCatalogPackageMediaAssetInput,
   CatalogPackageMediaAsset,
   CatalogPackageMediaAssetRow,
+  CatalogPackageStatus,
   CatalogPackageVersionMediaAssetInput,
 } from "../types";
 
 type PackageMediaKeyRow = Readonly<{ package_media_key: string }>;
+
+export type CatalogPackageMediaMutationResult = Readonly<{
+  mediaAsset: CatalogPackageMediaAsset;
+  applied: boolean;
+}>;
+
+function assertCatalogPackageIsDraft(
+  packageId: string,
+  status: CatalogPackageStatus,
+): void {
+  if (status === "draft") {
+    return;
+  }
+
+  throw new HttpError(
+    409,
+    `Catalog package is not a draft authoring target. packageId=${packageId} status=${status}`,
+    "CATALOG_PACKAGE_NOT_DRAFT",
+  );
+}
+
+async function scheduleDisplacedMediaBlobCleanupInExecutor(
+  executor: DatabaseExecutor,
+  mediaBlobId: string,
+): Promise<void> {
+  try {
+    await executor.query(
+      "SELECT content.schedule_media_blob_cleanup($1, $2)",
+      [mediaBlobId, mediaBlobCleanupDelayMs],
+    );
+  } catch (error) {
+    const { sqlState } = getDatabaseErrorFields(error);
+    if (sqlState === "55P03") {
+      throw new MediaBlobLifecycleBusyError();
+    }
+    if (sqlState === "23514") {
+      throw new MediaBlobLifecycleConflictError();
+    }
+    throw error;
+  }
+}
+
+async function loadCatalogPackageDraftMediaAssetForUpdateInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  packageMediaKey: string,
+): Promise<CatalogPackageMediaAssetRow | null> {
+  const result = await executor.query<CatalogPackageMediaAssetRow>(
+    [
+      "SELECT",
+      catalogPackageMediaAssetColumns,
+      "FROM catalog.package_media_assets",
+      "WHERE package_id = $1",
+      "AND package_version_id IS NULL",
+      "AND package_media_key = $2",
+      "FOR UPDATE",
+    ].join(" "),
+    [packageId, packageMediaKey],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function insertCatalogPackageDraftImageInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  packageMediaKey: string,
+  mediaBlobId: string,
+): Promise<CatalogPackageMediaAsset> {
+  const result = await executor.query<CatalogPackageMediaAssetRow>(
+    [
+      "INSERT INTO catalog.package_media_assets",
+      "(package_media_asset_id, package_id, package_version_id, package_media_key, media_blob_id, alt_text, credit, license)",
+      "SELECT gen_random_uuid(), $1, NULL, $2, media_blobs.media_blob_id, NULL, NULL, NULL",
+      "FROM content.media_blobs AS media_blobs",
+      "WHERE media_blobs.media_blob_id = $3",
+      "RETURNING",
+      catalogPackageMediaAssetColumns,
+    ].join(" "),
+    [packageId, packageMediaKey, mediaBlobId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(
+      400,
+      "Normalized media blob not found for catalog package image attachment.",
+      "CATALOG_MEDIA_BLOB_NOT_FOUND",
+    );
+  }
+  return mapCatalogPackageMediaAssetRow(row);
+}
+
+export async function createOrReplayCatalogPackageDraftCardImageInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  packageMediaKey: string,
+  mediaBlobId: string,
+): Promise<CatalogPackageMediaMutationResult> {
+  const normalizedPackageMediaKey = normalizePackageMediaKey(
+    packageMediaKey,
+    "packageMediaKey",
+  );
+  if (normalizedPackageMediaKey === "cover") {
+    throw new HttpError(
+      400,
+      "Catalog package media key cover is reserved for package cover replacement.",
+      "CATALOG_PACKAGE_MEDIA_KEY_RESERVED",
+    );
+  }
+  try {
+    const catalogPackage = await lockCatalogPackageInExecutor(executor, packageId);
+    assertCatalogPackageIsDraft(packageId, catalogPackage.status);
+    const existing = await loadCatalogPackageDraftMediaAssetForUpdateInExecutor(
+      executor,
+      packageId,
+      normalizedPackageMediaKey,
+    );
+    if (existing !== null) {
+      if (existing.media_blob_id !== mediaBlobId) {
+        throw new HttpError(
+          409,
+          `Catalog package media key already contains different normalized bytes. packageId=${packageId} packageMediaKey=${normalizedPackageMediaKey}`,
+          "CATALOG_PACKAGE_MEDIA_KEY_CONTENT_CONFLICT",
+        );
+      }
+      return { mediaAsset: mapCatalogPackageMediaAssetRow(existing), applied: false };
+    }
+
+    return {
+      mediaAsset: await insertCatalogPackageDraftImageInExecutor(
+        executor,
+        packageId,
+        normalizedPackageMediaKey,
+        mediaBlobId,
+      ),
+      applied: true,
+    };
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
+
+export async function replaceCatalogPackageDraftCoverInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  mediaBlobId: string,
+): Promise<CatalogPackageMediaMutationResult> {
+  const packageMediaKey = "cover";
+  try {
+    const catalogPackage = await lockCatalogPackageInExecutor(executor, packageId);
+    assertCatalogPackageIsDraft(packageId, catalogPackage.status);
+    const existing = await loadCatalogPackageDraftMediaAssetForUpdateInExecutor(
+      executor,
+      packageId,
+      packageMediaKey,
+    );
+    let mediaAsset: CatalogPackageMediaAsset;
+    let applied = catalogPackage.cover_package_media_key !== packageMediaKey;
+    if (existing === null) {
+      mediaAsset = await insertCatalogPackageDraftImageInExecutor(
+        executor,
+        packageId,
+        packageMediaKey,
+        mediaBlobId,
+      );
+      applied = true;
+    } else if (existing.media_blob_id === mediaBlobId) {
+      mediaAsset = mapCatalogPackageMediaAssetRow(existing);
+    } else {
+      const updateResult = await executor.query<CatalogPackageMediaAssetRow>(
+        [
+          "UPDATE catalog.package_media_assets",
+          "SET media_blob_id = $3",
+          "WHERE package_id = $1",
+          "AND package_version_id IS NULL",
+          "AND package_media_key = $2",
+          "RETURNING",
+          catalogPackageMediaAssetColumns,
+        ].join(" "),
+        [packageId, packageMediaKey, mediaBlobId],
+      );
+      const updated = updateResult.rows[0];
+      if (updated === undefined) {
+        throw new Error(
+          `Locked catalog package cover disappeared during replacement. packageId=${packageId}`,
+        );
+      }
+      mediaAsset = mapCatalogPackageMediaAssetRow(updated);
+      applied = true;
+    }
+
+    await executor.query(
+      [
+        "UPDATE catalog.packages SET cover_package_media_key = $2",
+        "WHERE package_id = $1 AND cover_package_media_key IS DISTINCT FROM $2",
+      ].join(" "),
+      [packageId, packageMediaKey],
+    );
+    if (existing !== null && existing.media_blob_id !== mediaBlobId) {
+      await scheduleDisplacedMediaBlobCleanupInExecutor(
+        executor,
+        existing.media_blob_id,
+      );
+    }
+    return { mediaAsset, applied };
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}
 
 function normalizePackageMediaAssetInput(
   input: AttachCatalogPackageMediaAssetInput,

--- a/apps/backend/src/catalog/authoring/imageIngestion.ts
+++ b/apps/backend/src/catalog/authoring/imageIngestion.ts
@@ -5,10 +5,7 @@ import {
 } from "../../database";
 import { unsafeTransactionWithDeadline } from "../../database/unsafe";
 import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
-import {
-  MediaBlobLifecycleBusyError,
-  MediaBlobLifecycleConflictError,
-} from "../../mediaAssets/blobLifecycle";
+import { MediaBlobLifecycleConflictError } from "../../mediaAssets/blobLifecycle";
 import {
   assertMediaBlobMatchesMetadata,
   findMediaBlobRowBySha256InExecutor,
@@ -32,6 +29,12 @@ import {
 import type { BackendObservationScope } from "../../observability/sentry/events";
 import { HttpError } from "../../shared/errors";
 import { maximumPublicCatalogMediaDownloadBytes } from "../publicMediaDelivery";
+import type { CatalogPackageMediaAsset } from "../types";
+import {
+  createOrReplayCatalogPackageDraftCardImageInExecutor,
+  replaceCatalogPackageDraftCoverInExecutor,
+  type CatalogPackageMediaMutationResult,
+} from "./draftMedia";
 
 const catalogImageBlobAdmissionCleanupDelayMs = 3_600_000;
 const maximumCatalogImageBlobIngestionRequestLifetimeMs = 60_000;
@@ -41,6 +44,24 @@ type CatalogImageBlobIngestionInput = Readonly<{
   deadlineAtMs: number;
   signal: AbortSignal;
   observationScope: BackendObservationScope;
+}>;
+
+export type CatalogPackageCardImageIngestionInput =
+  CatalogImageBlobIngestionInput & Readonly<{
+    packageId: string;
+    packageMediaKey: string;
+  }>;
+
+export type CatalogPackageCoverImageIngestionInput =
+  CatalogImageBlobIngestionInput & Readonly<{
+    packageId: string;
+  }>;
+
+export type CatalogPackageImageIngestionResult = Readonly<{
+  mediaAsset: CatalogPackageMediaAsset;
+  applied: boolean;
+  mimeType: string;
+  sizeBytes: number;
 }>;
 
 type CatalogImageBlobMetadata = Readonly<{
@@ -235,9 +256,6 @@ function rethrowCatalogImageBlobAdmissionError(error: unknown): never {
   if (hasSqlState(error, "23514")) {
     throw new MediaBlobLifecycleConflictError();
   }
-  if (hasSqlState(error, "55P03")) {
-    throw new MediaBlobLifecycleBusyError();
-  }
   throw error;
 }
 
@@ -384,24 +402,69 @@ const productionCatalogImageBlobIngestionDependencies: CatalogImageBlobIngestion
   nowFn: Date.now,
 };
 
+async function ingestCatalogCardImageBlobWithDeadline(
+  input: CatalogImageBlobIngestionInput,
+): Promise<MediaBlob> {
+  const normalizedImage = await normalizeImageBytesForCardUntilDeadline(
+    input.imageBytes,
+    input.deadlineAtMs,
+    input.signal,
+  );
+  return storeNormalizedCatalogImageBlob(
+    input,
+    normalizedImage,
+    imageJpegCardMediaBlobNormalizationVersion,
+    productionCatalogImageBlobIngestionDependencies,
+  );
+}
+
+async function ingestCatalogCoverImageBlobWithDeadline(
+  input: CatalogImageBlobIngestionInput,
+): Promise<MediaBlob> {
+  const normalizedImage = await normalizeImageBytesForCatalogCoverUntilDeadline(
+    input.imageBytes,
+    input.deadlineAtMs,
+    input.signal,
+  );
+  return storeNormalizedCatalogImageBlob(
+    input,
+    normalizedImage,
+    imageJpegCatalogCoverMediaBlobNormalizationVersion,
+    productionCatalogImageBlobIngestionDependencies,
+  );
+}
+
+async function mutateCatalogPackageImageWithReplay(
+  operation: (executor: DatabaseExecutor) => Promise<CatalogPackageMediaMutationResult>,
+  deadlineAtMs: number,
+  signal: AbortSignal,
+): Promise<CatalogPackageMediaMutationResult> {
+  return replayCommitUnknown(
+    () => unsafeTransactionWithDeadline(deadlineAtMs, operation),
+    deadlineAtMs,
+    signal,
+    Date.now,
+  );
+}
+
+function toCatalogPackageImageIngestionResult(
+  mediaBlob: MediaBlob,
+  mutation: CatalogPackageMediaMutationResult,
+): CatalogPackageImageIngestionResult {
+  return {
+    mediaAsset: mutation.mediaAsset,
+    applied: mutation.applied,
+    mimeType: mediaBlob.mimeType,
+    sizeBytes: mediaBlob.sizeBytes,
+  };
+}
+
 export async function ingestCatalogCardImageBlob(
   input: CatalogImageBlobIngestionInput,
 ): Promise<MediaBlob> {
   return withCatalogImageBlobDeadline(
     input,
-    async (deadlineInput) => {
-      const normalizedImage = await normalizeImageBytesForCardUntilDeadline(
-        deadlineInput.imageBytes,
-        deadlineInput.deadlineAtMs,
-        deadlineInput.signal,
-      );
-      return storeNormalizedCatalogImageBlob(
-        deadlineInput,
-        normalizedImage,
-        imageJpegCardMediaBlobNormalizationVersion,
-        productionCatalogImageBlobIngestionDependencies,
-      );
-    },
+    ingestCatalogCardImageBlobWithDeadline,
   );
 }
 
@@ -410,18 +473,43 @@ export async function ingestCatalogCoverImageBlob(
 ): Promise<MediaBlob> {
   return withCatalogImageBlobDeadline(
     input,
-    async (deadlineInput) => {
-      const normalizedImage = await normalizeImageBytesForCatalogCoverUntilDeadline(
-        deadlineInput.imageBytes,
-        deadlineInput.deadlineAtMs,
-        deadlineInput.signal,
-      );
-      return storeNormalizedCatalogImageBlob(
-        deadlineInput,
-        normalizedImage,
-        imageJpegCatalogCoverMediaBlobNormalizationVersion,
-        productionCatalogImageBlobIngestionDependencies,
-      );
-    },
+    ingestCatalogCoverImageBlobWithDeadline,
   );
+}
+
+export async function ingestCatalogPackageCardImage(
+  input: CatalogPackageCardImageIngestionInput,
+): Promise<CatalogPackageImageIngestionResult> {
+  return withCatalogImageBlobDeadline(input, async (deadlineInput) => {
+    const mediaBlob = await ingestCatalogCardImageBlobWithDeadline(deadlineInput);
+    const mutation = await mutateCatalogPackageImageWithReplay(
+      (executor) => createOrReplayCatalogPackageDraftCardImageInExecutor(
+        executor,
+        input.packageId,
+        input.packageMediaKey,
+        mediaBlob.mediaBlobId,
+      ),
+      deadlineInput.deadlineAtMs,
+      deadlineInput.signal,
+    );
+    return toCatalogPackageImageIngestionResult(mediaBlob, mutation);
+  });
+}
+
+export async function replaceCatalogPackageCoverImage(
+  input: CatalogPackageCoverImageIngestionInput,
+): Promise<CatalogPackageImageIngestionResult> {
+  return withCatalogImageBlobDeadline(input, async (deadlineInput) => {
+    const mediaBlob = await ingestCatalogCoverImageBlobWithDeadline(deadlineInput);
+    const mutation = await mutateCatalogPackageImageWithReplay(
+      (executor) => replaceCatalogPackageDraftCoverInExecutor(
+        executor,
+        input.packageId,
+        mediaBlob.mediaBlobId,
+      ),
+      deadlineInput.deadlineAtMs,
+      deadlineInput.signal,
+    );
+    return toCatalogPackageImageIngestionResult(mediaBlob, mutation);
+  });
 }

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -7,10 +7,14 @@ export {
 export {
   attachCatalogPackageDraftMediaAsset,
   attachCatalogPackageDraftMediaAssetInExecutor,
+  createOrReplayCatalogPackageDraftCardImageInExecutor,
+  replaceCatalogPackageDraftCoverInExecutor,
 } from "./authoring/draftMedia";
 export {
   ingestCatalogCardImageBlob,
   ingestCatalogCoverImageBlob,
+  ingestCatalogPackageCardImage,
+  replaceCatalogPackageCoverImage,
 } from "./authoring/imageIngestion";
 export {
   createCatalogPackageDraft,

--- a/apps/backend/src/entrypoints/directImageIngestionLambdaHandler.ts
+++ b/apps/backend/src/entrypoints/directImageIngestionLambdaHandler.ts
@@ -11,9 +11,9 @@ import {
   createAgentApiKeyErrorEnvelope,
   isAgentApiKeyAuthorizationHeader,
 } from "../agent/envelope";
-
-const directImageIngestionPathPattern =
-  /^\/(?:v1\/)?workspaces\/[^/]+\/media-assets\/images\/?$/u;
+import {
+  isDirectImageIngestionTarget,
+} from "../server/mediaRequests/directImageIngestionRouting";
 
 type JsonRecord = Readonly<Record<string, unknown>>;
 
@@ -86,7 +86,6 @@ function parseVersionTwoEvent(event: JsonRecord): number | null {
   if (
     event.version !== "2.0"
     || typeof rawPath !== "string"
-    || !directImageIngestionPathPattern.test(rawPath)
     || typeof event.rawQueryString !== "string"
     || !isHeaderRecord(event.headers)
     || !isRequestBody(event.body)
@@ -102,9 +101,10 @@ function parseVersionTwoEvent(event: JsonRecord): number | null {
     || http === null
     || typeof requestContext.requestId !== "string"
     || requestContext.requestId === ""
-    || http.method !== "POST"
+    || typeof http.method !== "string"
     || typeof http.path !== "string"
     || http.path !== rawPath
+    || !isDirectImageIngestionTarget({ method: http.method, path: rawPath })
   ) {
     return null;
   }
@@ -116,8 +116,8 @@ function parseVersionOneEvent(event: JsonRecord): number | null {
   const path = event.path;
   if (
     typeof path !== "string"
-    || !directImageIngestionPathPattern.test(path)
-    || event.httpMethod !== "POST"
+    || typeof event.httpMethod !== "string"
+    || !isDirectImageIngestionTarget({ method: event.httpMethod, path })
     || !isHeaderRecord(event.headers)
     || !isRequestBody(event.body)
     || typeof event.isBase64Encoded !== "boolean"

--- a/apps/backend/src/entrypoints/lambda.test.ts
+++ b/apps/backend/src/entrypoints/lambda.test.ts
@@ -177,7 +177,7 @@ test("shared direct-image guard remains before lazy runtime initialization", () 
     "const backendApiBootstrapHandler: BackendApiHandler",
   );
   const guardStart = source.indexOf(
-    "isDirectImageIngestionPostTarget(readApiGatewayRequestTarget(event))",
+    "isDirectImageIngestionTarget(readApiGatewayRequestTarget(event))",
     handlerStart,
   );
   const runtimeStart = source.indexOf(

--- a/apps/backend/src/entrypoints/lambda.ts
+++ b/apps/backend/src/entrypoints/lambda.ts
@@ -16,7 +16,7 @@ import {
   getAllowedBrowserOrigins,
 } from "../server/browserCors";
 import {
-  isDirectImageIngestionPostTarget,
+  isDirectImageIngestionTarget,
   isMultipartCompletionPostTarget,
   readApiGatewayRequestTarget,
 } from "../server/mediaRequests/directImageIngestionRouting";
@@ -126,7 +126,7 @@ const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => 
     null,
     null,
   );
-  if (isDirectImageIngestionPostTarget(readApiGatewayRequestTarget(event))) {
+  if (isDirectImageIngestionTarget(readApiGatewayRequestTarget(event))) {
     const requestId = requestContext.requestId ?? context.awsRequestId;
     const requestHeaders = Object.entries(event.headers ?? {});
     const readRequestHeader = (headerName: string): string | null =>

--- a/apps/backend/src/routes/catalog/admin.test.ts
+++ b/apps/backend/src/routes/catalog/admin.test.ts
@@ -4,12 +4,15 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AdminRequestContext } from "../../admin/authz";
 import type {
+  CatalogPackageMediaAsset,
   CatalogPackageVersion,
   CreateCatalogPackageVersionFromWorkspaceInput,
 } from "../../catalog/types";
+import type { CatalogPackageImageIngestionResult } from "../../catalog/authoring/imageIngestion";
 import type { AppEnv } from "../../server/app";
 import { HttpError } from "../../shared/errors";
 import { createCatalogAdminRoutes } from "./admin";
+import { createCatalogAdminImageIngestionRoutes } from "./adminImageIngestion";
 
 const packageId = "11111111-1111-4111-8111-111111111111";
 const packageVersionId = "22222222-2222-4222-8222-222222222222";
@@ -166,4 +169,140 @@ test("POST catalog version from workspace preserves malformed workspace errors",
   });
   assert.equal(authorizationChecks, 1);
   assert.equal(processingCalls, 0);
+});
+
+function createCatalogImageResult(packageMediaKey: string): CatalogPackageImageIngestionResult {
+  const timestamp = "2026-08-11T00:00:00.000Z";
+  const mediaAsset: CatalogPackageMediaAsset = {
+    packageMediaAssetId: "44444444-4444-4444-8444-444444444444",
+    packageId,
+    packageVersionId: null,
+    packageMediaKey,
+    mediaBlobId: "55555555-5555-4555-8555-555555555555",
+    altText: null,
+    credit: null,
+    license: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  return { mediaAsset, applied: true, mimeType: "image/jpeg", sizeBytes: 3 };
+}
+
+function createCatalogImageTestApp(
+  authorize: () => Promise<AdminRequestContext>,
+  ingestCard: (packageMediaKey: string, imageBytes: Buffer) => Promise<CatalogPackageImageIngestionResult>,
+): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-1");
+    context.set("clientAppVersion", null);
+    context.set("clientPlatform", null);
+    await next();
+  });
+  app.onError((error, context) => {
+    if (error instanceof HttpError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({ error: error.message, code: error.code });
+    }
+    throw error;
+  });
+  app.route("/", createCatalogAdminImageIngestionRoutes({
+    allowedOrigins: [],
+    requireAdminRequestFn: authorize,
+    ingestCatalogPackageCardImageFn: async (input) => ingestCard(
+      input.packageMediaKey,
+      input.imageBytes,
+    ),
+    replaceCatalogPackageCoverImageFn: async () => createCatalogImageResult("cover"),
+  }));
+  return app;
+}
+
+test("catalog image routes authorize before validating raw bodies", async () => {
+  let processingCalls = 0;
+  const app = createCatalogImageTestApp(
+    async () => {
+      throw new HttpError(403, "Admin access required.", "ADMIN_ACCESS_REQUIRED");
+    },
+    async () => {
+      processingCalls += 1;
+      return createCatalogImageResult("diagram");
+    },
+  );
+
+  const response = await app.request(
+    `http://localhost/admin/catalog/packages/${packageId}/media-assets/images`,
+    { method: "POST", body: "not-an-image" },
+  );
+  assert.equal(response.status, 403);
+  assert.equal(processingCalls, 0);
+});
+
+test("catalog image routes validate raw input and never expose media blob IDs", async () => {
+  let cardCalls = 0;
+  const app = createCatalogImageTestApp(
+    async () => createAdminRequestContext(),
+    async (packageMediaKey, imageBytes) => {
+      cardCalls += 1;
+      assert.equal(packageMediaKey, "diagram");
+      assert.deepEqual(imageBytes, Buffer.from([1, 2, 3]));
+      return createCatalogImageResult(packageMediaKey);
+    },
+  );
+  const invalidResponse = await app.request(
+    `http://localhost/admin/catalog/packages/${packageId}/media-assets/images`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "text/plain", "x-package-media-key": "diagram" },
+      body: "invalid",
+    },
+  );
+  assert.equal(invalidResponse.status, 415);
+  assert.equal(cardCalls, 0);
+
+  for (const [path, method, extraHeaders] of [
+    [`media-assets/images`, "POST", { "x-package-media-key": " Diagram " }],
+    ["cover", "PUT", {}],
+  ] as const) {
+    const response = await app.request(
+      `http://localhost/admin/catalog/packages/${packageId}/${path}`,
+      {
+        method,
+        headers: { "Content-Type": "image/png", ...extraHeaders },
+        body: Buffer.from([1, 2, 3]),
+      },
+    );
+    const payload = await response.json() as Readonly<{ mediaAsset: Readonly<Record<string, unknown>> }>;
+    assert.equal(response.status, method === "POST" ? 201 : 200);
+    assert.equal("mediaBlobId" in payload.mediaAsset, false);
+  }
+  assert.equal(cardCalls, 1);
+});
+
+test("catalog image routes normalize ingestion deadline errors", async () => {
+  for (const error of [
+    Object.assign(new Error("database deadline"), { code: "55P03" }),
+    Object.assign(new Error("database deadline"), { code: "57014" }),
+    new HttpError(503, "catalog deadline", "CATALOG_IMAGE_INGESTION_DEADLINE_INVALID"),
+  ]) {
+    const app = createCatalogImageTestApp(
+      async () => createAdminRequestContext(),
+      async () => {
+        throw error;
+      },
+    );
+    const response = await app.request(
+      `http://localhost/admin/catalog/packages/${packageId}/media-assets/images`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "image/png", "x-package-media-key": "diagram" },
+        body: Buffer.from([1, 2, 3]),
+      },
+    );
+    assert.equal(response.status, 503);
+    assert.equal(
+      (await response.json() as Readonly<{ code: string }>).code,
+      "MEDIA_ASSET_INGESTION_DEADLINE_EXCEEDED",
+    );
+  }
 });

--- a/apps/backend/src/routes/catalog/adminImageIngestion.ts
+++ b/apps/backend/src/routes/catalog/adminImageIngestion.ts
@@ -1,0 +1,260 @@
+import { Hono, type Context } from "hono";
+import {
+  requireCatalogAdminRequest,
+  type CatalogAdminRequestContext,
+} from "../../admin/authz";
+import {
+  ingestCatalogPackageCardImage,
+  replaceCatalogPackageCoverImage,
+  type CatalogPackageCardImageIngestionInput,
+  type CatalogPackageCoverImageIngestionInput,
+  type CatalogPackageImageIngestionResult,
+} from "../../catalog/authoring/imageIngestion";
+import { normalizePackageMediaKey } from "../../catalog/common";
+import type { CatalogPackageMediaAsset } from "../../catalog/types";
+import {
+  DatabaseDeadlineExceededError,
+  runDatabaseOperationsWithDeadline,
+} from "../../database";
+import { getDatabaseErrorFields } from "../../database/transient";
+import { readMediaAssetImageIngestionBytesWithAbortSignal } from "../../mediaAssets/validators";
+import type { BackendObservationScope } from "../../observability/sentry/events";
+import {
+  addBackendRuntimeBreadcrumb,
+  normalizeCaughtError,
+} from "../../observability/runtime";
+import { reportBackendExceptionOrBreadcrumb } from "../../observability/reporting";
+import type { AppEnv } from "../../server/appEnv";
+import { createBackendFailureDetails } from "../../server/logging";
+import {
+  createDirectImageIngestionDeadlineError,
+  createDirectImageIngestionRequestDeadline,
+  type DirectImageIngestionRequestDeadline,
+} from "../../mediaAssets/ingestion";
+import {
+  createStandaloneDirectImageIngestionRequestTiming,
+  getDirectImageIngestionRequestTiming,
+} from "../../server/mediaRequests/directImageIngestionRequestTiming";
+import { expectUuidString } from "../../server/requestParsing";
+import { HttpError } from "../../shared/errors";
+
+type PublicCatalogPackageMediaAsset = Omit<CatalogPackageMediaAsset, "mediaBlobId">;
+
+export type CatalogAdminImageIngestionRoutesOptions = Readonly<{
+  allowedOrigins: ReadonlyArray<string>;
+  requireAdminRequestFn?: (request: Request, allowedOrigins: ReadonlyArray<string>) => Promise<CatalogAdminRequestContext>;
+  ingestCatalogPackageCardImageFn?: (input: CatalogPackageCardImageIngestionInput) => Promise<CatalogPackageImageIngestionResult>;
+  replaceCatalogPackageCoverImageFn?: (input: CatalogPackageCoverImageIngestionInput) => Promise<CatalogPackageImageIngestionResult>;
+}>;
+
+function parsePackageId(value: string | undefined): string {
+  if (value === undefined) {
+    throw new HttpError(400, "packageId is required", "CATALOG_ADMIN_PARAM_REQUIRED");
+  }
+  try {
+    return expectUuidString(value, "packageId");
+  } catch {
+    throw new HttpError(400, "packageId must be a UUID", "CATALOG_ADMIN_PARAM_INVALID");
+  }
+}
+
+function parsePackageMediaKey(headers: Headers): string {
+  const value = headers.get("x-package-media-key");
+  if (value === null) {
+    throw new HttpError(400, "x-package-media-key header is required", "CATALOG_PACKAGE_MEDIA_KEY_REQUIRED");
+  }
+  const packageMediaKey = normalizePackageMediaKey(value, "x-package-media-key");
+  if (packageMediaKey === "cover") {
+    throw new HttpError(
+      400,
+      "x-package-media-key cover is reserved; use the package cover PUT endpoint.",
+      "CATALOG_PACKAGE_MEDIA_KEY_RESERVED",
+    );
+  }
+  return packageMediaKey;
+}
+
+function toPublicCatalogPackageMediaAsset(
+  mediaAsset: CatalogPackageMediaAsset,
+): PublicCatalogPackageMediaAsset {
+  const { mediaBlobId, ...publicMediaAsset } = mediaAsset;
+  void mediaBlobId;
+  return publicMediaAsset;
+}
+
+function createCatalogImageIngestionScope(context: Context<AppEnv>, userId: string | null): BackendObservationScope {
+  return {
+    service: "backend-api",
+    requestId: context.get("requestId"),
+    route: context.req.path,
+    method: context.req.method,
+    userId,
+    workspaceId: null,
+    chatRequestId: null,
+    runId: null,
+    sessionId: null,
+    clientAppVersion: context.get("clientAppVersion"),
+    clientPlatform: context.get("clientPlatform"),
+  };
+}
+
+function mapCatalogImageIngestionDeadlineError(
+  error: unknown,
+  deadline: DirectImageIngestionRequestDeadline,
+): unknown {
+  const { sqlState } = getDatabaseErrorFields(error);
+  if (
+    error instanceof DatabaseDeadlineExceededError
+    || (
+      error instanceof HttpError
+      && error.code === "CATALOG_IMAGE_INGESTION_DEADLINE_INVALID"
+    )
+    || sqlState === "55P03"
+    || sqlState === "57014"
+    || deadline.preprocessingSignal.aborted
+    || deadline.requestSignal.aborted
+  ) {
+    return createDirectImageIngestionDeadlineError("request");
+  }
+  return error;
+}
+
+function reportCatalogImageIngestionFailure(error: unknown, scope: BackendObservationScope): void {
+  const details = {
+    mediaAssetId: null,
+    ...createBackendFailureDetails(error),
+  };
+  reportBackendExceptionOrBreadcrumb(
+    error,
+    {
+      action: "media_asset_image_ingest_error",
+      error: normalizeCaughtError(error),
+      scope,
+      details,
+    },
+    { action: "media_asset_image_ingest_error", scope, details },
+  );
+}
+
+function reportAndRethrowCatalogImageIngestionError(
+  error: unknown,
+  deadline: DirectImageIngestionRequestDeadline,
+  context: Context<AppEnv>,
+  userId: string | null,
+): never {
+  const mappedError = mapCatalogImageIngestionDeadlineError(error, deadline);
+  reportCatalogImageIngestionFailure(mappedError, createCatalogImageIngestionScope(context, userId));
+  throw mappedError;
+}
+
+function addCatalogImageIngestionSuccess(
+  scope: BackendObservationScope,
+  result: CatalogPackageImageIngestionResult,
+  statusCode: number,
+): void {
+  addBackendRuntimeBreadcrumb({
+    action: "media_asset_image_ingest",
+    scope,
+    details: {
+      statusCode,
+      mediaAssetId: result.mediaAsset.packageMediaAssetId,
+      mimeType: result.mimeType,
+      sizeBytes: result.sizeBytes,
+      applied: result.applied,
+    },
+  });
+}
+
+function createRequestDeadline(): DirectImageIngestionRequestDeadline {
+  const timing = getDirectImageIngestionRequestTiming()
+    ?? createStandaloneDirectImageIngestionRequestTiming(Date.now());
+  return createDirectImageIngestionRequestDeadline(timing);
+}
+
+export function createCatalogAdminImageIngestionRoutes(options: CatalogAdminImageIngestionRoutesOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  const requireAdminRequestFn = options.requireAdminRequestFn
+    ?? requireCatalogAdminRequest;
+  const ingestCatalogPackageCardImageFn = options.ingestCatalogPackageCardImageFn
+    ?? ingestCatalogPackageCardImage;
+  const replaceCatalogPackageCoverImageFn = options.replaceCatalogPackageCoverImageFn
+    ?? replaceCatalogPackageCoverImage;
+
+  app.post("/admin/catalog/packages/:packageId/media-assets/images", async (context) => {
+    const deadline = createRequestDeadline();
+    let userId: string | null = null;
+    try {
+      const prepared = await runDatabaseOperationsWithDeadline(
+        deadline.preprocessingDeadlineAtMs,
+        async () => {
+          const admin = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+          userId = admin.userId;
+          const packageId = parsePackageId(context.req.param("packageId"));
+          const packageMediaKey = parsePackageMediaKey(context.req.raw.headers);
+          const imageBytes = await readMediaAssetImageIngestionBytesWithAbortSignal(
+            context.req.raw,
+            deadline.preprocessingSignal,
+          );
+          return { packageId, packageMediaKey, imageBytes };
+        },
+      );
+      deadline.disposePreprocessing();
+      const scope = createCatalogImageIngestionScope(context, userId);
+      const result = await ingestCatalogPackageCardImageFn({
+        packageId: prepared.packageId,
+        packageMediaKey: prepared.packageMediaKey,
+        imageBytes: prepared.imageBytes,
+        deadlineAtMs: deadline.requestDeadlineAtMs,
+        signal: deadline.requestSignal,
+        observationScope: scope,
+      });
+      addCatalogImageIngestionSuccess(scope, result, 201);
+      return context.json({
+        mediaAsset: toPublicCatalogPackageMediaAsset(result.mediaAsset),
+      }, 201);
+    } catch (error) {
+      reportAndRethrowCatalogImageIngestionError(error, deadline, context, userId);
+    } finally {
+      deadline.dispose();
+    }
+  });
+
+  app.put("/admin/catalog/packages/:packageId/cover", async (context) => {
+    const deadline = createRequestDeadline();
+    let userId: string | null = null;
+    try {
+      const prepared = await runDatabaseOperationsWithDeadline(
+        deadline.preprocessingDeadlineAtMs,
+        async () => {
+          const admin = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+          userId = admin.userId;
+          const packageId = parsePackageId(context.req.param("packageId"));
+          const imageBytes = await readMediaAssetImageIngestionBytesWithAbortSignal(
+            context.req.raw,
+            deadline.preprocessingSignal,
+          );
+          return { packageId, imageBytes };
+        },
+      );
+      deadline.disposePreprocessing();
+      const scope = createCatalogImageIngestionScope(context, userId);
+      const result = await replaceCatalogPackageCoverImageFn({
+        packageId: prepared.packageId,
+        imageBytes: prepared.imageBytes,
+        deadlineAtMs: deadline.requestDeadlineAtMs,
+        signal: deadline.requestSignal,
+        observationScope: scope,
+      });
+      addCatalogImageIngestionSuccess(scope, result, 200);
+      return context.json({
+        mediaAsset: toPublicCatalogPackageMediaAsset(result.mediaAsset),
+      });
+    } catch (error) {
+      reportAndRethrowCatalogImageIngestionError(error, deadline, context, userId);
+    } finally {
+      deadline.dispose();
+    }
+  });
+
+  return app;
+}

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -25,6 +25,7 @@ import { createSyncRoutes } from "../routes/sync/index";
 import { createSystemRoutes } from "../routes/system";
 import { createAdminRoutes } from "../routes/admin";
 import { createCatalogAdminRoutes } from "../routes/catalog/admin";
+import { createCatalogAdminImageIngestionRoutes } from "../routes/catalog/adminImageIngestion";
 import { createCatalogPublicRoutes } from "../routes/catalog/public";
 import { createCatalogInstallRoutes } from "../routes/catalog/install";
 import { createGuestAuthRoutes } from "../routes/guestAuth";
@@ -396,6 +397,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
   app.route("/", createWorkspaceRoutes({ allowedOrigins }));
   app.route("/", createAdminRoutes({ allowedOrigins }));
   app.route("/", createCatalogAdminRoutes({ allowedOrigins }));
+  app.route("/", createCatalogAdminImageIngestionRoutes({ allowedOrigins }));
   app.route("/", createCatalogPublicRoutes({}));
   app.route("/", createCatalogInstallRoutes({ allowedOrigins }));
   app.route("/", createCardsRoutes({ allowedOrigins }));

--- a/apps/backend/src/server/browserCors.ts
+++ b/apps/backend/src/server/browserCors.ts
@@ -14,6 +14,7 @@ export const browserCorsAllowHeaders = [
   "x-media-client-updated-at",
   "x-media-last-modified-by-replica-id",
   "x-media-last-operation-id",
+  "x-package-media-key",
 ] as const;
 
 export const browserCorsExposeHeaders = [

--- a/apps/backend/src/server/mediaRequests/directImageIngestionApp.ts
+++ b/apps/backend/src/server/mediaRequests/directImageIngestionApp.ts
@@ -9,6 +9,7 @@ import {
 } from "../../agent/envelope";
 import { getAuthConfig } from "../../auth/config";
 import { createDirectImageIngestionRoutes } from "../../routes/directImageIngestion";
+import { createCatalogAdminImageIngestionRoutes } from "../../routes/catalog/adminImageIngestion";
 import {
   createPublicHttpErrorDetails,
   HttpError,
@@ -40,7 +41,7 @@ function createDirectImageIngestionMountedApp(
   const app = new Hono<AppEnv>({ strict: false }).basePath(basePath);
   const browserCorsMiddleware = cors({
     origin: allowedOrigins,
-    allowMethods: ["POST", "OPTIONS"],
+    allowMethods: ["POST", "PUT", "OPTIONS"],
     allowHeaders: [...browserCorsAllowHeaders],
     exposeHeaders: [...browserCorsExposeHeaders],
     credentials: true,
@@ -119,6 +120,7 @@ function createDirectImageIngestionMountedApp(
     });
   });
   app.route("/", createDirectImageIngestionRoutes({ allowedOrigins }));
+  app.route("/", createCatalogAdminImageIngestionRoutes({ allowedOrigins }));
   return app;
 }
 

--- a/apps/backend/src/server/mediaRequests/directImageIngestionRouting.test.ts
+++ b/apps/backend/src/server/mediaRequests/directImageIngestionRouting.test.ts
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  isDirectImageIngestionPostTarget,
+  isDirectImageIngestionTarget,
   isMultipartCompletionPostTarget,
   readApiGatewayRequestTarget,
 } from "./directImageIngestionRouting";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 const directPath = `/workspaces/${workspaceId}/media-assets/images`;
+const catalogCardImagePath =
+  `/admin/catalog/packages/${workspaceId}/media-assets/images`;
+const catalogCoverImagePath = `/admin/catalog/packages/${workspaceId}/cover`;
 const multipartSessionId = "22222222-2222-4222-8222-222222222222";
 const multipartCompletionPath =
   `/workspaces/${workspaceId}/media-assets/upload-sessions/${multipartSessionId}/complete`;
@@ -40,8 +43,8 @@ function createHttpApiEvent(path: string, method: string): unknown {
   };
 }
 
-function matchesDirectImagePost(event: unknown): boolean {
-  return isDirectImageIngestionPostTarget(
+function matchesDirectImageTarget(event: unknown): boolean {
+  return isDirectImageIngestionTarget(
     readApiGatewayRequestTarget(event),
   );
 }
@@ -60,6 +63,9 @@ test("shared Lambda matches every direct-image POST path across REST v1 and HTTP
     ["single v1 prefix trailing slash", `/v1${directPath}/`],
     ["execute-api double-v1 spelling", `/v1/v1${directPath}`],
     ["repeated v1 prefixes", `/v1/v1/v1${directPath}`],
+    ["catalog card image", catalogCardImagePath],
+    ["catalog card image trailing slash", `${catalogCardImagePath}/`],
+    ["catalog card image v1", `/v1${catalogCardImagePath}`],
   ] as const;
   const eventFactories = [
     ["REST v1", createRestApiEvent],
@@ -69,11 +75,24 @@ test("shared Lambda matches every direct-image POST path across REST v1 and HTTP
   for (const [eventLabel, createEvent] of eventFactories) {
     for (const [pathLabel, path] of directPostPaths) {
       assert.equal(
-        matchesDirectImagePost(createEvent(path, "POST")),
+        matchesDirectImageTarget(createEvent(path, "POST")),
         true,
         `${eventLabel}: ${pathLabel}`,
       );
     }
+  }
+});
+
+test("shared Lambda matches only PUT for the exact catalog cover path", () => {
+  const eventFactories = [createRestApiEvent, createHttpApiEvent] as const;
+  for (const createEvent of eventFactories) {
+    assert.equal(matchesDirectImageTarget(createEvent(catalogCoverImagePath, "PUT")), true);
+    assert.equal(matchesDirectImageTarget(createEvent(`/v1${catalogCoverImagePath}/`, "PUT")), true);
+    assert.equal(matchesDirectImageTarget(createEvent(catalogCoverImagePath, "POST")), false);
+    assert.equal(
+      matchesDirectImageTarget(createEvent(`${catalogCoverImagePath}/unexpected`, "PUT")),
+      false,
+    );
   }
 });
 
@@ -95,13 +114,14 @@ test("shared Lambda preserves other methods and unrelated shared routes", () => 
     ["double trailing slash", `${directPath}//`, "POST"],
     ["missing workspace id", "/workspaces//media-assets/images", "POST"],
     ["discovery", "/v1/agent", "POST"],
+    ["catalog card image wrong method", catalogCardImagePath, "PUT"],
   ] as const;
   const eventFactories = [createRestApiEvent, createHttpApiEvent] as const;
 
   for (const createEvent of eventFactories) {
     for (const [label, path, method] of preservedTargets) {
       assert.equal(
-        matchesDirectImagePost(createEvent(path, method)),
+        matchesDirectImageTarget(createEvent(path, method)),
         false,
         label,
       );
@@ -172,7 +192,7 @@ test("route selection ignores client headers and uses REST v1 method and path fi
     },
   };
 
-  assert.equal(matchesDirectImagePost(event), false);
+  assert.equal(matchesDirectImageTarget(event), false);
 });
 
 test("route selection ignores client headers and uses HTTP v2 method and raw path fields", () => {
@@ -187,7 +207,7 @@ test("route selection ignores client headers and uses HTTP v2 method and raw pat
     },
   };
 
-  assert.equal(matchesDirectImagePost(event), false);
+  assert.equal(matchesDirectImageTarget(event), false);
 });
 
 test("malformed and unsupported events do not match the guarded route", () => {
@@ -206,6 +226,6 @@ test("malformed and unsupported events do not match the guarded route", () => {
   ];
 
   for (const event of malformedEvents) {
-    assert.equal(matchesDirectImagePost(event), false);
+    assert.equal(matchesDirectImageTarget(event), false);
   }
 });

--- a/apps/backend/src/server/mediaRequests/directImageIngestionRouting.ts
+++ b/apps/backend/src/server/mediaRequests/directImageIngestionRouting.ts
@@ -1,5 +1,9 @@
 const directImageIngestionPathPattern =
   /^\/(?:v1\/)*workspaces\/[^/]+\/media-assets\/images\/?$/u;
+const catalogCardImageIngestionPathPattern =
+  /^\/(?:v1\/)*admin\/catalog\/packages\/[^/]+\/media-assets\/images\/?$/u;
+const catalogCoverImageIngestionPathPattern =
+  /^\/(?:v1\/)*admin\/catalog\/packages\/[^/]+\/cover\/?$/u;
 
 export type RequestTarget = Readonly<{
   method: string;
@@ -34,12 +38,22 @@ export function readApiGatewayRequestTarget(event: unknown): RequestTarget | nul
     : null;
 }
 
-export function isDirectImageIngestionPostTarget(
+export function isDirectImageIngestionTarget(
   target: RequestTarget | null,
 ): boolean {
-  return target !== null
-    && target.method === "POST"
-    && directImageIngestionPathPattern.test(target.path);
+  if (target === null) {
+    return false;
+  }
+  return (
+    target.method === "POST"
+    && (
+      directImageIngestionPathPattern.test(target.path)
+      || catalogCardImageIngestionPathPattern.test(target.path)
+    )
+  ) || (
+    target.method === "PUT"
+    && catalogCoverImageIngestionPathPattern.test(target.path)
+  );
 }
 
 export function isMultipartCompletionPostTarget(

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -210,7 +210,7 @@ test("direct ingestion monitoring covers handled HTTP 5xx and thrown Lambda fail
   );
 });
 
-test("direct ingestion route keeps shared workspace fallbacks without synthesis", () => {
+test("direct ingestion routes keep shared workspace and catalog admin fallbacks", () => {
   const stack = new cdk.Stack();
   const restApi = new apigw.RestApi(stack, "Api");
   const sharedIntegration = new apigw.MockIntegration({
@@ -220,23 +220,44 @@ test("direct ingestion route keeps shared workspace fallbacks without synthesis"
     integrationResponses: [{ statusCode: "201" }],
   });
 
-  const directImages = addDirectImageIngestionApiRoutes(
+  const routes = addDirectImageIngestionApiRoutes(
     restApi,
     sharedIntegration,
     directIntegration,
   );
 
   assert.equal(
-    directImages.path,
+    routes.workspaceImages.path,
     "/workspaces/{workspaceId}/media-assets/images",
   );
-  assert.doesNotThrow(() => directImages.node.findChild("ANY"));
-  assert.doesNotThrow(() => directImages.node.findChild("POST"));
+  assert.doesNotThrow(() => routes.workspaceImages.node.findChild("ANY"));
+  assert.doesNotThrow(() => routes.workspaceImages.node.findChild("POST"));
+  assert.equal(
+    routes.catalogCardImages.path,
+    "/admin/catalog/packages/{packageId}/media-assets/images",
+  );
+  assert.doesNotThrow(() => routes.catalogCardImages.node.findChild("ANY"));
+  assert.doesNotThrow(() => routes.catalogCardImages.node.findChild("POST"));
+  assert.equal(
+    routes.catalogCover.path,
+    "/admin/catalog/packages/{packageId}/cover",
+  );
+  assert.doesNotThrow(() => routes.catalogCover.node.findChild("ANY"));
+  assert.doesNotThrow(() => routes.catalogCover.node.findChild("PUT"));
   const workspaces = restApi.root.getResource("workspaces");
   const workspace = workspaces?.getResource("{workspaceId}");
   const mediaAssets = workspace?.getResource("media-assets");
   assert.notEqual(workspace?.getResource("{proxy+}"), undefined);
   assert.notEqual(mediaAssets?.getResource("{proxy+}"), undefined);
+  const admin = restApi.root.getResource("admin");
+  const catalog = admin?.getResource("catalog");
+  const packages = catalog?.getResource("packages");
+  const catalogPackage = packages?.getResource("{packageId}");
+  const packageMediaAssets = catalogPackage?.getResource("media-assets");
+  assert.notEqual(admin?.getResource("{proxy+}"), undefined);
+  assert.notEqual(catalog?.getResource("{proxy+}"), undefined);
+  assert.notEqual(catalogPackage?.getResource("{proxy+}"), undefined);
+  assert.notEqual(packageMediaAssets?.getResource("{proxy+}"), undefined);
 });
 
 test("custom-domain mapping strips one v1 segment before direct route selection", () => {
@@ -372,6 +393,7 @@ test("chat live Lambda Function URL CORS exposes request id header", () => {
         "x-media-client-updated-at",
         "x-media-last-modified-by-replica-id",
         "x-media-last-operation-id",
+        "x-package-media-key",
       ],
       AllowMethods: ["GET"],
       AllowOrigins: ["https://app.example.test"],
@@ -463,6 +485,7 @@ test("default API Gateway generated errors expose supported request id headers",
     "x-media-client-updated-at",
     "x-media-last-modified-by-replica-id",
     "x-media-last-operation-id",
+    "x-package-media-key",
   ].join(",");
   const responseParameters = {
     "gatewayresponse.header.Access-Control-Allow-Credentials": "'true'",

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -104,11 +104,17 @@ export const publicRestApiDefaultIntegrationTimeoutSeconds = 29;
 export const directImageIngestionMaximumOnDemandInitSeconds = 10;
 export const directImageIngestionLambdaTimeoutSeconds = 15;
 
+export type DirectImageIngestionApiRoutes = Readonly<{
+  workspaceImages: apigw.Resource;
+  catalogCardImages: apigw.Resource;
+  catalogCover: apigw.Resource;
+}>;
+
 export function addDirectImageIngestionApiRoutes(
   restApi: apigw.RestApi,
   sharedIntegration: apigw.Integration,
   directIntegration: apigw.Integration,
-): apigw.Resource {
+): DirectImageIngestionApiRoutes {
   const workspaces = restApi.root.addResource("workspaces");
   workspaces.addMethod("ANY", sharedIntegration);
   const workspace = workspaces.addResource("{workspaceId}");
@@ -120,7 +126,32 @@ export function addDirectImageIngestionApiRoutes(
   const directImages = mediaAssets.addResource("images");
   directImages.addMethod("ANY", sharedIntegration);
   directImages.addMethod("POST", directIntegration);
-  return directImages;
+
+  const admin = restApi.root.addResource("admin");
+  admin.addMethod("ANY", sharedIntegration);
+  admin.addResource("{proxy+}").addMethod("ANY", sharedIntegration);
+  const catalog = admin.addResource("catalog");
+  catalog.addMethod("ANY", sharedIntegration);
+  catalog.addResource("{proxy+}").addMethod("ANY", sharedIntegration);
+  const packages = catalog.addResource("packages");
+  packages.addMethod("ANY", sharedIntegration);
+  const catalogPackage = packages.addResource("{packageId}");
+  catalogPackage.addMethod("ANY", sharedIntegration);
+  catalogPackage.addResource("{proxy+}").addMethod("ANY", sharedIntegration);
+  const packageMediaAssets = catalogPackage.addResource("media-assets");
+  packageMediaAssets.addMethod("ANY", sharedIntegration);
+  packageMediaAssets.addResource("{proxy+}").addMethod("ANY", sharedIntegration);
+  const catalogCardImages = packageMediaAssets.addResource("images");
+  catalogCardImages.addMethod("ANY", sharedIntegration);
+  catalogCardImages.addMethod("POST", directIntegration);
+  const catalogCover = catalogPackage.addResource("cover");
+  catalogCover.addMethod("ANY", sharedIntegration);
+  catalogCover.addMethod("PUT", directIntegration);
+  return {
+    workspaceImages: directImages,
+    catalogCardImages,
+    catalogCover,
+  };
 }
 
 interface GlobalMetricsConfig {
@@ -170,6 +201,7 @@ const browserCorsAllowHeaders = [
   "x-media-client-updated-at",
   "x-media-last-modified-by-replica-id",
   "x-media-last-operation-id",
+  "x-package-media-key",
 ] as const;
 
 const browserCorsExposeHeaders = [


### PR DESCRIPTION
## Summary
- add raw admin package card-image and cover upload endpoints with normalized image ingestion
- preserve replay and conflict semantics, atomic cover replacement, and displaced blob cleanup scheduling
- route the exact binary methods through the Sharp-enabled Lambda and API Gateway while retaining existing catalog flows
- add focused module and route boundary coverage for package mutation, deadline translation, and gateway routing

## Review evidence
- round 1 fixed the preprocessing deadline leak
- round 2 fixed broad lifecycle-busy classification; shared auth cancellation remained explicitly out of scope
- round 3 fixed raw PostgreSQL deadline-state translation
- round 4 fixed catalog deadline translation and admission lock classification
- round 5 fresh review reported no P0-P4 findings

## Checks
- Local project checks were not run, per repository rules for integration PRs.