### PR TITLE
Delist catalog test fixture

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -387,7 +387,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0110_collection_cover_media.sql
+            --require-migration 0111_delist_catalog_test_fixture.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,8 +71,8 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
-    migrationFileName: "0110_collection_cover_media.sql",
-    expectedMigrationCount: 112,
+    migrationFileName: "0111_delist_catalog_test_fixture.sql",
+    expectedMigrationCount: 113,
     testFiles: Object.freeze([
       "src/catalog/authoring/lockOrder.postgres.integration.ts",
       "src/catalog/distribution/public/public.postgres.integration.ts",

--- a/apps/backend/src/catalog/distribution/public/public.postgres.integration.ts
+++ b/apps/backend/src/catalog/distribution/public/public.postgres.integration.ts
@@ -1,23 +1,13 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import test from "node:test";
 import pg from "pg";
 import type { DatabaseExecutor, SqlValue } from "../../../database";
 import { loadPublicCatalogSnapshotInExecutor } from "./public";
 
-const fixtureAuthorId = "00000000-0000-4000-a105-000000000001";
-const fixturePackageId = "00000000-0000-4000-a105-000000000002";
-const fixturePackageVersionId = "00000000-0000-4000-a105-000000000003";
-const fixtureCardIds = [
-  "00000000-0000-4000-a105-000000000004",
-  "00000000-0000-4000-a105-000000000005",
-] as const;
-const fixtureCollectionId = "00000000-0000-4000-a107-000000000001";
-
-type CollectionFixtureRow = Readonly<{
-  collection_id: string;
-  package_id: string;
-  ordinal: number;
-}>;
+const delistedFixturePackageId = "00000000-0000-4000-a105-000000000002";
+const delistedFixturePackageVersionId = "00000000-0000-4000-a105-000000000003";
+const delistedFixtureCollectionId = "00000000-0000-4000-a107-000000000001";
 
 function requireTestDatabaseAdminUrl(): string {
   const databaseUrl = process.env.TEST_DATABASE_ADMIN_URL?.trim();
@@ -39,71 +29,293 @@ function createPoolExecutor(pool: pg.Pool): DatabaseExecutor {
   };
 }
 
-test("latest migrations expose the deterministic collection through the public catalog snapshot", async () => {
+test("latest migrations delist deterministic fixtures and expose test-owned public catalog data", async () => {
   const pool = new pg.Pool({
     connectionString: requireTestDatabaseAdminUrl(),
     application_name: "public-catalog-snapshot-integration",
   });
+  const suffix = randomUUID().replaceAll("-", "");
+  const authorId = randomUUID();
+  const packageId = randomUUID();
+  const packageVersionId = randomUUID();
+  const cardIds = [randomUUID(), randomUUID()] as const;
+  const collectionId = randomUUID();
+  const authorSlug = `public-snapshot-author-${suffix}`;
+  const packageSlug = `public-snapshot-package-${suffix}`;
+  const packageVersionSlug = `public-snapshot-version-${suffix}`;
+  const collectionSlug = `public-snapshot-collection-${suffix}`;
+  const adminEmail = "public-snapshot@example.test";
 
   try {
-    const fixtureResult = await pool.query<CollectionFixtureRow>(
-      `SELECT
-         collections.collection_id::text AS collection_id,
-         memberships.package_id::text AS package_id,
-         memberships.ordinal
-       FROM catalog.collections AS collections
-       INNER JOIN catalog.collection_packages AS memberships
-         ON memberships.collection_id = collections.collection_id
-       WHERE collections.collection_id = $1
-         AND collections.status = 'published'
-         AND collections.delisted_at IS NULL`,
-      [fixtureCollectionId],
-    );
-    assert.deepEqual(fixtureResult.rows, [{
-      collection_id: fixtureCollectionId,
-      package_id: fixturePackageId,
-      ordinal: 1,
-    }]);
+    const setupClient = await pool.connect();
+    try {
+      await setupClient.query("BEGIN");
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.authors",
+          "(author_id, slug, display_name, bio, website_url)",
+          "VALUES ($1, $2, $3, $4, NULL)",
+        ].join(" "),
+        [authorId, authorSlug, "Public Snapshot Author", "Integration-owned catalog author."],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.packages",
+          "(package_id, author_id, slug, title, summary, description, language_tags, topic_tags, license)",
+          "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        ].join(" "),
+        [
+          packageId,
+          authorId,
+          packageSlug,
+          "Public Snapshot Package",
+          "Integration-owned snapshot package.",
+          "Valid public catalog data created by the snapshot integration test.",
+          ["en"],
+          ["integration"],
+          "CC0-1.0",
+        ],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.package_versions",
+          "(package_version_id, package_id, version_number, slug, title, summary, description,",
+          "language_tags, topic_tags, license, card_count, created_by_admin_email)",
+          "VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, $9, 2, $10)",
+        ].join(" "),
+        [
+          packageVersionId,
+          packageId,
+          packageVersionSlug,
+          "Public Snapshot Package",
+          "Integration-owned snapshot package.",
+          "Valid public catalog data created by the snapshot integration test.",
+          ["en"],
+          ["integration"],
+          "CC0-1.0",
+          adminEmail,
+        ],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.package_cards",
+          "(package_card_id, package_version_id, stable_card_key, ordinal, front_text, back_text,",
+          "card_type, metadata, tags, media_asset_keys)",
+          "VALUES",
+          "($1, $3, 'snapshot-1', 1, 'What does the first snapshot card verify?',",
+          "'The first ordered card.', 'basic', '{\"version\":1,\"source\":null}'::jsonb, ARRAY['integration'], ARRAY[]::text[]),",
+          "($2, $3, 'snapshot-2', 2, 'What does the second snapshot card verify?',",
+          "'The second ordered card.', 'basic', '{\"version\":1,\"source\":null}'::jsonb, ARRAY['integration'], ARRAY[]::text[])",
+        ].join(" "),
+        [cardIds[0], cardIds[1], packageVersionId],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.package_review_events",
+          "(package_id, package_version_id, from_status, to_status, actor_admin_email, note)",
+          "VALUES ($1, $2, NULL, 'draft', $3, NULL)",
+        ].join(" "),
+        [packageId, packageVersionId, adminEmail],
+      );
+      await setupClient.query(
+        [
+          "UPDATE catalog.package_versions",
+          "SET status = 'submitted', submitted_at = now()",
+          "WHERE package_version_id = $1 AND status = 'draft'",
+        ].join(" "),
+        [packageVersionId],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.package_review_events",
+          "(package_id, package_version_id, from_status, to_status, actor_admin_email, note)",
+          "VALUES ($1, $2, 'draft', 'submitted', $3, NULL)",
+        ].join(" "),
+        [packageId, packageVersionId, adminEmail],
+      );
+      await setupClient.query(
+        [
+          "UPDATE catalog.package_versions",
+          "SET status = 'approved', reviewed_by_admin_email = $2, reviewed_at = now()",
+          "WHERE package_version_id = $1 AND status = 'submitted'",
+        ].join(" "),
+        [packageVersionId, adminEmail],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.package_review_events",
+          "(package_id, package_version_id, from_status, to_status, actor_admin_email, note)",
+          "VALUES ($1, $2, 'submitted', 'approved', $3, NULL)",
+        ].join(" "),
+        [packageId, packageVersionId, adminEmail],
+      );
+      await setupClient.query(
+        [
+          "UPDATE catalog.package_versions",
+          "SET status = 'published', published_at = now()",
+          "WHERE package_version_id = $1 AND status = 'approved'",
+        ].join(" "),
+        [packageVersionId],
+      );
+      await setupClient.query(
+        [
+          "UPDATE catalog.packages",
+          "SET status = 'published', published_at = now()",
+          "WHERE package_id = $1 AND status = 'draft'",
+        ].join(" "),
+        [packageId],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.package_review_events",
+          "(package_id, package_version_id, from_status, to_status, actor_admin_email, note)",
+          "VALUES ($1, $2, 'approved', 'published', $3, NULL)",
+        ].join(" "),
+        [packageId, packageVersionId, adminEmail],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.collections",
+          "(collection_id, slug, title, summary, description, language_tags, topic_tags, cover_package_id)",
+          "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        ].join(" "),
+        [
+          collectionId,
+          collectionSlug,
+          "Public Snapshot Collection",
+          "Integration-owned snapshot collection.",
+          "Valid ordered catalog collection created by the snapshot integration test.",
+          ["en"],
+          ["integration"],
+          packageId,
+        ],
+      );
+      await setupClient.query(
+        [
+          "UPDATE catalog.collections",
+          "SET status = 'published', published_at = now()",
+          "WHERE collection_id = $1 AND status = 'draft'",
+        ].join(" "),
+        [collectionId],
+      );
+      await setupClient.query(
+        [
+          "INSERT INTO catalog.collection_packages (collection_id, package_id, ordinal)",
+          "VALUES ($1, $2, 1)",
+        ].join(" "),
+        [collectionId, packageId],
+      );
+      await setupClient.query("COMMIT");
+    } catch (error) {
+      await setupClient.query("ROLLBACK");
+      throw error;
+    } finally {
+      setupClient.release();
+    }
 
     const snapshot = await loadPublicCatalogSnapshotInExecutor(createPoolExecutor(pool), {
       publicApiBaseUrl: "https://api.flashcards-open-source-app.com/v1",
       publicAppBaseUrl: "https://flashcards-open-source-app.com",
-      generatedAt: "2026-08-03T00:02:00.000Z",
+      generatedAt: "2026-08-14T00:00:00.000Z",
     });
 
-    const author = snapshot.authors.find((candidate) => candidate.authorId === fixtureAuthorId);
-    const catalogPackage = snapshot.packages.find((candidate) => candidate.packageId === fixturePackageId);
+    const author = snapshot.authors.find((candidate) => candidate.authorId === authorId);
+    const catalogPackage = snapshot.packages.find((candidate) => candidate.packageId === packageId);
     const packageVersion = snapshot.packageVersions.find(
-      (candidate) => candidate.packageVersionId === fixturePackageVersionId,
+      (candidate) => candidate.packageVersionId === packageVersionId,
     );
     const cards = snapshot.cards.filter(
-      (candidate) => candidate.packageVersionId === fixturePackageVersionId,
+      (candidate) => candidate.packageVersionId === packageVersionId,
     );
     const collection = snapshot.collections.find(
-      (candidate) => candidate.collectionId === fixtureCollectionId,
+      (candidate) => candidate.collectionId === collectionId,
     );
     const collectionPackage = snapshot.collectionPackages.find(
-      (candidate) => candidate.collectionId === fixtureCollectionId,
+      (candidate) => candidate.collectionId === collectionId
+        && candidate.packageId === packageId,
     );
 
     assert.equal(snapshot.schemaVersion, 1);
-    assert.equal(author?.authorId, fixtureAuthorId);
-    assert.equal(catalogPackage?.authorId, fixtureAuthorId);
-    assert.equal(catalogPackage?.latestPackageVersionId, fixturePackageVersionId);
-    assert.equal(packageVersion?.packageId, fixturePackageId);
+    assert.deepEqual(author, {
+      authorId,
+      slug: authorSlug,
+      displayName: "Public Snapshot Author",
+      bio: "Integration-owned catalog author.",
+      websiteUrl: null,
+    });
+    assert.equal(catalogPackage?.authorId, authorId);
+    assert.equal(catalogPackage?.slug, packageSlug);
+    assert.equal(catalogPackage?.status, "published");
+    assert.equal(catalogPackage?.latestPackageVersionId, packageVersionId);
+    assert.equal(catalogPackage?.versionCount, 1);
+    assert.equal(packageVersion?.packageId, packageId);
+    assert.equal(packageVersion?.versionNumber, 1);
+    assert.equal(packageVersion?.status, "published");
+    assert.equal(packageVersion?.slug, packageVersionSlug);
+    assert.equal(packageVersion?.title, "Public Snapshot Package");
+    assert.equal(packageVersion?.summary, "Integration-owned snapshot package.");
+    assert.equal(
+      packageVersion?.description,
+      "Valid public catalog data created by the snapshot integration test.",
+    );
+    assert.deepEqual(packageVersion?.languageTags, ["en"]);
+    assert.deepEqual(packageVersion?.topicTags, ["integration"]);
+    assert.equal(packageVersion?.license, "CC0-1.0");
+    assert.equal(packageVersion?.contentWarning, null);
+    assert.equal(packageVersion?.coverMediaAssetId, null);
+    assert.equal(packageVersion?.cardCount, 2);
     assert.equal(
       packageVersion?.installUrl,
-      `https://flashcards-open-source-app.com/catalog/import/${fixturePackageVersionId}`,
+      `https://flashcards-open-source-app.com/catalog/import/${packageVersionId}`,
     );
-    assert.deepEqual(cards.map((card) => card.packageCardId), fixtureCardIds);
-    assert.deepEqual(cards.map((card) => card.ordinal), [1, 2]);
-    assert.equal(collection?.coverPackageId, fixturePackageId);
+    assert.deepEqual(cards, [
+      {
+        packageCardId: cardIds[0],
+        packageVersionId,
+        ordinal: 1,
+        frontText: "What does the first snapshot card verify?",
+        backText: "The first ordered card.",
+        cardType: "basic",
+        tags: ["integration"],
+        mediaAssetIds: [],
+      },
+      {
+        packageCardId: cardIds[1],
+        packageVersionId,
+        ordinal: 2,
+        frontText: "What does the second snapshot card verify?",
+        backText: "The second ordered card.",
+        cardType: "basic",
+        tags: ["integration"],
+        mediaAssetIds: [],
+      },
+    ]);
+    assert.equal(collection?.slug, collectionSlug);
+    assert.equal(collection?.title, "Public Snapshot Collection");
+    assert.equal(collection?.status, "published");
+    assert.equal(collection?.coverPackageId, packageId);
     assert.equal("coverDownloadUrl" in (collection ?? {}), false);
     assert.deepEqual(collectionPackage, {
-      collectionId: fixtureCollectionId,
-      packageId: fixturePackageId,
+      collectionId,
+      packageId,
       ordinal: 1,
     });
+    assert.equal(
+      snapshot.packages.some((candidate) => candidate.packageId === delistedFixturePackageId),
+      false,
+    );
+    assert.equal(
+      snapshot.packageVersions.some(
+        (candidate) => candidate.packageVersionId === delistedFixturePackageVersionId,
+      ),
+      false,
+    );
+    assert.equal(
+      snapshot.collections.some(
+        (candidate) => candidate.collectionId === delistedFixtureCollectionId,
+      ),
+      false,
+    );
   } finally {
     await pool.end();
   }

--- a/db/migrations/0111_delist_catalog_test_fixture.sql
+++ b/db/migrations/0111_delist_catalog_test_fixture.sql
@@ -1,0 +1,495 @@
+-- Migration status: Current / additive.
+-- Introduces: forward-only delisting of deterministic public catalog test fixtures.
+-- Schemas touched/read explicitly: catalog, pg_catalog.
+
+DO $migration$
+DECLARE
+  fixture_author_id CONSTANT UUID := '00000000-0000-4000-a105-000000000001';
+  fixture_package_id CONSTANT UUID := '00000000-0000-4000-a105-000000000002';
+  fixture_version_id CONSTANT UUID := '00000000-0000-4000-a105-000000000003';
+  fixture_card_one_id CONSTANT UUID := '00000000-0000-4000-a105-000000000004';
+  fixture_card_two_id CONSTANT UUID := '00000000-0000-4000-a105-000000000005';
+  fixture_approval_event_id CONSTANT UUID := '00000000-0000-4000-a105-000000000006';
+  fixture_publication_event_id CONSTANT UUID := '00000000-0000-4000-a105-000000000007';
+  fixture_draft_event_id CONSTANT UUID := '00000000-0000-4000-a105-000000000008';
+  fixture_submission_event_id CONSTANT UUID := '00000000-0000-4000-a105-000000000009';
+  fixture_collection_id CONSTANT UUID := '00000000-0000-4000-a107-000000000001';
+  fixture_delist_event_id CONSTANT UUID := '00000000-0000-4000-a111-000000000001';
+  fixture_admin_email CONSTANT TEXT := 'catalog-system@flashcards-open-source-app.com';
+  fixture_created_at CONSTANT TIMESTAMPTZ := '2026-08-02 00:00:00+00';
+  fixture_submitted_at CONSTANT TIMESTAMPTZ := '2026-08-02 00:01:00+00';
+  fixture_reviewed_at CONSTANT TIMESTAMPTZ := '2026-08-02 00:02:00+00';
+  fixture_published_at CONSTANT TIMESTAMPTZ := '2026-08-02 00:03:00+00';
+  fixture_collection_created_at CONSTANT TIMESTAMPTZ := '2026-08-03 00:00:00+00';
+  fixture_collection_published_at CONSTANT TIMESTAMPTZ := '2026-08-03 00:01:00+00';
+  fixture_transaction_at CONSTANT TIMESTAMPTZ := now();
+  fixture_delisted_at CONSTANT TIMESTAMPTZ := fixture_transaction_at;
+  fixture_author catalog.authors%ROWTYPE;
+  fixture_package catalog.packages%ROWTYPE;
+  fixture_version catalog.package_versions%ROWTYPE;
+  fixture_collection catalog.collections%ROWTYPE;
+  fixture_author_package_count BIGINT;
+  fixture_version_count BIGINT;
+  fixture_card_count BIGINT;
+  fixture_media_asset_count BIGINT;
+  fixture_review_event_count BIGINT;
+  fixture_version_review_event_count BIGINT;
+  fixture_membership_count BIGINT;
+  fixture_package_membership_count BIGINT;
+  fixture_cover_reference_count BIGINT;
+  original_state_matches BOOLEAN;
+  terminal_state_matches BOOLEAN;
+  updated_count INTEGER;
+BEGIN
+  SELECT package_versions.*
+  INTO fixture_version
+  FROM catalog.package_versions AS package_versions
+  WHERE package_versions.package_version_id = fixture_version_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Catalog test fixture package version is missing: package_version_id=%', fixture_version_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT packages.*
+  INTO fixture_package
+  FROM catalog.packages AS packages
+  WHERE packages.package_id = fixture_package_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Catalog test fixture package is missing: package_id=%', fixture_package_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT authors.*
+  INTO fixture_author
+  FROM catalog.authors AS authors
+  WHERE authors.author_id = fixture_author_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Catalog test fixture author is missing: author_id=%', fixture_author_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT collections.*
+  INTO fixture_collection
+  FROM catalog.collections AS collections
+  WHERE collections.collection_id = fixture_collection_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Catalog test fixture collection is missing: collection_id=%', fixture_collection_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  PERFORM 1
+  FROM catalog.collections AS collections
+  WHERE collections.cover_package_id = fixture_package_id
+  ORDER BY collections.collection_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM catalog.package_cards AS package_cards
+  WHERE package_cards.package_version_id = fixture_version_id
+  ORDER BY package_cards.package_card_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM catalog.package_media_assets AS media_assets
+  WHERE media_assets.package_id = fixture_package_id
+  ORDER BY media_assets.package_media_asset_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM catalog.collection_packages AS collection_packages
+  WHERE collection_packages.collection_id = fixture_collection_id
+    OR collection_packages.package_id = fixture_package_id
+  ORDER BY collection_packages.collection_id, collection_packages.package_id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM catalog.package_review_events AS review_events
+  WHERE review_events.package_id = fixture_package_id
+    OR review_events.package_version_id = fixture_version_id
+    OR review_events.package_review_event_id = fixture_delist_event_id
+  ORDER BY review_events.package_review_event_id
+  FOR UPDATE;
+
+  IF fixture_author.slug <> 'flashcards-test-catalog'
+    OR fixture_author.display_name <> 'Flashcards Test Catalog'
+    OR fixture_author.bio IS DISTINCT FROM 'System author for public catalog test data.'
+    OR fixture_author.website_url IS NOT NULL
+    OR fixture_author.created_at <> fixture_created_at
+    OR fixture_author.updated_at <> fixture_created_at
+  THEN
+    RAISE EXCEPTION 'Catalog test fixture author conflicts with migration 0105: author_id=%', fixture_author_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_author_package_count
+  FROM catalog.packages AS packages
+  WHERE packages.author_id = fixture_author_id;
+
+  IF fixture_author_package_count <> 1 THEN
+    RAISE EXCEPTION 'Catalog test fixture author package graph conflicts: author_id=% expected_package_count=1 actual_package_count=%',
+      fixture_author_id,
+      fixture_author_package_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF fixture_package.author_id <> fixture_author_id
+    OR fixture_package.slug <> 'test'
+    OR fixture_package.title <> 'тест'
+    OR fixture_package.summary <> 'Minimal package for catalog installation testing.'
+    OR fixture_package.description <> 'Test-only public catalog content for verifying package installation.'
+    OR fixture_package.language_tags <> ARRAY['und']::TEXT[]
+    OR fixture_package.topic_tags <> ARRAY['test']::TEXT[]
+    OR fixture_package.license <> 'CC0-1.0'
+    OR fixture_package.content_warning IS NOT NULL
+    OR fixture_package.cover_package_media_key IS NOT NULL
+    OR fixture_package.created_at <> fixture_created_at
+    OR fixture_package.published_at IS DISTINCT FROM fixture_published_at
+  THEN
+    RAISE EXCEPTION 'Catalog test fixture package conflicts with migration 0105: package_id=%', fixture_package_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF fixture_version.package_id <> fixture_package_id
+    OR fixture_version.version_number <> 1
+    OR fixture_version.slug <> 'test'
+    OR fixture_version.title <> 'тест'
+    OR fixture_version.summary <> 'Minimal package for catalog installation testing.'
+    OR fixture_version.description <> 'Test-only public catalog content for verifying package installation.'
+    OR fixture_version.language_tags <> ARRAY['und']::TEXT[]
+    OR fixture_version.topic_tags <> ARRAY['test']::TEXT[]
+    OR fixture_version.license <> 'CC0-1.0'
+    OR fixture_version.content_warning IS NOT NULL
+    OR fixture_version.cover_package_media_key IS NOT NULL
+    OR fixture_version.source_workspace_id IS NOT NULL
+    OR fixture_version.card_count <> 2
+    OR fixture_version.created_by_admin_email <> fixture_admin_email
+    OR fixture_version.reviewed_by_admin_email IS DISTINCT FROM fixture_admin_email
+    OR fixture_version.created_at <> fixture_created_at
+    OR fixture_version.submitted_at IS DISTINCT FROM fixture_submitted_at
+    OR fixture_version.reviewed_at IS DISTINCT FROM fixture_reviewed_at
+    OR fixture_version.published_at IS DISTINCT FROM fixture_published_at
+  THEN
+    RAISE EXCEPTION 'Catalog test fixture package version conflicts with migration 0105: package_version_id=%', fixture_version_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF fixture_collection.slug <> 'test'
+    OR fixture_collection.title <> 'тест'
+    OR fixture_collection.summary <> 'Minimal collection for catalog testing.'
+    OR fixture_collection.description <> 'Test-only public catalog collection for verifying ordered package membership.'
+    OR fixture_collection.language_tags <> ARRAY['und']::TEXT[]
+    OR fixture_collection.topic_tags <> ARRAY['test']::TEXT[]
+    OR fixture_collection.cover_package_id IS DISTINCT FROM fixture_package_id
+    OR fixture_collection.cover_media_blob_id IS NOT NULL
+    OR fixture_collection.created_at <> fixture_collection_created_at
+    OR fixture_collection.published_at IS DISTINCT FROM fixture_collection_published_at
+  THEN
+    RAISE EXCEPTION 'Catalog test fixture collection conflicts with migrations 0107 and 0110: collection_id=%', fixture_collection_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_cover_reference_count
+  FROM catalog.collections AS collections
+  WHERE collections.cover_package_id = fixture_package_id;
+
+  IF fixture_cover_reference_count <> 1 THEN
+    RAISE EXCEPTION 'Catalog test fixture collection cover graph conflicts: package_id=% expected_cover_reference_count=1 actual_cover_reference_count=%',
+      fixture_package_id,
+      fixture_cover_reference_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_version_count
+  FROM catalog.package_versions AS package_versions
+  WHERE package_versions.package_id = fixture_package_id;
+
+  IF fixture_version_count <> 1 THEN
+    RAISE EXCEPTION 'Catalog test fixture package version membership conflicts: package_id=% expected_version_count=1 actual_version_count=%',
+      fixture_package_id,
+      fixture_version_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_card_count
+  FROM catalog.package_cards AS package_cards
+  WHERE package_cards.package_version_id = fixture_version_id;
+
+  IF fixture_card_count <> 2 OR NOT EXISTS (
+    SELECT 1
+    FROM catalog.package_cards AS package_cards
+    WHERE package_cards.package_card_id = fixture_card_one_id
+      AND package_cards.package_version_id = fixture_version_id
+      AND package_cards.stable_card_key = 'test-1'
+      AND package_cards.ordinal = 1
+      AND package_cards.front_text = 'test 1'
+      AND package_cards.back_text = 'test 2'
+      AND package_cards.card_type = 'basic'
+      AND package_cards.metadata = '{"version": 1, "source": null}'::JSONB
+      AND package_cards.tags = ARRAY['test']::TEXT[]
+      AND package_cards.media_asset_keys = ARRAY[]::TEXT[]
+      AND package_cards.created_at = fixture_created_at
+      AND package_cards.updated_at = fixture_created_at
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM catalog.package_cards AS package_cards
+    WHERE package_cards.package_card_id = fixture_card_two_id
+      AND package_cards.package_version_id = fixture_version_id
+      AND package_cards.stable_card_key = 'test-2'
+      AND package_cards.ordinal = 2
+      AND package_cards.front_text = 'test 3'
+      AND package_cards.back_text = 'test 4'
+      AND package_cards.card_type = 'basic'
+      AND package_cards.metadata = '{"version": 1, "source": null}'::JSONB
+      AND package_cards.tags = ARRAY['test']::TEXT[]
+      AND package_cards.media_asset_keys = ARRAY[]::TEXT[]
+      AND package_cards.created_at = fixture_created_at
+      AND package_cards.updated_at = fixture_created_at
+  ) THEN
+    RAISE EXCEPTION 'Catalog test fixture cards conflict with migration 0105: package_version_id=%', fixture_version_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_media_asset_count
+  FROM catalog.package_media_assets AS media_assets
+  WHERE media_assets.package_id = fixture_package_id;
+
+  IF fixture_media_asset_count <> 0 THEN
+    RAISE EXCEPTION 'Catalog test fixture media conflicts with migration 0105: package_id=% expected_media_asset_count=0 actual_media_asset_count=%',
+      fixture_package_id,
+      fixture_media_asset_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_membership_count
+  FROM catalog.collection_packages AS collection_packages
+  WHERE collection_packages.collection_id = fixture_collection_id;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_package_membership_count
+  FROM catalog.collection_packages AS collection_packages
+  WHERE collection_packages.package_id = fixture_package_id;
+
+  IF fixture_membership_count <> 1
+    OR fixture_package_membership_count <> 1
+    OR NOT EXISTS (
+    SELECT 1
+    FROM catalog.collection_packages AS collection_packages
+    WHERE collection_packages.collection_id = fixture_collection_id
+      AND collection_packages.package_id = fixture_package_id
+      AND collection_packages.ordinal = 1
+      AND collection_packages.created_at = fixture_collection_created_at
+  ) THEN
+    RAISE EXCEPTION 'Catalog test fixture collection membership conflicts with migration 0107: collection_id=%', fixture_collection_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_review_event_count
+  FROM catalog.package_review_events AS review_events
+  WHERE review_events.package_id = fixture_package_id;
+
+  SELECT pg_catalog.count(*)
+  INTO fixture_version_review_event_count
+  FROM catalog.package_review_events AS review_events
+  WHERE review_events.package_version_id = fixture_version_id;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM catalog.package_review_events AS review_events
+    WHERE review_events.package_review_event_id = fixture_draft_event_id
+      AND review_events.package_id = fixture_package_id
+      AND review_events.package_version_id = fixture_version_id
+      AND review_events.from_status IS NULL
+      AND review_events.to_status = 'draft'
+      AND review_events.actor_admin_email = fixture_admin_email
+      AND review_events.note IS NULL
+      AND review_events.created_at = fixture_created_at
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM catalog.package_review_events AS review_events
+    WHERE review_events.package_review_event_id = fixture_submission_event_id
+      AND review_events.package_id = fixture_package_id
+      AND review_events.package_version_id = fixture_version_id
+      AND review_events.from_status = 'draft'
+      AND review_events.to_status = 'submitted'
+      AND review_events.actor_admin_email = fixture_admin_email
+      AND review_events.note IS NULL
+      AND review_events.created_at = fixture_submitted_at
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM catalog.package_review_events AS review_events
+    WHERE review_events.package_review_event_id = fixture_approval_event_id
+      AND review_events.package_id = fixture_package_id
+      AND review_events.package_version_id = fixture_version_id
+      AND review_events.from_status = 'submitted'
+      AND review_events.to_status = 'approved'
+      AND review_events.actor_admin_email = fixture_admin_email
+      AND review_events.note = 'Approved deterministic catalog installation test content.'
+      AND review_events.created_at = fixture_reviewed_at
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM catalog.package_review_events AS review_events
+    WHERE review_events.package_review_event_id = fixture_publication_event_id
+      AND review_events.package_id = fixture_package_id
+      AND review_events.package_version_id = fixture_version_id
+      AND review_events.from_status = 'approved'
+      AND review_events.to_status = 'published'
+      AND review_events.actor_admin_email = fixture_admin_email
+      AND review_events.note = 'Published deterministic catalog installation test content.'
+      AND review_events.created_at = fixture_published_at
+  ) THEN
+    RAISE EXCEPTION 'Catalog test fixture review history conflicts with migration 0105: package_id=%', fixture_package_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT (
+    fixture_package.status = 'published'
+    AND fixture_package.updated_at = fixture_published_at
+    AND fixture_package.delisted_at IS NULL
+    AND fixture_version.status = 'published'
+    -- Migration 0105's status trigger stamped this field at apply time.
+    AND pg_catalog.isfinite(fixture_version.updated_at)
+    AND fixture_version.updated_at >= fixture_published_at
+    AND fixture_version.updated_at <= fixture_transaction_at
+    AND fixture_version.delisted_at IS NULL
+    AND fixture_collection.status = 'published'
+    AND fixture_collection.updated_at = fixture_collection_published_at
+    AND fixture_collection.delisted_at IS NULL
+    AND fixture_review_event_count = 4
+    AND fixture_version_review_event_count = 4
+    AND NOT EXISTS (
+      SELECT 1
+      FROM catalog.package_review_events AS review_events
+      WHERE review_events.package_review_event_id = fixture_delist_event_id
+    )
+  )
+  INTO original_state_matches;
+
+  SELECT (
+    fixture_package.status = 'delisted'
+    AND fixture_version.status = 'delisted'
+    AND fixture_collection.status = 'delisted'
+    AND fixture_package.delisted_at IS NOT NULL
+    AND pg_catalog.isfinite(fixture_package.delisted_at)
+    AND fixture_package.delisted_at >= fixture_collection_published_at
+    AND fixture_package.delisted_at <= fixture_transaction_at
+    AND fixture_package.delisted_at = fixture_version.delisted_at
+    AND fixture_package.delisted_at = fixture_collection.delisted_at
+    AND fixture_package.updated_at = fixture_package.delisted_at
+    AND fixture_version.updated_at = fixture_package.delisted_at
+    AND fixture_collection.updated_at = fixture_package.delisted_at
+    AND fixture_review_event_count = 5
+    AND fixture_version_review_event_count = 5
+    AND EXISTS (
+      SELECT 1
+      FROM catalog.package_review_events AS review_events
+      WHERE review_events.package_review_event_id = fixture_delist_event_id
+        AND review_events.package_id = fixture_package_id
+        AND review_events.package_version_id = fixture_version_id
+        AND review_events.from_status = 'published'
+        AND review_events.to_status = 'delisted'
+        AND review_events.actor_admin_email = fixture_admin_email
+        AND review_events.note = 'Delisted deterministic public catalog test fixture.'
+        AND review_events.created_at = fixture_package.delisted_at
+    )
+  )
+  INTO terminal_state_matches;
+
+  IF terminal_state_matches THEN
+    RETURN;
+  END IF;
+
+  IF NOT original_state_matches THEN
+    RAISE EXCEPTION 'Catalog test fixture lifecycle is neither the exact migration 0105/0107 state nor the exact migration 0111 terminal state: package_id=% package_status=% package_updated_at=% package_delisted_at=% package_version_id=% version_status=% version_updated_at=% version_delisted_at=% collection_id=% collection_status=% collection_updated_at=% collection_delisted_at=% package_review_event_count=% version_review_event_count=%',
+      fixture_package_id,
+      fixture_package.status,
+      fixture_package.updated_at,
+      fixture_package.delisted_at,
+      fixture_version_id,
+      fixture_version.status,
+      fixture_version.updated_at,
+      fixture_version.delisted_at,
+      fixture_collection_id,
+      fixture_collection.status,
+      fixture_collection.updated_at,
+      fixture_collection.delisted_at,
+      fixture_review_event_count,
+      fixture_version_review_event_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  UPDATE catalog.collections AS collections
+  SET status = 'delisted',
+      updated_at = fixture_delisted_at,
+      delisted_at = fixture_delisted_at
+  WHERE collections.collection_id = fixture_collection_id
+    AND collections.status = 'published';
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  IF updated_count <> 1 THEN
+    RAISE EXCEPTION 'Catalog test fixture collection changed before delisting: collection_id=%', fixture_collection_id
+      USING ERRCODE = '40001';
+  END IF;
+
+  UPDATE catalog.package_versions AS package_versions
+  SET status = 'delisted',
+      updated_at = fixture_delisted_at,
+      delisted_at = fixture_delisted_at
+  WHERE package_versions.package_version_id = fixture_version_id
+    AND package_versions.status = 'published';
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  IF updated_count <> 1 THEN
+    RAISE EXCEPTION 'Catalog test fixture package version changed before delisting: package_version_id=%', fixture_version_id
+      USING ERRCODE = '40001';
+  END IF;
+
+  INSERT INTO catalog.package_review_events (
+    package_review_event_id,
+    package_id,
+    package_version_id,
+    from_status,
+    to_status,
+    actor_admin_email,
+    note,
+    created_at
+  )
+  VALUES (
+    fixture_delist_event_id,
+    fixture_package_id,
+    fixture_version_id,
+    'published',
+    'delisted',
+    fixture_admin_email,
+    'Delisted deterministic public catalog test fixture.',
+    fixture_delisted_at
+  );
+
+  UPDATE catalog.packages AS packages
+  SET status = 'delisted',
+      updated_at = fixture_delisted_at,
+      delisted_at = fixture_delisted_at
+  WHERE packages.package_id = fixture_package_id
+    AND packages.status = 'published';
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  IF updated_count <> 1 THEN
+    RAISE EXCEPTION 'Catalog test fixture package changed before delisting: package_id=%', fixture_package_id
+      USING ERRCODE = '40001';
+  END IF;
+END;
+$migration$;

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -95,9 +95,15 @@ test("shared worker has exact permanent-prefix access and no public route", () =
 });
 
 test("release disables cleanup until the latest migration is confirmed", () => {
-  for (const relativePath of [
-    "../../.github/workflows/aws-web-release.yml",
-    "../../scripts/deploy/bootstrap.sh",
+  for (const { relativePath, requiredMigration } of [
+    {
+      relativePath: "../../.github/workflows/aws-web-release.yml",
+      requiredMigration: "0111_delist_catalog_test_fixture.sql",
+    },
+    {
+      relativePath: "../../scripts/deploy/bootstrap.sh",
+      requiredMigration: "0110_collection_cover_media.sql",
+    },
   ]) {
     const source = readSource(relativePath);
     const disabled = source.indexOf(
@@ -107,7 +113,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
       "mediaBlobCleanupEnabled=false",
     );
     const migration = source.indexOf(
-      "--require-migration 0110_collection_cover_media.sql",
+      `--require-migration ${requiredMigration}`,
     );
     const enabled = source.indexOf(
       "generatedMediaPromotionScheduleState=ENABLED",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0110_collection_cover_media.sql",
+    "--require-migration 0111_delist_catalog_test_fixture.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",


### PR DESCRIPTION
## Summary
- delist the deterministic public catalog test package, version, and collection through migration 0111
- make the public snapshot Postgres integration own its published lifecycle fixture
- advance migration boundaries, release gating, and workflow-facing assertions to 0111

## Validation
- Local checks not run; cloud CI owns executable validation.