### PR TITLE
Quiesce IndexedDB recovery continuations

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -373,7 +373,7 @@ export function AppShell(): ReactElement {
     createWorkspace,
     cloudSettings,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const [isAccountDeletionPendingState, setIsAccountDeletionPendingState] = useState<boolean>(isAccountDeletionPending);
   const [accountDeletionErrorMessage, setAccountDeletionErrorMessage] = useState<string>("");
   const [accountDeletionTechnicalError, setAccountDeletionTechnicalError] = useState<Error | null>(null);
@@ -404,6 +404,36 @@ export function AppShell(): ReactElement {
       ? accountDeletionErrorMessage
       : visibleTechnicalErrorMessage;
 
+  const reportAccountDeletionError = useCallback(function reportAccountDeletionError(error: unknown): void {
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    let wasCaptured = false;
+    if (normalizedError instanceof ApiContractError) {
+      captureApiContractError(normalizedError, {
+        feature: "auth",
+        sourceAction: "account_deletion_submit",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+      });
+      wasCaptured = true;
+    } else {
+      wasCaptured = captureAppOperationError(normalizedError, {
+        feature: "auth",
+        operation: "account_deletion_submit",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: null,
+      });
+    }
+
+    setAccountDeletionErrorMessage(normalizedError.message);
+    setAccountDeletionTechnicalError(wasCaptured ? normalizedError : null);
+    if (wasCaptured) {
+      showCapturedTechnicalError(normalizedError);
+    }
+  }, [activeWorkspace?.workspaceId, cloudSettings?.installationId, session?.userId, showCapturedTechnicalError]);
+
   const completeAccountDeletion = useCallback(async function completeAccountDeletion(): Promise<void> {
     if (isSessionVerified === false) {
       return;
@@ -418,47 +448,38 @@ export function AppShell(): ReactElement {
       if (persistedCsrfToken !== null) {
         primeSessionCsrfToken(persistedCsrfToken);
       }
-      await deleteMyAccount(deleteAccountConfirmationText);
-      await clearAllLocalBrowserData("account_deletion_submit");
+
+      try {
+        await deleteMyAccount(deleteAccountConfirmationText);
+      } catch (error) {
+        if ((error instanceof ApiError) === false || error.code !== "ACCOUNT_DELETED") {
+          throw error;
+        }
+      }
+
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        try {
+          await clearAllLocalBrowserData("account_deletion_submit");
+        } catch (error) {
+          reportAccountDeletionError(error);
+          if (indexedDbOpenRecoveryState.hasFailed()) {
+            window.location.href = buildLogoutLocalUrl();
+          }
+          return;
+        }
+
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          window.location.href = buildLogoutLocalUrl();
+          return;
+        }
+      }
       window.location.href = buildLogoutLocalUrl();
     } catch (error) {
-      if (error instanceof ApiError && error.code === "ACCOUNT_DELETED") {
-        await clearAllLocalBrowserData("account_deletion_submit");
-        window.location.href = buildLogoutLocalUrl();
-        return;
-      }
-
-      const normalizedError = error instanceof Error ? error : new Error(String(error));
-      let wasCaptured = false;
-      if (normalizedError instanceof ApiContractError) {
-        captureApiContractError(normalizedError, {
-          feature: "auth",
-          sourceAction: "account_deletion_submit",
-          userId: session?.userId ?? null,
-          workspaceId: activeWorkspace?.workspaceId ?? null,
-          installationId: cloudSettings?.installationId ?? null,
-        });
-        wasCaptured = true;
-      } else {
-        wasCaptured = captureAppOperationError(normalizedError, {
-          feature: "auth",
-          operation: "account_deletion_submit",
-          userId: session?.userId ?? null,
-          workspaceId: activeWorkspace?.workspaceId ?? null,
-          installationId: cloudSettings?.installationId ?? null,
-          entityId: null,
-        });
-      }
-
-      setAccountDeletionErrorMessage(normalizedError.message);
-      setAccountDeletionTechnicalError(wasCaptured ? normalizedError : null);
-      if (wasCaptured) {
-        showCapturedTechnicalError(normalizedError);
-      }
+      reportAccountDeletionError(error);
     } finally {
       setIsAccountDeletionSubmitting(false);
     }
-  }, [activeWorkspace?.workspaceId, cloudSettings?.installationId, isSessionVerified, session?.userId, showCapturedTechnicalError]);
+  }, [indexedDbOpenRecoveryState, isSessionVerified, reportAccountDeletionError]);
 
   useEffect(() => subscribeToAccountDeletionPending(() => {
     setIsAccountDeletionPendingState(isAccountDeletionPending());

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -610,6 +610,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       await processDueMediaUploadTransfersForWorkspace(
         workspace.workspaceId,
         abortController.signal,
+        indexedDbOpenRecoveryState.hasFailed,
       );
     })().catch((error: unknown): never => {
       markIndexedDbOpenRecoveryFailure(error);
@@ -772,6 +773,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           workspaceId,
           installationId,
           syncRunId,
+          hasFailed: indexedDbOpenRecoveryState.hasFailed,
           isOnlyWorkspaceForUser: isOnlyWorkspaceOfAccount(availableWorkspacesRef.current, workspaceId),
           requireWorkspaceSyncNotDiscarded: requireCurrentWorkspaceSync,
           publishWorkspaceSettings: publishCurrentWorkspaceSettings,

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadClaimLifecycle.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadClaimLifecycle.ts
@@ -2,6 +2,7 @@ import {
   ApiContractError,
   ApiError,
 } from "../../../api";
+import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import {
   claimNextDueMediaTransferByKind,
   markClaimedMediaTransferFailed,
@@ -189,7 +190,10 @@ async function renewUploadTransferClaim(
   return requireInProgressUploadClaimedAt(renewedTransfer);
 }
 
-export function startUploadClaimHeartbeat(transfer: MediaTransferQueueRecord): MediaUploadClaimHeartbeat {
+export function startUploadClaimHeartbeat(
+  transfer: MediaTransferQueueRecord,
+  hasFailed: () => boolean,
+): MediaUploadClaimHeartbeat {
   let claimedAt = requireInProgressUploadClaimedAt(transfer);
   let heartbeatError: unknown = null;
   let renewalTask: Promise<void> = Promise.resolve();
@@ -201,17 +205,22 @@ export function startUploadClaimHeartbeat(transfer: MediaTransferQueueRecord): M
   });
 
   const queueRenewal = (): void => {
-    if (heartbeatError !== null || didStop) {
+    if (heartbeatError !== null || didStop || hasFailed()) {
       return;
     }
 
     renewalTask = renewalTask
       .then(async (): Promise<void> => {
+        if (hasFailed()) {
+          return;
+        }
         claimedAt = await renewUploadTransferClaim(transfer, claimedAt);
       })
       .catch((error: unknown): void => {
         heartbeatError = error;
-        heartbeatFailureController.abort(error);
+        if (hasFailed() === false && isIndexedDbOpenRecoveryError(error) === false) {
+          heartbeatFailureController.abort(error);
+        }
         resolveHeartbeatFailure?.();
       });
   };
@@ -226,6 +235,9 @@ export function startUploadClaimHeartbeat(transfer: MediaTransferQueueRecord): M
       await renewalTask;
       if (heartbeatError !== null) {
         throw heartbeatError;
+      }
+      if (hasFailed()) {
+        return;
       }
     },
     waitForFailure: () => heartbeatFailurePromise,

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
@@ -156,7 +156,10 @@ function assertUploadSessionCreateResultMatchesTransfer(
   }
 }
 
-async function loadVerifiedUploadBytes(transfer: MediaTransferQueueRecord): Promise<VerifiedUploadBytes> {
+async function loadVerifiedUploadBytes(
+  transfer: MediaTransferQueueRecord,
+  hasFailed: () => boolean,
+): Promise<VerifiedUploadBytes | null> {
   if (transfer.sourceBlobCacheKey === null) {
     throw new PermanentMediaUploadError(`Media upload source blob is missing: transferId=${transfer.transferId}`);
   }
@@ -166,17 +169,26 @@ async function loadVerifiedUploadBytes(transfer: MediaTransferQueueRecord): Prom
   }
 
   const cacheRecord = await loadMediaBlobCacheRecord(transfer.sourceBlobCacheKey);
+  if (hasFailed()) {
+    return null;
+  }
   if (cacheRecord === null) {
     throw new PermanentMediaUploadError(`Media upload source blob cache record was not found: transferId=${transfer.transferId}, sourceBlobCacheKey=${transfer.sourceBlobCacheKey}`);
   }
 
   assertUploadCacheRecordMatchesTransfer(transfer, cacheRecord);
   const bytes = new Uint8Array(await cacheRecord.blob.arrayBuffer());
+  if (hasFailed()) {
+    return null;
+  }
   if (bytes.byteLength !== transfer.sizeBytes) {
     throw new PermanentMediaUploadError(`Media upload source byte length mismatch: transferId=${transfer.transferId}, expectedSizeBytes=${transfer.sizeBytes}, actualSizeBytes=${bytes.byteLength}`);
   }
 
   const actualSha256 = await calculateSha256Hex(toExactArrayBuffer(bytes));
+  if (hasFailed()) {
+    return null;
+  }
   if (actualSha256 !== transfer.sha256) {
     throw new PermanentMediaUploadError(`Media upload source sha256 mismatch: transferId=${transfer.transferId}, expectedSha256=${transfer.sha256}, actualSha256=${actualSha256}`);
   }
@@ -224,16 +236,24 @@ async function buildPlannedUploadParts(
   transfer: MediaTransferQueueRecord,
   uploadSession: MediaAssetUploadSession,
   bytes: Uint8Array,
-): Promise<ReadonlyArray<PlannedUploadPart>> {
+  hasFailed: () => boolean,
+): Promise<ReadonlyArray<PlannedUploadPart> | null> {
   assertUploadSessionMatchesBytes(transfer, uploadSession);
   const uploadParts: Array<PlannedUploadPart> = [];
   for (let partIndex = 0; partIndex < uploadSession.partCount; partIndex += 1) {
+    if (hasFailed()) {
+      return null;
+    }
     const startByte = partIndex * uploadSession.partSizeBytes;
     const endByte = Math.min(startByte + uploadSession.partSizeBytes, transfer.sizeBytes);
     const partBytes = bytes.subarray(startByte, endByte);
+    const sha256 = await calculateSha256Hex(toExactArrayBuffer(partBytes));
+    if (hasFailed()) {
+      return null;
+    }
     uploadParts.push({
       partNumber: partIndex + 1,
-      sha256: await calculateSha256Hex(toExactArrayBuffer(partBytes)),
+      sha256,
       startByte,
       endByte,
     });
@@ -248,9 +268,13 @@ async function runMultipartUploadSession(
   verifiedBytes: VerifiedUploadBytes,
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
-): Promise<MediaUploadCompletionResult> {
+  hasFailed: () => boolean,
+): Promise<MediaUploadCompletionResult | null> {
   try {
-    const parts = await buildPlannedUploadParts(transfer, uploadSession, verifiedBytes.bytes);
+    const parts = await buildPlannedUploadParts(transfer, uploadSession, verifiedBytes.bytes, hasFailed);
+    if (hasFailed() || parts === null) {
+      return null;
+    }
     const uploadedParts = await uploadParts(
       transfer,
       uploadSession,
@@ -258,14 +282,22 @@ async function runMultipartUploadSession(
       verifiedBytes.blob,
       heartbeat,
       signal,
+      hasFailed,
     );
+    if (hasFailed() || uploadedParts === null) {
+      return null;
+    }
     const result = await completeMultipartUploadSession(
       transfer,
       uploadSession,
       uploadedParts,
       heartbeat,
       signal,
+      hasFailed,
     );
+    if (hasFailed() || result === null) {
+      return null;
+    }
     try {
       assertUploadedMediaAssetMatchesTransfer(transfer, result.mediaAsset);
     } catch (error) {
@@ -287,6 +319,9 @@ async function runMultipartUploadSession(
     if (isIndexedDbOpenRecoveryError(error)) {
       throw error;
     }
+    if (hasFailed()) {
+      throw error;
+    }
 
     if (
       error instanceof MediaUploadCompletionTerminalError
@@ -296,6 +331,9 @@ async function runMultipartUploadSession(
     }
 
     const abortError = await abortUploadSessionAfterFailure(transfer, uploadSession.sessionId);
+    if (hasFailed()) {
+      throw error;
+    }
     throw combineUploadFailureWithAbortFailure(error, abortError);
   }
 }
@@ -305,13 +343,20 @@ async function uploadClaimedMediaTransfer(
   installationId: string,
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
-): Promise<MediaUploadCompletionResult> {
+  hasFailed: () => boolean,
+): Promise<MediaUploadCompletionResult | null> {
   const lastModifiedByReplicaId = await buildClientWorkspaceReplicaId(transfer.workspaceId, installationId);
+  if (hasFailed()) {
+    return null;
+  }
   const sessionCreateResult = await createMediaAssetUploadSession(
     transfer.workspaceId,
     buildUploadSessionCreateInput(transfer, lastModifiedByReplicaId),
     signal,
   );
+  if (hasFailed()) {
+    return null;
+  }
   assertUploadSessionCreateResultMatchesTransfer(transfer, sessionCreateResult);
   if (sessionCreateResult.status === "already_available") {
     assertUploadedMediaAssetMatchesTransfer(transfer, sessionCreateResult.mediaAsset);
@@ -323,22 +368,36 @@ async function uploadClaimedMediaTransfer(
 
   let verifiedBytes: VerifiedUploadBytes;
   try {
-    verifiedBytes = await loadVerifiedUploadBytes(transfer);
+    const loadedBytes = await loadVerifiedUploadBytes(transfer, hasFailed);
+    if (hasFailed() || loadedBytes === null) {
+      return null;
+    }
+    verifiedBytes = loadedBytes;
   } catch (error) {
     if (isIndexedDbOpenRecoveryError(error)) {
       throw error;
     }
+    if (hasFailed()) {
+      throw error;
+    }
 
     const abortError = await abortUploadSessionAfterFailure(transfer, sessionCreateResult.uploadSession.sessionId);
+    if (hasFailed()) {
+      throw error;
+    }
     throw combineUploadFailureWithAbortFailure(error, abortError);
   }
 
+  if (hasFailed()) {
+    return null;
+  }
   return runMultipartUploadSession(
     transfer,
     sessionCreateResult.uploadSession,
     verifiedBytes,
     heartbeat,
     signal,
+    hasFailed,
   );
 }
 
@@ -346,20 +405,43 @@ async function processClaimedUploadTransfer(
   transfer: MediaTransferQueueRecord,
   installationId: string,
   signal: AbortSignal,
+  hasFailed: () => boolean,
 ): Promise<void> {
-  const heartbeat = startUploadClaimHeartbeat(transfer);
+  if (hasFailed()) {
+    return;
+  }
+  const heartbeat = startUploadClaimHeartbeat(transfer, hasFailed);
   let retryableCompletionCause: ApiError | null = null;
   try {
-    const result = await uploadClaimedMediaTransfer(transfer, installationId, heartbeat, signal);
+    const result = await uploadClaimedMediaTransfer(transfer, installationId, heartbeat, signal, hasFailed);
+    if (hasFailed() || result === null) {
+      const heartbeatError = await heartbeat.stop();
+      if (heartbeatError !== null) {
+        throw heartbeatError;
+      }
+      return;
+    }
     retryableCompletionCause = result.retryableCompletionCause;
     const heartbeatError = await heartbeat.stop();
     if (heartbeatError !== null) {
       throw heartbeatError;
     }
+    if (hasFailed()) {
+      return;
+    }
 
     throwIfUploadLifecycleCancelled(signal);
+    if (hasFailed()) {
+      return;
+    }
     await putMediaAsset(result.mediaAsset);
+    if (hasFailed()) {
+      return;
+    }
     throwIfUploadLifecycleCancelled(signal);
+    if (hasFailed()) {
+      return;
+    }
     await markClaimedMediaTransferSucceeded({
       transferId: transfer.transferId,
       kind: "upload",
@@ -369,6 +451,9 @@ async function processClaimedUploadTransfer(
   } catch (error) {
     const heartbeatError = await heartbeat.stop();
     if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
+    if (hasFailed()) {
       throw error;
     }
     if (isIndexedDbOpenRecoveryError(heartbeatError)) {
@@ -386,13 +471,22 @@ async function processClaimedUploadTransfer(
             normalizeMediaUploadError(interruptionError),
           );
     if (isAuthRedirectError(failureError)) {
+      if (hasFailed()) {
+        throw failureError;
+      }
       await markAuthRedirectUploadTransferRetryable(transfer, heartbeat.getClaimedAt());
       throw failureError;
     }
 
     if (failureError instanceof MediaUploadCompletionTerminalError) {
+      if (hasFailed()) {
+        throw failureError;
+      }
       await markUploadTransferCompletionTerminal(transfer, failureError);
       return;
+    }
+    if (hasFailed()) {
+      throw failureError;
     }
     await markUploadTransferFailed(transfer, heartbeat.getClaimedAt(), failureError);
   }
@@ -401,12 +495,16 @@ async function processClaimedUploadTransfer(
 export async function processDueMediaUploadTransfersForWorkspace(
   workspaceId: string,
   signal: AbortSignal,
+  hasFailed: () => boolean,
 ): Promise<void> {
-  if (isBrowserOnline() === false || signal.aborted) {
+  if (isBrowserOnline() === false || signal.aborted || hasFailed()) {
     return;
   }
 
   const cloudSettings = await loadCloudSettings();
+  if (hasFailed()) {
+    return;
+  }
   if (
     cloudSettings === null
     || cloudSettings.cloudState !== "linked"
@@ -416,16 +514,31 @@ export async function processDueMediaUploadTransfersForWorkspace(
   }
 
   const installationId = requireCloudInstallationId(cloudSettings);
+  if (hasFailed()) {
+    return;
+  }
   await recoverStaleUploadTransferClaims(workspaceId, new Date().toISOString());
+  if (hasFailed()) {
+    return;
+  }
   while (true) {
-    if (signal.aborted) {
+    if (signal.aborted || hasFailed()) {
       return;
     }
     const transfer = await claimNextDueUploadTransfer(workspaceId, new Date().toISOString());
+    if (hasFailed()) {
+      return;
+    }
     if (transfer === null) {
       return;
     }
 
-    await processClaimedUploadTransfer(transfer, installationId, signal);
+    if (hasFailed()) {
+      return;
+    }
+    await processClaimedUploadTransfer(transfer, installationId, signal, hasFailed);
+    if (hasFailed()) {
+      return;
+    }
   }
 }

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
@@ -48,6 +48,7 @@ export function processDueMediaUploadTransfersForWorkspace(testWorkspaceId: stri
   return runMediaUploadTransferRunner(
     testWorkspaceId,
     new AbortController().signal,
+    (): boolean => false,
   );
 }
 
@@ -55,7 +56,7 @@ export function runDueMediaUploadTransfersForWorkspace(
   testWorkspaceId: string,
   signal: AbortSignal,
 ): Promise<void> {
-  return runMediaUploadTransferRunner(testWorkspaceId, signal);
+  return runMediaUploadTransferRunner(testWorkspaceId, signal, (): boolean => false);
 }
 
 function toTestUuidFromHexDigest(hexDigest: string): string {

--- a/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
+++ b/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
@@ -83,6 +83,7 @@ async function waitForCompletionRetry(
   delayMs: number,
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
+  hasFailed: () => boolean,
 ): Promise<void> {
   let timerId: number | null = null;
   let abortHandler: (() => void) | null = null;
@@ -112,8 +113,14 @@ async function waitForCompletionRetry(
     }
   }
 
+  if (hasFailed()) {
+    return;
+  }
   throwIfUploadLifecycleCancelled(signal);
   await heartbeat.throwIfFailed();
+  if (hasFailed()) {
+    return;
+  }
   throwIfUploadLifecycleCancelled(signal);
 }
 
@@ -121,13 +128,23 @@ async function validateCompletionOwnership(
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
   retryableCompletionCause: ApiError | null,
+  hasFailed: () => boolean,
 ): Promise<void> {
   try {
+    if (hasFailed()) {
+      return;
+    }
     throwIfUploadLifecycleCancelled(signal);
     await heartbeat.throwIfFailed();
+    if (hasFailed()) {
+      return;
+    }
     throwIfUploadLifecycleCancelled(signal);
   } catch (error) {
     if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
+    if (hasFailed()) {
       throw error;
     }
 
@@ -148,7 +165,8 @@ export async function completeMultipartUploadSession(
   uploadedParts: ReadonlyArray<UploadedMediaPart>,
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
-): Promise<MediaUploadCompletionResult> {
+  hasFailed: () => boolean,
+): Promise<MediaUploadCompletionResult | null> {
   const request = {
     parts: toCompleteParts(uploadedParts),
   };
@@ -157,16 +175,31 @@ export async function completeMultipartUploadSession(
   let lastRetryableCompletionError: ApiError | null = null;
 
   while (true) {
-    await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError);
+    if (hasFailed()) {
+      return null;
+    }
+    await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError, hasFailed);
+    if (hasFailed()) {
+      return null;
+    }
 
     try {
+      if (hasFailed()) {
+        return null;
+      }
       const result = await completeMediaAssetUploadSession(
         transfer.workspaceId,
         uploadSession.sessionId,
         request,
         completionSignal,
       );
-      await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError);
+      if (hasFailed()) {
+        return null;
+      }
+      await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError, hasFailed);
+      if (hasFailed()) {
+        return null;
+      }
       return {
         mediaAsset: result.mediaAsset,
         retryableCompletionCause: lastRetryableCompletionError,
@@ -175,12 +208,18 @@ export async function completeMultipartUploadSession(
       if (isIndexedDbOpenRecoveryError(error)) {
         throw error;
       }
+      if (hasFailed()) {
+        throw error;
+      }
 
       if (error instanceof MediaUploadCompletionTerminalError) {
         throw error;
       }
       if (isSameSessionCompletionRetryError(error) === false) {
-        await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError);
+        await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError, hasFailed);
+        if (hasFailed()) {
+          throw error;
+        }
         if (lastRetryableCompletionError !== null) {
           throw new MediaUploadCompletionTerminalError(
             "interrupted",
@@ -191,7 +230,10 @@ export async function completeMultipartUploadSession(
         throw error;
       }
       lastRetryableCompletionError = error;
-      await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError);
+      await validateCompletionOwnership(heartbeat, signal, lastRetryableCompletionError, hasFailed);
+      if (hasFailed()) {
+        throw error;
+      }
       if (attemptNumber >= apiNetworkRetryMaximumAttemptCount) {
         throw new MediaUploadCompletionTerminalError("retry_exhausted", error, null);
       }
@@ -209,9 +251,15 @@ export async function completeMultipartUploadSession(
         delayMs,
       });
       try {
-        await waitForCompletionRetry(delayMs, heartbeat, signal);
+        await waitForCompletionRetry(delayMs, heartbeat, signal, hasFailed);
+        if (hasFailed()) {
+          throw error;
+        }
       } catch (interruptionError) {
         if (isIndexedDbOpenRecoveryError(interruptionError)) {
+          throw interruptionError;
+        }
+        if (hasFailed()) {
           throw interruptionError;
         }
 

--- a/apps/web/src/appData/sync/mediaUploads/signedPartUpload.ts
+++ b/apps/web/src/appData/sync/mediaUploads/signedPartUpload.ts
@@ -93,7 +93,10 @@ function toBoundedSignedPartErrorField(value: string | null): string | null {
   return `${trimmedValue.slice(0, signedPartUploadErrorFieldMaximumLength)}...`;
 }
 
-async function readSignedPartUploadFailureBodyText(response: Response): Promise<string | null> {
+async function readSignedPartUploadFailureBodyText(
+  response: Response,
+  hasFailed: () => boolean,
+): Promise<string | null> {
   const responseBody = response.body;
   if (responseBody === null) {
     return null;
@@ -105,6 +108,9 @@ async function readSignedPartUploadFailureBodyText(response: Response): Promise<
   try {
     while (totalByteLength < signedPartUploadErrorBodyMaximumBytes) {
       const result = await reader.read();
+      if (hasFailed()) {
+        return null;
+      }
       if (result.done) {
         break;
       }
@@ -117,10 +123,16 @@ async function readSignedPartUploadFailureBodyText(response: Response): Promise<
       totalByteLength += chunk.byteLength;
       if (result.value.byteLength >= remainingByteLength) {
         await reader.cancel();
+        if (hasFailed()) {
+          return null;
+        }
         break;
       }
     }
   } catch (error) {
+    if (hasFailed()) {
+      throw error;
+    }
     console.warn("Media upload part failure body read failed", {
       errorName: readErrorName(error),
       errorMessage: toBoundedSignedPartErrorField(readErrorMessage(error)) ?? "none",
@@ -187,8 +199,14 @@ function parseS3ErrorBody(responseBody: string | null): Pick<SanitizedSignedPart
   };
 }
 
-async function readSanitizedSignedPartUploadFailure(response: Response): Promise<SanitizedSignedPartUploadFailure> {
-  const responseBody = await readSignedPartUploadFailureBodyText(response);
+async function readSanitizedSignedPartUploadFailure(
+  response: Response,
+  hasFailed: () => boolean,
+): Promise<SanitizedSignedPartUploadFailure | null> {
+  const responseBody = await readSignedPartUploadFailureBodyText(response, hasFailed);
+  if (hasFailed()) {
+    return null;
+  }
   const parsedBody = parseS3ErrorBody(responseBody);
   return {
     status: response.status,
@@ -241,7 +259,11 @@ async function uploadSignedPartOnce(
   part: PlannedUploadPart,
   blob: Blob,
   signal: AbortSignal,
-): Promise<string> {
+  hasFailed: () => boolean,
+): Promise<string | null> {
+  if (hasFailed()) {
+    return null;
+  }
   assertSignedPartUrlUsable(transfer, partUrl, part);
   let response: Response;
   try {
@@ -252,11 +274,20 @@ async function uploadSignedPartOnce(
       signal,
     });
   } catch (error) {
+    if (hasFailed()) {
+      throw error;
+    }
     throw new RetryableMediaUploadError(`Media upload part request failed: transferId=${transfer.transferId}, partNumber=${part.partNumber}, errorName=${readErrorName(error)}`);
+  }
+  if (hasFailed()) {
+    return null;
   }
 
   if (response.ok === false) {
-    const failure = await readSanitizedSignedPartUploadFailure(response);
+    const failure = await readSanitizedSignedPartUploadFailure(response, hasFailed);
+    if (hasFailed() || failure === null) {
+      return null;
+    }
     const message = describeSanitizedSignedPartUploadFailure(transfer, part, failure);
     if (isTransientStatusCode(response.status) || response.status === 403) {
       throw new RetryableMediaUploadError(message);
@@ -291,13 +322,20 @@ async function loadPartUrls(
   sessionId: string,
   parts: ReadonlyArray<PlannedUploadPart>,
   signal: AbortSignal,
-): Promise<ReadonlyArray<MediaAssetUploadPartUrl>> {
+  hasFailed: () => boolean,
+): Promise<ReadonlyArray<MediaAssetUploadPartUrl> | null> {
+  if (hasFailed()) {
+    return null;
+  }
   const response = await createMediaAssetUploadPartUrls(transfer.workspaceId, sessionId, {
     parts: parts.map((part) => ({
       partNumber: part.partNumber,
       sha256: part.sha256,
     })),
   }, signal);
+  if (hasFailed()) {
+    return null;
+  }
   if (response.sessionId !== sessionId) {
     throw new PermanentMediaUploadError(`Media upload part URL session mismatch: transferId=${transfer.transferId}, expectedSessionId=${sessionId}, actualSessionId=${response.sessionId}`);
   }
@@ -310,8 +348,13 @@ async function loadPartUrl(
   sessionId: string,
   part: PlannedUploadPart,
   signal: AbortSignal,
-): Promise<MediaAssetUploadPartUrl> {
-  const [partUrl] = await loadPartUrls(transfer, sessionId, [part], signal);
+  hasFailed: () => boolean,
+): Promise<MediaAssetUploadPartUrl | null> {
+  const partUrls = await loadPartUrls(transfer, sessionId, [part], signal, hasFailed);
+  if (hasFailed() || partUrls === null) {
+    return null;
+  }
+  const [partUrl] = partUrls;
   if (partUrl === undefined) {
     throw new PermanentMediaUploadError(`Media upload part URL response was empty: transferId=${transfer.transferId}, partNumber=${part.partNumber}`);
   }
@@ -326,24 +369,44 @@ async function uploadSignedPart(
   blob: Blob,
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
-): Promise<UploadedMediaPart> {
+  hasFailed: () => boolean,
+): Promise<UploadedMediaPart | null> {
   let attemptNumber = 1;
   while (true) {
+    if (hasFailed()) {
+      return null;
+    }
     try {
-      const partUrl = await loadPartUrl(transfer, sessionId, part, signal);
+      const partUrl = await loadPartUrl(transfer, sessionId, part, signal, hasFailed);
+      if (hasFailed() || partUrl === null) {
+        return null;
+      }
       await heartbeat.throwIfFailed();
+      if (hasFailed()) {
+        return null;
+      }
+      const eTag = await uploadSignedPartOnce(transfer, partUrl, part, blob, signal, hasFailed);
+      if (hasFailed() || eTag === null) {
+        return null;
+      }
       return {
         partNumber: part.partNumber,
-        eTag: await uploadSignedPartOnce(transfer, partUrl, part, blob, signal),
+        eTag,
         sha256: part.sha256,
       };
     } catch (error) {
+      if (hasFailed()) {
+        throw error;
+      }
       if (error instanceof RetryableMediaUploadError === false || attemptNumber >= signedPartUploadMaximumAttemptCount) {
         throw error;
       }
 
       warnSignedPartUploadRetry(transfer, part.partNumber, attemptNumber, error);
       await waitForSignedPartUploadRetry(signal);
+      if (hasFailed()) {
+        throw error;
+      }
       attemptNumber += 1;
     }
   }
@@ -356,18 +419,30 @@ export async function uploadParts(
   blob: Blob,
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
-): Promise<ReadonlyArray<UploadedMediaPart>> {
+  hasFailed: () => boolean,
+): Promise<ReadonlyArray<UploadedMediaPart> | null> {
   const uploadedParts: Array<UploadedMediaPart> = [];
   for (const part of parts) {
+    if (hasFailed()) {
+      return null;
+    }
     await heartbeat.throwIfFailed();
-    uploadedParts.push(await uploadSignedPart(
+    if (hasFailed()) {
+      return null;
+    }
+    const uploadedPart = await uploadSignedPart(
       transfer,
       uploadSession.sessionId,
       part,
       blob,
       heartbeat,
       signal,
-    ));
+      hasFailed,
+    );
+    if (hasFailed() || uploadedPart === null) {
+      return null;
+    }
+    uploadedParts.push(uploadedPart);
   }
 
   return uploadedParts;

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -79,6 +79,7 @@ function createRemoteSyncInput(): WorkspaceRemoteSyncInput {
     workspaceId: "workspace-1",
     installationId: "installation-1",
     syncRunId: "sync-run-1",
+    hasFailed: (): boolean => false,
     isOnlyWorkspaceForUser: true,
     requireWorkspaceSyncNotDiscarded: (_workspaceId: string): void => {},
     publishWorkspaceSettings: (_workspaceId, _settings): void => {},

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -147,13 +147,19 @@ async function loadAndStoreCurrentWorkspaceRestoreHistory(
   persistentStorageState: PersistentStorageState,
 ): Promise<void> {
   const localCardCount = await loadActiveCardCount(input.workspaceId);
+  if (input.hasFailed()) {
+    return;
+  }
   await storeCurrentWorkspaceRestoreHistory(input, lastAppliedHotChangeId, localCardCount, persistentStorageState);
 }
 
 async function observePersistentStorageForHydratedWorkspace(
   input: WorkspaceRemoteSyncInput,
-): Promise<PersistentStorageState> {
+): Promise<PersistentStorageState | null> {
   const persistentStorageState = await ensurePersistentStorage();
+  if (input.hasFailed()) {
+    return null;
+  }
   observePersistentStorageState({
     userId: input.userId,
     workspaceId: input.workspaceId,
@@ -174,6 +180,12 @@ function readErrorName(error: unknown): string {
 
 export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
   const syncStateBefore = await loadWorkspaceSyncState(input.workspaceId);
+  if (input.hasFailed()) {
+    return {
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    };
+  }
   const indexedDbOpenLifecycleSnapshot = readIndexedDbOpenLifecycleSnapshotForDiagnostics();
   const hotStateHydrated = syncStateBefore?.hasHydratedHotState ?? false;
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
@@ -183,11 +195,23 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     }
 
     const persistentStorageState = await observePersistentStorageForHydratedWorkspace(input);
+    if (input.hasFailed() || persistentStorageState === null) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule: false,
+      };
+    }
     await loadAndStoreCurrentWorkspaceRestoreHistory(
       input,
       syncStateBefore.lastAppliedHotChangeId,
       persistentStorageState,
     );
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule: false,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     return {
       didChangeProgressHistory: false,
@@ -197,6 +221,12 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
 
   const startedAtMs = Date.now();
   const localCardCountBefore = await loadActiveCardCount(input.workspaceId);
+  if (input.hasFailed()) {
+    return {
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    };
+  }
   const localBootstrapState = determineLocalBootstrapState(syncStateBefore, localCardCountBefore);
   const lastAppliedHotChangeIdBefore = syncStateBefore?.lastAppliedHotChangeId ?? null;
   const restoreHistoryBefore = loadWorkspaceRestoreHistory(input);
@@ -238,6 +268,12 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     if (isLocalDbRecovery && restoreHistoryBefore !== null) {
       recoveryFailurePhase = "pre_bootstrap_storage_read";
       persistentStorageStateBeforeRecovery = await readPersistentStorageState();
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       observeLocalDbMissing({
         userId: input.userId,
         workspaceId: input.workspaceId,
@@ -253,6 +289,12 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     }
 
     while (true) {
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       recoveryFailurePhase = "bootstrap_pull";
       const bootstrapPullStartedAtMs = Date.now();
@@ -265,6 +307,12 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         syncBootstrapPageSize,
         true,
       );
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       const bootstrapPullElapsedMs = Date.now() - bootstrapPullStartedAtMs;
       bootstrapPullDurationMs += bootstrapPullElapsedMs;
       bootstrapPageDurationMs = appendBootstrapPageDurationMs(bootstrapPageDurationMs, bootstrapPullElapsedMs);
@@ -277,10 +325,22 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
       if (await doHotSyncEntriesAffectReviewSchedule(input.workspaceId, bootstrapResult.entries)) {
         didChangeReviewSchedule = true;
       }
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 
       recoveryFailurePhase = "apply_hot_page";
       const applyHotPageStartedAtMs = Date.now();
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       await applyHotSyncPage(
         input.workspaceId,
         bootstrapResult.entries,
@@ -291,6 +351,12 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
             markHotStateHydrated: true,
           },
       );
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       applyHotPagesDurationMs += Date.now() - applyHotPageStartedAtMs;
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       publishWorkspaceSettingsFromEntries(input, bootstrapResult.entries);
@@ -301,15 +367,33 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
       }
     }
 
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     recoveryFailurePhase = "final_refresh";
     const finalRefreshStartedAtMs = Date.now();
     await input.refreshWorkspaceView(input.workspaceId);
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     finalRefreshDurationMs = Date.now() - finalRefreshStartedAtMs;
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     const durationMs = Date.now() - startedAtMs;
     recoveryFailurePhase = "local_card_count_after";
     localCardCountAfter = await loadActiveCardCount(input.workspaceId);
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     recoveryFailurePhase = "validate_bootstrap_result";
     if (nextHotChangeId === null) {
       throw new Error(`Workspace ${input.workspaceId} bootstrap did not return a hot change id`);
@@ -318,14 +402,32 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     recoveryFailurePhase = "persistent_storage";
     const persistentStorageStartedAtMs = Date.now();
     persistentStorageStateAfterRecovery = await observePersistentStorageForHydratedWorkspace(input);
+    if (input.hasFailed() || persistentStorageStateAfterRecovery === null) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     persistentStorageDurationMs = Date.now() - persistentStorageStartedAtMs;
     recoveryFailurePhase = "restore_history_store";
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     await storeCurrentWorkspaceRestoreHistory(
       input,
       nextHotChangeId,
       localCardCountAfter,
       persistentStorageStateAfterRecovery,
     );
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
 
     if (isLocalDbRecovery && restoreHistoryBefore !== null) {
       observeLocalDbRecoverySucceeded({
@@ -397,6 +499,12 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     // observations above so it cannot change localCardCountAfter, and after the
     // restore-history write so both keep describing the bootstrap result itself.
     if (isLocalDbRecovery === false) {
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       const demoCardSeedResult = await seedDemoCardForNewWorkspace({
         userId: input.userId,
@@ -406,6 +514,12 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         remoteIsEmpty,
         localCardCount: localCardCountAfter,
       });
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory: false,
+          didChangeReviewSchedule,
+        };
+      }
       if (demoCardSeedResult !== null && demoCardSeedResult.didChangeReviewSchedule) {
         didChangeReviewSchedule = true;
       }

--- a/apps/web/src/appData/sync/remote/pullHotChanges.ts
+++ b/apps/web/src/appData/sync/remote/pullHotChanges.ts
@@ -16,10 +16,22 @@ import type {
 
 export async function pullHotChanges(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
   let afterHotChangeId = await loadLastAppliedHotChangeId(input.workspaceId);
+  if (input.hasFailed()) {
+    return {
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    };
+  }
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   let didChangeReviewSchedule = false;
 
   while (true) {
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     const pullResult = await pullSyncChanges(
       input.workspaceId,
@@ -30,17 +42,41 @@ export async function pullHotChanges(input: WorkspaceRemoteSyncInput): Promise<R
       syncIncrementalPageSize,
       true,
     );
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 
     if (await doHotSyncEntriesAffectReviewSchedule(input.workspaceId, pullResult.changes)) {
       didChangeReviewSchedule = true;
     }
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     await applyHotSyncPage(input.workspaceId, pullResult.changes, {
       lastAppliedHotChangeId: pullResult.nextHotChangeId,
       markHotStateHydrated: false,
     });
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory: false,
+        didChangeReviewSchedule,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     publishWorkspaceSettingsFromEntries(input, pullResult.changes);
 

--- a/apps/web/src/appData/sync/remote/pullReviewHistory.ts
+++ b/apps/web/src/appData/sync/remote/pullReviewHistory.ts
@@ -13,11 +13,29 @@ import type {
 
 export async function pullReviewHistory(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
   let afterReviewSequenceId = await loadLastAppliedReviewSequenceId(input.workspaceId);
+  if (input.hasFailed()) {
+    return {
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    };
+  }
   const reviewHistoryHydrated = await hasHydratedReviewHistory(input.workspaceId);
+  if (input.hasFailed()) {
+    return {
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    };
+  }
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   let didChangeProgressHistory = false;
 
   while (true) {
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory,
+        didChangeReviewSchedule: false,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     const reviewHistoryResult = await pullReviewHistorySync(
       input.workspaceId,
@@ -27,12 +45,30 @@ export async function pullReviewHistory(input: WorkspaceRemoteSyncInput): Promis
       afterReviewSequenceId,
       syncIncrementalPageSize,
     );
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory,
+        didChangeReviewSchedule: false,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory,
+        didChangeReviewSchedule: false,
+      };
+    }
     await applyReviewHistorySyncPage(input.workspaceId, reviewHistoryResult.reviewEvents, {
       lastAppliedReviewSequenceId: reviewHistoryResult.nextReviewSequenceId,
       markReviewHistoryHydrated: reviewHistoryHydrated === false && reviewHistoryResult.hasMore === false,
     });
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory,
+        didChangeReviewSchedule: false,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 
     if (reviewHistoryResult.reviewEvents.length > 0) {

--- a/apps/web/src/appData/sync/remote/pushOutbox.ts
+++ b/apps/web/src/appData/sync/remote/pushOutbox.ts
@@ -27,11 +27,23 @@ function isAcknowledgedPushStatus(status: SyncPushResult["operations"][number]["
 
 export async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
   let currentOutbox = await listOutboxRecords(input.workspaceId);
+  if (input.hasFailed()) {
+    return {
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    };
+  }
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   let didChangeProgressHistory = false;
   let didChangeReviewSchedule = false;
 
   while (currentOutbox.length > 0) {
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory,
+        didChangeReviewSchedule,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     const batch = currentOutbox.slice(0, 100);
     const batchIncludesProgressReviewEvents = batch.some(isProgressReviewEventOperation);
@@ -48,12 +60,30 @@ export async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<Remot
         webAppVersion,
         batch.map((record) => record.operation),
       );
+      if (input.hasFailed()) {
+        return {
+          didChangeProgressHistory,
+          didChangeReviewSchedule,
+        };
+      }
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 
       for (const result of pushResult.operations) {
         if (isAcknowledgedPushStatus(result.status)) {
+          if (input.hasFailed()) {
+            return {
+              didChangeProgressHistory,
+              didChangeReviewSchedule,
+            };
+          }
           input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
           await deleteOutboxRecord(input.workspaceId, result.operationId);
+          if (input.hasFailed()) {
+            return {
+              didChangeProgressHistory,
+              didChangeReviewSchedule,
+            };
+          }
           if (reviewScheduleOperationIds.has(result.operationId)) {
             didChangeReviewSchedule = true;
           }
@@ -67,21 +97,36 @@ export async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<Remot
       if (isIndexedDbOpenRecoveryError(error)) {
         throw error;
       }
+      if (input.hasFailed()) {
+        throw error;
+      }
 
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       const errorMessage = getErrorMessage(error);
       for (const record of batch) {
+        if (input.hasFailed()) {
+          throw error;
+        }
         input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
         await putOutboxRecord({
           ...record,
           attemptCount: record.attemptCount + 1,
           lastError: errorMessage,
         });
+        if (input.hasFailed()) {
+          throw error;
+        }
       }
       throw error;
     }
 
     currentOutbox = await listOutboxRecords(input.workspaceId);
+    if (input.hasFailed()) {
+      return {
+        didChangeProgressHistory,
+        didChangeReviewSchedule,
+      };
+    }
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   }
 

--- a/apps/web/src/appData/sync/remote/syncRemote.ts
+++ b/apps/web/src/appData/sync/remote/syncRemote.ts
@@ -18,9 +18,25 @@ export type {
 
 export async function runWorkspaceRemoteSync(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
   let syncFlags = createEmptyRemoteSyncFlags();
+  if (input.hasFailed()) {
+    return syncFlags;
+  }
+
   syncFlags = mergeRemoteSyncFlags(syncFlags, await bootstrapHotState(input));
+  if (input.hasFailed()) {
+    return syncFlags;
+  }
+
   syncFlags = mergeRemoteSyncFlags(syncFlags, await pushOutbox(input));
+  if (input.hasFailed()) {
+    return syncFlags;
+  }
+
   syncFlags = mergeRemoteSyncFlags(syncFlags, await pullHotChanges(input));
+  if (input.hasFailed()) {
+    return syncFlags;
+  }
+
   syncFlags = mergeRemoteSyncFlags(syncFlags, await pullReviewHistory(input));
   return syncFlags;
 }

--- a/apps/web/src/appData/sync/remote/types.ts
+++ b/apps/web/src/appData/sync/remote/types.ts
@@ -17,6 +17,7 @@ export type WorkspaceRemoteSyncInput = Readonly<{
   workspaceId: string;
   installationId: string;
   syncRunId: string;
+  hasFailed: () => boolean;
   // True when this workspace is the only one the account owns, which is the user-scoped
   // signal for a brand-new user. Resolved by the sync engine from the account's workspace
   // list, because remote sync itself only ever sees one workspace.


### PR DESCRIPTION
## Summary
- cooperatively quiesce remote sync phases and media-upload continuations after IndexedDB recovery is latched
- allow already-awaited operations to finish without cancellation while preserving exact thrown Error objects for existing capture and reporting
- keep account deletion server requests intact and route recovery-owned local cleanup failures through the existing logout-local marker flow

## Validation
- Local checks were not run; cloud CI owns executable validation.