### PR TITLE
Run public catalog integration at collection-cover boundary

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -75,6 +75,7 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 112,
     testFiles: Object.freeze([
       "src/catalog/authoring/lockOrder.postgres.integration.ts",
+      "src/catalog/distribution/public/public.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/cleanup.postgres.integration.ts",
     ]),
   }),
@@ -92,7 +93,6 @@ export const boundaryDefinitions = Object.freeze([
     migrationFileName: "0107_catalog_test_collection.sql",
     expectedMigrationCount: 109,
     testFiles: Object.freeze([
-      "src/catalog/distribution/public/public.postgres.integration.ts",
       "src/catalog/distribution/install/install.postgres.integration.ts",
       "src/cards/generatedImageAppend.postgres.integration.ts",
       "src/chat/cardImages/operation.postgres.integration.ts",


### PR DESCRIPTION
## Summary

- move the public catalog snapshot integration from migration boundary 0107 to 0110
- keep older boundary coverage and all production migrations/runtime behavior unchanged

## Root cause

After PR #1437 fixed the two original 0110 fixtures, AWS/Web Release run 31532517938 passed boundary 0110 and exposed the next stale boundary assignment: the public snapshot test executes `loadPublicCatalogCollectionCoversInExecutor`, which now queries `catalog.collections.cover_media_blob_id` from migration 0110, but the test was still executed against the 0107 schema snapshot.

## Review and validation

- fresh static review: no P0-P4 issues found; no additional notes
- no local project checks run, per repository instructions; PR CI owns executable validation