### PR TITLE
fix: allow published package media authoring

### DIFF
--- a/apps/backend/src/catalog/authoring/authorsDrafts.test.ts
+++ b/apps/backend/src/catalog/authoring/authorsDrafts.test.ts
@@ -469,7 +469,7 @@ test("catalog package media assets attach through content.media_blobs", async ()
   assert.equal(queries.length, 2);
 });
 
-test("catalog package image authoring replays card bytes and safely replaces cover bytes", async () => {
+test("published catalog packages can stage and replay card images and replace covers for later versions", async () => {
   const replacementBlobId = "66666666-6666-4666-8666-666666666666";
   const cardMediaAssetId = "77777777-7777-4777-8777-777777777777";
   let cardRow: CatalogPackageMediaAssetRow | null = null;
@@ -493,7 +493,11 @@ test("catalog package image authoring replays card bytes and safely replaces cov
       params: ReadonlyArray<SqlValue>,
     ): Promise<pg.QueryResult<Row>> {
       if (text.includes("FROM catalog.packages") && text.includes("FOR UPDATE")) {
-        return createQueryResult([createPackageRow() as unknown as Row]);
+        return createQueryResult([{
+          ...createPackageRow(),
+          status: "published",
+          published_at: testTimestamp,
+        } as unknown as Row]);
       }
       if (text.includes("FROM catalog.package_media_assets") && text.includes("FOR UPDATE")) {
         const row = params[1] === "cover" ? coverRow : cardRow;

--- a/apps/backend/src/catalog/authoring/draftMedia.ts
+++ b/apps/backend/src/catalog/authoring/draftMedia.ts
@@ -21,7 +21,6 @@ import type {
   AttachCatalogPackageMediaAssetInput,
   CatalogPackageMediaAsset,
   CatalogPackageMediaAssetRow,
-  CatalogPackageStatus,
   CatalogPackageVersionMediaAssetInput,
 } from "../types";
 
@@ -31,21 +30,6 @@ export type CatalogPackageMediaMutationResult = Readonly<{
   mediaAsset: CatalogPackageMediaAsset;
   applied: boolean;
 }>;
-
-function assertCatalogPackageIsDraft(
-  packageId: string,
-  status: CatalogPackageStatus,
-): void {
-  if (status === "draft") {
-    return;
-  }
-
-  throw new HttpError(
-    409,
-    `Catalog package is not a draft authoring target. packageId=${packageId} status=${status}`,
-    "CATALOG_PACKAGE_NOT_DRAFT",
-  );
-}
 
 export async function scheduleDisplacedMediaBlobCleanupInExecutor(
   executor: DatabaseExecutor,
@@ -135,8 +119,7 @@ export async function createOrReplayCatalogPackageDraftCardImageInExecutor(
     );
   }
   try {
-    const catalogPackage = await lockCatalogPackageInExecutor(executor, packageId);
-    assertCatalogPackageIsDraft(packageId, catalogPackage.status);
+    await lockCatalogPackageInExecutor(executor, packageId);
     const existing = await loadCatalogPackageDraftMediaAssetForUpdateInExecutor(
       executor,
       packageId,
@@ -175,7 +158,6 @@ export async function replaceCatalogPackageDraftCoverInExecutor(
   const packageMediaKey = "cover";
   try {
     const catalogPackage = await lockCatalogPackageInExecutor(executor, packageId);
-    assertCatalogPackageIsDraft(packageId, catalogPackage.status);
     const existing = await loadCatalogPackageDraftMediaAssetForUpdateInExecutor(
       executor,
       packageId,


### PR DESCRIPTION
Allows published catalog packages to keep staging and replaying package-level card media and replacing their draft cover for later versions. Package locking, replay conflicts, lifecycle prelocks, cleanup, and route boundaries remain unchanged.

Validation: no local project checks were run per repository workflow. The fresh static review reported no P0-P4 findings or additional notes.