### PR TITLE
feat(web): move the share screen to the shared platform grid

### DIFF
--- a/apps/web/src/screens/share/ShareAppScreen.test.tsx
+++ b/apps/web/src/screens/share/ShareAppScreen.test.tsx
@@ -108,7 +108,7 @@ describe("ShareAppScreen", () => {
     expect(screen.textContent).toContain("Choose where you want to use the app.");
 
     const linkTestIds: ReadonlyArray<string> = Array.from(
-      container.querySelectorAll("[data-testid^='app-platform-link-']"),
+      container.querySelectorAll("[data-testid^='share-app-link-']"),
     ).map((element) => {
       const testId: string | null = element.getAttribute("data-testid");
       if (testId === null) {
@@ -118,27 +118,28 @@ describe("ShareAppScreen", () => {
       return testId;
     });
     expect(linkTestIds).toEqual([
-      "app-platform-link-ios",
-      "app-platform-link-android",
-      "app-platform-link-web",
+      "share-app-link-ios",
+      "share-app-link-android",
+      "share-app-link-web",
     ]);
 
-    const iosLink: HTMLElement = requireElement(container, "[data-testid='app-platform-link-ios']");
+    const iosLink: HTMLElement = requireElement(container, "[data-testid='share-app-link-ios']");
     expect(iosLink.getAttribute("href")).toBe(shareAppIosHref);
-    const androidLink: HTMLElement = requireElement(container, "[data-testid='app-platform-link-android']");
+    const androidLink: HTMLElement = requireElement(container, "[data-testid='share-app-link-android']");
     expect(androidLink.getAttribute("href")).toBe(shareAppAndroidHref);
-    const webLink: HTMLElement = requireElement(container, "[data-testid='app-platform-link-web']");
+    const webLink: HTMLElement = requireElement(container, "[data-testid='share-app-link-web']");
     expect(webLink.getAttribute("href")).toBe(`${window.location.origin}${reviewRoute}`);
     expect(webLink.getAttribute("target")).toBe("_blank");
-    expect(requireElement(container, "[data-testid='share-app-web-link-value']").textContent).toBe(
-      `${window.location.origin}${reviewRoute}`,
-    );
 
-    const platformGrid: HTMLElement = requireElement(container, "[data-testid='share-app-platform-links']");
+    // A desktop user agent keeps both store QR codes, and the web tile never gets one.
+    expect(container.querySelector("[data-testid='share-app-qr-ios']")).not.toBeNull();
+    expect(container.querySelector("[data-testid='share-app-qr-android']")).not.toBeNull();
+    expect(container.querySelector("[data-testid='share-app-qr-web']")).toBeNull();
+
+    const platformGrid: HTMLElement = requireElement(container, "[data-testid='share-app-grid']");
     const mcpOption: HTMLElement = requireElement(container, "[data-testid='share-app-mcp-option']");
-    expect(platformGrid.compareDocumentPosition(mcpOption) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
+    expect(mcpOption.parentElement).toBe(platformGrid);
+    expect(platformGrid.lastElementChild).toBe(mcpOption);
     expect(mcpOption.textContent).toContain("For AI Agent");
     expect(requireElement(container, "[data-testid='share-app-mcp-url']").textContent).toBe(expectedMcpServerUrl);
     expect(requireElement(container, "[data-testid='share-app-mcp-copy-button']").textContent).toBe("Copy");

--- a/apps/web/src/screens/share/ShareAppScreen.tsx
+++ b/apps/web/src/screens/share/ShareAppScreen.tsx
@@ -1,9 +1,13 @@
 import type { ReactElement } from "react";
+import {
+  AppPlatformLinksGrid,
+  buildAppPlatformOptions,
+  resolveClientPlatform,
+  type AppPlatformStoreLinks,
+} from "../../appPlatformLinks";
 import { getAppConfig } from "../../config";
 import { useI18n } from "../../i18n";
 import { reviewRoute } from "../../routes";
-import { AppPlatformLinks, type AppPlatformStoreLinks } from "./AppPlatformLinks";
-import { ShareMcpOption } from "./ShareMcpOption";
 
 export const shareAppStoreLinks: AppPlatformStoreLinks = {
   ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=share_app&mt=8",
@@ -19,18 +23,25 @@ export function ShareAppScreen(): ReactElement {
       <section className="content-card invite-panel" data-testid="share-app-screen">
         <h1 className="title">{t("shareApp.title")}</h1>
         <p className="subtitle">{t("shareApp.body")}</p>
-        <AppPlatformLinks
-          labels={{
-            ios: t("shareApp.links.ios"),
-            android: t("shareApp.links.android"),
-            web: t("shareApp.links.web"),
-          }}
-          storeLinks={shareAppStoreLinks}
-          webHref={webHref}
-          gridTestId="share-app-platform-links"
-          webHrefTestId="share-app-web-link-value"
+        <AppPlatformLinksGrid
+          options={buildAppPlatformOptions({
+            platforms: ["ios", "android", "web", "mcp"],
+            storeLinks: shareAppStoreLinks,
+            webHref,
+            labels: {
+              ios: t("appPlatformLinks.ios"),
+              android: t("appPlatformLinks.android"),
+              web: t("appPlatformLinks.web"),
+              mcp: t("appPlatformLinks.mcp.label"),
+            },
+            qrTitles: {
+              ios: t("appPlatformLinks.qr.ios"),
+              android: t("appPlatformLinks.qr.android"),
+            },
+            clientPlatform: resolveClientPlatform(navigator.userAgent),
+          })}
+          testIdPrefix="share-app"
         />
-        <ShareMcpOption />
       </section>
     </main>
   );


### PR DESCRIPTION
Migrates the **web share screen** (`apps/web/src/screens/share/ShareAppScreen.tsx`) onto the shared `appPlatformLinks` module.

## What changed

- `ShareAppScreen` now renders `AppPlatformLinksGrid` with options built by `buildAppPlatformOptions`, instead of the screen-local `AppPlatformLinks` + `ShareMcpOption` pair.
- The MCP tile is now the last cell inside the grid rather than a sibling rendered after it.
- QR codes follow `resolveClientPlatform(navigator.userAgent)`: both store tiles keep a QR on desktop, and the web tile never gets one.
- Labels come from the shared `appPlatformLinks.*` i18n keys.
- Link test ids move from `app-platform-link-*` to the prefixed `share-app-link-*`, and the grid test id is now `share-app-grid`.
- `ShareAppScreen.test.tsx` is updated to the new test ids and asserts the QR and MCP-inside-grid behavior.

## Queue context

This PR is part of the **app-platform-links unification queue** running on the `integration-app-platform-links` integration branch. Only the share surface migrates here; the **remaining surfaces migrate in sibling PRs** in the same queue.

The now-superseded files (the screen-local `AppPlatformLinks.tsx` and `ShareMcpOption.tsx`) and the **old i18n keys are deleted in item 06**, once every surface has moved over, so they intentionally stay in the tree for now.

**Promotion to `main` is deferred** to the integration branch promotion; this PR targets `integration-app-platform-links` only.