### PR TITLE
fix: revalidate mutable collection covers

### DIFF
--- a/apps/backend/src/catalog/distribution/public/collectionMedia.test.ts
+++ b/apps/backend/src/catalog/distribution/public/collectionMedia.test.ts
@@ -201,6 +201,7 @@ test("public collection cover routes return a backend URL and proxy verified byt
   assert.equal(loadedStorageKey, coverStorageKey);
   assert.equal(bytesResponse.headers.get("content-type"), "image/jpeg");
   assert.equal(bytesResponse.headers.get("content-length"), "3");
+  assert.equal(bytesResponse.headers.get("cache-control"), "public, no-cache");
   assert.deepEqual(Buffer.from(await bytesResponse.arrayBuffer()), Buffer.from([1, 2, 3]));
 });
 

--- a/apps/backend/src/routes/catalog/public.ts
+++ b/apps/backend/src/routes/catalog/public.ts
@@ -353,7 +353,7 @@ export function createCatalogPublicRoutes(options: CatalogPublicRoutesOptions): 
 
     context.header("Content-Type", objectBytes.mimeType ?? coverDownloadSource.collectionCover.mimeType);
     context.header("Content-Length", objectBytes.sizeBytes.toString());
-    context.header("Cache-Control", "public, max-age=3600");
+    context.header("Cache-Control", "public, no-cache");
     return context.body(new Uint8Array(objectBytes.bytes), 200);
   });
 


### PR DESCRIPTION
Cumulative review P3: collection-cover downloads use a stable URL while their bytes are mutable, so the previous one-hour freshness window could serve a replaced cover stale.

This changes only the mutable collection-cover byte response to the exact Cache-Control contract `public, no-cache`, requiring revalidation before reuse. Immutable package and card media retain their existing cache policy.

Fresh independent review completed with no P0-P4 findings.