### PR TITLE
Apply half radii throughout chat

### DIFF
--- a/apps/web/src/styles/features/chat/messages.css
+++ b/apps/web/src/styles/features/chat/messages.css
@@ -1,7 +1,7 @@
 .chat-msg {
   --chat-msg-padding-block: 11px;
   --chat-msg-radius: var(--radius-md);
-  --chat-msg-inner-radius: max(0px, calc(var(--chat-msg-radius) - var(--chat-msg-padding-block)));
+  --chat-msg-inner-radius: calc(var(--chat-msg-radius) / 2);
   font-size: 15px;
   line-height: 1.6;
   white-space: pre-wrap;
@@ -51,7 +51,7 @@
 
 .chat-card-part {
   --chat-card-part-padding: 12px;
-  --chat-card-part-inner-radius: max(0px, calc(var(--chat-msg-inner-radius, var(--radius-sm)) - var(--chat-card-part-padding)));
+  --chat-card-part-inner-radius: calc(var(--chat-msg-inner-radius, var(--radius-sm)) / 2);
   display: block;
   margin: 10px 0 6px;
   overflow: hidden;

--- a/apps/web/src/styles/features/chat/shell.css
+++ b/apps/web/src/styles/features/chat/shell.css
@@ -37,7 +37,7 @@
 .chat-sidebar-fullscreen {
   --chat-sidebar-padding: 12px;
   --chat-sidebar-radius: var(--radius-xl);
-  --chat-sidebar-inner-radius: max(0px, calc(var(--chat-sidebar-radius) - var(--chat-sidebar-padding)));
+  --chat-sidebar-inner-radius: calc(var(--chat-sidebar-radius) / 2);
   display: flex;
   flex-direction: column;
   min-height: 0;


### PR DESCRIPTION
## Summary
- derive the chat sidebar inner radius from half of its parent radius
- derive message-child and nested card-detail radii from half of their immediate parent radii
- preserve existing consumers, including SQL and Reasoning tool blocks

## Validation
- static review passed with no P0-P4 findings
- project checks not run per repository workflow