### PR TITLE
fix: keep referenced catalog blobs fenced

### DIFF
--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
@@ -366,6 +366,19 @@ test("catalog image admission stays fenced across reverse-SHA package and collec
          ) VALUES($1,$2,NULL,'cover',$3)`,
         [packageMediaAssetId, packageId, mediaBlobId],
       );
+      const replayedAdmission = await fixture.runtimePool.query<{
+        normalization_version: string;
+      }>(
+        "SELECT * FROM content.admit_catalog_image_blob_write($1,$2,$3,$4,$5,$6)",
+        admissionParams(
+          attachedSha256,
+          imageJpegCatalogCoverMediaBlobNormalizationVersion,
+        ),
+      );
+      assert.equal(
+        replayedAdmission.rows[0]?.normalization_version,
+        imageJpegCatalogCoverMediaBlobNormalizationVersion,
+      );
       assert.equal((await fixture.ownerPool.query<{ fenced: boolean }>(
         "SELECT cleanup_eligible_at IS NULL AS fenced FROM content.media_blob_lifecycles WHERE sha256=$1",
         [attachedSha256],

--- a/db/migrations/0109_catalog_image_blob_ingestion.sql
+++ b/db/migrations/0109_catalog_image_blob_ingestion.sql
@@ -355,10 +355,14 @@ BEGIN
   END IF;
 
   UPDATE content.media_blob_lifecycles AS lifecycles SET
-    cleanup_eligible_at = GREATEST(
-      COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ),
-      admitted_cleanup_at
-    ),
+    cleanup_eligible_at = CASE
+      WHEN content.media_blob_has_active_reference_internal(p_sha256)
+      THEN NULL
+      ELSE GREATEST(
+        COALESCE(lifecycles.cleanup_eligible_at, '-infinity'::TIMESTAMPTZ),
+        admitted_cleanup_at
+      )
+    END,
     cleanup_lease_token = NULL,
     cleanup_lease_expires_at = NULL,
     updated_at = admitted_at


### PR DESCRIPTION
## Summary
- preserve cleanup fencing when catalog image admission replays against an actively referenced blob
- retain delayed cleanup eligibility for genuinely unreferenced admissions
- cover referenced replay and unreferenced admission in the PostgreSQL integration flow

## Validation
- not run locally per repository workflow