### PR TITLE
Make Foundation table extraction static

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+FriendInvitations.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+FriendInvitations.swift
@@ -12,14 +12,14 @@ enum FriendInvitationDisplayNameValidationError: LocalizedError {
             return String(
                 localized: "progress.friend_invite.validation.length",
                 defaultValue: "Enter 1-30 characters.",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Validation error for a friend invite display name with an invalid trimmed length"
             )
         case .invalidCharacters:
             return String(
                 localized: "progress.friend_invite.validation.characters",
                 defaultValue: "Newlines and control characters are not allowed.",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Validation error for a friend invite display name containing control characters or newlines"
             )
         }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressErrorState.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/Refresh/FlashcardsStore+ProgressErrorState.swift
@@ -4,7 +4,7 @@ func localizedProgressUnavailableErrorMessage() -> String {
     String(
         localized: "progress.error.unavailable",
         defaultValue: "Progress is unavailable. Pull to refresh and try again.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Generic progress card message when progress cannot be prepared"
     )
 }
@@ -13,7 +13,7 @@ func localizedProgressSummaryRefreshErrorMessage() -> String {
     String(
         localized: "progress.error.summary_refresh_failed",
         defaultValue: "Progress summary couldn't refresh. Pull to try again.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Generic progress card message when summary refresh fails"
     )
 }
@@ -22,7 +22,7 @@ func localizedProgressSeriesRefreshErrorMessage() -> String {
     String(
         localized: "progress.error.series_refresh_failed",
         defaultValue: "Progress chart couldn't refresh. Pull to try again.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Generic progress card message when chart refresh fails"
     )
 }
@@ -31,7 +31,7 @@ func localizedProgressReviewScheduleRefreshErrorMessage() -> String {
     String(
         localized: "progress.error.review_schedule_refresh_failed",
         defaultValue: "Review schedule couldn't refresh. Pull to try again.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Generic progress card message when review schedule refresh fails"
     )
 }
@@ -40,7 +40,7 @@ func localizedProgressReviewScheduleRenderErrorMessage() -> String {
     String(
         localized: "progress.error.review_schedule_render_failed",
         defaultValue: "Review schedule couldn't be shown. Pull to try again.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Generic progress card message when review schedule rendering fails"
     )
 }
@@ -49,7 +49,7 @@ func localizedProgressLeaderboardRefreshErrorMessage() -> String {
     String(
         localized: "progress.error.leaderboard_refresh_failed",
         defaultValue: "Rating leaderboard couldn't refresh. Pull to try again.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Generic progress card message when rating leaderboard refresh fails"
     )
 }
@@ -58,7 +58,7 @@ func localizedProgressStreakLeaderboardRefreshErrorMessage() -> String {
     String(
         localized: "progress.error.streak_leaderboard_refresh_failed",
         defaultValue: "Streak leaderboard couldn't refresh. Pull to try again.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Generic progress card message when streak leaderboard refresh fails"
     )
 }

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftUI
 
-let progressStringsTableName: String = "Foundation"
 let progressReviewRatingChartOrder: [ReviewRating] = [.again, .hard, .good, .easy]
 
 func progressReviewChartPageDateRange(
@@ -132,56 +131,56 @@ func progressReviewScheduleBucketTitle(key: ReviewScheduleBucketKey) -> String {
         return String(
             localized: "progress.screen.review_schedule.bucket.new",
             defaultValue: "New",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for cards without a due date"
         )
     case .today:
         return String(
             localized: "progress.screen.review_schedule.bucket.today",
             defaultValue: "Today",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for overdue and due-today cards"
         )
     case .days1To7:
         return String(
             localized: "progress.screen.review_schedule.bucket.days_1_to_7",
             defaultValue: "1-7 days",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for cards due in one to seven days"
         )
     case .days8To30:
         return String(
             localized: "progress.screen.review_schedule.bucket.days_8_to_30",
             defaultValue: "8-30 days",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for cards due in eight to thirty days"
         )
     case .days31To90:
         return String(
             localized: "progress.screen.review_schedule.bucket.days_31_to_90",
             defaultValue: "31-90 days",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for cards due in thirty-one to ninety days"
         )
     case .days91To360:
         return String(
             localized: "progress.screen.review_schedule.bucket.days_91_to_360",
             defaultValue: "91-360 days",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for cards due in ninety-one to three hundred sixty days"
         )
     case .years1To2:
         return String(
             localized: "progress.screen.review_schedule.bucket.years_1_to_2",
             defaultValue: "1-2 years",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for cards due in one to two years"
         )
     case .later:
         return String(
             localized: "progress.screen.review_schedule.bucket.later",
             defaultValue: "Later",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Review schedule bucket label for cards due later than two years"
         )
     }
@@ -226,7 +225,7 @@ func progressReviewScheduleChartAccessibilityLabel() -> String {
     String(
         localized: "progress.screen.review_schedule.section_title",
         defaultValue: "Review schedule",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress review schedule section title"
     )
 }
@@ -238,7 +237,7 @@ func progressReviewScheduleBucketAccessibilityValue(
     let localizedFormat = String(
         localized: "progress.screen.review_schedule.bucket.accessibility_value",
         defaultValue: "%lld cards, %@",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Accessibility value for a review schedule bucket with card count and percentage"
     )
     return String(
@@ -260,7 +259,7 @@ func progressLeaderboardSectionTitle() -> String {
     String(
         localized: "progress.screen.leaderboard.section_title",
         defaultValue: "Rating leaderboard",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress rating leaderboard section title"
     )
 }
@@ -271,7 +270,7 @@ func progressLeaderboardInfoMessage(snapshotGeneratedAt: String?, now: Date) -> 
     let baseMessage = String(
         localized: "progress.screen.leaderboard.info.message",
         defaultValue: "Hard, Good, and Easy reviews count toward your rank. Again does not.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard info explanation of which review ratings count"
     )
 
@@ -287,7 +286,7 @@ func progressLeaderboardViewerRowTitle() -> String {
     String(
         localized: "progress.screen.leaderboard.row.you",
         defaultValue: "You",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard label for the viewer's own row"
     )
 }
@@ -296,7 +295,7 @@ func progressStreakLeaderboardSectionTitle() -> String {
     String(
         localized: "progress.screen.streak_leaderboard.section_title",
         defaultValue: "Streak leaderboard",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress streak leaderboard section title"
     )
 }
@@ -305,7 +304,7 @@ func progressStreakLeaderboardInfoMessage(snapshotGeneratedAt: String?, now: Dat
     let localizedFormat = String(
         localized: "progress.screen.streak_leaderboard.info.message",
         defaultValue: "Current streak days determine your rank. A streak day is any local day with at least one card review rated %1$@, %2$@, %3$@, or %4$@.",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress streak leaderboard info explanation of ranking metric"
     )
     let baseMessage = String(
@@ -330,7 +329,7 @@ func progressStreakLeaderboardDayCountText(streakDays: Int) -> String {
         return String(
             localized: "progress.screen.streak_leaderboard.day_count.one",
             defaultValue: "1 day",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress streak leaderboard singular day count"
         )
     }
@@ -338,7 +337,7 @@ func progressStreakLeaderboardDayCountText(streakDays: Int) -> String {
     let localizedFormat = String(
         localized: "progress.screen.streak_leaderboard.day_count.other",
         defaultValue: "%lld days",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress streak leaderboard plural day count"
     )
     return String(format: localizedFormat, locale: Locale.current, Int64(streakDays))
@@ -350,35 +349,35 @@ func progressLeaderboardWindowTitle(key: LeaderboardWindowKey) -> String {
         return String(
             localized: "progress.screen.leaderboard.window.last_24_hours",
             defaultValue: "24h",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard period selector label for the last 24 hours"
         )
     case .last3Days:
         return String(
             localized: "progress.screen.leaderboard.window.last_3_days",
             defaultValue: "3d",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard period selector label for the last 3 days"
         )
     case .last7Days:
         return String(
             localized: "progress.screen.leaderboard.window.last_7_days",
             defaultValue: "7d",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard period selector label for the last 7 days"
         )
     case .last30Days:
         return String(
             localized: "progress.screen.leaderboard.window.last_30_days",
             defaultValue: "30d",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard period selector label for the last 30 days"
         )
     case .allTime:
         return String(
             localized: "progress.screen.leaderboard.window.all_time",
             defaultValue: "All time",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard period selector label for all time"
         )
     }
@@ -395,7 +394,7 @@ func progressLeaderboardProfileFriendBadgeTitle() -> String {
     String(
         localized: "progress.leaderboard_profile.friend_badge",
         defaultValue: "Friend",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Badge text shown on a leaderboard profile when the profile belongs to a friend"
     )
 }
@@ -407,7 +406,7 @@ func progressLeaderboardProfileBestRatingText(
         return String(
             localized: "progress.leaderboard_profile.best_rating.none",
             defaultValue: "No rating yet",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Leaderboard profile best rating value when the profile has no rating placement"
         )
     }
@@ -415,7 +414,7 @@ func progressLeaderboardProfileBestRatingText(
     let localizedFormat = String(
         localized: "progress.leaderboard_profile.best_rating.format",
         defaultValue: "#%1$lld in %2$@",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Leaderboard profile best rating value with rank and leaderboard window, for example #2 in 24h"
     )
     return String(
@@ -444,7 +443,7 @@ func progressLeaderboardProfileCardCountText(totalCards: Int) -> String {
         return String(
             localized: "progress.leaderboard_profile.card_count.one",
             defaultValue: "1 card",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Leaderboard profile singular total card count"
         )
     }
@@ -452,7 +451,7 @@ func progressLeaderboardProfileCardCountText(totalCards: Int) -> String {
     let localizedFormat = String(
         localized: "progress.leaderboard_profile.card_count.other",
         defaultValue: "%lld cards",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Leaderboard profile plural total card count"
     )
     return String(format: localizedFormat, locale: Locale.current, Int64(totalCards))
@@ -487,7 +486,7 @@ func progressLeaderboardUpdatedText(snapshotGeneratedAt: String, now: Date) -> S
         let localizedFormat = String(
             localized: "progress.screen.leaderboard.updated_at.elapsed.hours_minutes",
             defaultValue: "%1$@ %2$@",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard freshness elapsed time with hours and remaining minutes"
         )
         elapsedText = String(
@@ -501,7 +500,7 @@ func progressLeaderboardUpdatedText(snapshotGeneratedAt: String, now: Date) -> S
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at",
         defaultValue: "Updated %@ ago",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard freshness text with localized elapsed time"
     )
     return String(format: localizedFormat, locale: Locale.current, elapsedText)
@@ -521,7 +520,7 @@ private func progressLeaderboardElapsedHourText(hours: Int64) -> String {
         return String(
             localized: "progress.screen.leaderboard.updated_at.hour.one",
             defaultValue: "1 hour",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard freshness singular elapsed hour"
         )
     }
@@ -529,7 +528,7 @@ private func progressLeaderboardElapsedHourText(hours: Int64) -> String {
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at.hour.other",
         defaultValue: "%lld hours",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard freshness plural elapsed hours"
     )
     return String(format: localizedFormat, locale: Locale.current, hours)
@@ -540,7 +539,7 @@ private func progressLeaderboardElapsedMinuteText(minutes: Int64) -> String {
         return String(
             localized: "progress.screen.leaderboard.updated_at.minute.one",
             defaultValue: "1 minute",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress leaderboard freshness singular elapsed minute"
         )
     }
@@ -548,7 +547,7 @@ private func progressLeaderboardElapsedMinuteText(minutes: Int64) -> String {
     let localizedFormat = String(
         localized: "progress.screen.leaderboard.updated_at.minute.other",
         defaultValue: "%lld minutes",
-        table: progressStringsTableName,
+        table: "Foundation",
         comment: "Progress leaderboard freshness plural elapsed minutes"
     )
     return String(format: localizedFormat, locale: Locale.current, minutes)

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -76,7 +76,7 @@ struct ProgressScreen: View {
                 String(
                     localized: "progress.screen.title",
                     defaultValue: "Progress",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress screen title"
                 )
             )

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressFriendInviteSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressFriendInviteSheet.swift
@@ -54,7 +54,7 @@ struct ProgressFriendInviteSheet: View {
                             String(
                                 localized: "progress.friend_invite.description",
                                 defaultValue: "Create a private friend link for the leaderboard.",
-                                table: progressStringsTableName,
+                                table: "Foundation",
                                 comment: "Body text explaining friend invite creation before the display name field"
                             )
                         )
@@ -67,7 +67,7 @@ struct ProgressFriendInviteSheet: View {
                         String(
                             localized: "progress.friend_invite.display_name.label",
                             defaultValue: "Friend name on your leaderboard",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Text field label for the private friend invite display name"
                         ),
                         text: self.$displayName,
@@ -75,7 +75,7 @@ struct ProgressFriendInviteSheet: View {
                             String(
                                 localized: "progress.friend_invite.display_name.prompt",
                                 defaultValue: "Your friend's name",
-                                table: progressStringsTableName,
+                                table: "Foundation",
                                 comment: "Prompt for an empty friend invite display name field"
                             )
                         )
@@ -96,7 +96,7 @@ struct ProgressFriendInviteSheet: View {
                         String(
                             localized: "progress.friend_invite.display_name.footer",
                             defaultValue: "Only you see this name in your leaderboard. Your friend chooses what to call you when accepting. Invite links expire in 2 days.",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Footer explaining private friend invite display names and expiration"
                         )
                     )
@@ -110,7 +110,7 @@ struct ProgressFriendInviteSheet: View {
                                 String(
                                     localized: "progress.friend_invite.share_subject",
                                     defaultValue: "Flashcards friend invite",
-                                    table: progressStringsTableName,
+                                    table: "Foundation",
                                     comment: "Subject for sharing a created friend invite link"
                                 )
                             ),
@@ -118,7 +118,7 @@ struct ProgressFriendInviteSheet: View {
                                 String(
                                     localized: "progress.friend_invite.share_message",
                                     defaultValue: "Open this Flashcards invite, sign in or sign up, and we will see each other in the app.",
-                                    table: progressStringsTableName,
+                                    table: "Foundation",
                                     comment: "Message for sharing a created friend invite link"
                                 )
                             )
@@ -127,7 +127,7 @@ struct ProgressFriendInviteSheet: View {
                                 String(
                                     localized: "progress.friend_invite.share_button",
                                     defaultValue: "Send Invite Link",
-                                    table: progressStringsTableName,
+                                    table: "Foundation",
                                     comment: "Button title for sharing a created friend invite link"
                                 ),
                                 systemImage: "square.and.arrow.up"
@@ -139,7 +139,7 @@ struct ProgressFriendInviteSheet: View {
                             String(
                                 localized: "progress.friend_invite.created_message",
                                 defaultValue: "They can open it, sign in or sign up, and then you will see each other in the app. Invite links expire in 2 days.",
-                                table: progressStringsTableName,
+                                table: "Foundation",
                                 comment: "Message shown after creating a friend invite link"
                             )
                         )
@@ -150,7 +150,7 @@ struct ProgressFriendInviteSheet: View {
                             String(
                                 localized: "progress.friend_invite.created_title",
                                 defaultValue: "Send this link to your friend",
-                                table: progressStringsTableName,
+                                table: "Foundation",
                                 comment: "Section header shown after a friend invite link is created"
                             )
                         )
@@ -170,7 +170,7 @@ struct ProgressFriendInviteSheet: View {
                 String(
                     localized: "progress.friend_invite.title",
                     defaultValue: "Add Friend",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Navigation title for the friend invite creation sheet"
                 )
             )
@@ -180,7 +180,7 @@ struct ProgressFriendInviteSheet: View {
                         String(
                             localized: "progress.friend_invite.done_button",
                             defaultValue: "Done",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Toolbar button title for dismissing the friend invite sheet"
                         )
                     ) {
@@ -223,7 +223,7 @@ struct ProgressFriendInviteSheet: View {
             return String(
                 localized: "progress.friend_invite.creating_button",
                 defaultValue: "Creating...",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Toolbar button title while creating a friend invite link"
             )
         }
@@ -231,7 +231,7 @@ struct ProgressFriendInviteSheet: View {
         return String(
             localized: "progress.friend_invite.create_button",
             defaultValue: "Create Link",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Toolbar button title for creating a friend invite link"
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressLeaderboardProfileSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressLeaderboardProfileSheet.swift
@@ -28,7 +28,7 @@ struct ProgressLeaderboardProfileSheet: View {
                             String(
                                 localized: "progress.leaderboard_profile.done_button",
                                 defaultValue: "Done",
-                                table: progressStringsTableName,
+                                table: "Foundation",
                                 comment: "Toolbar button title for dismissing a leaderboard profile sheet"
                             )
                         ) {
@@ -142,7 +142,7 @@ private struct ProgressLeaderboardProfileLoadingView: View {
                     String(
                         localized: "progress.leaderboard_profile.loading",
                         defaultValue: "Loading profile...",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Loading message for a leaderboard profile sheet"
                     )
                 )
@@ -193,7 +193,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                         String(
                             localized: "progress.leaderboard_profile.current_streak.label",
                             defaultValue: "Current streak",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Leaderboard profile current streak metric label"
                         )
                     )
@@ -210,7 +210,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                         String(
                             localized: "progress.leaderboard_profile.best_rating.label",
                             defaultValue: "Best rating",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Leaderboard profile best rating metric label"
                         )
                     )
@@ -220,7 +220,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                     String(
                         localized: "progress.leaderboard_profile.metrics.section_title",
                         defaultValue: "Metrics",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Leaderboard profile metrics section title"
                     )
                 )
@@ -233,7 +233,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                     String(
                         localized: "progress.leaderboard_profile.activity.section_title",
                         defaultValue: "Review activity",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Leaderboard profile review activity section title"
                     )
                 )
@@ -242,7 +242,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                     String(
                         localized: "progress.leaderboard_profile.activity.footer",
                         defaultValue: "Last 30 days.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Leaderboard profile review activity footer"
                     )
                 )
@@ -256,7 +256,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                         String(
                             localized: "progress.leaderboard_profile.joined.label",
                             defaultValue: "Joined",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Leaderboard profile joined date stats label"
                         )
                     )
@@ -269,7 +269,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                         String(
                             localized: "progress.leaderboard_profile.cards.label",
                             defaultValue: "Cards",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Leaderboard profile total cards stats label"
                         )
                     )
@@ -279,7 +279,7 @@ private struct ProgressLeaderboardProfileReadyView: View {
                     String(
                         localized: "progress.leaderboard_profile.stats.section_title",
                         defaultValue: "Stats",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Leaderboard profile stats section title"
                     )
                 )
@@ -349,7 +349,7 @@ private struct ProgressLeaderboardProfileActivityChart: View {
             String(
                 localized: "progress.leaderboard_profile.activity.chart.accessibility_label",
                 defaultValue: "Review activity",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Accessibility label for the leaderboard profile review activity chart"
             )
         )
@@ -359,7 +359,7 @@ private struct ProgressLeaderboardProfileActivityChart: View {
         String(
             localized: "progress.leaderboard_profile.activity.chart.date_axis",
             defaultValue: "Date",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Leaderboard profile review activity chart date axis label"
         )
     }
@@ -368,7 +368,7 @@ private struct ProgressLeaderboardProfileActivityChart: View {
         String(
             localized: "progress.leaderboard_profile.activity.chart.review_axis",
             defaultValue: "Reviews",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Leaderboard profile review activity chart review count axis label"
         )
     }
@@ -378,7 +378,7 @@ private struct ProgressLeaderboardProfileActivityChart: View {
             return String(
                 localized: "progress.leaderboard_profile.activity.review_count.one",
                 defaultValue: "1 review",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Leaderboard profile activity singular review count"
             )
         }
@@ -386,7 +386,7 @@ private struct ProgressLeaderboardProfileActivityChart: View {
         let localizedFormat = String(
             localized: "progress.leaderboard_profile.activity.review_count.other",
             defaultValue: "%lld reviews",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Leaderboard profile activity plural review count"
         )
         return String(format: localizedFormat, locale: Locale.current, Int64(reviewCount))
@@ -432,21 +432,21 @@ private struct ProgressLeaderboardProfileUnavailableView: View {
             return String(
                 localized: "progress.leaderboard_profile.unavailable.linked_account_required.title",
                 defaultValue: "Sign in required",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Leaderboard profile unavailable title when a linked account is required"
             )
         case .participationDisabled:
             return String(
                 localized: "progress.leaderboard_profile.unavailable.participation_disabled.title",
                 defaultValue: "Participation is off",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Leaderboard profile unavailable title when leaderboard participation is disabled"
             )
         case .profileUnavailable, .ready:
             return String(
                 localized: "progress.leaderboard_profile.unavailable.profile_unavailable.title",
                 defaultValue: "Profile unavailable",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Leaderboard profile unavailable title when the public profile cannot be shown"
             )
         }
@@ -458,21 +458,21 @@ private struct ProgressLeaderboardProfileUnavailableView: View {
             return String(
                 localized: "progress.leaderboard_profile.unavailable.linked_account_required.message",
                 defaultValue: "Sign in with email to view leaderboard profiles.",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Leaderboard profile unavailable message when a linked account is required"
             )
         case .participationDisabled:
             return String(
                 localized: "progress.leaderboard_profile.unavailable.participation_disabled.message",
                 defaultValue: "Profiles are visible only while rating leaderboard participation is on.",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Leaderboard profile unavailable message when leaderboard participation is disabled"
             )
         case .profileUnavailable, .ready:
             return String(
                 localized: "progress.leaderboard_profile.unavailable.profile_unavailable.message",
                 defaultValue: "This leaderboard profile cannot be shown right now.",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Leaderboard profile unavailable message when the public profile cannot be shown"
             )
         }
@@ -501,7 +501,7 @@ private struct ProgressLeaderboardProfileErrorView: View {
                     String(
                         localized: "progress.leaderboard_profile.error.title",
                         defaultValue: "Couldn't load profile",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Leaderboard profile load failure title"
                     ),
                     systemImage: "exclamationmark.triangle"
@@ -511,7 +511,7 @@ private struct ProgressLeaderboardProfileErrorView: View {
                     String(
                         localized: "progress.leaderboard_profile.error.message",
                         defaultValue: "Check your connection and try again.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Leaderboard profile load failure message"
                     )
                 )
@@ -520,7 +520,7 @@ private struct ProgressLeaderboardProfileErrorView: View {
                     String(
                         localized: "progress.leaderboard_profile.retry_button",
                         defaultValue: "Try Again",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Button title for retrying a leaderboard profile load"
                     )
                 ) {

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressLeaderboardSection.swift
@@ -45,7 +45,7 @@ struct ProgressLeaderboardSection: View {
             Button(
                 String(
                     localized: "shared.ok",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Confirmation button title"
                 ),
                 role: .cancel
@@ -89,7 +89,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.info.accessibility_label",
                     defaultValue: "About the rating leaderboard",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Accessibility label for the rating leaderboard info button"
                 )
             )
@@ -107,7 +107,7 @@ struct ProgressLeaderboardSection: View {
                     String(
                         localized: "progress.screen.leaderboard.invite.button",
                         defaultValue: "Add Friend",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Button title for creating a leaderboard friend invite link"
                     )
                 )
@@ -120,7 +120,7 @@ struct ProgressLeaderboardSection: View {
             String(
                 localized: "progress.screen.leaderboard.invite.accessibility_label",
                 defaultValue: "Add a friend",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Accessibility label for the leaderboard friend invite button"
             )
         )
@@ -142,7 +142,7 @@ struct ProgressLeaderboardSection: View {
             String(
                 localized: "progress.screen.leaderboard.window_picker.label",
                 defaultValue: "Period",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Accessibility label for the leaderboard period selector"
             ),
             selection: selectionBinding
@@ -198,7 +198,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.sign_in.title",
                     defaultValue: "Join the rating leaderboard",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress rating leaderboard sign-in placeholder title"
                 ),
                 systemImage: "person.crop.circle.badge.plus"
@@ -208,7 +208,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.sign_in.message",
                     defaultValue: "Sign in with email to see how your reviews rank on the rating leaderboard.",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress rating leaderboard sign-in placeholder message"
                 )
             )
@@ -217,7 +217,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.sign_in.button",
                     defaultValue: "Sign in or sign up",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress leaderboard sign-in placeholder button"
                 )
             ) {
@@ -233,7 +233,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.participation_disabled.title",
                     defaultValue: "Rating participation is off",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress rating leaderboard participation-disabled placeholder title"
                 ),
                 systemImage: "eye.slash"
@@ -243,7 +243,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.participation_disabled.message",
                     defaultValue: "Rankings are visible only while you participate in the rating leaderboard.",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress rating leaderboard participation-disabled placeholder message"
                 )
             )
@@ -252,7 +252,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.participation_disabled.button",
                     defaultValue: "Open rating leaderboard settings",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress rating leaderboard participation-disabled placeholder button"
                 )
             ) {
@@ -268,7 +268,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.unavailable.title",
                     defaultValue: "Not ready yet",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress rating leaderboard snapshot-unavailable placeholder title"
                 ),
                 systemImage: "hourglass"
@@ -278,7 +278,7 @@ struct ProgressLeaderboardSection: View {
                 String(
                     localized: "progress.screen.leaderboard.unavailable.message",
                     defaultValue: "The rating leaderboard is being prepared. Check back soon.",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress rating leaderboard snapshot-unavailable placeholder message"
                 )
             )
@@ -303,7 +303,7 @@ struct ProgressLeaderboardSection: View {
                     String(
                         localized: "progress.screen.leaderboard.load_failed.title",
                         defaultValue: "Couldn't load the rating leaderboard",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress rating leaderboard placeholder title after a failed load"
                     ),
                     systemImage: "exclamationmark.triangle"
@@ -313,7 +313,7 @@ struct ProgressLeaderboardSection: View {
                     String(
                         localized: "progress.screen.leaderboard.load_failed.message",
                         defaultValue: "Try again later.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress rating leaderboard placeholder message after a failed load"
                     )
                 )
@@ -324,7 +324,7 @@ struct ProgressLeaderboardSection: View {
                     String(
                         localized: "progress.screen.leaderboard.offline.title",
                         defaultValue: "You're offline",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress rating leaderboard offline placeholder title"
                     ),
                     systemImage: "wifi.slash"
@@ -334,7 +334,7 @@ struct ProgressLeaderboardSection: View {
                     String(
                         localized: "progress.screen.leaderboard.offline.message",
                         defaultValue: "Connect to the internet to load the rating leaderboard.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress rating leaderboard offline placeholder message"
                     )
                 )
@@ -468,7 +468,7 @@ private struct ProgressLeaderboardParticipantRowView: View {
         let localizedFormat = String(
             localized: "progress.screen.leaderboard.row.accessibility_value",
             defaultValue: "Rank %1$lld, %2$lld reviews",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Accessibility value for a leaderboard row with rank and qualified review count"
         )
         return String(

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressStreakLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/Leaderboard/ProgressStreakLeaderboardSection.swift
@@ -29,7 +29,7 @@ struct ProgressStreakLeaderboardSection: View {
             Button(
                 String(
                     localized: "shared.ok",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Confirmation button title"
                 ),
                 role: .cancel
@@ -68,7 +68,7 @@ struct ProgressStreakLeaderboardSection: View {
                 String(
                     localized: "progress.screen.streak_leaderboard.info.accessibility_label",
                     defaultValue: "About the streak leaderboard",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Accessibility label for the streak leaderboard info button"
                 )
             )
@@ -106,7 +106,7 @@ struct ProgressStreakLeaderboardSection: View {
                     String(
                         localized: "progress.screen.streak_leaderboard.load_failed.title",
                         defaultValue: "Couldn't load the streak leaderboard",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress streak leaderboard placeholder title after a failed load"
                     ),
                     systemImage: "exclamationmark.triangle"
@@ -116,7 +116,7 @@ struct ProgressStreakLeaderboardSection: View {
                     String(
                         localized: "progress.screen.streak_leaderboard.load_failed.message",
                         defaultValue: "Try again later.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress streak leaderboard placeholder message after a failed load"
                     )
                 )
@@ -127,7 +127,7 @@ struct ProgressStreakLeaderboardSection: View {
                     String(
                         localized: "progress.screen.streak_leaderboard.offline.title",
                         defaultValue: "You're offline",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress streak leaderboard offline placeholder title"
                     ),
                     systemImage: "wifi.slash"
@@ -137,7 +137,7 @@ struct ProgressStreakLeaderboardSection: View {
                     String(
                         localized: "progress.screen.streak_leaderboard.offline.message",
                         defaultValue: "Connect to the internet to load the streak leaderboard.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress streak leaderboard offline placeholder message"
                     )
                 )
@@ -233,7 +233,7 @@ private struct ProgressStreakLeaderboardParticipantRowView: View {
         let localizedFormat = String(
             localized: "progress.screen.streak_leaderboard.row.accessibility_value",
             defaultValue: "Rank %1$lld, %2$@",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Accessibility value for a streak leaderboard row with rank and streak day count"
         )
         return String(

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLoadedSections.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLoadedSections.swift
@@ -67,7 +67,7 @@ private struct ProgressStreakCard: View {
                 String(
                     localized: "progress.screen.streak.section_title",
                     defaultValue: "Streak",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress streak section title"
                 )
             )

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewScheduleSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewScheduleSection.swift
@@ -26,7 +26,7 @@ struct ProgressReviewScheduleSection: View {
                 String(
                     localized: "progress.screen.review_schedule.section_title",
                     defaultValue: "Review schedule",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress review schedule section title"
                 )
             )
@@ -77,7 +77,7 @@ struct ProgressReviewScheduleSection: View {
                     String(
                         localized: "progress.screen.review_schedule.empty",
                         defaultValue: "No active cards yet.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress review schedule empty caption"
                     )
                 )

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewsSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewsSection.swift
@@ -204,7 +204,7 @@ struct ProgressReviewsSection: View {
                         String(
                             localized: "progress.screen.reviews.section_title",
                             defaultValue: "Reviews",
-                            table: progressStringsTableName,
+                            table: "Foundation",
                             comment: "Progress reviews section title"
                         )
                     )
@@ -233,7 +233,7 @@ struct ProgressReviewsSection: View {
                             String(
                                 localized: "progress.screen.reviews.previous_week",
                                 defaultValue: "Previous week",
-                                table: progressStringsTableName,
+                                table: "Foundation",
                                 comment: "Accessibility label for the previous reviews week button"
                             )
                         )
@@ -248,7 +248,7 @@ struct ProgressReviewsSection: View {
                             String(
                                 localized: "progress.screen.reviews.next_week",
                                 defaultValue: "Next week",
-                                table: progressStringsTableName,
+                                table: "Foundation",
                                 comment: "Accessibility label for the next reviews week button"
                             )
                         )

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressStreakSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressStreakSection.swift
@@ -48,7 +48,7 @@ struct ProgressStreakSection: View {
             Button(
                 String(
                     localized: "shared.ok",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Confirmation button title"
                 ),
                 role: .cancel
@@ -62,7 +62,7 @@ struct ProgressStreakSection: View {
         String(
             localized: "progress.freeze_bank.info.title",
             defaultValue: "Streak freezes",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Title for the streak freeze bank explanation alert"
         )
     }
@@ -71,7 +71,7 @@ struct ProgressStreakSection: View {
         let localizedFormat = String(
             localized: "progress.freeze_bank.info.message",
             defaultValue: "Available: %@/%@. Recharge: %@/%@. Freezes protect missed days and recharge as your streak continues.",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Body for the streak freeze bank explanation alert. Parameters are available credits, capacity, next credit progress, and next credit required units."
         )
         return String(
@@ -230,7 +230,7 @@ private struct ProgressFreezeBankChip: View {
             String(
                 localized: "progress.freeze_bank.info.accessibility_hint",
                 defaultValue: "Shows how streak freezes work.",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Accessibility hint for the streak freeze bank info button"
             )
         )
@@ -240,7 +240,7 @@ private struct ProgressFreezeBankChip: View {
         let localizedFormat = String(
             localized: "progress.freeze_bank.accessibility",
             defaultValue: "Freeze bank %@ of %@ available.",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Accessibility label for the current streak freeze credit bank"
         )
         return String(
@@ -358,7 +358,7 @@ private struct ProgressStreakDayCell: View {
             let futureTitle = String(
                 localized: "progress.screen.streak.future_day.accessibility",
                 defaultValue: "Future day",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Accessibility label component for a future streak calendar day"
             )
 
@@ -369,14 +369,14 @@ private struct ProgressStreakDayCell: View {
         let todayTitle = String(
             localized: "progress.screen.today",
             defaultValue: "Today",
-            table: progressStringsTableName,
+            table: "Foundation",
             comment: "Progress today label"
         )
         let reviewsTitle = String.localizedStringWithFormat(
             String(
                 localized: "progress.screen.reviews.accessibility",
                 defaultValue: "%lld reviews",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Accessibility label suffix for daily review counts"
             ),
             Int64(self.day.reviewCount)
@@ -389,7 +389,7 @@ private struct ProgressStreakDayCell: View {
             streakStateTitle = String(
                 localized: "progress.screen.streak.frozen_day.accessibility",
                 defaultValue: "Frozen day",
-                table: progressStringsTableName,
+                table: "Foundation",
                 comment: "Accessibility label component for a streak day preserved by a freeze credit"
             )
         case .missed:

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressUnavailableCard.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressUnavailableCard.swift
@@ -7,7 +7,7 @@ struct ProgressUnavailableCard: View {
                 String(
                     localized: "progress.screen.unavailable.title",
                     defaultValue: "Progress is unavailable",
-                    table: progressStringsTableName,
+                    table: "Foundation",
                     comment: "Progress unavailable title"
                 ),
                 systemImage: "chart.bar.xaxis",
@@ -15,7 +15,7 @@ struct ProgressUnavailableCard: View {
                     String(
                         localized: "progress.screen.unavailable.description",
                         defaultValue: "Open review or reconnect cloud data, then refresh progress.",
-                        table: progressStringsTableName,
+                        table: "Foundation",
                         comment: "Progress unavailable description"
                     )
                 )

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPermissionSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPermissionSupport.swift
@@ -35,7 +35,7 @@ enum ReviewNotificationPermissionStatus: Hashable, Sendable {
             return String(
                 localized: "shared.action.open_settings",
                 table: "Foundation",
-                comment: "Notifications permission action title to open Settings"
+                comment: "Permission action title to open Settings"
             )
         case .notRequested:
             return String(

--- a/apps/ios/Flashcards/Flashcards/TransientBannerSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/TransientBannerSupport.swift
@@ -1,45 +1,44 @@
 import SwiftUI
 
-private let foundationStringsTableName: String = "Foundation"
 let transientBannerDefaultDismissDelayNanoseconds: UInt64 = 3_000_000_000
 let settingsWorkspaceLockedBannerMessage: String = String(
     localized: "transient_banner.workspace_changes_require_account",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when workspace changes require an account"
 )
 let reviewUpdatedOnAnotherDeviceBannerMessage: String = String(
     localized: "transient_banner.review_updated_on_another_device",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when a review is updated on another device"
 )
 let cardsUpdatedFromCloudBannerMessage: String = String(
     localized: "transient_banner.cards_updated_from_cloud",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when cards update from the cloud"
 )
 let aiChatOfflineBannerMessage: String = String(
     localized: "transient_banner.ai_chat_offline",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when AI chat is unavailable offline"
 )
 let aiChatActiveRunBannerMessage: String = String(
     localized: "transient_banner.ai_chat_active_run",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when an AI response is already in progress"
 )
 let reviewSpeechUnavailableBannerMessage: String = String(
     localized: "transient_banner.review_speech_unavailable",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when speech is unavailable on the device"
 )
 let testModeEnabledBannerMessage: String = String(
     localized: "transient_banner.test_mode_enabled",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when hidden test mode is enabled"
 )
 let testModeDisabledBannerMessage: String = String(
     localized: "transient_banner.test_mode_disabled",
-    table: foundationStringsTableName,
+    table: "Foundation",
     comment: "Banner message when hidden test mode is disabled"
 )
 


### PR DESCRIPTION
## Summary
- expose Foundation localization table names as call-site literals for compiler extraction
- remove the two obsolete Foundation table constants
- stabilize the shared open-Settings translator comment
- preserve ReviewCards table behavior

## Testing
- Not run locally; required GitHub checks own executable validation.