### PR TITLE
Restore lifecycle migration test boundaries

### DIFF
--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -78,7 +78,6 @@ export const boundaryDefinitions = Object.freeze([
       "src/catalog/distribution/install/install.postgres.integration.ts",
       "src/catalog/distribution/public/public.postgres.integration.ts",
       "src/mediaAssets/blobLifecycle/cleanup/sharedProvenance.postgres.integration.ts",
-      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
     ]),
   }),
   Object.freeze({
@@ -132,6 +131,7 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 101,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
+      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
       "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
       "src/mediaAssets/multipart/completion/completionReconciliation.postgres.integration.ts",
       "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
@@ -142,6 +142,7 @@ export const boundaryDefinitions = Object.freeze([
     expectedMigrationCount: 100,
     testFiles: Object.freeze([
       "src/database/deadline.postgres.integration.ts",
+      "src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts",
       "src/mediaAssets/ingestion/directIngestionApply.postgres.integration.ts",
       "src/mediaAssets/multipart/writerLifecycle/writerAbortReplay.postgres.integration.ts",
     ]),

--- a/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
+++ b/apps/backend/src/mediaAssets/blobLifecycle/lifecycle.postgres.integration.ts
@@ -914,9 +914,9 @@ test("media blob lifecycle coordinates writers, ambiguity, cleanup leases, and g
            RETURNING author_id
          )
          INSERT INTO catalog.packages (package_id, author_id, slug, title, summary, description,
-                                       language_tags, license)
+                                       language_tags, topic_tags, license)
          SELECT $2, author_id, $3 || '-package', 'Lifecycle', 'Lifecycle', 'Lifecycle',
-                ARRAY['en'], 'CC0-1.0'
+                ARRAY['en'], ARRAY[]::text[], 'CC0-1.0'
          FROM inserted_author`,
         [authorId, packageId, catalogSlug],
       );


### PR DESCRIPTION
## Summary

- restore the lifecycle migration-upgrade integration test to its historical 0098 and 0099 boundaries
- explicitly provide the required empty `topic_tags` fixture value at those old schemas
- leave the topic-free runtime and all other 0112-gated fixtures unchanged

## Production failure

[AWS run 31877112412](https://github.com/kirill-markin/flashcards-open-source-app/actions/runs/31877112412) failed before deployment because the test ran at boundary 0112 and attempted to drop `content.media_blob_lifecycles` after migration 0102 had created `content.media_blob_cleanup_attempts` with a dependent foreign key.

Running this historical upgrade harness at 0098 and 0099 removes that later dependency from the fixture lifecycle. The explicit empty topic array keeps its catalog seed valid before migration 0112 adds defaults; application/runtime writes remain topic-free and gated on 0112.