### PR TITLE
Drop upstream catalog topic columns

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -387,7 +387,7 @@ jobs:
         run: |
           bash scripts/deploy/migrate-aws.sh \
             --stack-name ${{ env.STACK_NAME }} \
-            --require-migration 0112_prepare_catalog_topic_removal.sql
+            --require-migration 0113_drop_catalog_topic_tags.sql
 
       - name: CDK deploy with reconciliation schedule enabled
         working-directory: infra/aws

--- a/apps/backend/scripts/postgresIntegrations/boundaries.mjs
+++ b/apps/backend/scripts/postgresIntegrations/boundaries.mjs
@@ -71,8 +71,8 @@ export const createdRolesByMigration = new Map([
 ]);
 export const boundaryDefinitions = Object.freeze([
   Object.freeze({
-    migrationFileName: "0112_prepare_catalog_topic_removal.sql",
-    expectedMigrationCount: 114,
+    migrationFileName: "0113_drop_catalog_topic_tags.sql",
+    expectedMigrationCount: 115,
     testFiles: Object.freeze([
       "src/catalog/authoring/lockOrder.postgres.integration.ts",
       "src/catalog/distribution/install/install.postgres.integration.ts",

--- a/apps/backend/src/catalog/distribution/install/replay.test.ts
+++ b/apps/backend/src/catalog/distribution/install/replay.test.ts
@@ -86,34 +86,6 @@ test("catalog install rejects stored replay results that violate the published r
   }
 });
 
-test("catalog install strips legacy topic tags while replaying a stored result", async () => {
-  const installInput: CatalogPackageInstallConfirmInput = {
-    installId: "catalog-install-stored-legacy-topic-tags",
-    installedAt: testInstallTimestamp,
-    clientUpdatedAt: testInstallTimestamp,
-    lastModifiedByReplicaId: testWorkspaceReplicaId,
-    operationIdPrefix: "catalog-install-stored-legacy-topic-tags",
-  };
-  const validResult = createStoredCatalogPackageInstallResult(installInput.installId);
-  const legacyStoredResult = {
-    ...validResult,
-    packageVersion: {
-      ...validResult.packageVersion,
-      topicTags: ["language"],
-    },
-  };
-
-  const replayedResult = await installCatalogPackageVersionInExecutor(
-    createCatalogPackageInstallReplayExecutor(installInput, legacyStoredResult),
-    testWorkspaceId,
-    testPackageVersionId,
-    installInput,
-  );
-
-  assert.deepEqual(replayedResult, validResult);
-  assert.equal(Object.hasOwn(replayedResult.packageVersion, "topicTags"), false);
-});
-
 test("catalog install rejects a contract-valid stored result that mismatches its durable identity", async () => {
   const installInput: CatalogPackageInstallConfirmInput = {
     installId: "catalog-install-stored-identity",
@@ -166,4 +138,3 @@ test("catalog install rejects a contract-valid stored result that mismatches its
     },
   );
 });
-

--- a/apps/backend/src/catalog/distribution/install/replay.ts
+++ b/apps/backend/src/catalog/distribution/install/replay.ts
@@ -68,11 +68,6 @@ const catalogPackageInstallPackageVersionSchema = z.object({
   author: catalogPackageInstallAuthorSchema,
 }).strict();
 
-const catalogPackageInstallStoredPackageVersionSchema =
-  catalogPackageInstallPackageVersionSchema.extend({
-    topicTags: z.array(z.string()).optional(),
-  }).strict();
-
 const catalogPackageInstallResultSchema = z.object({
   packageVersion: catalogPackageInstallPackageVersionSchema,
   installedCards: z.array(z.object({
@@ -97,17 +92,6 @@ const catalogPackageInstallResultSchema = z.object({
   }).strict(),
 }).strict();
 
-const catalogPackageInstallStoredResultSchema = catalogPackageInstallResultSchema.extend({
-  packageVersion: catalogPackageInstallStoredPackageVersionSchema,
-}).strict();
-
-function stripLegacyCatalogPackageInstallTopicTags(
-  storedResult: z.infer<typeof catalogPackageInstallStoredResultSchema>,
-): CatalogPackageInstallResult {
-  const { topicTags: _legacyTopicTags, ...packageVersion } = storedResult.packageVersion;
-  return { ...storedResult, packageVersion };
-}
-
 export function createCatalogPackageInstallRequestIdentity(
   packageVersionId: string,
   input: NormalizedCatalogPackageInstallConfirmInput,
@@ -129,7 +113,7 @@ function parseCatalogPackageInstallStoredResult(
   workspaceId: string,
   installId: string,
 ): CatalogPackageInstallResult {
-  const parsedResult = catalogPackageInstallStoredResultSchema.safeParse(value);
+  const parsedResult = catalogPackageInstallResultSchema.safeParse(value);
   if (parsedResult.success === false) {
     throw new HttpError(
       500,
@@ -144,7 +128,7 @@ function parseCatalogPackageInstallStoredResult(
     );
   }
 
-  return stripLegacyCatalogPackageInstallTopicTags(parsedResult.data);
+  return parsedResult.data;
 }
 
 function catalogPackageInstallStoredResultMismatchFields(

--- a/apps/backend/src/entrypoints/migrate-lambda.test.ts
+++ b/apps/backend/src/entrypoints/migrate-lambda.test.ts
@@ -8,12 +8,12 @@ test("migration Lambda distinguishes direct and CloudFormation invocations", () 
   assert.deepEqual(parseMigrationInvocation({
     RequestType: "Update",
     ResourceProperties: {
-      RequiredMigration: "0112_prepare_catalog_topic_removal.sql",
+      RequiredMigration: "0113_drop_catalog_topic_tags.sql",
       UnrelatedProperty: "ignored",
     },
   }), {
     kind: "provision",
-    requiredMigration: "0112_prepare_catalog_topic_removal.sql",
+    requiredMigration: "0113_drop_catalog_topic_tags.sql",
   });
 });
 

--- a/db/migrations/0113_drop_catalog_topic_tags.sql
+++ b/db/migrations/0113_drop_catalog_topic_tags.sql
@@ -1,0 +1,62 @@
+-- Migration status: Current / contract cleanup.
+-- Introduces: removal of the retired catalog topic columns after durable replay cleanup.
+-- Schemas touched/read explicitly: sync, catalog, pg_catalog.
+
+UPDATE sync.catalog_package_install_idempotency
+SET install_result = pg_catalog.jsonb_set(
+  install_result,
+  '{packageVersion}',
+  (install_result -> 'packageVersion') - 'topicTags',
+  false
+)
+WHERE pg_catalog.jsonb_typeof(install_result) = 'object'
+  AND pg_catalog.jsonb_typeof(install_result -> 'packageVersion') = 'object'
+  AND (install_result -> 'packageVersion') ? 'topicTags';
+
+CREATE OR REPLACE FUNCTION catalog.prevent_published_package_version_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  IF (
+      OLD.status IN ('published', 'delisted')
+      OR NEW.status IN ('published', 'delisted')
+    )
+    AND (
+      NEW.package_id IS DISTINCT FROM OLD.package_id
+      OR NEW.version_number IS DISTINCT FROM OLD.version_number
+      OR NEW.slug IS DISTINCT FROM OLD.slug
+      OR NEW.title IS DISTINCT FROM OLD.title
+      OR NEW.summary IS DISTINCT FROM OLD.summary
+      OR NEW.description IS DISTINCT FROM OLD.description
+      OR NEW.language_tags IS DISTINCT FROM OLD.language_tags
+      OR NEW.license IS DISTINCT FROM OLD.license
+      OR NEW.content_warning IS DISTINCT FROM OLD.content_warning
+      OR NEW.cover_package_media_key IS DISTINCT FROM OLD.cover_package_media_key
+      OR NEW.source_workspace_id IS DISTINCT FROM OLD.source_workspace_id
+      OR NEW.card_count IS DISTINCT FROM OLD.card_count
+      OR NEW.created_by_admin_email IS DISTINCT FROM OLD.created_by_admin_email
+      OR NEW.created_at IS DISTINCT FROM OLD.created_at
+      OR NEW.submitted_at IS DISTINCT FROM OLD.submitted_at
+      OR (
+        OLD.status IN ('published', 'delisted')
+        AND NEW.published_at IS DISTINCT FROM OLD.published_at
+      )
+    ) THEN
+    RAISE EXCEPTION 'Published catalog package versions are immutable'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER TABLE catalog.packages
+  DROP COLUMN topic_tags;
+
+ALTER TABLE catalog.package_versions
+  DROP COLUMN topic_tags;
+
+ALTER TABLE catalog.collections
+  DROP COLUMN topic_tags;

--- a/infra/aws/lib/migration-runner.test.ts
+++ b/infra/aws/lib/migration-runner.test.ts
@@ -24,7 +24,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   const migrationGate = databaseMigrationGate(
     stack,
     migrationFn,
-    "0112_prepare_catalog_topic_removal.sql",
+    "0113_drop_catalog_topic_tags.sql",
   );
   const dependentRuntime = new lambda.Function(stack, "DependentBackendHandler", {
     code: lambda.Code.fromInline("exports.handler = async () => ({});"),
@@ -40,7 +40,7 @@ test("database migration gate blocks the dependent backend runtime", () => {
   }>;
   const migrationGateEntry = Object.entries(template.Resources).find(([, resource]) => (
     resource.Type === "AWS::CloudFormation::CustomResource"
-    && resource.Properties?.RequiredMigration === "0112_prepare_catalog_topic_removal.sql"
+    && resource.Properties?.RequiredMigration === "0113_drop_catalog_topic_tags.sql"
   ));
   if (migrationGateEntry === undefined) {
     throw new Error("Synthesized template is missing the required database migration gate");

--- a/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
+++ b/infra/aws/lib/scheduled-jobs/generated-media-promotion.test.ts
@@ -98,7 +98,7 @@ test("release disables cleanup until the latest migration is confirmed", () => {
   for (const { relativePath, requiredMigration } of [
     {
       relativePath: "../../.github/workflows/aws-web-release.yml",
-      requiredMigration: "0112_prepare_catalog_topic_removal.sql",
+      requiredMigration: "0113_drop_catalog_topic_tags.sql",
     },
     {
       relativePath: "../../scripts/deploy/bootstrap.sh",

--- a/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
+++ b/infra/aws/lib/scheduled-jobs/multipart-completion-reconciliation.test.ts
@@ -205,7 +205,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
     "multipartCompletionReconciliationScheduleState=DISABLED",
   );
   const requiredMigration = workflow.indexOf(
-    "--require-migration 0112_prepare_catalog_topic_removal.sql",
+    "--require-migration 0113_drop_catalog_topic_tags.sql",
   );
   const enabledDeploy = workflow.indexOf(
     "multipartCompletionReconciliationScheduleState=ENABLED",
@@ -235,7 +235,7 @@ test("release deploys migration-gated runtime disabled, verifies migrations, the
   const stackSource = readLibSource("lib/stack.ts");
   assert.match(
     stackSource,
-    /databaseMigrationGate\([\s\S]*"0112_prepare_catalog_topic_removal\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
+    /databaseMigrationGate\([\s\S]*"0113_drop_catalog_topic_tags\.sql"[\s\S]*addDatabaseMigrationDependency\(api\.backendFn, migrationGate\)[\s\S]*addDatabaseMigrationDependency\(api\.directImageIngestionFn, migrationGate\)/,
   );
 
   const outputsSource = readLibSource("lib/outputs.ts");

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -340,7 +340,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const migrationGate = databaseMigrationGate(
       this,
       migrationFn,
-      "0112_prepare_catalog_topic_removal.sql",
+      "0113_drop_catalog_topic_tags.sql",
     );
     const api = apiGateway(this, {
       vpc: net.vpc,


### PR DESCRIPTION
## Summary

- complete the catalog topic-removal contract after the 05a AWS/Web production gate; run 31878044133 is green
- add migration 0113, which first scrubs legacy packageVersion.topicTags from durable catalog install JSON, then rewrites the published-version immutability trigger, then drops the three physical topic_tags columns
- advance the deployment migration gate and current PostgreSQL integration boundary to 0113
- remove the temporary stored-replay adapter while retaining strict result parsing

## Preserved contracts

- explicit removed-input and removed-query guards remain
- package language tags, card tags, collections, and collection membership remain
- historical migrations and historical lifecycle fixtures remain unchanged

## Validation

- fresh static review found no P0-P4 issues
- project checks were not run locally; cloud CI owns executable validation