### PR TITLE
fix: order package version lifecycle locks

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -74,6 +74,7 @@ export const boundaryDefinitions = Object.freeze([
     migrationFileName: "0110_collection_cover_media.sql",
     expectedMigrationCount: 112,
     testFiles: Object.freeze([
+      "src/catalog/authoring/lockOrder.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",
     ]),
   }),
@@ -93,7 +94,6 @@ export const boundaryDefinitions = Object.freeze([
     testFiles: Object.freeze([
       "src/catalog/distribution/public/public.postgres.integration.ts",
       "src/catalog/distribution/install/install.postgres.integration.ts",
-      "src/catalog/authoring/lockOrder.postgres.integration.ts",
       "src/cards/generatedImageAppend.postgres.integration.ts",
       "src/chat/cardImages/operation.postgres.integration.ts",
       "src/chat/cardImages/promotion/jobsLeasing.postgres.integration.ts",

--- a/apps/backend/src/catalog/authoring/lockOrder.postgres.integration.ts
+++ b/apps/backend/src/catalog/authoring/lockOrder.postgres.integration.ts
@@ -19,6 +19,14 @@ function requireTestDatabaseUrl(): string {
   return databaseUrl;
 }
 
+function requireRuntimeDatabaseUrl(): string {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error("DATABASE_URL is required for the catalog authoring lock-order integration test.");
+  }
+  return databaseUrl;
+}
+
 function createClientExecutor(client: pg.PoolClient): DatabaseExecutor {
   return {
     query<Row extends pg.QueryResultRow>(
@@ -49,11 +57,15 @@ async function waitForLockWait(
   throw new Error(`Timed out waiting for ${operationName} to reach a PostgreSQL lock wait.`);
 }
 
-function isLockNotAvailable(error: unknown): boolean {
+function hasPostgresCode(error: unknown, code: string): boolean {
   return typeof error === "object"
     && error !== null
     && "code" in error
-    && error.code === "55P03";
+    && error.code === code;
+}
+
+function isLockNotAvailable(error: unknown): boolean {
+  return hasPostgresCode(error, "55P03");
 }
 
 test("catalog package update locks the package before its selected author", async () => {
@@ -235,5 +247,168 @@ test("catalog package update locks the package before its selected author", asyn
       [[originalAuthorId, selectedAuthorId]],
     );
     await pool.end();
+  }
+});
+
+test("package-version and cover-swap contracts prelock reverse-ordered lifecycle rows by SHA", async () => {
+  const adminPool = new pg.Pool({
+    connectionString: requireTestDatabaseUrl(),
+    application_name: "catalog-version-lifecycle-lock-order-admin-integration",
+    max: 3,
+  });
+  const runtimePool = new pg.Pool({
+    connectionString: requireRuntimeDatabaseUrl(),
+    application_name: "catalog-version-lifecycle-lock-order-runtime-integration",
+    max: 2,
+  });
+  const blockerClient = await adminPool.connect();
+  const versionClient = await runtimePool.connect();
+  const coverClient = await runtimePool.connect();
+  const firstSha256 = randomUUID().replaceAll("-", "").repeat(2);
+  const secondSha256 = randomUUID().replaceAll("-", "").repeat(2);
+  const [lowSha256, highSha256] = firstSha256 < secondSha256
+    ? [firstSha256, secondSha256] as const
+    : [secondSha256, firstSha256] as const;
+  const lowMediaBlobId = randomUUID();
+  const highMediaBlobId = randomUUID();
+  const packageId = randomUUID();
+  const storageKey = (sha256: string): string => (
+    `media/blobs/sha256/${sha256.slice(0, 2)}/${sha256.slice(2, 4)}/${sha256}`
+  );
+  let versionLockPromise: Promise<unknown> | null = null;
+  let coverLockPromise: Promise<unknown> | null = null;
+  let blockerTransactionOpen = false;
+  let versionTransactionOpen = false;
+  let coverTransactionOpen = false;
+
+  try {
+    await adminPool.query(
+      [
+        "INSERT INTO content.media_blob_lifecycles",
+        "(sha256,storage_key,mime_type,size_bytes,normalization_version)",
+        "VALUES($1,$2,'image/jpeg',42,'passthrough-v1'),",
+        "($3,$4,'image/jpeg',42,'passthrough-v1')",
+      ].join(" "),
+      [lowSha256, storageKey(lowSha256), highSha256, storageKey(highSha256)],
+    );
+    await adminPool.query(
+      [
+        "INSERT INTO content.media_blobs",
+        "(media_blob_id,sha256,mime_type,size_bytes,storage_key,normalization_version)",
+        "VALUES($1,$2,'image/jpeg',42,$3,'passthrough-v1'),",
+        "($4,$5,'image/jpeg',42,$6,'passthrough-v1')",
+      ].join(" "),
+      [
+        lowMediaBlobId,
+        lowSha256,
+        storageKey(lowSha256),
+        highMediaBlobId,
+        highSha256,
+        storageKey(highSha256),
+      ],
+    );
+
+    await blockerClient.query("BEGIN");
+    blockerTransactionOpen = true;
+    await blockerClient.query(
+      "SELECT 1 FROM content.media_blob_lifecycles WHERE sha256=$1 FOR UPDATE",
+      [lowSha256],
+    );
+
+    await versionClient.query("BEGIN");
+    versionTransactionOpen = true;
+    await versionClient.query("SET LOCAL statement_timeout = '10s'");
+    const versionPid = Number((await versionClient.query<{ pid: number }>(
+      "SELECT pg_backend_pid() AS pid",
+    )).rows[0]?.pid);
+    versionLockPromise = versionClient.query(
+      "SELECT content.lock_catalog_package_version_media_blob_lifecycles($1,$2::uuid[])",
+      [packageId, [highMediaBlobId, lowMediaBlobId]],
+    );
+    await waitForLockWait(adminPool, versionPid, "reverse-ordered package-version prelock");
+
+    await coverClient.query("BEGIN");
+    coverTransactionOpen = true;
+    await coverClient.query("SET LOCAL statement_timeout = '10s'");
+    const coverPid = Number((await coverClient.query<{ pid: number }>(
+      "SELECT pg_backend_pid() AS pid",
+    )).rows[0]?.pid);
+    coverLockPromise = coverClient.query(
+      "SELECT content.lock_media_blob_lifecycles_for_reference_swap($1,$2)",
+      [highMediaBlobId, lowMediaBlobId],
+    );
+    await waitForLockWait(adminPool, coverPid, "concurrent cover-swap prelock");
+
+    const unlockedHighSha = await adminPool.query<{ sha256: string }>(
+      "SELECT sha256 FROM content.media_blob_lifecycles WHERE sha256=$1 FOR UPDATE NOWAIT",
+      [highSha256],
+    );
+    assert.equal(unlockedHighSha.rows[0]?.sha256, highSha256);
+
+    await blockerClient.query("COMMIT");
+    blockerTransactionOpen = false;
+    const firstCompleted = await Promise.race([
+      versionLockPromise.then(() => "version" as const),
+      coverLockPromise.then(() => "cover" as const),
+    ]);
+    if (firstCompleted === "version") {
+      await versionClient.query("COMMIT");
+      versionTransactionOpen = false;
+      await coverLockPromise;
+      await coverClient.query("COMMIT");
+      coverTransactionOpen = false;
+    } else {
+      await coverClient.query("COMMIT");
+      coverTransactionOpen = false;
+      await versionLockPromise;
+      await versionClient.query("COMMIT");
+      versionTransactionOpen = false;
+    }
+
+    await assert.rejects(
+      versionClient.query(
+        "SELECT content.lock_catalog_package_version_media_blob_lifecycles($1,$2::uuid[])",
+        [packageId, [lowMediaBlobId, randomUUID()]],
+      ),
+      (error: unknown) => hasPostgresCode(error, "23503"),
+    );
+    await adminPool.query(
+      "DELETE FROM content.media_blob_lifecycles WHERE sha256=$1",
+      [highSha256],
+    );
+    await assert.rejects(
+      versionClient.query(
+        "SELECT content.lock_catalog_package_version_media_blob_lifecycles($1,$2::uuid[])",
+        [packageId, [highMediaBlobId]],
+      ),
+      (error: unknown) => hasPostgresCode(error, "23514"),
+    );
+  } finally {
+    if (blockerTransactionOpen) {
+      await blockerClient.query("ROLLBACK");
+    }
+    if (versionTransactionOpen) {
+      await versionClient.query("ROLLBACK");
+    }
+    if (coverTransactionOpen) {
+      await coverClient.query("ROLLBACK");
+    }
+    await Promise.allSettled([
+      versionLockPromise ?? Promise.resolve(),
+      coverLockPromise ?? Promise.resolve(),
+    ]);
+    blockerClient.release();
+    versionClient.release();
+    coverClient.release();
+    await adminPool.query(
+      "DELETE FROM content.media_blobs WHERE media_blob_id=ANY($1::uuid[])",
+      [[lowMediaBlobId, highMediaBlobId]],
+    );
+    await adminPool.query(
+      "DELETE FROM content.media_blob_lifecycles WHERE sha256=ANY($1::text[])",
+      [[lowSha256, highSha256]],
+    );
+    await runtimePool.end();
+    await adminPool.end();
   }
 });

--- a/apps/backend/src/catalog/authoring/publication.test.ts
+++ b/apps/backend/src/catalog/authoring/publication.test.ts
@@ -118,6 +118,11 @@ function createCatalogPublicationBoundaryHarness(
         return createQueryResult([versionRow as unknown as Row]);
       }
 
+      if (text.includes("lock_catalog_package_version_media_blob_lifecycles")) {
+        assert.deepEqual(params, [testPackageId, []]);
+        return createQueryResult([]);
+      }
+
       if (text.includes("INSERT INTO catalog.package_media_assets") && text.includes("SELECT gen_random_uuid()")) {
         versionMediaKeys = [...input.draftMediaKeys];
         return createQueryResult([]);

--- a/apps/backend/src/catalog/authoring/versionCreation.ts
+++ b/apps/backend/src/catalog/authoring/versionCreation.ts
@@ -292,6 +292,17 @@ async function copyDraftMediaAssetsToPackageVersionInExecutor(
   );
 }
 
+async function lockPackageVersionMediaBlobLifecyclesInExecutor(
+  executor: DatabaseExecutor,
+  packageId: string,
+  versionMediaAssets: ReadonlyArray<CatalogPackageVersionMediaAssetInput>,
+): Promise<void> {
+  await executor.query(
+    "SELECT content.lock_catalog_package_version_media_blob_lifecycles($1, $2::uuid[])",
+    [packageId, versionMediaAssets.map((mediaAsset) => mediaAsset.mediaBlobId)],
+  );
+}
+
 async function insertPackageCardsInExecutor(
   executor: DatabaseExecutor,
   packageVersionId: string,
@@ -376,6 +387,11 @@ export async function createPackageVersionFromNormalizedCardsInExecutor(
     throw new Error("Expected catalog package version insert to return a row");
   }
 
+  await lockPackageVersionMediaBlobLifecyclesInExecutor(
+    executor,
+    packageId,
+    versionMediaAssets,
+  );
   await copyDraftMediaAssetsToPackageVersionInExecutor(executor, packageId, input.packageVersionId);
   await insertCatalogPackageVersionMediaAssetsInExecutor(
     executor,

--- a/apps/backend/src/catalog/authoring/workspaceSnapshots.test.ts
+++ b/apps/backend/src/catalog/authoring/workspaceSnapshots.test.ts
@@ -73,6 +73,11 @@ test("workspace-selected catalog versions generate fresh package card ids", asyn
         } as unknown as Row]);
       }
 
+      if (text.includes("lock_catalog_package_version_media_blob_lifecycles")) {
+        assert.deepEqual(params, [testPackageId, []]);
+        return createQueryResult([]);
+      }
+
       if (text.includes("INSERT INTO catalog.package_media_assets")) {
         assert.deepEqual(params, [testPackageId, testPackageVersionId]);
         return createQueryResult([]);
@@ -205,6 +210,14 @@ test("workspace-selected catalog versions preserve managed media as package medi
           ...createPackageVersionRow("draft"),
           source_workspace_id: testWorkspaceId,
         } as unknown as Row]);
+      }
+
+      if (text.includes("lock_catalog_package_version_media_blob_lifecycles")) {
+        assert.deepEqual(params, [
+          testPackageId,
+          [testMediaBlobId, testSecondMediaBlobId],
+        ]);
+        return createQueryResult([]);
       }
 
       if (text.includes("INSERT INTO catalog.package_media_assets")) {

--- a/db/migrations/0110_collection_cover_media.sql
+++ b/db/migrations/0110_collection_cover_media.sql
@@ -37,6 +37,74 @@ BEFORE INSERT OR UPDATE OF cover_media_blob_id ON catalog.collections
 FOR EACH ROW
 EXECUTE FUNCTION content.fence_catalog_collection_cover_reference();
 
+CREATE FUNCTION content.lock_media_blob_lifecycles_for_references(
+  p_media_blob_ids UUID[]
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  expected_count BIGINT;
+  ordered_media_blob_ids UUID[];
+  ordered_sha256s TEXT[];
+  requested_index INTEGER;
+  locked_sha256 TEXT;
+BEGIN
+  IF p_media_blob_ids IS NULL
+    OR pg_catalog.array_position(p_media_blob_ids, NULL) IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'p_media_blob_ids must be a non-null array of media blob ids'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT pg_catalog.count(DISTINCT requested.media_blob_id)
+  INTO expected_count
+  FROM pg_catalog.unnest(p_media_blob_ids) AS requested(media_blob_id);
+  IF expected_count = 0 THEN
+    RETURN;
+  END IF;
+
+  SELECT
+    pg_catalog.array_agg(blobs.media_blob_id ORDER BY blobs.sha256),
+    pg_catalog.array_agg(blobs.sha256 ORDER BY blobs.sha256)
+  INTO ordered_media_blob_ids, ordered_sha256s
+  FROM content.media_blobs AS blobs
+  WHERE blobs.media_blob_id = ANY(p_media_blob_ids);
+  IF COALESCE(pg_catalog.cardinality(ordered_media_blob_ids), 0) <> expected_count
+  THEN
+    RAISE EXCEPTION 'Media blob lifecycle lock request targets a missing media blob'
+      USING ERRCODE = '23503';
+  END IF;
+
+  FOREACH locked_sha256 IN ARRAY ordered_sha256s
+  LOOP
+    PERFORM 1
+    FROM content.media_blob_lifecycles AS lifecycles
+    WHERE lifecycles.sha256 = locked_sha256
+    FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Media blob lifecycle lock request targets missing lifecycle metadata'
+        USING ERRCODE = '23514';
+    END IF;
+  END LOOP;
+
+  FOR requested_index IN 1..pg_catalog.cardinality(ordered_media_blob_ids)
+  LOOP
+    PERFORM 1
+    FROM content.media_blobs AS blobs
+    WHERE blobs.media_blob_id = ordered_media_blob_ids[requested_index]
+      AND blobs.sha256 = ordered_sha256s[requested_index]
+    FOR SHARE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Media blob lifecycle lock request targets a missing media blob'
+        USING ERRCODE = '23503';
+    END IF;
+  END LOOP;
+END;
+$$;
+
 CREATE FUNCTION content.lock_media_blob_lifecycles_for_reference_swap(
   p_old_media_blob_id UUID,
   p_new_media_blob_id UUID
@@ -47,39 +115,70 @@ SECURITY DEFINER
 SET search_path = pg_catalog
 AS $$
 DECLARE
-  expected_count BIGINT;
-  locked_count BIGINT;
+  requested_media_blob_ids UUID[];
 BEGIN
   IF p_new_media_blob_id IS NULL THEN
     RAISE EXCEPTION 'p_new_media_blob_id is required' USING ERRCODE = '22023';
   END IF;
-  expected_count := CASE
+  requested_media_blob_ids := CASE
     WHEN p_old_media_blob_id IS NULL
       OR p_old_media_blob_id = p_new_media_blob_id
-    THEN 1
-    ELSE 2
+    THEN ARRAY[p_new_media_blob_id]
+    ELSE ARRAY[p_old_media_blob_id, p_new_media_blob_id]
   END;
-  SELECT pg_catalog.count(*) INTO locked_count
-  FROM content.media_blobs AS blobs
-  WHERE blobs.media_blob_id = p_new_media_blob_id
-    OR blobs.media_blob_id = p_old_media_blob_id;
-  IF locked_count <> expected_count THEN
-    RAISE EXCEPTION 'Media blob reference swap targets a missing media blob'
-      USING ERRCODE = '23503';
+  BEGIN
+    PERFORM content.lock_media_blob_lifecycles_for_references(
+      requested_media_blob_ids
+    );
+  EXCEPTION
+    WHEN foreign_key_violation THEN
+      RAISE EXCEPTION 'Media blob reference swap targets a missing media blob'
+        USING ERRCODE = '23503';
+    WHEN check_violation THEN
+      RAISE EXCEPTION 'Media blob reference swap targets missing lifecycle metadata'
+        USING ERRCODE = '23514';
+  END;
+END;
+$$;
+
+CREATE FUNCTION content.lock_catalog_package_version_media_blob_lifecycles(
+  p_package_id UUID,
+  p_version_media_blob_ids UUID[]
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  requested_media_blob_ids UUID[];
+BEGIN
+  IF p_package_id IS NULL THEN
+    RAISE EXCEPTION 'p_package_id is required' USING ERRCODE = '22023';
+  END IF;
+  IF p_version_media_blob_ids IS NULL
+    OR pg_catalog.array_position(p_version_media_blob_ids, NULL) IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'p_version_media_blob_ids must be a non-null array of media blob ids'
+      USING ERRCODE = '22023';
   END IF;
 
-  PERFORM 1
-  FROM content.media_blob_lifecycles AS lifecycles
-  INNER JOIN content.media_blobs AS blobs USING (sha256)
-  WHERE blobs.media_blob_id = p_new_media_blob_id
-    OR blobs.media_blob_id = p_old_media_blob_id
-  ORDER BY lifecycles.sha256
-  FOR UPDATE OF lifecycles;
-  GET DIAGNOSTICS locked_count = ROW_COUNT;
-  IF locked_count <> expected_count THEN
-    RAISE EXCEPTION 'Media blob reference swap targets missing lifecycle metadata'
-      USING ERRCODE = '23514';
-  END IF;
+  SELECT pg_catalog.array_agg(requested.media_blob_id)
+  INTO requested_media_blob_ids
+  FROM (
+    SELECT assets.media_blob_id
+    FROM catalog.package_media_assets AS assets
+    WHERE assets.package_id = p_package_id
+      AND assets.package_version_id IS NULL
+    UNION
+    SELECT version_media.media_blob_id
+    FROM pg_catalog.unnest(p_version_media_blob_ids)
+      AS version_media(media_blob_id)
+  ) AS requested;
+
+  PERFORM content.lock_media_blob_lifecycles_for_references(
+    COALESCE(requested_media_blob_ids, ARRAY[]::UUID[])
+  );
 END;
 $$;
 
@@ -322,7 +421,13 @@ $$;
 REVOKE ALL ON FUNCTION content.fence_catalog_collection_cover_reference()
 FROM PUBLIC, backend_app, auth_app, reporting_readonly;
 REVOKE ALL ON FUNCTION
+  content.lock_media_blob_lifecycles_for_references(UUID[])
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
   content.lock_media_blob_lifecycles_for_reference_swap(UUID, UUID)
+FROM PUBLIC, backend_app, auth_app, reporting_readonly;
+REVOKE ALL ON FUNCTION
+  content.lock_catalog_package_version_media_blob_lifecycles(UUID, UUID[])
 FROM PUBLIC, backend_app, auth_app, reporting_readonly;
 REVOKE ALL ON FUNCTION content.media_blob_has_active_reference_internal(TEXT)
 FROM PUBLIC, backend_app, auth_app, reporting_readonly;
@@ -331,4 +436,7 @@ REVOKE ALL ON FUNCTION
 FROM PUBLIC, backend_app, auth_app, reporting_readonly;
 GRANT EXECUTE ON FUNCTION
   content.lock_media_blob_lifecycles_for_reference_swap(UUID, UUID)
+TO backend_app;
+GRANT EXECUTE ON FUNCTION
+  content.lock_catalog_package_version_media_blob_lifecycles(UUID, UUID[])
 TO backend_app;


### PR DESCRIPTION
## Summary
- prelock all package-version media blob lifecycle rows in canonical SHA order
- reuse the lifecycle lock primitive for package versions and cover swaps
- add deterministic PostgreSQL concurrency coverage

## Review
- fresh review-kirill review: no P0-P4 findings
- local project checks not run per repository workflow