### PR TITLE
Fix catalog media PostgreSQL release fixtures

### DIFF
--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts
@@ -30,6 +30,7 @@ import {
 } from "./index";
 import {
   buildMediaBlobStorageKey,
+  buildMediaMultipartUploadStagingStorageKey,
   buildMediaUploadStagingStorageKey,
 } from "../storageKeys";
 import { imageJpegCardMediaBlobNormalizationVersion } from "../types";
@@ -554,7 +555,7 @@ test("catalog image admission stays fenced across reverse-SHA package and collec
           "DELETE FROM content.media_blobs WHERE media_blob_id=$1",
           [replacementMediaBlobId],
         ),
-        (error: unknown) => hasPostgresCode(error, "23503"),
+        (error: unknown) => hasPostgresCode(error, "23001"),
       );
       await fixture.ownerPool.query(
         "UPDATE content.media_blob_lifecycles SET cleanup_eligible_at=clock_timestamp()-interval '1 second' WHERE sha256=$1",
@@ -601,7 +602,7 @@ test("workspace multipart ingestion adopts existing catalog cover provenance", a
     const lastOperationId = randomUUID();
     const s3UploadId = `upload-${randomUUID()}`;
     const storageKey = buildMediaBlobStorageKey(sha256);
-    const stagingStorageKey = buildMediaUploadStagingStorageKey(
+    const stagingStorageKey = buildMediaMultipartUploadStagingStorageKey(
       fixture.workspaceId,
       mediaAssetId,
       sessionId,


### PR DESCRIPTION
## Summary

- expect PostgreSQL's `restrict_violation` SQLSTATE for the collection-cover `ON DELETE RESTRICT` assertion
- build the multipart fixture's staging key with the canonical session-scoped helper
- keep migrations and production lifecycle/security behavior unchanged

## Root cause

AWS/Web Release run 31530426932 reached the new 0110 PostgreSQL boundary, where two newly promoted fixtures encoded the wrong expectations: one treated a direct `RESTRICT` failure as `foreign_key_violation`, and one used the direct/generated upload key builder for a multipart session row.

## Review and validation

- fresh static review: no P0-P4 issues found; no additional notes
- no local project checks run, per repository instructions; PR CI owns executable validation