### PR TITLE
Use half-parent radii for nested web surfaces

### DIFF
--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -379,7 +379,7 @@
 .cell-select-overlay {
   --cell-select-overlay-padding: 6px;
   --cell-select-overlay-radius: var(--radius-md);
-  --cell-select-overlay-inner-radius: max(0px, calc(var(--cell-select-overlay-radius) - var(--cell-select-overlay-padding)));
+  --cell-select-overlay-inner-radius: calc(var(--cell-select-overlay-radius) / 2);
   z-index: 200;
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles/features/chat/messages.css
+++ b/apps/web/src/styles/features/chat/messages.css
@@ -1,7 +1,7 @@
 .chat-msg {
   --chat-msg-padding-block: 11px;
   --chat-msg-radius: var(--radius-md);
-  --chat-msg-inner-radius: max(0px, calc(var(--chat-msg-radius) - var(--chat-msg-padding-block)));
+  --chat-msg-inner-radius: calc(var(--chat-msg-radius) / 2);
   font-size: 15px;
   line-height: 1.6;
   white-space: pre-wrap;
@@ -51,7 +51,7 @@
 
 .chat-card-part {
   --chat-card-part-padding: 12px;
-  --chat-card-part-inner-radius: max(0px, calc(var(--chat-msg-inner-radius, var(--radius-sm)) - var(--chat-card-part-padding)));
+  --chat-card-part-inner-radius: calc(var(--chat-msg-inner-radius, var(--radius-sm)) / 2);
   display: block;
   margin: 10px 0 6px;
   overflow: hidden;

--- a/apps/web/src/styles/features/chat/shell.css
+++ b/apps/web/src/styles/features/chat/shell.css
@@ -37,7 +37,7 @@
 .chat-sidebar-fullscreen {
   --chat-sidebar-padding: 12px;
   --chat-sidebar-radius: var(--radius-xl);
-  --chat-sidebar-inner-radius: max(0px, calc(var(--chat-sidebar-radius) - var(--chat-sidebar-padding)));
+  --chat-sidebar-inner-radius: calc(var(--chat-sidebar-radius) / 2);
   display: flex;
   flex-direction: column;
   min-height: 0;

--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -14,8 +14,6 @@
 }
 
 .invite-panel {
-  /* Inner blocks follow the half-radius rule instead of the padding-derived default. */
-  --content-card-inner-radius: calc(var(--content-card-radius) / 2);
   width: min(100%, 560px);
   display: grid;
   gap: 16px;

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -2,9 +2,9 @@
 .review-queue-panel {
   --review-pane-padding: 12px;
   --review-pane-radius: var(--panel-inner-radius, var(--radius-lg));
-  --review-pane-inner-radius: max(0px, calc(var(--review-pane-radius) - var(--review-pane-padding)));
+  --review-pane-inner-radius: calc(var(--review-pane-radius) / 2);
   --review-card-radius: var(--panel-inner-radius, var(--radius-lg));
-  --review-managed-media-image-radius: max(0px, calc(var(--review-card-radius) - 4px));
+  --review-managed-media-image-radius: calc(var(--review-card-radius) / 2);
   display: grid;
   gap: 10px;
   min-width: 0;

--- a/apps/web/src/styles/features/review/review-filter.css
+++ b/apps/web/src/styles/features/review/review-filter.css
@@ -45,7 +45,7 @@
 .review-filter-menu {
   --review-filter-menu-padding: 10px;
   --review-filter-menu-radius: var(--radius-lg);
-  --review-filter-menu-inner-radius: max(0px, calc(var(--review-filter-menu-radius) - var(--review-filter-menu-padding)));
+  --review-filter-menu-inner-radius: calc(var(--review-filter-menu-radius) / 2);
   z-index: 30;
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -109,7 +109,7 @@
 .panel {
   --panel-padding: 16px;
   --panel-radius: var(--radius-xl);
-  --panel-inner-radius: max(0px, calc(var(--panel-radius) - var(--panel-padding)));
+  --panel-inner-radius: calc(var(--panel-radius) / 2);
   display: grid;
   gap: 16px;
   padding: var(--panel-padding);
@@ -153,7 +153,7 @@
   --content-card-padding-block: 12px;
   --content-card-padding-inline: 14px;
   --content-card-radius: var(--panel-inner-radius, var(--radius-md));
-  --content-card-inner-radius: max(0px, calc(var(--content-card-radius) - var(--content-card-padding-block)));
+  --content-card-inner-radius: calc(var(--content-card-radius) / 2);
   padding: var(--content-card-padding-block) var(--content-card-padding-inline);
   border: 0;
   border-radius: var(--content-card-radius);


### PR DESCRIPTION
## Summary

- Make parent-derived web inner-radius custom properties exactly 50% of their immediate named parent radius.
- Apply the rule across shared panels, cards, chat, review surfaces, and managed review media; SQL and Reasoning blocks become 7px under the 14px message radius.
- Remove the redundant invite-only override while preserving standalone controls, pills, circles, inherited radii, and explicit presentation shapes.

## Included item PRs

- #1449
- #1451
- #1452

Required CI runs on this promotion PR; no project checks were run locally.