### PR TITLE
feat(web): move friend invite to the shared platform grid and add its campaign

### DIFF
--- a/apps/web/src/screens/invite/FriendInviteScreen.test.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.test.tsx
@@ -175,8 +175,8 @@ describe("FriendInviteScreen", () => {
     expect(container.querySelector("[data-testid='friend-invite-success']")).not.toBeNull();
     expect(container.textContent).toContain("You are now friends");
     expect(container.textContent).toContain("Mobile apps require signing in with the same email.");
-    expect(container.querySelector("[data-testid='friend-invite-success-links']")).not.toBeNull();
-    const webLink = container.querySelector("[data-testid='app-platform-link-web']");
+    expect(container.querySelector("[data-testid='friend-invite-success-grid']")).not.toBeNull();
+    const webLink = container.querySelector("[data-testid='friend-invite-success-link-web']");
     if (!(webLink instanceof HTMLAnchorElement)) {
       throw new Error("Invite web app link was not found");
     }

--- a/apps/web/src/screens/invite/FriendInviteScreen.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.tsx
@@ -8,6 +8,12 @@ import {
   isAuthRedirectError,
   previewFriendInvitation,
 } from "../../api";
+import {
+  AppPlatformLinksGrid,
+  buildAppPlatformOptions,
+  resolveClientPlatform,
+  type AppPlatformStoreLinks,
+} from "../../appPlatformLinks";
 import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { invalidateServerProgress } from "../../appData/progress/invalidation/progressInvalidation";
 import { clearPersistedProgressLeaderboard } from "../../appData/progress/storage/progressStorage";
@@ -19,8 +25,12 @@ import type {
   FriendInvitationPreviewResponse,
   SessionInfo,
 } from "../../types";
-import { AppPlatformLinks, defaultAppPlatformStoreLinks } from "../share/AppPlatformLinks";
 import { validateFriendInvitationDisplayName } from "./friendInvitationDisplayName";
+
+export const friendInviteStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=friend_invite&mt=8",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=friend_invite",
+};
 
 type InviteLoadState = "loading" | "inactive" | "error" | "signed_out" | "ready" | "success";
 
@@ -79,16 +89,24 @@ function InviteSuccessLinks(): ReactElement {
   const webHref = `${getAppConfig().appBaseUrl}${progressLeaderboardRoute}`;
 
   return (
-    <AppPlatformLinks
-      labels={{
-        ios: t("friendInvite.links.ios"),
-        android: t("friendInvite.links.android"),
-        web: t("friendInvite.links.web"),
-      }}
-      storeLinks={defaultAppPlatformStoreLinks}
-      webHref={webHref}
-      gridTestId="friend-invite-success-links"
-      webHrefTestId="friend-invite-web-link-value"
+    <AppPlatformLinksGrid
+      options={buildAppPlatformOptions({
+        platforms: ["ios", "android", "web", "mcp"],
+        storeLinks: friendInviteStoreLinks,
+        webHref,
+        labels: {
+          ios: t("appPlatformLinks.ios"),
+          android: t("appPlatformLinks.android"),
+          web: t("appPlatformLinks.web"),
+          mcp: t("appPlatformLinks.mcp.label"),
+        },
+        qrTitles: {
+          ios: t("appPlatformLinks.qr.ios"),
+          android: t("appPlatformLinks.qr.android"),
+        },
+        clientPlatform: resolveClientPlatform(navigator.userAgent),
+      })}
+      testIdPrefix="friend-invite-success"
     />
   );
 }

--- a/apps/web/src/screens/settings/TestAppPlatformLinksScreen.tsx
+++ b/apps/web/src/screens/settings/TestAppPlatformLinksScreen.tsx
@@ -10,8 +10,8 @@ import { getAppConfig } from "../../config";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import { progressLeaderboardRoute, reviewRoute } from "../../routes";
 import { CatalogImportSuccessPanel, catalogImportStoreLinks } from "../catalog/CatalogImportSuccessPanel";
+import { friendInviteStoreLinks } from "../invite/FriendInviteScreen";
 import { webReviewMobilePromptStoreLinks } from "../review/mobileAppPromo/MobileAppPromotionDialog";
-import { defaultAppPlatformStoreLinks } from "../share/AppPlatformLinks";
 import { shareAppStoreLinks } from "../share/ShareAppScreen";
 import { SettingsGroup, SettingsShell } from "./SettingsShared";
 
@@ -56,12 +56,10 @@ function buildTestAppPlatformSurfaces(t: Translate, appBaseUrl: string): Readonl
       webHref: reviewWebHref,
     },
     {
-      // The friend-invite campaign links land with the friend-invite migration, so this
-      // preview uses the canonical store links the surface ships today.
       id: "friend-invite",
       heading: t("settingsTest.appPlatformLinks.surfaces.friendInvite"),
       platforms: ["ios", "android", "web", "mcp"],
-      storeLinks: defaultAppPlatformStoreLinks,
+      storeLinks: friendInviteStoreLinks,
       webHref: `${appBaseUrl}${progressLeaderboardRoute}`,
     },
   ];

--- a/docs/marketing-links.md
+++ b/docs/marketing-links.md
@@ -13,6 +13,7 @@ Current campaign buckets:
 | `marketplace` | Reserved for future catalog browsing surfaces; its use is not decided yet. |
 | `web_review_mobile_prompt` | Web review mobile app promotion prompt. |
 | `catalog_import` | Catalog package import screen in the web app. |
+| `friend_invite` | Friend invite acceptance screen in the web app. |
 
 ## Google Play
 


### PR DESCRIPTION
## Surface migrated

The **friend invite acceptance screen** (`apps/web/src/screens/invite/FriendInviteScreen.tsx`) now renders its success state with the shared `AppPlatformLinksGrid` + `buildAppPlatformOptions` instead of the legacy `AppPlatformLinks` component.

- Uses the shared `appPlatformLinks.*` i18n keys rather than the surface-local `friendInvite.links.*` keys.
- Adds surface-specific campaign store links (`friendInviteStoreLinks`) so the friend-invite surface is attributed with `ct=friend_invite` / `utm_campaign=friend_invite` instead of the generic default store links.
- Registers the `friend_invite` campaign bucket in `docs/marketing-links.md`.
- Points the settings `TestAppPlatformLinksScreen` friend-invite preview at the real campaign links and drops the placeholder comment.
- Test ids move to the shared prefix scheme (`friend-invite-success-grid`, `friend-invite-success-link-web`).

## Context

This is part of the **app-platform-links unification queue** on the `integration-app-platform-links` integration branch. The remaining surfaces migrate in sibling PRs against the same integration branch.

The superseded files (the legacy `AppPlatformLinks` component and `defaultAppPlatformStoreLinks`) and the now-unused old i18n keys (`friendInvite.links.*`) are **deleted in item 06**, once every surface has migrated off them. That is why this PR leaves them in place.

Promotion to `main` is deferred to the integration branch promotion.