### PR TITLE
refactor(web): finish the app platform links unification

### DIFF
--- a/apps/web/src/appPlatformLinks/AppPlatformMcpOption.tsx
+++ b/apps/web/src/appPlatformLinks/AppPlatformMcpOption.tsx
@@ -12,7 +12,7 @@ type AppPlatformMcpOptionProps = Readonly<{
 
 export function AppPlatformMcpOption(props: AppPlatformMcpOptionProps): ReactElement {
   const { label, testIdPrefix } = props;
-  const { t } = useI18n();
+  const { direction, t } = useI18n();
   const [copyStatus, setCopyStatus] = useState<AppPlatformMcpCopyStatus>("idle");
   // Several grids can share one page, so the heading id is derived from the caller's prefix.
   const titleElementId: string = `${testIdPrefix}-mcp-title`;
@@ -39,9 +39,12 @@ export function AppPlatformMcpOption(props: AppPlatformMcpOptionProps): ReactEle
     }
   }
 
+  // This block is all prose, so it carries the locale direction itself and stays
+  // readable even when an ancestor pins the grid to left-to-right for tile placement.
   return (
     <section
       className="app-platform-links-mcp-option"
+      dir={direction}
       data-testid={`${testIdPrefix}-mcp-option`}
       aria-labelledby={titleElementId}
     >

--- a/apps/web/src/appPlatformLinks/index.ts
+++ b/apps/web/src/appPlatformLinks/index.ts
@@ -1,15 +1,13 @@
 export {
   buildAppPlatformOptions,
   type AppPlatformKind,
-  type AppPlatformLabels,
-  type AppPlatformOption,
-  type AppPlatformQrTitles,
-  type AppPlatformStoreKind,
   type AppPlatformStoreLinks,
-  type BuildAppPlatformOptionsInput,
 } from "./appPlatformOptions";
 export { AppPlatformLinksGrid } from "./AppPlatformLinksGrid";
-export { AppPlatformMcpOption, publicMcpServerUrl } from "./AppPlatformMcpOption";
-export { AppPlatformQrCode } from "./AppPlatformQrCode";
-export { AppStoreBadge, GooglePlayBadge, WebAppIcon } from "./badges";
-export { resolveClientPlatform, type ClientPlatform } from "./clientPlatform";
+export { resolveClientPlatform } from "./clientPlatform";
+export {
+  catalogImportStoreLinks,
+  friendInviteStoreLinks,
+  shareAppStoreLinks,
+  webReviewMobilePromptStoreLinks,
+} from "./storeLinks";

--- a/apps/web/src/appPlatformLinks/storeLinks.ts
+++ b/apps/web/src/appPlatformLinks/storeLinks.ts
@@ -1,0 +1,27 @@
+import type { AppPlatformStoreLinks } from "./appPlatformOptions";
+
+/**
+ * Campaign-tagged store links, one set per surface that offers the app.
+ * The campaign tags are a governed contract documented in `docs/marketing-links.md`,
+ * so these URLs are the only thing that legitimately differs between surfaces.
+ */
+
+export const shareAppStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=share_app&mt=8",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=share_app",
+};
+
+export const webReviewMobilePromptStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=web_review_mobile_prompt&mt=8",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=web_review_mobile_prompt",
+};
+
+export const catalogImportStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=catalog_import&mt=8",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=catalog_import",
+};
+
+export const friendInviteStoreLinks: AppPlatformStoreLinks = {
+  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=friend_invite&mt=8",
+  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=friend_invite",
+};

--- a/apps/web/src/screens/catalog/CatalogImportSuccessPanel.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportSuccessPanel.tsx
@@ -2,17 +2,12 @@ import type { ReactElement } from "react";
 import {
   AppPlatformLinksGrid,
   buildAppPlatformOptions,
+  catalogImportStoreLinks,
   resolveClientPlatform,
-  type AppPlatformStoreLinks,
 } from "../../appPlatformLinks";
 import { getAppConfig } from "../../config";
 import { useI18n } from "../../i18n";
 import { reviewRoute } from "../../routes";
-
-export const catalogImportStoreLinks: AppPlatformStoreLinks = {
-  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=catalog_import&mt=8",
-  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=catalog_import",
-};
 
 type CatalogImportSuccessPanelProps = Readonly<{
   cardCount: number;

--- a/apps/web/src/screens/invite/FriendInviteScreen.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.tsx
@@ -11,8 +11,8 @@ import {
 import {
   AppPlatformLinksGrid,
   buildAppPlatformOptions,
+  friendInviteStoreLinks,
   resolveClientPlatform,
-  type AppPlatformStoreLinks,
 } from "../../appPlatformLinks";
 import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { invalidateServerProgress } from "../../appData/progress/invalidation/progressInvalidation";
@@ -26,11 +26,6 @@ import type {
   SessionInfo,
 } from "../../types";
 import { validateFriendInvitationDisplayName } from "./friendInvitationDisplayName";
-
-export const friendInviteStoreLinks: AppPlatformStoreLinks = {
-  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=friend_invite&mt=8",
-  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=friend_invite",
-};
 
 type InviteLoadState = "loading" | "inactive" | "error" | "signed_out" | "ready" | "success";
 

--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.test.tsx
@@ -4,12 +4,12 @@ import { act } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../../api/ApiTestSupport";
+import { webReviewMobilePromptStoreLinks } from "../../../appPlatformLinks";
 import { I18nProvider } from "../../../i18n";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../../i18n/runtime";
 import {
   MobileAppPromotionDialog,
   type MobileAppPromotionDialogProps,
-  webReviewMobilePromptStoreLinks,
 } from "./MobileAppPromotionDialog";
 
 function requireElement(container: HTMLElement, selector: string): HTMLElement {

--- a/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
+++ b/apps/web/src/screens/review/mobileAppPromo/MobileAppPromotionDialog.tsx
@@ -13,11 +13,6 @@ export type MobileAppPromotionDialogProps = Readonly<{
   storeLinks: AppPlatformStoreLinks;
 }>;
 
-export const webReviewMobilePromptStoreLinks: AppPlatformStoreLinks = {
-  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=web_review_mobile_prompt&mt=8",
-  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=web_review_mobile_prompt",
-};
-
 const mobileAppPromotionFocusableSelector = [
   "a[href]",
   "button:not([disabled])",

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -9,6 +9,7 @@ import {
 import { useAppData, useReviewLeaderboardBadge, useReviewProgressBadge } from "../../appData";
 import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { ALL_CARDS_REVIEW_FILTER, currentReviewCard } from "../../appData/domain";
+import { webReviewMobilePromptStoreLinks } from "../../appPlatformLinks";
 import {
   buildNextAutomaticFeedbackPromptAt,
   evaluateAutomaticFeedbackPromptEligibility,
@@ -70,10 +71,7 @@ import {
   mobileAppPromotionMinimumReviewCount,
   type MobileAppPromotionReviewActivity,
 } from "./mobileAppPromo/mobileAppPromotionEligibility";
-import {
-  type MobileAppPromotionDialogProps,
-  webReviewMobilePromptStoreLinks,
-} from "./mobileAppPromo/MobileAppPromotionDialog";
+import type { MobileAppPromotionDialogProps } from "./mobileAppPromo/MobileAppPromotionDialog";
 import { useReviewRatingReactions, type UseReviewRatingReactionsResult } from "./reactions/useReviewRatingReactions";
 import { makeReviewSpeakableText, useReviewSpeech } from "./speech/reviewSpeech";
 

--- a/apps/web/src/screens/settings/TestAppPlatformLinksScreen.tsx
+++ b/apps/web/src/screens/settings/TestAppPlatformLinksScreen.tsx
@@ -2,17 +2,18 @@ import type { ReactElement } from "react";
 import {
   AppPlatformLinksGrid,
   buildAppPlatformOptions,
+  catalogImportStoreLinks,
+  friendInviteStoreLinks,
   resolveClientPlatform,
+  shareAppStoreLinks,
+  webReviewMobilePromptStoreLinks,
   type AppPlatformKind,
   type AppPlatformStoreLinks,
 } from "../../appPlatformLinks";
 import { getAppConfig } from "../../config";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import { progressLeaderboardRoute, reviewRoute } from "../../routes";
-import { CatalogImportSuccessPanel, catalogImportStoreLinks } from "../catalog/CatalogImportSuccessPanel";
-import { friendInviteStoreLinks } from "../invite/FriendInviteScreen";
-import { webReviewMobilePromptStoreLinks } from "../review/mobileAppPromo/MobileAppPromotionDialog";
-import { shareAppStoreLinks } from "../share/ShareAppScreen";
+import { CatalogImportSuccessPanel } from "../catalog/CatalogImportSuccessPanel";
 import { SettingsGroup, SettingsShell } from "./SettingsShared";
 
 type Translate = (key: TranslationKey, values?: TranslationValues) => string;

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
 import { useAppData } from "../../appData";
 import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import { webReviewMobilePromptStoreLinks } from "../../appPlatformLinks";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import {
   settingsTestAnimationsRoute,
@@ -12,10 +13,7 @@ import {
   loadLocalSyncDiagnosticsReport,
   type LocalSyncDiagnosticsReport,
 } from "../../localDb/diagnostics/localSyncDiagnostics";
-import {
-  MobileAppPromotionDialog,
-  webReviewMobilePromptStoreLinks,
-} from "../review/mobileAppPromo/MobileAppPromotionDialog";
+import { MobileAppPromotionDialog } from "../review/mobileAppPromo/MobileAppPromotionDialog";
 import {
   appendReviewReactionEvent,
   matchesReducedReviewReactionMotion,

--- a/apps/web/src/screens/share/ShareAppScreen.tsx
+++ b/apps/web/src/screens/share/ShareAppScreen.tsx
@@ -3,16 +3,11 @@ import {
   AppPlatformLinksGrid,
   buildAppPlatformOptions,
   resolveClientPlatform,
-  type AppPlatformStoreLinks,
+  shareAppStoreLinks,
 } from "../../appPlatformLinks";
 import { getAppConfig } from "../../config";
 import { useI18n } from "../../i18n";
 import { reviewRoute } from "../../routes";
-
-export const shareAppStoreLinks: AppPlatformStoreLinks = {
-  ios: "https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=share_app&mt=8",
-  android: "https://play.google.com/store/apps/details?id=com.flashcardsopensourceapp.app&utm_source=flashcards_website&utm_medium=referral&utm_campaign=share_app",
-};
 
 export function ShareAppScreen(): ReactElement {
   const { t } = useI18n();

--- a/apps/web/src/styles/features/review/review-dialogs.css
+++ b/apps/web/src/styles/features/review/review-dialogs.css
@@ -92,11 +92,6 @@
   outline-offset: 3px;
 }
 
-/* The platform grid is forced left-to-right, so its text-only MCP cell reads in the locale direction again. */
-[dir="rtl"] .mobile-app-promo-dialog .app-platform-links-mcp-option {
-  direction: rtl;
-}
-
 .review-editor-delete-btn {
   color: #ffaea9;
 }


### PR DESCRIPTION
## What this migrates

This is the finishing item of the app-platform-links unification, and the surface it migrates is the **shared `appPlatformLinks` module itself** — the last place where the unified platform grid still depended on the individual screens instead of the other way around.

- The four campaign-tagged store link sets (`share_app`, `web_review_mobile_prompt`, `catalog_import`, `friend_invite`) move out of `ShareAppScreen.tsx`, `MobileAppPromotionDialog.tsx`, `CatalogImportSuccessPanel.tsx`, and `FriendInviteScreen.tsx` into one owned module, `apps/web/src/appPlatformLinks/storeLinks.ts`. Surfaces no longer import campaign links from each other's screen modules, and the test screen no longer reaches into four screens to render its previews.
- The `appPlatformLinks` barrel is narrowed to the symbols callers actually use, now that the migrated surfaces all consume the shared grid.
- `AppPlatformMcpOption` carries the locale direction itself via `dir={direction}` instead of being patched back by an RTL override in `review-dialogs.css`. The text-only MCP cell now reads in the locale direction wherever the grid is embedded, not only inside the review promo dialog.

The store URLs themselves are unchanged — this is a move, so every campaign tag documented in `docs/marketing-links.md` is preserved exactly.

## Queue context

- Part of the **app-platform-links unification queue** running on the `integration-app-platform-links` integration branch. Base for this PR is `integration-app-platform-links`, not `main`.
- The remaining surfaces migrate in **sibling PRs** on the same integration branch.
- The superseded files and the old i18n keys are deleted in **item 06** of the queue, not here.
- **Promotion to `main` is deferred** to the integration branch promotion, once the whole queue has landed on `integration-app-platform-links`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
