### PR TITLE
fix: type collection media route details

### DIFF
--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -317,6 +317,7 @@ export type WorkspacePackageImportDetails = Readonly<{
 export type MediaAssetRouteDetails = Readonly<{
   statusCode: number;
   mediaAssetId: string | null;
+  collectionId?: string;
   sessionId?: string | null;
   mimeType?: string;
   sizeBytes?: number;


### PR DESCRIPTION
## Summary

- add the optional `collectionId` field to `MediaAssetRouteDetails`
- keep the media ingestion route and runtime behavior unchanged

## Evidence

- PR #1427 remote `Type checks and builds` reported TS2353 at `adminImageIngestion.ts:206` because `collectionId` was not defined in `MediaAssetRouteDetails`
- a fresh independent review of this one-file fix completed with no P0-P4 findings

## Validation

- not run locally, as requested; the remote backend typecheck is the relevant CI gate