### PR TITLE
feat(web): move the catalog import success panel to the shared platform grid

### DIFF
--- a/apps/web/src/screens/catalog/CatalogImportScreen.test.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.test.tsx
@@ -649,6 +649,7 @@ describe("CatalogImportScreen", () => {
     expect(container.querySelector("[data-testid='catalog-import-success-qr-ios']")).not.toBeNull();
     expect(container.querySelector("[data-testid='catalog-import-success-qr-android']")).not.toBeNull();
     expect(container.querySelector("[data-testid='catalog-import-success-qr-web']")).toBeNull();
+    expect(container.querySelector("[data-testid='catalog-import-success-mcp-option']")).not.toBeNull();
   });
 
   it("reuses one install identity after an ambiguous response and accepts the verified replay result", async () => {

--- a/apps/web/src/screens/catalog/CatalogImportSuccessPanel.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportSuccessPanel.tsx
@@ -1,15 +1,13 @@
 import type { ReactElement } from "react";
-import { getAppConfig } from "../../config";
-import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
-import { reviewRoute } from "../../routes";
 import {
-  AppStoreBadge,
-  GooglePlayBadge,
-  WebAppIcon,
+  AppPlatformLinksGrid,
+  buildAppPlatformOptions,
+  resolveClientPlatform,
   type AppPlatformStoreLinks,
-} from "../share/AppPlatformLinks";
-import { MobileAppQrCode } from "../share/MobileAppQrCode";
-import { type ClientPlatform, resolveClientPlatform } from "../share/clientPlatform";
+} from "../../appPlatformLinks";
+import { getAppConfig } from "../../config";
+import { useI18n } from "../../i18n";
+import { reviewRoute } from "../../routes";
 
 export const catalogImportStoreLinks: AppPlatformStoreLinks = {
   ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=catalog_import&mt=8",
@@ -22,16 +20,6 @@ type CatalogImportSuccessPanelProps = Readonly<{
   workspaceName: string;
   accountEmail: string | null;
 }>;
-
-type CatalogImportSuccessOption = Readonly<{
-  platform: "ios" | "android" | "web";
-  href: string;
-  label: string;
-  badge: ReactElement;
-  qrTitle: string | null;
-}>;
-
-type TranslateFunction = (key: TranslationKey, values?: TranslationValues) => string;
 
 function CatalogImportSuccessCheck(): ReactElement {
   return (
@@ -51,51 +39,25 @@ function CatalogImportSuccessCheck(): ReactElement {
   );
 }
 
-/**
- * A QR code only helps when the visitor can scan it with another physical device,
- * so the platform they are already browsing from never shows one, and the web
- * option never shows one at all.
- */
-function buildCatalogImportSuccessOptions(
-  clientPlatform: ClientPlatform,
-  t: TranslateFunction,
-): ReadonlyArray<CatalogImportSuccessOption> {
-  const iosOption: CatalogImportSuccessOption = {
-    platform: "ios",
-    href: catalogImportStoreLinks.ios,
-    label: t("catalogImport.successOpenIos"),
-    badge: <AppStoreBadge />,
-    qrTitle: clientPlatform === "ios" ? null : t("mobileAppPromo.ios.qrLabel"),
-  };
-  const androidOption: CatalogImportSuccessOption = {
-    platform: "android",
-    href: catalogImportStoreLinks.android,
-    label: t("catalogImport.successOpenAndroid"),
-    badge: <GooglePlayBadge />,
-    qrTitle: clientPlatform === "android" ? null : t("mobileAppPromo.android.qrLabel"),
-  };
-  const webOption: CatalogImportSuccessOption = {
-    platform: "web",
-    href: `${getAppConfig().appBaseUrl}${reviewRoute}`,
-    label: t("catalogImport.successOpenWeb"),
-    badge: (
-      <>
-        <WebAppIcon />
-        <span className="catalog-import-success-option-label">{t("catalogImport.successOpenWeb")}</span>
-      </>
-    ),
-    qrTitle: null,
-  };
-
-  return clientPlatform === "android"
-    ? [androidOption, iosOption, webOption]
-    : [iosOption, androidOption, webOption];
-}
-
 export function CatalogImportSuccessPanel(props: CatalogImportSuccessPanelProps): ReactElement {
   const { cardCount, importTag, workspaceName, accountEmail } = props;
   const { t } = useI18n();
-  const options = buildCatalogImportSuccessOptions(resolveClientPlatform(navigator.userAgent), t);
+  const platformOptions = buildAppPlatformOptions({
+    platforms: ["ios", "android", "web", "mcp"],
+    storeLinks: catalogImportStoreLinks,
+    webHref: `${getAppConfig().appBaseUrl}${reviewRoute}`,
+    labels: {
+      ios: t("appPlatformLinks.ios"),
+      android: t("appPlatformLinks.android"),
+      web: t("appPlatformLinks.web"),
+      mcp: t("appPlatformLinks.mcp.label"),
+    },
+    qrTitles: {
+      ios: t("appPlatformLinks.qr.ios"),
+      android: t("appPlatformLinks.qr.android"),
+    },
+    clientPlatform: resolveClientPlatform(navigator.userAgent),
+  });
   const summaryMessage = importTag === null
     ? t("catalogImport.success", { count: cardCount })
     : t("catalogImport.successWithTag", { count: cardCount, tag: importTag });
@@ -128,30 +90,7 @@ export function CatalogImportSuccessPanel(props: CatalogImportSuccessPanelProps)
         <strong data-testid="catalog-import-success-workspace">{workspaceName}</strong>
       </p>
       <p className="invite-note" data-testid="catalog-import-success-email-note">{sameEmailNote}</p>
-      <div className="catalog-import-success-platforms">
-        {options.map((option) => (
-          <a
-            key={option.platform}
-            className={`catalog-import-success-option catalog-import-success-option-${option.platform}`}
-            href={option.href}
-            rel="noreferrer"
-            target="_blank"
-            aria-label={option.label}
-            data-testid={`catalog-import-success-link-${option.platform}`}
-          >
-            {option.badge}
-            {option.qrTitle === null ? null : (
-              <span className="catalog-import-success-qr-frame">
-                <MobileAppQrCode
-                  title={option.qrTitle}
-                  value={option.href}
-                  testId={`catalog-import-success-qr-${option.platform}`}
-                />
-              </span>
-            )}
-          </a>
-        ))}
-      </div>
+      <AppPlatformLinksGrid options={platformOptions} testIdPrefix="catalog-import-success" />
     </section>
   );
 }

--- a/apps/web/src/styles/features/invite.css
+++ b/apps/web/src/styles/features/invite.css
@@ -335,76 +335,6 @@
   margin: 0;
 }
 
-.catalog-import-success-platforms {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.catalog-import-success-option {
-  min-height: 92px;
-  padding: 14px 16px;
-  border: 0;
-  border-radius: var(--radius-md);
-  background: var(--surface-hover);
-  color: var(--text);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  text-decoration: none;
-  transition:
-    transform 140ms ease,
-    background 140ms ease,
-    color 140ms ease;
-}
-
-.catalog-import-success-option:hover {
-  background: var(--surface-pressed);
-  color: var(--text);
-  transform: translateY(-1px);
-}
-
-.catalog-import-success-option:focus-visible {
-  outline: 2px solid var(--text);
-  outline-offset: 3px;
-}
-
-/* The Google Play lockup is wider than the App Store badge, so it is capped lower to read as the same weight. */
-.catalog-import-success-option .invite-platform-badge-google-play {
-  max-height: 34px;
-}
-
-.catalog-import-success-option-web {
-  grid-column: 1 / -1;
-  min-height: 64px;
-  flex-direction: row;
-  gap: 10px;
-}
-
-.catalog-import-success-option-label {
-  color: var(--text);
-  font-size: 12px;
-  line-height: 1.1;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-  text-align: center;
-  text-transform: uppercase;
-}
-
-/* The QR frame stays white in every theme so scanners keep enough contrast. */
-.catalog-import-success-qr-frame {
-  width: 180px;
-  height: 180px;
-  max-width: 100%;
-  padding: 8px;
-  border-radius: 8px;
-  background: #fff;
-  display: grid;
-  place-items: center;
-}
-
 @media (max-width: 640px) {
   .invite-page {
     padding: 16px;
@@ -425,9 +355,5 @@
 
   .catalog-import-actions > .primary-btn {
     width: 100%;
-  }
-
-  .catalog-import-success-platforms {
-    grid-template-columns: minmax(0, 1fr);
   }
 }


### PR DESCRIPTION
## Surface migrated

The web **catalog import success panel** (`apps/web/src/screens/catalog/CatalogImportSuccessPanel.tsx`) now renders its platform options through the shared `AppPlatformLinksGrid` and `buildAppPlatformOptions` helpers from `apps/web/src/appPlatformLinks`, instead of its own local option builder, markup, and CSS.

Behaviour notes:
- The panel now also offers the MCP option alongside iOS, Android, and web.
- The catalog-import-specific platform/QR styles in `apps/web/src/styles/features/invite.css` are dropped because the shared grid owns that presentation.
- The `CatalogImportScreen` test asserts the MCP option is rendered.

## Context

This PR is part of the **app-platform-links unification queue** on the `integration-app-platform-links` integration branch. Each surface migrates to the shared platform-links module in its own PR, and this one covers only the catalog import success panel.

- The remaining surfaces migrate in sibling PRs on the same integration branch.
- The superseded files and the old i18n keys are deleted in **item 06**, so this PR intentionally leaves them in place.
- Promotion to `main` is deferred to the integration branch promotion; this PR targets `integration-app-platform-links` and must not be retargeted.