### PR TITLE
feat: expose public collection covers

### DIFF
--- a/apps/backend/src/catalog/distribution/public/collectionMedia.test.ts
+++ b/apps/backend/src/catalog/distribution/public/collectionMedia.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../../../database";
+import { createCatalogPublicRoutes } from "../../../routes/catalog/public";
+import { HttpError } from "../../../shared/errors";
+import { maximumPublicCatalogMediaDownloadBytes } from "../../publicMediaDelivery";
+import { createQueryResult } from "../../testSupport";
+import type { CatalogPublicCollectionCoverDownloadSource } from "../../types";
+import {
+  loadPublicCatalogCollectionCoverForDownloadInExecutor,
+} from "./index";
+import { createPublicCatalogRouteTestApp } from "./testSupport";
+
+const collectionId = "99999999-1111-4111-8111-111111111111";
+const coverMediaBlobId = "99999999-2222-4222-8222-222222222222";
+const coverSha256 = "b".repeat(64);
+const coverStorageKey = `media/blobs/sha256/bb/bb/${coverSha256}`;
+
+const collectionCoverRow = {
+  collection_id: collectionId,
+  cover_media_blob_id: coverMediaBlobId,
+  mime_type: "image/jpeg",
+  size_bytes: 3,
+  storage_key: coverStorageKey,
+  sha256: coverSha256,
+} as const;
+
+const collectionCoverDownloadSource: CatalogPublicCollectionCoverDownloadSource = {
+  collectionCover: {
+    collectionId,
+    mimeType: "image/jpeg",
+    sizeBytes: 3,
+  },
+  storageKey: coverStorageKey,
+  sha256: coverSha256,
+};
+
+test("public collection cover lookup requires public visibility and keeps private storage internal", async () => {
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      assert.match(text, /collections\.collection_id = \$1/);
+      assert.match(text, /collections\.status = 'published'/);
+      assert.match(text, /collections\.delisted_at IS NULL/);
+      assert.match(text, /LEFT JOIN content\.media_blobs AS media_blobs/);
+      assert.deepEqual(params, [collectionId]);
+      return createQueryResult([collectionCoverRow as unknown as Row]);
+    },
+  };
+
+  const source = await loadPublicCatalogCollectionCoverForDownloadInExecutor(
+    executor,
+    collectionId,
+  );
+
+  assert.deepEqual(source, collectionCoverDownloadSource);
+  assert.doesNotMatch(
+    JSON.stringify(source.collectionCover),
+    /coverMediaBlobId|mediaBlobId|storageKey|storage_key|media\/blobs|sha256/,
+  );
+});
+
+const unavailableCoverFixtures = [
+  {
+    name: "unpublished, delisted, or missing collection",
+    rows: [],
+    statusCode: 404,
+    code: "CATALOG_PUBLIC_COLLECTION_COVER_NOT_FOUND",
+  },
+  {
+    name: "collection without an independent cover",
+    rows: [{
+      ...collectionCoverRow,
+      cover_media_blob_id: null,
+      mime_type: null,
+      size_bytes: null,
+      storage_key: null,
+      sha256: null,
+    }],
+    statusCode: 404,
+    code: "CATALOG_PUBLIC_COLLECTION_COVER_NOT_FOUND",
+  },
+  {
+    name: "missing referenced media blob",
+    rows: [{
+      ...collectionCoverRow,
+      mime_type: null,
+      size_bytes: null,
+      storage_key: null,
+      sha256: null,
+    }],
+    statusCode: 409,
+    code: "CATALOG_PUBLIC_COLLECTION_COVER_MEDIA_NOT_FOUND",
+  },
+  {
+    name: "unsupported media type",
+    rows: [{ ...collectionCoverRow, mime_type: "text/plain" }],
+    statusCode: 415,
+    code: "CATALOG_PUBLIC_COLLECTION_COVER_UNSUPPORTED_TYPE",
+  },
+  {
+    name: "oversized media",
+    rows: [{
+      ...collectionCoverRow,
+      size_bytes: maximumPublicCatalogMediaDownloadBytes + 1,
+    }],
+    statusCode: 413,
+    code: "CATALOG_PUBLIC_COLLECTION_COVER_TOO_LARGE",
+  },
+  {
+    name: "non-canonical private storage",
+    rows: [{ ...collectionCoverRow, storage_key: "media/uploads/private-cover" }],
+    statusCode: 409,
+    code: "CATALOG_PUBLIC_COLLECTION_COVER_STORAGE_INVALID",
+  },
+] as const;
+
+for (const fixture of unavailableCoverFixtures) {
+  test(`public collection cover lookup rejects ${fixture.name} specifically`, async () => {
+    const executor: DatabaseExecutor = {
+      async query<Row extends pg.QueryResultRow>(
+        text: string,
+        params: ReadonlyArray<SqlValue>,
+      ): Promise<pg.QueryResult<Row>> {
+        assert.match(text, /collections\.status = 'published'/);
+        assert.match(text, /collections\.delisted_at IS NULL/);
+        assert.deepEqual(params, [collectionId]);
+        return createQueryResult(fixture.rows as unknown as ReadonlyArray<Row>);
+      },
+    };
+
+    await assert.rejects(
+      loadPublicCatalogCollectionCoverForDownloadInExecutor(executor, collectionId),
+      (error: unknown) => {
+        assert.ok(error instanceof HttpError);
+        assert.equal(error.statusCode, fixture.statusCode);
+        assert.equal(error.code, fixture.code);
+        assert.doesNotMatch(
+          error.message,
+          /coverMediaBlobId|mediaBlobId|storageKey|storage_key|media\/blobs|sha256/,
+        );
+        return true;
+      },
+    );
+  });
+}
+
+test("public collection cover routes return a backend URL and proxy verified bytes", async () => {
+  let lookupCount = 0;
+  let loadedStorageKey: string | null = null;
+  const app = createPublicCatalogRouteTestApp(createCatalogPublicRoutes({
+    loadPublicCatalogCollectionCoverForDownloadFn: async (requestedCollectionId) => {
+      lookupCount += 1;
+      assert.equal(requestedCollectionId, collectionId);
+      return collectionCoverDownloadSource;
+    },
+    loadMediaAssetObjectBytesFn: async (input) => {
+      loadedStorageKey = input.storageKey;
+      assert.equal(input.workspaceId, collectionId);
+      assert.equal(input.mediaAssetId, "cover");
+      assert.equal(input.mimeType, "image/jpeg");
+      assert.equal(input.sizeBytes, 3);
+      assert.equal(input.sha256, coverSha256);
+      assert.equal(input.maxByteSize, maximumPublicCatalogMediaDownloadBytes);
+      return {
+        bytes: Buffer.from([1, 2, 3]),
+        mimeType: "image/jpeg",
+        sizeBytes: 3,
+        sha256: coverSha256,
+      };
+    },
+  }));
+
+  const urlResponse = await app.request(
+    `http://localhost:8080/catalog/collections/${collectionId}/cover/download-url`,
+  );
+  const urlPayload = await urlResponse.json() as Readonly<Record<string, unknown>>;
+  assert.equal(urlResponse.status, 200);
+  assert.deepEqual(urlPayload, {
+    collectionCover: collectionCoverDownloadSource.collectionCover,
+    download: {
+      method: "GET",
+      url: `http://localhost:8080/v1/catalog/collections/${collectionId}/cover/download`,
+      expiresAt: null,
+      rangeRequests: false,
+    },
+  });
+  assert.doesNotMatch(
+    JSON.stringify(urlPayload),
+    /coverMediaBlobId|mediaBlobId|storageKey|storage_key|media\/blobs|sha256/,
+  );
+
+  const bytesResponse = await app.request(
+    `http://localhost:8080/catalog/collections/${collectionId}/cover/download`,
+  );
+  assert.equal(bytesResponse.status, 200);
+  assert.equal(lookupCount, 2);
+  assert.equal(loadedStorageKey, coverStorageKey);
+  assert.equal(bytesResponse.headers.get("content-type"), "image/jpeg");
+  assert.equal(bytesResponse.headers.get("content-length"), "3");
+  assert.deepEqual(Buffer.from(await bytesResponse.arrayBuffer()), Buffer.from([1, 2, 3]));
+});
+
+test("public collection cover byte route maps a missing private object to a catalog error", async () => {
+  const app = createPublicCatalogRouteTestApp(createCatalogPublicRoutes({
+    loadPublicCatalogCollectionCoverForDownloadFn: async () => collectionCoverDownloadSource,
+    loadMediaAssetObjectBytesFn: async () => {
+      throw new HttpError(
+        409,
+        `Completed media upload is not available for workspaceId=${collectionId} mediaAssetId=cover.`,
+        "MEDIA_ASSET_UPLOAD_NOT_FOUND",
+      );
+    },
+  }));
+
+  const response = await app.request(
+    `http://localhost:8080/catalog/collections/${collectionId}/cover/download`,
+  );
+  const payload = await response.json() as Readonly<Record<string, unknown>>;
+  assert.equal(response.status, 409);
+  assert.equal(payload.code, "CATALOG_PUBLIC_COLLECTION_COVER_OBJECT_NOT_FOUND");
+  assert.doesNotMatch(
+    JSON.stringify(payload),
+    /coverMediaBlobId|mediaBlobId|storageKey|storage_key|media\/blobs|sha256/,
+  );
+});

--- a/apps/backend/src/catalog/distribution/public/collectionMedia.ts
+++ b/apps/backend/src/catalog/distribution/public/collectionMedia.ts
@@ -1,0 +1,163 @@
+import type { DatabaseExecutor } from "../../../database";
+import { unsafeRepeatableReadReadOnlyTransaction } from "../../../database/core";
+import { buildMediaBlobStorageKey } from "../../../mediaAssets/storageKeys";
+import { HttpError } from "../../../shared/errors";
+import { getPublicCatalogMediaDeliveryIssue } from "../../publicMediaDelivery";
+import { isPublicCatalogTextSafe } from "../../publicSafety";
+import type { CatalogPublicCollectionCoverDownloadSource } from "../../types";
+
+type CatalogPublicCollectionCoverRow = Readonly<{
+  collection_id: string;
+  cover_media_blob_id: string | null;
+  mime_type: string | null;
+  size_bytes: string | number | null;
+  storage_key: string | null;
+  sha256: string | null;
+}>;
+
+const sha256Pattern = /^[0-9a-f]{64}$/u;
+
+function mapPublicCatalogCollectionCover(
+  row: CatalogPublicCollectionCoverRow,
+): CatalogPublicCollectionCoverDownloadSource {
+  if (row.cover_media_blob_id === null) {
+    throw new HttpError(
+      404,
+      `Published catalog collection cover not found. collectionId=${row.collection_id}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_NOT_FOUND",
+    );
+  }
+  if (
+    row.mime_type === null
+    || row.size_bytes === null
+    || row.storage_key === null
+    || row.sha256 === null
+  ) {
+    throw new HttpError(
+      409,
+      `Published catalog collection cover references missing media. collectionId=${row.collection_id}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_MEDIA_NOT_FOUND",
+    );
+  }
+  if (isPublicCatalogTextSafe(row.mime_type) === false) {
+    throw new HttpError(
+      409,
+      `Published catalog collection cover metadata is not public-safe. collectionId=${row.collection_id}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_METADATA_NOT_PUBLIC",
+    );
+  }
+
+  const sizeBytes = typeof row.size_bytes === "number"
+    ? row.size_bytes
+    : Number(row.size_bytes);
+  if (Number.isSafeInteger(sizeBytes) === false || sizeBytes < 0) {
+    throw new HttpError(
+      409,
+      `Published catalog collection cover has an invalid byte size. collectionId=${row.collection_id}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_SIZE_INVALID",
+    );
+  }
+  if (
+    sha256Pattern.test(row.sha256) === false
+    || row.storage_key !== buildMediaBlobStorageKey(row.sha256)
+  ) {
+    throw new HttpError(
+      409,
+      `Published catalog collection cover is outside private blob storage. collectionId=${row.collection_id}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_STORAGE_INVALID",
+    );
+  }
+
+  const deliveryIssue = getPublicCatalogMediaDeliveryIssue({
+    mimeType: row.mime_type,
+    sizeBytes,
+  });
+  if (deliveryIssue?.reason === "too_large") {
+    throw new HttpError(
+      413,
+      `Published catalog collection cover is too large for public delivery. collectionId=${row.collection_id}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_TOO_LARGE",
+    );
+  }
+  if (deliveryIssue?.reason === "unsupported_mime_type") {
+    throw new HttpError(
+      415,
+      `Published catalog collection cover type is not supported for public delivery. collectionId=${row.collection_id}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_UNSUPPORTED_TYPE",
+    );
+  }
+
+  return {
+    collectionCover: {
+      collectionId: row.collection_id,
+      mimeType: row.mime_type,
+      sizeBytes,
+    },
+    storageKey: row.storage_key,
+    sha256: row.sha256,
+  };
+}
+
+const publicCollectionCoverSelect = [
+  "SELECT",
+  "collections.collection_id AS collection_id,",
+  "collections.cover_media_blob_id AS cover_media_blob_id,",
+  "media_blobs.mime_type AS mime_type,",
+  "media_blobs.size_bytes AS size_bytes,",
+  "media_blobs.storage_key AS storage_key,",
+  "media_blobs.sha256 AS sha256",
+  "FROM catalog.collections AS collections",
+  "LEFT JOIN content.media_blobs AS media_blobs",
+  "ON media_blobs.media_blob_id = collections.cover_media_blob_id",
+] as const;
+
+export async function loadPublicCatalogCollectionCoversInExecutor(
+  executor: DatabaseExecutor,
+): Promise<ReadonlyArray<CatalogPublicCollectionCoverDownloadSource>> {
+  const result = await executor.query<CatalogPublicCollectionCoverRow>(
+    [
+      ...publicCollectionCoverSelect,
+      "WHERE collections.cover_media_blob_id IS NOT NULL",
+      "AND collections.status = 'published'",
+      "AND collections.delisted_at IS NULL",
+      "ORDER BY collections.collection_id ASC",
+    ].join(" "),
+    [],
+  );
+
+  return result.rows.map(mapPublicCatalogCollectionCover);
+}
+
+export async function loadPublicCatalogCollectionCoverForDownloadInExecutor(
+  executor: DatabaseExecutor,
+  collectionId: string,
+): Promise<CatalogPublicCollectionCoverDownloadSource> {
+  const result = await executor.query<CatalogPublicCollectionCoverRow>(
+    [
+      ...publicCollectionCoverSelect,
+      "WHERE collections.collection_id = $1",
+      "AND collections.status = 'published'",
+      "AND collections.delisted_at IS NULL",
+      "LIMIT 1",
+    ].join(" "),
+    [collectionId],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new HttpError(
+      404,
+      `Published catalog collection cover not found. collectionId=${collectionId}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_NOT_FOUND",
+    );
+  }
+
+  return mapPublicCatalogCollectionCover(row);
+}
+
+export async function loadPublicCatalogCollectionCoverForDownload(
+  collectionId: string,
+): Promise<CatalogPublicCollectionCoverDownloadSource> {
+  return unsafeRepeatableReadReadOnlyTransaction(async (executor) => (
+    loadPublicCatalogCollectionCoverForDownloadInExecutor(executor, collectionId)
+  ));
+}

--- a/apps/backend/src/catalog/distribution/public/index.ts
+++ b/apps/backend/src/catalog/distribution/public/index.ts
@@ -9,6 +9,11 @@ export {
   normalizeCatalogPublicPackageListInput,
 } from "./browse";
 export {
+  loadPublicCatalogCollectionCoverForDownload,
+  loadPublicCatalogCollectionCoverForDownloadInExecutor,
+  loadPublicCatalogCollectionCoversInExecutor,
+} from "./collectionMedia";
+export {
   loadPublicCatalogPackageMediaAssetsInExecutor,
   loadPublicCatalogPackageMediaForDownload,
   loadPublicCatalogPackageMediaForDownloadInExecutor,

--- a/apps/backend/src/catalog/distribution/public/public.postgres.integration.ts
+++ b/apps/backend/src/catalog/distribution/public/public.postgres.integration.ts
@@ -98,6 +98,7 @@ test("latest migrations expose the deterministic collection through the public c
     assert.deepEqual(cards.map((card) => card.packageCardId), fixtureCardIds);
     assert.deepEqual(cards.map((card) => card.ordinal), [1, 2]);
     assert.equal(collection?.coverPackageId, fixturePackageId);
+    assert.equal("coverDownloadUrl" in (collection ?? {}), false);
     assert.deepEqual(collectionPackage, {
       collectionId: fixtureCollectionId,
       packageId: fixturePackageId,

--- a/apps/backend/src/catalog/distribution/public/public.ts
+++ b/apps/backend/src/catalog/distribution/public/public.ts
@@ -1,6 +1,9 @@
 export {
   listPublicCatalogPackages,
   listPublicCatalogPackagesInExecutor,
+  loadPublicCatalogCollectionCoverForDownload,
+  loadPublicCatalogCollectionCoverForDownloadInExecutor,
+  loadPublicCatalogCollectionCoversInExecutor,
   loadPublicCatalogPackageDetail,
   loadPublicCatalogPackageDetailInExecutor,
   loadPublicCatalogPackageMediaAssetsInExecutor,

--- a/apps/backend/src/catalog/distribution/public/snapshot.test.ts
+++ b/apps/backend/src/catalog/distribution/public/snapshot.test.ts
@@ -39,6 +39,8 @@ test("public catalog snapshot resolves Markdown-only media and excludes incomple
   const unsafeCollectionId = "66666666-6666-4666-8666-666666666666";
   const firstCollectionId = "99999999-8888-4888-8888-888888888888";
   const secondCollectionId = "99999999-9999-4999-8999-999999999999";
+  const collectionCoverSha256 = "b".repeat(64);
+  const collectionCoverStorageKey = `media/blobs/sha256/bb/bb/${collectionCoverSha256}`;
   const privateCoverMediaKey = testWorkspaceMediaAssetId;
   const publicApiBaseUrl = "https://api.example.com/v1";
   const publicAppBaseUrl = "https://app.example.com";
@@ -115,6 +117,19 @@ test("public catalog snapshot resolves Markdown-only media and excludes incomple
       params: ReadonlyArray<SqlValue>,
     ): Promise<pg.QueryResult<Row>> {
       assert.deepEqual(params, []);
+      if (text.includes("WHERE collections.cover_media_blob_id IS NOT NULL")) {
+        assert.match(text, /LEFT JOIN content\.media_blobs AS media_blobs/);
+        assert.match(text, /collections\.status = 'published'/);
+        assert.match(text, /collections\.delisted_at IS NULL/);
+        return createQueryResult([{
+          collection_id: firstCollectionId,
+          cover_media_blob_id: "99999999-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          mime_type: "image/jpeg",
+          size_bytes: 1_234,
+          storage_key: collectionCoverStorageKey,
+          sha256: collectionCoverSha256,
+        }] as unknown as ReadonlyArray<Row>);
+      }
       if (text.includes("FROM catalog.collection_packages AS memberships")) {
         assert.match(text, /collections\.status = 'published'/);
         assert.match(text, /packages\.status = 'published'/);
@@ -282,7 +297,12 @@ test("public catalog snapshot resolves Markdown-only media and excludes incomple
     { collectionId: secondCollectionId, packageId: testPackageId, ordinal: 3 },
   ]);
   assert.equal(snapshot.collections[0]?.coverPackageId, testPackageId);
+  assert.equal(
+    snapshot.collections[0]?.coverDownloadUrl,
+    `${publicApiBaseUrl}/catalog/collections/${firstCollectionId}/cover/download`,
+  );
   assert.equal(snapshot.collections[1]?.coverPackageId, null);
+  assert.equal("coverDownloadUrl" in (snapshot.collections[1] ?? {}), false);
 
   const authorIds = new Set(snapshot.authors.map((author) => author.authorId));
   const packageIds = new Set(snapshot.packages.map((catalogPackage) => catalogPackage.packageId));
@@ -320,6 +340,7 @@ test("public catalog snapshot resolves Markdown-only media and excludes incomple
   assert.doesNotMatch(JSON.stringify(snapshot), new RegExp(unsafeOnlyPackageCardId));
   assert.doesNotMatch(JSON.stringify(snapshot), new RegExp(unsafeCollectionId));
   assert.doesNotMatch(JSON.stringify(snapshot), new RegExp(unsafeStorageKeyPathDestination));
+  assert.doesNotMatch(JSON.stringify(snapshot), /cover_media_blob_id|storage_key|media\/blobs|sha256/);
 });
 
 const ineligibleSnapshotPublicRelationFixtures: ReadonlyArray<readonly [
@@ -372,6 +393,9 @@ for (const [fixtureName, relationPatch] of ineligibleSnapshotPublicRelationFixtu
         params: ReadonlyArray<SqlValue>,
       ): Promise<pg.QueryResult<Row>> {
         assert.deepEqual(params, []);
+        if (text.includes("WHERE collections.cover_media_blob_id IS NOT NULL")) {
+          return createQueryResult([]);
+        }
         if (text.includes("FROM catalog.collection_packages AS memberships")) {
           return createQueryResult([{
             collection_id: collectionId,
@@ -481,6 +505,9 @@ for (const [fixtureName, ineligibleFixture] of ineligibleSnapshotMediaFixtures) 
         params: ReadonlyArray<SqlValue>,
       ): Promise<pg.QueryResult<Row>> {
         assert.deepEqual(params, []);
+        if (text.includes("WHERE collections.cover_media_blob_id IS NOT NULL")) {
+          return createQueryResult([]);
+        }
         if (text.includes("FROM catalog.collection_packages AS memberships")) {
           return createQueryResult([
             {
@@ -684,4 +711,3 @@ test("public catalog snapshot route serves the exact unversioned catalog path", 
     }
   }
 });
-

--- a/apps/backend/src/catalog/distribution/public/snapshot.ts
+++ b/apps/backend/src/catalog/distribution/public/snapshot.ts
@@ -28,6 +28,7 @@ import type {
   TimestampValue,
 } from "../../types";
 import { catalogPublicSnapshotSchemaVersion } from "../../types";
+import { loadPublicCatalogCollectionCoversInExecutor } from "./collectionMedia";
 
 type PublicCatalogQuery = Readonly<{
   text: string;
@@ -369,6 +370,20 @@ function buildSnapshotMediaDownloadUrl(
   ].join("/");
 }
 
+function buildSnapshotCollectionCoverDownloadUrl(
+  publicApiBaseUrl: string,
+  collectionId: string,
+): string {
+  return [
+    publicApiBaseUrl,
+    "catalog",
+    "collections",
+    collectionId,
+    "cover",
+    "download",
+  ].join("/");
+}
+
 function getSnapshotCardRequiredMediaAssetKeys(
   row: CatalogPublicSnapshotCardRow,
 ): ReadonlyArray<string> {
@@ -695,6 +710,8 @@ function assertPublicSnapshotCollectionTextSafe(
 function mapCatalogPublicSnapshotCollections(
   rows: ReadonlyArray<CatalogPublicSnapshotCollectionRow>,
   publicPackageIds: ReadonlySet<string>,
+  collectionCoverIds: ReadonlySet<string>,
+  publicApiBaseUrl: string,
 ): ReadonlyArray<CatalogPublicSnapshotCollection> {
   return rows.map((row) => {
     assertPublicSnapshotCollectionTextSafe(row.collection_id, row.slug);
@@ -719,6 +736,12 @@ function mapCatalogPublicSnapshotCollections(
       coverPackageId: row.cover_package_id !== null && publicPackageIds.has(row.cover_package_id)
         ? row.cover_package_id
         : null,
+      ...(collectionCoverIds.has(row.collection_id) ? {
+        coverDownloadUrl: buildSnapshotCollectionCoverDownloadUrl(
+          publicApiBaseUrl,
+          row.collection_id,
+        ),
+      } : {}),
       status: "published",
       updatedAt: toIsoString(row.updated_at),
       publishedAt: toIsoString(row.published_at),
@@ -766,6 +789,7 @@ export async function loadPublicCatalogSnapshotInExecutor(
     collectionsQuery.text,
     collectionsQuery.params,
   );
+  const collectionCovers = await loadPublicCatalogCollectionCoversInExecutor(executor);
   const collectionPackagesQuery = buildPublicCatalogSnapshotCollectionPackagesQuery();
   const collectionPackagesResult = await executor.query<CatalogPublicSnapshotCollectionPackageRow>(
     collectionPackagesQuery.text,
@@ -797,9 +821,14 @@ export async function loadPublicCatalogSnapshotInExecutor(
   const mediaAssetIdsByKey = indexSnapshotMediaAssets(mediaAssets);
   const packages = mapCatalogPublicSnapshotPackages(packageVersionRows);
   const publicPackageIds = new Set(packages.map((catalogPackage) => catalogPackage.packageId));
+  const collectionCoverIds = new Set(collectionCovers.map(
+    (cover) => cover.collectionCover.collectionId,
+  ));
   const collections = mapCatalogPublicSnapshotCollections(
     collectionRows,
     publicPackageIds,
+    collectionCoverIds,
+    input.publicApiBaseUrl,
   );
   const publicCollectionIds = new Set(collections.map((collection) => collection.collectionId));
 

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -45,6 +45,9 @@ export {
 export {
   listPublicCatalogPackages,
   listPublicCatalogPackagesInExecutor,
+  loadPublicCatalogCollectionCoverForDownload,
+  loadPublicCatalogCollectionCoverForDownloadInExecutor,
+  loadPublicCatalogCollectionCoversInExecutor,
   loadPublicCatalogSnapshot,
   loadPublicCatalogSnapshotInExecutor,
   loadPublicCatalogPackageDetail,

--- a/apps/backend/src/catalog/types.ts
+++ b/apps/backend/src/catalog/types.ts
@@ -297,6 +297,18 @@ export type CatalogPublicPackageMediaDownloadSource = Readonly<{
   sha256: string;
 }>;
 
+export type CatalogPublicCollectionCover = Readonly<{
+  collectionId: string;
+  mimeType: string;
+  sizeBytes: number;
+}>;
+
+export type CatalogPublicCollectionCoverDownloadSource = Readonly<{
+  collectionCover: CatalogPublicCollectionCover;
+  storageKey: string;
+  sha256: string;
+}>;
+
 export const catalogPublicSnapshotSchemaVersion = 1 as const;
 
 export type CatalogPublicSnapshotAuthor = Readonly<{
@@ -369,6 +381,7 @@ export type CatalogPublicSnapshotCollection = Readonly<{
   languageTags: ReadonlyArray<string>;
   topicTags: ReadonlyArray<string>;
   coverPackageId: string | null;
+  coverDownloadUrl?: string;
   status: "published";
   updatedAt: string;
   publishedAt: string;

--- a/apps/backend/src/routes/catalog/public.ts
+++ b/apps/backend/src/routes/catalog/public.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import {
   listPublicCatalogPackages,
+  loadPublicCatalogCollectionCoverForDownload,
   loadPublicCatalogSnapshot,
   loadPublicCatalogPackageDetail,
   loadPublicCatalogPackageMediaForDownload,
@@ -17,6 +18,7 @@ import {
 } from "../../catalog/publicMediaDelivery";
 import type {
   CatalogPublicPackageCardPreview,
+  CatalogPublicCollectionCoverDownloadSource,
   CatalogPublicPackageDetail,
   CatalogPublicPackageListInput,
   CatalogPublicPackageMediaDownloadSource,
@@ -56,6 +58,9 @@ type CatalogPublicRoutesOptions = Readonly<{
     packageVersionId: string,
     packageMediaKey: string,
   ) => Promise<CatalogPublicPackageMediaDownloadSource>;
+  loadPublicCatalogCollectionCoverForDownloadFn?: (
+    collectionId: string,
+  ) => Promise<CatalogPublicCollectionCoverDownloadSource>;
   loadMediaAssetObjectBytesFn?: (
     input: LoadMediaAssetObjectBytesInput,
   ) => Promise<LoadedMediaAssetObjectBytes>;
@@ -124,6 +129,18 @@ function parsePackageVersionIdParam(value: string | undefined): string {
   }
 }
 
+function parseCollectionIdParam(value: string | undefined): string {
+  if (value === undefined) {
+    throw new HttpError(400, "collectionId is required", "CATALOG_PUBLIC_PARAM_REQUIRED");
+  }
+
+  try {
+    return expectUuidString(value, "collectionId");
+  } catch {
+    throw new HttpError(400, "collectionId must be a UUID", "CATALOG_PUBLIC_PARAM_INVALID");
+  }
+}
+
 function parsePackageMediaKeyParam(value: string | undefined): string {
   if (value === undefined) {
     throw new HttpError(400, "packageMediaKey is required", "CATALOG_PUBLIC_PARAM_REQUIRED");
@@ -179,6 +196,40 @@ function createBackendDownloadUrl(
   ].join("/");
 }
 
+function createBackendCollectionCoverDownloadUrl(
+  requestUrl: string,
+  collectionId: string,
+): string {
+  return [
+    getPublicApiBaseUrl(requestUrl),
+    "catalog",
+    "collections",
+    collectionId,
+    "cover",
+    "download",
+  ].join("/");
+}
+
+function rethrowCollectionCoverObjectLoadError(error: unknown, collectionId: string): never {
+  if (error instanceof HttpError && error.code === "MEDIA_ASSET_UPLOAD_NOT_FOUND") {
+    throw new HttpError(
+      409,
+      `Published catalog collection cover object is missing. collectionId=${collectionId}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_OBJECT_NOT_FOUND",
+      error.details ?? undefined,
+    );
+  }
+  if (error instanceof HttpError && error.code === "MEDIA_ASSET_OBJECT_BYTES_TOO_LARGE") {
+    throw new HttpError(
+      413,
+      `Published catalog collection cover is too large for public delivery. collectionId=${collectionId}`,
+      "CATALOG_PUBLIC_COLLECTION_COVER_TOO_LARGE",
+    );
+  }
+
+  throw error;
+}
+
 function assertPublicCatalogMediaDownloadSupported(
   mediaDownloadSource: CatalogPublicPackageMediaDownloadSource,
 ): void {
@@ -221,6 +272,8 @@ export function createCatalogPublicRoutes(options: CatalogPublicRoutesOptions): 
     ?? loadPublicCatalogPackageVersionCardPreview;
   const loadPublicCatalogPackageMediaForDownloadFn = options.loadPublicCatalogPackageMediaForDownloadFn
     ?? loadPublicCatalogPackageMediaForDownload;
+  const loadPublicCatalogCollectionCoverForDownloadFn = options.loadPublicCatalogCollectionCoverForDownloadFn
+    ?? loadPublicCatalogCollectionCoverForDownload;
   const loadMediaAssetObjectBytesFn = options.loadMediaAssetObjectBytesFn ?? loadMediaAssetObjectBytes;
 
   app.get("/catalog", async (context) => context.json(await loadPublicCatalogSnapshotFn(
@@ -252,6 +305,56 @@ export function createCatalogPublicRoutes(options: CatalogPublicRoutesOptions): 
       limit: parseLimitQuery(context.req.query("limit"), "limit", defaultCardPreviewLimit),
     });
     return context.json({ packageVersionId, cards });
+  });
+
+  app.get("/catalog/collections/:collectionId/cover/download-url", async (context) => {
+    const collectionId = parseCollectionIdParam(context.req.param("collectionId"));
+    const coverDownloadSource = await loadPublicCatalogCollectionCoverForDownloadFn(collectionId);
+    const download = {
+      method: "GET",
+      url: createBackendCollectionCoverDownloadUrl(context.req.url, collectionId),
+      expiresAt: null,
+      rangeRequests: false,
+    } as const;
+
+    return context.json({
+      collectionCover: coverDownloadSource.collectionCover,
+      download,
+    });
+  });
+
+  app.get("/catalog/collections/:collectionId/cover/download", async (context) => {
+    const requestId = context.get("requestId");
+    const collectionId = parseCollectionIdParam(context.req.param("collectionId"));
+    const scope = createCatalogPublicScope(
+      requestId,
+      context.req.path,
+      context.req.method,
+      context.get("clientAppVersion"),
+      context.get("clientPlatform"),
+    );
+    const coverDownloadSource = await loadPublicCatalogCollectionCoverForDownloadFn(collectionId);
+
+    let objectBytes: LoadedMediaAssetObjectBytes;
+    try {
+      objectBytes = await loadMediaAssetObjectBytesFn({
+        workspaceId: collectionId,
+        mediaAssetId: "cover",
+        storageKey: coverDownloadSource.storageKey,
+        mimeType: coverDownloadSource.collectionCover.mimeType,
+        sizeBytes: coverDownloadSource.collectionCover.sizeBytes,
+        sha256: coverDownloadSource.sha256,
+        maxByteSize: maximumPublicCatalogMediaDownloadBytes,
+        observationScope: scope,
+      });
+    } catch (error) {
+      rethrowCollectionCoverObjectLoadError(error, collectionId);
+    }
+
+    context.header("Content-Type", objectBytes.mimeType ?? coverDownloadSource.collectionCover.mimeType);
+    context.header("Content-Length", objectBytes.sizeBytes.toString());
+    context.header("Cache-Control", "public, max-age=3600");
+    return context.body(new Uint8Array(objectBytes.bytes), 200);
   });
 
   app.get("/catalog/package-versions/:packageVersionId/media-assets/:packageMediaKey/download-url", async (context) => {

--- a/apps/web/src/api/endpoints/catalog.test.ts
+++ b/apps/web/src/api/endpoints/catalog.test.ts
@@ -17,6 +17,7 @@ const workspaceId = "11111111-1111-4111-8111-111111111111";
 const packageVersionId = "22222222-2222-4222-8222-222222222222";
 const packageId = "33333333-3333-4333-8333-333333333333";
 const authorId = "44444444-4444-4444-8444-444444444444";
+const collectionId = "99999999-9999-4999-8999-999999999999";
 
 function createPackageVersion(): CatalogPackageInstallPackageVersion {
   return {
@@ -104,7 +105,32 @@ describe("catalog API endpoints", () => {
         }],
         cards: [],
         mediaAssets: [],
-        collections: [],
+        collections: [{
+          collectionId,
+          slug: "test-collection",
+          title: "Test collection",
+          summary: "Test collection",
+          description: "Test collection",
+          languageTags: ["en"],
+          topicTags: ["test"],
+          coverPackageId: packageId,
+          coverDownloadUrl: `http://localhost:8080/v1/catalog/collections/${collectionId}/cover/download`,
+          status: "published",
+          updatedAt: "2026-08-01T10:00:00.000Z",
+          publishedAt: "2026-08-01T10:00:00.000Z",
+        }, {
+          collectionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          slug: "legacy-collection",
+          title: "Legacy collection",
+          summary: "Legacy collection",
+          description: "Legacy collection",
+          languageTags: ["en"],
+          topicTags: ["test"],
+          coverPackageId: packageId,
+          status: "published",
+          updatedAt: "2026-08-01T10:00:00.000Z",
+          publishedAt: "2026-08-01T10:00:00.000Z",
+        }],
         collectionPackages: [],
       }), {
         status: 200,
@@ -130,7 +156,12 @@ describe("catalog API endpoints", () => {
       operationIdPrefix: "77777777-7777-4777-8777-777777777777",
     };
 
-    await expect(loadPublicCatalog()).resolves.toMatchObject({ schemaVersion: 1 });
+    const catalog = await loadPublicCatalog();
+    expect(catalog).toMatchObject({ schemaVersion: 1 });
+    expect(catalog.collections[0]?.coverDownloadUrl).toBe(
+      `http://localhost:8080/v1/catalog/collections/${collectionId}/cover/download`,
+    );
+    expect("coverDownloadUrl" in (catalog.collections[1] ?? {})).toBe(false);
     await expect(previewCatalogPackageInstall(workspaceId, packageVersionId)).resolves.toEqual(previewResponse);
     await expect(confirmCatalogPackageInstall(workspaceId, packageVersionId, options)).resolves.toEqual(confirmResponse);
 

--- a/apps/web/src/apiContracts/catalog.ts
+++ b/apps/web/src/apiContracts/catalog.ts
@@ -23,6 +23,7 @@ import {
   parseNonNegativeInteger,
   parseNullableString,
   parseObject,
+  parseOptionalField,
   parseRequiredField,
   parseString,
   parseStringArray,
@@ -149,6 +150,13 @@ function parseCatalogPublicSnapshotCollection(
   path: string,
 ): CatalogPublicSnapshotCollection {
   const objectValue = parseObject(value, endpoint, path);
+  const coverDownloadUrl = parseOptionalField(
+    objectValue,
+    "coverDownloadUrl",
+    endpoint,
+    path,
+    parseString,
+  );
   return {
     collectionId: parseRequiredField(objectValue, "collectionId", endpoint, path, parseString),
     slug: parseRequiredField(objectValue, "slug", endpoint, path, parseString),
@@ -158,6 +166,7 @@ function parseCatalogPublicSnapshotCollection(
     languageTags: parseRequiredField(objectValue, "languageTags", endpoint, path, parseStringArray),
     topicTags: parseRequiredField(objectValue, "topicTags", endpoint, path, parseStringArray),
     coverPackageId: parseRequiredField(objectValue, "coverPackageId", endpoint, path, parseNullableString),
+    ...(coverDownloadUrl === undefined ? {} : { coverDownloadUrl }),
     status: parseLiteral(
       parseRequiredField(objectValue, "status", endpoint, path, parseString),
       endpoint,

--- a/apps/web/src/types/catalog.ts
+++ b/apps/web/src/types/catalog.ts
@@ -68,6 +68,7 @@ export type CatalogPublicSnapshotCollection = Readonly<{
   languageTags: ReadonlyArray<string>;
   topicTags: ReadonlyArray<string>;
   coverPackageId: string | null;
+  coverDownloadUrl?: string;
   status: "published";
   updatedAt: string;
   publishedAt: string;


### PR DESCRIPTION
## Summary

- add public collection-cover lookup, backend-controlled download URL, and verified byte delivery
- keep catalog snapshot schema version 1 and preserve coverPackageId while adding optional coverDownloadUrl
- retain the optional field at the web parser/type boundary without adding UI
- leave API Gateway unchanged because the existing GET /catalog/{proxy+} route reaches both endpoints

## Review

- fresh independent review completed with no P0-P4 findings
- reviewed patch is 622 changed lines, below the approximate 700-line target

## Checks

- no local project checks were run, per repository rules for integration PRs