### PR TITLE
Accept Sentry package traits serialization

### DIFF
--- a/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/project.pbxproj
+++ b/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/project.pbxproj
@@ -572,6 +572,8 @@
 				kind = upToNextMajorVersion;
 				minimumVersion = 9.19.0;
 			};
+			traits = (
+			);
 		};
 		A10000000000000000000040 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;


### PR DESCRIPTION
## Summary
- accept Xcode explicit empty package-traits serialization for Sentry
- preserve the existing Sentry URL and version requirement

## Testing
- not run locally per repository workflow; GitHub CI owns validation