### PR TITLE
Stop futile IndexedDB recovery retries

### DIFF
--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -12,6 +12,7 @@ import {
   type LocalBrowserDataCleanupReason,
 } from "../../../accountDeletion";
 import type { TranslationKey } from "../../../i18n";
+import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import { loadCloudSettings, putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import { normalizeCaughtError, setWebObservabilityUser } from "../../../observability/webObservability";
@@ -94,6 +95,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     clearConfirmedUserScopedState,
   } = params;
   const resumePromiseRef = useRef<Promise<void> | null>(null);
+  const indexedDbOpenRecoveryFailedRef = useRef<boolean>(false);
 
   const initialize = useCallback(async function initialize(): Promise<void> {
     const shouldPreserveWarmStartState = sessionLoadState === "ready"
@@ -294,6 +296,10 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
   }, [revalidateActiveSession, runSyncSilently, setErrorMessage, setSessionErrorMessage, setSessionTechnicalError, setTechnicalError]);
 
   const resumeInBackground = useCallback(async function resumeInBackground(): Promise<void> {
+    if (indexedDbOpenRecoveryFailedRef.current) {
+      return;
+    }
+
     const activeResume = resumePromiseRef.current;
     if (activeResume !== null) {
       return activeResume;
@@ -317,8 +323,13 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
             return;
           }
 
+          const isIndexedDbOpenRecoveryFailure = isIndexedDbOpenRecoveryError(error);
+          if (isIndexedDbOpenRecoveryFailure) {
+            indexedDbOpenRecoveryFailedRef.current = true;
+          }
+
           lastError = error;
-          if (attemptNumber === resumeRetryCount) {
+          if (isIndexedDbOpenRecoveryFailure || attemptNumber === resumeRetryCount) {
             break;
           }
 

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -17,6 +17,7 @@ import {
 import {
   loadWorkspaceSettings,
 } from "../../../localDb/cards/workspace";
+import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import type {
   Card,
   CloudSettings,
@@ -625,6 +626,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     const syncTask = (async (): Promise<void> => {
       let syncInstallationId: string | null = null;
+      let didFailWithIndexedDbOpenRecoveryError = false;
       const syncRunId = createSyncRunId();
       const requireCurrentWorkspaceSync = function requireCurrentWorkspaceSync(currentWorkspaceId: string): void {
         requireWorkspaceSyncNotDiscarded(currentWorkspaceId, syncGeneration);
@@ -692,6 +694,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         }
 
         const normalizedError = normalizeCaughtError(error);
+        didFailWithIndexedDbOpenRecoveryError = isIndexedDbOpenRecoveryError(normalizedError);
         Object.assign(normalizedError, {
           syncRunId,
         });
@@ -715,7 +718,11 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
           const needsResync = needsResyncWorkspaceIdsRef.current.has(workspaceId);
           needsResyncWorkspaceIdsRef.current.delete(workspaceId);
-          if (needsResync && discardedSyncWorkspaceIdsRef.current.has(workspaceId) === false) {
+          if (
+            needsResync
+            && didFailWithIndexedDbOpenRecoveryError === false
+            && discardedSyncWorkspaceIdsRef.current.has(workspaceId) === false
+          ) {
             runSyncInBackground(runSyncForWorkspace(workspace));
           }
         }


### PR DESCRIPTION
## Summary
- stop foreground resume retries after the known page-lifetime IndexedDB open failure
- suppress queued sync reruns after the same classified failure
- preserve existing reporting and unrelated retry behavior

## Testing
- not run locally; cloud PR CI owns validation