### PR TITLE
feat(web): move the review promo dialog to the shared platform grid

### DIFF
--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
@@ -168,47 +168,41 @@ describe("MobileAppPromotionDialog", () => {
     });
 
     const closeButton = requireElement(container, "[data-testid='mobile-app-promo-close']");
-    const androidBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-android']");
+    const mcpCopyButton = requireElement(container, "[data-testid='mobile-app-promo-mcp-copy-button']");
 
-    androidBadgeLink.focus();
+    mcpCopyButton.focus();
     await dispatchWindowKeyDown("Tab", false);
     expect(document.activeElement).toBe(closeButton);
 
     closeButton.focus();
     await dispatchWindowKeyDown("Tab", true);
-    expect(document.activeElement).toBe(androidBadgeLink);
+    expect(document.activeElement).toBe(mcpCopyButton);
   });
 
-  it("renders store links, platform test ids, and QR output for each platform", async () => {
+  it("renders the platform grid cells, store links, and QR output for each platform", async () => {
     await renderDialog({
       isOpen: true,
       onDismiss: () => undefined,
       storeLinks: webReviewMobilePromptStoreLinks,
     });
 
-    const platformTestIds: ReadonlyArray<string> = Array.from(
-      container.querySelectorAll("[data-testid^='mobile-app-promo-platform-']"),
-    ).map((element) => {
+    const grid = requireElement(container, "[data-testid='mobile-app-promo-grid']");
+    const gridTestIds: ReadonlyArray<string> = Array.from(grid.children).map((element) => {
       const testId = element.getAttribute("data-testid");
       if (testId === null) {
-        throw new Error("Expected platform test id");
+        throw new Error("Expected grid cell test id");
       }
 
       return testId;
     });
-    expect(platformTestIds).toEqual([
-      "mobile-app-promo-platform-ios",
-      "mobile-app-promo-platform-android",
+    expect(gridTestIds).toEqual([
+      "mobile-app-promo-link-ios",
+      "mobile-app-promo-link-android",
+      "mobile-app-promo-mcp-option",
     ]);
 
-    const iosPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-ios']");
-    const androidPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-android']");
-    expect(iosPlatform.compareDocumentPosition(androidPlatform) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-
-    const iosBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-ios']");
-    const androidBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-badge-android']");
+    const iosBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-link-ios']");
+    const androidBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-link-android']");
 
     expect(iosBadgeLink.href).toBe(webReviewMobilePromptStoreLinks.ios);
     expect(androidBadgeLink.href).toBe(webReviewMobilePromptStoreLinks.android);
@@ -237,18 +231,12 @@ describe("MobileAppPromotionDialog", () => {
 
     expect(document.documentElement.dir).toBe("rtl");
 
-    const platformGrid = requireElement(container, "[data-testid='mobile-app-promo-platforms']");
-    const iosPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-ios']");
-    const androidPlatform = requireElement(container, "[data-testid='mobile-app-promo-platform-android']");
-    const iosPlatformContent = requireElement(container, "[data-testid='mobile-app-promo-content-ios']");
-    const androidPlatformContent = requireElement(container, "[data-testid='mobile-app-promo-content-android']");
+    const platformGrid = requireElement(container, "[data-testid='mobile-app-promo-grid']");
+    const iosBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-link-ios']");
+    const androidBadgeLink = requireAnchor(container, "[data-testid='mobile-app-promo-link-android']");
 
-    expect(platformGrid.getAttribute("dir")).toBe("ltr");
-    expect(iosPlatform.getAttribute("dir")).toBe("ltr");
-    expect(androidPlatform.getAttribute("dir")).toBe("ltr");
-    expect(iosPlatformContent.getAttribute("dir")).toBe("rtl");
-    expect(androidPlatformContent.getAttribute("dir")).toBe("rtl");
-    expect(iosPlatform.compareDocumentPosition(androidPlatform) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(platformGrid.parentElement?.getAttribute("dir")).toBe("ltr");
+    expect(iosBadgeLink.compareDocumentPosition(androidBadgeLink) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });

--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, type ReactElement } from "react";
-import { useI18n } from "../../../i18n";
 import {
-  AppStoreBadge,
-  GooglePlayBadge,
+  AppPlatformLinksGrid,
+  buildAppPlatformOptions,
+  resolveClientPlatform,
   type AppPlatformStoreLinks,
-} from "../../share/AppPlatformLinks";
-import { MobileAppQrCode } from "../../share/MobileAppQrCode";
+} from "../../../appPlatformLinks";
+import { useI18n } from "../../../i18n";
 
 export type MobileAppPromotionDialogProps = Readonly<{
   isOpen: boolean;
@@ -69,7 +69,7 @@ function trapFocusInsideDialog(event: KeyboardEvent, dialog: HTMLElement): void 
 
 export function MobileAppPromotionDialog(props: MobileAppPromotionDialogProps): ReactElement | null {
   const { isOpen, onDismiss, storeLinks } = props;
-  const { direction, t } = useI18n();
+  const { t } = useI18n();
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const dialogRef = useRef<HTMLElement | null>(null);
   const onDismissRef = useRef(onDismiss);
@@ -146,74 +146,27 @@ export function MobileAppPromotionDialog(props: MobileAppPromotionDialogProps): 
           </button>
         </div>
 
-        <div className="mobile-app-promo-platforms" dir="ltr" data-testid="mobile-app-promo-platforms">
-          <section
-            className="mobile-app-promo-platform"
-            aria-labelledby="mobile-app-promo-ios-title"
-            dir="ltr"
-            data-testid="mobile-app-promo-platform-ios"
-          >
-            <div
-              className="mobile-app-promo-platform-content"
-              dir={direction}
-              data-testid="mobile-app-promo-content-ios"
-            >
-              <h3 id="mobile-app-promo-ios-title" className="mobile-app-promo-platform-title">
-                {t("mobileAppPromo.ios.title")}
-              </h3>
-              <a
-                className="mobile-app-promo-badge-link"
-                href={storeLinks.ios}
-                rel="noreferrer"
-                target="_blank"
-                aria-label={t("mobileAppPromo.ios.storeLinkLabel")}
-                data-testid="mobile-app-promo-badge-ios"
-              >
-                <AppStoreBadge />
-              </a>
-              <div className="mobile-app-promo-qr-frame">
-                <MobileAppQrCode
-                  title={t("mobileAppPromo.ios.qrLabel")}
-                  value={storeLinks.ios}
-                  testId="mobile-app-promo-qr-ios"
-                />
-              </div>
-            </div>
-          </section>
-
-          <section
-            className="mobile-app-promo-platform"
-            aria-labelledby="mobile-app-promo-android-title"
-            dir="ltr"
-            data-testid="mobile-app-promo-platform-android"
-          >
-            <div
-              className="mobile-app-promo-platform-content"
-              dir={direction}
-              data-testid="mobile-app-promo-content-android"
-            >
-              <h3 id="mobile-app-promo-android-title" className="mobile-app-promo-platform-title">
-                {t("mobileAppPromo.android.title")}
-              </h3>
-              <a
-                className="mobile-app-promo-badge-link"
-                href={storeLinks.android}
-                rel="noreferrer"
-                target="_blank"
-                aria-label={t("mobileAppPromo.android.storeLinkLabel")}
-                data-testid="mobile-app-promo-badge-android"
-              >
-                <GooglePlayBadge />
-              </a>
-              <div className="mobile-app-promo-qr-frame">
-                <MobileAppQrCode
-                  title={t("mobileAppPromo.android.qrLabel")}
-                  value={storeLinks.android}
-                  testId="mobile-app-promo-qr-android"
-                />
-              </div>
-            </div>
-          </section>
+        {/* The store tiles keep a stable left-to-right order under right-to-left locales. */}
+        <div dir="ltr">
+          <AppPlatformLinksGrid
+            options={buildAppPlatformOptions({
+              platforms: ["ios", "android", "mcp"],
+              storeLinks,
+              webHref: null,
+              labels: {
+                ios: t("appPlatformLinks.ios"),
+                android: t("appPlatformLinks.android"),
+                web: t("appPlatformLinks.web"),
+                mcp: t("appPlatformLinks.mcp.label"),
+              },
+              qrTitles: {
+                ios: t("appPlatformLinks.qr.ios"),
+                android: t("appPlatformLinks.qr.android"),
+              },
+              clientPlatform: resolveClientPlatform(navigator.userAgent),
+            })}
+            testIdPrefix="mobile-app-promo"
+          />
         </div>
       </section>
     </div>

--- a/apps/web/src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.mobileAppPromotion.test.tsx
@@ -68,8 +68,8 @@ describe("TestSettingsScreen mobile app promotion preview", () => {
     });
 
     expect(requireElement(container, "mobile-app-promo-dialog")).toBeTruthy();
-    expect(requireElement(container, "mobile-app-promo-platform-ios")).toBeTruthy();
-    expect(requireElement(container, "mobile-app-promo-platform-android")).toBeTruthy();
+    expect(requireElement(container, "mobile-app-promo-link-ios")).toBeTruthy();
+    expect(requireElement(container, "mobile-app-promo-link-android")).toBeTruthy();
 
     const closeButton = requireElement(container, "mobile-app-promo-close");
     await act(async () => {

--- a/apps/web/src/styles/features/review/review-dialogs.css
+++ b/apps/web/src/styles/features/review/review-dialogs.css
@@ -87,75 +87,14 @@
   flex: 0 0 auto;
 }
 
-.mobile-app-promo-platforms {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 24px;
-}
-
-.mobile-app-promo-platform {
-  min-width: 0;
-}
-
-.mobile-app-promo-platform-content {
-  display: grid;
-  gap: 12px;
-  align-content: start;
-}
-
-.mobile-app-promo-platform + .mobile-app-promo-platform {
-  padding-inline-start: 24px;
-  border-inline-start: 1px solid var(--panel-border);
-}
-
-.mobile-app-promo-platform-title {
-  margin: 0;
-  color: var(--text);
-  font-size: 1rem;
-  line-height: 1.2;
-}
-
-.mobile-app-promo-badge-link {
-  width: fit-content;
-  height: 44px;
-  border-radius: 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-}
-
-.mobile-app-promo-close:focus-visible,
-.mobile-app-promo-badge-link:focus-visible {
+.mobile-app-promo-close:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
 
-.mobile-app-promo-badge-link .invite-platform-badge {
-  width: auto;
-  max-width: 100%;
-  height: 40px;
-  object-fit: contain;
-}
-
-.mobile-app-promo-badge-link .invite-platform-badge-google-play {
-  max-height: 40px;
-}
-
-.mobile-app-promo-qr-frame {
-  width: 180px;
-  height: 180px;
-  padding: 8px;
-  border-radius: 8px;
-  background: #fff;
-  display: grid;
-  place-items: center;
-}
-
-.mobile-app-promo-qr-code {
-  display: block;
-  width: 164px;
-  height: 164px;
+/* The platform grid is forced left-to-right, so its text-only MCP cell reads in the locale direction again. */
+[dir="rtl"] .mobile-app-promo-dialog .app-platform-links-mcp-option {
+  direction: rtl;
 }
 
 .review-editor-delete-btn {
@@ -177,17 +116,6 @@
 
   .mobile-app-promo-header {
     display: grid;
-  }
-
-  .mobile-app-promo-platforms {
-    grid-template-columns: 1fr;
-  }
-
-  .mobile-app-promo-platform + .mobile-app-promo-platform {
-    padding-block-start: 20px;
-    padding-inline-start: 0;
-    border-block-start: 1px solid var(--panel-border);
-    border-inline-start: 0;
   }
 
   .mobile-app-promo-close {


### PR DESCRIPTION
## Surface migrated

The web **review-screen mobile app promotion dialog** (`apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx`).

It now renders its store tiles through the shared `appPlatformLinks` module — `AppPlatformLinksGrid`, `buildAppPlatformOptions`, and `resolveClientPlatform` — instead of its own bespoke per-platform sections, store badges, and QR frames. The promo-specific styles that this markup owned are removed from `apps/web/src/styles/features/review/review-dialogs.css`, and the dialog's tests are updated to the shared grid's test ids.

## Context

This PR is part of the **app-platform-links unification queue** and targets the `integration-app-platform-links` integration branch, not `main`.

- The remaining surfaces migrate to the shared grid in **sibling PRs** on the same integration branch.
- The **superseded files and the old i18n keys are deleted in item 06**, so this PR intentionally leaves them in place — nothing is removed here that another unmigrated surface still uses.
- **Promotion to `main` is deferred** to the integration branch promotion once every item in the queue has landed.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>