### PR TITLE
fix(web): harden IndexedDB recovery lifecycle

### DIFF
--- a/apps/web/src/AccountMenu.tsx
+++ b/apps/web/src/AccountMenu.tsx
@@ -1,5 +1,8 @@
 import { type FormEvent, type ReactElement, useCallback, useEffect, useRef, useState } from "react";
-import { useAppErrorDialog } from "./appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "./appError/AppErrorContext";
 import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } from "./floating";
 import { useI18n } from "./i18n";
 import type { WorkspaceSummary } from "./types";
@@ -37,7 +40,7 @@ export function AccountMenu(props: Props): ReactElement {
     onSelectWorkspace,
     onCreateWorkspace,
   } = props;
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatDateTime } = useI18n();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isCreating, setIsCreating] = useState<boolean>(false);
@@ -103,20 +106,35 @@ export function AccountMenu(props: Props): ReactElement {
   }, [isCreating]);
 
   async function handleWorkspaceSelect(workspaceId: string): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (isWorkspaceManagementLocked) {
       showMessage(workspaceManagementLockedMessage);
       return;
     }
 
     setErrorMessage("");
-    await onSelectWorkspace(workspaceId);
-    setIsOpen(false);
-    setIsCreating(false);
-    setNewWorkspaceName("");
+    try {
+      await onSelectWorkspace(workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      setIsOpen(false);
+      setIsCreating(false);
+      setNewWorkspaceName("");
+    } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+      throw error;
+    }
   }
 
   async function handleCreateWorkspace(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     if (isWorkspaceManagementLocked) {
       showMessage(workspaceManagementLockedMessage);
@@ -132,10 +150,14 @@ export function AccountMenu(props: Props): ReactElement {
     try {
       setErrorMessage("");
       await onCreateWorkspace(trimmedName);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setIsOpen(false);
       setIsCreating(false);
       setNewWorkspaceName("");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const nextErrorMessage = error instanceof Error ? error.message : String(error);
       const isExpectedError = nextErrorMessage === t("app.sessionUnavailable")
         || nextErrorMessage === t("app.sessionRestoringActionLocked")

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,10 +2,18 @@ import { Suspense, lazy, useCallback, useEffect, useRef, useState, type ReactEle
 import { BrowserRouter, NavLink, Navigate, Route, Routes as RouterRoutes, useLocation, useParams } from "react-router";
 import { AccountMenu } from "./AccountMenu";
 import {
+  beginAccountDeletionRetryAttempt,
   clearAllLocalBrowserData,
   deleteAccountConfirmationText,
+  hasAccountDeletionAttemptDispatched,
   isAccountDeletionPending,
+  isAccountDeletionServerConfirmed,
+  loadAccountDeletionAttemptId,
   loadAccountDeletionCsrfToken,
+  markAccountDeletionAttemptDispatched,
+  markAccountDeletionServerConfirmed,
+  runWithAccountDeletionLock,
+  setAccountDeletionPending,
   subscribeToAccountDeletionPending,
 } from "./accountDeletion";
 import { AppDataProvider, useAppData } from "./appData";
@@ -403,6 +411,26 @@ export function AppShell(): ReactElement {
     : accountDeletionTechnicalError === null
       ? accountDeletionErrorMessage
       : visibleTechnicalErrorMessage;
+  const visiblePendingAccountDeletionErrorMessage = visibleAccountDeletionErrorMessage === ""
+    ? visibleSessionErrorMessage
+    : visibleAccountDeletionErrorMessage;
+
+  const selectInitialWorkspace = useCallback(async function selectInitialWorkspace(workspaceId: string): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    try {
+      await chooseWorkspace(workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
+    } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+      throw error;
+    }
+  }, [chooseWorkspace, indexedDbOpenRecoveryState]);
 
   const reportAccountDeletionError = useCallback(function reportAccountDeletionError(error: unknown): void {
     const normalizedError = error instanceof Error ? error : new Error(String(error));
@@ -435,51 +463,122 @@ export function AppShell(): ReactElement {
   }, [activeWorkspace?.workspaceId, cloudSettings?.installationId, session?.userId, showCapturedTechnicalError]);
 
   const completeAccountDeletion = useCallback(async function completeAccountDeletion(): Promise<void> {
-    if (isSessionVerified === false) {
+    let didStartSubmission = false;
+    try {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      if (isSessionVerified === false) {
+        if (sessionLoadState !== "error") {
+          return;
+        }
+
+        didStartSubmission = true;
+        setIsAccountDeletionSubmitting(true);
+        setAccountDeletionErrorMessage("");
+        setAccountDeletionTechnicalError(null);
+        await initialize();
+        indexedDbOpenRecoveryState.throwIfFailed();
+        return;
+      }
+
+      await runWithAccountDeletionLock(
+        indexedDbOpenRecoveryState.signal,
+        async (): Promise<void> => {
+          indexedDbOpenRecoveryState.throwIfFailed();
+          if (isAccountDeletionPending() === false) {
+            return;
+          }
+
+          const isServerConfirmed = isAccountDeletionServerConfirmed();
+          if (isServerConfirmed === false && hasAccountDeletionAttemptDispatched()) {
+            return;
+          }
+
+          didStartSubmission = true;
+          setIsAccountDeletionSubmitting(true);
+          setAccountDeletionErrorMessage("");
+          setAccountDeletionTechnicalError(null);
+
+          if (isServerConfirmed === false) {
+            const persistedCsrfToken = loadAccountDeletionCsrfToken();
+            if (persistedCsrfToken !== null) {
+              primeSessionCsrfToken(persistedCsrfToken);
+            }
+
+            markAccountDeletionAttemptDispatched();
+            try {
+              await deleteMyAccount(deleteAccountConfirmationText);
+              markAccountDeletionServerConfirmed();
+            } catch (error) {
+              if ((error instanceof ApiError) === false || error.code !== "ACCOUNT_DELETED") {
+                indexedDbOpenRecoveryState.throwIfFailed();
+                throw error;
+              }
+
+              markAccountDeletionServerConfirmed();
+            }
+          }
+
+          indexedDbOpenRecoveryState.throwIfFailed();
+          await clearAllLocalBrowserData(
+            "account_deletion_submit",
+            indexedDbOpenRecoveryState.throwIfFailed,
+          );
+          indexedDbOpenRecoveryState.throwIfFailed();
+          window.location.href = buildLogoutLocalUrl();
+          setAccountDeletionPending(false);
+        },
+      );
+      indexedDbOpenRecoveryState.throwIfFailed();
+    } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+      reportAccountDeletionError(error);
+    } finally {
+      if (didStartSubmission && indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsAccountDeletionSubmitting(false);
+      }
+    }
+  }, [indexedDbOpenRecoveryState, initialize, isSessionVerified, reportAccountDeletionError, sessionLoadState]);
+
+  const retryAccountDeletion = useCallback(async function retryAccountDeletion(): Promise<void> {
+    if (
+      isAccountDeletionServerConfirmed()
+      || (isSessionVerified === false && hasAccountDeletionAttemptDispatched() === false)
+    ) {
+      await completeAccountDeletion();
       return;
     }
 
-    setIsAccountDeletionSubmitting(true);
-    setAccountDeletionErrorMessage("");
-    setAccountDeletionTechnicalError(null);
+    const expectedAttemptId = loadAccountDeletionAttemptId();
+    if (expectedAttemptId === null) {
+      return;
+    }
 
     try {
-      const persistedCsrfToken = loadAccountDeletionCsrfToken();
-      if (persistedCsrfToken !== null) {
-        primeSessionCsrfToken(persistedCsrfToken);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      const didBeginRetryAttempt = await runWithAccountDeletionLock(
+        indexedDbOpenRecoveryState.signal,
+        async (): Promise<boolean> => {
+          indexedDbOpenRecoveryState.throwIfFailed();
+          return beginAccountDeletionRetryAttempt(expectedAttemptId);
+        },
+      );
+      indexedDbOpenRecoveryState.throwIfFailed();
+      if (didBeginRetryAttempt === false) {
+        return;
       }
 
-      try {
-        await deleteMyAccount(deleteAccountConfirmationText);
-      } catch (error) {
-        if ((error instanceof ApiError) === false || error.code !== "ACCOUNT_DELETED") {
-          throw error;
-        }
-      }
-
-      if (indexedDbOpenRecoveryState.hasFailed() === false) {
-        try {
-          await clearAllLocalBrowserData("account_deletion_submit");
-        } catch (error) {
-          reportAccountDeletionError(error);
-          if (indexedDbOpenRecoveryState.hasFailed()) {
-            window.location.href = buildLogoutLocalUrl();
-          }
-          return;
-        }
-
-        if (indexedDbOpenRecoveryState.hasFailed()) {
-          window.location.href = buildLogoutLocalUrl();
-          return;
-        }
-      }
-      window.location.href = buildLogoutLocalUrl();
+      await completeAccountDeletion();
     } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       reportAccountDeletionError(error);
-    } finally {
-      setIsAccountDeletionSubmitting(false);
     }
-  }, [indexedDbOpenRecoveryState, isSessionVerified, reportAccountDeletionError]);
+  }, [completeAccountDeletion, indexedDbOpenRecoveryState, isSessionVerified, reportAccountDeletionError]);
 
   useEffect(() => subscribeToAccountDeletionPending(() => {
     setIsAccountDeletionPendingState(isAccountDeletionPending());
@@ -567,12 +666,12 @@ export function AppShell(): ReactElement {
               ? t("app.deleteAccountInProgress")
               : t("app.deleteAccountRestoring")}
           </p>
-          {visibleAccountDeletionErrorMessage !== "" ? <p className="error-banner">{visibleAccountDeletionErrorMessage}</p> : null}
+          {visiblePendingAccountDeletionErrorMessage !== "" ? <p className="error-banner">{visiblePendingAccountDeletionErrorMessage}</p> : null}
           <button
             className="primary-btn"
             type="button"
-            disabled={isAccountDeletionSubmitting}
-            onClick={() => void completeAccountDeletion()}
+            disabled={isAccountDeletionSubmitting || (isSessionVerified === false && sessionLoadState !== "error")}
+            onClick={() => void retryAccountDeletion()}
           >
             {isAccountDeletionSubmitting ? t("app.deleting") : t("app.deleteAccountRetry")}
           </button>
@@ -631,7 +730,7 @@ export function AppShell(): ReactElement {
                 key={workspace.workspaceId}
                 className="workspace-choice-btn"
                 type="button"
-                onClick={() => void chooseWorkspace(workspace.workspaceId)}
+                onClick={() => void selectInitialWorkspace(workspace.workspaceId)}
                 disabled={isChoosingWorkspace}
               >
                 <span className="workspace-choice-name">{workspace.name}</span>

--- a/apps/web/src/accountDeletion.test.ts
+++ b/apps/web/src/accountDeletion.test.ts
@@ -2,10 +2,21 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  beginAccountDeletionRetryAttempt,
   clearAllLocalBrowserData,
   clearBrowserReauthRequired,
+  hasAccountDeletionAttemptDispatched,
+  isAccountDeletionPending,
+  isAccountDeletionServerConfirmed,
   isBrowserReauthRequired,
+  loadAccountDeletionAttemptId,
+  loadAccountDeletionCsrfToken,
+  markAccountDeletionAttemptDispatched,
+  markAccountDeletionServerConfirmed,
   markBrowserReauthRequired,
+  runWithAccountDeletionLock,
+  setAccountDeletionPending,
+  storeAccountDeletionCsrfToken,
 } from "./accountDeletion";
 import { AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY } from "./chat/preferences/AIChatPreferencesContext";
 import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
@@ -32,6 +43,30 @@ const seededCloudSettings: CloudSettings = {
   onboardingCompleted: true,
   updatedAt: "2026-04-10T00:00:00.000Z",
 };
+
+function ignoreIndexedDbOpenRecoveryFailure(): void {
+}
+
+function installSerialAccountDeletionLockMock(): void {
+  let previousRequest: Promise<void> = Promise.resolve();
+  Object.defineProperty(window.navigator, "locks", {
+    configurable: true,
+    value: {
+      request<Result>(
+        _name: string,
+        _options: Readonly<{ signal: AbortSignal }>,
+        action: () => Promise<Result>,
+      ): Promise<Result> {
+        const result = previousRequest.then(action);
+        previousRequest = result.then(
+          (): void => undefined,
+          (): void => undefined,
+        );
+        return result;
+      },
+    },
+  });
+}
 
 function createStorageMock(): Storage {
   const state = new Map<string, string>();
@@ -124,6 +159,13 @@ function mockUnavailableIndexedDbOpen(): void {
   }));
 }
 
+function mockOrdinaryIndexedDbOpenFailure(): void {
+  vi.spyOn(indexedDB, "open").mockImplementation(() => createMockOpenDbRequest((request) => {
+    Object.assign(request, { error: new DOMException("IndexedDB unavailable", "InvalidStateError") });
+    request.onerror?.(new Event("error"));
+  }));
+}
+
 beforeEach(async () => {
   await clearWebSyncCache();
   Object.defineProperty(window, "localStorage", {
@@ -138,6 +180,7 @@ beforeEach(async () => {
 afterEach(async () => {
   window.localStorage.clear();
   clearBrowserReauthRequired();
+  Reflect.deleteProperty(window.navigator, "locks");
   vi.restoreAllMocks();
   await clearWebSyncCache();
 });
@@ -148,7 +191,7 @@ describe("account deletion local cleanup helpers", () => {
     await putCloudSettings(seededCloudSettings);
     mockBlockedThenSuccessfulDeleteDatabase();
 
-    await expect(clearAllLocalBrowserData("logout_marker")).resolves.toBeUndefined();
+    await expect(clearAllLocalBrowserData("logout_marker", ignoreIndexedDbOpenRecoveryFailure)).resolves.toBeUndefined();
 
     expectLocalBrowserStateCleared();
     await expect(loadCloudSettings()).resolves.toBeNull();
@@ -168,7 +211,7 @@ describe("account deletion local cleanup helpers", () => {
     await putCloudSettings(seededCloudSettings);
     mockFailingDeleteDatabase();
 
-    await expect(clearAllLocalBrowserData("logout_marker")).resolves.toBeUndefined();
+    await expect(clearAllLocalBrowserData("logout_marker", ignoreIndexedDbOpenRecoveryFailure)).resolves.toBeUndefined();
 
     expectLocalBrowserStateCleared();
     await expect(loadCloudSettings()).resolves.toBeNull();
@@ -187,21 +230,20 @@ describe("account deletion local cleanup helpers", () => {
     mockUnavailableIndexedDbOpen();
     mockFailingDeleteDatabase();
 
-    await expect(clearAllLocalBrowserData("logout_marker")).rejects.toThrow("Failed to open IndexedDB");
-    expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).toBeNull();
-    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
-    expect(window.localStorage.getItem(SYNC_RESTORE_HISTORY_STORAGE_KEY)).toBeNull();
+    await expect(clearAllLocalBrowserData("logout_marker", ignoreIndexedDbOpenRecoveryFailure)).rejects.toThrow("Failed to open IndexedDB");
+    expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).not.toBeNull();
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).not.toBeNull();
+    expect(window.localStorage.getItem(SYNC_RESTORE_HISTORY_STORAGE_KEY)).not.toBeNull();
     expect(window.localStorage.getItem("flashcards-browser-reauth-required")).toBe("1");
     expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBe("1");
     expect(isBrowserReauthRequired()).toBe(true);
     expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
     expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
     expect(window.localStorage.getItem(AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY)).toBe("false");
-    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+    expect(observabilityMocks.addWebBreadcrumbMock).not.toHaveBeenCalledWith(expect.objectContaining({
       action: "local_browser_data_cleanup",
       details: expect.objectContaining({
         eventName: "local_browser_data_cleanup_failed",
-        errorName: "UnknownError",
       }),
     }));
   });
@@ -210,7 +252,7 @@ describe("account deletion local cleanup helpers", () => {
     seedLocalBrowserState();
     await putCloudSettings(seededCloudSettings);
 
-    await expect(clearAllLocalBrowserData("confirmed_account_switch")).resolves.toBeUndefined();
+    await expect(clearAllLocalBrowserData("confirmed_account_switch", ignoreIndexedDbOpenRecoveryFailure)).resolves.toBeUndefined();
 
     expectLocalBrowserStateCleared();
     await expect(loadCloudSettings()).resolves.toBeNull();
@@ -223,6 +265,195 @@ describe("account deletion local cleanup helpers", () => {
         localStorageCleared: true,
       }),
     }));
+  });
+
+  it("preserves pending account deletion proof until successful cleanup is handed off", async () => {
+    seedLocalBrowserState();
+    setAccountDeletionPending(true);
+    storeAccountDeletionCsrfToken("csrf-token");
+    markAccountDeletionServerConfirmed();
+    markAccountDeletionAttemptDispatched();
+    await putCloudSettings(seededCloudSettings);
+
+    await expect(clearAllLocalBrowserData("account_deletion_submit", ignoreIndexedDbOpenRecoveryFailure)).resolves.toBeUndefined();
+
+    expect(isAccountDeletionPending()).toBe(true);
+    expect(loadAccountDeletionCsrfToken()).toBe("csrf-token");
+    expect(isAccountDeletionServerConfirmed()).toBe(true);
+    expect(hasAccountDeletionAttemptDispatched()).toBe(true);
+
+    setAccountDeletionPending(false);
+
+    expect(isAccountDeletionPending()).toBe(false);
+    expect(loadAccountDeletionCsrfToken()).toBeNull();
+    expect(isAccountDeletionServerConfirmed()).toBe(false);
+    expect(loadAccountDeletionAttemptId()).toBeNull();
+    expect(hasAccountDeletionAttemptDispatched()).toBe(false);
+  });
+
+  it("preserves pending account deletion proof after ordinary IndexedDB cleanup failure", async () => {
+    seedLocalBrowserState();
+    setAccountDeletionPending(true);
+    storeAccountDeletionCsrfToken("csrf-token");
+    markAccountDeletionServerConfirmed();
+    markAccountDeletionAttemptDispatched();
+    await putCloudSettings(seededCloudSettings);
+    mockOrdinaryIndexedDbOpenFailure();
+    mockFailingDeleteDatabase();
+
+    await expect(clearAllLocalBrowserData("account_deletion_submit", ignoreIndexedDbOpenRecoveryFailure)).rejects.toThrow("Failed to open IndexedDB");
+
+    expect(isAccountDeletionPending()).toBe(true);
+    expect(loadAccountDeletionCsrfToken()).toBe("csrf-token");
+    expect(isAccountDeletionServerConfirmed()).toBe(true);
+    expect(hasAccountDeletionAttemptDispatched()).toBe(true);
+  });
+
+  it("preserves pending account deletion proof after canonical IndexedDB recovery", async () => {
+    seedLocalBrowserState();
+    setAccountDeletionPending(true);
+    storeAccountDeletionCsrfToken("csrf-token");
+    markAccountDeletionServerConfirmed();
+    markAccountDeletionAttemptDispatched();
+    await putCloudSettings(seededCloudSettings);
+    mockUnavailableIndexedDbOpen();
+    mockFailingDeleteDatabase();
+
+    await expect(clearAllLocalBrowserData("account_deletion_submit", ignoreIndexedDbOpenRecoveryFailure)).rejects.toThrow("Failed to open IndexedDB");
+
+    expect(isAccountDeletionPending()).toBe(true);
+    expect(loadAccountDeletionCsrfToken()).toBe("csrf-token");
+    expect(isAccountDeletionServerConfirmed()).toBe(true);
+    expect(hasAccountDeletionAttemptDispatched()).toBe(true);
+  });
+
+  it("does not infer server confirmation from a new pending deletion", () => {
+    markAccountDeletionServerConfirmed();
+    storeAccountDeletionCsrfToken("csrf-token");
+
+    setAccountDeletionPending(true);
+
+    expect(isAccountDeletionPending()).toBe(true);
+    expect(loadAccountDeletionCsrfToken()).toBe("csrf-token");
+    expect(isAccountDeletionServerConfirmed()).toBe(false);
+  });
+
+  it("resets and clears the dispatch claim with pending attempt lifecycle", () => {
+    setAccountDeletionPending(true);
+    const firstAttemptId = loadAccountDeletionAttemptId();
+    markAccountDeletionAttemptDispatched();
+
+    expect(firstAttemptId).not.toBeNull();
+    expect(hasAccountDeletionAttemptDispatched()).toBe(true);
+
+    setAccountDeletionPending(true);
+
+    expect(loadAccountDeletionAttemptId()).not.toBe(firstAttemptId);
+    expect(hasAccountDeletionAttemptDispatched()).toBe(false);
+
+    markAccountDeletionAttemptDispatched();
+    setAccountDeletionPending(false);
+
+    expect(loadAccountDeletionAttemptId()).toBeNull();
+    expect(hasAccountDeletionAttemptDispatched()).toBe(false);
+  });
+
+  it("keeps server confirmation when the following recovery checkpoint throws", () => {
+    setAccountDeletionPending(true);
+    const recoveryError = new Error("IndexedDB recovery required");
+
+    expect(() => {
+      markAccountDeletionServerConfirmed();
+      throw recoveryError;
+    }).toThrow(recoveryError);
+
+    expect(isAccountDeletionPending()).toBe(true);
+    expect(isAccountDeletionServerConfirmed()).toBe(true);
+  });
+
+  it("prevents automatic waiters from dispatching after an ordinary owner failure", async () => {
+    installSerialAccountDeletionLockMock();
+    setAccountDeletionPending(true);
+    let deleteRequestCount = 0;
+    const recoveryController = new AbortController();
+    const ordinaryDeleteError = new Error("Account deletion request failed");
+
+    const completePendingDeletion = (): Promise<void> => runWithAccountDeletionLock(
+      recoveryController.signal,
+      async (): Promise<void> => {
+        if (
+          isAccountDeletionPending() === false
+          || isAccountDeletionServerConfirmed()
+          || hasAccountDeletionAttemptDispatched()
+        ) {
+          return;
+        }
+
+        markAccountDeletionAttemptDispatched();
+        deleteRequestCount += 1;
+        throw ordinaryDeleteError;
+      },
+    );
+
+    const results = await Promise.allSettled([
+      completePendingDeletion(),
+      completePendingDeletion(),
+      completePendingDeletion(),
+    ]);
+
+    expect(deleteRequestCount).toBe(1);
+    expect(results[0]).toEqual({ status: "rejected", reason: ordinaryDeleteError });
+    expect(results[1]).toEqual({ status: "fulfilled", value: undefined });
+    expect(results[2]).toEqual({ status: "fulfilled", value: undefined });
+    expect(isAccountDeletionPending()).toBe(true);
+    expect(isAccountDeletionServerConfirmed()).toBe(false);
+    expect(hasAccountDeletionAttemptDispatched()).toBe(true);
+  });
+
+  it("collapses simultaneous explicit retries into one new dispatched attempt", async () => {
+    installSerialAccountDeletionLockMock();
+    setAccountDeletionPending(true);
+    markAccountDeletionAttemptDispatched();
+    let deleteRequestCount = 0;
+    const recoveryController = new AbortController();
+
+    const completePendingDeletion = (): Promise<void> => runWithAccountDeletionLock(
+      recoveryController.signal,
+      async (): Promise<void> => {
+        if (
+          isAccountDeletionPending() === false
+          || isAccountDeletionServerConfirmed()
+          || hasAccountDeletionAttemptDispatched()
+        ) {
+          return;
+        }
+
+        markAccountDeletionAttemptDispatched();
+        deleteRequestCount += 1;
+        markAccountDeletionServerConfirmed();
+      },
+    );
+    const retryPendingDeletion = async (): Promise<void> => {
+      const expectedAttemptId = loadAccountDeletionAttemptId();
+      if (expectedAttemptId === null) {
+        return;
+      }
+
+      const didBeginRetryAttempt = await runWithAccountDeletionLock(
+        recoveryController.signal,
+        async (): Promise<boolean> => beginAccountDeletionRetryAttempt(expectedAttemptId),
+      );
+      if (didBeginRetryAttempt) {
+        await completePendingDeletion();
+      }
+    };
+
+    await Promise.all([retryPendingDeletion(), retryPendingDeletion()]);
+
+    expect(deleteRequestCount).toBe(1);
+    expect(isAccountDeletionPending()).toBe(true);
+    expect(isAccountDeletionServerConfirmed()).toBe(true);
+    expect(hasAccountDeletionAttemptDispatched()).toBe(true);
   });
 
   it("treats the legacy auth reset marker as reauth required", () => {

--- a/apps/web/src/accountDeletion.ts
+++ b/apps/web/src/accountDeletion.ts
@@ -1,6 +1,7 @@
 import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "./i18n/runtime";
-import { clearWebSyncCache } from "./localDb/cache";
+import { clearWebSyncCacheForLocalBrowserDataCleanup } from "./localDb/cache";
+import { isIndexedDbOpenRecoveryError } from "./localDb/core/indexedDbOpenRecovery";
 import {
   addWebBreadcrumb,
   type LocalBrowserDataCleanupReason,
@@ -17,7 +18,10 @@ const AUTH_RESET_REQUIRED_KEY = "flashcards-auth-reset-required";
 const BROWSER_REAUTH_REQUIRED_KEY = "flashcards-browser-reauth-required";
 const ACCOUNT_DELETION_PENDING_KEY = "flashcards-account-deletion-pending";
 const ACCOUNT_DELETION_CSRF_TOKEN_KEY = "flashcards-account-deletion-csrf-token";
+const ACCOUNT_DELETION_SERVER_CONFIRMED_KEY = "flashcards-account-deletion-server-confirmed";
+const ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY = "flashcards-account-deletion-attempt-dispatched";
 const ACCOUNT_DELETION_EVENT_NAME = "flashcards-account-deletion-pending-change";
+const ACCOUNT_DELETION_LOCK_NAME = "flashcards-account-deletion";
 const APP_LOCAL_STORAGE_PREFIX = "flashcards-";
 const APP_LOCAL_STORAGE_KEYS: ReadonlyArray<string> = [
   "selected-review-filter",
@@ -53,7 +57,12 @@ function dispatchAccountDeletionChange(): void {
 }
 
 export function isAccountDeletionPending(): boolean {
-  return getBrowserStorage()?.getItem(ACCOUNT_DELETION_PENDING_KEY) === "1";
+  return loadAccountDeletionAttemptId() !== null;
+}
+
+export function loadAccountDeletionAttemptId(): string | null {
+  const attemptId = getBrowserStorage()?.getItem(ACCOUNT_DELETION_PENDING_KEY) ?? null;
+  return attemptId === null || attemptId === "" ? null : attemptId;
 }
 
 export function setAccountDeletionPending(isPending: boolean): void {
@@ -64,10 +73,14 @@ export function setAccountDeletionPending(isPending: boolean): void {
   }
 
   if (isPending) {
-    browserStorage.setItem(ACCOUNT_DELETION_PENDING_KEY, "1");
+    browserStorage.setItem(ACCOUNT_DELETION_PENDING_KEY, crypto.randomUUID());
+    browserStorage.removeItem(ACCOUNT_DELETION_SERVER_CONFIRMED_KEY);
+    browserStorage.removeItem(ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY);
   } else {
     browserStorage.removeItem(ACCOUNT_DELETION_PENDING_KEY);
     browserStorage.removeItem(ACCOUNT_DELETION_CSRF_TOKEN_KEY);
+    browserStorage.removeItem(ACCOUNT_DELETION_SERVER_CONFIRMED_KEY);
+    browserStorage.removeItem(ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY);
   }
 
   dispatchAccountDeletionChange();
@@ -89,16 +102,19 @@ export function subscribeToAccountDeletionPending(listener: AccountDeletionListe
   };
 }
 
-export function consumeAccountDeletedMarker(): boolean {
+export function hasAccountDeletedMarker(): boolean {
+  return new URL(window.location.href).searchParams.get("account_deleted") === "1";
+}
+
+export function removeAccountDeletedMarker(): void {
   const url = new URL(window.location.href);
   if (url.searchParams.get("account_deleted") !== "1") {
-    return false;
+    return;
   }
 
   url.searchParams.delete("account_deleted");
   const nextUrl = `${url.pathname}${url.search}${url.hash}`;
   window.history.replaceState({}, document.title, nextUrl);
-  return true;
 }
 
 export function storeAccountDeletionCsrfToken(csrfToken: string | null): void {
@@ -118,6 +134,56 @@ export function storeAccountDeletionCsrfToken(csrfToken: string | null): void {
 export function loadAccountDeletionCsrfToken(): string | null {
   const csrfToken = getBrowserStorage()?.getItem(ACCOUNT_DELETION_CSRF_TOKEN_KEY) ?? null;
   return csrfToken === null || csrfToken === "" ? null : csrfToken;
+}
+
+export function isAccountDeletionServerConfirmed(): boolean {
+  return getBrowserStorage()?.getItem(ACCOUNT_DELETION_SERVER_CONFIRMED_KEY) === "1";
+}
+
+export function markAccountDeletionServerConfirmed(): void {
+  getBrowserStorage()?.setItem(ACCOUNT_DELETION_SERVER_CONFIRMED_KEY, "1");
+}
+
+export function hasAccountDeletionAttemptDispatched(): boolean {
+  const browserStorage = getBrowserStorage();
+  const attemptId = loadAccountDeletionAttemptId();
+  return attemptId !== null
+    && browserStorage?.getItem(ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY) === attemptId;
+}
+
+export function markAccountDeletionAttemptDispatched(): void {
+  const browserStorage = getBrowserStorage();
+  const attemptId = loadAccountDeletionAttemptId();
+  if (browserStorage === null || attemptId === null) {
+    throw new Error("Cannot dispatch account deletion without a pending attempt");
+  }
+
+  browserStorage.setItem(ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY, attemptId);
+}
+
+export function beginAccountDeletionRetryAttempt(expectedAttemptId: string): boolean {
+  const browserStorage = getBrowserStorage();
+  if (
+    browserStorage?.getItem(ACCOUNT_DELETION_PENDING_KEY) !== expectedAttemptId
+    || browserStorage.getItem(ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY) !== expectedAttemptId
+  ) {
+    return false;
+  }
+
+  browserStorage.setItem(ACCOUNT_DELETION_PENDING_KEY, crypto.randomUUID());
+  browserStorage.removeItem(ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY);
+  return true;
+}
+
+export function runWithAccountDeletionLock<Result>(
+  signal: AbortSignal,
+  action: () => Promise<Result>,
+): Promise<Result> {
+  return navigator.locks.request(
+    ACCOUNT_DELETION_LOCK_NAME,
+    { mode: "exclusive", signal },
+    action,
+  );
 }
 
 function normalizeCleanupError(error: unknown): Error {
@@ -216,6 +282,13 @@ function shouldRemoveAppLocalStorageKeyAfterIncompleteIndexedDbCleanup(storageKe
   return shouldRemoveAppLocalStorageKey(storageKey);
 }
 
+function isPendingAccountDeletionStorageKey(storageKey: string): boolean {
+  return storageKey === ACCOUNT_DELETION_PENDING_KEY
+    || storageKey === ACCOUNT_DELETION_CSRF_TOKEN_KEY
+    || storageKey === ACCOUNT_DELETION_SERVER_CONFIRMED_KEY
+    || storageKey === ACCOUNT_DELETION_ATTEMPT_DISPATCHED_KEY;
+}
+
 export function markBrowserReauthRequired(): void {
   getBrowserStorage()?.setItem(BROWSER_REAUTH_REQUIRED_KEY, "1");
 }
@@ -254,7 +327,10 @@ export function clearAuthResetRequired(): void {
  * preserves device identity, UI language, local chat UI preferences, and local
  * tester tooling across re-login while still clearing application data.
  */
-export async function clearAllLocalBrowserData(reason: LocalBrowserDataCleanupReason): Promise<void> {
+export async function clearAllLocalBrowserData(
+  reason: LocalBrowserDataCleanupReason,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<void> {
   const browserStorage = getBrowserStorage();
   let indexedDbError: Error | null = null;
 
@@ -267,16 +343,29 @@ export async function clearAllLocalBrowserData(reason: LocalBrowserDataCleanupRe
     errorMessage: null,
   });
 
+  throwIfIndexedDbOpenRecoveryFailed();
   try {
-    await clearWebSyncCache();
+    await clearWebSyncCacheForLocalBrowserDataCleanup(throwIfIndexedDbOpenRecoveryFailed);
+    throwIfIndexedDbOpenRecoveryFailed();
   } catch (error) {
+    throwIfIndexedDbOpenRecoveryFailed();
+    if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
     indexedDbError = normalizeCleanupError(error);
   }
 
+  throwIfIndexedDbOpenRecoveryFailed();
   if (browserStorage !== null) {
-    const shouldRemoveStorageKey = indexedDbError === null
+    const shouldRemoveBaseStorageKey: BrowserStorageKeyPredicate = indexedDbError === null
       ? shouldRemoveAppLocalStorageKey
       : shouldRemoveAppLocalStorageKeyAfterIncompleteIndexedDbCleanup;
+    const shouldRemoveStorageKey: BrowserStorageKeyPredicate = reason === "account_deletion_submit"
+      ? (storageKey: string): boolean => (
+        isPendingAccountDeletionStorageKey(storageKey) === false
+        && shouldRemoveBaseStorageKey(storageKey)
+      )
+      : shouldRemoveBaseStorageKey;
     clearUserScopedBrowserStorage(browserStorage, shouldRemoveStorageKey);
   }
 

--- a/apps/web/src/api/endpoints/chat.test.ts
+++ b/apps/web/src/api/endpoints/chat.test.ts
@@ -66,7 +66,7 @@ describe("chat API endpoints", () => {
       .mockResolvedValueOnce(createChatSnapshotResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    await getChatSnapshot("session-1", "workspace-1");
+    await getChatSnapshot("session-1", "workspace-1", new AbortController().signal);
 
     const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
     expect(requestUrl.pathname).toBe("/v1/chat");
@@ -90,7 +90,7 @@ describe("chat API endpoints", () => {
       }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(getChatSnapshot("session-1", "workspace-1")).resolves.toMatchObject({
+    await expect(getChatSnapshot("session-1", "workspace-1", new AbortController().signal)).resolves.toMatchObject({
       sessionId: "session-1",
       chatConfig: {
         features: {
@@ -159,6 +159,7 @@ describe("chat API endpoints", () => {
       "web",
       "session-1",
       "workspace-1",
+      new AbortController().signal,
     );
 
     const chatRequestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;

--- a/apps/web/src/api/endpoints/chat.ts
+++ b/apps/web/src/api/endpoints/chat.ts
@@ -37,9 +37,14 @@ function buildChatSnapshotPath(sessionId: string, workspaceId: string): string {
   return `/chat?${searchParams.toString()}`;
 }
 
-export async function getChatSnapshot(sessionId: string, workspaceId: string): Promise<ChatSessionSnapshot> {
+export async function getChatSnapshot(
+  sessionId: string,
+  workspaceId: string,
+  signal: AbortSignal,
+): Promise<ChatSessionSnapshot> {
   return parseContractResponse(await requestJson(buildChatSnapshotPath(sessionId, workspaceId), {
     method: "GET",
+    signal,
   }, allowAuthRecoveryWithTransientNetworkRetry), "GET /chat", parseChatSessionSnapshotResponse);
 }
 
@@ -47,6 +52,7 @@ export async function getChatSnapshotWithResumeDiagnostics(
   sessionId: string,
   workspaceId: string,
   diagnostics: ChatResumeRequestDiagnostics,
+  signal: AbortSignal,
 ): Promise<ChatSessionSnapshot> {
   return parseContractResponse(await requestJson(buildChatSnapshotPath(sessionId, workspaceId), {
     method: "GET",
@@ -55,6 +61,7 @@ export async function getChatSnapshotWithResumeDiagnostics(
       "X-Client-Platform": "web",
       "X-Client-Version": webAppVersion,
     },
+    signal,
   }, allowAuthRecoveryWithTransientNetworkRetry), "GET /chat", parseChatSessionSnapshotResponse);
 }
 
@@ -136,6 +143,7 @@ export async function transcribeChatAudio(
   source: ChatTranscriptionSource,
   sessionId: string,
   workspaceId: string,
+  signal: AbortSignal,
 ): Promise<ChatTranscriptionResponse> {
   const mediaType = normalizeAudioMediaType(blob.type === "" ? "audio/webm" : blob.type);
   const file = new File([blob], `chat-dictation.${extensionForAudioMediaType(mediaType)}`, { type: mediaType });
@@ -148,5 +156,6 @@ export async function transcribeChatAudio(
   return parseContractResponse(await requestJson("/chat/transcriptions", {
     method: "POST",
     body: formData,
+    signal,
   }, allowAuthRecovery), "POST /chat/transcriptions", parseChatTranscriptionResponse);
 }

--- a/apps/web/src/api/endpoints/mediaAssets.ts
+++ b/apps/web/src/api/endpoints/mediaAssets.ts
@@ -24,9 +24,11 @@ import {
 export async function loadMediaAssetDownloadUrl(
   workspaceId: string,
   mediaAssetId: string,
+  signal: AbortSignal,
 ): Promise<MediaAssetDownloadUrlResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/media-assets/${mediaAssetId}/download-url`, {
     method: "GET",
+    signal,
   }, allowAuthRecoveryWithTransientNetworkRetry), `GET /workspaces/${workspaceId}/media-assets/${mediaAssetId}/download-url`, parseMediaAssetDownloadUrlResponse);
 }
 

--- a/apps/web/src/api/endpoints/sync.test.ts
+++ b/apps/web/src/api/endpoints/sync.test.ts
@@ -20,7 +20,16 @@ describe("sync API endpoints", () => {
       }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await pullSyncChanges("workspace-1", "device-1", "web", "1.0.0", 41, 100, true);
+    await pullSyncChanges(
+      "workspace-1",
+      "device-1",
+      "web",
+      "1.0.0",
+      41,
+      100,
+      true,
+      new AbortController().signal,
+    );
 
     const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
     const requestBody = JSON.parse(String(requestInit?.body)) as Readonly<{ includeMediaAssets?: unknown }>;
@@ -66,7 +75,15 @@ describe("sync API endpoints", () => {
       }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await pullReviewHistorySync("workspace-1", "device-1", "web", "1.0.0", 41, 100);
+    const result = await pullReviewHistorySync(
+      "workspace-1",
+      "device-1",
+      "web",
+      "1.0.0",
+      41,
+      100,
+      new AbortController().signal,
+    );
 
     expect(result).toEqual({
       reviewEvents: [

--- a/apps/web/src/api/endpoints/sync.ts
+++ b/apps/web/src/api/endpoints/sync.ts
@@ -30,6 +30,7 @@ export async function pushSyncOperations(
   platform: "web",
   appVersion: string,
   operations: ReadonlyArray<SyncPushOperation>,
+  signal: AbortSignal,
 ): Promise<SyncPushResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/push`, {
     method: "POST",
@@ -39,6 +40,7 @@ export async function pushSyncOperations(
       appVersion,
       operations,
     }),
+    signal,
   }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/push`, parseSyncPushResultResponse);
 }
 
@@ -50,6 +52,7 @@ export async function pullSyncChanges(
   afterHotChangeId: number,
   limit: number,
   includeMediaAssets: boolean,
+  signal: AbortSignal,
 ): Promise<SyncPullResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/pull`, {
     method: "POST",
@@ -61,6 +64,7 @@ export async function pullSyncChanges(
       limit,
       includeMediaAssets,
     }),
+    signal,
   }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/pull`, parseSyncPullResultResponse);
 }
 
@@ -72,6 +76,7 @@ export async function bootstrapPullSyncState(
   cursor: string | null,
   limit: number,
   includeMediaAssets: boolean,
+  signal: AbortSignal,
 ): Promise<SyncBootstrapPullResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/bootstrap`, {
     method: "POST",
@@ -84,6 +89,7 @@ export async function bootstrapPullSyncState(
       limit,
       includeMediaAssets,
     }),
+    signal,
   }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/bootstrap`, parseSyncBootstrapPullResultResponse);
 }
 
@@ -94,6 +100,7 @@ export async function bootstrapPushSyncState(
   appVersion: string,
   entries: ReadonlyArray<SyncBootstrapEntry>,
   includeMediaAssets: boolean,
+  signal: AbortSignal,
 ): Promise<SyncBootstrapPushResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/bootstrap`, {
     method: "POST",
@@ -105,6 +112,7 @@ export async function bootstrapPushSyncState(
       entries,
       includeMediaAssets,
     }),
+    signal,
   }, allowAuthRecovery), `POST /workspaces/${workspaceId}/sync/bootstrap`, parseSyncBootstrapPushResultResponse);
 }
 
@@ -115,6 +123,7 @@ export async function pullReviewHistorySync(
   appVersion: string,
   afterReviewSequenceId: number,
   limit: number,
+  signal: AbortSignal,
 ): Promise<SyncReviewHistoryPullResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/review-history/pull`, {
     method: "POST",
@@ -125,6 +134,7 @@ export async function pullReviewHistorySync(
       afterReviewSequenceId,
       limit,
     }),
+    signal,
   }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/review-history/pull`, parseSyncReviewHistoryPullResultResponse);
 }
 
@@ -134,6 +144,7 @@ export async function importReviewHistorySync(
   platform: "web",
   appVersion: string,
   reviewEvents: ReadonlyArray<ReviewEvent>,
+  signal: AbortSignal,
 ): Promise<SyncReviewHistoryImportResult> {
   return parseContractResponse(await requestJson(`/workspaces/${workspaceId}/sync/review-history/import`, {
     method: "POST",
@@ -143,5 +154,6 @@ export async function importReviewHistorySync(
       appVersion,
       reviewEvents,
     }),
+    signal,
   }, allowAuthRecovery), `POST /workspaces/${workspaceId}/sync/review-history/import`, parseSyncReviewHistoryImportResultResponse);
 }

--- a/apps/web/src/api/transport/transport.network-retry.test.ts
+++ b/apps/web/src/api/transport/transport.network-retry.test.ts
@@ -263,7 +263,7 @@ describe("API transport network retry", () => {
       .mockResolvedValueOnce(createChatSnapshotResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(getChatSnapshot("session-1", "workspace-1")).resolves.toMatchObject({
+    await expect(getChatSnapshot("session-1", "workspace-1", new AbortController().signal)).resolves.toMatchObject({
       sessionId: "session-1",
     });
 
@@ -305,6 +305,7 @@ describe("API transport network retry", () => {
       0,
       200,
       false,
+      new AbortController().signal,
     )).resolves.toEqual({
       changes: [],
       nextHotChangeId: 42,
@@ -345,6 +346,7 @@ describe("API transport network retry", () => {
       0,
       200,
       false,
+      new AbortController().signal,
     )).resolves.toEqual({
       changes: [],
       nextHotChangeId: 42,
@@ -374,7 +376,7 @@ describe("API transport network retry", () => {
       .mockResolvedValueOnce(createChatSnapshotResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(getChatSnapshot("session-1", "workspace-1")).resolves.toMatchObject({
+    await expect(getChatSnapshot("session-1", "workspace-1", new AbortController().signal)).resolves.toMatchObject({
       sessionId: "session-1",
     });
 
@@ -458,7 +460,7 @@ describe("API transport network retry", () => {
       .catch((error: unknown): unknown => error);
     await waitForFetchCallCount(fetchMock, 2);
 
-    const retryPromise = getChatSnapshot("session-1", "workspace-1");
+    const retryPromise = getChatSnapshot("session-1", "workspace-1", new AbortController().signal);
     await waitForFetchCallCount(fetchMock, 3);
     refreshResponse.resolve(new Response(null, { status: 200 }));
 
@@ -521,6 +523,7 @@ describe("API transport network retry", () => {
       0,
       200,
       false,
+      new AbortController().signal,
     );
     refreshResponse.resolve(new Response(null, { status: 200 }));
 
@@ -556,7 +559,7 @@ describe("API transport network retry", () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockRejectedValue(new TypeError("Failed to fetch"));
     vi.stubGlobal("fetch", fetchMock);
-    const snapshotPromise = getChatSnapshot("session-1", "workspace-1");
+    const snapshotPromise = getChatSnapshot("session-1", "workspace-1", new AbortController().signal);
 
     await expect(snapshotPromise).rejects.toBeInstanceOf(ApiNetworkError);
     await expect(snapshotPromise).rejects.toMatchObject({

--- a/apps/web/src/api/transport/transport.ts
+++ b/apps/web/src/api/transport/transport.ts
@@ -66,6 +66,98 @@ let sessionTransportReadyPromise: Promise<void> | null = null;
 let sessionTransportReadyNetworkRetryMode: NetworkRetryMode | null = null;
 let redirectInFlight = false;
 let navigationHandler: NavigateToUrl | null = null;
+let indexedDbOpenRecoverySignal: AbortSignal | null = null;
+
+export function bindIndexedDbOpenRecoverySignal(signal: AbortSignal): () => void {
+  const previousSignal = indexedDbOpenRecoverySignal;
+  indexedDbOpenRecoverySignal = signal;
+  return (): void => {
+    if (indexedDbOpenRecoverySignal === signal) {
+      indexedDbOpenRecoverySignal = previousSignal;
+    }
+  };
+}
+
+function readAbortError(signal: AbortSignal): Error {
+  const reason: unknown = signal.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+  if (typeof reason === "string" && reason.trim() !== "") {
+    return new Error(reason);
+  }
+  return new DOMException("Request was aborted", "AbortError");
+}
+
+function throwIfRequestAborted(signal: AbortSignal | null): void {
+  if (indexedDbOpenRecoverySignal?.aborted) {
+    throw readAbortError(indexedDbOpenRecoverySignal);
+  }
+  if (signal?.aborted) {
+    throw readAbortError(signal);
+  }
+}
+
+function mergeRequestSignal(lifecycleSignal: AbortSignal | null | undefined): AbortSignal | undefined {
+  const recoverySignal = indexedDbOpenRecoverySignal;
+  if (recoverySignal === null) {
+    return lifecycleSignal ?? undefined;
+  }
+  if (lifecycleSignal === undefined || lifecycleSignal === null || lifecycleSignal === recoverySignal) {
+    return recoverySignal;
+  }
+  return AbortSignal.any([recoverySignal, lifecycleSignal]);
+}
+
+function attachRecoverySignal(init: RequestInit): RequestInit {
+  const signal = mergeRequestSignal(init.signal);
+  return signal === init.signal ? init : { ...init, signal };
+}
+
+function waitForSharedTransportTask<ResultType>(
+  task: Promise<ResultType>,
+  signal: AbortSignal | null,
+): Promise<ResultType> {
+  if (indexedDbOpenRecoverySignal?.aborted) {
+    return Promise.reject(readAbortError(indexedDbOpenRecoverySignal));
+  }
+  if (signal === null) {
+    return task;
+  }
+  if (signal.aborted) {
+    try {
+      throwIfRequestAborted(signal);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  return new Promise<ResultType>((resolve, reject) => {
+    const handleAbort = (): void => {
+      signal.removeEventListener("abort", handleAbort);
+      try {
+        throwIfRequestAborted(signal);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+    task.then(
+      (result: ResultType): void => {
+        signal.removeEventListener("abort", handleAbort);
+        resolve(result);
+      },
+      (error: unknown): void => {
+        signal.removeEventListener("abort", handleAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function selectSharedAuthTaskSignal(requestSignal: AbortSignal | null): AbortSignal | null {
+  return indexedDbOpenRecoverySignal ?? requestSignal;
+}
 
 /**
  * A terminal browser-auth failure locks warm start until `/me` confirms which
@@ -234,18 +326,19 @@ export function createApiNetworkRetryDelayMs(attemptCount: number): number {
   return Math.floor(Math.random() * cappedDelayMs);
 }
 
-function waitForApiNetworkRetry(
-  attemptCount: number,
+function waitForTransportDelay(
+  delayMs: number,
   signal: AbortSignal | null,
 ): Promise<void> {
-  const delayMs = createApiNetworkRetryDelayMs(attemptCount);
   return new Promise((resolve, reject) => {
     let timerId: number | null = null;
     const abortHandler = (): void => {
       if (timerId !== null) {
         window.clearTimeout(timerId);
+        timerId = null;
       }
-      reject(signal?.reason);
+      signal?.removeEventListener("abort", abortHandler);
+      reject(signal === null ? new DOMException("Request was aborted", "AbortError") : readAbortError(signal));
     };
     if (signal?.aborted === true) {
       abortHandler();
@@ -254,10 +347,18 @@ function waitForApiNetworkRetry(
 
     timerId = window.setTimeout((): void => {
       signal?.removeEventListener("abort", abortHandler);
+      timerId = null;
       resolve();
     }, delayMs);
     signal?.addEventListener("abort", abortHandler, { once: true });
   });
+}
+
+function waitForApiNetworkRetry(
+  attemptCount: number,
+  signal: AbortSignal | null,
+): Promise<void> {
+  return waitForTransportDelay(createApiNetworkRetryDelayMs(attemptCount), signal);
 }
 
 function warnApiTransportRetry(error: ApiNetworkError): void {
@@ -290,6 +391,7 @@ async function performFetch(
       headers,
     });
   } catch (error) {
+    throwIfRequestAborted(init.signal ?? null);
     throw createFetchApiNetworkError(pathname, init, error, attemptCount);
   }
 }
@@ -303,9 +405,13 @@ async function performWithNetworkRetry<Result>(
   let attemptCount = 1;
 
   while (true) {
+    throwIfRequestAborted(init.signal ?? null);
     try {
-      return await performAttempt(attemptCount);
+      const result = await performAttempt(attemptCount);
+      throwIfRequestAborted(init.signal ?? null);
+      return result;
     } catch (error) {
+      throwIfRequestAborted(init.signal ?? null);
       if (
         error instanceof ApiNetworkError === false
         || error.endpoint !== endpoint
@@ -362,12 +468,19 @@ async function redirectToLogin(prepareForAuthRedirectCallback: PrepareForAuthRed
  * Loads `/me` without attempting another refresh cycle. This function is used
  * only inside auth recovery to ensure a failed refresh cannot recurse forever.
  */
-async function loadSessionInfoWithoutRecovery(networkRetryMode: NetworkRetryMode): Promise<SessionInfo> {
+async function loadSessionInfoWithoutRecovery(
+  networkRetryMode: NetworkRetryMode,
+  signal: AbortSignal | null,
+): Promise<SessionInfo> {
   const session = parseContractResponse(
-    await requestJson("/me", { method: "GET" }, createSkipAuthRecoveryOptions(networkRetryMode)),
+    await requestJson("/me", {
+      method: "GET",
+      ...(signal === null ? {} : { signal }),
+    }, createSkipAuthRecoveryOptions(networkRetryMode)),
     "GET /me",
     parseSessionInfoResponse,
   );
+  throwIfRequestAborted(signal);
   setSessionCsrfToken(session.csrfToken, session.authTransport);
   redirectInFlight = false;
   return session;
@@ -394,8 +507,12 @@ function createRefreshSessionNetworkError(error: unknown): ApiError {
   });
 }
 
-async function createRefreshSessionResponseError(response: Response): Promise<ApiError> {
+async function createRefreshSessionResponseError(
+  response: Response,
+  signal: AbortSignal | null,
+): Promise<ApiError> {
   const payload = await readJsonResponse(response);
+  throwIfRequestAborted(signal);
   const fallbackMessage = typeof payload.value === "string" ? payload.value : `Request failed with status ${response.status}`;
   return new ApiError({
     statusCode: response.status,
@@ -414,32 +531,29 @@ function createRefreshSessionRetryDelay(attemptIndex: number): number {
   return Math.floor(Math.random() * cappedDelayMs);
 }
 
-function waitForRefreshSessionRetry(attemptIndex: number): Promise<void> {
-  const delayMs = createRefreshSessionRetryDelay(attemptIndex);
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, delayMs);
-  });
+function waitForRefreshSessionRetry(attemptIndex: number, signal: AbortSignal | null): Promise<void> {
+  return waitForTransportDelay(createRefreshSessionRetryDelay(attemptIndex), signal);
 }
 
-function waitForRefreshSessionReconciliation(): Promise<void> {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, refreshSessionReconciliationDelayMs);
-  });
+function waitForRefreshSessionReconciliation(signal: AbortSignal | null): Promise<void> {
+  return waitForTransportDelay(refreshSessionReconciliationDelayMs, signal);
 }
 
 async function reconcileRefreshSession(
   networkRetryMode: NetworkRetryMode,
   refreshNetworkError: ApiError,
+  signal: AbortSignal | null,
 ): Promise<void> {
   for (
     let attemptCount = 1;
     attemptCount <= refreshSessionReconciliationMaximumAttemptCount;
     attemptCount += 1
   ) {
-    await waitForRefreshSessionReconciliation();
+    await waitForRefreshSessionReconciliation(signal);
 
     try {
-      await loadSessionInfoWithoutRecovery(networkRetryMode);
+      await loadSessionInfoWithoutRecovery(networkRetryMode, signal);
+      throwIfRequestAborted(signal);
       return;
     } catch (error) {
       if (error instanceof ApiError === false || error.statusCode !== 401) {
@@ -459,35 +573,42 @@ async function reconcileRefreshSession(
  * Calls the auth service refresh endpoint with shared cookies and distinguishes
  * a normal refresh from a session verified after ambiguous network failures.
  */
-async function refreshBrowserSession(networkRetryMode: NetworkRetryMode): Promise<RefreshBrowserSessionResult> {
+async function refreshBrowserSession(
+  networkRetryMode: NetworkRetryMode,
+  signal: AbortSignal | null,
+): Promise<RefreshBrowserSessionResult> {
   const config = getAppConfig();
   let lastNetworkError: ApiError | null = null;
   let networkRejectionCount = 0;
 
   for (let attemptIndex = 0; attemptIndex < refreshSessionMaximumAttemptCount; attemptIndex += 1) {
+    throwIfRequestAborted(signal);
     let response: Response;
 
     try {
       response = await fetch(`${config.authBaseUrl}/api/refresh-session`, {
         method: "POST",
         credentials: "include",
+        ...(signal === null ? {} : { signal }),
       });
     } catch (error) {
+      throwIfRequestAborted(signal);
       lastNetworkError = createRefreshSessionNetworkError(error);
       networkRejectionCount += 1;
       if (hasRemainingRefreshAttempt(attemptIndex)) {
-        await waitForRefreshSessionRetry(attemptIndex);
+        await waitForRefreshSessionRetry(attemptIndex, signal);
         continue;
       }
 
       if (networkRejectionCount === refreshSessionMaximumAttemptCount) {
-        await reconcileRefreshSession(networkRetryMode, lastNetworkError);
+        await reconcileRefreshSession(networkRetryMode, lastNetworkError, signal);
         return "reconciled";
       }
 
       throw lastNetworkError;
     }
 
+    throwIfRequestAborted(signal);
     if (response.ok) {
       return "refreshed";
     }
@@ -498,11 +619,11 @@ async function refreshBrowserSession(networkRetryMode: NetworkRetryMode): Promis
     }
 
     if (isTransientRefreshSessionStatus(response.status) && hasRemainingRefreshAttempt(attemptIndex)) {
-      await waitForRefreshSessionRetry(attemptIndex);
+      await waitForRefreshSessionRetry(attemptIndex, signal);
       continue;
     }
 
-    throw await createRefreshSessionResponseError(response);
+    throw await createRefreshSessionResponseError(response, signal);
   }
 
   if (lastNetworkError !== null) {
@@ -520,9 +641,14 @@ function shouldRetryAfterWeakerSessionRecovery(error: unknown, options: RequestO
   return options.networkRetryMode === "transient" && error instanceof ApiNetworkError;
 }
 
-function startSessionRecovery(options: RequestOptions): Promise<void> {
+function startSessionRecovery(
+  options: RequestOptions,
+  requestSignal: AbortSignal | null,
+): Promise<void> {
+  const authTaskSignal = selectSharedAuthTaskSignal(requestSignal);
   const recoveryTask = (async (): Promise<void> => {
-    const refreshResult = await refreshBrowserSession(options.networkRetryMode);
+    const refreshResult = await refreshBrowserSession(options.networkRetryMode, authTaskSignal);
+    throwIfRequestAborted(authTaskSignal);
     if (refreshResult === "unauthorized") {
       await redirectToLogin(options.prepareForAuthRedirect);
     }
@@ -532,7 +658,8 @@ function startSessionRecovery(options: RequestOptions): Promise<void> {
     }
 
     try {
-      await loadSessionInfoWithoutRecovery(options.networkRetryMode);
+      await loadSessionInfoWithoutRecovery(options.networkRetryMode, authTaskSignal);
+      throwIfRequestAborted(authTaskSignal);
     } catch (error) {
       if (error instanceof ApiError && error.statusCode === 401) {
         await redirectToLogin(options.prepareForAuthRedirect);
@@ -551,22 +678,25 @@ function startSessionRecovery(options: RequestOptions): Promise<void> {
   sessionRecoveryPromise = trackedRecoveryTask;
   sessionRecoveryNetworkRetryMode = options.networkRetryMode;
 
-  return sessionRecoveryPromise;
+  return trackedRecoveryTask;
 }
 
-async function recoverSession(options: RequestOptions): Promise<void> {
+async function recoverSession(
+  options: RequestOptions,
+  requestSignal: AbortSignal | null,
+): Promise<void> {
   while (true) {
     const activeRecovery = sessionRecoveryPromise;
     if (
       activeRecovery !== null
       && canReuseNetworkRetryPromise(sessionRecoveryNetworkRetryMode, options.networkRetryMode)
     ) {
-      return activeRecovery;
+      return waitForSharedTransportTask(activeRecovery, requestSignal);
     }
 
     if (activeRecovery !== null) {
       try {
-        await activeRecovery;
+        await waitForSharedTransportTask(activeRecovery, requestSignal);
         return;
       } catch (error) {
         if (shouldRetryAfterWeakerSessionRecovery(error, options) === false) {
@@ -577,7 +707,7 @@ async function recoverSession(options: RequestOptions): Promise<void> {
       }
     }
 
-    return startSessionRecovery(options);
+    return waitForSharedTransportTask(startSessionRecovery(options, requestSignal), requestSignal);
   }
 }
 
@@ -585,17 +715,22 @@ async function recoverSession(options: RequestOptions): Promise<void> {
  * Reloads the current session-bound CSRF token after another same-site app has
  * rotated the shared session cookie.
  */
-async function recoverSessionCsrf(options: RequestOptions): Promise<void> {
+async function recoverSessionCsrf(
+  options: RequestOptions,
+  requestSignal: AbortSignal | null,
+): Promise<void> {
   const activeRecovery = sessionCsrfRecoveryPromise;
   if (
     activeRecovery !== null
     && canReuseNetworkRetryPromise(sessionCsrfRecoveryNetworkRetryMode, options.networkRetryMode)
   ) {
-    return activeRecovery;
+    return waitForSharedTransportTask(activeRecovery, requestSignal);
   }
 
+  const authTaskSignal = selectSharedAuthTaskSignal(requestSignal);
   const recoveryTask = (async (): Promise<void> => {
-    await loadSessionInfoWithRecovery(options);
+    await loadSessionInfoWithRecovery(options, authTaskSignal);
+    throwIfRequestAborted(authTaskSignal);
   })();
 
   const trackedRecoveryTask = recoveryTask.finally(() => {
@@ -607,16 +742,19 @@ async function recoverSessionCsrf(options: RequestOptions): Promise<void> {
   sessionCsrfRecoveryPromise = trackedRecoveryTask;
   sessionCsrfRecoveryNetworkRetryMode = options.networkRetryMode;
 
-  return sessionCsrfRecoveryPromise;
+  return waitForSharedTransportTask(trackedRecoveryTask, requestSignal);
 }
 
-async function ensureSessionTransportReadyForUnsafeRequest(options: RequestOptions): Promise<void> {
+async function ensureSessionTransportReadyForUnsafeRequest(
+  options: RequestOptions,
+  requestSignal: AbortSignal | null,
+): Promise<void> {
   if (sessionCsrfState !== "unknown") {
     return;
   }
 
   if (sessionRecoveryPromise !== null) {
-    await recoverSession(options);
+    await recoverSession(options, requestSignal);
     return;
   }
 
@@ -625,12 +763,14 @@ async function ensureSessionTransportReadyForUnsafeRequest(options: RequestOptio
     activeBootstrap !== null
     && canReuseNetworkRetryPromise(sessionTransportReadyNetworkRetryMode, options.networkRetryMode)
   ) {
-    await activeBootstrap;
+    await waitForSharedTransportTask(activeBootstrap, requestSignal);
     return;
   }
 
+  const authTaskSignal = selectSharedAuthTaskSignal(requestSignal);
   const readinessTask = (async (): Promise<void> => {
-    await loadSessionInfoWithRecovery(options);
+    await loadSessionInfoWithRecovery(options, authTaskSignal);
+    throwIfRequestAborted(authTaskSignal);
   })();
 
   const trackedReadinessTask = readinessTask.finally(() => {
@@ -641,7 +781,7 @@ async function ensureSessionTransportReadyForUnsafeRequest(options: RequestOptio
   });
   sessionTransportReadyPromise = trackedReadinessTask;
   sessionTransportReadyNetworkRetryMode = options.networkRetryMode;
-  await trackedReadinessTask;
+  await waitForSharedTransportTask(trackedReadinessTask, requestSignal);
 }
 
 /**
@@ -655,12 +795,16 @@ async function requestResponse(
   options: RequestOptions,
   attemptCount: number,
 ): Promise<Response> {
+  const requestSignal = init.signal ?? null;
+  throwIfRequestAborted(requestSignal);
   if (isUnsafeMethod(getMethod(init))) {
-    await ensureSessionTransportReadyForUnsafeRequest(options);
+    await ensureSessionTransportReadyForUnsafeRequest(options, requestSignal);
+    throwIfRequestAborted(requestSignal);
   }
 
   const endpoint = buildSanitizedRequestEndpoint(pathname, init);
   let response: Response = await performFetch(pathname, init, "include", attemptCount);
+  throwIfRequestAborted(requestSignal);
   if (options.authRecoveryMode === "skip") {
     return response;
   }
@@ -674,22 +818,26 @@ async function requestResponse(
       }
 
       didRecoverSession = true;
-      await recoverSession(options);
+      await recoverSession(options, requestSignal);
+      throwIfRequestAborted(requestSignal);
       response = await performFetch(pathname, init, "include", attemptCount);
+      throwIfRequestAborted(requestSignal);
       continue;
     }
 
-    if (
-      didRecoverSessionCsrf === false
-      && isUnsafeMethod(getMethod(init))
-      && await isRecoverableSessionCsrfResponse(response, {
+    const isRecoverableSessionCsrf = didRecoverSessionCsrf === false && isUnsafeMethod(getMethod(init))
+      ? await isRecoverableSessionCsrfResponse(response, {
         attemptCount,
         endpoint,
       })
-    ) {
+      : false;
+    throwIfRequestAborted(requestSignal);
+    if (isRecoverableSessionCsrf) {
       didRecoverSessionCsrf = true;
-      await recoverSessionCsrf(options);
+      await recoverSessionCsrf(options, requestSignal);
+      throwIfRequestAborted(requestSignal);
       response = await performFetch(pathname, init, "include", attemptCount);
+      throwIfRequestAborted(requestSignal);
       continue;
     }
 
@@ -702,12 +850,13 @@ export async function requestJson(
   init: RequestInit,
   options: RequestOptions,
 ): Promise<ParsedResponsePayload> {
-  const endpoint = buildSanitizedRequestEndpoint(pathname, init);
-  return performWithNetworkRetry(endpoint, init, options, async (attemptCount: number) => {
-    const response = await requestResponse(pathname, init, options, attemptCount);
+  const requestInit = attachRecoverySignal(init);
+  const endpoint = buildSanitizedRequestEndpoint(pathname, requestInit);
+  return performWithNetworkRetry(endpoint, requestInit, options, async (attemptCount: number) => {
+    const response = await requestResponse(pathname, requestInit, options, attemptCount);
     return parseJsonPayload(
       response,
-      buildRequestEndpoint(pathname, init),
+      buildRequestEndpoint(pathname, requestInit),
       {
         attemptCount,
         endpoint,
@@ -721,7 +870,7 @@ export async function requestJson(
  * credential-free CORS and intentionally do not participate in auth recovery.
  */
 export async function requestPublicJson(pathname: string): Promise<ParsedResponsePayload> {
-  const init: RequestInit = { method: "GET" };
+  const init = attachRecoverySignal({ method: "GET" });
   const options = skipAuthRecoveryWithTransientNetworkRetry;
   const endpoint = buildSanitizedRequestEndpoint(pathname, init);
   return performWithNetworkRetry(endpoint, init, options, async (attemptCount: number) => {
@@ -742,10 +891,11 @@ export async function requestBlob(
   init: RequestInit,
   options: RequestOptions,
 ): Promise<BlobResponsePayload> {
-  const endpoint = buildRequestEndpoint(pathname, init);
-  const sanitizedEndpoint = buildSanitizedRequestEndpoint(pathname, init);
-  return performWithNetworkRetry(sanitizedEndpoint, init, options, async (attemptCount: number) => {
-    const response = await requestResponse(pathname, init, options, attemptCount);
+  const requestInit = attachRecoverySignal(init);
+  const endpoint = buildRequestEndpoint(pathname, requestInit);
+  const sanitizedEndpoint = buildSanitizedRequestEndpoint(pathname, requestInit);
+  return performWithNetworkRetry(sanitizedEndpoint, requestInit, options, async (attemptCount: number) => {
+    const response = await requestResponse(pathname, requestInit, options, attemptCount);
     if (!response.ok) {
       await parseJsonPayload(response, endpoint, {
         attemptCount,
@@ -770,12 +920,12 @@ export async function requestBlob(
  * CSRF token when the backend authenticates the request via shared cookies.
  */
 export async function getSession(): Promise<SessionInfo> {
-  return loadSessionInfoWithRecovery(allowAuthRecoveryWithTransientNetworkRetry);
+  return loadSessionInfoWithRecovery(allowAuthRecoveryWithTransientNetworkRetry, null);
 }
 
 export async function getOptionalSession(): Promise<SessionInfo | null> {
   try {
-    return await loadSessionInfoWithoutRecovery("transient");
+    return await loadSessionInfoWithoutRecovery("transient", null);
   } catch (error) {
     if (error instanceof ApiError && error.statusCode === 401) {
       return null;
@@ -790,17 +940,22 @@ export async function getOptionalSession(): Promise<SessionInfo | null> {
  * UI state. Callers should use this on tab resume before background sync.
  */
 export async function revalidateSession(): Promise<SessionInfo> {
-  return loadSessionInfoWithRecovery(allowAuthRecoveryWithTransientNetworkRetry);
+  return loadSessionInfoWithRecovery(allowAuthRecoveryWithTransientNetworkRetry, null);
 }
 
 /**
  * Loads `/me` through the normal request pipeline so the API layer can recover
  * from one expired session token without forcing a full page reload.
  */
-async function loadSessionInfoWithRecovery(options: RequestOptions): Promise<SessionInfo> {
+async function loadSessionInfoWithRecovery(
+  options: RequestOptions,
+  signal: AbortSignal | null,
+): Promise<SessionInfo> {
   const session = parseContractResponse(await requestJson("/me", {
     method: "GET",
+    ...(signal === null ? {} : { signal }),
   }, options), "GET /me", parseSessionInfoResponse);
+  throwIfRequestAborted(signal);
   setSessionCsrfToken(session.csrfToken, session.authTransport);
   redirectInFlight = false;
   return session;

--- a/apps/web/src/appData/context/provider.tsx
+++ b/apps/web/src/appData/context/provider.tsx
@@ -10,10 +10,7 @@ import {
   type SetStateAction,
 } from "react";
 import { revalidateSession } from "../../api";
-import {
-  ownsIndexedDbOpenRecoveryFailure,
-  useAppErrorDialog,
-} from "../../appError/AppErrorContext";
+import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
 import { loadActiveCardCount } from "../../localDb/cards/cards";
 import type {
@@ -88,7 +85,7 @@ function resolveTechnicalErrorAction(
 export function AppDataProvider(props: Props): ReactElement {
   const { children } = props;
   const { t } = useI18n();
-  const { indexedDbOpenRecoveryState, showCapturedTechnicalError, showTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   useProgressInvalidationRefresh();
   const [warmStartSnapshot] = useState(loadWarmStartSnapshot);
   const [sessionLoadState, setSessionLoadState] = useState<SessionLoadState>(
@@ -146,10 +143,10 @@ export function AppDataProvider(props: Props): ReactElement {
 
   const setSessionTechnicalError = useCallback<Dispatch<SetStateAction<Error | null>>>((nextErrorAction): void => {
     const nextError = resolveTechnicalErrorAction(sessionTechnicalErrorRef.current, nextErrorAction);
-    if (
-      indexedDbOpenRecoveryState.hasFailed()
-      && (nextError === null || ownsIndexedDbOpenRecoveryFailure(indexedDbOpenRecoveryState.markFailed(nextError)) === false)
-    ) {
+    if (nextError !== null) {
+      indexedDbOpenRecoveryState.markFailed(nextError);
+    }
+    if (indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -159,10 +156,10 @@ export function AppDataProvider(props: Props): ReactElement {
 
   const setTechnicalError = useCallback<Dispatch<SetStateAction<Error | null>>>((nextErrorAction): void => {
     const nextError = resolveTechnicalErrorAction(technicalErrorRef.current, nextErrorAction);
-    if (
-      indexedDbOpenRecoveryState.hasFailed()
-      && (nextError === null || ownsIndexedDbOpenRecoveryFailure(indexedDbOpenRecoveryState.markFailed(nextError)) === false)
-    ) {
+    if (nextError !== null) {
+      indexedDbOpenRecoveryState.markFailed(nextError);
+    }
+    if (indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -171,14 +168,20 @@ export function AppDataProvider(props: Props): ReactElement {
   }, [indexedDbOpenRecoveryState]);
 
   const setSessionErrorMessage = useCallback<Dispatch<SetStateAction<string>>>((nextMessageAction): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     setSessionTechnicalError(null);
     setSessionErrorMessageState(nextMessageAction);
-  }, [setSessionTechnicalError]);
+  }, [indexedDbOpenRecoveryState, setSessionTechnicalError]);
 
   const setErrorMessage = useCallback<Dispatch<SetStateAction<string>>>((nextMessageAction): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     setTechnicalError(null);
     setErrorMessageState(nextMessageAction);
-  }, [setTechnicalError]);
+  }, [indexedDbOpenRecoveryState, setTechnicalError]);
 
   useEffect(() => {
     if (sessionLoadState !== "error" || sessionTechnicalError === null) {
@@ -279,25 +282,18 @@ export function AppDataProvider(props: Props): ReactElement {
     }
 
     void refreshLocalCardCount().catch((error: unknown): void => {
-      const markResult = indexedDbOpenRecoveryState.markFailed(error);
-      if (markResult === "not_recovery") {
-        throw error;
+      indexedDbOpenRecoveryState.markFailed(error);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
       }
 
-      showTechnicalError(error, {
-        feature: "sync",
-        operation: "refresh_local_metadata",
-        userId: session?.userId ?? null,
-        workspaceId: activeWorkspace?.workspaceId ?? null,
-        installationId: null,
-        entityId: null,
-      });
+      throw error;
     });
 
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspace, indexedDbOpenRecoveryState, localReadVersion, session?.userId, showTechnicalError]);
+  }, [activeWorkspace, indexedDbOpenRecoveryState, localReadVersion]);
 
   useEffect(() => {
     if (

--- a/apps/web/src/appData/progress/badge/reviewLeaderboardBadge.ts
+++ b/apps/web/src/appData/progress/badge/reviewLeaderboardBadge.ts
@@ -4,6 +4,7 @@ import { useAppData } from "../../context/provider";
 import { useProgressInvalidationState } from "../invalidation/progressInvalidation";
 import { resolveBestLeaderboardPlacement } from "../leaderboardPlacement";
 import { useProgressSource } from "../progressSource";
+import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 
 const EMPTY_REVIEW_LEADERBOARD_BADGE_STATE: ReviewLeaderboardBadgeState = {
   rank: null,
@@ -40,6 +41,7 @@ export function useReviewLeaderboardBadge(): ReviewLeaderboardBadgeState {
     cloudSettings,
     sessionVerificationState,
   } = useAppData();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const { progressLocalVersion, progressServerInvalidationVersion } = useProgressInvalidationState();
   const { progressSourceState, refreshProgress } = useProgressSource({
     activeWorkspace,
@@ -51,6 +53,7 @@ export function useReviewLeaderboardBadge(): ReviewLeaderboardBadgeState {
     progressServerInvalidationVersion,
     leaderboardAutoRefreshEnabled: false,
     canExposeTechnicalErrors: false,
+    indexedDbOpenRecoveryState,
     sections: REVIEW_LEADERBOARD_BADGE_SECTIONS,
   });
 

--- a/apps/web/src/appData/progress/badge/reviewProgressBadge.ts
+++ b/apps/web/src/appData/progress/badge/reviewProgressBadge.ts
@@ -4,6 +4,7 @@ import { createDefaultStreakFreeze } from "../../../progress/streakFreeze";
 import { useProgressInvalidationState } from "../invalidation/progressInvalidation";
 import { useProgressSource } from "../progressSource";
 import { useAppData } from "../../context/provider";
+import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 
 const EMPTY_REVIEW_PROGRESS_BADGE_STATE: ReviewProgressBadgeState = {
   streakDays: 0,
@@ -64,6 +65,7 @@ export function useReviewProgressBadge(): ReviewProgressBadgeState {
     cloudSettings,
     sessionVerificationState,
   } = useAppData();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const { progressLocalVersion, progressServerInvalidationVersion } = useProgressInvalidationState();
   const { progressSourceState } = useProgressSource({
     activeWorkspace,
@@ -75,6 +77,7 @@ export function useReviewProgressBadge(): ReviewProgressBadgeState {
     progressServerInvalidationVersion,
     leaderboardAutoRefreshEnabled: true,
     canExposeTechnicalErrors: false,
+    indexedDbOpenRecoveryState,
     sections: REVIEW_PROGRESS_BADGE_SECTIONS,
   });
 

--- a/apps/web/src/appData/progress/source/pipelines/leaderboardSource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/leaderboardSource.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef } from "react";
 import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../../appError/AppErrorContext";
+import {
   ApiNetworkError,
   loadProgressLeaderboard,
   loadProgressStreakLeaderboard,
@@ -27,6 +31,7 @@ import {
   captureProgressServerLoadError,
   getErrorMessage,
   normalizeProgressSourceError,
+  runRecoveryGuardedProgressLocalRead,
   type ProgressCanLoadServerBaseRef,
   type ProgressScopeKeyRef,
   type ProgressSourceDispatch,
@@ -64,6 +69,7 @@ type ProgressLeaderboardSourcePipelineParams = Readonly<{
   currentScopeKeyRef: ProgressScopeKeyRef;
   dispatch: ProgressSourceDispatch;
   installationId: string | null;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   manualRefreshVersion: number;
   progressLocalVersion: number;
   refreshKey: string | null;
@@ -113,6 +119,7 @@ export function useProgressLeaderboardSourcePipeline(
     currentScopeKeyRef,
     dispatch,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     refreshKey,
@@ -126,6 +133,10 @@ export function useProgressLeaderboardSourcePipeline(
 
   useEffect(() => {
     currentScopeKeyRef.current = scopeKey;
+
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     if (scopeKey === null) {
       dispatch({ type: "leaderboard_scope_reset" });
@@ -154,10 +165,10 @@ export function useProgressLeaderboardSourcePipeline(
         : createProgressStreakLeaderboardSnapshot(persistedStreakLeaderboard, false),
       canRenderServerBase: canLoadServerBaseRef.current,
     });
-  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, scopeKey]);
+  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, scopeKey]);
 
   useEffect(() => {
-    if (scopeKey === null) {
+    if (scopeKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -171,9 +182,13 @@ export function useProgressLeaderboardSourcePipeline(
     const currentSequence = localLoadSequenceRef.current + 1;
     localLoadSequenceRef.current = currentSequence;
 
-    void loadLocalLeaderboardViewerCounts(accessibleWorkspaceIds, new Date()).then((localViewerCounts) => {
+    void runRecoveryGuardedProgressLocalRead(
+      () => loadLocalLeaderboardViewerCounts(accessibleWorkspaceIds, new Date()),
+      indexedDbOpenRecoveryState,
+    ).then((localViewerCounts) => {
       if (
-        currentScopeKeyRef.current !== scopeKey
+        indexedDbOpenRecoveryState.hasFailed()
+        || currentScopeKeyRef.current !== scopeKey
         || localLoadSequenceRef.current !== currentSequence
       ) {
         return;
@@ -186,6 +201,10 @@ export function useProgressLeaderboardSourcePipeline(
         canRenderServerBase: canLoadServerBaseRef.current,
       });
     }).catch((error: unknown) => {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       if (
         currentScopeKeyRef.current !== scopeKey
         || localLoadSequenceRef.current !== currentSequence
@@ -216,6 +235,7 @@ export function useProgressLeaderboardSourcePipeline(
     canExposeTechnicalErrors,
     currentScopeKeyRef,
     dispatch,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     scopeKey,
@@ -226,6 +246,10 @@ export function useProgressLeaderboardSourcePipeline(
     nextRefreshKey: string,
     bypassFreshnessGate: boolean,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     requestedRefreshRequestsRef.current.set(targetScopeKey, {
       refreshKey: nextRefreshKey,
       bypassFreshnessGate,
@@ -269,6 +293,9 @@ export function useProgressLeaderboardSourcePipeline(
 
           try {
             const serverLeaderboard = await loadProgressLeaderboard();
+            if (indexedDbOpenRecoveryState.hasFailed()) {
+              return;
+            }
             const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
               .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
 
@@ -286,6 +313,10 @@ export function useProgressLeaderboardSourcePipeline(
               });
             }
           } catch (error: unknown) {
+            if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+              return;
+            }
+
             const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
               .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
 
@@ -325,13 +356,17 @@ export function useProgressLeaderboardSourcePipeline(
 
     serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
     return refreshPromise;
-  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, installationId]);
 
   const refreshProgressStreakLeaderboard = useCallback<RefreshProgressStreakLeaderboard>(async function refreshProgressStreakLeaderboard(
     targetScopeKey: ProgressScopeKey,
     nextRefreshKey: string,
     bypassFreshnessGate: boolean,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     requestedStreakRefreshRequestsRef.current.set(targetScopeKey, {
       refreshKey: nextRefreshKey,
       bypassFreshnessGate,
@@ -375,6 +410,9 @@ export function useProgressLeaderboardSourcePipeline(
 
           try {
             const serverLeaderboard = await loadProgressStreakLeaderboard();
+            if (indexedDbOpenRecoveryState.hasFailed()) {
+              return;
+            }
             const isCurrentRefreshRequest: boolean = requestedStreakRefreshRequestsRef.current
               .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
 
@@ -392,6 +430,10 @@ export function useProgressLeaderboardSourcePipeline(
               });
             }
           } catch (error: unknown) {
+            if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+              return;
+            }
+
             const isCurrentRefreshRequest: boolean = requestedStreakRefreshRequestsRef.current
               .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
 
@@ -431,14 +473,14 @@ export function useProgressLeaderboardSourcePipeline(
 
     streakServerRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
     return refreshPromise;
-  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, installationId]);
 
   useEffect(() => {
     if (autoRefreshEnabled === false) {
       return;
     }
 
-    if (scopeKey === null || refreshKey === null) {
+    if (scopeKey === null || refreshKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -455,6 +497,7 @@ export function useProgressLeaderboardSourcePipeline(
     }
   }, [
     autoRefreshEnabled,
+    indexedDbOpenRecoveryState,
     refreshKey,
     refreshProgressLeaderboard,
     refreshProgressStreakLeaderboard,

--- a/apps/web/src/appData/progress/source/pipelines/progressSourcePipelineHelpers.ts
+++ b/apps/web/src/appData/progress/source/pipelines/progressSourcePipelineHelpers.ts
@@ -1,4 +1,5 @@
 import type { Dispatch, MutableRefObject } from "react";
+import type { IndexedDbOpenRecoveryState } from "../../../../appError/AppErrorContext";
 import {
   ApiContractError,
   ApiError,
@@ -31,6 +32,23 @@ export type ProgressLocalLoadOperation =
   | "progress_series_local_load"
   | "progress_review_schedule_local_load"
   | "progress_leaderboard_local_load";
+
+export async function runRecoveryGuardedProgressLocalRead<ResultType>(
+  createRead: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createRead();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
 
 export type ProgressServerLoadObservationContext = Readonly<{
   operation: ProgressServerLoadOperation;

--- a/apps/web/src/appData/progress/source/pipelines/reviewScheduleSource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/reviewScheduleSource.ts
@@ -1,4 +1,8 @@
 import { useCallback, useEffect, useRef } from "react";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../../appError/AppErrorContext";
 import { loadProgressReviewSchedule } from "../../../../api";
 import {
   calculatePendingProgressReviewScheduleCardTotalDelta,
@@ -22,6 +26,7 @@ import {
   captureProgressServerLoadError,
   getErrorMessage,
   normalizeProgressSourceError,
+  runRecoveryGuardedProgressLocalRead,
   type ProgressCanLoadServerBaseRef,
   type ProgressNumberRef,
   type ProgressScopeKeyRef,
@@ -54,6 +59,7 @@ type ProgressReviewScheduleSourcePipelineParams = Readonly<{
   dispatch: ProgressSourceDispatch;
   input: ProgressReviewScheduleInput;
   installationId: string | null;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   manualRefreshVersion: number;
   progressScheduleLocalVersion: number;
   progressScheduleLocalVersionRef: ProgressNumberRef;
@@ -74,6 +80,7 @@ export function useProgressReviewScheduleSourcePipeline(
     dispatch,
     input,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressScheduleLocalVersion,
     progressScheduleLocalVersionRef,
@@ -86,6 +93,10 @@ export function useProgressReviewScheduleSourcePipeline(
 
   useEffect(() => {
     currentScopeKeyRef.current = scopeKey;
+
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     if (scopeKey === null) {
       dispatch({ type: "review_schedule_scope_reset" });
@@ -110,13 +121,14 @@ export function useProgressReviewScheduleSourcePipeline(
     canLoadServerBaseRef,
     currentScopeKeyRef,
     dispatch,
+    indexedDbOpenRecoveryState,
     input.timeZone,
     progressScheduleLocalVersionRef,
     scopeKey,
   ]);
 
   useEffect(() => {
-    if (scopeKey === null) {
+    if (scopeKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -124,10 +136,22 @@ export function useProgressReviewScheduleSourcePipeline(
     localLoadSequenceRef.current = currentSequence;
 
     void Promise.all([
-      loadLocalProgressReviewSchedule(accessibleWorkspaceIds, input),
-      hasPendingProgressReviewScheduleCardChanges(accessibleWorkspaceIds),
-      hasCompleteLocalProgressReviewScheduleCoverage(accessibleWorkspaceIds),
-      calculatePendingProgressReviewScheduleCardTotalDelta(accessibleWorkspaceIds),
+      runRecoveryGuardedProgressLocalRead(
+        () => loadLocalProgressReviewSchedule(accessibleWorkspaceIds, input),
+        indexedDbOpenRecoveryState,
+      ),
+      runRecoveryGuardedProgressLocalRead(
+        () => hasPendingProgressReviewScheduleCardChanges(accessibleWorkspaceIds),
+        indexedDbOpenRecoveryState,
+      ),
+      runRecoveryGuardedProgressLocalRead(
+        () => hasCompleteLocalProgressReviewScheduleCoverage(accessibleWorkspaceIds),
+        indexedDbOpenRecoveryState,
+      ),
+      runRecoveryGuardedProgressLocalRead(
+        () => calculatePendingProgressReviewScheduleCardTotalDelta(accessibleWorkspaceIds),
+        indexedDbOpenRecoveryState,
+      ),
     ]).then(([
       localReviewSchedule,
       hasPendingLocalCardChanges,
@@ -135,7 +159,8 @@ export function useProgressReviewScheduleSourcePipeline(
       pendingLocalCardTotalDelta,
     ]) => {
       if (
-        currentScopeKeyRef.current !== scopeKey
+        indexedDbOpenRecoveryState.hasFailed()
+        || currentScopeKeyRef.current !== scopeKey
         || localLoadSequenceRef.current !== currentSequence
       ) {
         return;
@@ -152,6 +177,10 @@ export function useProgressReviewScheduleSourcePipeline(
         canRenderServerBase: canLoadServerBaseRef.current,
       });
     }).catch((error: unknown) => {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       if (
         currentScopeKeyRef.current !== scopeKey
         || localLoadSequenceRef.current !== currentSequence
@@ -184,6 +213,7 @@ export function useProgressReviewScheduleSourcePipeline(
     currentScopeKeyRef,
     dispatch,
     input,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressScheduleLocalVersion,
     scopeKey,
@@ -195,6 +225,10 @@ export function useProgressReviewScheduleSourcePipeline(
     nextRefreshKey: string,
     nextProgressScheduleLocalVersion: number,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     requestedRefreshRequestsRef.current.set(targetScopeKey, {
       refreshKey: nextRefreshKey,
       progressScheduleLocalVersion: nextProgressScheduleLocalVersion,
@@ -221,6 +255,9 @@ export function useProgressReviewScheduleSourcePipeline(
 
           try {
             const serverReviewSchedule = await loadProgressReviewSchedule(refreshInput);
+            if (indexedDbOpenRecoveryState.hasFailed()) {
+              return;
+            }
             const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
               .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
 
@@ -239,6 +276,10 @@ export function useProgressReviewScheduleSourcePipeline(
               });
             }
           } catch (error: unknown) {
+            if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+              return;
+            }
+
             const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
               .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
 
@@ -281,10 +322,10 @@ export function useProgressReviewScheduleSourcePipeline(
 
     serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
     return refreshPromise;
-  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, installationId]);
 
   useEffect(() => {
-    if (scopeKey === null || refreshKey === null) {
+    if (scopeKey === null || refreshKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -299,6 +340,7 @@ export function useProgressReviewScheduleSourcePipeline(
       progressScheduleLocalVersion,
     );
   }, [
+    indexedDbOpenRecoveryState,
     input,
     progressScheduleLocalVersion,
     refreshKey,

--- a/apps/web/src/appData/progress/source/pipelines/seriesSource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/seriesSource.ts
@@ -1,4 +1,8 @@
 import { useCallback, useEffect, useRef } from "react";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../../appError/AppErrorContext";
 import { loadProgressSeries } from "../../../../api";
 import {
   loadLocalProgressActiveDates,
@@ -24,6 +28,7 @@ import {
   captureProgressServerLoadError,
   getErrorMessage,
   normalizeProgressSourceError,
+  runRecoveryGuardedProgressLocalRead,
   type ProgressCanLoadServerBaseRef,
   type ProgressScopeKeyRef,
   type ProgressSourceDispatch,
@@ -49,6 +54,7 @@ type ProgressSeriesSourcePipelineParams = Readonly<{
   dispatch: ProgressSourceDispatch;
   input: ProgressSeriesInput;
   installationId: string | null;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   manualRefreshVersion: number;
   progressLocalVersion: number;
   refreshKey: string | null;
@@ -68,6 +74,7 @@ export function useProgressSeriesSourcePipeline(
     dispatch,
     input,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     refreshKey,
@@ -79,6 +86,10 @@ export function useProgressSeriesSourcePipeline(
 
   useEffect(() => {
     currentScopeKeyRef.current = scopeKey;
+
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     if (scopeKey === null) {
       dispatch({
@@ -98,10 +109,10 @@ export function useProgressSeriesSourcePipeline(
       serverBase: persistedSeries === null ? null : createProgressSeriesSnapshot(persistedSeries, "server", false),
       canRenderServerBase: canLoadServerBaseRef.current,
     });
-  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, scopeKey]);
+  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, scopeKey]);
 
   useEffect(() => {
-    if (scopeKey === null) {
+    if (scopeKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -109,11 +120,24 @@ export function useProgressSeriesSourcePipeline(
     localLoadSequenceRef.current = currentSequence;
 
     void Promise.all([
-      loadLocalProgressDailyReviews(accessibleWorkspaceIds, input),
-      loadLocalProgressActiveDates(accessibleWorkspaceIds, input.timeZone),
-      loadPendingProgressDailyReviews(accessibleWorkspaceIds, input),
+      runRecoveryGuardedProgressLocalRead(
+        () => loadLocalProgressDailyReviews(accessibleWorkspaceIds, input),
+        indexedDbOpenRecoveryState,
+      ),
+      runRecoveryGuardedProgressLocalRead(
+        () => loadLocalProgressActiveDates(accessibleWorkspaceIds, input.timeZone),
+        indexedDbOpenRecoveryState,
+      ),
+      runRecoveryGuardedProgressLocalRead(
+        () => loadPendingProgressDailyReviews(accessibleWorkspaceIds, input),
+        indexedDbOpenRecoveryState,
+      ),
     ]).then(([localDailyReviews, localActiveDates, pendingLocalDailyReviews]) => {
-      if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
+      if (
+        indexedDbOpenRecoveryState.hasFailed()
+        || currentScopeKeyRef.current !== scopeKey
+        || localLoadSequenceRef.current !== currentSequence
+      ) {
         return;
       }
 
@@ -130,6 +154,10 @@ export function useProgressSeriesSourcePipeline(
         canRenderServerBase: canLoadServerBaseRef.current,
       });
     }).catch((error: unknown) => {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
         return;
       }
@@ -158,6 +186,7 @@ export function useProgressSeriesSourcePipeline(
     currentScopeKeyRef,
     dispatch,
     input,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     scopeKey,
@@ -168,6 +197,10 @@ export function useProgressSeriesSourcePipeline(
     refreshInput: ProgressSeriesInput,
     nextRefreshKey: string,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     requestedRefreshKeysRef.current.set(targetScopeKey, nextRefreshKey);
 
     const inFlightRefresh = serverRefreshPromisesRef.current.get(targetScopeKey);
@@ -191,6 +224,9 @@ export function useProgressSeriesSourcePipeline(
 
           try {
             const serverSeries = normalizeProgressSeries(await loadProgressSeries(refreshInput));
+            if (indexedDbOpenRecoveryState.hasFailed()) {
+              return;
+            }
             const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
               === requestedRefreshKey;
 
@@ -208,6 +244,10 @@ export function useProgressSeriesSourcePipeline(
               });
             }
           } catch (error: unknown) {
+            if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+              return;
+            }
+
             const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
               === requestedRefreshKey;
 
@@ -246,10 +286,10 @@ export function useProgressSeriesSourcePipeline(
 
     serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
     return refreshPromise;
-  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, installationId]);
 
   useEffect(() => {
-    if (scopeKey === null || refreshKey === null) {
+    if (scopeKey === null || refreshKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -258,7 +298,7 @@ export function useProgressSeriesSourcePipeline(
     }
 
     void refreshProgressSeries(scopeKey, input, refreshKey);
-  }, [input, refreshKey, refreshProgressSeries, scopeKey]);
+  }, [indexedDbOpenRecoveryState, input, refreshKey, refreshProgressSeries, scopeKey]);
 
   return {
     refreshProgressSeries,

--- a/apps/web/src/appData/progress/source/pipelines/summarySource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/summarySource.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef } from "react";
 import { loadProgressSummary } from "../../../../api";
 import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../../appError/AppErrorContext";
+import {
   hasPendingProgressReviewEvents,
   loadLocalProgressActiveDates,
   loadLocalProgressSummary,
@@ -21,6 +25,7 @@ import {
   captureProgressServerLoadError,
   getErrorMessage,
   normalizeProgressSourceError,
+  runRecoveryGuardedProgressLocalRead,
   type ProgressCanLoadServerBaseRef,
   type ProgressScopeKeyRef,
   type ProgressSourceDispatch,
@@ -46,6 +51,7 @@ type ProgressSummarySourcePipelineParams = Readonly<{
   dispatch: ProgressSourceDispatch;
   input: ProgressSummaryInput;
   installationId: string | null;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   manualRefreshVersion: number;
   progressLocalVersion: number;
   refreshKey: string | null;
@@ -65,6 +71,7 @@ export function useProgressSummarySourcePipeline(
     dispatch,
     input,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     refreshKey,
@@ -76,6 +83,10 @@ export function useProgressSummarySourcePipeline(
 
   useEffect(() => {
     currentScopeKeyRef.current = scopeKey;
+
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     if (scopeKey === null) {
       dispatch({
@@ -96,10 +107,10 @@ export function useProgressSummarySourcePipeline(
       serverBase: persistedSummary === null ? null : createProgressSummarySnapshot(persistedSummary, "server", false),
       canRenderServerBase: canLoadServerBaseRef.current,
     });
-  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, input.today, scopeKey]);
+  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, input.today, scopeKey]);
 
   useEffect(() => {
-    if (scopeKey === null) {
+    if (scopeKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -107,11 +118,24 @@ export function useProgressSummarySourcePipeline(
     localLoadSequenceRef.current = currentSequence;
 
     void Promise.all([
-      loadLocalProgressSummary(accessibleWorkspaceIds, input),
-      loadLocalProgressActiveDates(accessibleWorkspaceIds, input.timeZone),
-      hasPendingProgressReviewEvents(accessibleWorkspaceIds),
+      runRecoveryGuardedProgressLocalRead(
+        () => loadLocalProgressSummary(accessibleWorkspaceIds, input),
+        indexedDbOpenRecoveryState,
+      ),
+      runRecoveryGuardedProgressLocalRead(
+        () => loadLocalProgressActiveDates(accessibleWorkspaceIds, input.timeZone),
+        indexedDbOpenRecoveryState,
+      ),
+      runRecoveryGuardedProgressLocalRead(
+        () => hasPendingProgressReviewEvents(accessibleWorkspaceIds),
+        indexedDbOpenRecoveryState,
+      ),
     ]).then(([localSummary, localFallbackActiveDates, hasPendingLocalReviews]) => {
-      if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
+      if (
+        indexedDbOpenRecoveryState.hasFailed()
+        || currentScopeKeyRef.current !== scopeKey
+        || localLoadSequenceRef.current !== currentSequence
+      ) {
         return;
       }
 
@@ -129,6 +153,10 @@ export function useProgressSummarySourcePipeline(
         canRenderServerBase: canLoadServerBaseRef.current,
       });
     }).catch((error: unknown) => {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
         return;
       }
@@ -157,6 +185,7 @@ export function useProgressSummarySourcePipeline(
     currentScopeKeyRef,
     dispatch,
     input,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     scopeKey,
@@ -167,6 +196,10 @@ export function useProgressSummarySourcePipeline(
     refreshInput: ProgressSummaryInput,
     nextRefreshKey: string,
   ): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     requestedRefreshKeysRef.current.set(targetScopeKey, nextRefreshKey);
 
     const inFlightRefresh = serverRefreshPromisesRef.current.get(targetScopeKey);
@@ -190,6 +223,9 @@ export function useProgressSummarySourcePipeline(
 
           try {
             const serverSummary = await loadProgressSummary(refreshInput);
+            if (indexedDbOpenRecoveryState.hasFailed()) {
+              return;
+            }
             const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
               === requestedRefreshKey;
 
@@ -207,6 +243,10 @@ export function useProgressSummarySourcePipeline(
               });
             }
           } catch (error: unknown) {
+            if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+              return;
+            }
+
             const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
               === requestedRefreshKey;
 
@@ -245,10 +285,10 @@ export function useProgressSummarySourcePipeline(
 
     serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
     return refreshPromise;
-  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+  }, [activeWorkspaceId, canExposeTechnicalErrors, canLoadServerBaseRef, currentScopeKeyRef, dispatch, indexedDbOpenRecoveryState, installationId]);
 
   useEffect(() => {
-    if (scopeKey === null || refreshKey === null) {
+    if (scopeKey === null || refreshKey === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -257,7 +297,7 @@ export function useProgressSummarySourcePipeline(
     }
 
     void refreshProgressSummary(scopeKey, input, refreshKey);
-  }, [input, refreshKey, refreshProgressSummary, scopeKey]);
+  }, [indexedDbOpenRecoveryState, input, refreshKey, refreshProgressSummary, scopeKey]);
 
   return {
     refreshProgressSummary,

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -42,6 +42,15 @@ import {
 } from "../state/progressScope";
 import { resetProgressTimeContextStateForTests } from "../time/progressTimeContext";
 import type { SessionVerificationState } from "../../session/workspaceSessionTypes";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
+
+const indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState = {
+  hasFailed: () => false,
+  isFailed: false,
+  markFailed: () => "not_recovery",
+  signal: new AbortController().signal,
+  throwIfFailed: () => undefined,
+};
 
 const progressSourceMocks = vi.hoisted(() => ({
   loadProgressSummaryMock: vi.fn<(input: Readonly<{ timeZone: string; today: string }>) => Promise<ProgressSummaryPayload>>(),
@@ -279,6 +288,7 @@ function renderProgressSourceHarness(
       progressServerInvalidationVersion: currentProps.progressServerInvalidationVersion,
       leaderboardAutoRefreshEnabled: true,
       canExposeTechnicalErrors,
+      indexedDbOpenRecoveryState,
       sections: currentProps.sections,
     });
     return null;
@@ -343,6 +353,7 @@ export function renderInvalidationHarness(props: HarnessProps): Readonly<{
       progressServerInvalidationVersion,
       leaderboardAutoRefreshEnabled: true,
       canExposeTechnicalErrors: true,
+      indexedDbOpenRecoveryState,
       sections: currentProps.sections,
     });
     return null;

--- a/apps/web/src/appData/progress/source/useProgressSource.ts
+++ b/apps/web/src/appData/progress/source/useProgressSource.ts
@@ -14,6 +14,7 @@ import type {
   ProgressSummaryInput,
   WorkspaceSummary,
 } from "../../../types";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import {
   buildProgressReviewScheduleInputForDateContext,
   buildProgressSeriesInputForDateContext,
@@ -53,6 +54,7 @@ type UseProgressSourceParams = Readonly<{
   progressServerInvalidationVersion: number;
   leaderboardAutoRefreshEnabled: boolean;
   canExposeTechnicalErrors: boolean;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   sections: ProgressSourceSections;
 }>;
 
@@ -72,6 +74,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     progressServerInvalidationVersion,
     leaderboardAutoRefreshEnabled,
     canExposeTechnicalErrors,
+    indexedDbOpenRecoveryState,
     sections,
   } = params;
   const { includeSummary, includeSeries, includeReviewSchedule, includeLeaderboard } = sections;
@@ -152,6 +155,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     dispatch,
     input: summaryInput,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     refreshKey: summaryRefreshKey,
@@ -167,6 +171,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     dispatch,
     input: seriesInput,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     refreshKey: seriesRefreshKey,
@@ -182,6 +187,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     dispatch,
     input: reviewScheduleInput,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressScheduleLocalVersion,
     progressScheduleLocalVersionRef,
@@ -201,6 +207,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     currentScopeKeyRef: currentLeaderboardScopeKeyRef,
     dispatch,
     installationId,
+    indexedDbOpenRecoveryState,
     manualRefreshVersion,
     progressLocalVersion,
     refreshKey: leaderboardRefreshKey,
@@ -208,6 +215,10 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
   });
 
   const refreshProgress = useCallback(async function refreshProgress(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (
       summaryScopeKey === null
       && seriesScopeKey === null
@@ -292,6 +303,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     await Promise.all(refreshPromises);
   }, [
     canLoadServerBase,
+    indexedDbOpenRecoveryState,
     leaderboardScopeKey,
     progressScheduleLocalVersion,
     progressServerInvalidationVersion,

--- a/apps/web/src/appData/session/actions/useWorkspaceActions.ts
+++ b/apps/web/src/appData/session/actions/useWorkspaceActions.ts
@@ -9,10 +9,7 @@ import {
   resetWorkspaceProgress as resetWorkspaceProgressRequest,
   selectWorkspace,
 } from "../../../api";
-import {
-  ownsIndexedDbOpenRecoveryFailure,
-  type IndexedDbOpenRecoveryState,
-} from "../../../appError/AppErrorContext";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import type { TranslationKey } from "../../../i18n";
 import { captureApiContractError } from "../../../observability/apiContractObservation";
 import { normalizeCaughtError } from "../../../observability/webObservability";
@@ -109,6 +106,8 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
   } = params;
 
   const chooseWorkspace = useCallback(async function chooseWorkspace(workspaceId: string): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
+
     const verifiedSession = requireVerifiedWorkspaceSession(session, sessionVerificationState, t);
 
     setIsChoosingWorkspace(true);
@@ -123,6 +122,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         null,
       ));
       const selectedWorkspace = await selectWorkspace(workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       logWorkspaceTransition("workspace_select_client_succeeded", buildWorkspaceInteractionLogDetails(
         sessionVerificationState,
         verifiedSession,
@@ -132,18 +132,19 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         selectedWorkspace.workspaceId,
         null,
       ));
-      if (indexedDbOpenRecoveryState.hasFailed()) {
-        return;
-      }
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       await activateWorkspace(verifiedSession, availableWorkspaces, selectedWorkspace);
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      const normalizedError = normalizeCaughtError(error);
+      indexedDbOpenRecoveryState.markFailed(normalizedError);
+      indexedDbOpenRecoveryState.throwIfFailed();
+
       if (isAuthRedirectError(error)) {
         return;
       }
 
-      const normalizedError = normalizeCaughtError(error);
-      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceActionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -157,14 +158,12 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
           nextErrorMessage,
         ), normalizedError);
       }
-      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
-        return;
-      }
-
       setErrorMessage(nextErrorMessage);
       setTechnicalError(isExpectedError ? null : normalizedError);
     } finally {
-      setIsChoosingWorkspace(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsChoosingWorkspace(false);
+      }
     }
   }, [
     activateWorkspace,
@@ -181,6 +180,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
   ]);
 
   const createWorkspace = useCallback(async function createWorkspace(name: string): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     const verifiedSession = requireVerifiedWorkspaceSession(session, sessionVerificationState, t);
 
     const trimmedName = name.trim();
@@ -200,6 +200,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         null,
       ));
       const createdWorkspace = await createWorkspaceRequest(trimmedName);
+      indexedDbOpenRecoveryState.throwIfFailed();
       logWorkspaceTransition("workspace_create_client_succeeded", buildWorkspaceInteractionLogDetails(
         sessionVerificationState,
         verifiedSession,
@@ -209,19 +210,19 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         createdWorkspace.workspaceId,
         null,
       ));
-      if (indexedDbOpenRecoveryState.hasFailed()) {
-        return;
-      }
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       const nextWorkspaces = replaceWorkspaceSummary(availableWorkspaces, createdWorkspace);
       await activateWorkspace(verifiedSession, nextWorkspaces, createdWorkspace);
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      const normalizedError = normalizeCaughtError(error);
+      indexedDbOpenRecoveryState.markFailed(normalizedError);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isAuthRedirectError(error)) {
         return;
       }
 
-      const normalizedError = normalizeCaughtError(error);
-      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceActionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -235,15 +236,13 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
           nextErrorMessage,
         ), normalizedError);
       }
-      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
-        throw error;
-      }
-
       setErrorMessage(nextErrorMessage);
       setTechnicalError(isExpectedError ? null : normalizedError);
       throw error;
     } finally {
-      setIsChoosingWorkspace(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsChoosingWorkspace(false);
+      }
     }
   }, [
     activateWorkspace,
@@ -263,6 +262,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     workspaceId: string,
     name: string,
   ): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     const verifiedSession = requireVerifiedWorkspaceSession(session, sessionVerificationState, t);
 
     const trimmedName = name.trim();
@@ -273,6 +273,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     setIsChoosingWorkspace(true);
     try {
       const renamedWorkspace = await renameWorkspaceRequest(workspaceId, trimmedName);
+      indexedDbOpenRecoveryState.throwIfFailed();
       const nextWorkspaces = replaceWorkspaceSummary(availableWorkspaces, renamedWorkspace);
       setAvailableWorkspaces(nextWorkspaces);
       if (activeWorkspace?.workspaceId === workspaceId) {
@@ -283,6 +284,8 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
       }
       setErrorMessage("");
     } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isAuthRedirectError(error)) {
         return;
       }
@@ -296,12 +299,15 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
       });
       throw error;
     } finally {
-      setIsChoosingWorkspace(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsChoosingWorkspace(false);
+      }
     }
   }, [
     activeWorkspace,
     availableWorkspaces,
     cloudSettings?.installationId,
+    indexedDbOpenRecoveryState,
     session,
     sessionVerificationState,
     t,
@@ -315,6 +321,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     workspaceId: string,
     confirmationText: string,
   ): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     const verifiedSession = requireVerifiedWorkspaceSession(session, sessionVerificationState, t);
 
     setIsChoosingWorkspace(true);
@@ -325,14 +332,13 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         availableWorkspaceIds: availableWorkspaces.map((workspace) => workspace.workspaceId),
       });
       const response = await deleteWorkspaceRequest(workspaceId, confirmationText);
+      indexedDbOpenRecoveryState.throwIfFailed();
       logWorkspaceTransition("workspace_delete_client_succeeded", {
         workspaceId,
         deletedWorkspaceId: response.deletedWorkspaceId,
         replacementWorkspaceId: response.workspace.workspaceId,
       });
-      if (indexedDbOpenRecoveryState.hasFailed()) {
-        return;
-      }
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       discardWorkspaceSync(response.deletedWorkspaceId);
       const nextWorkspaces = replaceWorkspaceSummary(
@@ -345,12 +351,13 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         nextWorkspaceIds: nextWorkspaces.map((workspace) => workspace.workspaceId),
       });
       await activateWorkspace(verifiedSession, nextWorkspaces, response.workspace);
-      if (indexedDbOpenRecoveryState.hasFailed()) {
-        return;
-      }
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       setErrorMessage("");
     } catch (error) {
+      const normalizedError = normalizeCaughtError(error);
+      indexedDbOpenRecoveryState.markFailed(normalizedError);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isAuthRedirectError(error)) {
         logWorkspaceTransition("workspace_delete_client_redirected", {
           workspaceId,
@@ -359,8 +366,6 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
         return;
       }
 
-      const normalizedError = normalizeCaughtError(error);
-      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceActionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -369,15 +374,13 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
           errorMessage: nextErrorMessage,
         }, normalizedError);
       }
-      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
-        throw error;
-      }
-
       setErrorMessage(nextErrorMessage);
       setTechnicalError(isExpectedError ? null : normalizedError);
       throw error;
     } finally {
-      setIsChoosingWorkspace(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsChoosingWorkspace(false);
+      }
     }
   }, [
     activateWorkspace,
@@ -395,6 +398,7 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
   const loadWorkspaceResetProgressPreview = useCallback(async function loadWorkspaceResetProgressPreview(
     workspaceId: string,
   ): Promise<WorkspaceResetProgressPreview> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     requireVerifiedWorkspaceSession(session, sessionVerificationState, t);
 
     if (cloudSettings?.cloudState !== "linked") {
@@ -404,23 +408,28 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
     try {
       if (activeWorkspace?.workspaceId === workspaceId) {
         await runSync();
+        indexedDbOpenRecoveryState.throwIfFailed();
       }
       const preview = await loadWorkspaceResetProgressPreviewRequest(workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setErrorMessage("");
       return preview;
     } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isAuthRedirectError(error)) {
         return Promise.reject(error);
       }
 
       throw error;
     }
-  }, [activeWorkspace?.workspaceId, cloudSettings?.cloudState, runSync, session, sessionVerificationState, t, setErrorMessage]);
+  }, [activeWorkspace?.workspaceId, cloudSettings?.cloudState, indexedDbOpenRecoveryState, runSync, session, sessionVerificationState, t, setErrorMessage]);
 
   const resetWorkspaceProgress = useCallback(async function resetWorkspaceProgress(
     workspaceId: string,
     confirmationText: string,
   ): Promise<ResetWorkspaceProgressResponse> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     requireVerifiedWorkspaceSession(session, sessionVerificationState, t);
 
     if (cloudSettings?.cloudState !== "linked") {
@@ -429,19 +438,22 @@ export function useWorkspaceActions(params: UseWorkspaceActionsParams): Workspac
 
     try {
       const response = await resetWorkspaceProgressRequest(workspaceId, confirmationText);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (activeWorkspace?.workspaceId === workspaceId) {
         runWorkspaceActionTaskInBackground(runSync());
       }
       setErrorMessage("");
       return response;
     } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isAuthRedirectError(error)) {
         return Promise.reject(error);
       }
 
       throw error;
     }
-  }, [activeWorkspace?.workspaceId, cloudSettings?.cloudState, runSync, session, sessionVerificationState, t, setErrorMessage]);
+  }, [activeWorkspace?.workspaceId, cloudSettings?.cloudState, indexedDbOpenRecoveryState, runSync, session, sessionVerificationState, t, setErrorMessage]);
 
   return {
     chooseWorkspace,

--- a/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
+++ b/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
@@ -9,11 +9,7 @@ import {
   clearAllLocalBrowserData,
   type LocalBrowserDataCleanupReason,
 } from "../../../accountDeletion";
-import {
-  isIndexedDbOpenRecoveryFailureMark,
-  ownsIndexedDbOpenRecoveryFailure,
-  type IndexedDbOpenRecoveryState,
-} from "../../../appError/AppErrorContext";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import { putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import type {
   SessionInfo,
@@ -80,9 +76,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
   const clearConfirmedUserScopedState = useCallback(async function clearConfirmedUserScopedState(
     reason: LocalBrowserDataCleanupReason,
   ): Promise<void> {
-    if (indexedDbOpenRecoveryState.hasFailed()) {
-      return;
-    }
+    indexedDbOpenRecoveryState.throwIfFailed();
 
     workspaceBootstrapGenerationRef.current += 1;
     deferredBootstrapWorkspaceRef.current = null;
@@ -96,12 +90,11 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     setTechnicalError(null);
     resetUserScopedUiState();
     await discardAllSyncWork(async (): Promise<void> => {
-      if (indexedDbOpenRecoveryState.hasFailed()) {
-        return;
-      }
-
-      await clearAllLocalBrowserData(reason);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      await clearAllLocalBrowserData(reason, indexedDbOpenRecoveryState.throwIfFailed);
+      indexedDbOpenRecoveryState.throwIfFailed();
     });
+    indexedDbOpenRecoveryState.throwIfFailed();
   }, [
     discardAllSyncWork,
     indexedDbOpenRecoveryState,
@@ -210,22 +203,24 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
         });
       } catch (error) {
         const normalizedError = normalizeCaughtError(error);
-        const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
-        if (isIndexedDbOpenRecoveryFailureMark(markResult) === false) {
-          if (isCurrentBootstrapGeneration() === false) {
-            return;
-          }
+        indexedDbOpenRecoveryState.markFailed(normalizedError);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
 
-          if (isAuthRedirectError(error)) {
-            logWorkspaceTransition("workspace_activate_bootstrap_redirected", {
-              workspaceId: workspace.workspaceId,
-              redirected: true,
-              sessionVerificationState,
-              bootstrapPhase,
-            });
-            setSessionLoadState("redirecting");
-            return;
-          }
+        if (isCurrentBootstrapGeneration() === false) {
+          return;
+        }
+
+        if (isAuthRedirectError(error)) {
+          logWorkspaceTransition("workspace_activate_bootstrap_redirected", {
+            workspaceId: workspace.workspaceId,
+            redirected: true,
+            sessionVerificationState,
+            bootstrapPhase,
+          });
+          setSessionLoadState("redirecting");
+          return;
         }
 
         const nextErrorMessage = getErrorMessage(normalizedError);
@@ -238,10 +233,6 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
             bootstrapPhase,
           }, normalizedError);
         }
-        if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
-          return;
-        }
-
         setSessionErrorMessage(nextErrorMessage);
         setErrorMessage(nextErrorMessage);
         setSessionTechnicalError(syncFailureCaptureState === false ? null : normalizedError);
@@ -304,6 +295,7 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
       await putCloudSettings(linkedCloudSettings);
     } catch (error) {
       indexedDbOpenRecoveryState.markFailed(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
       throw error;
     }
     if (indexedDbOpenRecoveryState.hasFailed()) {

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -1,22 +1,24 @@
 import { useCallback, useEffect, useRef } from "react";
 import {
   ApiError,
+  buildLogoutLocalUrl,
   getSession,
   isAuthRedirectError,
   revalidateSession as revalidateSessionRequest,
 } from "../../../api";
 import {
   clearBrowserReauthRequired,
-  consumeAccountDeletedMarker,
+  hasAccountDeletedMarker,
+  isAccountDeletionPending,
+  isAccountDeletionServerConfirmed,
   isBrowserReauthRequired,
+  markAccountDeletionServerConfirmed,
+  removeAccountDeletedMarker,
+  runWithAccountDeletionLock,
+  setAccountDeletionPending,
   type LocalBrowserDataCleanupReason,
 } from "../../../accountDeletion";
-import {
-  isIndexedDbOpenRecoveryFailureMark,
-  ownsIndexedDbOpenRecoveryFailure,
-  type IndexedDbOpenRecoveryMarkResult,
-  type IndexedDbOpenRecoveryState,
-} from "../../../appError/AppErrorContext";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import type { TranslationKey } from "../../../i18n";
 import { loadCloudSettings, putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
@@ -28,9 +30,10 @@ import {
   resolveLocalDataCleanupReasonForVerifiedSession,
 } from "../cloud/workspaceSessionCloud";
 import {
-  consumeLoggedOutMarker,
   createSessionAccountSwitchError,
+  hasLoggedOutMarker,
   isSessionAccountSwitchError,
+  removeLoggedOutMarker,
   resumeRetryCount,
   resumeRetryDelayMs,
   waitForDelay,
@@ -103,6 +106,27 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
   } = params;
   const resumePromiseRef = useRef<Promise<void> | null>(null);
 
+  const resumeConfirmedAccountDeletion = useCallback(async function resumeConfirmedAccountDeletion(): Promise<void> {
+    await runWithAccountDeletionLock(
+      indexedDbOpenRecoveryState.signal,
+      async (): Promise<void> => {
+        indexedDbOpenRecoveryState.throwIfFailed();
+        if (
+          isAccountDeletionPending() === false
+          || isAccountDeletionServerConfirmed() === false
+        ) {
+          return;
+        }
+
+        await clearConfirmedUserScopedState("account_deletion_submit");
+        indexedDbOpenRecoveryState.throwIfFailed();
+        window.location.href = buildLogoutLocalUrl();
+        setAccountDeletionPending(false);
+      },
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+  }, [clearConfirmedUserScopedState, indexedDbOpenRecoveryState]);
+
   const initialize = useCallback(async function initialize(): Promise<void> {
     if (indexedDbOpenRecoveryState.hasFailed()) {
       return;
@@ -130,18 +154,16 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     setTechnicalError(null);
 
     try {
-      if (consumeLoggedOutMarker()) {
+      if (hasLoggedOutMarker()) {
         await clearConfirmedUserScopedState("logout_marker");
-        if (indexedDbOpenRecoveryState.hasFailed()) {
-          return;
-        }
+        indexedDbOpenRecoveryState.throwIfFailed();
+        removeLoggedOutMarker();
       }
 
-      if (consumeAccountDeletedMarker()) {
+      if (hasAccountDeletedMarker()) {
         await clearConfirmedUserScopedState("account_deleted_marker");
-        if (indexedDbOpenRecoveryState.hasFailed()) {
-          return;
-        }
+        indexedDbOpenRecoveryState.throwIfFailed();
+        removeAccountDeletedMarker();
 
         setSession(null);
         setWebObservabilityUser(null);
@@ -152,8 +174,30 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
         return;
       }
 
+      if (isAccountDeletionPending() && isAccountDeletionServerConfirmed()) {
+        await resumeConfirmedAccountDeletion();
+        return;
+      }
+
       const wasBrowserReauthRequired = isBrowserReauthRequired();
-      const currentSession = await getSession();
+      let currentSession: SessionInfo;
+      try {
+        currentSession = await getSession();
+      } catch (error) {
+        if (
+          isAccountDeletionPending()
+          && error instanceof ApiError
+          && error.code === "ACCOUNT_DELETED"
+        ) {
+          markAccountDeletionServerConfirmed();
+          indexedDbOpenRecoveryState.throwIfFailed();
+          await resumeConfirmedAccountDeletion();
+          return;
+        }
+
+        indexedDbOpenRecoveryState.throwIfFailed();
+        throw error;
+      }
       if (indexedDbOpenRecoveryState.hasFailed()) {
         return;
       }
@@ -191,6 +235,12 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
 
       setSessionVerificationState("verified");
     } catch (error) {
+      const normalizedError = normalizeCaughtError(error);
+      indexedDbOpenRecoveryState.markFailed(normalizedError);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       if (isAuthRedirectError(error)) {
         logWorkspaceTransition("session_bootstrap_redirected", {
           redirected: true,
@@ -205,8 +255,6 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
         return;
       }
 
-      const normalizedError = normalizeCaughtError(error);
-      const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const isExpectedError = isExpectedWorkspaceSessionApiError(normalizedError);
       if (isExpectedError === false) {
@@ -215,10 +263,6 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
           sessionVerificationState,
         }, normalizedError);
       }
-      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
-        return;
-      }
-
       setSessionLoadState("error");
       setSessionErrorMessage(nextErrorMessage);
       setSessionTechnicalError(isExpectedError ? null : normalizedError);
@@ -228,6 +272,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     clearConfirmedUserScopedState,
     indexedDbOpenRecoveryState,
     resolveInitialWorkspace,
+    resumeConfirmedAccountDeletion,
     session,
     sessionLoadState,
     sessionVerificationState,
@@ -299,7 +344,8 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
           return false;
         } catch (error) {
           const normalizedError = normalizeCaughtError(error);
-          const markResult = indexedDbOpenRecoveryState.markFailed(normalizedError);
+          indexedDbOpenRecoveryState.markFailed(normalizedError);
+          indexedDbOpenRecoveryState.throwIfFailed();
           const nextErrorMessage = getErrorMessage(normalizedError);
           const isExpectedError = isExpectedWorkspaceSessionApiError(normalizedError);
           if (isExpectedError === false) {
@@ -308,10 +354,6 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
               sessionVerificationState,
             }, normalizedError);
           }
-          if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(markResult) === false) {
-            throw createSessionAccountSwitchError(nextErrorMessage);
-          }
-
           setSessionLoadState("error");
           setSessionErrorMessage(nextErrorMessage);
           setErrorMessage(nextErrorMessage);
@@ -329,6 +371,8 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       setTechnicalError(null);
       return true;
     } catch (error) {
+      indexedDbOpenRecoveryState.markFailed(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isAuthRedirectError(error)) {
         return false;
       }
@@ -382,13 +426,17 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
     trackedResumePromise = (async (): Promise<void> => {
       let attemptNumber = 1;
       let lastError: unknown = null;
-      let lastMarkResult: IndexedDbOpenRecoveryMarkResult = "not_recovery";
 
       while (attemptNumber <= resumeRetryCount) {
         try {
           await runResumeAttempt();
           return;
         } catch (error) {
+          indexedDbOpenRecoveryState.markFailed(error);
+          if (indexedDbOpenRecoveryState.hasFailed()) {
+            return;
+          }
+
           if (isAuthRedirectError(error)) {
             return;
           }
@@ -397,22 +445,22 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
             return;
           }
 
-          lastMarkResult = indexedDbOpenRecoveryState.markFailed(error);
-
           lastError = error;
-          if (isIndexedDbOpenRecoveryFailureMark(lastMarkResult) || attemptNumber === resumeRetryCount) {
-            break;
-          }
-
-          if (indexedDbOpenRecoveryState.hasFailed()) {
+          if (attemptNumber === resumeRetryCount) {
             break;
           }
 
           await waitForDelay(resumeRetryDelayMs);
+          if (indexedDbOpenRecoveryState.hasFailed()) {
+            return;
+          }
           attemptNumber += 1;
         }
       }
 
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       const normalizedError = normalizeCaughtError(lastError);
       const nextErrorMessage = getErrorMessage(normalizedError);
       const syncFailureCaptureState = getSyncFailureObservationCaptureState(normalizedError);
@@ -426,10 +474,6 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
           entityId: null,
         })
         : syncFailureCaptureState;
-      if (indexedDbOpenRecoveryState.hasFailed() && ownsIndexedDbOpenRecoveryFailure(lastMarkResult) === false) {
-        throw normalizedError;
-      }
-
       setErrorMessage(nextErrorMessage);
       setTechnicalError(didCaptureResumeError ? normalizedError : null);
       throw normalizedError;
@@ -444,7 +488,12 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
   }, [activeWorkspace?.workspaceId, indexedDbOpenRecoveryState, runResumeAttempt, session?.userId, setErrorMessage, setTechnicalError]);
 
   useEffect(() => {
-    if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null) {
+    if (
+      indexedDbOpenRecoveryState.isFailed
+      || sessionLoadState !== "ready"
+      || sessionVerificationState !== "verified"
+      || session === null
+    ) {
       return;
     }
 
@@ -475,7 +524,13 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [resumeInBackground, session, sessionLoadState, sessionVerificationState]);
+  }, [
+    indexedDbOpenRecoveryState.isFailed,
+    resumeInBackground,
+    session,
+    sessionLoadState,
+    sessionVerificationState,
+  ]);
 
   return {
     initialize,

--- a/apps/web/src/appData/session/lifecycle/workspaceLifecycleHelpers.ts
+++ b/apps/web/src/appData/session/lifecycle/workspaceLifecycleHelpers.ts
@@ -7,16 +7,19 @@ export type SessionAccountSwitchError = Error & Readonly<{
   name: typeof sessionAccountSwitchErrorName;
 }>;
 
-export function consumeLoggedOutMarker(): boolean {
+export function hasLoggedOutMarker(): boolean {
+  return new URL(window.location.href).searchParams.get("logged_out") === "1";
+}
+
+export function removeLoggedOutMarker(): void {
   const url = new URL(window.location.href);
   if (url.searchParams.get("logged_out") !== "1") {
-    return false;
+    return;
   }
 
   url.searchParams.delete("logged_out");
   const nextUrl = `${url.pathname}${url.search}${url.hash}`;
   window.history.replaceState({}, document.title, nextUrl);
-  return true;
 }
 
 export function createSessionAccountSwitchError(errorMessage: string): SessionAccountSwitchError {

--- a/apps/web/src/appData/session/useWorkspaceSessionTestSupport.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSessionTestSupport.tsx
@@ -20,7 +20,10 @@ import { clearWebSyncCache } from "../../localDb/cache";
 
 const indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState = {
   hasFailed: (): boolean => false,
+  isFailed: false,
   markFailed: () => "not_recovery",
+  signal: new AbortController().signal,
+  throwIfFailed: (): void => {},
 };
 
 const observabilityMocks = vi.hoisted(() => ({

--- a/apps/web/src/appData/sync/engine/useSyncEngine.mediaUploadLifecycle.test.tsx
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.mediaUploadLifecycle.test.tsx
@@ -17,7 +17,10 @@ import { useSyncEngine } from "./useSyncEngine";
 
 const indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState = {
   hasFailed: (): boolean => false,
+  isFailed: false,
   markFailed: () => "not_recovery",
+  signal: new AbortController().signal,
+  throwIfFailed: (): void => {},
 };
 
 const syncEngineMocks = vi.hoisted(() => ({

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -10,7 +10,6 @@ import {
 } from "../../../api";
 import {
   isIndexedDbOpenRecoveryFailureMark,
-  ownsIndexedDbOpenRecoveryFailure,
   type IndexedDbOpenRecoveryMarkResult,
   type IndexedDbOpenRecoveryState,
 } from "../../../appError/AppErrorContext";
@@ -213,6 +212,8 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   const activeWorkspaceRef = useRef<WorkspaceSummary | null>(activeWorkspace);
   const availableWorkspacesRef = useRef<ReadonlyArray<WorkspaceSummary>>(availableWorkspaces);
   const syncPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
+  const syncAbortControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const workspaceSyncGenerationsRef = useRef<Map<string, number>>(new Map());
   const localReadPromisesRef = useRef<Set<Promise<unknown>>>(new Set());
   const localMutationPromisesRef = useRef<Set<Promise<unknown>>>(new Set());
   const mediaUploadPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
@@ -293,6 +294,21 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     return markResult;
   }, [clearAllMediaUploadRetryTimers, indexedDbOpenRecoveryState]);
 
+  const waitForRecoveryGuardedSyncPhase = useCallback(async function waitForRecoveryGuardedSyncPhase<ResultType>(
+    phase: Promise<ResultType>,
+  ): Promise<ResultType> {
+    try {
+      const result = await phase;
+      indexedDbOpenRecoveryState.throwIfFailed();
+      return result;
+    } catch (error) {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      markIndexedDbOpenRecoveryFailure(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      throw error;
+    }
+  }, [indexedDbOpenRecoveryState, markIndexedDbOpenRecoveryFailure]);
+
   const abortAllMediaUploadTransfers = useCallback(function abortAllMediaUploadTransfers(): void {
     for (const controller of mediaUploadAbortControllersRef.current.values()) {
       controller.abort(new Error("Media upload lifecycle was discarded"));
@@ -300,8 +316,71 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     mediaUploadAbortControllersRef.current.clear();
   }, []);
 
+  const abortWorkspaceRemoteSync = useCallback(function abortWorkspaceRemoteSync(
+    workspaceId: string,
+    reason: Error,
+  ): void {
+    const controller = syncAbortControllersRef.current.get(workspaceId);
+    if (controller === undefined) {
+      return;
+    }
+
+    controller.abort(reason);
+    syncAbortControllersRef.current.delete(workspaceId);
+  }, []);
+
+  const abortAllWorkspaceRemoteSyncs = useCallback(function abortAllWorkspaceRemoteSyncs(
+    reason: Error,
+  ): void {
+    for (const controller of syncAbortControllersRef.current.values()) {
+      controller.abort(reason);
+    }
+    syncAbortControllersRef.current.clear();
+  }, []);
+
+  useEffect(() => {
+    if (indexedDbOpenRecoveryState.isFailed === false) {
+      return;
+    }
+
+    let recoveryError: Error;
+    try {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      return;
+    } catch (error) {
+      if (error instanceof Error === false) {
+        throw error;
+      }
+      recoveryError = error;
+    }
+
+    syncGenerationRef.current += 1;
+    abortAllWorkspaceRemoteSyncs(recoveryError);
+    syncPromisesRef.current.clear();
+    syncingWorkspaceIdsRef.current.clear();
+    abortAllMediaUploadTransfers();
+    mediaUploadLifecycleGenerationRef.current += 1;
+    mediaUploadNeedsRunWorkspaceIdsRef.current.clear();
+    clearAllMediaUploadRetryTimers();
+    needsResyncWorkspaceIdsRef.current.clear();
+  }, [
+    abortAllMediaUploadTransfers,
+    abortAllWorkspaceRemoteSyncs,
+    clearAllMediaUploadRetryTimers,
+    indexedDbOpenRecoveryState,
+  ]);
+
   const discardWorkspaceSync = useCallback(function discardWorkspaceSync(workspaceId: string): void {
     discardedSyncWorkspaceIdsRef.current.add(workspaceId);
+    workspaceSyncGenerationsRef.current.set(
+      workspaceId,
+      (workspaceSyncGenerationsRef.current.get(workspaceId) ?? 0) + 1,
+    );
+    abortWorkspaceRemoteSync(
+      workspaceId,
+      new Error(`Workspace remote sync was discarded: workspaceId=${workspaceId}`),
+    );
+    syncPromisesRef.current.delete(workspaceId);
     mediaUploadAbortControllersRef.current.get(workspaceId)?.abort(
       new Error(`Media upload workspace lifecycle was discarded: workspaceId=${workspaceId}`),
     );
@@ -310,14 +389,14 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     needsResyncWorkspaceIdsRef.current.delete(workspaceId);
     syncingWorkspaceIdsRef.current.delete(workspaceId);
     refreshSyncIndicator();
-  }, [clearMediaUploadRetryTimer, refreshSyncIndicator]);
+  }, [abortWorkspaceRemoteSync, clearMediaUploadRetryTimer, refreshSyncIndicator]);
 
   const discardAllSyncWork = useCallback(async function discardAllSyncWork(
     runWhileDiscarding: () => Promise<void>,
   ): Promise<void> {
     const activeDiscard = discardAllSyncWorkPromiseRef.current;
     if (activeDiscard !== null) {
-      return activeDiscard;
+      return waitForRecoveryGuardedSyncPhase(activeDiscard);
     }
 
     const discardTask = (async (): Promise<void> => {
@@ -326,8 +405,9 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       const activeLocalReadTasks = [...localReadPromisesRef.current.values()];
       const activeLocalMutationTasks = [...localMutationPromisesRef.current.values()];
       const activeMediaUploadTasks = [...mediaUploadPromisesRef.current.values()];
-      abortAllMediaUploadTransfers();
       syncGenerationRef.current += 1;
+      abortAllWorkspaceRemoteSyncs(new Error("All workspace remote sync work was discarded"));
+      abortAllMediaUploadTransfers();
       mediaUploadLifecycleGenerationRef.current += 1;
       syncPromisesRef.current.clear();
       mediaUploadPromisesRef.current.clear();
@@ -339,13 +419,13 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       refreshSyncIndicator();
 
       try {
-        await Promise.allSettled([
+        await waitForRecoveryGuardedSyncPhase(Promise.allSettled([
           ...activeSyncTasks,
           ...activeLocalReadTasks,
           ...activeLocalMutationTasks,
           ...activeMediaUploadTasks,
-        ]);
-        await runWhileDiscarding();
+        ]));
+        await waitForRecoveryGuardedSyncPhase(runWhileDiscarding());
       } finally {
         discardAllSyncWorkPromiseRef.current = null;
         isDiscardingAllSyncWorkRef.current = false;
@@ -353,19 +433,29 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     })();
     discardAllSyncWorkPromiseRef.current = discardTask;
     return discardTask;
-  }, [abortAllMediaUploadTransfers, clearAllMediaUploadRetryTimers, refreshSyncIndicator]);
+  }, [abortAllMediaUploadTransfers, abortAllWorkspaceRemoteSyncs, clearAllMediaUploadRetryTimers, refreshSyncIndicator, waitForRecoveryGuardedSyncPhase]);
+
+  const isCurrentWorkspaceSync = useCallback(function isCurrentWorkspaceSync(
+    workspaceId: string,
+    syncGeneration: number,
+    workspaceSyncGeneration: number,
+  ): boolean {
+    return syncGeneration === syncGenerationRef.current
+      && workspaceSyncGeneration === (workspaceSyncGenerationsRef.current.get(workspaceId) ?? 0);
+  }, []);
 
   const requireWorkspaceSyncNotDiscarded = useCallback(function requireWorkspaceSyncNotDiscarded(
     workspaceId: string,
     syncGeneration: number,
+    workspaceSyncGeneration: number,
   ): void {
     if (
-      syncGeneration !== syncGenerationRef.current
+      isCurrentWorkspaceSync(workspaceId, syncGeneration, workspaceSyncGeneration) === false
       || discardedSyncWorkspaceIdsRef.current.has(workspaceId)
     ) {
       throw createWorkspaceSyncDiscardedError(workspaceId);
     }
-  }, []);
+  }, [isCurrentWorkspaceSync]);
 
   const isStaleWorkspaceNotFoundError = useCallback(function isStaleWorkspaceNotFoundError(
     workspaceId: string,
@@ -374,20 +464,39 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     return isWorkspaceNotFoundError(error) && isVisibleWorkspace(workspaceId) === false;
   }, [isVisibleWorkspace]);
 
-  const runLocalDataRead = useCallback(async function runLocalDataRead<ResultType>(
+  const runLocalDataRead = useCallback(function runLocalDataRead<ResultType>(
     createReadTask: () => Promise<ResultType>,
   ): Promise<ResultType> {
     if (isDiscardingAllSyncWorkRef.current) {
       throw new Error("Workspace is unavailable");
     }
 
-    const readTask: Promise<ResultType> = Promise.resolve().then(createReadTask);
-    const trackedReadTask = readTask.finally(() => {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    let readTask: Promise<ResultType>;
+    try {
+      readTask = createReadTask();
+    } catch (error) {
+      markIndexedDbOpenRecoveryFailure(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      throw error;
+    }
+    const guardedReadTask = readTask.then(
+      (result: ResultType): ResultType => {
+        indexedDbOpenRecoveryState.throwIfFailed();
+        return result;
+      },
+      (error: unknown): never => {
+        markIndexedDbOpenRecoveryFailure(error);
+        indexedDbOpenRecoveryState.throwIfFailed();
+        throw error;
+      },
+    );
+    const trackedReadTask = guardedReadTask.finally(() => {
       localReadPromisesRef.current.delete(trackedReadTask);
     });
     localReadPromisesRef.current.add(trackedReadTask);
     return trackedReadTask;
-  }, []);
+  }, [indexedDbOpenRecoveryState, markIndexedDbOpenRecoveryFailure]);
 
   const refreshLocalMetadata = useCallback(async function refreshLocalMetadata(workspaceId: string): Promise<void> {
     if (isDiscardingAllSyncWorkRef.current || indexedDbOpenRecoveryState.hasFailed()) {
@@ -396,8 +505,8 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     const metadataGeneration = syncGenerationRef.current;
     const [workspaceSettings, cloudSettings] = await runLocalDataRead(() => Promise.all([
-      loadWorkspaceSettings(workspaceId),
-      loadCloudSettings(),
+      waitForRecoveryGuardedSyncPhase(loadWorkspaceSettings(workspaceId)),
+      waitForRecoveryGuardedSyncPhase(loadCloudSettings()),
     ])).catch((error: unknown): never => {
       const normalizedError = normalizeCaughtError(error);
       if (isIndexedDbOpenRecoveryFailureMark(markIndexedDbOpenRecoveryFailure(normalizedError))) {
@@ -418,11 +527,11 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     if (isVisibleWorkspace(workspaceId)) {
       setWorkspaceSettings(workspaceSettings);
     }
-  }, [indexedDbOpenRecoveryState, isVisibleWorkspace, markIndexedDbOpenRecoveryFailure, runLocalDataRead, setCloudSettings, setWorkspaceSettings]);
+  }, [indexedDbOpenRecoveryState, isVisibleWorkspace, markIndexedDbOpenRecoveryFailure, runLocalDataRead, setCloudSettings, setWorkspaceSettings, waitForRecoveryGuardedSyncPhase]);
 
   const refreshWorkspaceView = useCallback(async function refreshWorkspaceView(workspaceId: string): Promise<void> {
     const metadataGeneration = syncGenerationRef.current;
-    await refreshLocalMetadata(workspaceId);
+    await waitForRecoveryGuardedSyncPhase(refreshLocalMetadata(workspaceId));
     if (
       metadataGeneration !== syncGenerationRef.current
       || indexedDbOpenRecoveryState.hasFailed()
@@ -433,7 +542,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     if (isVisibleWorkspace(workspaceId)) {
       bumpLocalReadVersion();
     }
-  }, [bumpLocalReadVersion, indexedDbOpenRecoveryState, isVisibleWorkspace, refreshLocalMetadata]);
+  }, [bumpLocalReadVersion, indexedDbOpenRecoveryState, isVisibleWorkspace, refreshLocalMetadata, waitForRecoveryGuardedSyncPhase]);
 
   const publishWorkspaceSettings = useCallback(function publishWorkspaceSettings(
     workspaceId: string,
@@ -445,8 +554,8 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   }, [isVisibleWorkspace, setWorkspaceSettings]);
 
   const reportGlobalSyncError = useCallback(function reportGlobalSyncError(report: SyncFailureReport): void {
-    const markResult = markIndexedDbOpenRecoveryFailure(report.error);
-    if (ownsIndexedDbOpenRecoveryFailure(markResult) === false && indexedDbOpenRecoveryState.hasFailed()) {
+    markIndexedDbOpenRecoveryFailure(report.error);
+    if (indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -467,8 +576,11 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     workspaceId: string,
   ): void {
     const normalizedError = normalizeCaughtError(error);
-    const markResult = markIndexedDbOpenRecoveryFailure(normalizedError);
-    const wasCaptured = captureAppOperationError(normalizedError, {
+    markIndexedDbOpenRecoveryFailure(normalizedError);
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+    captureAppOperationError(normalizedError, {
       feature: "sync",
       operation: "media_upload_transfers",
       userId,
@@ -476,13 +588,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       installationId: null,
       entityId: null,
     });
-    if (isIndexedDbOpenRecoveryFailureMark(markResult)) {
-      reportGlobalSyncError({
-        error: normalizedError,
-        wasCaptured,
-      });
-    }
-  }, [markIndexedDbOpenRecoveryFailure, reportGlobalSyncError]);
+  }, [indexedDbOpenRecoveryState, markIndexedDbOpenRecoveryFailure]);
 
   const readCurrentRunnableMediaUploadSession = useCallback(function readCurrentRunnableMediaUploadSession(
     workspace: WorkspaceSummary,
@@ -513,7 +619,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       return null;
     }
 
-    const cloudSettings = await loadCloudSettings();
+    const cloudSettings = await waitForRecoveryGuardedSyncPhase(loadCloudSettings());
     const verifiedSession = readCurrentRunnableMediaUploadSession(workspace);
     if (
       verifiedSession === null
@@ -523,7 +629,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     return verifiedSession;
-  }, [readCurrentRunnableMediaUploadSession]);
+  }, [readCurrentRunnableMediaUploadSession, waitForRecoveryGuardedSyncPhase]);
 
   const scheduleMediaUploadRetryTimerForWorkspace = useCallback(async function scheduleMediaUploadRetryTimerForWorkspace(
     workspace: WorkspaceSummary,
@@ -533,7 +639,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     const mediaUploadLifecycleGeneration = mediaUploadLifecycleGenerationRef.current;
-    if (await loadRunnableMediaUploadSession(workspace) === null) {
+    if (await waitForRecoveryGuardedSyncPhase(loadRunnableMediaUploadSession(workspace)) === null) {
       return;
     }
 
@@ -541,12 +647,19 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       return;
     }
 
-    const nextAttemptAt = await loadNextPendingMediaTransferAttemptAtByKind(workspace.workspaceId, "upload");
+    const nextAttemptAt = await waitForRecoveryGuardedSyncPhase(
+      loadNextPendingMediaTransferAttemptAtByKind(
+        workspace.workspaceId,
+        "upload",
+        indexedDbOpenRecoveryState,
+      ),
+    );
+    const runnableSession = await waitForRecoveryGuardedSyncPhase(loadRunnableMediaUploadSession(workspace));
     if (
       mediaUploadLifecycleGeneration !== mediaUploadLifecycleGenerationRef.current
       || indexedDbOpenRecoveryState.hasFailed()
       || nextAttemptAt === null
-      || await loadRunnableMediaUploadSession(workspace) === null
+      || runnableSession === null
     ) {
       return;
     }
@@ -574,7 +687,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       runMediaUploadTransfersForWorkspaceRef.current(workspace);
     }, delayMs);
     mediaUploadRetryTimerIdsRef.current.set(workspace.workspaceId, timerId);
-  }, [clearMediaUploadRetryTimer, indexedDbOpenRecoveryState, loadRunnableMediaUploadSession]);
+  }, [clearMediaUploadRetryTimer, indexedDbOpenRecoveryState, loadRunnableMediaUploadSession, waitForRecoveryGuardedSyncPhase]);
 
   const runMediaUploadTransfersForWorkspace = useCallback(function runMediaUploadTransfersForWorkspace(
     workspace: WorkspaceSummary,
@@ -597,9 +710,13 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     const mediaUploadLifecycleGeneration = mediaUploadLifecycleGenerationRef.current;
     const abortController = new AbortController();
+    const mediaUploadSignal = AbortSignal.any([
+      indexedDbOpenRecoveryState.signal,
+      abortController.signal,
+    ]);
     mediaUploadAbortControllersRef.current.set(workspace.workspaceId, abortController);
     const mediaUploadTask = (async (): Promise<void> => {
-      if (await loadRunnableMediaUploadSession(workspace) === null) {
+      if (await waitForRecoveryGuardedSyncPhase(loadRunnableMediaUploadSession(workspace)) === null) {
         return;
       }
 
@@ -607,13 +724,19 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         return;
       }
 
-      await processDueMediaUploadTransfersForWorkspace(
-        workspace.workspaceId,
-        abortController.signal,
-        indexedDbOpenRecoveryState.hasFailed,
+      await waitForRecoveryGuardedSyncPhase(
+        processDueMediaUploadTransfersForWorkspace(
+          workspace.workspaceId,
+          mediaUploadSignal,
+          indexedDbOpenRecoveryState.hasFailed,
+          indexedDbOpenRecoveryState.markFailed,
+          indexedDbOpenRecoveryState.throwIfFailed,
+        ),
       );
     })().catch((error: unknown): never => {
+      indexedDbOpenRecoveryState.throwIfFailed();
       markIndexedDbOpenRecoveryFailure(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
       throw error;
     }).finally(() => {
       if (mediaUploadAbortControllersRef.current.get(workspace.workspaceId) === abortController) {
@@ -655,6 +778,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     readCurrentRunnableMediaUploadSession,
     reportMediaUploadError,
     scheduleMediaUploadRetryTimerForWorkspace,
+    waitForRecoveryGuardedSyncPhase,
   ]);
 
   useEffect(() => {
@@ -665,13 +789,18 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     isSyncEngineMountedRef.current = true;
     return () => {
       isSyncEngineMountedRef.current = false;
+      syncGenerationRef.current += 1;
+      abortAllWorkspaceRemoteSyncs(new Error("Workspace remote sync stopped because the sync engine unmounted"));
+      syncPromisesRef.current.clear();
+      syncingWorkspaceIdsRef.current.clear();
+      needsResyncWorkspaceIdsRef.current.clear();
       abortAllMediaUploadTransfers();
       mediaUploadLifecycleGenerationRef.current += 1;
       mediaUploadPromisesRef.current.clear();
       mediaUploadNeedsRunWorkspaceIdsRef.current.clear();
       clearAllMediaUploadRetryTimers();
     };
-  }, [abortAllMediaUploadTransfers, clearAllMediaUploadRetryTimers]);
+  }, [abortAllMediaUploadTransfers, abortAllWorkspaceRemoteSyncs, clearAllMediaUploadRetryTimers]);
 
   useEffect(() => () => {
     if (activeWorkspaceId !== null) {
@@ -683,14 +812,15 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     workspaceId: string,
   ): Promise<void> {
     while (true) {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const activeSync = syncPromisesRef.current.get(workspaceId);
       if (activeSync === undefined) {
         return;
       }
 
-      await activeSync;
+      await waitForRecoveryGuardedSyncPhase(activeSync);
     }
-  }, []);
+  }, [indexedDbOpenRecoveryState, waitForRecoveryGuardedSyncPhase]);
 
   const runSyncForWorkspaceInternal = useCallback(async function runSyncForWorkspaceInternal(
     workspace: WorkspaceSummary,
@@ -709,6 +839,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     const workspaceId = workspace.workspaceId;
     const syncGeneration = syncGenerationRef.current;
+    const workspaceSyncGeneration = workspaceSyncGenerationsRef.current.get(workspaceId) ?? 0;
     if (discardedSyncWorkspaceIdsRef.current.has(workspaceId)) {
       return;
     }
@@ -716,17 +847,24 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     const activeSync = syncPromisesRef.current.get(workspaceId);
     if (activeSync !== undefined) {
       needsResyncWorkspaceIdsRef.current.add(workspaceId);
-      return activeSync;
+      return waitForRecoveryGuardedSyncPhase(activeSync);
     }
 
     syncingWorkspaceIdsRef.current.add(workspaceId);
     refreshSyncIndicator();
+    const syncAbortController = new AbortController();
+    const syncSignal = AbortSignal.any([
+      indexedDbOpenRecoveryState.signal,
+      syncAbortController.signal,
+    ]);
+    syncAbortControllersRef.current.set(workspaceId, syncAbortController);
 
-    const syncTask = (async (): Promise<void> => {
+    let syncTask: Promise<void>;
+    syncTask = (async (): Promise<void> => {
       let syncInstallationId: string | null = null;
       const syncRunId = createSyncRunId();
       const requireCurrentWorkspaceSync = function requireCurrentWorkspaceSync(currentWorkspaceId: string): void {
-        requireWorkspaceSyncNotDiscarded(currentWorkspaceId, syncGeneration);
+        requireWorkspaceSyncNotDiscarded(currentWorkspaceId, syncGeneration, workspaceSyncGeneration);
       };
       const publishCurrentWorkspaceSettings = function publishCurrentWorkspaceSettings(
         currentWorkspaceId: string,
@@ -737,7 +875,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       };
       const refreshCurrentWorkspaceView = async function refreshCurrentWorkspaceView(currentWorkspaceId: string): Promise<void> {
         requireCurrentWorkspaceSync(currentWorkspaceId);
-        await refreshWorkspaceView(currentWorkspaceId);
+        await waitForRecoveryGuardedSyncPhase(refreshWorkspaceView(currentWorkspaceId));
         requireCurrentWorkspaceSync(currentWorkspaceId);
       };
       const observeAndReportSyncFailure = function observeAndReportSyncFailure(error: Error): Error {
@@ -760,7 +898,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
       try {
         requireCurrentWorkspaceSync(workspaceId);
-        const cloudSettings = await loadCloudSettings();
+        const cloudSettings = await waitForRecoveryGuardedSyncPhase(loadCloudSettings());
         requireCurrentWorkspaceSync(workspaceId);
         if (indexedDbOpenRecoveryState.hasFailed()) {
           return;
@@ -768,23 +906,25 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
         const installationId = requireCloudInstallationId(cloudSettings);
         syncInstallationId = installationId;
-        const syncFlags = await runWorkspaceRemoteSync({
+        const syncFlags = await waitForRecoveryGuardedSyncPhase(runWorkspaceRemoteSync({
           userId: session.userId,
           workspaceId,
           installationId,
           syncRunId,
+          signal: syncSignal,
           hasFailed: indexedDbOpenRecoveryState.hasFailed,
+          indexedDbOpenRecoveryState,
           isOnlyWorkspaceForUser: isOnlyWorkspaceOfAccount(availableWorkspacesRef.current, workspaceId),
           requireWorkspaceSyncNotDiscarded: requireCurrentWorkspaceSync,
           publishWorkspaceSettings: publishCurrentWorkspaceSettings,
           refreshWorkspaceView: refreshCurrentWorkspaceView,
-        });
+        }));
 
         if (indexedDbOpenRecoveryState.hasFailed()) {
           return;
         }
 
-        await refreshCurrentWorkspaceView(workspaceId);
+        await waitForRecoveryGuardedSyncPhase(refreshCurrentWorkspaceView(workspaceId));
         if (indexedDbOpenRecoveryState.hasFailed()) {
           return;
         }
@@ -799,11 +939,10 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         runMediaUploadTransfersForWorkspace(workspace);
       } catch (error) {
         const normalizedError = normalizeCaughtError(error);
-        if (isIndexedDbOpenRecoveryFailureMark(markIndexedDbOpenRecoveryFailure(normalizedError))) {
-          throw observeAndReportSyncFailure(normalizedError);
-        }
+        markIndexedDbOpenRecoveryFailure(normalizedError);
+        indexedDbOpenRecoveryState.throwIfFailed();
 
-        if (syncGeneration !== syncGenerationRef.current) {
+        if (isCurrentWorkspaceSync(workspaceId, syncGeneration, workspaceSyncGeneration) === false) {
           return;
         }
 
@@ -827,8 +966,16 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
         throw observeAndReportSyncFailure(normalizedError);
       } finally {
-        if (syncGeneration === syncGenerationRef.current) {
+        if (syncAbortControllersRef.current.get(workspaceId) === syncAbortController) {
+          syncAbortControllersRef.current.delete(workspaceId);
+        }
+        if (syncPromisesRef.current.get(workspaceId) === syncTask) {
           syncPromisesRef.current.delete(workspaceId);
+        }
+        if (
+          isCurrentWorkspaceSync(workspaceId, syncGeneration, workspaceSyncGeneration)
+          && indexedDbOpenRecoveryState.hasFailed() === false
+        ) {
           syncingWorkspaceIdsRef.current.delete(workspaceId);
           refreshSyncIndicator();
 
@@ -849,6 +996,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     return syncTask;
   }, [
     indexedDbOpenRecoveryState,
+    isCurrentWorkspaceSync,
     markIndexedDbOpenRecoveryFailure,
     publishWorkspaceSettings,
     refreshSyncIndicator,
@@ -858,29 +1006,33 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     session,
     sessionVerificationState,
     isStaleWorkspaceNotFoundError,
+    waitForRecoveryGuardedSyncPhase,
   ]);
 
   const runSyncForWorkspace = useCallback(async function runSyncForWorkspace(
     workspace: WorkspaceSummary,
   ): Promise<void> {
-    await runSyncForWorkspaceInternal(workspace, reportGlobalSyncError);
-  }, [reportGlobalSyncError, runSyncForWorkspaceInternal]);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    await waitForRecoveryGuardedSyncPhase(runSyncForWorkspaceInternal(workspace, reportGlobalSyncError));
+  }, [indexedDbOpenRecoveryState, reportGlobalSyncError, runSyncForWorkspaceInternal, waitForRecoveryGuardedSyncPhase]);
 
   const runSync = useCallback(async function runSync(): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (activeWorkspace === null) {
       return;
     }
 
-    await runSyncForWorkspace(activeWorkspace);
-  }, [activeWorkspace, runSyncForWorkspace]);
+    await waitForRecoveryGuardedSyncPhase(runSyncForWorkspace(activeWorkspace));
+  }, [activeWorkspace, indexedDbOpenRecoveryState, runSyncForWorkspace, waitForRecoveryGuardedSyncPhase]);
 
   const runSyncSilently = useCallback(async function runSyncSilently(): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (activeWorkspace === null) {
       return;
     }
 
-    await runSyncForWorkspaceInternal(activeWorkspace, ignoreSyncError);
-  }, [activeWorkspace, ignoreSyncError, runSyncForWorkspaceInternal]);
+    await waitForRecoveryGuardedSyncPhase(runSyncForWorkspaceInternal(activeWorkspace, ignoreSyncError));
+  }, [activeWorkspace, ignoreSyncError, indexedDbOpenRecoveryState, runSyncForWorkspaceInternal, waitForRecoveryGuardedSyncPhase]);
 
   const runMediaUploadTransfers = useCallback(function runMediaUploadTransfers(): void {
     if (activeWorkspace === null) {
@@ -891,14 +1043,24 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   }, [activeWorkspace, runMediaUploadTransfersForWorkspace]);
 
   useEffect(() => {
-    if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null || activeWorkspace === null) {
+    if (
+      indexedDbOpenRecoveryState.isFailed
+      || sessionLoadState !== "ready"
+      || sessionVerificationState !== "verified"
+      || session === null
+      || activeWorkspace === null
+    ) {
       return;
     }
 
-    void refreshLocalMetadata(activeWorkspace.workspaceId).catch((error: unknown): void => {
+    void waitForRecoveryGuardedSyncPhase(refreshLocalMetadata(activeWorkspace.workspaceId)).catch((error: unknown): void => {
       const normalizedError = normalizeCaughtError(error);
-      const markResult = markIndexedDbOpenRecoveryFailure(normalizedError);
-      const wasCaptured = captureAppOperationError(normalizedError, {
+      markIndexedDbOpenRecoveryFailure(normalizedError);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
+      captureAppOperationError(normalizedError, {
         feature: "sync",
         operation: "refresh_local_metadata",
         userId: session.userId,
@@ -906,29 +1068,30 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         installationId: null,
         entityId: null,
       });
-      if (isIndexedDbOpenRecoveryFailureMark(markResult)) {
-        reportGlobalSyncError({
-          error: normalizedError,
-          wasCaptured,
-        });
-      }
     });
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     runMediaUploadTransfersForWorkspace(activeWorkspace);
   }, [
     activeWorkspace,
+    indexedDbOpenRecoveryState,
     markIndexedDbOpenRecoveryFailure,
     refreshLocalMetadata,
-    reportGlobalSyncError,
     runMediaUploadTransfersForWorkspace,
     runSyncForWorkspace,
     session,
     sessionLoadState,
     sessionVerificationState,
+    waitForRecoveryGuardedSyncPhase,
   ]);
 
   useEffect(() => {
-    if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null || activeWorkspace === null) {
+    if (
+      indexedDbOpenRecoveryState.isFailed
+      || sessionLoadState !== "ready"
+      || sessionVerificationState !== "verified"
+      || session === null
+      || activeWorkspace === null
+    ) {
       return;
     }
 
@@ -940,17 +1103,25 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     return () => {
       window.removeEventListener("online", handleOnline);
     };
-  }, [activeWorkspace, runMediaUploadTransfersForWorkspace, session, sessionLoadState, sessionVerificationState]);
+  }, [
+    activeWorkspace,
+    indexedDbOpenRecoveryState.isFailed,
+    runMediaUploadTransfersForWorkspace,
+    session,
+    sessionLoadState,
+    sessionVerificationState,
+  ]);
 
   const refreshLocalData = useCallback(async function refreshLocalData(): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (activeWorkspace === null) {
       return;
     }
 
-    await refreshWorkspaceView(activeWorkspace.workspaceId);
-    await runSyncForWorkspace(activeWorkspace);
-    await waitForWorkspaceSyncToSettle(activeWorkspace.workspaceId);
-  }, [activeWorkspace, refreshWorkspaceView, runSyncForWorkspace, waitForWorkspaceSyncToSettle]);
+    await waitForRecoveryGuardedSyncPhase(refreshWorkspaceView(activeWorkspace.workspaceId));
+    await waitForRecoveryGuardedSyncPhase(runSyncForWorkspace(activeWorkspace));
+    await waitForRecoveryGuardedSyncPhase(waitForWorkspaceSyncToSettle(activeWorkspace.workspaceId));
+  }, [activeWorkspace, indexedDbOpenRecoveryState, refreshWorkspaceView, runSyncForWorkspace, waitForRecoveryGuardedSyncPhase, waitForWorkspaceSyncToSettle]);
 
   const getCardById = useCallback(async function getCardById(cardId: string): Promise<Card> {
     if (activeWorkspace === null) {
@@ -972,120 +1143,164 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     if (isDiscardingAllSyncWorkRef.current) {
       throw new Error("Workspace is unavailable");
     }
-  }, []);
 
-  const runLocalWorkspaceMutation = useCallback(async function runLocalWorkspaceMutation<T>(
+    indexedDbOpenRecoveryState.throwIfFailed();
+  }, [indexedDbOpenRecoveryState]);
+
+  const runLocalWorkspaceMutation = useCallback(function runLocalWorkspaceMutation<T>(
     createMutationTask: () => Promise<T>,
   ): Promise<T> {
     requireLocalWorkspaceMutationReady();
-    const mutationTask = createMutationTask();
-    const trackedMutationTask = mutationTask.finally(() => {
+    let mutationTask: Promise<T>;
+    try {
+      mutationTask = createMutationTask();
+    } catch (error) {
+      markIndexedDbOpenRecoveryFailure(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      throw error;
+    }
+    const guardedMutationTask = mutationTask.then(
+      (result: T): T => {
+        indexedDbOpenRecoveryState.throwIfFailed();
+        return result;
+      },
+      (error: unknown): never => {
+        markIndexedDbOpenRecoveryFailure(error);
+        indexedDbOpenRecoveryState.throwIfFailed();
+        throw error;
+      },
+    );
+    const trackedMutationTask = guardedMutationTask.finally(() => {
       localMutationPromisesRef.current.delete(trackedMutationTask);
     });
     localMutationPromisesRef.current.add(trackedMutationTask);
     return trackedMutationTask;
-  }, [requireLocalWorkspaceMutationReady]);
+  }, [indexedDbOpenRecoveryState, markIndexedDbOpenRecoveryFailure, requireLocalWorkspaceMutationReady]);
 
   const createCardItem = useCallback(async function createCardItem(input: CreateCardInput): Promise<Card> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await runLocalWorkspaceMutation(() => createCardLocally({
-      workspaceId: activeWorkspaceId,
-      input,
-      clientUpdatedAt: nowIso(),
-    }));
+    const mutationResult = await runLocalWorkspaceMutation(() => createCardLocally(
+      {
+        workspaceId: activeWorkspaceId,
+        input,
+        clientUpdatedAt: nowIso(),
+      },
+      indexedDbOpenRecoveryState,
+    ));
+    indexedDbOpenRecoveryState.throwIfFailed();
     bumpLocalReadVersion();
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, indexedDbOpenRecoveryState, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const createDeckItem = useCallback(async function createDeckItem(input: CreateDeckInput): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await runLocalWorkspaceMutation(() => createDeckLocally({
-      workspaceId: activeWorkspaceId,
-      input,
-      clientUpdatedAt: nowIso(),
-    }));
+    const mutationResult = await runLocalWorkspaceMutation(() => createDeckLocally(
+      {
+        workspaceId: activeWorkspaceId,
+        input,
+        clientUpdatedAt: nowIso(),
+      },
+      indexedDbOpenRecoveryState,
+    ));
+    indexedDbOpenRecoveryState.throwIfFailed();
     bumpLocalReadVersion();
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.deck;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, indexedDbOpenRecoveryState, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const updateCardItem = useCallback(async function updateCardItem(cardId: string, input: UpdateCardInput): Promise<Card> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await runLocalWorkspaceMutation(() => updateCardLocally({
-      workspaceId: activeWorkspaceId,
-      cardId,
-      input,
-      clientUpdatedAt: nowIso(),
-    }));
+    const mutationResult = await runLocalWorkspaceMutation(() => updateCardLocally(
+      {
+        workspaceId: activeWorkspaceId,
+        cardId,
+        input,
+        clientUpdatedAt: nowIso(),
+      },
+      indexedDbOpenRecoveryState,
+    ));
+    indexedDbOpenRecoveryState.throwIfFailed();
     bumpLocalReadVersion();
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, indexedDbOpenRecoveryState, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const updateDeckItem = useCallback(async function updateDeckItem(deckId: string, input: UpdateDeckInput): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await runLocalWorkspaceMutation(() => updateDeckLocally({
-      workspaceId: activeWorkspaceId,
-      deckId,
-      input,
-      clientUpdatedAt: nowIso(),
-    }));
+    const mutationResult = await runLocalWorkspaceMutation(() => updateDeckLocally(
+      {
+        workspaceId: activeWorkspaceId,
+        deckId,
+        input,
+        clientUpdatedAt: nowIso(),
+      },
+      indexedDbOpenRecoveryState,
+    ));
+    indexedDbOpenRecoveryState.throwIfFailed();
     bumpLocalReadVersion();
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.deck;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, indexedDbOpenRecoveryState, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const deleteCardItem = useCallback(async function deleteCardItem(cardId: string): Promise<Card> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await runLocalWorkspaceMutation(() => deleteCardLocally({
-      workspaceId: activeWorkspaceId,
-      cardId,
-      clientUpdatedAt: nowIso(),
-    }));
+    const mutationResult = await runLocalWorkspaceMutation(() => deleteCardLocally(
+      {
+        workspaceId: activeWorkspaceId,
+        cardId,
+        clientUpdatedAt: nowIso(),
+      },
+      indexedDbOpenRecoveryState,
+    ));
+    indexedDbOpenRecoveryState.throwIfFailed();
     bumpLocalReadVersion();
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, indexedDbOpenRecoveryState, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const deleteDeckItem = useCallback(async function deleteDeckItem(deckId: string): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await runLocalWorkspaceMutation(() => deleteDeckLocally({
-      workspaceId: activeWorkspaceId,
-      deckId,
-      clientUpdatedAt: nowIso(),
-    }));
+    const mutationResult = await runLocalWorkspaceMutation(() => deleteDeckLocally(
+      {
+        workspaceId: activeWorkspaceId,
+        deckId,
+        clientUpdatedAt: nowIso(),
+      },
+      indexedDbOpenRecoveryState,
+    ));
+    indexedDbOpenRecoveryState.throwIfFailed();
     bumpLocalReadVersion();
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.deck;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, indexedDbOpenRecoveryState, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const submitReviewItem = useCallback(async function submitReviewItem(
     cardId: string,
@@ -1097,19 +1312,23 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     const reviewedAtClient = nowIso();
     const reviewedTimeZone = getBrowserTimeZone();
-    const mutationResult = await runLocalWorkspaceMutation(() => submitReviewLocally({
-      workspaceId: activeWorkspaceId,
-      cardId,
-      rating,
-      reviewedAtClient,
-      reviewedTimeZone,
-    }));
+    const mutationResult = await runLocalWorkspaceMutation(() => submitReviewLocally(
+      {
+        workspaceId: activeWorkspaceId,
+        cardId,
+        rating,
+        reviewedAtClient,
+        reviewedTimeZone,
+      },
+      indexedDbOpenRecoveryState,
+    ));
+    indexedDbOpenRecoveryState.throwIfFailed();
     bumpLocalReadVersion();
     invalidateLocalProgress();
     invalidateLocalReviewSchedule();
     runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, indexedDbOpenRecoveryState, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const seedLinkedWorkspace = useCallback(async function seedLinkedWorkspace(
     request: TestSeedRequest,
@@ -1127,15 +1346,19 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     validateSeedRequest(request);
     await runLocalDataRead(() => ensureWorkspaceSeedReady({
+      indexedDbOpenRecoveryState,
       workspace: activeWorkspace,
       waitForWorkspaceSyncToSettle,
       refreshWorkspaceView,
       runSyncForWorkspace,
     }));
+    indexedDbOpenRecoveryState.throwIfFailed();
     const seedMutationResult = await runLocalWorkspaceMutation(() => seedWorkspaceLocally({
+      indexedDbOpenRecoveryState,
       workspaceId: activeWorkspaceId,
       request,
     }));
+    indexedDbOpenRecoveryState.throwIfFailed();
 
     bumpLocalReadVersion();
     if (seedMutationResult.didChangeReviewSchedule) {
@@ -1146,13 +1369,16 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     await runSyncForWorkspace(activeWorkspace);
+    indexedDbOpenRecoveryState.throwIfFailed();
     await waitForWorkspaceSyncToSettle(activeWorkspaceId);
+    indexedDbOpenRecoveryState.throwIfFailed();
 
     return seedMutationResult.seedResult;
   }, [
     activeWorkspace,
     activeWorkspaceId,
     bumpLocalReadVersion,
+    indexedDbOpenRecoveryState,
     refreshWorkspaceView,
     runLocalDataRead,
     runLocalWorkspaceMutation,

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -859,8 +859,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     ]);
     syncAbortControllersRef.current.set(workspaceId, syncAbortController);
 
-    let syncTask: Promise<void>;
-    syncTask = (async (): Promise<void> => {
+    const syncTask = (async (): Promise<void> => {
       let syncInstallationId: string | null = null;
       const syncRunId = createSyncRunId();
       const requireCurrentWorkspaceSync = function requireCurrentWorkspaceSync(currentWorkspaceId: string): void {
@@ -968,8 +967,6 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       } finally {
         if (syncAbortControllersRef.current.get(workspaceId) === syncAbortController) {
           syncAbortControllersRef.current.delete(workspaceId);
-        }
-        if (syncPromisesRef.current.get(workspaceId) === syncTask) {
           syncPromisesRef.current.delete(workspaceId);
         }
         if (

--- a/apps/web/src/appData/sync/local/demoCard.ts
+++ b/apps/web/src/appData/sync/local/demoCard.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../i18n/runtime";
 import { isIndexedDbOpenRecoveryError } from "../../../localDb/core/indexedDbOpenRecovery";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import { nowIso } from "../../domain";
 import {
   createCardLocally,
@@ -34,6 +35,7 @@ type DemoCardText = Readonly<{
 }>;
 
 export type SeedDemoCardInput = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   userId: string;
   workspaceId: string;
   installationId: string;
@@ -91,6 +93,7 @@ function buildDemoCardText(): DemoCardText {
 export async function seedDemoCardForNewWorkspace(
   input: SeedDemoCardInput,
 ): Promise<LocalCardMutationResult | null> {
+  input.indexedDbOpenRecoveryState.throwIfFailed();
   if (
     input.isOnlyWorkspaceForUser !== true
     || input.remoteIsEmpty !== true
@@ -101,16 +104,22 @@ export async function seedDemoCardForNewWorkspace(
 
   try {
     const demoCardText = buildDemoCardText();
-    return await createCardLocally({
-      workspaceId: input.workspaceId,
-      input: {
-        frontText: demoCardText.frontText,
-        backText: demoCardText.backText,
-        tags: [demoCardTag],
+    return await createCardLocally(
+      {
+        workspaceId: input.workspaceId,
+        input: {
+          frontText: demoCardText.frontText,
+          backText: demoCardText.backText,
+          tags: [demoCardTag],
+        },
+        clientUpdatedAt: nowIso(),
       },
-      clientUpdatedAt: nowIso(),
-    });
+      input.indexedDbOpenRecoveryState,
+    );
   } catch (error) {
+    input.indexedDbOpenRecoveryState.throwIfFailed();
+    input.indexedDbOpenRecoveryState.markFailed(error);
+    input.indexedDbOpenRecoveryState.throwIfFailed();
     captureAppOperationError(error, {
       feature: "sync",
       operation: "demo_card_seed",

--- a/apps/web/src/appData/sync/local/syncLocalMutations.ts
+++ b/apps/web/src/appData/sync/local/syncLocalMutations.ts
@@ -36,6 +36,7 @@ import {
   loadRequiredCloudInstallationId,
   requireCloudInstallationId,
 } from "./syncCloudSettings";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 
 export type LocalReviewRating = 0 | 1 | 2 | 3;
 
@@ -113,10 +114,17 @@ export async function requireDeck(workspaceId: string, deckId: string): Promise<
   return deck;
 }
 
-export async function createCardLocally(input: CreateCardLocallyInput): Promise<LocalCardMutationResult> {
+export async function createCardLocally(
+  input: CreateCardLocallyInput,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<LocalCardMutationResult> {
+  indexedDbOpenRecoveryState.throwIfFailed();
   const normalizedInput = normalizeCreateCardInput(input.input);
   const operationId = crypto.randomUUID().toLowerCase();
-  const installationId = await loadRequiredCloudInstallationId();
+  const installationId = await runRecoveryGuardedSyncLocalOperation(
+    loadRequiredCloudInstallationId,
+    indexedDbOpenRecoveryState,
+  );
   const nextCard = buildInitialCard(normalizedInput, input.clientUpdatedAt, installationId, operationId);
   const didChangeReviewSchedule = doesCardMutationAffectReviewSchedule(null, nextCard);
   const nextOutboxRecord: PersistedOutboxRecord = {
@@ -129,8 +137,14 @@ export async function createCardLocally(input: CreateCardLocallyInput): Promise<
     operation: buildCardUpsertOperation(nextCard),
   };
 
-  await putCard(input.workspaceId, nextCard);
-  await putOutboxRecord(nextOutboxRecord);
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putCard(input.workspaceId, nextCard),
+    indexedDbOpenRecoveryState,
+  );
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putOutboxRecord(nextOutboxRecord),
+    indexedDbOpenRecoveryState,
+  );
   return {
     card: nextCard,
     didChangeProgressHistory: false,
@@ -138,10 +152,17 @@ export async function createCardLocally(input: CreateCardLocallyInput): Promise<
   };
 }
 
-export async function createDeckLocally(input: CreateDeckLocallyInput): Promise<LocalDeckMutationResult> {
+export async function createDeckLocally(
+  input: CreateDeckLocallyInput,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<LocalDeckMutationResult> {
+  indexedDbOpenRecoveryState.throwIfFailed();
   const normalizedInput = normalizeCreateDeckInput(input.input);
   const operationId = crypto.randomUUID().toLowerCase();
-  const installationId = await loadRequiredCloudInstallationId();
+  const installationId = await runRecoveryGuardedSyncLocalOperation(
+    loadRequiredCloudInstallationId,
+    indexedDbOpenRecoveryState,
+  );
   const nextDeck = {
     ...buildDeck(normalizedInput, input.clientUpdatedAt, installationId, operationId),
     workspaceId: input.workspaceId,
@@ -155,18 +176,34 @@ export async function createDeckLocally(input: CreateDeckLocallyInput): Promise<
     operation: buildDeckUpsertOperation(nextDeck),
   };
 
-  await putDeck(nextDeck);
-  await putOutboxRecord(nextOutboxRecord);
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putDeck(nextDeck),
+    indexedDbOpenRecoveryState,
+  );
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putOutboxRecord(nextOutboxRecord),
+    indexedDbOpenRecoveryState,
+  );
   return {
     deck: nextDeck,
   };
 }
 
-export async function updateCardLocally(input: UpdateCardLocallyInput): Promise<LocalCardMutationResult> {
-  const existingCard = await requireCard(input.workspaceId, input.cardId);
+export async function updateCardLocally(
+  input: UpdateCardLocallyInput,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<LocalCardMutationResult> {
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const existingCard = await runRecoveryGuardedSyncLocalOperation(
+    () => requireCard(input.workspaceId, input.cardId),
+    indexedDbOpenRecoveryState,
+  );
   const normalizedInput = normalizeUpdateCardInput(input.input);
   const operationId = crypto.randomUUID().toLowerCase();
-  const installationId = await loadRequiredCloudInstallationId();
+  const installationId = await runRecoveryGuardedSyncLocalOperation(
+    loadRequiredCloudInstallationId,
+    indexedDbOpenRecoveryState,
+  );
   const nextCard = buildUpdatedCard(existingCard, normalizedInput, input.clientUpdatedAt, installationId, operationId);
   const didChangeReviewSchedule = doesCardMutationAffectReviewSchedule(existingCard, nextCard);
   const nextOutboxRecord: PersistedOutboxRecord = {
@@ -179,8 +216,14 @@ export async function updateCardLocally(input: UpdateCardLocallyInput): Promise<
     operation: buildCardUpsertOperation(nextCard),
   };
 
-  await putCard(input.workspaceId, nextCard);
-  await putOutboxRecord(nextOutboxRecord);
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putCard(input.workspaceId, nextCard),
+    indexedDbOpenRecoveryState,
+  );
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putOutboxRecord(nextOutboxRecord),
+    indexedDbOpenRecoveryState,
+  );
   return {
     card: nextCard,
     didChangeProgressHistory: false,
@@ -188,11 +231,21 @@ export async function updateCardLocally(input: UpdateCardLocallyInput): Promise<
   };
 }
 
-export async function updateDeckLocally(input: UpdateDeckLocallyInput): Promise<LocalDeckMutationResult> {
-  const existingDeck = await requireDeck(input.workspaceId, input.deckId);
+export async function updateDeckLocally(
+  input: UpdateDeckLocallyInput,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<LocalDeckMutationResult> {
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const existingDeck = await runRecoveryGuardedSyncLocalOperation(
+    () => requireDeck(input.workspaceId, input.deckId),
+    indexedDbOpenRecoveryState,
+  );
   const normalizedInput = normalizeUpdateDeckInput(input.input);
   const operationId = crypto.randomUUID().toLowerCase();
-  const installationId = await loadRequiredCloudInstallationId();
+  const installationId = await runRecoveryGuardedSyncLocalOperation(
+    loadRequiredCloudInstallationId,
+    indexedDbOpenRecoveryState,
+  );
   const nextDeck = buildUpdatedDeck(existingDeck, normalizedInput, input.clientUpdatedAt, installationId, operationId);
   const nextOutboxRecord: PersistedOutboxRecord = {
     operationId,
@@ -203,17 +256,33 @@ export async function updateDeckLocally(input: UpdateDeckLocallyInput): Promise<
     operation: buildDeckUpsertOperation(nextDeck),
   };
 
-  await putDeck(nextDeck);
-  await putOutboxRecord(nextOutboxRecord);
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putDeck(nextDeck),
+    indexedDbOpenRecoveryState,
+  );
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putOutboxRecord(nextOutboxRecord),
+    indexedDbOpenRecoveryState,
+  );
   return {
     deck: nextDeck,
   };
 }
 
-export async function deleteCardLocally(input: DeleteCardLocallyInput): Promise<LocalCardMutationResult> {
-  const existingCard = await requireCard(input.workspaceId, input.cardId);
+export async function deleteCardLocally(
+  input: DeleteCardLocallyInput,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<LocalCardMutationResult> {
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const existingCard = await runRecoveryGuardedSyncLocalOperation(
+    () => requireCard(input.workspaceId, input.cardId),
+    indexedDbOpenRecoveryState,
+  );
   const operationId = crypto.randomUUID().toLowerCase();
-  const installationId = await loadRequiredCloudInstallationId();
+  const installationId = await runRecoveryGuardedSyncLocalOperation(
+    loadRequiredCloudInstallationId,
+    indexedDbOpenRecoveryState,
+  );
   const nextCard = buildDeletedCard(existingCard, input.clientUpdatedAt, installationId, operationId);
   const didChangeReviewSchedule = doesCardMutationAffectReviewSchedule(existingCard, nextCard);
   const nextOutboxRecord: PersistedOutboxRecord = {
@@ -226,8 +295,14 @@ export async function deleteCardLocally(input: DeleteCardLocallyInput): Promise<
     operation: buildCardUpsertOperation(nextCard),
   };
 
-  await putCard(input.workspaceId, nextCard);
-  await putOutboxRecord(nextOutboxRecord);
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putCard(input.workspaceId, nextCard),
+    indexedDbOpenRecoveryState,
+  );
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putOutboxRecord(nextOutboxRecord),
+    indexedDbOpenRecoveryState,
+  );
   return {
     card: nextCard,
     didChangeProgressHistory: false,
@@ -235,10 +310,20 @@ export async function deleteCardLocally(input: DeleteCardLocallyInput): Promise<
   };
 }
 
-export async function deleteDeckLocally(input: DeleteDeckLocallyInput): Promise<LocalDeckMutationResult> {
-  const existingDeck = await requireDeck(input.workspaceId, input.deckId);
+export async function deleteDeckLocally(
+  input: DeleteDeckLocallyInput,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<LocalDeckMutationResult> {
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const existingDeck = await runRecoveryGuardedSyncLocalOperation(
+    () => requireDeck(input.workspaceId, input.deckId),
+    indexedDbOpenRecoveryState,
+  );
   const operationId = crypto.randomUUID().toLowerCase();
-  const installationId = await loadRequiredCloudInstallationId();
+  const installationId = await runRecoveryGuardedSyncLocalOperation(
+    loadRequiredCloudInstallationId,
+    indexedDbOpenRecoveryState,
+  );
   const nextDeck = buildDeletedDeck(existingDeck, input.clientUpdatedAt, installationId, operationId);
   const nextOutboxRecord: PersistedOutboxRecord = {
     operationId,
@@ -249,19 +334,52 @@ export async function deleteDeckLocally(input: DeleteDeckLocallyInput): Promise<
     operation: buildDeckUpsertOperation(nextDeck),
   };
 
-  await putDeck(nextDeck);
-  await putOutboxRecord(nextOutboxRecord);
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putDeck(nextDeck),
+    indexedDbOpenRecoveryState,
+  );
+  await runRecoveryGuardedSyncLocalOperation(
+    () => putOutboxRecord(nextOutboxRecord),
+    indexedDbOpenRecoveryState,
+  );
   return {
     deck: nextDeck,
   };
 }
 
-export async function submitReviewLocally(input: SubmitReviewLocallyInput): Promise<LocalCardMutationResult> {
+async function runRecoveryGuardedSyncLocalOperation<ResultType>(
+  createOperation: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createOperation();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
+
+export async function submitReviewLocally(
+  input: SubmitReviewLocallyInput,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<LocalCardMutationResult> {
   const [existingCard, schedulerSettings, cloudSettings] = await Promise.all([
-    requireCard(input.workspaceId, input.cardId),
-    loadWorkspaceSettings(input.workspaceId),
-    loadCloudSettings(),
+    runRecoveryGuardedSyncLocalOperation(
+      () => requireCard(input.workspaceId, input.cardId),
+      indexedDbOpenRecoveryState,
+    ),
+    runRecoveryGuardedSyncLocalOperation(
+      () => loadWorkspaceSettings(input.workspaceId),
+      indexedDbOpenRecoveryState,
+    ),
+    runRecoveryGuardedSyncLocalOperation(loadCloudSettings, indexedDbOpenRecoveryState),
   ]);
+  indexedDbOpenRecoveryState.throwIfFailed();
   if (schedulerSettings === null) {
     throw new Error("Workspace scheduler settings are not loaded");
   }
@@ -316,9 +434,13 @@ export async function submitReviewLocally(input: SubmitReviewLocallyInput): Prom
   };
 
   await putReviewEvent(nextReviewEvent);
+  indexedDbOpenRecoveryState.throwIfFailed();
   await putCard(input.workspaceId, nextCard);
+  indexedDbOpenRecoveryState.throwIfFailed();
   await putOutboxRecord(reviewEventOutboxRecord);
+  indexedDbOpenRecoveryState.throwIfFailed();
   await putOutboxRecord(cardOutboxRecord);
+  indexedDbOpenRecoveryState.throwIfFailed();
   return {
     card: nextCard,
     didChangeProgressHistory: true,

--- a/apps/web/src/appData/sync/local/syncSeed.ts
+++ b/apps/web/src/appData/sync/local/syncSeed.ts
@@ -14,6 +14,7 @@ import {
   createCardLocally,
   submitReviewLocally,
 } from "./syncLocalMutations";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 
 const deterministicSeedReviewTimeZone = "UTC";
 
@@ -24,6 +25,7 @@ export type WorkspaceSeedReadiness = Readonly<{
 }>;
 
 export type EnsureWorkspaceSeedReadyInput = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   workspace: WorkspaceSummary;
   waitForWorkspaceSyncToSettle: (workspaceId: string) => Promise<void>;
   refreshWorkspaceView: (workspaceId: string) => Promise<void>;
@@ -31,6 +33,7 @@ export type EnsureWorkspaceSeedReadyInput = Readonly<{
 }>;
 
 export type SeedWorkspaceLocallyInput = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   workspaceId: string;
   request: TestSeedRequest;
 }>;
@@ -80,12 +83,33 @@ function isWorkspaceSeedReady(readiness: WorkspaceSeedReadiness): boolean {
   return readiness.workspaceSettingsLoaded && readiness.hotStateHydrated && readiness.reviewHistoryHydrated;
 }
 
-async function loadWorkspaceSeedReadiness(workspaceId: string): Promise<WorkspaceSeedReadiness> {
+async function runRecoveryGuardedSeedRead<ResultType>(
+  createRead: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createRead();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
+
+async function loadWorkspaceSeedReadiness(
+  workspaceId: string,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<WorkspaceSeedReadiness> {
   const [workspaceSettings, hotStateHydrated, reviewHistoryHydrated] = await Promise.all([
-    loadWorkspaceSettings(workspaceId),
-    hasHydratedHotState(workspaceId),
-    hasHydratedReviewHistory(workspaceId),
+    runRecoveryGuardedSeedRead(() => loadWorkspaceSettings(workspaceId), indexedDbOpenRecoveryState),
+    runRecoveryGuardedSeedRead(() => hasHydratedHotState(workspaceId), indexedDbOpenRecoveryState),
+    runRecoveryGuardedSeedRead(() => hasHydratedReviewHistory(workspaceId), indexedDbOpenRecoveryState),
   ]);
+  indexedDbOpenRecoveryState.throwIfFailed();
 
   return {
     workspaceSettingsLoaded: workspaceSettings !== null,
@@ -95,21 +119,27 @@ async function loadWorkspaceSeedReadiness(workspaceId: string): Promise<Workspac
 }
 
 export async function ensureWorkspaceSeedReady(input: EnsureWorkspaceSeedReadyInput): Promise<void> {
+  input.indexedDbOpenRecoveryState.throwIfFailed();
   const workspaceId = input.workspace.workspaceId;
 
   await input.waitForWorkspaceSyncToSettle(workspaceId);
+  input.indexedDbOpenRecoveryState.throwIfFailed();
 
-  let readiness = await loadWorkspaceSeedReadiness(workspaceId);
+  let readiness = await loadWorkspaceSeedReadiness(workspaceId, input.indexedDbOpenRecoveryState);
   if (isWorkspaceSeedReady(readiness)) {
     await input.refreshWorkspaceView(workspaceId);
+    input.indexedDbOpenRecoveryState.throwIfFailed();
     return;
   }
 
   await input.runSyncForWorkspace(input.workspace);
+  input.indexedDbOpenRecoveryState.throwIfFailed();
   await input.waitForWorkspaceSyncToSettle(workspaceId);
+  input.indexedDbOpenRecoveryState.throwIfFailed();
   await input.refreshWorkspaceView(workspaceId);
+  input.indexedDbOpenRecoveryState.throwIfFailed();
 
-  readiness = await loadWorkspaceSeedReadiness(workspaceId);
+  readiness = await loadWorkspaceSeedReadiness(workspaceId, input.indexedDbOpenRecoveryState);
   if (isWorkspaceSeedReady(readiness)) {
     return;
   }
@@ -124,26 +154,37 @@ export async function ensureWorkspaceSeedReady(input: EnsureWorkspaceSeedReadyIn
 }
 
 export async function seedWorkspaceLocally(input: SeedWorkspaceLocallyInput): Promise<SeedWorkspaceLocallyResult> {
+  input.indexedDbOpenRecoveryState.throwIfFailed();
   validateSeedRequest(input.request);
 
   const seededCards: Array<TestSeedCardResult> = [];
   let didChangeProgressHistory = false;
 
   for (const seedCard of input.request.cards) {
-    let nextCard = (await createCardLocally({
-      workspaceId: input.workspaceId,
-      input: seedCard,
-      clientUpdatedAt: seedCard.createdAt,
-    })).card;
+    input.indexedDbOpenRecoveryState.throwIfFailed();
+    let nextCard = (await createCardLocally(
+      {
+        workspaceId: input.workspaceId,
+        input: seedCard,
+        clientUpdatedAt: seedCard.createdAt,
+      },
+      input.indexedDbOpenRecoveryState,
+    )).card;
+    input.indexedDbOpenRecoveryState.throwIfFailed();
 
     for (const review of seedCard.reviews) {
-      const reviewResult = await submitReviewLocally({
-        workspaceId: input.workspaceId,
-        cardId: nextCard.cardId,
-        rating: review.rating,
-        reviewedAtClient: review.reviewedAtClient,
-        reviewedTimeZone: deterministicSeedReviewTimeZone,
-      });
+      input.indexedDbOpenRecoveryState.throwIfFailed();
+      const reviewResult = await submitReviewLocally(
+        {
+          workspaceId: input.workspaceId,
+          cardId: nextCard.cardId,
+          rating: review.rating,
+          reviewedAtClient: review.reviewedAtClient,
+          reviewedTimeZone: deterministicSeedReviewTimeZone,
+        },
+        input.indexedDbOpenRecoveryState,
+      );
+      input.indexedDbOpenRecoveryState.throwIfFailed();
       nextCard = reviewResult.card;
       if (reviewResult.didChangeProgressHistory) {
         didChangeProgressHistory = true;

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadClaimLifecycle.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadClaimLifecycle.ts
@@ -192,41 +192,100 @@ async function renewUploadTransferClaim(
 
 export function startUploadClaimHeartbeat(
   transfer: MediaTransferQueueRecord,
+  signal: AbortSignal,
   hasFailed: () => boolean,
+  markFailed: (error: unknown) => void,
 ): MediaUploadClaimHeartbeat {
   let claimedAt = requireInProgressUploadClaimedAt(transfer);
   let heartbeatError: unknown = null;
   let renewalTask: Promise<void> = Promise.resolve();
   let didStop = false;
+  let timerId: number | null = null;
   let resolveHeartbeatFailure: (() => void) | null = null;
   const heartbeatFailureController = new AbortController();
   const heartbeatFailurePromise = new Promise<void>((resolve) => {
     resolveHeartbeatFailure = resolve;
   });
 
+  const clearHeartbeatTimer = (): void => {
+    if (timerId === null) {
+      return;
+    }
+
+    window.clearInterval(timerId);
+    timerId = null;
+  };
+
+  const handleLifecycleAbort = (): void => {
+    didStop = true;
+    clearHeartbeatTimer();
+    resolveHeartbeatFailure?.();
+  };
+
   const queueRenewal = (): void => {
-    if (heartbeatError !== null || didStop || hasFailed()) {
+    if (hasFailed()) {
+      handleLifecycleAbort();
+      return;
+    }
+    if (heartbeatError !== null || didStop || signal.aborted) {
       return;
     }
 
     renewalTask = renewalTask
       .then(async (): Promise<void> => {
         if (hasFailed()) {
+          handleLifecycleAbort();
           return;
         }
-        claimedAt = await renewUploadTransferClaim(transfer, claimedAt);
+        if (heartbeatError !== null || didStop || signal.aborted) {
+          return;
+        }
+        const renewedClaimedAt = await renewUploadTransferClaim(transfer, claimedAt);
+        claimedAt = renewedClaimedAt;
+        if (hasFailed()) {
+          handleLifecycleAbort();
+          return;
+        }
+        if (heartbeatError !== null || didStop || signal.aborted) {
+          return;
+        }
       })
       .catch((error: unknown): void => {
-        heartbeatError = error;
-        if (hasFailed() === false && isIndexedDbOpenRecoveryError(error) === false) {
+        if (isIndexedDbOpenRecoveryError(error)) {
+          const wasRecoveryAlreadyActive = hasFailed();
+          markFailed(error);
+          if (wasRecoveryAlreadyActive || didStop || signal.aborted) {
+            handleLifecycleAbort();
+            return;
+          }
+          heartbeatError = error;
+          didStop = true;
+          clearHeartbeatTimer();
           heartbeatFailureController.abort(error);
+          resolveHeartbeatFailure?.();
+          return;
         }
+        if (didStop || signal.aborted) {
+          resolveHeartbeatFailure?.();
+          return;
+        }
+        if (hasFailed()) {
+          handleLifecycleAbort();
+          return;
+        }
+        heartbeatError = error;
+        heartbeatFailureController.abort(error);
         resolveHeartbeatFailure?.();
       });
   };
 
-  const timerId = window.setInterval(queueRenewal, mediaUploadClaimHeartbeatMs);
-  queueRenewal();
+  signal.addEventListener("abort", handleLifecycleAbort, { once: true });
+  if (signal.aborted) {
+    handleLifecycleAbort();
+  } else {
+    timerId = window.setInterval(queueRenewal, mediaUploadClaimHeartbeatMs);
+    queueRenewal();
+  }
 
   return {
     failureSignal: heartbeatFailureController.signal,
@@ -244,8 +303,9 @@ export function startUploadClaimHeartbeat(
     stop: async (): Promise<unknown | null> => {
       if (didStop === false) {
         didStop = true;
-        window.clearInterval(timerId);
       }
+      clearHeartbeatTimer();
+      signal.removeEventListener("abort", handleLifecycleAbort);
 
       await renewalTask;
       return heartbeatError;

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
@@ -272,6 +272,7 @@ async function runMultipartUploadSession(
   markFailed: (error: unknown) => void,
   throwIfFailed: () => void,
 ): Promise<MediaUploadCompletionResult | null> {
+  let hasStartedCompletion = false;
   try {
     const parts = await buildPlannedUploadParts(transfer, uploadSession, verifiedBytes.bytes, hasFailed);
     if (hasFailed() || parts === null) {
@@ -289,6 +290,7 @@ async function runMultipartUploadSession(
     if (hasFailed() || uploadedParts === null) {
       return null;
     }
+    hasStartedCompletion = true;
     const result = await completeMultipartUploadSession(
       transfer,
       uploadSession,
@@ -327,12 +329,14 @@ async function runMultipartUploadSession(
     if (hasFailed()) {
       throw error;
     }
-
     if (
       error instanceof MediaUploadCompletionTerminalError
       || isSameSessionCompletionRetryError(error)
     ) {
       throw error;
+    }
+    if (hasStartedCompletion) {
+      throwIfUploadLifecycleCancelled(signal);
     }
 
     const abortError = await abortUploadSessionAfterFailure(

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
@@ -269,6 +269,8 @@ async function runMultipartUploadSession(
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
   hasFailed: () => boolean,
+  markFailed: (error: unknown) => void,
+  throwIfFailed: () => void,
 ): Promise<MediaUploadCompletionResult | null> {
   try {
     const parts = await buildPlannedUploadParts(transfer, uploadSession, verifiedBytes.bytes, hasFailed);
@@ -316,6 +318,9 @@ async function runMultipartUploadSession(
     }
     return result;
   } catch (error) {
+    throwIfFailed();
+    markFailed(error);
+    throwIfFailed();
     if (isIndexedDbOpenRecoveryError(error)) {
       throw error;
     }
@@ -330,10 +335,13 @@ async function runMultipartUploadSession(
       throw error;
     }
 
-    const abortError = await abortUploadSessionAfterFailure(transfer, uploadSession.sessionId);
-    if (hasFailed()) {
-      throw error;
-    }
+    const abortError = await abortUploadSessionAfterFailure(
+      transfer,
+      uploadSession.sessionId,
+      markFailed,
+      throwIfFailed,
+    );
+    throwIfFailed();
     throw combineUploadFailureWithAbortFailure(error, abortError);
   }
 }
@@ -344,6 +352,8 @@ async function uploadClaimedMediaTransfer(
   heartbeat: MediaUploadClaimHeartbeat,
   signal: AbortSignal,
   hasFailed: () => boolean,
+  markFailed: (error: unknown) => void,
+  throwIfFailed: () => void,
 ): Promise<MediaUploadCompletionResult | null> {
   const lastModifiedByReplicaId = await buildClientWorkspaceReplicaId(transfer.workspaceId, installationId);
   if (hasFailed()) {
@@ -374,6 +384,9 @@ async function uploadClaimedMediaTransfer(
     }
     verifiedBytes = loadedBytes;
   } catch (error) {
+    throwIfFailed();
+    markFailed(error);
+    throwIfFailed();
     if (isIndexedDbOpenRecoveryError(error)) {
       throw error;
     }
@@ -381,10 +394,13 @@ async function uploadClaimedMediaTransfer(
       throw error;
     }
 
-    const abortError = await abortUploadSessionAfterFailure(transfer, sessionCreateResult.uploadSession.sessionId);
-    if (hasFailed()) {
-      throw error;
-    }
+    const abortError = await abortUploadSessionAfterFailure(
+      transfer,
+      sessionCreateResult.uploadSession.sessionId,
+      markFailed,
+      throwIfFailed,
+    );
+    throwIfFailed();
     throw combineUploadFailureWithAbortFailure(error, abortError);
   }
 
@@ -398,6 +414,8 @@ async function uploadClaimedMediaTransfer(
     heartbeat,
     signal,
     hasFailed,
+    markFailed,
+    throwIfFailed,
   );
 }
 
@@ -406,14 +424,24 @@ async function processClaimedUploadTransfer(
   installationId: string,
   signal: AbortSignal,
   hasFailed: () => boolean,
+  markFailed: (error: unknown) => void,
+  throwIfFailed: () => void,
 ): Promise<void> {
   if (hasFailed()) {
     return;
   }
-  const heartbeat = startUploadClaimHeartbeat(transfer, hasFailed);
+  const heartbeat = startUploadClaimHeartbeat(transfer, signal, hasFailed, markFailed);
   let retryableCompletionCause: ApiError | null = null;
   try {
-    const result = await uploadClaimedMediaTransfer(transfer, installationId, heartbeat, signal, hasFailed);
+    const result = await uploadClaimedMediaTransfer(
+      transfer,
+      installationId,
+      heartbeat,
+      signal,
+      hasFailed,
+      markFailed,
+      throwIfFailed,
+    );
     if (hasFailed() || result === null) {
       const heartbeatError = await heartbeat.stop();
       if (heartbeatError !== null) {
@@ -449,9 +477,14 @@ async function processClaimedUploadTransfer(
       completedAt: new Date().toISOString(),
     });
   } catch (error) {
+    throwIfFailed();
+    markFailed(error);
+    throwIfFailed();
     const heartbeatError = await heartbeat.stop();
-    if (isIndexedDbOpenRecoveryError(error)) {
-      throw error;
+    throwIfFailed();
+    if (heartbeatError !== null) {
+      markFailed(heartbeatError);
+      throwIfFailed();
     }
     if (hasFailed()) {
       throw error;
@@ -496,6 +529,8 @@ export async function processDueMediaUploadTransfersForWorkspace(
   workspaceId: string,
   signal: AbortSignal,
   hasFailed: () => boolean,
+  markFailed: (error: unknown) => void,
+  throwIfFailed: () => void,
 ): Promise<void> {
   if (isBrowserOnline() === false || signal.aborted || hasFailed()) {
     return;
@@ -536,7 +571,14 @@ export async function processDueMediaUploadTransfersForWorkspace(
     if (hasFailed()) {
       return;
     }
-    await processClaimedUploadTransfer(transfer, installationId, signal, hasFailed);
+    await processClaimedUploadTransfer(
+      transfer,
+      installationId,
+      signal,
+      hasFailed,
+      markFailed,
+      throwIfFailed,
+    );
     if (hasFailed()) {
       return;
     }

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferRunner.ts
@@ -336,7 +336,15 @@ async function runMultipartUploadSession(
       throw error;
     }
     if (hasStartedCompletion) {
-      throwIfUploadLifecycleCancelled(signal);
+      try {
+        throwIfUploadLifecycleCancelled(signal);
+      } catch (cancellationError) {
+        throw new MediaUploadCompletionTerminalError(
+          "interrupted",
+          null,
+          normalizeMediaUploadError(cancellationError),
+        );
+      }
     }
 
     const abortError = await abortUploadSessionAfterFailure(

--- a/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
+++ b/apps/web/src/appData/sync/mediaUploads/mediaUploadTransferTestSupport.ts
@@ -49,6 +49,8 @@ export function processDueMediaUploadTransfersForWorkspace(testWorkspaceId: stri
     testWorkspaceId,
     new AbortController().signal,
     (): boolean => false,
+    (): void => undefined,
+    (): void => undefined,
   );
 }
 
@@ -56,7 +58,13 @@ export function runDueMediaUploadTransfersForWorkspace(
   testWorkspaceId: string,
   signal: AbortSignal,
 ): Promise<void> {
-  return runMediaUploadTransferRunner(testWorkspaceId, signal, (): boolean => false);
+  return runMediaUploadTransferRunner(
+    testWorkspaceId,
+    signal,
+    (): boolean => false,
+    (): void => undefined,
+    (): void => undefined,
+  );
 }
 
 function toTestUuidFromHexDigest(hexDigest: string): string {

--- a/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
+++ b/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
@@ -37,20 +37,23 @@ type MediaUploadCompletionTerminalReason = "retry_exhausted" | "interrupted";
 
 export class MediaUploadCompletionTerminalError extends PermanentMediaUploadError {
   readonly reason: MediaUploadCompletionTerminalReason;
-  readonly completionCause: ApiError;
+  readonly completionCause: ApiError | null;
   readonly interruptionCause: Error | null;
 
   constructor(
     reason: MediaUploadCompletionTerminalReason,
-    completionCause: ApiError,
+    completionCause: ApiError | null,
     interruptionCause: Error | null,
   ) {
+    const completionDescription = completionCause === null
+      ? "none"
+      : describeApiError(completionCause);
     const interruptionDescription = interruptionCause === null
       ? "none"
       : describeUploadError(interruptionCause);
     super(
       `Media upload completion stopped for this local run: reason=${reason}, `
-      + `completionError=${describeApiError(completionCause)}, `
+      + `completionError=${completionDescription}, `
       + `interruptionError=${interruptionDescription}`,
     );
     this.name = "MediaUploadCompletionTerminalError";

--- a/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
+++ b/apps/web/src/appData/sync/mediaUploads/multipartCompletion.ts
@@ -292,11 +292,18 @@ function warnUploadSessionAbortFailure(
 export async function abortUploadSessionAfterFailure(
   transfer: MediaTransferQueueRecord,
   sessionId: string,
+  markFailed: (error: unknown) => void,
+  throwIfFailed: () => void,
 ): Promise<unknown | null> {
   try {
+    throwIfFailed();
     await abortMediaAssetUploadSession(transfer.workspaceId, sessionId);
+    throwIfFailed();
     return null;
   } catch (error) {
+    throwIfFailed();
+    markFailed(error);
+    throwIfFailed();
     warnUploadSessionAbortFailure(transfer, sessionId, error);
     return error;
   }

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -79,7 +79,15 @@ function createRemoteSyncInput(): WorkspaceRemoteSyncInput {
     workspaceId: "workspace-1",
     installationId: "installation-1",
     syncRunId: "sync-run-1",
+    signal: new AbortController().signal,
     hasFailed: (): boolean => false,
+    indexedDbOpenRecoveryState: {
+      hasFailed: (): boolean => false,
+      isFailed: false,
+      markFailed: (): "not_recovery" => "not_recovery",
+      signal: new AbortController().signal,
+      throwIfFailed: (): void => {},
+    },
     isOnlyWorkspaceForUser: true,
     requireWorkspaceSyncNotDiscarded: (_workspaceId: string): void => {},
     publishWorkspaceSettings: (_workspaceId, _settings): void => {},
@@ -416,6 +424,7 @@ describe("sync lifecycle observation", () => {
       null,
       1000,
       true,
+      expect.any(AbortSignal),
     );
     expect(apiMocks.pullSyncChangesMock).toHaveBeenCalledWith(
       "workspace-1",
@@ -425,6 +434,7 @@ describe("sync lifecycle observation", () => {
       12,
       500,
       true,
+      expect.any(AbortSignal),
     );
     expect(apiMocks.pullReviewHistorySyncMock).toHaveBeenCalledWith(
       "workspace-1",
@@ -433,6 +443,7 @@ describe("sync lifecycle observation", () => {
       webAppVersion,
       0,
       500,
+      expect.any(AbortSignal),
     );
   });
 

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -306,6 +306,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         bootstrapCursor,
         syncBootstrapPageSize,
         true,
+        input.signal,
       );
       if (input.hasFailed()) {
         return {
@@ -507,6 +508,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
       }
       input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       const demoCardSeedResult = await seedDemoCardForNewWorkspace({
+        indexedDbOpenRecoveryState: input.indexedDbOpenRecoveryState,
         userId: input.userId,
         workspaceId: input.workspaceId,
         installationId: input.installationId,
@@ -530,6 +532,9 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
       didChangeReviewSchedule,
     };
   } catch (error) {
+    input.indexedDbOpenRecoveryState.throwIfFailed();
+    input.indexedDbOpenRecoveryState.markFailed(error);
+    input.indexedDbOpenRecoveryState.throwIfFailed();
     if (isLocalDbRecovery && restoreHistoryBefore !== null) {
       observeLocalDbRecoveryFailed({
         userId: input.userId,

--- a/apps/web/src/appData/sync/remote/pullHotChanges.ts
+++ b/apps/web/src/appData/sync/remote/pullHotChanges.ts
@@ -41,6 +41,7 @@ export async function pullHotChanges(input: WorkspaceRemoteSyncInput): Promise<R
       afterHotChangeId,
       syncIncrementalPageSize,
       true,
+      input.signal,
     );
     if (input.hasFailed()) {
       return {

--- a/apps/web/src/appData/sync/remote/pullReviewHistory.ts
+++ b/apps/web/src/appData/sync/remote/pullReviewHistory.ts
@@ -44,6 +44,7 @@ export async function pullReviewHistory(input: WorkspaceRemoteSyncInput): Promis
       webAppVersion,
       afterReviewSequenceId,
       syncIncrementalPageSize,
+      input.signal,
     );
     if (input.hasFailed()) {
       return {

--- a/apps/web/src/appData/sync/remote/pushOutbox.ts
+++ b/apps/web/src/appData/sync/remote/pushOutbox.ts
@@ -59,6 +59,7 @@ export async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<Remot
         "web",
         webAppVersion,
         batch.map((record) => record.operation),
+        input.signal,
       );
       if (input.hasFailed()) {
         return {

--- a/apps/web/src/appData/sync/remote/types.ts
+++ b/apps/web/src/appData/sync/remote/types.ts
@@ -3,6 +3,7 @@ import type {
   SyncChange,
   WorkspaceSchedulerSettings,
 } from "../../../types";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 
 export type HotSyncEntry = SyncBootstrapEntry | SyncChange;
 export type CardHotSyncEntry = Extract<HotSyncEntry, Readonly<{ entityType: "card" }>>;
@@ -17,7 +18,9 @@ export type WorkspaceRemoteSyncInput = Readonly<{
   workspaceId: string;
   installationId: string;
   syncRunId: string;
+  signal: AbortSignal;
   hasFailed: () => boolean;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   // True when this workspace is the only one the account owns, which is the user-scoped
   // signal for a brand-new user. Resolved by the sync engine from the account's workspace
   // list, because remote sync itself only ever sees one workspace.

--- a/apps/web/src/appError/AppErrorContext.tsx
+++ b/apps/web/src/appError/AppErrorContext.tsx
@@ -1,4 +1,15 @@
-import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactElement, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { bindIndexedDbOpenRecoverySignal } from "../api/transport/transport";
 import { type TranslationKey, type TranslationValues, useI18n } from "../i18n";
 import { isIndexedDbOpenRecoveryError } from "../localDb/core/indexedDbOpenRecovery";
 import { captureAppOperationError } from "../observability/appOperationObservation";
@@ -24,7 +35,10 @@ export type AppTechnicalErrorContext = Readonly<{
 
 export type IndexedDbOpenRecoveryState = Readonly<{
   hasFailed: () => boolean;
+  isFailed: boolean;
   markFailed: (error: unknown) => IndexedDbOpenRecoveryMarkResult;
+  signal: AbortSignal;
+  throwIfFailed: () => void;
 }>;
 
 export type IndexedDbOpenRecoveryMarkResult = "not_recovery" | "first_failure" | "first_failure_repeat" | "later_failure";
@@ -33,8 +47,13 @@ export function isIndexedDbOpenRecoveryFailureMark(result: IndexedDbOpenRecovery
   return result !== "not_recovery";
 }
 
-export function ownsIndexedDbOpenRecoveryFailure(result: IndexedDbOpenRecoveryMarkResult): boolean {
-  return result === "first_failure" || result === "first_failure_repeat";
+export function markIndexedDbOpenRecoveryFailureAndCheckActive(
+  state: IndexedDbOpenRecoveryState,
+  error: unknown,
+): boolean {
+  const markResult = state.markFailed(error);
+  const hasFailed = state.hasFailed();
+  return isIndexedDbOpenRecoveryFailureMark(markResult) || hasFailed;
 }
 
 type AppErrorDialogContextValue = Readonly<{
@@ -63,7 +82,6 @@ function buildPresentationMessages(t: AppErrorTranslate): AppErrorPresentationMe
       message: t("appError.indexedDbReloadRecovery.message"),
       guidance: t("appError.indexedDbReloadRecovery.guidance"),
       reload: t("appError.indexedDbReloadRecovery.reload"),
-      later: t("appError.indexedDbReloadRecovery.later"),
     },
     labels: {
       name: t("appError.technicalError.labels.name"),
@@ -91,13 +109,24 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
   const { children } = props;
   const { t } = useI18n();
   const [presentation, setPresentation] = useState<AppErrorPresentation | null>(null);
+  const [isIndexedDbOpenRecoveryFailed, setIsIndexedDbOpenRecoveryFailed] = useState<boolean>(false);
+  const [indexedDbOpenRecoveryAbortController] = useState<AbortController>(() => new AbortController());
   const indexedDbOpenRecoveryRef = useRef<{
     firstError: Error | null;
-    hasPresented: boolean;
-    isPresenting: boolean;
-  }>({ firstError: null, hasPresented: false, isPresenting: false });
+  }>({ firstError: null });
+
+  useLayoutEffect(() => bindIndexedDbOpenRecoverySignal(indexedDbOpenRecoveryAbortController.signal), [
+    indexedDbOpenRecoveryAbortController,
+  ]);
 
   const hasIndexedDbOpenRecoveryFailed = useCallback((): boolean => indexedDbOpenRecoveryRef.current.firstError !== null, []);
+
+  const throwIfIndexedDbOpenRecoveryFailed = useCallback((): void => {
+    const firstError = indexedDbOpenRecoveryRef.current.firstError;
+    if (firstError !== null) {
+      throw firstError;
+    }
+  }, []);
 
   const markIndexedDbOpenRecoveryFailed = useCallback((error: unknown): IndexedDbOpenRecoveryMarkResult => {
     if (isIndexedDbOpenRecoveryError(error) === false) {
@@ -108,18 +137,21 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
     if (firstError === null) {
       indexedDbOpenRecoveryRef.current = {
         firstError: error,
-        hasPresented: true,
-        isPresenting: true,
       };
+      indexedDbOpenRecoveryAbortController.abort(error);
+      setIsIndexedDbOpenRecoveryFailed(true);
       setPresentation(buildAppErrorPresentation(error, buildPresentationMessages(t)));
       return "first_failure";
     }
 
     return firstError === error ? "first_failure_repeat" : "later_failure";
-  }, [t]);
+  }, [indexedDbOpenRecoveryAbortController, t]);
 
   const dismiss = useCallback((): void => {
-    indexedDbOpenRecoveryRef.current.isPresenting = false;
+    if (indexedDbOpenRecoveryRef.current.firstError !== null) {
+      return;
+    }
+
     setPresentation(null);
   }, []);
 
@@ -138,8 +170,7 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
       return;
     }
 
-    const recoveryState = indexedDbOpenRecoveryRef.current;
-    if (recoveryState.firstError !== null && (recoveryState.hasPresented === false || recoveryState.isPresenting)) {
+    if (indexedDbOpenRecoveryRef.current.firstError !== null) {
       return;
     }
 
@@ -147,6 +178,11 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
   }, [markIndexedDbOpenRecoveryFailed, t]);
 
   const showTechnicalError = useCallback((error: unknown, context: AppTechnicalErrorContext): boolean => {
+    const markResult = markIndexedDbOpenRecoveryFailed(error);
+    if (markResult !== "not_recovery" || indexedDbOpenRecoveryRef.current.firstError !== null) {
+      return false;
+    }
+
     const wasCaptured = captureAppOperationError(error, {
       feature: context.feature,
       operation: context.operation,
@@ -161,16 +197,29 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
     }
 
     return wasCaptured;
-  }, [showCapturedTechnicalError]);
+  }, [markIndexedDbOpenRecoveryFailed, showCapturedTechnicalError]);
 
   const showTechnicalErrorPreview = useCallback((): void => {
+    if (indexedDbOpenRecoveryRef.current.firstError !== null) {
+      return;
+    }
+
     setPresentation(buildAppErrorPresentation(buildPreviewError(), buildPresentationMessages(t)));
   }, [t]);
 
   const indexedDbOpenRecoveryState = useMemo((): IndexedDbOpenRecoveryState => ({
     hasFailed: hasIndexedDbOpenRecoveryFailed,
+    isFailed: isIndexedDbOpenRecoveryFailed,
     markFailed: markIndexedDbOpenRecoveryFailed,
-  }), [hasIndexedDbOpenRecoveryFailed, markIndexedDbOpenRecoveryFailed]);
+    signal: indexedDbOpenRecoveryAbortController.signal,
+    throwIfFailed: throwIfIndexedDbOpenRecoveryFailed,
+  }), [
+    hasIndexedDbOpenRecoveryFailed,
+    isIndexedDbOpenRecoveryFailed,
+    indexedDbOpenRecoveryAbortController,
+    markIndexedDbOpenRecoveryFailed,
+    throwIfIndexedDbOpenRecoveryFailed,
+  ]);
 
   const contextValue = useMemo((): AppErrorDialogContextValue => ({
     showTechnicalError,
@@ -182,7 +231,7 @@ export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): Reac
 
   return (
     <AppErrorDialogContext.Provider value={contextValue}>
-      {children}
+      {isIndexedDbOpenRecoveryFailed ? null : children}
       <AppErrorDialog presentation={presentation} onAction={performAction} onDismiss={dismiss} />
     </AppErrorDialogContext.Provider>
   );

--- a/apps/web/src/appError/AppErrorDialog.tsx
+++ b/apps/web/src/appError/AppErrorDialog.tsx
@@ -66,12 +66,25 @@ export function AppErrorDialog(props: AppErrorDialogProps): ReactElement | null 
       return undefined;
     }
 
+    const isRecoveryPresentation = presentation.kind === "indexeddb-reload-recovery";
     previousFocusRef.current = document.activeElement instanceof HTMLElement
       ? document.activeElement
       : null;
     initialFocusButtonRef.current?.focus();
 
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (isRecoveryPresentation) {
+        event.stopImmediatePropagation();
+        if (event.key === "Escape") {
+          event.preventDefault();
+          return;
+        }
+        if (event.key === "Tab" && dialogRef.current !== null) {
+          trapFocusInsideDialog(event, dialogRef.current);
+        }
+        return;
+      }
+
       if (event.key === "Escape") {
         event.preventDefault();
         event.stopImmediatePropagation();
@@ -90,13 +103,24 @@ export function AppErrorDialog(props: AppErrorDialogProps): ReactElement | null 
     window.addEventListener("keydown", handleKeyDown, true);
     return (): void => {
       window.removeEventListener("keydown", handleKeyDown, true);
-      previousFocusRef.current?.focus();
+      if (isRecoveryPresentation === false) {
+        previousFocusRef.current?.focus();
+      }
       previousFocusRef.current = null;
     };
   }, [onDismiss, presentation]);
 
   function dismissFromBackdrop(event: MouseEvent<HTMLDivElement>): void {
-    if (event.target === event.currentTarget) {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    if (presentation?.kind === "indexeddb-reload-recovery") {
+      event.preventDefault();
+      initialFocusButtonRef.current?.focus();
+      return;
+    }
+
+    if (presentation !== null) {
       onDismiss();
     }
   }
@@ -134,25 +158,15 @@ export function AppErrorDialog(props: AppErrorDialogProps): ReactElement | null 
 
         <div className="screen-actions">
           {presentation.kind === "indexeddb-reload-recovery" ? (
-            <>
-              <button
-                ref={initialFocusButtonRef}
-                type="button"
-                className="ghost-btn"
-                onClick={onDismiss}
-                data-testid="app-error-dialog-later"
-              >
-                {presentation.dismissLabel}
-              </button>
-              <button
-                type="button"
-                className="primary-btn"
-                onClick={() => onAction(presentation.action)}
-                data-testid="app-error-dialog-reload"
-              >
-                {presentation.action.label}
-              </button>
-            </>
+            <button
+              ref={initialFocusButtonRef}
+              type="button"
+              className="primary-btn"
+              onClick={() => onAction(presentation.action)}
+              data-testid="app-error-dialog-reload"
+            >
+              {presentation.action.label}
+            </button>
           ) : (
             <button
               ref={initialFocusButtonRef}

--- a/apps/web/src/appError/appErrorPresentation.ts
+++ b/apps/web/src/appError/appErrorPresentation.ts
@@ -28,7 +28,6 @@ type IndexedDbReloadRecoveryPresentation = Readonly<{
   guidance: string;
   technicalDetails: string;
   action: ReloadPageAppErrorAction;
-  dismissLabel: string;
 }>;
 
 export type AppErrorPresentation = TechnicalErrorPresentation | IndexedDbReloadRecoveryPresentation;
@@ -57,7 +56,6 @@ export type AppErrorPresentationMessages = Readonly<{
     message: string;
     guidance: string;
     reload: string;
-    later: string;
   }>;
   labels: AppErrorPresentationLabels;
 }>;
@@ -153,7 +151,6 @@ export function buildAppErrorPresentation(
         kind: "reload-page",
         label: messages.indexedDbReloadRecovery.reload,
       },
-      dismissLabel: messages.indexedDbReloadRecovery.later,
     };
   }
 

--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -1,6 +1,9 @@
 import { useRef, type ReactElement } from "react";
 import { useAppData } from "../../appData";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
 import type { WebAppOperation } from "../../observability/webObservability";
 import { useChatDraft } from "../composer/drafts/ChatDraftContext";
@@ -37,7 +40,7 @@ type Props = Readonly<{
 export function ChatPanel(props: Props): ReactElement {
   const { mode } = props;
   const appData = useAppData();
-  const { showCapturedTechnicalError, showTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError, showTechnicalError } = useAppErrorDialog();
   const { t, formatNumber } = useI18n();
   const { aiChatComposerSuggestionsEnabled } = useAIChatPreferences();
   const {
@@ -126,6 +129,7 @@ export function ChatPanel(props: Props): ReactElement {
     ensureRemoteSession,
     focusComposerRequestVersion,
     inputText: draftInputText,
+    indexedDbOpenRecoveryState,
     onTechnicalError: showChatTechnicalError,
     t,
     textareaRef,
@@ -150,6 +154,7 @@ export function ChatPanel(props: Props): ReactElement {
     draftInputText,
     draftPendingAttachments,
     draftUpdatedAt: draft.updatedAt,
+    indexedDbOpenRecoveryState,
     isSessionVerified: appData.isSessionVerified,
     pendingSyncMessage: t("chatPanel.transientErrors.pendingSync"),
     moveDraftToSession,
@@ -168,7 +173,8 @@ export function ChatPanel(props: Props): ReactElement {
   });
   const rootClassName = mode === "sidebar" ? "chat-sidebar" : "chat-sidebar-fullscreen";
   const isDictationVisible = dictationState !== "idle";
-  const isChatActionLocked = appData.isSessionVerified === false;
+  const isChatActionLocked = appData.isSessionVerified === false
+    || indexedDbOpenRecoveryState.hasFailed();
   const areAttachmentsEnabled = chatConfig.features.attachmentsEnabled;
   const isDictationEnabled = chatConfig.features.dictationEnabled;
   const isChatConversationReadyForAttachments = isHistoryLoaded && currentSessionId !== null;
@@ -201,7 +207,11 @@ export function ChatPanel(props: Props): ReactElement {
     canAttachDraftFiles,
     currentSessionId,
     draftInputText,
+    indexedDbOpenRecoveryState,
     onTechnicalError: (error) => {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       showChatTechnicalError(error, "chat_attachment_prepare");
     },
     pendingAttachmentsRef,
@@ -210,7 +220,7 @@ export function ChatPanel(props: Props): ReactElement {
   const { handleKeyDown } = useChatComposerKeyboard({
     composerAction,
     sendPendingMessage,
-    stopMessage,
+    stopMessage: handleStopMessage,
   });
   const hasDraftContent = hasChatDraftContent(inputText, pendingAttachments);
   const composerState = getChatComposerState({
@@ -250,6 +260,44 @@ export function ChatPanel(props: Props): ReactElement {
       ? t("chatPanel.dictation.listening")
       : t("chatPanel.dictation.transcribing");
 
+  async function handleStartNewConversation(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    try {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      suppressNextSessionDraftCarryover(currentSessionId);
+      startNewConversationComposerReset(currentSessionId);
+      discardDictation();
+      const nextSessionId = await clearConversation();
+      indexedDbOpenRecoveryState.throwIfFailed();
+      finishNewConversationComposerReset(nextSessionId);
+    } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async function handleStopMessage(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    try {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      await stopMessage();
+      indexedDbOpenRecoveryState.throwIfFailed();
+    } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+      throw error;
+    }
+  }
+
   return (
     <div
       ref={rootRef}
@@ -267,7 +315,9 @@ export function ChatPanel(props: Props): ReactElement {
           className={`chat-resize-handle${isDragging ? " dragging" : ""}`}
           onMouseDown={(event) => {
             event.preventDefault();
-            beginResizeDrag();
+            if (indexedDbOpenRecoveryState.hasFailed() === false) {
+              beginResizeDrag();
+            }
           }}
         />
       ) : null}
@@ -280,13 +330,7 @@ export function ChatPanel(props: Props): ReactElement {
           <button
             type="button"
             className="chat-close-btn"
-            onClick={() => {
-              suppressNextSessionDraftCarryover(currentSessionId);
-              startNewConversationComposerReset(currentSessionId);
-              discardDictation();
-              void clearConversation()
-                .then((nextSessionId) => finishNewConversationComposerReset(nextSessionId));
-            }}
+            onClick={() => void handleStartNewConversation()}
             disabled={isStopping || isChatActionLocked}
             data-testid="chat-new-button"
           >
@@ -297,9 +341,12 @@ export function ChatPanel(props: Props): ReactElement {
               type="button"
               className="chat-close-btn"
               onClick={() => {
-                discardDictation();
-                setIsOpen(false);
+                if (indexedDbOpenRecoveryState.hasFailed() === false) {
+                  discardDictation();
+                  setIsOpen(false);
+                }
               }}
+              disabled={isChatActionLocked}
             >
               &laquo;
             </button>
@@ -335,7 +382,17 @@ export function ChatPanel(props: Props): ReactElement {
                 key={`${message.timestamp}-${index}`}
                 className={`chat-msg chat-msg-${message.role}`}
               >
-                {renderStoredMessageContent(message, t, (error) => showChatTechnicalError(error, "chat_tool_call_copy"))}
+                {renderStoredMessageContent(
+                  message,
+                  t,
+                  (error) => {
+                    if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+                      return true;
+                    }
+                    return showChatTechnicalError(error, "chat_tool_call_copy");
+                  },
+                  () => indexedDbOpenRecoveryState.hasFailed() === false,
+                )}
                 {isLastAssistant ? (
                   <span className="chat-streaming-indicator">
                     <span className="chat-dots" />
@@ -403,6 +460,9 @@ export function ChatPanel(props: Props): ReactElement {
                 data-suggestion-id={suggestion.id}
                 data-suggestion-index={index}
                 onClick={() => {
+                  if (indexedDbOpenRecoveryState.hasFailed()) {
+                    return;
+                  }
                   updateInputText((currentText) =>
                     currentText.length === 0
                       ? suggestion.text
@@ -438,6 +498,9 @@ export function ChatPanel(props: Props): ReactElement {
             disabled={isDraftInputBlocked}
             data-testid="chat-composer-input"
             onChange={(event) => {
+              if (indexedDbOpenRecoveryState.hasFailed()) {
+                return;
+              }
               replaceInputText(event.target.value);
               updateTrackedDraftSelection(event.target);
             }}
@@ -460,7 +523,11 @@ export function ChatPanel(props: Props): ReactElement {
               type="button"
               className={`chat-mic-btn${dictationState === "recording" ? " chat-mic-btn-recording" : ""}`}
               aria-label={microphoneAriaLabel}
-              onClick={() => void handleMicrophoneClick(canStartDictation)}
+              onClick={() => {
+                if (indexedDbOpenRecoveryState.hasFailed() === false) {
+                  void handleMicrophoneClick(canStartDictation);
+                }
+              }}
               disabled={isDictationButtonDisabled}
             >
               {dictationState === "recording" ? (
@@ -488,8 +555,12 @@ export function ChatPanel(props: Props): ReactElement {
                 type="button"
                 className="chat-stop-btn"
                 aria-label={t("chatPanel.actions.stopAriaLabel")}
-                onClick={() => void stopMessage()}
-                disabled={isStopping}
+                onClick={() => {
+                  if (indexedDbOpenRecoveryState.hasFailed() === false) {
+                    void handleStopMessage();
+                  }
+                }}
+                disabled={isStopping || isChatActionLocked}
                 data-testid="chat-stop-button"
               >
                 <span className="chat-stop-btn-icon" aria-hidden="true" />
@@ -530,7 +601,12 @@ export function ChatPanel(props: Props): ReactElement {
             <button
               type="button"
               className="primary-btn"
-              onClick={dismissErrorDialog}
+              onClick={() => {
+                if (indexedDbOpenRecoveryState.hasFailed() === false) {
+                  dismissErrorDialog();
+                }
+              }}
+              disabled={isChatActionLocked}
             >
               OK
             </button>

--- a/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx
@@ -178,7 +178,7 @@ describe("ChatPanel hydration lifecycle", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-local-fresh", "workspace-1");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-local-fresh", "workspace-1", expect.any(AbortSignal));
   });
 
   it("keeps a typed draft when hydration accepts a replacement session id", async () => {
@@ -301,7 +301,7 @@ describe("ChatPanel hydration lifecycle", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-assistant-only", "workspace-1");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-assistant-only", "workspace-1", expect.any(AbortSignal));
     expect(createNewChatSessionMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-terminal-reconcile.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-terminal-reconcile.test.tsx
@@ -160,7 +160,7 @@ describe("ChatPanel send terminal reconcile", () => {
     await flushAsync();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith(sessionId, "workspace-1");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith(sessionId, "workspace-1", expect.any(AbortSignal));
 
     await sendMessage("second send rejected before acceptance");
     await flushAsync();

--- a/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-warm-start-races.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-warm-start-races.test.tsx
@@ -57,7 +57,7 @@ describe("ChatPanel send warm-start races", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1", expect.any(AbortSignal));
 
     await sendMessage("recover before stale snapshot resolves");
     await flushAsync();
@@ -134,7 +134,7 @@ describe("ChatPanel send warm-start races", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1", expect.any(AbortSignal));
 
     await sendMessage("recover while provisioning waits");
     await flushAsync();
@@ -202,7 +202,7 @@ describe("ChatPanel send warm-start races", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1", expect.any(AbortSignal));
 
     await sendMessage("recover before stale snapshot fails");
     await flushAsync();
@@ -246,7 +246,7 @@ describe("ChatPanel send warm-start races", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-stale", "workspace-1", expect.any(AbortSignal));
 
     await sendMessage("do not recover after stale hydration applies");
     await flushAsync();

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -790,6 +790,8 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
       _blob: Blob,
       _source: "web",
       sessionId: string,
+      _workspaceId: string,
+      _signal: AbortSignal,
     ) => ({
       text: "dictated text",
       sessionId,

--- a/apps/web/src/chat/attachments/useChatAttachments.ts
+++ b/apps/web/src/chat/attachments/useChatAttachments.ts
@@ -6,6 +6,10 @@ import {
   type MutableRefObject,
 } from "react";
 import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../appError/AppErrorContext";
+import {
   ATTACHMENT_PAYLOAD_LIMIT_BYTES,
   IMAGE_MEDIA_TYPE_PREFIX,
   buildContentParts,
@@ -37,6 +41,7 @@ type UseChatAttachmentsParams = Readonly<{
   canAttachDraftFiles: boolean;
   currentSessionId: string | null;
   draftInputText: string;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   onTechnicalError: (error: unknown) => void;
   pendingAttachmentsRef: MutableRefObject<ReadonlyArray<PendingAttachment>>;
   setPendingAttachmentsState: (nextAttachments: ReadonlyArray<PendingAttachment>) => void;
@@ -120,6 +125,7 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
     canAttachDraftFiles,
     currentSessionId,
     draftInputText,
+    indexedDbOpenRecoveryState,
     onTechnicalError,
     pendingAttachmentsRef,
     setPendingAttachmentsState,
@@ -130,7 +136,7 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
   canAttachDraftFilesRef.current = canAttachDraftFiles;
 
   async function handleAttach(attachment: PendingAttachment): Promise<void> {
-    if (!canAttachDraftFilesRef.current) {
+    if (indexedDbOpenRecoveryState.hasFailed() || !canAttachDraftFilesRef.current) {
       return;
     }
 
@@ -155,11 +161,16 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
       && attachment.mediaType.startsWith(IMAGE_MEDIA_TYPE_PREFIX)
     ) {
       try {
+        indexedDbOpenRecoveryState.throwIfFailed();
         finalAttachment = await recompressImageAttachment(
           attachment,
           EXTRA_AGGRESSIVE_IMAGE_COMPRESSION,
         );
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         onTechnicalError(error);
         return;
       }
@@ -177,7 +188,7 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
       });
     }
 
-    if (!canAttachDraftFilesRef.current) {
+    if (indexedDbOpenRecoveryState.hasFailed() || !canAttachDraftFilesRef.current) {
       return;
     }
 
@@ -191,6 +202,10 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
 
   async function ingestFiles(files: ReadonlyArray<File>): Promise<void> {
     for (const file of files) {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       const sizeError = checkFileSize(file);
       if (sizeError !== null) {
         window.alert(attachmentLimitMessage);
@@ -198,8 +213,16 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
       }
 
       try {
-        await handleAttach(await prepareAttachment(file));
+        indexedDbOpenRecoveryState.throwIfFailed();
+        const attachment = await prepareAttachment(file);
+        indexedDbOpenRecoveryState.throwIfFailed();
+        await handleAttach(attachment);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
+
         if (isChatAttachmentTooLargeError(error)) {
           window.alert(attachmentLimitMessage);
           continue;
@@ -221,6 +244,10 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
   }
 
   function removeAttachment(index: number): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const currentAttachments = pendingAttachmentsRef.current;
     setPendingAttachmentsState([
       ...currentAttachments.slice(0, index),
@@ -230,6 +257,9 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
 
   function handleDragEnter(event: DragEvent<HTMLDivElement>): void {
     event.preventDefault();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     event.dataTransfer.dropEffect = canAttachDraftFiles ? "copy" : "none";
     if (!canAttachDraftFiles) {
       dragCounterRef.current = 0;
@@ -245,6 +275,9 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
 
   function handleDragLeave(event: DragEvent<HTMLDivElement>): void {
     event.preventDefault();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     if (!canAttachDraftFiles) {
       dragCounterRef.current = 0;
       setIsDragOver(false);
@@ -259,11 +292,16 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
 
   function handleDragOver(event: DragEvent<HTMLDivElement>): void {
     event.preventDefault();
-    event.dataTransfer.dropEffect = canAttachDraftFiles ? "copy" : "none";
+    event.dataTransfer.dropEffect = canAttachDraftFiles && indexedDbOpenRecoveryState.hasFailed() === false
+      ? "copy"
+      : "none";
   }
 
   async function handleDrop(event: DragEvent<HTMLDivElement>): Promise<void> {
     event.preventDefault();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     dragCounterRef.current = 0;
     setIsDragOver(false);
 
@@ -272,10 +310,13 @@ export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttach
     }
 
     await ingestFiles(Array.from(event.dataTransfer.files));
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
   }
 
   function handlePaste(event: ClipboardEvent<HTMLTextAreaElement>): void {
-    if (!canAttachDraftFiles) {
+    if (indexedDbOpenRecoveryState.hasFailed() || !canAttachDraftFiles) {
       return;
     }
 

--- a/apps/web/src/chat/composer/dictation/useChatDictationCapture.ts
+++ b/apps/web/src/chat/composer/dictation/useChatDictationCapture.ts
@@ -1,4 +1,8 @@
-import { useEffect, useRef, useState, type MutableRefObject, type RefObject } from "react";
+import { useCallback, useEffect, useRef, useState, type MutableRefObject, type RefObject } from "react";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
 import {
   ApiError,
   isAuthRedirectError,
@@ -25,6 +29,7 @@ type UseChatDictationCaptureParams = Readonly<{
   ensureRemoteSession: () => Promise<string>;
   focusComposerRequestVersion: number;
   inputText: string;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   onTechnicalError: (error: unknown, operation: ChatDictationTechnicalOperation) => boolean;
   t: Translate;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
@@ -148,6 +153,7 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
     ensureRemoteSession,
     focusComposerRequestVersion,
     inputText,
+    indexedDbOpenRecoveryState,
     onTechnicalError,
     t,
     textareaRef,
@@ -156,6 +162,7 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
   const [dictationState, setDictationState] = useState<ChatDictationState>("idle");
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
+  const transcriptionAbortControllerRef = useRef<AbortController | null>(null);
   const recordedChunksRef = useRef<Array<Blob>>([]);
   const currentSessionIdRef = useRef<string | null>(currentSessionId);
   const draftSelectionRef = useRef<ChatDraftSelection | null>(null);
@@ -164,12 +171,26 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
   const shouldRestoreTextareaFocusAfterDictationRef = useRef<boolean>(false);
   const isMountedRef = useRef<boolean>(true);
 
+  const stopActiveDictationResources = useCallback((): void => {
+    transcriptionAbortControllerRef.current?.abort(new DOMException("Chat dictation stopped", "AbortError"));
+    transcriptionAbortControllerRef.current = null;
+    const recorder = mediaRecorderRef.current;
+    if (recorder !== null && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+    cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+  }, []);
+
   useEffect(() => {
     currentSessionIdRef.current = currentSessionId;
   }, [currentSessionId]);
 
   useEffect(() => {
-    if (pendingComposerFocusRestoreRef.current === false || dictationState !== "idle") {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || pendingComposerFocusRestoreRef.current === false
+      || dictationState !== "idle"
+    ) {
       return;
     }
 
@@ -183,15 +204,15 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
   });
 
   useEffect(() => {
-    if (dictationState !== "idle") {
+    if (indexedDbOpenRecoveryState.hasFailed() || dictationState !== "idle") {
       return;
     }
 
     textareaRef.current?.focus();
-  }, [dictationState, focusComposerRequestVersion, textareaRef]);
+  }, [dictationState, focusComposerRequestVersion, indexedDbOpenRecoveryState, textareaRef]);
 
   useEffect(() => {
-    if (dictationState !== "idle") {
+    if (indexedDbOpenRecoveryState.hasFailed() || dictationState !== "idle") {
       return;
     }
 
@@ -212,20 +233,39 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
     draftSelectionRef.current = { start, end };
     pendingTextareaSelectionRef.current = null;
     shouldRestoreTextareaFocusAfterDictationRef.current = false;
-  }, [dictationState, inputText, textareaRef]);
+  }, [dictationState, indexedDbOpenRecoveryState, inputText, textareaRef]);
+
+  useEffect(() => {
+    const handleRecoveryAbort = (): void => {
+      stopActiveDictationResources();
+      draftSelectionRef.current = null;
+      pendingTextareaSelectionRef.current = null;
+      pendingComposerFocusRestoreRef.current = false;
+      shouldRestoreTextareaFocusAfterDictationRef.current = false;
+    };
+
+    if (indexedDbOpenRecoveryState.signal.aborted) {
+      handleRecoveryAbort();
+      return undefined;
+    }
+
+    indexedDbOpenRecoveryState.signal.addEventListener("abort", handleRecoveryAbort, { once: true });
+    return (): void => {
+      indexedDbOpenRecoveryState.signal.removeEventListener("abort", handleRecoveryAbort);
+    };
+  }, [indexedDbOpenRecoveryState.signal, stopActiveDictationResources]);
 
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
-      const recorder = mediaRecorderRef.current;
-      if (recorder !== null && recorder.state !== "inactive") {
-        recorder.stop();
-      }
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+      stopActiveDictationResources();
     };
-  }, []);
+  }, [stopActiveDictationResources]);
 
   function updateTrackedDraftSelection(textarea: HTMLTextAreaElement): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     draftSelectionRef.current = {
       start: textarea.selectionStart,
       end: textarea.selectionEnd,
@@ -238,16 +278,14 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
   }
 
   function requestComposerFocusRestore(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     pendingComposerFocusRestoreRef.current = true;
   }
 
   function discardDictation(): void {
-    const recorder = mediaRecorderRef.current;
-    if (recorder !== null && recorder.state !== "inactive") {
-      recorder.stop();
-    }
-
-    cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+    stopActiveDictationResources();
     draftSelectionRef.current = null;
     pendingTextareaSelectionRef.current = null;
     shouldRestoreTextareaFocusAfterDictationRef.current = false;
@@ -257,7 +295,7 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
   }
 
   async function startDictation(): Promise<void> {
-    if (dictationState !== "idle") {
+    if (indexedDbOpenRecoveryState.hasFailed() || dictationState !== "idle") {
       return;
     }
 
@@ -286,7 +324,9 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
 
     let stream: MediaStream | null = null;
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       stream = await mediaDevices.getUserMedia({ audio: true, video: false });
+      indexedDbOpenRecoveryState.throwIfFailed();
       const recorderMimeType = chooseSupportedRecordingMimeType();
       const recorder = recorderMimeType === null
         ? new MediaRecorder(stream)
@@ -304,9 +344,19 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
         setDictationState("recording");
       }
     } catch (error) {
+      const isRecoveryActive = markIndexedDbOpenRecoveryFailureAndCheckActive(
+        indexedDbOpenRecoveryState,
+        error,
+      );
       stopMediaStream(stream);
       cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+      if (isRecoveryActive) {
+        return;
+      }
       const permissionState = await queryBrowserPermissionState("microphone");
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       if (isMountedRef.current) {
         if (isExpectedBrowserMediaPermissionError(error)) {
           window.alert(explainBrowserMediaPermissionError("microphone", error, permissionState, t));
@@ -319,6 +369,12 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
   }
 
   async function stopDictation(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      stopActiveDictationResources();
+      pendingComposerFocusRestoreRef.current = false;
+      return;
+    }
+
     const recorder = mediaRecorderRef.current;
     if (recorder === null || recorder.state === "inactive") {
       cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
@@ -328,8 +384,11 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
 
     setDictationState("transcribing");
 
+    let transcriptionAbortController: AbortController | null = null;
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const audioBlob = await stopMediaRecorder(recorder, recordedChunksRef);
+      indexedDbOpenRecoveryState.throwIfFailed();
       stopMediaStream(mediaStreamRef.current);
       if (audioBlob.size <= 0) {
         if (isMountedRef.current) {
@@ -343,12 +402,17 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
       }
 
       const sessionId = await ensureRemoteSession();
+      indexedDbOpenRecoveryState.throwIfFailed();
+      transcriptionAbortController = new AbortController();
+      transcriptionAbortControllerRef.current = transcriptionAbortController;
       const transcription = await transcribeChatAudio(
         audioBlob,
         "web",
         sessionId,
         activeWorkspaceId,
+        transcriptionAbortController.signal,
       );
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (transcription.sessionId !== sessionId) {
         throw new Error(t("chatPanel.errors.transcriptionUnexpectedSessionId"));
       }
@@ -373,6 +437,10 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
         });
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       if (isMountedRef.current) {
         if (error instanceof Error && error.message === "MICROPHONE_RECORDING_FAILED") {
           window.alert(t("chatPanel.alerts.microphoneUnavailable"));
@@ -387,16 +455,26 @@ export function useChatDictationCapture(params: UseChatDictationCaptureParams): 
         }
       }
     } finally {
+      if (transcriptionAbortControllerRef.current === transcriptionAbortController) {
+        transcriptionAbortControllerRef.current = null;
+      }
       cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-      if (isMountedRef.current) {
+      if (isMountedRef.current && indexedDbOpenRecoveryState.hasFailed() === false) {
         setDictationState("idle");
       }
     }
   }
 
   async function handleMicrophoneClick(canStartDictation: boolean): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (dictationState === "recording") {
       await stopDictation();
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       return;
     }
 

--- a/apps/web/src/chat/composer/useChatComposerSend.ts
+++ b/apps/web/src/chat/composer/useChatComposerSend.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState, type MutableRefObject } from "react";
 import { isCapturedSyncFailure } from "../../appData/sync/observation/syncErrorObservation";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../appError/AppErrorContext";
 import { listOutboxRecords } from "../../localDb/sync/outbox";
 import type { ChatComposerSendPhase } from "./drafts/ChatDraftContext";
 import {
@@ -36,6 +40,7 @@ type UseChatComposerSendParams = Readonly<{
   draftPendingAttachments: ReadonlyArray<PendingAttachment>;
   draftUpdatedAt: number | null;
   isSessionVerified: boolean;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   pendingSyncMessage: string;
   moveDraftToSession: (sourceSessionId: string | null, sourceDraftUpdatedAt: number | null, targetSessionId: string, nextDraft: ChatDraftContent) => number | null;
   onCapturedTechnicalError: (error: unknown) => void;
@@ -75,6 +80,7 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
     draftPendingAttachments,
     draftUpdatedAt,
     isSessionVerified,
+    indexedDbOpenRecoveryState,
     pendingSyncMessage,
     moveDraftToSession,
     onCapturedTechnicalError,
@@ -110,7 +116,10 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
   }, []);
 
   useEffect(() => {
-    if (activeWorkspaceIdRef.current === activeWorkspaceId) {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || activeWorkspaceIdRef.current === activeWorkspaceId
+    ) {
       return;
     }
 
@@ -119,7 +128,7 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
     setIsDraftOptimisticallyClearedForSend(false);
     pendingAttachmentsRef.current = draftPendingAttachments;
     setSendPhase("idle");
-  }, [activeWorkspaceId, draftPendingAttachments, setSendPhase]);
+  }, [activeWorkspaceId, draftPendingAttachments, indexedDbOpenRecoveryState, setSendPhase]);
 
   function setPendingAttachmentsState(nextAttachments: ReadonlyArray<PendingAttachment>): void {
     pendingAttachmentsRef.current = nextAttachments;
@@ -226,6 +235,10 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
   }
 
   async function sendPendingMessage(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (dictationState !== "idle" || composerAction !== "send" || sendPhase !== "idle") {
       return;
     }
@@ -274,6 +287,9 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
         return;
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isSendLifecycleRequestCurrent(requestSequence) === false) {
         return;
       }
@@ -290,7 +306,9 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
     }
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const outboxRecords = await listOutboxRecords(activeWorkspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isSendLifecycleRequestCurrent(requestSequence) === false) {
         return;
       }
@@ -302,6 +320,9 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
         return;
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isSendLifecycleRequestCurrent(requestSequence) === false) {
         return;
       }
@@ -320,9 +341,13 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
     setSendPhase("startingRun");
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       let pendingDraftSessionId: string | null = sourceSessionId;
       let resultDraftUpdatedAt: number | null = sourceDraftUpdatedAt;
       const handleSessionDraftTargetReady = (targetSessionId: string): number | null => {
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return resultDraftUpdatedAt;
+        }
         if (pendingDraftSessionId === targetSessionId) {
           return resultDraftUpdatedAt;
         }
@@ -343,6 +368,7 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
         attachments: nextAttachments,
         onSessionDraftTargetReady: handleSessionDraftTargetReady,
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (result.accepted) {
         clearAcceptedSendStoredDrafts(
           sourceSessionId,
@@ -377,8 +403,13 @@ export function useChatComposerSend(params: UseChatComposerSendParams): ChatComp
           result.sessionId,
         );
       }
+    } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+      throw error;
     } finally {
-      if (isSendLifecycleRequestCurrent(requestSequence)) {
+      if (indexedDbOpenRecoveryState.hasFailed() === false && isSendLifecycleRequestCurrent(requestSequence)) {
         setSendPhase("idle");
       }
     }

--- a/apps/web/src/chat/handoff/useAiCardHandoff.ts
+++ b/apps/web/src/chat/handoff/useAiCardHandoff.ts
@@ -1,5 +1,9 @@
 import { useCallback } from "react";
 import { useAppData } from "../../appData";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import type { Card } from "../../types";
 import { makeCardPendingAttachment } from "../attachments/chatCardParts";
 import { useOptionalChatDraft } from "../composer/drafts/ChatDraftContext";
@@ -8,12 +12,18 @@ import { useOptionalChatSession } from "../sessionController";
 
 export function useAiCardHandoff(): (card: Card) => Promise<boolean> {
   const { setErrorMessage } = useAppData();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const draftContext = useOptionalChatDraft();
   const chatLayout = useOptionalChatLayout();
   const session = useOptionalChatSession();
 
   return useCallback(async (card: Card): Promise<boolean> => {
-    if (draftContext === null || chatLayout === null || session === null) {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || draftContext === null
+      || chatLayout === null
+      || session === null
+    ) {
       return false;
     }
 
@@ -54,20 +64,26 @@ export function useAiCardHandoff(): (card: Card) => Promise<boolean> {
     let targetSessionId = sourceSessionId;
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (sourceSessionId === null || isDirtyConversation) {
+        indexedDbOpenRecoveryState.throwIfFailed();
         draftContext.suppressNextSessionDraftCarryover(sourceSessionId);
         const clearedSessionId = await session.clearConversation();
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (clearedSessionId !== null) {
           targetSessionId = clearedSessionId;
         }
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return false;
+      }
       const message = error instanceof Error ? error.message : String(error);
       setErrorMessage(`AI handoff failed. ${message}`);
       return false;
     }
 
-    if (targetSessionId === null) {
+    if (targetSessionId === null || indexedDbOpenRecoveryState.hasFailed()) {
       return false;
     }
 
@@ -86,6 +102,7 @@ export function useAiCardHandoff(): (card: Card) => Promise<boolean> {
   }, [
     chatLayout,
     draftContext,
+    indexedDbOpenRecoveryState,
     setErrorMessage,
     session,
   ]);

--- a/apps/web/src/chat/history/chatMessageContent.tsx
+++ b/apps/web/src/chat/history/chatMessageContent.tsx
@@ -77,7 +77,12 @@ async function copyToolCallSection(
   sectionTitle: string,
   t: Translate,
   onTechnicalError: ChatMessageTechnicalErrorHandler,
+  canStartAction: () => boolean,
 ): Promise<void> {
+  if (canStartAction() === false) {
+    return;
+  }
+
   if (typeof navigator.clipboard?.writeText !== "function") {
     window.alert(t("chatMessageContent.failedToCopy", { section: sectionTitle.toLowerCase() }));
     return;
@@ -86,6 +91,10 @@ async function copyToolCallSection(
   try {
     await navigator.clipboard.writeText(text);
   } catch (error) {
+    if (canStartAction() === false) {
+      return;
+    }
+
     if (isExpectedClipboardWriteError(error)) {
       window.alert(toClipboardErrorMessage(sectionTitle, t));
       return;
@@ -103,6 +112,7 @@ function renderToolCallSection(
   sectionClassName: "input" | "output",
   t: Translate,
   onTechnicalError: ChatMessageTechnicalErrorHandler,
+  canStartAction: () => boolean,
 ): ReactElement | null {
   if (text === null || text === "") {
     return null;
@@ -119,8 +129,9 @@ function renderToolCallSection(
           type="button"
           className="chat-tool-call-copy"
           onClick={() => {
-            void copyToolCallSection(text, sectionTitle, t, onTechnicalError);
+            void copyToolCallSection(text, sectionTitle, t, onTechnicalError, canStartAction);
           }}
+          disabled={canStartAction() === false}
         >
           {t("chatMessageContent.copy")}
         </button>
@@ -170,6 +181,7 @@ export function renderStoredMessageContent(
   message: StoredMessage,
   t: Translate,
   onTechnicalError: ChatMessageTechnicalErrorHandler,
+  canStartAction: () => boolean,
 ): ReactElement {
   const elements: Array<ReactElement> = [];
   let previousPartNeedsTextSeparator = false;
@@ -242,8 +254,8 @@ export function renderStoredMessageContent(
           <span className="chat-tool-call-summary-main" title={summaryText}>{summaryText}</span>
           <span className="chat-tool-call-status">{toolCallStatusLabel(part.status, t)}</span>
         </summary>
-        {renderToolCallSection(t("chatMessageContent.request"), part.input, "input", t, onTechnicalError)}
-        {renderToolCallSection(t("chatMessageContent.response"), part.output, "output", t, onTechnicalError)}
+        {renderToolCallSection(t("chatMessageContent.request"), part.input, "input", t, onTechnicalError, canStartAction)}
+        {renderToolCallSection(t("chatMessageContent.response"), part.output, "output", t, onTechnicalError, canStartAction)}
       </details>,
     );
   }

--- a/apps/web/src/chat/sessionController/actions/useActions.ts
+++ b/apps/web/src/chat/sessionController/actions/useActions.ts
@@ -1,5 +1,9 @@
 import { useCallback, useRef, type Dispatch } from "react";
 import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
+import {
   ApiContractError,
   ApiError,
   AuthRedirectError,
@@ -56,6 +60,7 @@ import type { ChatHistoryState } from "../../history/useChatHistory";
 type FreshSessionErrorPresentation = "new_chat" | "refresh" | "silent";
 
 type UseChatSessionActionsParams = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   workspaceId: string | null;
   isRemoteReady: boolean;
   uiLocale: Locale;
@@ -203,6 +208,7 @@ export function useChatSessionActions(
   params: UseChatSessionActionsParams,
 ): ChatSessionActions {
   const {
+    indexedDbOpenRecoveryState,
     workspaceId,
     isRemoteReady,
     uiLocale,
@@ -286,13 +292,23 @@ export function useChatSessionActions(
   const provisionRemoteSession = useCallback(async (
     sessionId: string,
   ): Promise<NewChatSessionResponse> => {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (workspaceId === null) {
       throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
     }
 
     const activeProvisioning = getActiveProvisioningState();
     if (activeProvisioning !== null && activeProvisioning.sessionId === sessionId) {
-      return activeProvisioning.promise;
+      try {
+        const response = await activeProvisioning.promise;
+        indexedDbOpenRecoveryState.throwIfFailed();
+        return response;
+      } catch (error) {
+        indexedDbOpenRecoveryState.throwIfFailed();
+        indexedDbOpenRecoveryState.markFailed(error);
+        indexedDbOpenRecoveryState.throwIfFailed();
+        throw error;
+      }
     }
 
     const nextPromise = createNewChatSession(sessionId, workspaceId, uiLocale);
@@ -304,7 +320,14 @@ export function useChatSessionActions(
     };
 
     try {
-      return await nextPromise;
+      const response = await nextPromise;
+      indexedDbOpenRecoveryState.throwIfFailed();
+      return response;
+    } catch (error) {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      indexedDbOpenRecoveryState.markFailed(error);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      throw error;
     } finally {
       const currentProvisioning = remoteSessionProvisioningRef.current;
       if (
@@ -316,7 +339,7 @@ export function useChatSessionActions(
         remoteSessionProvisioningRef.current = null;
       }
     }
-  }, [uiLocale, workspaceId]);
+  }, [indexedDbOpenRecoveryState, uiLocale, uiMessages, workspaceId]);
 
   const beginFreshSessionRequestSequence = useCallback((): number => {
     const nextSequence = clearConversationRequestSequenceRef.current + 1;
@@ -408,10 +431,15 @@ export function useChatSessionActions(
     requestSequence: number,
     errorPresentation: FreshSessionErrorPresentation,
   ): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const requestLocale = uiLocale;
     void (async (): Promise<void> => {
       try {
         const response = await provisionRemoteSession(sessionId);
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (response.sessionId !== sessionId) {
           return;
         }
@@ -430,6 +458,10 @@ export function useChatSessionActions(
         });
         storeChatConfig(response.chatConfig);
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
+
         if (isFreshSessionEnsureCurrent(sessionId, requestSequence, requestLocale) === false) {
           return;
         }
@@ -453,7 +485,7 @@ export function useChatSessionActions(
         });
       }
     })();
-  }, [dispatch, isFreshSessionEnsureCurrent, provisionRemoteSession, uiMessages, workspaceId]);
+  }, [dispatch, indexedDbOpenRecoveryState, isFreshSessionEnsureCurrent, provisionRemoteSession, uiMessages, workspaceId]);
 
   const ensureFreshSessionInBackground = useCallback((sessionId: string, requestSequence: number): void => {
     ensureFreshSession(sessionId, requestSequence, "silent");
@@ -464,6 +496,7 @@ export function useChatSessionActions(
   }, [ensureFreshSession]);
 
   const ensureRemoteSession = useCallback(async (): Promise<string> => {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (workspaceId === null) {
       throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
     }
@@ -515,6 +548,7 @@ export function useChatSessionActions(
     };
 
     const resolution = await resolveRemoteSession();
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (
       resolution.provisionedResponse !== null
       && runtimeRefs.currentWorkspaceIdRef.current === workspaceId
@@ -530,9 +564,10 @@ export function useChatSessionActions(
     }
 
     return resolution.sessionId;
-  }, [dispatch, isRemoteReady, provisionRemoteSession, runtimeRefs, uiMessages, workspaceId]);
+  }, [dispatch, indexedDbOpenRecoveryState, isRemoteReady, provisionRemoteSession, runtimeRefs, uiMessages, workspaceId]);
 
   const ensureRemoteSessionForHydration = useCallback(async (): Promise<string> => {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (workspaceId === null) {
       throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
     }
@@ -547,6 +582,7 @@ export function useChatSessionActions(
     if (currentSessionId !== null) {
       if (activeProvisioning !== null && activeProvisioning.sessionId === currentSessionId) {
         const response = await activeProvisioning.promise;
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (response.sessionId !== currentSessionId) {
           throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
         }
@@ -557,6 +593,7 @@ export function useChatSessionActions(
 
     if (activeProvisioning !== null) {
       const response = await activeProvisioning.promise;
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (response.sessionId !== activeProvisioning.sessionId) {
         throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
       }
@@ -566,12 +603,13 @@ export function useChatSessionActions(
 
     const nextSessionId = createClientChatSessionId();
     const response = await provisionRemoteSession(nextSessionId);
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (response.sessionId !== nextSessionId) {
       throw createRemoteSessionProvisioningError(uiMessages.unexpectedSessionId);
     }
 
     return response.sessionId;
-  }, [isRemoteReady, provisionRemoteSession, runtimeRefs, uiMessages, workspaceId]);
+  }, [indexedDbOpenRecoveryState, isRemoteReady, provisionRemoteSession, runtimeRefs, uiMessages, workspaceId]);
 
   const sendMessage = useCallback(async (
     sendParams: SendChatMessageParams,
@@ -615,6 +653,10 @@ export function useChatSessionActions(
     });
 
     const failRemoteSessionRequest = (error: unknown): SendChatMessageResult => {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return createRejectedSendResult(state.currentSessionId);
+      }
+
       captureChatRunRequestError(error, workspaceId, {
         operation: "chat_remote_session_failed",
         sessionId: runtimeRefs.currentSessionIdRef.current,
@@ -643,6 +685,10 @@ export function useChatSessionActions(
     };
 
     const activateRecoveredSession = (session: NewChatSessionResponse): boolean => {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return false;
+      }
+
       if (prepareDraftTargetSession(session.sessionId) === false) {
         return false;
       }
@@ -663,6 +709,7 @@ export function useChatSessionActions(
 
     const recoverAndActivateSession = async (): Promise<SessionConflictRecovery> => {
       const recovery = await recoverFromSessionIdConflict(requestSequence, sourceSessionId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (recovery.status === "recovered" && activateRecoveredSession(recovery.session) === false) {
         return { status: "stale" };
       }
@@ -675,11 +722,16 @@ export function useChatSessionActions(
 
     try {
       const ensuredSessionId = await ensureRemoteSession();
+      indexedDbOpenRecoveryState.throwIfFailed();
       sessionId = ensuredSessionId;
       if (prepareDraftTargetSession(ensuredSessionId) === false) {
         return finishStaleRequest();
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return createRejectedSendResult(state.currentSessionId);
+      }
+
       if (isRequestSequenceCurrent(requestSequence) === false) {
         return finishStaleRequest();
       }
@@ -687,6 +739,7 @@ export function useChatSessionActions(
       if (isChatSessionIdConflictError(error)) {
         try {
           const recovery = await recoverAndActivateSession();
+          indexedDbOpenRecoveryState.throwIfFailed();
           if (recovery.status === "recovered") {
             didRecoverSessionIdConflict = true;
             sessionId = recovery.session.sessionId;
@@ -694,6 +747,10 @@ export function useChatSessionActions(
             return finishStaleRequest();
           }
         } catch (recoveryError) {
+          if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, recoveryError)) {
+            return createRejectedSendResult(state.currentSessionId);
+          }
+
           if (isRequestSequenceCurrent(requestSequence) === false) {
             return finishStaleRequest();
           }
@@ -723,6 +780,7 @@ export function useChatSessionActions(
     });
 
     const startRunForSession = async (requestSessionId: string): Promise<StartChatRunResponse | null> => {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const requestBody = createStartRunRequestBody(requestSessionId);
       if (toRequestBodySizeBytes(requestBody) > ATTACHMENT_PAYLOAD_LIMIT_BYTES) {
         dispatch({
@@ -732,7 +790,9 @@ export function useChatSessionActions(
         return null;
       }
 
-      return startChatRun(requestBody);
+      const startRunResponse = await startChatRun(requestBody);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      return startRunResponse;
     };
 
     const failStartRunRequest = (
@@ -740,6 +800,10 @@ export function useChatSessionActions(
       requestSessionId: string,
       resultSessionId: string | null,
     ): SendChatMessageResult => {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return createRejectedSendResult(resultSessionId);
+      }
+
       if (isChatApiError(error) && error.code === "CHAT_ACTIVE_RUN_IN_PROGRESS") {
         dispatch({
           type: "error_shown",
@@ -792,11 +856,16 @@ export function useChatSessionActions(
 
     try {
       const initialResponse = await startRunForSession(sessionId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (initialResponse === null) {
         return createRejectedSendResult(didRecoverSessionIdConflict ? sessionId : state.currentSessionId);
       }
       response = initialResponse;
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return createRejectedSendResult(state.currentSessionId);
+      }
+
       if (isRequestSequenceCurrent(requestSequence) === false) {
         return finishStaleRequest();
       }
@@ -804,17 +873,23 @@ export function useChatSessionActions(
       if (isChatSessionIdConflictError(error) && didRecoverSessionIdConflict === false) {
         try {
           const recovery = await recoverAndActivateSession();
+          indexedDbOpenRecoveryState.throwIfFailed();
           if (recovery.status === "recovered") {
             didRecoverSessionIdConflict = true;
             sessionId = recovery.session.sessionId;
 
             try {
               const retryResponse = await startRunForSession(recovery.session.sessionId);
+              indexedDbOpenRecoveryState.throwIfFailed();
               if (retryResponse === null) {
                 return createRejectedSendResult(recovery.session.sessionId);
               }
               response = retryResponse;
             } catch (retryError) {
+              if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, retryError)) {
+                return createRejectedSendResult(recovery.session.sessionId);
+              }
+
               if (isRequestSequenceCurrent(requestSequence) === false) {
                 return finishStaleRequest();
               }
@@ -827,6 +902,10 @@ export function useChatSessionActions(
             return finishStaleRequest();
           }
         } catch (retryError) {
+          if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, retryError)) {
+            return createRejectedSendResult(state.currentSessionId);
+          }
+
           if (isRequestSequenceCurrent(requestSequence) === false) {
             return finishStaleRequest();
           }
@@ -890,6 +969,7 @@ export function useChatSessionActions(
     appendUserMessage,
     dispatch,
     getActiveRequestSequence,
+    indexedDbOpenRecoveryState,
     invalidatePendingSnapshotRequests,
     isDocumentVisibleRef,
     isRemoteReady,
@@ -939,6 +1019,7 @@ export function useChatSessionActions(
       }
 
       const response = await stopChatRun(requestSessionId, requestWorkspaceId, requestActiveRunId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isStopRequestCurrent() === false) {
         if (isStopRequestSessionCurrent()) {
           dispatch({ type: "stop_request_stale", runId: requestActiveRunId });
@@ -967,6 +1048,10 @@ export function useChatSessionActions(
         return;
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       if (requestWorkspaceId !== null && isStopRequestCurrent() === false) {
         if (isStopRequestSessionCurrent()) {
           dispatch({ type: "stop_request_stale", runId: requestActiveRunId });
@@ -995,6 +1080,7 @@ export function useChatSessionActions(
   }, [
     dispatch,
     hasActiveLiveConnection,
+    indexedDbOpenRecoveryState,
     reconcileTerminalSnapshot,
     runtimeRefs.runStateRef,
     runtimeRefs.activeRunIdRef,
@@ -1009,6 +1095,10 @@ export function useChatSessionActions(
   ]);
 
   const clearConversation = useCallback(async (): Promise<string | null> => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return null;
+    }
+
     beginFreshSessionRequestSequence();
 
     if (workspaceId === null) {
@@ -1038,6 +1128,7 @@ export function useChatSessionActions(
     detachLiveStream,
     dispatch,
     ensureFreshSession,
+    indexedDbOpenRecoveryState,
     invalidatePendingSnapshotRequests,
     resetSnapshotTracking,
     workspaceId,

--- a/apps/web/src/chat/sessionController/context.tsx
+++ b/apps/web/src/chat/sessionController/context.tsx
@@ -1,5 +1,9 @@
 import { createContext, useCallback, useContext, type ReactElement, type ReactNode } from "react";
 import { useAppData } from "../../appData";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
 import { USER_VISIBLE_ATTACHMENT_LIMIT_MB } from "../shared/chatHelpers";
 import {
@@ -16,6 +20,7 @@ const ChatSessionControllerContext = createContext<ChatSessionController | null>
 export function ChatSessionControllerProvider(props: Props): ReactElement {
   const { children } = props;
   const appData = useAppData();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const { locale, t, formatNumber } = useI18n();
   const activeWorkspaceId = appData.activeWorkspace?.workspaceId ?? null;
   const runSync = appData.runSync;
@@ -26,15 +31,21 @@ export function ChatSessionControllerProvider(props: Props): ReactElement {
     // from one post-run sync after any tool-backed run, not from chat-specific
     // invalidation callbacks.
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       await runSync();
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        indexedDbOpenRecoveryState.throwIfFailed();
+      }
       const message = error instanceof Error ? error.message : String(error);
       setAppErrorMessage(`Chat sync failed. ${message}`);
       throw error;
     }
-  }, [runSync, setAppErrorMessage]);
+  }, [indexedDbOpenRecoveryState, runSync, setAppErrorMessage]);
 
   const controller = useChatSessionController({
+    indexedDbOpenRecoveryState,
     workspaceId: activeWorkspaceId,
     isRemoteReady: appData.sessionVerificationState === "verified",
     uiLocale: locale,

--- a/apps/web/src/chat/sessionController/lifecycle/useHydrationLifecycle.ts
+++ b/apps/web/src/chat/sessionController/lifecycle/useHydrationLifecycle.ts
@@ -1,4 +1,8 @@
 import { useCallback, useEffect, useEffectEvent, useRef, type Dispatch } from "react";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
 import type { Locale } from "../../../i18n/types";
 import { loadStoredChatConfig } from "../support/config";
 import type {
@@ -20,6 +24,7 @@ import type { ChatHistoryState } from "../../history/useChatHistory";
 import type { ChatSessionControllerUiMessages } from "../support/types";
 
 type UseChatSessionHydrationLifecycleParams = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   workspaceId: string | null;
   isRemoteReady: boolean;
   uiLocale: Locale;
@@ -41,6 +46,7 @@ export function useChatSessionHydrationLifecycle(
   params: UseChatSessionHydrationLifecycleParams,
 ): void {
   const {
+    indexedDbOpenRecoveryState,
     workspaceId,
     isRemoteReady,
     uiLocale,
@@ -109,6 +115,10 @@ export function useChatSessionHydrationLifecycle(
   }, [detachLiveStream, dispatch, replaceMessages, resetSnapshotTracking, uiLocale]);
 
   const runHydrationLifecycle = useEffectEvent((isDisposedRef: { current: boolean }): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const isWorkspaceTransition = hydratedWorkspaceIdRef.current !== workspaceId;
     const isLocaleTransition = isWorkspaceTransition === false
       && workspaceId !== null
@@ -215,7 +225,7 @@ export function useChatSessionHydrationLifecycle(
           "initial_hydration",
           null,
         );
-        if (isDisposedRef.current || snapshot === null) {
+        if (indexedDbOpenRecoveryState.hasFailed() || isDisposedRef.current || snapshot === null) {
           return;
         }
 
@@ -225,6 +235,10 @@ export function useChatSessionHydrationLifecycle(
           startSnapshotLiveStream(snapshot, null);
         }
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
+
         if (isDisposedRef.current) {
           return;
         }
@@ -238,7 +252,7 @@ export function useChatSessionHydrationLifecycle(
           message: `${uiMessages.refreshFailedPrefix} ${toErrorMessage(error, uiMessages.errorFallbacks)}`,
         });
       } finally {
-        if (isDisposedRef.current === false) {
+        if (isDisposedRef.current === false && indexedDbOpenRecoveryState.hasFailed() === false) {
           dispatch({
             type: "set_history_loaded",
             isHistoryLoaded: true,
@@ -257,7 +271,7 @@ export function useChatSessionHydrationLifecycle(
   }, [isRemoteReady, uiLocale, workspaceId]);
 
   useEffect(() => {
-    if (state.isHistoryLoaded) {
+    if (indexedDbOpenRecoveryState.hasFailed() || state.isHistoryLoaded) {
       return;
     }
 
@@ -267,5 +281,5 @@ export function useChatSessionHydrationLifecycle(
         isHistoryLoaded: true,
       });
     }
-  }, [dispatch, state.isHistoryLoaded, workspaceId]);
+  }, [dispatch, indexedDbOpenRecoveryState, state.isHistoryLoaded, workspaceId]);
 }

--- a/apps/web/src/chat/sessionController/snapshotSync/useLiveSession.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useLiveSession.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 import type { ChatLiveStream } from "../../../types";
 import {
   ChatLiveContractError,
@@ -24,6 +25,7 @@ type LiveStreamDisposition = "pending" | "terminal";
 type UseChatLiveSessionParams = Readonly<{
   applyLiveEvent: (event: ChatLiveEvent) => void;
   finalizeInterruptedRun: (message: string) => void;
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   onVisibleResumeRequested: () => void;
   onRecoverableStreamError: (
     sessionId: string,
@@ -152,6 +154,7 @@ export function useChatLiveSession(
   const {
     applyLiveEvent,
     finalizeInterruptedRun,
+    indexedDbOpenRecoveryState,
     onVisibleResumeRequested,
     onRecoverableStreamError,
     onUnexpectedStreamEnd,
@@ -218,6 +221,12 @@ export function useChatLiveSession(
     onLiveAttachConnectedRef.current = onLiveAttachConnected;
   }, [onLiveAttachConnected]);
 
+  useEffect(() => {
+    if (indexedDbOpenRecoveryState.isFailed) {
+      detachLiveStream(null, null);
+    }
+  }, [detachLiveStream, indexedDbOpenRecoveryState.isFailed]);
+
   /**
    * Attaches live SSE only while the chat surface is visible. Existing sessions
    * must provide the latest known cursor so the stream continues after the last
@@ -232,11 +241,15 @@ export function useChatLiveSession(
   ): void => {
     detachLiveStream(null, null);
 
-    if (isDocumentVisibleRef.current === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isDocumentVisibleRef.current === false) {
       return;
     }
 
     const abortController = new AbortController();
+    const liveStreamSignal = AbortSignal.any([
+      indexedDbOpenRecoveryState.signal,
+      abortController.signal,
+    ]);
     let liveStreamDisposition: LiveStreamDisposition = "pending";
     let didReportConnected = false;
     activeLiveConnectionRef.current = { sessionId, runId, abortController };
@@ -248,11 +261,12 @@ export function useChatLiveSession(
       runId,
       afterCursor,
       resumeAttemptId,
-      signal: abortController.signal,
+      signal: liveStreamSignal,
       onEvent: (event) => {
         const activeConnection = activeLiveConnectionRef.current;
         if (
-          activeConnection?.sessionId !== sessionId
+          indexedDbOpenRecoveryState.hasFailed()
+          || activeConnection?.sessionId !== sessionId
           || activeConnection.runId !== runId
           || event.sessionId !== sessionId
           || event.runId !== runId
@@ -273,7 +287,7 @@ export function useChatLiveSession(
         applyLiveEventRef.current(event);
       },
     }).then(() => {
-      if (abortController.signal.aborted) {
+      if (liveStreamSignal.aborted || indexedDbOpenRecoveryState.hasFailed()) {
         return;
       }
 
@@ -290,7 +304,7 @@ export function useChatLiveSession(
 
       onUnexpectedStreamEndRef.current(sessionId, runId);
     }).catch((error: unknown) => {
-      if (abortController.signal.aborted) {
+      if (liveStreamSignal.aborted || indexedDbOpenRecoveryState.hasFailed()) {
         return;
       }
 
@@ -310,7 +324,7 @@ export function useChatLiveSession(
       captureLiveStreamError(normalizedError, sessionId, runId, resumeAttemptId);
       finalizeInterruptedRunRef.current(normalizedError.message);
     });
-  }, [detachLiveStream]);
+  }, [detachLiveStream, indexedDbOpenRecoveryState]);
 
   useEffect(() => {
     if (typeof document === "undefined") {
@@ -336,6 +350,9 @@ export function useChatLiveSession(
         return;
       }
 
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       onVisibleResumeRequestedRef.current();
     };
 
@@ -343,7 +360,7 @@ export function useChatLiveSession(
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [detachLiveStream]);
+  }, [detachLiveStream, indexedDbOpenRecoveryState]);
 
   useEffect(() => {
     return () => {

--- a/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
+++ b/apps/web/src/chat/sessionController/snapshotSync/useSnapshotSync.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, type Dispatch, type MutableRefObject } from "react";
 import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+} from "../../../appError/AppErrorContext";
+import {
   ApiContractError,
   ApiError,
   AuthRedirectError,
@@ -42,6 +46,7 @@ import type { ChatLiveEvent } from "../../streaming/liveStream";
 const assistantMessageDoneTerminalReconcileDelayMs = 5_000;
 
 type UseChatSessionSnapshotSyncParams = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   controllerId: string;
   workspaceId: string | null;
   isRemoteReady: boolean;
@@ -402,6 +407,7 @@ export function useChatSessionSnapshotSync(
   params: UseChatSessionSnapshotSyncParams,
 ): ChatSessionSnapshotSync {
   const {
+    indexedDbOpenRecoveryState,
     controllerId,
     workspaceId,
     isRemoteReady,
@@ -429,6 +435,7 @@ export function useChatSessionSnapshotSync(
   const chatConfigRef = useRef<ChatSessionControllerState["chatConfig"]>(state.chatConfig);
   const lastSnapshotUpdatedAtRef = useRef<number | null>(initialLastSnapshotUpdatedAt);
   const snapshotRequestVersionRef = useRef<number>(0);
+  const activeSnapshotAbortControllersRef = useRef<Set<AbortController>>(new Set<AbortController>());
   const visibilityResumePromiseRef = useRef<Promise<void> | null>(null);
   const streamTransportRecoveryPromiseRef = useRef<Promise<void> | null>(null);
   const activeToolRunPostSyncPromiseRef = useRef<Promise<void> | null>(null);
@@ -473,6 +480,13 @@ export function useChatSessionSnapshotSync(
     snapshotRequestVersionRef.current += 1;
   }, []);
 
+  const abortPendingSnapshotRequests = useCallback((): void => {
+    for (const controller of activeSnapshotAbortControllersRef.current) {
+      controller.abort();
+    }
+    activeSnapshotAbortControllersRef.current.clear();
+  }, []);
+
   const clearAssistantMessageDoneTerminalReconcileTimer = useCallback((): void => {
     const timerId = assistantMessageDoneTerminalReconcileTimerRef.current;
     if (timerId === null) {
@@ -491,7 +505,8 @@ export function useChatSessionSnapshotSync(
     assistantMessageDoneTerminalReconcileTimerRef.current = window.setTimeout((): void => {
       assistantMessageDoneTerminalReconcileTimerRef.current = null;
       if (
-        currentSessionIdRef.current !== sessionId
+        indexedDbOpenRecoveryState.hasFailed()
+        || currentSessionIdRef.current !== sessionId
         || runStateRef.current !== "running"
         || activeRunIdRef.current !== runId
       ) {
@@ -500,7 +515,7 @@ export function useChatSessionSnapshotSync(
 
       reconcileTerminalSnapshotRef.current(sessionId);
     }, assistantMessageDoneTerminalReconcileDelayMs);
-  }, [clearAssistantMessageDoneTerminalReconcileTimer]);
+  }, [clearAssistantMessageDoneTerminalReconcileTimer, indexedDbOpenRecoveryState]);
 
   const resetSnapshotTracking = useCallback((updatedAt: number | null): void => {
     clearAssistantMessageDoneTerminalReconcileTimer();
@@ -516,7 +531,7 @@ export function useChatSessionSnapshotSync(
   }, []);
 
   const requestToolRunPostSyncIfNeeded = useCallback((): Promise<void> => {
-    if (pendingToolRunPostSyncRef.current === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || pendingToolRunPostSyncRef.current === false) {
       return Promise.resolve();
     }
 
@@ -531,7 +546,9 @@ export function useChatSessionSnapshotSync(
     let postSyncRequestPromise: Promise<void> | null = null;
     postSyncRequestPromise = (async (): Promise<void> => {
       try {
+        indexedDbOpenRecoveryState.throwIfFailed();
         await onToolRunPostSyncRequested();
+        indexedDbOpenRecoveryState.throwIfFailed();
         pendingToolRunPostSyncRef.current = false;
         dispatch({ type: "tool_run_post_sync_consumed" });
       } finally {
@@ -543,20 +560,23 @@ export function useChatSessionSnapshotSync(
 
     activeToolRunPostSyncPromiseRef.current = postSyncRequestPromise;
     return postSyncRequestPromise;
-  }, [dispatch, onToolRunPostSyncRequested]);
+  }, [dispatch, indexedDbOpenRecoveryState, onToolRunPostSyncRequested]);
 
   const triggerToolRunPostSyncIfNeeded = useCallback((): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     void requestToolRunPostSyncIfNeeded().catch(() => undefined);
-  }, [requestToolRunPostSyncIfNeeded]);
+  }, [indexedDbOpenRecoveryState, requestToolRunPostSyncIfNeeded]);
 
   const markPendingToolRunPostSync = useCallback((): void => {
-    if (pendingToolRunPostSyncRef.current) {
+    if (indexedDbOpenRecoveryState.hasFailed() || pendingToolRunPostSyncRef.current) {
       return;
     }
 
     pendingToolRunPostSyncRef.current = true;
     dispatch({ type: "tool_run_post_sync_marked" });
-  }, [dispatch]);
+  }, [dispatch, indexedDbOpenRecoveryState]);
 
   const markRunHadToolCallsFromSnapshot = useCallback((
     activeRun: ChatActiveRun | null,
@@ -577,6 +597,10 @@ export function useChatSessionSnapshotSync(
   }, [markPendingToolRunPostSync]);
 
   const applyLiveEvent = useCallback((event: ChatLiveEvent): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (event.type === "assistant_delta") {
       setKnownLiveCursor(event.cursor);
       appendAssistantText(event.text, event.itemId, event.cursor);
@@ -670,6 +694,7 @@ export function useChatSessionSnapshotSync(
     completeAssistantReasoningSummary,
     dispatch,
     finishAssistantMessage,
+    indexedDbOpenRecoveryState,
     markPendingToolRunPostSync,
     state.currentSessionId,
     state.mainContentInvalidationVersion,
@@ -691,14 +716,19 @@ export function useChatSessionSnapshotSync(
   } = useChatLiveSession({
     applyLiveEvent,
     finalizeInterruptedRun: (message) => {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       dispatch({
         type: "run_interrupted",
         message: toErrorMessage(new Error(message), uiMessages.errorFallbacks),
       });
     },
+    indexedDbOpenRecoveryState,
     onVisibleResumeRequested: () => {
       if (
-        isDocumentVisibleRef.current === false
+        indexedDbOpenRecoveryState.hasFailed()
+        || isDocumentVisibleRef.current === false
         || workspaceId === null
         || isRemoteReady === false
         || state.isHistoryLoaded === false
@@ -723,7 +753,11 @@ export function useChatSessionSnapshotSync(
             "visible_resume",
             resumeAttemptId,
           );
-          if (snapshot === null || isDocumentVisibleRef.current === false) {
+          if (
+            indexedDbOpenRecoveryState.hasFailed()
+            || snapshot === null
+            || isDocumentVisibleRef.current === false
+          ) {
             return;
           }
 
@@ -740,6 +774,10 @@ export function useChatSessionSnapshotSync(
 
           detachLiveStream(snapshot.sessionId, null);
         } catch (error) {
+          if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+            return;
+          }
+
           if (isDocumentVisibleRef.current === false) {
             return;
           }
@@ -759,7 +797,7 @@ export function useChatSessionSnapshotSync(
       visibilityResumePromiseRef.current = refreshPromise;
     },
     onRecoverableStreamError: (sessionId) => {
-      if (streamTransportRecoveryPromiseRef.current !== null) {
+      if (indexedDbOpenRecoveryState.hasFailed() || streamTransportRecoveryPromiseRef.current !== null) {
         return;
       }
 
@@ -773,7 +811,7 @@ export function useChatSessionSnapshotSync(
             "stream_transport_error",
             resumeAttemptId,
           );
-          if (snapshot === null) {
+          if (indexedDbOpenRecoveryState.hasFailed() || snapshot === null) {
             return;
           }
 
@@ -797,6 +835,10 @@ export function useChatSessionSnapshotSync(
             });
           }
         } catch (error) {
+          if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+            return;
+          }
+
           detachLiveStream(null, null);
           dispatch({
             type: "run_interrupted",
@@ -812,9 +854,14 @@ export function useChatSessionSnapshotSync(
       streamTransportRecoveryPromiseRef.current = recoveryPromise;
     },
     onLiveAttachConnected: () => {
-      dispatch({ type: "live_attach_connected" });
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        dispatch({ type: "live_attach_connected" });
+      }
     },
     onUnexpectedStreamEnd: (sessionId, runId) => {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       clearAssistantMessageDoneTerminalReconcileTimer();
       dispatch({
         type: "stop_finished",
@@ -829,7 +876,7 @@ export function useChatSessionSnapshotSync(
             "unexpected_stream_end",
             null,
           );
-          if (snapshot === null) {
+          if (indexedDbOpenRecoveryState.hasFailed() || snapshot === null) {
             return;
           }
 
@@ -849,6 +896,10 @@ export function useChatSessionSnapshotSync(
             });
           }
         } catch (error) {
+          if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+            return;
+          }
+
           dispatch({
             type: "run_interrupted",
             message: `${uiMessages.refreshFailedPrefix} ${toErrorMessage(error, uiMessages.errorFallbacks)}`,
@@ -858,14 +909,39 @@ export function useChatSessionSnapshotSync(
     },
   });
 
+  useEffect(() => {
+    if (indexedDbOpenRecoveryState.isFailed === false) {
+      return;
+    }
+
+    invalidatePendingSnapshotRequests();
+    abortPendingSnapshotRequests();
+    clearAssistantMessageDoneTerminalReconcileTimer();
+    pendingToolRunPostSyncRef.current = false;
+    visibilityResumePromiseRef.current = null;
+    streamTransportRecoveryPromiseRef.current = null;
+    activeToolRunPostSyncPromiseRef.current = null;
+  }, [
+    abortPendingSnapshotRequests,
+    clearAssistantMessageDoneTerminalReconcileTimer,
+    indexedDbOpenRecoveryState.isFailed,
+    invalidatePendingSnapshotRequests,
+  ]);
+
   const loadAndApplySnapshot = useCallback(async (
     sessionId: string,
     replaceHistory: boolean,
     trigger: SnapshotRequestTrigger,
     resumeAttemptId: number | null,
   ): Promise<ChatSessionSnapshot | null> => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return null;
+    }
+
     const requestVersion = snapshotRequestVersionRef.current + 1;
     snapshotRequestVersionRef.current = requestVersion;
+    const abortController = new AbortController();
+    activeSnapshotAbortControllersRef.current.add(abortController);
 
     debugLog("snapshot_request_started", {
       workspaceId,
@@ -876,13 +952,20 @@ export function useChatSessionSnapshotSync(
     });
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (workspaceId === null) {
         throw new Error(uiMessages.workspaceRequired);
       }
 
       const snapshot = resumeAttemptId === null
-        ? await getChatSnapshot(sessionId, workspaceId)
-        : await getChatSnapshotWithResumeDiagnostics(sessionId, workspaceId, { resumeAttemptId });
+        ? await getChatSnapshot(sessionId, workspaceId, abortController.signal)
+        : await getChatSnapshotWithResumeDiagnostics(
+          sessionId,
+          workspaceId,
+          { resumeAttemptId },
+          abortController.signal,
+        );
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (requestVersion !== snapshotRequestVersionRef.current) {
         return null;
       }
@@ -951,6 +1034,12 @@ export function useChatSessionSnapshotSync(
       });
       return snapshot;
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        invalidatePendingSnapshotRequests();
+        clearAssistantMessageDoneTerminalReconcileTimer();
+        return null;
+      }
+
       if (requestVersion !== snapshotRequestVersionRef.current) {
         return null;
       }
@@ -964,10 +1053,15 @@ export function useChatSessionSnapshotSync(
       });
       captureChatSnapshotError(error, workspaceId, sessionId, trigger, resumeAttemptId);
       throw error;
+    } finally {
+      activeSnapshotAbortControllersRef.current.delete(abortController);
     }
   }, [
     debugLog,
     dispatch,
+    clearAssistantMessageDoneTerminalReconcileTimer,
+    indexedDbOpenRecoveryState,
+    invalidatePendingSnapshotRequests,
     markRunHadToolCallsFromSnapshot,
     replaceMessages,
     triggerToolRunPostSyncIfNeeded,
@@ -982,6 +1076,9 @@ export function useChatSessionSnapshotSync(
     activeRun: ChatActiveRun,
     resumeAttemptId: number | null,
   ): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     setKnownActiveRunId(activeRun.runId);
     startLiveStream(
       sessionId,
@@ -990,22 +1087,30 @@ export function useChatSessionSnapshotSync(
       activeRun.live.cursor,
       resumeAttemptId,
     );
-  }, [setKnownActiveRunId, startLiveStream]);
+  }, [indexedDbOpenRecoveryState, setKnownActiveRunId, startLiveStream]);
 
   const startSnapshotLiveStream = useCallback((
     snapshot: ChatSessionSnapshot,
     resumeAttemptId: number | null,
   ): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     if (snapshot.activeRun === null) {
       detachLiveStream(snapshot.sessionId, null);
       return;
     }
 
     startActiveRunLiveStream(snapshot.sessionId, snapshot.activeRun, resumeAttemptId);
-  }, [detachLiveStream, startActiveRunLiveStream]);
+  }, [detachLiveStream, indexedDbOpenRecoveryState, startActiveRunLiveStream]);
 
   const reconcileTerminalSnapshot = useCallback((sessionId: string | null): void => {
-    if (workspaceId === null || isRemoteReady === false || sessionId === null) {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || workspaceId === null
+      || isRemoteReady === false
+      || sessionId === null
+    ) {
       return;
     }
 
@@ -1017,7 +1122,7 @@ export function useChatSessionSnapshotSync(
           "terminal_reconcile",
           null,
         );
-        if (snapshot === null) {
+        if (indexedDbOpenRecoveryState.hasFailed() || snapshot === null) {
           return;
         }
 
@@ -1028,6 +1133,10 @@ export function useChatSessionSnapshotSync(
 
         detachLiveStream(snapshot.sessionId, null);
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
+
         detachLiveStream(null, null);
         dispatch({
           type: "run_interrupted",
@@ -1038,6 +1147,7 @@ export function useChatSessionSnapshotSync(
   }, [
     detachLiveStream,
     dispatch,
+    indexedDbOpenRecoveryState,
     isDocumentVisibleRef,
     isRemoteReady,
     loadAndApplySnapshot,
@@ -1051,8 +1161,10 @@ export function useChatSessionSnapshotSync(
   }, [reconcileTerminalSnapshot]);
 
   useEffect(() => () => {
+    invalidatePendingSnapshotRequests();
+    abortPendingSnapshotRequests();
     clearAssistantMessageDoneTerminalReconcileTimer();
-  }, [clearAssistantMessageDoneTerminalReconcileTimer]);
+  }, [abortPendingSnapshotRequests, clearAssistantMessageDoneTerminalReconcileTimer, invalidatePendingSnapshotRequests]);
 
   return {
     isLiveStreamConnected,

--- a/apps/web/src/chat/sessionController/support/types.ts
+++ b/apps/web/src/chat/sessionController/support/types.ts
@@ -4,6 +4,7 @@ import type { ChatErrorFallbackMessages } from "../../shared/chatHelpers";
 import type { PendingAttachment } from "../../attachments/FileAttachment";
 import type { StoredMessage } from "../../history/useChatHistory";
 import type { ChatComposerAction, ChatRunState } from "../state/runState";
+import type { IndexedDbOpenRecoveryState } from "../../../appError/AppErrorContext";
 
 export type ChatSessionControllerUiMessages = Readonly<{
   activeRunInProgress: string;
@@ -23,6 +24,7 @@ export type ChatSessionControllerUiMessages = Readonly<{
 }>;
 
 export type UseChatSessionControllerParams = Readonly<{
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState;
   workspaceId: string | null;
   isRemoteReady: boolean;
   uiLocale: Locale;

--- a/apps/web/src/chat/sessionController/useController.ts
+++ b/apps/web/src/chat/sessionController/useController.ts
@@ -38,6 +38,7 @@ export function useChatSessionController(
   params: UseChatSessionControllerParams,
 ): ChatSessionController {
   const {
+    indexedDbOpenRecoveryState,
     workspaceId,
     isRemoteReady,
     uiLocale,
@@ -46,7 +47,14 @@ export function useChatSessionController(
   } = params;
   const controllerIdRef = useRef<string>(createChatControllerDebugId());
   const controllerId = controllerIdRef.current;
-  const initialWarmStartSnapshotRef = useRef(loadChatSessionWarmStartSnapshot(workspaceId));
+  const initialWarmStartSnapshotRef = useRef<ReturnType<typeof loadChatSessionWarmStartSnapshot>>(null);
+  const didLoadInitialWarmStartSnapshotRef = useRef<boolean>(false);
+  if (didLoadInitialWarmStartSnapshotRef.current === false) {
+    didLoadInitialWarmStartSnapshotRef.current = true;
+    initialWarmStartSnapshotRef.current = indexedDbOpenRecoveryState.hasFailed()
+      ? null
+      : loadChatSessionWarmStartSnapshot(workspaceId);
+  }
   const initialWarmStartSnapshot = initialWarmStartSnapshotRef.current;
   const initialWarmStartSnapshotIsStale = initialWarmStartSnapshot === null
     ? false
@@ -63,6 +71,7 @@ export function useChatSessionController(
   const [state, dispatch] = useReducer(chatSessionControllerReducer, bootstrap.initialState);
   const history = useChatHistory(bootstrap.initialMessages);
   const snapshotSync = useChatSessionSnapshotSync({
+    indexedDbOpenRecoveryState,
     controllerId,
     workspaceId,
     isRemoteReady,
@@ -76,6 +85,7 @@ export function useChatSessionController(
       : null,
   });
   const actions = useChatSessionActions({
+    indexedDbOpenRecoveryState,
     workspaceId,
     isRemoteReady,
     uiLocale,
@@ -87,6 +97,7 @@ export function useChatSessionController(
   });
 
   useChatSessionHydrationLifecycle({
+    indexedDbOpenRecoveryState,
     workspaceId,
     isRemoteReady,
     uiLocale,
@@ -114,7 +125,12 @@ export function useChatSessionController(
   }, []);
 
   const persistWarmStartSnapshot = useEffectEvent((): void => {
-    if (workspaceId === null || state.currentSessionId === null || state.isHistoryLoaded === false) {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || workspaceId === null
+      || state.currentSessionId === null
+      || state.isHistoryLoaded === false
+    ) {
       return;
     }
 
@@ -146,33 +162,50 @@ export function useChatSessionController(
   ]);
 
   const dismissErrorDialog = useCallback((): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     dispatch({ type: "error_dismissed" });
-  }, []);
+  }, [indexedDbOpenRecoveryState]);
 
   const acceptServerSessionId = useCallback((sessionId: string | null): void => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     dispatch({
       type: "accept_server_session_id",
       sessionId,
     });
-  }, []);
+  }, [indexedDbOpenRecoveryState]);
 
   const sendMessage = useCallback(async (
     sendParams: SendChatMessageParams,
   ): Promise<SendChatMessageResult> => {
-    return actions.sendMessage(sendParams);
-  }, [actions]);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await actions.sendMessage(sendParams);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  }, [actions, indexedDbOpenRecoveryState]);
 
   const ensureRemoteSession = useCallback(async (): Promise<string> => {
-    return actions.ensureRemoteSession();
-  }, [actions]);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const sessionId = await actions.ensureRemoteSession();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return sessionId;
+  }, [actions, indexedDbOpenRecoveryState]);
 
   const stopMessage = useCallback(async (): Promise<void> => {
+    indexedDbOpenRecoveryState.throwIfFailed();
     await actions.stopMessage();
-  }, [actions]);
+    indexedDbOpenRecoveryState.throwIfFailed();
+  }, [actions, indexedDbOpenRecoveryState]);
 
   const clearConversation = useCallback(async (): Promise<string | null> => {
-    return actions.clearConversation();
-  }, [actions]);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const sessionId = await actions.clearConversation();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return sessionId;
+  }, [actions, indexedDbOpenRecoveryState]);
 
   return {
     messages: history.messages,

--- a/apps/web/src/feedback/automaticFeedbackPrompt.ts
+++ b/apps/web/src/feedback/automaticFeedbackPrompt.ts
@@ -4,6 +4,7 @@ import {
   loadLocalProgressSummary,
 } from "../localDb/progress/progress";
 import { buildProgressDateContext } from "../progress/progressDates";
+import type { IndexedDbOpenRecoveryState } from "../appError/AppErrorContext";
 
 export type AutomaticFeedbackPromptReviewActivity = Readonly<{
   today: string;
@@ -139,22 +140,30 @@ export function shouldRequestAutomaticFeedbackState(input: AutomaticFeedbackProm
 export async function loadAutomaticFeedbackPromptReviewActivity(
   workspaceId: string,
   now: Date,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
 ): Promise<AutomaticFeedbackPromptReviewActivity> {
   const dateContext = buildProgressDateContext(now);
   const [
     summary,
     todayReviews,
   ] = await Promise.all([
-    loadLocalProgressSummary([workspaceId], {
-      timeZone: dateContext.timeZone,
-      today: dateContext.today,
-    }),
-    loadLocalProgressDailyReviews([workspaceId], {
-      timeZone: dateContext.timeZone,
-      from: dateContext.today,
-      to: dateContext.today,
-    }),
+    runRecoveryGuardedAutomaticFeedbackRead(
+      () => loadLocalProgressSummary([workspaceId], {
+        timeZone: dateContext.timeZone,
+        today: dateContext.today,
+      }),
+      indexedDbOpenRecoveryState,
+    ),
+    runRecoveryGuardedAutomaticFeedbackRead(
+      () => loadLocalProgressDailyReviews([workspaceId], {
+        timeZone: dateContext.timeZone,
+        from: dateContext.today,
+        to: dateContext.today,
+      }),
+      indexedDbOpenRecoveryState,
+    ),
   ]);
+  indexedDbOpenRecoveryState.throwIfFailed();
   const todayReviewCount = todayReviews.find((point) => point.date === dateContext.today)?.reviewCount ?? 0;
   const previousReviewDayCount = summary.activeReviewDays - (summary.hasReviewedToday ? 1 : 0);
 
@@ -164,4 +173,21 @@ export async function loadAutomaticFeedbackPromptReviewActivity(
     todayReviewCount,
     hasPreviousReviewDay: previousReviewDayCount > 0,
   };
+}
+
+async function runRecoveryGuardedAutomaticFeedbackRead<ResultType>(
+  createRead: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createRead();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
 }

--- a/apps/web/src/localDb/core/cache.ts
+++ b/apps/web/src/localDb/core/cache.ts
@@ -1,5 +1,20 @@
-import { deleteDatabase } from "./database";
+import {
+  deleteDatabase,
+  deleteDatabaseForLocalBrowserDataCleanup,
+} from "./database";
 
 export async function clearWebSyncCache(): Promise<void> {
   await deleteDatabase();
+}
+
+export async function clearWebSyncCacheForLocalBrowserDataCleanup(
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<void> {
+  try {
+    await deleteDatabaseForLocalBrowserDataCleanup(throwIfIndexedDbOpenRecoveryFailed);
+    throwIfIndexedDbOpenRecoveryFailed();
+  } catch (error) {
+    throwIfIndexedDbOpenRecoveryFailed();
+    throw error;
+  }
 }

--- a/apps/web/src/localDb/core/database.ts
+++ b/apps/web/src/localDb/core/database.ts
@@ -12,6 +12,7 @@ import {
   type WebObservationScope,
 } from "../../observability/webObservability";
 import { upgradeDatabase } from "./databaseMigrations";
+import { isIndexedDbOpenRecoveryError } from "./indexedDbOpenRecovery";
 import { databaseName, databaseVersion } from "./databaseSchema";
 import type { DatabaseStores } from "./databaseSchema";
 
@@ -209,7 +210,9 @@ export function openDatabase(): Promise<IDBDatabase> {
 
     request.onerror = () => {
       const error = describeIndexedDbOperationError("Failed to open IndexedDB", request.error, "open");
-      addIndexedDbOperationFailedBreadcrumb("open", request.error, error);
+      if (isIndexedDbOpenRecoveryError(error) === false) {
+        addIndexedDbOperationFailedBreadcrumb("open", request.error, error);
+      }
       reject(error);
     };
 
@@ -401,16 +404,25 @@ function clearAllObjectStores(database: IDBDatabase): Promise<void> {
   });
 }
 
-async function wipeAllObjectStores(): Promise<void> {
+async function wipeAllObjectStores(
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<void> {
   const database = await openDatabase();
   try {
+    throwIfIndexedDbOpenRecoveryFailed();
     await clearAllObjectStores(database);
+    throwIfIndexedDbOpenRecoveryFailed();
+  } catch (error) {
+    throwIfIndexedDbOpenRecoveryFailed();
+    throw error;
   } finally {
     database.close();
   }
 }
 
-async function databaseExists(): Promise<boolean> {
+async function databaseExists(
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<boolean> {
   if (typeof indexedDB.databases !== "function") {
     // Capability missing in older browsers: assume the database exists; the
     // wipe open below creates it when absent, which is harmless.
@@ -419,8 +431,13 @@ async function databaseExists(): Promise<boolean> {
 
   try {
     const databases = await indexedDB.databases();
+    throwIfIndexedDbOpenRecoveryFailed();
     return databases.some((databaseInfo) => databaseInfo.name === databaseName);
   } catch (error) {
+    throwIfIndexedDbOpenRecoveryFailed();
+    if (isIndexedDbOpenRecoveryError(error)) {
+      throw error;
+    }
     // Enumeration failure is non-fatal: proceed with the wipe open, which
     // raises an actionable open error when storage is actually broken.
     console.warn("IndexedDB databases() enumeration failed", {
@@ -506,6 +523,33 @@ function requestDeleteDatabaseBestEffort(): Promise<DeleteDatabaseOutcome> {
   });
 }
 
+function ignoreIndexedDbOpenRecoveryFailure(): void {
+}
+
+async function waitForDatabaseCleanupPhase<ResultType>(
+  phase: Promise<ResultType>,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<ResultType> {
+  try {
+    const result = await phase;
+    throwIfIndexedDbOpenRecoveryFailed();
+    return result;
+  } catch (error) {
+    throwIfIndexedDbOpenRecoveryFailed();
+    throw error;
+  }
+}
+
+function throwActiveIndexedDbOpenRecoveryFailure(
+  results: ReadonlyArray<PromiseSettledResult<unknown>>,
+): void {
+  for (const result of results) {
+    if (result.status === "rejected" && isIndexedDbOpenRecoveryError(result.reason)) {
+      throw result.reason;
+    }
+  }
+}
+
 /**
  * Resets the local database for user-scoped cleanup.
  *
@@ -515,29 +559,49 @@ function requestDeleteDatabaseBestEffort(): Promise<DeleteDatabaseOutcome> {
  * either step removed the data; it fails only when the stores could not be
  * wiped and the database was not confirmed deleted.
  */
-export function deleteDatabase(): Promise<void> {
+function startDatabaseDeletion(throwIfIndexedDbOpenRecoveryFailed: () => void): Promise<void> {
+  throwIfIndexedDbOpenRecoveryFailed();
   const activeDelete = activeDatabaseDeletePromise;
   if (activeDelete !== null) {
-    return activeDelete;
+    return waitForDatabaseCleanupPhase(activeDelete, throwIfIndexedDbOpenRecoveryFailed);
   }
 
   const deleteTask = (async (): Promise<void> => {
     isDatabaseDeleteInProgress = true;
     try {
-      await Promise.allSettled([...activeDatabaseOperationPromises]);
+      const activeOperationResults = await waitForDatabaseCleanupPhase(
+        Promise.allSettled([...activeDatabaseOperationPromises]),
+        throwIfIndexedDbOpenRecoveryFailed,
+      );
+      throwActiveIndexedDbOpenRecoveryFailure(activeOperationResults);
 
       let wipeError: Error | null = null;
       try {
         // A missing database has nothing to wipe; skipping avoids creating
         // the full schema just to delete it on fresh browsers.
-        if (await databaseExists()) {
-          await wipeAllObjectStores();
+        const doesDatabaseExist = await waitForDatabaseCleanupPhase(
+          databaseExists(throwIfIndexedDbOpenRecoveryFailed),
+          throwIfIndexedDbOpenRecoveryFailed,
+        );
+        if (doesDatabaseExist) {
+          await waitForDatabaseCleanupPhase(
+            wipeAllObjectStores(throwIfIndexedDbOpenRecoveryFailed),
+            throwIfIndexedDbOpenRecoveryFailed,
+          );
         }
       } catch (error) {
+        throwIfIndexedDbOpenRecoveryFailed();
+        if (isIndexedDbOpenRecoveryError(error)) {
+          throw error;
+        }
         wipeError = error instanceof Error ? error : new Error(String(error));
       }
 
-      const deleteOutcome = await requestDeleteDatabaseBestEffort();
+      throwIfIndexedDbOpenRecoveryFailed();
+      const deleteOutcome = await waitForDatabaseCleanupPhase(
+        requestDeleteDatabaseBestEffort(),
+        throwIfIndexedDbOpenRecoveryFailed,
+      );
       if (wipeError !== null && deleteOutcome !== "deleted") {
         throw wipeError;
       }
@@ -548,6 +612,16 @@ export function deleteDatabase(): Promise<void> {
   })();
   activeDatabaseDeletePromise = deleteTask;
   return deleteTask;
+}
+
+export function deleteDatabase(): Promise<void> {
+  return startDatabaseDeletion(ignoreIndexedDbOpenRecoveryFailure);
+}
+
+export function deleteDatabaseForLocalBrowserDataCleanup(
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<void> {
+  return startDatabaseDeletion(throwIfIndexedDbOpenRecoveryFailed);
 }
 
 export type StoredEntity = StoredCard | Deck | ReviewEvent | ProgressDailyCountRecord;

--- a/apps/web/src/localDb/feedback/feedback.test.ts
+++ b/apps/web/src/localDb/feedback/feedback.test.ts
@@ -9,6 +9,8 @@ import {
   storeFeedbackSubmittedAt,
 } from "./feedback";
 
+const ignoreIndexedDbOpenRecoveryFailure = (): void => {};
+
 describe("local feedback prompt state", () => {
   beforeEach(async () => {
     await clearWebSyncCache();
@@ -30,7 +32,7 @@ describe("local feedback prompt state", () => {
         nextAutomaticPromptAt: "2026-05-20T09:00:00.000Z",
       },
       submittedAt: "2026-04-20T09:00:00.000Z",
-    });
+    }, ignoreIndexedDbOpenRecoveryFailure);
 
     await expect(loadFeedbackPromptState("user:user-1")).resolves.toEqual({
       ...emptyFeedbackPromptState,

--- a/apps/web/src/localDb/feedback/feedback.ts
+++ b/apps/web/src/localDb/feedback/feedback.ts
@@ -195,8 +195,13 @@ export async function putFeedbackPromptState(
   });
 }
 
-export async function storeFetchedFeedbackState(input: FeedbackStateFetchedInput): Promise<FeedbackPromptState> {
+export async function storeFetchedFeedbackState(
+  input: FeedbackStateFetchedInput,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<FeedbackPromptState> {
+  throwIfIndexedDbOpenRecoveryFailed();
   const currentState = await loadFeedbackPromptState(input.identityKey);
+  throwIfIndexedDbOpenRecoveryFailed();
   const nextState: FeedbackPromptState = {
     ...currentState,
     lastAutomaticFeedbackPromptShownAt: getLaterNullableIsoTimestamp(
@@ -212,12 +217,19 @@ export async function storeFetchedFeedbackState(input: FeedbackStateFetchedInput
     nextAutomaticFeedbackPromptAt: input.feedbackState.nextAutomaticPromptAt,
     lastFeedbackStateFetchedAt: input.fetchedAt,
   };
+  throwIfIndexedDbOpenRecoveryFailed();
   await putFeedbackPromptState(input.identityKey, nextState);
+  throwIfIndexedDbOpenRecoveryFailed();
   return nextState;
 }
 
-export async function storeFeedbackSubmittedAt(input: FeedbackSubmittedInput): Promise<FeedbackPromptState> {
+export async function storeFeedbackSubmittedAt(
+  input: FeedbackSubmittedInput,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<FeedbackPromptState> {
+  throwIfIndexedDbOpenRecoveryFailed();
   const currentState = await loadFeedbackPromptState(input.identityKey);
+  throwIfIndexedDbOpenRecoveryFailed();
   const localSubmittedAt = getLaterNullableIsoTimestamp(
     currentState.lastFeedbackSubmittedAt,
     input.submittedAt,
@@ -238,12 +250,19 @@ export async function storeFeedbackSubmittedAt(input: FeedbackSubmittedInput): P
     nextAutomaticFeedbackPromptAt: input.feedbackState.nextAutomaticPromptAt,
     lastFeedbackStateFetchedAt: input.submittedAt,
   };
+  throwIfIndexedDbOpenRecoveryFailed();
   await putFeedbackPromptState(input.identityKey, nextState);
+  throwIfIndexedDbOpenRecoveryFailed();
   return nextState;
 }
 
-export async function storeAutomaticFeedbackPromptShownAt(input: AutomaticPromptShownInput): Promise<FeedbackPromptState> {
+export async function storeAutomaticFeedbackPromptShownAt(
+  input: AutomaticPromptShownInput,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
+): Promise<FeedbackPromptState> {
+  throwIfIndexedDbOpenRecoveryFailed();
   const currentState = await loadFeedbackPromptState(input.identityKey);
+  throwIfIndexedDbOpenRecoveryFailed();
   const nextState: FeedbackPromptState = {
     ...currentState,
     lastAutomaticFeedbackPromptShownAt: getLaterNullableIsoTimestamp(
@@ -257,6 +276,8 @@ export async function storeAutomaticFeedbackPromptShownAt(input: AutomaticPrompt
       "nextAutomaticFeedbackPromptAt",
     ),
   };
+  throwIfIndexedDbOpenRecoveryFailed();
   await putFeedbackPromptState(input.identityKey, nextState);
+  throwIfIndexedDbOpenRecoveryFailed();
   return nextState;
 }

--- a/apps/web/src/localDb/mediaTransfers/mediaTransfers.test.ts
+++ b/apps/web/src/localDb/mediaTransfers/mediaTransfers.test.ts
@@ -4,6 +4,7 @@ import { Blob as NodeBlob } from "node:buffer";
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { MediaAsset } from "../../types";
+import type { IndexedDbOpenRecoveryState } from "../../appError/AppErrorContext";
 import { clearWebSyncCache } from "../core/cache";
 import { loadMediaAssetRecord } from "../mediaAssets";
 import {
@@ -24,6 +25,14 @@ import {
   recoverStaleInProgressMediaTransfersByKind,
   renewInProgressMediaTransferClaim,
 } from "./mediaTransfers";
+
+const indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState = {
+  hasFailed: () => false,
+  isFailed: false,
+  markFailed: () => "not_recovery",
+  signal: new AbortController().signal,
+  throwIfFailed: () => undefined,
+};
 
 describe("localDb media transfers", () => {
   beforeEach(async () => {
@@ -148,6 +157,7 @@ describe("localDb media transfers", () => {
     await expect(loadNextPendingMediaTransferAttemptAtByKind(
       "workspace-1",
       "upload",
+      indexedDbOpenRecoveryState,
     )).resolves.toBe("2026-03-10T09:30:00.000Z");
   });
 

--- a/apps/web/src/localDb/mediaTransfers/mediaTransfers.ts
+++ b/apps/web/src/localDb/mediaTransfers/mediaTransfers.ts
@@ -1,4 +1,5 @@
 import type { MediaAsset } from "../../types";
+import type { IndexedDbOpenRecoveryState } from "../../appError/AppErrorContext";
 import {
   closeDatabaseAfter,
   closeDatabaseAfterWrite,
@@ -582,12 +583,37 @@ async function loadNextPendingMediaTransferByStatusAndKind(
 export async function loadNextPendingMediaTransferAttemptAtByKind(
   workspaceId: string,
   kind: MediaTransferKind,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
 ): Promise<string | null> {
   const [queuedRecord, failedRecord] = await Promise.all([
-    loadNextPendingMediaTransferByStatusAndKind(workspaceId, "queued", kind),
-    loadNextPendingMediaTransferByStatusAndKind(workspaceId, "failed", kind),
+    runRecoveryGuardedMediaTransferRead(
+      () => loadNextPendingMediaTransferByStatusAndKind(workspaceId, "queued", kind),
+      indexedDbOpenRecoveryState,
+    ),
+    runRecoveryGuardedMediaTransferRead(
+      () => loadNextPendingMediaTransferByStatusAndKind(workspaceId, "failed", kind),
+      indexedDbOpenRecoveryState,
+    ),
   ]);
+  indexedDbOpenRecoveryState.throwIfFailed();
   return selectNextDueTransfer(queuedRecord, failedRecord)?.nextAttemptAt ?? null;
+}
+
+async function runRecoveryGuardedMediaTransferRead<ResultType>(
+  createRead: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createRead();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
 }
 
 export async function recoverStaleInProgressMediaTransfersByKind(

--- a/apps/web/src/localDb/mobileAppPromotion/mobileAppPromotion.test.ts
+++ b/apps/web/src/localDb/mobileAppPromotion/mobileAppPromotion.test.ts
@@ -11,6 +11,8 @@ import {
   storeMobileAppPromotionPromptShown,
 } from "./mobileAppPromotion";
 
+const ignoreIndexedDbOpenRecoveryFailure = (): void => {};
+
 describe("local mobile app promotion state", () => {
   beforeEach(async () => {
     await clearWebSyncCache();
@@ -25,7 +27,7 @@ describe("local mobile app promotion state", () => {
 
     await storeKnownMobileReviewEvent({
       identityKey: "user:user-2",
-    });
+    }, ignoreIndexedDbOpenRecoveryFailure);
 
     await expect(loadMobileAppPromotionState("user:user-1")).resolves.toEqual({
       ...emptyMobileAppPromotionState,
@@ -46,7 +48,7 @@ describe("local mobile app promotion state", () => {
       identityKey: "user:user-1",
       localDate: "2026-03-11",
       shownAt: "2026-03-11T08:00:00.000Z",
-    })).resolves.toEqual({
+    }, ignoreIndexedDbOpenRecoveryFailure)).resolves.toEqual({
       ...emptyMobileAppPromotionState,
       lastPromptShownLocalDate: "2026-03-11",
       lastPromptShownAt: "2026-03-11T08:00:00.000Z",
@@ -70,7 +72,7 @@ describe("local mobile app promotion state", () => {
       identityKey: "user:user-1",
       localDate: "2026-03-11",
       shownAt: "2026-03-11T08:00:00.000Z",
-    })).resolves.toEqual({
+    }, ignoreIndexedDbOpenRecoveryFailure)).resolves.toEqual({
       lastPromptShownLocalDate: null,
       lastPromptShownAt: null,
       knownHasMobileReviewEvent: true,
@@ -88,7 +90,7 @@ describe("local mobile app promotion state", () => {
       identityKey: "user:user-1",
       localDate: "2026-03-11",
       shownAt: "2026-03-11T08:00:00.000Z",
-    })).resolves.toEqual({
+    }, ignoreIndexedDbOpenRecoveryFailure)).resolves.toEqual({
       ...emptyMobileAppPromotionState,
       lastPromptShownLocalDate: "2026-03-12",
       lastPromptShownAt: "2026-03-12T08:00:00.000Z",

--- a/apps/web/src/localDb/mobileAppPromotion/mobileAppPromotion.ts
+++ b/apps/web/src/localDb/mobileAppPromotion/mobileAppPromotion.ts
@@ -179,27 +179,35 @@ export async function putMobileAppPromotionState(
 
 export async function storeMobileAppPromotionPromptShown(
   input: MobileAppPromotionPromptShownInput,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
 ): Promise<MobileAppPromotionState> {
   validateIsoLocalDate(input.localDate, "lastPromptShownLocalDate");
   validateIsoTimestamp(input.shownAt, "lastPromptShownAt");
 
+  throwIfIndexedDbOpenRecoveryFailed();
   const currentState = await loadMobileAppPromotionState(input.identityKey);
+  throwIfIndexedDbOpenRecoveryFailed();
   const nextState: MobileAppPromotionState = {
     ...currentState,
     lastPromptShownLocalDate: input.localDate,
     lastPromptShownAt: input.shownAt,
   };
+  throwIfIndexedDbOpenRecoveryFailed();
   await putMobileAppPromotionState(input.identityKey, nextState);
+  throwIfIndexedDbOpenRecoveryFailed();
   return nextState;
 }
 
 export async function clearMobileAppPromotionPromptShownIfCurrent(
   input: MobileAppPromotionPromptShownInput,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
 ): Promise<MobileAppPromotionState> {
   validateIsoLocalDate(input.localDate, "lastPromptShownLocalDate");
   validateIsoTimestamp(input.shownAt, "lastPromptShownAt");
 
+  throwIfIndexedDbOpenRecoveryFailed();
   const currentState = await loadMobileAppPromotionState(input.identityKey);
+  throwIfIndexedDbOpenRecoveryFailed();
   if (
     currentState.lastPromptShownLocalDate !== input.localDate
     || currentState.lastPromptShownAt !== input.shownAt
@@ -212,18 +220,25 @@ export async function clearMobileAppPromotionPromptShownIfCurrent(
     lastPromptShownLocalDate: null,
     lastPromptShownAt: null,
   };
+  throwIfIndexedDbOpenRecoveryFailed();
   await putMobileAppPromotionState(input.identityKey, nextState);
+  throwIfIndexedDbOpenRecoveryFailed();
   return nextState;
 }
 
 export async function storeKnownMobileReviewEvent(
   input: MobileReviewEventKnownInput,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
 ): Promise<MobileAppPromotionState> {
+  throwIfIndexedDbOpenRecoveryFailed();
   const currentState = await loadMobileAppPromotionState(input.identityKey);
+  throwIfIndexedDbOpenRecoveryFailed();
   const nextState: MobileAppPromotionState = {
     ...currentState,
     knownHasMobileReviewEvent: true,
   };
+  throwIfIndexedDbOpenRecoveryFailed();
   await putMobileAppPromotionState(input.identityKey, nextState);
+  throwIfIndexedDbOpenRecoveryFailed();
   return nextState;
 }

--- a/apps/web/src/screens/cards/form/CardForm.tsx
+++ b/apps/web/src/screens/cards/form/CardForm.tsx
@@ -10,6 +10,10 @@ import {
   type ReactElement,
   type RefObject,
 } from "react";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import {
   CardFormTagsField,
@@ -630,6 +634,7 @@ export const CardFormFields = forwardRef<CardFormFieldsHandle, Props>(function C
     onRetryMediaUploadTransfer,
   } = props;
   const { t, formatDateTime } = useI18n();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const frontFieldId = `${formIdPrefix}-front-text`;
   const backFieldId = `${formIdPrefix}-back-text`;
   const tagsFieldId = `${formIdPrefix}-tags-input`;
@@ -640,6 +645,7 @@ export const CardFormFields = forwardRef<CardFormFieldsHandle, Props>(function C
   const tagsFieldRef = useRef<CardFormTagsFieldHandle | null>(null);
   const formStateRef = useRef<CardFormState>(formState);
   const uploadTransferLoadSequenceRef = useRef<number>(0);
+  const uploadTransferRefreshIntervalIdRef = useRef<number | null>(null);
   const [uploadTransfersByMediaAssetId, setUploadTransfersByMediaAssetId] = useState<ReadonlyMap<string, MediaTransferQueueRecord>>(
     new Map<string, MediaTransferQueueRecord>(),
   );
@@ -666,7 +672,23 @@ export const CardFormFields = forwardRef<CardFormFieldsHandle, Props>(function C
     },
   }), []);
 
+  const stopUploadTransferStatusPolling = useCallback(function stopUploadTransferStatusPolling(): void {
+    const intervalId = uploadTransferRefreshIntervalIdRef.current;
+    if (intervalId === null) {
+      return;
+    }
+
+    window.clearInterval(intervalId);
+    uploadTransferRefreshIntervalIdRef.current = null;
+  }, []);
+
   const loadUploadTransferStatuses = useCallback(async function loadUploadTransferStatuses(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      uploadTransferLoadSequenceRef.current += 1;
+      stopUploadTransferStatusPolling();
+      return;
+    }
+
     const requestSequence = uploadTransferLoadSequenceRef.current + 1;
     uploadTransferLoadSequenceRef.current = requestSequence;
     const isCurrentRequest = function isCurrentRequest(): boolean {
@@ -679,16 +701,23 @@ export const CardFormFields = forwardRef<CardFormFieldsHandle, Props>(function C
     }
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const transfers = await loadMediaUploadTransfersForWorkspaceMediaAssets(workspaceId, referencedMediaAssetIds);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isCurrentRequest()) {
         setUploadTransfersByMediaAssetId(createMediaTransferByAssetId(transfers));
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        uploadTransferLoadSequenceRef.current += 1;
+        stopUploadTransferStatusPolling();
+        return;
+      }
       if (isCurrentRequest()) {
         warnMediaUploadStatusLoadFailed(workspaceId, referencedMediaAssetIds, error);
       }
     }
-  }, [referencedMediaAssetIds, workspaceId]);
+  }, [indexedDbOpenRecoveryState, referencedMediaAssetIds, stopUploadTransferStatusPolling, workspaceId]);
 
   useEffect(() => () => {
     uploadTransferLoadSequenceRef.current += 1;
@@ -699,18 +728,25 @@ export const CardFormFields = forwardRef<CardFormFieldsHandle, Props>(function C
   }, [loadUploadTransferStatuses, localReadVersion]);
 
   useEffect(() => {
-    if (hasRefreshableUploadTransfer(uploadTransfersByMediaAssetId) === false) {
+    if (
+      indexedDbOpenRecoveryState.isFailed
+      || hasRefreshableUploadTransfer(uploadTransfersByMediaAssetId) === false
+    ) {
       return undefined;
     }
 
     const intervalId = window.setInterval(() => {
       void loadUploadTransferStatuses();
     }, mediaUploadStatusRefreshIntervalMs);
+    uploadTransferRefreshIntervalIdRef.current = intervalId;
 
     return () => {
       window.clearInterval(intervalId);
+      if (uploadTransferRefreshIntervalIdRef.current === intervalId) {
+        uploadTransferRefreshIntervalIdRef.current = null;
+      }
     };
-  }, [loadUploadTransferStatuses, uploadTransfersByMediaAssetId]);
+  }, [indexedDbOpenRecoveryState.isFailed, loadUploadTransferStatuses, uploadTransfersByMediaAssetId]);
 
   function updateField<Key extends keyof CardFormState>(key: Key, value: CardFormState[Key]): void {
     onChange({

--- a/apps/web/src/screens/cards/form/CardFormScreen.lifecycleTestSupport.tsx
+++ b/apps/web/src/screens/cards/form/CardFormScreen.lifecycleTestSupport.tsx
@@ -11,6 +11,13 @@ import type { Card } from "../../../types";
 const mocks = vi.hoisted(() => ({
   deleteCardItemMock: vi.fn(),
   handoffCardToAiMock: vi.fn(),
+  indexedDbOpenRecoveryState: {
+    hasFailed: (): boolean => false,
+    isFailed: false,
+    markFailed: (): "not_recovery" => "not_recovery",
+    signal: new AbortController().signal,
+    throwIfFailed: (): void => {},
+  },
   loadCardByIdMock: vi.fn(),
   loadMediaAssetRecordMock: vi.fn(),
   loadMediaBlobCacheRecordMock: vi.fn(),
@@ -29,11 +36,16 @@ vi.mock("../../../appData", () => ({
   useAppData: mocks.useAppDataMock,
 }));
 
-vi.mock("../../../appError/AppErrorContext", () => ({
-  useAppErrorDialog: () => ({
-    showCapturedTechnicalError: mocks.showCapturedTechnicalErrorMock,
-  }),
-}));
+vi.mock("../../../appError/AppErrorContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../appError/AppErrorContext")>();
+  return {
+    ...actual,
+    useAppErrorDialog: () => ({
+      indexedDbOpenRecoveryState: mocks.indexedDbOpenRecoveryState,
+      showCapturedTechnicalError: mocks.showCapturedTechnicalErrorMock,
+    }),
+  };
+});
 
 vi.mock("../../../chat/handoff/useAiCardHandoff", () => ({
   useAiCardHandoff: () => mocks.handoffCardToAiMock,

--- a/apps/web/src/screens/cards/form/CardFormScreen.tsx
+++ b/apps/web/src/screens/cards/form/CardFormScreen.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useAppData } from "../../../appData";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useAiCardHandoff } from "../../../chat/handoff/useAiCardHandoff";
 import { useI18n } from "../../../i18n";
 import {
@@ -50,6 +54,23 @@ function toTagSuggestions(tags: Awaited<ReturnType<typeof loadWorkspaceTagsSumma
 
 const workspaceUnavailableErrorMessage = "Workspace is unavailable";
 
+async function runRecoveryGuardedLocalRead<ResultType>(
+  createRead: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createRead();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
+
 type CardFormIdentity = Readonly<{
   cardId: string | null;
   workspaceId: string;
@@ -90,7 +111,7 @@ export function CardFormScreen(): ReactElement {
     runMediaUploadTransfers,
     session,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const cardFormFieldsRef = useRef<CardFormFieldsHandle | null>(null);
   const formIdentityRef = useRef<CardFormIdentity | null>(null);
   const renderedFormIdentityRef = useRef<CardFormIdentity | null>(null);
@@ -216,6 +237,10 @@ export function CardFormScreen(): ReactElement {
   );
 
   const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const carriedTextareaSelection = (
       pendingTextareaSelectionRestoreRef.current?.restore.selection ?? null
     );
@@ -296,9 +321,18 @@ export function CardFormScreen(): ReactElement {
         formIdentity,
       );
       const [tagsSummary, loadedCard] = await Promise.all([
-        loadWorkspaceTagsSummary(workspaceId),
-        isCreateMode || cardId === undefined ? Promise.resolve(null) : loadCardById(workspaceId, cardId),
+        runRecoveryGuardedLocalRead(
+          () => loadWorkspaceTagsSummary(workspaceId),
+          indexedDbOpenRecoveryState,
+        ),
+        runRecoveryGuardedLocalRead(
+          () => isCreateMode || cardId === undefined
+            ? Promise.resolve(null)
+            : loadCardById(workspaceId, cardId),
+          indexedDbOpenRecoveryState,
+        ),
       ]);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isCurrentLoadRequest() === false) {
         return;
       }
@@ -401,6 +435,9 @@ export function CardFormScreen(): ReactElement {
         setLoadErrorMessage(t("cardForm.errors.cardNotFound"));
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isCurrentLoadRequest() === false) {
         return;
       }
@@ -425,7 +462,7 @@ export function CardFormScreen(): ReactElement {
       }
       setCurrentLoadErrorMessage(t("appError.technicalError.message"));
     } finally {
-      if (isCurrentLoadRequest()) {
+      if (isCurrentLoadRequest() && indexedDbOpenRecoveryState.hasFailed() === false) {
         setIsLoading(false);
       }
     }
@@ -434,6 +471,7 @@ export function CardFormScreen(): ReactElement {
     cancelPendingTextareaSelectionRestore,
     captureCurrentTextareaSelection,
     cardId,
+    indexedDbOpenRecoveryState,
     isCreateMode,
     resetTextareaSelectionRestore,
     scheduleTextareaSelectionRestore,
@@ -475,7 +513,7 @@ export function CardFormScreen(): ReactElement {
   }
 
   async function saveCurrentCard(): Promise<Card | null> {
-    if (isSubmissionAllowed() === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isSubmissionAllowed() === false) {
       return null;
     }
 
@@ -490,6 +528,7 @@ export function CardFormScreen(): ReactElement {
 
     try {
       const savedCard = await updateCardItem(cardId, buildUpdatePayload());
+      indexedDbOpenRecoveryState.throwIfFailed();
       successfulMutationGenerationRef.current += 1;
       reconciliationBaselineCardRef.current = savedCard;
       setCurrentCard(savedCard);
@@ -498,6 +537,9 @@ export function CardFormScreen(): ReactElement {
       setFormState(savedFormState);
       return savedCard;
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return null;
+      }
       const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("cardForm.errors.cardNotFound"));
       if (expectedErrorMessage !== null) {
         setActionErrorMessage(expectedErrorMessage);
@@ -521,11 +563,17 @@ export function CardFormScreen(): ReactElement {
       setActionErrorMessage(t("appError.technicalError.message"));
       return null;
     } finally {
-      setIsSaving(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSaving(false);
+      }
     }
   }
 
   async function handleSubmit(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     cardFormFieldsRef.current?.commitTagsDraft();
     if (isSubmissionAllowed() === false) {
       return;
@@ -544,12 +592,17 @@ export function CardFormScreen(): ReactElement {
           tags: currentFormState.tags,
         };
         await createCardItem(payload);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } else if (cardId !== undefined) {
         await updateCardItem(cardId, buildUpdatePayload());
+        indexedDbOpenRecoveryState.throwIfFailed();
       }
 
       navigate(cardsRoute);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("cardForm.errors.cardNotFound"));
       if (expectedErrorMessage !== null) {
         setActionErrorMessage(expectedErrorMessage);
@@ -572,12 +625,14 @@ export function CardFormScreen(): ReactElement {
       showCapturedTechnicalError(error);
       setActionErrorMessage(t("appError.technicalError.message"));
     } finally {
-      setIsSaving(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSaving(false);
+      }
     }
   }
 
   async function handleEditWithAi(): Promise<void> {
-    if (isAuthoringMedia) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isAuthoringMedia) {
       return;
     }
 
@@ -591,16 +646,25 @@ export function CardFormScreen(): ReactElement {
     }
 
     if (isCardFormStateDirty(currentCard, formStateRef.current) === false) {
-      await handoffCardToAi(currentCard);
+      const didHandoff = await handoffCardToAi(currentCard);
+      if (didHandoff === false || indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       return;
     }
 
     const savedCard = await saveCurrentCard();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
     if (savedCard === null) {
       return;
     }
 
-    await handoffCardToAi(savedCard);
+    const didHandoff = await handoffCardToAi(savedCard);
+    if (didHandoff === false || indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
   }
 
   function setManagedMediaFieldState(
@@ -621,6 +685,10 @@ export function CardFormScreen(): ReactElement {
   }
 
   async function handlePrepareImageMedia(request: CardFormImageMediaRequest): Promise<string | null> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return null;
+    }
+
     if (activeWorkspace === null) {
       setManagedMediaFieldError(request.field, t("cardForm.media.errors.workspaceUnavailable"));
       return null;
@@ -643,10 +711,14 @@ export function CardFormScreen(): ReactElement {
         installationId: cloudSettings.installationId,
         file: request.file,
         altText: request.altText,
-      });
+      }, indexedDbOpenRecoveryState.throwIfFailed);
+      indexedDbOpenRecoveryState.throwIfFailed();
       runMediaUploadTransfers();
       return result.markdown;
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return null;
+      }
       if (error instanceof UnsupportedImagePreparationError) {
         setManagedMediaFieldError(request.field, t("cardForm.media.errors.unsupportedImage"));
         return null;
@@ -664,17 +736,23 @@ export function CardFormScreen(): ReactElement {
       setManagedMediaFieldError(request.field, t("cardForm.media.errors.processingFailed"));
       return null;
     } finally {
-      setManagedMediaState((currentState) => ({
-        ...currentState,
-        [request.field]: {
-          ...currentState[request.field],
-          isProcessing: false,
-        },
-      }));
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setManagedMediaState((currentState) => ({
+          ...currentState,
+          [request.field]: {
+            ...currentState[request.field],
+            isProcessing: false,
+          },
+        }));
+      }
     }
   }
 
   async function handleRetryMediaUploadTransfer(request: CardFormMediaUploadRetryRequest): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setActionErrorMessage("");
     setErrorMessage("");
 
@@ -683,8 +761,12 @@ export function CardFormScreen(): ReactElement {
         ...request,
         retryAt: new Date().toISOString(),
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       runMediaUploadTransfers();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       captureAppOperationError(error, {
         feature: "cards",
         operation: "card_image_upload_retry",
@@ -699,6 +781,10 @@ export function CardFormScreen(): ReactElement {
   }
 
   async function handleDelete(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (cardId === undefined) {
       setActionErrorMessage(t("cardForm.errors.cardIdRequired"));
       return;
@@ -714,8 +800,12 @@ export function CardFormScreen(): ReactElement {
 
     try {
       await deleteCardItem(cardId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       navigate(cardsRoute);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("cardForm.errors.cardNotFound"));
       if (expectedErrorMessage !== null) {
         setActionErrorMessage(expectedErrorMessage);
@@ -738,7 +828,9 @@ export function CardFormScreen(): ReactElement {
       showCapturedTechnicalError(error);
       setActionErrorMessage(t("appError.technicalError.message"));
     } finally {
-      setIsDeleting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsDeleting(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/cards/form/cardImageAuthoring.ts
+++ b/apps/web/src/screens/cards/form/cardImageAuthoring.ts
@@ -84,16 +84,22 @@ function buildMediaBlobCacheRecord(
 
 export async function prepareCardImageMediaAuthoring(
   input: CardImageMediaAuthoringInput,
+  throwIfIndexedDbOpenRecoveryFailed: () => void,
 ): Promise<CardMediaAuthoringResult> {
+  throwIfIndexedDbOpenRecoveryFailed();
   const workspaceId = requireNonEmptyInput(input.workspaceId, "workspaceId");
   const installationId = requireNonEmptyInput(input.installationId, "installationId");
   const preparedImage = await prepareCardImageFile(input.file);
+  throwIfIndexedDbOpenRecoveryFailed();
   const bytes = await preparedImage.blob.arrayBuffer();
+  throwIfIndexedDbOpenRecoveryFailed();
   const sha256 = await calculateSha256Hex(bytes);
+  throwIfIndexedDbOpenRecoveryFailed();
   const createdAt = new Date().toISOString();
   const mediaAssetId = createLocalMediaId("mediaAssetId");
   const transferId = createLocalMediaId("transferId");
   const lastModifiedByReplicaId = await buildClientWorkspaceReplicaId(workspaceId, installationId);
+  throwIfIndexedDbOpenRecoveryFailed();
   const mediaAsset = buildLocalMediaAsset(
     workspaceId,
     mediaAssetId,
@@ -120,6 +126,7 @@ export async function prepareCardImageMediaAuthoring(
       nextAttemptAt: createdAt,
     },
   });
+  throwIfIndexedDbOpenRecoveryFailed();
 
   return {
     mediaAsset,

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useRef, useState, type ReactElement } from "rea
 import { Link } from "react-router";
 import { useAppData } from "../../../appData";
 import { normalizeTagKey } from "../../../appData/domain";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { getCardFilterActiveDimensionCount, normalizeCardFilter } from "../../../cardFilters";
 import { AnchoredFloatingOverlay, useAnchoredFloatingOutsidePointerDismiss } from "../../../floating";
 import { useI18n } from "../../../i18n";
@@ -55,6 +59,23 @@ type CardsQueryControl = Readonly<{
 const cardsPageSize = 50;
 const cardsSearchDebounceMs = 300;
 const maximumUserSortCount = 3;
+
+async function runRecoveryGuardedLocalRead<ResultType>(
+  createRead: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createRead();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
 
 function createInitialCardsQueryState(): CardsQueryState {
   return {
@@ -199,7 +220,7 @@ export function CardsScreen(): ReactElement {
     updateCardItem,
     setErrorMessage,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatDateTime, formatNumber } = useI18n();
   const [searchText, setSearchText] = useState<string>("");
   const [debouncedSearchText, setDebouncedSearchText] = useState<string>("");
@@ -268,12 +289,16 @@ export function CardsScreen(): ReactElement {
   });
 
   useEffect(() => {
+    if (indexedDbOpenRecoveryState.isFailed) {
+      return;
+    }
+
     const timeoutId = window.setTimeout(() => {
       setDebouncedSearchText(searchText);
     }, cardsSearchDebounceMs);
 
     return () => window.clearTimeout(timeoutId);
-  }, [searchText]);
+  }, [indexedDbOpenRecoveryState.isFailed, searchText]);
 
   function acceptCardsQueryWindow(
     queryIdentity: string,
@@ -343,6 +368,10 @@ export function CardsScreen(): ReactElement {
   }, []);
 
   async function resetCardsQuery(queryIdentity: string): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const requestSequence = cardsQueryControlRef.current.requestSequence + 1;
     activeEditorLifecyclesRef.current.clear();
     loadMoreSentinelIntersectionConsumedRef.current = false;
@@ -369,15 +398,19 @@ export function CardsScreen(): ReactElement {
 
     try {
       const [nextPage, tagsSummary] = await Promise.all([
-        queryLocalCardsPage(activeWorkspace.workspaceId, {
+        runRecoveryGuardedLocalRead(() => queryLocalCardsPage(activeWorkspace.workspaceId, {
           searchText: normalizedSearchText,
           cursor: null,
           limit: cardsPageSize,
           sorts,
           filter: cardFilter,
-        }),
-        loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
+        }), indexedDbOpenRecoveryState),
+        runRecoveryGuardedLocalRead(
+          () => loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
+          indexedDbOpenRecoveryState,
+        ),
       ]);
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
         return;
@@ -402,6 +435,9 @@ export function CardsScreen(): ReactElement {
         savedAt: new Date().toISOString(),
       });
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
         return;
       }
@@ -433,7 +469,8 @@ export function CardsScreen(): ReactElement {
 
   async function refreshCardsQuery(queryIdentity: string): Promise<void> {
     if (
-      activeWorkspace === null
+      indexedDbOpenRecoveryState.hasFailed()
+      || activeWorkspace === null
       || cardsQueryControlRef.current.queryIdentity !== queryIdentity
     ) {
       return;
@@ -456,15 +493,19 @@ export function CardsScreen(): ReactElement {
 
     try {
       const [nextPage, tagsSummary] = await Promise.all([
-        queryLocalCardsPage(activeWorkspace.workspaceId, {
+        runRecoveryGuardedLocalRead(() => queryLocalCardsPage(activeWorkspace.workspaceId, {
           searchText: normalizedSearchText,
           cursor: null,
           limit: refreshLimit,
           sorts,
           filter: cardFilter,
-        }),
-        loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
+        }), indexedDbOpenRecoveryState),
+        runRecoveryGuardedLocalRead(
+          () => loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
+          indexedDbOpenRecoveryState,
+        ),
       ]);
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
         return;
@@ -488,6 +529,9 @@ export function CardsScreen(): ReactElement {
         savedAt: new Date().toISOString(),
       });
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, queryIdentity, requestSequence)) {
         return;
       }
@@ -518,7 +562,8 @@ export function CardsScreen(): ReactElement {
   async function loadNextPage(): Promise<void> {
     const currentControl = cardsQueryControlRef.current;
     if (
-      activeWorkspace === null
+      indexedDbOpenRecoveryState.hasFailed()
+      || activeWorkspace === null
       || currentControl.queryIdentity !== cardsQueryIdentity
       || currentControl.nextCursor === null
       || currentControl.activeRequest !== null
@@ -547,6 +592,7 @@ export function CardsScreen(): ReactElement {
         sorts,
         filter: cardFilter,
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, cardsQueryIdentity, requestSequence)) {
         return;
@@ -558,6 +604,9 @@ export function CardsScreen(): ReactElement {
         mergeCardsQueryWindow(currentControl.authoritativeWindow, nextPage),
       );
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (!ownsCardsQueryRequest(cardsQueryControlRef.current, cardsQueryIdentity, requestSequence)) {
         return;
       }
@@ -661,14 +710,26 @@ export function CardsScreen(): ReactElement {
   }, [cardsQueryState.nextCursor, loadNextPage]);
 
   function handleInlineSave(card: Card, patch: UpdateCardInput): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return Promise.resolve();
+    }
+
     setSavingCardIds((currentCardIds) => new Set([...currentCardIds, card.cardId]));
     setErrorMessage("");
 
     const previousTail = inlineSaveTailsRef.current.get(card.cardId) ?? Promise.resolve();
     const savePromise = previousTail.then(async () => {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       try {
         await updateCardItem(card.cardId, patch);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("cardForm.errors.cardNotFound"));
         if (expectedErrorMessage !== null) {
           setErrorMessage(expectedErrorMessage);
@@ -691,7 +752,11 @@ export function CardsScreen(): ReactElement {
 
       try {
         await refreshCardsQuery(cardsQueryIdentity);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         showCapturedTechnicalError(error);
         setErrorMessage(t("appError.technicalError.message"));
       }
@@ -708,6 +773,9 @@ export function CardsScreen(): ReactElement {
       }
 
       inlineSaveTailsRef.current.delete(card.cardId);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       setSavingCardIds((currentCardIds) => {
         const nextCardIds = new Set(currentCardIds);
         nextCardIds.delete(card.cardId);

--- a/apps/web/src/screens/catalog/CatalogImportScreen.tsx
+++ b/apps/web/src/screens/catalog/CatalogImportScreen.tsx
@@ -12,7 +12,10 @@ import {
 import { AppDataProvider, useAppData } from "../../appData";
 import { requireCloudInstallationId } from "../../appData/sync/local/syncCloudSettings";
 import { getSyncFailureObservationCaptureState } from "../../appData/sync/observation/syncErrorObservation";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import { buildClientWorkspaceReplicaId } from "../../media/mediaCrypto";
 import { captureAppOperationError } from "../../observability/appOperationObservation";
@@ -376,7 +379,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     sessionErrorMessage,
     sessionLoadState,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatNumber } = useI18n();
   const isWorkspaceChoiceAvailable = availableWorkspaces.length > 1;
   const [step, setStep] = useState<CatalogImportStep>(() => (isWorkspaceChoiceAvailable ? "workspace" : "confirm"));
@@ -450,7 +453,8 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     identity: CatalogWorkspaceIdentity,
   ): Promise<void> {
     if (
-      activeSyncRequestRef.current !== null
+      indexedDbOpenRecoveryState.hasFailed()
+      || activeSyncRequestRef.current !== null
       || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, identity)
     ) {
       return;
@@ -462,7 +466,9 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     setSyncState({ status: "syncing" });
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       await refreshLocalData();
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (
         activeSyncRequestRef.current !== requestGeneration
         || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, identity)
@@ -471,6 +477,9 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       }
       setSyncState({ status: "succeeded" });
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (
         activeSyncRequestRef.current !== requestGeneration
         || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, identity)
@@ -494,9 +503,13 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
         activeSyncRequestRef.current = null;
       }
     }
-  }, [refreshLocalData, showCapturedTechnicalError, t, technicalErrorMessage]);
+  }, [indexedDbOpenRecoveryState, refreshLocalData, showCapturedTechnicalError, t, technicalErrorMessage]);
 
   const refreshPreview = useCallback(async function refreshPreview(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const requestIdentity = workspaceIdentityRef.current;
     if (!isImportAvailable || requestIdentity === null) {
       setErrorMessage(t("catalogImport.workspaceUnavailable"));
@@ -525,10 +538,12 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     setErrorMessage("");
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const response = await previewCatalogPackageInstall(
         requestIdentity.workspaceId,
         catalogContext.packageVersion.packageVersionId,
       );
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (response.packageVersion.packageVersionId !== catalogContext.packageVersion.packageVersionId) {
         throw new Error(
           `Catalog install preview returned a different package version. expected=${catalogContext.packageVersion.packageVersionId} actual=${response.packageVersion.packageVersionId}`,
@@ -548,6 +563,9 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
         removeTags: [...response.defaultOptions.removedTags],
       });
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (
         activePreviewRequestRef.current !== requestGeneration
         || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, requestIdentity)
@@ -568,7 +586,10 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       }
       setErrorMessage(wasCaptured ? technicalErrorMessage : getErrorMessage(error));
     } finally {
-      if (activePreviewRequestRef.current === requestGeneration) {
+      if (
+        indexedDbOpenRecoveryState.hasFailed() === false
+        && activePreviewRequestRef.current === requestGeneration
+      ) {
         activePreviewRequestRef.current = null;
         setIsPreviewing(false);
       }
@@ -576,6 +597,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
   }, [
     captureCatalogImportError,
     catalogContext.packageVersion.packageVersionId,
+    indexedDbOpenRecoveryState,
     isImportAvailable,
     showCapturedTechnicalError,
     step,
@@ -641,6 +663,10 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
   }
 
   async function selectCatalogWorkspace(nextWorkspaceId: string): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (nextWorkspaceId === workspaceId) {
       pendingWorkspaceSelectionRef.current = null;
       hasLeftInitialStepRef.current = true;
@@ -660,17 +686,28 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     pendingWorkspaceSelectionRef.current = nextWorkspaceId;
     setIsWorkspaceSelectionPending(true);
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       await chooseWorkspace(nextWorkspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       pendingWorkspaceSelectionRef.current = null;
       throw error;
     } finally {
-      workspaceSelectionInFlightRef.current = false;
-      setIsWorkspaceSelectionPending(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        workspaceSelectionInFlightRef.current = false;
+        setIsWorkspaceSelectionPending(false);
+      }
     }
   }
 
   async function confirmInstall(importOptions: WorkspaceImportOptions): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const requestIdentity = workspaceIdentityRef.current;
     if (!isImportAvailable || requestIdentity === null || activeWorkspace === null) {
       setErrorMessage(t("catalogImport.workspaceUnavailable"));
@@ -709,6 +746,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
     setIsInstalling(true);
     setErrorMessage("");
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (currentAttempt === null) {
         const installationId = requireCloudInstallationId(cloudSettings);
         if (installationId !== requestIdentity.installationId) {
@@ -717,6 +755,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
         }
 
         await refreshLocalData();
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (
           activeInstallRequestRef.current !== requestGeneration
           || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, requestIdentity)
@@ -725,6 +764,7 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
         }
 
         const replicaId = await buildClientWorkspaceReplicaId(requestIdentity.workspaceId, installationId);
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (
           activeInstallRequestRef.current !== requestGeneration
           || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, requestIdentity)
@@ -754,11 +794,13 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       }
 
       const requestAttempt = currentAttempt;
+      indexedDbOpenRecoveryState.throwIfFailed();
       const result = await confirmCatalogPackageInstall(
         requestAttempt.identity.workspaceId,
         catalogContext.packageVersion.packageVersionId,
         requestAttempt.options,
       );
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (
         activeInstallRequestRef.current !== requestGeneration
         || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, requestAttempt.identity)
@@ -789,6 +831,9 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       setStep("done");
       void runPostInstallSync(requestAttempt.identity);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (
         activeInstallRequestRef.current !== requestGeneration
         || !isSameCatalogWorkspaceIdentity(workspaceIdentityRef.current, requestIdentity)
@@ -813,7 +858,10 @@ function CatalogImportAuthenticatedContent(props: Readonly<{ catalogContext: Cat
       }
       setErrorMessage(wasCaptured ? technicalErrorMessage : getErrorMessage(error));
     } finally {
-      if (activeInstallRequestRef.current === requestGeneration) {
+      if (
+        indexedDbOpenRecoveryState.hasFailed() === false
+        && activeInstallRequestRef.current === requestGeneration
+      ) {
         activeInstallRequestRef.current = null;
         setIsInstalling(false);
       }
@@ -932,7 +980,7 @@ function CatalogImportAuthenticatedScreen(props: Readonly<{ catalogContext: Cata
 export function CatalogImportScreen(): ReactElement {
   const { packageVersionId: routePackageVersionId } = useParams();
   const packageVersionId = parsePackageVersionId(routePackageVersionId);
-  const { showTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showTechnicalError } = useAppErrorDialog();
   const { t } = useI18n();
   const [loadState, setLoadState] = useState<CatalogImportLoadState>("loading");
   const [catalogContext, setCatalogContext] = useState<CatalogImportContext | null>(null);
@@ -942,6 +990,10 @@ export function CatalogImportScreen(): ReactElement {
   const technicalErrorMessage = t("appError.technicalError.message");
 
   const loadCatalogImport = useCallback(async function loadCatalogImport(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const requestGeneration = loadRequestGenerationRef.current + 1;
     loadRequestGenerationRef.current = requestGeneration;
     if (packageVersionId === null) {
@@ -955,7 +1007,9 @@ export function CatalogImportScreen(): ReactElement {
     setSession(null);
     setErrorMessage("");
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const snapshot = await loadPublicCatalog();
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (loadRequestGenerationRef.current !== requestGeneration) {
         return;
       }
@@ -966,6 +1020,7 @@ export function CatalogImportScreen(): ReactElement {
       }
 
       const optionalSession = await getOptionalSession();
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (loadRequestGenerationRef.current !== requestGeneration) {
         return;
       }
@@ -973,6 +1028,9 @@ export function CatalogImportScreen(): ReactElement {
       setSession(optionalSession);
       setLoadState(optionalSession === null ? "signed_out" : "signed_in");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (loadRequestGenerationRef.current !== requestGeneration) {
         return;
       }
@@ -990,7 +1048,7 @@ export function CatalogImportScreen(): ReactElement {
       setErrorMessage(wasCaptured ? technicalErrorMessage : getErrorMessage(error));
       setLoadState("error");
     }
-  }, [packageVersionId, showTechnicalError, t, technicalErrorMessage]);
+  }, [indexedDbOpenRecoveryState, packageVersionId, showTechnicalError, t, technicalErrorMessage]);
 
   useEffect(() => {
     void loadCatalogImport();

--- a/apps/web/src/screens/friends/FriendInviteCreateDialog.tsx
+++ b/apps/web/src/screens/friends/FriendInviteCreateDialog.tsx
@@ -8,7 +8,10 @@ import {
 } from "../../api";
 import { isExpectedClipboardWriteError } from "../../access/browserAccess";
 import { useAppData } from "../../appData";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
 import type { FriendInvitationCreateResponse } from "../../types";
 import { validateFriendInvitationDisplayName } from "../invite/friendInvitationDisplayName";
@@ -37,7 +40,7 @@ function isExpectedFriendInvitationCreateError(error: unknown): boolean {
 export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): ReactElement {
   const { authRedirectUrl, canCreateInvite, onClose } = props;
   const { activeWorkspace, cloudSettings, session } = useAppData();
-  const { showTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showTechnicalError } = useAppErrorDialog();
   const { locale, t, formatDateTime } = useI18n();
   const [friendDisplayName, setFriendDisplayName] = useState<string>("");
   const [fieldErrorMessage, setFieldErrorMessage] = useState<string>("");
@@ -49,7 +52,28 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
   const [isSharing, setIsSharing] = useState<boolean>(false);
   const technicalErrorMessage = t("appError.technicalError.message");
 
+  function closeDialog(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    onClose();
+  }
+
+  function updateFriendDisplayName(value: string): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    setFriendDisplayName(value);
+    setFieldErrorMessage("");
+  }
+
   async function submitInviteCreate(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const validationMessage = validateFriendInvitationDisplayName(friendDisplayName, {
       required: t("progressScreen.leaderboard.invite.validation.required"),
       singleLine: t("progressScreen.leaderboard.invite.validation.singleLine"),
@@ -68,9 +92,13 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
       const response = await createFriendInvitation({
         inviteeDisplayName: friendDisplayName.trim(),
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       setCreatedInvite(response);
       setStatusMessage("");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isAuthRedirectError(error)) {
         return;
       }
@@ -90,11 +118,17 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
       });
       setErrorMessage(wasCaptured ? technicalErrorMessage : getErrorMessage(error));
     } finally {
-      setIsSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSubmitting(false);
+      }
     }
   }
 
   async function copyInviteLink(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (createdInvite === null) {
       throw new Error("Cannot copy a friend invite before it is created.");
     }
@@ -110,8 +144,12 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
       }
 
       await navigator.clipboard.writeText(createdInvite.inviteUrl);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setStatusMessage(t("progressScreen.leaderboard.invite.copied"));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isExpectedClipboardWriteError(error)) {
         setErrorMessage(t("progressScreen.leaderboard.invite.clipboardUnavailable"));
         return;
@@ -127,11 +165,17 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
       });
       setErrorMessage(wasCaptured ? technicalErrorMessage : getErrorMessage(error));
     } finally {
-      setIsCopying(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsCopying(false);
+      }
     }
   }
 
   async function shareInviteLink(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (createdInvite === null) {
       throw new Error("Cannot share a friend invite before it is created.");
     }
@@ -151,8 +195,12 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
         text: t("progressScreen.leaderboard.invite.shareText"),
         url: createdInvite.inviteUrl,
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       setStatusMessage(t("progressScreen.leaderboard.invite.shared"));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (error instanceof DOMException && error.name === "AbortError") {
         return;
       }
@@ -167,7 +215,9 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
       });
       setErrorMessage(wasCaptured ? technicalErrorMessage : getErrorMessage(error));
     } finally {
-      setIsSharing(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSharing(false);
+      }
     }
   }
 
@@ -178,7 +228,7 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
           <h2 id="progress-leaderboard-invite-title" className="panel-subtitle">
             {t("progressScreen.leaderboard.invite.title")}
           </h2>
-          <button className="ghost-btn progress-leaderboard-invite-close" type="button" onClick={onClose}>
+          <button className="ghost-btn progress-leaderboard-invite-close" type="button" onClick={closeDialog}>
             {t("common.cancel")}
           </button>
         </div>
@@ -195,8 +245,7 @@ export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): 
                   value={friendDisplayName}
                   disabled={isSubmitting}
                   onChange={(event) => {
-                    setFriendDisplayName(event.target.value);
-                    setFieldErrorMessage("");
+                    updateFriendDisplayName(event.target.value);
                   }}
                   data-testid="progress-leaderboard-invite-name-input"
                 />

--- a/apps/web/src/screens/invite/FriendInviteScreen.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.tsx
@@ -14,7 +14,10 @@ import {
   friendInviteStoreLinks,
   resolveClientPlatform,
 } from "../../appPlatformLinks";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { invalidateServerProgress } from "../../appData/progress/invalidation/progressInvalidation";
 import { clearPersistedProgressLeaderboard } from "../../appData/progress/storage/progressStorage";
 import { getAppConfig } from "../../config";
@@ -269,7 +272,7 @@ export function FriendInviteReadyPanel({
 export function FriendInviteScreen(): ReactElement {
   const { token } = useParams();
   const inviteToken = readInviteTokenParam(token);
-  const { showTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showTechnicalError } = useAppErrorDialog();
   const { locale, t } = useI18n();
   const [loadState, setLoadState] = useState<InviteLoadState>("loading");
   const [preview, setPreview] = useState<FriendInvitationPreviewResponse | null>(null);
@@ -282,6 +285,10 @@ export function FriendInviteScreen(): ReactElement {
   const technicalErrorMessage = t("appError.technicalError.message");
 
   async function loadInvite(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setLoadState("loading");
     setPreview(null);
     setSession(null);
@@ -291,6 +298,7 @@ export function FriendInviteScreen(): ReactElement {
 
     try {
       const previewResponse = await previewFriendInvitation(inviteToken);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setPreview(previewResponse);
       if (previewResponse.status === "inactive") {
         setLoadState("inactive");
@@ -298,9 +306,13 @@ export function FriendInviteScreen(): ReactElement {
       }
 
       const optionalSession = await getOptionalSession();
+      indexedDbOpenRecoveryState.throwIfFailed();
       setSession(optionalSession);
       setLoadState(optionalSession === null ? "signed_out" : "ready");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isAuthRedirectError(error)) {
         return;
       }
@@ -326,9 +338,13 @@ export function FriendInviteScreen(): ReactElement {
 
   useEffect(() => {
     void loadInvite();
-  }, [inviteToken]);
+  }, [indexedDbOpenRecoveryState, inviteToken]);
 
   async function submitInviteAcceptance(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (session === null) {
       setErrorMessage(t("friendInvite.signInBody"));
       setLoadState("signed_out");
@@ -352,6 +368,7 @@ export function FriendInviteScreen(): ReactElement {
       const response = await acceptFriendInvitation(inviteToken, {
         inviterDisplayName: friendDisplayName.trim(),
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       if (response.status === "inactive") {
         setLoadState("inactive");
@@ -365,6 +382,9 @@ export function FriendInviteScreen(): ReactElement {
         setLoadState("success");
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isAuthRedirectError(error)) {
         return;
       }
@@ -384,20 +404,34 @@ export function FriendInviteScreen(): ReactElement {
       });
       setErrorMessage(wasCaptured ? technicalErrorMessage : getErrorMessage(error));
     } finally {
-      setIsSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSubmitting(false);
+      }
     }
   }
 
   function retryInviteLoad(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     void loadInvite();
   }
 
   function updateFriendDisplayName(value: string): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setFriendDisplayName(value);
     setFieldErrorMessage("");
   }
 
   function acceptInvite(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     void submitInviteAcceptance();
   }
 

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -59,6 +59,7 @@ export function ProgressScreen(): ReactElement {
     progressScheduleLocalVersion,
     progressServerInvalidationVersion,
   } = useProgressInvalidationState();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const location = useLocation();
   const { progressSourceState, refreshProgress } = useProgressSource({
     activeWorkspace,
@@ -70,6 +71,7 @@ export function ProgressScreen(): ReactElement {
     progressServerInvalidationVersion,
     leaderboardAutoRefreshEnabled: true,
     canExposeTechnicalErrors: true,
+    indexedDbOpenRecoveryState,
     sections: {
       includeSummary: true,
       includeSeries: true,
@@ -114,8 +116,6 @@ export function ProgressScreen(): ReactElement {
     ?? progressSourceState.leaderboard.localViewerCountsTechnicalError
     ?? progressSourceState.streakLeaderboard.technicalError;
   const reviewProgressBadge = buildReviewProgressBadgeStateFromSummarySnapshot(progressSummary);
-  const { showCapturedTechnicalError } = useAppErrorDialog();
-
   useEffect(() => {
     if (technicalError === null) {
       shownTechnicalErrorRef.current = null;

--- a/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardProfileDialog.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardProfileDialog.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState, type ReactElement } from "react";
 import { createPortal } from "react-dom";
 import { loadProgressLeaderboardProfile } from "../../../api";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import type {
   ProgressLeaderboardProfile,
@@ -193,6 +197,7 @@ function ProgressLeaderboardProfileReadyBody(props: Readonly<{
 
 export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfileDialogProps): ReactElement {
   const { cachedProfile, initialProfile, onClose, onProfileLoaded } = props;
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const { t } = useI18n();
   const [retryCount, setRetryCount] = useState<number>(0);
   const [loadState, setLoadState] = useState<ProfileDialogLoadState>({
@@ -202,7 +207,7 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
 
   useEffect(() => {
     function closeOnEscape(event: KeyboardEvent): void {
-      if (event.key === "Escape") {
+      if (event.key === "Escape" && indexedDbOpenRecoveryState.hasFailed() === false) {
         onClose();
       }
     }
@@ -211,9 +216,13 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
     return () => {
       window.removeEventListener("keydown", closeOnEscape);
     };
-  }, [onClose]);
+  }, [indexedDbOpenRecoveryState, onClose]);
 
   useEffect(() => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (cachedProfile !== null) {
       setLoadState({
         kind: "loaded",
@@ -232,6 +241,7 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
     async function loadProfile(): Promise<void> {
       try {
         const profile = await loadProgressLeaderboardProfile(initialProfile.publicProfileId);
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (isCancelled) {
           return;
         }
@@ -243,6 +253,9 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
           profile,
         });
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCancelled) {
           return;
         }
@@ -260,7 +273,23 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
     return () => {
       isCancelled = true;
     };
-  }, [cachedProfile, initialProfile.publicProfileId, onProfileLoaded, retryCount]);
+  }, [cachedProfile, indexedDbOpenRecoveryState, initialProfile.publicProfileId, onProfileLoaded, retryCount]);
+
+  function closeDialog(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    onClose();
+  }
+
+  function retryProfileLoad(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    setRetryCount((previousRetryCount) => previousRetryCount + 1);
+  }
 
   const loadedProfile = cachedProfile
     ?? (
@@ -306,7 +335,7 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
           <button
             className="ghost-btn progress-leaderboard-profile-close"
             type="button"
-            onClick={onClose}
+            onClick={closeDialog}
             data-testid="progress-leaderboard-profile-close"
           >
             {t("progressScreen.leaderboard.profile.close")}
@@ -327,7 +356,7 @@ export function ProgressLeaderboardProfileDialog(props: ProgressLeaderboardProfi
             <button
               className="ghost-btn"
               type="button"
-              onClick={() => setRetryCount((previousRetryCount) => previousRetryCount + 1)}
+              onClick={retryProfileLoad}
               data-testid="progress-leaderboard-profile-retry"
             >
               {t("common.retry")}

--- a/apps/web/src/screens/review/ReviewScreen.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactElement } from "react";
 import { useAppData } from "../../appData";
+import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { FeedbackDialog } from "../../feedback/FeedbackDialog";
 import { ReviewEditorModal } from "./components/card/ReviewEditorModal";
 import { ReviewPane } from "./components/ReviewPane";
@@ -15,6 +16,7 @@ export { normalizeReviewMarkdownForWeb } from "./components/card/ReviewCardSide"
 
 export function ReviewScreen(): ReactElement {
   const { session } = useAppData();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const reviewReactionAnimationsEnabled = session?.preferences.reviewReactionAnimationsEnabled !== false;
   const {
     dismissReviewReactions,
@@ -33,12 +35,11 @@ export function ReviewScreen(): ReactElement {
 
   useEffect(() => {
     if (reviewReactionAnimationsEnabled) {
-      startReviewReactionLottiePrewarm();
-      return;
+      return startReviewReactionLottiePrewarm(indexedDbOpenRecoveryState.signal);
     }
 
     dismissReviewReactions();
-  }, [dismissReviewReactions, reviewReactionAnimationsEnabled]);
+  }, [dismissReviewReactions, indexedDbOpenRecoveryState.signal, reviewReactionAnimationsEnabled]);
 
   const reviewLayoutClassName = queuePanelProps.isReviewQueuePanelOpen
     ? "review-layout review-layout-queue-open"

--- a/apps/web/src/screens/review/components/card/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewCardSide.media.test.tsx
@@ -15,12 +15,29 @@ import type { MediaAsset } from "../../../../types";
 import { ReviewCardSide } from "./ReviewCardSide";
 
 const mediaMocks = vi.hoisted(() => ({
+  indexedDbOpenRecoveryState: {
+    hasFailed: (): boolean => false,
+    isFailed: false,
+    markFailed: (): "not_recovery" => "not_recovery",
+    signal: new AbortController().signal,
+    throwIfFailed: (): void => {},
+  },
   loadMediaAssetDownloadUrlMock: vi.fn(),
   loadMediaAssetRecordMock: vi.fn(),
   loadMediaBlobCacheRecordMock: vi.fn(),
   loadMediaUploadTransfersForWorkspaceMediaAssetsMock: vi.fn(),
   writeMediaBlobCacheRecordMock: vi.fn(),
 }));
+
+vi.mock("../../../../appError/AppErrorContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../appError/AppErrorContext")>();
+  return {
+    ...actual,
+    useAppErrorDialog: () => ({
+      indexedDbOpenRecoveryState: mediaMocks.indexedDbOpenRecoveryState,
+    }),
+  };
+});
 
 vi.mock("../../../../api", () => ({
   loadMediaAssetDownloadUrl: mediaMocks.loadMediaAssetDownloadUrlMock,

--- a/apps/web/src/screens/review/components/card/ReviewCardSide.media.test.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewCardSide.media.test.tsx
@@ -948,6 +948,7 @@ describe("ReviewCardSide managed media rendering", () => {
       headers: {
         Range: "bytes=0-3",
       },
+      signal: expect.any(AbortSignal),
     });
     expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledTimes(1);
     expect(mediaMocks.writeMediaBlobCacheRecordMock.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
@@ -991,12 +992,14 @@ describe("ReviewCardSide managed media rendering", () => {
       headers: {
         Range: "bytes=0-4194303",
       },
+      signal: expect.any(AbortSignal),
     });
     expect(fetchMock).toHaveBeenNthCalledWith(2, "https://media.example.test/large-signed-download", {
       method: "GET",
       headers: {
         Range: "bytes=4194304-4194306",
       },
+      signal: expect.any(AbortSignal),
     });
     expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledWith(expect.objectContaining({
       sha256: largeSha256,
@@ -1077,12 +1080,14 @@ describe("ReviewCardSide managed media rendering", () => {
       headers: {
         Range: "bytes=0-4",
       },
+      signal: expect.any(AbortSignal),
     });
     expect(fetchMock.mock.calls[1]?.[1]).toEqual({
       method: "GET",
       headers: {
         Range: "bytes=0-4",
       },
+      signal: expect.any(AbortSignal),
     });
     expect(mediaMocks.writeMediaBlobCacheRecordMock).toHaveBeenCalledWith(expect.objectContaining({
       sha256: refreshedSha256,

--- a/apps/web/src/screens/review/components/card/ReviewManagedMedia.tsx
+++ b/apps/web/src/screens/review/components/card/ReviewManagedMedia.tsx
@@ -8,6 +8,11 @@ import {
 } from "react";
 import { defaultUrlTransform } from "react-markdown";
 import { loadMediaAssetDownloadUrl } from "../../../../api";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+  useAppErrorDialog,
+} from "../../../../appError/AppErrorContext";
 import { useI18n } from "../../../../i18n";
 import { loadMediaAssetRecord } from "../../../../localDb/mediaAssets";
 import {
@@ -64,8 +69,62 @@ type ManagedMediaDownloadRange = Readonly<{
   startByte: number;
   endByte: number;
 }>;
+type ManagedMediaDownloadTask = Readonly<{
+  abortController: AbortController;
+  promise: Promise<MediaBlobCacheRecord>;
+}>;
 
-const activeManagedMediaDownloadPromises = new Map<string, Promise<MediaBlobCacheRecord>>();
+async function waitForRecoveryGuardedManagedMediaPhase<ResultType>(
+  createPhase: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createPhase();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
+
+function throwIfManagedMediaDownloadAborted(signal: AbortSignal): void {
+  if (signal.aborted === false) {
+    return;
+  }
+
+  if (signal.reason instanceof Error) {
+    throw signal.reason;
+  }
+
+  throw new DOMException("Managed media download was aborted", "AbortError");
+}
+
+async function waitForRecoveryAndAbortGuardedManagedMediaPhase<ResultType>(
+  createPhase: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    const result = await createPhase();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
+
+const activeManagedMediaDownloadTasks = new Map<string, ManagedMediaDownloadTask>();
 const managedMediaObjectUrlCache = new Map<string, ManagedMediaObjectUrlCacheEntry>();
 
 export function reviewMarkdownUrlTransform(url: string): string {
@@ -183,15 +242,38 @@ function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-async function calculateSha256Hex(bytes: ArrayBuffer): Promise<string> {
-  const digest = await requireSha256Digest().digest("SHA-256", bytes);
+async function calculateSha256Hex(
+  bytes: ArrayBuffer,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
+): Promise<string> {
+  const digest = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+    () => requireSha256Digest().digest("SHA-256", bytes),
+    indexedDbOpenRecoveryState,
+    signal,
+  );
+  indexedDbOpenRecoveryState.throwIfFailed();
+  throwIfManagedMediaDownloadAborted(signal);
   return bytesToHex(new Uint8Array(digest));
 }
 
-async function readDownloadFailureBody(response: Response): Promise<string> {
+async function readDownloadFailureBody(
+  response: Response,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
+): Promise<string> {
   try {
-    return await response.text();
+    const responseBody = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => response.text(),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    return responseBody;
   } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
     return `failed to read response body: ${readErrorMessage(error)}`;
   }
 }
@@ -224,10 +306,21 @@ async function readManagedMediaResponseBytes(
   mediaAsset: MediaAsset,
   response: Response,
   rangeHeader: string,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
 ): Promise<ArrayBuffer> {
   try {
-    return await response.arrayBuffer();
+    const bytes = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => response.arrayBuffer(),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    return bytes;
   } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
     throw new Error(`Managed media download response body read failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, status=${response.status}, error=${readErrorMessage(error)}`);
   }
 }
@@ -238,22 +331,39 @@ async function fetchManagedMediaRangeBytes(
   downloadUrl: string,
   range: ManagedMediaDownloadRange,
   isSingleRange: boolean,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
 ): Promise<ArrayBuffer> {
   const rangeHeader = `bytes=${range.startByte}-${range.endByte}`;
   let response: Response;
   try {
-    response = await fetch(downloadUrl, {
-      method: downloadMethod,
-      headers: {
-        Range: rangeHeader,
-      },
-    });
+    response = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => fetch(downloadUrl, {
+        method: downloadMethod,
+        headers: {
+          Range: rangeHeader,
+        },
+        signal,
+      }),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
   } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
     throw new Error(`Managed media ranged download request failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, error=${readErrorMessage(error)}`);
   }
 
   if (response.status === 206) {
-    const bytes = await readManagedMediaResponseBytes(mediaAsset, response, rangeHeader);
+    const bytes = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => readManagedMediaResponseBytes(mediaAsset, response, rangeHeader, indexedDbOpenRecoveryState, signal),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
     const expectedRangeSizeBytes = readManagedMediaDownloadRangeSize(range);
     if (bytes.byteLength !== expectedRangeSizeBytes) {
       throw new Error(`Managed media ranged download size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, expectedRangeSizeBytes=${expectedRangeSizeBytes}, actualRangeSizeBytes=${bytes.byteLength}, status=${response.status}`);
@@ -263,7 +373,13 @@ async function fetchManagedMediaRangeBytes(
   }
 
   if (isSingleRange && response.status === 200) {
-    const bytes = await readManagedMediaResponseBytes(mediaAsset, response, rangeHeader);
+    const bytes = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => readManagedMediaResponseBytes(mediaAsset, response, rangeHeader, indexedDbOpenRecoveryState, signal),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
     if (bytes.byteLength !== mediaAsset.sizeBytes) {
       throw new Error(`Managed media full download size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, expectedSizeBytes=${mediaAsset.sizeBytes}, actualSizeBytes=${bytes.byteLength}, status=${response.status}`);
     }
@@ -272,7 +388,13 @@ async function fetchManagedMediaRangeBytes(
   }
 
   if (response.ok === false) {
-    const responseBody = await readDownloadFailureBody(response);
+    const responseBody = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => readDownloadFailureBody(response, indexedDbOpenRecoveryState, signal),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
     throw new Error(`Managed media ranged download failed: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, sha256=${mediaAsset.sha256}, range=${rangeHeader}, status=${response.status}, statusText=${response.statusText}, responseBody=${responseBody}`);
   }
 
@@ -299,26 +421,61 @@ async function fetchManagedMediaBytes(
   mediaAsset: MediaAsset,
   downloadMethod: "GET",
   downloadUrl: string,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
 ): Promise<ArrayBuffer> {
   const ranges = planManagedMediaDownloadRanges(mediaAsset.sizeBytes, MANAGED_MEDIA_DOWNLOAD_RANGE_SIZE_BYTES);
   const chunks: Array<ArrayBuffer> = [];
   for (const range of ranges) {
-    chunks.push(await fetchManagedMediaRangeBytes(mediaAsset, downloadMethod, downloadUrl, range, ranges.length === 1));
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    const chunk = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => fetchManagedMediaRangeBytes(
+        mediaAsset,
+        downloadMethod,
+        downloadUrl,
+        range,
+        ranges.length === 1,
+        indexedDbOpenRecoveryState,
+        signal,
+      ),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    chunks.push(chunk);
   }
 
+  indexedDbOpenRecoveryState.throwIfFailed();
+  throwIfManagedMediaDownloadAborted(signal);
   return combineManagedMediaRangeBytes(mediaAsset, chunks);
 }
 
-async function verifyManagedMediaBytes(mediaAsset: MediaAsset, bytes: ArrayBuffer): Promise<Blob> {
+async function verifyManagedMediaBytes(
+  mediaAsset: MediaAsset,
+  bytes: ArrayBuffer,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
+): Promise<Blob> {
+  indexedDbOpenRecoveryState.throwIfFailed();
+  throwIfManagedMediaDownloadAborted(signal);
   if (bytes.byteLength !== mediaAsset.sizeBytes) {
     throw new Error(`Managed media download size mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, expectedSizeBytes=${mediaAsset.sizeBytes}, actualSizeBytes=${bytes.byteLength}`);
   }
 
-  const actualSha256 = await calculateSha256Hex(bytes);
+  const actualSha256 = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+    () => calculateSha256Hex(bytes, indexedDbOpenRecoveryState, signal),
+    indexedDbOpenRecoveryState,
+    signal,
+  );
+  indexedDbOpenRecoveryState.throwIfFailed();
+  throwIfManagedMediaDownloadAborted(signal);
   if (actualSha256 !== mediaAsset.sha256) {
     throw new Error(`Managed media download sha256 mismatch: workspaceId=${mediaAsset.workspaceId}, mediaAssetId=${mediaAsset.mediaAssetId}, expectedSha256=${mediaAsset.sha256}, actualSha256=${actualSha256}`);
   }
 
+  throwIfManagedMediaDownloadAborted(signal);
   return new Blob([bytes], { type: mediaAsset.mimeType });
 }
 
@@ -361,15 +518,41 @@ function assertDownloadMediaAssetMatchesLocal(localMediaAsset: MediaAsset, downl
   }
 }
 
-async function downloadVerifiedMediaBlob(mediaAsset: MediaAsset): Promise<Blob> {
+async function downloadVerifiedMediaBlob(
+  mediaAsset: MediaAsset,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+  signal: AbortSignal,
+): Promise<Blob> {
   let lastError: unknown = null;
   for (let attemptNumber = 1; attemptNumber <= MANAGED_MEDIA_DOWNLOAD_ATTEMPT_COUNT; attemptNumber += 1) {
-    const downloadResult = await loadMediaAssetDownloadUrl(mediaAsset.workspaceId, mediaAsset.mediaAssetId);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    const downloadResult = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => loadMediaAssetDownloadUrl(mediaAsset.workspaceId, mediaAsset.mediaAssetId, signal),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
     assertDownloadMediaAssetMatchesLocal(mediaAsset, downloadResult.mediaAsset);
     let bytes: ArrayBuffer;
     try {
-      bytes = await fetchManagedMediaBytes(mediaAsset, downloadResult.download.method, downloadResult.download.url);
+      bytes = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+        () => fetchManagedMediaBytes(
+          mediaAsset,
+          downloadResult.download.method,
+          downloadResult.download.url,
+          indexedDbOpenRecoveryState,
+          signal,
+        ),
+        indexedDbOpenRecoveryState,
+        signal,
+      );
+      indexedDbOpenRecoveryState.throwIfFailed();
+      throwIfManagedMediaDownloadAborted(signal);
     } catch (error) {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      throwIfManagedMediaDownloadAborted(signal);
       lastError = error;
       if (attemptNumber >= MANAGED_MEDIA_DOWNLOAD_ATTEMPT_COUNT) {
         break;
@@ -385,20 +568,59 @@ async function downloadVerifiedMediaBlob(mediaAsset: MediaAsset): Promise<Blob> 
       continue;
     }
 
-    return verifyManagedMediaBytes(mediaAsset, bytes);
+    const verifiedBlob = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => verifyManagedMediaBytes(mediaAsset, bytes, indexedDbOpenRecoveryState, signal),
+      indexedDbOpenRecoveryState,
+      signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(signal);
+    return verifiedBlob;
   }
 
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
-async function downloadMediaBlobCacheRecord(mediaAsset: MediaAsset): Promise<MediaBlobCacheRecord> {
-  const activeDownloadPromise = activeManagedMediaDownloadPromises.get(mediaAsset.sha256);
-  if (activeDownloadPromise !== undefined) {
-    return activeDownloadPromise;
+async function downloadMediaBlobCacheRecord(
+  mediaAsset: MediaAsset,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<MediaBlobCacheRecord> {
+  const activeDownloadTask = activeManagedMediaDownloadTasks.get(mediaAsset.sha256);
+  if (activeDownloadTask !== undefined) {
+    const activeCacheRecord = await waitForRecoveryGuardedManagedMediaPhase(
+      () => activeDownloadTask.promise,
+      indexedDbOpenRecoveryState,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return activeCacheRecord;
   }
 
+  const abortController = new AbortController();
+  const abortForRecovery = (): void => {
+    if (abortController.signal.aborted === false) {
+      abortController.abort(indexedDbOpenRecoveryState.signal.reason);
+    }
+  };
+  if (indexedDbOpenRecoveryState.signal.aborted) {
+    abortForRecovery();
+  } else {
+    indexedDbOpenRecoveryState.signal.addEventListener("abort", abortForRecovery, { once: true });
+  }
+  let downloadTask: ManagedMediaDownloadTask;
   const downloadPromise = (async (): Promise<MediaBlobCacheRecord> => {
-    const downloadedBlob = await downloadVerifiedMediaBlob(mediaAsset);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(abortController.signal);
+    const downloadedBlob = await waitForRecoveryAndAbortGuardedManagedMediaPhase(
+      () => downloadVerifiedMediaBlob(
+        mediaAsset,
+        indexedDbOpenRecoveryState,
+        abortController.signal,
+      ),
+      indexedDbOpenRecoveryState,
+      abortController.signal,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(abortController.signal);
     const now = new Date().toISOString();
     const cacheRecord: MediaBlobCacheRecord = {
       sha256: mediaAsset.sha256,
@@ -409,42 +631,92 @@ async function downloadMediaBlobCacheRecord(mediaAsset: MediaAsset): Promise<Med
       lastAccessedAt: now,
       sourceMediaAssetId: mediaAsset.mediaAssetId,
     };
-    await writeMediaBlobCacheRecord(cacheRecord);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(abortController.signal);
+    await waitForRecoveryGuardedManagedMediaPhase(
+      () => writeMediaBlobCacheRecord(cacheRecord),
+      indexedDbOpenRecoveryState,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throwIfManagedMediaDownloadAborted(abortController.signal);
     return cacheRecord;
   })().finally(() => {
-    activeManagedMediaDownloadPromises.delete(mediaAsset.sha256);
+    indexedDbOpenRecoveryState.signal.removeEventListener("abort", abortForRecovery);
+    if (activeManagedMediaDownloadTasks.get(mediaAsset.sha256) === downloadTask) {
+      activeManagedMediaDownloadTasks.delete(mediaAsset.sha256);
+    }
   });
-  activeManagedMediaDownloadPromises.set(mediaAsset.sha256, downloadPromise);
-  return downloadPromise;
+  downloadTask = {
+    abortController,
+    promise: downloadPromise,
+  };
+  activeManagedMediaDownloadTasks.set(mediaAsset.sha256, downloadTask);
+  const cacheRecord = await waitForRecoveryGuardedManagedMediaPhase(
+    () => downloadPromise,
+    indexedDbOpenRecoveryState,
+  );
+  indexedDbOpenRecoveryState.throwIfFailed();
+  return cacheRecord;
 }
 
-async function loadMediaBlobForReview(mediaAsset: MediaAsset): Promise<MediaBlobCacheRecord> {
-  const cacheRecord = await loadMediaBlobCacheRecord(mediaAsset.sha256);
+async function loadMediaBlobForReview(
+  mediaAsset: MediaAsset,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<MediaBlobCacheRecord> {
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const cacheRecord = await waitForRecoveryGuardedManagedMediaPhase(
+    () => loadMediaBlobCacheRecord(mediaAsset.sha256),
+    indexedDbOpenRecoveryState,
+  );
+  indexedDbOpenRecoveryState.throwIfFailed();
   if (cacheRecord !== null) {
     assertUsableMediaBlobCacheRecord(mediaAsset, cacheRecord);
     const accessedRecord: MediaBlobCacheRecord = {
       ...cacheRecord,
       lastAccessedAt: new Date().toISOString(),
     };
-    await writeMediaBlobCacheRecord(accessedRecord);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    await waitForRecoveryGuardedManagedMediaPhase(
+      () => writeMediaBlobCacheRecord(accessedRecord),
+      indexedDbOpenRecoveryState,
+    );
+    indexedDbOpenRecoveryState.throwIfFailed();
     return accessedRecord;
   }
 
-  return downloadMediaBlobCacheRecord(mediaAsset);
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const downloadedCacheRecord = await waitForRecoveryGuardedManagedMediaPhase(
+    () => downloadMediaBlobCacheRecord(mediaAsset, indexedDbOpenRecoveryState),
+    indexedDbOpenRecoveryState,
+  );
+  indexedDbOpenRecoveryState.throwIfFailed();
+  return downloadedCacheRecord;
 }
 
 async function loadManagedMediaBlob(
   workspaceId: string,
   mediaAssetId: string,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
 ): Promise<ManagedMediaBlobLoadResult | null> {
-  const mediaAsset = await loadMediaAssetRecord(workspaceId, mediaAssetId);
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const mediaAsset = await waitForRecoveryGuardedManagedMediaPhase(
+    () => loadMediaAssetRecord(workspaceId, mediaAssetId),
+    indexedDbOpenRecoveryState,
+  );
+  indexedDbOpenRecoveryState.throwIfFailed();
   if (mediaAsset === null || mediaAsset.deletedAt !== null) {
     return null;
   }
 
+  indexedDbOpenRecoveryState.throwIfFailed();
+  const cacheRecord = await waitForRecoveryGuardedManagedMediaPhase(
+    () => loadMediaBlobForReview(mediaAsset, indexedDbOpenRecoveryState),
+    indexedDbOpenRecoveryState,
+  );
+  indexedDbOpenRecoveryState.throwIfFailed();
   return {
     mediaAsset,
-    cacheRecord: await loadMediaBlobForReview(mediaAsset),
+    cacheRecord,
   };
 }
 
@@ -532,17 +804,30 @@ function waitForManagedImageLoad(image: HTMLImageElement, url: string): Promise<
   });
 }
 
-async function decodeManagedImageObjectUrl(url: string): Promise<ManagedMediaImageDimensions | null> {
+async function decodeManagedImageObjectUrl(
+  url: string,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ManagedMediaImageDimensions | null> {
+  indexedDbOpenRecoveryState.throwIfFailed();
   const image = new Image();
   image.src = url;
 
   try {
     if (typeof image.decode === "function") {
-      await image.decode();
+      await waitForRecoveryGuardedManagedMediaPhase(
+        () => image.decode(),
+        indexedDbOpenRecoveryState,
+      );
+      indexedDbOpenRecoveryState.throwIfFailed();
     } else {
-      await waitForManagedImageLoad(image, url);
+      await waitForRecoveryGuardedManagedMediaPhase(
+        () => waitForManagedImageLoad(image, url),
+        indexedDbOpenRecoveryState,
+      );
+      indexedDbOpenRecoveryState.throwIfFailed();
     }
   } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
     throw new Error(`Managed media image decode failed: objectUrl=${url}, error=${readErrorMessage(error)}`);
   }
 
@@ -647,6 +932,7 @@ export function ManagedMediaReference(props: Readonly<{
     workspaceId,
   } = props;
   const { t } = useI18n();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const [loadState, setLoadState] = useState<ManagedMediaLoadState>({ status: "loading" });
   const loadStateRef = useRef<ManagedMediaLoadState>(loadState);
 
@@ -714,6 +1000,13 @@ export function ManagedMediaReference(props: Readonly<{
     }
 
     async function loadManagedMedia(): Promise<void> {
+      try {
+        indexedDbOpenRecoveryState.throwIfFailed();
+      } catch (error) {
+        markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error);
+        return;
+      }
+
       if (workspaceId === null) {
         updateLoadState({ status: "unavailable", mediaAsset: null });
         return;
@@ -725,8 +1018,19 @@ export function ManagedMediaReference(props: Readonly<{
 
       let loadResult: ManagedMediaBlobLoadResult | null;
       try {
-        loadResult = await loadManagedMediaBlob(workspaceId, mediaAssetId);
+        loadResult = await waitForRecoveryGuardedManagedMediaPhase(
+          () => loadManagedMediaBlob(
+            workspaceId,
+            mediaAssetId,
+            indexedDbOpenRecoveryState,
+          ),
+          indexedDbOpenRecoveryState,
+        );
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCancelled) {
           return;
         }
@@ -748,6 +1052,7 @@ export function ManagedMediaReference(props: Readonly<{
       let objectUrlRetention: ManagedMediaObjectUrlRetention;
       let imageDimensions: ManagedMediaImageDimensions | null = null;
       try {
+        indexedDbOpenRecoveryState.throwIfFailed();
         const currentLoadState = loadStateRef.current;
         objectUrlRetention = retainObjectUrlForReadyMedia(currentLoadState, loadResult.mediaAsset, loadResult.cacheRecord);
         if (objectUrlRetention.isAcquiredLease) {
@@ -755,13 +1060,27 @@ export function ManagedMediaReference(props: Readonly<{
         }
 
         if (classifyManagedMediaKind(loadResult.mediaAsset.mimeType) === "image") {
-          imageDimensions = objectUrlRetention.isAcquiredLease
-            ? await decodeManagedImageObjectUrl(objectUrlRetention.objectUrlLease.url)
-            : currentLoadState.status === "ready"
+          if (objectUrlRetention.isAcquiredLease) {
+            imageDimensions = await waitForRecoveryGuardedManagedMediaPhase(
+              () => decodeManagedImageObjectUrl(
+                objectUrlRetention.objectUrlLease.url,
+                indexedDbOpenRecoveryState,
+              ),
+              indexedDbOpenRecoveryState,
+            );
+            indexedDbOpenRecoveryState.throwIfFailed();
+          } else {
+            imageDimensions = currentLoadState.status === "ready"
               ? currentLoadState.imageDimensions
               : null;
+          }
         }
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          releaseProvisionalObjectUrlLease();
+          return;
+        }
         if (isCancelled) {
           releaseProvisionalObjectUrlLease();
           return;
@@ -795,7 +1114,7 @@ export function ManagedMediaReference(props: Readonly<{
       isCancelled = true;
       releaseProvisionalObjectUrlLease();
     };
-  }, [localReadVersion, mediaAssetId, referenceState, workspaceId]);
+  }, [indexedDbOpenRecoveryState, localReadVersion, mediaAssetId, referenceState, workspaceId]);
 
   const childrenText = readTextFromReactNode(children);
   if (referenceState !== "ready") {

--- a/apps/web/src/screens/review/components/card/useReviewCardEditor.ts
+++ b/apps/web/src/screens/review/components/card/useReviewCardEditor.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../../appError/AppErrorContext";
 import type { TranslationKey } from "../../../../i18n";
 import { UnsupportedImagePreparationError } from "../../../../media/imagePreparation";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
@@ -139,7 +142,7 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
     userId,
     workspaceId,
   } = params;
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const editorIdentityRef = useRef<ReviewEditorIdentity | null>(null);
   const reconciliationBaselineCardRef = useRef<Card | null>(null);
   const lastProcessedObservedCardMarkerRef = useRef<ReviewCardObservationMarker | null>(null);
@@ -353,6 +356,10 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
   }, [resetTextareaSelectionRestore]);
 
   function handleOpenEditor(card: Card): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     resetTextareaSelectionRestore();
     const initialFormState = toCardFormState(card);
     const presentationGeneration = presentationGenerationRef.current + 1;
@@ -390,7 +397,7 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
   }
 
   async function handleEditorSave(): Promise<void> {
-    if (isAuthoringMedia || isEditorSubmissionAllowed() === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isAuthoringMedia || isEditorSubmissionAllowed() === false) {
       return;
     }
 
@@ -415,6 +422,7 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
         backText: submittedFormState.backText,
         tags: submittedFormState.tags,
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isEditorPresentationCurrent(presentationToken) === false) {
         return;
       }
@@ -426,6 +434,9 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
 
       handleCloseEditorIfCurrent(presentationToken);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isEditorPresentationCurrent(presentationToken) === false) {
         return;
       }
@@ -447,14 +458,14 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       showCapturedTechnicalError(error);
       setEditorErrorMessage(t("appError.technicalError.message"));
     } finally {
-      if (isEditorPresentationCurrent(presentationToken)) {
+      if (indexedDbOpenRecoveryState.hasFailed() === false && isEditorPresentationCurrent(presentationToken)) {
         setIsEditorSaving(false);
       }
     }
   }
 
   async function handleEditorSaveForAiHandoff(): Promise<Card | null> {
-    if (isAuthoringMedia || isEditorSubmissionAllowed() === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isAuthoringMedia || isEditorSubmissionAllowed() === false) {
       return null;
     }
 
@@ -479,6 +490,7 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
         backText: submittedFormState.backText,
         tags: submittedFormState.tags,
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isEditorPresentationCurrent(presentationToken) === false) {
         return null;
       }
@@ -494,6 +506,9 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       setEditorFormState(savedFormState);
       return savedCard;
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return null;
+      }
       if (isEditorPresentationCurrent(presentationToken) === false) {
         return null;
       }
@@ -516,14 +531,14 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       setEditorErrorMessage(t("appError.technicalError.message"));
       return null;
     } finally {
-      if (isEditorPresentationCurrent(presentationToken)) {
+      if (indexedDbOpenRecoveryState.hasFailed() === false && isEditorPresentationCurrent(presentationToken)) {
         setIsEditorSaving(false);
       }
     }
   }
 
   async function handleEditorDelete(): Promise<void> {
-    if (isAuthoringMedia) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isAuthoringMedia) {
       return;
     }
 
@@ -542,8 +557,12 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
 
     try {
       await deleteCardItem(editingCardId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       handleCloseEditor();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const expectedErrorMessage = getExpectedCardMutationInlineErrorMessage(error, t("reviewEditor.errors.cardNotFound"));
       if (expectedErrorMessage !== null) {
         setEditorErrorMessage(expectedErrorMessage);
@@ -561,7 +580,9 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       showCapturedTechnicalError(error);
       setEditorErrorMessage(t("appError.technicalError.message"));
     } finally {
-      setIsEditorSaving(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsEditorSaving(false);
+      }
     }
   }
 
@@ -583,6 +604,10 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
   }
 
   async function handlePrepareImageMedia(request: CardFormImageMediaRequest): Promise<string | null> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return null;
+    }
+
     if (workspaceId === null) {
       setManagedMediaFieldError(request.field, t("cardForm.media.errors.workspaceUnavailable"));
       return null;
@@ -605,10 +630,14 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
         installationId,
         file: request.file,
         altText: request.altText,
-      });
+      }, indexedDbOpenRecoveryState.throwIfFailed);
+      indexedDbOpenRecoveryState.throwIfFailed();
       runMediaUploadTransfers();
       return result.markdown;
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return null;
+      }
       if (error instanceof UnsupportedImagePreparationError) {
         setManagedMediaFieldError(request.field, t("cardForm.media.errors.unsupportedImage"));
         return null;
@@ -626,17 +655,23 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       setManagedMediaFieldError(request.field, t("cardForm.media.errors.processingFailed"));
       return null;
     } finally {
-      setManagedMediaState((currentState) => ({
-        ...currentState,
-        [request.field]: {
-          ...currentState[request.field],
-          isProcessing: false,
-        },
-      }));
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setManagedMediaState((currentState) => ({
+          ...currentState,
+          [request.field]: {
+            ...currentState[request.field],
+            isProcessing: false,
+          },
+        }));
+      }
     }
   }
 
   async function handleRetryMediaUploadTransfer(request: CardFormMediaUploadRetryRequest): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setEditorErrorMessage("");
     setErrorMessage("");
 
@@ -645,8 +680,12 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
         ...request,
         retryAt: new Date().toISOString(),
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       runMediaUploadTransfers();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       captureAppOperationError(error, {
         feature: "review",
         operation: "review_card_image_upload_retry",

--- a/apps/web/src/screens/review/data/useReviewScreenData.ts
+++ b/apps/web/src/screens/review/data/useReviewScreenData.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { ALL_CARDS_REVIEW_FILTER } from "../../../appData/domain";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import { loadDecksListSnapshot } from "../../../localDb/cards/decks";
 import {
@@ -73,9 +77,25 @@ type CarriedReviewDataContext = Readonly<{
   localReadVersion: number;
 }>;
 
-export type ReviewSubmissionOutcome = "saved" | "failed" | "stale";
+export type ReviewSubmissionOutcome = "saved" | "failed" | "stale" | "cancelled";
 
 const workspaceUnavailableErrorMessage = "Workspace is unavailable";
+
+async function waitForRecoveryGuardedReviewPhase<ResultType>(
+  phase: Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    const result = await phase;
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
 
 function isWorkspaceUnavailableError(error: unknown): boolean {
   return error instanceof Error && error.message === workspaceUnavailableErrorMessage;
@@ -118,7 +138,7 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     userId,
   } = params;
   const { formatCount, messages, t } = useI18n();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const [canonicalReviewQueue, setCanonicalReviewQueue] = useState<ReadonlyArray<Card>>([]);
   const [queueCards, setQueueCards] = useState<ReadonlyArray<Card>>([]);
   const [reviewCounts, setReviewCounts] = useState<ReviewCounts>(createEmptyReviewCounts);
@@ -279,13 +299,14 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     const shouldShowBlockingLoader = loadedReviewDataContextKeyRef.current !== reviewDataContextKey;
 
     async function loadReviewData(): Promise<void> {
-      if (loadedWorkspaceIdRef.current !== activeWorkspaceId) {
-        setLocalHotStateStatus("loading");
-        setLocalWorkspaceCardCount(0);
-      }
-      setReviewLoadErrorMessage("");
-
       try {
+        indexedDbOpenRecoveryState.throwIfFailed();
+        if (loadedWorkspaceIdRef.current !== activeWorkspaceId) {
+          setLocalHotStateStatus("loading");
+          setLocalWorkspaceCardCount(0);
+        }
+        setReviewLoadErrorMessage("");
+
         if (activeWorkspaceId === null) {
           throw new Error(workspaceUnavailableErrorMessage);
         }
@@ -296,13 +317,31 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           tagsSummary,
           decksSnapshot,
           isHotStateHydrated,
-        ] = await Promise.all([
-          loadReviewQueueSnapshot(activeWorkspaceId, selectedReviewFilter, 8),
-          loadReviewTimelinePage(activeWorkspaceId, selectedReviewFilter, 200, 0),
-          loadWorkspaceTagsSummary(activeWorkspaceId),
-          loadDecksListSnapshot(activeWorkspaceId),
-          hasHydratedHotState(activeWorkspaceId),
-        ]);
+        ] = await waitForRecoveryGuardedReviewPhase(Promise.all([
+          waitForRecoveryGuardedReviewPhase(
+            loadReviewQueueSnapshot(activeWorkspaceId, selectedReviewFilter, 8),
+            indexedDbOpenRecoveryState,
+          ),
+          waitForRecoveryGuardedReviewPhase(
+            loadReviewTimelinePage(activeWorkspaceId, selectedReviewFilter, 200, 0),
+            indexedDbOpenRecoveryState,
+          ),
+          waitForRecoveryGuardedReviewPhase(
+            loadWorkspaceTagsSummary(activeWorkspaceId),
+            indexedDbOpenRecoveryState,
+          ),
+          waitForRecoveryGuardedReviewPhase(
+            loadDecksListSnapshot(activeWorkspaceId),
+            indexedDbOpenRecoveryState,
+          ),
+          waitForRecoveryGuardedReviewPhase(
+            hasHydratedHotState(activeWorkspaceId),
+            indexedDbOpenRecoveryState,
+          ),
+        ]), indexedDbOpenRecoveryState);
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
         if (isCancelled) {
           return;
         }
@@ -335,13 +374,19 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           ),
         );
         const previousPresentedCard = shouldShowBlockingLoader ? null : presentedCardRef.current;
-        const resolvedPresentedCard = await resolvePresentedCard(
-          canonicalReviewQueueBeforePresentation,
-          previousPresentedCard,
-          nextResolvedReviewFilter,
-          decksSnapshot.deckSummaries,
-          getCardById,
+        const resolvedPresentedCard = await waitForRecoveryGuardedReviewPhase(
+          resolvePresentedCard(
+            canonicalReviewQueueBeforePresentation,
+            previousPresentedCard,
+            nextResolvedReviewFilter,
+            decksSnapshot.deckSummaries,
+            getCardById,
+          ),
+          indexedDbOpenRecoveryState,
         );
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return;
+        }
         if (isCancelled) {
           return;
         }
@@ -413,6 +458,9 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           selectReviewFilter(nextResolvedReviewFilter);
         }
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCancelled) {
           return;
         }
@@ -441,9 +489,13 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspaceId, getCardById, localReadVersion, reviewDataContextKey, selectReviewFilter, selectedReviewFilter]);
+  }, [activeWorkspaceId, getCardById, indexedDbOpenRecoveryState, localReadVersion, reviewDataContextKey, selectReviewFilter, selectedReviewFilter]);
 
   async function handleReview(card: Card, rating: 0 | 1 | 2 | 3): Promise<ReviewSubmissionOutcome> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return "cancelled";
+    }
+
     if (loadedReviewDataContextKeyRef.current !== reviewDataContextKeyRef.current) {
       return "stale";
     }
@@ -474,8 +526,17 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     setCurrentReviewSessionSignature(optimisticActiveReviewQueue, optimisticQueueCards);
 
     try {
-      await submitReviewItem(submissionContext.cardId, rating);
+      await waitForRecoveryGuardedReviewPhase(
+        submitReviewItem(submissionContext.cardId, rating),
+        indexedDbOpenRecoveryState,
+      );
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return "cancelled";
+      }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return "cancelled";
+      }
       const observationIdentity = observationIdentityRef.current;
       pendingReviewSnapshotsRef.current = removePendingReviewSnapshot(
         pendingReviewSnapshotsRef.current,
@@ -496,8 +557,17 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
 
       let freshRollbackCard: Card | null = null;
       try {
-        freshRollbackCard = await loadPresentedCardForPreservation(submissionContext.cardId, getCardById);
-      } catch {
+        freshRollbackCard = await waitForRecoveryGuardedReviewPhase(
+          loadPresentedCardForPreservation(submissionContext.cardId, getCardById),
+          indexedDbOpenRecoveryState,
+        );
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return "cancelled";
+        }
+      } catch (rollbackError) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, rollbackError)) {
+          return "cancelled";
+        }
         // The submit failure owns the visible technical report; rollback lookup is only UI preservation.
       }
       const currentResolvedReviewFilter = resolvedReviewFilterRef.current;
@@ -610,13 +680,19 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           pendingReviewSnapshotsBeforeClear,
           new Set([submissionContext.cardId]),
         );
-        const nextChunk = await loadReviewQueueChunk(
-          currentWorkspaceId,
-          resolvedReviewFilterRef.current,
-          requestedReviewQueueCursor,
-          8 - nextCanonicalReviewQueue.length,
-          excludedCardIds,
+        const nextChunk = await waitForRecoveryGuardedReviewPhase(
+          loadReviewQueueChunk(
+            currentWorkspaceId,
+            resolvedReviewFilterRef.current,
+            requestedReviewQueueCursor,
+            8 - nextCanonicalReviewQueue.length,
+            excludedCardIds,
+          ),
+          indexedDbOpenRecoveryState,
         );
+        if (indexedDbOpenRecoveryState.hasFailed()) {
+          return "cancelled";
+        }
         if (
           isReviewSubmissionContextCurrent(
             submissionContext,
@@ -663,6 +739,9 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
         setQueueCardsState(replenishedQueueCards);
         setCurrentReviewSessionSignature(replenishedActiveReviewQueue, replenishedQueueCards);
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return "cancelled";
+        }
         if (
           isReviewSubmissionContextCurrent(
             submissionContext,

--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
@@ -2,6 +2,8 @@
 import { act, useEffect, type ReactElement } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppErrorDialogProvider } from "../../../appError/AppErrorContext";
+import { I18nProvider } from "../../../i18n";
 import {
   makeReviewReactionRating,
   reviewReactionRatings,
@@ -242,11 +244,15 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
 
     await act(async () => {
       currentRoot.render(
-        <ReviewReactionLayerHarness
-          onResult={(result) => {
-            latestResult = result;
-          }}
-        />,
+        <I18nProvider>
+          <AppErrorDialogProvider>
+            <ReviewReactionLayerHarness
+              onResult={(result) => {
+                latestResult = result;
+              }}
+            />
+          </AppErrorDialogProvider>
+        </I18nProvider>,
       );
     });
   }

--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, type CSSProperties, type ReactElement } from "react";
 import type { AnimationItem } from "lottie-web";
+import { useAppErrorDialog } from "../../../appError/AppErrorContext";
 import {
   matchesReducedReviewReactionMotion,
   reviewReactionAnimationDurationMillis,
@@ -190,11 +191,19 @@ type ReviewReactionLottieAnimationProps = Readonly<{
 
 function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps): ReactElement {
   const { eventId, onReactionEventFallback, variant } = props;
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const mountedContainer = containerRef.current;
     if (mountedContainer === null) {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       reportReviewReactionLottieFailure(
         new Error("Review reaction Lottie container was not mounted."),
         "render",
@@ -208,6 +217,9 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
     try {
       animationItem = mountReservedReviewReactionLottieRender(eventId, variant, mountedContainer).animationItem;
     } catch (error: unknown) {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
       reportReviewReactionLottieFailure(error, "render", variant);
       onReactionEventFallback(eventId);
       return;
@@ -215,7 +227,7 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
 
     let hasReportedFailure = false;
     const handlePlaybackFailure = (error: unknown): void => {
-      if (hasReportedFailure) {
+      if (hasReportedFailure || indexedDbOpenRecoveryState.hasFailed()) {
         return;
       }
 
@@ -252,7 +264,7 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
       removeDataFailedListener();
       unmountReservedReviewReactionLottieRender(eventId);
     };
-  }, [eventId, onReactionEventFallback, variant]);
+  }, [eventId, indexedDbOpenRecoveryState, onReactionEventFallback, variant]);
 
   return (
     <div ref={containerRef} className={reviewReactionLottieContainerClassByVariant[variant]} />

--- a/apps/web/src/screens/review/reactions/lottie/reviewReactionLottie.ts
+++ b/apps/web/src/screens/review/reactions/lottie/reviewReactionLottie.ts
@@ -118,6 +118,11 @@ type ReviewReactionLottiePreparedRender = Readonly<{
   variant: ReviewReactionLottieVariant;
 }>;
 
+type ReviewReactionLottieWorkOwner = Readonly<{
+  controller: AbortController;
+  removeRecoveryAbortListener: () => void;
+}>;
+
 const reviewReactionLottieVariantSet: ReadonlySet<ReviewReactionRenderableVariant> = new Set(
   reviewReactionLottieVariants,
 );
@@ -402,6 +407,7 @@ let reviewReactionLottieMountedRenderEventIds: Set<string> = new Set<string>();
 let reviewReactionLottieReleaseRequestedEventIds: Set<string> = new Set<string>();
 let reviewReactionLottieOffscreenRoot: HTMLDivElement | null = null;
 let reviewReactionLottieStateGeneration = 0;
+let reviewReactionLottieWorkOwner: ReviewReactionLottieWorkOwner | null = null;
 
 export const reviewReactionLottieFallbackVariant: ReviewReactionFallbackVariant = "fallbackCrownBounce";
 
@@ -419,7 +425,7 @@ export function reviewReactionLottieAssetFailure(variant: ReviewReactionLottieVa
   return reviewReactionLottieFailureByVariant[variant];
 }
 
-export function resetReviewReactionLottieStateForTests(): void {
+function clearReviewReactionLottieState(): void {
   reviewReactionLottieStateGeneration += 1;
   destroyReviewReactionLottiePreparedRenders(reviewReactionLottiePreparedRenderByVariant);
   for (const preparedRender of reviewReactionLottieReservedRenderByEventId.values()) {
@@ -440,6 +446,83 @@ export function resetReviewReactionLottieStateForTests(): void {
   reviewReactionLottieOffscreenRoot = null;
 }
 
+function detachReviewReactionLottieWorkOwner(
+  owner: ReviewReactionLottieWorkOwner,
+  reason: unknown,
+): boolean {
+  if (reviewReactionLottieWorkOwner !== owner) {
+    return false;
+  }
+
+  owner.removeRecoveryAbortListener();
+  owner.controller.abort(reason);
+  reviewReactionLottieWorkOwner = null;
+  reviewReactionLottieStateGeneration += 1;
+  if (reviewReactionLottiePlayerReady === false) {
+    reviewReactionLottiePlayerPromise = null;
+  }
+  reviewReactionLottieAnimationPromiseByVariant = makeEmptyReviewReactionLottieAnimationPromiseByVariant();
+  reviewReactionLottiePreparedRenderPromiseByVariant = makeEmptyReviewReactionLottiePreparedRenderPromiseByVariant();
+  return true;
+}
+
+function stopAndClearReviewReactionLottieWork(
+  owner: ReviewReactionLottieWorkOwner,
+  reason: unknown,
+): void {
+  if (detachReviewReactionLottieWorkOwner(owner, reason) === false) {
+    return;
+  }
+
+  clearReviewReactionLottieState();
+}
+
+function createReviewReactionLottieWorkOwner(recoverySignal: AbortSignal): ReviewReactionLottieWorkOwner {
+  if (reviewReactionLottieWorkOwner !== null) {
+    stopAndClearReviewReactionLottieWork(
+      reviewReactionLottieWorkOwner,
+      new DOMException("Review reaction Lottie prewarm was replaced", "AbortError"),
+    );
+  }
+
+  const controller = new AbortController();
+  let owner: ReviewReactionLottieWorkOwner | null = null;
+  const handleRecoveryAbort = (): void => {
+    if (owner === null) {
+      return;
+    }
+    stopAndClearReviewReactionLottieWork(owner, recoverySignal.reason);
+  };
+  recoverySignal.addEventListener("abort", handleRecoveryAbort, { once: true });
+  owner = {
+    controller,
+    removeRecoveryAbortListener: () => {
+      recoverySignal.removeEventListener("abort", handleRecoveryAbort);
+    },
+  };
+  reviewReactionLottieWorkOwner = owner;
+  if (recoverySignal.aborted) {
+    handleRecoveryAbort();
+  }
+  return owner;
+}
+
+function getReviewReactionLottieWorkSignal(): AbortSignal {
+  return reviewReactionLottieWorkOwner?.controller.signal ?? new AbortController().signal;
+}
+
+export function resetReviewReactionLottieStateForTests(): void {
+  if (reviewReactionLottieWorkOwner !== null) {
+    stopAndClearReviewReactionLottieWork(
+      reviewReactionLottieWorkOwner,
+      new DOMException("Review reaction Lottie state was reset", "AbortError"),
+    );
+    return;
+  }
+
+  clearReviewReactionLottieState();
+}
+
 function destroyReviewReactionLottiePreparedRenders(
   preparedRenderByVariant: ReviewReactionLottiePreparedRenderByVariant,
 ): void {
@@ -455,7 +538,8 @@ function destroyReviewReactionLottiePreparedRender(preparedRender: ReviewReactio
   preparedRender.container.remove();
 }
 
-function loadReviewReactionLottiePlayer(): Promise<LottiePlayer> {
+function loadReviewReactionLottiePlayer(signal: AbortSignal): Promise<LottiePlayer> {
+  signal.throwIfAborted();
   if (reviewReactionLottiePlayerPromise !== null) {
     return reviewReactionLottiePlayerPromise;
   }
@@ -463,12 +547,14 @@ function loadReviewReactionLottiePlayer(): Promise<LottiePlayer> {
   const generation = reviewReactionLottieStateGeneration;
   reviewReactionLottiePlayerPromise = import("lottie-web/build/player/lottie_light")
     .then((lottieModule: ReviewReactionLottiePlayerModule): LottiePlayer => {
+      signal.throwIfAborted();
       if (generation === reviewReactionLottieStateGeneration) {
         reviewReactionLottiePlayerReady = true;
       }
       return lottieModule.default;
     })
     .catch((error: unknown): never => {
+      signal.throwIfAborted();
       if (generation === reviewReactionLottieStateGeneration) {
         reviewReactionLottiePlayerReady = false;
         reviewReactionLottiePlayerPromise = null;
@@ -485,12 +571,16 @@ function isReviewReactionLottieAnimationData(animationData: unknown): animationD
 
 async function fetchReviewReactionLottieAnimationData(
   variant: ReviewReactionLottieVariant,
+  signal: AbortSignal,
 ): Promise<object> {
+  signal.throwIfAborted();
   const url = reviewReactionLottieAnimationUrlByVariant[variant];
   let response: Response;
   try {
-    response = await fetch(url);
+    response = await fetch(url, { signal });
+    signal.throwIfAborted();
   } catch (error: unknown) {
+    signal.throwIfAborted();
     throw new Error(
       `Failed to fetch review reaction Lottie animation JSON for variant ${variant} from ${url}.`,
       { cause: error },
@@ -498,7 +588,9 @@ async function fetchReviewReactionLottieAnimationData(
   }
 
   if (!response.ok) {
+    signal.throwIfAborted();
     const responseBody = await response.text();
+    signal.throwIfAborted();
     throw new Error(
       `Failed to fetch review reaction Lottie animation JSON for variant ${variant} from ${url}. `
         + `Received status ${response.status} ${response.statusText}. Response body: ${responseBody}`,
@@ -507,8 +599,11 @@ async function fetchReviewReactionLottieAnimationData(
 
   let animationData: unknown;
   try {
+    signal.throwIfAborted();
     animationData = await response.json();
+    signal.throwIfAborted();
   } catch (error: unknown) {
+    signal.throwIfAborted();
     throw new Error(
       `Failed to parse review reaction Lottie animation JSON for variant ${variant} from ${url}.`,
       { cause: error },
@@ -524,7 +619,11 @@ async function fetchReviewReactionLottieAnimationData(
   return animationData;
 }
 
-function loadReviewReactionLottieAnimationData(variant: ReviewReactionLottieVariant): Promise<object> {
+function loadReviewReactionLottieAnimationData(
+  variant: ReviewReactionLottieVariant,
+  signal: AbortSignal,
+): Promise<object> {
+  signal.throwIfAborted();
   const cachedAnimationData = reviewReactionLottieAnimationDataByVariant[variant];
   if (cachedAnimationData !== null) {
     return Promise.resolve(cachedAnimationData);
@@ -535,27 +634,34 @@ function loadReviewReactionLottieAnimationData(variant: ReviewReactionLottieVari
     return cachedAnimationPromise;
   }
 
-  const animationDataPromise = fetchReviewReactionLottieAnimationData(variant)
+  const generation = reviewReactionLottieStateGeneration;
+  const animationDataPromise = fetchReviewReactionLottieAnimationData(variant, signal)
     .then((animationData: object): object => {
-      reviewReactionLottieAnimationDataByVariant = {
-        ...reviewReactionLottieAnimationDataByVariant,
-        [variant]: animationData,
-      };
-      reviewReactionLottieAnimationPromiseByVariant = {
-        ...reviewReactionLottieAnimationPromiseByVariant,
-        [variant]: null,
-      };
+      signal.throwIfAborted();
+      if (generation === reviewReactionLottieStateGeneration) {
+        reviewReactionLottieAnimationDataByVariant = {
+          ...reviewReactionLottieAnimationDataByVariant,
+          [variant]: animationData,
+        };
+        reviewReactionLottieAnimationPromiseByVariant = {
+          ...reviewReactionLottieAnimationPromiseByVariant,
+          [variant]: null,
+        };
+      }
       return animationData;
     })
     .catch((error: unknown): never => {
-      reviewReactionLottieAnimationDataByVariant = {
-        ...reviewReactionLottieAnimationDataByVariant,
-        [variant]: null,
-      };
-      reviewReactionLottieAnimationPromiseByVariant = {
-        ...reviewReactionLottieAnimationPromiseByVariant,
-        [variant]: null,
-      };
+      signal.throwIfAborted();
+      if (generation === reviewReactionLottieStateGeneration) {
+        reviewReactionLottieAnimationDataByVariant = {
+          ...reviewReactionLottieAnimationDataByVariant,
+          [variant]: null,
+        };
+        reviewReactionLottieAnimationPromiseByVariant = {
+          ...reviewReactionLottieAnimationPromiseByVariant,
+          [variant]: null,
+        };
+      }
       throw error;
     });
 
@@ -567,7 +673,8 @@ function loadReviewReactionLottieAnimationData(variant: ReviewReactionLottieVari
   return animationDataPromise;
 }
 
-function requireReviewReactionLottieDocumentBody(): HTMLElement {
+function requireReviewReactionLottieDocumentBody(signal: AbortSignal): HTMLElement {
+  signal.throwIfAborted();
   if (typeof document === "undefined" || document.body === null) {
     throw new Error("Review reaction Lottie prewarm requires a mounted document body.");
   }
@@ -575,13 +682,15 @@ function requireReviewReactionLottieDocumentBody(): HTMLElement {
   return document.body;
 }
 
-function makeReviewReactionLottieOffscreenRoot(): HTMLDivElement {
+function makeReviewReactionLottieOffscreenRoot(signal: AbortSignal): HTMLDivElement {
+  signal.throwIfAborted();
   const existingRoot = reviewReactionLottieOffscreenRoot;
   if (existingRoot !== null && existingRoot.isConnected) {
     return existingRoot;
   }
 
-  const body = requireReviewReactionLottieDocumentBody();
+  const body = requireReviewReactionLottieDocumentBody(signal);
+  signal.throwIfAborted();
   const root = document.createElement("div");
   root.setAttribute("aria-hidden", "true");
   root.setAttribute("data-review-reaction-lottie-prewarm-root", "true");
@@ -593,14 +702,18 @@ function makeReviewReactionLottieOffscreenRoot(): HTMLDivElement {
   root.style.top = "-10000px";
   root.style.opacity = "0";
   root.style.pointerEvents = "none";
+  signal.throwIfAborted();
   body.appendChild(root);
   reviewReactionLottieOffscreenRoot = root;
   return root;
 }
 
-function makeReviewReactionLottieOffscreenContainer(): HTMLDivElement {
-  const root = makeReviewReactionLottieOffscreenRoot();
+function makeReviewReactionLottieOffscreenContainer(signal: AbortSignal): HTMLDivElement {
+  signal.throwIfAborted();
+  const root = makeReviewReactionLottieOffscreenRoot(signal);
+  signal.throwIfAborted();
   const container = document.createElement("div");
+  signal.throwIfAborted();
   root.appendChild(container);
   return container;
 }
@@ -608,7 +721,7 @@ function makeReviewReactionLottieOffscreenContainer(): HTMLDivElement {
 function moveReviewReactionLottieRenderToOffscreenRoot(
   preparedRender: ReviewReactionLottiePreparedRender,
 ): void {
-  makeReviewReactionLottieOffscreenRoot().appendChild(preparedRender.container);
+  makeReviewReactionLottieOffscreenRoot(getReviewReactionLottieWorkSignal()).appendChild(preparedRender.container);
 }
 
 function makeReviewReactionLottieRenderEventError(
@@ -623,7 +736,9 @@ function makeReviewReactionLottieRenderEventError(
 function waitForReviewReactionLottiePreparedRender(
   animationItem: AnimationItem,
   variant: ReviewReactionLottieVariant,
+  signal: AbortSignal,
 ): Promise<void> {
+  signal.throwIfAborted();
   if (animationItem.isLoaded) {
     return Promise.resolve();
   }
@@ -638,6 +753,7 @@ function waitForReviewReactionLottiePreparedRender(
       removeDomLoadedListener?.();
       removeDataFailedListener?.();
       removeErrorListener?.();
+      signal.removeEventListener("abort", markRenderAborted);
       removeDomLoadedListener = null;
       removeDataFailedListener = null;
       removeErrorListener = null;
@@ -663,6 +779,17 @@ function waitForReviewReactionLottiePreparedRender(
       reject(makeReviewReactionLottieRenderEventError(eventName, variant));
     };
 
+    const markRenderAborted = (): void => {
+      if (hasSettled) {
+        return;
+      }
+
+      hasSettled = true;
+      removeListeners();
+      reject(signal.reason);
+    };
+
+    signal.addEventListener("abort", markRenderAborted, { once: true });
     removeDomLoadedListener = animationItem.addEventListener("DOMLoaded", markRenderReady);
     removeDataFailedListener = animationItem.addEventListener("data_failed", () => {
       markRenderFailed("data_failed");
@@ -672,21 +799,27 @@ function waitForReviewReactionLottiePreparedRender(
     });
     if (animationItem.isLoaded) {
       markRenderReady();
+    } else if (signal.aborted) {
+      markRenderAborted();
     }
   });
 }
 
 async function makeReviewReactionLottiePreparedRender(
   variant: ReviewReactionLottieVariant,
+  signal: AbortSignal,
 ): Promise<ReviewReactionLottiePreparedRender> {
+  signal.throwIfAborted();
   const [player, animationData] = await Promise.all([
-    loadReviewReactionLottiePlayer(),
-    loadReviewReactionLottieAnimationData(variant),
+    loadReviewReactionLottiePlayer(signal),
+    loadReviewReactionLottieAnimationData(variant, signal),
   ]);
-  const container = makeReviewReactionLottieOffscreenContainer();
+  signal.throwIfAborted();
+  const container = makeReviewReactionLottieOffscreenContainer(signal);
   let animationItem: AnimationItem;
 
   try {
+    signal.throwIfAborted();
     animationItem = player.loadAnimation({
       container,
       renderer: "svg",
@@ -703,7 +836,8 @@ async function makeReviewReactionLottiePreparedRender(
   }
 
   try {
-    await waitForReviewReactionLottiePreparedRender(animationItem, variant);
+    await waitForReviewReactionLottiePreparedRender(animationItem, variant, signal);
+    signal.throwIfAborted();
   } catch (error: unknown) {
     animationItem.destroy();
     container.remove();
@@ -724,7 +858,9 @@ async function makeReviewReactionLottiePreparedRender(
 
 function prewarmReviewReactionLottieVariant(
   variant: ReviewReactionLottieVariant,
+  signal: AbortSignal,
 ): Promise<ReviewReactionLottiePreparedRender> {
+  signal.throwIfAborted();
   const preparedRender = reviewReactionLottiePreparedRenderByVariant[variant];
   if (preparedRender !== null) {
     return Promise.resolve(preparedRender);
@@ -736,8 +872,9 @@ function prewarmReviewReactionLottieVariant(
   }
 
   const generation = reviewReactionLottieStateGeneration;
-  const nextPreparedRenderPromise = makeReviewReactionLottiePreparedRender(variant)
+  const nextPreparedRenderPromise = makeReviewReactionLottiePreparedRender(variant, signal)
     .then((nextPreparedRender: ReviewReactionLottiePreparedRender): ReviewReactionLottiePreparedRender => {
+      signal.throwIfAborted();
       if (generation !== reviewReactionLottieStateGeneration) {
         destroyReviewReactionLottiePreparedRender(nextPreparedRender);
         return nextPreparedRender;
@@ -758,6 +895,7 @@ function prewarmReviewReactionLottieVariant(
       return nextPreparedRender;
     })
     .catch((error: unknown): never => {
+      signal.throwIfAborted();
       if (generation === reviewReactionLottieStateGeneration) {
         reviewReactionLottiePreparedRenderByVariant = {
           ...reviewReactionLottiePreparedRenderByVariant,
@@ -794,7 +932,15 @@ function reportReviewReactionLottiePrewarmFailure(
 }
 
 function startReviewReactionLottieVariantPrewarm(variant: ReviewReactionLottieVariant): void {
-  void prewarmReviewReactionLottieVariant(variant).catch((error: unknown) => {
+  const signal = getReviewReactionLottieWorkSignal();
+  if (signal.aborted) {
+    return;
+  }
+
+  void prewarmReviewReactionLottieVariant(variant, signal).catch((error: unknown) => {
+    if (signal.aborted) {
+      return;
+    }
     reportReviewReactionLottiePrewarmFailure(error, variant);
   });
 }
@@ -802,7 +948,10 @@ function startReviewReactionLottieVariantPrewarm(variant: ReviewReactionLottieVa
 export async function loadReviewReactionLottieAsset(
   variant: ReviewReactionLottieVariant,
 ): Promise<ReviewReactionLottieAsset> {
-  const preparedRender = await prewarmReviewReactionLottieVariant(variant);
+  const signal = getReviewReactionLottieWorkSignal();
+  signal.throwIfAborted();
+  const preparedRender = await prewarmReviewReactionLottieVariant(variant, signal);
+  signal.throwIfAborted();
   return {
     animationData: preparedRender.animationData,
     player: preparedRender.player,
@@ -810,9 +959,12 @@ export async function loadReviewReactionLottieAsset(
 }
 
 export async function prewarmReviewReactionLottieAssets(): Promise<ReviewReactionLottiePreloadResult> {
+  const signal = getReviewReactionLottieWorkSignal();
+  signal.throwIfAborted();
   const settledPreparedRenders = await Promise.allSettled(
-    reviewReactionLottieVariants.map((variant) => prewarmReviewReactionLottieVariant(variant)),
+    reviewReactionLottieVariants.map((variant) => prewarmReviewReactionLottieVariant(variant, signal)),
   );
+  signal.throwIfAborted();
   const failures: Array<ReviewReactionLottieAssetFailure> = [];
 
   for (const [index, settledPreparedRender] of settledPreparedRenders.entries()) {
@@ -832,22 +984,44 @@ export async function loadReviewReactionLottieAssets(): Promise<ReviewReactionLo
   return prewarmReviewReactionLottieAssets();
 }
 
-export function startReviewReactionLottiePrewarm(): void {
+export function startReviewReactionLottiePrewarm(recoverySignal: AbortSignal): () => void {
+  const owner = createReviewReactionLottieWorkOwner(recoverySignal);
+  if (owner.controller.signal.aborted) {
+    return () => undefined;
+  }
+
   void prewarmReviewReactionLottieAssets()
     .then((result: ReviewReactionLottiePreloadResult): void => {
+      owner.controller.signal.throwIfAborted();
       for (const failure of result.failures) {
+        owner.controller.signal.throwIfAborted();
         reportReviewReactionLottiePrewarmFailure(failure.error, failure.variant);
       }
     })
     .catch((error: unknown): void => {
+      if (owner.controller.signal.aborted) {
+        return;
+      }
       reportReviewReactionLottiePrewarmFailure(error, null);
     });
+
+  return () => {
+    stopAndClearReviewReactionLottieWork(
+      owner,
+      new DOMException("Review reaction Lottie prewarm was stopped", "AbortError"),
+    );
+  };
 }
 
 export function reserveReviewReactionLottieRender(
   eventId: string,
   variant: ReviewReactionLottieVariant,
 ): boolean {
+  const signal = getReviewReactionLottieWorkSignal();
+  if (signal.aborted) {
+    return false;
+  }
+
   if (reviewReactionLottieReservedRenderByEventId.has(eventId)) {
     throw new Error(`Review reaction Lottie render reservation already exists for event ${eventId}.`);
   }
@@ -871,6 +1045,7 @@ export function mountReservedReviewReactionLottieRender(
   variant: ReviewReactionLottieVariant,
   container: HTMLDivElement,
 ): ReviewReactionLottieMountedRender {
+  getReviewReactionLottieWorkSignal().throwIfAborted();
   const preparedRender = reviewReactionLottieReservedRenderByEventId.get(eventId);
   if (preparedRender === undefined) {
     throw new Error(`Review reaction Lottie render reservation is missing for event ${eventId} variant ${variant}.`);

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -7,7 +7,10 @@ import {
   submitFeedback,
 } from "../../api";
 import { useAppData, useReviewLeaderboardBadge, useReviewProgressBadge } from "../../appData";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { ALL_CARDS_REVIEW_FILTER, currentReviewCard } from "../../appData/domain";
 import { webReviewMobilePromptStoreLinks } from "../../appPlatformLinks";
 import {
@@ -141,7 +144,7 @@ export function useReviewScreenController(
   const reviewLeaderboardBadge = useReviewLeaderboardBadge();
   const reviewProgressBadge = useReviewProgressBadge();
   const { formatCount, locale, messages, t } = useI18n();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError, showTechnicalError } = useAppErrorDialog();
   const [isAnswerVisible, setIsAnswerVisible] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [reviewSubmitState, setReviewSubmitState] = useState<ReviewSubmitState>("idle");
@@ -334,6 +337,10 @@ export function useReviewScreenController(
   let reviewButtonErrorMessage: string = "";
   let reviewButtonScheduleError: Error | null = null;
 
+  function markIndexedDbOpenRecoveryFailure(error: unknown): boolean {
+    return markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error);
+  }
+
   function captureFeedbackOperationError(
     error: unknown,
     operation: "feedback_activity_load" | "feedback_state_load" | "feedback_prompt_event" | "feedback_submit",
@@ -412,6 +419,7 @@ export function useReviewScreenController(
 
   async function postAutomaticFeedbackPromptEvent(eventType: FeedbackPromptEventType): Promise<void> {
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const now = new Date();
       const feedbackState = await recordFeedbackPromptEvent(buildFeedbackPromptEventRequest({
         workspaceId: activeWorkspace?.workspaceId ?? null,
@@ -419,12 +427,17 @@ export function useReviewScreenController(
         eventType,
         now,
       }));
+      indexedDbOpenRecoveryState.throwIfFailed();
       await storeFetchedFeedbackState({
         identityKey: feedbackPromptIdentityKey,
         feedbackState,
         fetchedAt: now.toISOString(),
-      });
+      }, indexedDbOpenRecoveryState.throwIfFailed);
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailure(error)) {
+        return;
+      }
       captureFeedbackOperationError(error, "feedback_prompt_event", eventType);
     }
   }
@@ -436,12 +449,21 @@ export function useReviewScreenController(
     }
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const now = new Date();
       const nowMillis = now.getTime();
       let reviewActivity: AutomaticFeedbackPromptReviewActivity;
       try {
-        reviewActivity = await loadAutomaticFeedbackPromptReviewActivity(workspaceId, now);
+        reviewActivity = await loadAutomaticFeedbackPromptReviewActivity(
+          workspaceId,
+          now,
+          indexedDbOpenRecoveryState,
+        );
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailure(error)) {
+          return;
+        }
         captureFeedbackOperationError(error, "feedback_activity_load", null);
         return;
       }
@@ -449,7 +471,11 @@ export function useReviewScreenController(
       let promptState: FeedbackPromptState;
       try {
         promptState = await loadFeedbackPromptState(feedbackPromptIdentityKey);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailure(error)) {
+          return;
+        }
         captureFeedbackOperationError(error, "feedback_state_load", null);
         return;
       }
@@ -462,17 +488,22 @@ export function useReviewScreenController(
       if (shouldRequestAutomaticFeedbackState(decisionInput)) {
         try {
           const feedbackState = await loadFeedbackState();
+          indexedDbOpenRecoveryState.throwIfFailed();
           promptState = await storeFetchedFeedbackState({
             identityKey: feedbackPromptIdentityKey,
             feedbackState,
             fetchedAt: new Date().toISOString(),
-          });
+          }, indexedDbOpenRecoveryState.throwIfFailed);
+          indexedDbOpenRecoveryState.throwIfFailed();
           decisionInput = {
             reviewActivity,
             promptState,
             nowMillis: Date.now(),
           };
         } catch (error) {
+          if (markIndexedDbOpenRecoveryFailure(error)) {
+            return;
+          }
           captureFeedbackOperationError(error, "feedback_state_load", null);
           return;
         }
@@ -491,13 +522,17 @@ export function useReviewScreenController(
         identityKey: feedbackPromptIdentityKey,
         shownAt: shownAt.toISOString(),
         nextAutomaticFeedbackPromptAt: buildNextAutomaticFeedbackPromptAt(shownAt),
-      });
+      }, indexedDbOpenRecoveryState.throwIfFailed);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setFeedbackMessage("");
       setFeedbackErrorMessage("");
       setIsFeedbackSubmitting(false);
       setIsFeedbackDialogOpen(true);
       void postAutomaticFeedbackPromptEvent("automatic_prompt_shown");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailure(error)) {
+        return;
+      }
       captureFeedbackOperationError(error, "feedback_state_load", null);
     }
   }
@@ -516,11 +551,16 @@ export function useReviewScreenController(
     }
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const now = new Date();
       let reviewActivity: MobileAppPromotionReviewActivity;
       try {
         reviewActivity = await loadMobileAppPromotionReviewActivity(workspaceId, now);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailure(error)) {
+          return { kind: "cancelled" };
+        }
         captureMobileAppPromotionOperationError(error, "mobile_app_promo_activity_load", null);
         return buildSkippedMobileAppPromotionDecision(promptContext);
       }
@@ -540,7 +580,11 @@ export function useReviewScreenController(
       let promptState: MobileAppPromotionState;
       try {
         promptState = await loadMobileAppPromotionState(promptContext.identityKey);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailure(error)) {
+          return { kind: "cancelled" };
+        }
         captureMobileAppPromotionOperationError(error, "mobile_app_promo_state_load", null);
         return buildSkippedMobileAppPromotionDecision(promptContext);
       }
@@ -561,7 +605,11 @@ export function useReviewScreenController(
       let hasMobileReviewEvent: boolean;
       try {
         hasMobileReviewEvent = (await loadReviewPlatformSummary()).hasMobileReviewEvent;
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailure(error)) {
+          return { kind: "cancelled" };
+        }
         captureMobileAppPromotionOperationError(error, "mobile_app_promo_status_load", null);
         return buildSkippedMobileAppPromotionDecision(promptContext);
       }
@@ -574,8 +622,12 @@ export function useReviewScreenController(
         try {
           await storeKnownMobileReviewEvent({
             identityKey: promptContext.identityKey,
-          });
+          }, indexedDbOpenRecoveryState.throwIfFailed);
+          indexedDbOpenRecoveryState.throwIfFailed();
         } catch (error) {
+          if (markIndexedDbOpenRecoveryFailure(error)) {
+            return { kind: "cancelled" };
+          }
           captureMobileAppPromotionOperationError(error, "mobile_app_promo_state_save", null);
         }
         return buildSkippedMobileAppPromotionDecision(promptContext);
@@ -583,7 +635,11 @@ export function useReviewScreenController(
 
       try {
         promptState = await loadMobileAppPromotionState(promptContext.identityKey);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailure(error)) {
+          return { kind: "cancelled" };
+        }
         captureMobileAppPromotionOperationError(error, "mobile_app_promo_state_load", null);
         return buildSkippedMobileAppPromotionDecision(promptContext);
       }
@@ -612,8 +668,12 @@ export function useReviewScreenController(
           identityKey: promptContext.identityKey,
           localDate: reviewActivity.today,
           shownAt: shownAtIso,
-        });
+        }, indexedDbOpenRecoveryState.throwIfFailed);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailure(error)) {
+          return { kind: "cancelled" };
+        }
         captureMobileAppPromotionOperationError(error, "mobile_app_promo_state_save", null);
         return buildSkippedMobileAppPromotionDecision(promptContext);
       }
@@ -625,8 +685,12 @@ export function useReviewScreenController(
             identityKey: promptContext.identityKey,
             localDate: reviewActivity.today,
             shownAt: shownAtIso,
-          });
+          }, indexedDbOpenRecoveryState.throwIfFailed);
+          indexedDbOpenRecoveryState.throwIfFailed();
         } catch (error) {
+          if (markIndexedDbOpenRecoveryFailure(error)) {
+            return { kind: "cancelled" };
+          }
           captureMobileAppPromotionOperationError(error, "mobile_app_promo_state_save", null);
         }
         return buildSkippedMobileAppPromotionDecision(promptContext);
@@ -635,6 +699,9 @@ export function useReviewScreenController(
       setIsMobileAppPromotionDialogOpen(true);
       return { kind: "opened" };
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailure(error)) {
+        return { kind: "cancelled" };
+      }
       captureMobileAppPromotionOperationError(error, "mobile_app_promo_state_load", null);
       return buildSkippedMobileAppPromotionDecision(promptContext);
     }
@@ -671,6 +738,13 @@ export function useReviewScreenController(
     const promptContext = mobileAppPromotionPromptContextRef.current;
     const mobileAppPromotionDecision = await maybeOpenMobileAppPromotion(promptContext);
     if (
+      mobileAppPromotionDecision.kind === "cancelled"
+      || indexedDbOpenRecoveryState.hasFailed()
+    ) {
+      return;
+    }
+
+    if (
       mobileAppPromotionDecision.kind === "skipped"
       && isMobileAppPromotionPromptContextCurrent(promptContext)
     ) {
@@ -694,6 +768,10 @@ export function useReviewScreenController(
   }
 
   async function submitAutomaticFeedback(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const normalizedMessage = normalizeFeedbackMessage(feedbackMessage);
     if (normalizedMessage === "") {
       setFeedbackErrorMessage(t("feedback.emptyError"));
@@ -723,23 +801,35 @@ export function useReviewScreenController(
     setIsFeedbackSubmitting(true);
     setFeedbackErrorMessage("");
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const feedbackState = await submitFeedback(submissionRequest);
+      indexedDbOpenRecoveryState.throwIfFailed();
       await storeFeedbackSubmittedAt({
         identityKey: feedbackPromptIdentityKey,
         feedbackState,
         submittedAt: submissionRequest.createdAtClient,
-      });
+      }, indexedDbOpenRecoveryState.throwIfFailed);
+      indexedDbOpenRecoveryState.throwIfFailed();
       closeFeedbackDialog();
       showReviewFeedbackMessage(t("feedback.success"));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailure(error)) {
+        return;
+      }
       captureFeedbackOperationError(error, "feedback_submit", submissionRequest.feedbackSubmissionId);
       setFeedbackErrorMessage(t("feedback.submitError"));
     } finally {
-      setIsFeedbackSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsFeedbackSubmitting(false);
+      }
     }
   }
 
   async function handleReview(card: Card, rating: ReviewRating): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     emitReviewReaction(rating);
     setIsSubmitting(true);
     setReviewSubmitState("submitting");
@@ -751,6 +841,10 @@ export function useReviewScreenController(
 
     try {
       reviewSubmissionOutcome = await handleReviewData(card, rating);
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        reviewSubmissionOutcome = "cancelled";
+        return;
+      }
       if (reviewSubmissionOutcome !== "saved") {
         return;
       }
@@ -773,18 +867,24 @@ export function useReviewScreenController(
         void maybeOpenPostReviewPrompt();
       }
     } finally {
-      setIsSubmitting(false);
-      if (reviewSubmissionOutcome === "stale") {
-        setLastSubmittedReview(null);
-        setReviewSubmitState("idle");
-      } else {
-        setReviewSubmitState(reviewSubmissionOutcome === "saved" ? "settled" : "failed");
+      if (reviewSubmissionOutcome !== "cancelled" && indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSubmitting(false);
+        if (reviewSubmissionOutcome === "stale") {
+          setLastSubmittedReview(null);
+          setReviewSubmitState("idle");
+        } else {
+          setReviewSubmitState(reviewSubmissionOutcome === "saved" ? "settled" : "failed");
+        }
       }
     }
   }
 
   async function handleEditorAiHandoff(): Promise<void> {
-    if (editingCard === null || isEditorSubmissionAllowed() === false) {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || editingCard === null
+      || isEditorSubmissionAllowed() === false
+    ) {
       return;
     }
 
@@ -795,13 +895,31 @@ export function useReviewScreenController(
     const cardForHandoff = isCardFormStateDirty(editingCard, editorFormState)
       ? await handleEditorSaveForAiHandoff()
       : editingCard;
-    if (cardForHandoff === null) {
+    if (cardForHandoff === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
-    const didHandoff = await handoffCardToAi(cardForHandoff);
-    if (didHandoff) {
+    const didHandoff = await handleReviewPaneAiHandoff(cardForHandoff);
+    if (didHandoff && indexedDbOpenRecoveryState.hasFailed() === false) {
       handleCloseEditorIfCurrent(presentationToken);
+    }
+  }
+
+  async function handleReviewPaneAiHandoff(card: Card): Promise<boolean> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return false;
+    }
+
+    try {
+      indexedDbOpenRecoveryState.throwIfFailed();
+      const didHandoff = await handoffCardToAi(card);
+      indexedDbOpenRecoveryState.throwIfFailed();
+      return didHandoff;
+    } catch (error) {
+      if (markIndexedDbOpenRecoveryFailure(error)) {
+        return false;
+      }
+      throw error;
     }
   }
 
@@ -815,8 +933,13 @@ export function useReviewScreenController(
 
   async function handleRetryReviewLoad(): Promise<void> {
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       await refreshLocalData();
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailure(error)) {
+        return;
+      }
       handleRefreshLocalDataError({
         error,
         context: {
@@ -842,6 +965,21 @@ export function useReviewScreenController(
     setIsAnswerVisible(false);
     stopSpeech();
   }, [selectedCard?.cardId, stopSpeech]);
+
+  useEffect(() => {
+    if (indexedDbOpenRecoveryState.isFailed === false) {
+      return;
+    }
+
+    stopSpeech();
+    dismissReviewReactions();
+    const currentContext = mobileAppPromotionPromptContextRef.current;
+    mobileAppPromotionPromptContextRef.current = {
+      ...currentContext,
+      generation: currentContext.generation + 1,
+    };
+    mobileAppPromotionCheckInFlightRef.current = null;
+  }, [dismissReviewReactions, indexedDbOpenRecoveryState.isFailed, stopSpeech]);
 
   useEffect(() => {
     recentReviewRatingsRef.current = [];
@@ -915,12 +1053,13 @@ export function useReviewScreenController(
       || selectedCard === null
       || reviewButtonErrorCaptureKey === ""
       || lastCapturedReviewButtonErrorKeyRef.current === reviewButtonErrorCaptureKey
+      || indexedDbOpenRecoveryState.hasFailed()
     ) {
       return;
     }
 
     lastCapturedReviewButtonErrorKeyRef.current = reviewButtonErrorCaptureKey;
-    captureAppOperationError(reviewButtonScheduleError, {
+    showTechnicalError(reviewButtonScheduleError, {
       feature: "review",
       operation: "review_schedule_preview",
       userId: session?.userId ?? null,
@@ -928,14 +1067,14 @@ export function useReviewScreenController(
       installationId: cloudSettings?.installationId ?? null,
       entityId: selectedCard.cardId,
     });
-    showCapturedTechnicalError(reviewButtonScheduleError);
   }, [
     activeWorkspace?.workspaceId,
     cloudSettings?.installationId,
+    indexedDbOpenRecoveryState,
     reviewButtonErrorCaptureKey,
     reviewButtonScheduleError,
     selectedCard,
-    showCapturedTechnicalError,
+    showTechnicalError,
     session?.userId,
   ]);
 
@@ -1024,7 +1163,7 @@ export function useReviewScreenController(
       lastSubmittedReview,
       localReadVersion,
       loadingReviewCurrentCard,
-      onAiHandoff: handoffCardToAi,
+      onAiHandoff: handleReviewPaneAiHandoff,
       onEditCard: handleOpenEditor,
       onRevealAnswer: handleRevealAnswer,
       onReview: handleReview,

--- a/apps/web/src/screens/settings/FeedbackSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/FeedbackSettingsScreen.tsx
@@ -1,7 +1,10 @@
 import { useState, type FormEvent, type ReactElement } from "react";
 import { ApiError, submitFeedback } from "../../api";
 import { useAppData } from "../../appData";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import {
   buildFeedbackSubmissionRequest,
   feedbackMaximumMessageLength,
@@ -38,7 +41,7 @@ export function FeedbackSettingsScreen(): ReactElement {
     cloudSettings,
     session,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { locale, t } = useI18n();
   const { message, showMessage } = useTransientMessage(3000);
   const [feedbackMessage, setFeedbackMessage] = useState<string>("");
@@ -52,6 +55,10 @@ export function FeedbackSettingsScreen(): ReactElement {
   const technicalErrorMessage = t("appError.technicalError.message");
 
   async function submitSettingsFeedback(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const normalizedMessage = normalizeFeedbackMessage(feedbackMessage);
     if (normalizedMessage === "") {
       setFeedbackErrorMessage(t("feedback.emptyError"));
@@ -91,14 +98,20 @@ export function FeedbackSettingsScreen(): ReactElement {
     setIsFeedbackSubmitting(true);
     setFeedbackErrorMessage("");
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const feedbackState = await submitFeedback(submissionRequest);
+      indexedDbOpenRecoveryState.throwIfFailed();
       try {
         await storeFeedbackSubmittedAt({
           identityKey: feedbackPromptIdentityKey,
           feedbackState,
           submittedAt: submissionRequest.createdAtClient,
-        });
+        }, indexedDbOpenRecoveryState.throwIfFailed);
+        indexedDbOpenRecoveryState.throwIfFailed();
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         const wasCaptured = captureAppOperationError(error, {
           feature: "feedback",
           operation: "feedback_submit",
@@ -111,9 +124,13 @@ export function FeedbackSettingsScreen(): ReactElement {
           showCapturedTechnicalError(error);
         }
       }
+      indexedDbOpenRecoveryState.throwIfFailed();
       setFeedbackMessage("");
       showMessage(t("feedback.success"));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isExpectedFeedbackSubmitError(error)) {
         setFeedbackErrorMessage(t("feedback.submitError"));
         return;
@@ -132,7 +149,9 @@ export function FeedbackSettingsScreen(): ReactElement {
       }
       setFeedbackErrorMessage(wasCaptured ? technicalErrorMessage : t("feedback.submitError"));
     } finally {
-      setIsFeedbackSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsFeedbackSubmitting(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/LeaderboardParticipationSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/LeaderboardParticipationSettingsScreen.tsx
@@ -7,7 +7,10 @@ import {
 import { useAppData } from "../../appData";
 import { invalidateServerProgress } from "../../appData/progress/invalidation/progressInvalidation";
 import { clearPersistedProgressLeaderboard } from "../../appData/progress/storage/progressStorage";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
 import { captureAppOperationError } from "../../observability/appOperationObservation";
 import type { CommunityPublicProfile } from "../../types";
@@ -15,7 +18,7 @@ import { SettingsGroup, SettingsShell } from "./SettingsShared";
 
 export function LeaderboardParticipationSettingsScreen(): ReactElement {
   const { activeWorkspace, cloudSettings, isSessionVerified, session } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t } = useI18n();
   const [communityProfile, setCommunityProfile] = useState<CommunityPublicProfile | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>("");
@@ -44,6 +47,10 @@ export function LeaderboardParticipationSettingsScreen(): ReactElement {
   }
 
   useEffect(() => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (canManageLeaderboardParticipation === false) {
       setCommunityProfile(null);
       setErrorMessage("");
@@ -57,13 +64,21 @@ export function LeaderboardParticipationSettingsScreen(): ReactElement {
     let isCancelled = false;
 
     async function refreshCommunityProfileOnOpen(): Promise<void> {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       try {
         const profile = await loadCommunityProfile();
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (isCancelled === false) {
           setCommunityProfile(profile);
           setErrorMessage("");
         }
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCancelled || isAuthRedirectError(error)) {
           return;
         }
@@ -83,9 +98,13 @@ export function LeaderboardParticipationSettingsScreen(): ReactElement {
     return () => {
       isCancelled = true;
     };
-  }, [canManageLeaderboardParticipation, isSessionVerified, session?.userId]);
+  }, [canManageLeaderboardParticipation, indexedDbOpenRecoveryState, isSessionVerified, session?.userId]);
 
   async function persistLeaderboardParticipation(nextEnabled: boolean): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (session === null) {
       setErrorMessage(t("app.sessionUnavailable"));
       return;
@@ -112,12 +131,16 @@ export function LeaderboardParticipationSettingsScreen(): ReactElement {
       const updatedProfile = await updateCommunityProfile({
         leaderboardParticipationEnabled: nextEnabled,
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       setCommunityProfile(updatedProfile);
       // Drop the cached leaderboard payload and invalidate server progress so the
       // Progress tab refetches immediately instead of serving stale participation.
       clearPersistedProgressLeaderboard();
       invalidateServerProgress();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       setCommunityProfile(previousProfile);
       if (isAuthRedirectError(error)) {
         return;
@@ -131,7 +154,9 @@ export function LeaderboardParticipationSettingsScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      setIsSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSubmitting(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/ReviewAnimationsSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/ReviewAnimationsSettingsScreen.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState, type ReactElement } from "react";
 import { isAuthRedirectError, updateAccountPreferences } from "../../api";
 import { useAppData } from "../../appData";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { useI18n } from "../../i18n";
 import { captureAppOperationError } from "../../observability/appOperationObservation";
 import type { AccountPreferences } from "../../types";
@@ -16,7 +19,7 @@ export function ReviewAnimationsSettingsScreen(): ReactElement {
     session,
     setAccountPreferences,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t } = useI18n();
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -32,12 +35,20 @@ export function ReviewAnimationsSettingsScreen(): ReactElement {
     let isCancelled = false;
 
     async function refreshPreferencesOnOpen(): Promise<void> {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       try {
         await refreshAccountPreferences();
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (isCancelled === false) {
           setErrorMessage("");
         }
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCancelled || isAuthRedirectError(error)) {
           return;
         }
@@ -57,7 +68,7 @@ export function ReviewAnimationsSettingsScreen(): ReactElement {
     return () => {
       isCancelled = true;
     };
-  }, [isSessionVerified, refreshAccountPreferences, session?.userId]);
+  }, [indexedDbOpenRecoveryState, isSessionVerified, refreshAccountPreferences, session?.userId]);
 
   function capturePreferenceOperationError(error: unknown, operation: "account_preferences_refresh" | "account_preferences_update"): boolean {
     return captureAppOperationError(error, {
@@ -71,10 +82,18 @@ export function ReviewAnimationsSettingsScreen(): ReactElement {
   }
 
   async function refreshPreferencesAfterPatch(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     try {
       await refreshAccountPreferences();
+      indexedDbOpenRecoveryState.throwIfFailed();
       setErrorMessage("");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isAuthRedirectError(error)) {
         return;
       }
@@ -90,6 +109,10 @@ export function ReviewAnimationsSettingsScreen(): ReactElement {
   }
 
   async function persistReviewAnimationsPreference(nextEnabled: boolean): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (session === null) {
       setErrorMessage(t("app.sessionUnavailable"));
       return;
@@ -112,9 +135,14 @@ export function ReviewAnimationsSettingsScreen(): ReactElement {
 
     try {
       const response = await updateAccountPreferences(nextPreferences);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setAccountPreferences(targetUserId, response.preferences);
       await refreshPreferencesAfterPatch();
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       setAccountPreferences(targetUserId, previousPreferences);
       if (isAuthRedirectError(error)) {
         return;
@@ -128,7 +156,9 @@ export function ReviewAnimationsSettingsScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      setIsSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsSubmitting(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/SettingsScreen.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState, type ReactElement } from "react";
 import { isAuthRedirectError } from "../../api";
 import { useAppData } from "../../appData";
 import { canLoadProgressServerBase } from "../../appData/progress/progressSource";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { getAppConfig } from "../../config";
 import {
   autoLocalePreference,
@@ -94,6 +98,7 @@ export function SettingsScreen(): ReactElement {
     setErrorMessage,
     workspaceSettings,
   } = useAppData();
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const { localePreference, t } = useI18n();
   const { aiChatComposerSuggestionsEnabled } = useAIChatPreferences();
   const { isTestModeEnabled } = useTestMode();
@@ -107,21 +112,55 @@ export function SettingsScreen(): ReactElement {
   const canCreateInvite = canLoadProgressServerBase(sessionVerificationState, cloudSettings);
   const appShareUrl = `${getAppConfig().appBaseUrl}${shareRoute}`;
 
+  function openInviteDialog(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    setIsInviteDialogOpen(true);
+  }
+
+  function closeInviteDialog(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
+    setIsInviteDialogOpen(false);
+  }
+
   useEffect(() => {
     if (session === null || isSessionVerified === false) {
       return;
     }
 
-    void refreshAccountPreferences().catch((error: unknown) => {
-      if (isAuthRedirectError(error)) {
+    async function refreshPreferences(): Promise<void> {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
         return;
       }
 
-      setErrorMessage(error instanceof Error ? error.message : String(error));
-    });
-  }, [isSessionVerified, refreshAccountPreferences, session?.userId, setErrorMessage]);
+      try {
+        await refreshAccountPreferences();
+        indexedDbOpenRecoveryState.throwIfFailed();
+      } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
+        if (isAuthRedirectError(error)) {
+          return;
+        }
+
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+      }
+    }
+
+    void refreshPreferences();
+  }, [indexedDbOpenRecoveryState, isSessionVerified, refreshAccountPreferences, session?.userId, setErrorMessage]);
 
   async function shareApp(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setShareStatusMessage("");
     setShareErrorMessage("");
 
@@ -136,8 +175,12 @@ export function SettingsScreen(): ReactElement {
         text: t("settingsHome.shareApp.shareText"),
         url: appShareUrl,
       });
+      indexedDbOpenRecoveryState.throwIfFailed();
       setShareStatusMessage(t("settingsHome.shareApp.shared"));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (error instanceof DOMException && error.name === "AbortError") {
         return;
       }
@@ -177,7 +220,7 @@ export function SettingsScreen(): ReactElement {
               className="primary-btn settings-invite-btn"
               type="button"
               aria-label={t("settingsHome.inviteFriend.ariaLabel")}
-              onClick={() => setIsInviteDialogOpen(true)}
+              onClick={openInviteDialog}
               data-testid="settings-invite-open"
             >
               {t("settingsHome.inviteFriend.actionText")}
@@ -399,7 +442,7 @@ export function SettingsScreen(): ReactElement {
         <FriendInviteCreateDialog
           canCreateInvite={canCreateInvite}
           authRedirectUrl={window.location.href}
-          onClose={() => setIsInviteDialogOpen(false)}
+          onClose={closeInviteDialog}
         />
       ) : null}
     </SettingsShell>

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
 import { useAppData } from "../../appData";
-import { useAppErrorDialog } from "../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../appError/AppErrorContext";
 import { webReviewMobilePromptStoreLinks } from "../../appPlatformLinks";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import {
@@ -220,7 +223,7 @@ function buildManagedMediaSyncFields(report: LocalSyncDiagnosticsReport): Readon
 
 export function TestLocalSyncDiagnosticsScreen(): ReactElement {
   const { activeWorkspace } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatNumber } = useI18n();
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
   const isMountedRef = useRef<boolean>(false);
@@ -231,6 +234,10 @@ export function TestLocalSyncDiagnosticsScreen(): ReactElement {
   const technicalErrorMessage = t("appError.technicalError.message");
 
   const refreshDiagnostics = useCallback(async (): Promise<void> => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (activeWorkspaceId === null) {
       setReport(null);
       setLoadErrorMessage(t("settingsTest.localSyncDiagnostics.noWorkspace"));
@@ -244,12 +251,16 @@ export function TestLocalSyncDiagnosticsScreen(): ReactElement {
 
     try {
       const nextReport = await loadLocalSyncDiagnosticsReport(activeWorkspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (isMountedRef.current === false) {
         return;
       }
 
       setReport(nextReport);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isMountedRef.current === false) {
         return;
       }
@@ -258,11 +269,11 @@ export function TestLocalSyncDiagnosticsScreen(): ReactElement {
       setReport(null);
       setLoadErrorMessage(technicalErrorMessage);
     } finally {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && indexedDbOpenRecoveryState.hasFailed() === false) {
         setIsLoading(false);
       }
     }
-  }, [activeWorkspaceId, showCapturedTechnicalError, t, technicalErrorMessage]);
+  }, [activeWorkspaceId, indexedDbOpenRecoveryState, showCapturedTechnicalError, t, technicalErrorMessage]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -485,6 +496,7 @@ function clearTrimmedReviewReactionTimers(
 }
 
 export function TestAnimationsScreen(): ReactElement {
+  const { indexedDbOpenRecoveryState } = useAppErrorDialog();
   const { t, formatNumber } = useI18n();
   const [activeReviewReactionEvents, setActiveReviewReactionEvents] = useState<ReadonlyArray<ReviewReactionEvent>>([]);
   const [motionMode, setMotionMode] = useState<ReviewReactionMotionMode>(
@@ -506,8 +518,8 @@ export function TestAnimationsScreen(): ReactElement {
   }
 
   useEffect(() => {
-    startReviewReactionLottiePrewarm();
-  }, []);
+    return startReviewReactionLottiePrewarm(indexedDbOpenRecoveryState.signal);
+  }, [indexedDbOpenRecoveryState.signal]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -597,6 +609,7 @@ export function TestAnimationsScreen(): ReactElement {
     eventId: string,
     variant: ReviewReactionVariantDistributionEntry["variant"],
   ): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (!isReviewReactionLottieVariant(variant)) {
       throw new Error(`Test animation variant ${variant} is not a Lottie variant.`);
     }
@@ -605,6 +618,7 @@ export function TestAnimationsScreen(): ReactElement {
     }
 
     await loadReviewReactionLottieAsset(variant);
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (reserveReviewReactionLottieRender(eventId, variant)) {
       return;
     }
@@ -613,12 +627,14 @@ export function TestAnimationsScreen(): ReactElement {
   }
 
   async function playAnimation(entry: ReviewReactionVariantDistributionEntry): Promise<void> {
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (!isReviewReactionLottieVariant(entry.variant)) {
       throw new Error(`Test animation entry ${entry.id} is not a Lottie variant.`);
     }
 
     const eventId = crypto.randomUUID();
     await reserveTestAnimationRender(eventId, entry.variant);
+    indexedDbOpenRecoveryState.throwIfFailed();
     if (!isMountedRef.current) {
       releaseReviewReactionLottieRender(eventId);
       return;
@@ -664,6 +680,9 @@ export function TestAnimationsScreen(): ReactElement {
                   data-testid="test-animation-row"
                   onClick={() => {
                     void playAnimation(entry).catch((error: unknown) => {
+                      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+                        return;
+                      }
                       reportTestAnimationPlaybackFailure(error, entry);
                     });
                   }}

--- a/apps/web/src/screens/settings/account/AgentConnectionsScreen.tsx
+++ b/apps/web/src/screens/settings/account/AgentConnectionsScreen.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState, type ReactElement } from "react";
 import { ApiContractError, createAgentApiKey, listAgentApiKeys, revokeAgentApiKey } from "../../../api";
 import { useAppData } from "../../../appData";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import { captureApiContractError } from "../../../observability/apiContractObservation";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
@@ -10,7 +13,7 @@ import { SettingsShell } from "../SettingsShared";
 
 export function AgentConnectionsScreen(): ReactElement {
   const { activeWorkspace, cloudSettings, isSessionVerified, session } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatDateTime } = useI18n();
   const [connections, setConnections] = useState<ReadonlyArray<AgentApiKeyConnection>>([]);
   const [instructions, setInstructions] = useState<string>("");
@@ -24,6 +27,10 @@ export function AgentConnectionsScreen(): ReactElement {
   const technicalErrorMessage = t("appError.technicalError.message");
 
   useEffect(() => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (isSessionVerified === false) {
       setIsLoading(false);
       // Do not keep a one-time secret on screen across a session loss/redirect.
@@ -33,16 +40,24 @@ export function AgentConnectionsScreen(): ReactElement {
     }
 
     void loadConnections();
-  }, [isSessionVerified]);
+  }, [indexedDbOpenRecoveryState, isSessionVerified]);
 
   async function loadConnections(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setIsLoading(true);
     try {
       const result = await listAgentApiKeys();
+      indexedDbOpenRecoveryState.throwIfFailed();
       setConnections(result.connections);
       setInstructions(result.instructions);
       setErrorMessage("");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasContractErrorCaptured = captureApiContractError(error, {
         feature: "settings",
         sourceAction: "agent_connections_load",
@@ -68,24 +83,31 @@ export function AgentConnectionsScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      setIsLoading(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsLoading(false);
+      }
     }
   }
 
   async function handleGenerate(): Promise<void> {
-    if (isSessionVerified === false || isGenerating) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isSessionVerified === false || isGenerating) {
       return;
     }
 
     setIsGenerating(true);
     try {
       const result = await createAgentApiKey(newKeyLabel.trim());
+      indexedDbOpenRecoveryState.throwIfFailed();
       setGeneratedApiKey(result.apiKey);
       setIsCopied(false);
       setNewKeyLabel("");
       setErrorMessage("");
       await loadConnections();
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasContractErrorCaptured = captureApiContractError(error, {
         feature: "settings",
         sourceAction: "agent_connection_create",
@@ -111,19 +133,29 @@ export function AgentConnectionsScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : t("agentConnections.generateError"));
       }
     } finally {
-      setIsGenerating(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsGenerating(false);
+      }
     }
   }
 
   async function handleCopyGeneratedKey(): Promise<void> {
-    if (generatedApiKey === null || typeof navigator.clipboard?.writeText !== "function") {
+    if (
+      indexedDbOpenRecoveryState.hasFailed()
+      || generatedApiKey === null
+      || typeof navigator.clipboard?.writeText !== "function"
+    ) {
       return;
     }
 
     try {
       await navigator.clipboard.writeText(generatedApiKey);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setIsCopied(true);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasCaptured = captureAppOperationError(error, {
         feature: "settings",
         operation: "agent_connection_copy_key",
@@ -139,24 +171,32 @@ export function AgentConnectionsScreen(): ReactElement {
   }
 
   function dismissGeneratedKey(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setGeneratedApiKey(null);
     setIsCopied(false);
   }
 
   async function handleRevoke(connectionId: string): Promise<void> {
-    if (isSessionVerified === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isSessionVerified === false) {
       return;
     }
 
     setBusyConnectionId(connectionId);
     try {
       const result = await revokeAgentApiKey(connectionId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setConnections((currentConnections) => currentConnections.map((connection) => (
         connection.connectionId === result.connection.connectionId ? result.connection : connection
       )));
       setInstructions(result.instructions);
       setErrorMessage("");
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasContractErrorCaptured = captureApiContractError(error, {
         feature: "settings",
         sourceAction: "agent_connection_revoke",
@@ -182,7 +222,9 @@ export function AgentConnectionsScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      setBusyConnectionId(null);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setBusyConnectionId(null);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/workspace/CurrentWorkspaceScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/CurrentWorkspaceScreen.tsx
@@ -8,7 +8,10 @@ import {
 } from "react";
 import { ApiContractError } from "../../../api";
 import { useAppData } from "../../../appData";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import { addWebBreadcrumb } from "../../../observability/webObservability";
@@ -33,7 +36,7 @@ export function CurrentWorkspaceScreen(): ReactElement {
     technicalError: workspaceActionTechnicalError,
     setErrorMessage: setWorkspaceActionErrorMessage,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatDateTime } = useI18n();
   const [isChangeDialogOpen, setIsChangeDialogOpen] = useState<boolean>(false);
   const [isCreating, setIsCreating] = useState<boolean>(false);
@@ -200,15 +203,30 @@ export function CurrentWorkspaceScreen(): ReactElement {
   }
 
   async function handleWorkspaceSelect(workspaceId: string, focusTarget: HTMLButtonElement): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setChangeErrorMessage("");
     setWorkspaceActionErrorMessage("");
     setPendingWorkspaceId(workspaceId);
     changeDialogOperationFocusRef.current = focusTarget;
-    await chooseWorkspace(workspaceId);
+    try {
+      await chooseWorkspace(workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
+    } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+      throw error;
+    }
   }
 
   async function handleCreateWorkspace(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     const trimmedName = newWorkspaceName.trim();
     if (trimmedName === "") {
@@ -221,8 +239,12 @@ export function CurrentWorkspaceScreen(): ReactElement {
       setWorkspaceActionErrorMessage("");
       changeDialogOperationFocusRef.current = newWorkspaceNameInputRef.current;
       await createWorkspace(trimmedName);
+      indexedDbOpenRecoveryState.throwIfFailed();
       closeChangeDialog();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const nextErrorMessage = error instanceof Error ? error.message : String(error);
       const isExpectedError = nextErrorMessage === t("app.sessionUnavailable")
         || nextErrorMessage === t("app.sessionRestoringActionLocked")
@@ -239,6 +261,9 @@ export function CurrentWorkspaceScreen(): ReactElement {
 
   async function handleRenameSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
 
     if (activeWorkspace === null) {
       setRenameErrorMessage(t("workspaceOverview.rename.workspaceUnavailable"));
@@ -266,8 +291,12 @@ export function CurrentWorkspaceScreen(): ReactElement {
 
     try {
       await renameWorkspace(activeWorkspace.workspaceId, trimmedWorkspaceName);
+      indexedDbOpenRecoveryState.throwIfFailed();
       closeRenameDialog();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (error instanceof ApiContractError === false) {
         const wasCaptured = captureAppOperationError(error, {
           feature: "settings",
@@ -294,7 +323,9 @@ export function CurrentWorkspaceScreen(): ReactElement {
       }
       setRenameErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
-      setIsRenameSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsRenameSubmitting(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/workspace/DeleteCurrentWorkspaceScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/DeleteCurrentWorkspaceScreen.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState, type ReactElement } from "react";
 import { ApiContractError, ApiError, loadWorkspaceDeletePreview } from "../../../api";
 import { useAppData } from "../../../appData";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import { captureApiContractError } from "../../../observability/apiContractObservation";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
@@ -31,7 +34,7 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
     isSessionVerified,
     session,
   } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatCount } = useI18n();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState<boolean>(false);
   const [deletePreview, setDeletePreview] = useState<WorkspaceDeletePreview | null>(null);
@@ -71,7 +74,7 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
   }
 
   async function openDeleteDialog(): Promise<void> {
-    if (activeWorkspace === null || isSessionVerified === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || activeWorkspace === null || isSessionVerified === false) {
       return;
     }
 
@@ -82,8 +85,12 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
 
     try {
       const preview = await loadWorkspaceDeletePreview(activeWorkspace.workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setDeletePreview(preview);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isExpectedWorkspaceDeleteError(error)) {
         setDeletePreviewErrorMessage(error.message);
         return;
@@ -122,6 +129,10 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
   }
 
   async function retryDeletePreview(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (activeWorkspace === null) {
       setDeletePreviewErrorMessage(t("workspaceOverview.rename.workspaceUnavailable"));
       return;
@@ -132,8 +143,12 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
 
     try {
       const preview = await loadWorkspaceDeletePreview(activeWorkspace.workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setDeletePreview(preview);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isExpectedWorkspaceDeleteError(error)) {
         setDeletePreviewErrorMessage(error.message);
         return;
@@ -172,7 +187,7 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
   }
 
   async function confirmDeleteWorkspace(): Promise<void> {
-    if (activeWorkspace === null || deletePreview === null) {
+    if (indexedDbOpenRecoveryState.hasFailed() || activeWorkspace === null || deletePreview === null) {
       return;
     }
 
@@ -181,8 +196,12 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
 
     try {
       await deleteWorkspace(activeWorkspace.workspaceId, deleteConfirmationValue);
+      indexedDbOpenRecoveryState.throwIfFailed();
       closeDeleteDialog();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const nextErrorMessage = error instanceof Error ? error.message : String(error);
       const isExpectedError = nextErrorMessage === t("app.sessionUnavailable")
         || nextErrorMessage === t("app.sessionRestoringActionLocked");
@@ -193,7 +212,9 @@ export function DeleteCurrentWorkspaceScreen(): ReactElement {
         setDeletePreviewErrorMessage(technicalErrorMessage);
       }
     } finally {
-      setIsDeleteSubmitting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsDeleteSubmitting(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/workspace/ResetStudyProgressScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/ResetStudyProgressScreen.tsx
@@ -5,7 +5,10 @@ import {
   isCapturedSyncFailure,
   isExpectedUnobservedSyncFailure,
 } from "../../../appData/sync/observation/syncErrorObservation";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import { captureApiContractError } from "../../../observability/apiContractObservation";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
@@ -26,7 +29,7 @@ export function ResetStudyProgressScreen(): ReactElement {
     session,
     setErrorMessage: setAppErrorMessage,
   } = useAppData();
-  const { showCapturedTechnicalError, showTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError, showTechnicalError } = useAppErrorDialog();
   const { t, formatCount } = useI18n();
   const [isResetDialogOpen, setIsResetDialogOpen] = useState<boolean>(false);
   const [resetConfirmationValue, setResetConfirmationValue] = useState<string>("");
@@ -95,7 +98,7 @@ export function ResetStudyProgressScreen(): ReactElement {
   }
 
   async function loadResetPreview(): Promise<void> {
-    if (activeWorkspace === null || isResetAvailable === false) {
+    if (indexedDbOpenRecoveryState.hasFailed() || activeWorkspace === null || isResetAvailable === false) {
       return;
     }
 
@@ -104,8 +107,12 @@ export function ResetStudyProgressScreen(): ReactElement {
 
     try {
       const preview = await loadWorkspaceResetProgressPreview(activeWorkspace.workspaceId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setResetPreview(preview);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (isCapturedSyncFailure(error)) {
         showCapturedTechnicalError(error);
         setAppErrorMessage(technicalErrorMessage);
@@ -154,12 +161,14 @@ export function ResetStudyProgressScreen(): ReactElement {
       }
       setResetErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
-      setIsResetPreviewLoading(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsResetPreviewLoading(false);
+      }
     }
   }
 
   async function executeReset(): Promise<void> {
-    if (activeWorkspace === null || resetPreview === null) {
+    if (indexedDbOpenRecoveryState.hasFailed() || activeWorkspace === null || resetPreview === null) {
       return;
     }
 
@@ -168,8 +177,12 @@ export function ResetStudyProgressScreen(): ReactElement {
 
     try {
       await resetWorkspaceProgress(activeWorkspace.workspaceId, resetConfirmationValue);
+      indexedDbOpenRecoveryState.throwIfFailed();
       clearResetDialogState();
       void refreshLocalData().catch((error: unknown) => {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCapturedSyncFailure(error)) {
           showCapturedTechnicalError(error);
           setAppErrorMessage(technicalErrorMessage);
@@ -191,6 +204,9 @@ export function ResetStudyProgressScreen(): ReactElement {
         setAppErrorMessage(wasCaptured ? technicalErrorMessage : error instanceof Error ? error.message : String(error));
       });
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (error instanceof ApiContractError) {
         const wasCaptured = captureApiContractError(error, {
           feature: "settings",
@@ -228,7 +244,9 @@ export function ResetStudyProgressScreen(): ReactElement {
       }
       setResetErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
-      setIsResetExecuting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsResetExecuting(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/workspace/TagsScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/TagsScreen.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import { useNavigate } from "react-router";
 import { useAppData } from "../../../appData";
-import { useAppErrorDialog } from "../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../appError/AppErrorContext";
 import { useI18n } from "../../../i18n";
 import { loadWorkspaceTagsSummary } from "../../../localDb/cards/workspace";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
@@ -16,7 +19,7 @@ const emptyTagsSummary: WorkspaceTagsSummary = {
 
 export function TagsScreen(): ReactElement {
   const { activeWorkspace, cloudSettings, localReadVersion, openReview, refreshLocalData, session } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatCount, formatNumber } = useI18n();
   const navigate = useNavigate();
   const [tagsSummary, setTagsSummary] = useState<WorkspaceTagsSummary>(emptyTagsSummary);
@@ -39,6 +42,10 @@ export function TagsScreen(): ReactElement {
     let isCancelled = false;
 
     async function loadScreenData(): Promise<void> {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       setIsLoading(true);
       setErrorMessage("");
 
@@ -48,12 +55,16 @@ export function TagsScreen(): ReactElement {
         }
 
         const nextTagsSummary = await loadWorkspaceTagsSummary(activeWorkspace.workspaceId);
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (isCancelled) {
           return;
         }
 
         setTagsSummary(nextTagsSummary);
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCancelled) {
           return;
         }
@@ -76,7 +87,7 @@ export function TagsScreen(): ReactElement {
         }
         setErrorMessage(error instanceof Error ? error.message : String(error));
       } finally {
-        if (!isCancelled) {
+        if (!isCancelled && indexedDbOpenRecoveryState.hasFailed() === false) {
           setIsLoading(false);
         }
       }
@@ -87,9 +98,13 @@ export function TagsScreen(): ReactElement {
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspace, localReadVersion]);
+  }, [activeWorkspace, indexedDbOpenRecoveryState, localReadVersion]);
 
   function handleOpenTagReview(tag: string): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const reviewFilter: ReviewFilter = {
       kind: "tags",
       tags: [tag],
@@ -100,9 +115,17 @@ export function TagsScreen(): ReactElement {
   }
 
   async function handleRefreshLocalData(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     try {
       await refreshLocalData();
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       handleRefreshLocalDataError({
         error,
         context: {

--- a/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useAppData } from "../../../../appData";
-import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../../appError/AppErrorContext";
 import { ALL_CARDS_REVIEW_FILTER, isCardDue } from "../../../../appData/domain";
 import { ALL_CARDS_DECK_SLUG } from "../../../../deckFilters";
 import { useI18n } from "../../../../i18n";
@@ -35,7 +38,7 @@ function hasDeckFilterRules(filterDefinition: DeckFilterDefinition): boolean {
 export function DeckDetailScreen(): ReactElement {
   const { deckId } = useParams();
   const navigate = useNavigate();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatCount, formatDateTime, formatNumber } = useI18n();
   const {
     activeWorkspace,
@@ -68,6 +71,10 @@ export function DeckDetailScreen(): ReactElement {
   };
 
   const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (deckId === undefined) {
       setScreenErrorMessage(t("deckDetail.errors.notFound"));
       setIsLoading(false);
@@ -84,10 +91,12 @@ export function DeckDetailScreen(): ReactElement {
 
       if (deckId === ALL_CARDS_DECK_SLUG) {
         const decksSnapshot = await loadDecksListSnapshot(activeWorkspace.workspaceId);
+        indexedDbOpenRecoveryState.throwIfFailed();
         const allCards = await loadCardsMatchingDeck(activeWorkspace.workspaceId, {
           version: 2,
           tags: [],
         });
+        indexedDbOpenRecoveryState.throwIfFailed();
         setDetailState({
           title: t("filters.allCards"),
           filterSummary: t("filters.allCards"),
@@ -105,6 +114,7 @@ export function DeckDetailScreen(): ReactElement {
       }
 
       const deck = await loadDeckById(activeWorkspace.workspaceId, deckId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (deck === null) {
         setDetailState(null);
         setScreenErrorMessage(t("deckDetail.errors.notFound"));
@@ -113,6 +123,7 @@ export function DeckDetailScreen(): ReactElement {
       }
 
       const matchingCards = await loadCardsMatchingDeck(activeWorkspace.workspaceId, deck.filterDefinition);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setDetailState({
         title: deck.name,
         filterSummary: formatDeckFilterSummary(deck.filterDefinition, t),
@@ -127,6 +138,9 @@ export function DeckDetailScreen(): ReactElement {
         emptyMessage: t("deckDetail.empty.deckCards"),
       });
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       if (activeWorkspace !== null) {
         const observationIdentity = observationIdentityRef.current;
         const wasCaptured = captureAppOperationError(error, {
@@ -145,15 +159,21 @@ export function DeckDetailScreen(): ReactElement {
       }
       setScreenErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
-      setIsLoading(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsLoading(false);
+      }
     }
-  }, [activeWorkspace, deckId, t]);
+  }, [activeWorkspace, deckId, indexedDbOpenRecoveryState, showCapturedTechnicalError, t, technicalErrorMessage]);
 
   useEffect(() => {
     void loadScreenData();
   }, [loadScreenData, localReadVersion]);
 
   async function handleDelete(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (deckId === undefined || deckId === ALL_CARDS_DECK_SLUG) {
       setScreenErrorMessage(t("deckDetail.errors.systemDeckDelete"));
       return;
@@ -169,8 +189,12 @@ export function DeckDetailScreen(): ReactElement {
 
     try {
       await deleteDeckItem(deckId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       navigate(settingsDecksRoute);
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasCaptured = captureAppOperationError(error, {
         feature: "settings",
         operation: "deck_delete",
@@ -186,12 +210,14 @@ export function DeckDetailScreen(): ReactElement {
         setScreenErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      setIsDeleting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsDeleting(false);
+      }
     }
   }
 
   function handleOpenReview(): void {
-    if (detailState === null) {
+    if (indexedDbOpenRecoveryState.hasFailed() || detailState === null) {
       return;
     }
 
@@ -200,9 +226,17 @@ export function DeckDetailScreen(): ReactElement {
   }
 
   async function handleRefreshLocalData(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     try {
       await refreshLocalData();
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       handleRefreshLocalDataError({
         error,
         context: {

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useAppData } from "../../../../appData";
-import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  type IndexedDbOpenRecoveryState,
+  useAppErrorDialog,
+} from "../../../../appError/AppErrorContext";
 import { ALL_CARDS_DECK_SLUG, buildDeckFilterDefinition } from "../../../../deckFilters";
 import { useI18n } from "../../../../i18n";
 import { buildSettingsDeckDetailRoute, settingsDecksRoute } from "../../../../routes";
@@ -30,6 +34,23 @@ type RefreshBarrier = Readonly<{
   promise: Promise<RefreshOutcome>;
   settle: (outcome: RefreshOutcome) => void;
 }>;
+
+async function runRecoveryGuardedLocalRead<ResultType>(
+  createRead: () => Promise<ResultType>,
+  indexedDbOpenRecoveryState: IndexedDbOpenRecoveryState,
+): Promise<ResultType> {
+  try {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    const result = await createRead();
+    indexedDbOpenRecoveryState.throwIfFailed();
+    return result;
+  } catch (error) {
+    indexedDbOpenRecoveryState.throwIfFailed();
+    indexedDbOpenRecoveryState.markFailed(error);
+    indexedDbOpenRecoveryState.throwIfFailed();
+    throw error;
+  }
+}
 
 function createInitialFormState(): FormState {
   return {
@@ -91,7 +112,7 @@ function createRefreshBarrier(
 export function DeckFormScreen(): ReactElement {
   const { deckId } = useParams();
   const navigate = useNavigate();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t } = useI18n();
   const {
     activeWorkspace,
@@ -178,6 +199,10 @@ export function DeckFormScreen(): ReactElement {
   }, [activeWorkspace?.workspaceId, deckId, isCreateMode]);
 
   const loadScreenData = useCallback(function loadScreenData(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return Promise.resolve();
+    }
+
     const requestSequence = loadRequestSequenceRef.current + 1;
     loadRequestSequenceRef.current = requestSequence;
     const requestEditorIdentity = renderedEditorIdentityRef.current;
@@ -220,13 +245,20 @@ export function DeckFormScreen(): ReactElement {
         }
 
         const [tagsSummary, loadedDeck] = await Promise.all([
-          loadWorkspaceTagsSummary(requestEditorIdentity.workspaceId),
-          deckId === undefined
-            ? Promise.resolve(null)
-            : deckId === ALL_CARDS_DECK_SLUG
-              ? Promise.reject(new Error(t("deckForm.systemDeckReadonly")))
-              : getDeckById(deckId),
+          runRecoveryGuardedLocalRead(
+            () => loadWorkspaceTagsSummary(requestEditorIdentity.workspaceId),
+            indexedDbOpenRecoveryState,
+          ),
+          runRecoveryGuardedLocalRead(
+            () => deckId === undefined
+              ? Promise.resolve(null)
+              : deckId === ALL_CARDS_DECK_SLUG
+                ? Promise.reject(new Error(t("deckForm.systemDeckReadonly")))
+                : getDeckById(deckId),
+            indexedDbOpenRecoveryState,
+          ),
         ]);
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (isCurrentLoadRequest() === false) {
           return;
         }
@@ -260,6 +292,9 @@ export function DeckFormScreen(): ReactElement {
         }
         refreshOutcome = "accepted";
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCurrentLoadRequest() === false) {
           return;
         }
@@ -293,13 +328,13 @@ export function DeckFormScreen(): ReactElement {
           setScreenErrorMessage(errorMessage);
         }
       } finally {
-        if (isCurrentLoadRequest()) {
+        if (isCurrentLoadRequest() && indexedDbOpenRecoveryState.hasFailed() === false) {
           setIsLoading(false);
         }
         refreshBarrier?.settle(refreshOutcome);
       }
     })();
-  }, [activeWorkspace, deckId, getDeckById, showCapturedTechnicalError, t, technicalErrorMessage]);
+  }, [activeWorkspace, deckId, getDeckById, indexedDbOpenRecoveryState, showCapturedTechnicalError, t, technicalErrorMessage]);
 
   useLayoutEffect(() => {
     void loadScreenData();
@@ -330,6 +365,10 @@ export function DeckFormScreen(): ReactElement {
   async function readFormStateAfterLatestRefresh(
     submitEditorIdentity: DeckEditorIdentity,
   ): Promise<FormState | null> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return null;
+    }
+
     if (submitEditorIdentity.mode === "create") {
       return formStateRef.current;
     }
@@ -349,6 +388,9 @@ export function DeckFormScreen(): ReactElement {
       }
 
       const refreshOutcome = await refreshBarrier.promise;
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return null;
+      }
       if (isSubmitEditorCurrent() === false) {
         return null;
       }
@@ -372,7 +414,7 @@ export function DeckFormScreen(): ReactElement {
   }
 
   async function handleSubmit(): Promise<void> {
-    if (isSavingRef.current) {
+    if (indexedDbOpenRecoveryState.hasFailed() || isSavingRef.current) {
       return;
     }
 
@@ -387,6 +429,7 @@ export function DeckFormScreen(): ReactElement {
         throw new Error("Deck editor is unavailable");
       }
       const latestFormState = await readFormStateAfterLatestRefresh(submitEditorIdentity);
+      indexedDbOpenRecoveryState.throwIfFailed();
       if (latestFormState === null) {
         return;
       }
@@ -405,12 +448,17 @@ export function DeckFormScreen(): ReactElement {
 
       if (isCreateMode) {
         const createdDeck = await createDeckItem(payload);
+        indexedDbOpenRecoveryState.throwIfFailed();
         navigate(buildSettingsDeckDetailRoute(createdDeck.deckId));
       } else if (deckId !== undefined) {
         const updatedDeck = await updateDeckItem(deckId, payload);
+        indexedDbOpenRecoveryState.throwIfFailed();
         navigate(buildSettingsDeckDetailRoute(updatedDeck.deckId));
       }
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasCaptured = captureAppOperationError(error, {
         feature: "settings",
         operation: "deck_save",
@@ -426,8 +474,10 @@ export function DeckFormScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      isSavingRef.current = false;
-      setIsSaving(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        isSavingRef.current = false;
+        setIsSaving(false);
+      }
     }
   }
 

--- a/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import { Link } from "react-router";
 import { useAppData } from "../../../../appData";
-import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../../appError/AppErrorContext";
 import { ALL_CARDS_DECK_SLUG } from "../../../../deckFilters";
 import { useI18n } from "../../../../i18n";
 import { buildSettingsDeckDetailRoute, settingsDeckNewRoute } from "../../../../routes";
@@ -56,7 +59,7 @@ const emptyDecksSnapshot: DecksListSnapshot = {
 
 export function DecksScreen(): ReactElement {
   const { activeWorkspace, cloudSettings, localReadVersion, refreshLocalData, session } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatNumber } = useI18n();
   const [decksSnapshot, setDecksSnapshot] = useState<DecksListSnapshot>(emptyDecksSnapshot);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -78,6 +81,10 @@ export function DecksScreen(): ReactElement {
     let isCancelled = false;
 
     async function loadScreenData(): Promise<void> {
+      if (indexedDbOpenRecoveryState.hasFailed()) {
+        return;
+      }
+
       setIsLoading(true);
       setErrorMessage("");
 
@@ -87,12 +94,16 @@ export function DecksScreen(): ReactElement {
         }
 
         const nextDecksSnapshot = await loadDecksListSnapshot(activeWorkspace.workspaceId);
+        indexedDbOpenRecoveryState.throwIfFailed();
         if (isCancelled) {
           return;
         }
 
         setDecksSnapshot(nextDecksSnapshot);
       } catch (error) {
+        if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+          return;
+        }
         if (isCancelled) {
           return;
         }
@@ -115,7 +126,7 @@ export function DecksScreen(): ReactElement {
         }
         setErrorMessage(error instanceof Error ? error.message : String(error));
       } finally {
-        if (!isCancelled) {
+        if (!isCancelled && indexedDbOpenRecoveryState.hasFailed() === false) {
           setIsLoading(false);
         }
       }
@@ -126,14 +137,22 @@ export function DecksScreen(): ReactElement {
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspace, localReadVersion]);
+  }, [activeWorkspace, indexedDbOpenRecoveryState, localReadVersion]);
 
   const deckListEntries = makeDeckListEntries(decksSnapshot);
 
   async function handleRefreshLocalData(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     try {
       await refreshLocalData();
+      indexedDbOpenRecoveryState.throwIfFailed();
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       handleRefreshLocalDataError({
         error,
         context: {

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceExportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceExportScreen.tsx
@@ -4,7 +4,10 @@ import {
   previewWorkspacePackageExport,
 } from "../../../../api";
 import { useAppData } from "../../../../appData";
-import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../../appError/AppErrorContext";
 import { useI18n } from "../../../../i18n";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type {
@@ -190,7 +193,7 @@ function formatApproximateBytes(byteCount: number, formatNumberValue: NumberForm
 
 export function WorkspaceExportScreen(): ReactElement {
   const { activeWorkspace, cloudSettings, session } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatDateTime, formatNumber } = useI18n();
   const [isPackageExporting, setIsPackageExporting] = useState<boolean>(false);
   const [isPackageExportPreviewing, setIsPackageExportPreviewing] = useState<boolean>(false);
@@ -266,6 +269,10 @@ export function WorkspaceExportScreen(): ReactElement {
   }
 
   useEffect(() => {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (packageExportPreviewIdentity === null) {
       return;
     }
@@ -273,9 +280,13 @@ export function WorkspaceExportScreen(): ReactElement {
     if (packageExportPreviewIdentity.workspaceId !== activeWorkspaceId) {
       resetPackageExportState();
     }
-  }, [activeWorkspaceId, packageExportPreviewIdentity]);
+  }, [activeWorkspaceId, indexedDbOpenRecoveryState, packageExportPreviewIdentity]);
 
   async function previewPackageExportWithSelection(selectedCardTags: ReadonlyArray<string>): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (activeWorkspace === null) {
       setErrorMessage(t("workspaceExport.workspaceUnavailable"));
       setSuccessMessage("");
@@ -292,6 +303,7 @@ export function WorkspaceExportScreen(): ReactElement {
         activeWorkspace.workspaceId,
         buildWorkspacePackageExportPreviewRequest(selectedCardTags),
       );
+      indexedDbOpenRecoveryState.throwIfFailed();
       setPackageExportPreview(preview);
       setPackageExportPreviewIdentity({
         workspaceId: activeWorkspace.workspaceId,
@@ -303,6 +315,9 @@ export function WorkspaceExportScreen(): ReactElement {
       ));
       setPackageExportIncludedTags(buildWorkspacePackageIncludedTags(preview));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasCaptured = captureWorkspaceExportError(error);
       if (wasCaptured) {
         showCapturedTechnicalError(error);
@@ -311,15 +326,28 @@ export function WorkspaceExportScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      setIsPackageExportPreviewing(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsPackageExportPreviewing(false);
+      }
     }
   }
 
   async function previewPackageExport(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     await previewPackageExportWithSelection(packageExportSelectedCardTags);
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
   }
 
   async function downloadPackageExport(): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const currentPreview = currentPackageExportPreview;
     if (activeWorkspace === null || currentPreview === null) {
       resetPackageExportPreview();
@@ -337,6 +365,7 @@ export function WorkspaceExportScreen(): ReactElement {
         activeWorkspace.workspaceId,
         buildWorkspacePackageExportDownloadRequest(currentPreview, packageExportSelectedCardTags, packageExportIncludedTags),
       );
+      indexedDbOpenRecoveryState.throwIfFailed();
       triggerBlobDownload({
         blob: result.blob,
         filename: result.filename,
@@ -345,6 +374,9 @@ export function WorkspaceExportScreen(): ReactElement {
       });
       setSuccessMessage(t("workspaceExport.packageExportSuccess"));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
       const wasCaptured = captureWorkspaceExportError(error);
       if (wasCaptured) {
         showCapturedTechnicalError(error);
@@ -353,16 +385,26 @@ export function WorkspaceExportScreen(): ReactElement {
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     } finally {
-      setIsPackageExporting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsPackageExporting(false);
+      }
     }
   }
 
   function selectAllPackageExportCards(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setPackageExportSelectedCardTags([]);
     void previewPackageExportWithSelection([]);
   }
 
   function togglePackageExportCardSelectionTag(tag: string): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const selectedCardTags = packageExportSelectedCardTags.includes(tag)
       ? packageExportSelectedCardTags.filter((currentTag) => currentTag !== tag)
       : [...packageExportSelectedCardTags, tag];
@@ -372,6 +414,10 @@ export function WorkspaceExportScreen(): ReactElement {
   }
 
   function togglePackageExportIncludedTag(tag: string): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     setPackageExportIncludedTags((currentTags) => (
       currentTags.includes(tag)
         ? currentTags.filter((currentTag) => currentTag !== tag)

--- a/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/packages/WorkspaceImportScreen.tsx
@@ -6,7 +6,10 @@ import {
 } from "../../../../api";
 import { useAppData } from "../../../../appData";
 import { requireCloudInstallationId } from "../../../../appData/sync/local/syncCloudSettings";
-import { useAppErrorDialog } from "../../../../appError/AppErrorContext";
+import {
+  markIndexedDbOpenRecoveryFailureAndCheckActive,
+  useAppErrorDialog,
+} from "../../../../appError/AppErrorContext";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../../../i18n";
 import { buildClientWorkspaceReplicaId } from "../../../../media/mediaCrypto";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
@@ -159,7 +162,7 @@ function buildWorkspaceImportPreviewModel(
 
 export function WorkspaceImportScreen(): ReactElement {
   const { activeWorkspace, cloudSettings, isSessionVerified, refreshLocalData, session } = useAppData();
-  const { showCapturedTechnicalError } = useAppErrorDialog();
+  const { indexedDbOpenRecoveryState, showCapturedTechnicalError } = useAppErrorDialog();
   const { t, formatDateTime, formatNumber } = useI18n();
   const packageImportInputRef = useRef<HTMLInputElement | null>(null);
   const [isPackagePreviewing, setIsPackagePreviewing] = useState<boolean>(false);
@@ -187,7 +190,9 @@ export function WorkspaceImportScreen(): ReactElement {
     && isPackageImportAvailable
     && packageImportPreviewIdentity.workspaceId === activeWorkspaceId
     && packageImportPreviewIdentity.installationId === currentInstallationId;
-  const isPackageImportControlDisabled = !isPackageImportAvailable || isPackageImportBusy;
+  const isPackageImportControlDisabled = !isPackageImportAvailable
+    || isPackageImportBusy
+    || indexedDbOpenRecoveryState.hasFailed();
   const packageImportPreviewModel = packageImportPreview === null
     ? null
     : buildWorkspaceImportPreviewModel(packageImportPreview, t, formatDateTime, formatNumber);
@@ -215,7 +220,7 @@ export function WorkspaceImportScreen(): ReactElement {
   }
 
   useEffect(() => {
-    if (packageImportPreviewIdentity === null) {
+    if (packageImportPreviewIdentity === null || indexedDbOpenRecoveryState.hasFailed()) {
       return;
     }
 
@@ -225,9 +230,13 @@ export function WorkspaceImportScreen(): ReactElement {
     ) {
       resetPackageImportPreview();
     }
-  }, [activeWorkspaceId, currentInstallationId, packageImportPreviewIdentity]);
+  }, [activeWorkspaceId, currentInstallationId, indexedDbOpenRecoveryState, packageImportPreviewIdentity]);
 
   async function previewPackageImportFile(file: File): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (!isPackageImportAvailable) {
       setErrorMessage(t("workspaceImport.workspaceUnavailable"));
       setSuccessMessage("");
@@ -240,7 +249,9 @@ export function WorkspaceImportScreen(): ReactElement {
     resetPackageImportPreview();
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const preview = await previewWorkspacePackageImport(activeWorkspace.workspaceId, file);
+      indexedDbOpenRecoveryState.throwIfFailed();
       setPackageImportFile(file);
       setPackageImportPreview(preview);
       setPackageImportPreviewIdentity({
@@ -253,6 +264,10 @@ export function WorkspaceImportScreen(): ReactElement {
         removeTags: [...preview.defaultOptions.removedTags],
       });
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       const validationErrorMessage = getWorkspacePackageValidationErrorMessage(error, t);
       if (validationErrorMessage !== null) {
         setErrorMessage(validationErrorMessage);
@@ -266,14 +281,20 @@ export function WorkspaceImportScreen(): ReactElement {
         }
       }
     } finally {
-      setIsPackagePreviewing(false);
-      if (packageImportInputRef.current !== null) {
-        packageImportInputRef.current.value = "";
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsPackagePreviewing(false);
+        if (packageImportInputRef.current !== null) {
+          packageImportInputRef.current.value = "";
+        }
       }
     }
   }
 
   async function confirmPackageImport(importOptions: WorkspaceImportOptions): Promise<void> {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     if (!isPackageImportAvailable) {
       resetPackageImportPreview();
       setErrorMessage(t("workspaceImport.workspaceUnavailable"));
@@ -300,10 +321,13 @@ export function WorkspaceImportScreen(): ReactElement {
     setSuccessMessage("");
 
     try {
+      indexedDbOpenRecoveryState.throwIfFailed();
       const workspaceId = activeWorkspace.workspaceId;
       const installationId = requireCloudInstallationId(cloudSettings);
       await refreshLocalData();
+      indexedDbOpenRecoveryState.throwIfFailed();
       const replicaId = await buildClientWorkspaceReplicaId(workspaceId, installationId);
+      indexedDbOpenRecoveryState.throwIfFailed();
       const importId = crypto.randomUUID().toLowerCase();
       const importedAt = new Date().toISOString();
       const options: WorkspacePackageImportConfirmOptions = {
@@ -316,10 +340,13 @@ export function WorkspaceImportScreen(): ReactElement {
         lastModifiedByReplicaId: replicaId,
         operationIdPrefix: importId,
       };
+      indexedDbOpenRecoveryState.throwIfFailed();
       const result = await confirmWorkspacePackageImport(workspaceId, packageImportFile, options);
+      indexedDbOpenRecoveryState.throwIfFailed();
 
       resetPackageImportPreview();
       await refreshLocalData();
+      indexedDbOpenRecoveryState.throwIfFailed();
       setSuccessMessage(result.summary.importTag === null
         ? t("workspaceImport.packageImportSuccess", { count: result.summary.cardCount })
         : t("workspaceImport.packageImportSuccessWithTag", {
@@ -327,6 +354,10 @@ export function WorkspaceImportScreen(): ReactElement {
           tag: result.summary.importTag,
         }));
     } catch (error) {
+      if (markIndexedDbOpenRecoveryFailureAndCheckActive(indexedDbOpenRecoveryState, error)) {
+        return;
+      }
+
       const validationErrorMessage = getWorkspacePackageValidationErrorMessage(error, t);
       if (validationErrorMessage !== null) {
         setErrorMessage(validationErrorMessage);
@@ -340,11 +371,17 @@ export function WorkspaceImportScreen(): ReactElement {
         }
       }
     } finally {
-      setIsPackageImporting(false);
+      if (indexedDbOpenRecoveryState.hasFailed() === false) {
+        setIsPackageImporting(false);
+      }
     }
   }
 
   function handlePackageImportInputChange(): void {
+    if (indexedDbOpenRecoveryState.hasFailed()) {
+      return;
+    }
+
     const file = packageImportInputRef.current?.files?.[0] ?? null;
     if (file === null) {
       return;
@@ -394,8 +431,16 @@ export function WorkspaceImportScreen(): ReactElement {
             : null}
           errorMessage={errorMessage}
           successMessage={successMessage}
-          onSelect={() => packageImportInputRef.current?.click()}
-          onOptionsChange={setPackageImportOptions}
+          onSelect={() => {
+            if (indexedDbOpenRecoveryState.hasFailed() === false) {
+              packageImportInputRef.current?.click();
+            }
+          }}
+          onOptionsChange={(options) => {
+            if (indexedDbOpenRecoveryState.hasFailed() === false) {
+              setPackageImportOptions(options);
+            }
+          }}
           onConfirm={(options) => void confirmPackageImport(options)}
         />
       </section>


### PR DESCRIPTION
## Summary

- preserve the canonical first IndexedDB recovery error and abort page-level work
- guard local, sync, media, chat, review, feedback, and account-deletion continuations
- serialize account deletion across tabs with durable confirmation and attempt dispatch state

## Validation

- local executable checks were not run per repository policy
- full working-tree static review passed with no P0/P1 blockers
- accepted residual: intentional dictation cancellation may be reported as a technical transcription failure