### PR TITLE
fix(web): preserve mounted review reactions during cleanup

### DIFF
--- a/apps/web/src/screens/review/reactions/lottie/reviewReactionLottie.ts
+++ b/apps/web/src/screens/review/reactions/lottie/reviewReactionLottie.ts
@@ -428,8 +428,13 @@ export function reviewReactionLottieAssetFailure(variant: ReviewReactionLottieVa
 function clearReviewReactionLottieState(): void {
   reviewReactionLottieStateGeneration += 1;
   destroyReviewReactionLottiePreparedRenders(reviewReactionLottiePreparedRenderByVariant);
-  for (const preparedRender of reviewReactionLottieReservedRenderByEventId.values()) {
-    destroyReviewReactionLottiePreparedRender(preparedRender);
+  const mountedRenderByEventId = new Map<string, ReviewReactionLottiePreparedRender>();
+  for (const [eventId, preparedRender] of reviewReactionLottieReservedRenderByEventId.entries()) {
+    if (reviewReactionLottieMountedRenderEventIds.has(eventId)) {
+      mountedRenderByEventId.set(eventId, preparedRender);
+    } else {
+      destroyReviewReactionLottiePreparedRender(preparedRender);
+    }
   }
   reviewReactionLottieOffscreenRoot?.remove();
 
@@ -440,9 +445,9 @@ function clearReviewReactionLottieState(): void {
   reviewReactionLottiePreparedRenderByVariant = makeEmptyReviewReactionLottiePreparedRenderByVariant();
   reviewReactionLottiePreparedRenderPromiseByVariant = makeEmptyReviewReactionLottiePreparedRenderPromiseByVariant();
   reviewReactionLottieFailureByVariant = makeEmptyReviewReactionLottieFailureByVariant();
-  reviewReactionLottieReservedRenderByEventId = new Map<string, ReviewReactionLottiePreparedRender>();
-  reviewReactionLottieMountedRenderEventIds = new Set<string>();
-  reviewReactionLottieReleaseRequestedEventIds = new Set<string>();
+  reviewReactionLottieReservedRenderByEventId = mountedRenderByEventId;
+  reviewReactionLottieMountedRenderEventIds = new Set<string>(mountedRenderByEventId.keys());
+  reviewReactionLottieReleaseRequestedEventIds = new Set<string>(mountedRenderByEventId.keys());
   reviewReactionLottieOffscreenRoot = null;
 }
 


### PR DESCRIPTION
## Summary

- retain mounted review-reaction Lottie renders while recovery/prewarm state is cleared
- mark retained renders for release so their React consumer removes listeners before destroying the animation
- continue aborting background prewarm work and destroying every unmounted render immediately

## Root cause

The IndexedDB recovery lifecycle added a parent-effect cleanup that destroyed mounted Lottie animation items during navigation away from review. Lottie 5.13 clears its listener table in `destroy()`. React then ran the child effect cleanup, whose listener-removal callbacks accessed that cleared table and threw during the `/review` to `/cards` transition. The app-wide error boundary replaced the cards screen, and live smoke subsequently timed out waiting for `cards-search-input`.

## Validation

- fresh static patch review: clean; no P0/P1 findings
- local executable checks intentionally not run per repository policy
- existing live web smoke covers the reviewed-card-to-cards transition and remains the production regression gate
