### PR TITLE
fix: sanitize catalog storage errors

### DIFF
--- a/apps/backend/src/mediaAssets/storage/promotion/promotion.test.ts
+++ b/apps/backend/src/mediaAssets/storage/promotion/promotion.test.ts
@@ -15,6 +15,7 @@ import type {
   MultipartMediaBlobStorageCapability,
   MultipartMediaBlobWriterAttemptExactInput,
 } from "../../uploadSessions";
+import { createBackendFailureDetails } from "../../../observability/failureDetails";
 import { createPublicHttpErrorDetails, HttpError } from "../../../shared/errors";
 import {
   assertMediaAssetObjectMatchesWithDependencies,
@@ -254,6 +255,115 @@ test("catalog image storage reuses the conditional write and checksum winner ver
     `put:${testBlobStorageKey}`,
     `head:${testBlobStorageKey}`,
   ]);
+});
+
+test("catalog image storage keeps S3 failure diagnostics in internal error details", async () => {
+  const signal = AbortSignal.timeout(10_000);
+  const s3ErrorMessage =
+    `raw S3 body for s3://test-media-assets-bucket/${testBlobStorageKey}`;
+
+  await assert.rejects(
+    storeCatalogImageBlobBytesIfAbsentWithDependencies(
+      {
+        signal,
+        storageKey: testBlobStorageKey,
+        mimeType: "image/jpeg",
+        sizeBytes: testObjectBytes.byteLength,
+        sha256: testSha256,
+        bytes: testObjectBytes,
+        observationScope: testObservationScope,
+      },
+      {
+        s3Client: createFailingS3Client(
+          createS3Error(500, "InternalError", s3ErrorMessage),
+        ),
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 503);
+      assert.equal(error.code, "CATALOG_IMAGE_BLOB_STORAGE_UNAVAILABLE");
+      assert.match(error.message, new RegExp(testSha256));
+      assert.match(error.message, new RegExp(testBlobStorageKey));
+      assert.deepEqual(error.details?.catalogImageBlob, {
+        reason: "storage_temporarily_unavailable",
+        sha256: testSha256,
+        storageKey: testBlobStorageKey,
+        s3StatusCode: 500,
+        s3ErrorClass: "InternalError",
+        s3ErrorMessage,
+      });
+      assert.deepEqual(
+        createBackendFailureDetails(error).catalogImageBlob,
+        error.details?.catalogImageBlob,
+      );
+      assert.equal(createPublicHttpErrorDetails(error.details), null);
+      return true;
+    },
+  );
+});
+
+test("catalog image winner mismatch keeps blob diagnostics in internal error details", async () => {
+  const signal = AbortSignal.timeout(10_000);
+  const client = createTestS3Client();
+  client.send = (async (command: unknown) => {
+    if (command instanceof PutObjectCommand) {
+      throw createS3Error(412, "PreconditionFailed", "Object already exists");
+    }
+    if (command instanceof HeadObjectCommand) {
+      return createHeadObjectResponse({
+        sizeBytes: testObjectBytes.byteLength + 1,
+        mimeType: "image/png",
+        sha256: "0".repeat(64),
+        checksumType: "COMPOSITE",
+      });
+    }
+    throw new Error(
+      `Unexpected S3 command ${getUnexpectedS3CommandName(command)}`,
+    );
+  }) as S3Client["send"];
+
+  await assert.rejects(
+    storeCatalogImageBlobBytesIfAbsentWithDependencies(
+      {
+        signal,
+        storageKey: testBlobStorageKey,
+        mimeType: "image/jpeg",
+        sizeBytes: testObjectBytes.byteLength,
+        sha256: testSha256,
+        bytes: testObjectBytes,
+        observationScope: testObservationScope,
+      },
+      {
+        s3Client: client,
+        getMediaAssetsStorageConfigFn: getTestMediaAssetsStorageConfig,
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "CATALOG_IMAGE_BLOB_OBJECT_MISMATCH");
+      assert.match(error.message, new RegExp(testSha256));
+      assert.deepEqual(error.details?.catalogImageBlob, {
+        reason: "stored_object_mismatch",
+        sha256: testSha256,
+        storageKey: testBlobStorageKey,
+        mismatchedFields: [
+          "sizeBytes",
+          "mimeType",
+          "checksumType",
+          "sha256",
+        ],
+      });
+      assert.deepEqual(
+        createBackendFailureDetails(error).catalogImageBlob,
+        error.details?.catalogImageBlob,
+      );
+      assert.equal(createPublicHttpErrorDetails(error.details), null);
+      return true;
+    },
+  );
 });
 
 test("direct conditional PutObject retries 409 without verification and succeeds on retry", async () => {

--- a/apps/backend/src/mediaAssets/storage/promotion/promotion.ts
+++ b/apps/backend/src/mediaAssets/storage/promotion/promotion.ts
@@ -370,6 +370,14 @@ function createCatalogImageBlobObjectMismatchError(
     409,
     `Catalog image blob conflicts with stored object bytes. sha256=${input.sha256} mismatchedFields=${mismatchedFields.join(",")}`,
     "CATALOG_IMAGE_BLOB_OBJECT_MISMATCH",
+    {
+      catalogImageBlob: {
+        reason: "stored_object_mismatch",
+        sha256: input.sha256,
+        storageKey: input.storageKey,
+        mismatchedFields,
+      },
+    },
   );
 }
 
@@ -387,6 +395,16 @@ function createCatalogImageBlobStorageError(
       `s3ErrorClass=${error instanceof Error ? error.name : "UnknownError"}`,
     ].join(" "),
     "CATALOG_IMAGE_BLOB_STORAGE_UNAVAILABLE",
+    {
+      catalogImageBlob: {
+        reason: "storage_temporarily_unavailable",
+        sha256: input.sha256,
+        storageKey: input.storageKey,
+        s3StatusCode: getS3ErrorStatusCode(error),
+        s3ErrorClass: error instanceof Error ? error.name : "UnknownError",
+        s3ErrorMessage: error instanceof Error ? error.message : String(error),
+      },
+    },
   );
 }
 

--- a/apps/backend/src/observability/failureDetails.ts
+++ b/apps/backend/src/observability/failureDetails.ts
@@ -1,6 +1,7 @@
 import { AuthError } from "../auth";
 import {
   HttpError,
+  type CatalogImageBlobErrorDetails,
   type MediaAssetStorageErrorDetails,
 } from "../shared/errors";
 
@@ -15,6 +16,7 @@ export type BackendFailureDetails = Readonly<{
   message: string | null;
   validationIssues: ReadonlyArray<BackendValidationIssueDetail>;
   mediaAssetStorage?: MediaAssetStorageErrorDetails;
+  catalogImageBlob?: CatalogImageBlobErrorDetails;
 }>;
 
 function getInternalErrorMessage(error: unknown): string {
@@ -51,16 +53,28 @@ function getMediaAssetStorageErrorDetails(
   return undefined;
 }
 
+function getCatalogImageBlobErrorDetails(
+  error: AuthError | HttpError | unknown,
+): CatalogImageBlobErrorDetails | undefined {
+  if (error instanceof HttpError) {
+    return error.details?.catalogImageBlob;
+  }
+
+  return undefined;
+}
+
 export function createBackendFailureDetails(
   error: AuthError | HttpError | unknown,
 ): BackendFailureDetails {
   const mediaAssetStorage = getMediaAssetStorageErrorDetails(error);
+  const catalogImageBlob = getCatalogImageBlobErrorDetails(error);
   return {
     statusCode: getRequestErrorStatusCode(error),
     code: getRequestErrorCode(error),
     message: getInternalErrorMessage(error),
     validationIssues: summarizeValidationIssues(error),
     ...(mediaAssetStorage === undefined ? {} : { mediaAssetStorage }),
+    ...(catalogImageBlob === undefined ? {} : { catalogImageBlob }),
   };
 }
 

--- a/apps/backend/src/server/app.test.ts
+++ b/apps/backend/src/server/app.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   createApp,
   createAgentInstructions,
+  createPublicHttpErrorBody,
   getHttpErrorResponseHeaders,
 } from "./app";
 import {
@@ -274,6 +275,71 @@ test("getHttpErrorResponseHeaders adds Retry-After for service unavailable", () 
     ),
     [["Retry-After", "1"]],
   );
+});
+
+test("public HTTP error boundary sanitizes catalog blob diagnostics", () => {
+  const sha256 = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
+  const storageKey = `media/blobs/sha256/5e/88/${sha256}`;
+  const requestId = "request-catalog-image-1";
+  const fixtures = [
+    {
+      statusCode: 409,
+      code: "CATALOG_IMAGE_BLOB_OBJECT_MISMATCH",
+      internalMessage:
+        `Catalog image blob conflict. sha256=${sha256} storageKey=${storageKey}`,
+      details: {
+        reason: "stored_object_mismatch" as const,
+        sha256,
+        storageKey,
+        mismatchedFields: ["sha256"],
+      },
+      publicMessage:
+        "Catalog image storage conflict. Upload the image again and use requestId if the failure persists.",
+    },
+    {
+      statusCode: 503,
+      code: "CATALOG_IMAGE_BLOB_STORAGE_UNAVAILABLE",
+      internalMessage:
+        `Catalog image storage failed for s3://private-bucket/${storageKey}. raw S3 body`,
+      details: {
+        reason: "storage_temporarily_unavailable" as const,
+        sha256,
+        storageKey,
+        s3StatusCode: 500,
+        s3ErrorClass: "InternalError",
+        s3ErrorMessage: "raw S3 body",
+      },
+      publicMessage:
+        "Catalog image storage is temporarily unavailable. Retry shortly and use requestId if the failure persists.",
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const error = new HttpError(
+      fixture.statusCode,
+      fixture.internalMessage,
+      fixture.code,
+      { catalogImageBlob: fixture.details },
+    );
+    const body = createPublicHttpErrorBody(error, requestId);
+    const serializedBody = JSON.stringify(body);
+
+    assert.equal(error.message, fixture.internalMessage);
+    assert.deepEqual(body, {
+      error: fixture.publicMessage,
+      requestId,
+      code: fixture.code,
+    });
+    for (const privateDiagnostic of [
+      sha256,
+      storageKey,
+      "private-bucket",
+      "InternalError",
+      "raw S3 body",
+    ]) {
+      assert.equal(serializedBody.includes(privateDiagnostic), false);
+    }
+  }
 });
 
 test("getHttpErrorResponseHeaders adds Retry-After for temporary auth verification failures", () => {

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -12,7 +12,12 @@ import {
   isAgentApiKeyAuthorizationHeader,
 } from "../agent/envelope";
 import { getAuthConfig } from "../auth/config";
-import { createPublicHttpErrorDetails, HttpError, type PublicHttpErrorDetails } from "../shared/errors";
+import {
+  createPublicHttpErrorDetails,
+  createPublicHttpErrorMessage,
+  HttpError,
+  type PublicHttpErrorDetails,
+} from "../shared/errors";
 import { createChatRoutes } from "../routes/chat";
 import { createChatTranscriptionsRoutes } from "../routes/chatTranscriptions";
 import { createAgentRoutes } from "../routes/agent";
@@ -97,7 +102,7 @@ export function createPublicHttpErrorBody(error: HttpError, requestId: string): 
 }> {
   const publicDetails = createPublicHttpErrorDetails(error.details);
   return {
-    error: error.message,
+    error: createPublicHttpErrorMessage(error),
     requestId,
     code: error.code,
     ...(publicDetails === null ? {} : { details: publicDetails }),
@@ -327,6 +332,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
     if (error instanceof HttpError) {
       context.status(error.statusCode as ContentfulStatusCode);
       applyHttpErrorResponseHeaders(context, error);
+      const publicMessage = createPublicHttpErrorMessage(error);
       if (publicCatalogRequest) {
         return context.json(createPublicHttpErrorBody(error, requestId));
       }
@@ -335,7 +341,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
           createAgentApiKeyErrorEnvelope(
             context.req.url,
             error.code ?? "REQUEST_FAILED",
-            error.message,
+            publicMessage,
             error.statusCode,
             requestId,
             createPublicHttpErrorDetails(error.details) ?? undefined,
@@ -346,7 +352,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
         return context.json(
           createAgentConnectionManagementErrorEnvelope(
             error.code ?? "REQUEST_FAILED",
-            error.message,
+            publicMessage,
             createAgentConnectionManagementInstructions(error.code, error.statusCode),
             requestId,
           ),

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -89,6 +89,7 @@ function createErrorLevelRequestErrorDetails(
     code: details.code,
     validationIssues: details.validationIssues,
     ...(details.mediaAssetStorage === undefined ? {} : { mediaAssetStorage: details.mediaAssetStorage }),
+    ...(details.catalogImageBlob === undefined ? {} : { catalogImageBlob: details.catalogImageBlob }),
     sqlState: details.sqlState,
     errorClass: details.errorClass,
     errorMessage: details.errorMessage,

--- a/apps/backend/src/server/mediaRequests/directImageIngestionApp.ts
+++ b/apps/backend/src/server/mediaRequests/directImageIngestionApp.ts
@@ -12,6 +12,7 @@ import { createDirectImageIngestionRoutes } from "../../routes/directImageIngest
 import { createCatalogAdminImageIngestionRoutes } from "../../routes/catalog/adminImageIngestion";
 import {
   createPublicHttpErrorDetails,
+  createPublicHttpErrorMessage,
   HttpError,
 } from "../../shared/errors";
 import type { AppEnv } from "../appEnv";
@@ -84,18 +85,19 @@ function createDirectImageIngestionMountedApp(
       context.status(error.statusCode as ContentfulStatusCode);
       applyHttpErrorResponseHeaders(context, error);
       const publicDetails = createPublicHttpErrorDetails(error.details);
+      const publicMessage = createPublicHttpErrorMessage(error);
       if (apiKeyRequest) {
         return context.json(createAgentApiKeyErrorEnvelope(
           context.req.url,
           error.code ?? "REQUEST_FAILED",
-          error.message,
+          publicMessage,
           error.statusCode,
           requestId,
           publicDetails ?? undefined,
         ));
       }
       return context.json({
-        error: error.message,
+        error: publicMessage,
         requestId,
         code: error.code,
         ...(publicDetails === null ? {} : { details: publicDetails }),

--- a/apps/backend/src/shared/errors.ts
+++ b/apps/backend/src/shared/errors.ts
@@ -37,10 +37,28 @@ export type PublicMediaAssetStorageErrorDetails = Readonly<{
   retryable: boolean;
 }>;
 
+export type CatalogImageBlobErrorDetails = Readonly<
+  | {
+    reason: "stored_object_mismatch";
+    sha256: string;
+    storageKey: string;
+    mismatchedFields: ReadonlyArray<string>;
+  }
+  | {
+    reason: "storage_temporarily_unavailable";
+    sha256: string;
+    storageKey: string;
+    s3StatusCode: number | null;
+    s3ErrorClass: string;
+    s3ErrorMessage: string;
+  }
+>;
+
 export type HttpErrorDetails = Readonly<{
   validationIssues?: ReadonlyArray<ValidationIssueSummary>;
   syncConflict?: SyncConflictDetails;
   mediaAssetStorage?: MediaAssetStorageErrorDetails;
+  catalogImageBlob?: CatalogImageBlobErrorDetails;
   retryAfterSeconds?: number;
 }>;
 
@@ -111,5 +129,16 @@ export class HttpError extends Error {
     this.statusCode = statusCode;
     this.code = code ?? null;
     this.details = details ?? null;
+  }
+}
+
+export function createPublicHttpErrorMessage(error: HttpError): string {
+  switch (error.code) {
+    case "CATALOG_IMAGE_BLOB_OBJECT_MISMATCH":
+      return "Catalog image storage conflict. Upload the image again and use requestId if the failure persists.";
+    case "CATALOG_IMAGE_BLOB_STORAGE_UNAVAILABLE":
+      return "Catalog image storage is temporarily unavailable. Retry shortly and use requestId if the failure persists.";
+    default:
+      return error.message;
   }
 }


### PR DESCRIPTION
## Summary
- fix the cumulative P3 where catalog blob storage diagnostics crossed the public HTTP error boundary
- sanitize CATALOG_IMAGE_BLOB_STORAGE_UNAVAILABLE and CATALOG_IMAGE_BLOB_OBJECT_MISMATCH responses in both backend HTTP serializers
- preserve detailed internal HttpError messages and private structured telemetry while keeping status codes and error codes unchanged

## Review
- reviewed by one fresh empty-history review-kirill subagent
- no P0-P4 issues found and no additional notes

## Validation
- no local project checks run, per repository workflow