### PR TITLE
feat: add catalog collection cover upload

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -387,7 +387,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0109_catalog_image_blob_ingestion.sql
+            --require-migration 0110_collection_cover_media.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,8 +71,8 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
-    migrationFileName: "0109_catalog_image_blob_ingestion.sql",
-    expectedMigrationCount: 111,
+    migrationFileName: "0110_collection_cover_media.sql",
+    expectedMigrationCount: 112,
     testFiles: Object.freeze([
       "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",
     ]),

--- a/apps/backend/src/catalog/authoring/collectionCovers.ts
+++ b/apps/backend/src/catalog/authoring/collectionCovers.ts
@@ -1,0 +1,70 @@
+import type { DatabaseExecutor } from "../../database";
+import { rethrowCatalogPersistenceError } from "../errors";
+import {
+  catalogCollectionCoverColumns,
+  lockCatalogCollectionCoverInExecutor,
+  mapCatalogCollectionCoverRow,
+} from "../rows";
+import type {
+  CatalogCollectionCover,
+  CatalogCollectionCoverRow,
+} from "../types";
+import { scheduleDisplacedMediaBlobCleanupInExecutor } from "./draftMedia";
+
+export type CatalogCollectionCoverMutationResult = Readonly<{
+  collectionCover: CatalogCollectionCover;
+  applied: boolean;
+}>;
+
+export async function replaceCatalogCollectionCoverInExecutor(
+  executor: DatabaseExecutor,
+  collectionId: string,
+  mediaBlobId: string,
+): Promise<CatalogCollectionCoverMutationResult> {
+  try {
+    const existing = await lockCatalogCollectionCoverInExecutor(
+      executor,
+      collectionId,
+    );
+    if (existing.cover_media_blob_id === mediaBlobId) {
+      return {
+        collectionCover: mapCatalogCollectionCoverRow(existing),
+        applied: false,
+      };
+    }
+
+    await executor.query(
+      "SELECT content.lock_media_blob_lifecycles_for_reference_swap($1, $2)",
+      [existing.cover_media_blob_id, mediaBlobId],
+    );
+
+    const updateResult = await executor.query<CatalogCollectionCoverRow>(
+      [
+        "UPDATE catalog.collections",
+        "SET cover_media_blob_id = $2",
+        "WHERE collection_id = $1",
+        "RETURNING",
+        catalogCollectionCoverColumns,
+      ].join(" "),
+      [collectionId, mediaBlobId],
+    );
+    const updated = updateResult.rows[0];
+    if (updated === undefined) {
+      throw new Error(
+        `Locked catalog collection disappeared during cover replacement. collectionId=${collectionId}`,
+      );
+    }
+    if (existing.cover_media_blob_id !== null) {
+      await scheduleDisplacedMediaBlobCleanupInExecutor(
+        executor,
+        existing.cover_media_blob_id,
+      );
+    }
+    return {
+      collectionCover: mapCatalogCollectionCoverRow(updated),
+      applied: true,
+    };
+  } catch (error) {
+    rethrowCatalogPersistenceError(error);
+  }
+}

--- a/apps/backend/src/catalog/authoring/draftMedia.ts
+++ b/apps/backend/src/catalog/authoring/draftMedia.ts
@@ -47,7 +47,7 @@ function assertCatalogPackageIsDraft(
   );
 }
 
-async function scheduleDisplacedMediaBlobCleanupInExecutor(
+export async function scheduleDisplacedMediaBlobCleanupInExecutor(
   executor: DatabaseExecutor,
   mediaBlobId: string,
 ): Promise<void> {

--- a/apps/backend/src/catalog/authoring/imageIngestion.ts
+++ b/apps/backend/src/catalog/authoring/imageIngestion.ts
@@ -29,7 +29,14 @@ import {
 import type { BackendObservationScope } from "../../observability/sentry/events";
 import { HttpError } from "../../shared/errors";
 import { maximumPublicCatalogMediaDownloadBytes } from "../publicMediaDelivery";
-import type { CatalogPackageMediaAsset } from "../types";
+import type {
+  CatalogCollectionCover,
+  CatalogPackageMediaAsset,
+} from "../types";
+import {
+  replaceCatalogCollectionCoverInExecutor,
+  type CatalogCollectionCoverMutationResult,
+} from "./collectionCovers";
 import {
   createOrReplayCatalogPackageDraftCardImageInExecutor,
   replaceCatalogPackageDraftCoverInExecutor,
@@ -57,8 +64,20 @@ export type CatalogPackageCoverImageIngestionInput =
     packageId: string;
   }>;
 
+export type CatalogCollectionCoverImageIngestionInput =
+  CatalogImageBlobIngestionInput & Readonly<{
+    collectionId: string;
+  }>;
+
 export type CatalogPackageImageIngestionResult = Readonly<{
   mediaAsset: CatalogPackageMediaAsset;
+  applied: boolean;
+  mimeType: string;
+  sizeBytes: number;
+}>;
+
+export type CatalogCollectionCoverImageIngestionResult = Readonly<{
+  collectionCover: CatalogCollectionCover;
   applied: boolean;
   mimeType: string;
   sizeBytes: number;
@@ -434,17 +453,29 @@ async function ingestCatalogCoverImageBlobWithDeadline(
   );
 }
 
-async function mutateCatalogPackageImageWithReplay(
-  operation: (executor: DatabaseExecutor) => Promise<CatalogPackageMediaMutationResult>,
+async function mutateCatalogImageWithReplay<Result>(
+  operation: (executor: DatabaseExecutor) => Promise<Result>,
   deadlineAtMs: number,
   signal: AbortSignal,
-): Promise<CatalogPackageMediaMutationResult> {
+): Promise<Result> {
   return replayCommitUnknown(
     () => unsafeTransactionWithDeadline(deadlineAtMs, operation),
     deadlineAtMs,
     signal,
     Date.now,
   );
+}
+
+function toCatalogCollectionCoverImageIngestionResult(
+  mediaBlob: MediaBlob,
+  mutation: CatalogCollectionCoverMutationResult,
+): CatalogCollectionCoverImageIngestionResult {
+  return {
+    collectionCover: mutation.collectionCover,
+    applied: mutation.applied,
+    mimeType: mediaBlob.mimeType,
+    sizeBytes: mediaBlob.sizeBytes,
+  };
 }
 
 function toCatalogPackageImageIngestionResult(
@@ -482,7 +513,7 @@ export async function ingestCatalogPackageCardImage(
 ): Promise<CatalogPackageImageIngestionResult> {
   return withCatalogImageBlobDeadline(input, async (deadlineInput) => {
     const mediaBlob = await ingestCatalogCardImageBlobWithDeadline(deadlineInput);
-    const mutation = await mutateCatalogPackageImageWithReplay(
+    const mutation = await mutateCatalogImageWithReplay(
       (executor) => createOrReplayCatalogPackageDraftCardImageInExecutor(
         executor,
         input.packageId,
@@ -501,7 +532,7 @@ export async function replaceCatalogPackageCoverImage(
 ): Promise<CatalogPackageImageIngestionResult> {
   return withCatalogImageBlobDeadline(input, async (deadlineInput) => {
     const mediaBlob = await ingestCatalogCoverImageBlobWithDeadline(deadlineInput);
-    const mutation = await mutateCatalogPackageImageWithReplay(
+    const mutation = await mutateCatalogImageWithReplay(
       (executor) => replaceCatalogPackageDraftCoverInExecutor(
         executor,
         input.packageId,
@@ -511,5 +542,23 @@ export async function replaceCatalogPackageCoverImage(
       deadlineInput.signal,
     );
     return toCatalogPackageImageIngestionResult(mediaBlob, mutation);
+  });
+}
+
+export async function replaceCatalogCollectionCoverImage(
+  input: CatalogCollectionCoverImageIngestionInput,
+): Promise<CatalogCollectionCoverImageIngestionResult> {
+  return withCatalogImageBlobDeadline(input, async (deadlineInput) => {
+    const mediaBlob = await ingestCatalogCoverImageBlobWithDeadline(deadlineInput);
+    const mutation = await mutateCatalogImageWithReplay(
+      (executor) => replaceCatalogCollectionCoverInExecutor(
+        executor,
+        input.collectionId,
+        mediaBlob.mediaBlobId,
+      ),
+      deadlineInput.deadlineAtMs,
+      deadlineInput.signal,
+    );
+    return toCatalogCollectionCoverImageIngestionResult(mediaBlob, mutation);
   });
 }

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -11,9 +11,13 @@ export {
   replaceCatalogPackageDraftCoverInExecutor,
 } from "./authoring/draftMedia";
 export {
+  replaceCatalogCollectionCoverInExecutor,
+} from "./authoring/collectionCovers";
+export {
   ingestCatalogCardImageBlob,
   ingestCatalogCoverImageBlob,
   ingestCatalogPackageCardImage,
+  replaceCatalogCollectionCoverImage,
   replaceCatalogPackageCoverImage,
 } from "./authoring/imageIngestion";
 export {

--- a/apps/backend/src/catalog/rows.ts
+++ b/apps/backend/src/catalog/rows.ts
@@ -8,6 +8,8 @@ import {
 import type {
   CatalogAuthor,
   CatalogAuthorRow,
+  CatalogCollectionCover,
+  CatalogCollectionCoverRow,
   CatalogPackage,
   CatalogPackageMediaAsset,
   CatalogPackageMediaAssetRow,
@@ -55,6 +57,12 @@ export const catalogPackageMediaAssetColumns = [
   "credit",
   "license",
   "created_at",
+  "updated_at",
+].join(", ");
+
+export const catalogCollectionCoverColumns = [
+  "collection_id",
+  "cover_media_blob_id",
   "updated_at",
 ].join(", ");
 
@@ -132,6 +140,16 @@ export function mapCatalogPackageMediaAssetRow(row: CatalogPackageMediaAssetRow)
   };
 }
 
+export function mapCatalogCollectionCoverRow(
+  row: CatalogCollectionCoverRow,
+): CatalogCollectionCover {
+  return {
+    collectionId: row.collection_id,
+    coverMediaBlobId: row.cover_media_blob_id,
+    updatedAt: toIsoString(row.updated_at),
+  };
+}
+
 export function mapCatalogPackageVersionRow(row: CatalogPackageVersionRow): CatalogPackageVersion {
   return {
     packageVersionId: row.package_version_id,
@@ -177,6 +195,32 @@ export async function lockCatalogPackageInExecutor(
   const row = result.rows[0];
   if (row === undefined) {
     throw new HttpError(404, `Catalog package not found. packageId=${packageId}`, "CATALOG_PACKAGE_NOT_FOUND");
+  }
+
+  return row;
+}
+
+export async function lockCatalogCollectionCoverInExecutor(
+  executor: DatabaseExecutor,
+  collectionId: string,
+): Promise<CatalogCollectionCoverRow> {
+  const result = await executor.query<CatalogCollectionCoverRow>(
+    [
+      "SELECT",
+      catalogCollectionCoverColumns,
+      "FROM catalog.collections",
+      "WHERE collection_id = $1",
+      "FOR UPDATE",
+    ].join(" "),
+    [collectionId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(
+      404,
+      `Catalog collection not found. collectionId=${collectionId}`,
+      "CATALOG_COLLECTION_NOT_FOUND",
+    );
   }
 
   return row;

--- a/apps/backend/src/catalog/types.ts
+++ b/apps/backend/src/catalog/types.ts
@@ -107,6 +107,19 @@ export type UpdateCatalogPackageDraftInput = Readonly<{
   coverPackageMediaKey: string | null;
 }>;
 
+// TODO: Add future collection metadata/status and ordered-membership authoring.
+export type CatalogCollectionCoverRow = Readonly<{
+  collection_id: string;
+  cover_media_blob_id: string | null;
+  updated_at: TimestampValue;
+}>;
+
+export type CatalogCollectionCover = Readonly<{
+  collectionId: string;
+  coverMediaBlobId: string | null;
+  updatedAt: string;
+}>;
+
 export type CatalogPackageMediaAssetRow = Readonly<{
   package_media_asset_id: string;
   package_id: string;

--- a/apps/backend/src/entrypoints/directImageIngestionLambdaHandler.test.ts
+++ b/apps/backend/src/entrypoints/directImageIngestionLambdaHandler.test.ts
@@ -29,6 +29,8 @@ import {
 
 const directImagePath =
   "/workspaces/11111111-1111-4111-8111-111111111111/media-assets/images";
+const catalogCollectionCoverPath =
+  "/admin/catalog/collections/22222222-2222-4222-8222-222222222222/cover";
 const allowedOrigin = "https://app.flashcards-open-source-app.com";
 
 function createLambdaContext(remainingTimeMs: number): Context {
@@ -136,6 +138,27 @@ test("valid REST event carries its server-authored ingress timing", async () => 
   assert.equal(result.statusCode, 200);
   assert.equal(handleCalls, 1);
   assert.equal(context.callbackWaitsForEmptyEventLoop, false);
+});
+
+test("valid collection cover PUT reaches the dedicated Lambda boundary", () => {
+  const ingressAtMs = 1_000_000;
+  const event = {
+    ...createRestApiEvent(ingressAtMs, null) as unknown as Record<string, unknown>,
+    httpMethod: "PUT",
+    path: catalogCollectionCoverPath,
+    pathParameters: {
+      collectionId: "22222222-2222-4222-8222-222222222222",
+    },
+    resource: "/admin/catalog/collections/{collectionId}/cover",
+  } as unknown as LambdaEvent;
+
+  assert.notEqual(
+    parseDirectImageIngestionLambdaEvent(
+      event,
+      createLambdaContext(directImageIngestionLambdaInvokeTimeoutMs),
+    ),
+    null,
+  );
 });
 
 test("Lambda remaining time clamps the application deadline", async () => {

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0109_catalog_image_blob_ingestion.sql",
+      RequiredMigration: "0110_collection_cover_media.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0109_catalog_image_blob_ingestion.sql",
+    requiredMigration: "0110_collection_cover_media.sql",
   });
 });
 

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
@@ -6,9 +6,11 @@ import {
   enqueueGeneratedMediaPromotionJob,
   type EnqueueGeneratedMediaPromotionJobInput,
 } from "../../chat/cardImages/promotion/jobs";
+import { replaceCatalogCollectionCoverInExecutor } from "../../catalog/authoring/collectionCovers";
 import {
   transactionWithWorkspaceScope,
 } from "../../database";
+import { unsafeTransaction } from "../../database/unsafe";
 import {
   type PostgresIntegrationFixture,
   withPostgresIntegrationFixture,
@@ -299,15 +301,21 @@ async function deleteCleanupFixtures(
   );
 }
 
-test("catalog image admission is reclaimable until attachment fences cleanup", async () => {
+test("catalog image admission stays fenced across reverse-SHA collection cover replacement", async () => {
   await withPostgresIntegrationFixture(async (fixture) => {
-    const attachedSha256 = createSha256();
+    const firstCoverSha256 = createSha256();
+    const secondCoverSha256 = createSha256();
+    const [replacementSha256, attachedSha256] = firstCoverSha256 < secondCoverSha256
+      ? [firstCoverSha256, secondCoverSha256] as const
+      : [secondCoverSha256, firstCoverSha256] as const;
     const abandonedSha256 = createSha256();
-    const sha256s = [attachedSha256, abandonedSha256];
+    const sha256s = [attachedSha256, abandonedSha256, replacementSha256];
     const authorId = randomUUID();
     const packageId = randomUUID();
+    const collectionId = randomUUID();
     const packageMediaAssetId = randomUUID();
     const mediaBlobId = randomUUID();
+    const replacementMediaBlobId = randomUUID();
     const slug = randomUUID();
     const storageKey = (sha256: string) => buildMediaBlobStorageKey(sha256);
     try {
@@ -416,10 +424,89 @@ test("catalog image admission is reclaimable until attachment fences cleanup", a
         "DELETE FROM catalog.package_media_assets WHERE package_media_asset_id=$1",
         [packageMediaAssetId],
       );
+      await fixture.runtimePool.query(
+        "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+        admissionParams(
+          replacementSha256,
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+        ),
+      );
+      await fixture.runtimePool.query(
+        `INSERT INTO content.media_blobs(
+           media_blob_id,sha256,mime_type,size_bytes,storage_key,
+           normalization_version
+         ) VALUES($1,$2,'image/jpeg',42,$3,$4)`,
+        [
+          replacementMediaBlobId,
+          replacementSha256,
+          storageKey(replacementSha256),
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+        ],
+      );
+      await fixture.runtimePool.query(
+        `INSERT INTO catalog.collections(
+           collection_id,slug,title,summary,description,language_tags,
+           topic_tags,cover_package_id,cover_media_blob_id
+         ) VALUES($1,$2,'Images','Summary','Description',ARRAY['en'],
+           ARRAY['test'],$3,$4)`,
+        [collectionId, `image-collection-${slug}`, packageId, mediaBlobId],
+      );
       assert.equal((await fixture.runtimePool.query<{ scheduled: boolean }>(
         "SELECT content.schedule_media_blob_cleanup($1,$2) AS scheduled",
         [mediaBlobId, 1],
-      )).rows[0]?.scheduled, true);
+      )).rows[0]?.scheduled, false);
+
+      const replaced = await unsafeTransaction(
+        (executor) => replaceCatalogCollectionCoverInExecutor(
+          executor,
+          collectionId,
+          replacementMediaBlobId,
+        ),
+      );
+      assert.equal(replaced.applied, true);
+      assert.equal(
+        replaced.collectionCover.coverMediaBlobId,
+        replacementMediaBlobId,
+      );
+      const replayed = await unsafeTransaction(
+        (executor) => replaceCatalogCollectionCoverInExecutor(
+          executor,
+          collectionId,
+          replacementMediaBlobId,
+        ),
+      );
+      assert.equal(replayed.applied, false);
+      assert.deepEqual((await fixture.ownerPool.query<Readonly<{
+        cover_package_id: string | null;
+        cover_media_blob_id: string | null;
+        replacement_fenced: boolean;
+        old_cleanup_scheduled: boolean;
+      }>>(
+        `SELECT collections.cover_package_id,collections.cover_media_blob_id,
+           replacement_lifecycle.cleanup_eligible_at IS NULL AS replacement_fenced,
+           old_lifecycle.cleanup_eligible_at>clock_timestamp() AS old_cleanup_scheduled
+         FROM catalog.collections AS collections
+         INNER JOIN content.media_blobs AS replacement_blob
+           ON replacement_blob.media_blob_id=collections.cover_media_blob_id
+         INNER JOIN content.media_blob_lifecycles AS replacement_lifecycle
+           ON replacement_lifecycle.sha256=replacement_blob.sha256
+         INNER JOIN content.media_blob_lifecycles AS old_lifecycle
+           ON old_lifecycle.sha256=$2
+         WHERE collections.collection_id=$1`,
+        [collectionId, attachedSha256],
+      )).rows[0], {
+        cover_package_id: packageId,
+        cover_media_blob_id: replacementMediaBlobId,
+        replacement_fenced: true,
+        old_cleanup_scheduled: true,
+      });
+      await assert.rejects(
+        fixture.runtimePool.query(
+          "DELETE FROM content.media_blobs WHERE media_blob_id=$1",
+          [replacementMediaBlobId],
+        ),
+        (error: unknown) => hasPostgresCode(error, "23503"),
+      );
       await fixture.ownerPool.query(
         "UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=clock_timestamp()-interval '1 second' WHERE sha256=$1",
         [attachedSha256],
@@ -436,6 +523,10 @@ test("catalog image admission is reclaimable until attachment fences cleanup", a
         (error: unknown) => hasPostgresCode(error, "55P03"),
       );
     } finally {
+      await fixture.ownerPool.query(
+        "DELETE FROM catalog.collections WHERE collection_id=$1",
+        [collectionId],
+      );
       await fixture.ownerPool.query("DELETE FROM catalog.packages WHERE package_id=$1", [packageId]);
       await fixture.ownerPool.query("DELETE FROM catalog.authors WHERE author_id=$1", [authorId]);
       await fixture.ownerPool.query(

--- a/apps/backend/src/routes/catalog/admin.test.ts
+++ b/apps/backend/src/routes/catalog/admin.test.ts
@@ -4,17 +4,22 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AdminRequestContext } from "../../admin/authz";
 import type {
+  CatalogCollectionCover,
   CatalogPackageMediaAsset,
   CatalogPackageVersion,
   CreateCatalogPackageVersionFromWorkspaceInput,
 } from "../../catalog/types";
-import type { CatalogPackageImageIngestionResult } from "../../catalog/authoring/imageIngestion";
+import type {
+  CatalogCollectionCoverImageIngestionResult,
+  CatalogPackageImageIngestionResult,
+} from "../../catalog/authoring/imageIngestion";
 import type { AppEnv } from "../../server/app";
 import { HttpError } from "../../shared/errors";
 import { createCatalogAdminRoutes } from "./admin";
 import { createCatalogAdminImageIngestionRoutes } from "./adminImageIngestion";
 
 const packageId = "11111111-1111-4111-8111-111111111111";
+const collectionId = "66666666-6666-4666-8666-666666666666";
 const packageVersionId = "22222222-2222-4222-8222-222222222222";
 const cardId = "33333333-3333-4333-8333-333333333333";
 const legacyWorkspaceId = "35274129-ef97-d366-954c-955b4bb0fbf0";
@@ -188,9 +193,24 @@ function createCatalogImageResult(packageMediaKey: string): CatalogPackageImageI
   return { mediaAsset, applied: true, mimeType: "image/jpeg", sizeBytes: 3 };
 }
 
+function createCatalogCollectionCoverResult(): CatalogCollectionCoverImageIngestionResult {
+  const collectionCover: CatalogCollectionCover = {
+    collectionId,
+    coverMediaBlobId: "77777777-7777-4777-8777-777777777777",
+    updatedAt: "2026-08-11T00:00:00.000Z",
+  };
+  return {
+    collectionCover,
+    applied: true,
+    mimeType: "image/jpeg",
+    sizeBytes: 3,
+  };
+}
+
 function createCatalogImageTestApp(
   authorize: () => Promise<AdminRequestContext>,
   ingestCard: (packageMediaKey: string, imageBytes: Buffer) => Promise<CatalogPackageImageIngestionResult>,
+  replaceCollectionCover: (receivedCollectionId: string, imageBytes: Buffer) => Promise<CatalogCollectionCoverImageIngestionResult>,
 ): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   app.use("*", async (context, next) => {
@@ -214,6 +234,10 @@ function createCatalogImageTestApp(
       input.imageBytes,
     ),
     replaceCatalogPackageCoverImageFn: async () => createCatalogImageResult("cover"),
+    replaceCatalogCollectionCoverImageFn: async (input) => replaceCollectionCover(
+      input.collectionId,
+      input.imageBytes,
+    ),
   }));
   return app;
 }
@@ -228,18 +252,28 @@ test("catalog image routes authorize before validating raw bodies", async () => 
       processingCalls += 1;
       return createCatalogImageResult("diagram");
     },
+    async () => {
+      processingCalls += 1;
+      return createCatalogCollectionCoverResult();
+    },
   );
 
-  const response = await app.request(
-    `http://localhost/admin/catalog/packages/${packageId}/media-assets/images`,
-    { method: "POST", body: "not-an-image" },
-  );
-  assert.equal(response.status, 403);
+  for (const [path, method] of [
+    [`/admin/catalog/packages/${packageId}/media-assets/images`, "POST"],
+    [`/admin/catalog/collections/${collectionId}/cover`, "PUT"],
+  ] as const) {
+    const response = await app.request(
+      `http://localhost${path}`,
+      { method, body: "not-an-image" },
+    );
+    assert.equal(response.status, 403);
+  }
   assert.equal(processingCalls, 0);
 });
 
 test("catalog image routes validate raw input and never expose media blob IDs", async () => {
   let cardCalls = 0;
+  let collectionCalls = 0;
   const app = createCatalogImageTestApp(
     async () => createAdminRequestContext(),
     async (packageMediaKey, imageBytes) => {
@@ -247,6 +281,12 @@ test("catalog image routes validate raw input and never expose media blob IDs", 
       assert.equal(packageMediaKey, "diagram");
       assert.deepEqual(imageBytes, Buffer.from([1, 2, 3]));
       return createCatalogImageResult(packageMediaKey);
+    },
+    async (receivedCollectionId, imageBytes) => {
+      collectionCalls += 1;
+      assert.equal(receivedCollectionId, collectionId);
+      assert.deepEqual(imageBytes, Buffer.from([1, 2, 3]));
+      return createCatalogCollectionCoverResult();
     },
   );
   const invalidResponse = await app.request(
@@ -276,7 +316,21 @@ test("catalog image routes validate raw input and never expose media blob IDs", 
     assert.equal(response.status, method === "POST" ? 201 : 200);
     assert.equal("mediaBlobId" in payload.mediaAsset, false);
   }
+  const collectionResponse = await app.request(
+    `http://localhost/admin/catalog/collections/${collectionId}/cover`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "image/png" },
+      body: Buffer.from([1, 2, 3]),
+    },
+  );
+  const collectionPayload = await collectionResponse.json() as Readonly<{
+    collectionCover: Readonly<Record<string, unknown>>;
+  }>;
+  assert.equal(collectionResponse.status, 200);
+  assert.equal("coverMediaBlobId" in collectionPayload.collectionCover, false);
   assert.equal(cardCalls, 1);
+  assert.equal(collectionCalls, 1);
 });
 
 test("catalog image routes normalize ingestion deadline errors", async () => {
@@ -290,6 +344,7 @@ test("catalog image routes normalize ingestion deadline errors", async () => {
       async () => {
         throw error;
       },
+      async () => createCatalogCollectionCoverResult(),
     );
     const response = await app.request(
       `http://localhost/admin/catalog/packages/${packageId}/media-assets/images`,

--- a/apps/backend/src/routes/catalog/adminImageIngestion.ts
+++ b/apps/backend/src/routes/catalog/adminImageIngestion.ts
@@ -5,13 +5,19 @@ import {
 } from "../../admin/authz";
 import {
   ingestCatalogPackageCardImage,
+  replaceCatalogCollectionCoverImage,
   replaceCatalogPackageCoverImage,
+  type CatalogCollectionCoverImageIngestionInput,
+  type CatalogCollectionCoverImageIngestionResult,
   type CatalogPackageCardImageIngestionInput,
   type CatalogPackageCoverImageIngestionInput,
   type CatalogPackageImageIngestionResult,
 } from "../../catalog/authoring/imageIngestion";
 import { normalizePackageMediaKey } from "../../catalog/common";
-import type { CatalogPackageMediaAsset } from "../../catalog/types";
+import type {
+  CatalogCollectionCover,
+  CatalogPackageMediaAsset,
+} from "../../catalog/types";
 import {
   DatabaseDeadlineExceededError,
   runDatabaseOperationsWithDeadline,
@@ -39,12 +45,14 @@ import { expectUuidString } from "../../server/requestParsing";
 import { HttpError } from "../../shared/errors";
 
 type PublicCatalogPackageMediaAsset = Omit<CatalogPackageMediaAsset, "mediaBlobId">;
+type PublicCatalogCollectionCover = Omit<CatalogCollectionCover, "coverMediaBlobId">;
 
 export type CatalogAdminImageIngestionRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
   requireAdminRequestFn?: (request: Request, allowedOrigins: ReadonlyArray<string>) => Promise<CatalogAdminRequestContext>;
   ingestCatalogPackageCardImageFn?: (input: CatalogPackageCardImageIngestionInput) => Promise<CatalogPackageImageIngestionResult>;
   replaceCatalogPackageCoverImageFn?: (input: CatalogPackageCoverImageIngestionInput) => Promise<CatalogPackageImageIngestionResult>;
+  replaceCatalogCollectionCoverImageFn?: (input: CatalogCollectionCoverImageIngestionInput) => Promise<CatalogCollectionCoverImageIngestionResult>;
 }>;
 
 function parsePackageId(value: string | undefined): string {
@@ -55,6 +63,17 @@ function parsePackageId(value: string | undefined): string {
     return expectUuidString(value, "packageId");
   } catch {
     throw new HttpError(400, "packageId must be a UUID", "CATALOG_ADMIN_PARAM_INVALID");
+  }
+}
+
+function parseCollectionId(value: string | undefined): string {
+  if (value === undefined) {
+    throw new HttpError(400, "collectionId is required", "CATALOG_ADMIN_PARAM_REQUIRED");
+  }
+  try {
+    return expectUuidString(value, "collectionId");
+  } catch {
+    throw new HttpError(400, "collectionId must be a UUID", "CATALOG_ADMIN_PARAM_INVALID");
   }
 }
 
@@ -80,6 +99,14 @@ function toPublicCatalogPackageMediaAsset(
   const { mediaBlobId, ...publicMediaAsset } = mediaAsset;
   void mediaBlobId;
   return publicMediaAsset;
+}
+
+function toPublicCatalogCollectionCover(
+  collectionCover: CatalogCollectionCover,
+): PublicCatalogCollectionCover {
+  const { coverMediaBlobId, ...publicCollectionCover } = collectionCover;
+  void coverMediaBlobId;
+  return publicCollectionCover;
 }
 
 function createCatalogImageIngestionScope(context: Context<AppEnv>, userId: string | null): BackendObservationScope {
@@ -165,6 +192,25 @@ function addCatalogImageIngestionSuccess(
   });
 }
 
+function addCatalogCollectionCoverIngestionSuccess(
+  scope: BackendObservationScope,
+  result: CatalogCollectionCoverImageIngestionResult,
+  statusCode: number,
+): void {
+  addBackendRuntimeBreadcrumb({
+    action: "media_asset_image_ingest",
+    scope,
+    details: {
+      statusCode,
+      mediaAssetId: null,
+      collectionId: result.collectionCover.collectionId,
+      mimeType: result.mimeType,
+      sizeBytes: result.sizeBytes,
+      applied: result.applied,
+    },
+  });
+}
+
 function createRequestDeadline(): DirectImageIngestionRequestDeadline {
   const timing = getDirectImageIngestionRequestTiming()
     ?? createStandaloneDirectImageIngestionRequestTiming(Date.now());
@@ -179,6 +225,8 @@ export function createCatalogAdminImageIngestionRoutes(options: CatalogAdminImag
     ?? ingestCatalogPackageCardImage;
   const replaceCatalogPackageCoverImageFn = options.replaceCatalogPackageCoverImageFn
     ?? replaceCatalogPackageCoverImage;
+  const replaceCatalogCollectionCoverImageFn = options.replaceCatalogCollectionCoverImageFn
+    ?? replaceCatalogCollectionCoverImage;
 
   app.post("/admin/catalog/packages/:packageId/media-assets/images", async (context) => {
     const deadline = createRequestDeadline();
@@ -248,6 +296,44 @@ export function createCatalogAdminImageIngestionRoutes(options: CatalogAdminImag
       addCatalogImageIngestionSuccess(scope, result, 200);
       return context.json({
         mediaAsset: toPublicCatalogPackageMediaAsset(result.mediaAsset),
+      });
+    } catch (error) {
+      reportAndRethrowCatalogImageIngestionError(error, deadline, context, userId);
+    } finally {
+      deadline.dispose();
+    }
+  });
+
+  // TODO: Add future collection metadata/status and ordered-membership authoring.
+  app.put("/admin/catalog/collections/:collectionId/cover", async (context) => {
+    const deadline = createRequestDeadline();
+    let userId: string | null = null;
+    try {
+      const prepared = await runDatabaseOperationsWithDeadline(
+        deadline.preprocessingDeadlineAtMs,
+        async () => {
+          const admin = await requireAdminRequestFn(context.req.raw, options.allowedOrigins);
+          userId = admin.userId;
+          const collectionId = parseCollectionId(context.req.param("collectionId"));
+          const imageBytes = await readMediaAssetImageIngestionBytesWithAbortSignal(
+            context.req.raw,
+            deadline.preprocessingSignal,
+          );
+          return { collectionId, imageBytes };
+        },
+      );
+      deadline.disposePreprocessing();
+      const scope = createCatalogImageIngestionScope(context, userId);
+      const result = await replaceCatalogCollectionCoverImageFn({
+        collectionId: prepared.collectionId,
+        imageBytes: prepared.imageBytes,
+        deadlineAtMs: deadline.requestDeadlineAtMs,
+        signal: deadline.requestSignal,
+        observationScope: scope,
+      });
+      addCatalogCollectionCoverIngestionSuccess(scope, result, 200);
+      return context.json({
+        collectionCover: toPublicCatalogCollectionCover(result.collectionCover),
       });
     } catch (error) {
       reportAndRethrowCatalogImageIngestionError(error, deadline, context, userId);

--- a/apps/backend/src/server/mediaRequests/directImageIngestionRouting.test.ts
+++ b/apps/backend/src/server/mediaRequests/directImageIngestionRouting.test.ts
@@ -11,6 +11,8 @@ const directPath = `/workspaces/${workspaceId}/media-assets/images`;
 const catalogCardImagePath =
   `/admin/catalog/packages/${workspaceId}/media-assets/images`;
 const catalogCoverImagePath = `/admin/catalog/packages/${workspaceId}/cover`;
+const catalogCollectionCoverImagePath =
+  `/admin/catalog/collections/${workspaceId}/cover`;
 const multipartSessionId = "22222222-2222-4222-8222-222222222222";
 const multipartCompletionPath =
   `/workspaces/${workspaceId}/media-assets/upload-sessions/${multipartSessionId}/complete`;
@@ -83,16 +85,21 @@ test("shared Lambda matches every direct-image POST path across REST v1 and HTTP
   }
 });
 
-test("shared Lambda matches only PUT for the exact catalog cover path", () => {
+test("shared Lambda matches only PUT for the exact catalog cover paths", () => {
   const eventFactories = [createRestApiEvent, createHttpApiEvent] as const;
   for (const createEvent of eventFactories) {
-    assert.equal(matchesDirectImageTarget(createEvent(catalogCoverImagePath, "PUT")), true);
-    assert.equal(matchesDirectImageTarget(createEvent(`/v1${catalogCoverImagePath}/`, "PUT")), true);
-    assert.equal(matchesDirectImageTarget(createEvent(catalogCoverImagePath, "POST")), false);
-    assert.equal(
-      matchesDirectImageTarget(createEvent(`${catalogCoverImagePath}/unexpected`, "PUT")),
-      false,
-    );
+    for (const coverPath of [
+      catalogCoverImagePath,
+      catalogCollectionCoverImagePath,
+    ]) {
+      assert.equal(matchesDirectImageTarget(createEvent(coverPath, "PUT")), true);
+      assert.equal(matchesDirectImageTarget(createEvent(`/v1${coverPath}/`, "PUT")), true);
+      assert.equal(matchesDirectImageTarget(createEvent(coverPath, "POST")), false);
+      assert.equal(
+        matchesDirectImageTarget(createEvent(`${coverPath}/unexpected`, "PUT")),
+        false,
+      );
+    }
   }
 });
 
@@ -115,6 +122,7 @@ test("shared Lambda preserves other methods and unrelated shared routes", () => 
     ["missing workspace id", "/workspaces//media-assets/images", "POST"],
     ["discovery", "/v1/agent", "POST"],
     ["catalog card image wrong method", catalogCardImagePath, "PUT"],
+    ["collection cover wrong method", catalogCollectionCoverImagePath, "PATCH"],
   ] as const;
   const eventFactories = [createRestApiEvent, createHttpApiEvent] as const;
 

--- a/apps/backend/src/server/mediaRequests/directImageIngestionRouting.ts
+++ b/apps/backend/src/server/mediaRequests/directImageIngestionRouting.ts
@@ -4,6 +4,8 @@ const catalogCardImageIngestionPathPattern =
   /^\/(?:v1\/)*admin\/catalog\/packages\/[^/]+\/media-assets\/images\/?$/u;
 const catalogCoverImageIngestionPathPattern =
   /^\/(?:v1\/)*admin\/catalog\/packages\/[^/]+\/cover\/?$/u;
+const catalogCollectionCoverImageIngestionPathPattern =
+  /^\/(?:v1\/)*admin\/catalog\/collections\/[^/]+\/cover\/?$/u;
 
 export type RequestTarget = Readonly<{
   method: string;
@@ -52,7 +54,10 @@ export function isDirectImageIngestionTarget(
     )
   ) || (
     target.method === "PUT"
-    && catalogCoverImageIngestionPathPattern.test(target.path)
+    && (
+      catalogCoverImageIngestionPathPattern.test(target.path)
+      || catalogCollectionCoverImageIngestionPathPattern.test(target.path)
+    )
   );
 }
 

--- a/db/migrations/0110_collection_cover_media.sql
+++ b/db/migrations/0110_collection_cover_media.sql
@@ -1,0 +1,334 @@
+-- Current additive migration for independently owned catalog collection covers.
+-- Schemas touched/read explicitly: catalog, content, org, sync, pg_catalog.
+
+ALTER TABLE catalog.collections
+  ADD COLUMN cover_media_blob_id UUID
+    REFERENCES content.media_blobs(media_blob_id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_collections_cover_media_blob
+  ON catalog.collections(cover_media_blob_id)
+  WHERE cover_media_blob_id IS NOT NULL;
+
+COMMENT ON COLUMN catalog.collections.cover_media_blob_id IS
+  'Current independently uploaded collection cover; legacy cover_package_id remains available for backward compatibility.';
+
+CREATE FUNCTION content.fence_catalog_collection_cover_reference()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.cover_media_blob_id IS NOT NULL THEN
+      PERFORM content.fence_media_blob_reference(NEW.cover_media_blob_id);
+    END IF;
+  ELSIF NEW.cover_media_blob_id IS NOT NULL
+    AND NEW.cover_media_blob_id IS DISTINCT FROM OLD.cover_media_blob_id
+  THEN
+    PERFORM content.fence_media_blob_reference(NEW.cover_media_blob_id);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER collections_cover_media_blob_reference_fence
+BEFORE INSERT OR UPDATE OF cover_media_blob_id ON catalog.collections
+FOR EACH ROW
+EXECUTE FUNCTION content.fence_catalog_collection_cover_reference();
+
+CREATE FUNCTION content.lock_media_blob_lifecycles_for_reference_swap(
+  p_old_media_blob_id UUID,
+  p_new_media_blob_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  expected_count BIGINT;
+  locked_count BIGINT;
+BEGIN
+  IF p_new_media_blob_id IS NULL THEN
+    RAISE EXCEPTION 'p_new_media_blob_id is required' USING ERRCODE = '22023';
+  END IF;
+  expected_count := CASE
+    WHEN p_old_media_blob_id IS NULL
+      OR p_old_media_blob_id = p_new_media_blob_id
+    THEN 1
+    ELSE 2
+  END;
+  SELECT pg_catalog.count(*) INTO locked_count
+  FROM content.media_blobs AS blobs
+  WHERE blobs.media_blob_id = p_new_media_blob_id
+    OR blobs.media_blob_id = p_old_media_blob_id;
+  IF locked_count <> expected_count THEN
+    RAISE EXCEPTION 'Media blob reference swap targets a missing media blob'
+      USING ERRCODE = '23503';
+  END IF;
+
+  PERFORM 1
+  FROM content.media_blob_lifecycles AS lifecycles
+  INNER JOIN content.media_blobs AS blobs USING (sha256)
+  WHERE blobs.media_blob_id = p_new_media_blob_id
+    OR blobs.media_blob_id = p_old_media_blob_id
+  ORDER BY lifecycles.sha256
+  FOR UPDATE OF lifecycles;
+  GET DIAGNOSTICS locked_count = ROW_COUNT;
+  IF locked_count <> expected_count THEN
+    RAISE EXCEPTION 'Media blob reference swap targets missing lifecycle metadata'
+      USING ERRCODE = '23514';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION content.media_blob_has_active_reference_internal(
+  p_sha256 TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM content.media_assets AS assets
+    INNER JOIN content.media_blobs AS blobs
+      ON blobs.media_blob_id = assets.media_blob_id
+    WHERE blobs.sha256 = p_sha256
+      AND assets.deleted_at IS NULL
+  ) OR EXISTS (
+    SELECT 1
+    FROM catalog.package_media_assets AS assets
+    INNER JOIN content.media_blobs AS blobs
+      ON blobs.media_blob_id = assets.media_blob_id
+    WHERE blobs.sha256 = p_sha256
+  ) OR EXISTS (
+    SELECT 1
+    FROM catalog.collections AS collections
+    INNER JOIN content.media_blobs AS blobs
+      ON blobs.media_blob_id = collections.cover_media_blob_id
+    WHERE blobs.sha256 = p_sha256
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION content.terminalize_media_blob_writers_before_workspace_delete()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  owner_user_id TEXT;
+  affected_sha256s TEXT[];
+  affected_sha256 TEXT;
+  terminalized_at TIMESTAMPTZ;
+BEGIN
+  FOR owner_user_id IN
+    SELECT owners.user_id
+    FROM (
+      SELECT memberships.user_id
+      FROM org.workspace_memberships AS memberships
+      WHERE memberships.workspace_id = OLD.workspace_id
+      UNION
+      SELECT snapshots.user_id
+      FROM content.media_blob_writer_owner_snapshots AS snapshots
+      WHERE snapshots.workspace_id = OLD.workspace_id
+      UNION
+      SELECT attempts.user_id
+      FROM content.media_blob_writer_attempts AS attempts
+      WHERE attempts.workspace_id = OLD.workspace_id
+    ) AS owners
+    ORDER BY owners.user_id
+  LOOP
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+      pg_catalog.hashtextextended(
+        owner_user_id || ':' || OLD.workspace_id::TEXT,
+        0::BIGINT
+      )
+    );
+  END LOOP;
+
+  PERFORM 1
+  FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = OLD.workspace_id
+  ORDER BY sessions.media_upload_session_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM sync.workspace_sync_metadata AS metadata
+  WHERE metadata.workspace_id = OLD.workspace_id
+  FOR UPDATE;
+
+  SELECT pg_catalog.array_agg(DISTINCT writers.sha256 ORDER BY writers.sha256)
+  INTO affected_sha256s
+  FROM (
+    SELECT reservations.sha256
+    FROM content.media_blob_writer_reservations AS reservations
+    WHERE reservations.workspace_id = OLD.workspace_id
+      AND reservations.writer_kind IN (
+        'direct_ingestion',
+        'multipart_completion'
+      )
+    UNION
+    SELECT attempts.sha256
+    FROM content.media_blob_writer_attempts AS attempts
+    WHERE attempts.workspace_id = OLD.workspace_id
+  ) AS writers;
+
+  IF affected_sha256s IS NULL THEN
+    RETURN OLD;
+  END IF;
+
+  FOREACH affected_sha256 IN ARRAY affected_sha256s
+  LOOP
+    PERFORM 1
+    FROM content.media_blob_lifecycles AS lifecycles
+    WHERE lifecycles.sha256 = affected_sha256
+    FOR UPDATE;
+  END LOOP;
+
+  PERFORM 1
+  FROM content.media_blob_writer_reservations AS reservations
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN (
+      'direct_ingestion',
+      'multipart_completion'
+    )
+  ORDER BY
+    reservations.sha256,
+    reservations.writer_kind,
+    reservations.media_asset_id,
+    reservations.operation_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_blob_writer_owner_snapshots AS snapshots
+  WHERE snapshots.workspace_id = OLD.workspace_id
+  ORDER BY snapshots.reservation_token
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_blob_writer_attempts AS attempts
+  WHERE attempts.workspace_id = OLD.workspace_id
+  ORDER BY
+    attempts.writer_kind,
+    attempts.media_asset_id,
+    attempts.operation_id,
+    attempts.attempt_token
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_assets AS assets
+  WHERE assets.workspace_id = OLD.workspace_id
+  ORDER BY assets.media_asset_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM content.media_blobs AS blobs
+  WHERE blobs.sha256 = ANY(affected_sha256s)
+  ORDER BY blobs.sha256
+  FOR SHARE;
+
+  DELETE FROM content.media_upload_sessions AS sessions
+  WHERE sessions.workspace_id = OLD.workspace_id;
+
+  DELETE FROM content.media_assets AS assets
+  WHERE assets.workspace_id = OLD.workspace_id;
+
+  UPDATE content.media_blob_writer_reservations AS reservations
+  SET state = 'unreferenced'
+  WHERE reservations.workspace_id = OLD.workspace_id
+    AND reservations.writer_kind IN (
+      'direct_ingestion',
+      'multipart_completion'
+    )
+    AND reservations.state <> 'unreferenced';
+
+  terminalized_at := pg_catalog.clock_timestamp();
+
+  UPDATE content.media_blob_writer_attempts AS attempts
+  SET
+    state = 'cancelled',
+    outcome = 'aborted',
+    terminal_at = terminalized_at
+  WHERE attempts.workspace_id = OLD.workspace_id
+    AND attempts.state = 'leased';
+
+  UPDATE content.media_blob_lifecycles AS lifecycles
+  SET
+    cleanup_eligible_at = GREATEST(
+      COALESCE(
+        lifecycles.cleanup_eligible_at,
+        '-infinity'::TIMESTAMPTZ
+      ),
+      terminalized_at + interval '1 hour'
+    ),
+    cleanup_lease_token = CASE
+      WHEN lifecycles.cleanup_lease_expires_at =
+        'infinity'::TIMESTAMPTZ
+      THEN lifecycles.cleanup_lease_token
+      ELSE NULL
+    END,
+    cleanup_lease_expires_at = CASE
+      WHEN lifecycles.cleanup_lease_expires_at =
+        'infinity'::TIMESTAMPTZ
+      THEN lifecycles.cleanup_lease_expires_at
+      ELSE NULL
+    END,
+    updated_at = terminalized_at
+  WHERE lifecycles.sha256 = ANY(affected_sha256s)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM content.media_assets AS assets
+      INNER JOIN content.media_blobs AS blobs
+        ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256
+        AND assets.deleted_at IS NULL
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM catalog.package_media_assets AS assets
+      INNER JOIN content.media_blobs AS blobs
+        ON blobs.media_blob_id = assets.media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM catalog.collections AS collections
+      INNER JOIN content.media_blobs AS blobs
+        ON blobs.media_blob_id = collections.cover_media_blob_id
+      WHERE blobs.sha256 = lifecycles.sha256
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM content.media_blob_writer_reservations AS reservations
+      WHERE reservations.sha256 = lifecycles.sha256
+        AND reservations.state NOT IN ('finalized', 'unreferenced')
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM content.media_blob_writer_attempts AS attempts
+      WHERE attempts.sha256 = lifecycles.sha256
+        AND attempts.state = 'leased'
+    );
+
+  RETURN OLD;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION content.fence_catalog_collection_cover_reference()
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.lock_media_blob_lifecycles_for_reference_swap(UUID, UUID)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION content.media_blob_has_active_reference_internal(TEXT)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.terminalize_media_blob_writers_before_workspace_delete()
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+GRANT EXECUTE ON FUNCTION
+  content.lock_media_blob_lifecycles_for_reference_swap(UUID, UUID)
+TO backend_app;

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -244,6 +244,12 @@ test("direct ingestion routes keep shared workspace and catalog admin fallbacks"
   );
   assert.doesNotThrow(() => routes.catalogCover.node.findChild("ANY"));
   assert.doesNotThrow(() => routes.catalogCover.node.findChild("PUT"));
+  assert.equal(
+    routes.catalogCollectionCover.path,
+    "/admin/catalog/collections/{collectionId}/cover",
+  );
+  assert.doesNotThrow(() => routes.catalogCollectionCover.node.findChild("ANY"));
+  assert.doesNotThrow(() => routes.catalogCollectionCover.node.findChild("PUT"));
   const workspaces = restApi.root.getResource("workspaces");
   const workspace = workspaces?.getResource("{workspaceId}");
   const mediaAssets = workspace?.getResource("media-assets");
@@ -254,10 +260,13 @@ test("direct ingestion routes keep shared workspace and catalog admin fallbacks"
   const packages = catalog?.getResource("packages");
   const catalogPackage = packages?.getResource("{packageId}");
   const packageMediaAssets = catalogPackage?.getResource("media-assets");
+  const collections = catalog?.getResource("collections");
+  const catalogCollection = collections?.getResource("{collectionId}");
   assert.notEqual(admin?.getResource("{proxy+}"), undefined);
   assert.notEqual(catalog?.getResource("{proxy+}"), undefined);
   assert.notEqual(catalogPackage?.getResource("{proxy+}"), undefined);
   assert.notEqual(packageMediaAssets?.getResource("{proxy+}"), undefined);
+  assert.notEqual(catalogCollection?.getResource("{proxy+}"), undefined);
 });
 
 test("custom-domain mapping strips one v1 segment before direct route selection", () => {

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -108,6 +108,7 @@ export type DirectImageIngestionApiRoutes = Readonly<{
   workspaceImages: apigw.Resource;
   catalogCardImages: apigw.Resource;
   catalogCover: apigw.Resource;
+  catalogCollectionCover: apigw.Resource;
 }>;
 
 export function addDirectImageIngestionApiRoutes(
@@ -147,10 +148,20 @@ export function addDirectImageIngestionApiRoutes(
   const catalogCover = catalogPackage.addResource("cover");
   catalogCover.addMethod("ANY", sharedIntegration);
   catalogCover.addMethod("PUT", directIntegration);
+
+  const collections = catalog.addResource("collections");
+  collections.addMethod("ANY", sharedIntegration);
+  const catalogCollection = collections.addResource("{collectionId}");
+  catalogCollection.addMethod("ANY", sharedIntegration);
+  catalogCollection.addResource("{proxy+}").addMethod("ANY", sharedIntegration);
+  const catalogCollectionCover = catalogCollection.addResource("cover");
+  catalogCollectionCover.addMethod("ANY", sharedIntegration);
+  catalogCollectionCover.addMethod("PUT", directIntegration);
   return {
     workspaceImages: directImages,
     catalogCardImages,
     catalogCover,
+    catalogCollectionCover,
   };
 }
 

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0109_catalog_image_blob_ingestion.sql",
+    "0110_collection_cover_media.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0109_catalog_image_blob_ingestion.sql"
+    && resource.Properties?.RequiredMigration === "0110_collection_cover_media.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -107,7 +107,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
       "mediaBlobCleanupEnabled=false",
     );
     const migration = source.indexOf(
-      "--require-migration 0109_catalog_image_blob_ingestion.sql",
+      "--require-migration 0110_collection_cover_media.sql",
     );
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0109_catalog_image_blob_ingestion.sql",
+    "--require-migration 0110_collection_cover_media.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -235,7 +235,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0109_catalog_image_blob_ingestion\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0110_collection_cover_media\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");
@@ -260,7 +260,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const bootstrapMigration = bootstrapScript.indexOf(
-    "--require-migration 0109_catalog_image_blob_ingestion.sql",
+    "--require-migration 0110_collection_cover_media.sql",
   );
   const bootstrapEnabled = bootstrapScript.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -340,7 +340,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0109_catalog_image_blob_ingestion.sql",
+      "0110_collection_cover_media.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,
@@ -369,6 +369,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       userPoolClientId: authResult.userPoolClient.userPoolClientId,
     });
     addDatabaseMigrationDependency(api.backendFn, migrationGate);
+    addDatabaseMigrationDependency(api.directImageIngestionFn, migrationGate);
     const web = webApp(this, {
       baseDomain,
       webCertificateArnUsEast1,

--- a/scripts/deploy/bootstrap.sh
+++ b/scripts/deploy/bootstrap.sh
@@ -146,7 +146,7 @@ npx cdk deploy --all --require-approval never \
 echo "=== Verify required database migration ==="
 bash "${ROOT_DIR}/scripts/deploy/migrate-aws.sh" \
   --stack-name "$STACK_NAME" \
-  --require-migration 0109_catalog_image_blob_ingestion.sql
+  --require-migration 0110_collection_cover_media.sql
 
 echo "=== CDK deploy with reconciliation schedule enabled ==="
 npx cdk deploy --all --require-approval never \


### PR DESCRIPTION
## Summary

- add migration 0110 for nullable collection cover media references, active-reference fencing, lifecycle cleanup, and deterministic lifecycle lock ordering
- add admin collection-cover ingestion through the existing catalog JPEG normalization path and the exact direct Lambda/API Gateway route
- advance migration gates and deployment dependencies, including gating the direct image-ingestion Lambda on migration 0110
- add focused integration and boundary coverage without exposing collection covers publicly or adding collection CRUD/versioning

## Review

- first fresh review found two P2 findings: a missing direct-image Lambda migration dependency and opposite-order lifecycle lock deadlock risk
- both findings were fixed with the Lambda migration dependency and SHA-ordered lifecycle locks before reference mutation
- second fresh review found no P0-P4 findings
- reviewed patch is one coherent collection-cover unit; 857 meaningful lines, 57 above the rough target due to the selected deployment and concurrency fixes

## Checks

- not run locally, per repository rules for project tests, lint, typecheck, builds, formatters, migrations, and validation scripts