### PR TITLE
Canonicalize IndexedDB open recovery grouping

### DIFF
--- a/apps/web/src/localDb/core/indexedDbOpenRecovery.ts
+++ b/apps/web/src/localDb/core/indexedDbOpenRecovery.ts
@@ -1,0 +1,12 @@
+export type IndexedDbOpenRecoveryError = Error & Readonly<{
+  indexedDbOperation: "open";
+  indexedDbErrorName: "UnknownError";
+}>;
+
+export function isIndexedDbOpenRecoveryError(error: unknown): error is IndexedDbOpenRecoveryError {
+  return error instanceof Error
+    && "indexedDbOperation" in error
+    && error.indexedDbOperation === "open"
+    && "indexedDbErrorName" in error
+    && error.indexedDbErrorName === "UnknownError";
+}

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react";
 import type { Scope } from "@sentry/react";
+import { isIndexedDbOpenRecoveryError } from "../localDb/core/indexedDbOpenRecovery";
 import { isBrowserApiNetworkError } from "./apiNetworkErrorPolicy";
 import { isWebSentryEnabled } from "./instrument";
 
@@ -829,6 +830,10 @@ export function captureWebException(event: WebExceptionEvent): void {
 }
 
 export function buildWebExceptionFingerprint(event: WebExceptionEvent): Array<string> {
+  if (isIndexedDbOpenRecoveryError(event.error)) {
+    return ["web.indexeddb.open.unknown_error"];
+  }
+
   if (event.action === "app_operation_failed") {
     return ["{{ default }}", event.action, event.details.operation];
   }


### PR DESCRIPTION
Summary:
- add a strict reusable discriminator for IndexedDB open UnknownError failures
- group matching Sentry events under one stable root fingerprint
- preserve existing metadata, contexts, and non-matching behavior

Validation:
- static review passed with no P0-P4 findings
- project checks were not run locally; PR CI owns executable validation