### PR TITLE
fix: decouple direct image failure details

### DIFF
--- a/apps/backend/src/observability/failureDetails.ts
+++ b/apps/backend/src/observability/failureDetails.ts
@@ -1,0 +1,79 @@
+import { AuthError } from "../auth";
+import {
+  HttpError,
+  type MediaAssetStorageErrorDetails,
+} from "../shared/errors";
+
+export type BackendValidationIssueDetail = Readonly<{
+  path: string;
+  code: string;
+}>;
+
+export type BackendFailureDetails = Readonly<{
+  statusCode: number;
+  code: string | null;
+  message: string | null;
+  validationIssues: ReadonlyArray<BackendValidationIssueDetail>;
+  mediaAssetStorage?: MediaAssetStorageErrorDetails;
+}>;
+
+function getInternalErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getRequestErrorStatusCode(error: AuthError | HttpError | unknown): number {
+  if (error instanceof AuthError || error instanceof HttpError) {
+    return error.statusCode;
+  }
+
+  return 500;
+}
+
+function getRequestErrorCode(error: AuthError | HttpError | unknown): string | null {
+  if (error instanceof AuthError) {
+    return "AUTH_UNAUTHORIZED";
+  }
+
+  if (error instanceof HttpError) {
+    return error.code;
+  }
+
+  return "INTERNAL_ERROR";
+}
+
+function getMediaAssetStorageErrorDetails(
+  error: AuthError | HttpError | unknown,
+): MediaAssetStorageErrorDetails | undefined {
+  if (error instanceof HttpError) {
+    return error.details?.mediaAssetStorage;
+  }
+
+  return undefined;
+}
+
+export function createBackendFailureDetails(
+  error: AuthError | HttpError | unknown,
+): BackendFailureDetails {
+  const mediaAssetStorage = getMediaAssetStorageErrorDetails(error);
+  return {
+    statusCode: getRequestErrorStatusCode(error),
+    code: getRequestErrorCode(error),
+    message: getInternalErrorMessage(error),
+    validationIssues: summarizeValidationIssues(error),
+    ...(mediaAssetStorage === undefined ? {} : { mediaAssetStorage }),
+  };
+}
+
+export function summarizeValidationIssues(
+  error: HttpError | unknown,
+): ReadonlyArray<BackendValidationIssueDetail> {
+  if (!(error instanceof HttpError)) {
+    return [];
+  }
+
+  const validationIssues = error.details?.validationIssues ?? [];
+  return validationIssues.map((issue) => ({
+    path: issue.path,
+    code: issue.code,
+  }));
+}

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -1,5 +1,11 @@
 import type { AgentSqlSurface } from "../../aiTools/agentSql/shared";
-import type { MediaAssetStorageErrorDetails, SyncConflictEntityType } from "../../shared/errors";
+import type { SyncConflictEntityType } from "../../shared/errors";
+import type { BackendFailureDetails } from "../failureDetails";
+
+export type {
+  BackendFailureDetails,
+  BackendValidationIssueDetail,
+} from "../failureDetails";
 
 export type BackendService =
   | "backend-api"
@@ -32,11 +38,6 @@ export type BackendTraceCarrier = Readonly<{
   baggage: string | null;
 }>;
 
-export type BackendValidationIssueDetail = Readonly<{
-  path: string;
-  code: string;
-}>;
-
 export type BackendErrorLogDetails = Readonly<{
   errorClass: string;
   errorMessage: string;
@@ -44,14 +45,6 @@ export type BackendErrorLogDetails = Readonly<{
   sourceFile: string | null;
   sourceLine: number | null;
   sourceColumn: number | null;
-}>;
-
-export type BackendFailureDetails = Readonly<{
-  statusCode: number;
-  code: string | null;
-  message: string | null;
-  validationIssues: ReadonlyArray<BackendValidationIssueDetail>;
-  mediaAssetStorage?: MediaAssetStorageErrorDetails;
 }>;
 
 export type RequestErrorDetails = BackendFailureDetails & BackendErrorLogDetails & Readonly<{

--- a/apps/backend/src/routes/catalog/adminImageIngestion.ts
+++ b/apps/backend/src/routes/catalog/adminImageIngestion.ts
@@ -24,6 +24,7 @@ import {
 } from "../../database";
 import { getDatabaseErrorFields } from "../../database/transient";
 import { readMediaAssetImageIngestionBytesWithAbortSignal } from "../../mediaAssets/validators";
+import { createBackendFailureDetails } from "../../observability/failureDetails";
 import type { BackendObservationScope } from "../../observability/sentry/events";
 import {
   addBackendRuntimeBreadcrumb,
@@ -31,7 +32,6 @@ import {
 } from "../../observability/runtime";
 import { reportBackendExceptionOrBreadcrumb } from "../../observability/reporting";
 import type { AppEnv } from "../../server/appEnv";
-import { createBackendFailureDetails } from "../../server/logging";
 import {
   createDirectImageIngestionDeadlineError,
   createDirectImageIngestionRequestDeadline,

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -1,5 +1,6 @@
 import { AuthError, authVerificationTemporarilyUnavailableCode } from "../auth";
-import { HttpError, type MediaAssetStorageErrorDetails } from "../shared/errors";
+import { HttpError } from "../shared/errors";
+import { createBackendFailureDetails } from "../observability/failureDetails";
 import { sanitizeBackendTelemetryValue } from "../observability/sanitizer";
 import {
   addBackendBreadcrumb,
@@ -11,13 +12,13 @@ import {
   type BackendObservationScope,
   type BackendService,
   type BackendErrorLogDetails,
-  type BackendFailureDetails,
   type RequestErrorDetails,
 } from "../observability/sentry";
 
-function getInternalErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
+export {
+  createBackendFailureDetails,
+  summarizeValidationIssues,
+} from "../observability/failureDetails";
 
 export type ErrorLogContext = BackendErrorLogDetails;
 
@@ -70,45 +71,6 @@ function shouldLogRequestErrorAtErrorLevel(error: AuthError | HttpError | unknow
   }
 
   return true;
-}
-
-function getRequestErrorStatusCode(error: AuthError | HttpError | unknown): number {
-  if (error instanceof AuthError || error instanceof HttpError) {
-    return error.statusCode;
-  }
-
-  return 500;
-}
-
-function getRequestErrorCode(error: AuthError | HttpError | unknown): string | null {
-  if (error instanceof AuthError) {
-    return "AUTH_UNAUTHORIZED";
-  }
-
-  if (error instanceof HttpError) {
-    return error.code;
-  }
-
-  return "INTERNAL_ERROR";
-}
-
-function getMediaAssetStorageErrorDetails(error: AuthError | HttpError | unknown): MediaAssetStorageErrorDetails | undefined {
-  if (error instanceof HttpError) {
-    return error.details?.mediaAssetStorage;
-  }
-
-  return undefined;
-}
-
-export function createBackendFailureDetails(error: AuthError | HttpError | unknown): BackendFailureDetails {
-  const mediaAssetStorage = getMediaAssetStorageErrorDetails(error);
-  return {
-    statusCode: getRequestErrorStatusCode(error),
-    code: getRequestErrorCode(error),
-    message: getInternalErrorMessage(error),
-    validationIssues: summarizeValidationIssues(error),
-    ...(mediaAssetStorage === undefined ? {} : { mediaAssetStorage }),
-  };
 }
 
 function createRequestErrorDetails(error: AuthError | HttpError | unknown): RequestErrorDetails {
@@ -293,18 +255,4 @@ export function logAgentSqlEvent(payload: AgentSqlLogPayload): void {
     scope,
     details,
   });
-}
-
-export function summarizeValidationIssues(
-  error: HttpError | unknown,
-): ReadonlyArray<Readonly<{ path: string; code: string }>> {
-  if (!(error instanceof HttpError)) {
-    return [];
-  }
-
-  const validationIssues = error.details?.validationIssues ?? [];
-  return validationIssues.map((issue) => ({
-    path: issue.path,
-    code: issue.code,
-  }));
 }


### PR DESCRIPTION
## Summary

- extract backend failure-detail construction and its types into a Sentry-free observability module
- preserve the existing server logging and Sentry event type compatibility exports
- import the pure helper directly from the catalog direct-image ingestion route

## Context

This addresses the backend bundle-boundary failure observed in PR #1427, where the dedicated direct image ingestion Lambda reached the Sentry SDK through `server/logging.ts`.

A fresh independent review of this focused patch completed with no P0-P4 findings.

## Validation

Local checks were not run, following the repository workflow.