### PR TITLE
Adopt half radii for shared surfaces

### DIFF
--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -14,8 +14,6 @@
 }
 
 .invite-panel {
-  /* Inner blocks follow the half-radius rule instead of the padding-derived default. */
-  --content-card-inner-radius: calc(var(--content-card-radius) / 2);
   width: min(100%, 560px);
   display: grid;
   gap: 16px;

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -109,7 +109,7 @@
 .panel {
   --panel-padding: 16px;
   --panel-radius: var(--radius-xl);
-  --panel-inner-radius: max(0px, calc(var(--panel-radius) - var(--panel-padding)));
+  --panel-inner-radius: calc(var(--panel-radius) / 2);
   display: grid;
   gap: 16px;
   padding: var(--panel-padding);
@@ -153,7 +153,7 @@
   --content-card-padding-block: 12px;
   --content-card-padding-inline: 14px;
   --content-card-radius: var(--panel-inner-radius, var(--radius-md));
-  --content-card-inner-radius: max(0px, calc(var(--content-card-radius) - var(--content-card-padding-block)));
+  --content-card-inner-radius: calc(var(--content-card-radius) / 2);
   padding: var(--content-card-padding-block) var(--content-card-padding-inline);
   border: 0;
   border-radius: var(--content-card-radius);


### PR DESCRIPTION
## Summary
- derive shared panel and content-card inner radii directly from their parent radii
- remove the redundant invite-specific override

## Validation
- not run locally per repository workflow
- fresh static review found no P0-P4 issues