### PR TITLE
docs: clarify that a new App Store campaign token needs no registration

### DIFF
--- a/docs/marketing-links.md
+++ b/docs/marketing-links.md
@@ -36,8 +36,11 @@ Current marketing-site App Store campaign URL:
 
 `https://apps.apple.com/app/apple-store/id6760538964?pt=128797295&ct=marketing_site&mt=8`
 
-Keep the App Store Connect-generated URL as-is once generated; do not rewrite
-the path manually.
+Keep the path and the `pt` and `mt` parameters exactly as App Store Connect
+generated them; do not rewrite them manually. Only `ct` differs per bucket,
+and its value is chosen freely without registering the campaign there first.
+A new campaign appears in App Store Connect Analytics on its own after roughly
+five first-time downloads from distinct Apple IDs and 24 hours.
 
 Track fine-grained button placement in site or product analytics, not in store
 campaign names.


### PR DESCRIPTION
The previous wording in `docs/marketing-links.md` said to keep the App Store Connect-generated URL as-is once generated and not rewrite the path manually. Read literally, that implied every new `ct` campaign bucket had to be generated in App Store Connect first before it could be used in a link.

That is not the case. `ct` is a free-form token: you pick the value yourself and use it immediately, with no prior registration in App Store Connect. The campaign shows up in App Store Connect Analytics on its own after roughly five first-time downloads from distinct Apple IDs and about 24 hours.

What actually is fixed is the link path and the `pt` and `mt` parameters — those must stay exactly as App Store Connect generated them. This change rewords the section to state that distinction directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)