### PR TITLE
Refactor catalog authoring workflows

### DIFF
--- a/apps/backend/src/catalog/authoring/authorsDrafts.test.ts
+++ b/apps/backend/src/catalog/authoring/authorsDrafts.test.ts
@@ -27,7 +27,7 @@ import {
   attachCatalogPackageDraftMediaAssetInExecutor,
   createOrReplayCatalogPackageDraftCardImageInExecutor,
   replaceCatalogPackageDraftCoverInExecutor,
-} from "./draftMedia";
+} from "./media/draftMedia";
 import { createCatalogPackageDraftInExecutor, updateCatalogPackageDraftInExecutor } from "./drafts";
 
 function createAuthorRow(websiteUrl: string | null): CatalogAuthorRow {

--- a/apps/backend/src/catalog/authoring/drafts.ts
+++ b/apps/backend/src/catalog/authoring/drafts.ts
@@ -8,7 +8,7 @@ import {
   normalizeSlug,
   normalizeTextArray,
 } from "../common";
-import { assertDraftMediaKeysExistInExecutor } from "./draftMedia";
+import { assertDraftMediaKeysExistInExecutor } from "./media/draftMedia";
 import { rethrowCatalogPersistenceError } from "../errors";
 import {
   getPublicCatalogAuthorEligibilityIssue,

--- a/apps/backend/src/catalog/authoring/media/collectionCovers.ts
+++ b/apps/backend/src/catalog/authoring/media/collectionCovers.ts
@@ -1,14 +1,14 @@
-import type { DatabaseExecutor } from "../../database";
-import { rethrowCatalogPersistenceError } from "../errors";
+import type { DatabaseExecutor } from "../../../database";
+import { rethrowCatalogPersistenceError } from "../../errors";
 import {
   catalogCollectionCoverColumns,
   lockCatalogCollectionCoverInExecutor,
   mapCatalogCollectionCoverRow,
-} from "../rows";
+} from "../../rows";
 import type {
   CatalogCollectionCover,
   CatalogCollectionCoverRow,
-} from "../types";
+} from "../../types";
 import { scheduleDisplacedMediaBlobCleanupInExecutor } from "./draftMedia";
 
 export type CatalogCollectionCoverMutationResult = Readonly<{

--- a/apps/backend/src/catalog/authoring/media/draftMedia.ts
+++ b/apps/backend/src/catalog/authoring/media/draftMedia.ts
@@ -1,28 +1,28 @@
-import type { DatabaseExecutor } from "../../database";
-import { getDatabaseErrorFields } from "../../database/transient";
-import { unsafeTransaction } from "../../database/core";
+import type { DatabaseExecutor } from "../../../database";
+import { getDatabaseErrorFields } from "../../../database/transient";
+import { unsafeTransaction } from "../../../database/core";
 import {
   mediaBlobCleanupDelayMs,
   MediaBlobLifecycleBusyError,
   MediaBlobLifecycleConflictError,
-} from "../../mediaAssets/blobLifecycle";
-import { HttpError } from "../../shared/errors";
+} from "../../../mediaAssets/blobLifecycle";
+import { HttpError } from "../../../shared/errors";
 import {
   normalizeNullableString,
   normalizePackageMediaKey,
-} from "../common";
-import { rethrowCatalogPersistenceError } from "../errors";
+} from "../../common";
+import { rethrowCatalogPersistenceError } from "../../errors";
 import {
   catalogPackageMediaAssetColumns,
   lockCatalogPackageInExecutor,
   mapCatalogPackageMediaAssetRow,
-} from "../rows";
+} from "../../rows";
 import type {
   AttachCatalogPackageMediaAssetInput,
   CatalogPackageMediaAsset,
   CatalogPackageMediaAssetRow,
   CatalogPackageVersionMediaAssetInput,
-} from "../types";
+} from "../../types";
 
 type PackageMediaKeyRow = Readonly<{ package_media_key: string }>;
 

--- a/apps/backend/src/catalog/authoring/media/imageIngestion.ts
+++ b/apps/backend/src/catalog/authoring/media/imageIngestion.ts
@@ -2,17 +2,17 @@ import { createHash } from "node:crypto";
 import {
   DatabaseDeadlineExceededError,
   type DatabaseExecutor,
-} from "../../database";
-import { unsafeTransactionWithDeadline } from "../../database/unsafe";
-import { DatabaseCommitOutcomeUnknownError } from "../../database/transient";
-import { MediaBlobLifecycleConflictError } from "../../mediaAssets/blobLifecycle";
+} from "../../../database";
+import { unsafeTransactionWithDeadline } from "../../../database/unsafe";
+import { DatabaseCommitOutcomeUnknownError } from "../../../database/transient";
+import { MediaBlobLifecycleConflictError } from "../../../mediaAssets/blobLifecycle";
 import {
   assertMediaBlobMatchesMetadata,
   findMediaBlobRowBySha256InExecutor,
   mapMediaBlobRow,
-} from "../../mediaAssets/persistence";
-import { storeCatalogImageBlobBytesIfAbsent } from "../../mediaAssets/storage/direct";
-import { buildMediaBlobStorageKey } from "../../mediaAssets/storageKeys";
+} from "../../../mediaAssets/persistence";
+import { storeCatalogImageBlobBytesIfAbsent } from "../../../mediaAssets/storage/direct";
+import { buildMediaBlobStorageKey } from "../../../mediaAssets/storageKeys";
 import {
   imageJpegCardMediaBlobNormalizationVersion,
   imageJpegCatalogCoverMediaBlobNormalizationVersion,
@@ -20,19 +20,19 @@ import {
   type MediaBlob,
   type MediaBlobNormalizationVersion,
   type MediaBlobRow,
-} from "../../mediaAssets/types";
+} from "../../../mediaAssets/types";
 import {
   normalizeImageBytesForCardUntilDeadline,
   normalizeImageBytesForCatalogCoverUntilDeadline,
   type NormalizedImageBytes,
-} from "../../mediaAssets/ingestion/imageNormalization";
-import type { BackendObservationScope } from "../../observability/sentry/events";
-import { HttpError } from "../../shared/errors";
-import { maximumPublicCatalogMediaDownloadBytes } from "../publicMediaDelivery";
+} from "../../../mediaAssets/ingestion/imageNormalization";
+import type { BackendObservationScope } from "../../../observability/sentry/events";
+import { HttpError } from "../../../shared/errors";
+import { maximumPublicCatalogMediaDownloadBytes } from "../../publicMediaDelivery";
 import type {
   CatalogCollectionCover,
   CatalogPackageMediaAsset,
-} from "../types";
+} from "../../types";
 import {
   replaceCatalogCollectionCoverInExecutor,
   type CatalogCollectionCoverMutationResult,

--- a/apps/backend/src/catalog/authoring/versions/creation.ts
+++ b/apps/backend/src/catalog/authoring/versions/creation.ts
@@ -1,22 +1,22 @@
-import type { DatabaseExecutor } from "../../database";
-import { HttpError } from "../../shared/errors";
+import type { DatabaseExecutor } from "../../../database";
+import { HttpError } from "../../../shared/errors";
 import {
   extractMarkdownManagedMediaLifecycleIssues,
   type ManagedMediaLifecycleIssues,
-} from "../../workspacePackages";
+} from "../../../workspacePackages";
 import {
   normalizeAdminEmail,
   normalizeNonEmptyString,
   normalizePackageMediaKey,
   normalizeTextArray,
   toSafeNumber,
-} from "../common";
-import { rethrowCatalogPersistenceError } from "../errors";
+} from "../../common";
+import { rethrowCatalogPersistenceError } from "../../errors";
 import {
   catalogPackageVersionColumns,
   lockCatalogPackageInExecutor,
   mapCatalogPackageVersionRow,
-} from "../rows";
+} from "../../rows";
 import type {
   CatalogPackageCardSnapshotInput,
   CatalogPackageStatus,
@@ -24,11 +24,11 @@ import type {
   CatalogPackageVersionMediaAssetInput,
   CatalogPackageVersionRow,
   CreateCatalogPackageVersionInput,
-} from "../types";
+} from "../../types";
 import {
   assertDraftMediaKeysExistInExecutor,
   insertCatalogPackageVersionMediaAssetsInExecutor,
-} from "./draftMedia";
+} from "../media/draftMedia";
 
 export function collectCardManagedMediaLifecycleIssues(
   frontText: string,

--- a/apps/backend/src/catalog/authoring/versions/index.ts
+++ b/apps/backend/src/catalog/authoring/versions/index.ts
@@ -1,13 +1,13 @@
-import { unsafeTransaction } from "../../database/core";
+import { unsafeTransaction } from "../../../database/core";
 import type {
   CatalogPackageVersion,
   CreateCatalogPackageVersionFromWorkspaceInput,
   CreateCatalogPackageVersionInput,
   UpdateCatalogPackageVersionStatusInput,
-} from "../types";
+} from "../../types";
 import {
   createCatalogPackageVersionFromCardsInExecutor,
-} from "./versionCreation";
+} from "./creation";
 import {
   createCatalogPackageVersionFromWorkspaceSelectionInExecutor,
 } from "./workspaceSnapshots";
@@ -19,7 +19,7 @@ import {
 
 export {
   createCatalogPackageVersionFromCardsInExecutor,
-} from "./versionCreation";
+} from "./creation";
 export {
   createCatalogPackageVersionFromWorkspaceSelectionInExecutor,
 } from "./workspaceSnapshots";

--- a/apps/backend/src/catalog/authoring/versions/publication.test.ts
+++ b/apps/backend/src/catalog/authoring/versions/publication.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../../database";
-import { HttpError } from "../../shared/errors";
-import { maximumPublicCatalogMediaDownloadBytes } from "../publicMediaDelivery";
+import type { DatabaseExecutor, SqlValue } from "../../../database";
+import { HttpError } from "../../../shared/errors";
+import { maximumPublicCatalogMediaDownloadBytes } from "../../publicMediaDelivery";
 import {
   createQueryResult,
   testAuthorId,
@@ -11,18 +11,18 @@ import {
   testPackageVersionId,
   testTimestamp,
   testWorkspaceCardId,
-} from "../testSupport";
-import type { CatalogPackageStatus, CatalogPackageVersionRow } from "../types";
+} from "../../testSupport";
+import type { CatalogPackageStatus, CatalogPackageVersionRow } from "../../types";
 import {
   createPackageRow,
   createPackageVersionRow,
   unsafePublicCatalogStorageReference,
-} from "./authoringTestSupport";
+} from "../authoringTestSupport";
 import {
   createCatalogPackageVersionFromCardsInExecutor,
   publishCatalogPackageVersionInExecutor,
   updateCatalogPackageVersionReviewStatusInExecutor,
-} from "./versions";
+} from "./index";
 
 type CatalogPublicationBoundaryHarness = Readonly<{
   executor: DatabaseExecutor;

--- a/apps/backend/src/catalog/authoring/versions/publication.ts
+++ b/apps/backend/src/catalog/authoring/versions/publication.ts
@@ -1,30 +1,30 @@
-import type { DatabaseExecutor } from "../../database";
-import { HttpError } from "../../shared/errors";
-import { normalizeAdminEmail, normalizeNullableString } from "../common";
-import { rethrowCatalogPersistenceError } from "../errors";
+import type { DatabaseExecutor } from "../../../database";
+import { HttpError } from "../../../shared/errors";
+import { normalizeAdminEmail, normalizeNullableString } from "../../common";
+import { rethrowCatalogPersistenceError } from "../../errors";
 import {
   maximumPublicCatalogMediaDownloadBytes,
   publicCatalogMediaDownloadMimeTypes,
-} from "../publicMediaDelivery";
+} from "../../publicMediaDelivery";
 import {
   getPublicCatalogVersionEligibilityIssue,
   type PublicCatalogAuthorEligibilityInput,
   type PublicCatalogPackageEligibilityInput,
   type PublicCatalogVersionEligibilityIssue,
   type PublicCatalogVersionMediaAssetInput,
-} from "../publicSafety";
+} from "../../publicSafety";
 import {
   catalogPackageVersionColumns,
   lockCatalogPackageInExecutor,
   mapCatalogPackageVersionRow,
-} from "../rows";
+} from "../../rows";
 import type {
   CatalogPackageStatus,
   CatalogPackageVersion,
   CatalogPackageVersionRow,
   UpdateCatalogPackageVersionStatusInput,
-} from "../types";
-import { insertPackageVersionStatusEventInExecutor } from "./versionCreation";
+} from "../../types";
+import { insertPackageVersionStatusEventInExecutor } from "./creation";
 
 const reviewStatusRouteTargets: ReadonlySet<CatalogPackageStatus> = new Set([
   "draft",

--- a/apps/backend/src/catalog/authoring/versions/workspaceSnapshots.test.ts
+++ b/apps/backend/src/catalog/authoring/versions/workspaceSnapshots.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
-import type { DatabaseExecutor, SqlValue } from "../../database";
-import { HttpError } from "../../shared/errors";
+import type { DatabaseExecutor, SqlValue } from "../../../database";
+import { HttpError } from "../../../shared/errors";
 import {
   assertPublicPayloadDoesNotContainUnsafeMediaReferences,
   createQueryResult,
@@ -13,12 +13,12 @@ import {
   testWorkspaceCardId,
   testWorkspaceId,
   testWorkspaceMediaAssetId,
-} from "../testSupport";
-import { createPackageRow, createPackageVersionRow } from "./authoringTestSupport";
+} from "../../testSupport";
+import { createPackageRow, createPackageVersionRow } from "../authoringTestSupport";
 import {
   createCatalogPackageVersionFromCardsInExecutor,
   createCatalogPackageVersionFromWorkspaceSelectionInExecutor,
-} from "./versions";
+} from "./index";
 
 const testSecondWorkspaceMediaAssetId = "99999999-9999-4999-8999-999999999999";
 const testSecondMediaBlobId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";

--- a/apps/backend/src/catalog/authoring/versions/workspaceSnapshots.ts
+++ b/apps/backend/src/catalog/authoring/versions/workspaceSnapshots.ts
@@ -2,30 +2,30 @@ import { randomUUID } from "node:crypto";
 import {
   applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
-} from "../../database";
-import { HttpError } from "../../shared/errors";
+} from "../../../database";
+import { HttpError } from "../../../shared/errors";
 import {
   extractMarkdownFcAssetIds,
   rewriteMarkdownFcAssetUrlsToFcAssets,
-} from "../../workspacePackages";
-import { normalizeAdminEmail, normalizePackageMediaKey } from "../common";
-import { rethrowCatalogPersistenceError } from "../errors";
-import { lockCatalogPackageInExecutor } from "../rows";
+} from "../../../workspacePackages";
+import { normalizeAdminEmail, normalizePackageMediaKey } from "../../common";
+import { rethrowCatalogPersistenceError } from "../../errors";
+import { lockCatalogPackageInExecutor } from "../../rows";
 import type {
   CatalogPackageCardSnapshotInput,
   CatalogPackageVersion,
   CatalogPackageVersionMediaAssetInput,
   CatalogWorkspaceCardRow,
   CreateCatalogPackageVersionFromWorkspaceInput,
-} from "../types";
-import { loadCatalogPackageDraftMediaKeysInExecutor } from "./draftMedia";
+} from "../../types";
+import { loadCatalogPackageDraftMediaKeysInExecutor } from "../media/draftMedia";
 import {
   collectCardManagedMediaLifecycleIssues,
   createPackageVersionFromNormalizedCardsInExecutor,
   describeManagedMediaLifecycleIssues,
   hasManagedMediaLifecycleIssues,
   normalizeCreatePackageVersionInput,
-} from "./versionCreation";
+} from "./creation";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 

--- a/apps/backend/src/catalog/index.ts
+++ b/apps/backend/src/catalog/index.ts
@@ -9,17 +9,17 @@ export {
   attachCatalogPackageDraftMediaAssetInExecutor,
   createOrReplayCatalogPackageDraftCardImageInExecutor,
   replaceCatalogPackageDraftCoverInExecutor,
-} from "./authoring/draftMedia";
+} from "./authoring/media/draftMedia";
 export {
   replaceCatalogCollectionCoverInExecutor,
-} from "./authoring/collectionCovers";
+} from "./authoring/media/collectionCovers";
 export {
   ingestCatalogCardImageBlob,
   ingestCatalogCoverImageBlob,
   ingestCatalogPackageCardImage,
   replaceCatalogCollectionCoverImage,
   replaceCatalogPackageCoverImage,
-} from "./authoring/imageIngestion";
+} from "./authoring/media/imageIngestion";
 export {
   createCatalogPackageDraft,
   createCatalogPackageDraftInExecutor,

--- a/apps/backend/src/mediaAssets/blobLifecycle/cleanup/sharedProvenance.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/cleanup/sharedProvenance.postgres.integration.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
 import test from "node:test";
-import { replaceCatalogCollectionCoverInExecutor } from "../../../catalog/authoring/collectionCovers";
-import { replaceCatalogPackageDraftCoverInExecutor } from "../../../catalog/authoring/draftMedia";
+import { replaceCatalogCollectionCoverInExecutor } from "../../../catalog/authoring/media/collectionCovers";
+import { replaceCatalogPackageDraftCoverInExecutor } from "../../../catalog/authoring/media/draftMedia";
 import {
   transactionWithWorkspaceScope,
 } from "../../../database";

--- a/apps/backend/src/routes/catalog/admin.test.ts
+++ b/apps/backend/src/routes/catalog/admin.test.ts
@@ -13,7 +13,7 @@ import type {
   CatalogCollectionCoverImageIngestionResult,
   CatalogPackageCoverImageIngestionInput,
   CatalogPackageImageIngestionResult,
-} from "../../catalog/authoring/imageIngestion";
+} from "../../catalog/authoring/media/imageIngestion";
 import type { AppEnv } from "../../server/app";
 import { HttpError } from "../../shared/errors";
 import { createCatalogAdminRoutes } from "./admin";

--- a/apps/backend/src/routes/catalog/adminImageIngestion.ts
+++ b/apps/backend/src/routes/catalog/adminImageIngestion.ts
@@ -12,7 +12,7 @@ import {
   type CatalogPackageCardImageIngestionInput,
   type CatalogPackageCoverImageIngestionInput,
   type CatalogPackageImageIngestionResult,
-} from "../../catalog/authoring/imageIngestion";
+} from "../../catalog/authoring/media/imageIngestion";
 import { normalizePackageMediaKey } from "../../catalog/common";
 import type {
   CatalogCollectionCover,


### PR DESCRIPTION
## Summary

- group catalog media authoring modules under `authoring/media`
- group version creation, snapshot, and publication workflows under `authoring/versions`
- preserve the public versions facade and update mechanically affected imports

## Testing

- not run locally, per repository delivery workflow
- static review passed with no P0-P4 findings