### PR TITLE
Close IndexedDB recovery races

### DIFF
--- a/apps/web/src/appData/context/provider.tsx
+++ b/apps/web/src/appData/context/provider.tsx
@@ -10,6 +10,7 @@ import {
   type SetStateAction,
 } from "react";
 import { revalidateSession } from "../../api";
+import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
 import { loadActiveCardCount } from "../../localDb/cards/cards";
 import type {
@@ -77,6 +78,7 @@ function mergeRefreshedAccountSessionWithoutPreferences(
 export function AppDataProvider(props: Props): ReactElement {
   const { children } = props;
   const { t } = useI18n();
+  const { indexedDbOpenRecoveryState, showTechnicalError } = useAppErrorDialog();
   useProgressInvalidationRefresh();
   const [warmStartSnapshot] = useState(loadWarmStartSnapshot);
   const [sessionLoadState, setSessionLoadState] = useState<SessionLoadState>(
@@ -148,6 +150,7 @@ export function AppDataProvider(props: Props): ReactElement {
     setIsSyncing,
     setErrorMessage,
     setTechnicalError,
+    indexedDbOpenRecoveryState,
   });
 
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
@@ -188,25 +191,43 @@ export function AppDataProvider(props: Props): ReactElement {
     let isCancelled = false;
 
     async function refreshLocalCardCount(): Promise<void> {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       if (activeWorkspace === null) {
         setLocalCardCount(0);
         return;
       }
 
       const cardCount = await loadActiveCardCount(activeWorkspace.workspaceId);
-      if (isCancelled) {
+      if (isCancelled || indexedDbOpenRecoveryState.hasFailed()) {
         return;
       }
 
       setLocalCardCount(cardCount);
     }
 
-    void refreshLocalCardCount();
+    void refreshLocalCardCount().catch((error: unknown): void => {
+      const markResult = indexedDbOpenRecoveryState.markFailed(error);
+      if (markResult === "not_recovery") {
+        throw error;
+      }
+
+      showTechnicalError(error, {
+        feature: "sync",
+        operation: "refresh_local_metadata",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: null,
+        entityId: null,
+      });
+    });
 
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspace, localReadVersion]);
+  }, [activeWorkspace, indexedDbOpenRecoveryState, localReadVersion, session?.userId, showTechnicalError]);
 
   useEffect(() => {
     if (
@@ -368,6 +389,7 @@ export function AppDataProvider(props: Props): ReactElement {
     discardWorkspaceSync: syncEngine.discardWorkspaceSync,
     discardAllSyncWork: syncEngine.discardAllSyncWork,
     resetUserScopedUiState,
+    indexedDbOpenRecoveryState,
   });
 
   const value: AppDataContextValue = {

--- a/apps/web/src/appData/session/actions/useWorkspaceActions.ts
+++ b/apps/web/src/appData/session/actions/useWorkspaceActions.ts
@@ -9,6 +9,10 @@ import {
   resetWorkspaceProgress as resetWorkspaceProgressRequest,
   selectWorkspace,
 } from "../../../api";
+import {
+  ownsIndexedDbOpenRecoveryFailure,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
 import type { TranslationKey } from "../../../i18n";
 import { captureApiContractError } from "../../../observability/apiContractObservation";
 import { normalizeCaughtError } from "../../../observability/webObservability";
@@ -38,6 +42,7 @@ import type {
 type UseWorkspaceActionsParams =
   & Readonly<{
     t: (key: TranslationKey) => string;
+    indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
     activateWorkspace: (
       currentSession: SessionInfo,
       currentWorkspaces: ReadonlyArray<WorkspaceSummary>,
@@ -100,6 +105,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     activateWorkspace,
     runSync,
     discardWorkspaceSync,
+    indexedDbOpenRecoveryState,
   } = params;
 
   const chooseWorkspace = useCallback(async function chooseWorkspace(workspaceId: string): Promise<void> {
@@ -126,6 +132,10 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         selectedWorkspace.workspaceId,
         null,
       ));
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       await activateWorkspace(verifiedSession, availableWorkspaces, selectedWorkspace);
     } catch (error) {
       if (isAuthRedirectError(error)) {
@@ -133,6 +143,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
       }
 
       const normalizedError = normalizeCaughtError(error);
+      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceActionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -146,6 +157,10 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
           nextErrorMessage,
         ), normalizedError);
       }
+      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
+        return;
+      }
+
       setErrorMessage(nextErrorMessage);
       setTechnicalError(isExpectedError ? null : normalizedError);
     } finally {
@@ -156,6 +171,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     activeWorkspace,
     availableWorkspaces,
     cloudSettings,
+    indexedDbOpenRecoveryState,
     session,
     sessionVerificationState,
     t,
@@ -193,6 +209,10 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         createdWorkspace.workspaceId,
         null,
       ));
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       const nextWorkspaces = replaceWorkspaceSummary(availableWorkspaces, createdWorkspace);
       await activateWorkspace(verifiedSession, nextWorkspaces, createdWorkspace);
     } catch (error) {
@@ -201,6 +221,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
       }
 
       const normalizedError = normalizeCaughtError(error);
+      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceActionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -214,6 +235,10 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
           nextErrorMessage,
         ), normalizedError);
       }
+      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
+        throw error;
+      }
+
       setErrorMessage(nextErrorMessage);
       setTechnicalError(isExpectedError ? null : normalizedError);
       throw error;
@@ -225,6 +250,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     activeWorkspace,
     availableWorkspaces,
     cloudSettings,
+    indexedDbOpenRecoveryState,
     session,
     sessionVerificationState,
     t,
@@ -304,6 +330,10 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         deletedWorkspaceId: response.deletedWorkspaceId,
         replacementWorkspaceId: response.workspace.workspaceId,
       });
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       discardWorkspaceSync(response.deletedWorkspaceId);
       const nextWorkspaces = replaceWorkspaceSummary(
         availableWorkspaces.filter((workspace) => workspace.workspaceId !== response.deletedWorkspaceId),
@@ -315,6 +345,10 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         nextWorkspaceIds: nextWorkspaces.map((workspace) => workspace.workspaceId),
       });
       await activateWorkspace(verifiedSession, nextWorkspaces, response.workspace);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       setErrorMessage("");
     } catch (error) {
       if (isAuthRedirectError(error)) {
@@ -326,6 +360,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
       }
 
       const normalizedError = normalizeCaughtError(error);
+      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceActionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -334,6 +369,10 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
           errorMessage: nextErrorMessage,
         }, normalizedError);
       }
+      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
+        throw error;
+      }
+
       setErrorMessage(nextErrorMessage);
       setTechnicalError(isExpectedError ? null : normalizedError);
       throw error;
@@ -344,6 +383,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     activateWorkspace,
     availableWorkspaces,
     discardWorkspaceSync,
+    indexedDbOpenRecoveryState,
     session,
     sessionVerificationState,
     t,

--- a/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
+++ b/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
@@ -80,6 +80,10 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
   const clearConfirmedUserScopedState = useCallback(async function clearConfirmedUserScopedState(
     reason: LocalBrowserDataCleanupReason,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     workspaceBootstrapGenerationRef.current += 1;
     deferredBootstrapWorkspaceRef.current = null;
     setSession(null);
@@ -92,10 +96,15 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     setTechnicalError(null);
     resetUserScopedUiState();
     await discardAllSyncWork(async (): Promise<void> => {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       await clearAllLocalBrowserData(reason);
     });
   }, [
     discardAllSyncWork,
+    indexedDbOpenRecoveryState,
     resetUserScopedUiState,
     setActiveWorkspace,
     setAvailableWorkspaces,
@@ -281,6 +290,10 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     currentWorkspaces: ReadonlyArray<WorkspaceSummary>,
     workspace: WorkspaceSummary,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     logWorkspaceTransition("workspace_activate_started", {
       workspaceId: workspace.workspaceId,
       selectedWorkspaceId: currentSession.selectedWorkspaceId,
@@ -293,6 +306,10 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
       indexedDbOpenRecoveryState.markFailed(error);
       throw error;
     }
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     logWorkspaceTransition("workspace_activate_cloud_settings_saved", {
       workspaceId: workspace.workspaceId,
       selectedWorkspaceId: workspace.workspaceId,

--- a/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
+++ b/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
@@ -9,6 +9,11 @@ import {
   clearAllLocalBrowserData,
   type LocalBrowserDataCleanupReason,
 } from "../../../accountDeletion";
+import {
+  isIndexedDbOpenRecoveryFailureMark,
+  ownsIndexedDbOpenRecoveryFailure,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
 import { putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import type {
   SessionInfo,
@@ -40,6 +45,9 @@ import type {
 import { normalizeCaughtError, type WorkspaceActivationBootstrapPhase } from "../../../observability/webObservability";
 
 type UseWorkspaceActivationParams =
+  & Readonly<{
+    indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
+  }>
   & Pick<WorkspaceSessionState, "activeWorkspace" | "sessionVerificationState">
   & WorkspaceSessionSetters
   & WorkspaceSessionSyncActions
@@ -63,6 +71,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     resetUserScopedUiState,
     activeWorkspace,
     sessionVerificationState,
+    indexedDbOpenRecoveryState,
   } = params;
   const workspaceBootstrapGenerationRef = useRef<number>(0);
   const deferredBootstrapWorkspaceRef = useRef<WorkspaceSummary | null>(null);
@@ -139,6 +148,10 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
       let bootstrapPhase: WorkspaceActivationBootstrapPhase = "refresh_before_sync";
       try {
         await refreshWorkspaceView(workspace.workspaceId);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         if (sessionVerificationState !== "verified") {
           if (isCurrentBootstrapGeneration() === false) {
             return;
@@ -158,12 +171,20 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
         deferredBootstrapWorkspaceRef.current = null;
         bootstrapPhase = "run_sync";
         await runSyncForWorkspace(workspace);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         if (isCurrentBootstrapGeneration() === false) {
           return;
         }
 
         bootstrapPhase = "final_refresh";
         await refreshWorkspaceView(workspace.workspaceId);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         if (isCurrentBootstrapGeneration() === false) {
           return;
         }
@@ -179,22 +200,25 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
           bootstrapPhase,
         });
       } catch (error) {
-        if (isCurrentBootstrapGeneration() === false) {
-          return;
-        }
-
-        if (isAuthRedirectError(error)) {
-          logWorkspaceTransition("workspace_activate_bootstrap_redirected", {
-            workspaceId: workspace.workspaceId,
-            redirected: true,
-            sessionVerificationState,
-            bootstrapPhase,
-          });
-          setSessionLoadState("redirecting");
-          return;
-        }
-
         const normalizedError = normalizeCaughtError(error);
+        const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
+        if (isIndexedDbOpenRecoveryFailureMark(markResult) === false) {
+          if (isCurrentBootstrapGeneration() === false) {
+            return;
+          }
+
+          if (isAuthRedirectError(error)) {
+            logWorkspaceTransition("workspace_activate_bootstrap_redirected", {
+              workspaceId: workspace.workspaceId,
+              redirected: true,
+              sessionVerificationState,
+              bootstrapPhase,
+            });
+            setSessionLoadState("redirecting");
+            return;
+          }
+        }
+
         const nextErrorMessage = getErrorMessage(normalizedError);
         const syncFailureCaptureState = getSyncFailureObservationCaptureState(normalizedError);
         if (syncFailureCaptureState === null) {
@@ -205,6 +229,10 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
             bootstrapPhase,
           }, normalizedError);
         }
+        if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
+          return;
+        }
+
         setSessionErrorMessage(nextErrorMessage);
         setErrorMessage(nextErrorMessage);
         setSessionTechnicalError(syncFailureCaptureState === false ? null : normalizedError);
@@ -212,6 +240,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
       }
     })();
   }, [
+    indexedDbOpenRecoveryState,
     refreshWorkspaceView,
     runSyncForWorkspace,
     sessionVerificationState,
@@ -223,7 +252,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
   ]);
 
   useEffect(() => {
-    if (sessionVerificationState !== "verified") {
+    if (indexedDbOpenRecoveryState.hasFailed() || sessionVerificationState !== "verified") {
       return;
     }
 
@@ -243,6 +272,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     activeWorkspace,
     bootstrapWorkspaceInBackground,
     deferredBootstrapVersion,
+    indexedDbOpenRecoveryState,
     sessionVerificationState,
   ]);
 
@@ -257,7 +287,12 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
       availableWorkspaceIds: currentWorkspaces.map((currentWorkspace) => currentWorkspace.workspaceId),
     });
     const linkedCloudSettings = buildLinkedCloudSettings(currentSession, workspace.workspaceId);
-    await putCloudSettings(linkedCloudSettings);
+    try {
+      await putCloudSettings(linkedCloudSettings);
+    } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      throw error;
+    }
     logWorkspaceTransition("workspace_activate_cloud_settings_saved", {
       workspaceId: workspace.workspaceId,
       selectedWorkspaceId: workspace.workspaceId,
@@ -276,6 +311,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     bootstrapWorkspaceInBackground(workspace);
   }, [
     bootstrapWorkspaceInBackground,
+    indexedDbOpenRecoveryState,
     publishSelectedWorkspace,
     setCloudSettings,
     setErrorMessage,
@@ -287,10 +323,21 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
   const resolveInitialWorkspace = useCallback(async function resolveInitialWorkspace(
     currentSession: SessionInfo,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const workspaces = await listWorkspaces();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     if (workspaces.length === 0) {
       const createdWorkspace = await createWorkspaceRequest(defaultWorkspaceName);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       await activateWorkspace(currentSession, [createdWorkspace], createdWorkspace);
       return;
     }
@@ -304,6 +351,10 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     if (workspaces.length === 1) {
       const onlyWorkspace = workspaces[0];
       const selectedOnlyWorkspace = await selectWorkspace(onlyWorkspace.workspaceId);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       await activateWorkspace(currentSession, [selectedOnlyWorkspace], selectedOnlyWorkspace);
       return;
     }
@@ -312,7 +363,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     setActiveWorkspace(null);
     setSession(currentSession);
     setSessionLoadState("selecting_workspace");
-  }, [activateWorkspace, setActiveWorkspace, setAvailableWorkspaces, setSession, setSessionLoadState]);
+  }, [activateWorkspace, indexedDbOpenRecoveryState, setActiveWorkspace, setAvailableWorkspaces, setSession, setSessionLoadState]);
 
   return {
     activateWorkspace,

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -404,6 +404,10 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
             break;
           }
 
+          if (indexedDbOpenRecoveryState.hasFailed()) {
+            break;
+          }
+
           await waitForDelay(resumeRetryDelayMs);
           attemptNumber += 1;
         }

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -11,8 +11,13 @@ import {
   isBrowserReauthRequired,
   type LocalBrowserDataCleanupReason,
 } from "../../../accountDeletion";
+import {
+  isIndexedDbOpenRecoveryFailureMark,
+  ownsIndexedDbOpenRecoveryFailure,
+  type IndexedDbOpenRecoveryMarkResult,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
 import type { TranslationKey } from "../../../i18n";
-import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import { loadCloudSettings, putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import { normalizeCaughtError, setWebObservabilityUser } from "../../../observability/webObservability";
@@ -46,6 +51,7 @@ type UseWorkspaceLifecycleParams =
     runSyncSilently: () => Promise<void>;
     resolveInitialWorkspace: (currentSession: SessionInfo) => Promise<void>;
     clearConfirmedUserScopedState: (reason: LocalBrowserDataCleanupReason) => Promise<void>;
+    indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   }>
   & WorkspaceSessionState
   & WorkspaceSessionSetters;
@@ -93,11 +99,15 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     runSyncSilently,
     resolveInitialWorkspace,
     clearConfirmedUserScopedState,
+    indexedDbOpenRecoveryState,
   } = params;
   const resumePromiseRef = useRef<Promise<void> | null>(null);
-  const indexedDbOpenRecoveryFailedRef = useRef<boolean>(false);
 
   const initialize = useCallback(async function initialize(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const shouldPreserveWarmStartState = sessionLoadState === "ready"
       && sessionVerificationState === "unverified"
       && session !== null
@@ -122,10 +132,17 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     try {
       if (consumeLoggedOutMarker()) {
         await clearConfirmedUserScopedState("logout_marker");
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
       }
 
       if (consumeAccountDeletedMarker()) {
         await clearConfirmedUserScopedState("account_deleted_marker");
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         setSession(null);
         setWebObservabilityUser(null);
         setSessionLoadState("deleted");
@@ -137,8 +154,16 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
 
       const wasBrowserReauthRequired = isBrowserReauthRequired();
       const currentSession = await getSession();
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       setWebObservabilityUser({ id: currentSession.userId });
       const persistedCloudSettings = await loadCloudSettings();
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       const localDataCleanupReason = resolveLocalDataCleanupReasonForVerifiedSession(
         persistedCloudSettings,
         currentSession,
@@ -146,13 +171,24 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       );
       if (localDataCleanupReason !== null) {
         await clearConfirmedUserScopedState(localDataCleanupReason);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
       }
 
       clearBrowserReauthRequired();
       const linkingReadyCloudSettings = buildLinkingReadyCloudSettings(currentSession);
       await putCloudSettings(linkingReadyCloudSettings);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       setCloudSettings(linkingReadyCloudSettings);
       await resolveInitialWorkspace(currentSession);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       setSessionVerificationState("verified");
     } catch (error) {
       if (isAuthRedirectError(error)) {
@@ -170,6 +206,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       }
 
       const normalizedError = normalizeCaughtError(error);
+      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceSessionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -178,6 +215,10 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
           sessionVerificationState,
         }, normalizedError);
       }
+      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
+        return;
+      }
+
       setSessionLoadState("error");
       setSessionErrorMessage(nextErrorMessage);
       setSessionTechnicalError(isExpectedError ? null : normalizedError);
@@ -185,6 +226,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     }
   }, [
     clearConfirmedUserScopedState,
+    indexedDbOpenRecoveryState,
     resolveInitialWorkspace,
     session,
     sessionLoadState,
@@ -215,27 +257,49 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
   }, []);
 
   const revalidateActiveSession = useCallback(async function revalidateActiveSession(): Promise<boolean> {
-    if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null) {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || sessionLoadState !== "ready"
+      || sessionVerificationState !== "verified"
+      || session === null
+    ) {
       return false;
     }
 
     try {
       const currentSession = await revalidateSessionRequest();
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return false;
+      }
+
       if (currentSession.userId !== session.userId) {
         try {
           setWebObservabilityUser({ id: currentSession.userId });
           await clearConfirmedUserScopedState("confirmed_account_switch");
+          if (indexedDbOpenRecoveryState.hasFailed()) {
+            return false;
+          }
+
           clearBrowserReauthRequired();
           const linkingReadyCloudSettings = buildLinkingReadyCloudSettings(currentSession);
           await putCloudSettings(linkingReadyCloudSettings);
+          if (indexedDbOpenRecoveryState.hasFailed()) {
+            return false;
+          }
+
           setCloudSettings(linkingReadyCloudSettings);
           await resolveInitialWorkspace(currentSession);
+          if (indexedDbOpenRecoveryState.hasFailed()) {
+            return false;
+          }
+
           setSessionVerificationState("verified");
           setSessionErrorMessage("");
           setErrorMessage("");
           return false;
         } catch (error) {
           const normalizedError = normalizeCaughtError(error);
+          const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
           const nextErrorMessage = getErrorMessage(normalizedError);
           const isExpectedError = isExpectedWorkspaceSessionApiError(normalizedError);
           if (isExpectedError === false) {
@@ -244,6 +308,10 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
               sessionVerificationState,
             }, normalizedError);
           }
+          if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
+            throw createSessionAccountSwitchError(nextErrorMessage);
+          }
+
           setSessionLoadState("error");
           setSessionErrorMessage(nextErrorMessage);
           setErrorMessage(nextErrorMessage);
@@ -269,6 +337,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     }
   }, [
     clearConfirmedUserScopedState,
+    indexedDbOpenRecoveryState,
     resolveInitialWorkspace,
     session,
     sessionLoadState,
@@ -289,14 +358,18 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       await runSyncSilently();
     }
 
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setSessionErrorMessage("");
     setErrorMessage("");
     setSessionTechnicalError(null);
     setTechnicalError(null);
-  }, [revalidateActiveSession, runSyncSilently, setErrorMessage, setSessionErrorMessage, setSessionTechnicalError, setTechnicalError]);
+  }, [indexedDbOpenRecoveryState, revalidateActiveSession, runSyncSilently, setErrorMessage, setSessionErrorMessage, setSessionTechnicalError, setTechnicalError]);
 
   const resumeInBackground = useCallback(async function resumeInBackground(): Promise<void> {
-    if (indexedDbOpenRecoveryFailedRef.current) {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -309,6 +382,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     trackedResumePromise = (async (): Promise<void> => {
       let attemptNumber = 1;
       let lastError: unknown = null;
+      let lastMarkResult: IndexedDbOpenRecoveryMarkResult = "not_recovery";
 
       while (attemptNumber <= resumeRetryCount) {
         try {
@@ -323,13 +397,10 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
             return;
           }
 
-          const isIndexedDbOpenRecoveryFailure = isIndexedDbOpenRecoveryError(error);
-          if (isIndexedDbOpenRecoveryFailure) {
-            indexedDbOpenRecoveryFailedRef.current = true;
-          }
+          lastMarkResult = indexedDbOpenRecoveryState.markFailed(error);
 
           lastError = error;
-          if (isIndexedDbOpenRecoveryFailure || attemptNumber === resumeRetryCount) {
+          if (isIndexedDbOpenRecoveryFailureMark(lastMarkResult) || attemptNumber === resumeRetryCount) {
             break;
           }
 
@@ -351,6 +422,10 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
           entityId: null,
         })
         : syncFailureCaptureState;
+      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(lastMarkResult) === false) {
+        throw normalizedError;
+      }
+
       setErrorMessage(nextErrorMessage);
       setTechnicalError(didCaptureResumeError ? normalizedError : null);
       throw normalizedError;
@@ -362,7 +437,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
 
     resumePromiseRef.current = trackedResumePromise;
     return trackedResumePromise;
-  }, [activeWorkspace?.workspaceId, runResumeAttempt, session?.userId, setErrorMessage, setTechnicalError]);
+  }, [activeWorkspace?.workspaceId, indexedDbOpenRecoveryState, runResumeAttempt, session?.userId, setErrorMessage, setTechnicalError]);
 
   useEffect(() => {
     if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null) {

--- a/apps/web/src/appData/session/useWorkspaceSessionTestSupport.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSessionTestSupport.tsx
@@ -1,6 +1,7 @@
 import { act, useEffect, useState, type ReactElement } from "react";
 import { vi, type Mock } from "vitest";
 import { setNavigationHandlerForTests, resetApiClientStateForTests } from "../../api";
+import type { IndexedDbOpenRecoveryState } from "../../appError/AppErrorContext";
 import { INSTALLATION_ID_STORAGE_KEY } from "../../clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../i18n/runtime";
 import { WARM_START_SNAPSHOT_STORAGE_KEY } from "./activation/warmStart";
@@ -16,6 +17,11 @@ import type { TranslationKey } from "../../i18n";
 import type { SessionLoadState } from "../context/types";
 import type { SessionVerificationState } from "./workspaceSessionTypes";
 import { clearWebSyncCache } from "../../localDb/cache";
+
+const indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState = {
+  hasFailed: (): boolean => false,
+  markFailed: () => "not_recovery",
+};
 
 const observabilityMocks = vi.hoisted(() => ({
   addWebBreadcrumbMock: vi.fn(),
@@ -263,6 +269,7 @@ export function TestHarness(props: TestHarnessProps): ReactElement {
 
   const actions = useWorkspaceSession({
     t: (key: TranslationKey): string => key,
+    indexedDbOpenRecoveryState,
     sessionLoadState,
     sessionVerificationState,
     session,

--- a/apps/web/src/appData/session/workspaceSessionTypes.ts
+++ b/apps/web/src/appData/session/workspaceSessionTypes.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import type { LocalBrowserDataCleanupReason } from "../../accountDeletion";
+import type { IndexedDbOpenRecoveryState } from "../../appError/AppErrorContext";
 import type { TranslationKey } from "../../i18n";
 import type {
   CloudSettings,
@@ -51,6 +52,7 @@ export type WorkspaceSessionUiActions = Readonly<{
 export type UseWorkspaceSessionParams =
   & Readonly<{
     t: (key: TranslationKey) => string;
+    indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   }>
   & WorkspaceSessionState
   & WorkspaceSessionSetters

--- a/apps/web/src/appData/sync/engine/useSyncEngine.mediaUploadLifecycle.test.tsx
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.mediaUploadLifecycle.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import type {
   CloudSettings,
   SessionInfo,
@@ -13,6 +14,11 @@ import type {
   WorkspaceSummary,
 } from "../../../types";
 import { useSyncEngine } from "./useSyncEngine";
+
+const indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState = {
+  hasFailed: (): boolean => false,
+  markFailed: () => "not_recovery",
+};
 
 const syncEngineMocks = vi.hoisted(() => ({
   processDueMediaUploadTransfersForWorkspace: vi.fn(),
@@ -112,6 +118,7 @@ function renderSyncEngineHarness(): Readonly<{
       setIsSyncing,
       setErrorMessage,
       setTechnicalError,
+      indexedDbOpenRecoveryState,
     });
     return null;
   }

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -9,6 +9,12 @@ import {
   isAuthRedirectError,
 } from "../../../api";
 import {
+  isIndexedDbOpenRecoveryFailureMark,
+  ownsIndexedDbOpenRecoveryFailure,
+  type IndexedDbOpenRecoveryMarkResult,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
+import {
   loadCloudSettings,
 } from "../../../localDb/sync/cloudSettings";
 import {
@@ -17,7 +23,6 @@ import {
 import {
   loadWorkspaceSettings,
 } from "../../../localDb/cards/workspace";
-import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import type {
   Card,
   CloudSettings,
@@ -96,6 +101,7 @@ type UseSyncEngineParams = Readonly<{
   setIsSyncing: Dispatch<SetStateAction<boolean>>;
   setErrorMessage: Dispatch<SetStateAction<string>>;
   setTechnicalError: Dispatch<SetStateAction<Error | null>>;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
 }>;
 
 type SyncEngine = Readonly<{
@@ -184,19 +190,9 @@ function isLinkedMediaUploadCloudSettings(
 
 function runMediaUploadTransfersInBackground(
   mediaUploadTask: Promise<void>,
-  userId: string,
-  workspaceId: string,
+  reportError: (error: unknown) => void,
 ): void {
-  void mediaUploadTask.catch((error: unknown): void => {
-    captureAppOperationError(error, {
-      feature: "sync",
-      operation: "media_upload_transfers",
-      userId,
-      workspaceId,
-      installationId: null,
-      entityId: null,
-    });
-  });
+  void mediaUploadTask.catch(reportError);
 }
 
 export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
@@ -212,6 +208,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     setIsSyncing,
     setErrorMessage,
     setTechnicalError,
+    indexedDbOpenRecoveryState,
   } = params;
   const activeWorkspaceRef = useRef<WorkspaceSummary | null>(activeWorkspace);
   const availableWorkspacesRef = useRef<ReadonlyArray<WorkspaceSummary>>(availableWorkspaces);
@@ -281,6 +278,20 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     mediaUploadRetryTimerIdsRef.current.clear();
   }, []);
+
+  const markIndexedDbOpenRecoveryFailure = useCallback(function markIndexedDbOpenRecoveryFailure(
+    error: unknown,
+  ): IndexedDbOpenRecoveryMarkResult {
+    const markResult = indexedDbOpenRecoveryState.markFailed(error);
+    if (isIndexedDbOpenRecoveryFailureMark(markResult) === false) {
+      return markResult;
+    }
+
+    needsResyncWorkspaceIdsRef.current.clear();
+    mediaUploadNeedsRunWorkspaceIdsRef.current.clear();
+    clearAllMediaUploadRetryTimers();
+    return markResult;
+  }, [clearAllMediaUploadRetryTimers, indexedDbOpenRecoveryState]);
 
   const abortAllMediaUploadTransfers = useCallback(function abortAllMediaUploadTransfers(): void {
     for (const controller of mediaUploadAbortControllersRef.current.values()) {
@@ -379,7 +390,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   }, []);
 
   const refreshLocalMetadata = useCallback(async function refreshLocalMetadata(workspaceId: string): Promise<void> {
-    if (isDiscardingAllSyncWorkRef.current) {
+    if (isDiscardingAllSyncWorkRef.current || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -387,8 +398,19 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     const [workspaceSettings, cloudSettings] = await runLocalDataRead(() => Promise.all([
       loadWorkspaceSettings(workspaceId),
       loadCloudSettings(),
-    ]));
-    if (metadataGeneration !== syncGenerationRef.current || isDiscardingAllSyncWorkRef.current) {
+    ])).catch((error: unknown): never => {
+      const normalizedError = normalizeCaughtError(error);
+      if (isIndexedDbOpenRecoveryFailureMark(markIndexedDbOpenRecoveryFailure(normalizedError))) {
+        throw normalizedError;
+      }
+
+      throw error;
+    });
+    if (
+      metadataGeneration !== syncGenerationRef.current
+      || isDiscardingAllSyncWorkRef.current
+      || indexedDbOpenRecoveryState.hasFailed()
+    ) {
       return;
     }
 
@@ -396,19 +418,22 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     if (isVisibleWorkspace(workspaceId)) {
       setWorkspaceSettings(workspaceSettings);
     }
-  }, [isVisibleWorkspace, runLocalDataRead, setCloudSettings, setWorkspaceSettings]);
+  }, [indexedDbOpenRecoveryState, isVisibleWorkspace, markIndexedDbOpenRecoveryFailure, runLocalDataRead, setCloudSettings, setWorkspaceSettings]);
 
   const refreshWorkspaceView = useCallback(async function refreshWorkspaceView(workspaceId: string): Promise<void> {
     const metadataGeneration = syncGenerationRef.current;
     await refreshLocalMetadata(workspaceId);
-    if (metadataGeneration !== syncGenerationRef.current) {
+    if (
+      metadataGeneration !== syncGenerationRef.current
+      || indexedDbOpenRecoveryState.hasFailed()
+    ) {
       return;
     }
 
     if (isVisibleWorkspace(workspaceId)) {
       bumpLocalReadVersion();
     }
-  }, [bumpLocalReadVersion, isVisibleWorkspace, refreshLocalMetadata]);
+  }, [bumpLocalReadVersion, indexedDbOpenRecoveryState, isVisibleWorkspace, refreshLocalMetadata]);
 
   const publishWorkspaceSettings = useCallback(function publishWorkspaceSettings(
     workspaceId: string,
@@ -420,16 +445,44 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   }, [isVisibleWorkspace, setWorkspaceSettings]);
 
   const reportGlobalSyncError = useCallback(function reportGlobalSyncError(report: SyncFailureReport): void {
+    const markResult = markIndexedDbOpenRecoveryFailure(report.error);
+    if (ownsIndexedDbOpenRecoveryFailure(markResult) === false && indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setErrorMessage(getErrorMessage(report.error));
     if (report.wasCaptured) {
       setTechnicalError(report.error);
     } else {
       setTechnicalError(null);
     }
-  }, [setErrorMessage, setTechnicalError]);
+  }, [indexedDbOpenRecoveryState, markIndexedDbOpenRecoveryFailure, setErrorMessage, setTechnicalError]);
 
   const ignoreSyncError = useCallback(function ignoreSyncError(_report: SyncFailureReport): void {
   }, []);
+
+  const reportMediaUploadError = useCallback(function reportMediaUploadError(
+    error: unknown,
+    userId: string,
+    workspaceId: string,
+  ): void {
+    const normalizedError = normalizeCaughtError(error);
+    const markResult = markIndexedDbOpenRecoveryFailure(normalizedError);
+    const wasCaptured = captureAppOperationError(normalizedError, {
+      feature: "sync",
+      operation: "media_upload_transfers",
+      userId,
+      workspaceId,
+      installationId: null,
+      entityId: null,
+    });
+    if (isIndexedDbOpenRecoveryFailureMark(markResult)) {
+      reportGlobalSyncError({
+        error: normalizedError,
+        wasCaptured,
+      });
+    }
+  }, [markIndexedDbOpenRecoveryFailure, reportGlobalSyncError]);
 
   const readCurrentRunnableMediaUploadSession = useCallback(function readCurrentRunnableMediaUploadSession(
     workspace: WorkspaceSummary,
@@ -437,6 +490,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     const currentSession = sessionRef.current;
     if (
       isDiscardingAllSyncWorkRef.current
+      || indexedDbOpenRecoveryState.hasFailed()
       || isSyncEngineMountedRef.current === false
       || sessionLoadStateRef.current !== "ready"
       || currentSession === null
@@ -449,7 +503,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     return currentSession;
-  }, []);
+  }, [indexedDbOpenRecoveryState]);
 
   const loadRunnableMediaUploadSession = useCallback(async function loadRunnableMediaUploadSession(
     workspace: WorkspaceSummary,
@@ -474,14 +528,23 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   const scheduleMediaUploadRetryTimerForWorkspace = useCallback(async function scheduleMediaUploadRetryTimerForWorkspace(
     workspace: WorkspaceSummary,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const mediaUploadLifecycleGeneration = mediaUploadLifecycleGenerationRef.current;
     if (await loadRunnableMediaUploadSession(workspace) === null) {
+      return;
+    }
+
+    if (indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
     const nextAttemptAt = await loadNextPendingMediaTransferAttemptAtByKind(workspace.workspaceId, "upload");
     if (
       mediaUploadLifecycleGeneration !== mediaUploadLifecycleGenerationRef.current
+      || indexedDbOpenRecoveryState.hasFailed()
       || nextAttemptAt === null
       || await loadRunnableMediaUploadSession(workspace) === null
     ) {
@@ -500,15 +563,23 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       }
 
       mediaUploadRetryTimerIdsRef.current.delete(workspace.workspaceId);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       runMediaUploadTransfersForWorkspaceRef.current(workspace);
     }, delayMs);
     mediaUploadRetryTimerIdsRef.current.set(workspace.workspaceId, timerId);
-  }, [clearMediaUploadRetryTimer, loadRunnableMediaUploadSession]);
+  }, [clearMediaUploadRetryTimer, indexedDbOpenRecoveryState, loadRunnableMediaUploadSession]);
 
   const runMediaUploadTransfersForWorkspace = useCallback(function runMediaUploadTransfersForWorkspace(
     workspace: WorkspaceSummary,
   ): void {
     clearMediaUploadRetryTimer(workspace.workspaceId);
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const currentSession = readCurrentRunnableMediaUploadSession(workspace);
     if (currentSession === null) {
       return;
@@ -528,10 +599,17 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         return;
       }
 
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       await processDueMediaUploadTransfersForWorkspace(
         workspace.workspaceId,
         abortController.signal,
       );
+    })().catch((error: unknown): never => {
+      markIndexedDbOpenRecoveryFailure(error);
+      throw error;
     })().finally(() => {
       if (mediaUploadAbortControllersRef.current.get(workspace.workspaceId) === abortController) {
         mediaUploadAbortControllersRef.current.delete(workspace.workspaceId);
@@ -543,6 +621,10 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         mediaUploadPromisesRef.current.delete(workspace.workspaceId);
         const needsAnotherRun = mediaUploadNeedsRunWorkspaceIdsRef.current.has(workspace.workspaceId);
         mediaUploadNeedsRunWorkspaceIdsRef.current.delete(workspace.workspaceId);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         if (needsAnotherRun && discardedSyncWorkspaceIdsRef.current.has(workspace.workspaceId) === false) {
           runMediaUploadTransfersForWorkspaceRef.current(workspace);
           return;
@@ -550,17 +632,23 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
         runMediaUploadTransfersInBackground(
           scheduleMediaUploadRetryTimerForWorkspace(workspace),
-          currentSession.userId,
-          workspace.workspaceId,
+          (error: unknown): void => {
+            reportMediaUploadError(error, currentSession.userId, workspace.workspaceId);
+          },
         );
       }
     });
     mediaUploadPromisesRef.current.set(workspace.workspaceId, mediaUploadTask);
-    runMediaUploadTransfersInBackground(mediaUploadTask, currentSession.userId, workspace.workspaceId);
+    runMediaUploadTransfersInBackground(mediaUploadTask, (error: unknown): void => {
+      reportMediaUploadError(error, currentSession.userId, workspace.workspaceId);
+    });
   }, [
     clearMediaUploadRetryTimer,
+    indexedDbOpenRecoveryState,
     loadRunnableMediaUploadSession,
+    markIndexedDbOpenRecoveryFailure,
     readCurrentRunnableMediaUploadSession,
+    reportMediaUploadError,
     scheduleMediaUploadRetryTimerForWorkspace,
   ]);
 
@@ -605,7 +693,12 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   ): Promise<void> {
     // Local writes may happen during warm start, but remote sync stays paused
     // until auth verification confirms which account owns this browser state.
-    if (isDiscardingAllSyncWorkRef.current || session === null || sessionVerificationState !== "verified") {
+    if (
+      isDiscardingAllSyncWorkRef.current
+      || indexedDbOpenRecoveryState.hasFailed()
+      || session === null
+      || sessionVerificationState !== "verified"
+    ) {
       return;
     }
 
@@ -626,7 +719,6 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     const syncTask = (async (): Promise<void> => {
       let syncInstallationId: string | null = null;
-      let didFailWithIndexedDbOpenRecoveryError = false;
       const syncRunId = createSyncRunId();
       const requireCurrentWorkspaceSync = function requireCurrentWorkspaceSync(currentWorkspaceId: string): void {
         requireWorkspaceSyncNotDiscarded(currentWorkspaceId, syncGeneration);
@@ -643,11 +735,32 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         await refreshWorkspaceView(currentWorkspaceId);
         requireCurrentWorkspaceSync(currentWorkspaceId);
       };
+      const observeAndReportSyncFailure = function observeAndReportSyncFailure(error: Error): Error {
+        Object.assign(error, {
+          syncRunId,
+        });
+        const wasCaptured = observeSyncFailure({
+          error,
+          userId: session.userId,
+          workspaceId,
+          installationId: syncInstallationId,
+        });
+        const observedError = attachSyncFailureObservation(error, wasCaptured);
+        reportSyncError({
+          error: observedError,
+          wasCaptured,
+        });
+        return observedError;
+      };
 
       try {
         requireCurrentWorkspaceSync(workspaceId);
         const cloudSettings = await loadCloudSettings();
         requireCurrentWorkspaceSync(workspaceId);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         const installationId = requireCloudInstallationId(cloudSettings);
         syncInstallationId = installationId;
         const syncFlags = await runWorkspaceRemoteSync({
@@ -661,7 +774,15 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           refreshWorkspaceView: refreshCurrentWorkspaceView,
         });
 
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         await refreshCurrentWorkspaceView(workspaceId);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
+
         if (syncFlags.didChangeProgressHistory) {
           invalidateProgress();
         }
@@ -671,6 +792,11 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         setErrorMessage("");
         runMediaUploadTransfersForWorkspace(workspace);
       } catch (error) {
+        const normalizedError = normalizeCaughtError(error);
+        if (isIndexedDbOpenRecoveryFailureMark(markIndexedDbOpenRecoveryFailure(normalizedError))) {
+          throw observeAndReportSyncFailure(normalizedError);
+        }
+
         if (syncGeneration !== syncGenerationRef.current) {
           return;
         }
@@ -693,23 +819,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           return;
         }
 
-        const normalizedError = normalizeCaughtError(error);
-        didFailWithIndexedDbOpenRecoveryError = isIndexedDbOpenRecoveryError(normalizedError);
-        Object.assign(normalizedError, {
-          syncRunId,
-        });
-        const wasCaptured = observeSyncFailure({
-          error: normalizedError,
-          userId: session.userId,
-          workspaceId,
-          installationId: syncInstallationId,
-        });
-        const observedError = attachSyncFailureObservation(normalizedError, wasCaptured);
-        reportSyncError({
-          error: observedError,
-          wasCaptured,
-        });
-        throw observedError;
+        throw observeAndReportSyncFailure(normalizedError);
       } finally {
         if (syncGeneration === syncGenerationRef.current) {
           syncPromisesRef.current.delete(workspaceId);
@@ -720,7 +830,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           needsResyncWorkspaceIdsRef.current.delete(workspaceId);
           if (
             needsResync
-            && didFailWithIndexedDbOpenRecoveryError === false
+            && indexedDbOpenRecoveryState.hasFailed() === false
             && discardedSyncWorkspaceIdsRef.current.has(workspaceId) === false
           ) {
             runSyncInBackground(runSyncForWorkspace(workspace));
@@ -732,6 +842,8 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     syncPromisesRef.current.set(workspaceId, syncTask);
     return syncTask;
   }, [
+    indexedDbOpenRecoveryState,
+    markIndexedDbOpenRecoveryFailure,
     publishWorkspaceSettings,
     refreshSyncIndicator,
     refreshWorkspaceView,
@@ -778,7 +890,9 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     void refreshLocalMetadata(activeWorkspace.workspaceId).catch((error: unknown): void => {
-      captureAppOperationError(error, {
+      const normalizedError = normalizeCaughtError(error);
+      const markResult = markIndexedDbOpenRecoveryFailure(normalizedError);
+      const wasCaptured = captureAppOperationError(normalizedError, {
         feature: "sync",
         operation: "refresh_local_metadata",
         userId: session.userId,
@@ -786,12 +900,20 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         installationId: null,
         entityId: null,
       });
+      if (isIndexedDbOpenRecoveryFailureMark(markResult)) {
+        reportGlobalSyncError({
+          error: normalizedError,
+          wasCaptured,
+        });
+      }
     });
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     runMediaUploadTransfersForWorkspace(activeWorkspace);
   }, [
     activeWorkspace,
+    markIndexedDbOpenRecoveryFailure,
     refreshLocalMetadata,
+    reportGlobalSyncError,
     runMediaUploadTransfersForWorkspace,
     runSyncForWorkspace,
     session,

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -557,6 +557,10 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     clearMediaUploadRetryTimer(workspace.workspaceId);
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const timerId = window.setTimeout((): void => {
       if (mediaUploadLifecycleGeneration !== mediaUploadLifecycleGenerationRef.current) {
         return;

--- a/apps/web/src/appData/sync/local/demoCard.ts
+++ b/apps/web/src/appData/sync/local/demoCard.ts
@@ -4,6 +4,7 @@ import {
   resolveLocaleState,
   translateMessage,
 } from "../../../i18n/runtime";
+import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import { nowIso } from "../../domain";
 import {
@@ -85,7 +86,8 @@ function buildDemoCardText(): DemoCardText {
 // Every condition is decided by the caller and passed in, so this stays a pure guard over
 // its input and never re-reads workspace state.
 //
-// Failing to seed must never fail a sync run, so a seed failure is reported and swallowed.
+// Ordinary seed failures must never fail a sync run, so they are reported and swallowed.
+// An IndexedDB open recovery failure must escape so the page-lifetime recovery latch can stop all local work.
 export async function seedDemoCardForNewWorkspace(
   input: SeedDemoCardInput,
 ): Promise<LocalCardMutationResult | null> {
@@ -117,6 +119,10 @@ export async function seedDemoCardForNewWorkspace(
       installationId: input.installationId,
       entityId: null,
     });
+    if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
+
     return null;
   }
 }

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
@@ -10,6 +10,7 @@ import {
   type MediaBlobCacheRecord,
   type MediaTransferQueueRecord,
 } from "../../../localDb/mediaTransfers";
+import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import { loadCloudSettings } from "../../../localDb/sync/cloudSettings";
 import type {
   MediaAsset,
@@ -268,6 +269,10 @@ async function runMultipartUploadSession(
     try {
       assertUploadedMediaAssetMatchesTransfer(transfer, result.mediaAsset);
     } catch (error) {
+      if (isIndexedDbOpenRecoveryError(error)) {
+        throw error;
+      }
+
       if (result.retryableCompletionCause !== null) {
         throw new MediaUploadCompletionTerminalError(
           "interrupted",
@@ -279,6 +284,10 @@ async function runMultipartUploadSession(
     }
     return result;
   } catch (error) {
+    if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
+
     if (
       error instanceof MediaUploadCompletionTerminalError
       || isSameSessionCompletionRetryError(error)
@@ -316,6 +325,10 @@ async function uploadClaimedMediaTransfer(
   try {
     verifiedBytes = await loadVerifiedUploadBytes(transfer);
   } catch (error) {
+    if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
+
     const abortError = await abortUploadSessionAfterFailure(transfer, sessionCreateResult.uploadSession.sessionId);
     throw combineUploadFailureWithAbortFailure(error, abortError);
   }
@@ -355,6 +368,13 @@ async function processClaimedUploadTransfer(
     });
   } catch (error) {
     const heartbeatError = await heartbeat.stop();
+    if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
+    if (isIndexedDbOpenRecoveryError(heartbeatError)) {
+      throw heartbeatError;
+    }
+
     const interruptionError = heartbeatError ?? error;
     const failureError = error instanceof MediaUploadCompletionTerminalError
       ? error

--- a/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
+++ b/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
@@ -7,6 +7,7 @@ import {
   isAuthRedirectError,
 } from "../../../api";
 import type { MediaTransferQueueRecord } from "../../../localDb/mediaTransfers";
+import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import type {
   CompleteMediaAssetUploadPartInput,
   MediaAsset,
@@ -126,6 +127,10 @@ async function validateCompletionOwnership(
     await heartbeat.throwIfFailed();
     throwIfUploadLifecycleCancelled(signal);
   } catch (error) {
+    if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
+
     if (retryableCompletionCause !== null) {
       throw new MediaUploadCompletionTerminalError(
         "interrupted",
@@ -167,6 +172,10 @@ export async function completeMultipartUploadSession(
         retryableCompletionCause: lastRetryableCompletionError,
       };
     } catch (error) {
+      if (isIndexedDbOpenRecoveryError(error)) {
+        throw error;
+      }
+
       if (error instanceof MediaUploadCompletionTerminalError) {
         throw error;
       }
@@ -202,6 +211,10 @@ export async function completeMultipartUploadSession(
       try {
         await waitForCompletionRetry(delayMs, heartbeat, signal);
       } catch (interruptionError) {
+        if (isIndexedDbOpenRecoveryError(interruptionError)) {
+          throw interruptionError;
+        }
+
         throw new MediaUploadCompletionTerminalError(
           "interrupted",
           error,
@@ -246,7 +259,15 @@ function describeUploadSessionCleanupFailure(primaryFailure: MediaUploadFailure,
 }
 
 export function combineUploadFailureWithAbortFailure(primaryError: unknown, abortError: unknown | null): unknown {
-  if (abortError === null || isAuthRedirectError(primaryError)) {
+  if (abortError === null || isIndexedDbOpenRecoveryError(primaryError)) {
+    return primaryError;
+  }
+
+  if (isIndexedDbOpenRecoveryError(abortError)) {
+    return abortError;
+  }
+
+  if (isAuthRedirectError(primaryError)) {
     return primaryError;
   }
 

--- a/apps/web/src/appData/sync/remote/pushOutbox.ts
+++ b/apps/web/src/appData/sync/remote/pushOutbox.ts
@@ -1,5 +1,6 @@
 import { pushSyncOperations } from "../../../api";
 import { webAppVersion } from "../../../clientIdentity";
+import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import {
   deleteOutboxRecord,
   isScheduleRelevantCardOutboxRecord,
@@ -63,6 +64,10 @@ export async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<Remot
         didChangeProgressHistory = true;
       }
     } catch (error) {
+      if (isIndexedDbOpenRecoveryError(error)) {
+        throw error;
+      }
+
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       const errorMessage = getErrorMessage(error);
       for (const record of batch) {

--- a/apps/web/src/appError/AppErrorContext.tsx
+++ b/apps/web/src/appError/AppErrorContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactElement, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactElement, type ReactNode } from "react";
 import { type TranslationKey, type TranslationValues, useI18n } from "../i18n";
+import { isIndexedDbOpenRecoveryError } from "../localDb/core/indexedDbOpenRecovery";
 import { captureAppOperationError } from "../observability/appOperationObservation";
 import type { WebAppOperation, WebObservationFeature } from "../observability/webObservability";
 import { AppErrorDialog } from "./AppErrorDialog";
@@ -21,11 +22,27 @@ export type AppTechnicalErrorContext = Readonly<{
   entityId: string | null;
 }>;
 
+export type IndexedDbOpenRecoveryState = Readonly<{
+  hasFailed: () => boolean;
+  markFailed: (error: unknown) => IndexedDbOpenRecoveryMarkResult;
+}>;
+
+export type IndexedDbOpenRecoveryMarkResult = "not_recovery" | "first_failure" | "first_failure_repeat" | "later_failure";
+
+export function isIndexedDbOpenRecoveryFailureMark(result: IndexedDbOpenRecoveryMarkResult): boolean {
+  return result !== "not_recovery";
+}
+
+export function ownsIndexedDbOpenRecoveryFailure(result: IndexedDbOpenRecoveryMarkResult): boolean {
+  return result === "first_failure" || result === "first_failure_repeat";
+}
+
 type AppErrorDialogContextValue = Readonly<{
   showTechnicalError: (error: unknown, context: AppTechnicalErrorContext) => boolean;
   showCapturedTechnicalError: (error: unknown) => void;
   showTechnicalErrorPreview: () => void;
   dismiss: () => void;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
 }>;
 
 type AppErrorDialogProviderProps = Readonly<{
@@ -74,8 +91,30 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
   const { children } = props;
   const { t } = useI18n();
   const [presentation, setPresentation] = useState<AppErrorPresentation | null>(null);
+  const indexedDbOpenRecoveryRef = useRef<{
+    firstError: Error | null;
+    hasPresented: boolean;
+    isPresenting: boolean;
+  }>({ firstError: null, hasPresented: false, isPresenting: false });
+
+  const hasIndexedDbOpenRecoveryFailed = useCallback((): boolean => indexedDbOpenRecoveryRef.current.firstError !== null, []);
+
+  const markIndexedDbOpenRecoveryFailed = useCallback((error: unknown): IndexedDbOpenRecoveryMarkResult => {
+    if (isIndexedDbOpenRecoveryError(error) === false) {
+      return "not_recovery";
+    }
+
+    const firstError = indexedDbOpenRecoveryRef.current.firstError;
+    if (firstError === null) {
+      indexedDbOpenRecoveryRef.current.firstError = error;
+      return "first_failure";
+    }
+
+    return firstError === error ? "first_failure_repeat" : "later_failure";
+  }, []);
 
   const dismiss = useCallback((): void => {
+    indexedDbOpenRecoveryRef.current.isPresenting = false;
     setPresentation(null);
   }, []);
 
@@ -89,8 +128,25 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
   }, [dismiss]);
 
   const showCapturedTechnicalError = useCallback((error: unknown): void => {
+    const markResult = markIndexedDbOpenRecoveryFailed(error);
+    if (markResult === "not_recovery") {
+      const recoveryState = indexedDbOpenRecoveryRef.current;
+      if (recoveryState.firstError !== null && (recoveryState.hasPresented === false || recoveryState.isPresenting)) {
+        return;
+      }
+
+      setPresentation(buildAppErrorPresentation(error, buildPresentationMessages(t)));
+      return;
+    }
+
+    if (ownsIndexedDbOpenRecoveryFailure(markResult) === false || indexedDbOpenRecoveryRef.current.hasPresented) {
+      return;
+    }
+
+    indexedDbOpenRecoveryRef.current.hasPresented = true;
+    indexedDbOpenRecoveryRef.current.isPresenting = true;
     setPresentation(buildAppErrorPresentation(error, buildPresentationMessages(t)));
-  }, [t]);
+  }, [markIndexedDbOpenRecoveryFailed, t]);
 
   const showTechnicalError = useCallback((error: unknown, context: AppTechnicalErrorContext): boolean => {
     const wasCaptured = captureAppOperationError(error, {
@@ -113,12 +169,18 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
     setPresentation(buildAppErrorPresentation(buildPreviewError(), buildPresentationMessages(t)));
   }, [t]);
 
+  const indexedDbOpenRecoveryState = useMemo((): IndexedDbOpenRecoveryState => ({
+    hasFailed: hasIndexedDbOpenRecoveryFailed,
+    markFailed: markIndexedDbOpenRecoveryFailed,
+  }), [hasIndexedDbOpenRecoveryFailed, markIndexedDbOpenRecoveryFailed]);
+
   const contextValue = useMemo((): AppErrorDialogContextValue => ({
     showTechnicalError,
     showCapturedTechnicalError,
     showTechnicalErrorPreview,
     dismiss,
-  }), [dismiss, showCapturedTechnicalError, showTechnicalError, showTechnicalErrorPreview]);
+    indexedDbOpenRecoveryState,
+  }), [dismiss, indexedDbOpenRecoveryState, showCapturedTechnicalError, showTechnicalError, showTechnicalErrorPreview]);
 
   return (
     <AppErrorDialogContext.Provider value={contextValue}>


### PR DESCRIPTION
## Summary

- Add one provider-owned page-lifetime recovery latch for strict IndexedDB open and UnknownError failures.
- Preserve the original Error object through sync, demo-card, outbox, and media boundaries so only the retained first failure can publish one reload prompt.
- Stop new retry and scheduling work after recovery owns the page while preserving local recovery data.
- Close the workspace action and activation presentation race, destructive cleanup race, and media and lifecycle retry-timer races without disabling manual workspace server requests or cancelling already-started work.

## Validation

- Local executable checks were not run by repository policy.
- Cloud PR Checks are the validation.