### PR TITLE
Migrate Sentry breadcrumb data setters

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
@@ -97,8 +97,14 @@ func sanitizeSentryBreadcrumb(_ breadcrumb: Breadcrumb) -> Breadcrumb? {
     breadcrumb.type = breadcrumb.type.map(redactedString)
     breadcrumb.message = breadcrumb.message.map(redactedString)
     breadcrumb.origin = breadcrumb.origin.map(redactedString)
-    breadcrumb.data = sanitizedBreadcrumbData(breadcrumb.data) ?? [:]
+    setSentryBreadcrumbData(sanitizedBreadcrumbData(breadcrumb.data) ?? [:], on: breadcrumb)
     return breadcrumb
+}
+
+func setSentryBreadcrumbData(_ data: [String: Any], on breadcrumb: Breadcrumb) {
+    for (key, value) in data {
+        breadcrumb.setData(value: value, key: key)
+    }
 }
 
 private func sanitizedBreadcrumbData(_ dictionary: [String: Any]?) -> [String: Any]? {

--- a/apps/ios/Flashcards/Flashcards/Observability/Sentry/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/Sentry/SentryCaptureMapping.swift
@@ -178,7 +178,10 @@ extension SentryObservabilityAdapter {
         let breadcrumb: Breadcrumb = Breadcrumb(level: level, category: category)
         breadcrumb.type = "default"
         breadcrumb.message = message
-        breadcrumb.data = sanitizedDictionary(self.dataWithProcessDiagnostics(data)) ?? [:]
+        setSentryBreadcrumbData(
+            sanitizedDictionary(self.dataWithProcessDiagnostics(data)) ?? [:],
+            on: breadcrumb
+        )
         SentrySDK.addBreadcrumb(breadcrumb)
     }
 


### PR DESCRIPTION
## Summary
- replace deprecated whole-dictionary breadcrumb data assignments with Sentry Cocoa per-key setters
- share one per-key writer across breadcrumb creation and sanitization
- preserve sanitized process diagnostics and caller precedence

## Validation
- not run locally; required PR checks own executable validation